### PR TITLE
fix(providers): sanitize boolean subschemas for grammar backends

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local grammar-constrained OpenAI-compatible backends (llama.cpp, LM Studio, vLLM) rejecting every tool request with `400 "Unable to generate parser for this template ... Unrecognized schema: true"`. The `task` tool's open `outputSchema` field normalizes to a bare boolean `true` subschema (issue #1179), which llama.cpp's JSON-schema→GBNF converter cannot compile. The chat-completions encoder now widens bare boolean subschemas into a value-accepting primitive union (and preserves closed-object `additionalProperties: false`) for these backends via the new `grammar` tool-schema flavor ([#5914](https://github.com/can1357/oh-my-pi/issues/5914)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -42,7 +42,13 @@ import {
 import { OpenAIHttpError, postOpenAIStream } from "../utils/openai-http";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
-import { adaptSchemaForStrict, NO_STRICT, normalizeSchemaForMoonshot, toolWireSchema } from "../utils/schema";
+import {
+	adaptSchemaForStrict,
+	NO_STRICT,
+	normalizeSchemaForMoonshot,
+	sanitizeSchemaForGrammar,
+	toolWireSchema,
+} from "../utils/schema";
 import {
 	type HealedToolCall,
 	StreamMarkupHealing,
@@ -2205,10 +2211,16 @@ function convertTools(
 					description: tool.description || "",
 					// Moonshot/Kimi native hosts validate against the stricter MFJS subset
 					// (const→enum, typed enums, no validators) and 400 otherwise.
+					// Grammar-constrained local backends (llama.cpp, LM Studio, vLLM)
+					// build a GBNF grammar from the schema and 400 with
+					// `Unrecognized schema: true` on the bare boolean subschema
+					// `toolWireSchema` emits for open fields (issue #5914).
 					parameters:
 						compat.toolSchemaFlavor === "moonshot-mfjs"
 							? (normalizeSchemaForMoonshot(wireParameters) as Record<string, unknown>)
-							: wireParameters,
+							: compat.toolSchemaFlavor === "grammar"
+								? sanitizeSchemaForGrammar(wireParameters)
+								: wireParameters,
 					// Only include strict if provider supports it. Some reject unknown fields.
 					...(includeStrict ? { strict: true } : includeExplicitFalse ? { strict: false } : {}),
 				},

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1126,18 +1126,19 @@ const OLLAMA_SCHEMA_VALUE_KEYS = new Set([
 ]);
 
 /**
- * Widened stand-in for a `true` / `{}` subschema in an Ollama-bound tool.
+ * Widened stand-in for a `true` / `{}` open subschema on a tool bound for a
+ * backend whose wire cannot encode a bare boolean subschema.
  *
  * `toolWireSchema()` normalizes empty schemas to boolean `true` upstream so
- * grammar-constrained samplers (llama.cpp, etc.) don't treat `{}` as
- * "generate an empty object" (issue #1179). Ollama's Go tool parser can't
- * unmarshal a boolean into its object-shaped `Schema` struct, so this
- * sanitizer replaces every open subschema with an explicit union of every
- * primitive JSON type. Both invariants survive: the wire has no boolean
- * subschema (Go accepts it), and llama.cpp's grammar sees a real value
- * union rather than a closed empty object.
+ * grammar-constrained samplers don't treat `{}` as "generate an empty object"
+ * (issue #1179). Two backends then choke on the bare boolean: Ollama's Go tool
+ * parser can't unmarshal it into its object-shaped `Schema` struct, and
+ * llama.cpp's JSON-schema→GBNF converter has no case for a boolean schema
+ * (issue #5914). Both sanitizers replace the open subschema with an explicit
+ * union of every primitive JSON type — the wire has no boolean subschema, and
+ * a grammar sampler sees a real value union rather than a closed empty object.
  */
-const OLLAMA_OPEN_SUBSCHEMA_WIDENING = Object.freeze({
+const OPEN_SUBSCHEMA_WIDENING = Object.freeze({
 	anyOf: [
 		{ type: "string" },
 		{ type: "number" },
@@ -1154,8 +1155,8 @@ const OLLAMA_OPEN_SUBSCHEMA_WIDENING = Object.freeze({
  */
 export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 	const normalizeNode = (value: unknown): unknown => {
-		if (value === true) return OLLAMA_OPEN_SUBSCHEMA_WIDENING;
-		if (value === false) return { not: OLLAMA_OPEN_SUBSCHEMA_WIDENING };
+		if (value === true) return OPEN_SUBSCHEMA_WIDENING;
+		if (value === false) return { not: OPEN_SUBSCHEMA_WIDENING };
 		if (!isJsonObject(value)) {
 			if (!Array.isArray(value)) return value;
 			let changed = false;
@@ -1226,6 +1227,92 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 		return changed ? output : value;
 	};
 	return normalizeNode(schema) as JsonObject;
+}
+
+/**
+ * Schema-valued keywords whose bare boolean value must be widened for a
+ * grammar-constrained backend. Excludes `additionalProperties` and
+ * `unevaluatedProperties`: llama.cpp's `_build_object_rule` reads their boolean
+ * form as meaningful closed/open-object semantics, and `additionalProperties:
+ * false` is exactly what `toolWireSchema` emits to pin a strict object shape.
+ */
+const GRAMMAR_SCHEMA_VALUE_KEYS: Record<string, true> = {
+	items: true,
+	additionalItems: true,
+	contains: true,
+	contentSchema: true,
+	propertyNames: true,
+	if: true,
+	// biome-ignore lint/suspicious/noThenProperty: JSON Schema keyword
+	then: true,
+	else: true,
+	not: true,
+	unevaluatedItems: true,
+};
+
+/**
+ * Rewrites the one JSON Schema form that grammar-constrained OpenAI-compatible
+ * backends (llama.cpp, LM Studio, vLLM) cannot compile to GBNF: a bare boolean
+ * subschema. `toolWireSchema` normalizes `{}` open subschemas to boolean `true`
+ * (issue #1179); llama.cpp's `json-schema-to-grammar.cpp` `visit()` has no case
+ * for a boolean schema and throws `Unrecognized schema: true` → HTTP 400 before
+ * the model is consulted (issue #5914).
+ *
+ * Narrower than {@link sanitizeSchemaForOllama}: only genuine subschema slots
+ * are widened. Boolean `additionalProperties`/`unevaluatedProperties` stay
+ * intact because the converter reads those as closed/open-object grammar
+ * semantics, and dropping `additionalProperties: false` would silently reopen
+ * every declared object.
+ */
+export function sanitizeSchemaForGrammar(schema: JsonObject): JsonObject {
+	const normalizeNode = (value: unknown, isSubschema: boolean): unknown => {
+		if (value === true) return isSubschema ? OPEN_SUBSCHEMA_WIDENING : value;
+		if (value === false) return isSubschema ? { not: OPEN_SUBSCHEMA_WIDENING } : value;
+		if (Array.isArray(value)) {
+			let changed = false;
+			const output = value.map(item => {
+				const next = normalizeNode(item, isSubschema);
+				if (next !== item) changed = true;
+				return next;
+			});
+			return changed ? output : value;
+		}
+		if (!isJsonObject(value)) return value;
+
+		let changed = false;
+		const output: JsonObject = {};
+		for (const key in value) {
+			if (!Object.hasOwn(value, key)) continue;
+			const child = value[key];
+			let next = child;
+			if (Object.hasOwn(SUBSCHEMA_MAP_KEYS, key) && isJsonObject(child)) {
+				let mapChanged = false;
+				const mapOutput: JsonObject = {};
+				for (const childKey in child) {
+					if (!Object.hasOwn(child, childKey)) continue;
+					const mapChild = child[childKey];
+					const normalizedChild = normalizeNode(mapChild, true);
+					if (normalizedChild !== mapChild) mapChanged = true;
+					mapOutput[childKey] = normalizedChild;
+				}
+				next = mapChanged ? mapOutput : child;
+			} else if (Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key) && Array.isArray(child)) {
+				let arrayChanged = false;
+				const arrayOutput = child.map(item => {
+					const normalizedItem = normalizeNode(item, true);
+					if (normalizedItem !== item) arrayChanged = true;
+					return normalizedItem;
+				});
+				next = arrayChanged ? arrayOutput : child;
+			} else if (Object.hasOwn(GRAMMAR_SCHEMA_VALUE_KEYS, key)) {
+				next = normalizeNode(child, true);
+			}
+			if (next !== child) changed = true;
+			output[key] = next;
+		}
+		return changed ? output : value;
+	};
+	return normalizeNode(schema, true) as JsonObject;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -2419,8 +2419,8 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 		return buildModel({
 			...gpt4oMiniSpec,
 			api: "openai-completions",
-			provider: "vllm",
-			baseUrl: "http://localhost:8000/v1",
+			provider: "custom",
+			baseUrl: "https://api.example.com/v1",
 			id: "local-model",
 		} as ModelSpec<"openai-completions">);
 	}
@@ -2446,5 +2446,106 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 		expect(op).toEqual({ type: "string", enum: ["pr_checkout", "pr_create"], description: "github operation" });
 		const paths = probeProperty(payload, "find", "paths");
 		expect(paths.minItems).toBe(1);
+	});
+});
+
+describe("grammar tool-schema normalization (issue #5914)", () => {
+	const primitiveUnion = {
+		anyOf: [
+			{ type: "string" },
+			{ type: "number" },
+			{ type: "boolean" },
+			{ type: "object" },
+			{ type: "array" },
+			{ type: "null" },
+		],
+	};
+
+	// An open field (`z.unknown()` / ArkType `"unknown"` / raw `{}`) becomes a
+	// bare boolean `true` after `toolWireSchema`'s empty-schema normalization
+	// (issue #1179). The `task` tool ships exactly this via `outputSchema`.
+	const openFieldTool: Tool = {
+		name: "task",
+		description: "spawn subagents",
+		parameters: {
+			type: "object",
+			properties: {
+				task: { type: "string" },
+				outputSchema: {},
+				nested: {
+					type: "object",
+					properties: { value: { type: "string" } },
+					additionalProperties: false,
+				},
+			},
+			required: ["task"],
+			additionalProperties: false,
+		},
+	};
+
+	function toolParameters(payload: unknown, toolName: string): Record<string, unknown> {
+		const tools = toObject(payload)?.tools;
+		if (!Array.isArray(tools)) throw new Error("payload tools missing");
+		for (const entry of tools) {
+			const fn = getNestedObject(entry, "function");
+			if (fn?.name === toolName) {
+				const params = toObject(fn.parameters);
+				if (!params) throw new Error(`tool ${toolName} has no parameters`);
+				return params;
+			}
+		}
+		throw new Error(`tool ${toolName} not in payload`);
+	}
+
+	function localLlamaModel(): Model<"openai-completions"> {
+		return buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "llama.cpp",
+			baseUrl: "http://127.0.0.1:8080/v1",
+			id: "qwen3-coder",
+		} as ModelSpec<"openai-completions">);
+	}
+
+	function remoteModel(): Model<"openai-completions"> {
+		return buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://api.example.com/v1",
+			id: "remote-model",
+		} as ModelSpec<"openai-completions">);
+	}
+
+	it("auto-detects the grammar flavor for local OpenAI-compatible backends", () => {
+		expect(localLlamaModel().compat.toolSchemaFlavor).toBe("grammar");
+	});
+
+	it("widens bare boolean subschemas and keeps additionalProperties:false", async () => {
+		const model = localLlamaModel();
+		const payload = await captureOpenAICompletionsPayload(model, { ...baseContext(), tools: [openFieldTool] });
+		const params = toolParameters(payload, "task");
+		const properties = toObject(params.properties);
+		if (!properties) throw new Error("task tool has no properties");
+
+		// The offending bare `true` (from the `{}` open field) becomes a
+		// value-accepting primitive union the GBNF converter can compile.
+		expect(properties.outputSchema).toEqual(primitiveUnion);
+		// No bare boolean subschema remains anywhere in the wire schema.
+		expect(JSON.stringify(params)).not.toContain('"outputSchema":true');
+		// The closed-object contract survives: dropping `additionalProperties:
+		// false` would silently reopen the object to arbitrary keys.
+		expect(params.additionalProperties).toBe(false);
+		const nested = toObject(properties.nested);
+		expect(nested?.additionalProperties).toBe(false);
+	});
+
+	it("leaves the wire schema untouched on non-grammar hosts", async () => {
+		const model = remoteModel();
+		expect(model.compat.toolSchemaFlavor).toBeUndefined();
+		const payload = await captureOpenAICompletionsPayload(model, { ...baseContext(), tools: [openFieldTool] });
+		const properties = toObject(toolParameters(payload, "task").properties);
+		// Off the grammar path the open field keeps the normalized bare boolean.
+		expect(properties?.outputSchema).toBe(true);
 	});
 });

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -532,7 +532,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
 		extraBody: isDirectDeepseekReasoning ? { thinking: { type: "enabled" } } : undefined,
 		toolStrictMode: isCerebras ? "all_strict" : "mixed",
-		toolSchemaFlavor: isMoonshotNative ? "moonshot-mfjs" : undefined,
+		toolSchemaFlavor: isMoonshotNative ? "moonshot-mfjs" : isLocalOpenAICompatBackend ? "grammar" : undefined,
 		streamIdleTimeoutMs,
 		stripDeepseekSpecialTokens:
 			isDeepseekModelIdOrName(spec.id) && (provider === "nvidia" || provider === "deepseek"),

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -318,11 +318,13 @@ export interface OpenAICompat {
 	 * standard JSON Schema constructs with HTTP 400.
 	 *
 	 * `"grammar"` triggers grammar-sampler normalization (widen bare boolean
-	 * `true`/`{}` subschemas into a value-accepting union of primitives, strip
-	 * boolean `additionalProperties`/`unevaluatedProperties`) because
-	 * grammar-constrained backends (llama.cpp, LM Studio, vLLM) build a GBNF
-	 * grammar from the JSON Schema and 400 with `Unrecognized schema: true` on a
-	 * bare boolean subschema (issue #5914).
+	 * `true`/`{}` subschemas in genuine subschema slots into a value-accepting
+	 * union of primitives) because grammar-constrained backends (llama.cpp, LM
+	 * Studio, vLLM) build a GBNF grammar from the JSON Schema and 400 with
+	 * `Unrecognized schema: true` on a bare boolean subschema (issue #5914).
+	 * Boolean `additionalProperties`/`unevaluatedProperties` are preserved — the
+	 * grammar converter reads them as closed/open-object semantics, and
+	 * `additionalProperties: false` pins the strict object shape.
 	 *
 	 * Default: auto-detected (`"moonshot-mfjs"` on api.moonshot.ai /
 	 * api.kimi.com, `"grammar"` on local OpenAI-compatible backends). Set

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -310,14 +310,25 @@ export interface OpenAICompat {
 	supportsStrictMode?: boolean;
 	/**
 	 * Tool-schema dialect the endpoint validates `tools.function.parameters`
-	 * against. `"moonshot-mfjs"` triggers Moonshot Flavored JSON Schema
-	 * normalization (collapse `const`→`enum`, infer `type` on bare enums, strip
-	 * unsupported validators/`prefixItems`) because Moonshot/Kimi native hosts
-	 * reject standard JSON Schema constructs with HTTP 400. Default:
-	 * auto-detected (`"moonshot-mfjs"` on api.moonshot.ai / api.kimi.com). Set
-	 * `"none"` to opt a custom Moonshot-compatible host out.
+	 * against.
+	 *
+	 * `"moonshot-mfjs"` triggers Moonshot Flavored JSON Schema normalization
+	 * (collapse `const`→`enum`, infer `type` on bare enums, strip unsupported
+	 * validators/`prefixItems`) because Moonshot/Kimi native hosts reject
+	 * standard JSON Schema constructs with HTTP 400.
+	 *
+	 * `"grammar"` triggers grammar-sampler normalization (widen bare boolean
+	 * `true`/`{}` subschemas into a value-accepting union of primitives, strip
+	 * boolean `additionalProperties`/`unevaluatedProperties`) because
+	 * grammar-constrained backends (llama.cpp, LM Studio, vLLM) build a GBNF
+	 * grammar from the JSON Schema and 400 with `Unrecognized schema: true` on a
+	 * bare boolean subschema (issue #5914).
+	 *
+	 * Default: auto-detected (`"moonshot-mfjs"` on api.moonshot.ai /
+	 * api.kimi.com, `"grammar"` on local OpenAI-compatible backends). Set
+	 * `"none"` to opt a custom host out.
 	 */
-	toolSchemaFlavor?: "moonshot-mfjs" | "none";
+	toolSchemaFlavor?: "moonshot-mfjs" | "grammar" | "none";
 	/**
 	 * Stream-watchdog idle-timeout floor in ms for slow reasoning hosts.
 	 * Default: auto-detected (GLM coding-plan hosts, direct DeepSeek reasoning).


### PR DESCRIPTION
## Repro
Any omp session against a local llama.cpp server that exposes tools fails on the first turn with HTTP 400 before the model is consulted: `Unable to generate parser for this template. Automatic parser generation failed: JSON schema conversion failed:\nUnrecognized schema: true`. Reproduced by running the real `openai-completions` encoder against a `llama.cpp` model spec (`provider: "llama.cpp"`, loopback `baseUrl`) with the `task` tool and inspecting `tools[0].function.parameters` — `outputSchema` serializes as a bare boolean `true`.

## Cause
The `task` tool's open `outputSchema?: "unknown"` field (`packages/coding-agent/src/task/types.ts`) compiles to JSON Schema `{}`, which `normalizeEmptySchemas()` (`packages/ai/src/utils/schema/wire.ts`) rewrites to boolean `true` in every schema-value position (intentional, issue #1179). For `llama.cpp` `compat.supportsStrictMode === false`, so `baseParameters` ship unchanged from `convertTools` (`packages/ai/src/providers/openai-completions.ts`). llama.cpp's `json-schema-to-grammar.cpp` `visit()` has no case for a boolean schema and reaches the final `!schema_type.is_string()` branch, throwing `Unrecognized schema: true`. Only the Ollama transport ran a boolean-subschema sanitizer; the chat-completions tool-serialization site had none.

## Fix
- `packages/catalog/src/types.ts`: extend `toolSchemaFlavor` with a `"grammar"` variant.
- `packages/catalog/src/compat/openai.ts`: auto-detect `toolSchemaFlavor: "grammar"` for local OpenAI-compatible backends (`isLocalOpenAICompatBackend`).
- `packages/ai/src/utils/schema/normalize.ts`: rename the shared open-subschema widening constant and add `sanitizeSchemaForGrammar()` — narrower than the Ollama sanitizer: it widens bare boolean/empty subschemas into a primitive-type union but preserves boolean `additionalProperties`/`unevaluatedProperties`, which llama.cpp reads as meaningful closed/open-object semantics.
- `packages/ai/src/providers/openai-completions.ts`: run `sanitizeSchemaForGrammar` at the tool-serialization site when `compat.toolSchemaFlavor === "grammar"`.

## Verification
`bun test` in `packages/ai` (`openai-completions-compat.test.ts`, `ollama-thinking-disable.test.ts`, `schema-normalization.test.ts`) and `packages/catalog` — all green. New regression tests assert the widened primitive union, the absence of any bare boolean subschema, and the preserved `additionalProperties: false` on the llama.cpp path, plus the untouched wire schema off the grammar path. Manually confirmed the widened schema through the real encoder pipeline: `outputSchema` becomes `{ anyOf: [{type:"string"}, ...] }` and `additionalProperties: false` survives. The one full-suite failure (`proxy.test.ts` env-var ordering) is a pre-existing flake unrelated to this change — it passes in isolation and touches no schema code. Fixes #5914