### PR TITLE
perf(coding-agent): skip blob resolution for clean session entries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Skipped blob-resolution traversal for session entries that contain no persisted blob references. ([#5922](https://github.com/can1357/oh-my-pi/issues/5922))
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -240,6 +240,21 @@ function shouldResolveImagePayload(value: unknown, key: string | undefined): val
 	return (key === "content" && isImageBlock(value)) || key === "images";
 }
 
+function containsBlobRef(value: unknown): boolean {
+	if (typeof value === "string") return isBlobRef(value);
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			if (containsBlobRef(item)) return true;
+		}
+		return false;
+	}
+	if (typeof value !== "object" || value === null) return false;
+	for (const item of Object.values(value)) {
+		if (containsBlobRef(item)) return true;
+	}
+	return false;
+}
+
 async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, key?: string): Promise<void> {
 	if (shouldResolveImagePayload(value, key)) {
 		value.data = await resolveImageData(blobStore, value.data);
@@ -272,9 +287,12 @@ async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, ke
 }
 
 export async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobStore): Promise<void> {
-	await Promise.all(
-		entries.filter(entry => entry.type !== "session").map(entry => resolvePersistedBlobRefs(entry, blobStore)),
-	);
+	const sessionEntries = entries.filter(entry => entry.type !== "session");
+	const pending: Promise<void>[] = [];
+	for (const entry of sessionEntries) {
+		if (containsBlobRef(entry)) pending.push(resolvePersistedBlobRefs(entry, blobStore));
+	}
+	await Promise.all(pending);
 }
 
 /**

--- a/packages/coding-agent/test/session-blob-resolver-optimization.test.ts
+++ b/packages/coding-agent/test/session-blob-resolver-optimization.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "bun:test";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
+import { BlobStore } from "../src/session/blob-store";
+import type { FileEntry } from "../src/session/session-entries";
+import { resolveBlobRefsInEntries } from "../src/session/session-loader";
+
+const ref = (hash: string): string => `blob:sha256:${hash}`;
+
+function messageEntry(message: object): FileEntry {
+	return {
+		type: "message",
+		id: crypto.randomUUID(),
+		parentId: null,
+		timestamp: "2026-07-17T00:00:00.000Z",
+		message,
+	} as FileEntry;
+}
+
+class ScriptedStore extends BlobStore {
+	readonly reads: string[] = [];
+
+	constructor(
+		dir: string,
+		private readonly read: (hash: string) => Promise<Buffer | null>,
+	) {
+		super(dir);
+	}
+
+	override async get(hash: string): Promise<Buffer | null> {
+		this.reads.push(hash);
+		return this.read(hash);
+	}
+}
+
+describe("blob resolver optimization invariants", () => {
+	it("retains the matched-payload early return", async () => {
+		using tempDir = TempDir.createSync("@blob-resolver-early-return-");
+		const store = new ScriptedStore(tempDir.path(), async hash => Buffer.from(hash));
+		const image = {
+			type: "image",
+			data: ref("payload"),
+			mimeType: "image/png",
+			image_url: ref("nested-provider-url"),
+		};
+
+		await resolveBlobRefsInEntries([messageEntry({ role: "user", content: [image] })], store);
+
+		expect(image.data).toBe(Buffer.from("payload").toString("base64"));
+		expect(image.image_url).toBe(ref("nested-provider-url"));
+		expect(store.reads).toEqual(["payload"]);
+	});
+
+	it("retains the content/images key gate", async () => {
+		using tempDir = TempDir.createSync("@blob-resolver-key-gate-");
+		const store = new ScriptedStore(tempDir.path(), async hash => Buffer.from(hash));
+		const metadataImage = { type: "image", data: ref("metadata"), mimeType: "image/png" };
+		const contentImage = { type: "image", data: ref("content"), mimeType: "image/png" };
+
+		await resolveBlobRefsInEntries(
+			[messageEntry({ role: "user", metadata: metadataImage, content: [contentImage] })],
+			store,
+		);
+
+		expect(metadataImage.data).toBe(ref("metadata"));
+		expect(contentImage.data).toBe(Buffer.from("content").toString("base64"));
+		expect(store.reads).toEqual(["content"]);
+	});
+
+	it("ignores inherited traversal keys", async () => {
+		using tempDir = TempDir.createSync("@blob-resolver-own-keys-");
+		const store = new ScriptedStore(tempDir.path(), async hash => Buffer.from(hash));
+		const inheritedImage = { type: "image", data: ref("inherited"), mimeType: "image/png" };
+		const wrapper = Object.create({ content: [inheritedImage] }) as Record<string, object>;
+		wrapper.own = { note: "plain" };
+
+		await resolveBlobRefsInEntries([messageEntry({ role: "toolResult", details: wrapper })], store);
+
+		expect(inheritedImage.data).toBe(ref("inherited"));
+		expect(store.reads).toEqual([]);
+	});
+
+	it("preserves warning order across result, image_url, and descendants", async () => {
+		using tempDir = TempDir.createSync("@blob-resolver-warning-order-");
+		const slowResult = Promise.withResolvers<Buffer | null>();
+		const store = new ScriptedStore(tempDir.path(), async hash =>
+			hash === "slow-result" ? slowResult.promise : null,
+		);
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const node = {
+			type: "image_generation_call",
+			result: ref("slow-result"),
+			image_url: ref("provider-url"),
+			content: [{ type: "image", data: ref("child-image"), mimeType: "image/png" }],
+		};
+
+		try {
+			const resolving = resolveBlobRefsInEntries([messageEntry({ role: "assistant", node })], store);
+			expect(store.reads).toEqual(["slow-result"]);
+			slowResult.resolve(null);
+			await resolving;
+			expect(warn.mock.calls.map(([message, fields]) => [message, fields?.hash])).toEqual([
+				["Blob not found for image reference", "slow-result"],
+				["Blob not found for persisted image data URL", "provider-url"],
+				["Blob not found for image reference", "child-image"],
+			]);
+			expect(store.reads).toEqual(["slow-result", "provider-url", "child-image"]);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("does not snapshot aliased descendant refs before their dependency", async () => {
+		using tempDir = TempDir.createSync("@blob-resolver-shared-mutation-");
+		const parentResponse = Promise.withResolvers<Buffer | null>();
+		const sharedMutation = Promise.withResolvers<void>();
+		let sharedReads = 0;
+		const store = new ScriptedStore(tempDir.path(), async hash => {
+			if (hash === "parent") return parentResponse.promise;
+			if (hash === "shared") {
+				sharedReads += 1;
+				if (sharedReads > 1) throw new Error("duplicate shared read");
+				return Buffer.from("shared");
+			}
+			throw new Error(`unexpected read: ${hash}`);
+		});
+		let sharedData = ref("shared");
+		const shared = {
+			type: "image",
+			get data(): string {
+				return sharedData;
+			},
+			set data(value: string) {
+				sharedData = value;
+				sharedMutation.resolve();
+			},
+			mimeType: "image/png",
+		};
+		const message = {
+			role: "assistant",
+			immediate: { content: [shared] },
+			delayed: {
+				type: "image_generation_call",
+				result: ref("parent"),
+				content: [shared],
+			},
+		};
+
+		const resolving = resolveBlobRefsInEntries([messageEntry(message)], store);
+		await sharedMutation.promise;
+		parentResponse.resolve(Buffer.from("parent"));
+		await resolving;
+
+		expect(sharedReads).toBe(1);
+		expect(shared.data).toBe(Buffer.from("shared").toString("base64"));
+		expect(message.delayed.result).toBe(Buffer.from("parent").toString("base64"));
+		expect(store.reads).toEqual(["shared", "parent"]);
+	});
+
+	it("scans each entry at the original map initiation point", async () => {
+		using tempDir = TempDir.createSync("@blob-resolver-entry-mutation-");
+		const secondMessage: {
+			role: string;
+			content: string | Array<{ type: string; data: string; mimeType: string }>;
+		} = { role: "user", content: "plain before the first read starts" };
+		const store = new ScriptedStore(tempDir.path(), async hash => {
+			if (hash === "first") {
+				secondMessage.content = [{ type: "image", data: ref("second"), mimeType: "image/png" }];
+				return Buffer.from("first");
+			}
+			if (hash === "second") return Buffer.from("second");
+			throw new Error(`unexpected read: ${hash}`);
+		});
+		const firstImage = { type: "image", data: ref("first"), mimeType: "image/png" };
+
+		await resolveBlobRefsInEntries(
+			[messageEntry({ role: "user", content: [firstImage] }), messageEntry(secondMessage)],
+			store,
+		);
+
+		expect(Array.isArray(secondMessage.content)).toBe(true);
+		if (!Array.isArray(secondMessage.content)) throw new Error("entry mutation was not applied");
+		expect(secondMessage.content[0]?.data).toBe(Buffer.from("second").toString("base64"));
+		expect(store.reads).toEqual(["first", "second"]);
+	});
+});

--- a/packages/coding-agent/test/session-blob-resolver-optimization.test.ts
+++ b/packages/coding-agent/test/session-blob-resolver-optimization.test.ts
@@ -1,19 +1,42 @@
 import { describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, ImageContent, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
 import { logger, TempDir } from "@oh-my-pi/pi-utils";
 import { BlobStore } from "../src/session/blob-store";
-import type { FileEntry } from "../src/session/session-entries";
+import type { SessionMessageEntry } from "../src/session/session-entries";
 import { resolveBlobRefsInEntries } from "../src/session/session-loader";
 
 const ref = (hash: string): string => `blob:sha256:${hash}`;
 
-function messageEntry(message: object): FileEntry {
+function messageEntry(message: AgentMessage): SessionMessageEntry {
 	return {
 		type: "message",
 		id: crypto.randomUUID(),
 		parentId: null,
 		timestamp: "2026-07-17T00:00:00.000Z",
 		message,
-	} as FileEntry;
+	};
+}
+
+function assistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5-mini",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+		...overrides,
+	};
 }
 
 class ScriptedStore extends BlobStore {
@@ -36,14 +59,17 @@ describe("blob resolver optimization invariants", () => {
 	it("retains the matched-payload early return", async () => {
 		using tempDir = TempDir.createSync("@blob-resolver-early-return-");
 		const store = new ScriptedStore(tempDir.path(), async hash => Buffer.from(hash));
-		const image = {
+		// Transport-native history keeps provider image URLs on the same block as
+		// the inline image payload; resolving `data` must not descend into it.
+		const image: ImageContent & { image_url: string } = {
 			type: "image",
 			data: ref("payload"),
 			mimeType: "image/png",
 			image_url: ref("nested-provider-url"),
 		};
+		const message: UserMessage = { role: "user", content: [image], timestamp: 0 };
 
-		await resolveBlobRefsInEntries([messageEntry({ role: "user", content: [image] })], store);
+		await resolveBlobRefsInEntries([messageEntry(message)], store);
 
 		expect(image.data).toBe(Buffer.from("payload").toString("base64"));
 		expect(image.image_url).toBe(ref("nested-provider-url"));
@@ -53,15 +79,21 @@ describe("blob resolver optimization invariants", () => {
 	it("retains the content/images key gate", async () => {
 		using tempDir = TempDir.createSync("@blob-resolver-key-gate-");
 		const store = new ScriptedStore(tempDir.path(), async hash => Buffer.from(hash));
-		const metadataImage = { type: "image", data: ref("metadata"), mimeType: "image/png" };
-		const contentImage = { type: "image", data: ref("content"), mimeType: "image/png" };
+		const detailsImage = { type: "image", data: ref("details"), mimeType: "image/png" };
+		const contentImage: ImageContent = { type: "image", data: ref("content"), mimeType: "image/png" };
+		const message: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "call-key-gate",
+			toolName: "read",
+			content: [contentImage],
+			details: detailsImage,
+			isError: false,
+			timestamp: 0,
+		};
 
-		await resolveBlobRefsInEntries(
-			[messageEntry({ role: "user", metadata: metadataImage, content: [contentImage] })],
-			store,
-		);
+		await resolveBlobRefsInEntries([messageEntry(message)], store);
 
-		expect(metadataImage.data).toBe(ref("metadata"));
+		expect(detailsImage.data).toBe(ref("details"));
 		expect(contentImage.data).toBe(Buffer.from("content").toString("base64"));
 		expect(store.reads).toEqual(["content"]);
 	});
@@ -70,10 +102,19 @@ describe("blob resolver optimization invariants", () => {
 		using tempDir = TempDir.createSync("@blob-resolver-own-keys-");
 		const store = new ScriptedStore(tempDir.path(), async hash => Buffer.from(hash));
 		const inheritedImage = { type: "image", data: ref("inherited"), mimeType: "image/png" };
-		const wrapper = Object.create({ content: [inheritedImage] }) as Record<string, object>;
+		const wrapper: Record<string, object> = Object.create({ content: [inheritedImage] });
 		wrapper.own = { note: "plain" };
+		const message: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "call-own-keys",
+			toolName: "read",
+			content: [],
+			details: wrapper,
+			isError: false,
+			timestamp: 0,
+		};
 
-		await resolveBlobRefsInEntries([messageEntry({ role: "toolResult", details: wrapper })], store);
+		await resolveBlobRefsInEntries([messageEntry(message)], store);
 
 		expect(inheritedImage.data).toBe(ref("inherited"));
 		expect(store.reads).toEqual([]);
@@ -86,15 +127,17 @@ describe("blob resolver optimization invariants", () => {
 			hash === "slow-result" ? slowResult.promise : null,
 		);
 		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		const node = {
+		// OpenAI Responses items persist on the assistant provider payload.
+		const node: Record<string, unknown> = {
 			type: "image_generation_call",
 			result: ref("slow-result"),
 			image_url: ref("provider-url"),
 			content: [{ type: "image", data: ref("child-image"), mimeType: "image/png" }],
 		};
+		const message = assistantMessage({ providerPayload: { type: "openaiResponsesHistory", items: [node] } });
 
 		try {
-			const resolving = resolveBlobRefsInEntries([messageEntry({ role: "assistant", node })], store);
+			const resolving = resolveBlobRefsInEntries([messageEntry(message)], store);
 			expect(store.reads).toEqual(["slow-result"]);
 			slowResult.resolve(null);
 			await resolving;
@@ -124,7 +167,7 @@ describe("blob resolver optimization invariants", () => {
 			throw new Error(`unexpected read: ${hash}`);
 		});
 		let sharedData = ref("shared");
-		const shared = {
+		const shared: ImageContent = {
 			type: "image",
 			get data(): string {
 				return sharedData;
@@ -135,15 +178,15 @@ describe("blob resolver optimization invariants", () => {
 			},
 			mimeType: "image/png",
 		};
-		const message = {
-			role: "assistant",
-			immediate: { content: [shared] },
-			delayed: {
-				type: "image_generation_call",
-				result: ref("parent"),
-				content: [shared],
-			},
+		const node: Record<string, unknown> = {
+			type: "image_generation_call",
+			result: ref("parent"),
+			content: [shared],
 		};
+		const message = assistantMessage({
+			content: [shared],
+			providerPayload: { type: "openaiResponsesHistory", items: [node] },
+		});
 
 		const resolving = resolveBlobRefsInEntries([messageEntry(message)], store);
 		await sharedMutation.promise;
@@ -152,16 +195,13 @@ describe("blob resolver optimization invariants", () => {
 
 		expect(sharedReads).toBe(1);
 		expect(shared.data).toBe(Buffer.from("shared").toString("base64"));
-		expect(message.delayed.result).toBe(Buffer.from("parent").toString("base64"));
+		expect(node.result).toBe(Buffer.from("parent").toString("base64"));
 		expect(store.reads).toEqual(["shared", "parent"]);
 	});
 
 	it("scans each entry at the original map initiation point", async () => {
 		using tempDir = TempDir.createSync("@blob-resolver-entry-mutation-");
-		const secondMessage: {
-			role: string;
-			content: string | Array<{ type: string; data: string; mimeType: string }>;
-		} = { role: "user", content: "plain before the first read starts" };
+		const secondMessage: UserMessage = { role: "user", content: "plain before the first read starts", timestamp: 0 };
 		const store = new ScriptedStore(tempDir.path(), async hash => {
 			if (hash === "first") {
 				secondMessage.content = [{ type: "image", data: ref("second"), mimeType: "image/png" }];
@@ -170,16 +210,17 @@ describe("blob resolver optimization invariants", () => {
 			if (hash === "second") return Buffer.from("second");
 			throw new Error(`unexpected read: ${hash}`);
 		});
-		const firstImage = { type: "image", data: ref("first"), mimeType: "image/png" };
+		const firstImage: ImageContent = { type: "image", data: ref("first"), mimeType: "image/png" };
+		const firstMessage: UserMessage = { role: "user", content: [firstImage], timestamp: 0 };
 
-		await resolveBlobRefsInEntries(
-			[messageEntry({ role: "user", content: [firstImage] }), messageEntry(secondMessage)],
-			store,
-		);
+		await resolveBlobRefsInEntries([messageEntry(firstMessage), messageEntry(secondMessage)], store);
 
 		expect(Array.isArray(secondMessage.content)).toBe(true);
 		if (!Array.isArray(secondMessage.content)) throw new Error("entry mutation was not applied");
-		expect(secondMessage.content[0]?.data).toBe(Buffer.from("second").toString("base64"));
+		const resolvedImage = secondMessage.content[0];
+		expect(resolvedImage?.type).toBe("image");
+		if (resolvedImage?.type !== "image") throw new Error("expected resolved image content");
+		expect(resolvedImage.data).toBe(Buffer.from("second").toString("base64"));
 		expect(store.reads).toEqual(["first", "second"]);
 	});
 });


### PR DESCRIPTION
## What

In `resolveBlobRefsInEntries`, filter out session headers first, then for each remaining entry run a recursive synchronous `containsBlobRef` precheck and immediately start the existing `resolvePersistedBlobRefs` only on positives. Negative entries never enter the async walk; positive scheduling keeps the original per-entry map initiation timing.

## Why

Session open always walked every non-header entry with a recursive `Promise.all` tree, even when the entry was pure text. Long text-heavy sessions paid that cost on almost every history row. A recursive `isBlobRef` precheck over the JSON-derived entry skips the async machinery for clean rows while leaving the resolver body unchanged for rows that actually externalized images.

Fixes #5922

### Exact mechanism / invariants

All production changes are in `packages/coding-agent/src/session/session-loader.ts`:

1. **`containsBlobRef(value)`** (new, synchronous):
   - string → `isBlobRef(value)` (`startsWith("blob:sha256:")`)
   - array → early-exit recursive scan of elements
   - plain object → early-exit recursive scan of `Object.values`
   - other primitives / null → false
2. **`resolveBlobRefsInEntries(entries, blobStore)`**:
   - `sessionEntries = entries.filter(entry => entry.type !== "session")` (header filter first, same as before)
   - `pending: Promise<void>[] = []`
   - `for (const entry of sessionEntries) { if (containsBlobRef(entry)) pending.push(resolvePersistedBlobRefs(entry, blobStore)); }`
   - `await Promise.all(pending)`
3. **`resolvePersistedBlobRefs` is unchanged**: matched image-payload early return, content/`images` key gate, `image_generation_call.result` then `image_url`, then child `Object.entries` walks stay as-is.

Scheduling invariant: each entry is prechecked and (if positive) starts resolution at the same point the old `.map(...)` would have started that entry. Do **not** `filter(containsBlobRef)` over the whole list before starting any resolver: a later entry that is mutated to contain a ref during an earlier `BlobStore.get` must still be scanned after that mutation.

Domain: exactness is claimed for production `FileEntry` trees (JSON-derived, acyclic plain data, plus the shared-holder and synchronously mutating `BlobStore` cases covered by the new tests). Proxy/cyclic inputs are not valid persisted session trees.

## Testing

**Behavioral (this PR):**

`packages/coding-agent/test/session-blob-resolver-optimization.test.ts`, suite `blob resolver optimization invariants` (6 tests):

1. Matched-payload early return: image block under `content` resolves `data` and does not also resolve a nested sibling `image_url` on the same matched payload.
2. content/`images` key gate: image-shaped payload under `metadata` stays a blob ref; the same shape under `content` resolves.
3. Own-key traversal only: image data reachable only via an inherited prototype `content` is not resolved; no store reads.
4. Warning order: missing-blob warnings for `image_generation_call.result`, then `image_url`, then child image `data`, with read order matching that sequence when the first read is held open.
5. Alias / shared mutation: two holders sharing one image object resolve the shared `data` once; a delayed parent `result` does not force a second shared read or snapshot the alias before the dependency path runs.
6. Map-initiation timing: while the first entry’s `BlobStore.get` is in flight, a later plain entry is mutated to contain a blob ref; that later entry still resolves (proves scan-start-per-entry, not scan-all-then-map).

Focused local check used during integration (not a campaign-wide suite count):

```bash
cd packages/coding-agent
bunx biome check src/session/session-loader.ts test/session-blob-resolver-optimization.test.ts test/session-persistence-images.test.ts
bun test test/session-blob-resolver-optimization.test.ts test/session-persistence-images.test.ts
```

(6/6 exactness tests, 18 asserts; with persistence-image neighbors 8/8, 29 asserts on the integration tree.)

**Benchmarks (empirical, local):**

Selection / interleaved packet (10 rotated base vs prefilter rounds; common N5000 whole-phase `blob_resolve`):

| Workload | Base median | After median | Paired median vs base |
|---|---:|---:|---:|
| common N5000 | 105.627 ms | 35.324 ms | **2.994×** |
| sparse N25000, 1% positive | 380.839 ms | 44.444 ms | **8.924×** |
| dense positive N750 | 51.192 ms | 52.962 ms | **0.990×** (~1% slower) |
| missing N10000 | 59.844 ms | 73.361 ms | **0.829×** (~17% slower) |
| immediate error N5000 | 57.126 ms | 62.177 ms | **0.919×** (~8% slower) |

Winner elapsed CVs and paired-ratio CVs on the selected series stayed under 0.20. Observables (common context/id hashes, dense/sparse/missing/error output hashes, missing read count/order, forced error string) matched the untouched base on those fixtures.

Final integrated remeasure using the same command shape:

```bash
PI_CODING_AGENT_DIR=<tmp> SESSION_LOAD_WORKDIR=<tmp> SESSION_LOAD_MODE=measure SESSION_LOAD_NS=2000,5000 \
  bun packages/coding-agent/bench/session-load-context.bench.ts
```

- `blob_resolve` N=5000: median wall **31.786 ms**, CV **10.12%**, median alloc **14,779,200** bytes, median retained **19,695,736** bytes
- vs baseline common band midpoint **102.5 ms** → **3.225×**
- N=5000 invariants stable: `entry_count=5001`, `branch_len=5000`, `context_messages=5000`, `id_seq_hash=76fdec1a…`, `context_hash=d00fd2a3…` (matches selection common output hash)
- Malformed N=5000 counts: truncated_midline loaded/parsed **3502**; garbage_line **5001**; missing_header loaded **0** / parsed **5000**

These are measured medians on the author’s machine, not formal complexity bounds.

## Risks

- Positive-entry double scan: entries that do contain blob refs pay a full synchronous tree walk before the existing async walk. Dense, missing-blob, and immediate-error workloads show a modest slowdown (table above); the win is on common/sparse text-heavy sessions.
- False positives: any string that is a real `blob:sha256:…` ref triggers the full resolver even if it is not at a resolvable image site (same as today’s descent reaching that string). Non-ref substrings do not match `isBlobRef`.
- Scheduling regressions: a future rewrite that prefilters the whole list before starting any `resolvePersistedBlobRefs` would re-break the “later entry mutated during earlier get” contract covered by test 6.
- Domain: precheck uses own enumerable values (`Object.values` / array elements). That matches the production JSON session domain; exotic prototype/proxy trees are out of scope.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
