### PR TITLE
docs(advisor): clarify concern delivery after a self-ended yield

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -114,7 +114,7 @@ Two session/client constraints can still preserve a note whose normal delivery p
 - **Plan mode:** every would-be advisor steer is preserved as a visible card, even while the primary loop is streaming, because only user-driven turns converge on ask/resolve.
 - **ACP with deferred agent-initiated turns:** when `deferAgentInitiatedTurns` is enabled and the bridge has not allowed agent-initiated turns, an idle would-be steer is preserved because the client cannot represent the triggered turn as busy. Advice raised while the primary loop is already streaming can still steer into that live turn.
 
-So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work and the current mode/client permits steering**; otherwise the note is preserved as a card until the user resumes.
+So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work and the current mode/client permits steering**. When steering is blocked instead, the note is either preserved as a card (the terminal-answer, plan-mode, and deferred-ACP cases above) or downgraded to a non-interrupting aside (the `advisor.immuneTurns` cooldown below); either way it waits for the next step boundary or resume rather than waking the agent.
 
 `advisor.immuneTurns` limits interruption frequency. After the advisor successfully delivers a `concern` or `blocker` through the steering channel, later concerns/blockers are routed as non-interrupting asides until the configured number of primary turns has completed. The default is `3`. `nit` notes are unchanged, and advice raised while user-interrupt auto-resume suppression is active is still preserved instead of restarting a stopped run.
 

--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -89,8 +89,8 @@ The `advise` tool accepts one note and an optional severity:
 | Severity | Delivery | Intended use |
 |---|---|---|
 | omitted / `nit` | Non-interrupting aside, batched into the primary transcript at the next step boundary. | Cleanup, simplification, low-risk edge cases. |
-| `concern` | Interrupting steering message — but see the terminal-answer exception below: a `concern` raised after the agent has produced its final text answer with no queued work left is preserved as a visible card, not steered. | Material risk, likely wrong direction, missing constraint, hallucinated API. |
-| `blocker` | Interrupting steering message. | Continuing would clearly waste work or produce broken output. |
+| `concern` | Interrupting steering message when the delivery constraints below permit it. A late terminal-answer `concern` is preserved as a visible card instead. | Material risk, likely wrong direction, missing constraint, hallucinated API. |
+| `blocker` | Interrupting steering message when the delivery constraints below permit it. Unlike a `concern`, a terminal answer alone does not prevent it from triggering a turn. | Continuing would clearly waste work or produce broken output. |
 
 Interrupting advice is sent through the steering channel and can abort in-flight tools at the next steering boundary. Each note (interrupting or batched) is rendered into the primary transcript as an `<advisory>` element — severity rides a `severity` attribute, and a `guidance` attribute carries the "weigh, don't blindly obey" framing (the primary agent's system prompt never mentions advisories, so the tag is its only cue). Note bodies are XML-escaped so advice containing `<`, `>`, or `&` can't break the wrapper:
 
@@ -102,14 +102,19 @@ note text
 
 When you deliberately interrupt the agent (Esc, or a cancel from collab, ACP, RPC, the SDK, or an extension), the advisor stops auto-resuming it. An interrupting `concern`/`blocker` raised while the run is stopped is recorded as a visible advisor card instead of restarting the turn, and a concern already in flight when you interrupt is preserved the same way rather than driving a surprise resume. The advice re-enters context the next time you resume — a new message, the `.`/`c` continue shortcut, or a steer/follow-up.
 
-A normal yield the agent drove itself is treated differently from a deliberate interrupt, but it is not a blanket "always steers and resumes". Two things decide whether a `concern`/`blocker` raised after such a yield wakes the primary:
+A normal yield the agent drove itself is treated differently from a deliberate interrupt, but it is not a blanket "always steers and resumes". The loop state and completed turn first determine the normal delivery path:
 
-- **While the loop is still streaming** (the raise arrived before the yield, or during a resume you already drove), the note steers into the live turn.
+- **While the loop is still streaming** (the raise arrived before the yield, or during a resume you already drove), the note normally steers into the live turn.
 - **Once the loop has yielded and gone idle**, delivery keys on how the turn ended:
-  - If the primary's tail is a **terminal text answer with no queued work**, a late `concern` is preserved as a visible card rather than waking the agent to restate a completed turn (#4840) — it re-enters context on the next resume (a new message, `.`/`c`, or a steer/follow-up), exactly like the interrupt case. A `blocker` is the exception: it still steers a triggered turn, because it means the agent handed off broken or unexercised work that must be acknowledged before the turn is considered done (#5628).
-  - Otherwise (the agent yielded mid-work, no terminal answer), an idle `concern`/`blocker` triggers a fresh turn so the advice is acted on immediately.
+  - If the primary's tail is a **terminal text answer with no queued work**, a late `concern` is preserved as a visible card rather than waking the agent to restate a completed turn (#4840) — it re-enters context on the next resume (a new message, `.`/`c`, or a steer/follow-up), exactly like the interrupt case. A `blocker` is the exception: it normally steers a triggered turn, because it means the agent handed off broken or unexercised work that must be acknowledged before the turn is considered done (#5628).
+  - Otherwise (the agent yielded mid-work, no terminal answer), an idle `concern`/`blocker` normally triggers a fresh turn so the advice is acted on immediately.
 
-So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work**; a `concern` that lands only after the final answer is intentionally a passive card, not a resume.
+Two session/client constraints can still preserve a note whose normal delivery path is steering:
+
+- **Plan mode:** every would-be advisor steer is preserved as a visible card, even while the primary loop is streaming, because only user-driven turns converge on ask/resolve.
+- **ACP with deferred agent-initiated turns:** when `deferAgentInitiatedTurns` is enabled and the bridge has not allowed agent-initiated turns, an idle would-be steer is preserved because the client cannot represent the triggered turn as busy. Advice raised while the primary loop is already streaming can still steer into that live turn.
+
+So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work and the current mode/client permits steering**; otherwise the note is preserved as a card until the user resumes.
 
 `advisor.immuneTurns` limits interruption frequency. After the advisor successfully delivers a `concern` or `blocker` through the steering channel, later concerns/blockers are routed as non-interrupting asides until the configured number of primary turns has completed. The default is `3`. `nit` notes are unchanged, and advice raised while user-interrupt auto-resume suppression is active is still preserved instead of restarting a stopped run.
 

--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -89,7 +89,7 @@ The `advise` tool accepts one note and an optional severity:
 | Severity | Delivery | Intended use |
 |---|---|---|
 | omitted / `nit` | Non-interrupting aside, batched into the primary transcript at the next step boundary. | Cleanup, simplification, low-risk edge cases. |
-| `concern` | Interrupting steering message. | Material risk, likely wrong direction, missing constraint, hallucinated API. |
+| `concern` | Interrupting steering message — but see the terminal-answer exception below: a `concern` raised after the agent has produced its final text answer with no queued work left is preserved as a visible card, not steered. | Material risk, likely wrong direction, missing constraint, hallucinated API. |
 | `blocker` | Interrupting steering message. | Continuing would clearly waste work or produce broken output. |
 
 Interrupting advice is sent through the steering channel and can abort in-flight tools at the next steering boundary. Each note (interrupting or batched) is rendered into the primary transcript as an `<advisory>` element — severity rides a `severity` attribute, and a `guidance` attribute carries the "weigh, don't blindly obey" framing (the primary agent's system prompt never mentions advisories, so the tag is its only cue). Note bodies are XML-escaped so advice containing `<`, `>`, or `&` can't break the wrapper:
@@ -100,7 +100,16 @@ note text
 </advisory>
 ```
 
-When you deliberately interrupt the agent (Esc, or a cancel from collab, ACP, RPC, the SDK, or an extension), the advisor stops auto-resuming it. An interrupting `concern`/`blocker` raised while the run is stopped is recorded as a visible advisor card instead of restarting the turn, and a concern already in flight when you interrupt is preserved the same way rather than driving a surprise resume. The advice re-enters context the next time you resume — a new message, the `.`/`c` continue shortcut, or a steer/follow-up. A normal yield is unaffected: the advisor can still steer and resume a run the agent ended on its own.
+When you deliberately interrupt the agent (Esc, or a cancel from collab, ACP, RPC, the SDK, or an extension), the advisor stops auto-resuming it. An interrupting `concern`/`blocker` raised while the run is stopped is recorded as a visible advisor card instead of restarting the turn, and a concern already in flight when you interrupt is preserved the same way rather than driving a surprise resume. The advice re-enters context the next time you resume — a new message, the `.`/`c` continue shortcut, or a steer/follow-up.
+
+A normal yield the agent drove itself is treated differently from a deliberate interrupt, but it is not a blanket "always steers and resumes". Two things decide whether a `concern`/`blocker` raised after such a yield wakes the primary:
+
+- **While the loop is still streaming** (the raise arrived before the yield, or during a resume you already drove), the note steers into the live turn.
+- **Once the loop has yielded and gone idle**, delivery keys on how the turn ended:
+  - If the primary's tail is a **terminal text answer with no queued work**, a late `concern` is preserved as a visible card rather than waking the agent to restate a completed turn (#4840) — it re-enters context on the next resume (a new message, `.`/`c`, or a steer/follow-up), exactly like the interrupt case. A `blocker` is the exception: it still steers a triggered turn, because it means the agent handed off broken or unexercised work that must be acknowledged before the turn is considered done (#5628).
+  - Otherwise (the agent yielded mid-work, no terminal answer), an idle `concern`/`blocker` triggers a fresh turn so the advice is acted on immediately.
+
+So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work**; a `concern` that lands only after the final answer is intentionally a passive card, not a resume.
 
 `advisor.immuneTurns` limits interruption frequency. After the advisor successfully delivers a `concern` or `blocker` through the steering channel, later concerns/blockers are routed as non-interrupting asides until the configured number of primary turns has completed. The default is `3`. `nit` notes are unchanged, and advice raised while user-interrupt auto-resume suppression is active is still preserved instead of restarting a stopped run.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `docs/advisor-watchdog.md` overstating advisor delivery for a normal yield: the severity table listed `concern` as unconditionally interrupting and the prose promised a self-ended run could always be steered/resumed. Documented the #4840 terminal-answer exception — a `concern` raised after the primary's final text answer with no queued work is preserved as a passive card, not a resume, while a `blocker` still steers (#5628) ([#5913](https://github.com/can1357/oh-my-pi/issues/5913)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `docs/advisor-watchdog.md` overstating advisor delivery for a normal yield: the severity table listed `concern` as unconditionally interrupting and the prose promised a self-ended run could always be steered/resumed. Documented the #4840 terminal-answer exception — a `concern` raised after the primary's final text answer with no queued work is preserved as a passive card, not a resume, while a `blocker` still steers (#5628) ([#5913](https://github.com/can1357/oh-my-pi/issues/5913)).
+- Fixed `docs/advisor-watchdog.md` overstating advisor delivery for a normal yield: the severity table listed `concern` as unconditionally interrupting and the prose promised a self-ended run could always be steered/resumed. Documented the #4840 terminal-answer exception (`concern` becomes a passive card while `blocker` normally steers, #5628) plus the plan-mode and deferred-ACP constraints that preserve would-be steers until the user resumes ([#5913](https://github.com/can1357/oh-my-pi/issues/5913)).
 
 ## [17.0.3] - 2026-07-17
 


### PR DESCRIPTION
## Repro
With `advisor.enabled: true` and a `concern`-severity `advise()` call raised while the primary agent is **idle after a normal yield** (terminal text answer, no queued work, no user interrupt), the note is recorded as a passive advisor card and only enters context on the next resume — never steered. `docs/advisor-watchdog.md` promised the opposite: its severity table listed `concern` as unconditionally "Interrupting steering message" and its prose said "A normal yield is unaffected: the advisor can still steer and resume a run the agent ended on its own." The reporter (#5913) observed 3/3 idle-raised concerns delivered as silent cards vs. 9/9 running-raised concerns steered, and the docs gave no account of the split.

## Cause
No code defect — the docs were stale. `resolveAdvisorDeliveryChannel` (`packages/coding-agent/src/advisor/advise-tool.ts:125`) returns `preserve` for an interrupting note when `terminalAnswerNoQueuedWork && severity !== "blocker" && !streaming && !aborting`. `terminalAnswerNoQueuedWork` is computed by `#hasTerminalTextAnswerWithoutQueuedWork()` (`agent-session.ts:3343`), independent of the user-interrupt (`autoResumeSuppressed`) path. This is the intended #4840 behavior (commit `708eafaf8d`): a late `concern` must not wake the agent to restate a completed turn; a `blocker` is the explicit exception (#5628) and still steers a triggered turn. The running controls delivered because the raise preceded the yield (`streaming: true`), never reaching the `preserve` branch.

## Fix
- `docs/advisor-watchdog.md` severity table: the `concern` delivery cell now points at the terminal-answer exception instead of stating unconditional interruption.
- Replaced the incorrect one-line "normal yield is unaffected" claim with a paragraph documenting the two decision axes: streaming (steers live) vs. idle, and for idle the terminal-answer carve-out (`concern` → preserved card re-entering on resume; `blocker` → steers a triggered turn) vs. mid-work idle (triggers a fresh turn).
- Added an `[Unreleased] ### Fixed` CHANGELOG entry for the coding-agent package.

## Verification
Documentation-only change; the "test" is re-reading the diff against the code path. Confirmed the new prose matches `resolveAdvisorDeliveryChannel`'s branch conditions (`advise-tool.ts:133-138`) and the terminal-answer helper (`agent-session.ts:3343-3348`) line-for-line: `concern` + terminal answer + not streaming + not aborting → `preserve`; `blocker` → `steer`; idle without a terminal answer → `steer` (triggered turn). No code touched, so no test run required. Fixes #5913