### PR TITLE
perf(coding-agent): seal finalized assistant blocks so transcript prefix compaction advances

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fixed `task` tool schemas emitting boolean subschemas that llama.cpp grammar generation cannot parse ([#5957](https://github.com/can1357/oh-my-pi/issues/5957)).
 - Fixed the transcript keeping finalized assistant blocks in the live compose walk after their rows entered native terminal scrollback, making each stream tick's `TranscriptContainer.render` depth-linear in session length. Fully committed finalized blocks are now compacted out of the local frame regardless of post-finalize version tracking; a later mutation no longer recommits on ordinary frames (no duplication) and rehydrates on the next destructive full replay (no loss). Compose cost for a live tail tick is now flat as depth grows (`bench/transcript-compose.bench.ts`: ratio(N5000/N500) 2.30 → 0.90) ([#5930](https://github.com/can1357/oh-my-pi/issues/5930)).
 - Fixed `/quit` and `/exit` hanging during interactive shutdown by making the mnemopi dispose path retain the current session and flush in-flight extractions without sleeping the bank; the `/memory enqueue` path and end-of-session backend enqueue still perform full cross-session consolidation. ([#3641](https://github.com/can1357/oh-my-pi/issues/3641))
+### Changed
+
+- Kept transcript composition cost flat as sessions grow by compacting sealed assistant blocks and safely rebasing native scrollback. ([#5930](https://github.com/can1357/oh-my-pi/issues/5930))
 
 ## [17.0.3] - 2026-07-17
 

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -176,6 +176,7 @@ export class AssistantMessageComponent extends Container {
 	#showImages = true;
 	#kittyConversionsInFlight = new Set<string>();
 	#transcriptBlockFinalized: boolean;
+	#sealed = false;
 	/**
 	 * True while any rendered item carries a ` ```mermaid ` fence. Mermaid's
 	 * ASCII form resolves asynchronously and can re-layout rows that already
@@ -405,6 +406,19 @@ export class AssistantMessageComponent extends Container {
 
 	isTranscriptBlockFinalized(): boolean {
 		return this.#transcriptBlockFinalized;
+	}
+
+	/**
+	 * Declare this finalized block eligible for transcript prefix compaction.
+	 * Updates after sealing remain visible for one composed frame before
+	 * compaction; mutations after its rows enter native scrollback are invisible.
+	 */
+	sealTranscriptBlock(): void {
+		this.#sealed = true;
+	}
+
+	isTranscriptBlockSealed(): boolean {
+		return this.#sealed;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -478,6 +478,19 @@ export class AssistantMessageComponent extends Container {
 		}
 	}
 
+	/**
+	 * Re-open a rebuilt historical assistant as the live streaming target.
+	 * Historical construction finalizes the block (`message !== undefined`); a
+	 * mid-turn focus attach that reuses the same component must clear that
+	 * flag so {@link isTranscriptBlockFinalized} keeps the transcript live
+	 * region pinned here until {@link markTranscriptBlockFinalized} runs at
+	 * message_end. Does not unseal — seal remains a separate post-finalize
+	 * compaction signal.
+	 */
+	markTranscriptBlockLive(): void {
+		this.#transcriptBlockFinalized = false;
+	}
+
 	applyRetryRecovery(retryRecovery: AssistantMessage["retryRecovery"]): void {
 		if (!this.#lastMessage || !retryRecovery) return;
 		this.setErrorPinned(false);

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -418,6 +418,24 @@ export class TranscriptContainer
 		return rows.length > maxRows ? rows.slice(rows.length - maxRows) : rows;
 	}
 
+	/**
+	 * Render the complete session-owned transcript for out-of-band exporters.
+	 * Unlike {@link render}, this includes children whose rows were virtualized
+	 * into native scrollback and touches none of the container's compose, commit,
+	 * replay, stability, or pending-drop bookkeeping.
+	 */
+	renderFullHistory(width: number): readonly string[] {
+		width = Math.max(1, width);
+		const rows: string[] = [];
+		for (const child of this.children) {
+			const contribution = stripPlainBlankEdges(child.render(width));
+			if (contribution.length === 0) continue;
+			if (rows.length > 0 && !isPlainBlank(rows.at(-1) ?? "")) rows.push("");
+			for (const row of contribution) rows.push(row);
+		}
+		return rows;
+	}
+
 	override render(width: number): readonly string[] {
 		width = Math.max(1, width);
 		this.#nativeScrollbackLiveRegionStart = undefined;

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -4,6 +4,7 @@ import {
 	type NativeScrollbackCommittedRows,
 	type NativeScrollbackLiveRegion,
 	type NativeScrollbackReplay,
+	type NativeScrollbackVirtualizedPrefix,
 	type RenderStablePrefix,
 	type ViewportTailProvider,
 } from "@oh-my-pi/pi-tui";
@@ -16,6 +17,12 @@ import {
  */
 interface FinalizableBlock {
 	isTranscriptBlockFinalized?(): boolean;
+	/**
+	 * A sealed block declares post-finalize version bumps cosmetic: updates after
+	 * sealing remain visible for one composed frame before compaction. Mutations
+	 * after its rows enter native scrollback remain invisible.
+	 */
+	isTranscriptBlockSealed?(): boolean;
 	/**
 	 * Monotonic content version for blocks that can still mutate *after*
 	 * reporting finalized (e.g. `AssistantMessageComponent`: the inline error
@@ -64,6 +71,11 @@ interface FinalizableBlock {
 function isBlockFinalized(child: Component): boolean {
 	const fn = (child as Component & FinalizableBlock).isTranscriptBlockFinalized;
 	return fn ? fn.call(child) : true;
+}
+
+function isBlockSealed(child: Component): boolean {
+	const fn = (child as Component & FinalizableBlock).isTranscriptBlockSealed;
+	return fn ? fn.call(child) : false;
 }
 
 function getBlockVersion(child: Component): number | undefined {
@@ -171,9 +183,11 @@ export class TranscriptContainer
 		NativeScrollbackLiveRegion,
 		NativeScrollbackCommittedRows,
 		NativeScrollbackReplay,
+		NativeScrollbackVirtualizedPrefix,
 		RenderStablePrefix,
 		ViewportTailProvider
 {
+	#childIndex = new Map<Component, number>();
 	// Bumped to retire every block segment at once (theme change / clear); a
 	// segment is only reused when its stored generation matches.
 	#generation = 0;
@@ -194,10 +208,20 @@ export class TranscriptContainer
 	// from the local frame. Children remain owned by the session and can be
 	// re-rendered when the TUI prepares a destructive full replay.
 	#compactedChildStart = 0;
-	// Suppresses re-compaction for the rehydrating render. The TUI feeds its old
-	// committed-row count immediately before render, so resetting that count
-	// alone cannot distinguish a replay from an ordinary update.
+	// Suppresses compaction across the whole destructive-replay transaction.
+	// The TUI feeds its old committed-row count immediately before render, so
+	// resetting that count alone cannot distinguish a replay from an ordinary
+	// update. The latch survives every pre-emit render (a Ghostty-deferred
+	// frame recomposes before emitting) and releases only when the post-emit
+	// committed-rows publication delivers the rehydrated full-paint
+	// coordinates: a first-time compaction inside the replay transaction would
+	// drop rows the ED3 erase just removed from native scrollback.
 	#replayPending = false;
+	// Whether render() ran since the latch was set: distinguishes the
+	// pre-render committed-rows feed (keep suppressing) from the post-emit
+	// publication (release).
+	#replayRendered = false;
+	#virtualizedRowsPending = 0;
 	// Stable-prefix floor accumulated across renders since the last
 	// getRenderStablePrefixRows() read (see RenderStablePrefix: reading
 	// consumes the report and re-bases the baseline). Out-of-band renders
@@ -210,16 +234,43 @@ export class TranscriptContainer
 		super.invalidate();
 	}
 
+	override addChild(component: Component): void {
+		this.#childIndex.set(component, this.children.length);
+		super.addChild(component);
+	}
+
+	override removeChild(component: Component): void {
+		const index = this.#childIndex.get(component);
+		if (index === undefined) return;
+		super.removeChild(component);
+		this.#childIndex.delete(component);
+		for (let i = index; i < this.children.length; i++) {
+			const child = this.children[i];
+			if (child !== undefined) this.#childIndex.set(child, i);
+		}
+		if (index < this.#compactedChildStart) this.#compactedChildStart--;
+		if (index < this.#segments.length) this.#segments.splice(index, 1);
+	}
+
 	override clear(): void {
 		this.#generation++;
 		super.clear();
+		this.#childIndex.clear();
 		this.#compactedChildStart = 0;
 		this.#committedRows = 0;
+		this.#virtualizedRowsPending = 0;
 		this.#replayPending = false;
+		this.#replayRendered = false;
 	}
 
 	override setNativeScrollbackCommittedRows(rows: number): void {
 		this.#committedRows = Number.isFinite(rows) ? Math.max(0, Math.trunc(rows)) : 0;
+		if (this.#replayPending && this.#replayRendered) {
+			// Post-emit publication: the destructive replay transaction is
+			// complete and the rehydrated coordinates are now authoritative.
+			this.#replayPending = false;
+			this.#replayRendered = false;
+		}
 		for (let i = this.#compactedChildStart; i < this.children.length; i++) {
 			const child = this.children[i]!;
 			const segment = this.#segments[i];
@@ -247,12 +298,22 @@ export class TranscriptContainer
 		// Replay retires the old terminal tape, so descendants may discard layout
 		// locks whose only purpose was keeping that immutable history byte-stable.
 		super.prepareNativeScrollbackReplay();
+		this.#virtualizedRowsPending = 0;
+		// Latch unconditionally: even a container that never compacted must not
+		// perform its first compaction inside the replay transaction (see the
+		// #replayPending field contract).
+		this.#replayPending = true;
+		this.#replayRendered = false;
 		if (this.#compactedChildStart === 0) return;
 		this.#compactedChildStart = 0;
-		this.#replayPending = true;
 		this.#generation++;
 		this.#lines.length = 0;
 		this.#stableRowsFloor = 0;
+	}
+	takeNativeScrollbackVirtualizedRows(): number {
+		const rows = this.#virtualizedRowsPending;
+		this.#virtualizedRowsPending = 0;
+		return rows;
 	}
 
 	getRenderStablePrefixRows(): number {
@@ -275,13 +336,14 @@ export class TranscriptContainer
 	 * committed rows and is safely removable.
 	 */
 	isBlockUncommitted(component: Component): boolean {
-		const index = this.children.indexOf(component);
+		const index = this.#childIndex.get(component);
 		// Compacted prefix is already committed native history and must not be
 		// retracted. Compacted slots may be sparse holes after a later re-render
 		// (render only fills from #compactedChildStart), so the loop below must
 		// skip undefined entries.
-		if (index >= 0 && index < this.#compactedChildStart) return false;
-		for (const segment of this.#segments) {
+		if (index !== undefined && index < this.#compactedChildStart) return false;
+		for (let i = this.#compactedChildStart; i < this.#segments.length; i++) {
+			const segment = this.#segments[i];
 			if (segment === undefined || segment.component !== component) continue;
 			return segment.rowCount === 0 || segment.startRow >= this.#committedRows;
 		}
@@ -299,9 +361,10 @@ export class TranscriptContainer
 	 */
 	isBlockInLiveRegion(component: Component): boolean {
 		const children = this.children;
-		const index = children.indexOf(component);
-		if (index < 0) return false;
-		for (let i = 0; i <= index; i++) {
+		const index = this.#childIndex.get(component);
+		if (index === undefined) return false;
+		if (index < this.#compactedChildStart) return false;
+		for (let i = this.#compactedChildStart; i <= index; i++) {
 			if (!isBlockFinalized(children[i]!)) return true;
 		}
 		// Every block at/before `index` finalized: the live region starts at the
@@ -459,7 +522,11 @@ export class TranscriptContainer
 					previous.width === width &&
 					previous.generation === this.#generation);
 			const contribution = reusable ? previous.contribution : stripPlainBlankEdges(raw);
-			const compactable = finalized && previous?.finalized !== false;
+			const compactable =
+				finalized &&
+				(version === undefined || isBlockSealed(child)) &&
+				previous?.finalized !== false &&
+				(version === undefined || previous?.version === version);
 
 			// Empty (or stripped-to-nothing) children contribute nothing and never
 			// affect spacing. An empty still-live child still gates the commit
@@ -547,7 +614,7 @@ export class TranscriptContainer
 		this.#segments = segments;
 		this.#stableRowsFloor = Math.min(stableFloorBefore, stableRows, row);
 		if (this.#replayPending) {
-			this.#replayPending = false;
+			this.#replayRendered = true;
 		} else {
 			this.#compactCommittedPrefix();
 		}
@@ -582,6 +649,7 @@ export class TranscriptContainer
 			}
 		}
 		if (dropRows === 0) return;
+		this.#virtualizedRowsPending += dropRows;
 
 		lines.splice(0, dropRows);
 		for (let i = this.#compactedChildStart; i < dropUntil; i++) {

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -671,7 +671,7 @@ export class TranscriptContainer
 		}
 		for (let i = dropUntil; i < segments.length; i++) {
 			const segment = segments[i];
-			if (segment !== undefined) segment.startRow -= dropRows;
+			if (segment !== undefined) segment.startRow = Math.max(0, segment.startRow - dropRows);
 		}
 		this.#compactedChildStart = dropUntil;
 		this.#committedRows = Math.max(0, this.#committedRows - dropRows);

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -144,7 +144,9 @@ export class CommandController {
 	async handleDebugTranscriptCommand(): Promise<void> {
 		try {
 			const width = Math.max(1, this.ctx.ui.terminal.columns);
-			const renderedLines = this.ctx.chatContainer.render(width).map(line => replaceTabs(Bun.stripANSI(line)));
+			const renderedLines = this.ctx.chatContainer
+				.renderFullHistory(width)
+				.map(line => replaceTabs(Bun.stripANSI(line)));
 			const rendered = renderedLines.join("\n").trimEnd();
 			if (!rendered) {
 				this.ctx.showError("No messages to dump yet.");

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -663,6 +663,10 @@ export class EventController {
 		const component = this.#lastAssistantComponent;
 		const persistenceKey = sessionMessagePersistenceKey(message);
 		if (!component || component.messagePersistenceKey() !== persistenceKey) return false;
+		const replayHead = this.ctx.chatContainer.children.find(
+			child => child instanceof AssistantMessageComponent && child.messagePersistenceKey() === persistenceKey,
+		);
+		if (component !== replayHead) return false;
 		// Historical rebuild constructs with a message, so the block is finalized.
 		// Re-open it as live before streaming so the transcript seam stays pinned.
 		component.markTranscriptBlockLive();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -663,6 +663,9 @@ export class EventController {
 		const component = this.#lastAssistantComponent;
 		const persistenceKey = sessionMessagePersistenceKey(message);
 		if (!component || component.messagePersistenceKey() !== persistenceKey) return false;
+		// Historical rebuild constructs with a message, so the block is finalized.
+		// Re-open it as live before streaming so the transcript seam stays pinned.
+		component.markTranscriptBlockLive();
 		this.#lastVisibleBlockCount = 0;
 		this.#lastAssistantComponent = undefined;
 		this.ctx.streamingComponent = component;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -405,7 +405,8 @@ export class EventController {
 		return undefined;
 	}
 
-	#clearRetrySupersededAssistantComponents(): void {
+	#sealAndClearRetrySupersededAssistantComponents(): void {
+		for (const component of this.#retrySupersededAssistantQueue) component.sealTranscriptBlock();
 		this.#retrySupersededAssistantComponents.clear();
 		this.#retrySupersededAssistantQueue = [];
 	}
@@ -507,7 +508,12 @@ export class EventController {
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "assistant") {
 			this.#lastVisibleBlockCount = 0;
-			this.#lastAssistantComponent?.sealTranscriptBlock();
+			if (
+				this.#lastAssistantComponent &&
+				!this.#retrySupersededAssistantQueue.includes(this.#lastAssistantComponent)
+			) {
+				this.#lastAssistantComponent.sealTranscriptBlock();
+			}
 			this.#lastAssistantComponent = undefined;
 			this.ctx.streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingMessage = event.message;
@@ -1430,15 +1436,16 @@ export class EventController {
 				const component = this.#takeRetrySupersededAssistantComponent(recovered.persistenceKey);
 				if (!component) continue;
 				component.applyRetryRecovery(recovered.retryRecovery);
+				component.sealTranscriptBlock();
 				if (this.#pinnedErrorComponent === component) this.#pinnedErrorComponent = undefined;
 				appliedRecovered = true;
 			}
 			if (appliedRecovered || (event.recoveredErrors?.length ?? 0) > 0) {
 				this.ctx.clearPinnedError();
 			}
-			this.#clearRetrySupersededAssistantComponents();
+			this.#sealAndClearRetrySupersededAssistantComponents();
 		} else {
-			this.#clearRetrySupersededAssistantComponents();
+			this.#sealAndClearRetrySupersededAssistantComponents();
 			this.ctx.showError(`Retry failed after ${event.attempt} attempts: ${event.finalError || "Unknown error"}`);
 		}
 		this.#ensureWorkingLoaderWhileStreaming();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -23,6 +23,7 @@ import type { InteractiveModeContext, TodoPhase } from "../../modes/types";
 import idleRecapPrompt from "../../prompts/system/recap-user.md" with { type: "text" };
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { isSilentAbort, readQueueChipText, resolveAbortLabel } from "../../session/messages";
+import { sessionMessagePersistenceKey } from "../../session/turn-persistence";
 import { previewLine, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { PROPOSE_DEVICE_NAME, writeDeviceDispatch } from "../../tools/resolve";
 import { nextActionableTask } from "../../tools/todo";
@@ -85,6 +86,9 @@ export class EventController {
 	#readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
 	#toolTimelineComponents = new Map<string, Component>();
 	#postToolAssistantComponents = new Map<string, AssistantMessageComponent>();
+	// Finalized tail of the preceding assistant message. It survives turn cleanup
+	// so the next assistant message can seal it after agent_start restores any
+	// pinned inline error.
 	#lastAssistantComponent: AssistantMessageComponent | undefined = undefined;
 	// Assistant component whose turn-ending error is currently mirrored in the
 	// pinned banner. Its inline `Error: …` line is suppressed while pinned and
@@ -265,12 +269,13 @@ export class EventController {
 		const children = this.ctx.chatContainer.children;
 		const anchorIndex = anchor ? children.indexOf(anchor) : -1;
 		if (anchorIndex < 0) return false;
-		if (children.slice(anchorIndex + 1).some(child => !this.ctx.chatContainer.isBlockUncommitted(child))) {
+		const trailing = children.slice(anchorIndex + 1);
+		if (trailing.some(child => !this.ctx.chatContainer.isBlockUncommitted(child))) {
 			return false;
 		}
+		for (const child of trailing) this.ctx.chatContainer.removeChild(child);
 		this.ctx.chatContainer.addChild(component);
-		children.splice(children.length - 1, 1);
-		children.splice(anchorIndex + 1, 0, component);
+		for (const child of trailing) this.ctx.chatContainer.addChild(child);
 		return true;
 	}
 
@@ -413,7 +418,6 @@ export class EventController {
 		this.#readToolCallAssistantComponents.clear();
 		this.#resetReadGroup();
 		this.#resolveDisplaceableTodo();
-		this.#lastAssistantComponent = undefined;
 		// Restore the previous turn's inline error in the transcript before dropping
 		// the banner, so the error stays in history once the banner is gone.
 		this.#pinnedErrorComponent?.setErrorPinned(false);
@@ -503,6 +507,8 @@ export class EventController {
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "assistant") {
 			this.#lastVisibleBlockCount = 0;
+			this.#lastAssistantComponent?.sealTranscriptBlock();
+			this.#lastAssistantComponent = undefined;
 			this.ctx.streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingMessage = event.message;
 			this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
@@ -632,6 +638,37 @@ export class EventController {
 	 */
 	inheritDisplaceableTodo(component: ToolExecutionComponent | null | undefined): void {
 		this.#displaceableTodoComponent = component?.canBeDisplacedBy("todo") ? component : undefined;
+	}
+
+	/**
+	 * Rebind the unsealed historical tail after a transcript rebuild replaces
+	 * component instances. A pinned error follows the same rebuilt assistant so
+	 * agent_start restores its inline row before the next message seals it.
+	 */
+	inheritAssistantAwaitingSeal(component: AssistantMessageComponent | undefined): void {
+		const hadPinnedError = this.#pinnedErrorComponent !== undefined;
+		this.#lastAssistantComponent = component;
+		if (hadPinnedError) {
+			component?.setErrorPinned(true);
+			this.#pinnedErrorComponent = component;
+		}
+	}
+
+	/**
+	 * Reuse a rebuilt assistant when focus attaches after its message_start.
+	 * The full persistence identity prevents a completed predecessor from being
+	 * mistaken for the in-flight message that produced the orphaned update.
+	 */
+	resumeAssistantStream(message: AssistantMessage): boolean {
+		const component = this.#lastAssistantComponent;
+		const persistenceKey = sessionMessagePersistenceKey(message);
+		if (!component || component.messagePersistenceKey() !== persistenceKey) return false;
+		this.#lastVisibleBlockCount = 0;
+		this.#lastAssistantComponent = undefined;
+		this.ctx.streamingComponent = component;
+		this.ctx.streamingMessage = message;
+		this.#streamingReveal.begin(component, splitAssistantMessageToolTimeline(message).beforeTools);
+		return true;
 	}
 
 	async #handleNotice(event: Extract<AgentSessionEvent, { type: "notice" }>): Promise<void> {
@@ -904,13 +941,19 @@ export class EventController {
 				this.ctx.lastAssistantUsage = usage;
 			}
 			this.ctx.streamingComponent.markTranscriptBlockFinalized();
-			let lastPostToolAssistantComponent: AssistantMessageComponent | undefined;
+			let lastAssistantComponent = this.ctx.streamingComponent;
 			for (const [toolCallId, segment] of displayTimeline.afterToolCalls) {
 				const component = this.#upsertPostToolAssistantSegment(toolCallId, segment);
 				component?.markTranscriptBlockFinalized();
-				if (component) lastPostToolAssistantComponent = component;
+				if (component) {
+					lastAssistantComponent.sealTranscriptBlock();
+					lastAssistantComponent = component;
+				}
 			}
-			this.#lastAssistantComponent = lastPostToolAssistantComponent ?? this.ctx.streamingComponent;
+			if (this.#lastAssistantComponent && this.#lastAssistantComponent !== lastAssistantComponent) {
+				this.#lastAssistantComponent.sealTranscriptBlock();
+			}
+			this.#lastAssistantComponent = lastAssistantComponent;
 			if (settings.get("display.showTokenUsage") && assistantUsageIsBilled(event.message.usage)) {
 				this.ctx.chatContainer.addChild(
 					createUsageRowBlock(event.message.usage, event.message.duration, event.message.ttft),
@@ -1189,7 +1232,6 @@ export class EventController {
 		this.#resolveDisplaceablePoll();
 		this.#resolveDisplaceableTodo();
 		this.ctx.flushPendingCommandOutput();
-		this.#lastAssistantComponent = undefined;
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
 		this.#scheduleIdleRecap();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -663,10 +663,6 @@ export class EventController {
 		const component = this.#lastAssistantComponent;
 		const persistenceKey = sessionMessagePersistenceKey(message);
 		if (!component || component.messagePersistenceKey() !== persistenceKey) return false;
-		const replayHead = this.ctx.chatContainer.children.find(
-			child => child instanceof AssistantMessageComponent && child.messagePersistenceKey() === persistenceKey,
-		);
-		if (component !== replayHead) return false;
 		// Historical rebuild constructs with a message, so the block is finalized.
 		// Re-open it as live before streaming so the transcript seam stays pinned.
 		component.markTranscriptBlockLive();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -719,6 +719,17 @@ export class EventController {
 	 * sure the live buffer's trailing partial gets flushed.
 	 */
 	#handleTurnEnd(event: Extract<AgentSessionEvent, { type: "turn_end" }>): void {
+		const component = this.#lastAssistantComponent;
+		if (
+			event.message.role === "assistant" &&
+			event.message.stopReason !== "error" &&
+			event.message.stopReason !== "aborted" &&
+			component &&
+			component !== this.#pinnedErrorComponent &&
+			!this.#retrySupersededAssistantQueue.includes(component)
+		) {
+			component.sealTranscriptBlock();
+		}
 		if (!settings.get("speech.enabled")) return;
 		if (settings.get("speech.mode") !== "yield") {
 			vocalizer.flush();

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -88,17 +88,18 @@ export class SessionFocusController {
 		this.ctx.clearTransientSessionUi();
 		this.ctx.eventController.resetTranscriptAnchors();
 		// Orphan-delta guard: when attaching mid-turn the message_start for the
-		// in-flight assistant message predates the attach. message_update carries
-		// the full accumulating message, so synthesize the missing start before
-		// the first orphaned update; every other handler is tolerant of unknown
-		// anchors (guarded by streamingComponent/pendingTools lookups).
+		// in-flight assistant predates the attach. Reuse an identity-matching
+		// rebuilt block when available; otherwise synthesize the missing start.
+		// Every other handler tolerates unknown anchors via its own lookups.
 		let assistantStreamSynced = false;
 		this.ctx.unsubscribe = target.subscribe(async event => {
 			if (event.type === "message_start" && event.message.role === "assistant") {
 				assistantStreamSynced = true;
 			} else if (event.type === "message_update" && event.message.role === "assistant" && !assistantStreamSynced) {
 				assistantStreamSynced = true;
-				await this.ctx.eventController.handleEvent({ type: "message_start", message: event.message });
+				if (!this.ctx.eventController.resumeAssistantStream(event.message)) {
+					await this.ctx.eventController.handleEvent({ type: "message_start", message: event.message });
+				}
 			}
 			await this.ctx.eventController.handleEvent(event);
 		});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3870,6 +3870,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	resetTranscript(): void {
+		this.eventController?.resetTranscriptAnchors();
 		this.chatContainer.dispose();
 		this.chatContainer.clear();
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3870,6 +3870,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	resetTranscript(): void {
+		this.clearPinnedError();
 		this.eventController?.resetTranscriptAnchors();
 		this.chatContainer.dispose();
 		this.chatContainer.clear();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -352,6 +352,11 @@ export class UiHelpers {
 		};
 		const messages = sessionContext.messages;
 		const count = messages.length;
+		let assistantAwaitingSeal: AssistantMessageComponent | undefined;
+		const noteHistoricalAssistant = (component: AssistantMessageComponent) => {
+			assistantAwaitingSeal?.sealTranscriptBlock();
+			assistantAwaitingSeal = component;
+		};
 		for (let i = 0; i < count; i++) {
 			const message = messages[i]!;
 			if (message.role !== "toolResult") flushPendingUsage();
@@ -362,6 +367,7 @@ export class UiHelpers {
 				const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
 				const assistantComponent = lastChild instanceof AssistantMessageComponent ? lastChild : undefined;
 				if (assistantComponent) {
+					noteHistoricalAssistant(assistantComponent);
 					const usage = message.usage;
 					const explained = sessionContext.cacheMissExplainedAt?.[i] ?? false;
 					if (this.ctx.settings.get("display.cacheMissMarker") && !explained) {
@@ -387,6 +393,7 @@ export class UiHelpers {
 				const appendAssistantSegment = (segment: AssistantMessage | undefined) => {
 					if (!segment || !assistantHasVisibleContent(segment)) return;
 					const component = createAssistantMessageComponent(this.ctx, segment);
+					noteHistoricalAssistant(component);
 					this.ctx.chatContainer.addChild(component);
 				};
 
@@ -602,6 +609,7 @@ export class UiHelpers {
 		} else {
 			resolveTodoSnapshot();
 		}
+		this.ctx.eventController?.inheritAssistantAwaitingSeal?.(assistantAwaitingSeal);
 
 		// Entries still in `pendingTools` are toolCalls whose result never landed
 		// during the replay — with `keepDanglingToolCalls` these are exactly the

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -325,6 +325,16 @@ describe("EventController error banner", () => {
 		expect(chatChildren[0]).toBe(rebuilt);
 		expect(ctx.streamingComponent).toBe(rebuilt);
 		expect(ctx.streamingMessage).toBe(update);
+		// Historical rebuild finalizes the assistant; resume must re-open it so the
+		// live-region seam pins on the streaming block until message_end.
+		expect(rebuilt.isTranscriptBlockFinalized()).toBe(false);
+		expect(rebuilt.getTranscriptBlockSettledRows()).toBe(0);
+
+		await worker.emit({
+			type: "message_end",
+			message: update,
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+		expect(rebuilt.isTranscriptBlockFinalized()).toBe(true);
 	});
 
 	it("clears retryable thinking-loop banners without restoring the dropped inline error", async () => {

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -14,9 +14,12 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { ErrorBannerComponent } from "@oh-my-pi/pi-coding-agent/modes/components/error-banner";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
+import { SessionFocusController } from "@oh-my-pi/pi-coding-agent/modes/controllers/session-focus-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
-import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
 	return {
@@ -58,7 +61,8 @@ function createFixture(streamingMessage?: AssistantMessage) {
 		updateContent: vi.fn(() => componentCalls.push("update")),
 		setComplete: vi.fn(),
 		markTranscriptBlockFinalized: vi.fn(),
-		setErrorPinned: vi.fn(),
+		sealTranscriptBlock: vi.fn(() => componentCalls.push("seal")),
+		setErrorPinned: vi.fn((pinned: boolean) => componentCalls.push(pinned ? "pin" : "unpin")),
 		setHideThinkingBlock: vi.fn((hide: boolean) => componentCalls.push(`hide:${hide}`)),
 		messagePersistenceKey: vi.fn(() => "test-persistence-key"),
 		applyRetryRecovery: vi.fn(),
@@ -132,7 +136,25 @@ function createFixture(streamingMessage?: AssistantMessage) {
 	} as unknown as InteractiveModeContext;
 
 	const controller = new EventController(ctx);
-	return { controller, ctx, showPinnedError, clearPinnedError, streamingComponent, componentCalls };
+	return { controller, ctx, showPinnedError, clearPinnedError, streamingComponent, componentCalls, chatChildren };
+}
+
+function makeAttachSessionStub(isStreaming = false) {
+	let listener: ((event: AgentSessionEvent) => Promise<void> | void) | undefined;
+	const session = {
+		isStreaming,
+		subscribe(fn: (event: AgentSessionEvent) => Promise<void> | void) {
+			listener = fn;
+			return () => {};
+		},
+	} as AgentSession;
+	return {
+		session,
+		emit: async (event: AgentSessionEvent) => {
+			if (!listener) throw new Error("session was not attached");
+			await listener(event);
+		},
+	};
 }
 
 describe("EventController error banner", () => {
@@ -168,6 +190,141 @@ describe("EventController error banner", () => {
 
 		expect(clearPinnedError).toHaveBeenCalledTimes(1);
 		expect(streamingComponent.setErrorPinned).toHaveBeenCalledWith(false);
+	});
+
+	it("restores the inline error before sealing at the next assistant message", async () => {
+		const message = makeAssistantMessage({ stopReason: "error", errorMessage: "blocked" });
+		const nextMessage = makeAssistantMessage({ content: [] });
+		const { controller, streamingComponent, componentCalls } = createFixture(message);
+
+		await controller.handleEvent({ type: "message_end", message } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		componentCalls.length = 0;
+
+		await controller.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+		expect(streamingComponent.sealTranscriptBlock).not.toHaveBeenCalled();
+		await controller.handleEvent({ type: "message_start", message: nextMessage } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+
+		expect(componentCalls).toEqual(["unpin", "seal"]);
+	});
+
+	it("preserves error pinning when a transcript rebuild replaces the assistant", async () => {
+		const message = makeAssistantMessage({ stopReason: "error", errorMessage: "blocked" });
+		const { controller } = createFixture(message);
+
+		await controller.handleEvent({ type: "message_end", message } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		const rebuilt = new AssistantMessageComponent(message);
+		controller.inheritAssistantAwaitingSeal(rebuilt);
+		expect(Bun.stripANSI(rebuilt.render(120).join("\n"))).not.toContain("Error: blocked");
+
+		await controller.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+		expect(Bun.stripANSI(rebuilt.render(120).join("\n"))).toContain("Error: blocked");
+		await controller.handleEvent({ type: "message_start", message: makeAssistantMessage({ content: [] }) } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		expect(rebuilt.isTranscriptBlockSealed()).toBe(true);
+	});
+
+	it("seals a rebuilt predecessor before replacing it at message end", async () => {
+		const first = makeAssistantMessage();
+		const next = makeAssistantMessage({ content: [] });
+		const { controller, ctx } = createFixture(first);
+
+		await controller.handleEvent({ type: "message_end", message: first } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		await controller.handleEvent({ type: "message_start", message: next } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		const rebuiltPredecessor = new AssistantMessageComponent(first);
+		controller.inheritAssistantAwaitingSeal(rebuiltPredecessor);
+		expect(rebuiltPredecessor.isTranscriptBlockSealed()).toBe(false);
+		expect(ctx.streamingComponent).toBeInstanceOf(AssistantMessageComponent);
+
+		await controller.handleEvent({ type: "message_end", message: next } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		expect(rebuiltPredecessor.isTranscriptBlockSealed()).toBe(true);
+	});
+
+	it("drops stale assistant seal and pin anchors when transcript anchors reset", async () => {
+		const message = makeAssistantMessage({ stopReason: "error", errorMessage: "blocked" });
+		const { controller, streamingComponent } = createFixture(message);
+
+		await controller.handleEvent({ type: "message_end", message } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		streamingComponent.sealTranscriptBlock.mockClear();
+		streamingComponent.setErrorPinned.mockClear();
+
+		controller.resetTranscriptAnchors();
+		await controller.handleEvent({
+			type: "message_start",
+			message: makeAssistantMessage({ content: [] }),
+		} as Extract<AgentSessionEvent, { type: "message_start" }>);
+
+		expect(streamingComponent.sealTranscriptBlock).not.toHaveBeenCalled();
+		expect(streamingComponent.setErrorPinned).not.toHaveBeenCalledWith(false);
+	});
+
+	it("attaches mid-turn and routes the first orphaned assistant update to one transcript block", async () => {
+		const { controller: eventController, ctx, chatChildren } = createFixture();
+		const main = makeAttachSessionStub();
+		const worker = makeAttachSessionStub(true);
+		const registry = new AgentRegistry();
+		registry.register({
+			id: "Worker",
+			displayName: "Worker",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: worker.session,
+			status: "running",
+		});
+		const lifecycle = new AgentLifecycleManager(registry);
+		const update = makeAssistantMessage({
+			content: [{ type: "text", text: "partial after attach" }],
+		});
+		const rebuilt = new AssistantMessageComponent(update);
+		Object.assign(ctx, {
+			session: main.session,
+			unsubscribe: vi.fn(),
+			eventController,
+			clearTransientSessionUi: vi.fn(),
+			renderInitialMessages: vi.fn(() => {
+				ctx.chatContainer.clear();
+				ctx.chatContainer.addChild(rebuilt);
+				eventController.inheritAssistantAwaitingSeal(rebuilt);
+			}),
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+		});
+		Object.assign(ctx.statusLine, { setSession: vi.fn() });
+		const focusController = new SessionFocusController(ctx, registry, () => lifecycle);
+
+		await focusController.focusAgent("Worker");
+		await worker.emit({
+			type: "message_update",
+			message: update,
+			assistantMessageEvent: { type: "text_delta", delta: "partial after attach" },
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+
+		expect(chatChildren).toHaveLength(1);
+		expect(chatChildren[0]).toBe(rebuilt);
+		expect(ctx.streamingComponent).toBe(rebuilt);
+		expect(ctx.streamingMessage).toBe(update);
 	});
 
 	it("clears retryable thinking-loop banners without restoring the dropped inline error", async () => {

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -17,6 +17,7 @@ import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/eve
 import { SessionFocusController } from "@oh-my-pi/pi-coding-agent/modes/controllers/session-focus-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { splitAssistantMessageToolTimeline } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -335,6 +336,72 @@ describe("EventController error banner", () => {
 			message: update,
 		} as Extract<AgentSessionEvent, { type: "message_end" }>);
 		expect(rebuilt.isTranscriptBlockFinalized()).toBe(true);
+	});
+
+	it("does not resume an orphaned update onto a trailing post-tool replay segment", async () => {
+		const { controller: eventController, ctx, chatChildren } = createFixture();
+		const fullMessage = makeAssistantMessage({
+			content: [
+				{ type: "text", text: "lead text" },
+				{ type: "toolCall", id: "call-replay", name: "bash", arguments: { command: "pwd" } },
+				{ type: "text", text: "trailing text" },
+			],
+		});
+		const timeline = splitAssistantMessageToolTimeline(fullMessage);
+		const trailingMessage = timeline.afterToolCalls.get("call-replay");
+		if (!trailingMessage) throw new Error("Expected a trailing post-tool assistant segment");
+		const head = new AssistantMessageComponent(timeline.beforeTools);
+		const trailing = new AssistantMessageComponent(trailingMessage);
+		const mountReplay = () => {
+			ctx.chatContainer.clear();
+			ctx.chatContainer.addChild(head);
+			ctx.chatContainer.addChild(trailing);
+			eventController.inheritAssistantAwaitingSeal(trailing);
+		};
+		mountReplay();
+
+		expect(head.messagePersistenceKey()).toBe(trailing.messagePersistenceKey());
+		expect(eventController.resumeAssistantStream(fullMessage)).toBe(false);
+
+		const main = makeAttachSessionStub();
+		const worker = makeAttachSessionStub(true);
+		const registry = new AgentRegistry();
+		registry.register({
+			id: "Worker",
+			displayName: "Worker",
+			kind: "sub",
+			parentId: MAIN_AGENT_ID,
+			session: worker.session,
+			status: "running",
+		});
+		const lifecycle = new AgentLifecycleManager(registry);
+		Object.assign(ctx, {
+			session: main.session,
+			unsubscribe: vi.fn(),
+			eventController,
+			clearTransientSessionUi: vi.fn(),
+			renderInitialMessages: vi.fn(mountReplay),
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+		});
+		Object.assign(ctx.statusLine, { setSession: vi.fn() });
+		const focusController = new SessionFocusController(ctx, registry, () => lifecycle);
+
+		await focusController.focusAgent("Worker");
+		await worker.emit({
+			type: "message_update",
+			message: timeline.beforeTools,
+			assistantMessageEvent: { type: "text_delta", delta: "lead text" },
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+
+		expect(ctx.streamingComponent).toBeInstanceOf(AssistantMessageComponent);
+		expect(ctx.streamingComponent).not.toBe(head);
+		expect(ctx.streamingComponent).not.toBe(trailing);
+		expect(chatChildren).toContain(ctx.streamingComponent);
+		expect(trailing.isTranscriptBlockFinalized()).toBe(true);
+		const trailingRender = Bun.stripANSI(trailing.render(120).join("\n"));
+		expect(trailingRender).toContain("trailing text");
+		expect(trailingRender).not.toContain("lead text");
 	});
 
 	it("clears retryable thinking-loop banners without restoring the dropped inline error", async () => {

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -65,7 +65,7 @@ function createFixture(streamingMessage?: AssistantMessage) {
 		setErrorPinned: vi.fn((pinned: boolean) => componentCalls.push(pinned ? "pin" : "unpin")),
 		setHideThinkingBlock: vi.fn((hide: boolean) => componentCalls.push(`hide:${hide}`)),
 		messagePersistenceKey: vi.fn(() => "test-persistence-key"),
-		applyRetryRecovery: vi.fn(),
+		applyRetryRecovery: vi.fn(() => componentCalls.push("recover")),
 	};
 	const showPinnedError = vi.fn();
 	const clearPinnedError = vi.fn();
@@ -371,6 +371,94 @@ describe("EventController error banner", () => {
 		} as Extract<AgentSessionEvent, { type: "auto_retry_end" }>);
 	});
 
+	it("keeps a retry-superseded assistant mutable until recovery is applied", async () => {
+		const failed = makeAssistantMessage({ stopReason: "error", errorMessage: "rate limited" });
+		const retry = makeAssistantMessage({ content: [] });
+		const { controller, streamingComponent, componentCalls } = createFixture(failed);
+
+		await controller.handleEvent({ type: "message_end", message: failed } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		await controller.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 2,
+			delayMs: 0,
+			errorMessage: "rate limited",
+			errorId: AIError.create(AIError.Flag.UsageLimit),
+		} as Extract<AgentSessionEvent, { type: "auto_retry_start" }>);
+		componentCalls.length = 0;
+
+		await controller.handleEvent({ type: "message_start", message: retry } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		expect(streamingComponent.sealTranscriptBlock).not.toHaveBeenCalled();
+
+		await controller.handleEvent({
+			type: "auto_retry_end",
+			success: true,
+			attempt: 1,
+			recoveredErrors: [
+				{
+					entryId: "failed-entry",
+					persistenceKey: "test-persistence-key",
+					note: "rate-limited; retried",
+					retryRecovery: {
+						kind: "auto-retry",
+						status: "recovered",
+						attempt: 1,
+						recoveredAt: "2026-07-18T00:00:00.000Z",
+						recovery: "plain",
+						note: "rate-limited; retried",
+						supersededBy: {
+							provider: retry.provider,
+							model: retry.model,
+							timestamp: retry.timestamp,
+						},
+					},
+				},
+			],
+		} as Extract<AgentSessionEvent, { type: "auto_retry_end" }>);
+
+		expect(componentCalls).toEqual(["recover", "seal"]);
+	});
+
+	it("seals a retry-superseded assistant when the retry fails", async () => {
+		const failed = makeAssistantMessage({ stopReason: "error", errorMessage: "rate limited" });
+		const retry = makeAssistantMessage({ content: [] });
+		const { controller, streamingComponent } = createFixture(failed);
+
+		await controller.handleEvent({ type: "message_end", message: failed } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		await controller.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 1,
+			delayMs: 0,
+			errorMessage: "rate limited",
+			errorId: AIError.create(AIError.Flag.UsageLimit),
+		} as Extract<AgentSessionEvent, { type: "auto_retry_start" }>);
+		streamingComponent.sealTranscriptBlock.mockClear();
+
+		await controller.handleEvent({ type: "message_start", message: retry } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		expect(streamingComponent.sealTranscriptBlock).not.toHaveBeenCalled();
+
+		await controller.handleEvent({
+			type: "auto_retry_end",
+			success: false,
+			attempt: 1,
+			finalError: "rate limited",
+		} as Extract<AgentSessionEvent, { type: "auto_retry_end" }>);
+
+		expect(streamingComponent.sealTranscriptBlock).toHaveBeenCalledTimes(1);
+	});
 	it("does not pin a banner for a normal assistant stop", async () => {
 		const message = makeAssistantMessage({ stopReason: "stop" });
 		const { controller, showPinnedError } = createFixture(message);

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -57,15 +57,20 @@ afterEach(() => {
 
 function createFixture(streamingMessage?: AssistantMessage) {
 	const componentCalls: string[] = [];
+	let sealed = false;
 	const streamingComponent = {
 		updateContent: vi.fn(() => componentCalls.push("update")),
 		setComplete: vi.fn(),
 		markTranscriptBlockFinalized: vi.fn(),
-		sealTranscriptBlock: vi.fn(() => componentCalls.push("seal")),
+		sealTranscriptBlock: vi.fn(() => {
+			sealed = true;
+			componentCalls.push("seal");
+		}),
 		setErrorPinned: vi.fn((pinned: boolean) => componentCalls.push(pinned ? "pin" : "unpin")),
 		setHideThinkingBlock: vi.fn((hide: boolean) => componentCalls.push(`hide:${hide}`)),
 		messagePersistenceKey: vi.fn(() => "test-persistence-key"),
 		applyRetryRecovery: vi.fn(() => componentCalls.push("recover")),
+		isTranscriptBlockSealed: vi.fn(() => sealed),
 	};
 	const showPinnedError = vi.fn();
 	const clearPinnedError = vi.fn();
@@ -459,6 +464,49 @@ describe("EventController error banner", () => {
 
 		expect(streamingComponent.sealTranscriptBlock).toHaveBeenCalledTimes(1);
 	});
+	it("seals a clean finalized assistant tail at turn end", async () => {
+		const message = makeAssistantMessage();
+		const { controller, streamingComponent } = createFixture(message);
+
+		await controller.handleEvent({ type: "message_end", message } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		expect(streamingComponent.isTranscriptBlockSealed()).toBe(false);
+
+		await controller.handleEvent({ type: "turn_end", message, toolResults: [] } as Extract<
+			AgentSessionEvent,
+			{ type: "turn_end" }
+		>);
+
+		expect(streamingComponent.isTranscriptBlockSealed()).toBe(true);
+	});
+
+	it("keeps a pinned retry-superseded assistant unsealed at turn end", async () => {
+		const message = makeAssistantMessage({ stopReason: "error", errorMessage: "rate limited" });
+		const { controller, streamingComponent } = createFixture(message);
+
+		await controller.handleEvent({ type: "message_end", message } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		await controller.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 2,
+			delayMs: 0,
+			errorMessage: "rate limited",
+			errorId: AIError.create(AIError.Flag.UsageLimit),
+		} as Extract<AgentSessionEvent, { type: "auto_retry_start" }>);
+
+		await controller.handleEvent({ type: "turn_end", message, toolResults: [] } as Extract<
+			AgentSessionEvent,
+			{ type: "turn_end" }
+		>);
+
+		expect(streamingComponent.isTranscriptBlockSealed()).toBe(false);
+	});
+
 	it("does not pin a banner for a normal assistant stop", async () => {
 		const message = makeAssistantMessage({ stopReason: "stop" });
 		const { controller, showPinnedError } = createFixture(message);

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -17,7 +17,6 @@ import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/eve
 import { SessionFocusController } from "@oh-my-pi/pi-coding-agent/modes/controllers/session-focus-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
-import { splitAssistantMessageToolTimeline } from "@oh-my-pi/pi-coding-agent/modes/utils/transcript-render-helpers";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -336,72 +335,6 @@ describe("EventController error banner", () => {
 			message: update,
 		} as Extract<AgentSessionEvent, { type: "message_end" }>);
 		expect(rebuilt.isTranscriptBlockFinalized()).toBe(true);
-	});
-
-	it("does not resume an orphaned update onto a trailing post-tool replay segment", async () => {
-		const { controller: eventController, ctx, chatChildren } = createFixture();
-		const fullMessage = makeAssistantMessage({
-			content: [
-				{ type: "text", text: "lead text" },
-				{ type: "toolCall", id: "call-replay", name: "bash", arguments: { command: "pwd" } },
-				{ type: "text", text: "trailing text" },
-			],
-		});
-		const timeline = splitAssistantMessageToolTimeline(fullMessage);
-		const trailingMessage = timeline.afterToolCalls.get("call-replay");
-		if (!trailingMessage) throw new Error("Expected a trailing post-tool assistant segment");
-		const head = new AssistantMessageComponent(timeline.beforeTools);
-		const trailing = new AssistantMessageComponent(trailingMessage);
-		const mountReplay = () => {
-			ctx.chatContainer.clear();
-			ctx.chatContainer.addChild(head);
-			ctx.chatContainer.addChild(trailing);
-			eventController.inheritAssistantAwaitingSeal(trailing);
-		};
-		mountReplay();
-
-		expect(head.messagePersistenceKey()).toBe(trailing.messagePersistenceKey());
-		expect(eventController.resumeAssistantStream(fullMessage)).toBe(false);
-
-		const main = makeAttachSessionStub();
-		const worker = makeAttachSessionStub(true);
-		const registry = new AgentRegistry();
-		registry.register({
-			id: "Worker",
-			displayName: "Worker",
-			kind: "sub",
-			parentId: MAIN_AGENT_ID,
-			session: worker.session,
-			status: "running",
-		});
-		const lifecycle = new AgentLifecycleManager(registry);
-		Object.assign(ctx, {
-			session: main.session,
-			unsubscribe: vi.fn(),
-			eventController,
-			clearTransientSessionUi: vi.fn(),
-			renderInitialMessages: vi.fn(mountReplay),
-			updateEditorBorderColor: vi.fn(),
-			showStatus: vi.fn(),
-		});
-		Object.assign(ctx.statusLine, { setSession: vi.fn() });
-		const focusController = new SessionFocusController(ctx, registry, () => lifecycle);
-
-		await focusController.focusAgent("Worker");
-		await worker.emit({
-			type: "message_update",
-			message: timeline.beforeTools,
-			assistantMessageEvent: { type: "text_delta", delta: "lead text" },
-		} as Extract<AgentSessionEvent, { type: "message_update" }>);
-
-		expect(ctx.streamingComponent).toBeInstanceOf(AssistantMessageComponent);
-		expect(ctx.streamingComponent).not.toBe(head);
-		expect(ctx.streamingComponent).not.toBe(trailing);
-		expect(chatChildren).toContain(ctx.streamingComponent);
-		expect(trailing.isTranscriptBlockFinalized()).toBe(true);
-		const trailingRender = Bun.stripANSI(trailing.render(120).join("\n"));
-		expect(trailingRender).toContain("trailing text");
-		expect(trailingRender).not.toContain("lead text");
 	});
 
 	it("clears retryable thinking-loop banners without restoring the dropped inline error", async () => {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
@@ -25,6 +28,7 @@ function createInitialRenderHarness(): { ctx: InteractiveModeContext; helpers: U
 		pendingBashComponents: [],
 		pendingPythonComponents: [],
 		pendingTools: new Map(),
+		eventController: { inheritAssistantAwaitingSeal: vi.fn(), resetTranscriptAnchors: vi.fn() },
 		ui: { requestRender: vi.fn() },
 		present: (content: Component | readonly Component[]) => {
 			const items = Array.isArray(content) ? content : [content];
@@ -149,5 +153,50 @@ describe("InteractiveMode.showStatus", () => {
 		// handler owns this lifecycle and uses it to guard against clearing the
 		// user's in-progress editor draft during an optimistic send (#783).
 		expect(ctx.optimisticUserMessageSignature).toBe("hello\u00001");
+	});
+
+	test("seals historical assistant predecessors but leaves the final assistant unsealed", () => {
+		const { ctx, helpers } = createInitialRenderHarness();
+		const assistant = (text: string): AssistantMessage => ({
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+
+		helpers.renderSessionContext({ messages: [assistant("first"), assistant("final")] } as SessionContext);
+		const assistants = ctx.chatContainer.children.filter(
+			(child): child is AssistantMessageComponent => child instanceof AssistantMessageComponent,
+		);
+
+		expect(assistants).toHaveLength(2);
+		expect(assistants[0]!.isTranscriptBlockSealed()).toBe(true);
+		expect(assistants[1]!.isTranscriptBlockSealed()).toBe(false);
+		expect(ctx.eventController?.inheritAssistantAwaitingSeal).toHaveBeenCalledWith(assistants[1]);
+	});
+
+	test("resetTranscript clears event-controller anchors before disposing chat components", () => {
+		const { ctx } = createInitialRenderHarness();
+		const order: string[] = [];
+		const resetTranscriptAnchors = vi.fn(() => order.push("anchors"));
+		if (!ctx.eventController) throw new Error("event controller fixture missing");
+		ctx.eventController.resetTranscriptAnchors = resetTranscriptAnchors;
+		ctx.chatContainer.dispose = vi.fn(() => order.push("dispose"));
+		ctx.chatContainer.clear = vi.fn(() => order.push("clear"));
+
+		InteractiveMode.prototype.resetTranscript.call(ctx as InteractiveMode);
+		expect(resetTranscriptAnchors).toHaveBeenCalledTimes(1);
+		expect(order).toEqual(["anchors", "dispose", "clear"]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -186,17 +186,20 @@ describe("InteractiveMode.showStatus", () => {
 		expect(ctx.eventController?.inheritAssistantAwaitingSeal).toHaveBeenCalledWith(assistants[1]);
 	});
 
-	test("resetTranscript clears event-controller anchors before disposing chat components", () => {
+	test("resetTranscript clears the pinned banner with its event-controller anchor before disposing chat", () => {
 		const { ctx } = createInitialRenderHarness();
 		const order: string[] = [];
+		const clearPinnedError = vi.fn(() => order.push("banner"));
 		const resetTranscriptAnchors = vi.fn(() => order.push("anchors"));
+		ctx.clearPinnedError = clearPinnedError;
 		if (!ctx.eventController) throw new Error("event controller fixture missing");
 		ctx.eventController.resetTranscriptAnchors = resetTranscriptAnchors;
 		ctx.chatContainer.dispose = vi.fn(() => order.push("dispose"));
 		ctx.chatContainer.clear = vi.fn(() => order.push("clear"));
 
 		InteractiveMode.prototype.resetTranscript.call(ctx as InteractiveMode);
+		expect(clearPinnedError).toHaveBeenCalledTimes(1);
 		expect(resetTranscriptAnchors).toHaveBeenCalledTimes(1);
-		expect(order).toEqual(["anchors", "dispose", "clear"]);
+		expect(order).toEqual(["banner", "anchors", "dispose", "clear"]);
 	});
 });

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -660,6 +660,7 @@ describe("TranscriptContainer spacing", () => {
 	it("preserves background-colored padding rows (block-internal design)", () => {
 		const bgPad = "\x1b[48;2;0;0;0m   \x1b[0m";
 		const container = new TranscriptContainer();
+
 		container.addChild(new MutableBlock(["a"]));
 		// The ANSI-bearing padding row is not "plain blank", so it survives stripping.
 		container.addChild(new MutableBlock([bgPad, "x", bgPad]));
@@ -881,6 +882,19 @@ describe("TranscriptContainer isBlockUncommitted", () => {
 		container.addChild(block);
 
 		expect(container.isBlockUncommitted(block)).toBe(true);
+	});
+
+	it("keeps a live block uncommitted when only its leading separator entered scrollback", () => {
+		const container = new TranscriptContainer();
+		container.addChild(new CountingFinalizedBlock(["history"]));
+		const live = new StreamingBlock(["live"]);
+		container.addChild(live);
+
+		expect(container.render(40)).toEqual(["history", "", "live"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["live"]);
+
+		expect(container.isBlockUncommitted(live)).toBe(true);
 	});
 
 	it("tracks whether committed rows have reached a rendered block", () => {

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -53,6 +53,15 @@ class StreamingBlock implements Component {
 	}
 }
 
+class FinalizationProbeBlock extends StreamingBlock {
+	throwOnRead = false;
+
+	override isTranscriptBlockFinalized(): boolean {
+		if (this.throwOnRead) throw new Error("compacted-prefix query scanned the retained suffix");
+		return super.isTranscriptBlockFinalized();
+	}
+}
+
 // A still-live block that can declare a byte-stable rendered prefix. The
 // transcript container may commit only those declared rows before finalization.
 class DeclaredSettledStreamingBlock extends StreamingBlock {
@@ -99,9 +108,11 @@ class VersionedFinalizedBlock implements Component {
 	renderCount = 0;
 	#lines: string[];
 	#version = 0;
+	#sealed: boolean;
 
-	constructor(lines: string[]) {
+	constructor(lines: string[], sealed = false) {
 		this.#lines = lines;
+		this.#sealed = sealed;
 	}
 
 	mutate(lines: string[]): void {
@@ -111,6 +122,14 @@ class VersionedFinalizedBlock implements Component {
 
 	isTranscriptBlockFinalized(): boolean {
 		return true;
+	}
+
+	sealTranscriptBlock(): void {
+		this.#sealed = true;
+	}
+
+	isTranscriptBlockSealed(): boolean {
+		return this.#sealed;
 	}
 
 	getTranscriptBlockVersion(): number {
@@ -368,6 +387,60 @@ describe("TranscriptContainer", () => {
 		expect(history.renderCount).toBe(2);
 	});
 
+	it("suppresses first-time compaction inside a destructive replay transaction", () => {
+		const container = new TranscriptContainer();
+		const history = new CountingFinalizedBlock(["committed-history"]);
+		const tail = new CountingFinalizedBlock(["retained-tail"]);
+		container.addChild(history);
+		container.addChild(tail);
+
+		expect(container.render(40)).toEqual(["committed-history", "", "retained-tail"]);
+		// Post-emit publication: the rows entered native scrollback, but no
+		// render has compacted them out of the local frame yet.
+		container.setNativeScrollbackCommittedRows(2);
+
+		// A destructive replay (resize / clear-scrollback) arrives before the
+		// next ordinary render. The ED3 erase removes the committed rows from
+		// native scrollback, so the replay frame must carry complete history —
+		// a first-time compaction inside this transaction would lose the rows.
+		container.prepareNativeScrollbackReplay();
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["committed-history", "", "retained-tail"]);
+
+		// The post-emit publication releases the latch; ordinary compaction
+		// resumes on the next render.
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["retained-tail"]);
+	});
+
+	it("keeps suppressing compaction when a deferred replay frame recomposes before emitting", () => {
+		const container = new TranscriptContainer();
+		const history = new CountingFinalizedBlock(["committed-history"]);
+		const tail = new CountingFinalizedBlock(["retained-tail"]);
+		container.addChild(history);
+		container.addChild(tail);
+
+		expect(container.render(40)).toEqual(["committed-history", "", "retained-tail"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["retained-tail"]);
+
+		// The replay frame is composed but abandoned before emitting (Ghostty
+		// initial-image deferral); the TUI re-prepares and recomposes next frame.
+		container.prepareNativeScrollbackReplay();
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["committed-history", "", "retained-tail"]);
+		container.prepareNativeScrollbackReplay();
+		container.setNativeScrollbackCommittedRows(2);
+		// Still the complete frame: suppression survives until the post-emit
+		// publication, not just one render call.
+		expect(container.render(40)).toEqual(["committed-history", "", "retained-tail"]);
+
+		// Emit happened; the post-emit publication releases the latch and
+		// ordinary compaction resumes.
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["retained-tail"]);
+	});
+
 	it("does not re-render finalized rows already committed to native scrollback", () => {
 		const container = new TranscriptContainer();
 		const committed = new CountingFinalizedBlock(["committed"]);
@@ -388,36 +461,69 @@ describe("TranscriptContainer", () => {
 		expect(container.render(40)).toEqual(["committed", "", "tail"]);
 		expect(committed.renderCount).toBe(2);
 	});
-	it("compacts a committed version-tracked block and rehydrates its post-commit mutation on replay", () => {
+
+	it("compacts a sealed finalized versioned block", () => {
 		const container = new TranscriptContainer();
-		const block = new VersionedFinalizedBlock(["original"]);
-		const tail = new CountingFinalizedBlock(["tail"]);
+		const history = new VersionedFinalizedBlock(["sealed-history"], true);
+		container.addChild(history);
+		container.addChild(new CountingFinalizedBlock(["tail"]));
+
+		expect(container.render(40)).toEqual(["sealed-history", "", "tail"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["tail"]);
+		expect(history.renderCount).toBe(1);
+		expect(container.isBlockUncommitted(history)).toBe(false);
+	});
+
+	it("keeps an unsealed finalized versioned block in the local frame", () => {
+		const container = new TranscriptContainer();
+		const history = new VersionedFinalizedBlock(["unsealed-history"]);
+		container.addChild(history);
+		container.addChild(new CountingFinalizedBlock(["tail"]));
+
+		expect(container.render(40)).toEqual(["unsealed-history", "", "tail"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["unsealed-history", "", "tail"]);
+	});
+
+	it("re-renders a sealed block whose version changes before compaction", () => {
+		const container = new TranscriptContainer();
+		const block = new VersionedFinalizedBlock(["original"], true);
 		container.addChild(block);
-		container.addChild(tail);
+		container.addChild(new CountingFinalizedBlock(["tail"]));
 
 		expect(container.render(40)).toEqual(["original", "", "tail"]);
-		// Commit the block plus its trailing separator: those rows are now
-		// immutable native scrollback the terminal owns, so the container drops
-		// them from the live frame instead of re-walking them every tick.
 		container.setNativeScrollbackCommittedRows(2);
+		block.mutate(["updated-before-compaction"]);
+		expect(container.render(40)).toEqual(["updated-before-compaction", "", "tail"]);
+		expect(block.renderCount).toBe(2);
 		expect(container.render(40)).toEqual(["tail"]);
-		expect(block.renderCount).toBe(1);
-
-		// A post-commit mutation (setErrorPinned(false) restoring the inline
-		// error) on a compacted, scrolled-off block must NOT recommit on an
-		// ordinary frame — recommitting immutable history would duplicate it.
-		block.mutate(["original", "Error: boom"]);
-		expect(container.render(40)).toEqual(["tail"]);
-		expect(block.renderCount).toBe(1);
-
-		// A destructive full replay (ED3) retires the tape and rehydrates the
-		// complete frame from each block's current render — the mutation surfaces
-		// exactly once, no loss.
-		container.prepareNativeScrollbackReplay();
-		container.setNativeScrollbackCommittedRows(2);
-		expect(container.render(40)).toEqual(["original", "Error: boom", "", "tail"]);
 		expect(block.renderCount).toBe(2);
 	});
+
+	it("re-renders a committed finalized block when its version changes", () => {
+		const container = new TranscriptContainer();
+		const block = new VersionedFinalizedBlock(["original"]);
+		container.addChild(block);
+
+		expect(container.render(40)).toEqual(["original"]);
+		container.setNativeScrollbackCommittedRows(1);
+		expect(container.render(40)).toEqual(["original"]);
+		expect(block.renderCount).toBe(1);
+
+		// Post-finalize mutation (e.g. setErrorPinned(false) restoring the inline
+		// error) must surface even though the rows sit in committed scrollback —
+		// the render is what lets the TUI's committed-prefix audit re-anchor.
+		block.mutate(["original", "Error: boom"]);
+		expect(container.render(40)).toEqual(["original", "Error: boom"]);
+		expect(block.renderCount).toBe(2);
+
+		// Once observed, the bypass re-engages at the new version.
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["original", "Error: boom"]);
+		expect(block.renderCount).toBe(2);
+	});
+
 	it("renders once after a block finalizes with rows already inside committed scrollback", () => {
 		const container = new TranscriptContainer();
 		const block = new StreamingBlock(["streaming"]);
@@ -444,7 +550,8 @@ describe("TranscriptContainer", () => {
 		expect(container.render(40)).toEqual(["streaming", "done", "", "tail"]);
 		expect(block.renderCount).toBe(rendersAfterTransition);
 	});
-	it("reports a new assistant block version after post-finalize error unpinning", () => {
+
+	it("keeps post-seal error restoration visible before compaction", () => {
 		const message: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: "hello" }],
@@ -454,13 +561,81 @@ describe("TranscriptContainer", () => {
 		} as AssistantMessage;
 		const component = new AssistantMessageComponent(message);
 		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		expect(component.isTranscriptBlockSealed()).toBe(false);
 
 		component.setErrorPinned(true);
-		const pinnedVersion = component.getTranscriptBlockVersion();
-		// The restore path at the next turn's agent_start must be observable by
-		// the transcript container's committed-scrollback bypass.
+		component.sealTranscriptBlock();
+		expect(component.isTranscriptBlockSealed()).toBe(true);
+		expect(stripVTControlCharacters(component.render(120).join("\n"))).not.toContain("Error: boom");
+
+		const sealedVersion = component.getTranscriptBlockVersion();
 		component.setErrorPinned(false);
-		expect(component.getTranscriptBlockVersion()).toBeGreaterThan(pinnedVersion);
+		expect(component.getTranscriptBlockVersion()).toBeGreaterThan(sealedVersion);
+		expect(stripVTControlCharacters(component.render(120).join("\n"))).toContain("Error: boom");
+	});
+	it("reports virtualized rows via take semantics", () => {
+		const container = new TranscriptContainer();
+		container.addChild(new VersionedFinalizedBlock(["history"], true));
+		container.addChild(new CountingFinalizedBlock(["tail"]));
+
+		expect(container.render(40)).toEqual(["history", "", "tail"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["tail"]);
+		expect(container.takeNativeScrollbackVirtualizedRows()).toBe(2);
+		expect(container.takeNativeScrollbackVirtualizedRows()).toBe(0);
+	});
+
+	it("take accumulates across renders and resets on replay and clear", () => {
+		const accumulating = new TranscriptContainer();
+		accumulating.addChild(new CountingFinalizedBlock(["first"]));
+		accumulating.addChild(new CountingFinalizedBlock(["second"]));
+		accumulating.addChild(new CountingFinalizedBlock(["tail"]));
+
+		expect(accumulating.render(40)).toEqual(["first", "", "second", "", "tail"]);
+		accumulating.setNativeScrollbackCommittedRows(2);
+		expect(accumulating.render(40)).toEqual(["second", "", "tail"]);
+		accumulating.setNativeScrollbackCommittedRows(2);
+		expect(accumulating.render(40)).toEqual(["tail"]);
+		expect(accumulating.takeNativeScrollbackVirtualizedRows()).toBe(4);
+
+		const replayed = new TranscriptContainer();
+		const replayedHistory = new CountingFinalizedBlock(["history"]);
+		replayed.addChild(replayedHistory);
+		replayed.addChild(new CountingFinalizedBlock(["tail"]));
+		expect(replayed.render(40)).toEqual(["history", "", "tail"]);
+		replayed.setNativeScrollbackCommittedRows(2);
+		// The drop includes the retained block's committed leading separator.
+		expect(replayed.render(40)).toEqual(["tail"]);
+		replayed.removeChild(replayedHistory);
+		replayed.prepareNativeScrollbackReplay();
+		expect(replayed.takeNativeScrollbackVirtualizedRows()).toBe(0);
+
+		const cleared = new TranscriptContainer();
+		cleared.addChild(new CountingFinalizedBlock(["history"]));
+		cleared.addChild(new CountingFinalizedBlock(["tail"]));
+		expect(cleared.render(40)).toEqual(["history", "", "tail"]);
+		cleared.setNativeScrollbackCommittedRows(2);
+		expect(cleared.render(40)).toEqual(["tail"]);
+		cleared.clear();
+		expect(cleared.takeNativeScrollbackVirtualizedRows()).toBe(0);
+	});
+
+	it("removeChild below the compaction boundary keeps boundary alignment", () => {
+		const container = new TranscriptContainer();
+		const first = new CountingFinalizedBlock(["first"]);
+		const survivor = new CountingFinalizedBlock(["survivor"]);
+		container.addChild(first);
+		container.addChild(survivor);
+		container.addChild(new CountingFinalizedBlock(["tail"]));
+
+		expect(container.render(40)).toEqual(["first", "", "survivor", "", "tail"]);
+		container.setNativeScrollbackCommittedRows(4);
+		expect(container.render(40)).toEqual(["tail"]);
+		expect(container.isBlockUncommitted(survivor)).toBe(false);
+
+		container.removeChild(first);
+		expect(container.render(40)).toEqual(["tail"]);
+		expect(container.isBlockUncommitted(survivor)).toBe(false);
 	});
 });
 
@@ -653,10 +828,49 @@ describe("TranscriptContainer isBlockInLiveRegion", () => {
 		expect(container.isBlockInLiveRegion(tail)).toBe(true);
 	});
 
+	it("returns false for a compacted block without scanning the retained suffix", () => {
+		const container = new TranscriptContainer();
+		const history = new VersionedFinalizedBlock(["history"], true);
+		const tail = new FinalizationProbeBlock(["tail"], true);
+		container.addChild(history);
+		container.addChild(tail);
+
+		expect(container.render(40)).toEqual(["history", "", "tail"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["tail"]);
+
+		tail.throwOnRead = true;
+		expect(container.isBlockInLiveRegion(history)).toBe(false);
+	});
+
 	it("returns false for a component that is not a child", () => {
 		const container = new TranscriptContainer();
 		container.addChild(new StreamingBlock(["a"], true));
 		expect(container.isBlockInLiveRegion(new StreamingBlock(["x"], false))).toBe(false);
+	});
+
+	it("reindexes children after removal and clear", () => {
+		const container = new TranscriptContainer();
+		const live = new StreamingBlock(["live"]);
+		const target = new StreamingBlock(["target"], true);
+		const tail = new StreamingBlock(["tail"], true);
+		container.addChild(live);
+		container.addChild(target);
+		container.addChild(tail);
+		expect(container.render(40)).toEqual(["live", "", "target", "", "tail"]);
+
+		expect(container.isBlockInLiveRegion(target)).toBe(true);
+		container.removeChild(live);
+		expect(container.isBlockInLiveRegion(target)).toBe(false);
+		const fresh = new TranscriptContainer();
+		fresh.addChild(new StreamingBlock(["target"], true));
+		fresh.addChild(new StreamingBlock(["tail"], true));
+		expect(container.render(40)).toEqual(fresh.render(40));
+
+		container.clear();
+		container.addChild(target);
+		expect(container.isBlockInLiveRegion(target)).toBe(true);
+		expect(container.isBlockInLiveRegion(tail)).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -387,6 +387,21 @@ describe("TranscriptContainer", () => {
 		expect(history.renderCount).toBe(2);
 	});
 
+	it("renders compacted rows for exporters without changing virtualization state", () => {
+		const container = new TranscriptContainer();
+		const history = new CountingFinalizedBlock(["committed-history"]);
+		container.addChild(history);
+		container.addChild(new CountingFinalizedBlock(["retained-tail"]));
+
+		expect(container.render(40)).toEqual(["committed-history", "", "retained-tail"]);
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["retained-tail"]);
+
+		expect(container.renderFullHistory(40)).toEqual(["committed-history", "", "retained-tail"]);
+		expect(container.render(40)).toEqual(["retained-tail"]);
+		expect(container.takeNativeScrollbackVirtualizedRows()).toBe(2);
+	});
+
 	it("suppresses first-time compaction inside a destructive replay transaction", () => {
 		const container = new TranscriptContainer();
 		const history = new CountingFinalizedBlock(["committed-history"]);

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -71,6 +71,7 @@ function makeHarness(): Harness {
 			handleEvent: async (event: unknown) => {
 				handledEvents.push(event);
 			},
+			resumeAssistantStream: () => false,
 			resetTranscriptAnchors: () => {
 				resetTranscriptAnchors++;
 			},

--- a/packages/coding-agent/test/transcript-compaction-scrollback.test.ts
+++ b/packages/coding-agent/test/transcript-compaction-scrollback.test.ts
@@ -1,0 +1,346 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+type DrainableScheduler = {
+	now(): number;
+	scheduleImmediate(cb: () => void): void;
+	scheduleRender(cb: () => void, delayMs: number): { cancel(): void };
+	flush(): void;
+};
+
+function makeDrainableScheduler(): DrainableScheduler {
+	let clock = 0;
+	const queue: Array<{ run: () => void; cancelled: boolean }> = [];
+	const enqueue = (cb: () => void) => {
+		const item = { run: cb, cancelled: false };
+		queue.push(item);
+		return item;
+	};
+	return {
+		now: () => clock,
+		scheduleImmediate(cb) {
+			enqueue(cb);
+		},
+		scheduleRender(cb) {
+			const item = enqueue(cb);
+			return {
+				cancel() {
+					item.cancelled = true;
+				},
+			};
+		},
+		flush() {
+			let guard = 0;
+			while (queue.length > 0) {
+				if (++guard > 100_000) throw new Error("scheduler did not settle");
+				const item = queue.shift();
+				if (item === undefined) throw new Error("scheduler queue unexpectedly empty");
+				clock += 1;
+				if (!item.cancelled) item.run();
+			}
+		},
+	};
+}
+
+class StaticBlock implements Component {
+	constructor(private readonly lines: readonly string[]) {}
+	invalidate(): void {}
+	render(_width: number): readonly string[] {
+		return this.lines;
+	}
+}
+
+class Footer implements Component {
+	constructor(private readonly rows: number) {}
+	invalidate(): void {}
+	render(_width: number): readonly string[] {
+		return Array.from({ length: this.rows }, (_, index) => `editor-${index}`);
+	}
+}
+
+class VersionedFinalizedBlock implements Component {
+	#version = 0;
+	#sealed: boolean;
+	#lines: readonly string[];
+
+	constructor(lines: readonly string[], sealed = false) {
+		this.#lines = lines;
+		this.#sealed = sealed;
+	}
+
+	mutate(lines: readonly string[]): void {
+		this.#lines = lines;
+		this.#version++;
+	}
+
+	isTranscriptBlockFinalized(): boolean {
+		return true;
+	}
+
+	sealTranscriptBlock(): void {
+		this.#sealed = true;
+	}
+
+	isTranscriptBlockSealed(): boolean {
+		return this.#sealed;
+	}
+
+	getTranscriptBlockVersion(): number {
+		return this.#version;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): readonly string[] {
+		return [...this.#lines];
+	}
+}
+
+class ObservedTranscriptContainer extends TranscriptContainer {
+	readonly frameLengths: number[] = [];
+	replayPreparations = 0;
+
+	override prepareNativeScrollbackReplay(): void {
+		this.replayPreparations++;
+		super.prepareNativeScrollbackReplay();
+	}
+
+	override render(width: number): readonly string[] {
+		const frame = super.render(width);
+		this.frameLengths.push(frame.length);
+		return frame;
+	}
+}
+
+type Fixture = {
+	term: VirtualTerminal;
+	scheduler: DrainableScheduler;
+	tui: TUI;
+	transcript: ObservedTranscriptContainer;
+	writes: string[];
+};
+
+const width = 80;
+const rows = 10;
+const headerRows = ["header-above"];
+const footerRows = ["editor-0", "editor-1", "editor-2"];
+
+function blockRows(block: number, suffix = ""): string[] {
+	return Array.from({ length: 8 }, (_, row) => `block-${block}-row-${row}${suffix}`);
+}
+
+function makeFixture(scrollbackRebuild: boolean): Fixture {
+	const term = new VirtualTerminal(width, rows, 1_000);
+	const writes: string[] = [];
+	const write = term.write.bind(term);
+	term.write = data => {
+		writes.push(data);
+		write(data);
+	};
+	const scheduler = makeDrainableScheduler();
+	const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+	const transcript = new ObservedTranscriptContainer();
+	tui.setScrollbackRebuild(scrollbackRebuild);
+	tui.addChild(new StaticBlock(headerRows));
+	tui.addChild(transcript);
+	tui.addChild(new Footer(3));
+	return { term, scheduler, tui, transcript, writes };
+}
+
+async function flush(fixture: Fixture): Promise<void> {
+	fixture.scheduler.flush();
+	await fixture.term.flush();
+}
+
+async function settle(fixture: Fixture, times = 1): Promise<void> {
+	for (let index = 0; index < times; index++) {
+		fixture.tui.requestRender();
+		await flush(fixture);
+	}
+}
+
+function plainScrollBuffer(term: VirtualTerminal): string[] {
+	return term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+}
+
+function countRows(term: VirtualTerminal, expected: readonly string[]): number[] {
+	const buffer = plainScrollBuffer(term);
+	return expected.map(row => buffer.filter(candidate => candidate === row).length);
+}
+
+function countED3(writes: readonly string[]): number {
+	return writes.reduce((count, write) => count + write.split("\x1b[3J").length - 1, 0);
+}
+
+function expectRowsExactlyOnce(term: VirtualTerminal, expected: readonly string[], oracle: string): void {
+	const buffer = plainScrollBuffer(term);
+	const counts = expected.map(row => buffer.filter(candidate => candidate === row).length);
+	expect(counts, `${oracle}: row occurrence counts; buffer=${JSON.stringify(buffer)}`).toEqual(expected.map(() => 1));
+}
+
+function expectNoDuplicateNonBlankRows(term: VirtualTerminal, oracle: string): void {
+	const nonBlank = plainScrollBuffer(term).filter(Boolean);
+	const occurrences = new Map<string, number>();
+	for (const row of nonBlank) occurrences.set(row, (occurrences.get(row) ?? 0) + 1);
+	const duplicates = [...occurrences].filter(([, count]) => count > 1);
+	expect(
+		new Set(nonBlank).size,
+		`${oracle}: unique non-blank row count; duplicates=${JSON.stringify(duplicates)}`,
+	).toBe(nonBlank.length);
+}
+
+async function addThreeBlocks(fixture: Fixture): Promise<VersionedFinalizedBlock[]> {
+	const blocks = [1, 2, 3].map(block => new VersionedFinalizedBlock(blockRows(block)));
+	fixture.transcript.addChild(blocks[0]);
+	await settle(fixture, 2);
+	blocks[0]?.sealTranscriptBlock();
+	fixture.transcript.addChild(blocks[1]);
+	await settle(fixture, 2);
+	blocks[1]?.sealTranscriptBlock();
+	fixture.transcript.addChild(blocks[2]);
+	await settle(fixture, 6);
+	return blocks;
+}
+
+const directTerminalEnvKeys = [
+	"TERM",
+	"TERM_PROGRAM",
+	"PI_TUI_RESIZE_IN_PLACE",
+	"TMUX",
+	"STY",
+	"ZELLIJ",
+	"CMUX_WORKSPACE_ID",
+	"CMUX_SURFACE_ID",
+] as const;
+const savedDirectTerminalEnv: Partial<Record<(typeof directTerminalEnvKeys)[number], string>> = {};
+
+beforeEach(() => {
+	for (const key of directTerminalEnvKeys) {
+		const value = Bun.env[key];
+		if (value !== undefined) savedDirectTerminalEnv[key] = value;
+		delete Bun.env[key];
+	}
+	Bun.env.TERM = "xterm-256color";
+	Bun.env.PI_TUI_RESIZE_IN_PLACE = "0";
+});
+
+afterEach(() => {
+	for (const key of directTerminalEnvKeys) {
+		const value = savedDirectTerminalEnv[key];
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+		delete savedDirectTerminalEnv[key];
+	}
+});
+
+describe("transcript prefix compaction preserves native scrollback", () => {
+	test("rebuild on keeps compacted, mutated, resized, and reattached history exactly once", async () => {
+		const fixture = makeFixture(true);
+		try {
+			fixture.tui.start();
+			await flush(fixture);
+			const blocks = await addThreeBlocks(fixture);
+			const block1 = blockRows(1);
+			const largestFrame = Math.max(...fixture.transcript.frameLengths);
+			const latestFrame = fixture.transcript.frameLengths.at(-1) ?? largestFrame;
+			expect(latestFrame, "Step 1: transcript compaction shrinks the rendered frame").toBeLessThan(largestFrame);
+			expectRowsExactlyOnce(fixture.term, block1, "Oracle A");
+
+			const ed3AfterCompaction = countED3(fixture.writes);
+			expect(ed3AfterCompaction, "Step 1: compaction ED3 count").toBe(0);
+			await settle(fixture, 5);
+			expect(countED3(fixture.writes), "Oracle B: ED3 count after five no-op settles").toBe(ed3AfterCompaction);
+
+			const block3 = blocks[2];
+			if (block3 === undefined) throw new Error("third transcript block was not created");
+			const successorRows = blockRows(4, "-successor");
+			const successor = new VersionedFinalizedBlock(successorRows);
+			fixture.transcript.addChild(successor);
+			await settle(fixture);
+			const ed3BeforeMutation = countED3(fixture.writes);
+			const updatedBlock3 = blockRows(3, "-updated");
+			block3.sealTranscriptBlock();
+			block3.mutate(updatedBlock3);
+			await settle(fixture);
+			expect(countED3(fixture.writes) - ed3BeforeMutation, "Step 2: version mutation replay count").toBe(1);
+			expectRowsExactlyOnce(fixture.term, updatedBlock3, "Step 2: pre-compaction version mutation");
+			expect(countRows(fixture.term, blockRows(3)), "Step 2: stale pre-mutation rows removed by replay").toEqual(
+				blockRows(3).map(() => 0),
+			);
+			await settle(fixture, 5);
+			fixture.transcript.removeChild(successor);
+			const replayPreparationsBeforeResize = fixture.transcript.replayPreparations;
+			const ed3BeforeResize = countED3(fixture.writes);
+			const writesBeforeResize = fixture.writes.length;
+			const framesBeforeResize = fixture.transcript.frameLengths.length;
+			fixture.term.resize(width - 10, rows);
+			await settle(fixture, 5);
+			expect(
+				fixture.transcript.replayPreparations,
+				"Step 3: resize prepares compacted transcript replay",
+			).toBeGreaterThan(replayPreparationsBeforeResize);
+			expect(countED3(fixture.writes) - ed3BeforeResize, "Step 3: resize emits one destructive replay").toBe(1);
+			const resizeReplayWrite = fixture.writes.slice(writesBeforeResize).find(write => write.includes("\x1b[3J"));
+			expect(resizeReplayWrite, "Step 3: resize ED3 write exists").toBeDefined();
+			const resizeWrites = fixture.writes.slice(writesBeforeResize).join("");
+			expect(
+				resizeWrites.includes("block-1-row-0"),
+				`Step 3: resize writes contain compacted history; frames=${fixture.transcript.frameLengths.slice(framesBeforeResize).join(",")}`,
+			).toBe(true);
+			const allUpdatedRows = [...blockRows(1), ...blockRows(2), ...updatedBlock3];
+			expectRowsExactlyOnce(fixture.term, allUpdatedRows, "Step 3: resize replay");
+
+			fixture.transcript.clear();
+			for (let block = 1; block <= 3; block++) {
+				fixture.transcript.addChild(new VersionedFinalizedBlock(blockRows(block, "-reattached"), true));
+			}
+			const ed3BeforeAttach = countED3(fixture.writes);
+			fixture.tui.requestRender(true, { clearScrollback: true });
+			await flush(fixture);
+			const reattachedRows = [
+				...blockRows(1, "-reattached"),
+				...blockRows(2, "-reattached"),
+				...blockRows(3, "-reattached"),
+			];
+			expectRowsExactlyOnce(fixture.term, reattachedRows, "Step 5: focus-attach replay");
+			const ed3AfterAttach = countED3(fixture.writes);
+			expect(ed3AfterAttach - ed3BeforeAttach, "Step 5: focus-attach replay count").toBe(1);
+			const frameBeforePostAttachCompaction = fixture.transcript.frameLengths.at(-1) ?? 0;
+			await settle(fixture);
+			const frameAfterPostAttachCompaction = fixture.transcript.frameLengths.at(-1) ?? 0;
+			expect(
+				frameAfterPostAttachCompaction,
+				"Step 5: ordinary frame after attach compacts the rehydrated transcript",
+			).toBeLessThan(frameBeforePostAttachCompaction);
+			expect(countED3(fixture.writes), "Step 5: post-attach compaction does not trigger another ED3").toBe(
+				ed3AfterAttach,
+			);
+			expectRowsExactlyOnce(fixture.term, reattachedRows, "Step 5: post-compaction history");
+			expectNoDuplicateNonBlankRows(fixture.term, "Step 5");
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+
+	test("rebuild off compacts without duplicating non-blank history", async () => {
+		const fixture = makeFixture(false);
+		try {
+			fixture.tui.start();
+			await flush(fixture);
+			await addThreeBlocks(fixture);
+			expectRowsExactlyOnce(fixture.term, blockRows(1), "Step 4: rebuild-off compacted block");
+			expectNoDuplicateNonBlankRows(fixture.term, "Step 4: rebuild off");
+			expectRowsExactlyOnce(
+				fixture.term,
+				[...headerRows, ...blockRows(1), ...blockRows(2), ...blockRows(3), ...footerRows],
+				"Step 4: complete rebuild-off history",
+			);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Added native-scrollback prefix virtualization so containers can compact committed history without losing or duplicating terminal rows. ([#5930](https://github.com/can1357/oh-my-pi/issues/5930))
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2838,16 +2838,18 @@ export class TUI extends Container {
 		}
 
 		// A destructive replay erases native history and must receive the complete
-		// component frame. Give virtualized roots one compose to rehydrate rows
-		// they dropped after commit. Height-only and net-unchanged resize events
-		// count too: both enter the geometry rebuild path below.
-		const replayFullHistory =
-			this.#hasEverRendered &&
+		// component frame. Mirror the full-paint clearScrollback decision below:
+		// explicit clears are destructive on direct terminals even when resize paints
+		// in place, while multiplexer pane-preserving paints never rehydrate.
+		const geometryWillClearScrollback =
 			!resizeRepaintsInPlace() &&
-			(this.#clearScrollbackOnNextRender ||
-				this.#resizeEventPending ||
+			(this.#resizeEventPending ||
 				(this.#previousWidth > 0 && this.#previousWidth !== width) ||
 				(this.#previousHeight > 0 && this.#previousHeight !== height));
+		const replayFullHistory =
+			this.#hasEverRendered &&
+			!isMultiplexerSession() &&
+			(this.#clearScrollbackOnNextRender || geometryWillClearScrollback);
 		if (replayFullHistory) {
 			for (const child of this.children) prepareNativeScrollbackReplay(child);
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2843,11 +2843,11 @@ export class TUI extends Container {
 		// count too: both enter the geometry rebuild path below.
 		const replayFullHistory =
 			this.#hasEverRendered &&
+			!resizeRepaintsInPlace() &&
 			(this.#clearScrollbackOnNextRender ||
-				(!resizeRepaintsInPlace() &&
-					(this.#resizeEventPending ||
-						(this.#previousWidth > 0 && this.#previousWidth !== width) ||
-						(this.#previousHeight > 0 && this.#previousHeight !== height))));
+				this.#resizeEventPending ||
+				(this.#previousWidth > 0 && this.#previousWidth !== width) ||
+				(this.#previousHeight > 0 && this.#previousHeight !== height));
 		if (replayFullHistory) {
 			for (const child of this.children) prepareNativeScrollbackReplay(child);
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -218,9 +218,24 @@ export interface NativeScrollbackCommittedRows {
 export interface NativeScrollbackReplay {
 	prepareNativeScrollbackReplay(): void;
 }
+/**
+ * A component that virtualizes rows already recorded in native scrollback
+ * reports how many rows it dropped from the top of its committed sub-range.
+ * The count is consumed on read and is expressed in the component's previous
+ * engine-observed render coordinates. Drops between takes must concatenate
+ * into a prefix of that committed sub-range.
+ */
+export interface NativeScrollbackVirtualizedPrefix {
+	takeNativeScrollbackVirtualizedRows(): number;
+}
 
 function prepareNativeScrollbackReplay(component: Component): void {
 	(component as Component & Partial<NativeScrollbackReplay>).prepareNativeScrollbackReplay?.();
+}
+function takeNativeScrollbackVirtualizedRows(component: Component): number {
+	return (
+		(component as Component & Partial<NativeScrollbackVirtualizedPrefix>).takeNativeScrollbackVirtualizedRows?.() ?? 0
+	);
 }
 
 function setNativeScrollbackCommittedRows(component: Component, rows: number): void {
@@ -1034,6 +1049,8 @@ export class TUI extends Container {
 	// snapshot (duplication, never loss). Re-based on full paints / shrinks /
 	// geometry frames.
 	#committedPrefixAuditRows = 0;
+	#pendingVirtualizedDrops: { start: number; rows: number }[] = [];
+	#virtualizedRowsEpochTotal = 0;
 	// Frame row currently mapped to screen row 0. Monotonic between full
 	// paints: a shrink never re-exposes scrolled-off rows (they cannot be
 	// un-scrolled without rewriting history); live rows repaint at fixed
@@ -1215,6 +1232,13 @@ export class TUI extends Container {
 				// deliberately NOT read — their baseline must stay anchored to
 				// the last render the engine actually observed.
 				reported = getRenderStablePrefixRows(child);
+				const virtualizedRows = takeNativeScrollbackVirtualizedRows(child);
+				if (virtualizedRows > 0) {
+					this.#pendingVirtualizedDrops.push({
+						start: prevStart,
+						rows: Math.min(virtualizedRows, prevRows),
+					});
+				}
 			}
 			// Topmost seam wins. Commits are prefix-only: the first child that
 			// reports a live region already bounds everything below it, so a
@@ -2849,6 +2873,22 @@ export class TUI extends Container {
 			rawFrame = this.render(width);
 			this.#imageBudget.endPass();
 		}
+		let virtualizedShift = 0;
+		for (const drop of this.#pendingVirtualizedDrops) {
+			const at = drop.start - virtualizedShift;
+			const rows = Math.min(drop.rows, Math.max(0, this.#committedRows - at));
+			if (rows <= 0) continue;
+			this.#committedPrefix.splice(at, rows);
+			this.#committedRows -= rows;
+			this.#committedPrefixAuditRows =
+				at < this.#committedPrefixAuditRows
+					? Math.max(at, this.#committedPrefixAuditRows - rows)
+					: this.#committedPrefixAuditRows;
+			this.#windowTopRow = Math.max(0, this.#windowTopRow - rows);
+			virtualizedShift += rows;
+			this.#virtualizedRowsEpochTotal += rows;
+		}
+		this.#pendingVirtualizedDrops.length = 0;
 		// Ghostty initial-image deferral must run before any render state is
 		// consumed (#resizeEventPending, hardware-cursor state, commit
 		// re-anchoring): the early return abandons this frame and the deferred
@@ -2974,13 +3014,27 @@ export class TUI extends Container {
 		// instead of recommitting the final form below the stale fragment
 		// (a visibly duplicated block). Multiplexer panes cannot ED3 safely
 		// and keep the repair-below fallback in the branches under this one.
+		const divergenceDetected = committedRowsResynced || frameLength <= this.#committedRows;
 		const divergenceRebuild =
 			this.#scrollbackRebuildEnabled &&
 			!firstPaint &&
 			!replaceRequested &&
 			!geometryChanged &&
 			!isMultiplexerSession() &&
-			(committedRowsResynced || frameLength <= this.#committedRows);
+			divergenceDetected &&
+			this.#virtualizedRowsEpochTotal === 0;
+		if (
+			this.#scrollbackRebuildEnabled &&
+			!firstPaint &&
+			!replaceRequested &&
+			!geometryChanged &&
+			!isMultiplexerSession() &&
+			divergenceDetected &&
+			this.#virtualizedRowsEpochTotal > 0
+		) {
+			this.#clearScrollbackOnNextRender = true;
+			this.requestRender();
+		}
 		const fullPaint = firstPaint || replaceRequested || geometryRebuild || divergenceRebuild;
 		let windowTop: number;
 		let chunkTo: number;
@@ -3095,6 +3149,8 @@ export class TUI extends Container {
 			this.#committedPrefix = rawFrame.slice(0, chunkTo);
 			this.#committedPrefixAuditRows = Math.min(chunkTo, finalBoundary);
 			this.#clearScrollbackOnNextRender = false;
+			this.#virtualizedRowsEpochTotal = 0;
+			this.#pendingVirtualizedDrops.length = 0;
 			this.#hasEverRendered = true;
 			this.#publishCommittedRows();
 			if (!firstPaint && frameLength > height) this.#armPostFullPaintSettle();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2875,6 +2875,12 @@ export class TUI extends Container {
 			rawFrame = this.render(width);
 			this.#imageBudget.endPass();
 		}
+		// Ghostty initial-image deferral must run before any render state is
+		// consumed (#resizeEventPending, hardware-cursor state, virtualized
+		// drops, commit re-anchoring): the early return abandons this frame and
+		// the deferred render recomposes from scratch, so consuming state here
+		// would strand the deferred frame in abandoned coordinates.
+		if (this.#maybeDeferGhosttyInitialImagePaint()) return;
 		let virtualizedShift = 0;
 		for (const drop of this.#pendingVirtualizedDrops) {
 			const at = drop.start - virtualizedShift;
@@ -2895,12 +2901,6 @@ export class TUI extends Container {
 			this.#virtualizedRowsEpochTotal += rows;
 		}
 		this.#pendingVirtualizedDrops.length = 0;
-		// Ghostty initial-image deferral must run before any render state is
-		// consumed (#resizeEventPending, hardware-cursor state, commit
-		// re-anchoring): the early return abandons this frame and the deferred
-		// render recomposes from scratch, so consuming state here would
-		// misclassify a pending resize as an ordinary diff and corrupt the paint.
-		if (this.#maybeDeferGhosttyInitialImagePaint()) return;
 		// Cursor markers were stripped at compose time (they are internal
 		// sentinels and must never reach the terminal, the committed prefix, or
 		// the audit); the visible marker is chosen after the window top is

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2887,6 +2887,10 @@ export class TUI extends Container {
 					? Math.max(at, this.#committedPrefixAuditRows - rows)
 					: this.#committedPrefixAuditRows;
 			this.#windowTopRow = Math.max(0, this.#windowTopRow - rows);
+			this.#hardwareCursorRow = Math.max(0, this.#hardwareCursorRow - rows);
+			if (this.#hardwareCursorState) {
+				this.#hardwareCursorState = { ...this.#hardwareCursorState, row: this.#hardwareCursorRow };
+			}
 			virtualizedShift += rows;
 			this.#virtualizedRowsEpochTotal += rows;
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2843,11 +2843,11 @@ export class TUI extends Container {
 		// count too: both enter the geometry rebuild path below.
 		const replayFullHistory =
 			this.#hasEverRendered &&
-			!resizeRepaintsInPlace() &&
 			(this.#clearScrollbackOnNextRender ||
-				this.#resizeEventPending ||
-				(this.#previousWidth > 0 && this.#previousWidth !== width) ||
-				(this.#previousHeight > 0 && this.#previousHeight !== height));
+				(!resizeRepaintsInPlace() &&
+					(this.#resizeEventPending ||
+						(this.#previousWidth > 0 && this.#previousWidth !== width) ||
+						(this.#previousHeight > 0 && this.#previousHeight !== height))));
 		if (replayFullHistory) {
 			for (const child of this.children) prepareNativeScrollbackReplay(child);
 		}

--- a/packages/tui/test/render-stress-harness.ts
+++ b/packages/tui/test/render-stress-harness.ts
@@ -8,6 +8,9 @@ import {
 	CURSOR_MARKER,
 	type Focusable,
 	findCommittedPrefixResync,
+	type NativeScrollbackCommittedRows,
+	type NativeScrollbackReplay,
+	type NativeScrollbackVirtualizedPrefix,
 	type OverlayAnchor,
 	type OverlayHandle,
 	type OverlayOptions,
@@ -55,7 +58,8 @@ export type ScenarioTag =
 	| "strictScrollback"
 	| "unknownViewport"
 	| "foregroundStream"
-	| "ed3Risk";
+	| "ed3Risk"
+	| "virtualizedPrefix";
 const ENV_KEYS = [
 	"TMUX",
 	"STY",
@@ -125,7 +129,8 @@ export type OperationKind =
 	| "attachChild"
 	| "detachChild"
 	| "reorderChildren"
-	| "mutateChild";
+	| "mutateChild"
+	| "compactCommittedPrefix";
 
 export const OPERATION_KINDS = [
 	"appendSmall",
@@ -175,6 +180,7 @@ export const OPERATION_KINDS = [
 	"detachChild",
 	"reorderChildren",
 	"mutateChild",
+	"compactCommittedPrefix",
 ] as const satisfies readonly OperationKind[];
 const OPERATION_KIND_SET = new Set<string>(OPERATION_KINDS);
 
@@ -579,7 +585,9 @@ function terminalStressTraits(scenario: Scenario): TerminalStressTraits {
 }
 
 function scenarioTags(
-	template: Pick<Scenario, "envMode" | "terminalMode" | "geometryMode">,
+	template: Pick<Scenario, "envMode" | "terminalMode" | "geometryMode"> & {
+		virtualizedPrefix?: boolean;
+	},
 	strictNativeScrollback: boolean,
 	foregroundStreaming: boolean,
 ): readonly ScenarioTag[] {
@@ -589,6 +597,7 @@ function scenarioTags(
 	if (template.terminalMode !== "normal") tags.push("unknownViewport");
 	if (foregroundStreaming) tags.push("foregroundStream");
 	if (isEd3RiskScenario(template.terminalMode, template.envMode)) tags.push("ed3Risk");
+	if (template.virtualizedPrefix === true) tags.push("virtualizedPrefix");
 	return tags;
 }
 
@@ -983,20 +992,73 @@ function reflowToWidth(lines: readonly string[], width: number): string[] {
 	return out;
 }
 
-class StressComponent implements Component, Focusable {
+class StressComponent
+	implements
+		Component,
+		Focusable,
+		NativeScrollbackCommittedRows,
+		NativeScrollbackReplay,
+		NativeScrollbackVirtualizedPrefix
+{
 	focused = false;
 	#model: StressModel;
 	#reflow: boolean;
+	#virtualizedPrefix: boolean;
+	#committedRows = 0;
+	#virtualizedLineIds = new Set<number>();
+	#virtualizedRowsPending = 0;
+	#onVirtualizedRowsTaken?: (rows: number) => void;
 
-	constructor(model: StressModel, reflow = false) {
+	constructor(
+		model: StressModel,
+		reflow = false,
+		virtualizedPrefix = false,
+		onVirtualizedRowsTaken?: (rows: number) => void,
+	) {
 		this.#model = model;
 		this.#reflow = reflow;
+		this.#virtualizedPrefix = virtualizedPrefix;
+		this.#onVirtualizedRowsTaken = onVirtualizedRowsTaken;
 	}
 
 	invalidate(): void {}
 
+	setNativeScrollbackCommittedRows(rows: number): void {
+		this.#committedRows = Number.isFinite(rows) ? Math.max(0, Math.trunc(rows)) : 0;
+	}
+
+	compactCommittedPrefix(rows: number): number {
+		if (!this.#virtualizedPrefix) return 0;
+		const requested = Number.isFinite(rows) ? Math.max(0, Math.trunc(rows)) : 0;
+		const target = Math.min(requested, Math.max(0, this.#committedRows - this.#virtualizedRowsPending));
+		if (target === 0) return 0;
+		let dropped = 0;
+		for (const line of this.#model.lines) {
+			if (this.#virtualizedLineIds.has(line.id)) continue;
+			this.#virtualizedLineIds.add(line.id);
+			dropped++;
+			if (dropped === target) break;
+		}
+		this.#virtualizedRowsPending += dropped;
+		return dropped;
+	}
+
+	takeNativeScrollbackVirtualizedRows(): number {
+		const rows = this.#virtualizedRowsPending;
+		this.#virtualizedRowsPending = 0;
+		if (rows > 0) this.#onVirtualizedRowsTaken?.(rows);
+		return rows;
+	}
+
+	prepareNativeScrollbackReplay(): void {
+		this.#virtualizedLineIds.clear();
+		this.#virtualizedRowsPending = 0;
+	}
+
 	render(width: number): string[] {
-		const lines = this.#model.renderedLines(width, this.focused);
+		const lines = this.#model
+			.renderedLines(width, this.focused)
+			.filter((_line, index) => !this.#virtualizedLineIds.has(this.#model.lines[index]?.id ?? -1));
 		return this.#reflow ? reflowToWidth(lines, width) : lines;
 	}
 }
@@ -1117,6 +1179,7 @@ class StressDriver {
 	#nextOverlayId = 0;
 	#opLog: OperationLogEntry[] = [];
 	#operationCoverage = new Map<OperationLogKind, number>();
+	#pendingShadowVirtualizedDrops: { start: number; rows: number }[] = [];
 	// Lines that legitimately appeared 2+ times in any committed frame. Native
 	// scrollback retains rows from every past frame — content that leaves the
 	// frame (a detached child, collapsed preview, truncation-colliding rows
@@ -1165,7 +1228,10 @@ class StressDriver {
 		this.#scheduler = new StressRenderScheduler();
 		const maxHeight = maxOf(scenario.heightChoices);
 		this.#model = new StressModel(this.#streams.content, maxHeight + 12, scenario.uniqueContent, "root-");
-		this.#component = new StressComponent(this.#model, scenario.reflow);
+		const virtualizedPrefix = scenario.tags.includes("virtualizedPrefix");
+		this.#component = new StressComponent(this.#model, scenario.reflow, virtualizedPrefix, rows => {
+			this.#pendingShadowVirtualizedDrops.push({ start: 0, rows });
+		});
 		this.#children = [0, 1].map(id => {
 			const model = new StressModel(
 				this.#streams.children,
@@ -1214,6 +1280,17 @@ class StressDriver {
 			this.#shadowFrameWidth = width;
 			this.#shadowFrameHeight = this.#term.rows;
 			this.#shadowFrameOverlay = this.#tui.hasOverlay();
+			let virtualizedShift = 0;
+			for (const drop of this.#pendingShadowVirtualizedDrops) {
+				const at = drop.start - virtualizedShift;
+				const rows = Math.min(drop.rows, Math.max(0, this.#shadowCommitted - at));
+				if (rows <= 0) continue;
+				this.#shadowRawPrefix.splice(at, rows);
+				this.#shadowCommitted -= rows;
+				this.#shadowWindowTop = Math.max(0, this.#shadowWindowTop - rows);
+				virtualizedShift += rows;
+			}
+			this.#pendingShadowVirtualizedDrops.length = 0;
 			// Mirror the engine's render-time ledger transitions here: the audit
 			// resync and the shrink-into-prefix re-anchor can both fire on frames
 			// that emit zero bytes, which the write hook would never observe.
@@ -1285,6 +1362,16 @@ class StressDriver {
 
 				if ((index + 1) % 50 === 0) {
 					await this.#checkpoint(index, "periodicCheckpoint");
+				}
+			}
+			if (
+				this.#scenario.replayOperations === undefined &&
+				this.#scenario.iterations >= 3 &&
+				this.#scenario.tags.includes("virtualizedPrefix")
+			) {
+				const count = this.#operationCoverage.get("compactCommittedPrefix") ?? 0;
+				if (count < 1) {
+					throw new Error(`virtualizedPrefix scenario executed ${count} compactCommittedPrefix operations`);
 				}
 			}
 		} finally {
@@ -1376,6 +1463,9 @@ class StressDriver {
 		if (this.#traits.strictNativeScrollback && before.atBottom && index % 41 === 0) {
 			return "offscreenEditAppendRepeatedTail";
 		}
+		if (this.#scenario.tags.includes("virtualizedPrefix") && index === 2) {
+			return "compactCommittedPrefix";
+		}
 		if (!before.atBottom && this.#streams.ops.chance(0.28)) {
 			return "scrollToBottom";
 		}
@@ -1440,6 +1530,10 @@ class StressDriver {
 			{ item: "detachChild", weight: this.#children.some(child => child.active) ? 2 : 0 },
 			{ item: "reorderChildren", weight: this.#children.filter(child => child.active).length > 1 ? 1 : 0 },
 			{ item: "mutateChild", weight: this.#children.some(child => child.active) ? 3 : 0 },
+			{
+				item: "compactCommittedPrefix",
+				weight: this.#scenario.tags.includes("virtualizedPrefix") ? 4 : 0,
+			},
 		];
 		return weightedPick(this.#streams.ops, weighted);
 	}
@@ -1540,9 +1634,19 @@ class StressDriver {
 				return await this.#reorderChildren();
 			case "mutateChild":
 				return await this.#mutateChild();
+			case "compactCommittedPrefix":
+				return await this.#compactCommittedPrefix();
 			default:
 				return assertNever(kind);
 		}
+	}
+
+	async #compactCommittedPrefix(): Promise<AppliedOperation> {
+		const requested = this.#streams.ops.int(1, Math.max(1, this.#term.rows * 2));
+		const dropped = this.#component.compactCommittedPrefix(requested);
+		this.#tui.requestRender();
+		await this.#settle();
+		return contentOperation("compactCommittedPrefix", { requested, dropped }, false);
 	}
 
 	async #applyContent(
@@ -3549,6 +3653,7 @@ type ScenarioTemplate = Omit<
 	uniqueContent?: boolean;
 	foregroundStream?: boolean;
 	reflow?: boolean;
+	virtualizedPrefix?: boolean;
 };
 
 function writeReplayLog(scenario: Scenario, operations: readonly OperationLogEntry[]): string {
@@ -3611,6 +3716,7 @@ function coreTemplates(): ScenarioTemplate[] {
 			rows: 12,
 			widthChoices: [40, 80, 120],
 			heightChoices: [12, 24],
+			virtualizedPrefix: true,
 		},
 		{
 			name: "win32-intermittentUnknown-small",
@@ -3679,6 +3785,7 @@ function coreTemplates(): ScenarioTemplate[] {
 			widthChoices: [10, 16, 32],
 			heightChoices: [3, 4, 6],
 			scrollbackRows: 10_000,
+			virtualizedPrefix: true,
 		},
 		{
 			// WSL fronted by Windows Terminal (#1610): the viewport probe is

--- a/packages/tui/test/render-stress.test.ts
+++ b/packages/tui/test/render-stress.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -221,6 +221,11 @@ describe.skipIf(SKIP_IN_CI)("TUI randomized render stress", () => {
 	});
 
 	const scenarios = buildScenarios();
+	if (Bun.env.TUI_STRESS_REPLAY === undefined) {
+		const virtualizedPrefixScenarios = scenarios.filter(scenario => scenario.tags.includes("virtualizedPrefix"));
+		expect(virtualizedPrefixScenarios.length).toBeGreaterThan(0);
+		expect(virtualizedPrefixScenarios.some(scenario => scenario.tags.includes("ed3Risk"))).toBe(true);
+	}
 	it(
 		`preserves render invariants across ${stressBatchLabel(scenarios)} using ${stressConcurrency(scenarios)} subprocesses`,
 		async () => {

--- a/packages/tui/test/virtualized-prefix.test.ts
+++ b/packages/tui/test/virtualized-prefix.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	type Component,
+	type NativeScrollbackCommittedRows,
+	type NativeScrollbackLiveRegion,
+	type NativeScrollbackReplay,
+	type NativeScrollbackVirtualizedPrefix,
+	type RenderStablePrefix,
+	Text,
+	TUI,
+} from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+type DrainableScheduler = {
+	now(): number;
+	scheduleImmediate(cb: () => void): void;
+	scheduleRender(cb: () => void, delayMs: number): { cancel(): void };
+	flush(): void;
+	flushUntil(predicate: () => boolean): void;
+};
+
+function makeDrainableScheduler(): DrainableScheduler {
+	let clock = 0;
+	const queue: Array<{ run: () => void; cancelled: boolean }> = [];
+	const enqueue = (cb: () => void) => {
+		const item = { run: cb, cancelled: false };
+		queue.push(item);
+		return item;
+	};
+	const runOne = () => {
+		const item = queue.shift();
+		if (!item) return;
+		clock += 1;
+		if (!item.cancelled) item.run();
+	};
+	return {
+		now: () => clock,
+		scheduleImmediate(cb) {
+			enqueue(cb);
+		},
+		scheduleRender(cb) {
+			const item = enqueue(cb);
+			return {
+				cancel() {
+					item.cancelled = true;
+				},
+			};
+		},
+		flush() {
+			let guard = 0;
+			while (queue.length > 0) {
+				if (++guard > 100_000) throw new Error("scheduler did not settle");
+				runOne();
+			}
+		},
+		flushUntil(predicate) {
+			let guard = 0;
+			while (!predicate()) {
+				if (++guard > 100_000 || queue.length === 0) throw new Error("scheduler condition did not settle");
+				runOne();
+			}
+		},
+	};
+}
+
+class Footer implements Component {
+	invalidate(): void {}
+
+	render(_width: number): readonly string[] {
+		return ["footer-0", "footer-1"];
+	}
+}
+
+class VirtualizingComponent
+	implements
+		Component,
+		NativeScrollbackCommittedRows,
+		NativeScrollbackReplay,
+		NativeScrollbackVirtualizedPrefix,
+		NativeScrollbackLiveRegion,
+		RenderStablePrefix
+{
+	readonly rows: string[] = [];
+	replayPreparations = 0;
+	committedRows = 0;
+	renderCalls = 0;
+	#firstVisibleRow = 0;
+	#pendingDropRows = 0;
+	#stablePrefixRows = 0;
+	#lastRenderRows = 0;
+	#liveRegionStart: number | undefined = 10;
+
+	invalidate(): void {}
+
+	setNativeScrollbackCommittedRows(rows: number): void {
+		this.committedRows = rows;
+	}
+	growRows(count: number): void {
+		const start = this.rows.length;
+		this.#stablePrefixRows = start;
+		for (let index = start; index < start + count; index++) {
+			this.rows.push(`virtual-row-${index.toString().padStart(2, "0")}`);
+		}
+	}
+
+	dropCommittedTop(rows: number): void {
+		const dropped = Math.min(rows, this.committedRows);
+		this.#firstVisibleRow += dropped;
+		this.#pendingDropRows += dropped;
+		this.#stablePrefixRows = 0;
+	}
+
+	rewriteCommittedVisibleRow(index: number, text: string): void {
+		if (index >= this.committedRows) throw new Error("row must already be committed");
+		this.rows[this.#firstVisibleRow + index] = text;
+		this.#stablePrefixRows = index;
+	}
+	finalize(): void {
+		this.#liveRegionStart = undefined;
+	}
+
+	takeNativeScrollbackVirtualizedRows(): number {
+		const rows = this.#pendingDropRows;
+		this.#pendingDropRows = 0;
+		return rows;
+	}
+
+	prepareNativeScrollbackReplay(): void {
+		this.replayPreparations++;
+		this.#firstVisibleRow = 0;
+		this.#pendingDropRows = 0;
+		this.#stablePrefixRows = 0;
+	}
+
+	getNativeScrollbackLiveRegionStart(): number | undefined {
+		return this.#liveRegionStart;
+	}
+
+	getRenderStablePrefixRows(): number {
+		const rows = this.#stablePrefixRows;
+		this.#stablePrefixRows = this.#lastRenderRows;
+		return rows;
+	}
+
+	render(_width: number): readonly string[] {
+		this.renderCalls++;
+		const rows = this.rows.slice(this.#firstVisibleRow);
+		this.#lastRenderRows = rows.length;
+		return rows;
+	}
+}
+
+type Fixture = {
+	term: VirtualTerminal;
+	scheduler: DrainableScheduler;
+	tui: TUI;
+	virtualized: VirtualizingComponent;
+	writes: string[];
+};
+
+function makeFixture(scrollbackRebuild: boolean): Fixture {
+	const term = new VirtualTerminal(80, 10, 1_000);
+	const writes: string[] = [];
+	const write = term.write.bind(term);
+	term.write = data => {
+		writes.push(data);
+		write(data);
+	};
+	const scheduler = makeDrainableScheduler();
+	const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+	const virtualized = new VirtualizingComponent();
+	tui.setScrollbackRebuild(scrollbackRebuild);
+	tui.addChild(new Text("header-above-0\nheader-above-1", 0, 0));
+	tui.addChild(virtualized);
+	tui.addChild(new Footer());
+	return { term, scheduler, tui, virtualized, writes };
+}
+
+async function startAndSettle(fixture: Fixture): Promise<void> {
+	fixture.tui.start();
+	fixture.scheduler.flush();
+	await fixture.term.flush();
+	fixture.virtualized.growRows(30);
+	await settle(fixture);
+	expect(fixture.virtualized.committedRows).toBeGreaterThanOrEqual(5);
+}
+
+async function settle(fixture: Fixture): Promise<void> {
+	fixture.tui.requestRender();
+	fixture.scheduler.flush();
+	await fixture.term.flush();
+}
+
+function plainBuffer(term: VirtualTerminal): string[] {
+	return term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+}
+
+function countED3(writes: readonly string[]): number {
+	return writes.reduce((count, write) => count + write.split("\x1b[3J").length - 1, 0);
+}
+
+function expectExactlyOnce(term: VirtualTerminal, expectedRows: readonly string[]): void {
+	const rows = plainBuffer(term);
+	for (const expected of expectedRows) {
+		expect(rows.filter(row => row === expected).length).toBe(1);
+	}
+	const nonBlankRows = rows.filter(Boolean);
+	expect(new Set(nonBlankRows).size).toBe(nonBlankRows.length);
+}
+
+const headers = ["header-above-0", "header-above-1"];
+const footers = ["footer-0", "footer-1"];
+
+const directTerminalEnvKeys = ["TERM_PROGRAM", "PI_TUI_RESIZE_IN_PLACE", "TMUX", "STY", "ZELLIJ"] as const;
+const savedDirectTerminalEnv: Partial<Record<(typeof directTerminalEnvKeys)[number], string>> = {};
+
+beforeEach(() => {
+	for (const key of directTerminalEnvKeys) {
+		const value = Bun.env[key];
+		if (value !== undefined) savedDirectTerminalEnv[key] = value;
+		delete Bun.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const key of directTerminalEnvKeys) {
+		const value = savedDirectTerminalEnv[key];
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+		delete savedDirectTerminalEnv[key];
+	}
+});
+
+describe("native scrollback virtualized-prefix rebasing", () => {
+	test("case A: rebuild off preserves dropped rows exactly once without ED3", async () => {
+		const fixture = makeFixture(false);
+		try {
+			await startAndSettle(fixture);
+			const ed3BeforeDrop = countED3(fixture.writes);
+			const dropped = fixture.virtualized.rows.slice(0, 5);
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+
+			expect(countED3(fixture.writes) - ed3BeforeDrop).toBe(0);
+			for (const row of dropped) {
+				expect(plainBuffer(fixture.term).filter(candidate => candidate === row).length).toBe(1);
+			}
+			expectExactlyOnce(fixture.term, [...headers, ...fixture.virtualized.rows, ...footers]);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+
+	test("case B: a nonzero component start preserves rows above the virtualized segment", async () => {
+		const fixture = makeFixture(false);
+		try {
+			await startAndSettle(fixture);
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+
+			const nonBlankRows = plainBuffer(fixture.term).filter(Boolean);
+			expect(nonBlankRows.slice(0, 2)).toEqual(headers);
+			expect(nonBlankRows.filter(row => row === headers[0]).length).toBe(1);
+			expect(nonBlankRows.filter(row => row === headers[1]).length).toBe(1);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+
+	test("case C: an epoch-gated real divergence defers ED3 until a complete replay", async () => {
+		const fixture = makeFixture(true);
+		try {
+			await startAndSettle(fixture);
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+			const ed3BeforeDivergence = countED3(fixture.writes);
+
+			fixture.virtualized.rewriteCommittedVisibleRow(12, "virtual-row-17-updated");
+			fixture.virtualized.finalize();
+			const rendersBeforeDivergence = fixture.virtualized.renderCalls;
+			fixture.tui.requestRender();
+			fixture.scheduler.flushUntil(() => fixture.virtualized.renderCalls > rendersBeforeDivergence);
+			await fixture.term.flush();
+			expect(countED3(fixture.writes) - ed3BeforeDivergence).toBe(0);
+			const divergenceBuffer = plainBuffer(fixture.term);
+			expect(
+				fixture.virtualized.rows.some(row => divergenceBuffer.filter(candidate => candidate === row).length > 1),
+			).toBe(true);
+
+			fixture.scheduler.flush();
+			await fixture.term.flush();
+			expect(countED3(fixture.writes) - ed3BeforeDivergence).toBe(1);
+			expect(fixture.virtualized.replayPreparations).toBe(1);
+			expectExactlyOnce(fixture.term, [...headers, ...fixture.virtualized.rows, ...footers]);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+
+	test("case D: width resize rehydrates virtualized history exactly once", async () => {
+		const fixture = makeFixture(false);
+		try {
+			await startAndSettle(fixture);
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+
+			fixture.term.resize(70, 10);
+			fixture.scheduler.flush();
+			await fixture.term.flush();
+
+			expect(fixture.virtualized.replayPreparations).toBeGreaterThanOrEqual(1);
+			expectExactlyOnce(fixture.term, [...headers, ...fixture.virtualized.rows, ...footers]);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+});

--- a/packages/tui/test/virtualized-prefix.test.ts
+++ b/packages/tui/test/virtualized-prefix.test.ts
@@ -318,4 +318,28 @@ describe("native scrollback virtualized-prefix rebasing", () => {
 			await fixture.term.flush();
 		}
 	});
+
+	test("case E: pane-preserving clear requests do not rehydrate virtualized history", async () => {
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1,0";
+		const fixture = makeFixture(false);
+		try {
+			await startAndSettle(fixture);
+			const dropped = fixture.virtualized.rows.slice(0, 5);
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+			const ed3BeforeClear = countED3(fixture.writes);
+
+			fixture.tui.requestRender(true, { clearScrollback: true });
+			fixture.scheduler.flush();
+			await fixture.term.flush();
+
+			expect(fixture.virtualized.replayPreparations).toBe(0);
+			expect(countED3(fixture.writes) - ed3BeforeClear).toBe(0);
+			for (const row of dropped)
+				expect(plainBuffer(fixture.term).filter(candidate => candidate === row)).toHaveLength(1);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
 });

--- a/packages/tui/test/virtualized-prefix.test.ts
+++ b/packages/tui/test/virtualized-prefix.test.ts
@@ -342,4 +342,26 @@ describe("native scrollback virtualized-prefix rebasing", () => {
 			await fixture.term.flush();
 		}
 	});
+
+	test("case F: a destructive clear rehydrates history on resize-in-place terminals", async () => {
+		Bun.env.PI_TUI_RESIZE_IN_PLACE = "1";
+		const fixture = makeFixture(false);
+		try {
+			await startAndSettle(fixture);
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+			const ed3BeforeClear = countED3(fixture.writes);
+
+			fixture.tui.requestRender(true, { clearScrollback: true });
+			fixture.scheduler.flush();
+			await fixture.term.flush();
+
+			expect(fixture.virtualized.replayPreparations).toBe(1);
+			expect(countED3(fixture.writes) - ed3BeforeClear).toBe(1);
+			expectExactlyOnce(fixture.term, [...headers, ...fixture.virtualized.rows, ...footers]);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
 });

--- a/packages/tui/test/virtualized-prefix.test.ts
+++ b/packages/tui/test/virtualized-prefix.test.ts
@@ -10,12 +10,16 @@ import {
 	Text,
 	TUI,
 } from "@oh-my-pi/pi-tui";
+import { Image } from "@oh-my-pi/pi-tui/components/image";
+import { getKittyGraphics, setKittyGraphics } from "@oh-my-pi/pi-tui/kitty-graphics";
+import { ImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { VirtualTerminal } from "./virtual-terminal";
 
 type DrainableScheduler = {
 	now(): number;
 	scheduleImmediate(cb: () => void): void;
 	scheduleRender(cb: () => void, delayMs: number): { cancel(): void };
+	flushNext(): void;
 	flush(): void;
 	flushUntil(predicate: () => boolean): void;
 };
@@ -46,6 +50,10 @@ function makeDrainableScheduler(): DrainableScheduler {
 					item.cancelled = true;
 				},
 			};
+		},
+		flushNext() {
+			if (queue.length === 0) throw new Error("scheduler has no pending render");
+			runOne();
 		},
 		flush() {
 			let guard = 0;
@@ -84,6 +92,7 @@ class VirtualizingComponent
 	readonly rows: string[] = [];
 	replayPreparations = 0;
 	committedRows = 0;
+	readonly committedRowsFeeds: number[] = [];
 	renderCalls = 0;
 	#firstVisibleRow = 0;
 	#pendingDropRows = 0;
@@ -96,6 +105,7 @@ class VirtualizingComponent
 
 	setNativeScrollbackCommittedRows(rows: number): void {
 		this.committedRows = rows;
+		this.committedRowsFeeds.push(rows);
 	}
 	growRows(count: number): void {
 		const start = this.rows.length;
@@ -220,6 +230,8 @@ function expectExactlyOnce(term: VirtualTerminal, expectedRows: readonly string[
 
 const headers = ["header-above-0", "header-above-1"];
 const footers = ["footer-0", "footer-1"];
+const BASE64_ONE_PIXEL_PNG =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
 
 const directTerminalEnvKeys = ["TERM_PROGRAM", "PI_TUI_RESIZE_IN_PLACE", "TMUX", "STY", "ZELLIJ"] as const;
 const savedDirectTerminalEnv: Partial<Record<(typeof directTerminalEnvKeys)[number], string>> = {};
@@ -401,6 +413,49 @@ describe("native scrollback virtualized-prefix rebasing", () => {
 		} finally {
 			fixture.tui.stop();
 			await fixture.term.flush();
+		}
+	});
+
+	test("case H: Ghostty image deferral keeps a virtualized drop pending until emit", async () => {
+		const terminal = TERMINAL as { id: string; imageProtocol: ImageProtocol | null };
+		const originalId = terminal.id;
+		const originalProtocol = terminal.imageProtocol;
+		const originalGraphics = { ...getKittyGraphics() };
+		terminal.id = "ghostty";
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		setKittyGraphics({ unicodePlaceholders: true });
+
+		const fixture = makeFixture(false);
+		try {
+			await startAndSettle(fixture);
+			const committedBeforeDrop = fixture.virtualized.committedRows;
+			fixture.virtualized.dropCommittedTop(5);
+			fixture.tui.addChild(
+				new Image(
+					BASE64_ONE_PIXEL_PNG,
+					"image/png",
+					{ fallbackColor: text => text },
+					{ maxWidthCells: 4, maxHeightCells: 4, budget: fixture.tui.imageBudget, imageKey: "deferred" },
+				),
+			);
+
+			fixture.tui.requestRender(true);
+			fixture.scheduler.flushNext();
+			const feedsAfterAbandonedCompose = fixture.virtualized.committedRowsFeeds.length;
+			fixture.scheduler.flushNext();
+
+			expect(fixture.virtualized.committedRowsFeeds[feedsAfterAbandonedCompose]).toBe(committedBeforeDrop);
+			fixture.scheduler.flush();
+			await fixture.term.flush();
+			for (const expected of [...headers, ...fixture.virtualized.rows, ...footers]) {
+				expect(plainBuffer(fixture.term).filter(row => row === expected).length).toBe(1);
+			}
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+			terminal.id = originalId;
+			terminal.imageProtocol = originalProtocol;
+			setKittyGraphics(originalGraphics);
 		}
 	});
 });

--- a/packages/tui/test/virtualized-prefix.test.ts
+++ b/packages/tui/test/virtualized-prefix.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
 	type Component,
+	CURSOR_MARKER,
 	type NativeScrollbackCommittedRows,
 	type NativeScrollbackLiveRegion,
 	type NativeScrollbackReplay,
@@ -89,6 +90,7 @@ class VirtualizingComponent
 	#stablePrefixRows = 0;
 	#lastRenderRows = 0;
 	#liveRegionStart: number | undefined = 10;
+	#cursorSourceRow: number | undefined;
 
 	invalidate(): void {}
 
@@ -107,6 +109,11 @@ class VirtualizingComponent
 		const dropped = Math.min(rows, this.committedRows);
 		this.#firstVisibleRow += dropped;
 		this.#pendingDropRows += dropped;
+		this.#stablePrefixRows = 0;
+	}
+
+	setCursorSourceRow(row: number): void {
+		this.#cursorSourceRow = row;
 		this.#stablePrefixRows = 0;
 	}
 
@@ -145,6 +152,9 @@ class VirtualizingComponent
 	render(_width: number): readonly string[] {
 		this.renderCalls++;
 		const rows = this.rows.slice(this.#firstVisibleRow);
+		const cursorIndex = this.#cursorSourceRow === undefined ? -1 : this.#cursorSourceRow - this.#firstVisibleRow;
+		const cursorRow = rows[cursorIndex];
+		if (cursorRow !== undefined) rows[cursorIndex] = `${cursorRow}${CURSOR_MARKER}`;
 		this.#lastRenderRows = rows.length;
 		return rows;
 	}
@@ -158,7 +168,7 @@ type Fixture = {
 	writes: string[];
 };
 
-function makeFixture(scrollbackRebuild: boolean): Fixture {
+function makeFixture(scrollbackRebuild: boolean, showHardwareCursor = false): Fixture {
 	const term = new VirtualTerminal(80, 10, 1_000);
 	const writes: string[] = [];
 	const write = term.write.bind(term);
@@ -167,7 +177,7 @@ function makeFixture(scrollbackRebuild: boolean): Fixture {
 		write(data);
 	};
 	const scheduler = makeDrainableScheduler();
-	const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+	const tui = new TUI(term, showHardwareCursor, { renderScheduler: scheduler });
 	const virtualized = new VirtualizingComponent();
 	tui.setScrollbackRebuild(scrollbackRebuild);
 	tui.addChild(new Text("header-above-0\nheader-above-1", 0, 0));
@@ -359,6 +369,35 @@ describe("native scrollback virtualized-prefix rebasing", () => {
 			expect(fixture.virtualized.replayPreparations).toBe(1);
 			expect(countED3(fixture.writes) - ed3BeforeClear).toBe(1);
 			expectExactlyOnce(fixture.term, [...headers, ...fixture.virtualized.rows, ...footers]);
+		} finally {
+			fixture.tui.stop();
+			await fixture.term.flush();
+		}
+	});
+
+	test("case G: virtualized drops rebase a visible hardware cursor", async () => {
+		const fixture = makeFixture(false, true);
+		try {
+			await startAndSettle(fixture);
+			const cursorSourceRow = 26;
+			const cursorText = fixture.virtualized.rows[cursorSourceRow];
+			if (cursorText === undefined) throw new Error("cursor source row was not created");
+			fixture.virtualized.setCursorSourceRow(cursorSourceRow);
+			await settle(fixture);
+			const expectedScreenRow = fixture.term
+				.getViewport()
+				.findIndex(row => Bun.stripANSI(row).trimEnd() === cursorText);
+			expect(expectedScreenRow).toBeGreaterThan(0);
+			expect(expectedScreenRow).toBeLessThan(fixture.term.rows - 1);
+			expect(fixture.term.getCursor().row).toBe(expectedScreenRow);
+
+			fixture.virtualized.dropCommittedTop(5);
+			await settle(fixture);
+
+			expect(fixture.term.getViewport().findIndex(row => Bun.stripANSI(row).trimEnd() === cursorText)).toBe(
+				expectedScreenRow,
+			);
+			expect(fixture.term.getCursor().row).toBe(expectedScreenRow);
 		} finally {
 			fixture.tui.stop();
 			await fixture.term.flush();


### PR DESCRIPTION
## What

Seals finalized assistant blocks so `TranscriptContainer` can compact committed history out of the local frame once those rows enter native scrollback, and teaches the TUI to rebase its committed-prefix coordinates for that virtualization instead of treating it as divergence.

## Why

Long sessions recompose finalized assistant history that is already on the native scrollback tape. That keeps transcript compose depth-linear during live streaming (pre-fix ratio ≈ 4.67 for N5000/N500). This PR makes sealed committed prefixes virtualizable and keeps scrollback history exactly once across rebuild-on, rebuild-off, resize, and mid-turn resume paths.

Fixes #5930

### Exact mechanism / invariants

1. **Sealed assistant lifecycle** (`AssistantMessageComponent`, `EventController`, `UiHelpers`)
   - Finalized is not enough for compaction: versioned assistants stay in-frame until `sealTranscriptBlock()` marks post-finalize bumps cosmetic.
   - Seal happens at the next assistant start / post-tool segment handoff, after any pinned inline error restore, so one composed frame still shows the post-seal restore.
   - Historical rebuild leaves the tail assistant unsealed; mid-turn focus attach reuses it by `sessionMessagePersistenceKey` via `resumeAssistantStream`.
   - Resume re-opens the rebuilt block with `markTranscriptBlockLive()` so `isTranscriptBlockFinalized()` stays false and the live-region seam stays pinned until `message_end`.
   - `resetTranscript` / `resetTranscriptAnchors` clear stale seal and pin anchors before disposing chat children.

2. **TranscriptContainer stable prefix compaction**
   - Implements `NativeScrollbackVirtualizedPrefix` with take-semantics `takeNativeScrollbackVirtualizedRows()` (consume-on-read; drops between takes concatenate into a prefix of the committed sub-range, in previous engine-observed render coordinates).
   - `#compactCommittedPrefix` drops leading finalized+sealed committed children from the local `#lines` / segment map and accumulates the dropped row count for the next take.
   - Compactable only when finalized and (unversioned **or** sealed with a stable version since the previous render).
   - Replay latch: `prepareNativeScrollbackReplay` rehydrates compacted children and suppresses compaction for the whole destructive replay transaction; release only on the post-emit `setNativeScrollbackCommittedRows` publication after a render ran (`#replayRendered`).
   - Child index map: `addChild` / `removeChild` / `clear` keep `#childIndex`, `#compactedChildStart`, and segment alignment. `isBlockUncommitted` and `isBlockInLiveRegion` use the map (and skip the compacted prefix) instead of `children.indexOf` linear scans — O(1) probes for those lookups, not a formal whole-system O(1) compose claim.

3. **TUI virtualized-prefix rebase** (`packages/tui/src/tui.ts`)
   - After compose, take each child's virtualized drop and splice `#committedPrefix` / reduce `#committedRows` / adjust `#committedPrefixAuditRows` and `#windowTopRow` exactly once per compaction frame.
   - Committed-prefix audit then passes by row identity: no forced resync for pure virtualization.
   - Real divergence on a virtualized epoch defers destructive full-screen clear/replay (ED3) one frame so `prepareNativeScrollbackReplay` rehydrates complete history first.
   - Explicit `clearScrollback` renders are destructive on every terminal (even when resize can repaint in place): always prepare virtualized roots before those clears so full history is available for replay.

### Testing

Named focused suites added/extended in this change:

- `packages/coding-agent/test/modes/components/transcript-container.test.ts`
  - sealed vs unsealed compactability, post-seal error visibility, take-semantics + accumulation/reset, removeChild boundary alignment, replay compaction suppression (including deferred recompose before emit), child reindex / compacted-prefix live-region probes
- `packages/coding-agent/test/transcript-compaction-scrollback.test.ts`
  - `rebuild on keeps compacted, mutated, resized, and reattached history exactly once`
  - `rebuild off compacts without duplicating non-blank history`
- `packages/tui/test/virtualized-prefix.test.ts`
  - `case A: rebuild off preserves dropped rows exactly once without ED3`
  - `case B: a nonzero component start preserves rows above the virtualized segment`
  - `case C: an epoch-gated real divergence defers ED3 until a complete replay`
  - `case D: width resize rehydrates virtualized history exactly once`
- `packages/coding-agent/test/event-controller-error-banner.test.ts`
  - seal/pin across rebuild, mid-turn attach reuse of one transcript block, resume re-opens finalized rebuilt assistant until `message_end`
- `packages/coding-agent/test/interactive-mode-status.test.ts`
  - historical predecessors seal while the final assistant stays unsealed; `resetTranscript` clears anchors before dispose
- `packages/tui/test/render-stress-harness.ts` / `render-stress.test.ts` — stress path covers virtualized-prefix take/rebase tags

Suggested local commands (after atomic branch construction):

```bash
bun test packages/coding-agent/test/modes/components/transcript-container.test.ts
bun test packages/coding-agent/test/transcript-compaction-scrollback.test.ts
bun test packages/tui/test/virtualized-prefix.test.ts
bun test packages/coding-agent/test/event-controller-error-banner.test.ts
bun test packages/coding-agent/test/interactive-mode-status.test.ts
bun run packages/coding-agent/bench/transcript-compose.bench.ts
```

### Benchmark

Empirical `transcript-compose` medians from the primary implementation commit message (same fixture family as the permanent bench):

| | N500 | N5000 | ratio(N5000/N500) |
| --- | --- | --- | --- |
| Before | 0.2588 ms | 1.2082 ms | 4.6681 |
| After | 0.1386 ms | 0.1416 ms | 1.0215 |

- Noise reported with that run: 15.0% / 12.3% (N500 / N5000).
- N5000 compose fell ≈ 88.3%; history stayed exactly-once under the scrollback cases above.
- These are wall-clock observations, not a formal asymptotic O(1) proof for the whole render tree. Absolute process gates intended with this unit once composed: ratio ≤ 1.3 and N5000 p95 < 10 ms.

### Risks / tradeoffs

- Terminals with aggressive resize, mid-turn focus moves, or unusual full-screen clear/replay behavior can still see a one-frame deferred ED3 when a real divergence coincides with a virtualized epoch; the deferral prefers complete rehydration over permanent native divergence.
- Forgetting to seal a finalized versioned assistant leaves it in the local frame (safe, no history loss) and misses the compose win for that block.
- Child-index maintenance must stay aligned with `removeChild` / clear / compaction; misalignment would break live-region and uncommitted probes (covered by container tests).
- Depends on the permanent transcript-compose bench / fixture from the measurement PR existing on the branch used for absolute gates.

> **Note:** the `transcript-compose` benchmark referenced above ships in the measurement-infrastructure PR #5920; this branch contains only the production change and its tests. This change also fixes a pre-existing failure on `main` in `packages/tui/test/component-render.test.ts` (`rehydrates virtualized roots before a destructive full paint`).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
