### PR TITLE
fix(stt): select a supported Linux ffmpeg input

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bundled Linux ffmpeg recording by selecting its available ALSA input when PulseAudio support is absent, and surfaced recorder stderr when capture fails ([#5907](https://github.com/can1357/oh-my-pi/issues/5907)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/stt/recorder.ts
+++ b/packages/coding-agent/src/stt/recorder.ts
@@ -11,6 +11,8 @@ export interface RecordingHandle {
 }
 
 const isWindows = process.platform === "win32";
+const linuxFFmpegFormats = new Map<string, "pulse" | "alsa">();
+const ffmpegCaptureFlags = ["-hide_banner", "-loglevel", "error", "-nostats"];
 
 /**
  * Returns available recording tools in priority order.
@@ -36,6 +38,36 @@ async function detectWindowsAudioDevice(bin: string): Promise<string> {
 	return audioDevices[0];
 }
 
+async function ffmpegInputArgs(bin: string): Promise<string[]> {
+	if (isWindows) {
+		return ["-f", "dshow", "-i", `audio=${await detectWindowsAudioDevice(bin)}`];
+	}
+	if (process.platform === "darwin") {
+		return ["-f", "avfoundation", "-i", ":default"];
+	}
+
+	let format = linuxFFmpegFormats.get(bin);
+	if (!format) {
+		const result = await $`${bin} -hide_banner -demuxers`.quiet().nothrow();
+		if (result.exitCode !== 0) {
+			const stderr = result.stderr.toString().trim();
+			throw new Error(
+				`Could not inspect ffmpeg input formats (code ${result.exitCode}): ${stderr || "(no output)"}`,
+			);
+		}
+		const demuxers = result.stdout.toString();
+		if (/^\s*D\s+(?:d\s+)?pulse(?:\s|$)/m.test(demuxers)) {
+			format = "pulse";
+		} else if (/^\s*D\s+(?:d\s+)?alsa(?:\s|$)/m.test(demuxers)) {
+			format = "alsa";
+		} else {
+			throw new Error("ffmpeg supports neither PulseAudio nor ALSA input on Linux");
+		}
+		linuxFFmpegFormats.set(bin, format);
+	}
+	return ["-f", format, "-i", "default"];
+}
+
 // ── Recording implementations ──────────────────────────────────────
 
 async function startSoxRecording(bin: string, outputPath: string): Promise<RecordingHandle> {
@@ -44,7 +76,7 @@ async function startSoxRecording(bin: string, outputPath: string): Promise<Recor
 
 	const proc = Bun.spawn([bin, ...inputArgs, "-r", "16000", "-c", "1", "-b", "16", "-t", "wav", outputPath], {
 		stdout: "pipe",
-		stderr: "ignore",
+		stderr: "pipe",
 	});
 	await verifyProcessAlive(proc, "sox");
 	return {
@@ -56,48 +88,24 @@ async function startSoxRecording(bin: string, outputPath: string): Promise<Recor
 }
 
 async function startFFmpegRecording(bin: string, outputPath: string): Promise<RecordingHandle> {
-	let args: string[];
-	if (isWindows) {
-		const device = await detectWindowsAudioDevice(bin);
-		args = [
-			bin,
-			"-f",
-			"dshow",
-			"-i",
-			`audio=${device}`,
-			"-ar",
-			"16000",
-			"-ac",
-			"1",
-			"-sample_fmt",
-			"s16",
-			"-y",
-			outputPath,
-		];
-	} else if (process.platform === "darwin") {
-		args = [
-			bin,
-			"-f",
-			"avfoundation",
-			"-i",
-			":default",
-			"-ar",
-			"16000",
-			"-ac",
-			"1",
-			"-sample_fmt",
-			"s16",
-			"-y",
-			outputPath,
-		];
-	} else {
-		args = [bin, "-f", "pulse", "-i", "default", "-ar", "16000", "-ac", "1", "-sample_fmt", "s16", "-y", outputPath];
-	}
+	const args = [
+		bin,
+		...ffmpegCaptureFlags,
+		...(await ffmpegInputArgs(bin)),
+		"-ar",
+		"16000",
+		"-ac",
+		"1",
+		"-sample_fmt",
+		"s16",
+		"-y",
+		outputPath,
+	];
 
 	const proc = Bun.spawn(args, {
 		stdin: "pipe",
 		stdout: "pipe",
-		stderr: "ignore",
+		stderr: "pipe",
 	});
 	await verifyProcessAlive(proc, "ffmpeg");
 
@@ -119,7 +127,7 @@ async function startFFmpegRecording(bin: string, outputPath: string): Promise<Re
 async function startArecordRecording(bin: string, outputPath: string): Promise<RecordingHandle> {
 	const proc = Bun.spawn([bin, "-f", "S16_LE", "-r", "16000", "-c", "1", outputPath], {
 		stdout: "pipe",
-		stderr: "ignore",
+		stderr: "pipe",
 	});
 	await verifyProcessAlive(proc, "arecord");
 	return {
@@ -260,20 +268,19 @@ async function startPowerShellRecording(outputPath: string): Promise<RecordingHa
 
 // ── Health check ───────────────────────────────────────────────────
 
-type RecorderProcess = Subprocess<"ignore" | "pipe", "pipe", "ignore">;
+type RecorderProcess = Subprocess<"ignore" | "pipe", "pipe", "pipe">;
 
 async function verifyProcessAlive(proc: RecorderProcess, tool: string): Promise<void> {
 	await Bun.sleep(300);
 
 	const exited = await Promise.race([proc.exited.then(code => code), Bun.sleep(0).then(() => "running" as const)]);
-
-	if (exited !== "running") {
-		let stderr = "";
-		if (proc.stderr && typeof proc.stderr !== "number") {
-			stderr = await new Response(proc.stderr as ReadableStream).text();
-		}
-		throw new Error(`${tool} exited immediately (code ${exited}): ${stderr.trim() || "(no output)"}`);
+	if (exited === "running") {
+		void proc.stderr.pipeTo(new WritableStream<Uint8Array>()).catch(() => {});
+		return;
 	}
+
+	const stderr = await new Response(proc.stderr).text();
+	throw new Error(`${tool} exited immediately (code ${exited}): ${stderr.trim() || "(no output)"}`);
 }
 
 // ── Public API ─────────────────────────────────────────────────────
@@ -415,12 +422,18 @@ async function streamingRecorderArgs(recorder: ResolvedRecorder): Promise<string
 		case "arecord":
 			return [bin, "-f", "S16_LE", "-r", "16000", "-c", "1", "-t", "raw", "-"];
 		case "ffmpeg": {
-			const input = isWindows
-				? ["-f", "dshow", "-i", `audio=${await detectWindowsAudioDevice(bin)}`]
-				: process.platform === "darwin"
-					? ["-f", "avfoundation", "-i", ":default"]
-					: ["-f", "pulse", "-i", "default"];
-			return [bin, ...input, "-ar", "16000", "-ac", "1", "-f", "s16le", "pipe:1"];
+			return [
+				bin,
+				...ffmpegCaptureFlags,
+				...(await ffmpegInputArgs(bin)),
+				"-ar",
+				"16000",
+				"-ac",
+				"1",
+				"-f",
+				"s16le",
+				"pipe:1",
+			];
 		}
 		case "powershell":
 			throw new Error("PowerShell recorder cannot stream PCM to a pipe");
@@ -439,7 +452,7 @@ async function startStreamingRecordingWithRecorder(
 ): Promise<StreamingRecordingHandle> {
 	const args = await streamingRecorderArgs(recorder);
 	logger.debug("Starting streaming audio recording", { tool: recorder.tool, bin: recorder.bin });
-	const proc = Bun.spawn(args, { stdin: "pipe", stdout: "pipe", stderr: "ignore" });
+	const proc = Bun.spawn(args, { stdin: "pipe", stdout: "pipe", stderr: "pipe" });
 
 	// Read s16le bytes off stdout, carrying any trailing odd byte across chunk
 	// boundaries so a sample is never split. Runs until the process closes stdout.

--- a/packages/coding-agent/test/stt-recorder.test.ts
+++ b/packages/coding-agent/test/stt-recorder.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { startRecording } from "@oh-my-pi/pi-coding-agent/stt/recorder";
+import * as toolsManager from "@oh-my-pi/pi-coding-agent/utils/tools-manager";
+import * as piUtils from "@oh-my-pi/pi-utils";
+
+let tmp = "";
+
+async function installFakeFFmpeg(options: { demuxers: string; capture: string }): Promise<string> {
+	const bin = path.join(tmp, "ffmpeg");
+	const argsPath = path.join(tmp, "args.json");
+	await Bun.write(
+		bin,
+		`#!/usr/bin/env bun
+const args = Bun.argv.slice(2);
+if (args.includes("-demuxers")) {
+	await Bun.write(Bun.stdout, ${JSON.stringify(options.demuxers)});
+} else {
+	await Bun.write(${JSON.stringify(argsPath)}, JSON.stringify(args));
+	${options.capture}
+}
+`,
+	);
+	await fs.chmod(bin, 0o755);
+	return bin;
+}
+
+beforeEach(async () => {
+	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-stt-recorder-"));
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform !== "linux")("Linux ffmpeg recording", () => {
+	it("uses ALSA when ffmpeg has no PulseAudio demuxer", async () => {
+		const bin = await installFakeFFmpeg({
+			demuxers: " D d alsa            ALSA audio input\n",
+			capture: "await Bun.stdin.text();",
+		});
+		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "ffmpeg" ? bin : null));
+		vi.spyOn(toolsManager, "getToolPath").mockReturnValue(bin);
+
+		const recording = await startRecording(path.join(tmp, "recording.wav"));
+		await recording.stop();
+
+		const args = await Bun.file(path.join(tmp, "args.json")).text();
+		expect(args).toContain('"-f","alsa","-i","default"');
+		expect(args).not.toContain('"pulse"');
+	});
+
+	it("reports ffmpeg stderr when capture exits immediately", async () => {
+		const bin = await installFakeFFmpeg({
+			demuxers: " D d pulse           Pulse audio input\n D d alsa            ALSA audio input\n",
+			capture: 'await Bun.write(Bun.stderr, "Unknown input format: pulse\\n"); process.exit(234);',
+		});
+		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "ffmpeg" ? bin : null));
+		vi.spyOn(toolsManager, "getToolPath").mockReturnValue(bin);
+
+		await expect(startRecording(path.join(tmp, "recording.wav"))).rejects.toThrow(
+			"ffmpeg exited immediately (code 234): Unknown input format: pulse",
+		);
+	});
+});


### PR DESCRIPTION
## Repro
Downloaded the configured `eugeneware/ffmpeg-static` Linux x64 asset and ran `/tmp/omp-issue-5907-ffmpeg -hide_banner -f pulse -i default -t 0.1 -f null -`; it exited 234 with `Unknown input format: 'pulse'`.

## Cause
`packages/coding-agent/src/stt/recorder.ts` hard-coded `-f pulse -i default` in both `startFFmpegRecording` and `streamingRecorderArgs`, even when `detectRecorders` selected the bundled ffmpeg build that has ALSA but no PulseAudio demuxer. The recorder spawn paths also configured `stderr: "ignore"`, making `verifyProcessAlive` unable to include ffmpeg's diagnostic.

## Fix
- Probe each Linux ffmpeg binary's demuxer table once, prefer PulseAudio when present, and select ALSA otherwise.
- Pipe and drain recorder stderr, preserving it when a process exits during the startup health check.
- Suppress ffmpeg banners and progress stats so surfaced errors stay diagnostic.
- Add Linux regressions for ALSA selection and immediate-exit stderr reporting.

## Verification
`bun test packages/coding-agent/test/stt-recorder.test.ts` passes 2 tests; `bun run check:types` passes in `packages/coding-agent`. A smoke run through `startRecording` with the downloaded static asset selected ALSA instead of PulseAudio and surfaced the host's actual missing-ALSA-configuration error; the original `Unknown input format: 'pulse'` failure no longer occurs. Fixes #5907