### PR TITLE
fix(ai): widen boolean tool subschemas for grammar-constrained local …

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ([#5914](https://github.com/can1357/oh-my-pi/issues/5914)) llama.cpp rejecting every tool-carrying request with HTTP 400 `Unable to generate parser for this template ... Unrecognized schema: true`. `toolWireSchema` intentionally emits a bare boolean `true` for unconstrained fields (issue #1179), and `supportsStrictMode` is off for these hosts so the raw parameters ship unchanged; the openai-completions encoder now widens boolean subschemas (`true`/`false`) into a value-accepting `anyOf` of primitives and strips boolean `additionalProperties`/`unevaluatedProperties` for grammar-constrained backends. This regressed on 2026-07-17 when the `task` tool gained an `outputSchema?: unknown` field, shipping `properties.outputSchema: true` to llama.cpp on every request.
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -24,7 +24,7 @@ import {
 	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 } from "../utils/idle-iterator";
-import { sanitizeSchemaForOllama, toolWireSchema } from "../utils/schema";
+import { sanitizeSchemaForGrammarConstrainedSampler, toolWireSchema } from "../utils/schema";
 import {
 	getStreamMarkupHealingPattern,
 	type HealedToolCall,
@@ -281,7 +281,7 @@ function convertTools(tools: Tool[] | undefined): OllamaFunctionTool[] | undefin
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: sanitizeSchemaForOllama(toolWireSchema(tool)),
+			parameters: sanitizeSchemaForGrammarConstrainedSampler(toolWireSchema(tool)),
 		},
 	}));
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -9,23 +9,23 @@ import * as AIError from "../error";
 import { getKimiCommonHeaders } from "../registry/oauth/kimi";
 import { getEnvApiKey } from "../stream";
 import type {
-	AssistantMessage,
-	Context,
-	Message,
-	MessageAttribution,
-	Model,
-	ProviderSessionState,
-	RawSseEvent,
-	ServiceTier,
-	StopReason,
-	StreamFunction,
-	StreamOptions,
-	TextContent,
-	ThinkingContent,
-	Tool,
-	ToolCall,
-	ToolChoice,
-	ToolResultMessage,
+  AssistantMessage,
+  Context,
+  Message,
+  MessageAttribution,
+  Model,
+  ProviderSessionState,
+  RawSseEvent,
+  ServiceTier,
+  StopReason,
+  StreamFunction,
+  StreamOptions,
+  TextContent,
+  ThinkingContent,
+  Tool,
+  ToolCall,
+  ToolChoice,
+  ToolResultMessage,
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
@@ -34,76 +34,82 @@ import { hasVisibleAssistantContent, withEmptyCompletionRetry } from "../utils/e
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import {
-	getOpenAIStreamFirstEventTimeoutMs,
-	getOpenAIStreamIdleTimeoutMs,
-	iterateWithIdleTimeout,
-	iterateWithTerminalGrace,
+  getOpenAIStreamFirstEventTimeoutMs,
+  getOpenAIStreamIdleTimeoutMs,
+  iterateWithIdleTimeout,
+  iterateWithTerminalGrace,
 } from "../utils/idle-iterator";
 import { OpenAIHttpError, postOpenAIStream } from "../utils/openai-http";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
-import { adaptSchemaForStrict, NO_STRICT, normalizeSchemaForMoonshot, toolWireSchema } from "../utils/schema";
 import {
-	type HealedToolCall,
-	StreamMarkupHealing,
-	type StreamMarkupHealingEvent,
+  adaptSchemaForStrict,
+  NO_STRICT,
+  normalizeSchemaForMoonshot,
+  sanitizeSchemaForGrammarConstrainedSampler,
+  toolWireSchema,
+} from "../utils/schema";
+import {
+  type HealedToolCall,
+  StreamMarkupHealing,
+  type StreamMarkupHealingEvent,
 } from "../utils/stream-markup-healing";
 import { isForcedToolChoice, mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
 import type {
-	ChatCompletionAssistantMessageParam,
-	ChatCompletionChunk,
-	ChatCompletionContentPart,
-	ChatCompletionContentPartImage,
-	ChatCompletionContentPartText,
-	ChatCompletionMessageParam,
-	ChatCompletionTool,
-	ChatCompletionToolMessageParam,
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionChunk,
+  ChatCompletionContentPart,
+  ChatCompletionContentPartImage,
+  ChatCompletionContentPartText,
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionToolMessageParam,
 } from "./openai-chat-wire";
 import {
-	applyOpenAIReasoningEffortFallback,
-	clearOpenAIReasoningEffortFallbackState,
-	createOpenAIReasoningEffortFallbackKey,
-	createOpenAIReasoningEffortFallbackState,
-	getOpenAIReasoningEffortFallback,
-	type OpenAIReasoningEffortFallback,
-	type OpenAIReasoningEffortFallbackState,
-	rememberOpenAIReasoningEffortFallback,
-	resolveOpenAIReasoningEffortFallback,
+  applyOpenAIReasoningEffortFallback,
+  clearOpenAIReasoningEffortFallbackState,
+  createOpenAIReasoningEffortFallbackKey,
+  createOpenAIReasoningEffortFallbackState,
+  getOpenAIReasoningEffortFallback,
+  type OpenAIReasoningEffortFallback,
+  type OpenAIReasoningEffortFallbackState,
+  rememberOpenAIReasoningEffortFallback,
+  resolveOpenAIReasoningEffortFallback,
 } from "./openai-reasoning-fallback";
 import {
-	applyChatCompletionsCompatPolicy,
-	applyChatCompletionsToolStream,
-	applyOpenAIExtraBody,
-	applyOpenAIGatewayRouting,
-	applyOpenAIServiceTier,
-	applyOpenRouterReportedCost,
-	applyWireModelIdTransform,
-	calculateOpenAIUsageAccounting,
-	clearOpenAIStrictToolsState,
-	createInitialResponsesAssistantMessage,
-	createOpenAIStrictToolsState,
-	disableStrictToolsForScope,
-	getOpenAIPromptCacheKey,
-	getOpenAIStrictToolsScope,
-	isCompiledGrammarTooLargeStrictError,
-	isOpenRouterAnthropicModel,
-	isStrictToolsDisabledForScope,
-	type OpenAICompatPolicy,
-	type OpenAICompletionsParams,
-	type OpenAIRequestSetup,
-	type OpenAIStrictToolsState,
-	parseAzureDeploymentNameMap,
-	resolveOpenAICompatPolicy,
-	resolveOpenAICompletionsOutputClamp,
-	resolveOpenAIOutputTokenParam,
-	resolveOpenAIRequestSetup,
-	shouldRetryWithoutStrictTools,
+  applyChatCompletionsCompatPolicy,
+  applyChatCompletionsToolStream,
+  applyOpenAIExtraBody,
+  applyOpenAIGatewayRouting,
+  applyOpenAIServiceTier,
+  applyOpenRouterReportedCost,
+  applyWireModelIdTransform,
+  calculateOpenAIUsageAccounting,
+  clearOpenAIStrictToolsState,
+  createInitialResponsesAssistantMessage,
+  createOpenAIStrictToolsState,
+  disableStrictToolsForScope,
+  getOpenAIPromptCacheKey,
+  getOpenAIStrictToolsScope,
+  isCompiledGrammarTooLargeStrictError,
+  isOpenRouterAnthropicModel,
+  isStrictToolsDisabledForScope,
+  type OpenAICompatPolicy,
+  type OpenAICompletionsParams,
+  type OpenAIRequestSetup,
+  type OpenAIStrictToolsState,
+  parseAzureDeploymentNameMap,
+  resolveOpenAICompatPolicy,
+  resolveOpenAICompletionsOutputClamp,
+  resolveOpenAIOutputTokenParam,
+  resolveOpenAIRequestSetup,
+  shouldRetryWithoutStrictTools,
 } from "./openai-shared";
 import { transformMessages } from "./transform-messages";
 import {
-	isDashscopeCompatibleModeTextOnlyQwen,
-	joinTextWithImagePlaceholder,
-	NON_VISION_IMAGE_PLACEHOLDER,
+  isDashscopeCompatibleModeTextOnlyQwen,
+  joinTextWithImagePlaceholder,
+  NON_VISION_IMAGE_PLACEHOLDER,
 } from "./vision-guard";
 
 export { applyOpenRouterRoutingVariant } from "./openai-shared";
@@ -111,62 +117,62 @@ export { applyOpenRouterRoutingVariant } from "./openai-shared";
 type OpenAICompletionsReasoningField = NonNullable<ResolvedOpenAICompat["reasoningContentField"]>;
 
 type ProviderAttributedChatCompletionChunk = ChatCompletionChunk & {
-	provider?: unknown;
+  provider?: unknown;
 };
 
 type OpenAICompletionsChoiceUsage = ChatCompletionChunk.Choice & {
-	usage?: unknown;
+  usage?: unknown;
 };
 
 type OpenAICompletionsDeltaWithReasoningDetails = ChatCompletionChunk.Choice["delta"] & {
-	reasoning_details?: unknown;
+  reasoning_details?: unknown;
 };
 
 type OpenAICompletionsAssistantMessageParam = ChatCompletionAssistantMessageParam &
-	Partial<Record<OpenAICompletionsReasoningField, string>> & {
-		reasoning_details?: unknown[];
-	};
+  Partial<Record<OpenAICompletionsReasoningField, string>> & {
+    reasoning_details?: unknown[];
+  };
 
 type OpenAICompletionsToolMessageParam = ChatCompletionToolMessageParam & {
-	name?: string;
+  name?: string;
 };
 
 type OpenAICompletionsUsageLike = {
-	completion_tokens?: unknown;
-	prompt_tokens?: unknown;
-	cached_tokens?: unknown;
-	prompt_cache_hit_tokens?: unknown;
-	prompt_cache_miss_tokens?: unknown;
-	prompt_tokens_details?: unknown;
-	completion_tokens_details?: unknown;
+  completion_tokens?: unknown;
+  prompt_tokens?: unknown;
+  cached_tokens?: unknown;
+  prompt_cache_hit_tokens?: unknown;
+  prompt_cache_miss_tokens?: unknown;
+  prompt_tokens_details?: unknown;
+  completion_tokens_details?: unknown;
 };
 
 type OpenAICompletionsPromptTokenDetails = {
-	cached_tokens?: unknown;
-	cache_write_tokens?: unknown;
+  cached_tokens?: unknown;
+  cache_write_tokens?: unknown;
 };
 
 type OpenAICompletionsCompletionTokenDetails = {
-	reasoning_tokens?: unknown;
+  reasoning_tokens?: unknown;
 };
 
 function firstPositiveNumber(...values: unknown[]): number {
-	for (const value of values) {
-		if (typeof value === "number" && value > 0) return value;
-	}
-	return 0;
+  for (const value of values) {
+    if (typeof value === "number" && value > 0) return value;
+  }
+  return 0;
 }
 
 function hasPositiveCacheReadTokenField(rawUsage: object): boolean {
-	const usageLike = rawUsage as OpenAICompletionsUsageLike;
-	if (typeof usageLike.cached_tokens === "number" && usageLike.cached_tokens > 0) return true;
-	if (typeof usageLike.prompt_cache_hit_tokens === "number" && usageLike.prompt_cache_hit_tokens > 0) return true;
+  const usageLike = rawUsage as OpenAICompletionsUsageLike;
+  if (typeof usageLike.cached_tokens === "number" && usageLike.cached_tokens > 0) return true;
+  if (typeof usageLike.prompt_cache_hit_tokens === "number" && usageLike.prompt_cache_hit_tokens > 0) return true;
 
-	const rawPromptTokenDetails = usageLike.prompt_tokens_details;
-	if (typeof rawPromptTokenDetails !== "object" || rawPromptTokenDetails === null) return false;
+  const rawPromptTokenDetails = usageLike.prompt_tokens_details;
+  if (typeof rawPromptTokenDetails !== "object" || rawPromptTokenDetails === null) return false;
 
-	const promptTokenDetails = rawPromptTokenDetails as OpenAICompletionsPromptTokenDetails;
-	return typeof promptTokenDetails.cached_tokens === "number" && promptTokenDetails.cached_tokens > 0;
+  const promptTokenDetails = rawPromptTokenDetails as OpenAICompletionsPromptTokenDetails;
+  return typeof promptTokenDetails.cached_tokens === "number" && promptTokenDetails.cached_tokens > 0;
 }
 
 /**
@@ -174,18 +180,18 @@ function hasPositiveCacheReadTokenField(rawUsage: object): boolean {
  * Mistral requires tool IDs to be exactly 9 alphanumeric characters (a-z, A-Z, 0-9).
  */
 function normalizeMistralToolId(id: string, isMistral: boolean): string {
-	if (!isMistral) return id;
-	// Remove non-alphanumeric characters
-	let normalized = id.replace(/[^a-zA-Z0-9]/g, "");
-	// Mistral requires exactly 9 characters
-	if (normalized.length < 9) {
-		// Pad with deterministic characters based on original ID to ensure matching
-		const padding = "ABCDEFGHI";
-		normalized = normalized + padding.slice(0, 9 - normalized.length);
-	} else if (normalized.length > 9) {
-		normalized = normalized.slice(0, 9);
-	}
-	return normalized;
+  if (!isMistral) return id;
+  // Remove non-alphanumeric characters
+  let normalized = id.replace(/[^a-zA-Z0-9]/g, "");
+  // Mistral requires exactly 9 characters
+  if (normalized.length < 9) {
+    // Pad with deterministic characters based on original ID to ensure matching
+    const padding = "ABCDEFGHI";
+    normalized = normalized + padding.slice(0, 9 - normalized.length);
+  } else if (normalized.length > 9) {
+    normalized = normalized.slice(0, 9);
+  }
+  return normalized;
 }
 // Direct DeepSeek model ids on NanoGPT are routed via the default tools-capable
 // path. We deliberately do NOT append `:tools` here: with `:tools`, NanoGPT
@@ -195,30 +201,30 @@ function normalizeMistralToolId(id: string, isMistral: boolean): string {
 // envelope leaks) which `StreamMarkupHealing` heals into a structured call
 // client-side.
 function resolveOpenAICompletionsRoutingEffort(
-	model: Model<"openai-completions">,
-	effort: Effort | undefined,
+  model: Model<"openai-completions">,
+  effort: Effort | undefined,
 ): Effort | undefined {
-	if (!effort) return undefined;
-	if (model.thinking?.efforts.includes(effort)) return effort;
-	const compatMappedEffort = model.compat.reasoningEffortMap?.[effort] as Effort | undefined;
-	if (compatMappedEffort && model.thinking?.efforts.includes(compatMappedEffort)) return compatMappedEffort;
-	const thinkingMappedEffort = model.thinking?.effortMap?.[effort] as Effort | undefined;
-	if (thinkingMappedEffort && model.thinking?.efforts.includes(thinkingMappedEffort)) return thinkingMappedEffort;
-	return effort;
+  if (!effort) return undefined;
+  if (model.thinking?.efforts.includes(effort)) return effort;
+  const compatMappedEffort = model.compat.reasoningEffortMap?.[effort] as Effort | undefined;
+  if (compatMappedEffort && model.thinking?.efforts.includes(compatMappedEffort)) return compatMappedEffort;
+  const thinkingMappedEffort = model.thinking?.effortMap?.[effort] as Effort | undefined;
+  if (thinkingMappedEffort && model.thinking?.efforts.includes(thinkingMappedEffort)) return thinkingMappedEffort;
+  return effort;
 }
 
 function resolveOpenAICompletionsModelId(
-	model: Model<"openai-completions">,
-	options: OpenAICompletionsOptions | undefined,
+  model: Model<"openai-completions">,
+  options: OpenAICompletionsOptions | undefined,
 ): string {
-	// Effort-tier variants route per request effort (off → bare id, efforts →
-	// the thinking backing id); catalog variants (Copilot long-context `-1m`
-	// entries) pin via `requestModelId`; everything else serializes `model.id`.
-	const requestedEffort =
-		options?.reasoning && !options.disableReasoning && model.reasoning ? (options.reasoning as Effort) : undefined;
-	const effort = resolveOpenAICompletionsRoutingEffort(model, requestedEffort);
-	const wireId = resolveWireModelId(model, effort);
-	return applyWireModelIdTransform(wireId, model.compat.wireModelIdMode, options?.openrouterVariant);
+  // Effort-tier variants route per request effort (off → bare id, efforts →
+  // the thinking backing id); catalog variants (Copilot long-context `-1m`
+  // entries) pin via `requestModelId`; everything else serializes `model.id`.
+  const requestedEffort =
+    options?.reasoning && !options.disableReasoning && model.reasoning ? (options.reasoning as Effort) : undefined;
+  const effort = resolveOpenAICompletionsRoutingEffort(model, requestedEffort);
+  const wireId = resolveWireModelId(model, effort);
+  return applyWireModelIdTransform(wireId, model.compat.wireModelIdMode, options?.openrouterVariant);
 }
 
 /**
@@ -233,164 +239,164 @@ function resolveOpenAICompletionsModelId(
  * we never emit JS object sigils as visible output.
  */
 function normalizeStreamingContentText(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (Array.isArray(content)) {
-		let out = "";
-		for (const part of content) {
-			if (typeof part === "string") {
-				out += part;
-			} else if (part && typeof part === "object") {
-				const obj = part as { type?: unknown; text?: unknown };
-				if ((obj.type === undefined || obj.type === "text") && typeof obj.text === "string") {
-					out += obj.text;
-				}
-			}
-		}
-		return out;
-	}
-	if (content && typeof content === "object") {
-		const obj = content as { type?: unknown; text?: unknown };
-		if ((obj.type === undefined || obj.type === "text") && typeof obj.text === "string") {
-			return obj.text;
-		}
-	}
-	return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    let out = "";
+    for (const part of content) {
+      if (typeof part === "string") {
+        out += part;
+      } else if (part && typeof part === "object") {
+        const obj = part as { type?: unknown; text?: unknown };
+        if ((obj.type === undefined || obj.type === "text") && typeof obj.text === "string") {
+          out += obj.text;
+        }
+      }
+    }
+    return out;
+  }
+  if (content && typeof content === "object") {
+    const obj = content as { type?: unknown; text?: unknown };
+    if ((obj.type === undefined || obj.type === "text") && typeof obj.text === "string") {
+      return obj.text;
+    }
+  }
+  return "";
 }
 
 function serializeToolArguments(value: unknown): string {
-	if (value && typeof value === "object" && !Array.isArray(value)) {
-		try {
-			return JSON.stringify(value);
-		} catch {
-			return "{}";
-		}
-	}
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "{}";
+    }
+  }
 
-	if (typeof value === "string") {
-		const trimmed = value.trim();
-		if (trimmed.length === 0) return "{}";
-		try {
-			const parsed = JSON.parse(trimmed);
-			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-				return JSON.stringify(parsed);
-			}
-		} catch {}
-		return "{}";
-	}
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return "{}";
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return JSON.stringify(parsed);
+      }
+    } catch { }
+    return "{}";
+  }
 
-	return "{}";
+  return "{}";
 }
 
 function cloneStreamingArgumentValue(value: unknown): unknown {
-	if (Array.isArray(value)) {
-		return value.map(cloneStreamingArgumentValue);
-	}
-	if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-		return mergeStreamingArgumentObjects(undefined, value as Record<string, unknown>);
-	}
-	return value;
+  if (Array.isArray(value)) {
+    return value.map(cloneStreamingArgumentValue);
+  }
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return mergeStreamingArgumentObjects(undefined, value as Record<string, unknown>);
+  }
+  return value;
 }
 
 function streamingArgumentValuesEqual(left: unknown, right: unknown): boolean {
-	if (left === right) return true;
-	if (Array.isArray(left) && Array.isArray(right)) {
-		if (left.length !== right.length) return false;
-		for (let i = 0; i < left.length; i++) {
-			if (!streamingArgumentValuesEqual(left[i], right[i])) return false;
-		}
-		return true;
-	}
-	if (
-		left !== null &&
-		typeof left === "object" &&
-		!Array.isArray(left) &&
-		right !== null &&
-		typeof right === "object" &&
-		!Array.isArray(right)
-	) {
-		const leftObject = left as Record<string, unknown>;
-		const rightObject = right as Record<string, unknown>;
-		let leftKeys = 0;
-		for (const key in leftObject) {
-			if (!Object.hasOwn(leftObject, key) || key === "__proto__" || key === "constructor" || key === "prototype")
-				continue;
-			leftKeys++;
-			if (!Object.hasOwn(rightObject, key) || !streamingArgumentValuesEqual(leftObject[key], rightObject[key])) {
-				return false;
-			}
-		}
-		let rightKeys = 0;
-		for (const key in rightObject) {
-			if (!Object.hasOwn(rightObject, key) || key === "__proto__" || key === "constructor" || key === "prototype")
-				continue;
-			rightKeys++;
-		}
-		return leftKeys === rightKeys;
-	}
-	return false;
+  if (left === right) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) return false;
+    for (let i = 0; i < left.length; i++) {
+      if (!streamingArgumentValuesEqual(left[i], right[i])) return false;
+    }
+    return true;
+  }
+  if (
+    left !== null &&
+    typeof left === "object" &&
+    !Array.isArray(left) &&
+    right !== null &&
+    typeof right === "object" &&
+    !Array.isArray(right)
+  ) {
+    const leftObject = left as Record<string, unknown>;
+    const rightObject = right as Record<string, unknown>;
+    let leftKeys = 0;
+    for (const key in leftObject) {
+      if (!Object.hasOwn(leftObject, key) || key === "__proto__" || key === "constructor" || key === "prototype")
+        continue;
+      leftKeys++;
+      if (!Object.hasOwn(rightObject, key) || !streamingArgumentValuesEqual(leftObject[key], rightObject[key])) {
+        return false;
+      }
+    }
+    let rightKeys = 0;
+    for (const key in rightObject) {
+      if (!Object.hasOwn(rightObject, key) || key === "__proto__" || key === "constructor" || key === "prototype")
+        continue;
+      rightKeys++;
+    }
+    return leftKeys === rightKeys;
+  }
+  return false;
 }
 
 function streamingArgumentArrayStartsWith(value: unknown[], prefix: unknown[]): boolean {
-	if (prefix.length > value.length) return false;
-	for (let i = 0; i < prefix.length; i++) {
-		if (!streamingArgumentValuesEqual(value[i], prefix[i])) return false;
-	}
-	return true;
+  if (prefix.length > value.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (!streamingArgumentValuesEqual(value[i], prefix[i])) return false;
+  }
+  return true;
 }
 
 function mergeStreamingArgumentArrays(prev: unknown[], fragment: unknown[]): unknown[] {
-	if (streamingArgumentArrayStartsWith(fragment, prev)) {
-		return fragment.map(cloneStreamingArgumentValue);
-	}
-	if (streamingArgumentArrayStartsWith(prev, fragment)) {
-		return prev.map(cloneStreamingArgumentValue);
-	}
-	const merged = prev.map(cloneStreamingArgumentValue);
-	for (const value of fragment) {
-		merged.push(cloneStreamingArgumentValue(value));
-	}
-	return merged;
+  if (streamingArgumentArrayStartsWith(fragment, prev)) {
+    return fragment.map(cloneStreamingArgumentValue);
+  }
+  if (streamingArgumentArrayStartsWith(prev, fragment)) {
+    return prev.map(cloneStreamingArgumentValue);
+  }
+  const merged = prev.map(cloneStreamingArgumentValue);
+  for (const value of fragment) {
+    merged.push(cloneStreamingArgumentValue(value));
+  }
+  return merged;
 }
 
 function mergeStreamingArgumentValues(prev: unknown, fragment: unknown): unknown {
-	if (typeof prev === "string" && typeof fragment === "string") {
-		return fragment.startsWith(prev) ? fragment : prev + fragment;
-	}
-	if (Array.isArray(prev) && Array.isArray(fragment)) {
-		return mergeStreamingArgumentArrays(prev, fragment);
-	}
-	if (
-		prev !== null &&
-		typeof prev === "object" &&
-		!Array.isArray(prev) &&
-		fragment !== null &&
-		typeof fragment === "object" &&
-		!Array.isArray(fragment)
-	) {
-		return mergeStreamingArgumentObjects(prev as Record<string, unknown>, fragment as Record<string, unknown>);
-	}
-	return cloneStreamingArgumentValue(fragment);
+  if (typeof prev === "string" && typeof fragment === "string") {
+    return fragment.startsWith(prev) ? fragment : prev + fragment;
+  }
+  if (Array.isArray(prev) && Array.isArray(fragment)) {
+    return mergeStreamingArgumentArrays(prev, fragment);
+  }
+  if (
+    prev !== null &&
+    typeof prev === "object" &&
+    !Array.isArray(prev) &&
+    fragment !== null &&
+    typeof fragment === "object" &&
+    !Array.isArray(fragment)
+  ) {
+    return mergeStreamingArgumentObjects(prev as Record<string, unknown>, fragment as Record<string, unknown>);
+  }
+  return cloneStreamingArgumentValue(fragment);
 }
 
 function mergeStreamingArgumentObjects(
-	prev: Record<string, unknown> | undefined,
-	fragment: Record<string, unknown>,
+  prev: Record<string, unknown> | undefined,
+  fragment: Record<string, unknown>,
 ): Record<string, unknown> {
-	const merged: Record<string, unknown> = {};
-	if (prev) {
-		for (const key in prev) {
-			if (!Object.hasOwn(prev, key) || key === "__proto__" || key === "constructor" || key === "prototype") continue;
-			merged[key] = cloneStreamingArgumentValue(prev[key]);
-		}
-	}
-	for (const key in fragment) {
-		if (!Object.hasOwn(fragment, key) || key === "__proto__" || key === "constructor" || key === "prototype")
-			continue;
-		merged[key] = Object.hasOwn(merged, key)
-			? mergeStreamingArgumentValues(merged[key], fragment[key])
-			: cloneStreamingArgumentValue(fragment[key]);
-	}
-	return merged;
+  const merged: Record<string, unknown> = {};
+  if (prev) {
+    for (const key in prev) {
+      if (!Object.hasOwn(prev, key) || key === "__proto__" || key === "constructor" || key === "prototype") continue;
+      merged[key] = cloneStreamingArgumentValue(prev[key]);
+    }
+  }
+  for (const key in fragment) {
+    if (!Object.hasOwn(fragment, key) || key === "__proto__" || key === "constructor" || key === "prototype")
+      continue;
+    merged[key] = Object.hasOwn(merged, key)
+      ? mergeStreamingArgumentValues(merged[key], fragment[key])
+      : cloneStreamingArgumentValue(fragment[key]);
+  }
+  return merged;
 }
 
 /**
@@ -399,17 +405,17 @@ function mergeStreamingArgumentObjects(
  * to be present when messages include tool_calls or tool role messages.
  */
 function hasToolHistory(messages: Message[]): boolean {
-	for (const msg of messages) {
-		if (msg.role === "toolResult") {
-			return true;
-		}
-		if (msg.role === "assistant") {
-			if (msg.content.some(block => block.type === "toolCall")) {
-				return true;
-			}
-		}
-	}
-	return false;
+  for (const msg of messages) {
+    if (msg.role === "toolResult") {
+      return true;
+    }
+    if (msg.role === "assistant") {
+      if (msg.content.some(block => block.type === "toolCall")) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 /**
  * Identify "real progress" stream chunks vs. keepalives, role-only preambles,
@@ -425,100 +431,100 @@ function hasToolHistory(messages: Message[]): boolean {
  * (longer) first-event timeout to keep governing until real output appears.
  */
 export function isOpenAICompletionsProgressChunk(chunk: unknown): boolean {
-	if (!chunk || typeof chunk !== "object") return false;
-	const record = chunk as {
-		usage?: unknown;
-		choices?: ReadonlyArray<{
-			finish_reason?: unknown;
-			usage?: unknown;
-			delta?: {
-				content?: unknown;
-				tool_calls?: unknown;
-				reasoning?: unknown;
-				reasoning_content?: unknown;
-				reasoning_text?: unknown;
-				refusal?: unknown;
-			};
-		}>;
-	};
-	if (record.usage) return true;
-	const choice = Array.isArray(record.choices) ? record.choices[0] : undefined;
-	if (!choice) return false;
-	if (choice.finish_reason) return true;
-	if (choice.usage) return true;
-	const delta = choice.delta;
-	if (!delta) return false;
-	const content = delta.content;
-	if (typeof content === "string" ? content.length > 0 : Array.isArray(content) && content.length > 0) return true;
-	if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) return true;
-	if (typeof delta.reasoning === "string" && delta.reasoning.length > 0) return true;
-	if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) return true;
-	if (typeof delta.reasoning_text === "string" && delta.reasoning_text.length > 0) return true;
-	if (typeof delta.refusal === "string" && delta.refusal.length > 0) return true;
-	return false;
+  if (!chunk || typeof chunk !== "object") return false;
+  const record = chunk as {
+    usage?: unknown;
+    choices?: ReadonlyArray<{
+      finish_reason?: unknown;
+      usage?: unknown;
+      delta?: {
+        content?: unknown;
+        tool_calls?: unknown;
+        reasoning?: unknown;
+        reasoning_content?: unknown;
+        reasoning_text?: unknown;
+        refusal?: unknown;
+      };
+    }>;
+  };
+  if (record.usage) return true;
+  const choice = Array.isArray(record.choices) ? record.choices[0] : undefined;
+  if (!choice) return false;
+  if (choice.finish_reason) return true;
+  if (choice.usage) return true;
+  const delta = choice.delta;
+  if (!delta) return false;
+  const content = delta.content;
+  if (typeof content === "string" ? content.length > 0 : Array.isArray(content) && content.length > 0) return true;
+  if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) return true;
+  if (typeof delta.reasoning === "string" && delta.reasoning.length > 0) return true;
+  if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) return true;
+  if (typeof delta.reasoning_text === "string" && delta.reasoning_text.length > 0) return true;
+  if (typeof delta.refusal === "string" && delta.refusal.length > 0) return true;
+  return false;
 }
 
 export interface OpenAICompletionsOptions extends StreamOptions {
-	toolChoice?: ToolChoice;
-	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
-	/** Force-disable reasoning where supported, or request the lowest effort on generic effort endpoints. */
-	disableReasoning?: boolean;
-	serviceTier?: ServiceTier;
-	/** @internal True when maxTokens came from the caller, not the model default. */
-	maxTokensExplicit?: boolean;
-	/**
-	 * Routing-variant suffix appended to OpenRouter model IDs when none is
-	 * already present (`anthropic/claude-haiku-latest` → `…:nitro`). Common
-	 * values: `"nitro"`, `"floor"`, `"online"`, `"exacto"`. Ignored when the
-	 * resolved `model.id` already contains a colon-suffix after the last
-	 * provider segment (explicit `:nitro` in the selector or a catalog entry
-	 * with the variant baked in).
-	 */
-	openrouterVariant?: string;
+  toolChoice?: ToolChoice;
+  reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+  /** Force-disable reasoning where supported, or request the lowest effort on generic effort endpoints. */
+  disableReasoning?: boolean;
+  serviceTier?: ServiceTier;
+  /** @internal True when maxTokens came from the caller, not the model default. */
+  maxTokensExplicit?: boolean;
+  /**
+   * Routing-variant suffix appended to OpenRouter model IDs when none is
+   * already present (`anthropic/claude-haiku-latest` → `…:nitro`). Common
+   * values: `"nitro"`, `"floor"`, `"online"`, `"exacto"`. Ignored when the
+   * resolved `model.id` already contains a colon-suffix after the last
+   * provider segment (explicit `:nitro` in the selector or a catalog entry
+   * with the variant baked in).
+   */
+  openrouterVariant?: string;
 }
 
 type AppliedToolStrictMode = "mixed" | "all_strict" | "none";
 type ToolStrictModeOverride = Exclude<ResolvedOpenAICompat["toolStrictMode"], "mixed"> | undefined;
 
 type BuiltOpenAICompletionTools = {
-	tools: ChatCompletionTool[];
-	toolStrictMode: AppliedToolStrictMode;
-	/** True when at least one wire tool was sent with `strict: true`. */
-	strictToolsApplied: boolean;
+  tools: ChatCompletionTool[];
+  toolStrictMode: AppliedToolStrictMode;
+  /** True when at least one wire tool was sent with `strict: true`. */
+  strictToolsApplied: boolean;
 };
 
 const OPENAI_COMPLETIONS_PROVIDER_SESSION_STATE_PREFIX = "openai-completions:";
 
 type OpenAICompletionsProviderSessionState = ProviderSessionState &
-	OpenAIStrictToolsState &
-	OpenAIReasoningEffortFallbackState;
+  OpenAIStrictToolsState &
+  OpenAIReasoningEffortFallbackState;
 
 function createOpenAICompletionsProviderSessionState(): OpenAICompletionsProviderSessionState {
-	const strictToolsState = createOpenAIStrictToolsState();
-	const reasoningEffortFallbackState = createOpenAIReasoningEffortFallbackState();
-	const state: OpenAICompletionsProviderSessionState = {
-		...strictToolsState,
-		...reasoningEffortFallbackState,
-		close: () => {
-			clearOpenAIStrictToolsState(state);
-			clearOpenAIReasoningEffortFallbackState(state);
-		},
-	};
-	return state;
+  const strictToolsState = createOpenAIStrictToolsState();
+  const reasoningEffortFallbackState = createOpenAIReasoningEffortFallbackState();
+  const state: OpenAICompletionsProviderSessionState = {
+    ...strictToolsState,
+    ...reasoningEffortFallbackState,
+    close: () => {
+      clearOpenAIStrictToolsState(state);
+      clearOpenAIReasoningEffortFallbackState(state);
+    },
+  };
+  return state;
 }
 
 function getOpenAICompletionsProviderSessionState(
-	model: Model<"openai-completions">,
-	baseUrl: string | undefined,
-	providerSessionState: Map<string, ProviderSessionState> | undefined,
+  model: Model<"openai-completions">,
+  baseUrl: string | undefined,
+  providerSessionState: Map<string, ProviderSessionState> | undefined,
 ): OpenAICompletionsProviderSessionState | undefined {
-	if (!providerSessionState) return undefined;
-	const key = `${OPENAI_COMPLETIONS_PROVIDER_SESSION_STATE_PREFIX}${model.provider}:${baseUrl ?? ""}:${model.id}`;
-	const existing = providerSessionState.get(key) as OpenAICompletionsProviderSessionState | undefined;
-	if (existing) return existing;
-	const created = createOpenAICompletionsProviderSessionState();
-	providerSessionState.set(key, created);
-	return created;
+  if (!providerSessionState) return undefined;
+  const key = `${OPENAI_COMPLETIONS_PROVIDER_SESSION_STATE_PREFIX}${model.provider}:${baseUrl ?? ""}:${model.id}`;
+  const existing = providerSessionState.get(key) as OpenAICompletionsProviderSessionState | undefined;
+  if (existing) return existing;
+  const created = createOpenAICompletionsProviderSessionState();
+  providerSessionState.set(key, created);
+  return created;
 }
 
 // DeepSeek models leak chat-template special tokens (e.g. `<｜tool_calls_begin｜>`,
@@ -534,35 +540,35 @@ const DEEPSEEK_SPECIAL_TOKEN_AT_END_REGEX = /<(?:｜|\|)[A-Za-z0-9_.｜|▁]{1,6
 const DEEPSEEK_OPEN_DELIMS = ["<｜", "<|"] as const;
 
 function stripDeepseekSpecialTokens(text: string): string {
-	const stripped = text.replace(DEEPSEEK_SPECIAL_TOKEN_REGEX, "");
-	if (stripped === text) return text;
+  const stripped = text.replace(DEEPSEEK_SPECIAL_TOKEN_REGEX, "");
+  if (stripped === text) return text;
 
-	let normalized = stripped;
-	if (DEEPSEEK_SPECIAL_TOKEN_AT_START_REGEX.test(text)) normalized = normalized.replace(/^\s+/u, "");
-	if (DEEPSEEK_SPECIAL_TOKEN_AT_END_REGEX.test(text)) normalized = normalized.replace(/\s+$/u, "");
-	return normalized;
+  let normalized = stripped;
+  if (DEEPSEEK_SPECIAL_TOKEN_AT_START_REGEX.test(text)) normalized = normalized.replace(/^\s+/u, "");
+  if (DEEPSEEK_SPECIAL_TOKEN_AT_END_REGEX.test(text)) normalized = normalized.replace(/\s+$/u, "");
+  return normalized;
 }
 
 // Find a trailing partial `<｜...` (or `<|...`) that has not yet been closed by a
 // matching `｜>`/`|>`, so it can be held back until the next chunk arrives. A solo
 // trailing `<` is also held in case it is the start of a new token.
 function getTrailingPartialDeepseekToken(text: string): string {
-	let bestIdx = -1;
-	for (const delim of DEEPSEEK_OPEN_DELIMS) {
-		const idx = text.lastIndexOf(delim);
-		if (idx > bestIdx) bestIdx = idx;
-	}
-	if (bestIdx === -1) {
-		return text.endsWith("<") ? "<" : "";
-	}
-	const tail = text.slice(bestIdx);
-	if (tail.includes("｜>") || tail.includes("|>")) return "";
-	// Cap the held-back length so a stray `<｜` in normal prose can't grow unboundedly.
-	if (tail.length > 256) return "";
-	return tail;
+  let bestIdx = -1;
+  for (const delim of DEEPSEEK_OPEN_DELIMS) {
+    const idx = text.lastIndexOf(delim);
+    if (idx > bestIdx) bestIdx = idx;
+  }
+  if (bestIdx === -1) {
+    return text.endsWith("<") ? "<" : "";
+  }
+  const tail = text.slice(bestIdx);
+  if (tail.includes("｜>") || tail.includes("|>")) return "";
+  // Cap the held-back length so a stray `<｜` in normal prose can't grow unboundedly.
+  if (tail.length > 256) return "";
+  return tail;
 }
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
-	"OpenAI completions stream timed out while waiting for the first event";
+  "OpenAI completions stream timed out while waiting for the first event";
 // How long to keep draining the stream after a `finish_reason` chunk arrived.
 // Compliant hosts follow it (almost) immediately with an optional usage-only
 // chunk and the `[DONE]` sentinel, so the window only ever elapses on hosts
@@ -572,797 +578,797 @@ const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 const OPENAI_COMPLETIONS_POST_FINISH_GRACE_MS = 2_500;
 
 const streamOpenAICompletionsOnce = (
-	model: Model<"openai-completions">,
-	context: Context,
-	options?: OpenAICompletionsOptions,
+  model: Model<"openai-completions">,
+  context: Context,
+  options?: OpenAICompletionsOptions,
 ): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
+  const stream = new AssistantMessageEventStream();
 
-	(async () => {
-		const startTime = performance.now();
-		let firstTokenTime: number | undefined;
-		const policy = resolveOpenAICompatForRequest(model, options);
+  (async () => {
+    const startTime = performance.now();
+    let firstTokenTime: number | undefined;
+    const policy = resolveOpenAICompatForRequest(model, options);
 
-		const output: AssistantMessage = createInitialResponsesAssistantMessage(model.api, model.provider, model.id);
-		let rawRequestDump: RawHttpRequestDump | undefined;
-		const abortTracker = createAbortSourceTracker(options?.signal);
-		const firstEventTimeoutAbortError = new AIError.StreamTimeoutError(
-			OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
-		);
-		const { requestAbortController, requestSignal } = abortTracker;
-		const onSseEvent = options?.onSseEvent;
-		const rawSseObserver = onSseEvent
-			? (event: RawSseEvent) => {
-					if (!event.event && event.data && event.data !== "[DONE]") {
-						try {
-							const parsed = JSON.parse(event.data);
-							const resolvedEvent =
-								typeof parsed.type === "string"
-									? parsed.type
-									: typeof parsed.object === "string"
-										? parsed.object
-										: null;
-							if (resolvedEvent) {
-								event.event = resolvedEvent;
-								event.raw = [`event: ${resolvedEvent}`, ...event.raw];
-							}
-						} catch {}
-					}
-					onSseEvent(event, model);
-				}
-			: undefined;
-		// Assigned once the block helpers exist (they are scoped to the `try`);
-		// the catch handler uses it to close open blocks before emitting the
-		// terminal error so both exit paths obey the same block lifecycle.
-		let finishOpenBlocksOnError: () => void = () => {};
+    const output: AssistantMessage = createInitialResponsesAssistantMessage(model.api, model.provider, model.id);
+    let rawRequestDump: RawHttpRequestDump | undefined;
+    const abortTracker = createAbortSourceTracker(options?.signal);
+    const firstEventTimeoutAbortError = new AIError.StreamTimeoutError(
+      OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
+    );
+    const { requestAbortController, requestSignal } = abortTracker;
+    const onSseEvent = options?.onSseEvent;
+    const rawSseObserver = onSseEvent
+      ? (event: RawSseEvent) => {
+        if (!event.event && event.data && event.data !== "[DONE]") {
+          try {
+            const parsed = JSON.parse(event.data);
+            const resolvedEvent =
+              typeof parsed.type === "string"
+                ? parsed.type
+                : typeof parsed.object === "string"
+                  ? parsed.object
+                  : null;
+            if (resolvedEvent) {
+              event.event = resolvedEvent;
+              event.raw = [`event: ${resolvedEvent}`, ...event.raw];
+            }
+          } catch { }
+        }
+        onSseEvent(event, model);
+      }
+      : undefined;
+    // Assigned once the block helpers exist (they are scoped to the `try`);
+    // the catch handler uses it to close open blocks before emitting the
+    // terminal error so both exit paths obey the same block lifecycle.
+    let finishOpenBlocksOnError: () => void = () => { };
 
-		try {
-			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const idleTimeoutFallbackMs = model.compat.streamIdleTimeoutMs;
-			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs(idleTimeoutFallbackMs);
-			const firstEventTimeoutMs =
-				options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
-			const requestTimeoutMs =
-				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
-			const { copilotPremiumRequests, baseUrl, headers, query, requestHeaders } = createRequestSetup(
-				model,
-				context,
-				apiKey,
-				options?.headers,
-				options?.initiatorOverride,
-				getOpenAIPromptCacheKey(options),
-			);
-			const premiumRequestsTotal = copilotPremiumRequests;
-			let appliedStrictTools = false;
-			const requestReasoningEffortFallbacks = new Map<string, OpenAIReasoningEffortFallback>();
-			const attemptedReasoningEffortFallbacks = new Set<string>();
-			let activeReasoningEffortFallbackKey: string | undefined;
-			let activeRequestParams: OpenAICompletionsParams | undefined;
-			const providerSessionState = getOpenAICompletionsProviderSessionState(
-				model,
-				baseUrl,
-				options?.providerSessionState,
-			);
-			const strictToolsScope = getOpenAIStrictToolsScope(model, baseUrl);
-			let disableStrictTools = isStrictToolsDisabledForScope(providerSessionState, strictToolsScope);
-			const trimmedBaseUrl = baseUrl.replace(/\/+$/, "");
-			const completionsUrl = query
-				? `${trimmedBaseUrl}/chat/completions?${new URLSearchParams(query)}`
-				: `${trimmedBaseUrl}/chat/completions`;
-			const createCompletionsStream = async (toolStrictModeOverride?: ToolStrictModeOverride) => {
-				const effectiveToolStrictModeOverride = disableStrictTools ? "none" : toolStrictModeOverride;
-				const { params, strictToolsApplied } = buildParams(
-					model,
-					context,
-					options,
-					effectiveToolStrictModeOverride,
-				);
-				appliedStrictTools = strictToolsApplied;
-				const reasoningEffortFallbackKey = createOpenAIReasoningEffortFallbackKey(
-					"chat-completions",
-					trimmedBaseUrl,
-					params.model,
-				);
-				const requestReasoningEffortFallback = requestReasoningEffortFallbacks.has(reasoningEffortFallbackKey)
-					? requestReasoningEffortFallbacks.get(reasoningEffortFallbackKey)
-					: getOpenAIReasoningEffortFallback(providerSessionState, reasoningEffortFallbackKey);
-				if (requestReasoningEffortFallback !== undefined) {
-					applyOpenAIReasoningEffortFallback(params, requestReasoningEffortFallback);
-				}
-				activeReasoningEffortFallbackKey = reasoningEffortFallbackKey;
-				activeRequestParams = params;
-				options?.onPayload?.(params);
-				rawRequestDump = {
-					provider: model.provider,
-					api: output.api,
-					model: model.id,
-					method: "POST",
-					url: completionsUrl,
-					headers: requestHeaders,
-					body: params,
-				};
-				let requestTimeout: NodeJS.Timeout | undefined;
-				if (requestTimeoutMs !== undefined) {
-					requestTimeout = setTimeout(
-						() => abortTracker.abortLocally(firstEventTimeoutAbortError),
-						requestTimeoutMs,
-					);
-				}
-				try {
-					const headersWithTimeout = { ...headers };
-					if (requestTimeoutMs !== undefined) {
-						headersWithTimeout["X-Stainless-Timeout"] = Math.floor(requestTimeoutMs / 1000).toString();
-					}
-					const { events, response, requestId } = await postOpenAIStream<ChatCompletionChunk>({
-						url: completionsUrl,
-						headers: headersWithTimeout,
-						body: params,
-						signal: requestSignal,
-						fetch: options?.fetch,
-						// Transient 408/429/5xx get Retry-After-aware transport retries.
-						// The first-event watchdog above aborts `requestSignal`, which
-						// bounds every attempt and backoff sleep — retries cannot
-						// extend the deadline.
-						onSseEvent: rawSseObserver,
-					});
-					await notifyProviderResponse(options, response, model, requestId);
-					return events;
-				} finally {
-					// Headers arrived (or the request failed); from here the
-					// first-event deadline is enforced by `iterateWithIdleTimeout`.
-					if (requestTimeout !== undefined) clearTimeout(requestTimeout);
-				}
-			};
-			let openaiStream: AsyncIterable<ChatCompletionChunk>;
-			try {
-				openaiStream = await callWithCopilotModelRetry(() => createCompletionsStream(), {
-					provider: model.provider,
-					signal: requestSignal,
-				});
-			} catch (error) {
-				const capturedErrorResponse = error instanceof OpenAIHttpError ? error.captured : undefined;
-				const reasoningEffortFallback =
-					activeReasoningEffortFallbackKey && activeRequestParams && !requestSignal.aborted
-						? resolveOpenAIReasoningEffortFallback(error, capturedErrorResponse, activeRequestParams, {
-								explicitDisable: options?.disableReasoning === true && options.reasoning === undefined,
-							})
-						: undefined;
-				if (reasoningEffortFallback !== undefined && activeReasoningEffortFallbackKey) {
-					const retryMarker = `${activeReasoningEffortFallbackKey}:${String(reasoningEffortFallback)}`;
-					if (attemptedReasoningEffortFallbacks.has(retryMarker)) throw error;
-					attemptedReasoningEffortFallbacks.add(retryMarker);
-					requestReasoningEffortFallbacks.set(activeReasoningEffortFallbackKey, reasoningEffortFallback);
-					openaiStream = await createCompletionsStream();
-					rememberOpenAIReasoningEffortFallback(
-						providerSessionState,
-						activeReasoningEffortFallbackKey,
-						reasoningEffortFallback,
-					);
-				} else if (
-					isOpenRouterAnthropicModel(model) &&
-					!disableStrictTools &&
-					isCompiledGrammarTooLargeStrictError(error, capturedErrorResponse)
-				) {
-					disableStrictToolsForScope(providerSessionState, strictToolsScope);
-					disableStrictTools = true;
-					openaiStream = await createCompletionsStream("none");
-				} else {
-					if (!shouldRetryWithoutStrictTools(error, capturedErrorResponse, appliedStrictTools, context.tools)) {
-						throw error;
-					}
-					// Remember the rejection for the rest of the session so every
-					// subsequent request doesn't pay a strict-400 + retry round-trip.
-					disableStrictToolsForScope(providerSessionState, strictToolsScope);
-					disableStrictTools = true;
-					openaiStream = await createCompletionsStream("none");
-				}
-			}
-			if (premiumRequestsTotal !== undefined) {
-				output.usage.premiumRequests = premiumRequestsTotal;
-			}
-			stream.push({ type: "start", partial: output });
+    try {
+      const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+      const idleTimeoutFallbackMs = model.compat.streamIdleTimeoutMs;
+      const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs(idleTimeoutFallbackMs);
+      const firstEventTimeoutMs =
+        options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
+      const requestTimeoutMs =
+        firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
+      const { copilotPremiumRequests, baseUrl, headers, query, requestHeaders } = createRequestSetup(
+        model,
+        context,
+        apiKey,
+        options?.headers,
+        options?.initiatorOverride,
+        getOpenAIPromptCacheKey(options),
+      );
+      const premiumRequestsTotal = copilotPremiumRequests;
+      let appliedStrictTools = false;
+      const requestReasoningEffortFallbacks = new Map<string, OpenAIReasoningEffortFallback>();
+      const attemptedReasoningEffortFallbacks = new Set<string>();
+      let activeReasoningEffortFallbackKey: string | undefined;
+      let activeRequestParams: OpenAICompletionsParams | undefined;
+      const providerSessionState = getOpenAICompletionsProviderSessionState(
+        model,
+        baseUrl,
+        options?.providerSessionState,
+      );
+      const strictToolsScope = getOpenAIStrictToolsScope(model, baseUrl);
+      let disableStrictTools = isStrictToolsDisabledForScope(providerSessionState, strictToolsScope);
+      const trimmedBaseUrl = baseUrl.replace(/\/+$/, "");
+      const completionsUrl = query
+        ? `${trimmedBaseUrl}/chat/completions?${new URLSearchParams(query)}`
+        : `${trimmedBaseUrl}/chat/completions`;
+      const createCompletionsStream = async (toolStrictModeOverride?: ToolStrictModeOverride) => {
+        const effectiveToolStrictModeOverride = disableStrictTools ? "none" : toolStrictModeOverride;
+        const { params, strictToolsApplied } = buildParams(
+          model,
+          context,
+          options,
+          effectiveToolStrictModeOverride,
+        );
+        appliedStrictTools = strictToolsApplied;
+        const reasoningEffortFallbackKey = createOpenAIReasoningEffortFallbackKey(
+          "chat-completions",
+          trimmedBaseUrl,
+          params.model,
+        );
+        const requestReasoningEffortFallback = requestReasoningEffortFallbacks.has(reasoningEffortFallbackKey)
+          ? requestReasoningEffortFallbacks.get(reasoningEffortFallbackKey)
+          : getOpenAIReasoningEffortFallback(providerSessionState, reasoningEffortFallbackKey);
+        if (requestReasoningEffortFallback !== undefined) {
+          applyOpenAIReasoningEffortFallback(params, requestReasoningEffortFallback);
+        }
+        activeReasoningEffortFallbackKey = reasoningEffortFallbackKey;
+        activeRequestParams = params;
+        options?.onPayload?.(params);
+        rawRequestDump = {
+          provider: model.provider,
+          api: output.api,
+          model: model.id,
+          method: "POST",
+          url: completionsUrl,
+          headers: requestHeaders,
+          body: params,
+        };
+        let requestTimeout: NodeJS.Timeout | undefined;
+        if (requestTimeoutMs !== undefined) {
+          requestTimeout = setTimeout(
+            () => abortTracker.abortLocally(firstEventTimeoutAbortError),
+            requestTimeoutMs,
+          );
+        }
+        try {
+          const headersWithTimeout = { ...headers };
+          if (requestTimeoutMs !== undefined) {
+            headersWithTimeout["X-Stainless-Timeout"] = Math.floor(requestTimeoutMs / 1000).toString();
+          }
+          const { events, response, requestId } = await postOpenAIStream<ChatCompletionChunk>({
+            url: completionsUrl,
+            headers: headersWithTimeout,
+            body: params,
+            signal: requestSignal,
+            fetch: options?.fetch,
+            // Transient 408/429/5xx get Retry-After-aware transport retries.
+            // The first-event watchdog above aborts `requestSignal`, which
+            // bounds every attempt and backoff sleep — retries cannot
+            // extend the deadline.
+            onSseEvent: rawSseObserver,
+          });
+          await notifyProviderResponse(options, response, model, requestId);
+          return events;
+        } finally {
+          // Headers arrived (or the request failed); from here the
+          // first-event deadline is enforced by `iterateWithIdleTimeout`.
+          if (requestTimeout !== undefined) clearTimeout(requestTimeout);
+        }
+      };
+      let openaiStream: AsyncIterable<ChatCompletionChunk>;
+      try {
+        openaiStream = await callWithCopilotModelRetry(() => createCompletionsStream(), {
+          provider: model.provider,
+          signal: requestSignal,
+        });
+      } catch (error) {
+        const capturedErrorResponse = error instanceof OpenAIHttpError ? error.captured : undefined;
+        const reasoningEffortFallback =
+          activeReasoningEffortFallbackKey && activeRequestParams && !requestSignal.aborted
+            ? resolveOpenAIReasoningEffortFallback(error, capturedErrorResponse, activeRequestParams, {
+              explicitDisable: options?.disableReasoning === true && options.reasoning === undefined,
+            })
+            : undefined;
+        if (reasoningEffortFallback !== undefined && activeReasoningEffortFallbackKey) {
+          const retryMarker = `${activeReasoningEffortFallbackKey}:${String(reasoningEffortFallback)}`;
+          if (attemptedReasoningEffortFallbacks.has(retryMarker)) throw error;
+          attemptedReasoningEffortFallbacks.add(retryMarker);
+          requestReasoningEffortFallbacks.set(activeReasoningEffortFallbackKey, reasoningEffortFallback);
+          openaiStream = await createCompletionsStream();
+          rememberOpenAIReasoningEffortFallback(
+            providerSessionState,
+            activeReasoningEffortFallbackKey,
+            reasoningEffortFallback,
+          );
+        } else if (
+          isOpenRouterAnthropicModel(model) &&
+          !disableStrictTools &&
+          isCompiledGrammarTooLargeStrictError(error, capturedErrorResponse)
+        ) {
+          disableStrictToolsForScope(providerSessionState, strictToolsScope);
+          disableStrictTools = true;
+          openaiStream = await createCompletionsStream("none");
+        } else {
+          if (!shouldRetryWithoutStrictTools(error, capturedErrorResponse, appliedStrictTools, context.tools)) {
+            throw error;
+          }
+          // Remember the rejection for the rest of the session so every
+          // subsequent request doesn't pay a strict-400 + retry round-trip.
+          disableStrictToolsForScope(providerSessionState, strictToolsScope);
+          disableStrictTools = true;
+          openaiStream = await createCompletionsStream("none");
+        }
+      }
+      if (premiumRequestsTotal !== undefined) {
+        output.usage.premiumRequests = premiumRequestsTotal;
+      }
+      stream.push({ type: "start", partial: output });
 
-			// Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
-			// native API) leak chat-template tool-call markers in `delta.content` even
-			// though tool calls are also surfaced structurally. Strip the leaked markers
-			// so users don't see raw `<｜...｜>` tokens.
-			const stripDeepseekChatTemplateTokens = policy.stream.stripSpecialTokens === "deepseek";
-			type ToolCallStreamBlock = ToolCall & {
-				partialArgs?: string | Record<string, unknown>;
-				streamIndex?: number;
-				[kStreamingLastParseLen]?: number;
-			};
-			type OpenAIStreamBlock = TextContent | ThinkingContent | ToolCallStreamBlock;
-			const pendingToolCallBlocks: ToolCallStreamBlock[] = [];
-			const toolCallBlockByIndex = new Map<number, ToolCallStreamBlock>();
-			// Blocks born from an unkeyed multi-entry `tool_calls` array (no `id`,
-			// no `index`), tracked by array offset so continuation chunks that omit
-			// the entry name still route back to the sibling created earlier
-			// instead of collapsing onto `currentBlock`.
-			const unkeyedBatchBlocks: (ToolCallStreamBlock | undefined)[] = [];
-			const clearUnkeyedBatchSlot = (block: ToolCallStreamBlock): void => {
-				for (let index = 0; index < unkeyedBatchBlocks.length; index++) {
-					if (unkeyedBatchBlocks[index] === block) unkeyedBatchBlocks[index] = undefined;
-				}
-			};
-			let currentBlock: OpenAIStreamBlock | undefined;
-			const blockIndex = (block: OpenAIStreamBlock | undefined): number => {
-				if (!block) return Math.max(0, output.content.length - 1);
-				return output.content.indexOf(block);
-			};
-			const finishToolCallBlock = (block: ToolCallStreamBlock): void => {
-				if (block.partialArgs === undefined) return;
-				const contentIndex = blockIndex(block);
-				if (contentIndex < 0) return;
-				// Object-shaped `partialArgs` came from MiniMax-compatible hosts that stream
-				// `function.arguments` as an object. The per-chunk handler holds them with an
-				// empty wire delta (see the object branch below) because emitting each chunk's
-				// `JSON.stringify(rawArgs)` would feed concat-based downstream consumers
-				// (proxy.ts, openai-chat-server, openai-responses-server, anthropic-messages-server)
-				// an invalid concatenation like `{"input":"a"}{"input":"b"}`. Flush the final
-				// merged object as one concat-safe delta now so those consumers reconstruct the
-				// args correctly before observing `toolcall_end`.
-				if (typeof block.partialArgs === "object" && !Array.isArray(block.partialArgs)) {
-					const fullJson = JSON.stringify(block.partialArgs);
-					if (fullJson.length > 0 && fullJson !== "{}") {
-						stream.push({ type: "toolcall_delta", contentIndex, delta: fullJson, partial: output });
-					}
-				}
-				block.arguments =
-					typeof block.partialArgs === "string" ? parseStreamingJson(block.partialArgs) : block.partialArgs;
-				delete block.partialArgs;
-				if (block.streamIndex !== undefined) {
-					toolCallBlockByIndex.delete(block.streamIndex);
-					delete block.streamIndex;
-				}
-				const pendingIndex = pendingToolCallBlocks.indexOf(block);
-				if (pendingIndex >= 0) pendingToolCallBlocks.splice(pendingIndex, 1);
-				clearUnkeyedBatchSlot(block);
-				stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
-			};
-			const finishPendingToolCallBlocks = (): void => {
-				for (const block of [...pendingToolCallBlocks]) {
-					finishToolCallBlock(block);
-				}
-			};
-			const finishCurrentBlock = (block: OpenAIStreamBlock | undefined): void => {
-				if (!block) return;
-				const contentIndex = blockIndex(block);
-				if (contentIndex < 0) return;
-				if (block.type === "text") {
-					stream.push({ type: "text_end", contentIndex, content: block.text, partial: output });
-					return;
-				}
-				if (block.type === "thinking") {
-					stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial: output });
-					return;
-				}
-				finishToolCallBlock(block);
-			};
-			finishOpenBlocksOnError = () => {
-				if (currentBlock?.type !== "toolCall") finishCurrentBlock(currentBlock);
-				finishPendingToolCallBlocks();
-			};
-			const appendText = (
-				message: AssistantMessage,
-				eventStream: AssistantMessageEventStream,
-				text: string,
-			): void => {
-				if (currentBlock?.type !== "text") {
-					// Leave toolCall blocks pending across text transitions: chunks after
-					// the first typically carry only `index`, so a finished (de-registered)
-					// call would be reborn as a nameless phantom block when its arguments
-					// resume. The stream-end sweep finalizes pending calls.
-					if (currentBlock?.type !== "toolCall") finishCurrentBlock(currentBlock);
-					currentBlock = { type: "text", text: "" };
-					message.content.push(currentBlock);
-					eventStream.push({ type: "text_start", contentIndex: blockIndex(currentBlock), partial: message });
-				}
-				currentBlock.text += text;
-				eventStream.push({
-					type: "text_delta",
-					contentIndex: blockIndex(currentBlock),
-					delta: text,
-					partial: message,
-				});
-			};
-			const appendThinking = (
-				message: AssistantMessage,
-				eventStream: AssistantMessageEventStream,
-				thinking: string,
-				signature?: string,
-			): void => {
-				if (
-					currentBlock?.type !== "thinking" ||
-					(signature !== undefined && currentBlock.thinkingSignature !== signature)
-				) {
-					// Same as appendText: leave toolCall blocks pending so index-only
-					// continuation deltas can still find them.
-					if (currentBlock?.type !== "toolCall") finishCurrentBlock(currentBlock);
-					currentBlock = { type: "thinking", thinking: "", thinkingSignature: signature };
-					message.content.push(currentBlock);
-					eventStream.push({
-						type: "thinking_start",
-						contentIndex: blockIndex(currentBlock),
-						partial: message,
-					});
-				}
-				if (signature !== undefined && !currentBlock.thinkingSignature) {
-					currentBlock.thinkingSignature = signature;
-				}
-				currentBlock.thinking += thinking;
-				eventStream.push({
-					type: "thinking_delta",
-					contentIndex: blockIndex(currentBlock),
-					delta: thinking,
-					partial: message,
-				});
-			};
+      // Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
+      // native API) leak chat-template tool-call markers in `delta.content` even
+      // though tool calls are also surfaced structurally. Strip the leaked markers
+      // so users don't see raw `<｜...｜>` tokens.
+      const stripDeepseekChatTemplateTokens = policy.stream.stripSpecialTokens === "deepseek";
+      type ToolCallStreamBlock = ToolCall & {
+        partialArgs?: string | Record<string, unknown>;
+        streamIndex?: number;
+        [kStreamingLastParseLen]?: number;
+      };
+      type OpenAIStreamBlock = TextContent | ThinkingContent | ToolCallStreamBlock;
+      const pendingToolCallBlocks: ToolCallStreamBlock[] = [];
+      const toolCallBlockByIndex = new Map<number, ToolCallStreamBlock>();
+      // Blocks born from an unkeyed multi-entry `tool_calls` array (no `id`,
+      // no `index`), tracked by array offset so continuation chunks that omit
+      // the entry name still route back to the sibling created earlier
+      // instead of collapsing onto `currentBlock`.
+      const unkeyedBatchBlocks: (ToolCallStreamBlock | undefined)[] = [];
+      const clearUnkeyedBatchSlot = (block: ToolCallStreamBlock): void => {
+        for (let index = 0; index < unkeyedBatchBlocks.length; index++) {
+          if (unkeyedBatchBlocks[index] === block) unkeyedBatchBlocks[index] = undefined;
+        }
+      };
+      let currentBlock: OpenAIStreamBlock | undefined;
+      const blockIndex = (block: OpenAIStreamBlock | undefined): number => {
+        if (!block) return Math.max(0, output.content.length - 1);
+        return output.content.indexOf(block);
+      };
+      const finishToolCallBlock = (block: ToolCallStreamBlock): void => {
+        if (block.partialArgs === undefined) return;
+        const contentIndex = blockIndex(block);
+        if (contentIndex < 0) return;
+        // Object-shaped `partialArgs` came from MiniMax-compatible hosts that stream
+        // `function.arguments` as an object. The per-chunk handler holds them with an
+        // empty wire delta (see the object branch below) because emitting each chunk's
+        // `JSON.stringify(rawArgs)` would feed concat-based downstream consumers
+        // (proxy.ts, openai-chat-server, openai-responses-server, anthropic-messages-server)
+        // an invalid concatenation like `{"input":"a"}{"input":"b"}`. Flush the final
+        // merged object as one concat-safe delta now so those consumers reconstruct the
+        // args correctly before observing `toolcall_end`.
+        if (typeof block.partialArgs === "object" && !Array.isArray(block.partialArgs)) {
+          const fullJson = JSON.stringify(block.partialArgs);
+          if (fullJson.length > 0 && fullJson !== "{}") {
+            stream.push({ type: "toolcall_delta", contentIndex, delta: fullJson, partial: output });
+          }
+        }
+        block.arguments =
+          typeof block.partialArgs === "string" ? parseStreamingJson(block.partialArgs) : block.partialArgs;
+        delete block.partialArgs;
+        if (block.streamIndex !== undefined) {
+          toolCallBlockByIndex.delete(block.streamIndex);
+          delete block.streamIndex;
+        }
+        const pendingIndex = pendingToolCallBlocks.indexOf(block);
+        if (pendingIndex >= 0) pendingToolCallBlocks.splice(pendingIndex, 1);
+        clearUnkeyedBatchSlot(block);
+        stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
+      };
+      const finishPendingToolCallBlocks = (): void => {
+        for (const block of [...pendingToolCallBlocks]) {
+          finishToolCallBlock(block);
+        }
+      };
+      const finishCurrentBlock = (block: OpenAIStreamBlock | undefined): void => {
+        if (!block) return;
+        const contentIndex = blockIndex(block);
+        if (contentIndex < 0) return;
+        if (block.type === "text") {
+          stream.push({ type: "text_end", contentIndex, content: block.text, partial: output });
+          return;
+        }
+        if (block.type === "thinking") {
+          stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial: output });
+          return;
+        }
+        finishToolCallBlock(block);
+      };
+      finishOpenBlocksOnError = () => {
+        if (currentBlock?.type !== "toolCall") finishCurrentBlock(currentBlock);
+        finishPendingToolCallBlocks();
+      };
+      const appendText = (
+        message: AssistantMessage,
+        eventStream: AssistantMessageEventStream,
+        text: string,
+      ): void => {
+        if (currentBlock?.type !== "text") {
+          // Leave toolCall blocks pending across text transitions: chunks after
+          // the first typically carry only `index`, so a finished (de-registered)
+          // call would be reborn as a nameless phantom block when its arguments
+          // resume. The stream-end sweep finalizes pending calls.
+          if (currentBlock?.type !== "toolCall") finishCurrentBlock(currentBlock);
+          currentBlock = { type: "text", text: "" };
+          message.content.push(currentBlock);
+          eventStream.push({ type: "text_start", contentIndex: blockIndex(currentBlock), partial: message });
+        }
+        currentBlock.text += text;
+        eventStream.push({
+          type: "text_delta",
+          contentIndex: blockIndex(currentBlock),
+          delta: text,
+          partial: message,
+        });
+      };
+      const appendThinking = (
+        message: AssistantMessage,
+        eventStream: AssistantMessageEventStream,
+        thinking: string,
+        signature?: string,
+      ): void => {
+        if (
+          currentBlock?.type !== "thinking" ||
+          (signature !== undefined && currentBlock.thinkingSignature !== signature)
+        ) {
+          // Same as appendText: leave toolCall blocks pending so index-only
+          // continuation deltas can still find them.
+          if (currentBlock?.type !== "toolCall") finishCurrentBlock(currentBlock);
+          currentBlock = { type: "thinking", thinking: "", thinkingSignature: signature };
+          message.content.push(currentBlock);
+          eventStream.push({
+            type: "thinking_start",
+            contentIndex: blockIndex(currentBlock),
+            partial: message,
+          });
+        }
+        if (signature !== undefined && !currentBlock.thinkingSignature) {
+          currentBlock.thinkingSignature = signature;
+        }
+        currentBlock.thinking += thinking;
+        eventStream.push({
+          type: "thinking_delta",
+          contentIndex: blockIndex(currentBlock),
+          delta: thinking,
+          partial: message,
+        });
+      };
 
-			const appendTextDelta = (text: string): void => {
-				if (!text) return;
-				if (!firstTokenTime) firstTokenTime = performance.now();
-				appendText(output, stream, text);
-			};
-			// Tracks the last full cumulative reasoning snapshot per signature (the
-			// reasoning field name) so dedup survives block transitions. Required
-			// for MiniMax-M3: once `</think>` and visible text arrive, currentBlock
-			// flips to "text", but later chunks keep carrying the same cumulative
-			// `reasoning_content` snapshot. Without an external tracker the guard
-			// below misses and the snapshot gets re-emitted as a fresh thinking
-			// block after the answer has started.
-			const lastCumulativeReasoningBySignature = new Map<string, string>();
-			const appendThinkingDelta = (
-				thinking: string,
-				signature?: string,
-				source: "delta" | "cumulative" = "delta",
-			): void => {
-				if (!thinking) return;
-				let emittedThinking = thinking;
-				if (source === "cumulative") {
-					const key = signature ?? "";
-					const lastSnapshot = lastCumulativeReasoningBySignature.get(key) ?? "";
-					if (thinking.startsWith(lastSnapshot)) {
-						emittedThinking = thinking.slice(lastSnapshot.length);
-					}
-					lastCumulativeReasoningBySignature.set(key, thinking);
-					if (!emittedThinking) return;
-				}
-				if (!firstTokenTime) firstTokenTime = performance.now();
-				appendThinking(output, stream, emittedThinking, signature);
-			};
+      const appendTextDelta = (text: string): void => {
+        if (!text) return;
+        if (!firstTokenTime) firstTokenTime = performance.now();
+        appendText(output, stream, text);
+      };
+      // Tracks the last full cumulative reasoning snapshot per signature (the
+      // reasoning field name) so dedup survives block transitions. Required
+      // for MiniMax-M3: once `</think>` and visible text arrive, currentBlock
+      // flips to "text", but later chunks keep carrying the same cumulative
+      // `reasoning_content` snapshot. Without an external tracker the guard
+      // below misses and the snapshot gets re-emitted as a fresh thinking
+      // block after the answer has started.
+      const lastCumulativeReasoningBySignature = new Map<string, string>();
+      const appendThinkingDelta = (
+        thinking: string,
+        signature?: string,
+        source: "delta" | "cumulative" = "delta",
+      ): void => {
+        if (!thinking) return;
+        let emittedThinking = thinking;
+        if (source === "cumulative") {
+          const key = signature ?? "";
+          const lastSnapshot = lastCumulativeReasoningBySignature.get(key) ?? "";
+          if (thinking.startsWith(lastSnapshot)) {
+            emittedThinking = thinking.slice(lastSnapshot.length);
+          }
+          lastCumulativeReasoningBySignature.set(key, thinking);
+          if (!emittedThinking) return;
+        }
+        if (!firstTokenTime) firstTokenTime = performance.now();
+        appendThinking(output, stream, emittedThinking, signature);
+      };
 
-			let deepseekStripBuffer = "";
-			const flushDeepseekStripBuffer = (final: boolean): void => {
-				if (deepseekStripBuffer.length === 0) return;
-				let flushable: string;
-				if (final) {
-					flushable = deepseekStripBuffer;
-					deepseekStripBuffer = "";
-				} else {
-					const trailing = getTrailingPartialDeepseekToken(deepseekStripBuffer);
-					flushable = deepseekStripBuffer.slice(0, deepseekStripBuffer.length - trailing.length);
-					deepseekStripBuffer = trailing;
-				}
-				const stripped = stripDeepseekSpecialTokens(flushable);
-				if (stripped && (stripped === flushable || stripped.trim().length > 0)) appendTextDelta(stripped);
-			};
-			const appendProcessedText = (processedText: string): void => {
-				if (processedText.length === 0) return;
-				if (stripDeepseekChatTemplateTokens) {
-					deepseekStripBuffer += processedText;
-					flushDeepseekStripBuffer(false);
-				} else {
-					appendTextDelta(processedText);
-				}
-			};
-			const streamMarkupHealingPattern = policy.stream.markupHealingPattern;
-			const streamMarkupHealing = streamMarkupHealingPattern
-				? new StreamMarkupHealing({ pattern: streamMarkupHealingPattern })
-				: undefined;
-			const explicitReasoningDeltasMayBeCumulative = policy.stream.reasoningDeltasMayBeCumulative;
-			let suppressHealedThinking = false;
-			let healedToolCallEmitted = false;
-			const emitHealedToolCall = (call: HealedToolCall): void => {
-				finishCurrentBlock(currentBlock);
-				const block: ToolCall & { partialArgs: string } = {
-					type: "toolCall",
-					id: call.id,
-					name: call.name,
-					arguments: {},
-					partialArgs: call.arguments,
-				};
-				block.arguments = parseStreamingJson(call.arguments);
-				currentBlock = block;
-				output.content.push(block);
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(block), partial: output });
-				stream.push({
-					type: "toolcall_delta",
-					contentIndex: blockIndex(block),
-					delta: call.arguments,
-					partial: output,
-				});
-				finishCurrentBlock(block);
-				currentBlock = undefined;
-				healedToolCallEmitted = true;
-			};
-			const emitHealingEvent = (event: StreamMarkupHealingEvent, suppressThinking: boolean): void => {
-				if (event.type === "text") {
-					appendProcessedText(event.text);
-				} else if (event.type === "thinking") {
-					if (!suppressThinking) appendThinkingDelta(event.thinking);
-				} else {
-					emitHealedToolCall(event.call);
-				}
-			};
-			const flushHealedToolCalls = (): void => {
-				if (!streamMarkupHealing) return;
-				const calls = streamMarkupHealing.drainCompleted();
-				for (const call of calls) emitHealedToolCall(call);
-			};
+      let deepseekStripBuffer = "";
+      const flushDeepseekStripBuffer = (final: boolean): void => {
+        if (deepseekStripBuffer.length === 0) return;
+        let flushable: string;
+        if (final) {
+          flushable = deepseekStripBuffer;
+          deepseekStripBuffer = "";
+        } else {
+          const trailing = getTrailingPartialDeepseekToken(deepseekStripBuffer);
+          flushable = deepseekStripBuffer.slice(0, deepseekStripBuffer.length - trailing.length);
+          deepseekStripBuffer = trailing;
+        }
+        const stripped = stripDeepseekSpecialTokens(flushable);
+        if (stripped && (stripped === flushable || stripped.trim().length > 0)) appendTextDelta(stripped);
+      };
+      const appendProcessedText = (processedText: string): void => {
+        if (processedText.length === 0) return;
+        if (stripDeepseekChatTemplateTokens) {
+          deepseekStripBuffer += processedText;
+          flushDeepseekStripBuffer(false);
+        } else {
+          appendTextDelta(processedText);
+        }
+      };
+      const streamMarkupHealingPattern = policy.stream.markupHealingPattern;
+      const streamMarkupHealing = streamMarkupHealingPattern
+        ? new StreamMarkupHealing({ pattern: streamMarkupHealingPattern })
+        : undefined;
+      const explicitReasoningDeltasMayBeCumulative = policy.stream.reasoningDeltasMayBeCumulative;
+      let suppressHealedThinking = false;
+      let healedToolCallEmitted = false;
+      const emitHealedToolCall = (call: HealedToolCall): void => {
+        finishCurrentBlock(currentBlock);
+        const block: ToolCall & { partialArgs: string } = {
+          type: "toolCall",
+          id: call.id,
+          name: call.name,
+          arguments: {},
+          partialArgs: call.arguments,
+        };
+        block.arguments = parseStreamingJson(call.arguments);
+        currentBlock = block;
+        output.content.push(block);
+        stream.push({ type: "toolcall_start", contentIndex: blockIndex(block), partial: output });
+        stream.push({
+          type: "toolcall_delta",
+          contentIndex: blockIndex(block),
+          delta: call.arguments,
+          partial: output,
+        });
+        finishCurrentBlock(block);
+        currentBlock = undefined;
+        healedToolCallEmitted = true;
+      };
+      const emitHealingEvent = (event: StreamMarkupHealingEvent, suppressThinking: boolean): void => {
+        if (event.type === "text") {
+          appendProcessedText(event.text);
+        } else if (event.type === "thinking") {
+          if (!suppressThinking) appendThinkingDelta(event.thinking);
+        } else {
+          emitHealedToolCall(event.call);
+        }
+      };
+      const flushHealedToolCalls = (): void => {
+        if (!streamMarkupHealing) return;
+        const calls = streamMarkupHealing.drainCompleted();
+        for (const call of calls) emitHealedToolCall(call);
+      };
 
-			// Terminal-chunk bookkeeping for the post-finish grace window below.
-			// `streamFinishedAt` flips when a chunk carries `finish_reason`;
-			// `sawUsagePayload` flips when a usage payload was parsed. Some
-			// OpenAI-compatible servers send basic usage with `finish_reason` and
-			// cache-read details in a trailing usage-only chunk, so only the
-			// no-choice terminal path may break while those details are pending.
-			let streamFinishedAt: number | undefined;
-			let sawUsagePayload = false;
-			let awaitTrailingUsageDetails = false;
-			const applyUsagePayload = (rawUsage: object): void => {
-				output.usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal);
-				sawUsagePayload = true;
-				awaitTrailingUsageDetails = !hasPositiveCacheReadTokenField(rawUsage);
-			};
-			const timedOpenaiStream = iterateWithIdleTimeout(openaiStream, {
-				idleTimeoutMs,
-				firstItemTimeoutMs: firstEventTimeoutMs,
-				firstItemErrorMessage: OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
-				errorMessage: "OpenAI completions stream stalled while waiting for the next event",
-				onIdle: () => requestAbortController.abort(),
-				onFirstItemTimeout: () => abortTracker.abortLocally(firstEventTimeoutAbortError),
-				abortSignal: options?.signal,
-				isProgressItem: isOpenAICompletionsProgressChunk,
-			});
-			const terminalAwareStream = iterateWithTerminalGrace(timedOpenaiStream, {
-				finishedAtMs: () => streamFinishedAt,
-				graceMs: OPENAI_COMPLETIONS_POST_FINISH_GRACE_MS,
-				// The inner idle-timeout generator is parked mid-`next()` when the
-				// grace window closes, so abort the transport to settle that read
-				// and release the socket immediately (a queued `.return()` alone
-				// would wait on the never-arriving next chunk).
-				onGraceEnd: () => requestAbortController.abort(),
-			});
-			for await (const chunk of terminalAwareStream) {
-				if (!chunk || typeof chunk !== "object") continue;
+      // Terminal-chunk bookkeeping for the post-finish grace window below.
+      // `streamFinishedAt` flips when a chunk carries `finish_reason`;
+      // `sawUsagePayload` flips when a usage payload was parsed. Some
+      // OpenAI-compatible servers send basic usage with `finish_reason` and
+      // cache-read details in a trailing usage-only chunk, so only the
+      // no-choice terminal path may break while those details are pending.
+      let streamFinishedAt: number | undefined;
+      let sawUsagePayload = false;
+      let awaitTrailingUsageDetails = false;
+      const applyUsagePayload = (rawUsage: object): void => {
+        output.usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal);
+        sawUsagePayload = true;
+        awaitTrailingUsageDetails = !hasPositiveCacheReadTokenField(rawUsage);
+      };
+      const timedOpenaiStream = iterateWithIdleTimeout(openaiStream, {
+        idleTimeoutMs,
+        firstItemTimeoutMs: firstEventTimeoutMs,
+        firstItemErrorMessage: OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
+        errorMessage: "OpenAI completions stream stalled while waiting for the next event",
+        onIdle: () => requestAbortController.abort(),
+        onFirstItemTimeout: () => abortTracker.abortLocally(firstEventTimeoutAbortError),
+        abortSignal: options?.signal,
+        isProgressItem: isOpenAICompletionsProgressChunk,
+      });
+      const terminalAwareStream = iterateWithTerminalGrace(timedOpenaiStream, {
+        finishedAtMs: () => streamFinishedAt,
+        graceMs: OPENAI_COMPLETIONS_POST_FINISH_GRACE_MS,
+        // The inner idle-timeout generator is parked mid-`next()` when the
+        // grace window closes, so abort the transport to settle that read
+        // and release the socket immediately (a queued `.return()` alone
+        // would wait on the never-arriving next chunk).
+        onGraceEnd: () => requestAbortController.abort(),
+      });
+      for await (const chunk of terminalAwareStream) {
+        if (!chunk || typeof chunk !== "object") continue;
 
-				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
-				// and each chunk in a streamed completion carries the same id.
-				output.responseId ||= chunk.id;
+        // OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
+        // and each chunk in a streamed completion carries the same id.
+        output.responseId ||= chunk.id;
 
-				// Aggregators (OpenRouter, Vercel AI Gateway, …) report the upstream
-				// provider that actually served the request via a top-level `provider`
-				// field present on every chunk. Capture the first non-empty value so
-				// callers can attribute routing without re-parsing the raw stream.
-				if (!output.upstreamProvider) {
-					const upstreamProvider = (chunk as ProviderAttributedChatCompletionChunk).provider;
-					output.upstreamProvider =
-						typeof upstreamProvider === "string" && upstreamProvider.length > 0 ? upstreamProvider : undefined;
-				}
+        // Aggregators (OpenRouter, Vercel AI Gateway, …) report the upstream
+        // provider that actually served the request via a top-level `provider`
+        // field present on every chunk. Capture the first non-empty value so
+        // callers can attribute routing without re-parsing the raw stream.
+        if (!output.upstreamProvider) {
+          const upstreamProvider = (chunk as ProviderAttributedChatCompletionChunk).provider;
+          output.upstreamProvider =
+            typeof upstreamProvider === "string" && upstreamProvider.length > 0 ? upstreamProvider : undefined;
+        }
 
-				if (chunk.usage) {
-					applyUsagePayload(chunk.usage);
-				}
+        if (chunk.usage) {
+          applyUsagePayload(chunk.usage);
+        }
 
-				const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
-				if (!choice) {
-					// Trailing usage-only chunk (`stream_options.include_usage`) after
-					// `finish_reason`: the response is complete — stop pulling instead
-					// of waiting for `[DONE]`/close from hosts that never send either.
-					if (streamFinishedAt !== undefined && sawUsagePayload) break;
-					continue;
-				}
+        const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+        if (!choice) {
+          // Trailing usage-only chunk (`stream_options.include_usage`) after
+          // `finish_reason`: the response is complete — stop pulling instead
+          // of waiting for `[DONE]`/close from hosts that never send either.
+          if (streamFinishedAt !== undefined && sawUsagePayload) break;
+          continue;
+        }
 
-				if (!chunk.usage) {
-					const choiceUsage = (choice as OpenAICompletionsChoiceUsage).usage;
-					if (typeof choiceUsage === "object" && choiceUsage !== null) {
-						applyUsagePayload(choiceUsage);
-					}
-				}
+        if (!chunk.usage) {
+          const choiceUsage = (choice as OpenAICompletionsChoiceUsage).usage;
+          if (typeof choiceUsage === "object" && choiceUsage !== null) {
+            applyUsagePayload(choiceUsage);
+          }
+        }
 
-				if (choice.finish_reason) {
-					const finishReasonResult = mapStopReason(choice.finish_reason);
-					output.stopReason = finishReasonResult.stopReason;
-					if (finishReasonResult.errorMessage) {
-						output.errorMessage = finishReasonResult.errorMessage;
-					}
-					streamFinishedAt ??= Date.now();
-				}
+        if (choice.finish_reason) {
+          const finishReasonResult = mapStopReason(choice.finish_reason);
+          output.stopReason = finishReasonResult.stopReason;
+          if (finishReasonResult.errorMessage) {
+            output.errorMessage = finishReasonResult.errorMessage;
+          }
+          streamFinishedAt ??= Date.now();
+        }
 
-				if (choice.delta) {
-					// Some endpoints return reasoning in reasoning_content (llama.cpp),
-					// or reasoning (other openai compatible endpoints). Use the first
-					// non-empty reasoning field to avoid duplication when a chunk carries
-					// multiple aliases for the same reasoning text.
-					const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
-					const deltaRecord = choice.delta as Record<string, unknown>;
-					let foundReasoningField: string | undefined;
-					let foundReasoningDelta = "";
-					for (const field of reasoningFields) {
-						const reasoningDelta = deltaRecord[field];
-						if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
-							foundReasoningField = field;
-							foundReasoningDelta = reasoningDelta;
-							break;
-						}
-					}
+        if (choice.delta) {
+          // Some endpoints return reasoning in reasoning_content (llama.cpp),
+          // or reasoning (other openai compatible endpoints). Use the first
+          // non-empty reasoning field to avoid duplication when a chunk carries
+          // multiple aliases for the same reasoning text.
+          const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
+          const deltaRecord = choice.delta as Record<string, unknown>;
+          let foundReasoningField: string | undefined;
+          let foundReasoningDelta = "";
+          for (const field of reasoningFields) {
+            const reasoningDelta = deltaRecord[field];
+            if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
+              foundReasoningField = field;
+              foundReasoningDelta = reasoningDelta;
+              break;
+            }
+          }
 
-					if (foundReasoningField) {
-						appendThinkingDelta(
-							foundReasoningDelta,
-							foundReasoningField,
-							explicitReasoningDeltasMayBeCumulative ? "cumulative" : "delta",
-						);
-						suppressHealedThinking = true;
-					}
+          if (foundReasoningField) {
+            appendThinkingDelta(
+              foundReasoningDelta,
+              foundReasoningField,
+              explicitReasoningDeltasMayBeCumulative ? "cumulative" : "delta",
+            );
+            suppressHealedThinking = true;
+          }
 
-					const normalizedDeltaText = normalizeStreamingContentText(choice.delta.content);
-					if (normalizedDeltaText.length > 0) {
-						if (!firstTokenTime) firstTokenTime = performance.now();
-						const hasStructuredToolCalls =
-							Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
+          const normalizedDeltaText = normalizeStreamingContentText(choice.delta.content);
+          if (normalizedDeltaText.length > 0) {
+            if (!firstTokenTime) firstTokenTime = performance.now();
+            const hasStructuredToolCalls =
+              Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
 
-						if (streamMarkupHealing) {
-							const healingEvents = hasStructuredToolCalls
-								? streamMarkupHealing.feedEventsWithoutCalls(normalizedDeltaText)
-								: streamMarkupHealing.feedEvents(normalizedDeltaText);
-							for (const event of healingEvents) {
-								emitHealingEvent(event, suppressHealedThinking);
-							}
-						} else {
-							appendProcessedText(normalizedDeltaText);
-						}
-					}
+            if (streamMarkupHealing) {
+              const healingEvents = hasStructuredToolCalls
+                ? streamMarkupHealing.feedEventsWithoutCalls(normalizedDeltaText)
+                : streamMarkupHealing.feedEvents(normalizedDeltaText);
+              for (const event of healingEvents) {
+                emitHealingEvent(event, suppressHealedThinking);
+              }
+            } else {
+              appendProcessedText(normalizedDeltaText);
+            }
+          }
 
-					if (choice?.delta?.tool_calls && choice.delta.tool_calls.length > 0) {
-						const toolCalls = choice.delta.tool_calls;
-						for (let toolCallOffset = 0; toolCallOffset < toolCalls.length; toolCallOffset++) {
-							const toolCall = toolCalls[toolCallOffset]!;
-							const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
-							const incomingName = toolCall.function?.name || "";
-							// Multi-entry `tool_calls` arrays without `id`/`index` — either the
-							// opening chunk that carries per-entry names, or a continuation whose
-							// entries are argument-only. Either way, route by array offset so
-							// sibling calls stay isolated.
-							const unkeyedBatchedArrayEntry = toolCalls.length > 1 && streamIndex === undefined && !toolCall.id;
-							let block = streamIndex !== undefined ? toolCallBlockByIndex.get(streamIndex) : undefined;
-							if (!block && toolCall.id) {
-								block = pendingToolCallBlocks.find(candidate => candidate.id === toolCall.id);
-							}
-							if (!block && unkeyedBatchedArrayEntry) {
-								const offsetBlock = unkeyedBatchBlocks[toolCallOffset];
-								if (offsetBlock && offsetBlock.partialArgs !== undefined) block = offsetBlock;
-							}
-							if (
-								!block &&
-								!unkeyedBatchedArrayEntry &&
-								currentBlock?.type === "toolCall" &&
-								(!toolCall.id || currentBlock.id === toolCall.id)
-							) {
-								block = currentBlock;
-							}
+          if (choice?.delta?.tool_calls && choice.delta.tool_calls.length > 0) {
+            const toolCalls = choice.delta.tool_calls;
+            for (let toolCallOffset = 0; toolCallOffset < toolCalls.length; toolCallOffset++) {
+              const toolCall = toolCalls[toolCallOffset]!;
+              const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
+              const incomingName = toolCall.function?.name || "";
+              // Multi-entry `tool_calls` arrays without `id`/`index` — either the
+              // opening chunk that carries per-entry names, or a continuation whose
+              // entries are argument-only. Either way, route by array offset so
+              // sibling calls stay isolated.
+              const unkeyedBatchedArrayEntry = toolCalls.length > 1 && streamIndex === undefined && !toolCall.id;
+              let block = streamIndex !== undefined ? toolCallBlockByIndex.get(streamIndex) : undefined;
+              if (!block && toolCall.id) {
+                block = pendingToolCallBlocks.find(candidate => candidate.id === toolCall.id);
+              }
+              if (!block && unkeyedBatchedArrayEntry) {
+                const offsetBlock = unkeyedBatchBlocks[toolCallOffset];
+                if (offsetBlock && offsetBlock.partialArgs !== undefined) block = offsetBlock;
+              }
+              if (
+                !block &&
+                !unkeyedBatchedArrayEntry &&
+                currentBlock?.type === "toolCall" &&
+                (!toolCall.id || currentBlock.id === toolCall.id)
+              ) {
+                block = currentBlock;
+              }
 
-							if (!block) {
-								if (currentBlock?.type !== "toolCall") {
-									finishCurrentBlock(currentBlock);
-								}
-								block = {
-									type: "toolCall",
-									id: toolCall.id || "",
-									name: incomingName,
-									arguments: {},
-									partialArgs: "",
-									streamIndex,
-								};
-								if (streamIndex !== undefined) toolCallBlockByIndex.set(streamIndex, block);
-								pendingToolCallBlocks.push(block);
-								currentBlock = block;
-								output.content.push(block);
-								stream.push({
-									type: "toolcall_start",
-									contentIndex: blockIndex(block),
-									partial: output,
-								});
-								if (unkeyedBatchedArrayEntry) unkeyedBatchBlocks[toolCallOffset] = block;
-							} else {
-								// Resuming a pending call after interleaved text/thinking:
-								// close the text/thinking block we drifted into.
-								if (currentBlock !== block && currentBlock && currentBlock.type !== "toolCall") {
-									finishCurrentBlock(currentBlock);
-								}
-								currentBlock = block;
-								if (streamIndex !== undefined && block.streamIndex === undefined) {
-									block.streamIndex = streamIndex;
-									toolCallBlockByIndex.set(streamIndex, block);
-								}
-							}
+              if (!block) {
+                if (currentBlock?.type !== "toolCall") {
+                  finishCurrentBlock(currentBlock);
+                }
+                block = {
+                  type: "toolCall",
+                  id: toolCall.id || "",
+                  name: incomingName,
+                  arguments: {},
+                  partialArgs: "",
+                  streamIndex,
+                };
+                if (streamIndex !== undefined) toolCallBlockByIndex.set(streamIndex, block);
+                pendingToolCallBlocks.push(block);
+                currentBlock = block;
+                output.content.push(block);
+                stream.push({
+                  type: "toolcall_start",
+                  contentIndex: blockIndex(block),
+                  partial: output,
+                });
+                if (unkeyedBatchedArrayEntry) unkeyedBatchBlocks[toolCallOffset] = block;
+              } else {
+                // Resuming a pending call after interleaved text/thinking:
+                // close the text/thinking block we drifted into.
+                if (currentBlock !== block && currentBlock && currentBlock.type !== "toolCall") {
+                  finishCurrentBlock(currentBlock);
+                }
+                currentBlock = block;
+                if (streamIndex !== undefined && block.streamIndex === undefined) {
+                  block.streamIndex = streamIndex;
+                  toolCallBlockByIndex.set(streamIndex, block);
+                }
+              }
 
-							if (toolCall.id) block.id = toolCall.id;
-							if (incomingName) block.name = incomingName;
-							let delta = "";
-							// The OpenAI SDK types `function.arguments` as a JSON string, but MiniMax-compatible
-							// hosts stream a fully-formed object instead. Model both shapes so the branches below
-							// narrow honestly rather than widening through `unknown`.
-							const rawArgs = toolCall.function?.arguments as string | Record<string, unknown> | undefined;
-							if (typeof rawArgs === "string") {
-								if (rawArgs.length > 0) {
-									delta = rawArgs;
-									const prev = typeof block.partialArgs === "string" ? block.partialArgs : "";
-									block.partialArgs = prev + rawArgs;
-									const throttled = parseStreamingJsonThrottled(
-										block.partialArgs,
-										block[kStreamingLastParseLen] ?? 0,
-									);
-									if (throttled) {
-										block.arguments = throttled.value;
-										block[kStreamingLastParseLen] = throttled.parsedLen;
-									}
-								}
-							} else if (rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)) {
-								// MiniMax-compatible hosts stream `function.arguments` as an object instead of the
-								// OpenAI JSON-string contract. Most chunks carry the complete object in one delta,
-								// but cannot rely on that: replacing per-chunk drops earlier keys (and earlier
-								// string content for the same key) when the host fragments the args across deltas.
-								// Deep-merge into the accumulated object. Strings and arrays detect
-								// cumulative-vs-delta semantics by prefix, nested objects merge by key, and
-								// prototype-polluting keys are ignored before storing or comparing values.
-								//
-								// `delta` stays empty here: emitting `JSON.stringify(rawArgs)` per chunk feeds
-								// downstream concat-based accumulators (proxy.ts, openai-chat-server,
-								// openai-responses-server, anthropic-messages-server) an invalid sequence like
-								// `{"input":"a"}{"input":"b"}`. The merged object is flushed as a single
-								// concat-safe delta in `finishToolCallBlock` before `toolcall_end` instead.
-								const prev =
-									block.partialArgs !== null &&
-									typeof block.partialArgs === "object" &&
-									!Array.isArray(block.partialArgs)
-										? (block.partialArgs as Record<string, unknown>)
-										: undefined;
-								const merged = mergeStreamingArgumentObjects(prev, rawArgs);
-								block.partialArgs = merged;
-								block.arguments = merged;
-							}
-							stream.push({
-								type: "toolcall_delta",
-								contentIndex: blockIndex(block),
-								delta,
-								partial: output,
-							});
-						}
-					}
+              if (toolCall.id) block.id = toolCall.id;
+              if (incomingName) block.name = incomingName;
+              let delta = "";
+              // The OpenAI SDK types `function.arguments` as a JSON string, but MiniMax-compatible
+              // hosts stream a fully-formed object instead. Model both shapes so the branches below
+              // narrow honestly rather than widening through `unknown`.
+              const rawArgs = toolCall.function?.arguments as string | Record<string, unknown> | undefined;
+              if (typeof rawArgs === "string") {
+                if (rawArgs.length > 0) {
+                  delta = rawArgs;
+                  const prev = typeof block.partialArgs === "string" ? block.partialArgs : "";
+                  block.partialArgs = prev + rawArgs;
+                  const throttled = parseStreamingJsonThrottled(
+                    block.partialArgs,
+                    block[kStreamingLastParseLen] ?? 0,
+                  );
+                  if (throttled) {
+                    block.arguments = throttled.value;
+                    block[kStreamingLastParseLen] = throttled.parsedLen;
+                  }
+                }
+              } else if (rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)) {
+                // MiniMax-compatible hosts stream `function.arguments` as an object instead of the
+                // OpenAI JSON-string contract. Most chunks carry the complete object in one delta,
+                // but cannot rely on that: replacing per-chunk drops earlier keys (and earlier
+                // string content for the same key) when the host fragments the args across deltas.
+                // Deep-merge into the accumulated object. Strings and arrays detect
+                // cumulative-vs-delta semantics by prefix, nested objects merge by key, and
+                // prototype-polluting keys are ignored before storing or comparing values.
+                //
+                // `delta` stays empty here: emitting `JSON.stringify(rawArgs)` per chunk feeds
+                // downstream concat-based accumulators (proxy.ts, openai-chat-server,
+                // openai-responses-server, anthropic-messages-server) an invalid sequence like
+                // `{"input":"a"}{"input":"b"}`. The merged object is flushed as a single
+                // concat-safe delta in `finishToolCallBlock` before `toolcall_end` instead.
+                const prev =
+                  block.partialArgs !== null &&
+                    typeof block.partialArgs === "object" &&
+                    !Array.isArray(block.partialArgs)
+                    ? (block.partialArgs as Record<string, unknown>)
+                    : undefined;
+                const merged = mergeStreamingArgumentObjects(prev, rawArgs);
+                block.partialArgs = merged;
+                block.arguments = merged;
+              }
+              stream.push({
+                type: "toolcall_delta",
+                contentIndex: blockIndex(block),
+                delta,
+                partial: output,
+              });
+            }
+          }
 
-					const reasoningDetails = (choice.delta as OpenAICompletionsDeltaWithReasoningDetails).reasoning_details;
-					if (Array.isArray(reasoningDetails)) {
-						for (const detail of reasoningDetails) {
-							if (!detail || typeof detail !== "object") continue;
-							const detailObject = detail as { type?: unknown; id?: unknown; data?: unknown };
-							if (detailObject.type === "reasoning.encrypted" && detailObject.id && detailObject.data) {
-								const matchingToolCall = output.content.find(
-									b => b.type === "toolCall" && b.id === detailObject.id,
-								) as ToolCall | undefined;
-								if (matchingToolCall) {
-									matchingToolCall.thoughtSignature = JSON.stringify(detailObject);
-								}
-							}
-						}
-					}
-				}
+          const reasoningDetails = (choice.delta as OpenAICompletionsDeltaWithReasoningDetails).reasoning_details;
+          if (Array.isArray(reasoningDetails)) {
+            for (const detail of reasoningDetails) {
+              if (!detail || typeof detail !== "object") continue;
+              const detailObject = detail as { type?: unknown; id?: unknown; data?: unknown };
+              if (detailObject.type === "reasoning.encrypted" && detailObject.id && detailObject.data) {
+                const matchingToolCall = output.content.find(
+                  b => b.type === "toolCall" && b.id === detailObject.id,
+                ) as ToolCall | undefined;
+                if (matchingToolCall) {
+                  matchingToolCall.thoughtSignature = JSON.stringify(detailObject);
+                }
+              }
+            }
+          }
+        }
 
-				// If usage arrived on the finish chunk without cache-read fields,
-				// keep draining through the grace window for vLLM-style trailing
-				// usage details instead of finalizing the incomplete accounting.
-				if (streamFinishedAt !== undefined && sawUsagePayload && !awaitTrailingUsageDetails) break;
-			}
+        // If usage arrived on the finish chunk without cache-read fields,
+        // keep draining through the grace window for vLLM-style trailing
+        // usage details instead of finalizing the incomplete accounting.
+        if (streamFinishedAt !== undefined && sawUsagePayload && !awaitTrailingUsageDetails) break;
+      }
 
-			if (streamMarkupHealing) {
-				for (const event of streamMarkupHealing.flushEvents()) {
-					emitHealingEvent(event, suppressHealedThinking);
-				}
-				flushHealedToolCalls();
-				if (healedToolCallEmitted && output.stopReason === "stop") {
-					// Hosts that leak tool-call templates often still report
-					// `finish_reason: stop` for the surrounding turn. Promote
-					// only that natural-completion finish — leave `error`,
-					// `length`, `aborted`, etc. untouched.
-					output.stopReason = "toolUse";
-				}
-			}
+      if (streamMarkupHealing) {
+        for (const event of streamMarkupHealing.flushEvents()) {
+          emitHealingEvent(event, suppressHealedThinking);
+        }
+        flushHealedToolCalls();
+        if (healedToolCallEmitted && output.stopReason === "stop") {
+          // Hosts that leak tool-call templates often still report
+          // `finish_reason: stop` for the surrounding turn. Promote
+          // only that natural-completion finish — leave `error`,
+          // `length`, `aborted`, etc. untouched.
+          output.stopReason = "toolUse";
+        }
+      }
 
-			if (stripDeepseekChatTemplateTokens) {
-				flushDeepseekStripBuffer(true);
-			}
+      if (stripDeepseekChatTemplateTokens) {
+        flushDeepseekStripBuffer(true);
+      }
 
-			if (currentBlock?.type === "toolCall") {
-				finishPendingToolCallBlocks();
-			} else {
-				finishCurrentBlock(currentBlock);
-				finishPendingToolCallBlocks();
-			}
+      if (currentBlock?.type === "toolCall") {
+        finishPendingToolCallBlocks();
+      } else {
+        finishCurrentBlock(currentBlock);
+        finishPendingToolCallBlocks();
+      }
 
-			// Some OpenAI-compatible hosts stream structured `tool_calls` but report
-			// `finish_reason: "stop"` instead of `"tool_calls"`. In the OpenAI contract a
-			// tool call always means "execute and continue", so promote that
-			// natural-completion finish to `toolUse` whenever the turn produced tool-call
-			// blocks — the agent loop gates execution on the stop reason. `error`,
-			// `length`, and `aborted` are intentionally left untouched. (Anthropic's
-			// distinct `end_turn`-with-tool-calls "abandon" semantics live in its own
-			// provider and correctly keep `stop`.)
-			if (output.stopReason === "stop" && output.content.some(b => b.type === "toolCall")) {
-				output.stopReason = "toolUse";
-			}
+      // Some OpenAI-compatible hosts stream structured `tool_calls` but report
+      // `finish_reason: "stop"` instead of `"tool_calls"`. In the OpenAI contract a
+      // tool call always means "execute and continue", so promote that
+      // natural-completion finish to `toolUse` whenever the turn produced tool-call
+      // blocks — the agent loop gates execution on the stop reason. `error`,
+      // `length`, and `aborted` are intentionally left untouched. (Anthropic's
+      // distinct `end_turn`-with-tool-calls "abandon" semantics live in its own
+      // provider and correctly keep `stop`.)
+      if (output.stopReason === "stop" && output.content.some(b => b.type === "toolCall")) {
+        output.stopReason = "toolUse";
+      }
 
-			if (
-				policy.stream.emptyLengthFinishIsContextError &&
-				output.stopReason === "length" &&
-				!hasVisibleAssistantContent(output)
-			) {
-				output.stopReason = "error";
-				output.errorMessage = EMPTY_OLLAMA_LENGTH_COMPLETION_MESSAGE;
-			}
-			const localAbortReason = abortTracker.getLocalAbortReason();
-			if (localAbortReason) {
-				throw localAbortReason;
-			}
-			if (abortTracker.wasCallerAbort()) {
-				throw new AIError.AbortError();
-			}
+      if (
+        policy.stream.emptyLengthFinishIsContextError &&
+        output.stopReason === "length" &&
+        !hasVisibleAssistantContent(output)
+      ) {
+        output.stopReason = "error";
+        output.errorMessage = EMPTY_OLLAMA_LENGTH_COMPLETION_MESSAGE;
+      }
+      const localAbortReason = abortTracker.getLocalAbortReason();
+      if (localAbortReason) {
+        throw localAbortReason;
+      }
+      if (abortTracker.wasCallerAbort()) {
+        throw new AIError.AbortError();
+      }
 
-			if (output.stopReason === "aborted") {
-				throw new AIError.AbortError();
-			}
-			if (output.stopReason === "error") {
-				throw new AIError.ProviderResponseError(output.errorMessage || "Provider returned an error stop reason", {
-					provider: model.provider,
-					kind: "runtime",
-				});
-			}
+      if (output.stopReason === "aborted") {
+        throw new AIError.AbortError();
+      }
+      if (output.stopReason === "error") {
+        throw new AIError.ProviderResponseError(output.errorMessage || "Provider returned an error stop reason", {
+          provider: model.provider,
+          kind: "runtime",
+        });
+      }
 
-			output.errorMessage = undefined;
-			output.duration = performance.now() - startTime;
-			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			// Close open blocks first so consumers tracking text_/thinking_/toolcall_
-			// lifecycles never see orphaned starts on the error path. Best-effort: a
-			// throw here must not prevent the terminal error event below.
-			try {
-				finishOpenBlocksOnError();
-			} catch {}
-			const capturedErrorResponse = error instanceof OpenAIHttpError ? error.captured : undefined;
-			const result = await AIError.finalize(error, {
-				api: model.api,
-				provider: model.provider,
-				abortTracker,
-				rawRequestDump,
-				capturedErrorResponse,
-			});
-			output.stopReason = result.stopReason;
-			output.errorStatus = result.status;
-			output.errorId = result.id;
-			output.errorMessage = result.message;
-			// Some providers via OpenRouter include extra details here.
-			const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata?.raw;
-			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
-			output.duration = performance.now() - startTime;
-			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
-		}
-	})();
+      output.errorMessage = undefined;
+      output.duration = performance.now() - startTime;
+      if (firstTokenTime) output.ttft = firstTokenTime - startTime;
+      stream.push({ type: "done", reason: output.stopReason, message: output });
+      stream.end();
+    } catch (error) {
+      // Close open blocks first so consumers tracking text_/thinking_/toolcall_
+      // lifecycles never see orphaned starts on the error path. Best-effort: a
+      // throw here must not prevent the terminal error event below.
+      try {
+        finishOpenBlocksOnError();
+      } catch { }
+      const capturedErrorResponse = error instanceof OpenAIHttpError ? error.captured : undefined;
+      const result = await AIError.finalize(error, {
+        api: model.api,
+        provider: model.provider,
+        abortTracker,
+        rawRequestDump,
+        capturedErrorResponse,
+      });
+      output.stopReason = result.stopReason;
+      output.errorStatus = result.status;
+      output.errorId = result.id;
+      output.errorMessage = result.message;
+      // Some providers via OpenRouter include extra details here.
+      const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata?.raw;
+      if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
+      output.duration = performance.now() - startTime;
+      if (firstTokenTime) output.ttft = firstTokenTime - startTime;
+      stream.push({ type: "error", reason: output.stopReason, error: output });
+      stream.end();
+    }
+  })();
 
-	return stream;
+  return stream;
 };
 
 /**
@@ -1372,887 +1378,893 @@ const streamOpenAICompletionsOnce = (
  * the Anthropic provider via `withEmptyCompletionRetry`.
  */
 export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (model, context, options) =>
-	withEmptyCompletionRetry(model, context, options, streamOpenAICompletionsOnce);
+  withEmptyCompletionRetry(model, context, options, streamOpenAICompletionsOnce);
 
 function createRequestSetup(
-	model: Model<"openai-completions">,
-	context: Context,
-	apiKey?: string,
-	extraHeaders?: Record<string, string>,
-	initiatorOverride?: MessageAttribution,
-	promptCacheSessionId?: string,
+  model: Model<"openai-completions">,
+  context: Context,
+  apiKey?: string,
+  extraHeaders?: Record<string, string>,
+  initiatorOverride?: MessageAttribution,
+  promptCacheSessionId?: string,
 ): OpenAIRequestSetup & { baseUrl: string } {
-	const apiVersion = $env.AZURE_OPENAI_API_VERSION || "2024-10-21";
-	const deploymentName = parseAzureDeploymentNameMap($env.AZURE_OPENAI_DEPLOYMENT_NAME_MAP).get(model.id) ?? model.id;
-	const setup = resolveOpenAIRequestSetup(model, {
-		apiKey,
-		extraHeaders,
-		initiatorOverride,
-		promptCacheSessionId,
-		messages: context.messages,
-		defaultBaseUrl: "https://api.openai.com/v1",
-		// Provider auth/header overlay: Kimi-code hosts require shared client
-		// attribution headers prepended before caller headers. Kept here (not in
-		// the shared helper) because it is provider-specific request setup.
-		prependHeaders: model.provider === "kimi-code" ? getKimiCommonHeaders : undefined,
-		alibabaCodingPlanAuth: true,
-		azureChatCompletions: { apiVersion, deploymentName },
-	});
-	if (!setup.baseUrl) {
-		throw new AIError.ConfigurationError("OpenAI request setup did not resolve a base URL");
-	}
-	return setup as OpenAIRequestSetup & { baseUrl: string };
+  const apiVersion = $env.AZURE_OPENAI_API_VERSION || "2024-10-21";
+  const deploymentName = parseAzureDeploymentNameMap($env.AZURE_OPENAI_DEPLOYMENT_NAME_MAP).get(model.id) ?? model.id;
+  const setup = resolveOpenAIRequestSetup(model, {
+    apiKey,
+    extraHeaders,
+    initiatorOverride,
+    promptCacheSessionId,
+    messages: context.messages,
+    defaultBaseUrl: "https://api.openai.com/v1",
+    // Provider auth/header overlay: Kimi-code hosts require shared client
+    // attribution headers prepended before caller headers. Kept here (not in
+    // the shared helper) because it is provider-specific request setup.
+    prependHeaders: model.provider === "kimi-code" ? getKimiCommonHeaders : undefined,
+    alibabaCodingPlanAuth: true,
+    azureChatCompletions: { apiVersion, deploymentName },
+  });
+  if (!setup.baseUrl) {
+    throw new AIError.ConfigurationError("OpenAI request setup did not resolve a base URL");
+  }
+  return setup as OpenAIRequestSetup & { baseUrl: string };
 }
 
 function resolveOpenAICompatForRequest(
-	model: Model<"openai-completions">,
-	options: OpenAICompletionsOptions | undefined,
+  model: Model<"openai-completions">,
+  options: OpenAICompletionsOptions | undefined,
 ): OpenAICompatPolicy {
-	return resolveOpenAICompatPolicy(model, {
-		endpoint: "chat-completions",
-		reasoning: options?.reasoning,
-		disableReasoning: options?.disableReasoning,
-		toolChoice: mapToOpenAICompletionsToolChoice(options?.toolChoice),
-	});
+  return resolveOpenAICompatPolicy(model, {
+    endpoint: "chat-completions",
+    reasoning: options?.reasoning,
+    disableReasoning: options?.disableReasoning,
+    toolChoice: mapToOpenAICompletionsToolChoice(options?.toolChoice),
+  });
 }
 
 function dropOpenRouterKimiForcedToolReasoning(
-	params: OpenAICompletionsParams,
-	model: Model<"openai-completions">,
-	policy: OpenAICompatPolicy,
+  params: OpenAICompletionsParams,
+  model: Model<"openai-completions">,
+  policy: OpenAICompatPolicy,
 ): void {
-	if (
-		policy.reasoning.disableReason === "forced-tool-choice" &&
-		policy.reasoning.disableMode === "openrouter-enabled-false" &&
-		policy.compat.isOpenRouterHost &&
-		isKimiModelId(model.id)
-	) {
-		delete params.reasoning;
-	}
+  if (
+    policy.reasoning.disableReason === "forced-tool-choice" &&
+    policy.reasoning.disableMode === "openrouter-enabled-false" &&
+    policy.compat.isOpenRouterHost &&
+    isKimiModelId(model.id)
+  ) {
+    delete params.reasoning;
+  }
 }
 
 function buildParams(
-	model: Model<"openai-completions">,
-	context: Context,
-	options: OpenAICompletionsOptions | undefined,
-	toolStrictModeOverride?: ToolStrictModeOverride,
+  model: Model<"openai-completions">,
+  context: Context,
+  options: OpenAICompletionsOptions | undefined,
+  toolStrictModeOverride?: ToolStrictModeOverride,
 ): {
-	params: OpenAICompletionsParams;
-	toolStrictMode: AppliedToolStrictMode;
-	strictToolsApplied: boolean;
+  params: OpenAICompletionsParams;
+  toolStrictMode: AppliedToolStrictMode;
+  strictToolsApplied: boolean;
 } {
-	const initialPolicy = resolveOpenAICompatForRequest(model, options);
-	const initialCompat = initialPolicy.compat as ResolvedOpenAICompat;
+  const initialPolicy = resolveOpenAICompatForRequest(model, options);
+  const initialCompat = initialPolicy.compat as ResolvedOpenAICompat;
 
-	const requestModelId = resolveOpenAICompletionsModelId(model, options);
-	const params: OpenAICompletionsParams = {
-		model: requestModelId,
-		messages: [],
-		stream: true,
-	};
-	let toolStrictMode: AppliedToolStrictMode = "none";
-	let strictToolsApplied = false;
+  const requestModelId = resolveOpenAICompletionsModelId(model, options);
+  const params: OpenAICompletionsParams = {
+    model: requestModelId,
+    messages: [],
+    stream: true,
+  };
+  let toolStrictMode: AppliedToolStrictMode = "none";
+  let strictToolsApplied = false;
 
-	if (initialCompat.supportsUsageInStreaming !== false) {
-		params.stream_options = { include_usage: true };
-	}
+  if (initialCompat.supportsUsageInStreaming !== false) {
+    params.stream_options = { include_usage: true };
+  }
 
-	if (initialCompat.supportsStore) {
-		params.store = false;
-	}
+  if (initialCompat.supportsStore) {
+    params.store = false;
+  }
 
-	// OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
-	// sampling params with a 400 on every serving host (#5606).
-	if (initialCompat.supportsSamplingParams) {
-		if (options?.temperature !== undefined) {
-			params.temperature = options.temperature;
-		}
-		if (options?.topP !== undefined) {
-			params.top_p = options.topP;
-		}
-		if (options?.topK !== undefined) {
-			params.top_k = options.topK;
-		}
-		if (options?.minP !== undefined) {
-			params.min_p = options.minP;
-		}
-		if (options?.presencePenalty !== undefined) {
-			params.presence_penalty = options.presencePenalty;
-		}
-		if (options?.repetitionPenalty !== undefined) {
-			params.repetition_penalty = options.repetitionPenalty;
-		}
-		if (options?.frequencyPenalty !== undefined) {
-			params.frequency_penalty = options.frequencyPenalty;
-		}
-	}
-	if (options?.stopSequences?.length) {
-		const seqs = options.stopSequences;
-		params.stop = seqs.length === 1 ? seqs[0] : seqs.slice(0, 4);
-	}
-	applyOpenAIServiceTier(params, options?.serviceTier, model);
+  // OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
+  // sampling params with a 400 on every serving host (#5606).
+  if (initialCompat.supportsSamplingParams) {
+    if (options?.temperature !== undefined) {
+      params.temperature = options.temperature;
+    }
+    if (options?.topP !== undefined) {
+      params.top_p = options.topP;
+    }
+    if (options?.topK !== undefined) {
+      params.top_k = options.topK;
+    }
+    if (options?.minP !== undefined) {
+      params.min_p = options.minP;
+    }
+    if (options?.presencePenalty !== undefined) {
+      params.presence_penalty = options.presencePenalty;
+    }
+    if (options?.repetitionPenalty !== undefined) {
+      params.repetition_penalty = options.repetitionPenalty;
+    }
+    if (options?.frequencyPenalty !== undefined) {
+      params.frequency_penalty = options.frequencyPenalty;
+    }
+  }
+  if (options?.stopSequences?.length) {
+    const seqs = options.stopSequences;
+    params.stop = seqs.length === 1 ? seqs[0] : seqs.slice(0, 4);
+  }
+  applyOpenAIServiceTier(params, options?.serviceTier, model);
 
-	if (context.tools?.length) {
-		const builtTools = convertTools(context.tools, initialCompat, toolStrictModeOverride);
-		params.tools = builtTools.tools;
-		toolStrictMode = builtTools.toolStrictMode;
-		strictToolsApplied = builtTools.strictToolsApplied;
-	} else if (context.tools === undefined && hasToolHistory(context.messages)) {
-		// Anthropic (via LiteLLM/proxy) requires the `tools` param when the conversation
-		// contains tool_calls/tool_results, even when no tools are offered this turn.
-		// Only inject the sentinel when the caller passed `context.tools = undefined`
-		// (i.e. tools were not specified at all). An explicit `context.tools = []` means
-		// the caller opted out of tools for this turn (as /btw and IRC background replies
-		// do via AgentSession.runEphemeralTurn) — honour that intent and emit nothing,
-		// so LiteLLM → Bedrock never sees an empty `toolConfig` block.
-		params.tools = [];
-	}
+  if (context.tools?.length) {
+    const builtTools = convertTools(context.tools, initialCompat, toolStrictModeOverride);
+    params.tools = builtTools.tools;
+    toolStrictMode = builtTools.toolStrictMode;
+    strictToolsApplied = builtTools.strictToolsApplied;
+  } else if (context.tools === undefined && hasToolHistory(context.messages)) {
+    // Anthropic (via LiteLLM/proxy) requires the `tools` param when the conversation
+    // contains tool_calls/tool_results, even when no tools are offered this turn.
+    // Only inject the sentinel when the caller passed `context.tools = undefined`
+    // (i.e. tools were not specified at all). An explicit `context.tools = []` means
+    // the caller opted out of tools for this turn (as /btw and IRC background replies
+    // do via AgentSession.runEphemeralTurn) — honour that intent and emit nothing,
+    // so LiteLLM → Bedrock never sees an empty `toolConfig` block.
+    params.tools = [];
+  }
 
-	if (options?.toolChoice && initialCompat.supportsToolChoice) {
-		params.tool_choice = mapToOpenAICompletionsToolChoice(options.toolChoice);
-	}
-	if (
-		typeof params.tool_choice === "object" &&
-		params.tool_choice !== null &&
-		!initialCompat.supportsNamedToolChoice
-	) {
-		params.tool_choice = "required";
-	}
-	if (isForcedToolChoice(params.tool_choice) && !initialCompat.supportsForcedToolChoice) {
-		// Some thinking-required OpenAI-compatible models reject forced
-		// `tool_choice` while still accepting tools with the default auto
-		// selector. Keep the tool available and let the model choose it.
-		params.tool_choice = "auto";
-	}
+  if (options?.toolChoice && initialCompat.supportsToolChoice) {
+    params.tool_choice = mapToOpenAICompletionsToolChoice(options.toolChoice);
+  }
+  if (
+    typeof params.tool_choice === "object" &&
+    params.tool_choice !== null &&
+    !initialCompat.supportsNamedToolChoice
+  ) {
+    params.tool_choice = "required";
+  }
+  if (isForcedToolChoice(params.tool_choice) && !initialCompat.supportsForcedToolChoice) {
+    // Some thinking-required OpenAI-compatible models reject forced
+    // `tool_choice` while still accepting tools with the default auto
+    // selector. Keep the tool available and let the model choose it.
+    params.tool_choice = "auto";
+  }
 
-	if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {
-		// `tool_choice: "none"` with no tools to gate is redundant and also
-		// trips LiteLLM → Bedrock: the proxy serializes the directive into a
-		// `toolConfig` block, and Bedrock requires `toolConfig.tools` to be
-		// non-empty whenever the conversation already holds `toolUse`/`toolResult`
-		// content. Drop it whenever the resolved tools list is missing or empty.
-		// Side-channel turns hit this: `/btw` and IRC background replies route
-		// through `AgentSession.runEphemeralTurn`, which sets `context.tools = []`
-		// and `toolChoice: "none"` (see packages/coding-agent/src/session/agent-session.ts).
-		delete params.tool_choice;
-	}
+  if (params.tool_choice === "none" && (!Array.isArray(params.tools) || params.tools.length === 0)) {
+    // `tool_choice: "none"` with no tools to gate is redundant and also
+    // trips LiteLLM → Bedrock: the proxy serializes the directive into a
+    // `toolConfig` block, and Bedrock requires `toolConfig.tools` to be
+    // non-empty whenever the conversation already holds `toolUse`/`toolResult`
+    // content. Drop it whenever the resolved tools list is missing or empty.
+    // Side-channel turns hit this: `/btw` and IRC background replies route
+    // through `AgentSession.runEphemeralTurn`, which sets `context.tools = []`
+    // and `toolChoice: "none"` (see packages/coding-agent/src/session/agent-session.ts).
+    delete params.tool_choice;
+  }
 
-	const forcedToolName =
-		typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice
-			? params.tool_choice.function.name
-			: undefined;
-	if (
-		forcedToolName !== undefined &&
-		(!Array.isArray(params.tools) ||
-			!params.tools.some(tool => tool.type === "function" && tool.function.name === forcedToolName))
-	) {
-		// A forced named tool_choice is only valid when the same request offers
-		// that function in `tools`. Active-tool filtering normally enforces this
-		// before provider dispatch; this guard keeps raw provider callers from
-		// emitting a self-inconsistent OpenAI-compatible payload.
-		delete params.tool_choice;
-	}
+  const forcedToolName =
+    typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice
+      ? params.tool_choice.function.name
+      : undefined;
+  if (
+    forcedToolName !== undefined &&
+    (!Array.isArray(params.tools) ||
+      !params.tools.some(tool => tool.type === "function" && tool.function.name === forcedToolName))
+  ) {
+    // A forced named tool_choice is only valid when the same request offers
+    // that function in `tools`. Active-tool filtering normally enforces this
+    // before provider dispatch; this guard keeps raw provider callers from
+    // emitting a self-inconsistent OpenAI-compatible payload.
+    delete params.tool_choice;
+  }
 
-	const finalPolicy = resolveOpenAICompatPolicy(model, {
-		endpoint: "chat-completions",
-		reasoning: options?.reasoning,
-		disableReasoning: options?.disableReasoning,
-		toolChoice: params.tool_choice,
-	});
-	const compat = finalPolicy.compat as ResolvedOpenAICompat;
-	const messages = convertMessages(model, context, compat);
-	maybeAddAnthropicCacheControl(compat, messages);
-	params.messages = messages;
-	const outputToken = resolveOpenAIOutputTokenParam({
-		field: compat.maxTokensField,
-		maxTokens: options?.maxTokens,
-		maxTokensExplicit: options?.maxTokensExplicit ?? options?.maxTokens !== undefined,
-		modelMaxTokens: model.maxTokens,
-		omitMaxOutputTokens: model.omitMaxOutputTokens ?? false,
-		isOpenRouterHost: compat.isOpenRouterHost,
-		alwaysSendMaxTokens: compat.alwaysSendMaxTokens,
-		providerOutputClamp: resolveOpenAICompletionsOutputClamp(model, compat),
-	});
-	if (outputToken) {
-		if (outputToken.field === "max_tokens") {
-			params.max_tokens = outputToken.value;
-		} else if (outputToken.field === "max_completion_tokens") {
-			params.max_completion_tokens = outputToken.value;
-		}
-	}
-	applyChatCompletionsToolStream(params, model, compat);
+  const finalPolicy = resolveOpenAICompatPolicy(model, {
+    endpoint: "chat-completions",
+    reasoning: options?.reasoning,
+    disableReasoning: options?.disableReasoning,
+    toolChoice: params.tool_choice,
+  });
+  const compat = finalPolicy.compat as ResolvedOpenAICompat;
+  const messages = convertMessages(model, context, compat);
+  maybeAddAnthropicCacheControl(compat, messages);
+  params.messages = messages;
+  const outputToken = resolveOpenAIOutputTokenParam({
+    field: compat.maxTokensField,
+    maxTokens: options?.maxTokens,
+    maxTokensExplicit: options?.maxTokensExplicit ?? options?.maxTokens !== undefined,
+    modelMaxTokens: model.maxTokens,
+    omitMaxOutputTokens: model.omitMaxOutputTokens ?? false,
+    isOpenRouterHost: compat.isOpenRouterHost,
+    alwaysSendMaxTokens: compat.alwaysSendMaxTokens,
+    providerOutputClamp: resolveOpenAICompletionsOutputClamp(model, compat),
+  });
+  if (outputToken) {
+    if (outputToken.field === "max_tokens") {
+      params.max_tokens = outputToken.value;
+    } else if (outputToken.field === "max_completion_tokens") {
+      params.max_completion_tokens = outputToken.value;
+    }
+  }
+  applyChatCompletionsToolStream(params, model, compat);
 
-	applyChatCompletionsCompatPolicy(params, finalPolicy);
-	dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
+  applyChatCompletionsCompatPolicy(params, finalPolicy);
+  dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
 
-	applyOpenAIGatewayRouting(params, compat);
+  applyOpenAIGatewayRouting(params, compat);
 
-	applyOpenAIExtraBody(params, compat.extraBody, {
-		dropThinkingWhenReasoningEffort: compat.dropThinkingWhenReasoningEffort,
-	});
+  applyOpenAIExtraBody(params, compat.extraBody, {
+    dropThinkingWhenReasoningEffort: compat.dropThinkingWhenReasoningEffort,
+  });
 
-	return { params, toolStrictMode, strictToolsApplied };
+  return { params, toolStrictMode, strictToolsApplied };
 }
 
 export function parseChunkUsage(
-	rawUsage: object,
-	model: Model<"openai-completions">,
-	premiumRequests: number | undefined,
+  rawUsage: object,
+  model: Model<"openai-completions">,
+  premiumRequests: number | undefined,
 ): AssistantMessage["usage"] {
-	const usageLike = rawUsage as OpenAICompletionsUsageLike;
-	const rawPromptTokenDetails = usageLike.prompt_tokens_details;
-	const promptTokenDetails =
-		typeof rawPromptTokenDetails === "object" && rawPromptTokenDetails !== null
-			? (rawPromptTokenDetails as OpenAICompletionsPromptTokenDetails)
-			: undefined;
-	const rawCompletionTokenDetails = usageLike.completion_tokens_details;
-	const completionTokenDetails =
-		typeof rawCompletionTokenDetails === "object" && rawCompletionTokenDetails !== null
-			? (rawCompletionTokenDetails as OpenAICompletionsCompletionTokenDetails)
-			: undefined;
-	const completionTokens = usageLike.completion_tokens;
-	const promptTokens = usageLike.prompt_tokens;
-	const cachedTokens = usageLike.cached_tokens;
-	const promptCacheHitTokens = usageLike.prompt_cache_hit_tokens;
-	const promptCacheMissTokens = usageLike.prompt_cache_miss_tokens;
-	const promptTokenCachedTokens = promptTokenDetails?.cached_tokens;
-	const completionReasoningTokens = completionTokenDetails?.reasoning_tokens;
-	const cacheWriteTokens = promptTokenDetails?.cache_write_tokens;
-	const outputTokens = typeof completionTokens === "number" ? completionTokens : 0;
-	const accounting = calculateOpenAIUsageAccounting({
-		promptTokens: typeof promptTokens === "number" ? promptTokens : 0,
-		outputTokens,
-		cachedTokens: firstPositiveNumber(cachedTokens, promptCacheHitTokens, promptTokenCachedTokens),
-		reasoningTokens: typeof completionReasoningTokens === "number" ? completionReasoningTokens : 0,
-		cacheWriteOpenRouter: typeof cacheWriteTokens === "number" ? cacheWriteTokens : undefined,
-		cacheWriteDeepSeek: typeof promptCacheMissTokens === "number" ? promptCacheMissTokens : undefined,
-		hasDeepSeekCacheHitAndMiss: typeof promptCacheHitTokens === "number" && typeof promptCacheMissTokens === "number",
-	});
-	const usage: AssistantMessage["usage"] = {
-		...accounting,
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		...(premiumRequests !== undefined ? { premiumRequests } : {}),
-	};
-	calculateCost(model, usage);
-	applyOpenRouterReportedCost(model, usage, rawUsage);
-	return usage;
+  const usageLike = rawUsage as OpenAICompletionsUsageLike;
+  const rawPromptTokenDetails = usageLike.prompt_tokens_details;
+  const promptTokenDetails =
+    typeof rawPromptTokenDetails === "object" && rawPromptTokenDetails !== null
+      ? (rawPromptTokenDetails as OpenAICompletionsPromptTokenDetails)
+      : undefined;
+  const rawCompletionTokenDetails = usageLike.completion_tokens_details;
+  const completionTokenDetails =
+    typeof rawCompletionTokenDetails === "object" && rawCompletionTokenDetails !== null
+      ? (rawCompletionTokenDetails as OpenAICompletionsCompletionTokenDetails)
+      : undefined;
+  const completionTokens = usageLike.completion_tokens;
+  const promptTokens = usageLike.prompt_tokens;
+  const cachedTokens = usageLike.cached_tokens;
+  const promptCacheHitTokens = usageLike.prompt_cache_hit_tokens;
+  const promptCacheMissTokens = usageLike.prompt_cache_miss_tokens;
+  const promptTokenCachedTokens = promptTokenDetails?.cached_tokens;
+  const completionReasoningTokens = completionTokenDetails?.reasoning_tokens;
+  const cacheWriteTokens = promptTokenDetails?.cache_write_tokens;
+  const outputTokens = typeof completionTokens === "number" ? completionTokens : 0;
+  const accounting = calculateOpenAIUsageAccounting({
+    promptTokens: typeof promptTokens === "number" ? promptTokens : 0,
+    outputTokens,
+    cachedTokens: firstPositiveNumber(cachedTokens, promptCacheHitTokens, promptTokenCachedTokens),
+    reasoningTokens: typeof completionReasoningTokens === "number" ? completionReasoningTokens : 0,
+    cacheWriteOpenRouter: typeof cacheWriteTokens === "number" ? cacheWriteTokens : undefined,
+    cacheWriteDeepSeek: typeof promptCacheMissTokens === "number" ? promptCacheMissTokens : undefined,
+    hasDeepSeekCacheHitAndMiss: typeof promptCacheHitTokens === "number" && typeof promptCacheMissTokens === "number",
+  });
+  const usage: AssistantMessage["usage"] = {
+    ...accounting,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    ...(premiumRequests !== undefined ? { premiumRequests } : {}),
+  };
+  calculateCost(model, usage);
+  applyOpenRouterReportedCost(model, usage, rawUsage);
+  return usage;
 }
 
 function maybeAddAnthropicCacheControl(compat: ResolvedOpenAICompat, messages: ChatCompletionMessageParam[]): void {
-	if (compat.cacheControlFormat !== "anthropic") return;
-	// Anthropic-style caching requires cache_control on a text part. Add a breakpoint
-	// on the last user/assistant message (walking backwards until we find text content).
-	for (let i = messages.length - 1; i >= 0; i--) {
-		const msg = messages[i];
-		if (msg.role !== "user" && msg.role !== "assistant" && msg.role !== "developer") continue;
+  if (compat.cacheControlFormat !== "anthropic") return;
+  // Anthropic-style caching requires cache_control on a text part. Add a breakpoint
+  // on the last user/assistant message (walking backwards until we find text content).
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user" && msg.role !== "assistant" && msg.role !== "developer") continue;
 
-		const content = msg.content;
-		if (typeof content === "string") {
-			if (content.trim().length === 0) continue;
-			msg.content = [
-				Object.assign({ type: "text" as const, text: content }, { cache_control: { type: "ephemeral" } }),
-			];
-			return;
-		}
+    const content = msg.content;
+    if (typeof content === "string") {
+      if (content.trim().length === 0) continue;
+      msg.content = [
+        Object.assign({ type: "text" as const, text: content }, { cache_control: { type: "ephemeral" } }),
+      ];
+      return;
+    }
 
-		if (!Array.isArray(content)) continue;
+    if (!Array.isArray(content)) continue;
 
-		// Find last non-empty text part and add cache_control. Empty assistant
-		// content is valid for tool-call replay, but Anthropic/OpenRouter reject
-		// empty text blocks once cache_control turns it into structured content.
-		for (let j = content.length - 1; j >= 0; j--) {
-			const part = content[j];
-			if (part?.type === "text" && part.text.trim().length > 0) {
-				Object.assign(part, { cache_control: { type: "ephemeral" } });
-				return;
-			}
-		}
-	}
+    // Find last non-empty text part and add cache_control. Empty assistant
+    // content is valid for tool-call replay, but Anthropic/OpenRouter reject
+    // empty text blocks once cache_control turns it into structured content.
+    for (let j = content.length - 1; j >= 0; j--) {
+      const part = content[j];
+      if (part?.type === "text" && part.text.trim().length > 0) {
+        Object.assign(part, { cache_control: { type: "ephemeral" } });
+        return;
+      }
+    }
+  }
 }
 
 export function convertMessages(
-	model: Model<"openai-completions">,
-	context: Context,
-	compat: ResolvedOpenAICompat,
+  model: Model<"openai-completions">,
+  context: Context,
+  compat: ResolvedOpenAICompat,
 ): ChatCompletionMessageParam[] {
-	const params: ChatCompletionMessageParam[] = [];
+  const params: ChatCompletionMessageParam[] = [];
 
-	const maxNormalizedToolCallIdLength = compat.requiresMistralToolIds
-		? 9
-		: compat.usesOpenAIToolCallIdLimit
-			? 40
-			: undefined;
-	const duplicateToolCallIdSuffixPrefix = compat.requiresMistralToolIds ? "dup" : undefined;
-	const normalizeToolCallId = (id: string): string => {
-		if (compat.requiresMistralToolIds) return normalizeMistralToolId(id, true);
+  const maxNormalizedToolCallIdLength = compat.requiresMistralToolIds
+    ? 9
+    : compat.usesOpenAIToolCallIdLimit
+      ? 40
+      : undefined;
+  const duplicateToolCallIdSuffixPrefix = compat.requiresMistralToolIds ? "dup" : undefined;
+  const normalizeToolCallId = (id: string): string => {
+    if (compat.requiresMistralToolIds) return normalizeMistralToolId(id, true);
 
-		// Handle pipe-separated IDs from OpenAI Responses API
-		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
-		// These come from providers like github-copilot, openai-codex, opencode
-		// Extract just the call_id part and normalize it
-		if (id.includes("|")) {
-			const [callId] = id.split("|");
-			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
-			return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
-		}
+    // Handle pipe-separated IDs from OpenAI Responses API
+    // Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
+    // These come from providers like github-copilot, openai-codex, opencode
+    // Extract just the call_id part and normalize it
+    if (id.includes("|")) {
+      const [callId] = id.split("|");
+      // Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
+      return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
+    }
 
-		if (compat.usesOpenAIToolCallIdLimit) return id.length > 40 ? id.slice(0, 40) : id;
-		return id;
-	};
-	const transformedMessages = transformMessages(
-		context.messages,
-		model,
-		id => normalizeToolCallId(id),
-		maxNormalizedToolCallIdLength,
-		duplicateToolCallIdSuffixPrefix,
-		compat,
-	);
+    if (compat.usesOpenAIToolCallIdLimit) return id.length > 40 ? id.slice(0, 40) : id;
+    return id;
+  };
+  const transformedMessages = transformMessages(
+    context.messages,
+    model,
+    id => normalizeToolCallId(id),
+    maxNormalizedToolCallIdLength,
+    duplicateToolCallIdSuffixPrefix,
+    compat,
+  );
 
-	const remappedToolCallIds = new Map<string, string[]>();
-	let generatedToolCallIdCounter = 0;
+  const remappedToolCallIds = new Map<string, string[]>();
+  let generatedToolCallIdCounter = 0;
 
-	const generateFallbackToolCallId = (seed: string): string => {
-		generatedToolCallIdCounter += 1;
-		const hash = Bun.hash(`${model.provider}:${model.id}:${seed}:${generatedToolCallIdCounter}`).toString(36);
-		return `call_${hash}`;
-	};
+  const generateFallbackToolCallId = (seed: string): string => {
+    generatedToolCallIdCounter += 1;
+    const hash = Bun.hash(`${model.provider}:${model.id}:${seed}:${generatedToolCallIdCounter}`).toString(36);
+    return `call_${hash}`;
+  };
 
-	const rememberToolCallId = (originalId: string, normalizedId: string): void => {
-		const queue = remappedToolCallIds.get(originalId);
-		if (queue) {
-			queue.push(normalizedId);
-			return;
-		}
-		remappedToolCallIds.set(originalId, [normalizedId]);
-	};
+  const rememberToolCallId = (originalId: string, normalizedId: string): void => {
+    const queue = remappedToolCallIds.get(originalId);
+    if (queue) {
+      queue.push(normalizedId);
+      return;
+    }
+    remappedToolCallIds.set(originalId, [normalizedId]);
+  };
 
-	const consumeToolCallId = (originalId: string): string | null => {
-		const queue = remappedToolCallIds.get(originalId);
-		if (!queue || queue.length === 0) return null;
-		const nextId = queue.shift() ?? null;
-		if (queue.length === 0) remappedToolCallIds.delete(originalId);
-		return nextId;
-	};
+  const consumeToolCallId = (originalId: string): string | null => {
+    const queue = remappedToolCallIds.get(originalId);
+    if (!queue || queue.length === 0) return null;
+    const nextId = queue.shift() ?? null;
+    if (queue.length === 0) remappedToolCallIds.delete(originalId);
+    return nextId;
+  };
 
-	const ensureToolCallId = (rawId: string, seed: string): string => {
-		const normalized = normalizeToolCallId(rawId);
-		if (normalized.trim().length > 0) return normalized;
-		return generateFallbackToolCallId(seed);
-	};
+  const ensureToolCallId = (rawId: string, seed: string): string => {
+    const normalized = normalizeToolCallId(rawId);
+    if (normalized.trim().length > 0) return normalized;
+    return generateFallbackToolCallId(seed);
+  };
 
-	const systemPrompts = normalizeSystemPrompts(context.systemPrompt);
-	if (systemPrompts.length > 0) {
-		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
-		const role = useDeveloperRole ? "developer" : "system";
-		// Default to one block per ordered system prompt so the leading prefix
-		// stays byte-identical between turns and the provider's KV cache can
-		// reuse it. Hosts whose chat templates reject follow-up system messages
-		// (Qwen via vLLM, MiniMax, Alibaba Dashscope, Qwen Portal, …) opt out
-		// via `compat.supportsMultipleSystemMessages = false`; in that mode we
-		// coalesce into a single message joined by `\n\n`.
-		if (compat.supportsMultipleSystemMessages) {
-			for (const systemPrompt of systemPrompts) {
-				params.push({ role, content: systemPrompt });
-			}
-		} else {
-			params.push({ role, content: systemPrompts.join("\n\n") });
-		}
-	}
+  const systemPrompts = normalizeSystemPrompts(context.systemPrompt);
+  if (systemPrompts.length > 0) {
+    const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
+    const role = useDeveloperRole ? "developer" : "system";
+    // Default to one block per ordered system prompt so the leading prefix
+    // stays byte-identical between turns and the provider's KV cache can
+    // reuse it. Hosts whose chat templates reject follow-up system messages
+    // (Qwen via vLLM, MiniMax, Alibaba Dashscope, Qwen Portal, …) opt out
+    // via `compat.supportsMultipleSystemMessages = false`; in that mode we
+    // coalesce into a single message joined by `\n\n`.
+    if (compat.supportsMultipleSystemMessages) {
+      for (const systemPrompt of systemPrompts) {
+        params.push({ role, content: systemPrompt });
+      }
+    } else {
+      params.push({ role, content: systemPrompts.join("\n\n") });
+    }
+  }
 
-	let lastRole: string | null = null;
+  let lastRole: string | null = null;
 
-	for (let i = 0; i < transformedMessages.length; i++) {
-		const msg = transformedMessages[i];
-		// Some providers (e.g. Mistral/Devstral) don't allow user messages directly after tool results
-		// Insert a synthetic assistant message to bridge the gap
-		if (
-			compat.requiresAssistantAfterToolResult &&
-			lastRole === "toolResult" &&
-			(msg.role === "user" || msg.role === "developer")
-		) {
-			params.push({
-				role: "assistant",
-				content: "I have processed the tool results.",
-			});
-		}
+  for (let i = 0; i < transformedMessages.length; i++) {
+    const msg = transformedMessages[i];
+    // Some providers (e.g. Mistral/Devstral) don't allow user messages directly after tool results
+    // Insert a synthetic assistant message to bridge the gap
+    if (
+      compat.requiresAssistantAfterToolResult &&
+      lastRole === "toolResult" &&
+      (msg.role === "user" || msg.role === "developer")
+    ) {
+      params.push({
+        role: "assistant",
+        content: "I have processed the tool results.",
+      });
+    }
 
-		const devAsUser = !compat.supportsDeveloperRole;
-		if (msg.role === "user" || msg.role === "developer") {
-			const role = !devAsUser && msg.role === "developer" ? "developer" : "user";
-			if (typeof msg.content === "string") {
-				const text = msg.content.toWellFormed();
-				if (text.trim().length === 0) continue;
-				params.push({
-					role: role,
-					content: text,
-				});
-			} else {
-				const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
-				const content: ChatCompletionContentPart[] = [];
-				let omittedImages = false;
-				for (const item of msg.content) {
-					if (item.type === "text") {
-						const text = item.text.toWellFormed();
-						if (text.trim().length === 0) continue;
-						content.push({
-							type: "text",
-							text,
-						} satisfies ChatCompletionContentPartText);
-					} else if (supportsImages) {
-						content.push({
-							type: "image_url",
-							image_url: {
-								url: `data:${item.mimeType};base64,${item.data}`,
-								// Chat Completions has no "original"; omit it (provider default).
-								...(item.detail && item.detail !== "original" ? { detail: item.detail } : {}),
-							},
-						} satisfies ChatCompletionContentPartImage);
-					} else {
-						omittedImages = true;
-					}
-				}
-				if (omittedImages) {
-					content.push({
-						type: "text",
-						text: NON_VISION_IMAGE_PLACEHOLDER,
-					} satisfies ChatCompletionContentPartText);
-				}
-				if (content.length === 0) continue;
-				params.push({
-					role: "user",
-					content,
-				});
-			}
-		} else if (msg.role === "assistant") {
-			const assistantMsg: OpenAICompletionsAssistantMessageParam = {
-				role: "assistant",
-				content: null,
-			};
+    const devAsUser = !compat.supportsDeveloperRole;
+    if (msg.role === "user" || msg.role === "developer") {
+      const role = !devAsUser && msg.role === "developer" ? "developer" : "user";
+      if (typeof msg.content === "string") {
+        const text = msg.content.toWellFormed();
+        if (text.trim().length === 0) continue;
+        params.push({
+          role: role,
+          content: text,
+        });
+      } else {
+        const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
+        const content: ChatCompletionContentPart[] = [];
+        let omittedImages = false;
+        for (const item of msg.content) {
+          if (item.type === "text") {
+            const text = item.text.toWellFormed();
+            if (text.trim().length === 0) continue;
+            content.push({
+              type: "text",
+              text,
+            } satisfies ChatCompletionContentPartText);
+          } else if (supportsImages) {
+            content.push({
+              type: "image_url",
+              image_url: {
+                url: `data:${item.mimeType};base64,${item.data}`,
+                // Chat Completions has no "original"; omit it (provider default).
+                ...(item.detail && item.detail !== "original" ? { detail: item.detail } : {}),
+              },
+            } satisfies ChatCompletionContentPartImage);
+          } else {
+            omittedImages = true;
+          }
+        }
+        if (omittedImages) {
+          content.push({
+            type: "text",
+            text: NON_VISION_IMAGE_PLACEHOLDER,
+          } satisfies ChatCompletionContentPartText);
+        }
+        if (content.length === 0) continue;
+        params.push({
+          role: "user",
+          content,
+        });
+      }
+    } else if (msg.role === "assistant") {
+      const assistantMsg: OpenAICompletionsAssistantMessageParam = {
+        role: "assistant",
+        content: null,
+      };
 
-			const textBlocks = msg.content.filter(b => b.type === "text") as TextContent[];
-			// Filter out empty text blocks to avoid API validation errors
-			const nonEmptyTextBlocks = textBlocks.filter(b => b.text && b.text.trim().length > 0);
-			if (nonEmptyTextBlocks.length > 0) {
-				// Always send assistant content as a plain string. Some OpenAI-compatible
-				// backends mirror array-of-text-block payloads back to the model literally,
-				// causing recursive nested content in subsequent turns.
-				// Join ordinary adjacent text blocks with no separator so bridge
-				// stitching, imported transcripts, and streaming chunks keep their
-				// original byte sequence. Demoted-thinking blocks (kDemotedThinking,
-				// synthesized by transformMessages) are the one exception: bare
-				// Anthropic-dialect reasoning would otherwise glue onto the first word
-				// of the visible answer. Insert a paragraph break after them — only
-				// when another block actually follows, so a trailing demoted block
-				// never ships trailing whitespace.
-				assistantMsg.content = nonEmptyTextBlocks
-					.map((b, i) => {
-						const text = b.text.toWellFormed();
-						return isDemotedThinking(b) && i < nonEmptyTextBlocks.length - 1 ? `${text}\n` : text;
-					})
-					.join("");
-			}
+      const textBlocks = msg.content.filter(b => b.type === "text") as TextContent[];
+      // Filter out empty text blocks to avoid API validation errors
+      const nonEmptyTextBlocks = textBlocks.filter(b => b.text && b.text.trim().length > 0);
+      if (nonEmptyTextBlocks.length > 0) {
+        // Always send assistant content as a plain string. Some OpenAI-compatible
+        // backends mirror array-of-text-block payloads back to the model literally,
+        // causing recursive nested content in subsequent turns.
+        // Join ordinary adjacent text blocks with no separator so bridge
+        // stitching, imported transcripts, and streaming chunks keep their
+        // original byte sequence. Demoted-thinking blocks (kDemotedThinking,
+        // synthesized by transformMessages) are the one exception: bare
+        // Anthropic-dialect reasoning would otherwise glue onto the first word
+        // of the visible answer. Insert a paragraph break after them — only
+        // when another block actually follows, so a trailing demoted block
+        // never ships trailing whitespace.
+        assistantMsg.content = nonEmptyTextBlocks
+          .map((b, i) => {
+            const text = b.text.toWellFormed();
+            return isDemotedThinking(b) && i < nonEmptyTextBlocks.length - 1 ? `${text}\n` : text;
+          })
+          .join("");
+      }
 
-			// Handle thinking blocks
-			const thinkingBlocks = msg.content.filter(b => b.type === "thinking") as ThinkingContent[];
-			// Filter out empty thinking blocks to avoid API validation errors
-			const nonEmptyThinkingBlocks = thinkingBlocks.filter(b => b.thinking && b.thinking.trim().length > 0);
-			if (nonEmptyThinkingBlocks.length > 0) {
-				if (compat.requiresThinkingAsText) {
-					const thinkingText = nonEmptyThinkingBlocks
-						.map(b => renderDemotedThinking(model.id, b.thinking))
-						.join(" ");
-					// `content` is a plain string at this point (set above) or null —
-					// never an array. Prepend the demoted thinking to the string form.
-					assistantMsg.content =
-						typeof assistantMsg.content === "string" && assistantMsg.content.length > 0
-							? `${thinkingText} ${assistantMsg.content}`
-							: thinkingText;
-				} else if (compat.requiresReasoningContentForToolCalls) {
-					// Use the streamed signature when the backend accepts whichever
-					// recognized field name was emitted (allowsSynthetic=true). Backends
-					// like opencode-kimi-with-thinking and DeepSeek demand the exact
-					// configured `reasoningContentField` instead, so honor that here
-					// rather than echoing the upstream field name.
-					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
-					const wireField =
-						compat.allowsSyntheticReasoningContentForToolCalls &&
-						(signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text")
-							? signature
-							: signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text"
-								? (compat.reasoningContentField ?? "reasoning_content")
-								: undefined;
-					if (wireField) {
-						assistantMsg[wireField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
-					}
-				} else if (compat.thinkingFormat === "zai" && model.reasoning) {
-					// Z.AI / Zhipu / Moonshot Kimi (native) / Xiaomi MiMo accept
-					// `reasoning_content` as a continuation hint even when they don't
-					// strictly require it. Surfacing the preserved thinking text here
-					// keeps cross-API replays (Z.AI Anthropic → Z.AI OpenAI, etc.)
-					// shipping reasoning as structured `reasoning_content` rather than
-					// folded into conversation text (#3434). Signature is irrelevant on
-					// this path: `transform-messages` strips the source wire-format
-					// signature on cross-API replays before the block reaches us.
-					const reasoningField = compat.reasoningContentField ?? "reasoning_content";
-					assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
-				} else if (compat.replayReasoningContent) {
-					// Local llama.cpp-style servers (llama.cpp, LM Studio, vLLM, Ollama
-					// in openai-completions mode, custom providers pointed at a
-					// loopback baseUrl) re-tokenize the entire prompt every request.
-					// Qwen3 / DeepSeek-R1 / GLM chat templates reconstruct the prior
-					// assistant turn's `<think>` block from `reasoning_content`; if we
-					// drop the field the template re-renders the assistant turn
-					// without thinking content, the rendered tokens diverge from the
-					// slot's existing KV cache, and llama.cpp falls back to full
-					// prompt re-processing (#3528). Honor the streamed signature when
-					// it identifies a recognized wire field so a model that emitted
-					// `reasoning` (some llama.cpp builds) round-trips to the same
-					// field; otherwise fall back to the configured
-					// `reasoningContentField`. Gated by the new compat flag rather
-					// than the existing `requires*` flags because local servers
-					// accept but don't validate the field — they just need it to
-					// preserve cache locality.
-					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
-					const reasoningField: OpenAICompletionsReasoningField =
-						signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text"
-							? signature
-							: (compat.reasoningContentField ?? "reasoning_content");
-					assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
-				}
-			}
+      // Handle thinking blocks
+      const thinkingBlocks = msg.content.filter(b => b.type === "thinking") as ThinkingContent[];
+      // Filter out empty thinking blocks to avoid API validation errors
+      const nonEmptyThinkingBlocks = thinkingBlocks.filter(b => b.thinking && b.thinking.trim().length > 0);
+      if (nonEmptyThinkingBlocks.length > 0) {
+        if (compat.requiresThinkingAsText) {
+          const thinkingText = nonEmptyThinkingBlocks
+            .map(b => renderDemotedThinking(model.id, b.thinking))
+            .join(" ");
+          // `content` is a plain string at this point (set above) or null —
+          // never an array. Prepend the demoted thinking to the string form.
+          assistantMsg.content =
+            typeof assistantMsg.content === "string" && assistantMsg.content.length > 0
+              ? `${thinkingText} ${assistantMsg.content}`
+              : thinkingText;
+        } else if (compat.requiresReasoningContentForToolCalls) {
+          // Use the streamed signature when the backend accepts whichever
+          // recognized field name was emitted (allowsSynthetic=true). Backends
+          // like opencode-kimi-with-thinking and DeepSeek demand the exact
+          // configured `reasoningContentField` instead, so honor that here
+          // rather than echoing the upstream field name.
+          const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
+          const wireField =
+            compat.allowsSyntheticReasoningContentForToolCalls &&
+              (signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text")
+              ? signature
+              : signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text"
+                ? (compat.reasoningContentField ?? "reasoning_content")
+                : undefined;
+          if (wireField) {
+            assistantMsg[wireField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
+          }
+        } else if (compat.thinkingFormat === "zai" && model.reasoning) {
+          // Z.AI / Zhipu / Moonshot Kimi (native) / Xiaomi MiMo accept
+          // `reasoning_content` as a continuation hint even when they don't
+          // strictly require it. Surfacing the preserved thinking text here
+          // keeps cross-API replays (Z.AI Anthropic → Z.AI OpenAI, etc.)
+          // shipping reasoning as structured `reasoning_content` rather than
+          // folded into conversation text (#3434). Signature is irrelevant on
+          // this path: `transform-messages` strips the source wire-format
+          // signature on cross-API replays before the block reaches us.
+          const reasoningField = compat.reasoningContentField ?? "reasoning_content";
+          assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
+        } else if (compat.replayReasoningContent) {
+          // Local llama.cpp-style servers (llama.cpp, LM Studio, vLLM, Ollama
+          // in openai-completions mode, custom providers pointed at a
+          // loopback baseUrl) re-tokenize the entire prompt every request.
+          // Qwen3 / DeepSeek-R1 / GLM chat templates reconstruct the prior
+          // assistant turn's `<think>` block from `reasoning_content`; if we
+          // drop the field the template re-renders the assistant turn
+          // without thinking content, the rendered tokens diverge from the
+          // slot's existing KV cache, and llama.cpp falls back to full
+          // prompt re-processing (#3528). Honor the streamed signature when
+          // it identifies a recognized wire field so a model that emitted
+          // `reasoning` (some llama.cpp builds) round-trips to the same
+          // field; otherwise fall back to the configured
+          // `reasoningContentField`. Gated by the new compat flag rather
+          // than the existing `requires*` flags because local servers
+          // accept but don't validate the field — they just need it to
+          // preserve cache locality.
+          const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
+          const reasoningField: OpenAICompletionsReasoningField =
+            signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text"
+              ? signature
+              : (compat.reasoningContentField ?? "reasoning_content");
+          assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
+        }
+      }
 
-			if (compat.requiresReasoningContentForToolCalls) {
-				const streamedReasoningField = nonEmptyThinkingBlocks[0]?.thinkingSignature;
-				const reasoningField =
-					compat.allowsSyntheticReasoningContentForToolCalls &&
-					(streamedReasoningField === "reasoning_content" ||
-						streamedReasoningField === "reasoning" ||
-						streamedReasoningField === "reasoning_text")
-						? streamedReasoningField
-						: (compat.reasoningContentField ?? "reasoning_content");
-				const reasoningContent = assistantMsg[reasoningField];
-				if (!reasoningContent) {
-					const reasoning = assistantMsg.reasoning;
-					const reasoningText = assistantMsg.reasoning_text;
-					if (reasoning && reasoningField !== "reasoning") {
-						assistantMsg[reasoningField] = reasoning;
-					} else if (reasoningText && reasoningField !== "reasoning_text") {
-						assistantMsg[reasoningField] = reasoningText;
-					} else if (nonEmptyThinkingBlocks.length > 0) {
-						assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
-					}
-				}
-			}
+      if (compat.requiresReasoningContentForToolCalls) {
+        const streamedReasoningField = nonEmptyThinkingBlocks[0]?.thinkingSignature;
+        const reasoningField =
+          compat.allowsSyntheticReasoningContentForToolCalls &&
+            (streamedReasoningField === "reasoning_content" ||
+              streamedReasoningField === "reasoning" ||
+              streamedReasoningField === "reasoning_text")
+            ? streamedReasoningField
+            : (compat.reasoningContentField ?? "reasoning_content");
+        const reasoningContent = assistantMsg[reasoningField];
+        if (!reasoningContent) {
+          const reasoning = assistantMsg.reasoning;
+          const reasoningText = assistantMsg.reasoning_text;
+          if (reasoning && reasoningField !== "reasoning") {
+            assistantMsg[reasoningField] = reasoning;
+          } else if (reasoningText && reasoningField !== "reasoning_text") {
+            assistantMsg[reasoningField] = reasoningText;
+          } else if (nonEmptyThinkingBlocks.length > 0) {
+            assistantMsg[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
+          }
+        }
+      }
 
-			const toolCalls = msg.content.filter(b => b.type === "toolCall") as ToolCall[];
-			// Replay reasoning_content on assistant turns for backends that validate
-			// thinking-mode history. DeepSeek V4 requires reasoning_content on EVERY
-			// assistant turn once a prior turn included it — not just tool-call turns.
-			// The replay logic has three tiers:
-			//   1. Recover from thinking blocks with valid signatures (covers same-model replay
-			//      where nonEmptyThinkingBlocks may have filtered out empty-text blocks)
-			//   2. For providers that require the field but returned no reasoning at all
-			//      (e.g. proxy-stripped reasoning_content), emit an empty string
-			//   3. For providers that accept synthetic placeholders (Kimi, OpenRouter), emit "."
-			// DeepSeek V4 rejects synthetic "." placeholders — it validates the exact value —
-			// so the allowsSyntheticReasoningContentForToolCalls flag controls tier 3.
-			const canUseSyntheticReasoningContent =
-				compat.requiresReasoningContentForToolCalls &&
-				compat.allowsSyntheticReasoningContentForToolCalls &&
-				(compat.thinkingFormat === "openai" ||
-					compat.thinkingFormat === "openrouter" ||
-					compat.thinkingFormat === "zai");
-			// DeepSeek-compatible reasoning models require reasoning_content on all
-			// assistant turns. Providers that allow placeholders only need it on
-			// tool-call turns.
-			const needsReasoningOnAllTurns = compat.requiresReasoningContentForAllAssistantTurns;
-			const needsReasoningField = needsReasoningOnAllTurns || toolCalls.length > 0;
-			let hasReasoningField =
-				assistantMsg.reasoning_content !== undefined ||
-				assistantMsg.reasoning !== undefined ||
-				assistantMsg.reasoning_text !== undefined;
-			// Tier 1: Recover reasoning_content from ALL thinking blocks (including empty-text
-			// ones) when the provider requires exact replay and rejects synthetic placeholders.
-			// This covers the case where thinking blocks have valid signatures but were excluded
-			// by the nonEmptyThinkingBlocks filter above, or where thinking text is empty but
-			// the signature identifies the correct field name for replay.
-			// Only recognized OpenAI-compat reasoning field names qualify — opaque signatures
-			// from other providers (Anthropic encrypted, OpenAI Responses JSON, etc.) are not
-			// valid property names for the wire message.
-			if (
-				needsReasoningField &&
-				!hasReasoningField &&
-				compat.requiresReasoningContentForToolCalls &&
-				!compat.allowsSyntheticReasoningContentForToolCalls
-			) {
-				const allThinkingBlocks = msg.content.filter(b => b.type === "thinking") as ThinkingContent[];
-				if (allThinkingBlocks.length > 0) {
-					const signature = allThinkingBlocks[0].thinkingSignature;
-					if (signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text") {
-						const reasoningField = compat.reasoningContentField ?? "reasoning_content";
-						assistantMsg[reasoningField] = allThinkingBlocks.map(b => b.thinking).join("\n");
-						hasReasoningField = true;
-					}
-				}
-			}
-			// Tier 2: When the provider requires reasoning_content but there are genuinely no
-			// thinking blocks at all (e.g. proxy stripped reasoning_content from the response),
-			// emit an empty string. The field must be present; an empty string is the most honest
-			// representation of "no reasoning was captured."
-			if (
-				needsReasoningField &&
-				!hasReasoningField &&
-				compat.requiresReasoningContentForToolCalls &&
-				!compat.allowsSyntheticReasoningContentForToolCalls
-			) {
-				const reasoningField = compat.reasoningContentField ?? "reasoning_content";
-				assistantMsg[reasoningField] = "";
-				hasReasoningField = true;
-			}
-			// Tier 3: For providers that accept synthetic placeholders (Kimi, OpenRouter).
-			if (toolCalls.length > 0 && canUseSyntheticReasoningContent && !hasReasoningField) {
-				const reasoningField = compat.reasoningContentField ?? "reasoning_content";
-				assistantMsg[reasoningField] = ".";
-				hasReasoningField = true;
-			}
-			if (toolCalls.length > 0) {
-				assistantMsg.tool_calls = toolCalls.map((tc, toolCallIndex) => {
-					const toolCallId = ensureToolCallId(tc.id, `${i}:${toolCallIndex}:${tc.name}`);
-					rememberToolCallId(tc.id, toolCallId);
-					return {
-						id: normalizeMistralToolId(toolCallId, compat.requiresMistralToolIds),
-						type: "function" as const,
-						function: {
-							name: tc.name,
-							arguments: serializeToolArguments(tc.arguments),
-						},
-					};
-				});
-				const reasoningDetails = toolCalls
-					.filter(tc => tc.thoughtSignature)
-					.map(tc => {
-						try {
-							const parsed: unknown = JSON.parse(tc.thoughtSignature!);
-							return parsed;
-						} catch {
-							return null;
-						}
-					})
-					.filter(Boolean);
-				if (reasoningDetails.length > 0) {
-					assistantMsg.reasoning_details = reasoningDetails;
-				}
-			}
-			// Some OpenAI-compatible backends concatenate assistant content as a
-			// string even for tool-call replay. OpenAI accepts an empty string here;
-			// null trips strict/proxy implementations before the tool result is read.
-			if (assistantMsg.content === null && (hasReasoningField || assistantMsg.tool_calls)) {
-				assistantMsg.content = "";
-			}
-			// Skip assistant messages that have no content, no tool calls, and no reasoning payload.
-			// Some OpenAI-compatible backends require replaying reasoning-only assistant turns
-			// so follow-up requests preserve the provider-specific reasoning field name.
-			const content = assistantMsg.content;
-			const hasContent =
-				content !== null &&
-				content !== undefined &&
-				(typeof content === "string" ? content.length > 0 : content.length > 0);
-			if (!hasContent && assistantMsg.tool_calls && compat.requiresAssistantContentForToolCalls) {
-				assistantMsg.content = ".";
-			}
-			if (!hasContent && !assistantMsg.tool_calls && !hasReasoningField) {
-				continue;
-			}
-			params.push(assistantMsg);
-		} else if (msg.role === "toolResult") {
-			// Batch consecutive tool results and collect all images
-			const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
-			let j = i;
+      const toolCalls = msg.content.filter(b => b.type === "toolCall") as ToolCall[];
+      // Replay reasoning_content on assistant turns for backends that validate
+      // thinking-mode history. DeepSeek V4 requires reasoning_content on EVERY
+      // assistant turn once a prior turn included it — not just tool-call turns.
+      // The replay logic has three tiers:
+      //   1. Recover from thinking blocks with valid signatures (covers same-model replay
+      //      where nonEmptyThinkingBlocks may have filtered out empty-text blocks)
+      //   2. For providers that require the field but returned no reasoning at all
+      //      (e.g. proxy-stripped reasoning_content), emit an empty string
+      //   3. For providers that accept synthetic placeholders (Kimi, OpenRouter), emit "."
+      // DeepSeek V4 rejects synthetic "." placeholders — it validates the exact value —
+      // so the allowsSyntheticReasoningContentForToolCalls flag controls tier 3.
+      const canUseSyntheticReasoningContent =
+        compat.requiresReasoningContentForToolCalls &&
+        compat.allowsSyntheticReasoningContentForToolCalls &&
+        (compat.thinkingFormat === "openai" ||
+          compat.thinkingFormat === "openrouter" ||
+          compat.thinkingFormat === "zai");
+      // DeepSeek-compatible reasoning models require reasoning_content on all
+      // assistant turns. Providers that allow placeholders only need it on
+      // tool-call turns.
+      const needsReasoningOnAllTurns = compat.requiresReasoningContentForAllAssistantTurns;
+      const needsReasoningField = needsReasoningOnAllTurns || toolCalls.length > 0;
+      let hasReasoningField =
+        assistantMsg.reasoning_content !== undefined ||
+        assistantMsg.reasoning !== undefined ||
+        assistantMsg.reasoning_text !== undefined;
+      // Tier 1: Recover reasoning_content from ALL thinking blocks (including empty-text
+      // ones) when the provider requires exact replay and rejects synthetic placeholders.
+      // This covers the case where thinking blocks have valid signatures but were excluded
+      // by the nonEmptyThinkingBlocks filter above, or where thinking text is empty but
+      // the signature identifies the correct field name for replay.
+      // Only recognized OpenAI-compat reasoning field names qualify — opaque signatures
+      // from other providers (Anthropic encrypted, OpenAI Responses JSON, etc.) are not
+      // valid property names for the wire message.
+      if (
+        needsReasoningField &&
+        !hasReasoningField &&
+        compat.requiresReasoningContentForToolCalls &&
+        !compat.allowsSyntheticReasoningContentForToolCalls
+      ) {
+        const allThinkingBlocks = msg.content.filter(b => b.type === "thinking") as ThinkingContent[];
+        if (allThinkingBlocks.length > 0) {
+          const signature = allThinkingBlocks[0].thinkingSignature;
+          if (signature === "reasoning_content" || signature === "reasoning" || signature === "reasoning_text") {
+            const reasoningField = compat.reasoningContentField ?? "reasoning_content";
+            assistantMsg[reasoningField] = allThinkingBlocks.map(b => b.thinking).join("\n");
+            hasReasoningField = true;
+          }
+        }
+      }
+      // Tier 2: When the provider requires reasoning_content but there are genuinely no
+      // thinking blocks at all (e.g. proxy stripped reasoning_content from the response),
+      // emit an empty string. The field must be present; an empty string is the most honest
+      // representation of "no reasoning was captured."
+      if (
+        needsReasoningField &&
+        !hasReasoningField &&
+        compat.requiresReasoningContentForToolCalls &&
+        !compat.allowsSyntheticReasoningContentForToolCalls
+      ) {
+        const reasoningField = compat.reasoningContentField ?? "reasoning_content";
+        assistantMsg[reasoningField] = "";
+        hasReasoningField = true;
+      }
+      // Tier 3: For providers that accept synthetic placeholders (Kimi, OpenRouter).
+      if (toolCalls.length > 0 && canUseSyntheticReasoningContent && !hasReasoningField) {
+        const reasoningField = compat.reasoningContentField ?? "reasoning_content";
+        assistantMsg[reasoningField] = ".";
+        hasReasoningField = true;
+      }
+      if (toolCalls.length > 0) {
+        assistantMsg.tool_calls = toolCalls.map((tc, toolCallIndex) => {
+          const toolCallId = ensureToolCallId(tc.id, `${i}:${toolCallIndex}:${tc.name}`);
+          rememberToolCallId(tc.id, toolCallId);
+          return {
+            id: normalizeMistralToolId(toolCallId, compat.requiresMistralToolIds),
+            type: "function" as const,
+            function: {
+              name: tc.name,
+              arguments: serializeToolArguments(tc.arguments),
+            },
+          };
+        });
+        const reasoningDetails = toolCalls
+          .filter(tc => tc.thoughtSignature)
+          .map(tc => {
+            try {
+              const parsed: unknown = JSON.parse(tc.thoughtSignature!);
+              return parsed;
+            } catch {
+              return null;
+            }
+          })
+          .filter(Boolean);
+        if (reasoningDetails.length > 0) {
+          assistantMsg.reasoning_details = reasoningDetails;
+        }
+      }
+      // Some OpenAI-compatible backends concatenate assistant content as a
+      // string even for tool-call replay. OpenAI accepts an empty string here;
+      // null trips strict/proxy implementations before the tool result is read.
+      if (assistantMsg.content === null && (hasReasoningField || assistantMsg.tool_calls)) {
+        assistantMsg.content = "";
+      }
+      // Skip assistant messages that have no content, no tool calls, and no reasoning payload.
+      // Some OpenAI-compatible backends require replaying reasoning-only assistant turns
+      // so follow-up requests preserve the provider-specific reasoning field name.
+      const content = assistantMsg.content;
+      const hasContent =
+        content !== null &&
+        content !== undefined &&
+        (typeof content === "string" ? content.length > 0 : content.length > 0);
+      if (!hasContent && assistantMsg.tool_calls && compat.requiresAssistantContentForToolCalls) {
+        assistantMsg.content = ".";
+      }
+      if (!hasContent && !assistantMsg.tool_calls && !hasReasoningField) {
+        continue;
+      }
+      params.push(assistantMsg);
+    } else if (msg.role === "toolResult") {
+      // Batch consecutive tool results and collect all images
+      const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
+      let j = i;
 
-			for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
-				const toolMsg = transformedMessages[j] as ToolResultMessage;
+      for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
+        const toolMsg = transformedMessages[j] as ToolResultMessage;
 
-				// Extract text and image content
-				const textResult = toolMsg.content
-					.filter(c => c.type === "text")
-					.map(c => (c as TextContent).text)
-					.join("\n");
-				const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
-				const hasImages = toolMsg.content.some(c => c.type === "image");
-				const omittedImages = hasImages && !supportsImages;
+        // Extract text and image content
+        const textResult = toolMsg.content
+          .filter(c => c.type === "text")
+          .map(c => (c as TextContent).text)
+          .join("\n");
+        const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
+        const hasImages = toolMsg.content.some(c => c.type === "image");
+        const omittedImages = hasImages && !supportsImages;
 
-				// Always send tool result with text (or placeholder if only images)
-				const hasText = textResult.length > 0;
-				const remappedToolCallId = consumeToolCallId(toolMsg.toolCallId);
-				const resolvedToolCallId =
-					remappedToolCallId ?? ensureToolCallId(toolMsg.toolCallId, `${j}:${toolMsg.toolName ?? "tool"}`);
-				const toolResultContent = omittedImages
-					? joinTextWithImagePlaceholder(textResult, true)
-					: hasText
-						? textResult
-						: hasImages
-							? "(see attached image)"
-							: "";
-				const toolResultMsg: OpenAICompletionsToolMessageParam = {
-					role: "tool",
-					content: toolResultContent.toWellFormed(),
-					tool_call_id: normalizeMistralToolId(resolvedToolCallId, compat.requiresMistralToolIds),
-				};
-				if (compat.requiresToolResultName && toolMsg.toolName) {
-					toolResultMsg.name = toolMsg.toolName;
-				}
-				params.push(toolResultMsg);
+        // Always send tool result with text (or placeholder if only images)
+        const hasText = textResult.length > 0;
+        const remappedToolCallId = consumeToolCallId(toolMsg.toolCallId);
+        const resolvedToolCallId =
+          remappedToolCallId ?? ensureToolCallId(toolMsg.toolCallId, `${j}:${toolMsg.toolName ?? "tool"}`);
+        const toolResultContent = omittedImages
+          ? joinTextWithImagePlaceholder(textResult, true)
+          : hasText
+            ? textResult
+            : hasImages
+              ? "(see attached image)"
+              : "";
+        const toolResultMsg: OpenAICompletionsToolMessageParam = {
+          role: "tool",
+          content: toolResultContent.toWellFormed(),
+          tool_call_id: normalizeMistralToolId(resolvedToolCallId, compat.requiresMistralToolIds),
+        };
+        if (compat.requiresToolResultName && toolMsg.toolName) {
+          toolResultMsg.name = toolMsg.toolName;
+        }
+        params.push(toolResultMsg);
 
-				if (hasImages && supportsImages) {
-					for (const block of toolMsg.content) {
-						if (block.type === "image") {
-							imageBlocks.push({
-								type: "image_url",
-								image_url: {
-									url: `data:${block.mimeType};base64,${block.data}`,
-								},
-							});
-						}
-					}
-				}
-			}
+        if (hasImages && supportsImages) {
+          for (const block of toolMsg.content) {
+            if (block.type === "image") {
+              imageBlocks.push({
+                type: "image_url",
+                image_url: {
+                  url: `data:${block.mimeType};base64,${block.data}`,
+                },
+              });
+            }
+          }
+        }
+      }
 
-			i = j - 1;
+      i = j - 1;
 
-			// After all consecutive tool results, add a single user message with all images
-			if (imageBlocks.length > 0) {
-				if (compat.requiresAssistantAfterToolResult) {
-					params.push({
-						role: "assistant",
-						content: "I have processed the tool results.",
-					});
-				}
+      // After all consecutive tool results, add a single user message with all images
+      if (imageBlocks.length > 0) {
+        if (compat.requiresAssistantAfterToolResult) {
+          params.push({
+            role: "assistant",
+            content: "I have processed the tool results.",
+          });
+        }
 
-				params.push({
-					role: "user",
-					content: [
-						{
-							type: "text",
-							text: "Attached image(s) from tool result:",
-						},
-						...imageBlocks,
-					],
-				});
-				lastRole = "user";
-			} else {
-				lastRole = "toolResult";
-			}
-			continue;
-		}
+        params.push({
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Attached image(s) from tool result:",
+            },
+            ...imageBlocks,
+          ],
+        });
+        lastRole = "user";
+      } else {
+        lastRole = "toolResult";
+      }
+      continue;
+    }
 
-		lastRole =
-			msg.role === "developer"
-				? model.reasoning && compat.supportsDeveloperRole
-					? "developer"
-					: "system"
-				: msg.role;
-	}
+    lastRole =
+      msg.role === "developer"
+        ? model.reasoning && compat.supportsDeveloperRole
+          ? "developer"
+          : "system"
+        : msg.role;
+  }
 
-	return params;
+  return params;
 }
 
 function convertTools(
-	tools: Tool[],
-	compat: ResolvedOpenAICompat,
-	toolStrictModeOverride?: ToolStrictModeOverride,
+  tools: Tool[],
+  compat: ResolvedOpenAICompat,
+  toolStrictModeOverride?: ToolStrictModeOverride,
 ): BuiltOpenAICompletionTools {
-	const adaptedTools = tools.map(tool => {
-		const strict = !NO_STRICT && compat.supportsStrictMode !== false && tool.strict !== false;
-		const baseParameters = toolWireSchema(tool);
-		const adapted = adaptSchemaForStrict(baseParameters, strict);
-		return {
-			tool,
-			baseParameters,
-			parameters: adapted.schema,
-			strict: adapted.strict,
-		};
-	});
+  const adaptedTools = tools.map(tool => {
+    const strict = !NO_STRICT && compat.supportsStrictMode !== false && tool.strict !== false;
+    const baseParameters = toolWireSchema(tool);
+    const adapted = adaptSchemaForStrict(baseParameters, strict);
+    return {
+      tool,
+      baseParameters,
+      parameters: adapted.schema,
+      strict: adapted.strict,
+    };
+  });
 
-	const requestedStrictMode = toolStrictModeOverride ?? compat.toolStrictMode;
-	const toolStrictMode =
-		requestedStrictMode === "none"
-			? "none"
-			: requestedStrictMode === "all_strict"
-				? adaptedTools.every(tool => tool.strict)
-					? "all_strict"
-					: "none"
-				: "mixed";
+  const requestedStrictMode = toolStrictModeOverride ?? compat.toolStrictMode;
+  const toolStrictMode =
+    requestedStrictMode === "none"
+      ? "none"
+      : requestedStrictMode === "all_strict"
+        ? adaptedTools.every(tool => tool.strict)
+          ? "all_strict"
+          : "none"
+        : "mixed";
 
-	return {
-		tools: adaptedTools.map(({ tool, baseParameters, parameters, strict }) => {
-			const includeStrict = toolStrictMode === "all_strict" || (toolStrictMode === "mixed" && strict);
-			// `strict: false` is semantically distinct from omitted `strict` on some
-			// backends: with it absent, optional properties may be over-filled with
-			// placeholder values (#4336). Preserve the author's explicit `false`,
-			// but only in "mixed" mode against a provider that understands the
-			// field — the `all_strict → none` collapse and `supportsStrictMode:
-			// false` paths deliberately keep the wire flag uniformly absent.
-			const includeExplicitFalse =
-				!includeStrict &&
-				tool.strict === false &&
-				toolStrictMode === "mixed" &&
-				compat.supportsStrictMode !== false;
-			const wireParameters = includeStrict ? parameters : baseParameters;
-			return {
-				type: "function",
-				function: {
-					name: tool.name,
-					description: tool.description || "",
-					// Moonshot/Kimi native hosts validate against the stricter MFJS subset
-					// (const→enum, typed enums, no validators) and 400 otherwise.
-					parameters:
-						compat.toolSchemaFlavor === "moonshot-mfjs"
-							? (normalizeSchemaForMoonshot(wireParameters) as Record<string, unknown>)
-							: wireParameters,
-					// Only include strict if provider supports it. Some reject unknown fields.
-					...(includeStrict ? { strict: true } : includeExplicitFalse ? { strict: false } : {}),
-				},
-			};
-		}),
-		toolStrictMode,
-		strictToolsApplied:
-			tools.length > 0 &&
-			(toolStrictMode === "all_strict" || (toolStrictMode === "mixed" && adaptedTools.some(tool => tool.strict))),
-	};
+  return {
+    tools: adaptedTools.map(({ tool, baseParameters, parameters, strict }) => {
+      const includeStrict = toolStrictMode === "all_strict" || (toolStrictMode === "mixed" && strict);
+      // `strict: false` is semantically distinct from omitted `strict` on some
+      // backends: with it absent, optional properties may be over-filled with
+      // placeholder values (#4336). Preserve the author's explicit `false`,
+      // but only in "mixed" mode against a provider that understands the
+      // field — the `all_strict → none` collapse and `supportsStrictMode:
+      // false` paths deliberately keep the wire flag uniformly absent.
+      const includeExplicitFalse =
+        !includeStrict &&
+        tool.strict === false &&
+        toolStrictMode === "mixed" &&
+        compat.supportsStrictMode !== false;
+      const wireParameters = includeStrict ? parameters : baseParameters;
+      // Moonshot/Kimi native hosts validate against the stricter MFJS subset
+      // (const→enum, typed enums, no validators) and 400 otherwise.
+      // Local grammar-constrained backends (llama.cpp / lm-studio / vllm)
+      // reject bare boolean subschemas.
+      // Widen those subschemas before they reach the sampler (#4488).
+      const functionParameters =
+        compat.toolSchemaFlavor === "moonshot-mfjs"
+          ? (normalizeSchemaForMoonshot(wireParameters) as Record<string, unknown>)
+          : compat.sanitizeToolSchemaForGrammar
+            ? sanitizeSchemaForGrammarConstrainedSampler(wireParameters)
+            : wireParameters;
+      return {
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description || "",
+          parameters: functionParameters,
+          // Only include strict if provider supports it. Some reject unknown fields.
+          ...(includeStrict ? { strict: true } : includeExplicitFalse ? { strict: false } : {}),
+        },
+      };
+    }),
+    toolStrictMode,
+    strictToolsApplied:
+      tools.length > 0 &&
+      (toolStrictMode === "all_strict" || (toolStrictMode === "mixed" && adaptedTools.some(tool => tool.strict))),
+  };
 }
 
 const EMPTY_OLLAMA_LENGTH_COMPLETION_MESSAGE =
-	"Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.";
+  "Model returned no content: prompt filled the context window; raise Ollama num_ctx or shorten the prompt.";
 
 function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | string): {
-	stopReason: StopReason;
-	errorMessage?: string;
+  stopReason: StopReason;
+  errorMessage?: string;
 } {
-	if (reason === null) return { stopReason: "stop" };
-	switch (reason) {
-		case "stop":
-		case "end":
-			return { stopReason: "stop" };
-		case "length":
-			return { stopReason: "length" };
-		case "function_call":
-		case "tool_calls":
-			return { stopReason: "toolUse" };
-		case "content_filter":
-			return { stopReason: "error", errorMessage: "Provider finish_reason: content_filter" };
-		case "network_error":
-			return { stopReason: "error", errorMessage: "Provider finish_reason: network_error" };
-		case "error":
-			// Gateways (OpenRouter, Vercel AI Gateway, …) report upstream model
-			// failures as a bare `finish_reason: "error"` with no detail. These are
-			// almost always transient (e.g. Gemini MALFORMED_FUNCTION_CALL), so word
-			// the message to match the session retry classifier's transient-transport
-			// pattern (`provider.?returned.?error`) and get the turn auto-retried.
-			return { stopReason: "error", errorMessage: "Provider returned error finish_reason" };
-		default:
-			return {
-				stopReason: "error",
-				errorMessage: `Provider finish_reason: ${reason}`,
-			};
-	}
+  if (reason === null) return { stopReason: "stop" };
+  switch (reason) {
+    case "stop":
+    case "end":
+      return { stopReason: "stop" };
+    case "length":
+      return { stopReason: "length" };
+    case "function_call":
+    case "tool_calls":
+      return { stopReason: "toolUse" };
+    case "content_filter":
+      return { stopReason: "error", errorMessage: "Provider finish_reason: content_filter" };
+    case "network_error":
+      return { stopReason: "error", errorMessage: "Provider finish_reason: network_error" };
+    case "error":
+      // Gateways (OpenRouter, Vercel AI Gateway, …) report upstream model
+      // failures as a bare `finish_reason: "error"` with no detail. These are
+      // almost always transient (e.g. Gemini MALFORMED_FUNCTION_CALL), so word
+      // the message to match the session retry classifier's transient-transport
+      // pattern (`provider.?returned.?error`) and get the turn auto-retried.
+      return { stopReason: "error", errorMessage: "Provider returned error finish_reason" };
+    default:
+      return {
+        stopReason: "error",
+        errorMessage: `Provider finish_reason: ${reason}`,
+      };
+  }
 }

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -12,13 +12,13 @@ import { dereferenceJsonSchema } from "./dereference";
 import { upgradeJsonSchemaTo202012 } from "./draft";
 import { areJsonValuesEqual, mergeCompatibleEnumSchemas, mergePropertySchemas } from "./equality";
 import {
-	ALL_CCA_TYPE_SPECIFIC_KEYS,
-	CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS,
-	CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS,
-	COMBINATOR_KEYS,
-	LIFTABLE_TO_DESCRIPTION_FIELDS,
-	NON_STRUCTURAL_SCHEMA_KEYS,
-	UNSUPPORTED_SCHEMA_FIELDS,
+  ALL_CCA_TYPE_SPECIFIC_KEYS,
+  CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS,
+  CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS,
+  COMBINATOR_KEYS,
+  LIFTABLE_TO_DESCRIPTION_FIELDS,
+  NON_STRUCTURAL_SCHEMA_KEYS,
+  UNSUPPORTED_SCHEMA_FIELDS,
 } from "./fields";
 import { isValidJsonSchema } from "./meta-validator";
 import { type DescriptionSpillFormat, spillToDescription } from "./spill";
@@ -29,57 +29,57 @@ import { decontaminateZodInstance } from "./zod-decontaminate";
 export type ResidualSchemaIncompatibility = "type-array" | "type-null" | "nullable" | "combiners" | "not";
 
 export interface NormalizeSchemaOptions {
-	/** Coerce JSON Schema boolean subschemas for providers whose wire cannot encode them. */
-	coerceBooleanSubschemas?: boolean;
-	unsupportedFields: (key: string) => boolean;
-	normalizeFieldNames: boolean;
-	collapseNullFields: boolean;
-	normalizeTypeArrayToNullable: boolean;
-	stripNullableKeyword: boolean;
-	autoPropertyOrdering: boolean;
-	ensureObjectProperties: boolean;
-	liftStrippedToDescription:
-		| false
-		| {
-				keys?: (key: string) => boolean;
-				format?: DescriptionSpillFormat;
-		  };
-	mergeObjectCombiners: boolean;
-	collapseSameTypeCombiners: boolean;
-	collapseMixedTypeCombiners: boolean;
-	stripResidualCombinersFixpoint: boolean;
-	extractNullableFromUnions: boolean;
-	inferTypeForBareEnum: boolean;
-	foldOneOfIntoAnyOf: boolean;
-	dropNonScalarEnum: boolean;
-	rejectResidualIncompatibilities?: ReadonlyArray<ResidualSchemaIncompatibility>;
-	validateAndFallback?: { fallback: unknown };
+  /** Coerce JSON Schema boolean subschemas for providers whose wire cannot encode them. */
+  coerceBooleanSubschemas?: boolean;
+  unsupportedFields: (key: string) => boolean;
+  normalizeFieldNames: boolean;
+  collapseNullFields: boolean;
+  normalizeTypeArrayToNullable: boolean;
+  stripNullableKeyword: boolean;
+  autoPropertyOrdering: boolean;
+  ensureObjectProperties: boolean;
+  liftStrippedToDescription:
+  | false
+  | {
+    keys?: (key: string) => boolean;
+    format?: DescriptionSpillFormat;
+  };
+  mergeObjectCombiners: boolean;
+  collapseSameTypeCombiners: boolean;
+  collapseMixedTypeCombiners: boolean;
+  stripResidualCombinersFixpoint: boolean;
+  extractNullableFromUnions: boolean;
+  inferTypeForBareEnum: boolean;
+  foldOneOfIntoAnyOf: boolean;
+  dropNonScalarEnum: boolean;
+  rejectResidualIncompatibilities?: ReadonlyArray<ResidualSchemaIncompatibility>;
+  validateAndFallback?: { fallback: unknown };
 }
 
 interface NormalizeSchemaWalkOptions extends NormalizeSchemaOptions {
-	insideSchemaMap: boolean;
-	/**
-	 * True when the value currently being walked occupies a JSON Schema
-	 * *subschema* slot (root, combiner branch, `items`, a property value, …).
-	 * Only then is a bare `true`/`false` a boolean subschema to coerce; in a
-	 * keyword slot (`nullable`, `enum` entries, `additionalProperties`) it stays.
-	 */
-	booleanIsSubschema: boolean;
+  insideSchemaMap: boolean;
+  /**
+   * True when the value currently being walked occupies a JSON Schema
+   * *subschema* slot (root, combiner branch, `items`, a property value, …).
+   * Only then is a bare `true`/`false` a boolean subschema to coerce; in a
+   * keyword slot (`nullable`, `enum` entries, `additionalProperties`) it stays.
+   */
+  booleanIsSubschema: boolean;
 }
 
 interface ResidualIncompatibilityChecks {
-	typeArray: boolean;
-	typeNull: boolean;
-	nullable: boolean;
-	combiners: boolean;
-	not: boolean;
+  typeArray: boolean;
+  typeNull: boolean;
+  nullable: boolean;
+  combiners: boolean;
+  not: boolean;
 }
 
 const SNAKE_TO_CAMEL_RENAMES = new Map<string, string>([
-	["additional_properties", "additionalProperties"],
-	["any_of", "anyOf"],
-	["prefix_items", "prefixItems"],
-	["property_ordering", "propertyOrdering"],
+  ["additional_properties", "additionalProperties"],
+  ["any_of", "anyOf"],
+  ["prefix_items", "prefixItems"],
+  ["property_ordering", "propertyOrdering"],
 ]);
 
 const JSON_SCHEMA_COMBINERS = ["anyOf", "oneOf"] as const;
@@ -90,59 +90,59 @@ const CCA_FORBIDDEN_COMBINERS = new Set(["anyOf", "oneOf", "allOf"]);
  * `false` in one of these slots is a boolean subschema to coerce (issue #5604).
  */
 const SUBSCHEMA_VALUE_KEYS: Record<string, true> = {
-	items: true,
-	additionalItems: true,
-	unevaluatedItems: true,
-	not: true,
-	if: true,
-	// biome-ignore lint/suspicious/noThenProperty: JSON Schema keyword
-	then: true,
-	else: true,
-	contains: true,
-	propertyNames: true,
-	contentSchema: true,
+  items: true,
+  additionalItems: true,
+  unevaluatedItems: true,
+  not: true,
+  if: true,
+  // biome-ignore lint/suspicious/noThenProperty: JSON Schema keyword
+  then: true,
+  else: true,
+  contains: true,
+  propertyNames: true,
+  contentSchema: true,
 };
 
 /** Keywords whose value is an array of subschemas. */
 const SUBSCHEMA_ARRAY_KEYS: Record<string, true> = {
-	anyOf: true,
-	oneOf: true,
-	allOf: true,
-	prefixItems: true,
+  anyOf: true,
+  oneOf: true,
+  allOf: true,
+  prefixItems: true,
 };
 
 /** Keywords whose object value maps arbitrary names to subschemas. */
 const SUBSCHEMA_MAP_KEYS: Record<string, true> = {
-	properties: true,
-	patternProperties: true,
-	dependencies: true,
-	dependentSchemas: true,
-	$defs: true,
-	definitions: true,
+  properties: true,
+  patternProperties: true,
+  dependencies: true,
+  dependentSchemas: true,
+  $defs: true,
+  definitions: true,
 };
 
 const CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA = {
-	type: "object",
-	properties: {},
+  type: "object",
+  properties: {},
 } as const;
 
 function isGoogleUnsupportedSchemaField(key: string): boolean {
-	return Object.hasOwn(UNSUPPORTED_SCHEMA_FIELDS, key);
+  return Object.hasOwn(UNSUPPORTED_SCHEMA_FIELDS, key);
 }
 
 function isMcpUnsupportedSchemaField(key: string): boolean {
-	return key === "$schema";
+  return key === "$schema";
 }
 
 function isMoonshotUnsupportedSchemaField(key: string): boolean {
-	// `default` is an MFJS Meta Data field (kept); everything else here is a
-	// validation/decorative keyword or tuple form MFJS rejects.
-	if (key === "default") return false;
-	return Object.hasOwn(NON_STRUCTURAL_SCHEMA_KEYS, key) || key === "prefixItems";
+  // `default` is an MFJS Meta Data field (kept); everything else here is a
+  // validation/decorative keyword or tuple form MFJS rejects.
+  if (key === "default") return false;
+  return Object.hasOwn(NON_STRUCTURAL_SCHEMA_KEYS, key) || key === "prefixItems";
 }
 
 function isDefaultLiftableToDescriptionField(key: string): boolean {
-	return Object.hasOwn(LIFTABLE_TO_DESCRIPTION_FIELDS, key);
+  return Object.hasOwn(LIFTABLE_TO_DESCRIPTION_FIELDS, key);
 }
 
 /**
@@ -152,26 +152,26 @@ function isDefaultLiftableToDescriptionField(key: string): boolean {
  * existing camelCase entry, matching python-genai/_transformers.py:751.
  */
 function applySnakeCaseRenames(obj: JsonObject): JsonObject {
-	let needsRename = false;
-	for (const k in obj) {
-		if (!Object.hasOwn(obj, k)) continue;
-		if (SNAKE_TO_CAMEL_RENAMES.has(k)) {
-			needsRename = true;
-			break;
-		}
-	}
-	if (!needsRename) return obj;
-	const out: JsonObject = {};
-	for (const k in obj) {
-		if (!Object.hasOwn(obj, k)) continue;
-		const renamed = SNAKE_TO_CAMEL_RENAMES.get(k);
-		if (renamed !== undefined) {
-			out[renamed] = obj[k];
-		} else if (!outHasOwn(out, k)) {
-			out[k] = obj[k];
-		}
-	}
-	return out;
+  let needsRename = false;
+  for (const k in obj) {
+    if (!Object.hasOwn(obj, k)) continue;
+    if (SNAKE_TO_CAMEL_RENAMES.has(k)) {
+      needsRename = true;
+      break;
+    }
+  }
+  if (!needsRename) return obj;
+  const out: JsonObject = {};
+  for (const k in obj) {
+    if (!Object.hasOwn(obj, k)) continue;
+    const renamed = SNAKE_TO_CAMEL_RENAMES.get(k);
+    if (renamed !== undefined) {
+      out[renamed] = obj[k];
+    } else if (!outHasOwn(out, k)) {
+      out[k] = obj[k];
+    }
+  }
+  return out;
 }
 
 /**
@@ -181,546 +181,546 @@ function applySnakeCaseRenames(obj: JsonObject): JsonObject {
  * original reference otherwise (zero-allocation fast path).
  */
 function preHandleNullFields(obj: JsonObject): JsonObject {
-	if (obj.type === "null") {
-		const out: JsonObject = {};
-		for (const k in obj) {
-			if (!Object.hasOwn(obj, k) || k === "type") continue;
-			out[k] = obj[k];
-		}
-		out.nullable = true;
-		return out;
-	}
-	if (!Array.isArray(obj.anyOf)) return obj;
-	const variants = obj.anyOf as unknown[];
-	let sawNull = false;
-	const kept: unknown[] = [];
-	for (const v of variants) {
-		if (isJsonObject(v) && v.type === "null") {
-			sawNull = true;
-			continue;
-		}
-		kept.push(v);
-	}
-	if (!sawNull) return obj;
-	const out: JsonObject = {};
-	for (const k in obj) {
-		if (Object.hasOwn(obj, k)) out[k] = obj[k];
-	}
-	out.nullable = true;
-	if (kept.length === 0) {
-		delete out.anyOf;
-	} else if (kept.length === 1 && isJsonObject(kept[0])) {
-		delete out.anyOf;
-		const only = kept[0];
-		for (const k in only) {
-			if (Object.hasOwn(only, k) && !outHasOwn(out, k)) out[k] = only[k];
-		}
-	} else {
-		out.anyOf = kept;
-	}
-	return out;
+  if (obj.type === "null") {
+    const out: JsonObject = {};
+    for (const k in obj) {
+      if (!Object.hasOwn(obj, k) || k === "type") continue;
+      out[k] = obj[k];
+    }
+    out.nullable = true;
+    return out;
+  }
+  if (!Array.isArray(obj.anyOf)) return obj;
+  const variants = obj.anyOf as unknown[];
+  let sawNull = false;
+  const kept: unknown[] = [];
+  for (const v of variants) {
+    if (isJsonObject(v) && v.type === "null") {
+      sawNull = true;
+      continue;
+    }
+    kept.push(v);
+  }
+  if (!sawNull) return obj;
+  const out: JsonObject = {};
+  for (const k in obj) {
+    if (Object.hasOwn(obj, k)) out[k] = obj[k];
+  }
+  out.nullable = true;
+  if (kept.length === 0) {
+    delete out.anyOf;
+  } else if (kept.length === 1 && isJsonObject(kept[0])) {
+    delete out.anyOf;
+    const only = kept[0];
+    for (const k in only) {
+      if (Object.hasOwn(only, k) && !outHasOwn(out, k)) out[k] = only[k];
+    }
+  } else {
+    out.anyOf = kept;
+  }
+  return out;
 }
 
 function outHasOwn(obj: JsonObject, key: string): boolean {
-	return Object.hasOwn(obj, key);
+  return Object.hasOwn(obj, key);
 }
 
 function inferJsonSchemaTypeFromValue(value: unknown): string | undefined {
-	if (value === null) return "null";
-	if (Array.isArray(value)) return "array";
-	switch (typeof value) {
-		case "string":
-			return "string";
-		case "number":
-			return "number";
-		case "boolean":
-			return "boolean";
-		case "object":
-			return "object";
-		default:
-			return undefined;
-	}
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  switch (typeof value) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "object":
+      return "object";
+    default:
+      return undefined;
+  }
 }
 
 function pushEnumValue(values: unknown[], value: unknown): void {
-	if (!values.some(existing => areJsonValuesEqual(existing, value))) {
-		values.push(value);
-	}
+  if (!values.some(existing => areJsonValuesEqual(existing, value))) {
+    values.push(value);
+  }
 }
 
 function pushStrippedDescriptionEntry(
-	spill: Array<[string, unknown]> | undefined,
-	key: string,
-	value: unknown,
-	options: NormalizeSchemaWalkOptions,
+  spill: Array<[string, unknown]> | undefined,
+  key: string,
+  value: unknown,
+  options: NormalizeSchemaWalkOptions,
 ): Array<[string, unknown]> | undefined {
-	const lift = options.liftStrippedToDescription;
-	if (!lift) return spill;
-	const isLiftable = lift.keys ?? isDefaultLiftableToDescriptionField;
-	if (!isLiftable(key)) return spill;
-	const next = spill ?? [];
-	next.push([key, value]);
-	return next;
+  const lift = options.liftStrippedToDescription;
+  if (!lift) return spill;
+  const isLiftable = lift.keys ?? isDefaultLiftableToDescriptionField;
+  if (!isLiftable(key)) return spill;
+  const next = spill ?? [];
+  next.push([key, value]);
+  return next;
 }
 
 function applyDescriptionSpill(
-	result: JsonObject,
-	spill: Array<[string, unknown]> | undefined,
-	options: NormalizeSchemaWalkOptions,
+  result: JsonObject,
+  spill: Array<[string, unknown]> | undefined,
+  options: NormalizeSchemaWalkOptions,
 ): void {
-	const lift = options.liftStrippedToDescription;
-	if (!lift || spill === undefined) return;
-	spillToDescription(result, spill, lift.format ?? "spill");
+  const lift = options.liftStrippedToDescription;
+  if (!lift || spill === undefined) return;
+  spillToDescription(result, spill, lift.format ?? "spill");
 }
 
 function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions): unknown {
-	if (Array.isArray(value)) {
-		if (!enter(value)) return [];
-		try {
-			return value.map(entry => normalizeSchemaNode(entry, options));
-		} finally {
-			exit(value);
-		}
-	}
-	if (typeof value === "boolean") {
-		// A bare boolean is a JSON Schema subschema only in a subschema slot.
-		// The Google/CCA protobuf Schema wire has no representation for it
-		// (issue #5604): `true` accepts anything -> `{}`, `false` accepts nothing
-		// -> `{ not: {} }`. In a keyword slot (`nullable`, `enum` entry, …) a
-		// boolean is a plain value and is left untouched.
-		if (!options.coerceBooleanSubschemas || !options.booleanIsSubschema) return value;
-		return value ? {} : { not: {} };
-	}
-	if (!isJsonObject(value)) {
-		return value;
-	}
-	// `enter`/`exit` path-tracking (not a visited-set): DAG-shared subtrees are
-	// normalized at every occurrence; only true cycles short-circuit to `{}`.
-	if (!enter(value)) return {};
-	try {
-		return normalizeSchemaObjectNode(value, options);
-	} finally {
-		exit(value);
-	}
+  if (Array.isArray(value)) {
+    if (!enter(value)) return [];
+    try {
+      return value.map(entry => normalizeSchemaNode(entry, options));
+    } finally {
+      exit(value);
+    }
+  }
+  if (typeof value === "boolean") {
+    // A bare boolean is a JSON Schema subschema only in a subschema slot.
+    // The Google/CCA protobuf Schema wire has no representation for it
+    // (issue #5604): `true` accepts anything -> `{}`, `false` accepts nothing
+    // -> `{ not: {} }`. In a keyword slot (`nullable`, `enum` entry, …) a
+    // boolean is a plain value and is left untouched.
+    if (!options.coerceBooleanSubschemas || !options.booleanIsSubschema) return value;
+    return value ? {} : { not: {} };
+  }
+  if (!isJsonObject(value)) {
+    return value;
+  }
+  // `enter`/`exit` path-tracking (not a visited-set): DAG-shared subtrees are
+  // normalized at every occurrence; only true cycles short-circuit to `{}`.
+  if (!enter(value)) return {};
+  try {
+    return normalizeSchemaObjectNode(value, options);
+  } finally {
+    exit(value);
+  }
 }
 
 function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWalkOptions): unknown {
-	let obj = options.normalizeFieldNames && !options.insideSchemaMap ? applySnakeCaseRenames(value) : value;
-	if (options.collapseNullFields && !options.insideSchemaMap) {
-		obj = preHandleNullFields(obj);
-	}
-	const result: JsonObject = {};
-	let spill: Array<[string, unknown]> | undefined;
-	for (const combiner of JSON_SCHEMA_COMBINERS) {
-		if (!Array.isArray(obj[combiner])) continue;
-		const variants = obj[combiner] as JsonObject[];
-		const allHaveConst = variants.every(v => isJsonObject(v) && "const" in v);
-		if (!allHaveConst || variants.length === 0) continue;
+  let obj = options.normalizeFieldNames && !options.insideSchemaMap ? applySnakeCaseRenames(value) : value;
+  if (options.collapseNullFields && !options.insideSchemaMap) {
+    obj = preHandleNullFields(obj);
+  }
+  const result: JsonObject = {};
+  let spill: Array<[string, unknown]> | undefined;
+  for (const combiner of JSON_SCHEMA_COMBINERS) {
+    if (!Array.isArray(obj[combiner])) continue;
+    const variants = obj[combiner] as JsonObject[];
+    const allHaveConst = variants.every(v => isJsonObject(v) && "const" in v);
+    if (!allHaveConst || variants.length === 0) continue;
 
-		const dedupedEnum: unknown[] = [];
-		for (const variant of variants) {
-			pushEnumValue(dedupedEnum, variant.const);
-		}
-		result.enum = dedupedEnum;
+    const dedupedEnum: unknown[] = [];
+    for (const variant of variants) {
+      pushEnumValue(dedupedEnum, variant.const);
+    }
+    result.enum = dedupedEnum;
 
-		const explicitTypes = variants
-			.map(variant => variant.type)
-			.filter((variantType): variantType is string => typeof variantType === "string");
-		const allHaveSameExplicitType =
-			explicitTypes.length === variants.length &&
-			explicitTypes.every(variantType => variantType === explicitTypes[0]);
-		if (allHaveSameExplicitType && explicitTypes[0]) {
-			result.type = explicitTypes[0];
-		} else {
-			const inferredTypes = dedupedEnum
-				.map(enumValue => inferJsonSchemaTypeFromValue(enumValue))
-				.filter((inferredType): inferredType is string => inferredType !== undefined);
-			const inferredTypeSet = new Set(inferredTypes);
-			if (inferredTypeSet.size === 1) {
-				result.type = inferredTypes[0];
-			} else {
-				const nonNullInferredTypes = inferredTypes.filter(inferredType => inferredType !== "null");
-				const nonNullTypeSet = new Set(nonNullInferredTypes);
-				if (inferredTypes.includes("null") && nonNullTypeSet.size === 1) {
-					result.type = nonNullInferredTypes[0];
-					if (!options.stripNullableKeyword) {
-						result.nullable = true;
-					}
-				}
-			}
-		}
+    const explicitTypes = variants
+      .map(variant => variant.type)
+      .filter((variantType): variantType is string => typeof variantType === "string");
+    const allHaveSameExplicitType =
+      explicitTypes.length === variants.length &&
+      explicitTypes.every(variantType => variantType === explicitTypes[0]);
+    if (allHaveSameExplicitType && explicitTypes[0]) {
+      result.type = explicitTypes[0];
+    } else {
+      const inferredTypes = dedupedEnum
+        .map(enumValue => inferJsonSchemaTypeFromValue(enumValue))
+        .filter((inferredType): inferredType is string => inferredType !== undefined);
+      const inferredTypeSet = new Set(inferredTypes);
+      if (inferredTypeSet.size === 1) {
+        result.type = inferredTypes[0];
+      } else {
+        const nonNullInferredTypes = inferredTypes.filter(inferredType => inferredType !== "null");
+        const nonNullTypeSet = new Set(nonNullInferredTypes);
+        if (inferredTypes.includes("null") && nonNullTypeSet.size === 1) {
+          result.type = nonNullInferredTypes[0];
+          if (!options.stripNullableKeyword) {
+            result.nullable = true;
+          }
+        }
+      }
+    }
 
-		for (const key in obj) {
-			if (!Object.hasOwn(obj, key) || key === combiner || outHasOwn(result, key)) continue;
-			const entry = obj[key];
-			if (!options.insideSchemaMap && options.unsupportedFields(key)) {
-				spill = pushStrippedDescriptionEntry(spill, key, entry, options);
-				continue;
-			}
-			if (options.stripNullableKeyword && key === "nullable") continue;
-			result[key] = normalizeSchemaNode(entry, {
-				...options,
-				insideSchemaMap: !options.insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, key),
-				booleanIsSubschema:
-					options.insideSchemaMap ||
-					Object.hasOwn(SUBSCHEMA_VALUE_KEYS, key) ||
-					Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key),
-			});
-		}
-		applyDescriptionSpill(result, spill, options);
-		return applyNodePostProcessing(result, options);
-	}
+    for (const key in obj) {
+      if (!Object.hasOwn(obj, key) || key === combiner || outHasOwn(result, key)) continue;
+      const entry = obj[key];
+      if (!options.insideSchemaMap && options.unsupportedFields(key)) {
+        spill = pushStrippedDescriptionEntry(spill, key, entry, options);
+        continue;
+      }
+      if (options.stripNullableKeyword && key === "nullable") continue;
+      result[key] = normalizeSchemaNode(entry, {
+        ...options,
+        insideSchemaMap: !options.insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, key),
+        booleanIsSubschema:
+          options.insideSchemaMap ||
+          Object.hasOwn(SUBSCHEMA_VALUE_KEYS, key) ||
+          Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key),
+      });
+    }
+    applyDescriptionSpill(result, spill, options);
+    return applyNodePostProcessing(result, options);
+  }
 
-	let constValue: unknown;
-	for (const key in obj) {
-		if (!Object.hasOwn(obj, key)) continue;
-		const entry = obj[key];
-		if (!options.insideSchemaMap && options.unsupportedFields(key)) {
-			spill = pushStrippedDescriptionEntry(spill, key, entry, options);
-			continue;
-		}
-		if (options.stripNullableKeyword && key === "nullable") continue;
-		if (key === "const") {
-			constValue = entry;
-			continue;
-		}
-		result[key] = normalizeSchemaNode(entry, {
-			...options,
-			insideSchemaMap: !options.insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, key),
-			booleanIsSubschema:
-				options.insideSchemaMap ||
-				Object.hasOwn(SUBSCHEMA_VALUE_KEYS, key) ||
-				Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key),
-		});
-	}
+  let constValue: unknown;
+  for (const key in obj) {
+    if (!Object.hasOwn(obj, key)) continue;
+    const entry = obj[key];
+    if (!options.insideSchemaMap && options.unsupportedFields(key)) {
+      spill = pushStrippedDescriptionEntry(spill, key, entry, options);
+      continue;
+    }
+    if (options.stripNullableKeyword && key === "nullable") continue;
+    if (key === "const") {
+      constValue = entry;
+      continue;
+    }
+    result[key] = normalizeSchemaNode(entry, {
+      ...options,
+      insideSchemaMap: !options.insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, key),
+      booleanIsSubschema:
+        options.insideSchemaMap ||
+        Object.hasOwn(SUBSCHEMA_VALUE_KEYS, key) ||
+        Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key),
+    });
+  }
 
-	if (options.normalizeTypeArrayToNullable && Array.isArray(result.type)) {
-		const types = (result.type as unknown[]).filter((t): t is string => typeof t === "string");
-		const nonNull = types.filter(t => t !== "null");
-		if (types.includes("null") && !options.stripNullableKeyword) {
-			result.nullable = true;
-		}
-		result.type = nonNull[0] ?? types[0];
-	}
-	if (constValue !== undefined) {
-		const existingEnum = Array.isArray(result.enum) ? result.enum : [];
-		pushEnumValue(existingEnum, constValue);
-		result.enum = existingEnum;
-		if (!result.type) {
-			result.type = inferJsonSchemaTypeFromValue(constValue);
-		}
-	}
+  if (options.normalizeTypeArrayToNullable && Array.isArray(result.type)) {
+    const types = (result.type as unknown[]).filter((t): t is string => typeof t === "string");
+    const nonNull = types.filter(t => t !== "null");
+    if (types.includes("null") && !options.stripNullableKeyword) {
+      result.nullable = true;
+    }
+    result.type = nonNull[0] ?? types[0];
+  }
+  if (constValue !== undefined) {
+    const existingEnum = Array.isArray(result.enum) ? result.enum : [];
+    pushEnumValue(existingEnum, constValue);
+    result.enum = existingEnum;
+    if (!result.type) {
+      result.type = inferJsonSchemaTypeFromValue(constValue);
+    }
+  }
 
-	if (
-		options.inferTypeForBareEnum &&
-		!result.type &&
-		!Array.isArray(result.anyOf) &&
-		!Array.isArray(result.oneOf) &&
-		Array.isArray(result.enum) &&
-		result.enum.length > 0
-	) {
-		const enumTypes = (result.enum as unknown[]).map(inferJsonSchemaTypeFromValue);
-		if (enumTypes.every((t): t is string => typeof t === "string") && new Set(enumTypes).size === 1) {
-			result.type = enumTypes[0];
-		}
-	}
+  if (
+    options.inferTypeForBareEnum &&
+    !result.type &&
+    !Array.isArray(result.anyOf) &&
+    !Array.isArray(result.oneOf) &&
+    Array.isArray(result.enum) &&
+    result.enum.length > 0
+  ) {
+    const enumTypes = (result.enum as unknown[]).map(inferJsonSchemaTypeFromValue);
+    if (enumTypes.every((t): t is string => typeof t === "string") && new Set(enumTypes).size === 1) {
+      result.type = enumTypes[0];
+    }
+  }
 
-	if (options.collapseNullFields && result.type === "null") {
-		delete result.type;
-		if (!options.stripNullableKeyword) result.nullable = true;
-	}
+  if (options.collapseNullFields && result.type === "null") {
+    delete result.type;
+    if (!options.stripNullableKeyword) result.nullable = true;
+  }
 
-	if (
-		options.autoPropertyOrdering &&
-		result.type === "object" &&
-		!outHasOwn(result, "propertyOrdering") &&
-		isJsonObject(result.properties)
-	) {
-		const props = result.properties;
-		const keys: string[] = [];
-		for (const k in props) {
-			if (Object.hasOwn(props, k)) keys.push(k);
-		}
-		if (keys.length > 1) result.propertyOrdering = keys;
-	}
+  if (
+    options.autoPropertyOrdering &&
+    result.type === "object" &&
+    !outHasOwn(result, "propertyOrdering") &&
+    isJsonObject(result.properties)
+  ) {
+    const props = result.properties;
+    const keys: string[] = [];
+    for (const k in props) {
+      if (Object.hasOwn(props, k)) keys.push(k);
+    }
+    if (keys.length > 1) result.propertyOrdering = keys;
+  }
 
-	if (options.ensureObjectProperties && result.type === "object" && !outHasOwn(result, "properties")) {
-		result.properties = {};
-	}
+  if (options.ensureObjectProperties && result.type === "object" && !outHasOwn(result, "properties")) {
+    result.properties = {};
+  }
 
-	applyDescriptionSpill(result, spill, options);
-	return applyNodePostProcessing(result, options);
+  applyDescriptionSpill(result, spill, options);
+  return applyNodePostProcessing(result, options);
 }
 
 function applyNodePostProcessing(schema: JsonObject, options: NormalizeSchemaWalkOptions): JsonObject {
-	let current = schema;
-	for (const combiner of JSON_SCHEMA_COMBINERS) {
-		if (options.mergeObjectCombiners) current = mergeObjectCombinerVariants(current, combiner);
-		if (options.collapseMixedTypeCombiners) current = collapseMixedTypeCombinerVariants(current, combiner);
-		if (options.collapseSameTypeCombiners) current = collapseSameTypeCombinerVariants(current, combiner);
-	}
-	if (options.foldOneOfIntoAnyOf) current = foldOneOfIntoAnyOf(current);
-	if (options.dropNonScalarEnum) current = dropNonScalarEnumForMfjs(current);
-	return current;
+  let current = schema;
+  for (const combiner of JSON_SCHEMA_COMBINERS) {
+    if (options.mergeObjectCombiners) current = mergeObjectCombinerVariants(current, combiner);
+    if (options.collapseMixedTypeCombiners) current = collapseMixedTypeCombinerVariants(current, combiner);
+    if (options.collapseSameTypeCombiners) current = collapseSameTypeCombinerVariants(current, combiner);
+  }
+  if (options.foldOneOfIntoAnyOf) current = foldOneOfIntoAnyOf(current);
+  if (options.dropNonScalarEnum) current = dropNonScalarEnumForMfjs(current);
+  return current;
 }
 
 /** MFJS recognizes only `anyOf`; fold any residual `oneOf` into it (merging when both are present). */
 function foldOneOfIntoAnyOf(schema: JsonObject): JsonObject {
-	if (!Array.isArray(schema.oneOf)) return schema;
-	const rest = copySchemaWithout(schema, "oneOf");
-	const existing = Array.isArray(rest.anyOf) ? (rest.anyOf as unknown[]) : [];
-	rest.anyOf = [...existing, ...(schema.oneOf as unknown[])];
-	return rest;
+  if (!Array.isArray(schema.oneOf)) return schema;
+  const rest = copySchemaWithout(schema, "oneOf");
+  const existing = Array.isArray(rest.anyOf) ? (rest.anyOf as unknown[]) : [];
+  rest.anyOf = [...existing, ...(schema.oneOf as unknown[])];
+  return rest;
 }
 
 /** MFJS `enum` admits only string/number literals; drop an enum carrying other types, keeping the inferred `type`. */
 function dropNonScalarEnumForMfjs(schema: JsonObject): JsonObject {
-	if (!Array.isArray(schema.enum)) return schema;
-	const allScalar = (schema.enum as unknown[]).every(v => typeof v === "string" || typeof v === "number");
-	if (allScalar) return schema;
-	return copySchemaWithout(schema, "enum");
+  if (!Array.isArray(schema.enum)) return schema;
+  const allScalar = (schema.enum as unknown[]).every(v => typeof v === "string" || typeof v === "number");
+  if (allScalar) return schema;
+  return copySchemaWithout(schema, "enum");
 }
 
 /** Copy all keys from a schema except the specified combiner key. */
 export function copySchemaWithout(schema: JsonObject, combiner: string): JsonObject {
-	const { [combiner]: _, ...rest } = schema;
-	return rest;
+  const { [combiner]: _, ...rest } = schema;
+  return rest;
 }
 
 function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
-	const variantsRaw = schema[combiner];
-	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
-		return schema;
-	}
+  const variantsRaw = schema[combiner];
+  if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
+    return schema;
+  }
 
-	const variants: JsonObject[] = [];
-	for (const entry of variantsRaw) {
-		if (!isJsonObject(entry)) {
-			return schema;
-		}
-		const variantType = entry.type;
-		const hasObjectShape =
-			isJsonObject(entry.properties) ||
-			Array.isArray(entry.required) ||
-			Object.hasOwn(entry, "additionalProperties");
-		if (variantType === undefined && !hasObjectShape) {
-			return schema;
-		}
-		if (variantType !== undefined && variantType !== "object") {
-			return schema;
-		}
-		if (entry.properties !== undefined && !isJsonObject(entry.properties)) {
-			return schema;
-		}
-		if (entry.required !== undefined && !Array.isArray(entry.required)) {
-			return schema;
-		}
-		variants.push(entry);
-	}
+  const variants: JsonObject[] = [];
+  for (const entry of variantsRaw) {
+    if (!isJsonObject(entry)) {
+      return schema;
+    }
+    const variantType = entry.type;
+    const hasObjectShape =
+      isJsonObject(entry.properties) ||
+      Array.isArray(entry.required) ||
+      Object.hasOwn(entry, "additionalProperties");
+    if (variantType === undefined && !hasObjectShape) {
+      return schema;
+    }
+    if (variantType !== undefined && variantType !== "object") {
+      return schema;
+    }
+    if (entry.properties !== undefined && !isJsonObject(entry.properties)) {
+      return schema;
+    }
+    if (entry.required !== undefined && !Array.isArray(entry.required)) {
+      return schema;
+    }
+    variants.push(entry);
+  }
 
-	const mergedProperties: JsonObject = {};
-	const ownProperties = isJsonObject(schema.properties) ? schema.properties : {};
-	for (const name in ownProperties) {
-		if (Object.hasOwn(ownProperties, name)) mergedProperties[name] = ownProperties[name];
-	}
+  const mergedProperties: JsonObject = {};
+  const ownProperties = isJsonObject(schema.properties) ? schema.properties : {};
+  for (const name in ownProperties) {
+    if (Object.hasOwn(ownProperties, name)) mergedProperties[name] = ownProperties[name];
+  }
 
-	for (const variant of variants) {
-		const properties = isJsonObject(variant.properties) ? variant.properties : {};
-		for (const name in properties) {
-			if (!Object.hasOwn(properties, name)) continue;
-			const propertySchema = properties[name];
-			const existingSchema = mergedProperties[name];
-			mergedProperties[name] =
-				existingSchema === undefined ? propertySchema : mergePropertySchemas(existingSchema, propertySchema);
-		}
-	}
+  for (const variant of variants) {
+    const properties = isJsonObject(variant.properties) ? variant.properties : {};
+    for (const name in properties) {
+      if (!Object.hasOwn(properties, name)) continue;
+      const propertySchema = properties[name];
+      const existingSchema = mergedProperties[name];
+      mergedProperties[name] =
+        existingSchema === undefined ? propertySchema : mergePropertySchemas(existingSchema, propertySchema);
+    }
+  }
 
-	const nextSchema = copySchemaWithout(schema, combiner);
-	nextSchema.type = "object";
-	nextSchema.properties = mergedProperties;
+  const nextSchema = copySchemaWithout(schema, combiner);
+  nextSchema.type = "object";
+  nextSchema.properties = mergedProperties;
 
-	let requiredIntersection: string[] | undefined;
-	for (const variant of variants) {
-		const variantRequired = Array.isArray(variant.required)
-			? variant.required.filter((r): r is string => typeof r === "string")
-			: [];
-		if (requiredIntersection === undefined) {
-			requiredIntersection = [...variantRequired];
-		} else {
-			const reqSet = new Set(variantRequired);
-			requiredIntersection = requiredIntersection.filter(r => reqSet.has(r));
-		}
-	}
-	const parentRequired = Array.isArray(schema.required)
-		? schema.required.filter((r): r is string => typeof r === "string")
-		: [];
-	const safeRequired = new Set<string>();
-	for (const name of requiredIntersection ?? []) {
-		if (Object.hasOwn(mergedProperties, name)) safeRequired.add(name);
-	}
-	for (const name of parentRequired) {
-		if (Object.hasOwn(ownProperties, name) && Object.hasOwn(mergedProperties, name)) {
-			safeRequired.add(name);
-		}
-	}
-	const requiredInPropertyOrder: string[] = [];
-	for (const name in mergedProperties) {
-		if (Object.hasOwn(mergedProperties, name) && safeRequired.has(name)) requiredInPropertyOrder.push(name);
-	}
-	if (requiredInPropertyOrder.length > 0) {
-		nextSchema.required = requiredInPropertyOrder;
-	} else {
-		delete nextSchema.required;
-	}
+  let requiredIntersection: string[] | undefined;
+  for (const variant of variants) {
+    const variantRequired = Array.isArray(variant.required)
+      ? variant.required.filter((r): r is string => typeof r === "string")
+      : [];
+    if (requiredIntersection === undefined) {
+      requiredIntersection = [...variantRequired];
+    } else {
+      const reqSet = new Set(variantRequired);
+      requiredIntersection = requiredIntersection.filter(r => reqSet.has(r));
+    }
+  }
+  const parentRequired = Array.isArray(schema.required)
+    ? schema.required.filter((r): r is string => typeof r === "string")
+    : [];
+  const safeRequired = new Set<string>();
+  for (const name of requiredIntersection ?? []) {
+    if (Object.hasOwn(mergedProperties, name)) safeRequired.add(name);
+  }
+  for (const name of parentRequired) {
+    if (Object.hasOwn(ownProperties, name) && Object.hasOwn(mergedProperties, name)) {
+      safeRequired.add(name);
+    }
+  }
+  const requiredInPropertyOrder: string[] = [];
+  for (const name in mergedProperties) {
+    if (Object.hasOwn(mergedProperties, name) && safeRequired.has(name)) requiredInPropertyOrder.push(name);
+  }
+  if (requiredInPropertyOrder.length > 0) {
+    nextSchema.required = requiredInPropertyOrder;
+  } else {
+    delete nextSchema.required;
+  }
 
-	return nextSchema;
+  return nextSchema;
 }
 
 function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
-	const variantsRaw = schema[combiner];
-	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
-		return schema;
-	}
+  const variantsRaw = schema[combiner];
+  if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
+    return schema;
+  }
 
-	const seenTypes = new Set<string>();
-	const variantTypes: string[] = [];
-	const mergedVariantFields: JsonObject = {};
-	for (const entry of variantsRaw) {
-		if (!isJsonObject(entry) || typeof entry.type !== "string") {
-			return schema;
-		}
+  const seenTypes = new Set<string>();
+  const variantTypes: string[] = [];
+  const mergedVariantFields: JsonObject = {};
+  for (const entry of variantsRaw) {
+    if (!isJsonObject(entry) || typeof entry.type !== "string") {
+      return schema;
+    }
 
-		const variantType = entry.type;
-		if (seenTypes.has(variantType)) {
-			return schema;
-		}
+    const variantType = entry.type;
+    if (seenTypes.has(variantType)) {
+      return schema;
+    }
 
-		const allowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[variantType];
-		if (!allowedKeys) {
-			return schema;
-		}
+    const allowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[variantType];
+    if (!allowedKeys) {
+      return schema;
+    }
 
-		for (const key in entry) {
-			if (!Object.hasOwn(entry, key)) continue;
-			const variantValue = entry[key];
-			if (key === "type") continue;
-			if (!Object.hasOwn(allowedKeys, key) && !Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)) {
-				return schema;
-			}
+    for (const key in entry) {
+      if (!Object.hasOwn(entry, key)) continue;
+      const variantValue = entry[key];
+      if (key === "type") continue;
+      if (!Object.hasOwn(allowedKeys, key) && !Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)) {
+        return schema;
+      }
 
-			const existingValue = mergedVariantFields[key];
-			if (existingValue !== undefined && !areJsonValuesEqual(existingValue, variantValue)) {
-				if (key !== "description") return schema;
-				// Descriptions are annotations, so merge branch-local spill text instead of
-				// treating it as a structural incompatibility.
-				mergedVariantFields[key] = mergeSchemaDescriptions(existingValue, variantValue);
-				continue;
-			}
-			mergedVariantFields[key] = variantValue;
-		}
+      const existingValue = mergedVariantFields[key];
+      if (existingValue !== undefined && !areJsonValuesEqual(existingValue, variantValue)) {
+        if (key !== "description") return schema;
+        // Descriptions are annotations, so merge branch-local spill text instead of
+        // treating it as a structural incompatibility.
+        mergedVariantFields[key] = mergeSchemaDescriptions(existingValue, variantValue);
+        continue;
+      }
+      mergedVariantFields[key] = variantValue;
+    }
 
-		seenTypes.add(variantType);
-		variantTypes.push(variantType);
-	}
+    seenTypes.add(variantType);
+    variantTypes.push(variantType);
+  }
 
-	if (variantTypes.length < 2 || variantTypes.every(type => type === "object")) {
-		return schema;
-	}
-	const nextSchema = copySchemaWithout(schema, combiner);
-	const nonNullTypes = variantTypes.filter(t => t !== "null");
-	const chosenType: string = nonNullTypes[0] ?? variantTypes[0];
-	nextSchema.type = chosenType;
-	const chosenTypeAllowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[chosenType] ?? {};
+  if (variantTypes.length < 2 || variantTypes.every(type => type === "object")) {
+    return schema;
+  }
+  const nextSchema = copySchemaWithout(schema, combiner);
+  const nonNullTypes = variantTypes.filter(t => t !== "null");
+  const chosenType: string = nonNullTypes[0] ?? variantTypes[0];
+  nextSchema.type = chosenType;
+  const chosenTypeAllowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[chosenType] ?? {};
 
-	// Strip sibling keys that were copied from the parent and belong to a
-	// different type (e.g. `items` sibling on a now-string-typed schema).
-	for (const key in nextSchema) {
-		if (!Object.hasOwn(nextSchema, key)) continue;
-		if (key === "type") continue;
-		if (
-			Object.hasOwn(ALL_CCA_TYPE_SPECIFIC_KEYS, key) &&
-			!Object.hasOwn(chosenTypeAllowedKeys, key) &&
-			!Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)
-		) {
-			delete nextSchema[key];
-		}
-	}
+  // Strip sibling keys that were copied from the parent and belong to a
+  // different type (e.g. `items` sibling on a now-string-typed schema).
+  for (const key in nextSchema) {
+    if (!Object.hasOwn(nextSchema, key)) continue;
+    if (key === "type") continue;
+    if (
+      Object.hasOwn(ALL_CCA_TYPE_SPECIFIC_KEYS, key) &&
+      !Object.hasOwn(chosenTypeAllowedKeys, key) &&
+      !Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)
+    ) {
+      delete nextSchema[key];
+    }
+  }
 
-	for (const key in mergedVariantFields) {
-		if (!Object.hasOwn(mergedVariantFields, key)) continue;
-		// Drop type-specific keys that don't belong to the chosen type
-		if (!Object.hasOwn(chosenTypeAllowedKeys, key) && !Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)) {
-			continue;
-		}
-		const value = mergedVariantFields[key];
-		const existingValue = nextSchema[key];
-		if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {
-			if (key !== "description") return schema;
-			nextSchema[key] = mergeSchemaDescriptions(existingValue, value);
-			continue;
-		}
-		if (existingValue === undefined) {
-			nextSchema[key] = value;
-		}
-	}
-	return nextSchema;
+  for (const key in mergedVariantFields) {
+    if (!Object.hasOwn(mergedVariantFields, key)) continue;
+    // Drop type-specific keys that don't belong to the chosen type
+    if (!Object.hasOwn(chosenTypeAllowedKeys, key) && !Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)) {
+      continue;
+    }
+    const value = mergedVariantFields[key];
+    const existingValue = nextSchema[key];
+    if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {
+      if (key !== "description") return schema;
+      nextSchema[key] = mergeSchemaDescriptions(existingValue, value);
+      continue;
+    }
+    if (existingValue === undefined) {
+      nextSchema[key] = value;
+    }
+  }
+  return nextSchema;
 }
 
 function mergeSchemaDescriptions(existing: unknown, incoming: unknown): string {
-	if (typeof existing !== "string") return typeof incoming === "string" ? incoming : "";
-	if (typeof incoming !== "string" || incoming.length === 0 || existing === incoming) return existing;
-	if (existing.length === 0) return incoming;
-	return `${existing}\n\n${incoming}`;
+  if (typeof existing !== "string") return typeof incoming === "string" ? incoming : "";
+  if (typeof incoming !== "string" || incoming.length === 0 || existing === incoming) return existing;
+  if (existing.length === 0) return incoming;
+  return `${existing}\n\n${incoming}`;
 }
 
 function collapseSameTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
-	const variantsRaw = schema[combiner];
-	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) return schema;
-	let commonType: string | undefined;
-	const variants: JsonObject[] = [];
-	for (const entry of variantsRaw) {
-		if (!isJsonObject(entry) || typeof entry.type !== "string") return schema;
-		if (commonType === undefined) commonType = entry.type;
-		else if (entry.type !== commonType) return schema;
-		variants.push(entry);
-	}
-	const firstEntry = variants[0];
-	if (!firstEntry) return schema;
+  const variantsRaw = schema[combiner];
+  if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) return schema;
+  let commonType: string | undefined;
+  const variants: JsonObject[] = [];
+  for (const entry of variantsRaw) {
+    if (!isJsonObject(entry) || typeof entry.type !== "string") return schema;
+    if (commonType === undefined) commonType = entry.type;
+    else if (entry.type !== commonType) return schema;
+    variants.push(entry);
+  }
+  const firstEntry = variants[0];
+  if (!firstEntry) return schema;
 
-	// Same-type collapse otherwise keeps only the first variant's keys, silently
-	// dropping the other branches' `enum` members (e.g. an anyOf of two string
-	// enums collapsing to just the first).
-	const enumVariantCount = variants.reduce((n, variant) => n + (Array.isArray(variant.enum) ? 1 : 0), 0);
+  // Same-type collapse otherwise keeps only the first variant's keys, silently
+  // dropping the other branches' `enum` members (e.g. an anyOf of two string
+  // enums collapsing to just the first).
+  const enumVariantCount = variants.reduce((n, variant) => n + (Array.isArray(variant.enum) ? 1 : 0), 0);
 
-	let collapsed: JsonObject;
-	if (enumVariantCount === variants.length) {
-		// Every branch is an `enum` schema: fold them with
-		// `mergeCompatibleEnumSchemas`, which unions the members only when the
-		// branches agree on `type` and every non-`enum` field, returning null
-		// otherwise. Bail to the untouched schema on any disagreement so the
-		// residual-combiner fallback handles it instead of mislabeling.
-		let merged: JsonObject | null = firstEntry;
-		for (let i = 1; i < variants.length && merged !== null; i++) {
-			merged = mergeCompatibleEnumSchemas(merged, variants[i]);
-		}
-		if (merged === null) return schema;
-		collapsed = merged;
-	} else if (enumVariantCount > 0) {
-		// Mixed branches: at least one is unconstrained by `enum` and is therefore
-		// broader. Collapse onto the first such branch so the result keeps its
-		// (broader) keys — never narrowing to an enum branch's members or leaking
-		// its metadata (description/default).
-		collapsed = variants.find(variant => !Array.isArray(variant.enum)) ?? firstEntry;
-	} else {
-		// No `enum` branches: keep the original first-wins behavior.
-		collapsed = firstEntry;
-	}
+  let collapsed: JsonObject;
+  if (enumVariantCount === variants.length) {
+    // Every branch is an `enum` schema: fold them with
+    // `mergeCompatibleEnumSchemas`, which unions the members only when the
+    // branches agree on `type` and every non-`enum` field, returning null
+    // otherwise. Bail to the untouched schema on any disagreement so the
+    // residual-combiner fallback handles it instead of mislabeling.
+    let merged: JsonObject | null = firstEntry;
+    for (let i = 1; i < variants.length && merged !== null; i++) {
+      merged = mergeCompatibleEnumSchemas(merged, variants[i]);
+    }
+    if (merged === null) return schema;
+    collapsed = merged;
+  } else if (enumVariantCount > 0) {
+    // Mixed branches: at least one is unconstrained by `enum` and is therefore
+    // broader. Collapse onto the first such branch so the result keeps its
+    // (broader) keys — never narrowing to an enum branch's members or leaking
+    // its metadata (description/default).
+    collapsed = variants.find(variant => !Array.isArray(variant.enum)) ?? firstEntry;
+  } else {
+    // No `enum` branches: keep the original first-wins behavior.
+    collapsed = firstEntry;
+  }
 
-	const nextSchema = copySchemaWithout(schema, combiner);
-	for (const key in collapsed) {
-		if (Object.hasOwn(collapsed, key) && !outHasOwn(nextSchema, key)) nextSchema[key] = collapsed[key];
-	}
-	return nextSchema;
+  const nextSchema = copySchemaWithout(schema, combiner);
+  for (const key in collapsed) {
+    if (Object.hasOwn(collapsed, key) && !outHasOwn(nextSchema, key)) nextSchema[key] = collapsed[key];
+  }
+  return nextSchema;
 }
 
 /**
@@ -729,333 +729,333 @@ function collapseSameTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" 
  * create new anyOf in merged subtrees after child normalization already ran.
  */
 export function stripResidualCombiners(value: unknown, epoch: number = epochNext()): unknown {
-	if (Array.isArray(value)) {
-		if (!once(value, epoch)) return [];
-		return value.map(entry => stripResidualCombiners(entry, epoch));
-	}
-	if (!isJsonObject(value)) return value;
-	if (!once(value, epoch)) return {};
-	const result: JsonObject = {};
-	for (const key in value) {
-		if (Object.hasOwn(value, key)) result[key] = stripResidualCombiners(value[key], epoch);
-	}
-	let current: JsonObject = result;
-	let changed = true;
-	while (changed) {
-		changed = false;
-		for (const combiner of JSON_SCHEMA_COMBINERS) {
-			const sameType = collapseSameTypeCombinerVariants(current, combiner);
-			if (sameType !== current) {
-				current = sameType;
-				changed = true;
-			}
-			const mixed = collapseMixedTypeCombinerVariants(current, combiner);
-			if (mixed !== current) {
-				current = mixed;
-				changed = true;
-			}
-		}
-	}
-	return current;
+  if (Array.isArray(value)) {
+    if (!once(value, epoch)) return [];
+    return value.map(entry => stripResidualCombiners(entry, epoch));
+  }
+  if (!isJsonObject(value)) return value;
+  if (!once(value, epoch)) return {};
+  const result: JsonObject = {};
+  for (const key in value) {
+    if (Object.hasOwn(value, key)) result[key] = stripResidualCombiners(value[key], epoch);
+  }
+  let current: JsonObject = result;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const combiner of JSON_SCHEMA_COMBINERS) {
+      const sameType = collapseSameTypeCombinerVariants(current, combiner);
+      if (sameType !== current) {
+        current = sameType;
+        changed = true;
+      }
+      const mixed = collapseMixedTypeCombinerVariants(current, combiner);
+      if (mixed !== current) {
+        current = mixed;
+        changed = true;
+      }
+    }
+  }
+  return current;
 }
 
 interface NullableExtractionResult {
-	schema: unknown;
-	nullable: boolean;
+  schema: unknown;
+  nullable: boolean;
 }
 
 function extractNullableUnionSchema(schema: unknown): NullableExtractionResult {
-	if (!isJsonObject(schema)) {
-		return { schema, nullable: false };
-	}
+  if (!isJsonObject(schema)) {
+    return { schema, nullable: false };
+  }
 
-	if (schema.nullable === true) {
-		const nextSchema = { ...schema };
-		delete nextSchema.nullable;
-		return { schema: nextSchema, nullable: true };
-	}
+  if (schema.nullable === true) {
+    const nextSchema = { ...schema };
+    delete nextSchema.nullable;
+    return { schema: nextSchema, nullable: true };
+  }
 
-	if (Array.isArray(schema.type)) {
-		const typeVariants = schema.type.filter((entry): entry is string => typeof entry === "string");
-		const nonNullTypes = typeVariants.filter(entry => entry !== "null");
-		if (typeVariants.includes("null") && nonNullTypes.length === 1) {
-			const nextSchema = { ...schema, type: nonNullTypes[0] };
-			return { schema: nextSchema, nullable: true };
-		}
-	}
+  if (Array.isArray(schema.type)) {
+    const typeVariants = schema.type.filter((entry): entry is string => typeof entry === "string");
+    const nonNullTypes = typeVariants.filter(entry => entry !== "null");
+    if (typeVariants.includes("null") && nonNullTypes.length === 1) {
+      const nextSchema = { ...schema, type: nonNullTypes[0] };
+      return { schema: nextSchema, nullable: true };
+    }
+  }
 
-	for (const combiner of JSON_SCHEMA_COMBINERS) {
-		const variantsRaw = schema[combiner];
-		if (!Array.isArray(variantsRaw)) continue;
+  for (const combiner of JSON_SCHEMA_COMBINERS) {
+    const variantsRaw = schema[combiner];
+    if (!Array.isArray(variantsRaw)) continue;
 
-		let hasNullVariant = false;
-		const nonNullVariants: unknown[] = [];
-		for (const variant of variantsRaw) {
-			if (isJsonObject(variant) && variant.type === "null") {
-				let keyCount = 0;
-				for (const k in variant) {
-					if (!Object.hasOwn(variant, k)) continue;
-					if (++keyCount > 1) break;
-				}
-				if (keyCount === 1) {
-					hasNullVariant = true;
-					continue;
-				}
-			}
-			nonNullVariants.push(variant);
-		}
+    let hasNullVariant = false;
+    const nonNullVariants: unknown[] = [];
+    for (const variant of variantsRaw) {
+      if (isJsonObject(variant) && variant.type === "null") {
+        let keyCount = 0;
+        for (const k in variant) {
+          if (!Object.hasOwn(variant, k)) continue;
+          if (++keyCount > 1) break;
+        }
+        if (keyCount === 1) {
+          hasNullVariant = true;
+          continue;
+        }
+      }
+      nonNullVariants.push(variant);
+    }
 
-		if (!hasNullVariant || nonNullVariants.length !== 1 || !isJsonObject(nonNullVariants[0])) {
-			continue;
-		}
+    if (!hasNullVariant || nonNullVariants.length !== 1 || !isJsonObject(nonNullVariants[0])) {
+      continue;
+    }
 
-		const nextSchema = copySchemaWithout(schema, combiner);
-		const nonNullVariant = nonNullVariants[0];
-		for (const key in nonNullVariant) {
-			if (!Object.hasOwn(nonNullVariant, key)) continue;
-			const value = nonNullVariant[key];
-			const existingValue = nextSchema[key];
-			if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {
-				return { schema, nullable: false };
-			}
-			if (existingValue === undefined) {
-				nextSchema[key] = value;
-			}
-		}
-		return { schema: nextSchema, nullable: true };
-	}
+    const nextSchema = copySchemaWithout(schema, combiner);
+    const nonNullVariant = nonNullVariants[0];
+    for (const key in nonNullVariant) {
+      if (!Object.hasOwn(nonNullVariant, key)) continue;
+      const value = nonNullVariant[key];
+      const existingValue = nextSchema[key];
+      if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {
+        return { schema, nullable: false };
+      }
+      if (existingValue === undefined) {
+        nextSchema[key] = value;
+      }
+    }
+    return { schema: nextSchema, nullable: true };
+  }
 
-	return { schema, nullable: false };
+  return { schema, nullable: false };
 }
 
 interface NullableNormalizationResult {
-	schema: unknown;
-	nullable: boolean;
+  schema: unknown;
+  nullable: boolean;
 }
 
 function normalizeNullablePropertiesForCloudCodeAssist(
-	value: unknown,
-	isPropertySchema = false,
-	epoch: number = epochNext(),
+  value: unknown,
+  isPropertySchema = false,
+  epoch: number = epochNext(),
 ): NullableNormalizationResult {
-	if (Array.isArray(value)) {
-		if (!once(value, epoch)) {
-			return { schema: [], nullable: false };
-		}
-		return {
-			schema: value.map(entry => normalizeNullablePropertiesForCloudCodeAssist(entry, false, epoch).schema),
-			nullable: false,
-		};
-	}
-	if (!isJsonObject(value)) {
-		return { schema: value, nullable: false };
-	}
-	if (!once(value, epoch)) {
-		return { schema: {}, nullable: false };
-	}
+  if (Array.isArray(value)) {
+    if (!once(value, epoch)) {
+      return { schema: [], nullable: false };
+    }
+    return {
+      schema: value.map(entry => normalizeNullablePropertiesForCloudCodeAssist(entry, false, epoch).schema),
+      nullable: false,
+    };
+  }
+  if (!isJsonObject(value)) {
+    return { schema: value, nullable: false };
+  }
+  if (!once(value, epoch)) {
+    return { schema: {}, nullable: false };
+  }
 
-	const normalized: JsonObject = {};
-	for (const key in value) {
-		if (Object.hasOwn(value, key))
-			normalized[key] = normalizeNullablePropertiesForCloudCodeAssist(value[key], false, epoch).schema;
-	}
+  const normalized: JsonObject = {};
+  for (const key in value) {
+    if (Object.hasOwn(value, key))
+      normalized[key] = normalizeNullablePropertiesForCloudCodeAssist(value[key], false, epoch).schema;
+  }
 
-	if (isJsonObject(normalized.properties)) {
-		const properties = normalized.properties;
-		const required = new Set(
-			Array.isArray(normalized.required)
-				? normalized.required.filter((entry): entry is string => typeof entry === "string")
-				: [],
-		);
-		const nextProperties: JsonObject = {};
-		for (const name in properties) {
-			if (!Object.hasOwn(properties, name)) continue;
-			const normalizedProperty = normalizeNullablePropertiesForCloudCodeAssist(properties[name], true, epoch);
-			nextProperties[name] = normalizedProperty.schema;
-			if (normalizedProperty.nullable) {
-				required.delete(name);
-			}
-		}
-		normalized.properties = nextProperties;
-		if (Array.isArray(normalized.required)) {
-			normalized.required = Array.from(required);
-		}
-	}
+  if (isJsonObject(normalized.properties)) {
+    const properties = normalized.properties;
+    const required = new Set(
+      Array.isArray(normalized.required)
+        ? normalized.required.filter((entry): entry is string => typeof entry === "string")
+        : [],
+    );
+    const nextProperties: JsonObject = {};
+    for (const name in properties) {
+      if (!Object.hasOwn(properties, name)) continue;
+      const normalizedProperty = normalizeNullablePropertiesForCloudCodeAssist(properties[name], true, epoch);
+      nextProperties[name] = normalizedProperty.schema;
+      if (normalizedProperty.nullable) {
+        required.delete(name);
+      }
+    }
+    normalized.properties = nextProperties;
+    if (Array.isArray(normalized.required)) {
+      normalized.required = Array.from(required);
+    }
+  }
 
-	if (!isPropertySchema) {
-		return { schema: normalized, nullable: false };
-	}
+  if (!isPropertySchema) {
+    return { schema: normalized, nullable: false };
+  }
 
-	return extractNullableUnionSchema(normalized);
+  return extractNullableUnionSchema(normalized);
 }
 
 function createResidualIncompatibilityChecks(
-	checks: ReadonlyArray<ResidualSchemaIncompatibility> | undefined,
+  checks: ReadonlyArray<ResidualSchemaIncompatibility> | undefined,
 ): ResidualIncompatibilityChecks | undefined {
-	if (!checks || checks.length === 0) return undefined;
-	const result: ResidualIncompatibilityChecks = {
-		typeArray: false,
-		typeNull: false,
-		nullable: false,
-		combiners: false,
-		not: false,
-	};
-	for (const check of checks) {
-		switch (check) {
-			case "type-array":
-				result.typeArray = true;
-				break;
-			case "type-null":
-				result.typeNull = true;
-				break;
-			case "nullable":
-				result.nullable = true;
-				break;
-			case "not":
-				result.not = true;
-				break;
-			case "combiners":
-				result.combiners = true;
-				break;
-		}
-	}
-	return result;
+  if (!checks || checks.length === 0) return undefined;
+  const result: ResidualIncompatibilityChecks = {
+    typeArray: false,
+    typeNull: false,
+    nullable: false,
+    combiners: false,
+    not: false,
+  };
+  for (const check of checks) {
+    switch (check) {
+      case "type-array":
+        result.typeArray = true;
+        break;
+      case "type-null":
+        result.typeNull = true;
+        break;
+      case "nullable":
+        result.nullable = true;
+        break;
+      case "not":
+        result.not = true;
+        break;
+      case "combiners":
+        result.combiners = true;
+        break;
+    }
+  }
+  return result;
 }
 
 function hasResidualSchemaIncompatibilities(
-	value: unknown,
-	checks: ResidualIncompatibilityChecks,
-	epoch: number = epochNext(),
-	insideSchemaMap = false,
+  value: unknown,
+  checks: ResidualIncompatibilityChecks,
+  epoch: number = epochNext(),
+  insideSchemaMap = false,
 ): boolean {
-	if (Array.isArray(value)) {
-		if (!once(value, epoch)) return false;
-		return value.some(entry => hasResidualSchemaIncompatibilities(entry, checks, epoch, insideSchemaMap));
-	}
-	if (!isJsonObject(value)) {
-		return false;
-	}
-	if (!once(value, epoch)) {
-		return false;
-	}
+  if (Array.isArray(value)) {
+    if (!once(value, epoch)) return false;
+    return value.some(entry => hasResidualSchemaIncompatibilities(entry, checks, epoch, insideSchemaMap));
+  }
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  if (!once(value, epoch)) {
+    return false;
+  }
 
-	if (checks.typeArray && Array.isArray(value.type)) return true;
-	if (checks.typeNull && value.type === "null") return true;
-	if (checks.nullable && Object.hasOwn(value, "nullable")) return true;
-	if (!insideSchemaMap && checks.not && Object.hasOwn(value, "not")) return true;
-	if (!insideSchemaMap && checks.combiners) {
-		for (const combiner of CCA_FORBIDDEN_COMBINERS) {
-			if (Array.isArray(value[combiner])) return true;
-		}
-	}
-	for (const k in value) {
-		if (!Object.hasOwn(value, k)) continue;
-		if (
-			hasResidualSchemaIncompatibilities(
-				value[k],
-				checks,
-				epoch,
-				!insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, k),
-			)
-		) {
-			return true;
-		}
-	}
-	return false;
+  if (checks.typeArray && Array.isArray(value.type)) return true;
+  if (checks.typeNull && value.type === "null") return true;
+  if (checks.nullable && Object.hasOwn(value, "nullable")) return true;
+  if (!insideSchemaMap && checks.not && Object.hasOwn(value, "not")) return true;
+  if (!insideSchemaMap && checks.combiners) {
+    for (const combiner of CCA_FORBIDDEN_COMBINERS) {
+      if (Array.isArray(value[combiner])) return true;
+    }
+  }
+  for (const k in value) {
+    if (!Object.hasOwn(value, k)) continue;
+    if (
+      hasResidualSchemaIncompatibilities(
+        value[k],
+        checks,
+        epoch,
+        !insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, k),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function normalizeSchema(value: unknown, options: NormalizeSchemaOptions): unknown {
-	const detoxified = decontaminateZodInstance(value);
-	const upgraded = upgradeJsonSchemaTo202012(detoxified);
-	const dereferenced = dereferenceJsonSchema(upgraded);
-	let normalized = normalizeSchemaNode(dereferenced, {
-		...options,
-		insideSchemaMap: false,
-		booleanIsSubschema: true,
-	});
-	if (options.stripResidualCombinersFixpoint) {
-		normalized = stripResidualCombiners(normalized);
-	}
-	if (options.extractNullableFromUnions) {
-		normalized = normalizeNullablePropertiesForCloudCodeAssist(normalized).schema;
-	}
-	const residualChecks = createResidualIncompatibilityChecks(options.rejectResidualIncompatibilities);
-	if (residualChecks && hasResidualSchemaIncompatibilities(normalized, residualChecks)) {
-		logger.debug("Schema has residual provider incompatibilities, using fallback");
-		return options.validateAndFallback?.fallback ?? normalized;
-	}
-	if (options.validateAndFallback && !isValidJsonSchema(normalized)) {
-		logger.debug("Schema failed validation, using fallback");
-		return options.validateAndFallback.fallback;
-	}
-	return normalized;
+  const detoxified = decontaminateZodInstance(value);
+  const upgraded = upgradeJsonSchemaTo202012(detoxified);
+  const dereferenced = dereferenceJsonSchema(upgraded);
+  let normalized = normalizeSchemaNode(dereferenced, {
+    ...options,
+    insideSchemaMap: false,
+    booleanIsSubschema: true,
+  });
+  if (options.stripResidualCombinersFixpoint) {
+    normalized = stripResidualCombiners(normalized);
+  }
+  if (options.extractNullableFromUnions) {
+    normalized = normalizeNullablePropertiesForCloudCodeAssist(normalized).schema;
+  }
+  const residualChecks = createResidualIncompatibilityChecks(options.rejectResidualIncompatibilities);
+  if (residualChecks && hasResidualSchemaIncompatibilities(normalized, residualChecks)) {
+    logger.debug("Schema has residual provider incompatibilities, using fallback");
+    return options.validateAndFallback?.fallback ?? normalized;
+  }
+  if (options.validateAndFallback && !isValidJsonSchema(normalized)) {
+    logger.debug("Schema failed validation, using fallback");
+    return options.validateAndFallback.fallback;
+  }
+  return normalized;
 }
 
 export function normalizeSchemaForGoogle(value: unknown): unknown {
-	return normalizeSchema(value, {
-		coerceBooleanSubschemas: true,
-		unsupportedFields: isGoogleUnsupportedSchemaField,
-		normalizeFieldNames: true,
-		collapseNullFields: true,
-		normalizeTypeArrayToNullable: true,
-		stripNullableKeyword: false,
-		autoPropertyOrdering: true,
-		ensureObjectProperties: true,
-		liftStrippedToDescription: { format: "spill" },
-		mergeObjectCombiners: false,
-		collapseSameTypeCombiners: false,
-		collapseMixedTypeCombiners: false,
-		stripResidualCombinersFixpoint: false,
-		extractNullableFromUnions: false,
-		inferTypeForBareEnum: true,
-		dropNonScalarEnum: false,
-		foldOneOfIntoAnyOf: false,
-	});
+  return normalizeSchema(value, {
+    coerceBooleanSubschemas: true,
+    unsupportedFields: isGoogleUnsupportedSchemaField,
+    normalizeFieldNames: true,
+    collapseNullFields: true,
+    normalizeTypeArrayToNullable: true,
+    stripNullableKeyword: false,
+    autoPropertyOrdering: true,
+    ensureObjectProperties: true,
+    liftStrippedToDescription: { format: "spill" },
+    mergeObjectCombiners: false,
+    collapseSameTypeCombiners: false,
+    collapseMixedTypeCombiners: false,
+    stripResidualCombinersFixpoint: false,
+    extractNullableFromUnions: false,
+    inferTypeForBareEnum: true,
+    dropNonScalarEnum: false,
+    foldOneOfIntoAnyOf: false,
+  });
 }
 
 export function normalizeSchemaForCCA(value: unknown): unknown {
-	return normalizeSchema(value, {
-		coerceBooleanSubschemas: true,
-		unsupportedFields: isGoogleUnsupportedSchemaField,
-		normalizeFieldNames: true,
-		collapseNullFields: false,
-		normalizeTypeArrayToNullable: true,
-		stripNullableKeyword: true,
-		autoPropertyOrdering: false,
-		ensureObjectProperties: true,
-		liftStrippedToDescription: { format: "spill" },
-		mergeObjectCombiners: true,
-		collapseSameTypeCombiners: true,
-		collapseMixedTypeCombiners: true,
-		stripResidualCombinersFixpoint: true,
-		extractNullableFromUnions: true,
-		inferTypeForBareEnum: true,
-		dropNonScalarEnum: false,
-		foldOneOfIntoAnyOf: false,
-		rejectResidualIncompatibilities: ["type-array", "type-null", "nullable", "combiners", "not"],
-		validateAndFallback: { fallback: CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA },
-	});
+  return normalizeSchema(value, {
+    coerceBooleanSubschemas: true,
+    unsupportedFields: isGoogleUnsupportedSchemaField,
+    normalizeFieldNames: true,
+    collapseNullFields: false,
+    normalizeTypeArrayToNullable: true,
+    stripNullableKeyword: true,
+    autoPropertyOrdering: false,
+    ensureObjectProperties: true,
+    liftStrippedToDescription: { format: "spill" },
+    mergeObjectCombiners: true,
+    collapseSameTypeCombiners: true,
+    collapseMixedTypeCombiners: true,
+    stripResidualCombinersFixpoint: true,
+    extractNullableFromUnions: true,
+    inferTypeForBareEnum: true,
+    dropNonScalarEnum: false,
+    foldOneOfIntoAnyOf: false,
+    rejectResidualIncompatibilities: ["type-array", "type-null", "nullable", "combiners", "not"],
+    validateAndFallback: { fallback: CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA },
+  });
 }
 
 export function normalizeSchemaForMCP(value: unknown): unknown {
-	return normalizeSchema(value, {
-		unsupportedFields: isMcpUnsupportedSchemaField,
-		normalizeFieldNames: false,
-		collapseNullFields: false,
-		normalizeTypeArrayToNullable: false,
-		foldOneOfIntoAnyOf: false,
-		stripNullableKeyword: true,
-		autoPropertyOrdering: false,
-		ensureObjectProperties: false,
-		liftStrippedToDescription: false,
-		mergeObjectCombiners: false,
-		collapseSameTypeCombiners: false,
-		collapseMixedTypeCombiners: false,
-		stripResidualCombinersFixpoint: false,
-		extractNullableFromUnions: false,
-		inferTypeForBareEnum: false,
-		dropNonScalarEnum: false,
-	});
+  return normalizeSchema(value, {
+    unsupportedFields: isMcpUnsupportedSchemaField,
+    normalizeFieldNames: false,
+    collapseNullFields: false,
+    normalizeTypeArrayToNullable: false,
+    foldOneOfIntoAnyOf: false,
+    stripNullableKeyword: true,
+    autoPropertyOrdering: false,
+    ensureObjectProperties: false,
+    liftStrippedToDescription: false,
+    mergeObjectCombiners: false,
+    collapseSameTypeCombiners: false,
+    collapseMixedTypeCombiners: false,
+    stripResidualCombinersFixpoint: false,
+    extractNullableFromUnions: false,
+    inferTypeForBareEnum: false,
+    dropNonScalarEnum: false,
+  });
 }
 
 /**
@@ -1086,146 +1086,158 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  * and the depth-10 limit.
  */
 export function normalizeSchemaForMoonshot(value: unknown): unknown {
-	return normalizeSchema(value, {
-		unsupportedFields: isMoonshotUnsupportedSchemaField,
-		normalizeFieldNames: false,
-		collapseNullFields: false,
-		normalizeTypeArrayToNullable: true,
-		stripNullableKeyword: true,
-		autoPropertyOrdering: false,
-		ensureObjectProperties: false,
-		liftStrippedToDescription: { format: "spill" },
-		mergeObjectCombiners: false,
-		collapseSameTypeCombiners: false,
-		collapseMixedTypeCombiners: false,
-		stripResidualCombinersFixpoint: false,
-		extractNullableFromUnions: false,
-		inferTypeForBareEnum: true,
-		dropNonScalarEnum: true,
-		foldOneOfIntoAnyOf: true,
-	});
+  return normalizeSchema(value, {
+    unsupportedFields: isMoonshotUnsupportedSchemaField,
+    normalizeFieldNames: false,
+    collapseNullFields: false,
+    normalizeTypeArrayToNullable: true,
+    stripNullableKeyword: true,
+    autoPropertyOrdering: false,
+    ensureObjectProperties: false,
+    liftStrippedToDescription: { format: "spill" },
+    mergeObjectCombiners: false,
+    collapseSameTypeCombiners: false,
+    collapseMixedTypeCombiners: false,
+    stripResidualCombinersFixpoint: false,
+    extractNullableFromUnions: false,
+    inferTypeForBareEnum: true,
+    dropNonScalarEnum: true,
+    foldOneOfIntoAnyOf: true,
+  });
 }
 
 // ---------------------------------------------------------------------------
-// Ollama — Go schema parser compatibility
+// Grammar-constrained samplers — schema compatibility
 // ---------------------------------------------------------------------------
+// Ollama's Go `/api/chat` tool parser and llama.cpp's JSON-schema→GBNF grammar
+// generator (reached via the openai-completions encoder for `llama.cpp`,
+// `lm-studio`, `vllm`, and any OpenAI-compatible server) both reject
+// bare boolean subschemas (`true`/`false`) and boolean `additionalProperties`/
+// `unevaluatedProperties` with HTTP 400 "Unrecognized schema: true". This
+// sanitizer rewrites those forms into grammar-safe equivalents so unconstrained
+// fields still advertise "any JSON value" instead of collapsing to a closed
+// empty object (issue #1179) or 400-ing (issue #4488).
 
-const OLLAMA_SCHEMA_VALUE_KEYS = new Set([
-	"items",
-	"additionalItems",
-	"contains",
-	"contentSchema",
-	"propertyNames",
-	"if",
-	"then",
-	"else",
-	"not",
-	"additionalProperties",
-	"unevaluatedItems",
-	"unevaluatedProperties",
+const GRAMMAR_SCHEMA_VALUE_KEYS = new Set([
+  "items",
+  "additionalItems",
+  "contains",
+  "contentSchema",
+  "propertyNames",
+  "if",
+  "then",
+  "else",
+  "not",
+  "additionalProperties",
+  "unevaluatedItems",
+  "unevaluatedProperties",
 ]);
 
 /**
- * Widened stand-in for a `true` / `{}` subschema in an Ollama-bound tool.
+ * Widened stand-in for a `true` / `{}` subschema on a grammar-constrained wire.
  *
  * `toolWireSchema()` normalizes empty schemas to boolean `true` upstream so
  * grammar-constrained samplers (llama.cpp, etc.) don't treat `{}` as
- * "generate an empty object" (issue #1179). Ollama's Go tool parser can't
- * unmarshal a boolean into its object-shaped `Schema` struct, so this
- * sanitizer replaces every open subschema with an explicit union of every
- * primitive JSON type. Both invariants survive: the wire has no boolean
- * subschema (Go accepts it), and llama.cpp's grammar sees a real value
- * union rather than a closed empty object.
+ * "generate an empty object" (issue #1179). The Go/GBNF parsers those samplers
+ * use can't represent a bare boolean subschema, so this sanitizer replaces
+ * every open subschema with an explicit union of every primitive JSON type.
+ * Both invariants survive: the wire has no boolean subschema, and the sampler's
+ * grammar sees a real value union rather than a closed empty object.
  */
-const OLLAMA_OPEN_SUBSCHEMA_WIDENING = Object.freeze({
-	anyOf: [
-		{ type: "string" },
-		{ type: "number" },
-		{ type: "boolean" },
-		{ type: "object" },
-		{ type: "array" },
-		{ type: "null" },
-	],
+const GRAMMAR_OPEN_SUBSCHEMA_WIDENING = Object.freeze({
+  anyOf: [
+    { type: "string" },
+    { type: "number" },
+    { type: "boolean" },
+    { type: "object" },
+    { type: "array" },
+    { type: "null" },
+  ],
 });
 
 /**
- * Rewrites standard JSON Schema forms that Ollama's Go `/api/chat` tool parser
- * cannot unmarshal into its object-shaped `Schema` struct.
+ * Rewrites standard JSON Schema forms that grammar-constrained tool parsers
+ * (Ollama's Go `/api/chat` `Schema` struct, llama.cpp's GBNF generator) cannot
+ * represent: bare boolean subschemas (`true`/`false`) become a value-widening
+ * `anyOf` of primitives, boolean `additionalProperties`/`unevaluatedProperties`
+ * are stripped, and nullable `type` arrays are flattened. Applied on the
+ * openai-completions and ollama transports for local grammar-constrained
+ * backends (`compat.sanitizeToolSchemaForGrammar`).
  */
-export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
-	const normalizeNode = (value: unknown): unknown => {
-		if (value === true) return OLLAMA_OPEN_SUBSCHEMA_WIDENING;
-		if (value === false) return { not: OLLAMA_OPEN_SUBSCHEMA_WIDENING };
-		if (!isJsonObject(value)) {
-			if (!Array.isArray(value)) return value;
-			let changed = false;
-			const output = value.map(item => {
-				const next = normalizeNode(item);
-				if (next !== item) changed = true;
-				return next;
-			});
-			return changed ? output : value;
-		}
+export function sanitizeSchemaForGrammarConstrainedSampler(schema: JsonObject): JsonObject {
+  const normalizeNode = (value: unknown): unknown => {
+    if (value === true) return GRAMMAR_OPEN_SUBSCHEMA_WIDENING;
+    if (value === false) return { not: GRAMMAR_OPEN_SUBSCHEMA_WIDENING };
+    if (!isJsonObject(value)) {
+      if (!Array.isArray(value)) return value;
+      let changed = false;
+      const output = value.map(item => {
+        const next = normalizeNode(item);
+        if (next !== item) changed = true;
+        return next;
+      });
+      return changed ? output : value;
+    }
 
-		let changed = false;
-		const output: JsonObject = {};
-		let typeAlternatives: JsonObject[] | undefined;
-		for (const key in value) {
-			if (!Object.hasOwn(value, key)) continue;
-			const child = value[key];
-			if ((key === "additionalProperties" || key === "unevaluatedProperties") && typeof child === "boolean") {
-				changed = true;
-				continue;
-			}
-			if (key === "type" && Array.isArray(child)) {
-				const variants = child.filter((entry): entry is string => typeof entry === "string");
-				const uniqueVariants = [...new Set(variants)];
-				const nonNull = uniqueVariants.filter(entry => entry !== "null");
-				if (nonNull.length <= 1) {
-					output.type = nonNull[0] ?? uniqueVariants[0] ?? child[0];
-				} else {
-					typeAlternatives = uniqueVariants.map(entry => ({ type: entry }));
-				}
-				changed = true;
-				continue;
-			}
+    let changed = false;
+    const output: JsonObject = {};
+    let typeAlternatives: JsonObject[] | undefined;
+    for (const key in value) {
+      if (!Object.hasOwn(value, key)) continue;
+      const child = value[key];
+      if ((key === "additionalProperties" || key === "unevaluatedProperties") && typeof child === "boolean") {
+        changed = true;
+        continue;
+      }
+      if (key === "type" && Array.isArray(child)) {
+        const variants = child.filter((entry): entry is string => typeof entry === "string");
+        const uniqueVariants = [...new Set(variants)];
+        const nonNull = uniqueVariants.filter(entry => entry !== "null");
+        if (nonNull.length <= 1) {
+          output.type = nonNull[0] ?? uniqueVariants[0] ?? child[0];
+        } else {
+          typeAlternatives = uniqueVariants.map(entry => ({ type: entry }));
+        }
+        changed = true;
+        continue;
+      }
 
-			let next = child;
-			if (Object.hasOwn(SUBSCHEMA_MAP_KEYS, key) && isJsonObject(child)) {
-				let mapChanged = false;
-				const mapOutput: JsonObject = {};
-				for (const childKey in child) {
-					if (!Object.hasOwn(child, childKey)) continue;
-					const mapChild = child[childKey];
-					const normalizedChild = normalizeNode(mapChild);
-					if (normalizedChild !== mapChild) mapChanged = true;
-					mapOutput[childKey] = normalizedChild;
-				}
-				next = mapChanged ? mapOutput : child;
-			} else if (Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key) && Array.isArray(child)) {
-				let arrayChanged = false;
-				const arrayOutput = child.map(item => {
-					const normalizedItem = normalizeNode(item);
-					if (normalizedItem !== item) arrayChanged = true;
-					return normalizedItem;
-				});
-				next = arrayChanged ? arrayOutput : child;
-			} else if (OLLAMA_SCHEMA_VALUE_KEYS.has(key)) {
-				next = normalizeNode(child);
-			}
-			if (next !== child) changed = true;
-			output[key] = next;
-		}
+      let next = child;
+      if (Object.hasOwn(SUBSCHEMA_MAP_KEYS, key) && isJsonObject(child)) {
+        let mapChanged = false;
+        const mapOutput: JsonObject = {};
+        for (const childKey in child) {
+          if (!Object.hasOwn(child, childKey)) continue;
+          const mapChild = child[childKey];
+          const normalizedChild = normalizeNode(mapChild);
+          if (normalizedChild !== mapChild) mapChanged = true;
+          mapOutput[childKey] = normalizedChild;
+        }
+        next = mapChanged ? mapOutput : child;
+      } else if (Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key) && Array.isArray(child)) {
+        let arrayChanged = false;
+        const arrayOutput = child.map(item => {
+          const normalizedItem = normalizeNode(item);
+          if (normalizedItem !== item) arrayChanged = true;
+          return normalizedItem;
+        });
+        next = arrayChanged ? arrayOutput : child;
+      } else if (GRAMMAR_SCHEMA_VALUE_KEYS.has(key)) {
+        next = normalizeNode(child);
+      }
+      if (next !== child) changed = true;
+      output[key] = next;
+    }
 
-		if (typeAlternatives) {
-			const existingAllOf = output.allOf;
-			const typeUnion = { anyOf: typeAlternatives };
-			output.allOf = Array.isArray(existingAllOf) ? [typeUnion, ...existingAllOf] : [typeUnion];
-		}
+    if (typeAlternatives) {
+      const existingAllOf = output.allOf;
+      const typeUnion = { anyOf: typeAlternatives };
+      output.allOf = Array.isArray(existingAllOf) ? [typeUnion, ...existingAllOf] : [typeUnion];
+    }
 
-		return changed ? output : value;
-	};
-	return normalizeNode(schema) as JsonObject;
+    return changed ? output : value;
+  };
+  return normalizeNode(schema) as JsonObject;
 }
 
 // ---------------------------------------------------------------------------
@@ -1234,30 +1246,30 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 
 const OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
 const OPENAI_RESPONSES_SCHEMA_MAP_KEYS = new Set([
-	"properties",
-	"patternProperties",
-	// `dependencies` is the Draft-04..07 schema-valued form; older MCP servers
-	// still emit `{ dependencies: { foo: { type: "object" } } }`. String-array
-	// branches per key pass through `normalizeOpenAIResponsesSchemaNode`
-	// untouched because non-objects return as-is.
-	"dependencies",
-	"dependentSchemas",
-	"$defs",
-	"definitions",
+  "properties",
+  "patternProperties",
+  // `dependencies` is the Draft-04..07 schema-valued form; older MCP servers
+  // still emit `{ dependencies: { foo: { type: "object" } } }`. String-array
+  // branches per key pass through `normalizeOpenAIResponsesSchemaNode`
+  // untouched because non-objects return as-is.
+  "dependencies",
+  "dependentSchemas",
+  "$defs",
+  "definitions",
 ]);
 const OPENAI_RESPONSES_SCHEMA_VALUE_KEYS = new Set([
-	"items",
-	"additionalItems",
-	"contains",
-	"contentSchema",
-	"propertyNames",
-	"if",
-	"then",
-	"else",
-	"not",
-	"additionalProperties",
-	"unevaluatedItems",
-	"unevaluatedProperties",
+  "items",
+  "additionalItems",
+  "contains",
+  "contentSchema",
+  "propertyNames",
+  "if",
+  "then",
+  "else",
+  "not",
+  "additionalProperties",
+  "unevaluatedItems",
+  "unevaluatedProperties",
 ]);
 
 /**
@@ -1273,7 +1285,7 @@ const OPENAI_RESPONSES_SCHEMA_VALUE_KEYS = new Set([
  * would not survive).
  */
 export function sanitizeSchemaForOpenAIResponses(schema: JsonObject): JsonObject {
-	return normalizeOpenAIResponsesSchemaNode(schema, new WeakMap()) as JsonObject;
+  return normalizeOpenAIResponsesSchemaNode(schema, new WeakMap()) as JsonObject;
 }
 
 /**
@@ -1285,158 +1297,158 @@ const OPENAI_UNSUPPORTED_REGEX_LOOKAROUNDS = new Set(["=", "!", "<=", "<!"]);
 const OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK = ".*";
 
 function hasOpenAIUnsupportedRegexLookaround(pattern: string): boolean {
-	let groupStart = pattern.indexOf("(?");
-	while (groupStart !== -1) {
-		let escapes = 0;
-		for (let i = groupStart - 1; i >= 0 && pattern[i] === "\\"; i--) escapes++;
-		if (escapes % 2 === 0) {
-			const operator =
-				pattern[groupStart + 2] === "<" ? pattern.slice(groupStart + 2, groupStart + 4) : pattern[groupStart + 2];
-			if (OPENAI_UNSUPPORTED_REGEX_LOOKAROUNDS.has(operator)) return true;
-		}
-		groupStart = pattern.indexOf("(?", groupStart + 2);
-	}
-	return false;
+  let groupStart = pattern.indexOf("(?");
+  while (groupStart !== -1) {
+    let escapes = 0;
+    for (let i = groupStart - 1; i >= 0 && pattern[i] === "\\"; i--) escapes++;
+    if (escapes % 2 === 0) {
+      const operator =
+        pattern[groupStart + 2] === "<" ? pattern.slice(groupStart + 2, groupStart + 4) : pattern[groupStart + 2];
+      if (OPENAI_UNSUPPORTED_REGEX_LOOKAROUNDS.has(operator)) return true;
+    }
+    groupStart = pattern.indexOf("(?", groupStart + 2);
+  }
+  return false;
 }
 
 function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonObject, unknown>): unknown {
-	if (!isJsonObject(value)) return value;
+  if (!isJsonObject(value)) return value;
 
-	// `{}` (empty JSON Schema) ≡ `true` (JSON Schema draft 2020-12 §4.3.1).
-	// Grammar-constrained samplers (llama.cpp, etc.) treat the object form as
-	// "generate an empty object" rather than "any JSON value" (issue #1179).
-	// `toolWireSchema` already runs `normalizeEmptySchemas` upstream, but this
-	// guard remains as a safety net for callers that invoke
-	// `sanitizeSchemaForOpenAIResponses` directly on a schema that bypassed
-	// the wire-schema pipeline (e.g. provider-specific fixtures, debug paths).
-	if (isJsonObjectEmpty(value)) return true;
+  // `{}` (empty JSON Schema) ≡ `true` (JSON Schema draft 2020-12 §4.3.1).
+  // Grammar-constrained samplers (llama.cpp, etc.) treat the object form as
+  // "generate an empty object" rather than "any JSON value" (issue #1179).
+  // `toolWireSchema` already runs `normalizeEmptySchemas` upstream, but this
+  // guard remains as a safety net for callers that invoke
+  // `sanitizeSchemaForOpenAIResponses` directly on a schema that bypassed
+  // the wire-schema pipeline (e.g. provider-specific fixtures, debug paths).
+  if (isJsonObjectEmpty(value)) return true;
 
-	const cached = cache.get(value);
-	if (cached) return cached;
+  const cached = cache.get(value);
+  if (cached) return cached;
 
-	// Seed the cache with the in-flight `output` BEFORE recursing so that a
-	// child re-entering this node mid-walk gets the partial back instead of
-	// triggering an infinite recursion. A cycle hitting this seeded entry
-	// forces `changed = true` below (the cached partial is referentially
-	// distinct from `value`), which is why the final `cache.set(value, result)`
-	// never silently overwrites the seed with `value` on a cyclic input.
-	const output: JsonObject = {};
-	cache.set(value, output);
+  // Seed the cache with the in-flight `output` BEFORE recursing so that a
+  // child re-entering this node mid-walk gets the partial back instead of
+  // triggering an infinite recursion. A cycle hitting this seeded entry
+  // forces `changed = true` below (the cached partial is referentially
+  // distinct from `value`), which is why the final `cache.set(value, result)`
+  // never silently overwrites the seed with `value` on a cyclic input.
+  const output: JsonObject = {};
+  cache.set(value, output);
 
-	let changed = false;
-	for (const key in value) {
-		if (!Object.hasOwn(value, key)) continue;
-		// Drop only well-formed `oneOf` arrays here; they are re-emitted as
-		// `anyOf` after the loop so any neighboring `anyOf` entries can be
-		// concatenated. A non-array `oneOf` is malformed for the wire but
-		// still preserved verbatim so callers can see the original payload
-		// instead of having it silently disappear.
-		if (key === "oneOf" && Array.isArray(value.oneOf)) {
-			changed = true;
-			continue;
-		}
-		if (
-			key === "pattern" &&
-			typeof value.pattern === "string" &&
-			hasOpenAIUnsupportedRegexLookaround(value.pattern)
-		) {
-			changed = true;
-			continue;
-		}
+  let changed = false;
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) continue;
+    // Drop only well-formed `oneOf` arrays here; they are re-emitted as
+    // `anyOf` after the loop so any neighboring `anyOf` entries can be
+    // concatenated. A non-array `oneOf` is malformed for the wire but
+    // still preserved verbatim so callers can see the original payload
+    // instead of having it silently disappear.
+    if (key === "oneOf" && Array.isArray(value.oneOf)) {
+      changed = true;
+      continue;
+    }
+    if (
+      key === "pattern" &&
+      typeof value.pattern === "string" &&
+      hasOpenAIUnsupportedRegexLookaround(value.pattern)
+    ) {
+      changed = true;
+      continue;
+    }
 
-		const child = value[key];
-		let next: unknown = child;
-		if (key === "patternProperties" && isJsonObject(child)) {
-			next = normalizeOpenAIResponsesSchemaMap(child, cache, true);
-		} else if (OPENAI_RESPONSES_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
-			next = normalizeOpenAIResponsesSchemaMap(child, cache, false);
-		} else if (OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
-			next = normalizeOpenAIResponsesSchemaArray(child, cache);
-		} else if (OPENAI_RESPONSES_SCHEMA_VALUE_KEYS.has(key) && isJsonObject(child)) {
-			next = normalizeOpenAIResponsesSchemaNode(child, cache);
-		}
+    const child = value[key];
+    let next: unknown = child;
+    if (key === "patternProperties" && isJsonObject(child)) {
+      next = normalizeOpenAIResponsesSchemaMap(child, cache, true);
+    } else if (OPENAI_RESPONSES_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+      next = normalizeOpenAIResponsesSchemaMap(child, cache, false);
+    } else if (OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+      next = normalizeOpenAIResponsesSchemaArray(child, cache);
+    } else if (OPENAI_RESPONSES_SCHEMA_VALUE_KEYS.has(key) && isJsonObject(child)) {
+      next = normalizeOpenAIResponsesSchemaNode(child, cache);
+    }
 
-		if (next !== child) changed = true;
-		output[key] = next;
-	}
+    if (next !== child) changed = true;
+    output[key] = next;
+  }
 
-	if (Array.isArray(value.oneOf)) {
-		const rewrittenOneOf = normalizeOpenAIResponsesSchemaArray(value.oneOf, cache);
-		const existingAnyOf = output.anyOf;
-		output.anyOf = Array.isArray(existingAnyOf)
-			? [...existingAnyOf, ...(rewrittenOneOf as unknown[])]
-			: rewrittenOneOf;
-	}
+  if (Array.isArray(value.oneOf)) {
+    const rewrittenOneOf = normalizeOpenAIResponsesSchemaArray(value.oneOf, cache);
+    const existingAnyOf = output.anyOf;
+    output.anyOf = Array.isArray(existingAnyOf)
+      ? [...existingAnyOf, ...(rewrittenOneOf as unknown[])]
+      : rewrittenOneOf;
+  }
 
-	// Draft 2020-12 lets `type` be an array (e.g. `["object", "null"]`); treat
-	// any variant that includes "object" as an object position for the
-	// properties requirement.
-	if (declaresObjectType(value.type) && !Object.hasOwn(value, "properties")) {
-		output.properties = {};
-		changed = true;
-	}
+  // Draft 2020-12 lets `type` be an array (e.g. `["object", "null"]`); treat
+  // any variant that includes "object" as an object position for the
+  // properties requirement.
+  if (declaresObjectType(value.type) && !Object.hasOwn(value, "properties")) {
+    output.properties = {};
+    changed = true;
+  }
 
-	// Safe to overwrite the seed: any cyclic re-entry above already observed
-	// the seeded partial and set `changed = true` for that node, so a node
-	// that finishes with `changed === false` is provably non-cyclic and
-	// referentially equal to its input.
-	const result = changed ? (isJsonObjectEmpty(output) ? true : output) : value;
-	cache.set(value, result);
-	return result;
+  // Safe to overwrite the seed: any cyclic re-entry above already observed
+  // the seeded partial and set `changed = true` for that node, so a node
+  // that finishes with `changed === false` is provably non-cyclic and
+  // referentially equal to its input.
+  const result = changed ? (isJsonObjectEmpty(output) ? true : output) : value;
+  cache.set(value, result);
+  return result;
 }
 
 function declaresObjectType(type: unknown): boolean {
-	if (type === "object") return true;
-	if (!Array.isArray(type)) return false;
-	for (const variant of type) {
-		if (variant === "object") return true;
-	}
-	return false;
+  if (type === "object") return true;
+  if (!Array.isArray(type)) return false;
+  for (const variant of type) {
+    if (variant === "object") return true;
+  }
+  return false;
 }
 
 function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<JsonObject, unknown>): unknown[] {
-	let changed = false;
-	const output = value.map(item => {
-		const next = normalizeOpenAIResponsesSchemaNode(item, cache);
-		if (next !== item) changed = true;
-		return next;
-	});
-	return changed ? output : value;
+  let changed = false;
+  const output = value.map(item => {
+    const next = normalizeOpenAIResponsesSchemaNode(item, cache);
+    if (next !== item) changed = true;
+    return next;
+  });
+  return changed ? output : value;
 }
 
 function normalizeOpenAIResponsesSchemaMap(
-	schemaMap: JsonObject,
-	cache: WeakMap<JsonObject, unknown>,
-	stripUnsupportedRegexKeys: boolean,
+  schemaMap: JsonObject,
+  cache: WeakMap<JsonObject, unknown>,
+  stripUnsupportedRegexKeys: boolean,
 ): JsonObject {
-	let changed = false;
-	const output: JsonObject = {};
-	for (const key in schemaMap) {
-		if (!Object.hasOwn(schemaMap, key)) continue;
-		const child = schemaMap[key];
-		const next = normalizeOpenAIResponsesSchemaNode(child, cache);
-		if (next !== child) changed = true;
-		if (stripUnsupportedRegexKeys && hasOpenAIUnsupportedRegexLookaround(key)) {
-			changed = true;
-			appendOpenAIResponsesFallbackPatternProperty(output, next);
-			continue;
-		}
-		output[key] = next;
-	}
-	return changed ? output : schemaMap;
+  let changed = false;
+  const output: JsonObject = {};
+  for (const key in schemaMap) {
+    if (!Object.hasOwn(schemaMap, key)) continue;
+    const child = schemaMap[key];
+    const next = normalizeOpenAIResponsesSchemaNode(child, cache);
+    if (next !== child) changed = true;
+    if (stripUnsupportedRegexKeys && hasOpenAIUnsupportedRegexLookaround(key)) {
+      changed = true;
+      appendOpenAIResponsesFallbackPatternProperty(output, next);
+      continue;
+    }
+    output[key] = next;
+  }
+  return changed ? output : schemaMap;
 }
 
 function appendOpenAIResponsesFallbackPatternProperty(output: JsonObject, schema: unknown): void {
-	const existing = output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK];
-	if (existing === undefined) {
-		output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK] = schema;
-		return;
-	}
-	if (isJsonObject(existing) && Array.isArray(existing.anyOf) && Object.keys(existing).length === 1) {
-		existing.anyOf = [...existing.anyOf, schema];
-		return;
-	}
-	output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK] = { anyOf: [existing, schema] };
+  const existing = output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK];
+  if (existing === undefined) {
+    output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK] = schema;
+    return;
+  }
+  if (isJsonObject(existing) && Array.isArray(existing.anyOf) && Object.keys(existing).length === 1) {
+    existing.anyOf = [...existing.anyOf, schema];
+    return;
+  }
+  output[OPENAI_RESPONSES_PATTERN_PROPERTIES_FALLBACK] = { anyOf: [existing, schema] };
 }
 
 // ---------------------------------------------------------------------------
@@ -1451,47 +1463,47 @@ function appendOpenAIResponsesFallbackPatternProperty(output: JsonObject, schema
 type StrictPrimitiveType = "null" | "string" | "number" | "boolean";
 
 function primitiveJsonTypeOf(value: unknown): StrictPrimitiveType | undefined {
-	if (value === null) return "null";
-	switch (typeof value) {
-		case "string":
-			return "string";
-		case "number":
-			return "number";
-		case "boolean":
-			return "boolean";
-		default:
-			return undefined;
-	}
+  if (value === null) return "null";
+  switch (typeof value) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return undefined;
+  }
 }
 function jsonSchemaTypeAcceptsValue(type: string, value: unknown): boolean {
-	switch (type) {
-		case "null":
-			return value === null;
-		case "string":
-			return typeof value === "string";
-		case "number":
-			return typeof value === "number";
-		case "integer":
-			return typeof value === "number" && Number.isInteger(value);
-		case "boolean":
-			return typeof value === "boolean";
-		case "array":
-			return Array.isArray(value);
-		case "object":
-			return isJsonObject(value);
-		default:
-			return true;
-	}
+  switch (type) {
+    case "null":
+      return value === null;
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return isJsonObject(value);
+    default:
+      return true;
+  }
 }
 
 function narrowEnumToType(schema: Record<string, unknown>, type: string): boolean {
-	const enumValues = schema.enum;
-	if (!Array.isArray(enumValues)) return true;
+  const enumValues = schema.enum;
+  if (!Array.isArray(enumValues)) return true;
 
-	const narrowed = enumValues.filter(value => jsonSchemaTypeAcceptsValue(type, value));
-	if (narrowed.length === 0) return false;
-	if (narrowed.length !== enumValues.length) schema.enum = narrowed;
-	return true;
+  const narrowed = enumValues.filter(value => jsonSchemaTypeAcceptsValue(type, value));
+  if (narrowed.length === 0) return false;
+  if (narrowed.length !== enumValues.length) schema.enum = narrowed;
+  return true;
 }
 
 /**
@@ -1508,16 +1520,16 @@ function narrowEnumToType(schema: Record<string, unknown>, type: string): boolea
  * strict mode cannot represent them and the caller must fall back.
  */
 function inferStrictPrimitiveTypeFromEnumOrConst(node: Record<string, unknown>): StrictPrimitiveType | undefined {
-	const values: unknown[] = Array.isArray(node.enum) ? node.enum : Object.hasOwn(node, "const") ? [node.const] : [];
-	if (values.length === 0) return undefined;
-	let inferred: StrictPrimitiveType | undefined;
-	for (const value of values) {
-		const t = primitiveJsonTypeOf(value);
-		if (t === undefined) return undefined; // non-primitive (object/array) — strict can't represent
-		if (inferred === undefined) inferred = t;
-		else if (inferred !== t) return undefined; // mixed primitives
-	}
-	return inferred;
+  const values: unknown[] = Array.isArray(node.enum) ? node.enum : Object.hasOwn(node, "const") ? [node.const] : [];
+  if (values.length === 0) return undefined;
+  let inferred: StrictPrimitiveType | undefined;
+  for (const value of values) {
+    const t = primitiveJsonTypeOf(value);
+    if (t === undefined) return undefined; // non-primitive (object/array) — strict can't represent
+    if (inferred === undefined) inferred = t;
+    else if (inferred !== t) return undefined; // mixed primitives
+  }
+  return inferred;
 }
 
 /**
@@ -1536,7 +1548,7 @@ const kStrictSchema = Symbol("pi.schema.strict");
  * wherever they sit in a combinator or `items`/`prefixItems` position.
  */
 function isUnrepresentableStrictBranch(value: unknown): boolean {
-	return typeof value === "boolean" || (isJsonObject(value) && isJsonObjectEmpty(value));
+  return typeof value === "boolean" || (isJsonObject(value) && isJsonObjectEmpty(value));
 }
 
 /**
@@ -1559,80 +1571,80 @@ function isUnrepresentableStrictBranch(value: unknown): boolean {
  * `tryEnforceStrictSchema` rather than throwing during enforcement.
  */
 function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoch: number = epochNext()): boolean {
-	if (!once(schema, epoch)) return false;
+  if (!once(schema, epoch)) return false;
 
-	let hasPatternProperties = false;
-	if (isJsonObject(schema.patternProperties)) {
-		for (const _ in schema.patternProperties) {
-			hasPatternProperties = true;
-			break;
-		}
-	}
-	const additionalPropertiesValue = schema.additionalProperties;
-	const hasSchemaAdditionalProperties = additionalPropertiesValue === true || isJsonObject(additionalPropertiesValue);
-	if (hasPatternProperties || hasSchemaAdditionalProperties) {
-		return true;
-	}
+  let hasPatternProperties = false;
+  if (isJsonObject(schema.patternProperties)) {
+    for (const _ in schema.patternProperties) {
+      hasPatternProperties = true;
+      break;
+    }
+  }
+  const additionalPropertiesValue = schema.additionalProperties;
+  const hasSchemaAdditionalProperties = additionalPropertiesValue === true || isJsonObject(additionalPropertiesValue);
+  if (hasPatternProperties || hasSchemaAdditionalProperties) {
+    return true;
+  }
 
-	if (isJsonObject(schema.properties)) {
-		const properties = schema.properties;
-		for (const k in properties) {
-			const propertySchema = properties[k];
-			if (isUnrepresentableStrictBranch(propertySchema)) return true;
-			if (isJsonObject(propertySchema) && hasUnrepresentableStrictObjectMap(propertySchema, epoch)) {
-				return true;
-			}
-		}
-	}
+  if (isJsonObject(schema.properties)) {
+    const properties = schema.properties;
+    for (const k in properties) {
+      const propertySchema = properties[k];
+      if (isUnrepresentableStrictBranch(propertySchema)) return true;
+      if (isJsonObject(propertySchema) && hasUnrepresentableStrictObjectMap(propertySchema, epoch)) {
+        return true;
+      }
+    }
+  }
 
-	if (isUnrepresentableStrictBranch(schema.items)) {
-		return true;
-	}
-	if (isJsonObject(schema.items)) {
-		if (hasUnrepresentableStrictObjectMap(schema.items, epoch)) {
-			return true;
-		}
-	} else if (Array.isArray(schema.items)) {
-		for (const itemSchema of schema.items) {
-			if (isUnrepresentableStrictBranch(itemSchema)) return true;
-			if (isJsonObject(itemSchema) && hasUnrepresentableStrictObjectMap(itemSchema, epoch)) {
-				return true;
-			}
-		}
-	}
-	if (Array.isArray(schema.prefixItems)) {
-		for (const itemSchema of schema.prefixItems) {
-			if (isUnrepresentableStrictBranch(itemSchema)) return true;
-			if (isJsonObject(itemSchema) && hasUnrepresentableStrictObjectMap(itemSchema, epoch)) {
-				return true;
-			}
-		}
-	}
+  if (isUnrepresentableStrictBranch(schema.items)) {
+    return true;
+  }
+  if (isJsonObject(schema.items)) {
+    if (hasUnrepresentableStrictObjectMap(schema.items, epoch)) {
+      return true;
+    }
+  } else if (Array.isArray(schema.items)) {
+    for (const itemSchema of schema.items) {
+      if (isUnrepresentableStrictBranch(itemSchema)) return true;
+      if (isJsonObject(itemSchema) && hasUnrepresentableStrictObjectMap(itemSchema, epoch)) {
+        return true;
+      }
+    }
+  }
+  if (Array.isArray(schema.prefixItems)) {
+    for (const itemSchema of schema.prefixItems) {
+      if (isUnrepresentableStrictBranch(itemSchema)) return true;
+      if (isJsonObject(itemSchema) && hasUnrepresentableStrictObjectMap(itemSchema, epoch)) {
+        return true;
+      }
+    }
+  }
 
-	for (const key of COMBINATOR_KEYS) {
-		const variants = schema[key];
-		if (!Array.isArray(variants)) continue;
-		for (const variant of variants) {
-			if (isUnrepresentableStrictBranch(variant)) return true;
-			if (isJsonObject(variant) && hasUnrepresentableStrictObjectMap(variant, epoch)) {
-				return true;
-			}
-		}
-	}
+  for (const key of COMBINATOR_KEYS) {
+    const variants = schema[key];
+    if (!Array.isArray(variants)) continue;
+    for (const variant of variants) {
+      if (isUnrepresentableStrictBranch(variant)) return true;
+      if (isJsonObject(variant) && hasUnrepresentableStrictObjectMap(variant, epoch)) {
+        return true;
+      }
+    }
+  }
 
-	for (const defsKey of ["$defs", "definitions"] as const) {
-		const defs = schema[defsKey];
-		if (!isJsonObject(defs)) continue;
-		for (const k in defs) {
-			const defSchema = defs[k];
-			if (isUnrepresentableStrictBranch(defSchema)) return true;
-			if (isJsonObject(defSchema) && hasUnrepresentableStrictObjectMap(defSchema, epoch)) {
-				return true;
-			}
-		}
-	}
+  for (const defsKey of ["$defs", "definitions"] as const) {
+    const defs = schema[defsKey];
+    if (!isJsonObject(defs)) continue;
+    for (const k in defs) {
+      const defSchema = defs[k];
+      if (isUnrepresentableStrictBranch(defSchema)) return true;
+      if (isJsonObject(defSchema) && hasUnrepresentableStrictObjectMap(defSchema, epoch)) {
+        return true;
+      }
+    }
+  }
 
-	return false;
+  return false;
 }
 
 /**
@@ -1654,242 +1666,242 @@ function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoc
  * `cache` WeakMap dedupes shared subgraphs; the `epoch` is the cycle guard.
  */
 export function sanitizeSchemaForStrictMode(
-	schema: Record<string, unknown>,
-	epoch: number = epochNext(),
-	cache: WeakMap<Record<string, unknown>, Record<string, unknown>> = new WeakMap(),
-	root: Record<string, unknown> = schema,
+  schema: Record<string, unknown>,
+  epoch: number = epochNext(),
+  cache: WeakMap<Record<string, unknown>, Record<string, unknown>> = new WeakMap(),
+  root: Record<string, unknown> = schema,
 ): Record<string, unknown> {
-	const cached = cache.get(schema);
-	if (cached) return cached;
-	if (!once(schema, epoch)) return {};
+  const cached = cache.get(schema);
+  if (cached) return cached;
+  if (!once(schema, epoch)) return {};
 
-	// Pre-pass: unravel `$ref` with sibling keys by inlining the resolved def.
-	// OpenAI strict mode forbids `{$ref, description, ...}`; the SDK resolves
-	// and merges, with sibling keys taking precedence over the ref'd def.
-	// Cite: openai-python/src/openai/lib/_pydantic.py:96-110 (`_ensure_strict_json_schema`)
-	if (typeof schema.$ref === "string") {
-		let hasSibling = false;
-		for (const k in schema) {
-			if (k !== "$ref" && Object.hasOwn(schema, k)) {
-				hasSibling = true;
-				break;
-			}
-		}
-		if (hasSibling) {
-			const resolved = resolveStrictRef(root, schema.$ref);
-			if (resolved !== undefined) {
-				// Sibling keys on the schema override keys from the resolved def.
-				const merged: Record<string, unknown> = { ...resolved };
-				for (const k in schema) {
-					if (k === "$ref" || !Object.hasOwn(schema, k)) continue;
-					merged[k] = schema[k];
-				}
-				const result = sanitizeSchemaForStrictMode(merged, epoch, cache, root);
-				cache.set(schema, result);
-				return result;
-			}
-		}
-	}
+  // Pre-pass: unravel `$ref` with sibling keys by inlining the resolved def.
+  // OpenAI strict mode forbids `{$ref, description, ...}`; the SDK resolves
+  // and merges, with sibling keys taking precedence over the ref'd def.
+  // Cite: openai-python/src/openai/lib/_pydantic.py:96-110 (`_ensure_strict_json_schema`)
+  if (typeof schema.$ref === "string") {
+    let hasSibling = false;
+    for (const k in schema) {
+      if (k !== "$ref" && Object.hasOwn(schema, k)) {
+        hasSibling = true;
+        break;
+      }
+    }
+    if (hasSibling) {
+      const resolved = resolveStrictRef(root, schema.$ref);
+      if (resolved !== undefined) {
+        // Sibling keys on the schema override keys from the resolved def.
+        const merged: Record<string, unknown> = { ...resolved };
+        for (const k in schema) {
+          if (k === "$ref" || !Object.hasOwn(schema, k)) continue;
+          merged[k] = schema[k];
+        }
+        const result = sanitizeSchemaForStrictMode(merged, epoch, cache, root);
+        cache.set(schema, result);
+        return result;
+      }
+    }
+  }
 
-	// Pre-pass: collapse single-element `allOf` by inlining its sole entry.
-	// SDK semantics: `json_schema.update(ensured(all_of[0]))` — the inlined
-	// entry's keys WIN over original sibling keys, then `allOf` is dropped.
-	// Cite: openai-python/src/openai/lib/_pydantic.py:79-83
-	{
-		const allOf = schema.allOf;
-		if (Array.isArray(allOf) && allOf.length === 1 && isJsonObject(allOf[0])) {
-			const merged: Record<string, unknown> = { ...schema };
-			delete merged.allOf;
-			const sole = allOf[0] as Record<string, unknown>;
-			for (const k in sole) {
-				if (Object.hasOwn(sole, k)) merged[k] = sole[k];
-			}
-			const result = sanitizeSchemaForStrictMode(merged, epoch, cache, root);
-			cache.set(schema, result);
-			return result;
-		}
-	}
+  // Pre-pass: collapse single-element `allOf` by inlining its sole entry.
+  // SDK semantics: `json_schema.update(ensured(all_of[0]))` — the inlined
+  // entry's keys WIN over original sibling keys, then `allOf` is dropped.
+  // Cite: openai-python/src/openai/lib/_pydantic.py:79-83
+  {
+    const allOf = schema.allOf;
+    if (Array.isArray(allOf) && allOf.length === 1 && isJsonObject(allOf[0])) {
+      const merged: Record<string, unknown> = { ...schema };
+      delete merged.allOf;
+      const sole = allOf[0] as Record<string, unknown>;
+      for (const k in sole) {
+        if (Object.hasOwn(sole, k)) merged[k] = sole[k];
+      }
+      const result = sanitizeSchemaForStrictMode(merged, epoch, cache, root);
+      cache.set(schema, result);
+      return result;
+    }
+  }
 
-	const typeValue = schema.type;
-	if (Array.isArray(typeValue)) {
-		const typeVariants = typeValue.filter((entry): entry is string => typeof entry === "string");
-		const schemaWithoutType = { ...schema };
-		delete schemaWithoutType.type;
+  const typeValue = schema.type;
+  if (Array.isArray(typeValue)) {
+    const typeVariants = typeValue.filter((entry): entry is string => typeof entry === "string");
+    const schemaWithoutType = { ...schema };
+    delete schemaWithoutType.type;
 
-		const sanitizedWithoutType = sanitizeSchemaForStrictMode(schemaWithoutType, epoch, cache, root);
-		if (typeVariants.length === 0) {
-			cache.set(schema, sanitizedWithoutType);
-			return sanitizedWithoutType;
-		}
-		// Build one variant schema per type. Each variant keeps only the keywords
-		// relevant to that type — object-only keywords stay on the object variant,
-		// array-only keywords on the array variant, etc.
-		//
-		// `description` is metadata that applies to the whole union, not to any
-		// single type variant, so hoist it to the wrapper so both branches share
-		// it without duplication. Matches the optional-property wrap in
-		// `enforceStrictSchema` and the typical OpenAI strict-mode "description
-		// on the union" shape.
-		const { description, ...variantBase } = sanitizedWithoutType;
-		const variants: Record<string, unknown>[] = [];
-		for (const variantType of typeVariants) {
-			const variantSchema: Record<string, unknown> = { ...variantBase, type: variantType };
-			if (variantType !== "object") {
-				delete variantSchema.properties;
-				delete variantSchema.required;
-				delete variantSchema.additionalProperties;
-			}
-			if (variantType !== "array") {
-				delete variantSchema.items;
-			}
-			if (!narrowEnumToType(variantSchema, variantType)) continue;
-			variants.push(sanitizeSchemaForStrictMode(variantSchema, epoch, cache, root));
-		}
+    const sanitizedWithoutType = sanitizeSchemaForStrictMode(schemaWithoutType, epoch, cache, root);
+    if (typeVariants.length === 0) {
+      cache.set(schema, sanitizedWithoutType);
+      return sanitizedWithoutType;
+    }
+    // Build one variant schema per type. Each variant keeps only the keywords
+    // relevant to that type — object-only keywords stay on the object variant,
+    // array-only keywords on the array variant, etc.
+    //
+    // `description` is metadata that applies to the whole union, not to any
+    // single type variant, so hoist it to the wrapper so both branches share
+    // it without duplication. Matches the optional-property wrap in
+    // `enforceStrictSchema` and the typical OpenAI strict-mode "description
+    // on the union" shape.
+    const { description, ...variantBase } = sanitizedWithoutType;
+    const variants: Record<string, unknown>[] = [];
+    for (const variantType of typeVariants) {
+      const variantSchema: Record<string, unknown> = { ...variantBase, type: variantType };
+      if (variantType !== "object") {
+        delete variantSchema.properties;
+        delete variantSchema.required;
+        delete variantSchema.additionalProperties;
+      }
+      if (variantType !== "array") {
+        delete variantSchema.items;
+      }
+      if (!narrowEnumToType(variantSchema, variantType)) continue;
+      variants.push(sanitizeSchemaForStrictMode(variantSchema, epoch, cache, root));
+    }
 
-		if (variants.length === 0) {
-			cache.set(schema, sanitizedWithoutType);
-			return sanitizedWithoutType;
-		}
+    if (variants.length === 0) {
+      cache.set(schema, sanitizedWithoutType);
+      return sanitizedWithoutType;
+    }
 
-		if (variants.length === 1) {
-			const sole = variants[0] as Record<string, unknown>;
-			if (description !== undefined && !Object.hasOwn(sole, "description")) {
-				sole.description = description;
-			}
-			cache.set(schema, sole);
-			return sole;
-		}
+    if (variants.length === 1) {
+      const sole = variants[0] as Record<string, unknown>;
+      if (description !== undefined && !Object.hasOwn(sole, "description")) {
+        sole.description = description;
+      }
+      cache.set(schema, sole);
+      return sole;
+    }
 
-		const result: JsonObject = { anyOf: variants };
-		if (description !== undefined) result.description = description;
-		cache.set(schema, result);
-		return result;
-	}
-	// Scalar `type`: walk the keys, rewriting or stripping per strict-mode rules.
+    const result: JsonObject = { anyOf: variants };
+    if (description !== undefined) result.description = description;
+    cache.set(schema, result);
+    return result;
+  }
+  // Scalar `type`: walk the keys, rewriting or stripping per strict-mode rules.
 
-	const sanitized: Record<string, unknown> = {};
-	cache.set(schema, sanitized);
-	for (const key in schema) {
-		const value = schema[key];
-		if (key in NON_STRUCTURAL_SCHEMA_KEYS || key === "type" || key === "const" || key === "nullable") {
-			continue;
-		}
-		// `properties` map — recurse into each property schema.
+  const sanitized: Record<string, unknown> = {};
+  cache.set(schema, sanitized);
+  for (const key in schema) {
+    const value = schema[key];
+    if (key in NON_STRUCTURAL_SCHEMA_KEYS || key === "type" || key === "const" || key === "nullable") {
+      continue;
+    }
+    // `properties` map — recurse into each property schema.
 
-		if (key === "properties" && isJsonObject(value)) {
-			const properties: Record<string, unknown> = {};
-			for (const propertyName in value) {
-				const propertySchema = value[propertyName];
-				properties[propertyName] = isJsonObject(propertySchema)
-					? sanitizeSchemaForStrictMode(propertySchema, epoch, cache, root)
-					: propertySchema;
-			}
-			sanitized.properties = properties;
-			continue;
-		}
-		// `items` can be schema, tuple-array, or scalar boolean — recurse where applicable.
+    if (key === "properties" && isJsonObject(value)) {
+      const properties: Record<string, unknown> = {};
+      for (const propertyName in value) {
+        const propertySchema = value[propertyName];
+        properties[propertyName] = isJsonObject(propertySchema)
+          ? sanitizeSchemaForStrictMode(propertySchema, epoch, cache, root)
+          : propertySchema;
+      }
+      sanitized.properties = properties;
+      continue;
+    }
+    // `items` can be schema, tuple-array, or scalar boolean — recurse where applicable.
 
-		if (key === "items") {
-			if (isJsonObject(value)) {
-				sanitized.items = sanitizeSchemaForStrictMode(value, epoch, cache, root);
-			} else if (Array.isArray(value)) {
-				sanitized.items = value.map(entry =>
-					isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
-				);
-			} else {
-				sanitized.items = value;
-			}
-			continue;
-		}
-		// `prefixItems` is always an array of schemas (draft 2020-12).
+    if (key === "items") {
+      if (isJsonObject(value)) {
+        sanitized.items = sanitizeSchemaForStrictMode(value, epoch, cache, root);
+      } else if (Array.isArray(value)) {
+        sanitized.items = value.map(entry =>
+          isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
+        );
+      } else {
+        sanitized.items = value;
+      }
+      continue;
+    }
+    // `prefixItems` is always an array of schemas (draft 2020-12).
 
-		if (key === "prefixItems" && Array.isArray(value)) {
-			sanitized.prefixItems = value.map(entry =>
-				isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
-			);
-			continue;
-		}
-		// `anyOf`/`oneOf`/`allOf` arrays — recurse into each branch.
+    if (key === "prefixItems" && Array.isArray(value)) {
+      sanitized.prefixItems = value.map(entry =>
+        isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
+      );
+      continue;
+    }
+    // `anyOf`/`oneOf`/`allOf` arrays — recurse into each branch.
 
-		if (COMBINATOR_KEYS.includes(key as (typeof COMBINATOR_KEYS)[number]) && Array.isArray(value)) {
-			sanitized[key] = value.map(entry =>
-				isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
-			);
-			continue;
-		}
-		// Definition maps — recurse into each named schema.
+    if (COMBINATOR_KEYS.includes(key as (typeof COMBINATOR_KEYS)[number]) && Array.isArray(value)) {
+      sanitized[key] = value.map(entry =>
+        isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
+      );
+      continue;
+    }
+    // Definition maps — recurse into each named schema.
 
-		if ((key === "$defs" || key === "definitions") && isJsonObject(value)) {
-			const defs: Record<string, unknown> = {};
-			for (const definitionName in value) {
-				const definitionSchema = value[definitionName];
-				defs[definitionName] = isJsonObject(definitionSchema)
-					? sanitizeSchemaForStrictMode(definitionSchema, epoch, cache, root)
-					: definitionSchema;
-			}
-			sanitized[key] = defs;
-			continue;
-		}
-		// `additionalProperties` is owned by `enforceStrictSchema`, which sets it to false.
+    if ((key === "$defs" || key === "definitions") && isJsonObject(value)) {
+      const defs: Record<string, unknown> = {};
+      for (const definitionName in value) {
+        const definitionSchema = value[definitionName];
+        defs[definitionName] = isJsonObject(definitionSchema)
+          ? sanitizeSchemaForStrictMode(definitionSchema, epoch, cache, root)
+          : definitionSchema;
+      }
+      sanitized[key] = defs;
+      continue;
+    }
+    // `additionalProperties` is owned by `enforceStrictSchema`, which sets it to false.
 
-		if (key === "additionalProperties") {
-			continue;
-		}
+    if (key === "additionalProperties") {
+      continue;
+    }
 
-		if (key === "description" && typeof value === "string" && schema.default !== undefined) {
-			// Preserve `default:` info for strict-mode providers that strip the keyword.
-			// Inline as `(default: X)` text in the description, matching the convention for
-			// runtime-placeholder defaults (e.g. `cwd`) that cannot live in the keyword form.
-			const defaultVal = schema.default;
-			const formatted = typeof defaultVal === "string" ? defaultVal : JSON.stringify(defaultVal);
-			sanitized.description = value.includes("(default:") ? value : `${value} (default: ${formatted})`;
-			continue;
-		}
+    if (key === "description" && typeof value === "string" && schema.default !== undefined) {
+      // Preserve `default:` info for strict-mode providers that strip the keyword.
+      // Inline as `(default: X)` text in the description, matching the convention for
+      // runtime-placeholder defaults (e.g. `cwd`) that cannot live in the keyword form.
+      const defaultVal = schema.default;
+      const formatted = typeof defaultVal === "string" ? defaultVal : JSON.stringify(defaultVal);
+      sanitized.description = value.includes("(default:") ? value : `${value} (default: ${formatted})`;
+      continue;
+    }
 
-		sanitized[key] = value;
-	}
-	// Post-pass: re-derive `type` and turn dropped keywords into a representable shape.
+    sanitized[key] = value;
+  }
+  // Post-pass: re-derive `type` and turn dropped keywords into a representable shape.
 
-	if (Object.hasOwn(schema, "const")) {
-		const constVal = schema.const;
-		const existingEnum = Array.isArray(sanitized.enum) ? sanitized.enum : [];
-		if (!existingEnum.some(v => areJsonValuesEqual(v, constVal))) {
-			existingEnum.push(constVal);
-		}
-		sanitized.enum = existingEnum;
-	}
+  if (Object.hasOwn(schema, "const")) {
+    const constVal = schema.const;
+    const existingEnum = Array.isArray(sanitized.enum) ? sanitized.enum : [];
+    if (!existingEnum.some(v => areJsonValuesEqual(v, constVal))) {
+      existingEnum.push(constVal);
+    }
+    sanitized.enum = existingEnum;
+  }
 
-	// Preserve the original scalar type after the strip-and-rebuild loop.
-	if (typeof typeValue === "string") {
-		sanitized.type = typeValue;
-	}
+  // Preserve the original scalar type after the strip-and-rebuild loop.
+  if (typeof typeValue === "string") {
+    sanitized.type = typeValue;
+  }
 
-	if (sanitized.type === undefined && isJsonObject(sanitized.properties)) {
-		sanitized.type = "object";
-	}
+  if (sanitized.type === undefined && isJsonObject(sanitized.properties)) {
+    sanitized.type = "object";
+  }
 
-	if (sanitized.type === undefined && (sanitized.items !== undefined || sanitized.prefixItems !== undefined)) {
-		sanitized.type = "array";
-	}
+  if (sanitized.type === undefined && (sanitized.items !== undefined || sanitized.prefixItems !== undefined)) {
+    sanitized.type = "array";
+  }
 
-	// Last-resort inference: a bare `enum`/`const` with homogeneous primitives gets a `type`.
-	if (sanitized.type === undefined) {
-		const inferred = inferStrictPrimitiveTypeFromEnumOrConst(sanitized);
-		if (inferred !== undefined) sanitized.type = inferred;
-	}
+  // Last-resort inference: a bare `enum`/`const` with homogeneous primitives gets a `type`.
+  if (sanitized.type === undefined) {
+    const inferred = inferStrictPrimitiveTypeFromEnumOrConst(sanitized);
+    if (inferred !== undefined) sanitized.type = inferred;
+  }
 
-	// `nullable: true` was stripped above — re-introduce it as an `anyOf` wrapper.
-	// `description` hoists to the wrapper so both branches share it without
-	// duplication — matches the optional-property wrap in `enforceStrictSchema`
-	// and the typical OpenAI strict-mode "description on the union" shape.
-	if (schema.nullable === true) {
-		const { nullable: _, description, ...withoutNullable } = sanitized;
-		const wrapper: JsonObject = { anyOf: [withoutNullable, { type: "null" }] };
-		if (description !== undefined) wrapper.description = description;
-		return wrapper;
-	}
+  // `nullable: true` was stripped above — re-introduce it as an `anyOf` wrapper.
+  // `description` hoists to the wrapper so both branches share it without
+  // duplication — matches the optional-property wrap in `enforceStrictSchema`
+  // and the typical OpenAI strict-mode "description on the union" shape.
+  if (schema.nullable === true) {
+    const { nullable: _, description, ...withoutNullable } = sanitized;
+    const wrapper: JsonObject = { anyOf: [withoutNullable, { type: "null" }] };
+    if (description !== undefined) wrapper.description = description;
+    return wrapper;
+  }
 
-	return sanitized;
+  return sanitized;
 }
 
 /**
@@ -1900,11 +1912,11 @@ export function sanitizeSchemaForStrictMode(
  * branches of a non-pure node would drop those constraints.
  */
 function isPureAnyOfNode(value: unknown): value is Record<string, unknown> & { anyOf: unknown[] } {
-	if (!isJsonObject(value) || !Array.isArray(value.anyOf)) return false;
-	for (const key in value) {
-		if (key !== "anyOf" && key !== "description") return false;
-	}
-	return true;
+  if (!isJsonObject(value) || !Array.isArray(value.anyOf)) return false;
+  for (const key in value) {
+    if (key !== "anyOf" && key !== "description") return false;
+  }
+  return true;
 }
 
 /**
@@ -1922,177 +1934,177 @@ function isPureAnyOfNode(value: unknown): value is Record<string, unknown> & { a
  *   {@link tryEnforceStrictSchema} which catches this and degrades gracefully.
  */
 export function enforceStrictSchema(
-	schema: Record<string, unknown>,
-	cache: WeakMap<Record<string, unknown>, Record<string, unknown>> = new WeakMap(),
+  schema: Record<string, unknown>,
+  cache: WeakMap<Record<string, unknown>, Record<string, unknown>> = new WeakMap(),
 ): Record<string, unknown> {
-	if (!enter(schema)) {
-		throw new AIError.ValidationError("Schema contains a circular object graph — cannot enforce strict mode");
-	}
-	try {
-		const cached = cache.get(schema);
-		if (cached) return cached;
-		const result = { ...schema };
-		cache.set(schema, result);
-		return enforceStrictSchemaBody(schema, result, cache);
-	} finally {
-		exit(schema);
-	}
+  if (!enter(schema)) {
+    throw new AIError.ValidationError("Schema contains a circular object graph — cannot enforce strict mode");
+  }
+  try {
+    const cached = cache.get(schema);
+    if (cached) return cached;
+    const result = { ...schema };
+    cache.set(schema, result);
+    return enforceStrictSchemaBody(schema, result, cache);
+  } finally {
+    exit(schema);
+  }
 }
 
 function enforceStrictSchemaBody(
-	_schema: Record<string, unknown>,
-	result: Record<string, unknown>,
-	cache: WeakMap<Record<string, unknown>, Record<string, unknown>>,
+  _schema: Record<string, unknown>,
+  result: Record<string, unknown>,
+  cache: WeakMap<Record<string, unknown>, Record<string, unknown>>,
 ): Record<string, unknown> {
-	const isObjectType = result.type === "object";
-	if (isObjectType) {
-		result.additionalProperties = false;
-		const propertiesValue = result.properties;
-		const props =
-			propertiesValue != null && typeof propertiesValue === "object" && !Array.isArray(propertiesValue)
-				? (propertiesValue as Record<string, unknown>)
-				: {};
-		const originalRequired = new Set<string>(
-			Array.isArray(result.required)
-				? result.required.filter((value): value is string => typeof value === "string")
-				: [],
-		);
-		const strictProperties: Record<string, unknown> = {};
-		for (const key in props) {
-			const value = props[key];
-			const processed =
-				value != null && typeof value === "object" && !Array.isArray(value)
-					? enforceStrictSchema(value as Record<string, unknown>, cache)
-					: value;
-			// Optional property — wrap as nullable so strict mode accepts it
-			if (!originalRequired.has(key)) {
-				// Don't double-wrap if already nullable
-				if (
-					isJsonObject(processed) &&
-					Array.isArray(processed.anyOf) &&
-					processed.anyOf.some(v => isJsonObject(v) && v.type === "null")
-				) {
-					strictProperties[key] = processed;
-					continue;
-				}
-				if (isPureAnyOfNode(processed)) {
-					strictProperties[key] = { ...processed, anyOf: [...processed.anyOf, { type: "null" }] };
-					continue;
-				}
-				if (isJsonObject(processed) && typeof processed.description === "string") {
-					const { description, ...withoutDescription } = processed;
-					strictProperties[key] = { anyOf: [withoutDescription, { type: "null" }], description };
-					continue;
-				}
-				strictProperties[key] = { anyOf: [processed, { type: "null" }] };
-				continue;
-			}
-			strictProperties[key] = processed;
-		}
-		result.properties = strictProperties;
-		result.required = Object.keys(strictProperties);
-	}
-	if (result.items != null && typeof result.items === "object") {
-		if (Array.isArray(result.items)) {
-			result.items = result.items.map(entry =>
-				entry != null && typeof entry === "object" && !Array.isArray(entry)
-					? enforceStrictSchema(entry as Record<string, unknown>, cache)
-					: entry,
-			);
-		} else {
-			result.items = enforceStrictSchema(result.items as Record<string, unknown>, cache);
-		}
-	}
-	if (Array.isArray(result.prefixItems)) {
-		result.prefixItems = result.prefixItems.map(entry =>
-			entry != null && typeof entry === "object" && !Array.isArray(entry)
-				? enforceStrictSchema(entry as Record<string, unknown>, cache)
-				: entry,
-		);
-	}
-	for (const key of COMBINATOR_KEYS) {
-		if (Array.isArray(result[key])) {
-			result[key] = (result[key] as unknown[]).map(entry =>
-				entry != null && typeof entry === "object" && !Array.isArray(entry)
-					? enforceStrictSchema(entry as Record<string, unknown>, cache)
-					: entry,
-			);
-		}
-	}
-	// Splice nested pure unions into the parent `anyOf`: `(A ∨ B) ∨ C` ≡ `A ∨ B ∨ C`.
-	// Some strict-mode validators (e.g. DeepSeek behind OpenRouter) reject anyOf
-	// branches that carry no `type`, which is exactly what a nested combinator
-	// node looks like (#2270). Branch recursion above already flattened deeper
-	// levels bottom-up, so a single pass suffices.
-	if (Array.isArray(result.anyOf) && result.anyOf.some(isPureAnyOfNode)) {
-		const flattened: unknown[] = [];
-		for (const branch of result.anyOf) {
-			if (!isPureAnyOfNode(branch)) {
-				flattened.push(branch);
-				continue;
-			}
-			flattened.push(...branch.anyOf);
-			// Keep the inner annotation when the parent has none.
-			if (typeof branch.description === "string" && result.description === undefined) {
-				result.description = branch.description;
-			}
-		}
-		result.anyOf = flattened;
-	}
-	for (const defsKey of ["$defs", "definitions"] as const) {
-		if (result[defsKey] != null && typeof result[defsKey] === "object" && !Array.isArray(result[defsKey])) {
-			const defs = result[defsKey] as Record<string, unknown>;
-			const nextDefs: Record<string, unknown> = {};
-			for (const name in defs) {
-				const def = defs[name];
-				nextDefs[name] =
-					def != null && typeof def === "object" && !Array.isArray(def)
-						? enforceStrictSchema(def as Record<string, unknown>, cache)
-						: def;
-			}
-			result[defsKey] = nextDefs;
-		}
-	}
-	// Strict mode requires every schema node to declare a concrete type (or
-	// combinator / `$ref` / `not`). When `type` is missing, try to infer it
-	// from a homogeneous-primitive `enum` / `const` so direct calls to
-	// `enforceStrictSchema` (which bypass `sanitizeSchemaForStrictMode`'s own
-	// inference pass) still produce wire-valid output.
-	if (result.type === undefined) {
-		const inferred = inferStrictPrimitiveTypeFromEnumOrConst(result);
-		if (inferred !== undefined) result.type = inferred;
-	}
-	// Schemas like `{}`, `{items: {}}`, mixed-primitive enums, and non-primitive
-	// consts are not representable in strict mode — `enum`/`const` are not
-	// accepted as type substitutes here because they did not yield a single
-	// inferable type above.
-	if (
-		result.type === undefined &&
-		result.$ref === undefined &&
-		!COMBINATOR_KEYS.some(key => Array.isArray(result[key])) &&
-		!isJsonObject(result.not)
-	) {
-		throw new AIError.ValidationError("Schema node has no type, combinator, or $ref — cannot enforce strict mode");
-	}
-	return result;
+  const isObjectType = result.type === "object";
+  if (isObjectType) {
+    result.additionalProperties = false;
+    const propertiesValue = result.properties;
+    const props =
+      propertiesValue != null && typeof propertiesValue === "object" && !Array.isArray(propertiesValue)
+        ? (propertiesValue as Record<string, unknown>)
+        : {};
+    const originalRequired = new Set<string>(
+      Array.isArray(result.required)
+        ? result.required.filter((value): value is string => typeof value === "string")
+        : [],
+    );
+    const strictProperties: Record<string, unknown> = {};
+    for (const key in props) {
+      const value = props[key];
+      const processed =
+        value != null && typeof value === "object" && !Array.isArray(value)
+          ? enforceStrictSchema(value as Record<string, unknown>, cache)
+          : value;
+      // Optional property — wrap as nullable so strict mode accepts it
+      if (!originalRequired.has(key)) {
+        // Don't double-wrap if already nullable
+        if (
+          isJsonObject(processed) &&
+          Array.isArray(processed.anyOf) &&
+          processed.anyOf.some(v => isJsonObject(v) && v.type === "null")
+        ) {
+          strictProperties[key] = processed;
+          continue;
+        }
+        if (isPureAnyOfNode(processed)) {
+          strictProperties[key] = { ...processed, anyOf: [...processed.anyOf, { type: "null" }] };
+          continue;
+        }
+        if (isJsonObject(processed) && typeof processed.description === "string") {
+          const { description, ...withoutDescription } = processed;
+          strictProperties[key] = { anyOf: [withoutDescription, { type: "null" }], description };
+          continue;
+        }
+        strictProperties[key] = { anyOf: [processed, { type: "null" }] };
+        continue;
+      }
+      strictProperties[key] = processed;
+    }
+    result.properties = strictProperties;
+    result.required = Object.keys(strictProperties);
+  }
+  if (result.items != null && typeof result.items === "object") {
+    if (Array.isArray(result.items)) {
+      result.items = result.items.map(entry =>
+        entry != null && typeof entry === "object" && !Array.isArray(entry)
+          ? enforceStrictSchema(entry as Record<string, unknown>, cache)
+          : entry,
+      );
+    } else {
+      result.items = enforceStrictSchema(result.items as Record<string, unknown>, cache);
+    }
+  }
+  if (Array.isArray(result.prefixItems)) {
+    result.prefixItems = result.prefixItems.map(entry =>
+      entry != null && typeof entry === "object" && !Array.isArray(entry)
+        ? enforceStrictSchema(entry as Record<string, unknown>, cache)
+        : entry,
+    );
+  }
+  for (const key of COMBINATOR_KEYS) {
+    if (Array.isArray(result[key])) {
+      result[key] = (result[key] as unknown[]).map(entry =>
+        entry != null && typeof entry === "object" && !Array.isArray(entry)
+          ? enforceStrictSchema(entry as Record<string, unknown>, cache)
+          : entry,
+      );
+    }
+  }
+  // Splice nested pure unions into the parent `anyOf`: `(A ∨ B) ∨ C` ≡ `A ∨ B ∨ C`.
+  // Some strict-mode validators (e.g. DeepSeek behind OpenRouter) reject anyOf
+  // branches that carry no `type`, which is exactly what a nested combinator
+  // node looks like (#2270). Branch recursion above already flattened deeper
+  // levels bottom-up, so a single pass suffices.
+  if (Array.isArray(result.anyOf) && result.anyOf.some(isPureAnyOfNode)) {
+    const flattened: unknown[] = [];
+    for (const branch of result.anyOf) {
+      if (!isPureAnyOfNode(branch)) {
+        flattened.push(branch);
+        continue;
+      }
+      flattened.push(...branch.anyOf);
+      // Keep the inner annotation when the parent has none.
+      if (typeof branch.description === "string" && result.description === undefined) {
+        result.description = branch.description;
+      }
+    }
+    result.anyOf = flattened;
+  }
+  for (const defsKey of ["$defs", "definitions"] as const) {
+    if (result[defsKey] != null && typeof result[defsKey] === "object" && !Array.isArray(result[defsKey])) {
+      const defs = result[defsKey] as Record<string, unknown>;
+      const nextDefs: Record<string, unknown> = {};
+      for (const name in defs) {
+        const def = defs[name];
+        nextDefs[name] =
+          def != null && typeof def === "object" && !Array.isArray(def)
+            ? enforceStrictSchema(def as Record<string, unknown>, cache)
+            : def;
+      }
+      result[defsKey] = nextDefs;
+    }
+  }
+  // Strict mode requires every schema node to declare a concrete type (or
+  // combinator / `$ref` / `not`). When `type` is missing, try to infer it
+  // from a homogeneous-primitive `enum` / `const` so direct calls to
+  // `enforceStrictSchema` (which bypass `sanitizeSchemaForStrictMode`'s own
+  // inference pass) still produce wire-valid output.
+  if (result.type === undefined) {
+    const inferred = inferStrictPrimitiveTypeFromEnumOrConst(result);
+    if (inferred !== undefined) result.type = inferred;
+  }
+  // Schemas like `{}`, `{items: {}}`, mixed-primitive enums, and non-primitive
+  // consts are not representable in strict mode — `enum`/`const` are not
+  // accepted as type substitutes here because they did not yield a single
+  // inferable type above.
+  if (
+    result.type === undefined &&
+    result.$ref === undefined &&
+    !COMBINATOR_KEYS.some(key => Array.isArray(result[key])) &&
+    !isJsonObject(result.not)
+  ) {
+    throw new AIError.ValidationError("Schema node has no type, combinator, or $ref — cannot enforce strict mode");
+  }
+  return result;
 }
 
 export function tryEnforceStrictSchema(schema: Record<string, unknown>): {
-	schema: Record<string, unknown>;
-	strict: boolean;
+  schema: Record<string, unknown>;
+  strict: boolean;
 } {
-	return stamp(schema, kStrictSchema, s => {
-		const upgraded = upgradeJsonSchemaTo202012(s) as Record<string, unknown>;
-		if (hasUnrepresentableStrictObjectMap(upgraded)) {
-			return { schema: upgraded, strict: false };
-		}
-		try {
-			const sanitized = sanitizeSchemaForStrictMode(upgraded);
-			return { schema: enforceStrictSchema(sanitized), strict: true };
-		} catch {
-			return { schema: upgraded, strict: false };
-		}
-	});
+  return stamp(schema, kStrictSchema, s => {
+    const upgraded = upgradeJsonSchemaTo202012(s) as Record<string, unknown>;
+    if (hasUnrepresentableStrictObjectMap(upgraded)) {
+      return { schema: upgraded, strict: false };
+    }
+    try {
+      const sanitized = sanitizeSchemaForStrictMode(upgraded);
+      return { schema: enforceStrictSchema(sanitized), strict: true };
+    } catch {
+      return { schema: upgraded, strict: false };
+    }
+  });
 }
 
 /**
@@ -2102,14 +2114,14 @@ export function tryEnforceStrictSchema(schema: Record<string, unknown>): {
  * Cite: openai-python/src/openai/lib/_pydantic.py:118-129
  */
 function resolveStrictRef(root: Record<string, unknown>, ref: string): Record<string, unknown> | undefined {
-	if (!ref.startsWith("#/")) return undefined;
-	const segments = ref.slice(2).split("/");
-	let cursor: unknown = root;
-	for (const raw of segments) {
-		if (!isJsonObject(cursor)) return undefined;
-		// JSON Pointer unescape: ~1 → "/", ~0 → "~" (must run in that order).
-		const segment = raw.replace(/~1/g, "/").replace(/~0/g, "~");
-		cursor = cursor[segment];
-	}
-	return isJsonObject(cursor) ? cursor : undefined;
+  if (!ref.startsWith("#/")) return undefined;
+  const segments = ref.slice(2).split("/");
+  let cursor: unknown = root;
+  for (const raw of segments) {
+    if (!isJsonObject(cursor)) return undefined;
+    // JSON Pointer unescape: ~1 → "/", ~0 → "~" (must run in that order).
+    const segment = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    cursor = cursor[segment];
+  }
+  return isJsonObject(cursor) ? cursor : undefined;
 }

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -54,6 +54,7 @@ const compat: ResolvedOpenAICompat = {
 	allowsSyntheticReasoningContentForToolCalls: true,
 	replayReasoningContent: false,
 	qwenPreserveThinking: false,
+	sanitizeToolSchemaForGrammar: false,
 	requiresAssistantContentForToolCalls: false,
 	openRouterRouting: {},
 	vercelGatewayRouting: {},

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -202,6 +202,7 @@ describe("openai-completions compatibility", () => {
 			allowsSyntheticReasoningContentForToolCalls: true,
 			replayReasoningContent: false,
 			qwenPreserveThinking: false,
+			sanitizeToolSchemaForGrammar: false,
 			requiresAssistantContentForToolCalls: false,
 			openRouterRouting: {},
 			vercelGatewayRouting: {},

--- a/packages/ai/test/openai-completions-grammar-schema.test.ts
+++ b/packages/ai/test/openai-completions-grammar-schema.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, Model, ModelSpec, Tool } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { type } from "arktype";
+
+/**
+ * Regression: llama.cpp (and any grammar-constrained sampler reached via the
+ * openai-completions encoder — lm-studio, vllm, loopback) rejects bare boolean
+ * JSON Schema subschemas with HTTP 400 "Unrecognized schema: true".
+ *
+ * `toolWireSchema` intentionally emits `true` for unconstrained fields (issue
+ * #1179, so grammar samplers don't read `{}` as "generate an empty object"),
+ * and `supportsStrictMode === false` for these hosts so the raw `baseParameters`
+ * ship unchanged. An essential tool exposing an `unknown`-typed field — the
+ * `task` tool's `outputSchema?: "unknown"` added 2026-07-17 — therefore sent
+ * `properties.outputSchema: true` to llama.cpp and 400'd on every request.
+ *
+ * `compat.sanitizeToolSchemaForGrammar` widens those subschemas (issue #4488
+ * Ollama analog) before they reach the sampler.
+ */
+
+interface SerializedTool {
+	function?: { name?: string; parameters?: Record<string, unknown> };
+}
+interface ChatCompletionsPayload {
+	tools?: SerializedTool[];
+}
+
+// ArkType `"unknown"` compiles to `{}` → `normalizeEmptySchemas` rewrites it to
+// bare `true` — the exact shape that regressed against llama.cpp.
+const toolWithOpenField = {
+	name: "spawn",
+	description: "spawn a subagent with a caller-supplied output schema",
+	parameters: type({
+		task: "string",
+		"outputSchema?": "unknown",
+	}),
+} as unknown as Tool;
+
+const context: Context = {
+	messages: [{ role: "user", content: "run it", timestamp: 0 }],
+	tools: [toolWithOpenField],
+};
+
+function llamaCppModel(overrides: Partial<ModelSpec<"openai-completions">>): Model<"openai-completions"> {
+	return buildModel({
+		id: "qwen-3.6-27b",
+		name: "Qwen 3.6 27B",
+		api: "openai-completions",
+		provider: "llama.cpp",
+		baseUrl: "http://localhost:8080/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131_072,
+		maxTokens: 32_768,
+		...overrides,
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function capturePayload(target: Model<"openai-completions">): Promise<ChatCompletionsPayload> {
+	const { promise, resolve } = Promise.withResolvers<ChatCompletionsPayload>();
+	streamOpenAICompletions(target, context, {
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload as ChatCompletionsPayload),
+	});
+	return promise;
+}
+
+const SCHEMA_VALUE_KEYS: Record<string, true> = {
+	items: true,
+	additionalItems: true,
+	unevaluatedItems: true,
+	additionalProperties: true,
+	unevaluatedProperties: true,
+	not: true,
+	if: true,
+	// biome-ignore lint/suspicious/noThenProperty: JSON Schema conditional keyword, not a thenable
+	then: true,
+	else: true,
+	contains: true,
+	propertyNames: true,
+	contentSchema: true,
+};
+const SCHEMA_MAP_KEYS: Record<string, true> = {
+	properties: true,
+	patternProperties: true,
+	$defs: true,
+	definitions: true,
+	dependentSchemas: true,
+};
+const SCHEMA_ARRAY_KEYS: Record<string, true> = {
+	anyOf: true,
+	oneOf: true,
+	allOf: true,
+	prefixItems: true,
+};
+
+/** Collect every bare boolean (`true`/`false`) sitting in a schema-value slot. */
+function collectBooleanSubschemas(node: unknown, path: string, out: string[]): void {
+	if (node === true || node === false) {
+		out.push(`${path} = ${node}`);
+		return;
+	}
+	if (Array.isArray(node)) {
+		node.forEach((child, i) => {
+			collectBooleanSubschemas(child, `${path}[${i}]`, out);
+		});
+		return;
+	}
+	if (!node || typeof node !== "object") return;
+	for (const [key, value] of Object.entries(node)) {
+		if (key in SCHEMA_MAP_KEYS && value && typeof value === "object" && !Array.isArray(value)) {
+			for (const [propName, propSchema] of Object.entries(value as Record<string, unknown>)) {
+				collectBooleanSubschemas(propSchema, `${path}.${key}.${propName}`, out);
+			}
+		} else if (key in SCHEMA_ARRAY_KEYS && Array.isArray(value)) {
+			value.forEach((branch, i) => {
+				collectBooleanSubschemas(branch, `${path}.${key}[${i}]`, out);
+			});
+		} else if (key in SCHEMA_VALUE_KEYS) {
+			if (value === true || value === false) out.push(`${path}.${key} = ${value}`);
+			else collectBooleanSubschemas(value, `${path}.${key}`, out);
+		}
+	}
+}
+
+describe("openai-completions tool schema — grammar-constrained sampler compatibility", () => {
+	it("widens boolean subschemas for llama.cpp so no `true` reaches the grammar generator", async () => {
+		const payload = await capturePayload(llamaCppModel({}));
+		const parameters = payload.tools?.[0]?.function?.parameters;
+		if (!parameters) throw new Error("expected serialized tool parameters");
+
+		const booleanHits: string[] = [];
+		collectBooleanSubschemas(parameters, "parameters", booleanHits);
+		expect(booleanHits).toEqual([]);
+
+		// The previously-bare-`true` open field is now a value-widening union.
+		const outputSchema = (parameters.properties as Record<string, unknown>).outputSchema as Record<string, unknown>;
+		expect(outputSchema).not.toBe(true);
+		expect(outputSchema.anyOf).toEqual([
+			{ type: "string" },
+			{ type: "number" },
+			{ type: "boolean" },
+			{ type: "object" },
+			{ type: "array" },
+			{ type: "null" },
+		]);
+	});
+
+	it("applies the same widening to lm-studio and loopback OpenAI-compatible servers", async () => {
+		const lmStudio = await capturePayload(
+			llamaCppModel({ provider: "lm-studio", baseUrl: "http://127.0.0.1:1234/v1" }),
+		);
+		const hits: string[] = [];
+		collectBooleanSubschemas(lmStudio.tools?.[0]?.function?.parameters, "parameters", hits);
+		expect(hits).toEqual([]);
+	});
+
+	it("leaves boolean subschemas intact for non-grammar OpenAI hosts", async () => {
+		// OpenAI's tool parser accepts bare `true` (valid JSON Schema draft 2020-12),
+		// so the sanitizer must NOT fire for cloud hosts — only for local
+		// grammar-constrained backends.
+		const openai = await capturePayload(
+			llamaCppModel({
+				provider: "openai",
+				baseUrl: "https://api.openai.com/v1",
+				id: "gpt-4o-mini",
+				name: "GPT-4o mini",
+			}),
+		);
+		const outputSchema = ((openai.tools?.[0]?.function?.parameters?.properties ?? {}) as Record<string, unknown>)
+			.outputSchema;
+		expect(outputSchema).toBe(true);
+	});
+});

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -43,6 +43,7 @@ const compat: ResolvedOpenAICompat = {
 	allowsSyntheticReasoningContentForToolCalls: true,
 	replayReasoningContent: false,
 	qwenPreserveThinking: false,
+	sanitizeToolSchemaForGrammar: false,
 	requiresAssistantContentForToolCalls: false,
 	openRouterRouting: {},
 	vercelGatewayRouting: {},

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `OpenAICompat.sanitizeToolSchemaForGrammar` (resolved by `buildOpenAICompat`): when true (local grammar-constrained backends — `llama.cpp`/`lm-studio`/`vllm`/openai-compatible server), signals that the openai-completions encoder must widen bare boolean JSON Schema subschemas before sending, since the sampler's grammar generator rejects them with HTTP 400 `Unrecognized schema: true`. Mirrors the `replayReasoningContent` detection gate.
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -10,27 +10,27 @@
 import { isFireworksFastModelId } from "../fireworks-model-id";
 import { hostMatchesUrl, modelMatchesHost } from "../hosts";
 import {
-	isAnthropicNamespacedModelId,
-	isClaudeModelId,
-	isDeepseekModelIdOrName,
-	isGlm52ReasoningEffortModelId,
-	isGrokReasoningEffortCapable,
-	isKimiK3ModelId,
-	isKimiK26ModelId,
-	isKimiModelId,
-	isMimoModelIdOrName,
-	isOpenAISamplingRestrictedModelId,
-	isQwenModelId,
-	modelFamilyToken,
+  isAnthropicNamespacedModelId,
+  isClaudeModelId,
+  isDeepseekModelIdOrName,
+  isGlm52ReasoningEffortModelId,
+  isGrokReasoningEffortCapable,
+  isKimiK3ModelId,
+  isKimiK26ModelId,
+  isKimiModelId,
+  isMimoModelIdOrName,
+  isOpenAISamplingRestrictedModelId,
+  isQwenModelId,
+  modelFamilyToken,
 } from "../identity/family";
 import type {
-	ModelSpec,
-	OpenAICompat,
-	OpenAIStreamMarkupHealingPattern,
-	ResolvedOpenAICompat,
-	ResolvedOpenAIResponsesCompat,
-	ResolvedOpenAISharedCompat,
-	ResolvedOpenRouterCompat,
+  ModelSpec,
+  OpenAICompat,
+  OpenAIStreamMarkupHealingPattern,
+  ResolvedOpenAICompat,
+  ResolvedOpenAIResponsesCompat,
+  ResolvedOpenAISharedCompat,
+  ResolvedOpenRouterCompat,
 } from "../types";
 import { applyCompatOverrides } from "./apply";
 
@@ -52,8 +52,8 @@ const KIMI_REASONING_STREAM_IDLE_TIMEOUT_MS = 300_000;
 const KIMI_K27_CODE_MODEL_PATTERN = /(?:^|\/)kimi[-._]?k2(?:[._-]?|p)7[-._]?code(?:[-._]?highspeed)?$/i;
 
 function matchesKimiK27CodeFamily(spec: ModelSpec<"openai-completions">): boolean {
-	if (KIMI_K27_CODE_MODEL_PATTERN.test(spec.id)) return true;
-	return spec.id === "kimi-for-coding" && /k2\.?7 code/i.test(spec.name ?? "");
+  if (KIMI_K27_CODE_MODEL_PATTERN.test(spec.id)) return true;
+  return spec.id === "kimi-for-coding" && /k2\.?7 code/i.test(spec.name ?? "");
 }
 /** Xiaomi MiMo Pro on api.xiaomimimo.com can stall ~2min before the first event (issue #1770). */
 const XIAOMI_MIMO_STREAM_IDLE_TIMEOUT_MS = 300_000;
@@ -63,14 +63,14 @@ const ALIBABA_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS = 600_000;
 const LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS = 300_000;
 const MINIMAX_PROVIDER_OR_ID_PATTERN = /minimax/i;
 const DSML_HEALING_PROVIDERS = new Set([
-	"ollama",
-	"ollama-cloud",
-	"nvidia",
-	"deepseek",
-	"fireworks",
-	"nanogpt",
-	"opencode-go",
-	"openrouter",
+  "ollama",
+  "ollama-cloud",
+  "nvidia",
+  "deepseek",
+  "fireworks",
+  "nanogpt",
+  "opencode-go",
+  "openrouter",
 ]);
 
 // Ollama's OpenAI-compatible `reasoning.effort` accepts `high|medium|low|max|none`;
@@ -80,21 +80,21 @@ const DSML_HEALING_PROVIDERS = new Set([
 // different provider id must set `compat.reasoningEffortMap` themselves.
 
 function resolveReasoningDisableMode(
-	thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"],
+  thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"],
 ): ResolvedOpenAISharedCompat["reasoningDisableMode"] {
-	switch (thinkingFormat) {
-		case "openrouter":
-			return "openrouter-enabled-false";
-		case "zai":
-		case "kimi":
-			return "zai-thinking-disabled";
-		case "qwen":
-			return "qwen-enable-thinking-false";
-		case "qwen-chat-template":
-			return "qwen-template-false";
-		default:
-			return "lowest-effort";
-	}
+  switch (thinkingFormat) {
+    case "openrouter":
+      return "openrouter-enabled-false";
+    case "zai":
+    case "kimi":
+      return "zai-thinking-disabled";
+    case "qwen":
+      return "qwen-enable-thinking-false";
+    case "qwen-chat-template":
+      return "qwen-template-false";
+    default:
+      return "lowest-effort";
+  }
 }
 
 /**
@@ -108,29 +108,29 @@ function resolveReasoningDisableMode(
  * `undefined`) to avoid misfiring on legitimate fenced content.
  */
 function detectStreamMarkupHealingPattern(
-	provider: string,
-	modelId: string,
-	baseUrl: string,
+  provider: string,
+  modelId: string,
+  baseUrl: string,
 ): OpenAIStreamMarkupHealingPattern | undefined {
-	if (provider === "kimi-code" || provider === "moonshot" || /kimi[-/_.]?k2/i.test(modelId)) {
-		return "kimi";
-	}
-	if (isDeepseekModelIdOrName(modelId) && DSML_HEALING_PROVIDERS.has(provider)) {
-		return "dsml";
-	}
-	if (isOfficialOpenAIEndpoint(provider, baseUrl)) return undefined;
-	return "thinking";
+  if (provider === "kimi-code" || provider === "moonshot" || /kimi[-/_.]?k2/i.test(modelId)) {
+    return "kimi";
+  }
+  if (isDeepseekModelIdOrName(modelId) && DSML_HEALING_PROVIDERS.has(provider)) {
+    return "dsml";
+  }
+  if (isOfficialOpenAIEndpoint(provider, baseUrl)) return undefined;
+  return "thinking";
 }
 
 /** Strict official-OpenAI check: provider id `openai` and an `api.openai.com` host (missing baseUrl defaults there). */
 function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
-	if (provider !== "openai") return false;
-	if (!baseUrl) return true;
-	try {
-		return new URL(baseUrl).hostname === "api.openai.com";
-	} catch {
-		return false;
-	}
+  if (provider !== "openai") return false;
+  if (!baseUrl) return true;
+  try {
+    return new URL(baseUrl).hostname === "api.openai.com";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -149,40 +149,40 @@ function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
  * key and re-triggering the 400.
  */
 const OPENCODE_WHEN_THINKING: NonNullable<OpenAICompat["whenThinking"]> = {
-	requiresReasoningContentForToolCalls: true,
-	allowsSyntheticReasoningContentForToolCalls: false,
-	reasoningContentField: "reasoning_content",
+  requiresReasoningContentForToolCalls: true,
+  allowsSyntheticReasoningContentForToolCalls: false,
+  reasoningContentField: "reasoning_content",
 };
 
 const MIMO_REASONING_EFFORT_MAP: NonNullable<OpenAICompat["reasoningEffortMap"]> = {
-	minimal: "low",
-	xhigh: "high",
+  minimal: "low",
+  xhigh: "high",
 };
 
 function mergeMimoReasoningEffortMap(compat: ResolvedOpenAISharedCompat, enabled: boolean): void {
-	if (!enabled) return;
-	compat.reasoningEffortMap = { ...MIMO_REASONING_EFFORT_MAP, ...compat.reasoningEffortMap };
+  if (!enabled) return;
+  compat.reasoningEffortMap = { ...MIMO_REASONING_EFFORT_MAP, ...compat.reasoningEffortMap };
 }
 
 function detectStrictModeSupport(provider: string, baseUrl: string): boolean {
-	if (
-		provider === "openai" ||
-		provider === "openrouter" ||
-		provider === "cerebras" ||
-		provider === "together" ||
-		provider === "github-copilot" ||
-		provider === "zenmux"
-	) {
-		return true;
-	}
-	return (
-		hostMatchesUrl(baseUrl, "openai") ||
-		hostMatchesUrl(baseUrl, "azureOpenAI") ||
-		hostMatchesUrl(baseUrl, "cerebras") ||
-		hostMatchesUrl(baseUrl, "together") ||
-		hostMatchesUrl(baseUrl, "openrouter") ||
-		hostMatchesUrl(baseUrl, "deepseekFamily")
-	);
+  if (
+    provider === "openai" ||
+    provider === "openrouter" ||
+    provider === "cerebras" ||
+    provider === "together" ||
+    provider === "github-copilot" ||
+    provider === "zenmux"
+  ) {
+    return true;
+  }
+  return (
+    hostMatchesUrl(baseUrl, "openai") ||
+    hostMatchesUrl(baseUrl, "azureOpenAI") ||
+    hostMatchesUrl(baseUrl, "cerebras") ||
+    hostMatchesUrl(baseUrl, "together") ||
+    hostMatchesUrl(baseUrl, "openrouter") ||
+    hostMatchesUrl(baseUrl, "deepseekFamily")
+  );
 }
 
 /**
@@ -209,27 +209,27 @@ const LOCAL_OPENAI_COMPAT_PROVIDERS = new Set(["llama.cpp", "lm-studio", "vllm",
 const PROXY_OPENAI_COMPAT_PROVIDERS = new Set(["litellm"]);
 
 function hasLocalLoopbackBaseUrl(baseUrl: string | undefined): boolean {
-	if (!baseUrl) return false;
-	let hostname: string;
-	try {
-		hostname = new URL(baseUrl).hostname.toLowerCase();
-	} catch {
-		return false;
-	}
-	if (
-		hostname === "localhost" ||
-		hostname === "127.0.0.1" ||
-		hostname === "0.0.0.0" ||
-		hostname === "::1" ||
-		hostname === "[::1]"
-	) {
-		return true;
-	}
-	if (/^10\./.test(hostname)) return true;
-	if (/^192\.168\./.test(hostname)) return true;
-	if (/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)) return true;
-	if (hostname.endsWith(".local")) return true;
-	return false;
+  if (!baseUrl) return false;
+  let hostname: string;
+  try {
+    hostname = new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  ) {
+    return true;
+  }
+  if (/^10\./.test(hostname)) return true;
+  if (/^192\.168\./.test(hostname)) return true;
+  if (/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)) return true;
+  if (hostname.endsWith(".local")) return true;
+  return false;
 }
 
 /**
@@ -237,350 +237,358 @@ function hasLocalLoopbackBaseUrl(baseUrl: string | undefined): boolean {
  * Provider takes precedence over URL-based detection since it's explicitly configured.
  */
 export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): ResolvedOpenAICompat {
-	const provider = spec.provider;
-	const baseUrl = spec.baseUrl;
-	const hostModel = { provider, baseUrl };
+  const provider = spec.provider;
+  const baseUrl = spec.baseUrl;
+  const hostModel = { provider, baseUrl };
 
-	const isCerebras = modelMatchesHost(hostModel, "cerebras");
-	const isZai = modelMatchesHost(hostModel, "zai");
-	const isZhipu = modelMatchesHost(hostModel, "zhipu");
-	const supportsZaiReasoningEffort = (isZai || isZhipu) && isGlm52ReasoningEffortModelId(spec.id);
-	const isKilo = modelMatchesHost(hostModel, "kilo");
-	const isKimiModel = isKimiModelId(spec.id);
-	const isMoonshotNative = modelMatchesHost(hostModel, "moonshotNative");
-	const isMoonshotKimi = isKimiModel && isMoonshotNative;
-	// Kimi K3 (native) always reasons via OpenAI-style `reasoning_effort: "max"`
-	// and does NOT accept the K2.x binary `thinking: { type }` block, so it must
-	// stay on the "openai" thinking dialect even though it is a Moonshot-native
-	// Kimi model (#5756).
-	const isMoonshotKimiK3 = isMoonshotKimi && isKimiK3ModelId(spec.id);
-	const requiresEnabledThinking = isMoonshotKimi && matchesKimiK27CodeFamily(spec);
-	const usesMoonshotKimiPreservedThinking = isMoonshotKimi && isKimiK26ModelId(spec.id);
-	const isAnthropicModel =
-		modelMatchesHost(hostModel, "anthropic") || isClaudeModelId(spec.id) || isAnthropicNamespacedModelId(spec.id);
-	const isAlibaba = modelMatchesHost(hostModel, "alibabaDashscope");
-	const isNvidiaNim = modelMatchesHost(hostModel, "nvidia");
-	const isQwen = isQwenModelId(spec.id);
-	// DeepSeek V4 (and other reasoning-capable DeepSeek models) reject follow-up requests in
-	// thinking mode unless prior assistant tool-call turns include `reasoning_content`. The
-	// upstream model is reachable through many OpenAI-compat hosts (api.deepseek.com, Deepinfra,
-	// Kilo, NVIDIA NIM, Zenmux, OpenRouter, …), so we match by model id/name as well as by
-	// provider/baseUrl. The flag is gated by `spec.reasoning` because the invariant only
-	// applies when thinking mode is actually engaged.
-	const lowerId = spec.id.toLowerCase();
-	const lowerName = (spec.name ?? "").toLowerCase();
-	const isXiaomiHost = modelMatchesHost(hostModel, "xiaomi");
-	const isXiaomiMimo = isXiaomiHost && (isMimoModelIdOrName(spec.id) || isMimoModelIdOrName(spec.name ?? ""));
-	const isMimoReasoningEffortModel =
-		!isXiaomiHost && (isMimoModelIdOrName(spec.id) || isMimoModelIdOrName(spec.name ?? ""));
-	// OpenCode Zen's `big-pickle` is a DeepSeek reasoning alias; the upstream
-	// 400s come from DeepSeek and require exact reasoning_content replay.
-	const isOpenCodeDeepseekAlias =
-		provider === "opencode-zen" && (lowerId === "big-pickle" || lowerName === "big pickle");
-	const isDeepseekFamily =
-		modelMatchesHost(hostModel, "deepseekFamily") ||
-		isDeepseekModelIdOrName(spec.id) ||
-		isDeepseekModelIdOrName(spec.name ?? "") ||
-		isOpenCodeDeepseekAlias;
-	const isDirectDeepseekApi = modelMatchesHost(hostModel, "deepseekDirect");
-	const isDirectDeepseekReasoning = isDirectDeepseekApi && isDeepseekFamily && Boolean(spec.reasoning);
-	const isGrok = modelMatchesHost(hostModel, "xai");
-	const isMistral = modelMatchesHost(hostModel, "mistral");
-	const isOpenCodeHost = modelMatchesHost(hostModel, "opencode");
-	const isNonStandard =
-		isCerebras ||
-		isGrok ||
-		isMistral ||
-		hostMatchesUrl(baseUrl, "chutes") ||
-		hostMatchesUrl(baseUrl, "deepseekFamily") ||
-		hostMatchesUrl(baseUrl, "fireworks") ||
-		isAlibaba ||
-		isZai ||
-		isZhipu ||
-		isKilo ||
-		isQwen ||
-		isXiaomiHost ||
-		isMoonshotNative ||
-		isOpenCodeHost;
-	const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
-	const isLocalOpenAICompatBackend =
-		!PROXY_OPENAI_COMPAT_PROVIDERS.has(provider) &&
-		(LOCAL_OPENAI_COMPAT_PROVIDERS.has(provider) || hasLocalLoopbackBaseUrl(baseUrl));
+  const isCerebras = modelMatchesHost(hostModel, "cerebras");
+  const isZai = modelMatchesHost(hostModel, "zai");
+  const isZhipu = modelMatchesHost(hostModel, "zhipu");
+  const supportsZaiReasoningEffort = (isZai || isZhipu) && isGlm52ReasoningEffortModelId(spec.id);
+  const isKilo = modelMatchesHost(hostModel, "kilo");
+  const isKimiModel = isKimiModelId(spec.id);
+  const isMoonshotNative = modelMatchesHost(hostModel, "moonshotNative");
+  const isMoonshotKimi = isKimiModel && isMoonshotNative;
+  // Kimi K3 (native) always reasons via OpenAI-style `reasoning_effort: "max"`
+  // and does NOT accept the K2.x binary `thinking: { type }` block, so it must
+  // stay on the "openai" thinking dialect even though it is a Moonshot-native
+  // Kimi model (#5756).
+  const isMoonshotKimiK3 = isMoonshotKimi && isKimiK3ModelId(spec.id);
+  const requiresEnabledThinking = isMoonshotKimi && matchesKimiK27CodeFamily(spec);
+  const usesMoonshotKimiPreservedThinking = isMoonshotKimi && isKimiK26ModelId(spec.id);
+  const isAnthropicModel =
+    modelMatchesHost(hostModel, "anthropic") || isClaudeModelId(spec.id) || isAnthropicNamespacedModelId(spec.id);
+  const isAlibaba = modelMatchesHost(hostModel, "alibabaDashscope");
+  const isNvidiaNim = modelMatchesHost(hostModel, "nvidia");
+  const isQwen = isQwenModelId(spec.id);
+  // DeepSeek V4 (and other reasoning-capable DeepSeek models) reject follow-up requests in
+  // thinking mode unless prior assistant tool-call turns include `reasoning_content`. The
+  // upstream model is reachable through many OpenAI-compat hosts (api.deepseek.com, Deepinfra,
+  // Kilo, NVIDIA NIM, Zenmux, OpenRouter, …), so we match by model id/name as well as by
+  // provider/baseUrl. The flag is gated by `spec.reasoning` because the invariant only
+  // applies when thinking mode is actually engaged.
+  const lowerId = spec.id.toLowerCase();
+  const lowerName = (spec.name ?? "").toLowerCase();
+  const isXiaomiHost = modelMatchesHost(hostModel, "xiaomi");
+  const isXiaomiMimo = isXiaomiHost && (isMimoModelIdOrName(spec.id) || isMimoModelIdOrName(spec.name ?? ""));
+  const isMimoReasoningEffortModel =
+    !isXiaomiHost && (isMimoModelIdOrName(spec.id) || isMimoModelIdOrName(spec.name ?? ""));
+  // OpenCode Zen's `big-pickle` is a DeepSeek reasoning alias; the upstream
+  // 400s come from DeepSeek and require exact reasoning_content replay.
+  const isOpenCodeDeepseekAlias =
+    provider === "opencode-zen" && (lowerId === "big-pickle" || lowerName === "big pickle");
+  const isDeepseekFamily =
+    modelMatchesHost(hostModel, "deepseekFamily") ||
+    isDeepseekModelIdOrName(spec.id) ||
+    isDeepseekModelIdOrName(spec.name ?? "") ||
+    isOpenCodeDeepseekAlias;
+  const isDirectDeepseekApi = modelMatchesHost(hostModel, "deepseekDirect");
+  const isDirectDeepseekReasoning = isDirectDeepseekApi && isDeepseekFamily && Boolean(spec.reasoning);
+  const isGrok = modelMatchesHost(hostModel, "xai");
+  const isMistral = modelMatchesHost(hostModel, "mistral");
+  const isOpenCodeHost = modelMatchesHost(hostModel, "opencode");
+  const isNonStandard =
+    isCerebras ||
+    isGrok ||
+    isMistral ||
+    hostMatchesUrl(baseUrl, "chutes") ||
+    hostMatchesUrl(baseUrl, "deepseekFamily") ||
+    hostMatchesUrl(baseUrl, "fireworks") ||
+    isAlibaba ||
+    isZai ||
+    isZhipu ||
+    isKilo ||
+    isQwen ||
+    isXiaomiHost ||
+    isMoonshotNative ||
+    isOpenCodeHost;
+  const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
+  const isLocalOpenAICompatBackend =
+    !PROXY_OPENAI_COMPAT_PROVIDERS.has(provider) &&
+    (LOCAL_OPENAI_COMPAT_PROVIDERS.has(provider) || hasLocalLoopbackBaseUrl(baseUrl));
 
-	const useMaxTokens =
-		isMistral ||
-		isMoonshotNative ||
-		isZai ||
-		isZhipu ||
-		hostMatchesUrl(baseUrl, "chutes") ||
-		hostMatchesUrl(baseUrl, "fireworks") ||
-		isDirectDeepseekApi;
+  const useMaxTokens =
+    isMistral ||
+    isMoonshotNative ||
+    isZai ||
+    isZhipu ||
+    hostMatchesUrl(baseUrl, "chutes") ||
+    hostMatchesUrl(baseUrl, "fireworks") ||
+    isDirectDeepseekApi;
 
-	// Hosts whose chat-completions endpoints are known to accept multiple
-	// leading `system`/`developer` messages (preferred for KV-cache reuse).
-	// Anything outside this allowlist defaults to coalescing because
-	// strict chat templates (Qwen 3.5+ via vLLM, MiniMax, etc.) reject
-	// follow-up system messages with a 400.
-	const isOpenAIHost = modelMatchesHost(hostModel, "openai");
-	const isAzureHost = modelMatchesHost(hostModel, "azureOpenAI");
-	const isOpenRouter = modelMatchesHost(hostModel, "openrouter");
-	const isVercelGateway = modelMatchesHost(hostModel, "vercelAIGateway");
-	const isTogether = modelMatchesHost(hostModel, "together");
-	const isFireworks = hostMatchesUrl(baseUrl, "fireworks");
-	const isGroqHost = modelMatchesHost(hostModel, "groq");
-	const isCopilotHost = provider === "github-copilot";
-	const isZenmuxHost = provider === "zenmux";
-	// Endpoints/models that MUST receive a single system block. MiniMax's OpenAI
-	// endpoint returns error 2013 on multiple system messages; the Qwen 3.5+ chat
-	// template raises "System message must be at the beginning" / 500s with an
-	// internal_server_error when any system block appears past index 0. That
-	// template ships with the weights, so every Qwen-serving vLLM/SGLang host
-	// hits it — confirmed on Alibaba Dashscope, Qwen Portal, and Fireworks
-	// (`fireworks/qwen3.7-plus` 500'd on two leading system blocks). Gate on the
-	// Qwen family itself, not per-host: coalescing only trades away KV-cache reuse.
-	const isMiniMaxHost = modelMatchesHost(hostModel, "minimax");
-	const isQwenPortal = modelMatchesHost(hostModel, "qwenPortal");
-	const supportsMultipleSystemMessagesDefault =
-		!isMiniMaxHost &&
-		!isAlibaba &&
-		!isQwenPortal &&
-		!isQwen &&
-		(isOpenAIHost ||
-			isAzureHost ||
-			isOpenRouter ||
-			isCerebras ||
-			isTogether ||
-			isFireworks ||
-			isGroqHost ||
-			isDeepseekFamily ||
-			isMistral ||
-			isGrok ||
-			isZai ||
-			isZhipu ||
-			isCopilotHost ||
-			isZenmuxHost);
+  // Hosts whose chat-completions endpoints are known to accept multiple
+  // leading `system`/`developer` messages (preferred for KV-cache reuse).
+  // Anything outside this allowlist defaults to coalescing because
+  // strict chat templates (Qwen 3.5+ via vLLM, MiniMax, etc.) reject
+  // follow-up system messages with a 400.
+  const isOpenAIHost = modelMatchesHost(hostModel, "openai");
+  const isAzureHost = modelMatchesHost(hostModel, "azureOpenAI");
+  const isOpenRouter = modelMatchesHost(hostModel, "openrouter");
+  const isVercelGateway = modelMatchesHost(hostModel, "vercelAIGateway");
+  const isTogether = modelMatchesHost(hostModel, "together");
+  const isFireworks = hostMatchesUrl(baseUrl, "fireworks");
+  const isGroqHost = modelMatchesHost(hostModel, "groq");
+  const isCopilotHost = provider === "github-copilot";
+  const isZenmuxHost = provider === "zenmux";
+  // Endpoints/models that MUST receive a single system block. MiniMax's OpenAI
+  // endpoint returns error 2013 on multiple system messages; the Qwen 3.5+ chat
+  // template raises "System message must be at the beginning" / 500s with an
+  // internal_server_error when any system block appears past index 0. That
+  // template ships with the weights, so every Qwen-serving vLLM/SGLang host
+  // hits it — confirmed on Alibaba Dashscope, Qwen Portal, and Fireworks
+  // (`fireworks/qwen3.7-plus` 500'd on two leading system blocks). Gate on the
+  // Qwen family itself, not per-host: coalescing only trades away KV-cache reuse.
+  const isMiniMaxHost = modelMatchesHost(hostModel, "minimax");
+  const isQwenPortal = modelMatchesHost(hostModel, "qwenPortal");
+  const supportsMultipleSystemMessagesDefault =
+    !isMiniMaxHost &&
+    !isAlibaba &&
+    !isQwenPortal &&
+    !isQwen &&
+    (isOpenAIHost ||
+      isAzureHost ||
+      isOpenRouter ||
+      isCerebras ||
+      isTogether ||
+      isFireworks ||
+      isGroqHost ||
+      isDeepseekFamily ||
+      isMistral ||
+      isGrok ||
+      isZai ||
+      isZhipu ||
+      isCopilotHost ||
+      isZenmuxHost);
 
-	// Stream-watchdog floor: GLM coding-plan SKUs, Kimi K2.6, direct
-	// DeepSeek reasoning models, and local OpenAI-compatible backends can idle
-	// for minutes while reasoning or cold-loading weights; widen the idle
-	// timeout so warm-ups stop aborting and retrying.
-	const streamIdleTimeoutMs =
-		GLM_CODING_PLAN_MODEL_PATTERN.test(spec.id) && (isZai || isZhipu || isOpenCodeHost)
-			? GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS
-			: provider === "alibaba-coding-plan"
-				? ALIBABA_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS
-				: isXiaomiMimo
-					? XIAOMI_MIMO_STREAM_IDLE_TIMEOUT_MS
-					: spec.reasoning &&
-							(isKimiK26ModelId(spec.id) ||
-								isMoonshotKimiK3 ||
-								(isMoonshotKimi && matchesKimiK27CodeFamily(spec)))
-						? KIMI_REASONING_STREAM_IDLE_TIMEOUT_MS
-						: spec.reasoning && isDirectDeepseekApi
-							? DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS
-							: isLocalOpenAICompatBackend
-								? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
-								: undefined;
+  // Stream-watchdog floor: GLM coding-plan SKUs, Kimi K2.6, direct
+  // DeepSeek reasoning models, and local OpenAI-compatible backends can idle
+  // for minutes while reasoning or cold-loading weights; widen the idle
+  // timeout so warm-ups stop aborting and retrying.
+  const streamIdleTimeoutMs =
+    GLM_CODING_PLAN_MODEL_PATTERN.test(spec.id) && (isZai || isZhipu || isOpenCodeHost)
+      ? GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS
+      : provider === "alibaba-coding-plan"
+        ? ALIBABA_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS
+        : isXiaomiMimo
+          ? XIAOMI_MIMO_STREAM_IDLE_TIMEOUT_MS
+          : spec.reasoning &&
+            (isKimiK26ModelId(spec.id) ||
+              isMoonshotKimiK3 ||
+              (isMoonshotKimi && matchesKimiK27CodeFamily(spec)))
+            ? KIMI_REASONING_STREAM_IDLE_TIMEOUT_MS
+            : spec.reasoning && isDirectDeepseekApi
+              ? DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS
+              : isLocalOpenAICompatBackend
+                ? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
+                : undefined;
 
-	// Fireworks "Fast" variants (`<id>-fast`) are served from the router
-	// namespace (`accounts/fireworks/routers/<id>-fast`), like Fire Pass, rather
-	// than the `models/` namespace the rest of the `fireworks` provider uses.
-	const isFireworksFastRouter = provider === "fireworks" && isFireworksFastModelId(spec.id);
-	const wireModelIdMode: ResolvedOpenAISharedCompat["wireModelIdMode"] =
-		provider === "firepass" || isFireworksFastRouter
-			? "firepass"
-			: provider === "fireworks"
-				? "fireworks"
-				: isOpenRouter
-					? "openrouter"
-					: "raw";
-	const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] =
-		(isMoonshotKimi && !isMoonshotKimiK3) || isZai || isZhipu || isXiaomiMimo
-			? "zai"
-			: isOpenRouter
-				? "openrouter"
-				: isQwen && isNvidiaNim
-					? "qwen-chat-template"
-					: isQwen && isFireworks
-						? "openai"
-						: isAlibaba || isQwen
-							? "qwen"
-							: "openai";
+  // Fireworks "Fast" variants (`<id>-fast`) are served from the router
+  // namespace (`accounts/fireworks/routers/<id>-fast`), like Fire Pass, rather
+  // than the `models/` namespace the rest of the `fireworks` provider uses.
+  const isFireworksFastRouter = provider === "fireworks" && isFireworksFastModelId(spec.id);
+  const wireModelIdMode: ResolvedOpenAISharedCompat["wireModelIdMode"] =
+    provider === "firepass" || isFireworksFastRouter
+      ? "firepass"
+      : provider === "fireworks"
+        ? "fireworks"
+        : isOpenRouter
+          ? "openrouter"
+          : "raw";
+  const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] =
+    (isMoonshotKimi && !isMoonshotKimiK3) || isZai || isZhipu || isXiaomiMimo
+      ? "zai"
+      : isOpenRouter
+        ? "openrouter"
+        : isQwen && isNvidiaNim
+          ? "qwen-chat-template"
+          : isQwen && isFireworks
+            ? "openai"
+            : isAlibaba || isQwen
+              ? "qwen"
+              : "openai";
 
-	const compat: ResolvedOpenAICompat = {
-		supportsStore: !isNonStandard,
-		// `developer` is an OpenAI-Responses-era extension to the chat-completions schema. Almost
-		// every OpenAI-compatible host other than OpenAI itself (and Azure OpenAI, which mirrors
-		// the schema exactly) treats it as an unknown role: Moonshot returns a 400 "tokenization
-		// failed", Groq/Cerebras/etc. error or silently misroute. Default to `system` and require
-		// callers to opt in via `compat.supportsDeveloperRole: true` for hosts known to mirror
-		// OpenAI's reasoning-API surface.
-		supportsDeveloperRole: isOpenAIHost || isAzureHost,
-		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
-		supportsReasoningEffort: !isGrok && !isXiaomiMimo && (!(isZai || isZhipu) || supportsZaiReasoningEffort),
-		// GitHub Copilot's chat-completions endpoint rejects reasoning params wholesale.
-		supportsReasoningParams: provider !== "github-copilot",
-		// OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
-		// temperature/top_p/… with a 400 on every serving host (#5606).
-		supportsSamplingParams: !isOpenAISamplingRestrictedModelId(spec.id),
-		reasoningEffortMap: isMimoReasoningEffortModel ? MIMO_REASONING_EFFORT_MAP : {},
-		supportsUsageInStreaming: !isCerebras,
-		// pi-ai's thinking-loop guard is gemini-only; default the flag from the
-		// family classifier so OpenAI-compat proxies serving Gemini are covered.
-		// An opaque alias can opt in via `compat.enableGeminiThinkingLoopGuard`.
-		enableGeminiThinkingLoopGuard: modelFamilyToken(spec.id) === "gemini",
-		// Kimi (including via OpenRouter and Fireworks router-form IDs such as
-		// `accounts/fireworks/routers/kimi-*`) calculates TPM rate limits based on
-		// max_tokens, not actual output. The official Kimi K2 model guidance
-		// (https://docs.fireworks.ai/models/kimi-k2) also requires `max_tokens` for
-		// every call since the family can otherwise emit very long reasoning traces
-		// before the final answer.
-		alwaysSendMaxTokens: isKimiModel,
-		// Native Kimi K3 always reasons via `reasoning_effort: "max"` (never the
-		// K2.x binary `thinking` block that #827's forced-tool-choice conflict is
-		// about), so suppressing its effort would strip the mandatory `max` from
-		// normal forced-tool turns (e.g. plan-mode `toolChoice: "required"`) and
-		// leave K3 in an unsupported mode (#5758 review).
-		disableReasoningOnForcedToolChoice: (isKimiModel && !isMoonshotKimiK3) || isAnthropicModel,
-		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
-		supportsToolChoice: !isDirectDeepseekReasoning,
-		supportsForcedToolChoice: !requiresEnabledThinking,
-		supportsNamedToolChoice: provider !== "llama.cpp",
-		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
-		requiresToolResultName: isMistral,
-		requiresAssistantAfterToolResult: isMistral,
-		requiresThinkingAsText: isMistral,
-		requiresMistralToolIds: isMistral,
-		// Only Kimi's native hosts (Moonshot / Kimi-code, matched by `isMoonshotKimi`)
-		// speak the z.ai binary `thinking: { type }` field. Kimi reached through
-		// OpenAI-compatible proxies — Fireworks' Fire Pass router, OpenCode's gateway,
-		// etc. — drives reasoning via OpenAI-style `reasoning_effort`
-		// (low|medium|high|xhigh|max|none), so those stay on the "openai" path.
-		// NVIDIA NIM hosts Qwen with the vLLM convention
-		// (`chat_template_kwargs.enable_thinking`); top-level `enable_thinking`
-		// is rejected by NIM's `additionalProperties: false` request schema
-		// (issue #2299).
-		thinkingFormat,
-		kimiApiFormat: undefined,
-		reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
-		omitReasoningEffort: false,
-		includeEncryptedReasoning: true,
-		filterReasoningHistory: isOpenRouter && isAnthropicModel,
-		thinkingKeep: usesMoonshotKimiPreservedThinking ? "all" : undefined,
-		reasoningContentField: "reasoning_content",
-		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
-		//   - Kimi: documented invariant on its native API.
-		//   - DeepSeek-family reasoning models, including aliased OpenCode Zen models
-		//     like `big-pickle`, validate exact thinking-mode replay.
-		//   - Xiaomi MiMo models require exact `reasoning_content` replay on
-		//     thinking-mode tool-call continuations across standard and Token Plan hosts.
-		//   - Any reasoning-capable model reached through OpenRouter can enforce this
-		//     server-side whenever the request is in thinking mode. We can't translate
-		//     Anthropic's redacted/encrypted reasoning into provider-native plaintext,
-		//     so cross-provider continuations rely on a placeholder.
-		// OpenCode Kimi aliases handle reasoning content internally and reject
-		// client-sent `reasoning_content`, so exclude only that Kimi-on-OpenCode path
-		// (the `whenThinking` policy below re-enables the replay for thinking turns).
-		requiresReasoningContentForToolCalls:
-			(isKimiModel && !isOpenCodeProvider) ||
-			(isDeepseekFamily && Boolean(spec.reasoning)) ||
-			isXiaomiMimo ||
-			(isOpenRouter && Boolean(spec.reasoning)),
-		requiresReasoningContentForAllAssistantTurns:
-			((isDeepseekFamily && Boolean(spec.reasoning)) || isXiaomiMimo) && !isOpenRouter,
-		// DeepSeek V4 and Xiaomi MiMo reject synthetic reasoning_content placeholders (".") on tool-call turns.
-		// Kimi and OpenRouter accept them when actual reasoning is unavailable.
-		allowsSyntheticReasoningContentForToolCalls: (!isDeepseekFamily || !spec.reasoning) && !isXiaomiMimo,
-		// Local llama.cpp-style servers re-tokenize the entire chat-template
-		// prompt each request; Qwen3 / DeepSeek-R1 / GLM templates reconstruct
-		// the prior assistant turn's `<think>` block from `reasoning_content`,
-		// so dropping the field re-renders the assistant turn without thinking
-		// content and forces full prompt re-processing (#3528). The
-		// `requires*ReasoningContent*` flags above stay off for these hosts —
-		// they accept but don't validate the field — so the encoder needs a
-		// distinct opt-in to replay on every reasoning turn. NOT gated on
-		// `spec.reasoning`: the runtime discovery paths for `llama.cpp` /
-		// `lm-studio` / `openai-models-list` hardcode `reasoning: false`
-		// because the upstream `/models` endpoints don't advertise the
-		// capability, but the OpenAI stream parser still records incoming
-		// `reasoning_content` deltas as thinking blocks. Gating on the spec
-		// flag would leave every discovered local Qwen / DeepSeek model
-		// re-triggering #3528. The encoder only writes `reasoning_content`
-		// when a thinking block actually exists on the turn
-		// (`nonEmptyThinkingBlocks.length > 0`), so the flag is a no-op on
-		// pure-text histories.
-		replayReasoningContent: isLocalOpenAICompatBackend,
-		// `preserve_thinking: true` makes the Qwen3.6+ chat template render
-		// `<think>...</think>` for older assistant turns too, instead of
-		// stripping it the moment a new user message moves them past
-		// `last_query_index`. Without it, the slot's KV cache (which holds the
-		// raw `<think>X</think>` tokens emitted during generation) diverges
-		// from the next-turn render and llama.cpp falls back to full prompt
-		// re-processing — the exact symptom reported in #3541. Auto-enabled
-		// for Qwen thinking dialects on local llama.cpp-style backends (paired
-		// with `replayReasoningContent` above). Non-Qwen templates ignore the
-		// parameter, so the flag stays a no-op outside the Qwen path.
-		qwenPreserveThinking:
-			(thinkingFormat === "qwen" || thinkingFormat === "qwen-chat-template") && isLocalOpenAICompatBackend,
-		requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
-		cacheControlFormat: isOpenRouter && spec.id.startsWith("anthropic/") ? "anthropic" : undefined,
-		openRouterRouting: undefined,
-		vercelGatewayRouting: undefined,
-		isOpenRouterHost: isOpenRouter,
-		wireModelIdMode,
-		isVercelGatewayHost: isVercelGateway,
-		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
-		extraBody: isDirectDeepseekReasoning ? { thinking: { type: "enabled" } } : undefined,
-		toolStrictMode: isCerebras ? "all_strict" : "mixed",
-		toolSchemaFlavor: isMoonshotNative ? "moonshot-mfjs" : undefined,
-		streamIdleTimeoutMs,
-		stripDeepseekSpecialTokens:
-			isDeepseekModelIdOrName(spec.id) && (provider === "nvidia" || provider === "deepseek"),
-		streamMarkupHealingPattern: detectStreamMarkupHealingPattern(provider, spec.id, baseUrl),
-		reasoningDeltasMayBeCumulative:
-			MINIMAX_PROVIDER_OR_ID_PATTERN.test(provider) || MINIMAX_PROVIDER_OR_ID_PATTERN.test(spec.id),
-		emptyLengthFinishIsContextError: provider === "ollama",
-		usesOpenAIToolCallIdLimit: provider === "openai",
-		promptCacheSessionHeader: isGrok ? "x-grok-conv-id" : undefined,
-		dropThinkingWhenReasoningEffort: provider === "fireworks",
-	};
+  const compat: ResolvedOpenAICompat = {
+    supportsStore: !isNonStandard,
+    // `developer` is an OpenAI-Responses-era extension to the chat-completions schema. Almost
+    // every OpenAI-compatible host other than OpenAI itself (and Azure OpenAI, which mirrors
+    // the schema exactly) treats it as an unknown role: Moonshot returns a 400 "tokenization
+    // failed", Groq/Cerebras/etc. error or silently misroute. Default to `system` and require
+    // callers to opt in via `compat.supportsDeveloperRole: true` for hosts known to mirror
+    // OpenAI's reasoning-API surface.
+    supportsDeveloperRole: isOpenAIHost || isAzureHost,
+    supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
+    supportsReasoningEffort: !isGrok && !isXiaomiMimo && (!(isZai || isZhipu) || supportsZaiReasoningEffort),
+    // GitHub Copilot's chat-completions endpoint rejects reasoning params wholesale.
+    supportsReasoningParams: provider !== "github-copilot",
+    // OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
+    // temperature/top_p/… with a 400 on every serving host (#5606).
+    supportsSamplingParams: !isOpenAISamplingRestrictedModelId(spec.id),
+    reasoningEffortMap: isMimoReasoningEffortModel ? MIMO_REASONING_EFFORT_MAP : {},
+    supportsUsageInStreaming: !isCerebras,
+    // pi-ai's thinking-loop guard is gemini-only; default the flag from the
+    // family classifier so OpenAI-compat proxies serving Gemini are covered.
+    // An opaque alias can opt in via `compat.enableGeminiThinkingLoopGuard`.
+    enableGeminiThinkingLoopGuard: modelFamilyToken(spec.id) === "gemini",
+    // Kimi (including via OpenRouter and Fireworks router-form IDs such as
+    // `accounts/fireworks/routers/kimi-*`) calculates TPM rate limits based on
+    // max_tokens, not actual output. The official Kimi K2 model guidance
+    // (https://docs.fireworks.ai/models/kimi-k2) also requires `max_tokens` for
+    // every call since the family can otherwise emit very long reasoning traces
+    // before the final answer.
+    alwaysSendMaxTokens: isKimiModel,
+    // Native Kimi K3 always reasons via `reasoning_effort: "max"` (never the
+    // K2.x binary `thinking` block that #827's forced-tool-choice conflict is
+    // about), so suppressing its effort would strip the mandatory `max` from
+    // normal forced-tool turns (e.g. plan-mode `toolChoice: "required"`) and
+    // leave K3 in an unsupported mode (#5758 review).
+    disableReasoningOnForcedToolChoice: (isKimiModel && !isMoonshotKimiK3) || isAnthropicModel,
+    disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
+    supportsToolChoice: !isDirectDeepseekReasoning,
+    supportsForcedToolChoice: !requiresEnabledThinking,
+    supportsNamedToolChoice: provider !== "llama.cpp",
+    maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
+    requiresToolResultName: isMistral,
+    requiresAssistantAfterToolResult: isMistral,
+    requiresThinkingAsText: isMistral,
+    requiresMistralToolIds: isMistral,
+    // Only Kimi's native hosts (Moonshot / Kimi-code, matched by `isMoonshotKimi`)
+    // speak the z.ai binary `thinking: { type }` field. Kimi reached through
+    // OpenAI-compatible proxies — Fireworks' Fire Pass router, OpenCode's gateway,
+    // etc. — drives reasoning via OpenAI-style `reasoning_effort`
+    // (low|medium|high|xhigh|max|none), so those stay on the "openai" path.
+    // NVIDIA NIM hosts Qwen with the vLLM convention
+    // (`chat_template_kwargs.enable_thinking`); top-level `enable_thinking`
+    // is rejected by NIM's `additionalProperties: false` request schema
+    // (issue #2299).
+    thinkingFormat,
+    kimiApiFormat: undefined,
+    reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
+    omitReasoningEffort: false,
+    includeEncryptedReasoning: true,
+    filterReasoningHistory: isOpenRouter && isAnthropicModel,
+    thinkingKeep: usesMoonshotKimiPreservedThinking ? "all" : undefined,
+    reasoningContentField: "reasoning_content",
+    // Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
+    //   - Kimi: documented invariant on its native API.
+    //   - DeepSeek-family reasoning models, including aliased OpenCode Zen models
+    //     like `big-pickle`, validate exact thinking-mode replay.
+    //   - Xiaomi MiMo models require exact `reasoning_content` replay on
+    //     thinking-mode tool-call continuations across standard and Token Plan hosts.
+    //   - Any reasoning-capable model reached through OpenRouter can enforce this
+    //     server-side whenever the request is in thinking mode. We can't translate
+    //     Anthropic's redacted/encrypted reasoning into provider-native plaintext,
+    //     so cross-provider continuations rely on a placeholder.
+    // OpenCode Kimi aliases handle reasoning content internally and reject
+    // client-sent `reasoning_content`, so exclude only that Kimi-on-OpenCode path
+    // (the `whenThinking` policy below re-enables the replay for thinking turns).
+    requiresReasoningContentForToolCalls:
+      (isKimiModel && !isOpenCodeProvider) ||
+      (isDeepseekFamily && Boolean(spec.reasoning)) ||
+      isXiaomiMimo ||
+      (isOpenRouter && Boolean(spec.reasoning)),
+    requiresReasoningContentForAllAssistantTurns:
+      ((isDeepseekFamily && Boolean(spec.reasoning)) || isXiaomiMimo) && !isOpenRouter,
+    // DeepSeek V4 and Xiaomi MiMo reject synthetic reasoning_content placeholders (".") on tool-call turns.
+    // Kimi and OpenRouter accept them when actual reasoning is unavailable.
+    allowsSyntheticReasoningContentForToolCalls: (!isDeepseekFamily || !spec.reasoning) && !isXiaomiMimo,
+    // Local llama.cpp-style servers re-tokenize the entire chat-template
+    // prompt each request; Qwen3 / DeepSeek-R1 / GLM templates reconstruct
+    // the prior assistant turn's `<think>` block from `reasoning_content`,
+    // so dropping the field re-renders the assistant turn without thinking
+    // content and forces full prompt re-processing (#3528). The
+    // `requires*ReasoningContent*` flags above stay off for these hosts —
+    // they accept but don't validate the field — so the encoder needs a
+    // distinct opt-in to replay on every reasoning turn. NOT gated on
+    // `spec.reasoning`: the runtime discovery paths for `llama.cpp` /
+    // `lm-studio` / `openai-models-list` hardcode `reasoning: false`
+    // because the upstream `/models` endpoints don't advertise the
+    // capability, but the OpenAI stream parser still records incoming
+    // `reasoning_content` deltas as thinking blocks. Gating on the spec
+    // flag would leave every discovered local Qwen / DeepSeek model
+    // re-triggering #3528. The encoder only writes `reasoning_content`
+    // when a thinking block actually exists on the turn
+    // (`nonEmptyThinkingBlocks.length > 0`), so the flag is a no-op on
+    // pure-text histories.
+    replayReasoningContent: isLocalOpenAICompatBackend,
+    // `preserve_thinking: true` makes the Qwen3.6+ chat template render
+    // `<think>...</think>` for older assistant turns too, instead of
+    // stripping it the moment a new user message moves them past
+    // `last_query_index`. Without it, the slot's KV cache (which holds the
+    // raw `<think>X</think>` tokens emitted during generation) diverges
+    // from the next-turn render and llama.cpp falls back to full prompt
+    // re-processing — the exact symptom reported in #3541. Auto-enabled
+    // for Qwen thinking dialects on local llama.cpp-style backends (paired
+    // with `replayReasoningContent` above). Non-Qwen templates ignore the
+    // parameter, so the flag stays a no-op outside the Qwen path.
+    qwenPreserveThinking:
+      (thinkingFormat === "qwen" || thinkingFormat === "qwen-chat-template") && isLocalOpenAICompatBackend,
+    // Local grammar-constrained backends (llama.cpp / lm-studio / vllm )
+    // reject bare boolean subschemas in tool parameters with HTTP
+    // 400 "Unrecognized schema: true" — `toolWireSchema` emits `true` for
+    // unconstrained fields (issue #1179), and `supportsStrictMode === false`
+    // for these hosts so the raw `baseParameters` ship unchanged. Widen those
+    // subschemas before they reach the sampler (issue #4488 for the Ollama
+    // analog; same gate as `replayReasoningContent` above).
+    sanitizeToolSchemaForGrammar: isLocalOpenAICompatBackend,
+    requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
+    cacheControlFormat: isOpenRouter && spec.id.startsWith("anthropic/") ? "anthropic" : undefined,
+    openRouterRouting: undefined,
+    vercelGatewayRouting: undefined,
+    isOpenRouterHost: isOpenRouter,
+    wireModelIdMode,
+    isVercelGatewayHost: isVercelGateway,
+    supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
+    extraBody: isDirectDeepseekReasoning ? { thinking: { type: "enabled" } } : undefined,
+    toolStrictMode: isCerebras ? "all_strict" : "mixed",
+    toolSchemaFlavor: isMoonshotNative ? "moonshot-mfjs" : undefined,
+    streamIdleTimeoutMs,
+    stripDeepseekSpecialTokens:
+      isDeepseekModelIdOrName(spec.id) && (provider === "nvidia" || provider === "deepseek"),
+    streamMarkupHealingPattern: detectStreamMarkupHealingPattern(provider, spec.id, baseUrl),
+    reasoningDeltasMayBeCumulative:
+      MINIMAX_PROVIDER_OR_ID_PATTERN.test(provider) || MINIMAX_PROVIDER_OR_ID_PATTERN.test(spec.id),
+    emptyLengthFinishIsContextError: provider === "ollama",
+    usesOpenAIToolCallIdLimit: provider === "openai",
+    promptCacheSessionHeader: isGrok ? "x-grok-conv-id" : undefined,
+    dropThinkingWhenReasoningEffort: provider === "fireworks",
+  };
 
-	applyCompatOverrides(compat, spec.compat);
-	if (spec.compat?.reasoningDisableMode === undefined) {
-		compat.reasoningDisableMode = requiresEnabledThinking
-			? "omit"
-			: resolveReasoningDisableMode(compat.thinkingFormat);
-	}
-	if (spec.compat?.omitReasoningEffort === undefined && !compat.supportsReasoningEffort) {
-		compat.omitReasoningEffort = true;
-	}
-	mergeMimoReasoningEffortMap(compat, isMimoReasoningEffortModel);
+  applyCompatOverrides(compat, spec.compat);
+  if (spec.compat?.reasoningDisableMode === undefined) {
+    compat.reasoningDisableMode = requiresEnabledThinking
+      ? "omit"
+      : resolveReasoningDisableMode(compat.thinkingFormat);
+  }
+  if (spec.compat?.omitReasoningEffort === undefined && !compat.supportsReasoningEffort) {
+    compat.omitReasoningEffort = true;
+  }
+  mergeMimoReasoningEffortMap(compat, isMimoReasoningEffortModel);
 
-	const whenThinkingPolicy =
-		spec.compat?.whenThinking ?? (isOpenCodeProvider && spec.reasoning ? OPENCODE_WHEN_THINKING : undefined);
-	if (whenThinkingPolicy) {
-		const variant: ResolvedOpenAICompat = { ...compat };
-		applyCompatOverrides(variant, whenThinkingPolicy);
-		if (whenThinkingPolicy.reasoningDisableMode === undefined) {
-			variant.reasoningDisableMode = resolveReasoningDisableMode(variant.thinkingFormat);
-		}
-		if (whenThinkingPolicy.omitReasoningEffort === undefined && !variant.supportsReasoningEffort) {
-			variant.omitReasoningEffort = true;
-		}
-		mergeMimoReasoningEffortMap(variant, isMimoReasoningEffortModel);
-		compat.whenThinking = variant;
-	}
+  const whenThinkingPolicy =
+    spec.compat?.whenThinking ?? (isOpenCodeProvider && spec.reasoning ? OPENCODE_WHEN_THINKING : undefined);
+  if (whenThinkingPolicy) {
+    const variant: ResolvedOpenAICompat = { ...compat };
+    applyCompatOverrides(variant, whenThinkingPolicy);
+    if (whenThinkingPolicy.reasoningDisableMode === undefined) {
+      variant.reasoningDisableMode = resolveReasoningDisableMode(variant.thinkingFormat);
+    }
+    if (whenThinkingPolicy.omitReasoningEffort === undefined && !variant.supportsReasoningEffort) {
+      variant.omitReasoningEffort = true;
+    }
+    mergeMimoReasoningEffortMap(variant, isMimoReasoningEffortModel);
+    compat.whenThinking = variant;
+  }
 
-	return compat;
+  return compat;
 }
 
 interface OpenAIResponsesSpecLike {
-	id?: string;
-	provider: string;
-	name: string;
-	baseUrl: string;
-	reasoning?: boolean;
-	compat?: OpenAICompat;
+  id?: string;
+  provider: string;
+  name: string;
+  baseUrl: string;
+  reasoning?: boolean;
+  compat?: OpenAICompat;
 }
 
 /**
@@ -593,112 +601,112 @@ interface OpenAIResponsesSpecLike {
  * prompt-cache detection stay URL-keyed, as the historical call sites were.
  */
 export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): ResolvedOpenAIResponsesCompat {
-	const baseUrl = spec.baseUrl ?? "";
-	const isAzure = modelMatchesHost({ provider: spec.provider, baseUrl }, "azureOpenAI");
-	const isOpenRouter = modelMatchesHost({ provider: spec.provider, baseUrl }, "openrouter");
-	const isOpenAIUrl = hostMatchesUrl(baseUrl, "openai");
-	const id = spec.id ?? "";
-	const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] = isOpenRouter ? "openrouter" : "openai";
-	const isKimiModel = id ? isKimiModelId(id) : false;
-	const isAnthropicModel = id ? isClaudeModelId(id) || isAnthropicNamespacedModelId(id) : false;
-	const isDeepseekFamily = id ? isDeepseekModelIdOrName(id) || isDeepseekModelIdOrName(spec.name) : false;
-	const reasoningCapable = Boolean(spec.reasoning);
-	const isLocalOpenAICompatBackend =
-		!PROXY_OPENAI_COMPAT_PROVIDERS.has(spec.provider) &&
-		(LOCAL_OPENAI_COMPAT_PROVIDERS.has(spec.provider) || hasLocalLoopbackBaseUrl(baseUrl));
+  const baseUrl = spec.baseUrl ?? "";
+  const isAzure = modelMatchesHost({ provider: spec.provider, baseUrl }, "azureOpenAI");
+  const isOpenRouter = modelMatchesHost({ provider: spec.provider, baseUrl }, "openrouter");
+  const isOpenAIUrl = hostMatchesUrl(baseUrl, "openai");
+  const id = spec.id ?? "";
+  const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] = isOpenRouter ? "openrouter" : "openai";
+  const isKimiModel = id ? isKimiModelId(id) : false;
+  const isAnthropicModel = id ? isClaudeModelId(id) || isAnthropicNamespacedModelId(id) : false;
+  const isDeepseekFamily = id ? isDeepseekModelIdOrName(id) || isDeepseekModelIdOrName(spec.name) : false;
+  const reasoningCapable = Boolean(spec.reasoning);
+  const isLocalOpenAICompatBackend =
+    !PROXY_OPENAI_COMPAT_PROVIDERS.has(spec.provider) &&
+    (LOCAL_OPENAI_COMPAT_PROVIDERS.has(spec.provider) || hasLocalLoopbackBaseUrl(baseUrl));
 
-	const compat: ResolvedOpenAIResponsesCompat = {
-		supportsDeveloperRole: isAzure || isOpenAIUrl || hostMatchesUrl(baseUrl, "githubCopilot"),
-		supportsStrictMode: isAzure || detectStrictModeSupport(spec.provider, baseUrl),
-		supportsReasoningEffort: spec.provider !== "xai-oauth" || isGrokReasoningEffortCapable(id),
-		supportsLongPromptCacheRetention: isOpenAIUrl,
-		// Azure OpenAI and GitHub Copilot Responses paths require tool results
-		// to strictly match prior tool calls when building Responses inputs.
-		strictResponsesPairing: isAzure || spec.provider === "github-copilot",
-		// GitHub Copilot and xAI OAuth reject `detail: "original"` (400 / 422).
-		// Every other host preserves native-resolution frames (snapcompact relies
-		// on `original`). Detect Copilot by provider id or base-URL host so a
-		// model pointed at the Copilot host under a different provider id still
-		// clamps; xai-oauth is provider-id only (same host family as paid `xai`).
-		supportsImageDetailOriginal:
-			spec.provider !== "xai-oauth" && !modelMatchesHost({ provider: spec.provider, baseUrl }, "githubCopilot"),
-		reasoningEffortMap: {},
-		supportsReasoningParams: true,
-		// OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
-		// temperature/top_p/… with a 400 on every serving host (#5606).
-		supportsSamplingParams: !isOpenAISamplingRestrictedModelId(id),
-		thinkingFormat,
-		reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
-		omitReasoningEffort: false,
-		includeEncryptedReasoning: spec.provider !== "xai-oauth",
-		filterReasoningHistory: spec.provider === "xai-oauth" || (isOpenRouter && isAnthropicModel),
-		disableReasoningOnForcedToolChoice: isKimiModel,
-		disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
-		supportsToolChoice: true,
-		supportsForcedToolChoice: true,
-		supportsNamedToolChoice: true,
-		reasoningContentField: "reasoning_content",
-		requiresReasoningContentForToolCalls:
-			(isKimiModel || (isDeepseekFamily && reasoningCapable) || (isOpenRouter && reasoningCapable)) &&
-			reasoningCapable,
-		requiresReasoningContentForAllAssistantTurns: isDeepseekFamily && reasoningCapable && !isOpenRouter,
-		allowsSyntheticReasoningContentForToolCalls: !isDeepseekFamily || !reasoningCapable,
-		// The Responses API replays reasoning through encrypted `summary` items,
-		// not via a top-level `reasoning_content` field — this flag is
-		// chat-completions-only.
-		replayReasoningContent: false,
-		// Responses-only; the Qwen `preserve_thinking` template knob lives on
-		// the chat-completions wire shape, never on Responses.
-		qwenPreserveThinking: false,
-		requiresThinkingAsText: false,
-		requiresMistralToolIds: false,
-		requiresToolResultName: false,
-		requiresAssistantAfterToolResult: false,
-		requiresAssistantContentForToolCalls: isKimiModel,
-		openRouterRouting: undefined,
-		isOpenRouterHost: isOpenRouter,
-		wireModelIdMode: isOpenRouter ? "openrouter" : "raw",
-		alwaysSendMaxTokens: spec.id ? isKimiModelId(spec.id) : false,
-		enableGeminiThinkingLoopGuard: modelFamilyToken(spec.id ?? "") === "gemini",
-		supportsObfuscationOptOut: isOpenAIUrl || spec.provider === "openai",
-		stripDeepseekSpecialTokens:
-			Boolean(id) && isDeepseekModelIdOrName(id) && (spec.provider === "nvidia" || spec.provider === "deepseek"),
-		streamMarkupHealingPattern: id ? detectStreamMarkupHealingPattern(spec.provider, id, baseUrl) : undefined,
-		reasoningDeltasMayBeCumulative:
-			MINIMAX_PROVIDER_OR_ID_PATTERN.test(spec.provider) || (id ? MINIMAX_PROVIDER_OR_ID_PATTERN.test(id) : false),
-		emptyLengthFinishIsContextError: spec.provider === "ollama",
-		usesOpenAIToolCallIdLimit: spec.provider === "openai",
-		promptCacheSessionHeader: spec.provider === "xai-oauth" ? "x-grok-conv-id" : undefined,
-		streamIdleTimeoutMs: isLocalOpenAICompatBackend
-			? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
-			: spec.compat?.streamIdleTimeoutMs,
-	};
-	applyCompatOverrides(compat, spec.compat);
-	if (spec.compat?.reasoningDisableMode === undefined) {
-		compat.reasoningDisableMode = resolveReasoningDisableMode(compat.thinkingFormat);
-	}
-	if (spec.compat?.omitReasoningEffort === undefined && !compat.supportsReasoningEffort) {
-		compat.omitReasoningEffort = true;
-	}
-	return compat;
+  const compat: ResolvedOpenAIResponsesCompat = {
+    supportsDeveloperRole: isAzure || isOpenAIUrl || hostMatchesUrl(baseUrl, "githubCopilot"),
+    supportsStrictMode: isAzure || detectStrictModeSupport(spec.provider, baseUrl),
+    supportsReasoningEffort: spec.provider !== "xai-oauth" || isGrokReasoningEffortCapable(id),
+    supportsLongPromptCacheRetention: isOpenAIUrl,
+    // Azure OpenAI and GitHub Copilot Responses paths require tool results
+    // to strictly match prior tool calls when building Responses inputs.
+    strictResponsesPairing: isAzure || spec.provider === "github-copilot",
+    // GitHub Copilot and xAI OAuth reject `detail: "original"` (400 / 422).
+    // Every other host preserves native-resolution frames (snapcompact relies
+    // on `original`). Detect Copilot by provider id or base-URL host so a
+    // model pointed at the Copilot host under a different provider id still
+    // clamps; xai-oauth is provider-id only (same host family as paid `xai`).
+    supportsImageDetailOriginal:
+      spec.provider !== "xai-oauth" && !modelMatchesHost({ provider: spec.provider, baseUrl }, "githubCopilot"),
+    reasoningEffortMap: {},
+    supportsReasoningParams: true,
+    // OpenAI proprietary reasoning models (o-series, gpt-5+) reject explicit
+    // temperature/top_p/… with a 400 on every serving host (#5606).
+    supportsSamplingParams: !isOpenAISamplingRestrictedModelId(id),
+    thinkingFormat,
+    reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
+    omitReasoningEffort: false,
+    includeEncryptedReasoning: spec.provider !== "xai-oauth",
+    filterReasoningHistory: spec.provider === "xai-oauth" || (isOpenRouter && isAnthropicModel),
+    disableReasoningOnForcedToolChoice: isKimiModel,
+    disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
+    supportsToolChoice: true,
+    supportsForcedToolChoice: true,
+    supportsNamedToolChoice: true,
+    reasoningContentField: "reasoning_content",
+    requiresReasoningContentForToolCalls:
+      (isKimiModel || (isDeepseekFamily && reasoningCapable) || (isOpenRouter && reasoningCapable)) &&
+      reasoningCapable,
+    requiresReasoningContentForAllAssistantTurns: isDeepseekFamily && reasoningCapable && !isOpenRouter,
+    allowsSyntheticReasoningContentForToolCalls: !isDeepseekFamily || !reasoningCapable,
+    // The Responses API replays reasoning through encrypted `summary` items,
+    // not via a top-level `reasoning_content` field — this flag is
+    // chat-completions-only.
+    replayReasoningContent: false,
+    // Responses-only; the Qwen `preserve_thinking` template knob lives on
+    // the chat-completions wire shape, never on Responses.
+    qwenPreserveThinking: false,
+    requiresThinkingAsText: false,
+    requiresMistralToolIds: false,
+    requiresToolResultName: false,
+    requiresAssistantAfterToolResult: false,
+    requiresAssistantContentForToolCalls: isKimiModel,
+    openRouterRouting: undefined,
+    isOpenRouterHost: isOpenRouter,
+    wireModelIdMode: isOpenRouter ? "openrouter" : "raw",
+    alwaysSendMaxTokens: spec.id ? isKimiModelId(spec.id) : false,
+    enableGeminiThinkingLoopGuard: modelFamilyToken(spec.id ?? "") === "gemini",
+    supportsObfuscationOptOut: isOpenAIUrl || spec.provider === "openai",
+    stripDeepseekSpecialTokens:
+      Boolean(id) && isDeepseekModelIdOrName(id) && (spec.provider === "nvidia" || spec.provider === "deepseek"),
+    streamMarkupHealingPattern: id ? detectStreamMarkupHealingPattern(spec.provider, id, baseUrl) : undefined,
+    reasoningDeltasMayBeCumulative:
+      MINIMAX_PROVIDER_OR_ID_PATTERN.test(spec.provider) || (id ? MINIMAX_PROVIDER_OR_ID_PATTERN.test(id) : false),
+    emptyLengthFinishIsContextError: spec.provider === "ollama",
+    usesOpenAIToolCallIdLimit: spec.provider === "openai",
+    promptCacheSessionHeader: spec.provider === "xai-oauth" ? "x-grok-conv-id" : undefined,
+    streamIdleTimeoutMs: isLocalOpenAICompatBackend
+      ? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
+      : spec.compat?.streamIdleTimeoutMs,
+  };
+  applyCompatOverrides(compat, spec.compat);
+  if (spec.compat?.reasoningDisableMode === undefined) {
+    compat.reasoningDisableMode = resolveReasoningDisableMode(compat.thinkingFormat);
+  }
+  if (spec.compat?.omitReasoningEffort === undefined && !compat.supportsReasoningEffort) {
+    compat.omitReasoningEffort = true;
+  }
+  return compat;
 }
 
 type ResponsesOnlyCompat = Omit<ResolvedOpenAIResponsesCompat, keyof ResolvedOpenAISharedCompat>;
 
 function pickResponsesOnly(compat: ResolvedOpenAIResponsesCompat): ResponsesOnlyCompat {
-	return {
-		supportsLongPromptCacheRetention: compat.supportsLongPromptCacheRetention,
-		strictResponsesPairing: compat.strictResponsesPairing,
-		supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
-		supportsObfuscationOptOut: compat.supportsObfuscationOptOut,
-	} satisfies ResponsesOnlyCompat;
+  return {
+    supportsLongPromptCacheRetention: compat.supportsLongPromptCacheRetention,
+    strictResponsesPairing: compat.strictResponsesPairing,
+    supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
+    supportsObfuscationOptOut: compat.supportsObfuscationOptOut,
+  } satisfies ResponsesOnlyCompat;
 }
 
 export function buildOpenRouterCompat(spec: ModelSpec<"openrouter">): ResolvedOpenRouterCompat {
-	const chat = buildOpenAICompat({
-		...spec,
-		api: "openai-completions",
-	} as ModelSpec<"openai-completions">);
-	const responses = buildOpenAIResponsesCompat(spec);
-	return { ...chat, ...pickResponsesOnly(responses) } as ResolvedOpenRouterCompat;
+  const chat = buildOpenAICompat({
+    ...spec,
+    api: "openai-completions",
+  } as ModelSpec<"openai-completions">);
+  const responses = buildOpenAIResponsesCompat(spec);
+  return { ...chat, ...pickResponsesOnly(responses) } as ResolvedOpenRouterCompat;
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -6,83 +6,83 @@ export type { FetchImpl } from "@oh-my-pi/pi-utils";
 export type { KnownProvider } from "./provider-models/descriptors";
 
 export type KnownApi =
-	| "openai-completions"
-	| "openai-responses"
-	| "openrouter"
-	| "openai-codex-responses"
-	| "azure-openai-responses"
-	| "anthropic-messages"
-	| "bedrock-converse-stream"
-	| "google-generative-ai"
-	| "google-gemini-cli"
-	| "google-vertex"
-	| "ollama-chat"
-	| "cursor-agent"
-	| "gitlab-duo-agent"
-	| "devin-agent";
+  | "openai-completions"
+  | "openai-responses"
+  | "openrouter"
+  | "openai-codex-responses"
+  | "azure-openai-responses"
+  | "anthropic-messages"
+  | "bedrock-converse-stream"
+  | "google-generative-ai"
+  | "google-gemini-cli"
+  | "google-vertex"
+  | "ollama-chat"
+  | "cursor-agent"
+  | "gitlab-duo-agent"
+  | "devin-agent";
 export type Api = KnownApi | (string & {});
 
 /** Canonical thinking transport used by a model. */
 export type ThinkingControlMode =
-	| "effort"
-	| "budget"
-	| "google-level"
-	| "anthropic-adaptive"
-	| "anthropic-budget-effort";
+  | "effort"
+  | "budget"
+  | "google-level"
+  | "anthropic-adaptive"
+  | "anthropic-budget-effort";
 
 /** Per-model thinking capabilities used to clamp and map user-facing effort levels. */
 export interface ThinkingConfig {
-	/** Provider-specific transport used to encode the selected effort. */
-	mode: ThinkingControlMode;
-	/**
-	 * Supported user-facing efforts, ordered least → most intensive. Never
-	 * empty: a reasoning model without a controllable effort surface carries
-	 * `thinking: undefined` instead of an empty list.
-	 */
-	efforts: readonly Effort[];
-	/** Optional default effort applied when this model is selected. Falls back to global default if absent. */
-	defaultLevel?: Effort;
-	/**
-	 * Effort → provider wire-value remap, baked at build time. Identity for
-	 * efforts the map omits. Used by Anthropic adaptive thinking, OpenAI-
-	 * compatible `reasoning_effort`, and Responses-style reasoning params.
-	 */
-	effortMap?: Partial<Record<Effort, string>>;
-	/**
-	 * Adaptive thinking accepts the `display` field (Opus 4.7+, Fable/Mythos
-	 * 5). Also implies native interleaved thinking — no beta header needed.
-	 */
-	supportsDisplay?: boolean;
-	/**
-	 * Per-effort upstream wire-id routing for collapsed effort-tier variants
-	 * (`variant-collapse.ts`). Keyed by pi effort; `"off"` applies when
-	 * thinking is disabled. Missing keys fall back to `requestModelId ?? id`.
-	 */
-	effortRouting?: Readonly<Partial<Record<Effort | "off", string>>>;
-	/**
-	 * Per-effort thinking budget in tokens, baked at build time for collapsed
-	 * variants whose upstream expects an explicit `thinkingBudget` instead of a
-	 * value derived from the generic ladder (Antigravity Cloud Code Assist
-	 * gemini-3.x). Request mapping prefers caller `thinkingBudgets`, then this
-	 * map, then the provider default ladder. Only meaningful for `mode: "budget"`.
-	 */
-	effortBudgets?: Readonly<Partial<Record<Effort, number>>>;
-	/**
-	 * When true, a thinking-off request MUST explicitly suppress thinking on
-	 * the wire (google-level: `thinkingLevel: "MINIMAL"` + `includeThoughts:
-	 * false`; budget: `thinkingBudget: 0`) instead of omitting thinkingConfig —
-	 * Cloud Code Assist re-applies the per-id baked server default when the
-	 * config is absent.
-	 */
-	suppressWhenOff?: boolean;
-	/**
-	 * Reasoning is mandatory upstream: the endpoint rejects disabled or
-	 * omitted thinking (e.g. OpenRouter Gemini 3.x — "Reasoning is mandatory
-	 * for this endpoint and cannot be disabled"). Request mapping clamps
-	 * thinking-off to the lowest supported effort unless `suppressWhenOff`
-	 * provides an explicit wire off-path.
-	 */
-	requiresEffort?: boolean;
+  /** Provider-specific transport used to encode the selected effort. */
+  mode: ThinkingControlMode;
+  /**
+   * Supported user-facing efforts, ordered least → most intensive. Never
+   * empty: a reasoning model without a controllable effort surface carries
+   * `thinking: undefined` instead of an empty list.
+   */
+  efforts: readonly Effort[];
+  /** Optional default effort applied when this model is selected. Falls back to global default if absent. */
+  defaultLevel?: Effort;
+  /**
+   * Effort → provider wire-value remap, baked at build time. Identity for
+   * efforts the map omits. Used by Anthropic adaptive thinking, OpenAI-
+   * compatible `reasoning_effort`, and Responses-style reasoning params.
+   */
+  effortMap?: Partial<Record<Effort, string>>;
+  /**
+   * Adaptive thinking accepts the `display` field (Opus 4.7+, Fable/Mythos
+   * 5). Also implies native interleaved thinking — no beta header needed.
+   */
+  supportsDisplay?: boolean;
+  /**
+   * Per-effort upstream wire-id routing for collapsed effort-tier variants
+   * (`variant-collapse.ts`). Keyed by pi effort; `"off"` applies when
+   * thinking is disabled. Missing keys fall back to `requestModelId ?? id`.
+   */
+  effortRouting?: Readonly<Partial<Record<Effort | "off", string>>>;
+  /**
+   * Per-effort thinking budget in tokens, baked at build time for collapsed
+   * variants whose upstream expects an explicit `thinkingBudget` instead of a
+   * value derived from the generic ladder (Antigravity Cloud Code Assist
+   * gemini-3.x). Request mapping prefers caller `thinkingBudgets`, then this
+   * map, then the provider default ladder. Only meaningful for `mode: "budget"`.
+   */
+  effortBudgets?: Readonly<Partial<Record<Effort, number>>>;
+  /**
+   * When true, a thinking-off request MUST explicitly suppress thinking on
+   * the wire (google-level: `thinkingLevel: "MINIMAL"` + `includeThoughts:
+   * false`; budget: `thinkingBudget: 0`) instead of omitting thinkingConfig —
+   * Cloud Code Assist re-applies the per-id baked server default when the
+   * config is absent.
+   */
+  suppressWhenOff?: boolean;
+  /**
+   * Reasoning is mandatory upstream: the endpoint rejects disabled or
+   * omitted thinking (e.g. OpenRouter Gemini 3.x — "Reasoning is mandatory
+   * for this endpoint and cannot be disabled"). Request mapping clamps
+   * thinking-off to the lowest supported effort unless `suppressWhenOff`
+   * provides an explicit wire off-path.
+   */
+  requiresEffort?: boolean;
 }
 
 // `Provider` is any provider-id string; `KnownProvider` (re-exported above) enumerates
@@ -93,70 +93,70 @@ export type Provider = string;
 export type ThinkingBudgets = { [key in Effort]?: number };
 
 export interface Usage {
-	/** Non-cached conversation input tokens (matches the bucket the provider bills as new input). */
-	input: number;
-	/** Total conversation output tokens for the turn, including thinking, assistant text, and tool-call argument tokens. */
-	output: number;
-	/** Conversation tokens read from the prompt cache. */
-	cacheRead: number;
-	/** Conversation tokens written to the prompt cache (cache creation). */
-	cacheWrite: number;
-	/** Sum of input + output + cacheRead + cacheWrite plus provider-side orchestration tokens when reported. */
-	totalTokens: number;
-	/** Provider-side orchestration tokens, billed but not part of the conversation prompt/cache buckets. */
-	orchestration?: {
-		/** Non-cached orchestration input tokens. */
-		input?: number;
-		/** Orchestration tokens read from provider-side cache. */
-		cacheRead?: number;
-		/** Orchestration output tokens. */
-		output?: number;
-	};
-	/** Copilot premium-request counter, when applicable. */
-	premiumRequests?: number;
-	/**
-	 * Reasoning/thinking tokens included in `output`, when the provider reports them
-	 * (OpenAI `output_tokens_details.reasoning_tokens`, Google `thoughtsTokenCount`).
-	 * Always a subset of `output` — non-reasoning output is `output - reasoningTokens`.
-	 *
-	 * Providers that don't expose this leave it undefined rather than guessing;
-	 * `undefined` means unknown, NOT zero.
-	 */
-	reasoningTokens?: number;
-	/**
-	 * Cache-write TTL breakdown (Anthropic only). When set, the components sum to
-	 * `cacheWrite`. Absent providers do not populate this.
-	 */
-	cttl?: {
-		ephemeral5m?: number;
-		ephemeral1h?: number;
-	};
-	/**
-	 * Server-side tool invocations made during this turn (Anthropic web_search /
-	 * web_fetch, OpenAI built-in tools when reported). Counts requests, not tokens.
-	 */
-	server?: {
-		webSearch?: number;
-		webFetch?: number;
-	};
-	cost: {
-		input: number;
-		output: number;
-		cacheRead: number;
-		cacheWrite: number;
-		total: number;
-	};
+  /** Non-cached conversation input tokens (matches the bucket the provider bills as new input). */
+  input: number;
+  /** Total conversation output tokens for the turn, including thinking, assistant text, and tool-call argument tokens. */
+  output: number;
+  /** Conversation tokens read from the prompt cache. */
+  cacheRead: number;
+  /** Conversation tokens written to the prompt cache (cache creation). */
+  cacheWrite: number;
+  /** Sum of input + output + cacheRead + cacheWrite plus provider-side orchestration tokens when reported. */
+  totalTokens: number;
+  /** Provider-side orchestration tokens, billed but not part of the conversation prompt/cache buckets. */
+  orchestration?: {
+    /** Non-cached orchestration input tokens. */
+    input?: number;
+    /** Orchestration tokens read from provider-side cache. */
+    cacheRead?: number;
+    /** Orchestration output tokens. */
+    output?: number;
+  };
+  /** Copilot premium-request counter, when applicable. */
+  premiumRequests?: number;
+  /**
+   * Reasoning/thinking tokens included in `output`, when the provider reports them
+   * (OpenAI `output_tokens_details.reasoning_tokens`, Google `thoughtsTokenCount`).
+   * Always a subset of `output` — non-reasoning output is `output - reasoningTokens`.
+   *
+   * Providers that don't expose this leave it undefined rather than guessing;
+   * `undefined` means unknown, NOT zero.
+   */
+  reasoningTokens?: number;
+  /**
+   * Cache-write TTL breakdown (Anthropic only). When set, the components sum to
+   * `cacheWrite`. Absent providers do not populate this.
+   */
+  cttl?: {
+    ephemeral5m?: number;
+    ephemeral1h?: number;
+  };
+  /**
+   * Server-side tool invocations made during this turn (Anthropic web_search /
+   * web_fetch, OpenAI built-in tools when reported). Counts requests, not tokens.
+   */
+  server?: {
+    webSearch?: number;
+    webFetch?: number;
+  };
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
 }
 
 export type OpenAIReasoningFormat = "openai" | "openrouter" | "zai" | "kimi" | "qwen" | "qwen-chat-template";
 
 export type OpenAIReasoningDisableMode =
-	| "omit"
-	| "lowest-effort"
-	| "openrouter-enabled-false"
-	| "zai-thinking-disabled"
-	| "qwen-enable-thinking-false"
-	| "qwen-template-false";
+  | "omit"
+  | "lowest-effort"
+  | "openrouter-enabled-false"
+  | "zai-thinking-disabled"
+  | "qwen-enable-thinking-false"
+  | "qwen-template-false";
 
 export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "thinking";
 
@@ -165,203 +165,216 @@ export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "thinking";
  * Use this to override URL-based auto-detection for custom providers.
  */
 export interface OpenAICompat {
-	/** Whether the provider supports the `store` field. Default: auto-detected from URL. */
-	supportsStore?: boolean;
-	/** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
-	supportsDeveloperRole?: boolean;
-	/**
-	 * Whether the provider's chat-completions endpoint accepts multiple
-	 * leading `system`/`developer` messages. When false, ordered system
-	 * prompts are coalesced into a single message joined by `\n\n` so
-	 * strict chat templates (e.g. Qwen-served via vLLM, MiniMax) accept
-	 * the request. Default: detected per provider/baseUrl. Canonical
-	 * OpenAI/Azure/OpenRouter/Cerebras/Together/Fireworks/Groq/DeepSeek/
-	 * Mistral/xAI/Z.ai/GitHub Copilot/Zenmux are treated as `true`;
-	 * unknown or strict-template hosts default to `false`. Setting this
-	 * to `true` preserves separate blocks, which is preferred for
-	 * KV-cache reuse when the trailing prompt changes between calls.
-	 */
-	supportsMultipleSystemMessages?: boolean;
-	/** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */
-	supportsReasoningEffort?: boolean;
-	/** Optional mapping from pi-ai reasoning levels to provider/model-specific `reasoning_effort` values. */
-	reasoningEffortMap?: Partial<Record<Effort, string>>;
-	/** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
-	supportsUsageInStreaming?: boolean;
-	/**
-	 * Enable the Gemini thinking-loop guard (pi-ai stream layer) for this model.
-	 * Defaults to true when the model id classifies as the gemini family. Set
-	 * explicitly to cover an opaque OpenAI-compat proxy alias (e.g. `my-model`)
-	 * that routes to Gemini, or to false to opt a gemini-family id out.
-	 */
-	enableGeminiThinkingLoopGuard?: boolean;
-	/** Which field to use for max tokens. Default: auto-detected from URL. */
-	maxTokensField?: "max_completion_tokens" | "max_tokens";
-	/** Whether tool results require the `name` field. Default: auto-detected from URL. */
-	requiresToolResultName?: boolean;
-	/** Whether a user message after tool results requires an assistant message in between. Default: auto-detected from URL. */
-	requiresAssistantAfterToolResult?: boolean;
-	/** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
-	requiresThinkingAsText?: boolean;
-	/** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
-	requiresMistralToolIds?: boolean;
-	/** Format for reasoning/thinking parameter. `"kimi"` uses `thinking: { type, effort }`; other values select their provider-native reasoning fields. Default: `"openai"`. */
-	thinkingFormat?: OpenAIReasoningFormat;
-	/** Kimi Code transport selected by live per-model protocol metadata. User settings take precedence. */
-	kimiApiFormat?: "openai" | "anthropic";
-	/** Request-time disable encoding for the selected reasoning/thinking format. Default: derived from `thinkingFormat`. */
-	reasoningDisableMode?: OpenAIReasoningDisableMode;
-	/** Whether the provider rejects `reasoning.effort`/`reasoning_effort` even when the model reasons natively. Default: false unless reasoning effort is unsupported. */
-	omitReasoningEffort?: boolean;
-	/** Whether Responses requests should ask for encrypted reasoning replay items. Default: true. */
-	includeEncryptedReasoning?: boolean;
-	/** Whether replayed Responses history should strip native `type: "reasoning"` items before request encoding. Default: false. */
-	filterReasoningHistory?: boolean;
-	/** Optional `thinking.keep` value for Z.ai/Moonshot-style thinking params. Set false to suppress auto-detected keep. Default: auto-detected. */
-	thinkingKeep?: "all" | false;
-	/** Which reasoning content field to emit on assistant messages. Default: auto-detected. */
-	reasoningContentField?: "reasoning_content" | "reasoning" | "reasoning_text";
-	/** Whether assistant tool-call messages must include reasoning content. Default: false. */
-	requiresReasoningContentForToolCalls?: boolean;
-	/** Whether all assistant messages must include reasoning content. Default: false. */
-	requiresReasoningContentForAllAssistantTurns?: boolean;
-	/** Whether the provider accepts a synthetic placeholder (e.g. ".") for missing reasoning_content on tool-call turns. Default: true. Set to false for providers like DeepSeek that validate the exact reasoning_content value. */
-	allowsSyntheticReasoningContentForToolCalls?: boolean;
-	/**
-	 * Replay preserved thinking blocks as `reasoning_content` (or the configured
-	 * `reasoningContentField`) on EVERY assistant turn that carried reasoning,
-	 * regardless of whether the upstream provider validates the field. Local
-	 * llama.cpp-style servers (llama.cpp, LM Studio, vLLM, sglang, Ollama in
-	 * openai-completions mode) re-tokenize the full chat-template prompt every
-	 * request; Qwen3 / DeepSeek-R1 / GLM templates reconstruct the `<think>`
-	 * block from `reasoning_content`. Dropping the field re-renders the
-	 * assistant turn without `<think>`, diverging from the slot's KV cache state
-	 * and forcing full prompt re-processing (#3528). Default: auto-detected
-	 * (loopback/private baseUrl or local provider id with thinking-enabled
-	 * models).
-	 */
-	replayReasoningContent?: boolean;
-	/**
-	 * Send `preserve_thinking: true` so the Qwen3.6+ chat template renders
-	 * `<think>...</think>` markup for EVERY assistant turn (not just turns
-	 * after the last user message). Without it, the template strips the think
-	 * block from older assistant turns:
-	 *
-	 * ```jinja
-	 * {%- if (preserve_thinking is defined and preserve_thinking is true)
-	 *        or (loop.index0 > ns.last_query_index) %}
-	 *   <|im_start|>assistant\n<think>\n{rc}\n</think>\n\n{content}
-	 * {%- else %}
-	 *   <|im_start|>assistant\n{content}
-	 * ```
-	 *
-	 * The cache from the original generation has `<think>...</think>` tokens,
-	 * so once a new user message arrives the prior assistant turns become
-	 * "older" and the stripped re-render diverges — full prompt re-processing
-	 * on SWA models (#3541). Default: auto-detected (Qwen thinking format on
-	 * a local llama.cpp-style backend, paired with `replayReasoningContent`).
-	 * Non-Qwen templates ignore the flag, so the auto-detection is safe.
-	 */
-	qwenPreserveThinking?: boolean;
-	/** Whether assistant tool-call messages must include non-empty content. Default: false. */
-	requiresAssistantContentForToolCalls?: boolean;
-	/** Whether the provider supports the `tool_choice` parameter. Default: true. */
-	supportsToolChoice?: boolean;
-	/**
-	 * Whether forced `tool_choice` values (`"required"` or named tools) are accepted.
-	 * When false, request builders keep tools available but downgrade forced choices
-	 * to provider-default auto selection. Default: true.
-	 */
-	supportsForcedToolChoice?: boolean;
-	/**
-	 * Whether the chat-completions endpoint accepts the object form that pins one
-	 * named function (`{ type: "function", function: { name } }`). Some
-	 * OpenAI-compatible hosts such as llama.cpp only accept string
-	 * `tool_choice` values; request builders downgrade a named force to
-	 * `"required"` when this is false. Default: true.
-	 */
-	supportsNamedToolChoice?: boolean;
-	/**
-	 * Drop reasoning fields (`reasoning_effort`, OpenRouter `reasoning`) for
-	 * the request when `tool_choice` forces a tool call. Mirrors the Anthropic
-	 * `disableThinkingIfToolChoiceForced` rule for backends like Kimi that
-	 * 400 with `tool_choice 'specified' is incompatible with thinking
-	 * enabled` whenever both are present. Default: auto-detected (Kimi).
-	 */
-	disableReasoningOnForcedToolChoice?: boolean;
-	/**
-	 * Drop reasoning fields (`reasoning_effort`, OpenRouter `reasoning`) for
-	 * any request that sends `tool_choice`. Use for providers/models that accept
-	 * tools and `tool_choice`, but reject `tool_choice` while thinking is enabled.
-	 * Default: auto-detected (DeepSeek reasoning models).
-	 */
-	disableReasoningOnToolChoice?: boolean;
-	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
-	openRouterRouting?: OpenRouterRouting;
-	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */
-	vercelGatewayRouting?: VercelGatewayRouting;
-	/** Extra fields to include in request body (e.g. gateway routing hints for OpenClaw-style proxies). */
-	extraBody?: Record<string, unknown>;
-	/** Request-session header that should mirror the normalized prompt-cache key. Default: unset. */
-	promptCacheSessionHeader?: "x-grok-conv-id";
-	/** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
-	cacheControlFormat?: "anthropic" | undefined;
-	/** Whether the provider supports the `strict` field in tool definitions. Default: auto-detected per provider/baseUrl (conservative for unknown providers). */
-	supportsStrictMode?: boolean;
-	/**
-	 * Tool-schema dialect the endpoint validates `tools.function.parameters`
-	 * against. `"moonshot-mfjs"` triggers Moonshot Flavored JSON Schema
-	 * normalization (collapse `const`→`enum`, infer `type` on bare enums, strip
-	 * unsupported validators/`prefixItems`) because Moonshot/Kimi native hosts
-	 * reject standard JSON Schema constructs with HTTP 400. Default:
-	 * auto-detected (`"moonshot-mfjs"` on api.moonshot.ai / api.kimi.com). Set
-	 * `"none"` to opt a custom Moonshot-compatible host out.
-	 */
-	toolSchemaFlavor?: "moonshot-mfjs" | "none";
-	/**
-	 * Stream-watchdog idle-timeout floor in ms for slow reasoning hosts.
-	 * Default: auto-detected (GLM coding-plan hosts, direct DeepSeek reasoning).
-	 */
-	streamIdleTimeoutMs?: number;
-	/** Whether the host honors `prompt_cache_retention: "24h"` on the Responses API. Default: auto-detected (api.openai.com). */
-	supportsLongPromptCacheRetention?: boolean;
-	/** Whether tool schemas must be sent either all strict or all non-strict. Undefined keeps the existing per-tool mixed behavior. */
-	toolStrictMode?: "all_strict" | "none";
-	/** Whether request shaping may send reasoning params at all. Default: auto-detected (disabled for GitHub Copilot chat-completions). */
-	supportsReasoningParams?: boolean;
-	/**
-	 * Whether the endpoint accepts explicit sampling parameters (`temperature`,
-	 * `top_p`, `top_k`, `min_p`, penalties). OpenAI proprietary reasoning models
-	 * (o-series, gpt-5+) reject them with `400 Unsupported parameter:
-	 * 'temperature' is not supported with this model` on every serving host
-	 * (official, Azure, GitHub Copilot). When unset, auto-detected from the
-	 * model id. Default: true. Issue #5606.
-	 */
-	supportsSamplingParams?: boolean;
-	/** Always send a max-token field when the caller did not provide one. Default: auto-detected (Kimi-family models derive TPM limits from max_tokens). */
-	alwaysSendMaxTokens?: boolean;
-	/** Whether Responses-API tool-call/result history must be strictly paired. Default: auto-detected (Azure OpenAI, GitHub Copilot). */
-	strictResponsesPairing?: boolean;
-	/** Whether the Responses API accepts the `detail: "original"` image hint. Default: auto-detected (false for GitHub Copilot, which rejects it with a 400). */
-	supportsImageDetailOriginal?: boolean;
-	/** Whether streamed reasoning deltas for the same field may repeat the full cumulative text snapshot. Default: false. */
-	reasoningDeltasMayBeCumulative?: boolean;
-	/** Strip leaked DeepSeek chat-template special tokens from visible content deltas. Default: auto-detected. */
-	stripDeepseekSpecialTokens?: boolean;
-	/** Heal leaked chat-template/tool-call/thinking markup from visible content deltas. Default: auto-detected. */
-	streamMarkupHealingPattern?: OpenAIStreamMarkupHealingPattern;
-	/** Treat an empty length-finished stream as a context-window error. Default: auto-detected. */
-	emptyLengthFinishIsContextError?: boolean;
-	/** Normalize tool call ids to OpenAI's 40-character limit. Default: auto-detected. */
-	usesOpenAIToolCallIdLimit?: boolean;
-	/**
-	 * Compat deltas applied when a request actually engages thinking mode
-	 * (reasoning requested and not disabled, model reasoning-capable, and not
-	 * suppressed by a forced tool choice). `buildModel` materializes the full
-	 * alternate view as `compat.whenThinking`; handlers pointer-swap, never
-	 * spread. Default: auto-detected (OpenCode gateways, #1071/#1484).
-	 */
-	whenThinking?: Partial<Omit<OpenAICompat, "whenThinking">>;
+  /** Whether the provider supports the `store` field. Default: auto-detected from URL. */
+  supportsStore?: boolean;
+  /** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
+  supportsDeveloperRole?: boolean;
+  /**
+   * Whether the provider's chat-completions endpoint accepts multiple
+   * leading `system`/`developer` messages. When false, ordered system
+   * prompts are coalesced into a single message joined by `\n\n` so
+   * strict chat templates (e.g. Qwen-served via vLLM, MiniMax) accept
+   * the request. Default: detected per provider/baseUrl. Canonical
+   * OpenAI/Azure/OpenRouter/Cerebras/Together/Fireworks/Groq/DeepSeek/
+   * Mistral/xAI/Z.ai/GitHub Copilot/Zenmux are treated as `true`;
+   * unknown or strict-template hosts default to `false`. Setting this
+   * to `true` preserves separate blocks, which is preferred for
+   * KV-cache reuse when the trailing prompt changes between calls.
+   */
+  supportsMultipleSystemMessages?: boolean;
+  /** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */
+  supportsReasoningEffort?: boolean;
+  /** Optional mapping from pi-ai reasoning levels to provider/model-specific `reasoning_effort` values. */
+  reasoningEffortMap?: Partial<Record<Effort, string>>;
+  /** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
+  supportsUsageInStreaming?: boolean;
+  /**
+   * Enable the Gemini thinking-loop guard (pi-ai stream layer) for this model.
+   * Defaults to true when the model id classifies as the gemini family. Set
+   * explicitly to cover an opaque OpenAI-compat proxy alias (e.g. `my-model`)
+   * that routes to Gemini, or to false to opt a gemini-family id out.
+   */
+  enableGeminiThinkingLoopGuard?: boolean;
+  /** Which field to use for max tokens. Default: auto-detected from URL. */
+  maxTokensField?: "max_completion_tokens" | "max_tokens";
+  /** Whether tool results require the `name` field. Default: auto-detected from URL. */
+  requiresToolResultName?: boolean;
+  /** Whether a user message after tool results requires an assistant message in between. Default: auto-detected from URL. */
+  requiresAssistantAfterToolResult?: boolean;
+  /** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
+  requiresThinkingAsText?: boolean;
+  /** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
+  requiresMistralToolIds?: boolean;
+  /** Format for reasoning/thinking parameter. `"kimi"` uses `thinking: { type, effort }`; other values select their provider-native reasoning fields. Default: `"openai"`. */
+  thinkingFormat?: OpenAIReasoningFormat;
+  /** Kimi Code transport selected by live per-model protocol metadata. User settings take precedence. */
+  kimiApiFormat?: "openai" | "anthropic";
+  /** Request-time disable encoding for the selected reasoning/thinking format. Default: derived from `thinkingFormat`. */
+  reasoningDisableMode?: OpenAIReasoningDisableMode;
+  /** Whether the provider rejects `reasoning.effort`/`reasoning_effort` even when the model reasons natively. Default: false unless reasoning effort is unsupported. */
+  omitReasoningEffort?: boolean;
+  /** Whether Responses requests should ask for encrypted reasoning replay items. Default: true. */
+  includeEncryptedReasoning?: boolean;
+  /** Whether replayed Responses history should strip native `type: "reasoning"` items before request encoding. Default: false. */
+  filterReasoningHistory?: boolean;
+  /** Optional `thinking.keep` value for Z.ai/Moonshot-style thinking params. Set false to suppress auto-detected keep. Default: auto-detected. */
+  thinkingKeep?: "all" | false;
+  /** Which reasoning content field to emit on assistant messages. Default: auto-detected. */
+  reasoningContentField?: "reasoning_content" | "reasoning" | "reasoning_text";
+  /** Whether assistant tool-call messages must include reasoning content. Default: false. */
+  requiresReasoningContentForToolCalls?: boolean;
+  /** Whether all assistant messages must include reasoning content. Default: false. */
+  requiresReasoningContentForAllAssistantTurns?: boolean;
+  /** Whether the provider accepts a synthetic placeholder (e.g. ".") for missing reasoning_content on tool-call turns. Default: true. Set to false for providers like DeepSeek that validate the exact reasoning_content value. */
+  allowsSyntheticReasoningContentForToolCalls?: boolean;
+  /**
+   * Replay preserved thinking blocks as `reasoning_content` (or the configured
+   * `reasoningContentField`) on EVERY assistant turn that carried reasoning,
+   * regardless of whether the upstream provider validates the field. Local
+   * llama.cpp-style servers (llama.cpp, LM Studio, vLLM, sglang, Ollama in
+   * openai-completions mode) re-tokenize the full chat-template prompt every
+   * request; Qwen3 / DeepSeek-R1 / GLM templates reconstruct the `<think>`
+   * block from `reasoning_content`. Dropping the field re-renders the
+   * assistant turn without `<think>`, diverging from the slot's KV cache state
+   * and forcing full prompt re-processing (#3528). Default: auto-detected
+   * (loopback/private baseUrl or local provider id with thinking-enabled
+   * models).
+   */
+  replayReasoningContent?: boolean;
+  /**
+   * Send `preserve_thinking: true` so the Qwen3.6+ chat template renders
+   * `<think>...</think>` markup for EVERY assistant turn (not just turns
+   * after the last user message). Without it, the template strips the think
+   * block from older assistant turns:
+   *
+   * ```jinja
+   * {%- if (preserve_thinking is defined and preserve_thinking is true)
+   *        or (loop.index0 > ns.last_query_index) %}
+   *   <|im_start|>assistant\n<think>\n{rc}\n</think>\n\n{content}
+   * {%- else %}
+   *   <|im_start|>assistant\n{content}
+   * ```
+   *
+   * The cache from the original generation has `<think>...</think>` tokens,
+   * so once a new user message arrives the prior assistant turns become
+   * "older" and the stripped re-render diverges — full prompt re-processing
+   * on SWA models (#3541). Default: auto-detected (Qwen thinking format on
+   * a local llama.cpp-style backend, paired with `replayReasoningContent`).
+   * Non-Qwen templates ignore the flag, so the auto-detection is safe.
+   */
+  qwenPreserveThinking?: boolean;
+  /**
+   * Rewrite tool parameter schemas so grammar-constrained samplers can
+   * represent them: bare boolean subschemas (`true`/`false`) become a
+   * value-widening `anyOf` of primitives, boolean
+   * `additionalProperties`/`unevaluatedProperties` are stripped, and nullable
+   * `type` arrays are flattened. llama.cpp's JSON-schema→GBNF generator and
+   * Ollama's Go tool parser both 400 on a bare boolean subschema
+   * ("Unrecognized schema: true"), and `toolWireSchema` intentionally emits
+   * `true` for unconstrained fields (issue #1179), so the openai-completions
+   * encoder must widen those before sending. Default: auto-detected for local
+   * grammar-constrained backends (`llama.cpp`/`lm-studio`/`vllm`/openai-compatible server).
+   */
+  sanitizeToolSchemaForGrammar?: boolean;
+  /** Whether assistant tool-call messages must include non-empty content. Default: false. */
+  requiresAssistantContentForToolCalls?: boolean;
+  /** Whether the provider supports the `tool_choice` parameter. Default: true. */
+  supportsToolChoice?: boolean;
+  /**
+   * Whether forced `tool_choice` values (`"required"` or named tools) are accepted.
+   * When false, request builders keep tools available but downgrade forced choices
+   * to provider-default auto selection. Default: true.
+   */
+  supportsForcedToolChoice?: boolean;
+  /**
+   * Whether the chat-completions endpoint accepts the object form that pins one
+   * named function (`{ type: "function", function: { name } }`). Some
+   * OpenAI-compatible hosts such as llama.cpp only accept string
+   * `tool_choice` values; request builders downgrade a named force to
+   * `"required"` when this is false. Default: true.
+   */
+  supportsNamedToolChoice?: boolean;
+  /**
+   * Drop reasoning fields (`reasoning_effort`, OpenRouter `reasoning`) for
+   * the request when `tool_choice` forces a tool call. Mirrors the Anthropic
+   * `disableThinkingIfToolChoiceForced` rule for backends like Kimi that
+   * 400 with `tool_choice 'specified' is incompatible with thinking
+   * enabled` whenever both are present. Default: auto-detected (Kimi).
+   */
+  disableReasoningOnForcedToolChoice?: boolean;
+  /**
+   * Drop reasoning fields (`reasoning_effort`, OpenRouter `reasoning`) for
+   * any request that sends `tool_choice`. Use for providers/models that accept
+   * tools and `tool_choice`, but reject `tool_choice` while thinking is enabled.
+   * Default: auto-detected (DeepSeek reasoning models).
+   */
+  disableReasoningOnToolChoice?: boolean;
+  /** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
+  openRouterRouting?: OpenRouterRouting;
+  /** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */
+  vercelGatewayRouting?: VercelGatewayRouting;
+  /** Extra fields to include in request body (e.g. gateway routing hints for OpenClaw-style proxies). */
+  extraBody?: Record<string, unknown>;
+  /** Request-session header that should mirror the normalized prompt-cache key. Default: unset. */
+  promptCacheSessionHeader?: "x-grok-conv-id";
+  /** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
+  cacheControlFormat?: "anthropic" | undefined;
+  /** Whether the provider supports the `strict` field in tool definitions. Default: auto-detected per provider/baseUrl (conservative for unknown providers). */
+  supportsStrictMode?: boolean;
+  /**
+   * Tool-schema dialect the endpoint validates `tools.function.parameters`
+   * against. `"moonshot-mfjs"` triggers Moonshot Flavored JSON Schema
+   * normalization (collapse `const`→`enum`, infer `type` on bare enums, strip
+   * unsupported validators/`prefixItems`) because Moonshot/Kimi native hosts
+   * reject standard JSON Schema constructs with HTTP 400. Default:
+   * auto-detected (`"moonshot-mfjs"` on api.moonshot.ai / api.kimi.com). Set
+   * `"none"` to opt a custom Moonshot-compatible host out.
+   */
+  toolSchemaFlavor?: "moonshot-mfjs" | "none";
+  /**
+   * Stream-watchdog idle-timeout floor in ms for slow reasoning hosts.
+   * Default: auto-detected (GLM coding-plan hosts, direct DeepSeek reasoning).
+   */
+  streamIdleTimeoutMs?: number;
+  /** Whether the host honors `prompt_cache_retention: "24h"` on the Responses API. Default: auto-detected (api.openai.com). */
+  supportsLongPromptCacheRetention?: boolean;
+  /** Whether tool schemas must be sent either all strict or all non-strict. Undefined keeps the existing per-tool mixed behavior. */
+  toolStrictMode?: "all_strict" | "none";
+  /** Whether request shaping may send reasoning params at all. Default: auto-detected (disabled for GitHub Copilot chat-completions). */
+  supportsReasoningParams?: boolean;
+  /**
+   * Whether the endpoint accepts explicit sampling parameters (`temperature`,
+   * `top_p`, `top_k`, `min_p`, penalties). OpenAI proprietary reasoning models
+   * (o-series, gpt-5+) reject them with `400 Unsupported parameter:
+   * 'temperature' is not supported with this model` on every serving host
+   * (official, Azure, GitHub Copilot). When unset, auto-detected from the
+   * model id. Default: true. Issue #5606.
+   */
+  supportsSamplingParams?: boolean;
+  /** Always send a max-token field when the caller did not provide one. Default: auto-detected (Kimi-family models derive TPM limits from max_tokens). */
+  alwaysSendMaxTokens?: boolean;
+  /** Whether Responses-API tool-call/result history must be strictly paired. Default: auto-detected (Azure OpenAI, GitHub Copilot). */
+  strictResponsesPairing?: boolean;
+  /** Whether the Responses API accepts the `detail: "original"` image hint. Default: auto-detected (false for GitHub Copilot, which rejects it with a 400). */
+  supportsImageDetailOriginal?: boolean;
+  /** Whether streamed reasoning deltas for the same field may repeat the full cumulative text snapshot. Default: false. */
+  reasoningDeltasMayBeCumulative?: boolean;
+  /** Strip leaked DeepSeek chat-template special tokens from visible content deltas. Default: auto-detected. */
+  stripDeepseekSpecialTokens?: boolean;
+  /** Heal leaked chat-template/tool-call/thinking markup from visible content deltas. Default: auto-detected. */
+  streamMarkupHealingPattern?: OpenAIStreamMarkupHealingPattern;
+  /** Treat an empty length-finished stream as a context-window error. Default: auto-detected. */
+  emptyLengthFinishIsContextError?: boolean;
+  /** Normalize tool call ids to OpenAI's 40-character limit. Default: auto-detected. */
+  usesOpenAIToolCallIdLimit?: boolean;
+  /**
+   * Compat deltas applied when a request actually engages thinking mode
+   * (reasoning requested and not disabled, model reasoning-capable, and not
+   * suppressed by a forced tool choice). `buildModel` materializes the full
+   * alternate view as `compat.whenThinking`; handlers pointer-swap, never
+   * spread. Default: auto-detected (OpenCode gateways, #1071/#1484).
+   */
+  whenThinking?: Partial<Omit<OpenAICompat, "whenThinking">>;
 }
 
 /**
@@ -370,73 +383,73 @@ export interface OpenAICompat {
  * that proxy gateways (Vertex AI, AWS Bedrock-style fronts, etc.) reject.
  */
 export interface AnthropicCompat {
-	/**
-	 * Drop the top-level `strict: true` field on tool definitions. Vertex AI's
-	 * Anthropic-compatible endpoint rejects unknown tool fields with
-	 * `tools.<n>.custom.strict: Extra inputs are not permitted`.
-	 */
-	disableStrictTools?: boolean;
-	/**
-	 * Map adaptive thinking (`thinking: { type: "adaptive" }`) to
-	 * `{ type: "enabled", budget_tokens }`. Vertex AI rejects the `adaptive`
-	 * tag with `Input tag 'adaptive' ... does not match any of the expected
-	 * tags: 'disabled', 'enabled'`.
-	 */
-	disableAdaptiveThinking?: boolean;
-	/** Whether tools may include Anthropic's per-tool eager_input_streaming flag. Default: true for the canonical Anthropic API. */
-	supportsEagerToolInputStreaming?: boolean;
-	/** Whether long prompt-cache retention (`ttl: "1h"`) is supported. Default: true for canonical Anthropic API. */
-	supportsLongCacheRetention?: boolean;
-	/**
-	 * Whether mid-conversation `role: "system"` messages are accepted in the
-	 * `messages` array (Claude Opus 4.8+ and Claude Fable/Mythos 5 on the
-	 * first-party Claude API and Claude Platform on AWS). When unset,
-	 * auto-detected from the model id and base URL. Not available on Bedrock,
-	 * Vertex AI, or Microsoft Foundry.
-	 */
-	supportsMidConversationSystem?: boolean;
-	/**
-	 * Whether the model accepts a forced `tool_choice` (`{ type: "any" }` or
-	 * `{ type: "tool", name }`). Claude Fable/Mythos 5 reject forced tool use
-	 * outright ("tool_choice forces tool use is not compatible with this model");
-	 * the request builder downgrades forced choices to `auto` when this is false.
-	 * When unset, auto-detected from the model id. Default: true.
-	 */
-	supportsForcedToolChoice?: boolean;
-	/**
-	 * Whether the model accepts sampling parameters (`temperature`, `top_p`,
-	 * `top_k`). Opus 4.7+ and Fable/Mythos reject them with a 400. When unset,
-	 * auto-detected from the model id. Default: true.
-	 */
-	supportsSamplingParams?: boolean;
-	/**
-	 * Include a non-standard `id` field (aliasing `tool_use_id`) on
-	 * `tool_result` blocks. Z.AI's Anthropic-compatible proxy deserializes
-	 * tool results into a class that reads `.id` (issue #814). Default:
-	 * auto-detected (Z.AI hosts).
-	 */
-	requiresToolResultId?: boolean;
-	/**
-	 * Replay unsigned `thinking` blocks from prior assistant turns as native
-	 * thinking instead of demoting them to text. Official Anthropic enforces
-	 * signature-based thinking-chain integrity, so unsigned blocks must stay
-	 * text there; compatible reasoning endpoints (Z.AI, DeepSeek, …) emit
-	 * unsigned blocks and expect them back as `type: "thinking"` (#2005).
-	 * Default: auto-detected from provider/baseUrl and `model.reasoning`.
-	 */
-	replayUnsignedThinking?: boolean;
-	/**
-	 * Whether the endpoint requires `thinking.type: "enabled"` whenever the
-	 * model reasons. Use for models that reject omitted or disabled thinking.
-	 */
-	requiresThinkingEnabled?: boolean;
-	/**
-	 * Prefix Anthropic built-in tool names (`web_search`, `code_execution`, ...)
-	 * when they are ordinary client tools. Some Anthropic-compatible gateways
-	 * intercept those exact names as server tools and return raw search/result
-	 * blocks instead of normal `tool_use` calls.
-	 */
-	escapeBuiltinToolNames?: boolean;
+  /**
+   * Drop the top-level `strict: true` field on tool definitions. Vertex AI's
+   * Anthropic-compatible endpoint rejects unknown tool fields with
+   * `tools.<n>.custom.strict: Extra inputs are not permitted`.
+   */
+  disableStrictTools?: boolean;
+  /**
+   * Map adaptive thinking (`thinking: { type: "adaptive" }`) to
+   * `{ type: "enabled", budget_tokens }`. Vertex AI rejects the `adaptive`
+   * tag with `Input tag 'adaptive' ... does not match any of the expected
+   * tags: 'disabled', 'enabled'`.
+   */
+  disableAdaptiveThinking?: boolean;
+  /** Whether tools may include Anthropic's per-tool eager_input_streaming flag. Default: true for the canonical Anthropic API. */
+  supportsEagerToolInputStreaming?: boolean;
+  /** Whether long prompt-cache retention (`ttl: "1h"`) is supported. Default: true for canonical Anthropic API. */
+  supportsLongCacheRetention?: boolean;
+  /**
+   * Whether mid-conversation `role: "system"` messages are accepted in the
+   * `messages` array (Claude Opus 4.8+ and Claude Fable/Mythos 5 on the
+   * first-party Claude API and Claude Platform on AWS). When unset,
+   * auto-detected from the model id and base URL. Not available on Bedrock,
+   * Vertex AI, or Microsoft Foundry.
+   */
+  supportsMidConversationSystem?: boolean;
+  /**
+   * Whether the model accepts a forced `tool_choice` (`{ type: "any" }` or
+   * `{ type: "tool", name }`). Claude Fable/Mythos 5 reject forced tool use
+   * outright ("tool_choice forces tool use is not compatible with this model");
+   * the request builder downgrades forced choices to `auto` when this is false.
+   * When unset, auto-detected from the model id. Default: true.
+   */
+  supportsForcedToolChoice?: boolean;
+  /**
+   * Whether the model accepts sampling parameters (`temperature`, `top_p`,
+   * `top_k`). Opus 4.7+ and Fable/Mythos reject them with a 400. When unset,
+   * auto-detected from the model id. Default: true.
+   */
+  supportsSamplingParams?: boolean;
+  /**
+   * Include a non-standard `id` field (aliasing `tool_use_id`) on
+   * `tool_result` blocks. Z.AI's Anthropic-compatible proxy deserializes
+   * tool results into a class that reads `.id` (issue #814). Default:
+   * auto-detected (Z.AI hosts).
+   */
+  requiresToolResultId?: boolean;
+  /**
+   * Replay unsigned `thinking` blocks from prior assistant turns as native
+   * thinking instead of demoting them to text. Official Anthropic enforces
+   * signature-based thinking-chain integrity, so unsigned blocks must stay
+   * text there; compatible reasoning endpoints (Z.AI, DeepSeek, …) emit
+   * unsigned blocks and expect them back as `type: "thinking"` (#2005).
+   * Default: auto-detected from provider/baseUrl and `model.reasoning`.
+   */
+  replayUnsignedThinking?: boolean;
+  /**
+   * Whether the endpoint requires `thinking.type: "enabled"` whenever the
+   * model reasons. Use for models that reject omitted or disabled thinking.
+   */
+  requiresThinkingEnabled?: boolean;
+  /**
+   * Prefix Anthropic built-in tool names (`web_search`, `code_execution`, ...)
+   * when they are ordinary client tools. Some Anthropic-compatible gateways
+   * intercept those exact names as server tools and return raw search/result
+   * blocks instead of normal `tool_use` calls.
+   */
+  escapeBuiltinToolNames?: boolean;
 }
 
 /**
@@ -445,10 +458,10 @@ export interface AnthropicCompat {
  * @see https://openrouter.ai/docs/provider-routing
  */
 export interface OpenRouterRouting {
-	/** List of provider slugs to exclusively use for this request (e.g., ["amazon-bedrock", "anthropic"]). */
-	only?: string[];
-	/** List of provider slugs to try in order (e.g., ["anthropic", "openai"]). */
-	order?: string[];
+  /** List of provider slugs to exclusively use for this request (e.g., ["amazon-bedrock", "anthropic"]). */
+  only?: string[];
+  /** List of provider slugs to try in order (e.g., ["anthropic", "openai"]). */
+  order?: string[];
 }
 
 /**
@@ -457,10 +470,10 @@ export interface OpenRouterRouting {
  * @see https://vercel.com/docs/ai-gateway/models-and-providers/provider-options
  */
 export interface VercelGatewayRouting {
-	/** List of provider slugs to exclusively use for this request (e.g., ["bedrock", "anthropic"]). */
-	only?: string[];
-	/** List of provider slugs to try in order (e.g., ["anthropic", "openai"]). */
-	order?: string[];
+  /** List of provider slugs to exclusively use for this request (e.g., ["bedrock", "anthropic"]). */
+  only?: string[];
+  /** List of provider slugs to try in order (e.g., ["anthropic", "openai"]). */
+  order?: string[];
 }
 
 type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mixed";
@@ -470,50 +483,50 @@ type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mix
  * Each builder still computes its own per-surface value when defaults diverge.
  */
 export interface ResolvedOpenAISharedCompat {
-	supportsDeveloperRole: boolean;
-	supportsStrictMode: boolean;
-	supportsReasoningEffort: boolean;
-	reasoningEffortMap: Partial<Record<Effort, string>>;
-	supportsReasoningParams: boolean;
-	supportsSamplingParams: boolean;
-	thinkingFormat: OpenAIReasoningFormat;
-	/** Kimi Code transport selected by live per-model protocol metadata. */
-	kimiApiFormat?: OpenAICompat["kimiApiFormat"];
-	reasoningDisableMode: OpenAIReasoningDisableMode;
-	omitReasoningEffort: boolean;
-	includeEncryptedReasoning: boolean;
-	filterReasoningHistory: boolean;
-	disableReasoningOnForcedToolChoice: boolean;
-	disableReasoningOnToolChoice: boolean;
-	supportsToolChoice: boolean;
-	supportsForcedToolChoice: boolean;
-	supportsNamedToolChoice: boolean;
-	reasoningContentField?: OpenAICompat["reasoningContentField"];
-	requiresReasoningContentForToolCalls: boolean;
-	requiresReasoningContentForAllAssistantTurns: boolean;
-	allowsSyntheticReasoningContentForToolCalls: boolean;
-	replayReasoningContent: boolean;
-	qwenPreserveThinking: boolean;
-	requiresThinkingAsText: boolean;
-	requiresMistralToolIds: boolean;
-	requiresToolResultName: boolean;
-	requiresAssistantAfterToolResult: boolean;
-	requiresAssistantContentForToolCalls: boolean;
-	stripDeepseekSpecialTokens: boolean;
-	streamMarkupHealingPattern?: OpenAIStreamMarkupHealingPattern;
-	reasoningDeltasMayBeCumulative: boolean;
-	emptyLengthFinishIsContextError: boolean;
-	usesOpenAIToolCallIdLimit: boolean;
-	promptCacheSessionHeader?: OpenAICompat["promptCacheSessionHeader"];
-	/** The model sits behind OpenRouter (routing prefs and max-token omission apply). */
-	isOpenRouterHost: boolean;
-	/** Whether this endpoint needs a max-token field even when caller did not set one. */
-	alwaysSendMaxTokens: boolean;
-	/** See {@link OpenAICompat.enableGeminiThinkingLoopGuard}. Set by the builder from the family classifier. */
-	enableGeminiThinkingLoopGuard?: boolean;
-	openRouterRouting?: OpenAICompat["openRouterRouting"];
-	/** Provider-specific wire model-id transform applied to the base id. */
-	wireModelIdMode: "raw" | "firepass" | "fireworks" | "openrouter";
+  supportsDeveloperRole: boolean;
+  supportsStrictMode: boolean;
+  supportsReasoningEffort: boolean;
+  reasoningEffortMap: Partial<Record<Effort, string>>;
+  supportsReasoningParams: boolean;
+  supportsSamplingParams: boolean;
+  thinkingFormat: OpenAIReasoningFormat;
+  /** Kimi Code transport selected by live per-model protocol metadata. */
+  kimiApiFormat?: OpenAICompat["kimiApiFormat"];
+  reasoningDisableMode: OpenAIReasoningDisableMode;
+  omitReasoningEffort: boolean;
+  includeEncryptedReasoning: boolean;
+  filterReasoningHistory: boolean;
+  disableReasoningOnForcedToolChoice: boolean;
+  disableReasoningOnToolChoice: boolean;
+  supportsToolChoice: boolean;
+  supportsForcedToolChoice: boolean;
+  supportsNamedToolChoice: boolean;
+  reasoningContentField?: OpenAICompat["reasoningContentField"];
+  requiresReasoningContentForToolCalls: boolean;
+  requiresReasoningContentForAllAssistantTurns: boolean;
+  allowsSyntheticReasoningContentForToolCalls: boolean;
+  replayReasoningContent: boolean;
+  qwenPreserveThinking: boolean;
+  requiresThinkingAsText: boolean;
+  requiresMistralToolIds: boolean;
+  requiresToolResultName: boolean;
+  requiresAssistantAfterToolResult: boolean;
+  requiresAssistantContentForToolCalls: boolean;
+  stripDeepseekSpecialTokens: boolean;
+  streamMarkupHealingPattern?: OpenAIStreamMarkupHealingPattern;
+  reasoningDeltasMayBeCumulative: boolean;
+  emptyLengthFinishIsContextError: boolean;
+  usesOpenAIToolCallIdLimit: boolean;
+  promptCacheSessionHeader?: OpenAICompat["promptCacheSessionHeader"];
+  /** The model sits behind OpenRouter (routing prefs and max-token omission apply). */
+  isOpenRouterHost: boolean;
+  /** Whether this endpoint needs a max-token field even when caller did not set one. */
+  alwaysSendMaxTokens: boolean;
+  /** See {@link OpenAICompat.enableGeminiThinkingLoopGuard}. Set by the builder from the family classifier. */
+  enableGeminiThinkingLoopGuard?: boolean;
+  openRouterRouting?: OpenAICompat["openRouterRouting"];
+  /** Provider-specific wire model-id transform applied to the base id. */
+  wireModelIdMode: "raw" | "firepass" | "fireworks" | "openrouter";
 }
 
 /**
@@ -523,82 +536,82 @@ export interface ResolvedOpenAISharedCompat {
  * allocate.
  */
 export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
-	Required<
-		Omit<
-			OpenAICompat,
-			| "supportsDeveloperRole"
-			| "supportsReasoningEffort"
-			| "reasoningEffortMap"
-			| "supportsReasoningParams"
-			| "supportsSamplingParams"
-			| "thinkingFormat"
-			| "kimiApiFormat"
-			| "reasoningDisableMode"
-			| "omitReasoningEffort"
-			| "includeEncryptedReasoning"
-			| "filterReasoningHistory"
-			| "disableReasoningOnForcedToolChoice"
-			| "disableReasoningOnToolChoice"
-			| "supportsToolChoice"
-			| "supportsForcedToolChoice"
-			| "supportsNamedToolChoice"
-			| "reasoningContentField"
-			| "requiresReasoningContentForToolCalls"
-			| "requiresReasoningContentForAllAssistantTurns"
-			| "allowsSyntheticReasoningContentForToolCalls"
-			| "replayReasoningContent"
-			| "qwenPreserveThinking"
-			| "requiresThinkingAsText"
-			| "requiresMistralToolIds"
-			| "requiresToolResultName"
-			| "requiresAssistantAfterToolResult"
-			| "requiresAssistantContentForToolCalls"
-			| "stripDeepseekSpecialTokens"
-			| "streamMarkupHealingPattern"
-			| "reasoningDeltasMayBeCumulative"
-			| "emptyLengthFinishIsContextError"
-			| "usesOpenAIToolCallIdLimit"
-			| "promptCacheSessionHeader"
-			| "openRouterRouting"
-			| "isOpenRouterHost"
-			| "supportsStrictMode"
-			| "supportsLongPromptCacheRetention"
-			| "alwaysSendMaxTokens"
-			| "wireModelIdMode"
-			| "vercelGatewayRouting"
-			| "extraBody"
-			| "toolStrictMode"
-			| "toolSchemaFlavor"
-			| "streamIdleTimeoutMs"
-			| "cacheControlFormat"
-			| "thinkingKeep"
-			| "strictResponsesPairing"
-			| "supportsImageDetailOriginal"
-			| "enableGeminiThinkingLoopGuard"
-			| "whenThinking"
-		>
-	> & {
-		vercelGatewayRouting?: OpenAICompat["vercelGatewayRouting"];
-		extraBody?: OpenAICompat["extraBody"];
-		cacheControlFormat?: OpenAICompat["cacheControlFormat"];
-		thinkingKeep?: OpenAICompat["thinkingKeep"];
-		streamIdleTimeoutMs?: number;
-		toolStrictMode: ResolvedToolStrictMode;
-		toolSchemaFlavor?: OpenAICompat["toolSchemaFlavor"];
-		/** The model sits behind Vercel AI Gateway. */
-		isVercelGatewayHost: boolean;
-		dropThinkingWhenReasoningEffort: boolean;
-		/** Complete alternate view for thinking-engaged requests; swap pointers, never spread. */
-		whenThinking?: ResolvedOpenAICompat;
-	};
+  Required<
+    Omit<
+      OpenAICompat,
+      | "supportsDeveloperRole"
+      | "supportsReasoningEffort"
+      | "reasoningEffortMap"
+      | "supportsReasoningParams"
+      | "supportsSamplingParams"
+      | "thinkingFormat"
+      | "kimiApiFormat"
+      | "reasoningDisableMode"
+      | "omitReasoningEffort"
+      | "includeEncryptedReasoning"
+      | "filterReasoningHistory"
+      | "disableReasoningOnForcedToolChoice"
+      | "disableReasoningOnToolChoice"
+      | "supportsToolChoice"
+      | "supportsForcedToolChoice"
+      | "supportsNamedToolChoice"
+      | "reasoningContentField"
+      | "requiresReasoningContentForToolCalls"
+      | "requiresReasoningContentForAllAssistantTurns"
+      | "allowsSyntheticReasoningContentForToolCalls"
+      | "replayReasoningContent"
+      | "qwenPreserveThinking"
+      | "requiresThinkingAsText"
+      | "requiresMistralToolIds"
+      | "requiresToolResultName"
+      | "requiresAssistantAfterToolResult"
+      | "requiresAssistantContentForToolCalls"
+      | "stripDeepseekSpecialTokens"
+      | "streamMarkupHealingPattern"
+      | "reasoningDeltasMayBeCumulative"
+      | "emptyLengthFinishIsContextError"
+      | "usesOpenAIToolCallIdLimit"
+      | "promptCacheSessionHeader"
+      | "openRouterRouting"
+      | "isOpenRouterHost"
+      | "supportsStrictMode"
+      | "supportsLongPromptCacheRetention"
+      | "alwaysSendMaxTokens"
+      | "wireModelIdMode"
+      | "vercelGatewayRouting"
+      | "extraBody"
+      | "toolStrictMode"
+      | "toolSchemaFlavor"
+      | "streamIdleTimeoutMs"
+      | "cacheControlFormat"
+      | "thinkingKeep"
+      | "strictResponsesPairing"
+      | "supportsImageDetailOriginal"
+      | "enableGeminiThinkingLoopGuard"
+      | "whenThinking"
+    >
+  > & {
+    vercelGatewayRouting?: OpenAICompat["vercelGatewayRouting"];
+    extraBody?: OpenAICompat["extraBody"];
+    cacheControlFormat?: OpenAICompat["cacheControlFormat"];
+    thinkingKeep?: OpenAICompat["thinkingKeep"];
+    streamIdleTimeoutMs?: number;
+    toolStrictMode: ResolvedToolStrictMode;
+    toolSchemaFlavor?: OpenAICompat["toolSchemaFlavor"];
+    /** The model sits behind Vercel AI Gateway. */
+    isVercelGatewayHost: boolean;
+    dropThinkingWhenReasoningEffort: boolean;
+    /** Complete alternate view for thinking-engaged requests; swap pointers, never spread. */
+    whenThinking?: ResolvedOpenAICompat;
+  };
 
 /** Fully-resolved Responses-API compat view (same contract as `ResolvedOpenAICompat`). */
 export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompat {
-	supportsLongPromptCacheRetention: boolean;
-	strictResponsesPairing: boolean;
-	supportsImageDetailOriginal: boolean;
-	supportsObfuscationOptOut: boolean;
-	streamIdleTimeoutMs?: number;
+  supportsLongPromptCacheRetention: boolean;
+  strictResponsesPairing: boolean;
+  supportsImageDetailOriginal: boolean;
+  supportsObfuscationOptOut: boolean;
+  streamIdleTimeoutMs?: number;
 }
 
 /**
@@ -610,24 +623,24 @@ export type ResolvedOpenRouterCompat = ResolvedOpenAICompat & ResolvedOpenAIResp
 
 /** Fully-resolved anthropic-messages compat view (same contract as `ResolvedOpenAICompat`). */
 export type ResolvedAnthropicCompat = Required<AnthropicCompat> & {
-	/**
-	 * The configured endpoint is the official first-party Anthropic API
-	 * (https + exact `api.anthropic.com` host; a missing baseUrl counts as
-	 * official because dispatch defaults there). Gates OAuth framing, custom
-	 * env headers, and cache-TTL shaping without per-request URL parsing.
-	 */
-	officialEndpoint: boolean;
-	/**
-	 * The configured endpoint enforces Anthropic's signature protocol on
-	 * replayed thinking blocks — either the official API itself or a proxy
-	 * that forwards to it (GitHub Copilot, ZenMux, Cloudflare AI Gateway's
-	 * `/anthropic` route, Google Vertex's `publishers/anthropic/…`).
-	 * Downstream transforms strip stale cross-model thinking signatures on
-	 * these endpoints so the signing proxy doesn't 400 with
-	 * `Invalid signature in thinking block` (#4297). Superset of
-	 * {@link officialEndpoint}.
-	 */
-	signingEndpoint: boolean;
+  /**
+   * The configured endpoint is the official first-party Anthropic API
+   * (https + exact `api.anthropic.com` host; a missing baseUrl counts as
+   * official because dispatch defaults there). Gates OAuth framing, custom
+   * env headers, and cache-TTL shaping without per-request URL parsing.
+   */
+  officialEndpoint: boolean;
+  /**
+   * The configured endpoint enforces Anthropic's signature protocol on
+   * replayed thinking blocks — either the official API itself or a proxy
+   * that forwards to it (GitHub Copilot, ZenMux, Cloudflare AI Gateway's
+   * `/anthropic` route, Google Vertex's `publishers/anthropic/…`).
+   * Downstream transforms strip stale cross-model thinking signatures on
+   * these endpoints so the signing proxy doesn't 400 with
+   * `Invalid signature in thinking block` (#4297). Superset of
+   * {@link officialEndpoint}.
+   */
+  signingEndpoint: boolean;
 };
 
 /**
@@ -638,13 +651,13 @@ export type ResolvedAnthropicCompat = Required<AnthropicCompat> & {
  * effort ladder from identity for these models.
  */
 export interface DevinCompat {
-	/**
-	 * Trust only explicit `thinking` metadata; never derive a thinking surface
-	 * from model identity. A reasoning model with no explicit routed thinking
-	 * resolves to `thinking: undefined` (`reasoning: true`, no controllable
-	 * effort) instead of a fabricated minimal/low/medium/high ladder.
-	 */
-	trustExplicitThinkingOnly?: boolean;
+  /**
+   * Trust only explicit `thinking` metadata; never derive a thinking surface
+   * from model identity. A reasoning model with no explicit routed thinking
+   * resolves to `thinking: undefined` (`reasoning: true`, no controllable
+   * effort) instead of a fabricated minimal/low/medium/high ladder.
+   */
+  trustExplicitThinkingOnly?: boolean;
 }
 
 /** Fully-resolved devin-agent compat view. */
@@ -652,164 +665,164 @@ export type ResolvedDevinCompat = Required<DevinCompat>;
 
 /** Sparse, user-authored compat overrides for a given API (models.json / config vocabulary). */
 export type CompatConfigOf<TApi extends Api> = TApi extends
-	| "openai-completions"
-	| "openrouter"
-	| "openai-responses"
-	| "azure-openai-responses"
-	| "openai-codex-responses"
-	? OpenAICompat
-	: TApi extends "anthropic-messages"
-		? AnthropicCompat
-		: TApi extends "devin-agent"
-			? DevinCompat
-			: undefined;
+  | "openai-completions"
+  | "openrouter"
+  | "openai-responses"
+  | "azure-openai-responses"
+  | "openai-codex-responses"
+  ? OpenAICompat
+  : TApi extends "anthropic-messages"
+  ? AnthropicCompat
+  : TApi extends "devin-agent"
+  ? DevinCompat
+  : undefined;
 
 /** Resolved compat for a given API: complete record, materialized once by `buildModel`. */
 export type CompatOf<TApi extends Api> = TApi extends "openrouter"
-	? ResolvedOpenRouterCompat
-	: TApi extends "openai-completions"
-		? ResolvedOpenAICompat
-		: TApi extends "openai-responses" | "azure-openai-responses" | "openai-codex-responses"
-			? ResolvedOpenAIResponsesCompat
-			: TApi extends "anthropic-messages"
-				? ResolvedAnthropicCompat
-				: TApi extends "devin-agent"
-					? ResolvedDevinCompat
-					: undefined;
+  ? ResolvedOpenRouterCompat
+  : TApi extends "openai-completions"
+  ? ResolvedOpenAICompat
+  : TApi extends "openai-responses" | "azure-openai-responses" | "openai-codex-responses"
+  ? ResolvedOpenAIResponsesCompat
+  : TApi extends "anthropic-messages"
+  ? ResolvedAnthropicCompat
+  : TApi extends "devin-agent"
+  ? ResolvedDevinCompat
+  : undefined;
 
 /** Provider-native compaction endpoint configuration for one model. */
 export interface RemoteCompactionConfig<TApi extends Api = Api> {
-	/** Enables provider-native compaction for providers not enabled by built-in policy. */
-	enabled?: boolean;
-	/** Adapter family used by the configured compaction endpoint. */
-	api?: TApi;
-	/** Absolute V1 compact endpoint URL; when omitted, the adapter derives it from the model base URL. */
-	endpoint?: string;
-	/** Enables Responses-stream V2 compaction for models verified to support `compaction_trigger`. */
-	v2StreamingEnabled?: boolean;
-	/** Absolute Responses-stream endpoint URL for V2 compaction; overrides `streamingEndpoint`. */
-	v2Endpoint?: string;
-	/** Absolute provider streaming endpoint URL used by V2 compaction when no dedicated endpoint is set. */
-	streamingEndpoint?: string;
-	/** Model id sent to the compaction endpoint when it differs from the active model id. */
-	model?: string;
+  /** Enables provider-native compaction for providers not enabled by built-in policy. */
+  enabled?: boolean;
+  /** Adapter family used by the configured compaction endpoint. */
+  api?: TApi;
+  /** Absolute V1 compact endpoint URL; when omitted, the adapter derives it from the model base URL. */
+  endpoint?: string;
+  /** Enables Responses-stream V2 compaction for models verified to support `compaction_trigger`. */
+  v2StreamingEnabled?: boolean;
+  /** Absolute Responses-stream endpoint URL for V2 compaction; overrides `streamingEndpoint`. */
+  v2Endpoint?: string;
+  /** Absolute provider streaming endpoint URL used by V2 compaction when no dedicated endpoint is set. */
+  streamingEndpoint?: string;
+  /** Model id sent to the compaction endpoint when it differs from the active model id. */
+  model?: string;
 }
 
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
-	id: string;
-	/**
-	 * Model id to send on the wire when it differs from `id`. Used by catalog
-	 * variants that present one upstream model under several local entries —
-	 * e.g. GitHub Copilot long-context variants (`claude-opus-4.7-1m` requests
-	 * upstream `claude-opus-4.7`; the tier is a client-side context budget, not
-	 * a served model id). Providers MUST serialize `requestModelId ?? id`;
-	 * everything local (selection, caching, usage attribution) keys on `id`.
-	 */
-	requestModelId?: string;
-	/**
-	 * `reasoning.mode` to send on OpenAI Responses-family requests. Set on
-	 * generated pro aliases (`gpt-5.6-*-pro` on `openai`/`openai-codex`) that
-	 * pair a base wire id (`requestModelId`) with OpenAI's pro reasoning
-	 * serving path. Absent everywhere else; providers omit the wire field.
-	 */
-	reasoningMode?: "pro";
-	name: string;
-	api: TApi;
-	provider: Provider;
-	baseUrl: string;
-	reasoning: boolean;
-	input: ("text" | "image")[];
-	/**
-	 * Decoder family used for image inputs when it has narrower format support
-	 * than OMP's general image pipeline. `stb` local backends reject WebP.
-	 */
-	imageInputDecoder?: "stb";
-	/**
-	 * Native provider tool-call support. `false` is the only unsupported signal:
-	 * `true` and `undefined` both mean callers may use native tools. Catalog and
-	 * discovery sources should set this sparsely when an upstream explicitly
-	 * reports that native tool calling is unsupported.
-	 */
-	supportsTools?: boolean;
-	/** GitLab Duo Workflow root namespace selected during catalog discovery. */
-	gitlabDuoWorkflowRootNamespaceId?: string;
-	/** Cursor `max_mode` request flag returned by `GetUsableModels` for premium models that require max mode. */
-	cursorMaxMode?: boolean;
-	cost: {
-		input: number; // $/million tokens
-		output: number; // $/million tokens
-		cacheRead: number; // $/million tokens
-		cacheWrite: number; // $/million tokens
-	};
-	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
-	premiumMultiplier?: number;
-	contextWindow: number | null;
-	maxTokens: number | null;
-	/**
-	 * When `true`, providers MUST omit `max_output_tokens` (Responses) /
-	 * `max_tokens` / `max_completion_tokens` (Completions) from the outbound
-	 * request and let the upstream API decide the per-response cap. `maxTokens`
-	 * is still used locally for budgeting (compaction, context promotion); only
-	 * the wire field is suppressed.
-	 *
-	 * Use this for proxies (notably Ollama) that forward to a backend whose true
-	 * output limit OMP cannot discover — sending the wrong value triggers 400s
-	 * from the upstream provider.
-	 */
-	omitMaxOutputTokens?: boolean;
-	headers?: Record<string, string>;
-	/**
-	 * Streaming transport override. When `"pi-native"`, `streamSimple` routes
-	 * the request to the model's `baseUrl` via the auth-gateway's
-	 * `POST /v1/pi/stream` endpoint instead of dispatching the per-API
-	 * provider client. The `baseUrl` must point at an `omp auth-gateway`
-	 * (or compatible) host; `headers.Authorization` (or `apiKey` resolved by
-	 * the registry) carries the gateway bearer.
-	 *
-	 * Used by containerized omp installs (e.g. robomp slots) to route every
-	 * LLM call through a sidecar gateway that holds the real provider
-	 * credentials. The model's other metadata (pricing, context window,
-	 * thinking config, …) still resolves locally; only the streaming
-	 * dispatch is redirected.
-	 */
-	transport?: "pi-native";
-	/** Hint that websocket transport should be preferred when supported by the provider implementation. */
-	preferWebsockets?: boolean;
-	/** Codex Responses Lite transport: send the lite marker and carry instructions/tools as input items (mirrors codex-rs `use_responses_lite`). */
-	useResponsesLite?: boolean;
-	/** Preferred model to switch to when context promotion is triggered (model id or provider/id). */
-	contextPromotionTarget?: string;
-	/** Preferred model to use only for compaction (model id or provider/id); the active session model is unchanged. */
-	compactionModel?: string;
-	/** Provider-native compaction endpoint configuration. */
-	remoteCompaction?: RemoteCompactionConfig<TApi>;
-	/** Provider-assigned priority value (lower = higher priority). */
-	priority?: number;
-	/** Canonical thinking capability metadata for this model. */
-	thinking?: ThinkingConfig;
-	/**
-	 * Fully-resolved compatibility record, materialized once by `buildModel`.
-	 * Protocol handlers read fields; they never detect, resolve, or allocate.
-	 */
-	compat: CompatOf<TApi>;
-	/** Verbatim sparse compat from the spec (user/config intent), for introspection only. */
-	compatConfig?: CompatConfigOf<TApi>;
-	/**
-	 * Which shape to use when exposing the Codex `apply_patch` tool to this model.
-	 * Generated catalog policy sets `"freeform"` for first-party GPT-5 Responses
-	 * models that support OpenAI custom tools with a Lark grammar. The freeform
-	 * variant sends a raw patch string with no JSON envelope.
-	 * - `"function"` or undefined: JSON function-tool with `{input: string}` (spec §1.2).
-	 */
-	applyPatchToolType?: "freeform" | "function";
-	/**
-	 * Force OAuth-style request shaping for providers whose API key prefix doesn't
-	 * match an OAuth token (e.g. routing Anthropic traffic through a proxy that
-	 * expects Claude Code framing). When true, the streaming layer sets
-	 * `options.isOAuth = true` for the underlying provider call.
-	 */
-	isOAuth?: boolean;
+  id: string;
+  /**
+   * Model id to send on the wire when it differs from `id`. Used by catalog
+   * variants that present one upstream model under several local entries —
+   * e.g. GitHub Copilot long-context variants (`claude-opus-4.7-1m` requests
+   * upstream `claude-opus-4.7`; the tier is a client-side context budget, not
+   * a served model id). Providers MUST serialize `requestModelId ?? id`;
+   * everything local (selection, caching, usage attribution) keys on `id`.
+   */
+  requestModelId?: string;
+  /**
+   * `reasoning.mode` to send on OpenAI Responses-family requests. Set on
+   * generated pro aliases (`gpt-5.6-*-pro` on `openai`/`openai-codex`) that
+   * pair a base wire id (`requestModelId`) with OpenAI's pro reasoning
+   * serving path. Absent everywhere else; providers omit the wire field.
+   */
+  reasoningMode?: "pro";
+  name: string;
+  api: TApi;
+  provider: Provider;
+  baseUrl: string;
+  reasoning: boolean;
+  input: ("text" | "image")[];
+  /**
+   * Decoder family used for image inputs when it has narrower format support
+   * than OMP's general image pipeline. `stb` local backends reject WebP.
+   */
+  imageInputDecoder?: "stb";
+  /**
+   * Native provider tool-call support. `false` is the only unsupported signal:
+   * `true` and `undefined` both mean callers may use native tools. Catalog and
+   * discovery sources should set this sparsely when an upstream explicitly
+   * reports that native tool calling is unsupported.
+   */
+  supportsTools?: boolean;
+  /** GitLab Duo Workflow root namespace selected during catalog discovery. */
+  gitlabDuoWorkflowRootNamespaceId?: string;
+  /** Cursor `max_mode` request flag returned by `GetUsableModels` for premium models that require max mode. */
+  cursorMaxMode?: boolean;
+  cost: {
+    input: number; // $/million tokens
+    output: number; // $/million tokens
+    cacheRead: number; // $/million tokens
+    cacheWrite: number; // $/million tokens
+  };
+  /** Premium Copilot requests charged per user-initiated request (defaults to 1). */
+  premiumMultiplier?: number;
+  contextWindow: number | null;
+  maxTokens: number | null;
+  /**
+   * When `true`, providers MUST omit `max_output_tokens` (Responses) /
+   * `max_tokens` / `max_completion_tokens` (Completions) from the outbound
+   * request and let the upstream API decide the per-response cap. `maxTokens`
+   * is still used locally for budgeting (compaction, context promotion); only
+   * the wire field is suppressed.
+   *
+   * Use this for proxies (notably Ollama) that forward to a backend whose true
+   * output limit OMP cannot discover — sending the wrong value triggers 400s
+   * from the upstream provider.
+   */
+  omitMaxOutputTokens?: boolean;
+  headers?: Record<string, string>;
+  /**
+   * Streaming transport override. When `"pi-native"`, `streamSimple` routes
+   * the request to the model's `baseUrl` via the auth-gateway's
+   * `POST /v1/pi/stream` endpoint instead of dispatching the per-API
+   * provider client. The `baseUrl` must point at an `omp auth-gateway`
+   * (or compatible) host; `headers.Authorization` (or `apiKey` resolved by
+   * the registry) carries the gateway bearer.
+   *
+   * Used by containerized omp installs (e.g. robomp slots) to route every
+   * LLM call through a sidecar gateway that holds the real provider
+   * credentials. The model's other metadata (pricing, context window,
+   * thinking config, …) still resolves locally; only the streaming
+   * dispatch is redirected.
+   */
+  transport?: "pi-native";
+  /** Hint that websocket transport should be preferred when supported by the provider implementation. */
+  preferWebsockets?: boolean;
+  /** Codex Responses Lite transport: send the lite marker and carry instructions/tools as input items (mirrors codex-rs `use_responses_lite`). */
+  useResponsesLite?: boolean;
+  /** Preferred model to switch to when context promotion is triggered (model id or provider/id). */
+  contextPromotionTarget?: string;
+  /** Preferred model to use only for compaction (model id or provider/id); the active session model is unchanged. */
+  compactionModel?: string;
+  /** Provider-native compaction endpoint configuration. */
+  remoteCompaction?: RemoteCompactionConfig<TApi>;
+  /** Provider-assigned priority value (lower = higher priority). */
+  priority?: number;
+  /** Canonical thinking capability metadata for this model. */
+  thinking?: ThinkingConfig;
+  /**
+   * Fully-resolved compatibility record, materialized once by `buildModel`.
+   * Protocol handlers read fields; they never detect, resolve, or allocate.
+   */
+  compat: CompatOf<TApi>;
+  /** Verbatim sparse compat from the spec (user/config intent), for introspection only. */
+  compatConfig?: CompatConfigOf<TApi>;
+  /**
+   * Which shape to use when exposing the Codex `apply_patch` tool to this model.
+   * Generated catalog policy sets `"freeform"` for first-party GPT-5 Responses
+   * models that support OpenAI custom tools with a Lark grammar. The freeform
+   * variant sends a raw patch string with no JSON envelope.
+   * - `"function"` or undefined: JSON function-tool with `{input: string}` (spec §1.2).
+   */
+  applyPatchToolType?: "freeform" | "function";
+  /**
+   * Force OAuth-style request shaping for providers whose API key prefix doesn't
+   * match an OAuth token (e.g. routing Anthropic traffic through a proxy that
+   * expects Claude Code framing). When true, the streaming layer sets
+   * `options.isOAuth = true` for the underlying provider call.
+   */
+  isOAuth?: boolean;
 }
 
 /**
@@ -818,6 +831,6 @@ export interface Model<TApi extends Api = Api> {
  * sparse override shape and nothing is resolved yet.
  */
 export interface ModelSpec<TApi extends Api = Api> extends Omit<Model<TApi>, "compat" | "compatConfig"> {
-	/** Sparse compatibility overrides; resolved into `Model.compat` by `buildModel`. */
-	compat?: CompatConfigOf<TApi>;
+  /** Sparse compatibility overrides; resolved into `Model.compat` by `buildModel`. */
+  compat?: CompatConfigOf<TApi>;
 }


### PR DESCRIPTION
## Problem                                                                                                               

Addresses issue (#5914). After the 2026-07-17 `task` refactor (`feat(task): unified structured subagent execution`),                              
llama.cpprejects every tool-carrying request with:                                                                      
```
operator(): got exception: {"error":{"code":400,"message":"Unable to generate                                          
parser for this template. ... Unrecognized schema: true","type":"invalid_request_error"}}                              
```                             

## Fix                                
                                                                                   
- `OpenAICompat.sanitizeToolSchemaForGrammar` — resolved by `buildOpenAICompat` for                                      
local grammar-constrained backends (llama.cpp / lm-studio / vllm / loopback), same                                     
gate as `replayReasoningContent`.                                                                                      
- `openai-completions` `convertTools` now widens boolean subschemas (`true`/`false` →                                    
value `anyOf` of primitives), strips boolean `additionalProperties`/`unevaluatedProperties`,                           
and flattens nullable `type` arrays when the flag is set.                                                              
- Renamed `sanitizeSchemaForOllama` → `sanitizeSchemaForGrammarConstrainedSampler`                                       
(clean cutover; both transports now use it).                                                                           

## Verification           
                                                                                               
- New `openai-completions-grammar-schema.test.ts`: llama.cpp/lm-studio wire has zero                                     
boolean subschemas and `outputSchema` is the widened union; OpenAI cloud keeps `true`                                  
(sanitizer must not fire for non-grammar hosts).                                                                       
- Existing `ollama-thinking-disable` + schema suite (148 tests) green.                                                   
- `bun run check:ts` clean across catalog + ai + coding-agent.
