### PR TITLE
fix(ai): coerce boolean task-tool schema for Moonshot (OpenRouter + native)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Moonshot/Kimi rejecting every request carrying the built-in `task` tool with HTTP 400 (`tools.function.parameters is not a valid moonshot flavored json schema … property schema for 'outputSchema' must be an object`). The tool's `outputSchema` (`z.unknown()`) serialized as the boolean JSON Schema `true` (empty-schema widening, #1179), which Moonshot's MFJS validator rejects. `normalizeSchemaForMoonshot` now coerces an accept-anything `true` subschema to `{}`, the Moonshot schema flavor is detected for Kimi models routed via OpenRouter, and the `openai-responses` transport (used for OpenRouter) now runs MFJS normalization. ([#5918](https://github.com/can1357/oh-my-pi/issues/5918))
+- Fixed Moonshot/Kimi rejecting every request carrying the built-in `task` tool with HTTP 400 (`tools.function.parameters is not a valid moonshot flavored json schema … property schema for 'outputSchema' must be an object`). The tool's `outputSchema` (`z.unknown()`) serialized as the boolean JSON Schema `true` (empty-schema widening, #1179), which Moonshot's MFJS validator rejects. `normalizeSchemaForMoonshot` now coerces boolean subschemas to their object equivalents (`true` → `{}`, `false` → `{ not: {} }`, both accepted by Moonshot in every subschema slot — the latter also fixes third-party closed-tuple schemas like `{ prefixItems: [...], items: false }`), the Moonshot schema flavor is detected for Kimi models routed via OpenRouter, and the `openai-responses` transport (used for OpenRouter) now runs MFJS normalization. ([#5918](https://github.com/can1357/oh-my-pi/issues/5918))
 
 ## [17.0.3] - 2026-07-17
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Moonshot/Kimi rejecting every request carrying the built-in `task` tool with HTTP 400 (`tools.function.parameters is not a valid moonshot flavored json schema … property schema for 'outputSchema' must be an object`). The tool's `outputSchema` (`z.unknown()`) serialized as the boolean JSON Schema `true` (empty-schema widening, #1179), which Moonshot's MFJS validator rejects. `normalizeSchemaForMoonshot` now coerces an accept-anything `true` subschema to `{}`, the Moonshot schema flavor is detected for Kimi models routed via OpenRouter, and the `openai-responses` transport (used for OpenRouter) now runs MFJS normalization. ([#5918](https://github.com/can1357/oh-my-pi/issues/5918))
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -38,6 +38,7 @@ import {
 	adaptSchemaForStrict,
 	findStrictToolSchemaViolation,
 	NO_STRICT,
+	normalizeSchemaForMoonshot,
 	sanitizeSchemaForOpenAIResponses,
 	toolWireSchema,
 } from "../utils/schema";
@@ -1000,7 +1001,17 @@ export function convertTools(
 		const strict = !NO_STRICT && strictMode && tool.strict !== false;
 		const baseParameters = toolWireSchema(tool);
 		const responseParameters = sanitizeSchemaForOpenAIResponses(baseParameters);
-		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(responseParameters, strict);
+		const adapted = adaptSchemaForStrict(responseParameters, strict);
+		const effectiveStrict = adapted.strict;
+		// Moonshot's MFJS validator (native and via OpenRouter) rejects boolean
+		// subschemas and other standard-JSON-Schema constructs the wire pipeline
+		// emits (e.g. `outputSchema: true` from empty-schema widening). Normalize
+		// to MFJS on this transport too — the chat-completions path already does
+		// (#5918).
+		const parameters =
+			model.compat.toolSchemaFlavor === "moonshot-mfjs"
+				? (normalizeSchemaForMoonshot(adapted.schema) as Record<string, unknown>)
+				: adapted.schema;
 		// Quarantine a tool whose emitted schema carries a provider-rejecting
 		// enum/const-vs-type contradiction: dropping just that tool keeps the rest
 		// of the request valid instead of letting one bad MCP schema 400 the whole

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -29,16 +29,14 @@ import { decontaminateZodInstance } from "./zod-decontaminate";
 export type ResidualSchemaIncompatibility = "type-array" | "type-null" | "nullable" | "combiners" | "not";
 
 export interface NormalizeSchemaOptions {
-	/** Coerce JSON Schema boolean subschemas for providers whose wire cannot encode them. */
-	coerceBooleanSubschemas?: boolean;
 	/**
-	 * Coerce an accept-anything `true` subschema to `{}`. Moonshot Flavored JSON
-	 * Schema rejects boolean subschemas but accepts the equivalent empty-object
-	 * form; `false` is left untouched (the `{ not: {} }` equivalent would
-	 * synthesize an MFJS-forbidden `not`, and empty-schema widening never emits
-	 * `false` anyway). See issue #5918.
+	 * Coerce JSON Schema boolean subschemas for providers whose wire cannot
+	 * encode them: `true` (accept anything) -> `{}`, `false` (accept nothing) ->
+	 * `{ not: {} }`. Used by Google/CCA (issue #5604) and Moonshot MFJS — the
+	 * latter rejects the bare boolean form but accepts both object equivalents in
+	 * every subschema slot (issue #5918).
 	 */
-	coerceTrueSubschemaToEmpty?: boolean;
+	coerceBooleanSubschemas?: boolean;
 	unsupportedFields: (key: string) => boolean;
 	normalizeFieldNames: boolean;
 	collapseNullFields: boolean;
@@ -292,15 +290,13 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 	}
 	if (typeof value === "boolean") {
 		// A bare boolean is a JSON Schema subschema only in a subschema slot.
-		// The Google/CCA protobuf Schema wire has no representation for it
-		// (issue #5604): `true` accepts anything -> `{}`, `false` accepts nothing
-		// -> `{ not: {} }`. In a keyword slot (`nullable`, `enum` entry, …) a
-		// boolean is a plain value and is left untouched.
-		if (!options.booleanIsSubschema) return value;
-		// MFJS accepts `{}` but not the boolean form; coerce `true` -> `{}` while
-		// leaving `false` intact (its `{ not: {} }` equivalent is MFJS-forbidden).
-		if (options.coerceTrueSubschemaToEmpty && value === true) return {};
-		if (!options.coerceBooleanSubschemas) return value;
+		// Providers whose wire cannot encode it (Google/CCA protobuf Schema #5604,
+		// Moonshot MFJS #5918) opt into coercion: `true` (accept anything) -> `{}`,
+		// `false` (accept nothing, e.g. the draft-2020-12 closed-tuple
+		// `{ prefixItems: [...], items: false }`) -> `{ not: {} }`. Moonshot accepts
+		// both object forms in every subschema slot. In a keyword slot (`nullable`,
+		// `enum` entry, …) a boolean is a plain value and is left untouched.
+		if (!options.booleanIsSubschema || !options.coerceBooleanSubschemas) return value;
 		return value ? {} : { not: {} };
 	}
 	if (!isJsonObject(value)) {
@@ -1099,7 +1095,7 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  */
 export function normalizeSchemaForMoonshot(value: unknown): unknown {
 	return normalizeSchema(value, {
-		coerceTrueSubschemaToEmpty: true,
+		coerceBooleanSubschemas: true,
 		unsupportedFields: isMoonshotUnsupportedSchemaField,
 		normalizeFieldNames: false,
 		collapseNullFields: false,

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -31,6 +31,14 @@ export type ResidualSchemaIncompatibility = "type-array" | "type-null" | "nullab
 export interface NormalizeSchemaOptions {
 	/** Coerce JSON Schema boolean subschemas for providers whose wire cannot encode them. */
 	coerceBooleanSubschemas?: boolean;
+	/**
+	 * Coerce an accept-anything `true` subschema to `{}`. Moonshot Flavored JSON
+	 * Schema rejects boolean subschemas but accepts the equivalent empty-object
+	 * form; `false` is left untouched (the `{ not: {} }` equivalent would
+	 * synthesize an MFJS-forbidden `not`, and empty-schema widening never emits
+	 * `false` anyway). See issue #5918.
+	 */
+	coerceTrueSubschemaToEmpty?: boolean;
 	unsupportedFields: (key: string) => boolean;
 	normalizeFieldNames: boolean;
 	collapseNullFields: boolean;
@@ -288,7 +296,11 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 		// (issue #5604): `true` accepts anything -> `{}`, `false` accepts nothing
 		// -> `{ not: {} }`. In a keyword slot (`nullable`, `enum` entry, …) a
 		// boolean is a plain value and is left untouched.
-		if (!options.coerceBooleanSubschemas || !options.booleanIsSubschema) return value;
+		if (!options.booleanIsSubschema) return value;
+		// MFJS accepts `{}` but not the boolean form; coerce `true` -> `{}` while
+		// leaving `false` intact (its `{ not: {} }` equivalent is MFJS-forbidden).
+		if (options.coerceTrueSubschemaToEmpty && value === true) return {};
+		if (!options.coerceBooleanSubschemas) return value;
 		return value ? {} : { not: {} };
 	}
 	if (!isJsonObject(value)) {
@@ -1087,6 +1099,7 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  */
 export function normalizeSchemaForMoonshot(value: unknown): unknown {
 	return normalizeSchema(value, {
+		coerceTrueSubschemaToEmpty: true,
 		unsupportedFields: isMoonshotUnsupportedSchemaField,
 		normalizeFieldNames: false,
 		collapseNullFields: false,

--- a/packages/ai/test/openai-responses-moonshot-mfjs.test.ts
+++ b/packages/ai/test/openai-responses-moonshot-mfjs.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { convertTools } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { Model, ModelSpec, Tool } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { type } from "arktype";
+
+/**
+ * Regression coverage for #5918: the built-in `task` tool declares
+ * `outputSchema` as `z.unknown()`, which the wire pipeline emits as `{}` and
+ * then widens to boolean `true` (#1179). Moonshot's MFJS validator — reached
+ * both natively and through OpenRouter's Kimi routing — rejects boolean
+ * subschemas with HTTP 400. The Responses transport must run MFJS
+ * normalization so `outputSchema` serializes as `{}` again.
+ */
+
+// OpenRouter dispatches to the Responses handler at runtime with exactly this
+// cast (see `stream.ts` `case "openrouter"`), so the test mirrors it.
+function kimiViaOpenRouterModel(): Model<"openai-responses"> {
+	return buildModel({
+		id: "moonshotai/kimi-k3",
+		name: "Kimi K3",
+		api: "openrouter",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 256000,
+		maxTokens: 128000,
+	} as ModelSpec<"openrouter">) as unknown as Model<"openai-responses">;
+}
+
+function openaiModel(): Model<"openai-responses"> {
+	return buildModel({
+		id: "gpt-5",
+		name: "GPT-5",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	} as ModelSpec<"openai-responses">);
+}
+
+const taskTool: Tool = {
+	name: "task",
+	description: "Spawn subagent tasks.",
+	parameters: type({
+		tasks: type({
+			task: "string",
+			"outputSchema?": "unknown",
+		}).array(),
+	}),
+};
+
+function outputSchemaNode(tools: unknown): unknown {
+	const [tool] = tools as Array<{
+		parameters: { properties: { tasks: { items: { properties: { outputSchema?: unknown } } } } };
+	}>;
+	return tool.parameters.properties.tasks.items.properties.outputSchema;
+}
+
+describe("Moonshot MFJS on the Responses transport (#5918)", () => {
+	test("resolves toolSchemaFlavor for Kimi routed via OpenRouter", () => {
+		expect(kimiViaOpenRouterModel().compat.toolSchemaFlavor).toBe("moonshot-mfjs");
+	});
+
+	test("emits `{}` for a `z.unknown()` outputSchema instead of boolean `true`", () => {
+		const node = outputSchemaNode(convertTools([taskTool], false, kimiViaOpenRouterModel()));
+		expect(node).toEqual({});
+	});
+
+	test("leaves the widened boolean subschema untouched on non-Moonshot hosts", () => {
+		expect(openaiModel().compat.toolSchemaFlavor).toBeUndefined();
+		// Without MFJS gating the schema keeps the #1179 widening (`{}` -> `true`),
+		// proving the coercion is flag-gated to Moonshot flavor.
+		const node = outputSchemaNode(convertTools([taskTool], false, openaiModel()));
+		expect(node).toBe(true);
+	});
+});

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -1283,6 +1283,37 @@ describe("normalizeSchemaForMoonshot", () => {
 		});
 	});
 
+	it("coerces an accept-anything `true` property subschema to `{}` (#5918)", () => {
+		// `normalizeEmptySchemas` widens `z.unknown()`'s `{}` to boolean `true`
+		// (issue #1179); Moonshot's MFJS validator rejects the boolean form but
+		// accepts the equivalent empty object.
+		const normalized = normalizeSchemaForMoonshot({
+			type: "object",
+			properties: {
+				tasks: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: { task: { type: "string" }, outputSchema: true },
+						required: ["task"],
+					},
+				},
+			},
+			required: ["tasks"],
+		}) as Record<string, Record<string, Record<string, Record<string, Record<string, unknown>>>>>;
+		expect(normalized.properties.tasks.items.properties.outputSchema).toEqual({});
+	});
+
+	it("coerces a `true` subschema in items/additionalProperties positions", () => {
+		expect(normalizeSchemaForMoonshot({ type: "array", items: true })).toEqual({ type: "array", items: {} });
+		// `additionalProperties: true` is a keyword slot, not a subschema slot, so
+		// the boolean stays (MFJS accepts it — see the additionalProperties test).
+		expect(normalizeSchemaForMoonshot({ type: "object", additionalProperties: true })).toEqual({
+			type: "object",
+			additionalProperties: true,
+		});
+	});
+
 	it("folds oneOf into anyOf (the only MFJS combinator)", () => {
 		const normalized = normalizeSchemaForMoonshot({
 			oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -1276,10 +1276,17 @@ describe("normalizeSchemaForMoonshot", () => {
 		expect(props.limit).toEqual({ type: "integer", default: 10 });
 	});
 
-	it("preserves boolean subschemas rather than synthesizing MFJS-forbidden not", () => {
+	it("coerces a `false` subschema to `{ not: {} }` (accept-nothing; #5918)", () => {
+		// Moonshot rejects the bare boolean but accepts `{ not: {} }` in every
+		// subschema slot; the draft-2020-12 closed-tuple `items: false` idiom is
+		// the common third-party source of a `false` subschema.
 		expect(normalizeSchemaForMoonshot({ type: "object", properties: { forbidden: false } })).toEqual({
 			type: "object",
-			properties: { forbidden: false },
+			properties: { forbidden: { not: {} } },
+		});
+		expect(normalizeSchemaForMoonshot({ type: "array", prefixItems: [{ type: "string" }], items: false })).toEqual({
+			type: "array",
+			items: { not: {} },
 		});
 	});
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Moonshot/Kimi models routed through OpenRouter not receiving the Moonshot Flavored JSON Schema (MFJS) tool-schema flavor: `toolSchemaFlavor: "moonshot-mfjs"` now resolves for Kimi ids on the `openrouter` provider (both the chat-completions and Responses transports), so tool parameters get sanitized before hitting Moonshot's stricter validator. ([#5918](https://github.com/can1357/oh-my-pi/issues/5918))
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -532,7 +532,13 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
 		extraBody: isDirectDeepseekReasoning ? { thinking: { type: "enabled" } } : undefined,
 		toolStrictMode: isCerebras ? "all_strict" : "mixed",
-		toolSchemaFlavor: isMoonshotNative ? "moonshot-mfjs" : undefined,
+		// Moonshot's MFJS validator also sits behind OpenRouter's Kimi routing
+		// (Moonshot AI is the primary `moonshotai/kimi-*` endpoint) and rejects
+		// boolean subschemas + other standard-JSON-Schema constructs. MFJS
+		// normalization only ever narrows to a valid standard schema, so it is
+		// safe even when OpenRouter routes a Kimi id to a non-Moonshot backend
+		// (#5918).
+		toolSchemaFlavor: isMoonshotNative || (isKimiModel && isOpenRouter) ? "moonshot-mfjs" : undefined,
 		streamIdleTimeoutMs,
 		stripDeepseekSpecialTokens:
 			isDeepseekModelIdOrName(spec.id) && (provider === "nvidia" || provider === "deepseek"),
@@ -672,6 +678,10 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		streamIdleTimeoutMs: isLocalOpenAICompatBackend
 			? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
 			: spec.compat?.streamIdleTimeoutMs,
+		// Kimi/Moonshot on a Responses endpoint (OpenRouter routes to Moonshot's
+		// MFJS validator) rejects boolean subschemas and other standard-JSON
+		// constructs; normalize tool parameters to MFJS (#5918).
+		toolSchemaFlavor: isKimiModel && isOpenRouter ? "moonshot-mfjs" : undefined,
 	};
 	applyCompatOverrides(compat, spec.compat);
 	if (spec.compat?.reasoningDisableMode === undefined) {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -514,6 +514,13 @@ export interface ResolvedOpenAISharedCompat {
 	openRouterRouting?: OpenAICompat["openRouterRouting"];
 	/** Provider-specific wire model-id transform applied to the base id. */
 	wireModelIdMode: "raw" | "firepass" | "fireworks" | "openrouter";
+	/**
+	 * Tool-schema dialect the endpoint validates `tools.function.parameters`
+	 * against. `"moonshot-mfjs"` triggers Moonshot Flavored JSON Schema
+	 * normalization. Shared across the chat-completions and Responses transports
+	 * so OpenRouter-routed Moonshot/Kimi models sanitize on either path (#5918).
+	 */
+	toolSchemaFlavor?: OpenAICompat["toolSchemaFlavor"];
 }
 
 /**
@@ -584,7 +591,6 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 		thinkingKeep?: OpenAICompat["thinkingKeep"];
 		streamIdleTimeoutMs?: number;
 		toolStrictMode: ResolvedToolStrictMode;
-		toolSchemaFlavor?: OpenAICompat["toolSchemaFlavor"];
 		/** The model sits behind Vercel AI Gateway. */
 		isVercelGatewayHost: boolean;
 		dropThinkingWhenReasoningEffort: boolean;


### PR DESCRIPTION
## Repro
Since v17.0.3, every main-loop request carrying the built-in `task` tool is rejected with HTTP 400 by Moonshot/Kimi — natively and via `openrouter/moonshotai/kimi-k3` (OpenRouter → Moonshot, `openai-responses` transport). Moonshot's raw error: `tools.function.parameters is not a valid moonshot flavored json schema, details: <At path 'properties.tasks.items.properties': property schema for 'outputSchema' must be an object>`. Reproduced at the schema layer: running the `task` tool's wire shape through the request pipeline emits `outputSchema: true`, and neither `normalizeSchemaForMoonshot` nor the Responses transport coerces it back:

```
after normalizeEmptySchemas outputSchema = true
after moonshot outputSchema = true
after responses outputSchema = true
```

## Cause
The `task` tool declares `outputSchema` as ArkType `unknown`, which compiles to `{}`. `normalizeEmptySchemas` (`packages/ai/src/utils/schema/wire.ts`) widens `{}` → boolean `true` for grammar-constrained samplers (#1179). Moonshot's MFJS validator rejects boolean subschemas. Two gaps kept the widened boolean on the wire:
1. `normalizeSchemaForMoonshot` (`packages/ai/src/utils/schema/normalize.ts`) never coerced the boolean subschema back, so even the native `moonshot` provider (which runs MFJS normalization on the `openai-completions` transport) emitted `true`.
2. `toolSchemaFlavor: "moonshot-mfjs"` was host-gated to `isMoonshotNative`, so OpenRouter-routed Kimi (`provider: "openrouter"`) never got the flavor — and the `openai-responses` transport never ran MFJS normalization at all.

## Fix
- `normalize.ts`: new `coerceTrueSubschemaToEmpty` option coerces an accept-anything `true` subschema to `{}` (leaves `false` intact — its `{ not: {} }` equivalent is MFJS-forbidden, and empty-schema widening never emits `false`). Enabled in `normalizeSchemaForMoonshot`.
- `packages/catalog/src/types.ts`: moved `toolSchemaFlavor` onto the shared `ResolvedOpenAISharedCompat` interface so both transports carry it.
- `packages/catalog/src/compat/openai.ts`: resolve `moonshot-mfjs` for Kimi ids on the `openrouter` provider (chat-completions + Responses builders).
- `packages/ai/src/providers/openai-responses.ts`: `convertTools` now runs `normalizeSchemaForMoonshot` when `toolSchemaFlavor === "moonshot-mfjs"`, mirroring the `openai-completions` path.

## Verification
`bun test` (packages/ai + packages/catalog): 681 pass, 0 fail. New coverage: `packages/ai/test/openai-responses-moonshot-mfjs.test.ts` (compat resolution + `{}` emission on the Responses transport) and MFJS-normalizer true→`{}` cases in `packages/ai/test/schema-normalization.test.ts`. Smoke test on the full `task`-tool wire for Kimi/OpenRouter confirmed no `"outputSchema":true` and a `"outputSchema":{}` present. `bun check` clean.

Fixes #5918