### PR TITLE
perf(tui): scope ordinary keystroke repaints to the focused subtree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced long-session input latency by restricting quiet keystroke renders to the focused subtree while explicitly repainting sibling queue state. ([#5928](https://github.com/can1357/oh-my-pi/issues/5928))
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -746,6 +746,7 @@ export class UiHelpers {
 			const hintText = theme.fg("dim", `  ${theme.tree.hook} ${dequeueKey} to edit`);
 			this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
+		this.ctx.ui.requestComponentRender(this.ctx.pendingMessagesContainer);
 	}
 
 	queueCompactionMessage(text: string, mode: "steer" | "followUp", images?: ImageContent[]): void {

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -651,11 +651,12 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 	};
 	const pendingMessagesContainer = new Container();
 	const requestRender = vi.fn();
+	const requestComponentRender = vi.fn();
 	const updatePendingMessagesDisplay = vi.fn();
 
 	const ctx = {
 		editor,
-		ui: { requestRender },
+		ui: { requestRender, requestComponentRender },
 		pendingMessagesContainer,
 		session,
 		viewSession: session,
@@ -667,7 +668,7 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 		locallySubmittedUserSignatures: new Set<string>(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, pendingMessagesContainer };
+	return { ctx, editor, pendingMessagesContainer, requestComponentRender };
 }
 
 describe("UiHelpers / InputController against derived queued custom display", () => {
@@ -702,6 +703,26 @@ describe("UiHelpers / InputController against derived queued custom display", ()
 		expect(rendered).toContain("Steering · 1");
 		expect(rendered).toContain("1. /skill:test-skill arg1 arg2");
 		expect(rendered).not.toContain("Steer:");
+	});
+
+	it("requests the pending-container repaint after rebuilding and clearing it", async () => {
+		fixture = await createRealSession();
+		const { session } = fixture;
+		queueCustomSteer(session, "/skill:test-skill arg1 arg2");
+
+		const { ctx, pendingMessagesContainer, requestComponentRender } =
+			createStubInteractiveModeContextForUiHelpers(session);
+		const uiHelpers = new UiHelpers(ctx);
+		uiHelpers.updatePendingMessagesDisplay();
+
+		expect(pendingMessagesContainer.children.length).toBeGreaterThan(0);
+		expect(requestComponentRender).toHaveBeenNthCalledWith(1, pendingMessagesContainer);
+
+		session.clearQueue();
+		uiHelpers.updatePendingMessagesDisplay();
+
+		expect(pendingMessagesContainer.children).toHaveLength(0);
+		expect(requestComponentRender).toHaveBeenNthCalledWith(2, pendingMessagesContainer);
 	});
 
 	it("groups yield follow-ups under one heading", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Scoped quiet keystroke renders to the focused subtree instead of recomposing unrelated root components. ([#5928](https://github.com/can1357/oh-my-pi/issues/5928))
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2368,15 +2368,23 @@ export class TUI extends Container {
 			}
 		}
 
-		// Pass input to focused component (including Ctrl+C)
-		// The focused component can decide how to handle Ctrl+C
-		if (this.#focusedComponent?.handleInput) {
+		// Pass input to focused component (including Ctrl+C).
+		// The focused component can decide how to handle Ctrl+C.
+		// Ordinary keystrokes only dirty the focused subtree; handleInput may
+		// move focus (submit opening a selector) and the new surface is not in
+		// #componentRenderTargets, so fall back to a full frame then.
+		const focused = this.#focusedComponent;
+		if (focused?.handleInput) {
 			// Filter out key release events unless component opts in
-			if (isKeyRelease(data) && !this.#focusedComponent.wantsKeyRelease) {
+			if (isKeyRelease(data) && !focused.wantsKeyRelease) {
 				return;
 			}
-			this.#focusedComponent.handleInput(data);
-			this.requestRender();
+			focused.handleInput(data);
+			if (this.#focusedComponent === focused) {
+				this.requestComponentRender(focused);
+			} else {
+				this.requestRender();
+			}
 		}
 	}
 

--- a/packages/tui/test/component-render.test.ts
+++ b/packages/tui/test/component-render.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "bun:test";
 import {
 	type Component,
 	Container,
+	Editor,
+	type Focusable,
 	type NativeScrollbackCommittedRows,
 	type NativeScrollbackLiveRegion,
 	type NativeScrollbackReplay,
 	TUI,
 } from "@oh-my-pi/pi-tui";
 import { StressRenderScheduler } from "./render-stress-scheduler";
+import { defaultEditorTheme } from "./test-themes";
 import { VirtualTerminal } from "./virtual-terminal";
 
 // Behavioral tests for TUI.requestComponentRender: a component whose own
@@ -332,6 +335,166 @@ describe("TUI.requestComponentRender", () => {
 			expect(duplicated).toEqual([]);
 			const observed = Array.from(buffer.matchAll(/ROW-\d{3}/g), match => match[0]);
 			expect(observed).toEqual(markers);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+});
+
+describe("TUI keystroke-scoped render", () => {
+	it("does not re-render a quiet sibling transcript while typing in the focused editor", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1", "msg-2"]);
+		const editor = new Editor(defaultEditorTheme);
+		tui.addChild(transcript);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			const transcriptRenders = transcript.renders;
+
+			term.sendInput("x");
+			await scheduler.drain(term);
+
+			expect(editor.getText()).toBe("x");
+			expect(transcript.renders).toBe(transcriptRenders);
+			expect(visible(term).some(row => row.includes("msg-0"))).toBe(true);
+			expect(visible(term).some(row => row.includes("x"))).toBe(true);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("paints a sibling component render requested from the keystroke's own frame", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1"]);
+		// App wiring: typing in the editor rebuilds the pending-queue surface
+		// (UiHelpers.updatePendingMessagesDisplay) and asks for a component-scoped
+		// repaint of that sibling from inside onChange — the same frame the
+		// keystroke scopes to the editor. The sibling paint must land, not be
+		// silently dropped by the keystroke-scoped path.
+		const pending = new CountingLines(["pending:0"]);
+		const editor = new Editor(defaultEditorTheme);
+		editor.onChange = text => {
+			pending.set([`pending:${text.length}`]);
+			tui.requestComponentRender(pending);
+		};
+		tui.addChild(transcript);
+		tui.addChild(pending);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			expect(visible(term).some(row => row.includes("pending:0"))).toBe(true);
+			const transcriptRenders = transcript.renders;
+			const pendingRenders = pending.renders;
+
+			term.sendInput("x");
+			await scheduler.drain(term);
+
+			expect(editor.getText()).toBe("x");
+			// Not dropped: the sibling's new rows replaced its stale ones.
+			expect(visible(term).some(row => row.includes("pending:1"))).toBe(true);
+			expect(visible(term).some(row => row.includes("pending:0"))).toBe(false);
+			expect(pending.renders).toBeGreaterThan(pendingRenders);
+			// Still scoped: the quiet transcript was not recomposed.
+			expect(transcript.renders).toBe(transcriptRenders);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("keeps a correct viewport when a keystroke grows the editor by one wrapped row", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1"]);
+		const editor = new Editor(defaultEditorTheme);
+		// 34 chars fills the first content row at width 40; the next char wraps.
+		editor.setText("x".repeat(34));
+		tui.addChild(transcript);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			// Software cursor glyph is theme.symbols.inputCursor ("|"); assert the
+			// full viewport including transcript, border, and wrap seam.
+			expect(visible(term)).toEqual([
+				"msg-0",
+				"msg-1",
+				"+--------------------------------------+",
+				"+- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|-+",
+			]);
+			const transcriptRenders = transcript.renders;
+
+			term.sendInput("y");
+			await scheduler.drain(term);
+
+			expect(editor.getText()).toBe(`${"x".repeat(34)}y`);
+			expect(transcript.renders).toBe(transcriptRenders);
+			expect(visible(term)).toEqual([
+				"msg-0",
+				"msg-1",
+				"+--------------------------------------+",
+				"|  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  |",
+				"+- y|                                 -+",
+			]);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("falls back to a full compose when handleInput moves focus", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0"]);
+		const nextFocus = new CountingLines(["selector"]);
+		const focusMover: Component & Focusable = {
+			focused: false,
+			invalidate() {},
+			render() {
+				return this.focused ? ["editor-focused"] : ["editor-idle"];
+			},
+			handleInput() {
+				// Focus moves during input (submit opens a selector). The new
+				// surface is not in #componentRenderTargets, so the frame must
+				// compose fully and paint both the old and new roots.
+				tui.setFocus(nextFocus);
+			},
+		};
+
+		tui.addChild(transcript);
+		tui.addChild(focusMover);
+		tui.addChild(nextFocus);
+		tui.setFocus(focusMover);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual(["msg-0", "editor-focused", "selector"]);
+			const transcriptRenders = transcript.renders;
+
+			term.sendInput("x");
+			await scheduler.drain(term);
+
+			expect(transcript.renders).toBeGreaterThan(transcriptRenders);
+			expect(visible(term)).toEqual(["msg-0", "editor-idle", "selector"]);
+			expect(tui.getFocused()).toBe(nextFocus);
 		} finally {
 			tui.stop();
 			await term.flush();


### PR DESCRIPTION
## What

Ordinary keystrokes now request a component-scoped repaint of the focused subtree instead of an unconditional full root compose. When `handleInput` moves focus, the path still falls back to a full frame. Coding-agent pending-message / skill-queue updates explicitly request a component-scoped repaint of `pendingMessagesContainer` so sibling queue state still paints under the quieter keystroke path.

## Why

`TUI.#handleInput` previously always called `this.requestRender()` after dispatching to the focused component. That forced a full UI composition on every character, including re-render of quiet transcript siblings that did not change. In long sessions this makes typing cost follow transcript depth instead of editor work.

Fixes #5928

### Exact mechanism & invariants

1. **`packages/tui/src/tui.ts` — `#handleInput`**
   - Capture `const focused = this.#focusedComponent` before dispatch.
   - Call `focused.handleInput(data)` (key-release filter unchanged).
   - If focus is still the same component after dispatch: `this.requestComponentRender(focused)` (dirty only that subtree via the existing partial-compose path).
   - If focus changed during `handleInput` (e.g. submit opens a selector): `this.requestRender()` full-frame fallback, because the new surface is not in `#componentRenderTargets`.
   - Existing partial-compose safety gates (overlay up, root child list changed, component not in tree, etc.) are unchanged; this PR only chooses when keystrokes enter the component-scoped path vs full compose.

2. **`packages/coding-agent/src/modes/utils/ui-helpers.ts` — `UiHelpers.updatePendingMessagesDisplay`**
   - After rebuilding or clearing `this.ctx.pendingMessagesContainer` children, call  
     `this.ctx.ui.requestComponentRender(this.ctx.pendingMessagesContainer)`.
   - Needed because a focused-editor scoped keystroke frame will not automatically repaint this sibling when the skill/pending queue changes.

### Invariants

- Quiet printable typing with stable focus must not re-render a quiet transcript sibling.
- Editor growth that wraps an extra row still keeps a correct viewport under scoped compose.
- Focus-moving `handleInput` still fully composes so old and new roots paint.
- Pending-message container rebuild/clear requests an explicit component-scoped repaint of that container.

## Testing

**Behavioral (this PR):**

- `packages/tui/test/component-render.test.ts` — suite `TUI keystroke-scoped render`:
  - `does not re-render a quiet sibling transcript while typing in the focused editor`
  - `keeps a correct viewport when a keystroke grows the editor by one wrapped row`
  - `falls back to a full compose when handleInput moves focus`
- `packages/coding-agent/test/input-controller-skill-queue.test.ts` — suite `UiHelpers / InputController against derived queued custom display`:
  - `requests the pending-container repaint after rebuilding and clearing it`

```bash
bun test packages/tui/test/component-render.test.ts
bun test packages/coding-agent/test/input-controller-skill-queue.test.ts
bun run packages/tui/bench/keystroke-frame.bench.ts
```

**Measured keystroke-frame (author machine, permanent bench after the measurement PR):**

- Before: `keystroke_frame_ms` median `0.0747` stddev `0.0069`; transcript renders/key `1.00`
- After: `keystroke_frame_ms` median `0.0757` stddev `0.0050`; transcript renders/key mean `0` max `0`

Primary acceptance is quiet transcript siblings (`renders/key` mean and max `0`). Frame median stayed in the same sub-millisecond band; it is not claimed as a large wall-clock speedup. Numbers are empirical local measurements, not formal asymptotic guarantees.

### Risks

- Side-effecting siblings that mutate outside the focused subtree still need their own explicit `requestComponentRender` (or a full `requestRender`). This PR adds the pending-message container paint on the coding-agent queue path; other app surfaces that previously rode the unconditional full keystroke compose may still go silent if they update without requesting a paint.
- Overlay / root-structure / out-of-tree cases continue to rely on the existing partial-compose safety fallbacks; regressions there would show up as missing paints or forced full frames, not as a new code path invented here.
- Absolute hard fails on the keystroke-frame bench (`median < 5ms`, mean/max transcript renders/key exactly `0`, robust noise gate) belong with the permanent benches from the measurement PR and should only be asserted once that infrastructure is present.

> **Note:** the `keystroke-frame` benchmark referenced above ships in the measurement-infrastructure PR #5920; this branch contains only the production change and its tests. Separately, `packages/tui/test/component-render.test.ts` has one pre-existing failure on `main` (`rehydrates virtualized roots before a destructive full paint`) that is unrelated to this change and is fixed by the transcript prefix-compaction PR; this PR's added keystroke-scoped render tests pass.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
