### PR TITLE
perf(session): gate blob-ref resolution behind synchronous precheck

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Session load now skips the recursive async blob-ref resolver for entries with no `blob:sha256:` references. A cheap synchronous precheck gates the walk per entry (preserving the previous per-entry initiation order under synchronous store mutation), so text-heavy histories no longer pay the `Promise.all` tree descent for every non-session entry ([#5922](https://github.com/can1357/oh-my-pi/issues/5922)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -271,10 +271,38 @@ async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, ke
 	);
 }
 
+/**
+ * Cheap synchronous precheck: does this value's tree contain any `blob:sha256:` string?
+ * Early-exits on the first hit and allocates no promises, so blob-free entries skip the
+ * async {@link resolvePersistedBlobRefs} descent entirely. Conservative — a blob ref in a
+ * non-resolved position still returns true, which only costs an extra (no-op) walk.
+ */
+function containsBlobRef(value: unknown): boolean {
+	if (typeof value === "string") return isBlobRef(value);
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			if (containsBlobRef(item)) return true;
+		}
+		return false;
+	}
+	if (typeof value !== "object" || value === null) return false;
+	for (const key in value) {
+		if (containsBlobRef((value as Record<string, unknown>)[key])) return true;
+	}
+	return false;
+}
+
 export async function resolveBlobRefsInEntries(entries: FileEntry[], blobStore: BlobStore): Promise<void> {
-	await Promise.all(
-		entries.filter(entry => entry.type !== "session").map(entry => resolvePersistedBlobRefs(entry, blobStore)),
-	);
+	const pending: Promise<void>[] = [];
+	// Interleave precheck + initiation per entry so a positive entry begins resolution at the same
+	// relative point as the old filter+map schedule (no scan-all-first pass that could observe a
+	// later entry before an earlier resolution mutates it).
+	for (const entry of entries) {
+		if (entry.type === "session") continue;
+		if (!containsBlobRef(entry)) continue;
+		pending.push(resolvePersistedBlobRefs(entry, blobStore));
+	}
+	await Promise.all(pending);
 }
 
 /**

--- a/packages/coding-agent/test/session-persistence-images.test.ts
+++ b/packages/coding-agent/test/session-persistence-images.test.ts
@@ -125,4 +125,46 @@ describe("session image persistence", () => {
 		expect(resolvedImage?.data).toBe(data);
 		expect(resolvedItem?.result).toBe(data);
 	});
+
+	it("skips the async resolver for entries without blob refs while still resolving blob-ref entries", async () => {
+		using tempDir = TempDir.createSync("@session-blob-precheck-");
+		const blobStore = new BlobStore(tempDir.path());
+		let getCalls = 0;
+		const origGet = blobStore.get.bind(blobStore);
+		blobStore.get = async (hash: string) => {
+			getCalls++;
+			return origGet(hash);
+		};
+
+		const imageData = Buffer.alloc(1500, 7).toString("base64");
+		const withImage = messageEntry({
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [png(imageData)],
+			isError: false,
+			timestamp: 0,
+		} as unknown as ToolResultMessage);
+		const persistedWithImage = prepareEntryForPersistence(withImage, blobStore);
+
+		const textOnly: FileEntry[] = Array.from({ length: 50 }, (_, i) => ({
+			type: "message",
+			id: `text-${i}`,
+			parentId: i === 0 ? null : `text-${i - 1}`,
+			timestamp: new Date(0).toISOString(),
+			message: { role: "user", content: [text(`plain body ${i}`)], timestamp: 0 },
+		})) as unknown as FileEntry[];
+
+		const loaded: FileEntry[] = [
+			...textOnly.map(entry => structuredClone(entry)),
+			structuredClone(persistedWithImage),
+		];
+		await resolveBlobRefsInEntries(loaded, blobStore);
+
+		// The blob-ref entry resolves through BlobStore.get exactly once; the 50 text entries never touch it.
+		expect(getCalls).toBe(1);
+		const resolved = loaded[loaded.length - 1] as ToolResultEntry;
+		const resolvedImage = resolved.message.content.find((block): block is ImageContent => block.type === "image");
+		expect(resolvedImage?.data).toBe(imageData);
+	});
 });


### PR DESCRIPTION
## Repro
Opening a long, text-heavy session runs `resolveBlobRefsInEntries` after JSONL parse/migration. Every non-`session` entry was handed to the recursive async `resolvePersistedBlobRefs` walk, which builds `Promise.all` over arrays and object children even when the entry is plain text with no `blob:sha256:…` strings. A microbench over N=5000 blob-free `message` entries records `BlobStore.get` calls=0 yet a `blob_resolve` median of **19.5 ms** — pure async-descent overhead on entries that never touch `BlobStore`.

## Cause
`packages/coding-agent/src/session/session-loader.ts`: `resolveBlobRefsInEntries` did `entries.filter(e => e.type !== "session").map(e => resolvePersistedBlobRefs(e, blobStore))`. `resolvePersistedBlobRefs` always descends arrays/objects and only resolves at known image payload / `image_generation_call.result` / `image_url` sites via `isBlobRef` (a `startsWith("blob:sha256:")` check in `blob-store.ts`). There was no entry-level gate before the async walk started, so blob-free entries paid the full promise-allocating descent.

## Fix
- Add `containsBlobRef`: a cheap synchronous tree scan that early-exits on the first `blob:sha256:` string and allocates no promises (uses `for...in` per the repo's object-iteration rule).
- Rewrite `resolveBlobRefsInEntries` to interleave the precheck with per-entry initiation: skip `type === "session"`, skip entries the precheck rejects, and push the resolver promise for positive entries. Positive entries begin resolution at the same relative point as the old `filter`+`map` schedule — no scan-all-first pass that could reject a later entry before an earlier `BlobStore.get` mutation adds a ref.
- Add a regression test in `session-persistence-images.test.ts` asserting 50 text-only entries drive zero `BlobStore.get` calls while a blob-ref tool-result entry still resolves (`getCalls === 1`, image data restored).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/session-persistence-images.test.ts test/session-loader-stream.test.ts` → 7 pass / 0 fail (301 expect calls). Repro microbench after the fix: blob-free N=5000 `blob_resolve` median **19.5 ms → 1.1 ms** (~17x), `BlobStore.get` calls still 0; existing blob-ref persist/resolve parity tests unchanged. Prechecked dense/positive entries pay a small extra scan before the (unchanged) resolver runs. Fixes #5922