### PR TITLE
test(bench): long-session transcript, keystroke, and LLM assembly benches + multi-entry bench-guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,5 @@ python/robomp/web/verify-out/
 /verify-out/
 python/robomp/.env
 
-# Local, machine-specific boot perf baseline (see packages/coding-agent/scripts/bench-guard.ts)
-packages/coding-agent/bench/boot-baseline.json
+# Local, machine-specific perf baselines (see packages/coding-agent/scripts/bench-guard.ts)
+packages/coding-agent/bench/*-baseline.json

--- a/packages/coding-agent/bench/fixtures/synthetic-transcript.ts
+++ b/packages/coding-agent/bench/fixtures/synthetic-transcript.ts
@@ -1,0 +1,212 @@
+/**
+ * Shared synthetic long-session fixture for the long-session performance benches.
+ *
+ * Builds N alternating blocks (user / assistant markdown ~2KB with a code fence /
+ * 2 tool executions with ~10KB results) to approximate the 155-msg/1.5MB repro
+ * density (~10KB/message avg).
+ *
+ * Two surfaces:
+ * - UI components for transcript compose / render benches
+ * - AgentMessage[] for convertToLlm / estimateTokens assembly benches
+ */
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { Component } from "@oh-my-pi/pi-tui";
+import { AssistantMessageComponent } from "../../src/modes/components/assistant-message";
+import {
+	ToolExecutionComponent,
+	type ToolExecutionUi,
+} from "../../src/modes/components/tool-execution";
+import { UserMessageComponent } from "../../src/modes/components/user-message";
+
+const NOOP_UI: ToolExecutionUi = {
+	requestRender() {},
+	requestComponentRender() {},
+	resetDisplay() {},
+};
+
+const ASSISTANT_BODY = [
+	"## Analysis",
+	"",
+	"Here is a representative assistant reply with prose and a fenced code block.",
+	"The text is sized to ~2KB so long-session compose walks real Markdown L1 caches.",
+	"",
+	"```ts",
+	"export function summarize(lines: string[]): string {",
+	"  const joined = lines.join('\\n');",
+	"  return joined.length > 120 ? joined.slice(0, 117) + '...' : joined;",
+	"}",
+	"",
+	"const sample = Array.from({ length: 40 }, (_, i) => `row-${i}: value=${i * 3}`);",
+	"console.log(summarize(sample));",
+	"```",
+	"",
+	"Follow-up notes: prefer stable history walks, seal finalized blocks, and keep",
+	"keystroke frames from re-composing the entire transcript tree on every char.",
+	"padding ".repeat(80),
+].join("\n");
+
+const TOOL_RESULT_BODY = ("result-line: " + "x".repeat(80) + "\n").repeat(120); // ~10KB
+const USER_PROMPT =
+	"Please analyze the long-session transcript path and report compose cost.\n\n```ts\n// fixture user code\nconst n = 5000;\n```\n";
+
+function makeAssistantMessage(text: string, toolCallIds?: readonly string[]): AssistantMessage {
+	const content: AssistantMessage["content"] = [{ type: "text", text }];
+	if (toolCallIds) {
+		for (const id of toolCallIds) {
+			content.push({
+				type: "toolCall",
+				id,
+				name: "bash",
+				arguments: { command: `echo ${id}` },
+			});
+		}
+	}
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "bench",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: toolCallIds && toolCallIds.length > 0 ? "toolUse" : "stop",
+		timestamp: 0,
+	};
+}
+
+export interface SyntheticComponents {
+	/** All mounted children (finalized history + optional live lastAssistant). */
+	components: Component[];
+	/** Live unfinalized assistant at the end when `mutableTail` is true. */
+	lastAssistant: AssistantMessageComponent | undefined;
+}
+
+/**
+ * Build UI component array of roughly `n` message blocks.
+ * When `mutableTail` is true, reserves the final slot for an unfinalized
+ * assistant (history is N-1 finalized blocks; tail is always last).
+ */
+export function buildSyntheticComponents(n: number, options?: { mutableTail?: boolean }): SyntheticComponents {
+	const mutableTail = options?.mutableTail === true;
+	const total = Math.max(0, Math.trunc(n));
+	// Reserve one slot for the live tail so it is always the last component.
+	const historyCount = mutableTail ? Math.max(0, total - 1) : total;
+	const components: Component[] = [];
+	let remaining = historyCount;
+	let seq = 0;
+
+	while (remaining > 0) {
+		// user
+		if (remaining > 0) {
+			components.push(new UserMessageComponent(`${USER_PROMPT}#${seq}`));
+			remaining -= 1;
+			seq += 1;
+		}
+		// finalized assistant history
+		if (remaining > 0) {
+			const msg = makeAssistantMessage(`${ASSISTANT_BODY}\n\nseq=${seq}`);
+			const c = new AssistantMessageComponent(msg);
+			if (!c.isTranscriptBlockFinalized()) c.markTranscriptBlockFinalized();
+			components.push(c);
+			remaining -= 1;
+			seq += 1;
+		}
+		// two tool executions
+		for (let t = 0; t < 2 && remaining > 0; t++) {
+			const tool = new ToolExecutionComponent(
+				"read",
+				{ path: `/tmp/bench-${seq}-${t}.txt` },
+				{ showImages: false },
+				undefined,
+				NOOP_UI,
+			);
+			tool.updateResult(
+				{
+					content: [{ type: "text", text: `${TOOL_RESULT_BODY}#${seq}-${t}` }],
+					isError: false,
+				},
+				false,
+			);
+			tool.seal();
+			components.push(tool);
+			remaining -= 1;
+			seq += 1;
+		}
+	}
+
+	if (!mutableTail) {
+		return { components, lastAssistant: undefined };
+	}
+
+	// Live unfinalized assistant is always the last child — no message yet
+	// (compose bench mutates via updateContent outside the timed window).
+	const lastAssistant = new AssistantMessageComponent();
+	components.push(lastAssistant);
+
+	const last = components[components.length - 1];
+	if (last !== lastAssistant || lastAssistant.isTranscriptBlockFinalized()) {
+		throw new Error(
+			"synthetic-transcript: mutable lastAssistant must be last and unfinalized " +
+				`(last===lastAssistant=${last === lastAssistant}, finalized=${lastAssistant.isTranscriptBlockFinalized()})`,
+		);
+	}
+
+	return { components, lastAssistant };
+}
+
+/** Build AgentMessage[] with ~n entries (user / assistant / toolResult pattern). */
+export function buildSyntheticAgentMessages(n: number): AgentMessage[] {
+	const messages: AgentMessage[] = [];
+	let remaining = Math.max(0, Math.trunc(n));
+	let seq = 0;
+
+	while (remaining > 0) {
+		if (remaining > 0) {
+			messages.push({
+				role: "user",
+				content: `${USER_PROMPT}#${seq}`,
+				timestamp: seq,
+			});
+			remaining -= 1;
+			seq += 1;
+		}
+		if (remaining > 0) {
+			const id0 = `call_${seq}_0`;
+			const id1 = `call_${seq}_1`;
+			// If we still have room for tool results, emit toolUse assistant; else stop.
+			const emitTools = remaining > 2;
+			const assistant = makeAssistantMessage(
+				`${ASSISTANT_BODY}\n\nseq=${seq}`,
+				emitTools ? [id0, id1] : undefined,
+			);
+			messages.push(assistant);
+			remaining -= 1;
+			seq += 1;
+			if (emitTools) {
+				for (let t = 0; t < 2; t++) {
+					if (remaining <= 0) break;
+					const id = t === 0 ? id0 : id1;
+					messages.push({
+						role: "toolResult",
+						toolCallId: id,
+						toolName: "bash",
+						content: [{ type: "text", text: `${TOOL_RESULT_BODY}#${seq}-${t}` }],
+						isError: false,
+						timestamp: seq,
+					});
+					remaining -= 1;
+					seq += 1;
+				}
+			}
+		}
+	}
+
+	return messages;
+}

--- a/packages/coding-agent/bench/llm-assembly.bench.ts
+++ b/packages/coding-agent/bench/llm-assembly.bench.ts
@@ -87,12 +87,7 @@ console.log(`  fixture length=${templateMessages.length}`);
 
 /** Fresh object identities each episode (WeakMap-safe) without rebuild cost noise. */
 function freshHistoryFromTemplate(): AgentMessage[] {
-	return templateMessages.map(m => {
-		if (m && typeof m === "object") {
-			return { ...(m as object) } as AgentMessage;
-		}
-		return m;
-	});
+	return templateMessages.map(m => ({ ...m }));
 }
 
 // ── (a) convertToLlm successive growing history ─────────────────────────────

--- a/packages/coding-agent/bench/llm-assembly.bench.ts
+++ b/packages/coding-agent/bench/llm-assembly.bench.ts
@@ -1,0 +1,199 @@
+/**
+ * LLM assembly cost on a long AgentMessage[] history.
+ *
+ * Measures:
+ *  (a) convertToLlm on a growing history: 10 successive calls, append-2 between
+ *      each call. Reports first-call and steady-state (mean of last 3) so the
+ *      identity memo can show ≥10× improvement on steady-state.
+ *  (b) estimateTokens sweep — cold first/second on fresh message identities
+ *      before any multi-sweep warmup on shared identities.
+ *
+ * Target: steady-state repeat convert ≥10× faster than first call;
+ * second estimateTokens sweep ≥10× first.
+ *
+ *   bun run packages/coding-agent/bench/llm-assembly.bench.ts
+ */
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { estimateTokens } from "@oh-my-pi/pi-agent-core";
+import { convertToLlm } from "../src/session/messages";
+import { buildSyntheticAgentMessages } from "./fixtures/synthetic-transcript";
+
+const N = 5000;
+const CALLS_PER_EPISODE = 10;
+const APPEND_PER_CALL = 2;
+const WARMUP_EPISODES = 8;
+const MEASURE_EPISODES = 40;
+const SWEEPS_PER_SAMPLE = 8;
+const WARMUP_SWEEP_SAMPLES = 4;
+const MEASURE_SWEEP_SAMPLES = 24;
+
+function median(xs: number[]): number {
+	if (xs.length === 0) return 0;
+	const sorted = [...xs].sort((a, b) => a - b);
+	const mid = sorted.length >> 1;
+	if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+	return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}
+
+function stddev(xs: number[]): number {
+	if (xs.length < 2) return 0;
+	const mean = xs.reduce((a, b) => a + b, 0) / xs.length;
+	let sumSq = 0;
+	for (const x of xs) {
+		const d = x - mean;
+		sumSq += d * d;
+	}
+	return Math.sqrt(sumSq / (xs.length - 1));
+}
+
+function emitMetric(metric: string, median_ms: number, stddev_ms: number): void {
+	// Benches intentionally emit metrics on stdout (canonical streaming-throughput style).
+	console.log(JSON.stringify({ metric, median_ms, stddev_ms }));
+	console.log(`METRIC ${metric}=${median_ms.toFixed(4)}`);
+}
+
+function makePadMessage(i: number): AgentMessage {
+	return {
+		role: "user",
+		content: `append-turn pad #${i}: please continue analysis with extra context padding ${"z".repeat(200)}`,
+		timestamp: 1_000_000 + i,
+	};
+}
+
+/**
+ * One successive episode on a growing history:
+ * start from a FRESH base (new message identities each episode so the
+ * identity memo cannot poison first-call measurements), each of 10 calls runs
+ * convertToLlm then appends 2. Returns per-call timings.
+ */
+function runSuccessiveEpisode(freshBase: AgentMessage[]): number[] {
+	const history = freshBase.slice();
+	let pad = 0;
+	const times: number[] = [];
+	for (let call = 0; call < CALLS_PER_EPISODE; call++) {
+		const t0 = performance.now();
+		void convertToLlm(history);
+		times.push(performance.now() - t0);
+		for (let a = 0; a < APPEND_PER_CALL; a++) {
+			history.push(makePadMessage(pad++));
+		}
+	}
+	return times;
+}
+
+console.log(`llm-assembly: building N=${N} AgentMessage[] fixture…`);
+const templateMessages = buildSyntheticAgentMessages(N);
+console.log(`  fixture length=${templateMessages.length}`);
+
+/** Fresh object identities each episode (WeakMap-safe) without rebuild cost noise. */
+function freshHistoryFromTemplate(): AgentMessage[] {
+	return templateMessages.map(m => {
+		if (m && typeof m === "object") {
+			return { ...(m as object) } as AgentMessage;
+		}
+		return m;
+	});
+}
+
+// ── (a) convertToLlm successive growing history ─────────────────────────────
+// Fresh AgentMessage identities per episode so the memo cannot warm "first"
+// across samples. Template is cloned shallowly (new object identity, shared
+// nested content) to avoid N=5000 rebuild noise dominating stddev.
+for (let i = 0; i < WARMUP_EPISODES; i++) {
+	runSuccessiveEpisode(freshHistoryFromTemplate());
+}
+
+const convertEpisodeSamples: number[] = [];
+const firstCallSamples: number[] = [];
+const steadyCallSamples: number[] = [];
+
+for (let i = 0; i < MEASURE_EPISODES; i++) {
+	if (i % 8 === 0) Bun.gc(true);
+	const times = runSuccessiveEpisode(freshHistoryFromTemplate());
+	convertEpisodeSamples.push(times.reduce((a, b) => a + b, 0));
+	firstCallSamples.push(times[0] ?? 0);
+	const last3 = times.slice(-3);
+	steadyCallSamples.push(last3.reduce((a, b) => a + b, 0) / Math.max(last3.length, 1));
+}
+
+const convertMedian = median(convertEpisodeSamples);
+const convertSd = stddev(convertEpisodeSamples);
+const firstMedian = median(firstCallSamples);
+const steadyMedian = median(steadyCallSamples);
+
+console.log(
+	`  convertToLlm ${MEASURE_EPISODES} episodes × ${CALLS_PER_EPISODE} successive growing calls: ` +
+		`median=${convertMedian.toFixed(4)}ms/episode stddev=${convertSd.toFixed(4)}ms ` +
+		`(~${(convertMedian / CALLS_PER_EPISODE).toFixed(4)}ms/call)`,
+);
+console.log(
+	`  convert first-call median=${firstMedian.toFixed(4)}ms ` +
+		`steady(last3) median=${steadyMedian.toFixed(4)}ms ` +
+		`speedup=${firstMedian > 0 ? (firstMedian / Math.max(steadyMedian, 1e-9)).toFixed(2) : "n/a"}× ` +
+		`(target ≥10×)`,
+);
+emitMetric("llm_assembly_convert_ms", convertMedian, convertSd);
+emitMetric("llm_assembly_convert_first_ms", firstMedian, stddev(firstCallSamples));
+emitMetric("llm_assembly_convert_steady_ms", steadyMedian, stddev(steadyCallSamples));
+
+// ── (b) estimateTokens sweep ────────────────────────────────────────────────
+function sweepTokens(messages: AgentMessage[]): number {
+	let total = 0;
+	for (const m of messages) total += estimateTokens(m);
+	return total;
+}
+
+function multiSweepMs(messages: AgentMessage[], sweeps: number): { ms: number; total: number } {
+	let total = 0;
+	const t0 = performance.now();
+	for (let s = 0; s < sweeps; s++) total = sweepTokens(messages);
+	return { ms: (performance.now() - t0) / sweeps, total };
+}
+
+// Cold first/second on FRESH identities BEFORE any multi-sweep warmup.
+// Without memoization both may be similar; with memoization first >> second when memoized by identity.
+const coldMessages = buildSyntheticAgentMessages(N);
+const firstSweepT0 = performance.now();
+const coldTotal = sweepTokens(coldMessages);
+const firstSweep = performance.now() - firstSweepT0;
+const secondSweepT0 = performance.now();
+sweepTokens(coldMessages);
+const secondSweep = performance.now() - secondSweepT0;
+
+console.log(
+	`  estimateTokens cold first=${firstSweep.toFixed(4)}ms second=${secondSweep.toFixed(4)}ms ` +
+		`speedup=${firstSweep > 0 ? (firstSweep / Math.max(secondSweep, 1e-9)).toFixed(2) : "n/a"}× ` +
+		`totalTokens≈${coldTotal} (measured before warm multi-sweeps)`,
+);
+
+// Steady multi-sweep samples on a dedicated warm fixture (after cold capture).
+const warmMessages = buildSyntheticAgentMessages(N);
+for (let i = 0; i < WARMUP_SWEEP_SAMPLES; i++) multiSweepMs(warmMessages, SWEEPS_PER_SAMPLE);
+
+const sweepSamples: number[] = [];
+let lastTotal = 0;
+for (let i = 0; i < MEASURE_SWEEP_SAMPLES; i++) {
+	const r = multiSweepMs(warmMessages, SWEEPS_PER_SAMPLE);
+	sweepSamples.push(r.ms);
+	lastTotal = r.total;
+}
+
+const sweepMedian = median(sweepSamples);
+const sweepSd = stddev(sweepSamples);
+
+console.log(
+	`  estimateTokens sweep: median=${sweepMedian.toFixed(4)}ms stddev=${sweepSd.toFixed(4)}ms ` +
+		`totalTokens≈${lastTotal}`,
+);
+emitMetric("llm_assembly_estimate_tokens_ms", sweepMedian, sweepSd);
+emitMetric("llm_assembly_estimate_tokens_first_ms", firstSweep, 0);
+emitMetric("llm_assembly_estimate_tokens_second_ms", secondSweep, 0);
+
+const convertNoise = convertMedian > 0 ? convertSd / convertMedian : 0;
+const sweepNoise = sweepMedian > 0 ? sweepSd / sweepMedian : 0;
+if (convertNoise > 0.2) {
+	console.warn(`  warning: convert noise ${(convertNoise * 100).toFixed(1)}% > 20%`);
+}
+if (sweepNoise > 0.2) {
+	console.warn(`  warning: estimateTokens noise ${(sweepNoise * 100).toFixed(1)}% > 20%`);
+}

--- a/packages/coding-agent/bench/transcript-compose.bench.ts
+++ b/packages/coding-agent/bench/transcript-compose.bench.ts
@@ -119,6 +119,13 @@ console.log(`\nBenchmark: transcript-compose (live tail tick after committed fin
 const results = SIZES.map(n => {
 	const r = measure(n);
 	console.log(`  N=${n}: median ${r.median.toFixed(4)}ms  p95 ${r.p95.toFixed(4)}ms`);
+	process.stdout.write(
+		`${JSON.stringify({
+			metric: n === 500 ? "transcript_compose_n500_ms" : "transcript_compose_n5000_ms",
+			median_ms: r.median,
+			stddev_ms: 0,
+		})}\n`,
+	);
 	return r;
 });
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -45,8 +45,7 @@
     "gen:mupdf:reset": "bun scripts/embed-mupdf-wasm.ts --reset",
     "gen:native": "bun --cwd=../natives run gen:native",
     "gen:native:reset": "bun --cwd=../natives run gen:native:reset",
-    "prepack": "bun run gen:tool-views && bun run gen:bundle",
-    "bench:guard": "bun scripts/bench-guard.ts"
+    "prepack": "bun run gen:tool-views && bun run gen:bundle"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "catalog:",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -108,6 +108,7 @@
     "dist/cli.js",
     "dist/*.node",
     "scripts",
+    "!scripts/bench-guard.ts",
     "examples",
     "README.md",
     "CHANGELOG.md"

--- a/packages/coding-agent/scripts/bench-guard.ts
+++ b/packages/coding-agent/scripts/bench-guard.ts
@@ -82,6 +82,8 @@ const ENTRIES: BenchEntry[] = [
 	{
 		name: "keystroke-transcript-renders",
 		mode: "json-line",
+		// Same spawn as keystroke-frame: the bench emits both metrics, so both
+		// entries parse one shared run (see runJsonLineBench) instead of re-running.
 		args: ["run", "packages/tui/bench/keystroke-frame.bench.ts"],
 		baselinePath: path.join(benchDir, "keystroke-transcript-renders-baseline.json"),
 		metric: "keystroke_transcript_renders",
@@ -174,14 +176,34 @@ async function measureHyperfine(entry: HyperfineEntry): Promise<{ seconds: numbe
 	return { seconds: medianOfHyperfine(raw), raw };
 }
 
+type JsonLineRun = { stdout: string; code: number };
+
+// Entries sharing a spawn (cwd + args, e.g. the two keystroke-frame metrics)
+// reuse one bench run per guard invocation instead of spawning per metric.
+const jsonLineRuns = new Map<string, Promise<JsonLineRun>>();
+
+function runJsonLineBench(entry: JsonLineEntry): Promise<JsonLineRun> {
+	const key = `${entry.cwd}
+${JSON.stringify(entry.args)}`;
+	let run = jsonLineRuns.get(key);
+	if (!run) {
+		run = (async () => {
+			const proc = Bun.spawn(["bun", ...entry.args], {
+				cwd: entry.cwd,
+				stdout: "pipe",
+				stderr: "inherit",
+			});
+			const stdout = await new Response(proc.stdout).text();
+			const code = await proc.exited;
+			return { stdout, code };
+		})();
+		jsonLineRuns.set(key, run);
+	}
+	return run;
+}
+
 async function measureJsonLine(entry: JsonLineEntry): Promise<JsonMetric> {
-	const proc = Bun.spawn(["bun", ...entry.args], {
-		cwd: entry.cwd,
-		stdout: "pipe",
-		stderr: "inherit",
-	});
-	const stdout = await new Response(proc.stdout).text();
-	const code = await proc.exited;
+	const { stdout, code } = await runJsonLineBench(entry);
 	// Still try to parse metrics even if the process printed warnings.
 	const metric = parseJsonMetricLines(stdout, entry.metric);
 	if (code !== 0) {

--- a/packages/coding-agent/scripts/bench-guard.ts
+++ b/packages/coding-agent/scripts/bench-guard.ts
@@ -1,41 +1,169 @@
 #!/usr/bin/env bun
 /**
- * Boot-time regression guard (Phase A1 of the boot/TUI perf work).
+ * Local wall-clock regression guard for coding-agent / TUI long-session benches.
  *
- * Re-runs the `PI_TIMING=x` cold-boot benchmark under hyperfine and fails when
- * the median regresses past `baseline * THRESHOLD`. `PI_TIMING=x` runs the full
- * pre-paint chain in `runRootCommand` and then `process.exit(0)`, so the
- * never-exiting interactive launch becomes a terminating, benchmarkable boot.
+ * Multi-entry table:
+ *  - boot: hyperfine cold-boot (`PI_TIMING=x`) — stores raw hyperfine JSON
+ *  - json-line benches: run script, parse stdout JSON `{metric,median_ms,stddev_ms}`
  *
  * Boot wall-clock is MACHINE-RELATIVE: a baseline captured on one machine is
  * meaningless on another (and on CI). This is a LOCAL guard — regenerate the
  * baseline on the machine you measure on, then compare on that same machine.
  * It is intentionally NOT wired into CI for that reason.
  *
- *   bun scripts/bench-guard.ts --update   # capture/refresh the baseline
- *   bun scripts/bench-guard.ts            # measure + compare; exit 1 on regression
+ *   bun scripts/bench-guard.ts --update          # refresh all baselines
+ *   bun scripts/bench-guard.ts                   # measure + compare; exit 1 on regression
+ *   bun scripts/bench-guard.ts --only=boot,keystroke-frame
  *
- * Requires `hyperfine` on PATH.
+ * Hyperfine is required only for the boot entry. Json-line entries run without it.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const THRESHOLD = 1.05; // 5% regression budget
-const BASELINE_PATH = path.join(import.meta.dir, "..", "bench", "boot-baseline.json");
-const BENCH_COMMAND = "PI_TIMING=x PI_STRICT_EDIT_MODE=1 bun src/cli.ts";
-const cwd = path.join(import.meta.dir, "..");
+const codingAgentRoot = path.join(import.meta.dir, "..");
+const monorepoRoot = path.join(codingAgentRoot, "..", "..");
+const benchDir = path.join(codingAgentRoot, "bench");
 
-function medianOf(hyperfineJson: string): number {
+type HyperfineEntry = {
+	name: string;
+	mode: "hyperfine";
+	/** Shell command relative to coding-agent package cwd. */
+	command: string;
+	baselinePath: string;
+	cwd: string;
+};
+
+type JsonLineEntry = {
+	name: string;
+	mode: "json-line";
+	/** argv for Bun.spawn (no shell). Paths relative to monorepo root. */
+	args: string[];
+	baselinePath: string;
+	/** Metric name expected on a JSON stdout line. */
+	metric: string;
+	cwd: string;
+};
+
+type BenchEntry = HyperfineEntry | JsonLineEntry;
+
+const ENTRIES: BenchEntry[] = [
+	{
+		name: "boot",
+		mode: "hyperfine",
+		command: "PI_TIMING=x PI_STRICT_EDIT_MODE=1 bun src/cli.ts",
+		baselinePath: path.join(benchDir, "boot-baseline.json"),
+		cwd: codingAgentRoot,
+	},
+	{
+		name: "transcript-compose",
+		mode: "json-line",
+		args: ["run", "packages/coding-agent/bench/transcript-compose.bench.ts"],
+		baselinePath: path.join(benchDir, "transcript-compose-baseline.json"),
+		metric: "transcript_compose_n5000_ms",
+		cwd: monorepoRoot,
+	},
+	{
+		name: "keystroke-frame",
+		mode: "json-line",
+		args: ["run", "packages/tui/bench/keystroke-frame.bench.ts"],
+		baselinePath: path.join(benchDir, "keystroke-frame-baseline.json"),
+		metric: "keystroke_frame_ms",
+		cwd: monorepoRoot,
+	},
+	{
+		name: "llm-assembly",
+		mode: "json-line",
+		args: ["run", "packages/coding-agent/bench/llm-assembly.bench.ts"],
+		baselinePath: path.join(benchDir, "llm-assembly-baseline.json"),
+		metric: "llm_assembly_convert_ms",
+		cwd: monorepoRoot,
+	},
+	{
+		name: "keystroke-transcript-renders",
+		mode: "json-line",
+		args: ["run", "packages/tui/bench/keystroke-frame.bench.ts"],
+		baselinePath: path.join(benchDir, "keystroke-transcript-renders-baseline.json"),
+		metric: "keystroke_transcript_renders",
+		cwd: monorepoRoot,
+	},
+];
+
+type JsonMetric = {
+	metric: string;
+	median_ms: number;
+	stddev_ms: number;
+	captured_at?: string;
+};
+
+function parseArgs(argv: string[]): { update: boolean; only: Set<string> | undefined; help: boolean } {
+	let update = false;
+	let help = false;
+	let only: Set<string> | undefined;
+	for (const arg of argv) {
+		if (arg === "--update") update = true;
+		else if (arg === "--help" || arg === "-h") help = true;
+		else if (arg.startsWith("--only=")) {
+			only = new Set(
+				arg
+					.slice("--only=".length)
+					.split(",")
+					.map(s => s.trim())
+					.filter(Boolean),
+			);
+		}
+	}
+	return { update, only, help };
+}
+
+function medianOfHyperfine(hyperfineJson: string): number {
 	const parsed = JSON.parse(hyperfineJson) as { results: Array<{ mean: number; median?: number }> };
 	const result = parsed.results[0];
 	if (!result) throw new Error("hyperfine produced no result");
 	return result.median ?? result.mean;
 }
 
-async function measure(): Promise<{ seconds: number; raw: string }> {
-	const tmp = path.join(import.meta.dir, "..", "bench", `.boot-run-${Date.now()}.json`);
-	const proc = Bun.spawn(["hyperfine", "--warmup", "3", "--min-runs", "10", "--export-json", tmp, BENCH_COMMAND], {
-		cwd,
+function parseJsonMetricLines(stdout: string, metric: string): JsonMetric {
+	const lines = stdout.split("\n");
+	let last: JsonMetric | undefined;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith("{")) continue;
+		try {
+			const obj = JSON.parse(trimmed) as Partial<JsonMetric>;
+			if (obj.metric === metric && typeof obj.median_ms === "number" && Number.isFinite(obj.median_ms)) {
+				// Timing metrics should be >0; count metrics (e.g. renders) may be 0 after the scoped-repaint change.
+				const allowZero = metric === "keystroke_transcript_renders";
+				if (obj.median_ms > 0 || (allowZero && obj.median_ms === 0)) {
+					const sd = typeof obj.stddev_ms === "number" && Number.isFinite(obj.stddev_ms) ? obj.stddev_ms : 0;
+					last = {
+						metric: obj.metric,
+						median_ms: obj.median_ms,
+						stddev_ms: sd,
+					};
+				}
+			}
+		} catch {
+			// non-JSON noise
+		}
+	}
+	if (!last) {
+		throw new Error(`no finite JSON metric line for ${metric} in bench stdout`);
+	}
+	return last;
+}
+
+async function measureHyperfine(entry: HyperfineEntry): Promise<{ seconds: number; raw: string }> {
+	const which = Bun.spawn(["bash", "-lc", "command -v hyperfine"], { stdout: "pipe", stderr: "pipe" });
+	const whichCode = await which.exited;
+	if (whichCode !== 0) {
+		throw new Error(
+			`hyperfine not on PATH (required only for boot entry). Install hyperfine or run with --only=transcript-compose,keystroke-frame,llm-assembly`,
+		);
+	}
+	const tmp = path.join(benchDir, `.boot-run-${Date.now()}.json`);
+	const proc = Bun.spawn(["hyperfine", "--warmup", "3", "--min-runs", "10", "--export-json", tmp, entry.command], {
+		cwd: entry.cwd,
 		stdout: "inherit",
 		stderr: "inherit",
 	});
@@ -43,29 +171,126 @@ async function measure(): Promise<{ seconds: number; raw: string }> {
 	if (code !== 0) throw new Error(`hyperfine exited ${code}`);
 	const raw = await Bun.file(tmp).text();
 	fs.rmSync(tmp, { force: true });
-	return { seconds: medianOf(raw), raw };
+	return { seconds: medianOfHyperfine(raw), raw };
 }
 
-const update = process.argv.includes("--update");
-const { seconds, raw } = await measure();
+async function measureJsonLine(entry: JsonLineEntry): Promise<JsonMetric> {
+	const proc = Bun.spawn(["bun", ...entry.args], {
+		cwd: entry.cwd,
+		stdout: "pipe",
+		stderr: "inherit",
+	});
+	const stdout = await new Response(proc.stdout).text();
+	const code = await proc.exited;
+	// Still try to parse metrics even if the process printed warnings.
+	const metric = parseJsonMetricLines(stdout, entry.metric);
+	if (code !== 0) {
+		throw new Error(`bench ${entry.name} exited ${code}`);
+	}
+	return metric;
+}
 
-if (update) {
-	fs.mkdirSync(path.dirname(BASELINE_PATH), { recursive: true });
-	await Bun.write(BASELINE_PATH, raw);
-	console.log(`Baseline updated: ${(seconds * 1000).toFixed(0)}ms median -> ${BASELINE_PATH}`);
+function printHelp(): void {
+	console.log(`Usage: bun scripts/bench-guard.ts [--update] [--only=name,...]
+
+Entries:
+${ENTRIES.map(e => `  - ${e.name} (${e.mode})`).join("\n")}
+
+Exit codes: 0 ok, 1 regression, 2 missing baseline / measure failure.
+Wall-clock is MACHINE-RELATIVE and NOT CI-wired.`);
+}
+
+const { update, only, help } = parseArgs(process.argv.slice(2));
+if (help) {
+	printHelp();
 	process.exit(0);
 }
 
-if (!fs.existsSync(BASELINE_PATH)) {
-	console.error("No baseline found. Run `bun scripts/bench-guard.ts --update` on this machine first.");
+const selected = ENTRIES.filter(e => !only || only.has(e.name));
+if (selected.length === 0) {
+	console.error("No matching entries. Known:", ENTRIES.map(e => e.name).join(", "));
 	process.exit(2);
 }
 
-const baseline = medianOf(await Bun.file(BASELINE_PATH).text());
-const ratio = seconds / baseline;
-const verdict = ratio > THRESHOLD ? "REGRESSION" : "ok";
-console.log(
-	`boot median: ${(seconds * 1000).toFixed(0)}ms vs baseline ${(baseline * 1000).toFixed(0)}ms ` +
-		`(${((ratio - 1) * 100).toFixed(1)}%, budget ${((THRESHOLD - 1) * 100).toFixed(0)}%) -> ${verdict}`,
-);
-process.exit(ratio > THRESHOLD ? 1 : 0);
+let exitCode = 0;
+let missingBaseline = false;
+
+for (const entry of selected) {
+	try {
+		if (entry.mode === "hyperfine") {
+			const { seconds, raw } = await measureHyperfine(entry);
+			if (update) {
+				fs.mkdirSync(path.dirname(entry.baselinePath), { recursive: true });
+				await Bun.write(entry.baselinePath, raw);
+				console.log(
+					`[${entry.name}] Baseline updated: ${(seconds * 1000).toFixed(0)}ms median -> ${entry.baselinePath}`,
+				);
+				continue;
+			}
+			if (!fs.existsSync(entry.baselinePath)) {
+				console.error(
+					`[${entry.name}] No baseline found. Run \`bun scripts/bench-guard.ts --update\` on this machine first.`,
+				);
+				missingBaseline = true;
+				continue;
+			}
+			const baseline = medianOfHyperfine(await Bun.file(entry.baselinePath).text());
+			const ratio = seconds / baseline;
+			const verdict = ratio > THRESHOLD ? "REGRESSION" : "ok";
+			console.log(
+				`[${entry.name}] median: ${(seconds * 1000).toFixed(0)}ms vs baseline ${(baseline * 1000).toFixed(0)}ms ` +
+					`(${((ratio - 1) * 100).toFixed(1)}%, budget ${((THRESHOLD - 1) * 100).toFixed(0)}%) -> ${verdict}`,
+			);
+			if (ratio > THRESHOLD) exitCode = 1;
+		} else {
+			const measured = await measureJsonLine(entry);
+			if (update) {
+				const payload: JsonMetric = {
+					...measured,
+					captured_at: new Date().toISOString(),
+				};
+				fs.mkdirSync(path.dirname(entry.baselinePath), { recursive: true });
+				await Bun.write(entry.baselinePath, `${JSON.stringify(payload, null, 2)}\n`);
+				console.log(
+					`[${entry.name}] Baseline updated: ${measured.median_ms.toFixed(4)}ms (${measured.metric}) -> ${entry.baselinePath}`,
+				);
+				continue;
+			}
+			if (!fs.existsSync(entry.baselinePath)) {
+				console.error(
+					`[${entry.name}] No baseline found. Run \`bun scripts/bench-guard.ts --update --only=${entry.name}\` on this machine first.`,
+				);
+				missingBaseline = true;
+				continue;
+			}
+			const baselineRaw = JSON.parse(await Bun.file(entry.baselinePath).text()) as Partial<JsonMetric>;
+			const baselineMs = baselineRaw.median_ms;
+			if (typeof baselineMs !== "number" || !Number.isFinite(baselineMs) || baselineMs < 0) {
+				throw new Error(`invalid baseline for ${entry.name}: median_ms must be finite and >= 0`);
+			}
+			if (baselineMs === 0) {
+				// Count metrics may baseline at 0 (scoped-repaint renders). Any rise is a regression.
+				const verdict = measured.median_ms > 0 ? "REGRESSION" : "ok";
+				console.log(
+					`[${entry.name}] ${measured.metric}: ${measured.median_ms.toFixed(4)} vs baseline 0 -> ${verdict}`,
+				);
+				if (measured.median_ms > 0) exitCode = 1;
+				continue;
+			}
+			const ratio = measured.median_ms / baselineMs;
+			const verdict = ratio > THRESHOLD ? "REGRESSION" : "ok";
+			console.log(
+				`[${entry.name}] ${measured.metric}: ${measured.median_ms.toFixed(4)}ms vs baseline ${baselineMs.toFixed(4)}ms ` +
+					`(${((ratio - 1) * 100).toFixed(1)}%, budget ${((THRESHOLD - 1) * 100).toFixed(0)}%) -> ${verdict}`,
+			);
+			if (ratio > THRESHOLD) exitCode = 1;
+		}
+	} catch (err) {
+		console.error(`[${entry.name}] ${err instanceof Error ? err.message : String(err)}`);
+		// Treat measure failures as missing/setup (exit 2) rather than silent ok.
+		missingBaseline = true;
+	}
+}
+
+if (missingBaseline) process.exit(2);
+process.exit(exitCode);

--- a/packages/tui/bench/keystroke-frame.bench.ts
+++ b/packages/tui/bench/keystroke-frame.bench.ts
@@ -1,0 +1,227 @@
+/**
+ * Keystroke → render-complete frame cost with a session-scale transcript sibling.
+ *
+ * Mounts a CountingLines stand-in (15k cached rows) + Editor under a TUI driven
+ * by VirtualTerminal + StressRenderScheduler. Each keystroke is one printable
+ * char with editor reset outside the timed window (empty editor every press).
+ * An episode averages KEYS_PER_EPISODE independent one-key latencies so the
+ * sample window is long enough for stable median±stddev across episodes.
+ *
+ * Records:
+ *  - keystroke frame median_ms / stddev_ms (one keypress → render-complete)
+ *  - transcript stand-in render() calls per keystroke (target 0 after scoped repaint)
+ *
+ * Target: transcript renders/keystroke == 0 and median <5ms.
+ *
+ *   bun run packages/tui/bench/keystroke-frame.bench.ts
+ */
+import type { Component, EditorTheme } from "@oh-my-pi/pi-tui";
+import { Editor, TUI } from "@oh-my-pi/pi-tui";
+import { StressRenderScheduler } from "../test/render-stress-scheduler";
+import { VirtualTerminal } from "../test/virtual-terminal";
+
+const WARMUP_EPISODES = 8;
+const MEASURE_EPISODES = 40;
+/** Independent one-key timings averaged into each episode sample. */
+const KEYS_PER_EPISODE = 2000;
+const TRANSCRIPT_ROWS = 15_000;
+const COLS = 80;
+const ROWS = 24;
+
+function median(xs: number[]): number {
+	if (xs.length === 0) return 0;
+	const sorted = [...xs].sort((a, b) => a - b);
+	const mid = sorted.length >> 1;
+	if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+	return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}
+
+function stddev(xs: number[]): number {
+	if (xs.length < 2) return 0;
+	const mean = xs.reduce((a, b) => a + b, 0) / xs.length;
+	let sumSq = 0;
+	for (const x of xs) {
+		const d = x - mean;
+		sumSq += d * d;
+	}
+	return Math.sqrt(sumSq / (xs.length - 1));
+}
+
+/** Ref-stable leaf: returns the same array when unchanged; counts render() calls. */
+class CountingLines implements Component {
+	renders = 0;
+	#lines: readonly string[];
+
+	constructor(lines: readonly string[]) {
+		this.#lines = lines;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): readonly string[] {
+		this.renders += 1;
+		return this.#lines;
+	}
+}
+
+function minimalEditorTheme(): EditorTheme {
+	const id = (text: string) => text;
+	const box = {
+		topLeft: "+",
+		topRight: "+",
+		bottomLeft: "+",
+		bottomRight: "+",
+		horizontal: "-",
+		vertical: "|",
+		cross: "+",
+		teeDown: "+",
+		teeUp: "+",
+		teeLeft: "+",
+		teeRight: "+",
+	};
+	const symbols = {
+		cursor: ">",
+		inputCursor: "|",
+		boxRound: {
+			topLeft: "+",
+			topRight: "+",
+			bottomLeft: "+",
+			bottomRight: "+",
+			horizontal: "-",
+			vertical: "|",
+		},
+		boxSharp: box,
+		table: box,
+		quoteBorder: "|",
+		hrChar: "-",
+		colorSwatch: "[]",
+		spinnerFrames: ["-"],
+	};
+	return {
+		borderColor: id,
+		selectList: {
+			selectedPrefix: id,
+			selectedText: id,
+			description: id,
+			scrollInfo: id,
+			noMatch: id,
+			symbols,
+			hovered: id,
+		},
+		symbols,
+		hintStyle: id,
+	};
+}
+
+function emitMetric(metric: string, median_ms: number, stddev_ms: number): void {
+	// Benches intentionally emit metrics on stdout.
+	console.log(JSON.stringify({ metric, median_ms, stddev_ms }));
+	console.log(`METRIC ${metric}=${median_ms.toFixed(4)}`);
+}
+
+const lines = Array.from({ length: TRANSCRIPT_ROWS }, (_, i) => `history-row-${i}`);
+const term = new VirtualTerminal(COLS, ROWS, 2_000);
+const scheduler = new StressRenderScheduler();
+const tui = new TUI(term, true, { renderScheduler: scheduler });
+const transcript = new CountingLines(lines);
+const editor = new Editor(minimalEditorTheme());
+tui.addChild(transcript);
+tui.addChild(editor);
+tui.setFocus(editor);
+tui.start();
+await scheduler.drain(term);
+
+/**
+ * One keystroke from a clean empty editor. Reset + editor-scoped paint is
+ * outside the timed window so the metric is pure keypress → render-complete for
+ * a single printable char (empty → "x"). `setText` alone does not schedule a
+ * paint without onChange; requestComponentRender updates the editor segment of
+ * the display baseline without re-walking the 15k-row transcript stand-in.
+ * The timed path uses sendInput → #handleInput → requestRender (full compose).
+ */
+async function oneKeyLatency(): Promise<{ ms: number; renders: number }> {
+	editor.setText("");
+	tui.requestComponentRender(editor);
+	await scheduler.drain(term);
+	const rendersBefore = transcript.renders;
+	const t0 = performance.now();
+	term.sendInput("x");
+	await scheduler.drain(term);
+	return { ms: performance.now() - t0, renders: transcript.renders - rendersBefore };
+}
+
+/**
+ * Episode sample = mean of KEYS_PER_EPISODE independent single-key latencies
+ * (reset outside each timed press). Averaging lifts the sample window above the
+ * timer noise floor while keeping the metric as ms per one printable char.
+ */
+async function episodeSample(): Promise<{ ms: number; rendersPerKey: number }> {
+	let totalMs = 0;
+	let totalRenders = 0;
+	for (let k = 0; k < KEYS_PER_EPISODE; k++) {
+		const r = await oneKeyLatency();
+		totalMs += r.ms;
+		totalRenders += r.renders;
+	}
+	return {
+		ms: totalMs / KEYS_PER_EPISODE,
+		rendersPerKey: totalRenders / KEYS_PER_EPISODE,
+	};
+}
+
+for (let i = 0; i < WARMUP_EPISODES; i++) {
+	await episodeSample();
+}
+
+const frameSamples: number[] = [];
+const renderSamples: number[] = [];
+
+for (let i = 0; i < MEASURE_EPISODES; i++) {
+	Bun.gc(true);
+	const { ms, rendersPerKey } = await episodeSample();
+	frameSamples.push(ms);
+	renderSamples.push(rendersPerKey);
+}
+
+tui.stop();
+
+const med = median(frameSamples);
+const sd = stddev(frameSamples);
+const noise = med > 0 ? sd / med : 0;
+// Quiet-frame contract: mean renders/key over ALL episodes (not median of rates —
+// a median can be 0 while intermittent recomposes still fire).
+const meanRendersPerKey =
+	renderSamples.reduce((a, b) => a + b, 0) / Math.max(renderSamples.length, 1);
+const maxEpisodeRendersPerKey = renderSamples.reduce((a, b) => Math.max(a, b), 0);
+
+console.log(
+	`keystroke-frame: median=${med.toFixed(4)}ms/key stddev=${sd.toFixed(4)}ms ` +
+		`noise=${(noise * 100).toFixed(1)}% episodes=${MEASURE_EPISODES} keys/episode=${KEYS_PER_EPISODE}`,
+);
+console.log(
+	`  transcript renders/keystroke: mean=${meanRendersPerKey.toFixed(4)} ` +
+		`maxEpisode=${maxEpisodeRendersPerKey.toFixed(4)} ` +
+		`(target mean=0 and max=0)`,
+);
+if (noise > 0.2) {
+	console.warn(`  warning: stddev/median ${(noise * 100).toFixed(1)}% > 20%`);
+}
+
+emitMetric("keystroke_frame_ms", med, sd);
+// Guard schema reuses median_ms as the scalar; quiet gate = mean over episodes.
+console.log(
+	JSON.stringify({
+		metric: "keystroke_transcript_renders",
+		median_ms: meanRendersPerKey,
+		stddev_ms: stddev(renderSamples),
+	}),
+);
+console.log(`METRIC keystroke_transcript_renders=${meanRendersPerKey.toFixed(4)}`);
+console.log(
+	JSON.stringify({
+		metric: "keystroke_transcript_renders_max",
+		median_ms: maxEpisodeRendersPerKey,
+		stddev_ms: 0,
+	}),
+);
+console.log(`METRIC keystroke_transcript_renders_max=${maxEpisodeRendersPerKey.toFixed(4)}`);


### PR DESCRIPTION
## What

Adds permanent measurement benches for long-session transcript compose, keystroke frames, and LLM assembly, and generalizes `bench-guard` from a boot-only hyperfine check into a multi-entry local relative guard. Measurement only; no production behavior changes.

## Why

Long coding-agent sessions can spend most of their interactive cost recomposing large transcript component trees and rebuilding LLM context, but main currently has no permanent benches that surface those costs. Without a shared fixture and local relative guard, later performance work has no machine-local regression signal for the critical paths.

### Exact mechanism & invariants

1. **Shared synthetic long-session fixture** (`packages/coding-agent/bench/fixtures/synthetic-transcript.ts`)
   - Builds N alternating blocks sized to approximate the long-session density described in the fixture (~155 messages / ~1.5MB, ~10KB/message average).
   - Block pattern: user prompt, assistant markdown (~2KB with a fenced code block), then up to two sealed tool executions with ~10KB results each.
   - Two surfaces from the same density model:
     - `buildSyntheticComponents(n)` → TUI `Component[]` (optional live unfinalized tail assistant).
     - `buildSyntheticAgentMessages(n)` → `AgentMessage[]` for assembly benches.

2. **Three permanent benches**
   - `packages/coding-agent/bench/transcript-compose.bench.ts`
     - Mounts synthetic components in `TranscriptContainer`, finalizes history, simulates native scrollback commit after first paint, then times pure `container.render(width)` while mutating only the live tail assistant outside the timed window.
     - Emits `transcript_compose_n500_ms`, `transcript_compose_n5000_ms`, and `transcript_compose_ratio`.
   - `packages/tui/bench/keystroke-frame.bench.ts`
     - Mounts a 15k-row transcript stand-in (`CountingLines`) plus `Editor` under `TUI` + `VirtualTerminal` + `StressRenderScheduler`.
     - Times one printable keystroke → render-complete and records transcript-stand-in `render()` calls per key.
     - Emits `keystroke_frame_ms`, `keystroke_transcript_renders`, and `keystroke_transcript_renders_max`.
   - `packages/coding-agent/bench/llm-assembly.bench.ts`
     - Measures `convertToLlm` on a growing N=5000 history (10 successive calls, append-2 between calls; first-call vs steady last-3) and `estimateTokens` cold first/second plus multi-sweep medians.
     - Emits `llm_assembly_convert_ms`, first/steady convert metrics, and estimate-token first/second/sweep metrics.

3. **Generalized relative guard** (`packages/coding-agent/scripts/bench-guard.ts`)
   - Keeps the existing boot hyperfine entry and adds json-line entries for the new benches.
   - Parses stdout JSON lines of the form `{metric, median_ms, stddev_ms}`.
   - Relative regression budget is `THRESHOLD = 1.05` (5%) against machine-local baselines.
   - Guarded metrics: `transcript_compose_n5000_ms`, `keystroke_frame_ms`, `llm_assembly_convert_ms`, `keystroke_transcript_renders` (plus existing boot).
   - Baselines are machine-relative and intentionally not CI-wired; missing baseline exits 2, regression exits 1.

4. **Generated baselines ignored**
   - `.gitignore` replaces the single `boot-baseline.json` ignore with `packages/coding-agent/bench/*-baseline.json` so local relative snapshots stay uncommitted.

### Commands

```bash
bun run packages/coding-agent/bench/transcript-compose.bench.ts
bun run packages/tui/bench/keystroke-frame.bench.ts
bun run packages/coding-agent/bench/llm-assembly.bench.ts

# capture or refresh local baselines (machine-local)
bun packages/coding-agent/scripts/bench-guard.ts --update

# compare against local baselines
bun packages/coding-agent/scripts/bench-guard.ts
bun packages/coding-agent/scripts/bench-guard.ts --only=transcript-compose,keystroke-frame,llm-assembly
```

## Testing

Measurement-only pre-fix snapshot recorded with this change on the author’s machine:

- transcript compose: `n500 = 0.2792±0.0374ms`, `n5000 = 1.3204±0.0992ms`, `ratio(N5000/N500) = 4.73`
- keystroke frame: `≈0.07–0.08ms/key`, transcript renders/key = `1.00`
- LLM assembly: convert `3.94±0.55ms/episode`, estimateTokens sweep `5.76±0.71ms`

These numbers are empirical wall-clock observations, not absolute CI gates. The benches print later target guidance as warnings/metrics only; this PR does not hard-fail on ratio, renders/key, or assembly speedup thresholds.

### Risks

- Relative baselines are machine-local. A baseline captured on one machine is not meaningful on another, and the guard is intentionally not CI-wired.
- This PR only establishes measurement + relative regression budget. Absolute hard fails for compose ratio, keystroke quietness, and LLM steady-state speedup belong in the follow-up PRs that make those paths green, so this unit stays independently mergeable.
- Noise warnings (`stddev/median > 20%`) are advisory in these benches; they do not fail the process in this PR.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
