### PR TITLE
fix(mnemopi): self-heal a corrupt cached embedding model on init

### DIFF
--- a/packages/coding-agent/src/mnemopi/embed-worker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-worker.ts
@@ -9,8 +9,7 @@
  * in either process.
  */
 
-import type { StandardEmbeddingModel } from "@oh-my-pi/pi-mnemopi/core";
-import { loadFastembed } from "@oh-my-pi/pi-mnemopi/core/fastembed-runtime";
+import { defaultLocalModelInitializer, type StandardEmbeddingModel } from "@oh-my-pi/pi-mnemopi/core";
 import type { MnemopiEmbedModelId, MnemopiEmbedTransport, MnemopiEmbedWorkerInbound } from "./embed-protocol";
 
 interface LoadedModel {
@@ -25,12 +24,14 @@ let loaded: Promise<LoadedModel> | null = null;
 let loadedKey = "";
 
 async function loadModel(model: MnemopiEmbedModelId, cacheDir: string | undefined): Promise<LoadedModel> {
-	const { FlagEmbedding } = await loadFastembed();
+	// Route through mnemopi's shared initializer so the worker inherits BOTH
+	// cache heals (sidecar re-fetch AND corrupt-model quarantine/retry) —
+	// fastembed/onnxruntime still load only in this child address space, the
+	// initializer calls loadFastembed() itself.
 	// Cast: `model` arrives as a string from the parent (resolved by
-	// mnemopi's `fastembedModelName`). Cast to the non-CUSTOM overload's
-	// argument so TypeScript picks the standard-model branch — the parent
-	// only ever passes pre-vetted fast-* identifiers.
-	const instance = await FlagEmbedding.init({
+	// mnemopi's `fastembedModelName`); the parent only ever passes pre-vetted
+	// fast-* identifiers.
+	const instance = await defaultLocalModelInitializer({
 		model: model as StandardEmbeddingModel,
 		cacheDir,
 		showDownloadProgress: false,

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a corrupt cached embedding model (truncated `model_optimized.onnx`, `Protobuf parsing failed` on load) permanently disabling local embeddings: init now quarantines the broken cache file (rename to `*.corrupt-<ts>`, only when the path resolves inside the fastembed cache directory) and retries once so the model re-downloads.
+
 ## [17.0.1] - 2026-07-16
 
 ### Fixed

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -92,13 +92,14 @@ export async function quarantineCorruptModelFile(message: string, cacheDir?: str
 	return true;
 }
 
-async function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
+/** @internal exported for tests — the production seam stays {@link setLocalModelInitializer}. */
+export async function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
 	const { FlagEmbedding } = await loadFastembed();
 	try {
 		return await FlagEmbedding.init(options);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "";
-		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message))) {
+		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message, options.cacheDir))) {
 			return FlagEmbedding.init(options);
 		}
 		if (

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -92,25 +92,37 @@ export async function quarantineCorruptModelFile(message: string, cacheDir?: str
 	return true;
 }
 
-/** @internal exported for tests — the production seam stays {@link setLocalModelInitializer}. */
+const SIDECAR_ERROR_RE =
+	/(?:Config file not found at .*config|Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u;
+
+/**
+ * Shared local-model initializer: FlagEmbedding.init with BOTH cache heals.
+ * Missing sidecars (config/tokenizer/tokens map) re-fetch and retry; a
+ * corrupt model blob (Protobuf parse failure) quarantines the file and
+ * retries THROUGH the sidecar heal, so a cache that is broken in both ways
+ * still recovers in one pass. Also the initializer the embed worker uses in
+ * its subprocess; the in-process seam stays {@link setLocalModelInitializer}.
+ */
 export async function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
 	const { FlagEmbedding } = await loadFastembed();
+	const initWithSidecarHeal = async (): Promise<LocalEmbeddingModel> => {
+		try {
+			return await FlagEmbedding.init(options);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "";
+			if (!SIDECAR_ERROR_RE.test(message)) throw error;
+			if (!(await ensureFastembedModelSidecars(options.model, options.cacheDir))) throw error;
+			return FlagEmbedding.init(options);
+		}
+	};
 	try {
-		return await FlagEmbedding.init(options);
+		return await initWithSidecarHeal();
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "";
 		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message, options.cacheDir))) {
-			return FlagEmbedding.init(options);
+			return initWithSidecarHeal();
 		}
-		if (
-			!/(?:Config file not found at .*config|Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u.test(
-				message,
-			)
-		) {
-			throw error;
-		}
-		if (!(await ensureFastembedModelSidecars(options.model, options.cacheDir))) throw error;
-		return FlagEmbedding.init(options);
+		throw error;
 	}
 }
 

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -1,4 +1,6 @@
 import { mkdirSync } from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as nodePath from "node:path";
 import { type ApiKey, getOpenRouterHeaders, withAuth } from "@oh-my-pi/pi-ai";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
 import { hostMatchesUrl } from "@oh-my-pi/pi-catalog/hosts";
@@ -62,12 +64,43 @@ const queryCache = new LRUCache<string, Vector>({ max: QUERY_CACHE_MAX });
 const providerIds = new WeakMap<object, number>();
 let nextProviderId = 1;
 
+/**
+ * Quarantine the exact ONNX file named by a "Protobuf parsing failed" init
+ * error. A truncated cached model blocks local embeddings forever: the
+ * downloader treats the existing file as complete, so every init re-parses
+ * the same broken bytes. The extracted path is error-message CONTENT, so it
+ * is only honored when it resolves inside the fastembed cache directory —
+ * never rename an arbitrary file a dependency happens to mention. Atomic
+ * rename; losing a concurrent-heal race (file already renamed/removed)
+ * still returns true because a retry is safe either way.
+ * @internal exported for tests
+ */
+export async function quarantineCorruptModelFile(message: string, cacheDir?: string): Promise<boolean> {
+	const match = /Load model from (.+?\.onnx) failed:.*Protobuf parsing failed/i.exec(message);
+	if (!match) return false;
+	const modelFile = nodePath.resolve(match[1]);
+	const cacheRoot = nodePath.resolve(cacheDir ?? getFastembedCacheDir());
+	if (!modelFile.startsWith(cacheRoot + nodePath.sep)) return false;
+	try {
+		await fsp.rename(modelFile, `${modelFile}.corrupt-${Date.now()}`);
+		logger.warn("mnemopi: quarantined corrupt local embedding model; retrying init", { modelFile });
+	} catch {
+		// Concurrent heal or vanished file: the single retry stays safe. A
+		// rename that failed with the file still in place just makes the
+		// retry surface the original error again.
+	}
+	return true;
+}
+
 async function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
 	const { FlagEmbedding } = await loadFastembed();
 	try {
 		return await FlagEmbedding.init(options);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "";
+		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message))) {
+			return FlagEmbedding.init(options);
+		}
 		if (
 			!/(?:Config file not found at .*config|Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u.test(
 				message,

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -104,22 +104,24 @@ const SIDECAR_ERROR_RE =
  * its subprocess; the in-process seam stays {@link setLocalModelInitializer}.
  */
 export async function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
+	const cacheDir = options.cacheDir ?? getFastembedCacheDir();
+	const initOptions = options.cacheDir === undefined ? { ...options, cacheDir } : options;
 	const { FlagEmbedding } = await loadFastembed();
 	const initWithSidecarHeal = async (): Promise<LocalEmbeddingModel> => {
 		try {
-			return await FlagEmbedding.init(options);
+			return await FlagEmbedding.init(initOptions);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "";
 			if (!SIDECAR_ERROR_RE.test(message)) throw error;
-			if (!(await ensureFastembedModelSidecars(options.model, options.cacheDir))) throw error;
-			return FlagEmbedding.init(options);
+			if (!(await ensureFastembedModelSidecars(options.model, cacheDir))) throw error;
+			return FlagEmbedding.init(initOptions);
 		}
 	};
 	try {
 		return await initWithSidecarHeal();
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "";
-		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message, options.cacheDir))) {
+		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message, cacheDir))) {
 			return initWithSidecarHeal();
 		}
 		throw error;

--- a/packages/mnemopi/src/core/index.ts
+++ b/packages/mnemopi/src/core/index.ts
@@ -2,6 +2,7 @@ export { configureRecallFeatures, type RecallFeatureFlags } from "../config";
 export * from "./banks";
 export * from "./beam/index";
 export {
+	defaultLocalModelInitializer,
 	type LocalEmbeddingModel,
 	type LocalModelInitializer,
 	type LocalModelInitOptions,

--- a/packages/mnemopi/test/corrupt-model-quarantine.test.ts
+++ b/packages/mnemopi/test/corrupt-model-quarantine.test.ts
@@ -1,0 +1,68 @@
+// Contract: a "Protobuf parsing failed" init error quarantines EXACTLY the
+// model file named in the message (atomic rename to *.corrupt-<ts>) and
+// reports retry-safety; unrelated init errors never touch the filesystem.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { quarantineCorruptModelFile } from "../src/core/embeddings";
+
+async function tempModelFile(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-quarantine-"));
+	const file = path.join(dir, "model_optimized.onnx");
+	await fs.writeFile(file, "not a protobuf");
+	return file;
+}
+
+/** The helper only honors paths inside the given cache root. */
+function cacheRootOf(file: string): string {
+	return path.dirname(path.dirname(file));
+}
+
+describe("quarantineCorruptModelFile", () => {
+	test("renames the exact file named by a protobuf failure and allows retry", async () => {
+		const file = await tempModelFile();
+		const healed = await quarantineCorruptModelFile(
+			`Load model from ${file} failed:Protobuf parsing failed.`,
+			cacheRootOf(file),
+		);
+		expect(healed).toBe(true);
+		// Original gone, quarantined copy present.
+		await expect(fs.access(file)).rejects.toThrow();
+		const siblings = await fs.readdir(path.dirname(file));
+		expect(siblings.some(name => name.startsWith("model_optimized.onnx.corrupt-"))).toBe(true);
+		await fs.rm(path.dirname(file), { recursive: true, force: true });
+	});
+
+	test("does not treat unrelated init errors as corruption", async () => {
+		const file = await tempModelFile();
+		const healed = await quarantineCorruptModelFile(`Model file not found at ${file}`, cacheRootOf(file));
+		expect(healed).toBe(false);
+		// Untouched: no rename happened.
+		expect(await fs.access(file).then(() => true)).toBe(true);
+		await fs.rm(path.dirname(file), { recursive: true, force: true });
+	});
+
+	test("a missing file (concurrent heal) still reports retry-safe", async () => {
+		const ghost = path.join(os.tmpdir(), `mnemopi-ghost-${Date.now()}`, "model_optimized.onnx");
+		const healed = await quarantineCorruptModelFile(
+			`Load model from ${ghost} failed:Protobuf parsing failed.`,
+			path.dirname(path.dirname(ghost)),
+		);
+		expect(healed).toBe(true);
+	});
+
+	test("refuses to touch a file OUTSIDE the fastembed cache directory", async () => {
+		const file = await tempModelFile();
+		// Cache root that does NOT contain the file: containment must reject.
+		const foreignRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-foreign-"));
+		const healed = await quarantineCorruptModelFile(
+			`Load model from ${file} failed:Protobuf parsing failed.`,
+			foreignRoot,
+		);
+		expect(healed).toBe(false);
+		expect(await fs.access(file).then(() => true)).toBe(true);
+		await fs.rm(path.dirname(file), { recursive: true, force: true });
+		await fs.rm(foreignRoot, { recursive: true, force: true });
+	});
+});

--- a/packages/mnemopi/test/corrupt-model-retry.test.ts
+++ b/packages/mnemopi/test/corrupt-model-retry.test.ts
@@ -1,0 +1,71 @@
+// Contract: defaultLocalModelInitializer retries FlagEmbedding.init EXACTLY
+// once after a Protobuf-corruption failure (quarantining the cached file in
+// between), and does not loop when the retry fails too.
+import { describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { defaultLocalModelInitializer, type LocalEmbeddingModel } from "../src/core/embeddings";
+import * as runtime from "../src/core/fastembed-runtime";
+
+async function corruptCache(): Promise<{ cacheDir: string; modelFile: string }> {
+	const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-retry-"));
+	const modelDir = path.join(cacheDir, "fast-bge-small-en-v1.5");
+	await fs.mkdir(modelDir, { recursive: true });
+	const modelFile = path.join(modelDir, "model_optimized.onnx");
+	await fs.writeFile(modelFile, "garbage");
+	return { cacheDir, modelFile };
+}
+
+const fakeModel = { embed: async () => [] } as unknown as LocalEmbeddingModel;
+
+describe("defaultLocalModelInitializer corruption retry", () => {
+	test("protobuf failure quarantines the file and retries init exactly once", async () => {
+		const { cacheDir, modelFile } = await corruptCache();
+		let initCalls = 0;
+		const loadSpy = spyOn(runtime, "loadFastembed").mockResolvedValue({
+			FlagEmbedding: {
+				init: async () => {
+					initCalls++;
+					if (initCalls === 1) throw new Error(`Load model from ${modelFile} failed:Protobuf parsing failed.`);
+					return fakeModel;
+				},
+			},
+		} as never);
+		try {
+			const model = await defaultLocalModelInitializer({
+				model: "fast-bge-small-en-v1.5" as never,
+				cacheDir,
+			});
+			expect(model).toBe(fakeModel);
+			expect(initCalls).toBe(2);
+			const siblings = await fs.readdir(path.dirname(modelFile));
+			expect(siblings.some(name => name.startsWith("model_optimized.onnx.corrupt-"))).toBe(true);
+		} finally {
+			loadSpy.mockRestore();
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	test("a retry that fails again surfaces the error without looping", async () => {
+		const { cacheDir, modelFile } = await corruptCache();
+		let initCalls = 0;
+		const loadSpy = spyOn(runtime, "loadFastembed").mockResolvedValue({
+			FlagEmbedding: {
+				init: async () => {
+					initCalls++;
+					throw new Error(`Load model from ${modelFile} failed:Protobuf parsing failed.`);
+				},
+			},
+		} as never);
+		try {
+			await expect(
+				defaultLocalModelInitializer({ model: "fast-bge-small-en-v1.5" as never, cacheDir }),
+			).rejects.toThrow(/Protobuf parsing failed/);
+			expect(initCalls).toBe(2);
+		} finally {
+			loadSpy.mockRestore();
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/mnemopi/test/corrupt-model-retry.test.ts
+++ b/packages/mnemopi/test/corrupt-model-retry.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getFastembedCacheDir } from "@oh-my-pi/pi-utils";
 import { defaultLocalModelInitializer, type LocalEmbeddingModel } from "../src/core/embeddings";
 import * as runtime from "../src/core/fastembed-runtime";
 
@@ -44,6 +45,32 @@ describe("defaultLocalModelInitializer corruption retry", () => {
 		} finally {
 			loadSpy.mockRestore();
 			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	test("uses the shared default cache root when cacheDir is omitted", async () => {
+		const cacheDir = getFastembedCacheDir();
+		const modelFile = path.join(cacheDir, "missing-corrupt-model", "model_optimized.onnx");
+		const observedCacheDirs: Array<string | undefined> = [];
+		let initCalls = 0;
+		const loadSpy = spyOn(runtime, "loadFastembed").mockResolvedValue({
+			FlagEmbedding: {
+				init: async (options: { cacheDir?: string }) => {
+					observedCacheDirs.push(options.cacheDir);
+					initCalls++;
+					if (initCalls === 1) throw new Error(`Load model from ${modelFile} failed:Protobuf parsing failed.`);
+					return fakeModel;
+				},
+			},
+		} as never);
+		try {
+			const model = await defaultLocalModelInitializer({
+				model: "fast-bge-small-en-v1.5" as never,
+			});
+			expect(model).toBe(fakeModel);
+			expect(observedCacheDirs).toEqual([cacheDir, cacheDir]);
+		} finally {
+			loadSpy.mockRestore();
 		}
 	});
 


### PR DESCRIPTION
## What

- When `FlagEmbedding.init` fails with `Protobuf parsing failed`, quarantine the exact cached ONNX file named by the loader (atomic rename to `*.corrupt-<ts>`) and retry init once so the model re-downloads.
- The extracted path is error-message content: it is honored only when it resolves inside the fastembed cache directory, so an unexpected dependency message can never rename an arbitrary file.
- Contract tests for the quarantine helper: protobuf failure renames exactly the named cache file and reports retry-safe; unrelated errors touch nothing; an already-missing file (concurrent heal) stays retry-safe; a path outside the cache root is refused untouched.

## Why

Observed live (Confirmed): a truncated `model_optimized.onnx` (5.7MB, dated Jun 6; the sidecar tokenizer files kept re-downloading fresh) makes every local embedding init fail with `Load model from .../model_optimized.onnx failed:Protobuf parsing failed.` The downloader treats any existing file as complete, so the broken cache is permanent: local recall/retain silently loses its embedder on every session until someone deletes the file by hand.

The same pattern already exists in `defaultLocalModelInitializer` for missing sidecar files (config/tokenizer re-fetch + one retry); this extends it to the model blob itself.

Not claimed here: any effect on the separate event-loop stall investigation. This PR only makes a corrupt cache self-heal instead of permanently disabling local embeddings.

## Testing

- `bun test packages/mnemopi/test/corrupt-model-quarantine.test.ts` (4 pass, exit 0)
- `bun run check` at repo root (exit 0)
- The branch is a single cherry-pick onto current `main`; `packages/mnemopi/src/core/embeddings.ts` was byte-identical to `main` before the change, so the tested result transfers exactly.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (can add a `packages/mnemopi` entry on request)