### PR TITLE
perf(coding-agent): parallelize session dispose so /exit no longer stacks subsystem timeouts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced `/exit` latency by running independent disposal phases concurrently while preserving cleanup ordering. ([#5932](https://github.com/can1357/oh-my-pi/issues/5932))
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/bench/session-dispose.bench.ts
+++ b/packages/coding-agent/bench/session-dispose.bench.ts
@@ -1,0 +1,92 @@
+/**
+ * Idle AgentSession.dispose wall-clock (Workstream D).
+ *
+ * Measures empty/idle dispose with no pending network flush. Acceptance:
+ * median < 3000ms (the InteractiveMode "Still closing…" status budget).
+ *
+ *   bun run packages/coding-agent/bench/session-dispose.bench.ts
+ */
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const WARMUP = 4;
+const MEASURE = 24;
+
+function median(xs: number[]): number {
+	if (xs.length === 0) return 0;
+	const sorted = [...xs].sort((a, b) => a - b);
+	const mid = sorted.length >> 1;
+	if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+	return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}
+
+function stddev(xs: number[]): number {
+	if (xs.length < 2) return 0;
+	const mean = xs.reduce((a, b) => a + b, 0) / xs.length;
+	let sumSq = 0;
+	for (const x of xs) {
+		const d = x - mean;
+		sumSq += d * d;
+	}
+	return Math.sqrt(sumSq / (xs.length - 1));
+}
+
+function emitMetric(metric: string, median_ms: number, stddev_ms: number): void {
+	console.log(JSON.stringify({ metric, median_ms, stddev_ms }));
+	console.log(`METRIC ${metric}=${median_ms.toFixed(4)}`);
+}
+
+async function measureOnce(tempDir: TempDir, authStorage: AuthStorage): Promise<number> {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("expected bundled anthropic model");
+	const mock = createMockModel({ handler: () => ({ content: ["ok"] }) });
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: ["bench"], tools: [] },
+		streamFn: mock.stream,
+	});
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(tempDir.path()),
+		settings: Settings.isolated(),
+		modelRegistry,
+	});
+	const t0 = performance.now();
+	await session.dispose();
+	return performance.now() - t0;
+}
+
+async function main(): Promise<void> {
+	using tempDir = TempDir.createSync("@omp-dispose-bench-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+	for (let i = 0; i < WARMUP; i++) {
+		await measureOnce(tempDir, authStorage);
+	}
+
+	const samples: number[] = [];
+	for (let i = 0; i < MEASURE; i++) {
+		samples.push(await measureOnce(tempDir, authStorage));
+	}
+
+	authStorage.close();
+	const med = median(samples);
+	const sd = stddev(samples);
+	emitMetric("session.dispose.idle_ms", med, sd);
+	if (med >= 3_000) {
+		console.error(`FAIL: idle dispose median ${med.toFixed(2)}ms >= 3000ms status budget`);
+		process.exitCode = 1;
+	}
+}
+
+await main();

--- a/packages/coding-agent/bench/session-dispose.bench.ts
+++ b/packages/coding-agent/bench/session-dispose.bench.ts
@@ -40,8 +40,8 @@ function stddev(xs: number[]): number {
 }
 
 function emitMetric(metric: string, median_ms: number, stddev_ms: number): void {
-	console.log(JSON.stringify({ metric, median_ms, stddev_ms }));
-	console.log(`METRIC ${metric}=${median_ms.toFixed(4)}`);
+	process.stdout.write(`${JSON.stringify({ metric, median_ms, stddev_ms })}\n`);
+	process.stdout.write(`METRIC ${metric}=${median_ms.toFixed(4)}\n`);
 }
 
 async function measureOnce(tempDir: TempDir, authStorage: AuthStorage): Promise<number> {
@@ -84,7 +84,7 @@ async function main(): Promise<void> {
 	const sd = stddev(samples);
 	emitMetric("session.dispose.idle_ms", med, sd);
 	if (med >= 3_000) {
-		console.error(`FAIL: idle dispose median ${med.toFixed(2)}ms >= 3000ms status budget`);
+		process.stdout.write(`FAIL: idle dispose median ${med.toFixed(2)}ms >= 3000ms status budget\n`);
 		process.exitCode = 1;
 	}
 }

--- a/packages/coding-agent/bench/session-dispose.bench.ts
+++ b/packages/coding-agent/bench/session-dispose.bench.ts
@@ -1,5 +1,5 @@
 /**
- * Idle AgentSession.dispose wall-clock (Workstream D).
+ * Idle AgentSession.dispose wall-clock.
  *
  * Measures empty/idle dispose with no pending network flush. Acceptance:
  * median < 3000ms (the InteractiveMode "Still closing…" status budget).

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -124,6 +124,7 @@ export class AsyncJobManager {
 	readonly #inFlightDeliveries: AsyncJobDelivery[] = [];
 	readonly #deliveryPromises = new Set<Promise<void>>();
 	readonly #suppressedDeliveries = new Set<string>();
+	readonly #closedAdmissionOwners = new Set<string>();
 	readonly #watchedJobs = new Set<string>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #pollEscalation = new Map<string | undefined, PollEscalationState>();
@@ -174,6 +175,9 @@ export class AsyncJobManager {
 	): string {
 		if (this.#disposed) {
 			throw new Error("Async job manager is disposed");
+		}
+		if (options?.ownerId && this.#closedAdmissionOwners.has(options.ownerId)) {
+			throw new Error(`Background jobs are unavailable while session disposal is in progress (${options.ownerId})`);
 		}
 		// Queued jobs hold no execution slot yet — only count jobs that are
 		// actually running so a large parked batch cannot starve registration.
@@ -388,6 +392,11 @@ export class AsyncJobManager {
 			if (queued) continue;
 			this.#enqueueDelivery(jobId, job.status === "completed" ? (job.resultText ?? "") : (job.errorText ?? ""));
 		}
+	}
+
+	/** Permanently reject new jobs for one disposing session without sealing its shared manager. */
+	closeAdmissions(filter: AsyncJobFilter): void {
+		if (filter.ownerId) this.#closedAdmissionOwners.add(filter.ownerId);
 	}
 
 	/**

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -122,6 +122,7 @@ export class AsyncJobManager {
 	readonly #jobs = new Map<string, AsyncJob>();
 	readonly #deliveries: AsyncJobDelivery[] = [];
 	readonly #inFlightDeliveries: AsyncJobDelivery[] = [];
+	readonly #deliveryPromises = new Set<Promise<void>>();
 	readonly #suppressedDeliveries = new Set<string>();
 	readonly #watchedJobs = new Set<string>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
@@ -471,6 +472,22 @@ export class AsyncJobManager {
 		return true;
 	}
 
+	/**
+	 * Wait until no delivery callback can still invoke `onJobComplete`. Unlike
+	 * {@link drainDeliveries}, this remains valid after bounded `dispose()`
+	 * clears the queue/in-flight bookkeeping. Track callback promises separately
+	 * because owner-filtered drains can deliver outside the shared loop; re-sample
+	 * after every await so retry-loop handoffs cannot escape the barrier.
+	 */
+	async waitForDeliveryQuiescence(): Promise<void> {
+		while (true) {
+			const callbacks = Array.from(this.#deliveryPromises);
+			const loop = this.#deliveryLoop;
+			if (callbacks.length === 0 && !loop) return;
+			await Promise.all(loop ? [...callbacks, loop] : callbacks);
+		}
+	}
+
 	async dispose(options?: { timeoutMs?: number }): Promise<boolean> {
 		this.#disposed = true;
 		this.#clearEvictionTimers();
@@ -671,12 +688,14 @@ export class AsyncJobManager {
 					error: delivery.lastError,
 				});
 			} finally {
+				if (delivery.promise) this.#deliveryPromises.delete(delivery.promise);
 				const index = this.#inFlightDeliveries.indexOf(delivery);
 				if (index !== -1) this.#inFlightDeliveries.splice(index, 1);
 				if (this.#deliveries.length > 0) this.#ensureDeliveryLoop();
 			}
 		})();
 		delivery.promise = promise;
+		this.#deliveryPromises.add(promise);
 		return promise;
 	}
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -122,7 +122,8 @@ export class AsyncJobManager {
 	readonly #jobs = new Map<string, AsyncJob>();
 	readonly #deliveries: AsyncJobDelivery[] = [];
 	readonly #inFlightDeliveries: AsyncJobDelivery[] = [];
-	readonly #deliveryPromises = new Set<Promise<void>>();
+	/** Count of delivery callbacks that failed after dispose sealed the manager (terminal, never retried). */
+	#terminalDeliveryFailures = 0;
 	readonly #suppressedDeliveries = new Set<string>();
 	readonly #closedAdmissionOwners = new Set<string>();
 	readonly #watchedJobs = new Set<string>();
@@ -482,37 +483,70 @@ export class AsyncJobManager {
 	}
 
 	/**
-	 * Wait until no delivery callback can still invoke `onJobComplete`. Unlike
-	 * {@link drainDeliveries}, this remains valid after bounded `dispose()`
-	 * clears the queue/in-flight bookkeeping. Track callback promises separately
-	 * because owner-filtered drains can deliver outside the shared loop; re-sample
-	 * after every await so retry-loop handoffs cannot escape the barrier.
+	 * Manager-owned shutdown barrier. Single ordered sequence — no secondary
+	 * promise registry, no quiescence polling:
+	 *
+	 *  1. seal the manager (`#disposed`; `register()` already rejects, owner
+	 *     admissions were closed by the session via `closeAdmissions`);
+	 *  2. cancel every running job — a cancelled job's late return takes the
+	 *     `status === "cancelled"` branch in `register()` and can never enqueue
+	 *     a delivery, so the delivery set is frozen from here on;
+	 *  3. await job promises under the existing bound (abort-terminating jobs
+	 *     settle here; a job that ignores abort is detached, not awaited);
+	 *  4. drain every queued/in-flight delivery to completion through the
+	 *     existing `delivery.promise` bookkeeping — immediately, ignoring retry
+	 *     backoff, and terminally: a callback failure under `#disposed` is
+	 *     surfaced/logged, never requeued (see `#deliverDelivery`).
+	 *
+	 * `#suppressedDeliveries`/`#watchedJobs` are intentionally retained for the
+	 * dead manager's lifetime so the SDK's `isStale` staleness check stays
+	 * authoritative while the session persists late yield entries after this
+	 * drain.
+	 *
+	 * Irreducible edge (documented, not solved): a delivery callback that NEVER
+	 * settles cannot have both a hard-bounded dispose and guaranteed
+	 * persistence of its yield — there is no cancellable-callback or durable
+	 * journal seam. Step 4 therefore awaits callbacks unbounded; bounded exit
+	 * is proven for abort-terminating jobs plus the production SDK callback
+	 * (artifact persistence + a synchronous yieldQueue enqueue). Same spirit as
+	 * the documented session_shutdown/eval bounded-detach exceptions.
+	 *
+	 * Returns false when jobs exceeded the bound or a terminal delivery failed.
 	 */
-	async waitForDeliveryQuiescence(): Promise<void> {
-		while (true) {
-			const callbacks = Array.from(this.#deliveryPromises);
-			const loop = this.#deliveryLoop;
-			if (callbacks.length === 0 && !loop) return;
-			await Promise.all(loop ? [...callbacks, loop] : callbacks);
-		}
-	}
-
 	async dispose(options?: { timeoutMs?: number }): Promise<boolean> {
 		this.#disposed = true;
 		this.#clearEvictionTimers();
 		this.cancelAll();
 		const timeoutMs = Math.max(options?.timeoutMs ?? 3_000, 0);
-		const deadline = Date.now() + timeoutMs;
-		const jobsSettled = await this.#waitForAllUntil(deadline);
-		const drained = await this.drainDeliveries({ timeoutMs: Math.max(deadline - Date.now(), 0) });
+		const jobsSettled = await this.#waitForAllUntil(Date.now() + timeoutMs);
+		await this.#drainDeliveriesForDispose();
 		this.#clearEvictionTimers();
 		this.#jobs.clear();
-		this.#deliveries.length = 0;
-		this.#inFlightDeliveries.length = 0;
-		this.#suppressedDeliveries.clear();
-		this.#watchedJobs.clear();
 		this.#pollEscalation.clear();
-		return jobsSettled && drained;
+		return jobsSettled && this.#terminalDeliveryFailures === 0;
+	}
+
+	/**
+	 * Terminal delivery drain for `dispose()`: deliver everything still queued
+	 * (immediately — a pending retry's 30s backoff must not delay shutdown) and
+	 * await every in-flight callback. The shared delivery loop is deliberately
+	 * NOT awaited: it may be sleeping on a retry backoff timer; it wakes to a
+	 * shifted queue (or the `#disposed` check) and exits without delivering.
+	 */
+	async #drainDeliveriesForDispose(): Promise<void> {
+		while (true) {
+			const delivery = this.#deliveries.shift();
+			if (delivery) {
+				if (this.isDeliverySuppressed(delivery.jobId)) continue;
+				await this.#deliverDelivery(delivery);
+				continue;
+			}
+			const inFlight = this.#inFlightDeliveries
+				.map(d => d.promise)
+				.filter((p): p is Promise<void> => p !== undefined);
+			if (inFlight.length === 0) return;
+			await Promise.all(inFlight);
+		}
 	}
 
 	#resolveJobId(preferredId?: string): string {
@@ -623,6 +657,10 @@ export class AsyncJobManager {
 	}
 
 	#enqueueDelivery(jobId: string, text: string): void {
+		// A sealed manager can never grow its delivery set: dispose()'s terminal
+		// drain is the last writer barrier (a late resumeDeliveries must not
+		// re-open it).
+		if (this.#disposed) return;
 		// Skip delivery if already acknowledged
 		if (this.isDeliverySuppressed(jobId)) {
 			return;
@@ -638,6 +676,8 @@ export class AsyncJobManager {
 	}
 
 	#ensureDeliveryLoop(): void {
+		// During dispose the terminal drain is the sole delivery driver.
+		if (this.#disposed) return;
 		if (this.#deliveryLoop) {
 			return;
 		}
@@ -656,6 +696,9 @@ export class AsyncJobManager {
 
 	async #runDeliveryLoop(): Promise<void> {
 		while (this.#deliveries.length > 0) {
+			// dispose() owns any remaining deliveries; exit without competing
+			// (a wake from a retry-backoff sleep lands here).
+			if (this.#disposed) return;
 			const delivery = this.#deliveries[0];
 			if (this.isDeliverySuppressed(delivery.jobId)) {
 				this.#deliveries.shift();
@@ -686,25 +729,34 @@ export class AsyncJobManager {
 			} catch (error) {
 				delivery.attempt += 1;
 				delivery.lastError = error instanceof Error ? error.message : String(error);
-				delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
-				if (!this.isDeliverySuppressed(delivery.jobId)) {
-					this.#deliveries.push(delivery);
+				if (this.#disposed) {
+					// Terminal: retry backoff must not delay shutdown. Surface the
+					// loss; dispose() reports it through its return value.
+					this.#terminalDeliveryFailures += 1;
+					logger.error("Async job completion delivery failed terminally during dispose", {
+						jobId: delivery.jobId,
+						attempt: delivery.attempt,
+						error: delivery.lastError,
+					});
+				} else {
+					delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
+					if (!this.isDeliverySuppressed(delivery.jobId)) {
+						this.#deliveries.push(delivery);
+					}
+					logger.warn("Async job completion delivery failed", {
+						jobId: delivery.jobId,
+						attempt: delivery.attempt,
+						nextRetryAt: delivery.nextAttemptAt,
+						error: delivery.lastError,
+					});
 				}
-				logger.warn("Async job completion delivery failed", {
-					jobId: delivery.jobId,
-					attempt: delivery.attempt,
-					nextRetryAt: delivery.nextAttemptAt,
-					error: delivery.lastError,
-				});
 			} finally {
-				if (delivery.promise) this.#deliveryPromises.delete(delivery.promise);
 				const index = this.#inFlightDeliveries.indexOf(delivery);
 				if (index !== -1) this.#inFlightDeliveries.splice(index, 1);
 				if (this.#deliveries.length > 0) this.#ensureDeliveryLoop();
 			}
 		})();
 		delivery.promise = promise;
-		this.#deliveryPromises.add(promise);
 		return promise;
 	}
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -85,6 +85,8 @@ export interface AsyncJobRegisterOptions {
 	id?: string;
 	/** Registry id of the agent that owns this job; used to scope cancelAll. */
 	ownerId?: string;
+	/** Session instance making the registration; dispose seals only this exact instance. */
+	admissionScope?: object;
 	/** Registry id of the subagent this job runs; see {@link AsyncJob.agentId}. */
 	agentId?: string;
 	onProgress?: (text: string, details?: Record<string, unknown>) => void | Promise<void>;
@@ -125,7 +127,7 @@ export class AsyncJobManager {
 	/** Count of delivery callbacks that failed after dispose sealed the manager (terminal, never retried). */
 	#terminalDeliveryFailures = 0;
 	readonly #suppressedDeliveries = new Set<string>();
-	readonly #closedAdmissionOwners = new Set<string>();
+	readonly #closedAdmissionScopes = new WeakSet<object>();
 	readonly #watchedJobs = new Set<string>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #pollEscalation = new Map<string | undefined, PollEscalationState>();
@@ -177,8 +179,9 @@ export class AsyncJobManager {
 		if (this.#disposed) {
 			throw new Error("Async job manager is disposed");
 		}
-		if (options?.ownerId && this.#closedAdmissionOwners.has(options.ownerId)) {
-			throw new Error(`Background jobs are unavailable while session disposal is in progress (${options.ownerId})`);
+		if (options?.admissionScope && this.#closedAdmissionScopes.has(options.admissionScope)) {
+			const owner = options.ownerId ? ` (${options.ownerId})` : "";
+			throw new Error(`Background jobs are unavailable while session disposal is in progress${owner}`);
 		}
 		// Queued jobs hold no execution slot yet — only count jobs that are
 		// actually running so a large parked batch cannot starve registration.
@@ -395,9 +398,9 @@ export class AsyncJobManager {
 		}
 	}
 
-	/** Permanently reject new jobs for one disposing session without sealing its shared manager. */
-	closeAdmissions(filter: AsyncJobFilter): void {
-		if (filter.ownerId) this.#closedAdmissionOwners.add(filter.ownerId);
+	/** Reject new jobs from one disposing session instance without sealing its shared manager. */
+	closeAdmissions(scope: object): void {
+		this.#closedAdmissionScopes.add(scope);
 	}
 
 	/**
@@ -486,8 +489,8 @@ export class AsyncJobManager {
 	 * Manager-owned shutdown barrier. Single ordered sequence — no secondary
 	 * promise registry, no quiescence polling:
 	 *
-	 *  1. seal the manager (`#disposed`; `register()` already rejects, owner
-	 *     admissions were closed by the session via `closeAdmissions`);
+	 *  1. seal the manager (`#disposed`; `register()` already rejects, and the
+	 *     disposing session instance was sealed via `closeAdmissions`);
 	 *  2. cancel every running job — a cancelled job's late return takes the
 	 *     `status === "cancelled"` branch in `register()` and can never enqueue
 	 *     a delivery, so the delivery set is frozen from here on;

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -196,6 +196,13 @@ export interface MnemopiSessionStateOptions {
 	hasRecalledForFirstTurn?: boolean;
 }
 
+export interface MnemopiSessionDisposeOptions {
+	consolidate?: boolean;
+	timeoutMs?: number;
+	/** Runs after consolidation has actually settled, including detached consolidation. */
+	onConsolidationSettled?: () => void | Promise<void>;
+}
+
 export class MnemopiSessionState {
 	sessionId: string;
 	readonly config: MnemopiBackendConfig;
@@ -558,15 +565,22 @@ export class MnemopiSessionState {
 	 * episodic promotion / embedding for the LAST few turns is skipped,
 	 * and `maybeRetainOnAgentEnd` has already retained earlier turns).
 	 */
-	async dispose(options: { consolidate?: boolean; timeoutMs?: number } = {}): Promise<void> {
+	async dispose(options: MnemopiSessionDisposeOptions = {}): Promise<void> {
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
-		if (this.aliasOf) return;
+		const notifyConsolidationSettled = async (): Promise<void> => {
+			await options.onConsolidationSettled?.();
+		};
+		if (this.aliasOf) {
+			await notifyConsolidationSettled();
+			return;
+		}
 		const closeOwned = (): void => {
 			for (const memory of this.scoped.owned) memory.close();
 		};
 		if (options.consolidate === false) {
 			closeOwned();
+			await notifyConsolidationSettled();
 			return;
 		}
 		const consolidatePromise = this.consolidate().catch((error: unknown) => {
@@ -583,18 +597,21 @@ export class MnemopiSessionState {
 				logger.warn("Mnemopi: consolidate-on-dispose exceeded shutdown budget; detaching to background.", {
 					timeoutMs,
 				});
-				// Defer close until the in-flight consolidate settles so SQLite
-				// writes don't race a closed handle. The process is on the way
-				// to `postmortem.quit(0)`; if it exits first, the OS reclaims
-				// the handles (and a still-pending embed() goes down with the
-				// embed worker the caller is about to SIGKILL).
-				void consolidatePromise.finally(closeOwned);
+				// Defer close and dependent cleanup until the in-flight consolidate
+				// settles so neither can interrupt its SQLite or model work.
+				void consolidatePromise
+					.finally(closeOwned)
+					.then(notifyConsolidationSettled)
+					.catch((error: unknown) => {
+						logger.warn("Mnemopi: detached dispose cleanup failed.", { error: String(error) });
+					});
 				return;
 			}
 		} else {
 			await consolidatePromise;
 		}
 		closeOwned();
+		await notifyConsolidationSettled();
 	}
 }
 

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -199,7 +199,7 @@ export class TanCommandController {
 						}
 					}
 				},
-				{ ownerId, agentId: cloneId },
+				{ ownerId, agentId: cloneId, admissionScope: session },
 			);
 		} catch (error) {
 			if (cloneFile) await removeCloneSession(cloneFile);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3737,7 +3737,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		// for the pause while `session.dispose()` flushes memory consolidate and
 		// other cleanups (issue #3641). The await on the next line yields the
 		// event loop, giving requestRender() a tick to paint the status before
-		// dispose blocks.
+		// dispose blocks. If teardown runs longer than 3s (pending network flush),
+		// refresh the status so the wait stays visible without a new UI surface.
 		this.showStatus("Closing session…");
 
 		// Persist the draft and dispose the session through the shared teardown
@@ -3746,10 +3747,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		// first runs the work, the other awaits the same settled promise.
 		// The teardown is registered lazily in `init()` — a `/exit` reached
 		// before `init()` completed falls back to a direct dispose.
-		if (this.#signalTeardown) {
-			await this.#signalTeardown();
-		} else {
-			await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+		const stillClosingTimer = setTimeout(() => {
+			this.showStatus("Still closing… (flushing memory backend / network)");
+		}, 3_000);
+		try {
+			if (this.#signalTeardown) {
+				await this.#signalTeardown();
+			} else {
+				await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+			}
+		} finally {
+			clearTimeout(stillClosingTimer);
 		}
 
 		// Do not force a final render during teardown: disposed session/UI state can

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3750,6 +3750,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const stillClosingTimer = setTimeout(() => {
 			this.showStatus("Still closing… (flushing memory backend / network)");
 		}, 3_000);
+		let exitCode = 0;
 		try {
 			try {
 				if (this.#signalTeardown) {
@@ -3758,7 +3759,12 @@ export class InteractiveMode implements InteractiveModeContext {
 					await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
 				}
 			} catch (error) {
-				logger.warn("Failed to dispose interactive session during shutdown", { error: String(error) });
+				if (error instanceof AggregateError && error.message === "Session dispose subsystem failures") {
+					logger.warn("Failed to dispose interactive session during shutdown", { error: String(error) });
+				} else {
+					exitCode = 1;
+					logger.error("Failed to close interactive session storage during shutdown", { error: String(error) });
+				}
 			}
 		} finally {
 			clearTimeout(stillClosingTimer);
@@ -3781,7 +3787,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			process.stderr.write(`\n${chalk.dim(`Resume this session with ${APP_NAME} --resume ${sessionId}`)}\n`);
 		}
 
-		await postmortem.quit(0);
+		await postmortem.quit(exitCode);
 	}
 
 	async checkShutdownRequested(): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3756,6 +3756,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			} else {
 				await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
 			}
+		} catch (error) {
+			logger.warn("Failed to dispose interactive session during shutdown", { error: String(error) });
 		} finally {
 			clearTimeout(stillClosingTimer);
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -50,7 +50,6 @@ import {
 	postmortem,
 	prompt,
 	setProjectDir,
-	withTimeout,
 } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { reset as resetCapabilities } from "../capability";
@@ -208,8 +207,6 @@ import type {
 	TodoPhase,
 } from "./types";
 import { UiHelpers } from "./utils/ui-helpers";
-
-const SHUTDOWN_SESSION_FINALIZATION_BUDGET_MS = 5_000;
 
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
@@ -3762,17 +3759,6 @@ export class InteractiveMode implements InteractiveModeContext {
 				}
 			} catch (error) {
 				logger.warn("Failed to dispose interactive session during shutdown", { error: String(error) });
-			}
-			try {
-				await withTimeout(
-					this.session.waitForSessionStorageFinalization(),
-					SHUTDOWN_SESSION_FINALIZATION_BUDGET_MS,
-					"Timed out finalizing session storage during interactive shutdown",
-				);
-			} catch (error) {
-				logger.warn("Session storage still finalizing at interactive shutdown deadline", {
-					error: String(error),
-				});
 			}
 		} finally {
 			clearTimeout(stillClosingTimer);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -50,6 +50,7 @@ import {
 	postmortem,
 	prompt,
 	setProjectDir,
+	withTimeout,
 } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { reset as resetCapabilities } from "../capability";
@@ -207,6 +208,8 @@ import type {
 	TodoPhase,
 } from "./types";
 import { UiHelpers } from "./utils/ui-helpers";
+
+const SHUTDOWN_SESSION_FINALIZATION_BUDGET_MS = 5_000;
 
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
@@ -3751,13 +3754,26 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showStatus("Still closing… (flushing memory backend / network)");
 		}, 3_000);
 		try {
-			if (this.#signalTeardown) {
-				await this.#signalTeardown();
-			} else {
-				await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+			try {
+				if (this.#signalTeardown) {
+					await this.#signalTeardown();
+				} else {
+					await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+				}
+			} catch (error) {
+				logger.warn("Failed to dispose interactive session during shutdown", { error: String(error) });
 			}
-		} catch (error) {
-			logger.warn("Failed to dispose interactive session during shutdown", { error: String(error) });
+			try {
+				await withTimeout(
+					this.session.waitForSessionStorageFinalization(),
+					SHUTDOWN_SESSION_FINALIZATION_BUDGET_MS,
+					"Timed out finalizing session storage during interactive shutdown",
+				);
+			} catch (error) {
+				logger.warn("Session storage still finalizing at interactive shutdown deadline", {
+					error: String(error),
+				});
+			}
 		} finally {
 			clearTimeout(stillClosingTimer);
 		}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -123,6 +123,7 @@ import { discoverAuthStorage as discoverAuthStorageFromConfig } from "./session/
 import type { AuthStorage } from "./session/auth-storage";
 import { createInterruptedTurnAbortMessage } from "./session/exit-diagnostics";
 import {
+	ASYNC_RESULT_MESSAGE_TYPE,
 	type CustomMessage,
 	convertToLlm,
 	LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE,
@@ -242,7 +243,7 @@ function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): CustomMessag
 	};
 	return {
 		role: "custom",
-		customType: "async-result",
+		customType: ASYNC_RESULT_MESSAGE_TYPE,
 		content: prompt.render(asyncResultTemplate, {
 			multiple: jobs.length > 1,
 			jobs,
@@ -1599,7 +1600,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						if (asyncJobManager!.isDeliverySuppressed(jobId)) return;
 
 						const durationMs = job ? Math.max(0, Date.now() - job.startTime) : undefined;
-						session.yieldQueue.enqueue<AsyncResultEntry>("async-result", {
+						session.yieldQueue.enqueue<AsyncResultEntry>(ASYNC_RESULT_MESSAGE_TYPE, {
 							jobId,
 							result: formattedResult,
 							job,
@@ -2957,7 +2958,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		});
 		hasSession = true;
 		if (asyncJobManager) {
-			session.yieldQueue.register<AsyncResultEntry>("async-result", {
+			session.yieldQueue.register<AsyncResultEntry>(ASYNC_RESULT_MESSAGE_TYPE, {
 				isStale: entry => asyncJobManager.isDeliverySuppressed(entry.jobId),
 				build: buildAsyncResultBatchMessage,
 			});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6715,6 +6715,9 @@ export class AgentSession {
 	}
 
 	async #doDispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
+		// Phase A (sequential): mark dispose, emit session_shutdown, abort in-flight
+		// post-prompt work, then bound the post-prompt drain. Writers that can still
+		// append session entries must finish before Phase C's sessionManager.close().
 		this.beginDispose();
 		this.#recordSessionExit(options.reason ?? "dispose");
 		this.#cancelExitRecorder?.();
@@ -6748,102 +6751,183 @@ export class AgentSession {
 		this.abortCompaction();
 		const postPromptDrain = this.#cancelPostPromptTasks();
 		this.agent.abort();
-		await postPromptDrain;
+		// Bound the drain: tasks are already aborted; a hang past 5s was the historical
+		// /exit freeze. This is a hang-fix, not a flush drop — unexpected errors rethrow.
+		const postPromptDrainTimeoutMessage = "Timed out draining post-prompt tasks during dispose";
+		try {
+			await withTimeout(postPromptDrain, 5_000, postPromptDrainTimeoutMessage);
+		} catch (error) {
+			if (error instanceof Error && error.message === postPromptDrainTimeoutMessage) {
+				logger.warn("Post-prompt tasks still draining at dispose deadline");
+			} else {
+				throw error;
+			}
+		}
 		await this.#drainAutolearnCapture();
-		// Cancel jobs this agent registered so a subagent's teardown doesn't
-		// leak its background bash/task work into the parent's manager. Only
-		// the session that owns the manager goes on to dispose it (which itself
-		// nukes any leftover jobs and pending deliveries).
-		this.#cancelOwnAsyncJobs();
-		const ownedAsyncManager = this.#ownedAsyncJobManager;
-		if (ownedAsyncManager) {
-			const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
-			const deliveryState = ownedAsyncManager.getDeliveryState();
-			if (drained === false && deliveryState) {
-				logger.warn("Async job completion deliveries still pending during dispose", { ...deliveryState });
-			}
-			if (AsyncJobManager.instance() === ownedAsyncManager) {
-				AsyncJobManager.setInstance(undefined);
-			}
-		}
-		const evalExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
-		if (!evalExecutionsSettled) {
-			logger.warn("Detaching retained eval-kernel ownership during dispose while eval execution is still active");
-		}
-		await disposeKernelSessionsByOwner(this.#evalKernelOwnerId);
-		await disposeRubyKernelSessionsByOwner(this.#evalKernelOwnerId);
-		await disposeJuliaKernelSessionsByOwner(this.#evalKernelOwnerId);
-		// Release headless / spawned Chromium and worker tabs this session
-		// opened via the browser tool. The tool's `tabs`/`browsers` maps are
-		// module-global — subagents and future sessions share them — so we
-		// walk by `ownerSessionId` (assigned at `acquireTab` creation, never on
-		// reuse) and touch only what THIS session created. Bounded so a broken
-		// CDP close cannot stall `/exit`; mirrors the async-job/MCP pattern.
-		// (Issue #3963.)
+
+		// Capture state needed by Phase B branches before the barrier. Hindsight
+		// flush must still observe getHindsightSessionState() === hindsightState;
+		// clear the pointer only in Phase C after the barrier settles.
+		const hindsightState = this.getHindsightSessionState();
 		const browserOwnerId = this.sessionManager.getSessionId();
-		if (browserOwnerId) {
-			try {
-				const released = await withTimeout(
-					releaseTabsForOwner(browserOwnerId, { kill: true }),
-					3_000,
-					"Timed out releasing owned browser tabs during dispose",
-				);
-				if (released > 0) {
-					logger.debug("Released owned browser tabs during dispose", { ownerId: browserOwnerId, released });
+		const mnemopiState = setMnemopiSessionState(this, undefined);
+		const mnemopiConsolidateTimeoutMs = options.mnemopiConsolidateTimeoutMs;
+
+		// Phase B: independent subsystem teardown runs concurrently under one
+		// allSettled barrier. Each branch keeps its existing inner timeout/log
+		// behavior. Writers (async-job delivery drain, Hindsight flush, mnemopi
+		// dispose) complete before Phase C's sessionManager.close().
+		const phaseBResults = await Promise.allSettled([
+			// Async jobs: cancel this agent, dispose the owned manager (3s), clear singleton.
+			(async () => {
+				// Cancel jobs this agent registered so a subagent's teardown doesn't
+				// leak its background bash/task work into the parent's manager. Only
+				// the session that owns the manager goes on to dispose it (which itself
+				// nukes any leftover jobs and pending deliveries).
+				this.#cancelOwnAsyncJobs();
+				const ownedAsyncManager = this.#ownedAsyncJobManager;
+				if (ownedAsyncManager) {
+					// Clear the process-global singleton even when dispose rejects so a
+					// failed owned teardown cannot leave a dead manager installed for
+					// later top-level sessions / task async routing.
+					try {
+						const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
+						const deliveryState = ownedAsyncManager.getDeliveryState();
+						if (drained === false && deliveryState) {
+							logger.warn("Async job completion deliveries still pending during dispose", {
+								...deliveryState,
+							});
+						}
+					} finally {
+						if (AsyncJobManager.instance() === ownedAsyncManager) {
+							AsyncJobManager.setInstance(undefined);
+						}
+					}
 				}
-			} catch (error) {
-				logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
+			})(),
+			// Eval settle then three independent kernel-language disposes.
+			(async () => {
+				const evalExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
+				if (!evalExecutionsSettled) {
+					logger.warn(
+						"Detaching retained eval-kernel ownership during dispose while eval execution is still active",
+					);
+				}
+				await Promise.all([
+					disposeKernelSessionsByOwner(this.#evalKernelOwnerId),
+					disposeRubyKernelSessionsByOwner(this.#evalKernelOwnerId),
+					disposeJuliaKernelSessionsByOwner(this.#evalKernelOwnerId),
+				]);
+			})(),
+			// Browser tabs: bounded 3s CDP close (issue #3963).
+			(async () => {
+				// Release headless / spawned Chromium and worker tabs this session
+				// opened via the browser tool. The tool's `tabs`/`browsers` maps are
+				// module-global — subagents and future sessions share them — so we
+				// walk by `ownerSessionId` (assigned at `acquireTab` creation, never on
+				// reuse) and touch only what THIS session created. Bounded so a broken
+				// CDP close cannot stall `/exit`; mirrors the async-job/MCP pattern.
+				// (Issue #3963.)
+				if (!browserOwnerId) return;
+				try {
+					const released = await withTimeout(
+						releaseTabsForOwner(browserOwnerId, { kill: true }),
+						3_000,
+						"Timed out releasing owned browser tabs during dispose",
+					);
+					if (released > 0) {
+						logger.debug("Released owned browser tabs during dispose", {
+							ownerId: browserOwnerId,
+							released,
+						});
+					}
+				} catch (error) {
+					logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
+				}
+			})(),
+			// Tiny title client shutdown (no explicit timeout).
+			shutdownTinyTitleClient(),
+			// MCP owned-manager disconnect: bounded 3s, best-effort.
+			(async () => {
+				// Disconnect the MCP manager this session OWNS so its stdio servers are
+				// not orphaned at exit. Best-effort: a failure here must never throw out
+				// of dispose. Only owning (top-level) sessions provide this callback;
+				// subagents reuse a parent's manager and must not tear it down. Idempotent
+				// with the deferred-discovery disconnect in `createAgentSession`.
+				//
+				// BOUNDED: an owned manager may hold an HTTP/SSE server whose session-
+				// termination DELETE blocks up to the MCP request timeout (30s default,
+				// unbounded when OMP_MCP_TIMEOUT_MS=0), so awaiting `disconnectAll()`
+				// unbounded would stall /exit and print-mode shutdown on a broken remote
+				// endpoint. Race it against a short deadline — stdio close (the subprocess
+				// reap this targets) completes well within the bound; a slow transport
+				// close is left to finish detached. Mirrors the bounded async-job teardown.
+				if (!this.#disconnectOwnedMcpManager) return;
+				try {
+					await withTimeout(
+						this.#disconnectOwnedMcpManager(),
+						3_000,
+						"Timed out disconnecting owned MCP manager during dispose",
+					);
+				} catch (error) {
+					logger.warn("Failed to disconnect owned MCP manager during dispose", { error: String(error) });
+				}
+			})(),
+			// beginDispose() stopped the advisor and captured its recorder close; await
+			// it so the final advisor turn is flushed before the process may exit.
+			Promise.resolve(this.#advisorRecorderClosed),
+			// Hindsight retain flush is unbounded by decision (no data loss). Must complete
+			// before Phase C clears the session pointer — identity check in #doFlush.
+			// Flush the retain queue BEFORE clearing the session's pointer so
+			// `HindsightRetainQueue.#doFlush` still sees `session.getHindsightSessionState() === state`.
+			// Reversed, the spliced batch survives just long enough to fail the
+			// identity check and get dropped with a `session vanished` warning.
+			(async () => {
+				await hindsightState?.flushRetainQueue();
+			})(),
+			// Mnemopi dispose then embed shutdown as one sequential branch (#3031).
+			// Pointer was cleared before the barrier so other code cannot observe a
+			// half-disposed state across concurrent branches.
+			(async () => {
+				// Embed shutdown must run even when state.dispose rejects: consolidate
+				// failure must not leave the embeddings worker alive after session exit.
+				// Normal order remains dispose-then-shutdown so consolidate can still embed.
+				try {
+					await mnemopiState?.dispose({ timeoutMs: mnemopiConsolidateTimeoutMs });
+				} finally {
+					// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
+					// consolidate-on-dispose may still call `embed()` to store the final
+					// memories, and that round-trips through the worker we are about to
+					// hard-kill (issue #3031).
+					await shutdownMnemopiEmbedClient();
+				}
+			})(),
+		]);
+
+		// allSettled contains rejections that branch try/catch did not already
+		// log (e.g. async-job dispose, advisor recorder, hindsight flush). Keep
+		// dispose non-throwing for expected subsystem failures but surface them.
+		for (const result of phaseBResults) {
+			if (result.status === "rejected") {
+				logger.warn("Session dispose subsystem failed during parallel teardown", {
+					error: String(result.reason),
+				});
 			}
 		}
-		await shutdownTinyTitleClient();
+
+		// Phase C (sequential): power/empty-move cleanup, then session close
+		// (writers-before-close invariant: Phase A + Phase B flushes finished),
+		// provider sessions, Hindsight pointer clear/dispose, agent disconnect.
 		this.#releasePowerAssertion();
 		// Clean up an empty session created by this session's /move so it doesn't accumulate.
 		await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
 		this.#movedFromEmptySessionFile = undefined;
+		// Writers-before-close: async-job deliveries, post-prompt, Hindsight flush,
+		// and mnemopi dispose have all settled under the Phase B barrier above.
 		await this.sessionManager.close();
-		// beginDispose() stopped the advisor and captured its recorder close; await
-		// it so the final advisor turn is flushed before the process may exit.
-		await this.#advisorRecorderClosed;
 		this.#closeAllProviderSessions("dispose");
-		// Disconnect the MCP manager this session OWNS so its stdio servers are
-		// not orphaned at exit. Best-effort: a failure here must never throw out
-		// of dispose. Only owning (top-level) sessions provide this callback;
-		// subagents reuse a parent's manager and must not tear it down. Idempotent
-		// with the deferred-discovery disconnect in `createAgentSession`.
-		//
-		// BOUNDED: an owned manager may hold an HTTP/SSE server whose session-
-		// termination DELETE blocks up to the MCP request timeout (30s default,
-		// unbounded when OMP_MCP_TIMEOUT_MS=0), so awaiting `disconnectAll()`
-		// unbounded would stall /exit and print-mode shutdown on a broken remote
-		// endpoint. Race it against a short deadline — stdio close (the subprocess
-		// reap this targets) completes well within the bound; a slow transport
-		// close is left to finish detached. Mirrors the bounded async-job teardown.
-		if (this.#disconnectOwnedMcpManager) {
-			try {
-				await withTimeout(
-					this.#disconnectOwnedMcpManager(),
-					3_000,
-					"Timed out disconnecting owned MCP manager during dispose",
-				);
-			} catch (error) {
-				logger.warn("Failed to disconnect owned MCP manager during dispose", { error: String(error) });
-			}
-		}
-		// Flush the retain queue BEFORE clearing the session's pointer so
-		// `HindsightRetainQueue.#doFlush` still sees `session.getHindsightSessionState() === state`.
-		// Reversed, the spliced batch survives just long enough to fail the
-		// identity check and get dropped with a `session vanished` warning.
-		const hindsightState = this.getHindsightSessionState();
-		await hindsightState?.flushRetainQueue();
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();
-		const mnemopiState = setMnemopiSessionState(this, undefined);
-		await mnemopiState?.dispose({ timeoutMs: options.mnemopiConsolidateTimeoutMs });
-		// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
-		// consolidate-on-dispose may still call `embed()` to store the final
-		// memories, and that round-trips through the worker we are about to
-		// hard-kill (issue #3031).
-		await shutdownMnemopiEmbedClient();
 		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();
@@ -7693,6 +7777,18 @@ export class AgentSession {
 	 */
 	get hasPostPromptWork(): boolean {
 		return this.#postPromptTasks.size > 0;
+	}
+
+	/**
+	 * Test-only: register a promise as a post-prompt task so dispose's 5s drain
+	 * bound can be exercised without driving a full agent turn. Production code
+	 * must not call this.
+	 */
+	trackPostPromptTaskForTests(task: Promise<unknown>): void {
+		if (!isBunTestRuntime()) {
+			throw new Error("trackPostPromptTaskForTests is test-only");
+		}
+		this.#trackPostPromptTask(task);
 	}
 
 	/** All messages including custom types like BashExecutionMessage */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6754,8 +6754,10 @@ export class AgentSession {
 		// Bound the drain: tasks are already aborted; a hang past 5s was the historical
 		// /exit freeze. This is a hang-fix, not a flush drop — unexpected errors rethrow.
 		const postPromptDrainTimeoutMessage = "Timed out draining post-prompt tasks during dispose";
+		let postPromptTasksDrained = false;
 		try {
 			await withTimeout(postPromptDrain, 5_000, postPromptDrainTimeoutMessage);
+			postPromptTasksDrained = true;
 		} catch (error) {
 			if (error instanceof Error && error.message === postPromptDrainTimeoutMessage) {
 				logger.warn("Post-prompt tasks still draining at dispose deadline");
@@ -6770,41 +6772,48 @@ export class AgentSession {
 		// clear the pointer only in Phase C after the barrier settles.
 		const hindsightState = this.getHindsightSessionState();
 		const browserOwnerId = this.sessionManager.getSessionId();
-		const mnemopiState = setMnemopiSessionState(this, undefined);
 		const mnemopiConsolidateTimeoutMs = options.mnemopiConsolidateTimeoutMs;
 
-		// Phase B: independent subsystem teardown runs concurrently under one
-		// allSettled barrier. Each branch keeps its existing inner timeout/log
-		// behavior. Writers (async-job delivery drain, Hindsight flush, mnemopi
-		// dispose) complete before Phase C's sessionManager.close().
-		const phaseBResults = await Promise.allSettled([
-			// Async jobs: cancel this agent, dispose the owned manager (3s), clear singleton.
-			(async () => {
-				// Cancel jobs this agent registered so a subagent's teardown doesn't
-				// leak its background bash/task work into the parent's manager. Only
-				// the session that owns the manager goes on to dispose it (which itself
-				// nukes any leftover jobs and pending deliveries).
-				this.#cancelOwnAsyncJobs();
-				const ownedAsyncManager = this.#ownedAsyncJobManager;
-				if (ownedAsyncManager) {
-					// Clear the process-global singleton even when dispose rejects so a
-					// failed owned teardown cannot leave a dead manager installed for
-					// later top-level sessions / task async routing.
-					try {
-						const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
-						const deliveryState = ownedAsyncManager.getDeliveryState();
-						if (drained === false && deliveryState) {
-							logger.warn("Async job completion deliveries still pending during dispose", {
-								...deliveryState,
-							});
-						}
-					} finally {
-						if (AsyncJobManager.instance() === ownedAsyncManager) {
-							AsyncJobManager.setInstance(undefined);
-						}
+		// Async-job subagents share their parent's MCP manager and mnemopi state.
+		// Drain them first; independent teardown below still begins immediately.
+		const asyncJobDrain = (async () => {
+			// Cancel jobs this agent registered so a subagent's teardown doesn't
+			// leak its background bash/task work into the parent's manager. Only
+			// the session that owns the manager goes on to dispose it (which itself
+			// nukes any leftover jobs and pending deliveries).
+			this.#cancelOwnAsyncJobs();
+			const ownedAsyncManager = this.#ownedAsyncJobManager;
+			if (ownedAsyncManager) {
+				// Clear the process-global singleton even when dispose rejects so a
+				// failed owned teardown cannot leave a dead manager installed for
+				// later top-level sessions / task async routing.
+				try {
+					const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
+					const deliveryState = ownedAsyncManager.getDeliveryState();
+					if (drained === false && deliveryState) {
+						logger.warn("Async job completion deliveries still pending during dispose", {
+							...deliveryState,
+						});
+					}
+				} finally {
+					if (AsyncJobManager.instance() === ownedAsyncManager) {
+						AsyncJobManager.setInstance(undefined);
 					}
 				}
-			})(),
+			}
+		})();
+		// A rejected drain must still release shared resources. Its rejection remains
+		// visible through the Phase-B allSettled result below.
+		const asyncJobsSettled = asyncJobDrain.then(
+			() => undefined,
+			() => undefined,
+		);
+
+		// Phase B: independent subsystem teardown runs concurrently under one
+		// allSettled barrier. MCP and mnemopi wait only for async jobs, not for the
+		// other branches. All writers complete before Phase C closes session storage.
+		const phaseBResults = await Promise.allSettled([
+			asyncJobDrain,
 			// Eval settle then three independent kernel-language disposes.
 			(async () => {
 				const evalExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
@@ -6845,13 +6854,14 @@ export class AgentSession {
 					logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
 				}
 			})(),
-			// MCP owned-manager disconnect: bounded 3s, best-effort.
+			// MCP owned-manager disconnect: bounded 3s, best-effort. Async-job
+			// subagents reuse this manager, so do not disconnect until their drain settles.
 			(async () => {
-				// Disconnect the MCP manager this session OWNS so its stdio servers are
-				// not orphaned at exit. Best-effort: a failure here must never throw out
-				// of dispose. Only owning (top-level) sessions provide this callback;
-				// subagents reuse a parent's manager and must not tear it down. Idempotent
-				// with the deferred-discovery disconnect in `createAgentSession`.
+				await asyncJobsSettled;
+				// Disconnect only the manager this top-level session owns. Best-effort:
+				// a failure must never throw out of dispose. Subagents reuse a parent's
+				// manager and do not provide this callback. Idempotent with the
+				// deferred-discovery disconnect in `createAgentSession`.
 				//
 				// BOUNDED: an owned manager may hold an HTTP/SSE server whose session-
 				// termination DELETE blocks up to the MCP request timeout (30s default,
@@ -6883,10 +6893,12 @@ export class AgentSession {
 			(async () => {
 				await hindsightState?.flushRetainQueue();
 			})(),
-			// Mnemopi dispose and worker shutdown share one branch (#3031). A
-			// timed-out consolidation keeps the shared tiny-model worker alive
-			// until its detached model work actually settles.
+			// Mnemopi is shared with async-job subagents. Detach it only after their
+			// drain settles, and keep the shared tiny-model worker alive until detached
+			// consolidation actually settles.
 			(async () => {
+				await asyncJobsSettled;
+				const mnemopiState = setMnemopiSessionState(this, undefined);
 				try {
 					if (mnemopiState) {
 						await mnemopiState.dispose({
@@ -6924,16 +6936,38 @@ export class AgentSession {
 		const phaseBError =
 			phaseBErrors.length > 0 ? new AggregateError(phaseBErrors, "Session dispose subsystem failures") : undefined;
 
-		// Phase C (sequential): power/empty-move cleanup, then session close
-		// (writers-before-close invariant: Phase A + Phase B flushes finished),
+		// Phase C (sequential): power cleanup, then session storage finalization,
 		// provider sessions, Hindsight pointer clear/dispose, agent disconnect.
 		this.#releasePowerAssertion();
-		// Clean up an empty session created by this session's /move so it doesn't accumulate.
-		await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
-		this.#movedFromEmptySessionFile = undefined;
-		// Writers-before-close: async-job deliveries, post-prompt, Hindsight flush,
-		// and mnemopi dispose have all settled under the Phase B barrier above.
-		await this.sessionManager.close();
+		const finalizeSessionStorage = async (): Promise<void> => {
+			// Clean up an empty session created by this session's /move so it doesn't accumulate.
+			await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
+			this.#movedFromEmptySessionFile = undefined;
+			await this.sessionManager.close();
+		};
+		if (postPromptTasksDrained) {
+			await finalizeSessionStorage();
+		} else {
+			// Keep /exit bounded, but leave the writer open for a task that ignored abort.
+			// Its final persistence runs before its promise settles; close immediately afterward.
+			void (async () => {
+				try {
+					await postPromptDrain;
+				} catch (error) {
+					logger.warn("Deferred post-prompt drain failed during session storage finalization", {
+						error: String(error),
+					});
+				} finally {
+					try {
+						await finalizeSessionStorage();
+					} catch (error) {
+						logger.warn("Failed to finalize session storage after deferred post-prompt drain", {
+							error: String(error),
+						});
+					}
+				}
+			})();
+		}
 		this.#closeAllProviderSessions("dispose");
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6761,7 +6761,7 @@ export class AgentSession {
 	beginDispose(): void {
 		if (this.#isDisposed) return;
 		this.#isDisposed = true;
-		if (this.#agentId) this.#asyncJobManager?.closeAdmissions?.({ ownerId: this.#agentId });
+		if (this.#agentId) this.#asyncJobManager?.closeAdmissions?.(this);
 		this.#promptGeneration++;
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#titleGenerationAbortController.abort();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6811,6 +6811,11 @@ export class AgentSession {
 
 		// Async-job subagents share their parent's MCP manager and mnemopi state.
 		// Drain them first; independent teardown below still begins immediately.
+		// A delivery callback is limited to local artifact persistence plus a
+		// yieldQueue enqueue (sdk.ts); it has no abort seam. Preserve the no-loss
+		// contract by awaiting true callback quiescence after the bounded manager
+		// cleanup rather than force-closing session storage underneath it.
+		let timedOutDeliveryQuiescence: Promise<void> = Promise.resolve();
 		const asyncJobDrain = (async () => {
 			// Cancel jobs this agent registered so a subagent's teardown doesn't
 			// leak its background bash/task work into the parent's manager. Only
@@ -6826,9 +6831,10 @@ export class AgentSession {
 					const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
 					const deliveryState = ownedAsyncManager.getDeliveryState();
 					if (drained === false && deliveryState) {
-						logger.warn("Async job completion deliveries still pending during dispose", {
+						logger.warn("Async job completion deliveries exceeded bounded cleanup; awaiting quiescence", {
 							...deliveryState,
 						});
+						timedOutDeliveryQuiescence = ownedAsyncManager.waitForDeliveryQuiescence();
 					}
 				} finally {
 					if (AsyncJobManager.instance() === ownedAsyncManager) {
@@ -6843,10 +6849,14 @@ export class AgentSession {
 			() => undefined,
 			() => undefined,
 		);
-		// A completed async delivery can enqueue a yield flush, which is itself a
-		// new post-prompt task. Only declare quiescence after the manager can no
-		// longer enqueue deliveries, then repeatedly flush/reap until stable.
-		const postPromptDrain = asyncJobsSettled.then(() => this.#drainPostPromptTasksForDispose());
+		// Let the first stable-empty pass overlap a delivery callback that exceeded
+		// the manager's bounded cleanup. Then wait until that callback can no longer
+		// enqueue and run a second stable-empty pass to persist its late yield.
+		const initialPostPromptDrain = asyncJobsSettled.then(() => this.#drainPostPromptTasksForDispose());
+		const asyncDeliveryQuiescence = asyncJobsSettled.then(() => timedOutDeliveryQuiescence);
+		const postPromptDrain = Promise.all([initialPostPromptDrain, asyncDeliveryQuiescence]).then(() =>
+			this.#drainPostPromptTasksForDispose(),
+		);
 
 		// Phase B: independent subsystem teardown runs concurrently under one
 		// allSettled barrier. Async-shared resources wait for the full async-job

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6845,8 +6845,6 @@ export class AgentSession {
 					logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
 				}
 			})(),
-			// Tiny title client shutdown (no explicit timeout).
-			shutdownTinyTitleClient(),
 			// MCP owned-manager disconnect: bounded 3s, best-effort.
 			(async () => {
 				// Disconnect the MCP manager this session OWNS so its stdio servers are
@@ -6885,16 +6883,17 @@ export class AgentSession {
 			(async () => {
 				await hindsightState?.flushRetainQueue();
 			})(),
-			// Mnemopi dispose then embed shutdown as one sequential branch (#3031).
-			// Pointer was cleared before the barrier so other code cannot observe a
-			// half-disposed state across concurrent branches.
+			// Mnemopi dispose, then shared tiny-model and embed shutdown as one
+			// sequential branch (#3031). Pointer was cleared before the barrier so
+			// other code cannot observe a half-disposed state across concurrent branches.
 			(async () => {
-				// Embed shutdown must run even when state.dispose rejects: consolidate
-				// failure must not leave the embeddings worker alive after session exit.
-				// Normal order remains dispose-then-shutdown so consolidate can still embed.
+				// Both workers must be torn down even when state.dispose rejects. The
+				// shared tiny-model worker stays alive until consolidation finishes because
+				// providers.memoryModel routes consolidation through tinyModelClient.
 				try {
 					await mnemopiState?.dispose({ timeoutMs: mnemopiConsolidateTimeoutMs });
 				} finally {
+					await shutdownTinyTitleClient();
 					// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
 					// consolidate-on-dispose may still call `embed()` to store the final
 					// memories, and that round-trips through the worker we are about to

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6916,9 +6916,7 @@ export class AgentSession {
 			}
 		}
 		const phaseBError =
-			phaseBErrors.length > 0
-				? new AggregateError(phaseBErrors, "Session dispose subsystem failures")
-				: undefined;
+			phaseBErrors.length > 0 ? new AggregateError(phaseBErrors, "Session dispose subsystem failures") : undefined;
 
 		// Phase C (sequential): power/empty-move cleanup, then session close
 		// (writers-before-close invariant: Phase A + Phase B flushes finished),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6883,21 +6883,27 @@ export class AgentSession {
 			(async () => {
 				await hindsightState?.flushRetainQueue();
 			})(),
-			// Mnemopi dispose, then shared tiny-model and embed shutdown as one
-			// sequential branch (#3031). Pointer was cleared before the barrier so
-			// other code cannot observe a half-disposed state across concurrent branches.
+			// Mnemopi dispose and worker shutdown share one branch (#3031). A
+			// timed-out consolidation keeps the shared tiny-model worker alive
+			// until its detached model work actually settles.
 			(async () => {
-				// Both workers must be torn down even when state.dispose rejects. The
-				// shared tiny-model worker stays alive until consolidation finishes because
-				// providers.memoryModel routes consolidation through tinyModelClient.
 				try {
-					await mnemopiState?.dispose({ timeoutMs: mnemopiConsolidateTimeoutMs });
-				} finally {
+					if (mnemopiState) {
+						await mnemopiState.dispose({
+							timeoutMs: mnemopiConsolidateTimeoutMs,
+							onConsolidationSettled: shutdownTinyTitleClient,
+						});
+					} else {
+						await shutdownTinyTitleClient();
+					}
+				} catch (error) {
+					// dispose can reject before it reaches the completion callback.
 					await shutdownTinyTitleClient();
-					// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
-					// consolidate-on-dispose may still call `embed()` to store the final
-					// memories, and that round-trips through the worker we are about to
-					// hard-kill (issue #3031).
+					throw error;
+				} finally {
+					// The embedding worker remains intentionally bounded: timed-out
+					// consolidation may lose its last pending embedding, while working
+					// memory rows remain durable for the next session.
 					await shutdownMnemopiEmbedClient();
 				}
 			})(),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8791,7 +8791,7 @@ export class AgentSession {
 		}
 
 		try {
-			await this.#promptWithMessage(message, expandedText, {
+			return await this.#promptWithMessage(message, expandedText, {
 				...options,
 				images: normalizedImages,
 				prependMessages:
@@ -8804,7 +8804,6 @@ export class AgentSession {
 			// (e.g., compaction aborted, validation failed).
 			this.#toolChoiceQueue.removeByLabel("eager-todo");
 		}
-		return true;
 	}
 
 	async promptCustomMessage<T = unknown>(
@@ -8880,8 +8879,8 @@ export class AgentSession {
 			skipPostPromptRecoveryWait?: boolean;
 			acceptTerminalEmptyStop?: boolean;
 		},
-	): Promise<void> {
-		if (this.#isDisposed) return;
+	): Promise<boolean> {
+		if (this.#isDisposed) return false;
 		this.#beginInFlight();
 		const generation = this.#promptGeneration;
 		try {
@@ -8954,7 +8953,7 @@ export class AgentSession {
 			// Early bail-out: if a newer abort/prompt cycle started during setup,
 			// return before mutating shared state (nextTurn messages, system prompt).
 			if (this.#promptGeneration !== generation) {
-				return;
+				return false;
 			}
 
 			// A pending xd:// delta accompanies the next user-authored prompt,
@@ -9029,7 +9028,7 @@ export class AgentSession {
 
 			// Bail out if a newer abort/prompt cycle has started since we began setup
 			if (this.#promptGeneration !== generation) {
-				return;
+				return false;
 			}
 
 			// Auto thinking: classify this real user turn and set the effective level
@@ -9039,13 +9038,13 @@ export class AgentSession {
 			if (this.#autoThinking && message.role === "user") {
 				await this.#applyAutoThinkingLevel(expandedText, generation);
 				if (this.#promptGeneration !== generation) {
-					return;
+					return false;
 				}
 			}
 
 			await this.#runPrePromptCompactionIfNeeded(messages);
 			if (this.#promptGeneration !== generation) {
-				return;
+				return false;
 			}
 
 			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;
@@ -9062,14 +9061,17 @@ export class AgentSession {
 				nonMessageTokens,
 				cutoffCount: this.messages.length + messages.length,
 			});
+			let agentInvoked: boolean;
 			try {
-				await this.#promptAgentWithIdleRetry(messages, agentPromptOptions, generation);
+				agentInvoked = await this.#promptAgentWithIdleRetry(messages, agentPromptOptions, generation);
 			} finally {
 				this.#setPendingContextSnapshot(undefined);
 			}
+			if (!agentInvoked) return false;
 			if (!options?.skipPostPromptRecoveryWait) {
 				await this.#waitForPostPromptRecovery(generation);
 			}
+			return true;
 		} finally {
 			this.#endInFlight();
 		}
@@ -15591,13 +15593,13 @@ export class AgentSession {
 		messages: AgentMessage[],
 		options: { toolChoice?: ToolChoice } | undefined,
 		generation: number,
-	): Promise<void> {
+	): Promise<boolean> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
-			if (this.#isDisposed || this.#promptGeneration !== generation) return;
+			if (this.#isDisposed || this.#promptGeneration !== generation) return false;
 			try {
 				await this.agent.prompt(messages, options);
-				return;
+				return true;
 			} catch (err) {
 				if (!(err instanceof AgentBusyError)) {
 					throw err;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6709,9 +6709,18 @@ export class AgentSession {
 	 * double-drain the owned `AsyncJobManager` (issue #4080).
 	 */
 	#disposeCall?: Promise<void>;
+	#sessionStorageFinalization?: Promise<void>;
 	dispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
 		if (!this.#disposeCall) this.#disposeCall = this.#doDispose(options);
 		return this.#disposeCall;
+	}
+
+	/**
+	 * Wait for the session writer to close after a bounded dispose detached a
+	 * post-prompt task that ignored abort. Call after dispose() settles.
+	 */
+	waitForSessionStorageFinalization(): Promise<void> {
+		return this.#sessionStorageFinalization ?? Promise.resolve();
 	}
 
 	async #doDispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
@@ -6949,11 +6958,12 @@ export class AgentSession {
 			await this.sessionManager.close();
 		};
 		if (postPromptTasksDrained) {
-			await finalizeSessionStorage();
+			this.#sessionStorageFinalization = finalizeSessionStorage();
+			await this.#sessionStorageFinalization;
 		} else {
 			// Keep /exit bounded, but leave the writer open for a task that ignored abort.
 			// Its final persistence runs before its promise settles; close immediately afterward.
-			void (async () => {
+			this.#sessionStorageFinalization = (async () => {
 				try {
 					await postPromptDrain;
 				} catch (error) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6904,15 +6904,21 @@ export class AgentSession {
 		]);
 
 		// allSettled contains rejections that branch try/catch did not already
-		// log (e.g. async-job dispose, advisor recorder, hindsight flush). Keep
-		// dispose non-throwing for expected subsystem failures but surface them.
+		// log (e.g. async-job dispose, advisor recorder, hindsight flush). Log
+		// every failure, then preserve dispose()'s rejecting contract.
+		const phaseBErrors: unknown[] = [];
 		for (const result of phaseBResults) {
 			if (result.status === "rejected") {
+				phaseBErrors.push(result.reason);
 				logger.warn("Session dispose subsystem failed during parallel teardown", {
 					error: String(result.reason),
 				});
 			}
 		}
+		const phaseBError =
+			phaseBErrors.length > 0
+				? new AggregateError(phaseBErrors, "Session dispose subsystem failures")
+				: undefined;
 
 		// Phase C (sequential): power/empty-move cleanup, then session close
 		// (writers-before-close invariant: Phase A + Phase B flushes finished),
@@ -6937,6 +6943,7 @@ export class AgentSession {
 			this.#unsubscribeModelRoles = undefined;
 		}
 		this.#eventListeners = [];
+		if (phaseBError) throw phaseBError;
 	}
 
 	#closeAllProviderSessions(reason: string): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6947,17 +6947,25 @@ export class AgentSession {
 				await hindsightState?.flushRetainQueue();
 			})(),
 			// Mnemopi is shared with async-job subagents. Detach it only after their
-			// drain settles, and keep the shared tiny-model worker alive until detached
-			// consolidation actually settles.
+			// drain settles. Only local-tiny consolidation uses the shared title
+			// worker; remote/smol consolidation must not keep that worker alive if
+			// its bounded dispose detaches a hung request.
 			(async () => {
 				await postPromptDrain;
 				const mnemopiState = setMnemopiSessionState(this, undefined);
+				const mnemopiLlm = mnemopiState?.config?.providerOptions.llm;
+				const consolidationUsesTinyClient =
+					typeof mnemopiLlm === "object" &&
+					mnemopiLlm !== null &&
+					"complete" in mnemopiLlm &&
+					typeof mnemopiLlm.complete === "function";
 				try {
 					if (mnemopiState) {
 						await mnemopiState.dispose({
 							timeoutMs: mnemopiConsolidateTimeoutMs,
-							onConsolidationSettled: shutdownTinyTitleClient,
+							onConsolidationSettled: consolidationUsesTinyClient ? shutdownTinyTitleClient : undefined,
 						});
+						if (!consolidationUsesTinyClient) await shutdownTinyTitleClient();
 					} else {
 						await shutdownTinyTitleClient();
 					}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7787,13 +7787,11 @@ export class AgentSession {
 
 	/**
 	 * Test-only: register a promise as a post-prompt task so dispose's 5s drain
-	 * bound can be exercised without driving a full agent turn. Production code
-	 * must not call this.
+	 * bound can be exercised without driving a full agent turn. The seam is inert
+	 * outside Bun tests so SDK consumers cannot trigger test-only behavior.
 	 */
 	trackPostPromptTaskForTests(task: Promise<unknown>): void {
-		if (!isBunTestRuntime()) {
-			throw new Error("trackPostPromptTaskForTests is test-only");
-		}
+		if (!isBunTestRuntime()) return;
 		this.#trackPostPromptTask(task);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -365,6 +365,7 @@ import {
 	type ToolExecutionStartData,
 } from "./exit-diagnostics";
 import {
+	ASYNC_RESULT_MESSAGE_TYPE,
 	type BashExecutionMessage,
 	type CustomMessage,
 	type CustomMessagePayload,
@@ -4378,20 +4379,31 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Disposed inject path: the only yield content that may still be written
+	 * after dispose begins is a background job's `async-result` follow-up (the
+	 * no-loss contract). Every other kind — MCP resource-change notifications,
+	 * late diagnostics — is advisory and must NOT be persisted into a session
+	 * that will never resume this turn (a stray `role: "user"` MCP batch would
+	 * otherwise land in the transcript at shutdown).
+	 */
 	#persistYieldMessagesDuringDispose(messages: AgentMessage[]): void {
 		for (const message of messages) {
-			this.agent.appendMessage(message);
-			if (message.role === "hookMessage" || message.role === "custom") {
-				this.sessionManager.appendCustomMessageEntry(
-					message.customType,
-					message.content,
-					message.display,
-					message.details,
-					message.attribution ?? "agent",
-				);
-			} else {
-				this.#persistSessionMessageIfMissing(message);
+			if (message.role !== "custom" || message.customType !== ASYNC_RESULT_MESSAGE_TYPE) {
+				logger.debug("Dropping non-async-result yield message during dispose", {
+					role: message.role,
+					customType: message.role === "custom" || message.role === "hookMessage" ? message.customType : undefined,
+				});
+				continue;
 			}
+			this.agent.appendMessage(message);
+			this.sessionManager.appendCustomMessageEntry(
+				message.customType,
+				message.content,
+				message.display,
+				message.details,
+				message.attribution ?? "agent",
+			);
 		}
 	}
 
@@ -5282,29 +5294,36 @@ export class AgentSession {
 	}
 
 	/**
-	 * Drain disposal-owned post-prompt work to true quiescence. The controller
-	 * stays aborted for the remainder of the session: tasks spawned by a task
-	 * already unwinding cannot start fresh provider work. Yield deliveries that
-	 * arrived while the async-job manager drained are persisted directly by the
-	 * disposed inject path above, then their scheduled no-op tasks are reaped.
+	 * Reap disposal-owned post-prompt tasks. The controller stays aborted for
+	 * the remainder of the session, so a task scheduled while this loop runs
+	 * (or after it) is a no-op that settles without running user code — the
+	 * loop therefore terminates. Yield persistence is NOT this method's job:
+	 * dispose runs one targeted `#flushAsyncResultsForDispose()` after the
+	 * async-job manager's terminal delivery drain.
 	 */
 	async #drainPostPromptTasksForDispose(): Promise<void> {
 		this.#postPromptTasksAbortController.abort();
 		this.#resolveTtsrResume();
-
-		let emptyPasses = 0;
-		while (emptyPasses < 2) {
-			await this.yieldQueue.flush("idle");
-			const pendingTasks = Array.from(this.#postPromptTasks);
-			if (pendingTasks.length === 0 && !this.yieldQueue.has()) {
-				emptyPasses++;
-				await Promise.resolve();
-				continue;
-			}
-			emptyPasses = 0;
-			await Promise.allSettled(pendingTasks);
+		while (this.#postPromptTasks.size > 0) {
+			await Promise.allSettled(Array.from(this.#postPromptTasks));
 		}
 		this.#resolvePostPromptTasks();
+	}
+
+	/**
+	 * Dispose-time writer barrier for async-job follow-ups. Runs strictly after
+	 * `AsyncJobManager.dispose()` — the manager's terminal drain has awaited
+	 * every delivery callback, and the production callback's last act is the
+	 * synchronous `yieldQueue.enqueue` (sdk.ts), so no producer can add another
+	 * `async-result` entry after this flush. One pass persists the survivors
+	 * (suppressed entries drop via the SDK `isStale` check, which stays
+	 * authoritative because the dead manager retains its suppression sets);
+	 * every other yield kind is dropped, not persisted (see
+	 * `#persistYieldMessagesDuringDispose`).
+	 */
+	async #flushAsyncResultsForDispose(): Promise<void> {
+		await this.yieldQueue.flush("idle", ASYNC_RESULT_MESSAGE_TYPE);
+		this.yieldQueue.clear();
 	}
 	/**
 	 * Wait for retry, TTSR resume, and any background continuation to settle.
@@ -6821,16 +6840,10 @@ export class AgentSession {
 
 		// Async-job subagents share their parent's MCP manager and mnemopi state.
 		// Drain them first; independent teardown below still begins immediately.
-		// A delivery callback is limited to local artifact persistence plus a
-		// yieldQueue enqueue (sdk.ts); it has no abort seam. Preserve the no-loss
-		// contract by awaiting true callback quiescence after the bounded manager
-		// cleanup rather than force-closing session storage underneath it.
-		let timedOutDeliveryQuiescence: Promise<void> = Promise.resolve();
 		const asyncJobDrain = (async () => {
 			// Cancel jobs this agent registered so a subagent's teardown doesn't
 			// leak its background bash/task work into the parent's manager. Only
-			// the session that owns the manager goes on to dispose it (which itself
-			// nukes any leftover jobs and pending deliveries).
+			// the session that owns the manager goes on to dispose it.
 			this.#cancelOwnAsyncJobs();
 			const ownedAsyncManager = this.#ownedAsyncJobManager;
 			if (ownedAsyncManager) {
@@ -6838,13 +6851,20 @@ export class AgentSession {
 				// failed owned teardown cannot leave a dead manager installed for
 				// later top-level sessions / task async routing.
 				try {
-					const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
-					const deliveryState = ownedAsyncManager.getDeliveryState();
-					if (drained === false && deliveryState) {
-						logger.warn("Async job completion deliveries exceeded bounded cleanup; awaiting quiescence", {
-							...deliveryState,
+					// Manager-owned shutdown barrier (see AsyncJobManager.dispose):
+					// seals admissions, cancels jobs, awaits abort-terminating job
+					// promises under the 3s bound, then drains every queued/in-flight
+					// delivery callback to completion — a failed callback is terminal
+					// (logged, never retried), so retry backoff cannot delay shutdown.
+					// A delivery callback is limited to local artifact persistence
+					// plus a synchronous yieldQueue enqueue (sdk.ts); a callback that
+					// never settles is the documented irreducible edge and holds
+					// dispose open rather than losing its yield.
+					const clean = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
+					if (!clean) {
+						logger.warn("Async job teardown exceeded the job-settle bound or lost a terminal delivery", {
+							...ownedAsyncManager.getDeliveryState(),
 						});
-						timedOutDeliveryQuiescence = ownedAsyncManager.waitForDeliveryQuiescence();
 					}
 				} finally {
 					if (AsyncJobManager.instance() === ownedAsyncManager) {
@@ -6859,15 +6879,16 @@ export class AgentSession {
 			() => undefined,
 			() => undefined,
 		);
-		// Let the first stable-empty pass overlap a delivery callback that exceeded
-		// the manager's bounded cleanup. Then wait until that callback can no longer
-		// enqueue and run a second stable-empty pass to persist its late yield.
-		const initialPostPromptDrain = asyncJobsSettled.then(() => this.#drainPostPromptTasksForDispose());
-		const asyncDeliveryQuiescence = asyncJobsSettled.then(() => timedOutDeliveryQuiescence);
-		const postPromptDrain = Promise.all([initialPostPromptDrain, asyncDeliveryQuiescence]).then(() =>
-			this.#drainPostPromptTasksForDispose(),
-		);
-
+		// Writer barrier, in order: (1) the manager drain above ran every
+		// delivery callback to completion, so every async-result enqueue has
+		// happened; (2) reap the aborted post-prompt tasks; (3) one targeted
+		// yieldQueue flush persists the async-result entries and drops every
+		// other kind. No producer can enqueue past (1), so a single flush is a
+		// true barrier — no stable-empty polling, no second quiescence pass.
+		const postPromptDrain = asyncJobsSettled.then(async () => {
+			await this.#drainPostPromptTasksForDispose();
+			await this.#flushAsyncResultsForDispose();
+		});
 		// Phase B: independent subsystem teardown runs concurrently under one
 		// allSettled barrier. Async-shared resources wait for the full async-job
 		// plus post-prompt drain, but not for unrelated branches.
@@ -6991,9 +7012,10 @@ export class AgentSession {
 				}
 			})(),
 		]);
-		// A Phase-B branch may have queued one last delivery after the first
-		// quiescence pass. Seal the writer side with a final stable drain before
-		// aggregating failures and entering Phase C.
+		// A Phase-B branch may have scheduled one last post-prompt task (all
+		// no-ops under the aborted controller). Reap them so no dangling task
+		// promise survives into Phase C. Async-result persistence already
+		// happened inside postPromptDrain; this is task hygiene only.
 		await this.#drainPostPromptTasksForDispose();
 		// The first Hindsight flush may have completed before a disposal-time
 		// post-prompt continuation enqueued another retain. Re-drain after all

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6985,12 +6985,16 @@ export class AgentSession {
 		// quiescence pass. Seal the writer side with a final stable drain before
 		// aggregating failures and entering Phase C.
 		await this.#drainPostPromptTasksForDispose();
+		// The first Hindsight flush may have completed before a disposal-time
+		// post-prompt continuation enqueued another retain. Re-drain after all
+		// post-prompt work settles, while the session identity is still attached.
+		const finalHindsightFlushResults = await Promise.allSettled([hindsightState?.flushRetainQueue()]);
 
 		// allSettled contains rejections that branch try/catch did not already
 		// log (e.g. async-job dispose, advisor recorder, hindsight flush). Log
 		// every failure, then preserve dispose()'s rejecting contract.
 		const phaseBErrors: unknown[] = [];
-		for (const result of phaseBResults) {
+		for (const result of [...phaseBResults, ...finalHindsightFlushResults]) {
 			if (result.status === "rejected") {
 				phaseBErrors.push(result.reason);
 				logger.warn("Session dispose subsystem failed during parallel teardown", {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8646,13 +8646,15 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	/**
-	 * Returns `false` when the command was fully handled locally (extension or
-	 * custom-TS command consumed without calling the LLM). Returns `true` when
-	 * the prompt was forwarded to the agent — either directly or queued as a
-	 * steer/follow-up. Callers that render a UI or manage turn lifecycle (e.g.
-	 * the ACP agent) use this to know whether to expect an `agent_end` event.
+	 * Returns `false` when no agent turn starts: the command was handled locally
+	 * (extension or custom-TS command), or session disposal has begun. Returns
+	 * `true` when the prompt was forwarded to the agent — either directly or
+	 * queued as a steer/follow-up. Callers that render a UI or manage turn
+	 * lifecycle (e.g. the ACP agent) use this to know whether to expect an
+	 * `agent_end` event.
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<boolean> {
+		if (this.#isDisposed) return false;
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 
 		// Handle extension commands first (execute immediately, even during streaming)

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6810,8 +6810,8 @@ export class AgentSession {
 		);
 
 		// Phase B: independent subsystem teardown runs concurrently under one
-		// allSettled barrier. MCP and mnemopi wait only for async jobs, not for the
-		// other branches. All writers complete before Phase C closes session storage.
+		// allSettled barrier. Async-shared resources wait only for async jobs, not
+		// for the other branches. All writers complete before Phase C closes storage.
 		const phaseBResults = await Promise.allSettled([
 			asyncJobDrain,
 			// Eval settle then three independent kernel-language disposes.
@@ -6828,8 +6828,11 @@ export class AgentSession {
 					disposeJuliaKernelSessionsByOwner(this.#evalKernelOwnerId),
 				]);
 			})(),
-			// Browser tabs: bounded 3s CDP close (issue #3963).
+			// Browser tabs: bounded 3s CDP close (issue #3963). Async-job
+			// subagents can reuse parent-owned module-global tabs, so do not release
+			// them until their drain settles.
 			(async () => {
+				await asyncJobsSettled;
 				// Release headless / spawned Chromium and worker tabs this session
 				// opened via the browser tool. The tool's `tabs`/`browsers` maps are
 				// module-global — subagents and future sessions share them — so we

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3827,7 +3827,7 @@ export class AgentSession {
 	}
 
 	get asyncJobManager(): AsyncJobManager | undefined {
-		return this.#asyncJobManager;
+		return this.#isDisposed ? undefined : this.#asyncJobManager;
 	}
 
 	getAgentId(): string | undefined {
@@ -6742,6 +6742,7 @@ export class AgentSession {
 	beginDispose(): void {
 		if (this.#isDisposed) return;
 		this.#isDisposed = true;
+		if (this.#agentId) this.#asyncJobManager?.closeAdmissions?.({ ownerId: this.#agentId });
 		this.#promptGeneration++;
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#titleGenerationAbortController.abort();
@@ -6771,6 +6772,15 @@ export class AgentSession {
 	}
 
 	async #doDispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
+		// Teardown barrier invariant: synchronously gate every new admission before
+		// the first await, abort admitted producers, await their quiescence, flush
+		// independent sinks behind one barrier, then close storage. Upstream/main
+		// already has two bounded-detach exceptions: a timed-out session_shutdown
+		// handler retains raw sessionManager access, and an eval that ignores abort
+		// past its 3s + 1s settle budgets may finish after close. Do not "fix" either
+		// here by making shutdown unbounded; their lifecycle contracts need separate
+		// cancellation or write-rejection designs.
+		//
 		// Phase A (sequential): mark dispose, emit session_shutdown, and abort
 		// in-flight post-prompt work. The Phase-B barrier below owns the complete
 		// quiescence drain before Phase C closes session storage.
@@ -9198,6 +9208,7 @@ export class AgentSession {
 	 * Queue a steering message to interrupt the agent mid-run.
 	 */
 	async steer(text: string, images?: ImageContent[]): Promise<void> {
+		if (this.#isDisposed) return;
 		if (text.startsWith("/")) {
 			this.#throwIfExtensionCommand(text);
 		}
@@ -9214,6 +9225,7 @@ export class AgentSession {
 	 * flipping advisor auto-resume.
 	 */
 	async followUp(text: string, images?: ImageContent[], options?: FollowUpOptions): Promise<void> {
+		if (this.#isDisposed) return;
 		if (text.startsWith("/")) {
 			this.#throwIfExtensionCommand(text);
 		}
@@ -9236,6 +9248,7 @@ export class AgentSession {
 		const imageDescriptionNotice = normalizedImages?.length
 			? await this.#buildImageDescriptionNotice(normalizedImages)
 			: undefined;
+		if (this.#isDisposed) return;
 		if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);
 		this.agent.followUp({
 			role: "developer",
@@ -9265,6 +9278,7 @@ export class AgentSession {
 		const imageDescriptionNotice = normalizedImages?.length
 			? await this.#buildImageDescriptionNotice(normalizedImages)
 			: undefined;
+		if (this.#isDisposed) return;
 		if (mode === "followUp") {
 			if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);
 			this.agent.followUp({
@@ -9473,6 +9487,7 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		if (this.#isDisposed) return;
 		if (deliverAs === "followUp") {
 			this.agent.followUp(normalizedAppMessage);
 		} else {
@@ -9504,6 +9519,7 @@ export class AgentSession {
 			acceptTerminalEmptyStop?: boolean;
 		},
 	): Promise<boolean> {
+		if (this.#isDisposed) return false;
 		const normalizedPayload = normalizeCustomMessagePayload<T>(message);
 		const details =
 			options?.queueChipText && options.deliverAs !== "nextTurn"
@@ -9524,6 +9540,7 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		if (this.#isDisposed) return false;
 		if (this.isStreaming) {
 			if (options?.deliverAs === "nextTurn") {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, options?.triggerTurn ?? false);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2780,6 +2780,10 @@ export class AgentSession {
 			injectIdle: async messages => {
 				const first = messages[0];
 				if (!first) return;
+				if (this.#isDisposed) {
+					this.#persistYieldMessagesDuringDispose(messages);
+					return;
+				}
 				await this.agent.prompt(messages.length === 1 ? first : messages);
 			},
 			scheduleIdleFlush: run => {
@@ -4374,6 +4378,23 @@ export class AgentSession {
 		}
 	}
 
+	#persistYieldMessagesDuringDispose(messages: AgentMessage[]): void {
+		for (const message of messages) {
+			this.agent.appendMessage(message);
+			if (message.role === "hookMessage" || message.role === "custom") {
+				this.sessionManager.appendCustomMessageEntry(
+					message.customType,
+					message.content,
+					message.display,
+					message.details,
+					message.attribution ?? "agent",
+				);
+			} else {
+				this.#persistSessionMessageIfMissing(message);
+			}
+		}
+	}
+
 	/**
 	 * On a user-interrupted (`Esc`) abort, copy the trailing thinking run into a
 	 * hidden `display: false` continuity message for the next turn WITHOUT
@@ -5123,7 +5144,7 @@ export class AgentSession {
 					return;
 				}
 			}
-			if (signal.aborted) {
+			if (signal.aborted || this.#isDisposed) {
 				options?.onSkip?.("aborted");
 				return;
 			}
@@ -5258,6 +5279,32 @@ export class AgentSession {
 		if (this.#postPromptTasks.size === 0) {
 			this.#resolvePostPromptTasks();
 		}
+	}
+
+	/**
+	 * Drain disposal-owned post-prompt work to true quiescence. The controller
+	 * stays aborted for the remainder of the session: tasks spawned by a task
+	 * already unwinding cannot start fresh provider work. Yield deliveries that
+	 * arrived while the async-job manager drained are persisted directly by the
+	 * disposed inject path above, then their scheduled no-op tasks are reaped.
+	 */
+	async #drainPostPromptTasksForDispose(): Promise<void> {
+		this.#postPromptTasksAbortController.abort();
+		this.#resolveTtsrResume();
+
+		let emptyPasses = 0;
+		while (emptyPasses < 2) {
+			await this.yieldQueue.flush("idle");
+			const pendingTasks = Array.from(this.#postPromptTasks);
+			if (pendingTasks.length === 0 && !this.yieldQueue.has()) {
+				emptyPasses++;
+				await Promise.resolve();
+				continue;
+			}
+			emptyPasses = 0;
+			await Promise.allSettled(pendingTasks);
+		}
+		this.#resolvePostPromptTasks();
 	}
 	/**
 	 * Wait for retry, TTSR resume, and any background continuation to settle.
@@ -5722,14 +5769,20 @@ export class AgentSession {
 		const retryToken = ++this.#ttsrRetryToken;
 		const generation = this.#promptGeneration;
 		this.#schedulePostPromptTask(
-			async () => {
+			async signal => {
 				if (this.#ttsrRetryToken !== retryToken) {
 					this.#resolveTtsrResume();
 					return;
 				}
 
 				const targetAssistantIndex = this.#findTtsrAssistantIndex(targetMessageTimestamp);
-				if (!this.#ttsrAbortPending || this.#promptGeneration !== generation || targetAssistantIndex === -1) {
+				if (
+					!this.#ttsrAbortPending ||
+					signal.aborted ||
+					this.#isDisposed ||
+					this.#promptGeneration !== generation ||
+					targetAssistantIndex === -1
+				) {
 					this.#ttsrAbortPending = false;
 					this.#pendingTtsrInjections = [];
 					this.#perToolTtsrInjections.clear();
@@ -6687,11 +6740,14 @@ export class AgentSession {
 	 * gap slips past the disposal guards.
 	 */
 	beginDispose(): void {
+		if (this.#isDisposed) return;
 		this.#isDisposed = true;
+		this.#promptGeneration++;
+		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#titleGenerationAbortController.abort();
 		this.#abortAutolearnCapture();
 		this.#flushPendingIrcAsides();
-		this.yieldQueue.clear();
+		this.yieldQueue.clear("advisor");
 		this.agent.setAsideMessageProvider(undefined);
 		this.agent.hasIrcInterrupts = undefined;
 		this.#stopAdvisorRuntime();
@@ -6709,24 +6765,15 @@ export class AgentSession {
 	 * double-drain the owned `AsyncJobManager` (issue #4080).
 	 */
 	#disposeCall?: Promise<void>;
-	#sessionStorageFinalization?: Promise<void>;
 	dispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
 		if (!this.#disposeCall) this.#disposeCall = this.#doDispose(options);
 		return this.#disposeCall;
 	}
 
-	/**
-	 * Wait for the session writer to close after a bounded dispose detached a
-	 * post-prompt task that ignored abort. Call after dispose() settles.
-	 */
-	waitForSessionStorageFinalization(): Promise<void> {
-		return this.#sessionStorageFinalization ?? Promise.resolve();
-	}
-
 	async #doDispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
-		// Phase A (sequential): mark dispose, emit session_shutdown, abort in-flight
-		// post-prompt work, then bound the post-prompt drain. Writers that can still
-		// append session entries must finish before Phase C's sessionManager.close().
+		// Phase A (sequential): mark dispose, emit session_shutdown, and abort
+		// in-flight post-prompt work. The Phase-B barrier below owns the complete
+		// quiescence drain before Phase C closes session storage.
 		this.beginDispose();
 		this.#recordSessionExit(options.reason ?? "dispose");
 		this.#cancelExitRecorder?.();
@@ -6744,36 +6791,15 @@ export class AgentSession {
 		// implement only the dispatch surface.
 		this.#extensionRunner?.clearManagedTimers?.();
 		this.#fallbackExtensionTimers?.clearAll();
-		// Abort post-prompt work so the drain below can complete. Without this, a
-		// deferred-handoff task that has already advanced into
-		// `await this.handoff(...) → generateHandoff(...)` keeps awaiting a live LLM stream
-		// — Promise.allSettled() in #cancelPostPromptTasks then waits forever, freezing
-		// /exit and Ctrl+C-double-tap. The post-prompt task's own AbortSignal does not
-		// propagate into the inner handoff/compaction controllers, so we abort them
-		// explicitly. agent.abort() is needed for an agent.continue() that may have
-		// raced the deferred handoff (its streaming loop is awaited by the wrapper IIFE).
-		//
-		// Tool work (bash/eval/python) is NOT aborted here — those have their own
-		// dispose paths and shared kernels are contractually allowed to survive a
-		// session's dispose.
+		// Stop every production post-prompt task at its owned cancellation
+		// boundary. Keep this controller aborted: resetting it during disposal
+		// would let an async-result delivery start a fresh provider turn after
+		// agent.abort() had already fired.
 		this.abortRetry();
 		this.abortCompaction();
-		const postPromptDrain = this.#cancelPostPromptTasks();
+		this.#postPromptTasksAbortController.abort();
+		this.#resolveTtsrResume();
 		this.agent.abort();
-		// Bound the drain: tasks are already aborted; a hang past 5s was the historical
-		// /exit freeze. This is a hang-fix, not a flush drop — unexpected errors rethrow.
-		const postPromptDrainTimeoutMessage = "Timed out draining post-prompt tasks during dispose";
-		let postPromptTasksDrained = false;
-		try {
-			await withTimeout(postPromptDrain, 5_000, postPromptDrainTimeoutMessage);
-			postPromptTasksDrained = true;
-		} catch (error) {
-			if (error instanceof Error && error.message === postPromptDrainTimeoutMessage) {
-				logger.warn("Post-prompt tasks still draining at dispose deadline");
-			} else {
-				throw error;
-			}
-		}
 		await this.#drainAutolearnCapture();
 
 		// Capture state needed by Phase B branches before the barrier. Hindsight
@@ -6817,12 +6843,17 @@ export class AgentSession {
 			() => undefined,
 			() => undefined,
 		);
+		// A completed async delivery can enqueue a yield flush, which is itself a
+		// new post-prompt task. Only declare quiescence after the manager can no
+		// longer enqueue deliveries, then repeatedly flush/reap until stable.
+		const postPromptDrain = asyncJobsSettled.then(() => this.#drainPostPromptTasksForDispose());
 
 		// Phase B: independent subsystem teardown runs concurrently under one
-		// allSettled barrier. Async-shared resources wait only for async jobs, not
-		// for the other branches. All writers complete before Phase C closes storage.
+		// allSettled barrier. Async-shared resources wait for the full async-job
+		// plus post-prompt drain, but not for unrelated branches.
 		const phaseBResults = await Promise.allSettled([
 			asyncJobDrain,
+			postPromptDrain,
 			// Eval settle then three independent kernel-language disposes.
 			(async () => {
 				const evalExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
@@ -6841,7 +6872,7 @@ export class AgentSession {
 			// subagents can reuse parent-owned module-global tabs, so do not release
 			// them until their drain settles.
 			(async () => {
-				await asyncJobsSettled;
+				await postPromptDrain;
 				// Release headless / spawned Chromium and worker tabs this session
 				// opened via the browser tool. The tool's `tabs`/`browsers` maps are
 				// module-global — subagents and future sessions share them — so we
@@ -6869,7 +6900,7 @@ export class AgentSession {
 			// MCP owned-manager disconnect: bounded 3s, best-effort. Async-job
 			// subagents reuse this manager, so do not disconnect until their drain settles.
 			(async () => {
-				await asyncJobsSettled;
+				await postPromptDrain;
 				// Disconnect only the manager this top-level session owns. Best-effort:
 				// a failure must never throw out of dispose. Subagents reuse a parent's
 				// manager and do not provide this callback. Idempotent with the
@@ -6909,7 +6940,7 @@ export class AgentSession {
 			// drain settles, and keep the shared tiny-model worker alive until detached
 			// consolidation actually settles.
 			(async () => {
-				await asyncJobsSettled;
+				await postPromptDrain;
 				const mnemopiState = setMnemopiSessionState(this, undefined);
 				try {
 					if (mnemopiState) {
@@ -6932,6 +6963,10 @@ export class AgentSession {
 				}
 			})(),
 		]);
+		// A Phase-B branch may have queued one last delivery after the first
+		// quiescence pass. Seal the writer side with a final stable drain before
+		// aggregating failures and entering Phase C.
+		await this.#drainPostPromptTasksForDispose();
 
 		// allSettled contains rejections that branch try/catch did not already
 		// log (e.g. async-job dispose, advisor recorder, hindsight flush). Log
@@ -6948,39 +6983,13 @@ export class AgentSession {
 		const phaseBError =
 			phaseBErrors.length > 0 ? new AggregateError(phaseBErrors, "Session dispose subsystem failures") : undefined;
 
-		// Phase C (sequential): power cleanup, then session storage finalization,
-		// provider sessions, Hindsight pointer clear/dispose, agent disconnect.
+		// Phase C (sequential): close storage only after every Phase-B writer and
+		// the quiescence drain have settled. dispose() itself owns and awaits this
+		// finalization; no caller-specific follow-up promise can be skipped.
 		this.#releasePowerAssertion();
-		const finalizeSessionStorage = async (): Promise<void> => {
-			// Clean up an empty session created by this session's /move so it doesn't accumulate.
-			await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
-			this.#movedFromEmptySessionFile = undefined;
-			await this.sessionManager.close();
-		};
-		if (postPromptTasksDrained) {
-			this.#sessionStorageFinalization = finalizeSessionStorage();
-			await this.#sessionStorageFinalization;
-		} else {
-			// Keep /exit bounded, but leave the writer open for a task that ignored abort.
-			// Its final persistence runs before its promise settles; close immediately afterward.
-			this.#sessionStorageFinalization = (async () => {
-				try {
-					await postPromptDrain;
-				} catch (error) {
-					logger.warn("Deferred post-prompt drain failed during session storage finalization", {
-						error: String(error),
-					});
-				} finally {
-					try {
-						await finalizeSessionStorage();
-					} catch (error) {
-						logger.warn("Failed to finalize session storage after deferred post-prompt drain", {
-							error: String(error),
-						});
-					}
-				}
-			})();
-		}
+		await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
+		this.#movedFromEmptySessionFile = undefined;
+		await this.sessionManager.close();
 		this.#closeAllProviderSessions("dispose");
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();
@@ -8816,6 +8825,7 @@ export class AgentSession {
 			acceptTerminalEmptyStop?: boolean;
 		},
 	): Promise<void> {
+		if (this.#isDisposed) return;
 		this.#beginInFlight();
 		const generation = this.#promptGeneration;
 		try {
@@ -8997,7 +9007,7 @@ export class AgentSession {
 				cutoffCount: this.messages.length + messages.length,
 			});
 			try {
-				await this.#promptAgentWithIdleRetry(messages, agentPromptOptions);
+				await this.#promptAgentWithIdleRetry(messages, agentPromptOptions, generation);
 			} finally {
 				this.#setPendingContextSnapshot(undefined);
 			}
@@ -9315,9 +9325,12 @@ export class AgentSession {
 		}
 		this.#scheduledHiddenNextTurnGeneration = generation;
 		this.#schedulePostPromptTask(
-			async () => {
+			async signal => {
 				if (this.#scheduledHiddenNextTurnGeneration === generation) {
 					this.#scheduledHiddenNextTurnGeneration = undefined;
+				}
+				if (signal.aborted || this.#isDisposed || this.#promptGeneration !== generation) {
+					return;
 				}
 				if (this.#pendingNextTurnMessages.length === 0) {
 					return;
@@ -15511,9 +15524,14 @@ export class AgentSession {
 		this.#resolveRetry();
 	}
 
-	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+	async #promptAgentWithIdleRetry(
+		messages: AgentMessage[],
+		options: { toolChoice?: ToolChoice } | undefined,
+		generation: number,
+	): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
+			if (this.#isDisposed || this.#promptGeneration !== generation) return;
 			try {
 				await this.agent.prompt(messages, options);
 				return;

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -35,6 +35,8 @@ import { formatOutputNotice } from "../tools/output-meta";
 
 export const SKILL_PROMPT_MESSAGE_TYPE = "skill-prompt";
 export const LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE = "lsp-late-diagnostic";
+/** Yield-queue kind AND `customType` for background async-job completion follow-ups. */
+export const ASYNC_RESULT_MESSAGE_TYPE = "async-result";
 export const BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE = "background-tan-dispatch";
 
 /** Fallback type for extension-injected messages that omit a custom type. */

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -77,12 +77,15 @@ export class YieldQueue {
 		return false;
 	}
 
-	async flush(mode: YieldFlushMode): Promise<void> {
-		if (mode === "idle") {
+	/** Flush queued entries. With `onlyKind`, dispatch only that kind's entries
+	 *  and leave every other kind queued (dispose's async-result writer barrier). */
+	async flush(mode: YieldFlushMode, onlyKind?: string): Promise<void> {
+		if (mode === "idle" && onlyKind === undefined) {
 			this.#idleFlushPending = false;
 		}
 		const idleMessages: AgentMessage[] = [];
 		for (const [kind, dispatcher] of this.#dispatchers) {
+			if (onlyKind !== undefined && kind !== onlyKind) continue;
 			const entries = this.#drain(kind);
 			if (entries.length === 0) continue;
 			const message = this.#build(kind, dispatcher, entries);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1136,6 +1136,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				agentId,
 				queued: true,
 				ownerId: this.session.getAgentId?.() ?? undefined,
+				admissionScope: this.session,
 				onProgress: text => {
 					onUpdate?.({ content: [{ type: "text", text }], details: buildDetails() });
 				},

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -671,6 +671,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			},
 			{
 				ownerId: this.session.getAgentId?.() ?? undefined,
+				admissionScope: this.session,
 				onProgress: async text => {
 					latestText = text;
 					if (!forwardUpdates) return;

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -603,7 +603,7 @@ export class VibeSessionRegistry {
 					);
 				}
 			},
-			{ id: `${record.id}-t${turnIndex}`, agentId: record.id, ownerId: record.ownerId },
+			{ id: `${record.id}-t${turnIndex}`, agentId: record.id, ownerId: record.ownerId, admissionScope: session },
 		);
 		turn.jobId = jobId;
 		record.turn = turn;

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1068,6 +1068,26 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("finishes locally when session.prompt reports that no agent turn started", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId);
+		if (!session) throw new Error("session not registered");
+		session.prompt = async (text: string): Promise<boolean> => {
+			session.promptCalls.push(text);
+			return false;
+		};
+
+		const response = await harness.agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "prompt during teardown" }],
+		});
+
+		expect(session.promptCalls).toEqual(["prompt during teardown"]);
+		expect(response.stopReason).toBe("end_turn");
+		harness.abortController.abort();
+	});
+
 	it("does not duplicate the final answer when the assistant message_end arrives before agent_end", async () => {
 		// Companion to the #4902 regression: when message_end IS delivered, its
 		// fallback emission wins and the agent_end flush must stay silent.

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Workstream D: parallelize session dispose so /exit no longer stacks subsystem
+ * timeouts. Contracts:
+ *  - independent Phase-B branches start before either resolves (causal, not wall-only)
+ *  - post-prompt drain is bounded at 5s with the exact warn string
+ *  - async-job delivery write lands before sessionManager.close
+ *  - idle dispose stays under the 3s perceived-hang budget
+ *  - owned AsyncJobManager singleton clears even when dispose rejects
+ *  - mnemopi embed shutdown runs even when state.dispose rejects
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
+import * as mnemopiEmbedClientModule from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
+import {
+	type MnemopiSessionState,
+	setMnemopiSessionState,
+} from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
+
+type Deferred = {
+	promise: Promise<void>;
+	resolve: () => void;
+};
+
+function deferred(): Deferred {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	return { promise, resolve };
+}
+
+function hindsightFlushStub(flush: () => Promise<void>): HindsightSessionState {
+	const stub = {
+		flushRetainQueue: flush,
+		dispose: () => {},
+	};
+	return stub as HindsightSessionState;
+}
+
+describe("AgentSession dispose parallelization (WS-D)", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@omp-dispose-parallel-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		const current = session;
+		session = undefined;
+		if (current) {
+			await current.dispose();
+		}
+		authStorage?.close();
+		AsyncJobManager.resetForTests();
+		vi.restoreAllMocks();
+		tempDir?.removeSync();
+	});
+
+	async function createSession(options?: {
+		ownedAsyncJobManager?: AsyncJobManager;
+		persist?: boolean;
+	}): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected bundled anthropic model");
+		const mock = createMockModel({ handler: () => ({ content: ["ok"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+			},
+			streamFn: mock.stream,
+		});
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const sessionManager = options?.persist
+			? SessionManager.create(tempDir.path(), tempDir.path())
+			: SessionManager.inMemory(tempDir.path());
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry,
+			ownedAsyncJobManager: options?.ownedAsyncJobManager,
+			agentId: "Main",
+		});
+		return session;
+	}
+
+	it("starts independent Phase-B branches before either resolves", async () => {
+		const asyncStarted = deferred();
+		const hindsightStarted = deferred();
+		const asyncGate = deferred();
+		const hindsightGate = deferred();
+		const order: string[] = [];
+
+		const owned = {
+			dispose: async (_opts?: { timeoutMs?: number }) => {
+				order.push("async:start");
+				asyncStarted.resolve();
+				await asyncGate.promise;
+				order.push("async:end");
+				return true;
+			},
+			// #cancelOwnAsyncJobs calls cancelAll on the scoped manager before dispose.
+			cancelAll: () => {},
+			getDeliveryState: () => ({
+				queued: 0,
+				delivering: false,
+				pendingJobIds: [] as string[],
+			}),
+		} as AsyncJobManager;
+
+		const s = await createSession({ ownedAsyncJobManager: owned });
+		s.setHindsightSessionState(
+			hindsightFlushStub(async () => {
+				order.push("hindsight:start");
+				hindsightStarted.resolve();
+				await hindsightGate.promise;
+				order.push("hindsight:end");
+			}),
+		);
+
+		const disposePromise = s.dispose();
+		try {
+			// Causal barrier: both branches must have entered before either finishes.
+			// Start order between branches is not fixed — only that both start first.
+			await Promise.all([asyncStarted.promise, hindsightStarted.promise]);
+			expect(order).toContain("async:start");
+			expect(order).toContain("hindsight:start");
+			expect(order).not.toContain("async:end");
+			expect(order).not.toContain("hindsight:end");
+		} finally {
+			asyncGate.resolve();
+			hindsightGate.resolve();
+		}
+		await disposePromise;
+		session = undefined;
+
+		const asyncStartAt = order.indexOf("async:start");
+		const hindsightStartAt = order.indexOf("hindsight:start");
+		const firstEnd = Math.min(order.indexOf("async:end"), order.indexOf("hindsight:end"));
+		expect(asyncStartAt).toBeGreaterThanOrEqual(0);
+		expect(hindsightStartAt).toBeGreaterThanOrEqual(0);
+		expect(asyncStartAt).toBeLessThan(firstEnd);
+		expect(hindsightStartAt).toBeLessThan(firstEnd);
+	});
+
+	it(
+		"bounds a never-settling post-prompt task at 5s and logs the exact warn",
+		async () => {
+			// Real platform clock: withTimeout is implemented with setTimeout, and
+			// awaiting dispose under fake timers leaves the deadline timer unfired
+			// while the hang task never settles. This is the intentional 5s hang-fix.
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			const hang = deferred(); // intentionally never resolved
+
+			const s = await createSession();
+			s.trackPostPromptTaskForTests(hang.promise);
+			expect(s.hasPostPromptWork).toBe(true);
+
+			const started = performance.now();
+			await s.dispose();
+			session = undefined;
+			const elapsed = performance.now() - started;
+
+			expect(elapsed).toBeGreaterThanOrEqual(4_500);
+			expect(elapsed).toBeLessThan(7_000);
+			expect(
+				warnSpy.mock.calls.some(call => call[0] === "Post-prompt tasks still draining at dispose deadline"),
+			).toBe(true);
+		},
+		15_000,
+	);
+
+	it("writes async-job delivery entries before sessionManager.close", async () => {
+		const order: string[] = [];
+		const deliveryGate = deferred();
+		const deliveryEntered = deferred();
+
+		const asyncJobManager = new AsyncJobManager({
+			maxRunningJobs: 2,
+			retentionMs: 1_000,
+			onJobComplete: async (jobId, text) => {
+				deliveryEntered.resolve();
+				await deliveryGate.promise;
+				const manager = session?.sessionManager;
+				if (!manager) throw new Error("session missing during delivery");
+				manager.appendCustomMessageEntry(
+					"async-result",
+					`delivery:${jobId}:${text}`,
+					true,
+					{ jobId },
+					"agent",
+				);
+				order.push("delivery-write");
+			},
+		});
+		AsyncJobManager.setInstance(asyncJobManager);
+
+		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
+		const sessionFile = s.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("expected persisted session file");
+
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			order.push("close");
+			await originalClose();
+		};
+
+		asyncJobManager.register("bash", "writer job", async () => "payload", {
+			id: "writer-job",
+			ownerId: "Main",
+		});
+
+		// Await the real delivery-entry signal rather than a guessed sleep.
+		await deliveryEntered.promise;
+
+		const disposePromise = s.dispose();
+		// Release delivery after dispose has started so drain must complete first.
+		deliveryGate.resolve();
+		await disposePromise;
+		session = undefined;
+
+		expect(order[0]).toBe("delivery-write");
+		expect(order).toContain("close");
+		const writeAt = order.indexOf("delivery-write");
+		const closeAt = order.indexOf("close");
+		expect(writeAt).toBeGreaterThanOrEqual(0);
+		expect(closeAt).toBeGreaterThan(writeAt);
+
+		// Prefer in-memory entries (always available post-close); fall back to
+		// the on-disk JSONL when the file still exists after close.
+		const entries = s.sessionManager.getEntries();
+		const hasDelivery = entries.some(entry => {
+			if (entry.type !== "custom_message") return false;
+			const content = entry.content;
+			const text = typeof content === "string" ? content : JSON.stringify(content);
+			return text.includes("delivery:writer-job:payload");
+		});
+		if (!hasDelivery && fs.existsSync(sessionFile)) {
+			const body = fs.readFileSync(sessionFile, "utf8");
+			expect(body).toContain("delivery:writer-job:payload");
+		} else {
+			expect(hasDelivery).toBe(true);
+		}
+	});
+
+	it("idle dispose completes under the 3s status budget", async () => {
+		// Integration wall-clock check against the real platform clock: the
+		// perceived-hang status arms at 3s, and empty/idle dispose must finish
+		// under that without a pending network flush. Fake timers would not
+		// exercise the real subsystem teardown path.
+		const s = await createSession();
+		const started = performance.now();
+		await s.dispose();
+		session = undefined;
+		const elapsed = performance.now() - started;
+		expect(elapsed).toBeLessThan(3_000);
+	});
+
+	it("clears owned AsyncJobManager singleton when dispose rejects", async () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const owned = {
+			dispose: async (_opts?: { timeoutMs?: number }) => {
+				throw new Error("owned async dispose boom");
+			},
+			// #cancelOwnAsyncJobs calls cancelAll on the scoped manager before dispose.
+			cancelAll: () => {},
+			getDeliveryState: () => ({
+				queued: 0,
+				delivering: false,
+				pendingJobIds: [] as string[],
+			}),
+		} as AsyncJobManager;
+		AsyncJobManager.setInstance(owned);
+
+		const s = await createSession({ ownedAsyncJobManager: owned });
+		await s.dispose();
+		session = undefined;
+
+		expect(AsyncJobManager.instance()).toBeUndefined();
+		expect(
+			warnSpy.mock.calls.some(
+				call =>
+					call[0] === "Session dispose subsystem failed during parallel teardown" &&
+					String((call[1] as { error?: unknown } | undefined)?.error ?? "").includes(
+						"owned async dispose boom",
+					),
+			),
+		).toBe(true);
+	});
+
+	it("shuts down mnemopi embed client when state.dispose rejects", async () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		// Runtime method resolution through the module-level singleton — not the
+		// static named import of shutdownMnemopiEmbedClient — so the spy is observed.
+		const terminateSpy = vi
+			.spyOn(mnemopiEmbedClientModule.mnemopiEmbedClient, "terminate")
+			.mockResolvedValue(undefined);
+
+		const order: string[] = [];
+		const rejectingState = {
+			dispose: async (_opts?: { timeoutMs?: number; consolidate?: boolean }) => {
+				order.push("mnemopi:dispose");
+				throw new Error("mnemopi dispose boom");
+			},
+		} as MnemopiSessionState;
+
+		const s = await createSession();
+		setMnemopiSessionState(s, rejectingState);
+		await s.dispose();
+		session = undefined;
+
+		order.push("after-dispose");
+		expect(order).toEqual(["mnemopi:dispose", "after-dispose"]);
+		expect(terminateSpy).toHaveBeenCalled();
+		expect(
+			warnSpy.mock.calls.some(
+				call =>
+					call[0] === "Session dispose subsystem failed during parallel teardown" &&
+					String((call[1] as { error?: unknown } | undefined)?.error ?? "").includes("mnemopi dispose boom"),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -14,8 +14,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, type StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -82,6 +84,7 @@ describe("AgentSession dispose parallelization", () => {
 		ownedAsyncJobManager?: AsyncJobManager;
 		disconnectOwnedMcpManager?: () => Promise<void>;
 		persist?: boolean;
+		sideStreamFn?: StreamFn;
 	}): Promise<AgentSession> {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("expected bundled anthropic model");
@@ -106,6 +109,7 @@ describe("AgentSession dispose parallelization", () => {
 			modelRegistry,
 			ownedAsyncJobManager: options?.ownedAsyncJobManager,
 			disconnectOwnedMcpManager: options?.disconnectOwnedMcpManager,
+			sideStreamFn: options?.sideStreamFn,
 			agentId: "Main",
 		});
 		return session;
@@ -391,6 +395,75 @@ describe("AgentSession dispose parallelization", () => {
 		session = undefined;
 
 		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
+	it("aborts an in-flight deferred-handoff provider stream and completes dispose promptly", async () => {
+		const providerStarted = deferred();
+		let providerObservedAbort = false;
+		const sideStreamFn: StreamFn = (_model, _context, options) => {
+			const stream = new AssistantMessageEventStream();
+			const signal = options?.signal;
+			if (!signal) throw new Error("expected handoff provider abort signal");
+			providerStarted.resolve();
+			const abort = () => {
+				providerObservedAbort = true;
+				stream.fail(new DOMException("Provider fetch aborted", "AbortError"));
+			};
+			if (signal.aborted) abort();
+			else signal.addEventListener("abort", abort, { once: true });
+			return stream;
+		};
+		const s = await createSession({ sideStreamFn });
+		const model = s.model;
+		if (!model) throw new Error("expected session model");
+		const userMessage = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "prepare handoff" }],
+			timestamp: Date.now(),
+		};
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "handoff source" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		for (const message of [userMessage, assistantMessage]) {
+			s.agent.appendMessage(message);
+			s.sessionManager.appendMessage(message);
+		}
+
+		const handoffPromise = s.handoff();
+		s.trackPostPromptTaskForTests(handoffPromise);
+		await providerStarted.promise;
+
+		// This integration assertion deliberately uses the platform clock: fake timers
+		// cannot prove that the real abort-driven provider unwind makes /exit return.
+		let timeout: Timer | undefined;
+		const startedAt = performance.now();
+		const completed = await Promise.race([
+			s.dispose().then(() => true),
+			new Promise<boolean>(resolve => {
+				timeout = setTimeout(() => resolve(false), 1_000);
+			}),
+		]).finally(() => clearTimeout(timeout));
+		const elapsedMs = performance.now() - startedAt;
+		session = undefined;
+
+		expect(completed).toBe(true);
+		expect(providerObservedAbort).toBe(true);
+		expect(elapsedMs).toBeLessThan(1_000);
+		await expect(handoffPromise).rejects.toThrow("Handoff cancelled");
 	});
 
 	it("keeps the agent event subscription until a late continuation has drained", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -9,6 +9,7 @@
  *  - owned AsyncJobManager singleton clears even when dispose rejects
  *  - mnemopi embed shutdown runs even when state.dispose rejects
  *  - detached mnemopi consolidation keeps the shared tiny worker alive
+ *  - async-shared browser tabs are released only after the async-job drain
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
@@ -26,6 +27,9 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as tinyTitleClientModule from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
+import { acquireBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import { acquireTab, getTabsMapForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import { logger, TempDir } from "@oh-my-pi/pi-utils";
 
 type Deferred = {
@@ -195,6 +199,57 @@ describe("AgentSession dispose parallelization", () => {
 		session = undefined;
 
 		expect(order).toEqual(["async:start", "async:end", "mnemopi:dispose"]);
+	});
+
+	it("waits for async-job drain before releasing shared parent-owned browser tabs", async () => {
+		const asyncStarted = deferred();
+		const asyncGate = deferred();
+		const order: string[] = [];
+		const owned = {
+			dispose: async (_opts?: { timeoutMs?: number }) => {
+				order.push("async:start");
+				asyncStarted.resolve();
+				await asyncGate.promise;
+				order.push("async:end");
+				return true;
+			},
+			cancelAll: () => {},
+			getDeliveryState: () => ({ queued: 0, delivering: false, pendingJobIds: [] as string[] }),
+		} as AsyncJobManager;
+		vi.spyOn(CmuxSocketClient.prototype, "connect").mockResolvedValue(undefined);
+		vi.spyOn(CmuxSocketClient.prototype, "close").mockImplementation(() => undefined);
+		vi.spyOn(CmuxSocketClient.prototype, "request").mockImplementation(
+			async (method: string): Promise<Record<string, unknown>> => {
+				if (method === "browser.open_split") {
+					return { surface_id: "dispose-shared-tab", url: "about:blank" };
+				}
+				return {};
+			},
+		);
+
+		const s = await createSession({ ownedAsyncJobManager: owned });
+		const ownerId = s.sessionManager.getSessionId();
+		if (!ownerId) throw new Error("expected session id for browser tab ownership");
+		const browser = await acquireBrowser(
+			{ kind: "cmux", socketPath: "/tmp/omp-dispose-shared-tab.sock", surface: "dispose-shared-tab" },
+			{ cwd: "/tmp" },
+		);
+		await acquireTab("dispose-shared-tab", browser, { timeoutMs: 1_000, ownerSessionId: ownerId });
+
+		const disposePromise = s.dispose();
+		try {
+			await asyncStarted.promise;
+			for (let i = 0; i < 8; i++) await Promise.resolve();
+			expect(order).toEqual(["async:start"]);
+			expect(getTabsMapForTest().has("dispose-shared-tab")).toBe(true);
+		} finally {
+			asyncGate.resolve();
+		}
+		await disposePromise;
+		session = undefined;
+
+		expect(order).toEqual(["async:start", "async:end"]);
+		expect(getTabsMapForTest().has("dispose-shared-tab")).toBe(false);
 	});
 
 	it("waits for async-job drain before disconnecting the shared MCP manager", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -652,6 +652,64 @@ describe("AgentSession dispose parallelization", () => {
 		}
 	});
 
+	it("flushes an async-result enqueued after the bounded delivery drain times out", async () => {
+		vi.useFakeTimers();
+		const order: string[] = [];
+		const deliveryGate = deferred();
+		const deliveryEntered = deferred();
+		let targetSession: AgentSession | undefined;
+		const asyncJobManager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				deliveryEntered.resolve();
+				await deliveryGate.promise;
+				targetSession?.yieldQueue.enqueue("late-async-result", { jobId, text });
+			},
+		});
+		AsyncJobManager.setInstance(asyncJobManager);
+
+		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
+		targetSession = s;
+		s.yieldQueue.register<{ jobId: string; text: string }>("late-async-result", {
+			build: entries => ({
+				role: "custom",
+				customType: "async-result",
+				content: entries.map(entry => `${entry.jobId}:${entry.text}`).join("\n"),
+				display: true,
+				attribution: "agent",
+				timestamp: Date.now(),
+			}),
+		});
+		const originalAppendCustom = s.sessionManager.appendCustomMessageEntry.bind(s.sessionManager);
+		s.sessionManager.appendCustomMessageEntry = (customType, content, display, details, attribution) => {
+			if (customType === "async-result") order.push("late-async-result-write");
+			return originalAppendCustom(customType, content, display, details, attribution);
+		};
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			order.push("close");
+			await originalClose();
+		};
+
+		asyncJobManager.register("bash", "late delivery", async () => "payload", {
+			id: "late-delivery",
+			ownerId: "Main",
+		});
+		await deliveryEntered.promise;
+		const disposePromise = s.dispose();
+		await flushMicrotasks();
+		vi.advanceTimersByTime(3_001);
+		await flushMicrotasks();
+
+		// The bounded manager cleanup and initial stable-empty pass have elapsed,
+		// but storage must remain open until the live callback can no longer enqueue.
+		expect(order).not.toContain("close");
+		deliveryGate.resolve();
+		await disposePromise;
+		session = undefined;
+
+		expect(order).toEqual(["late-async-result-write", "close"]);
+	});
+
 	it("flushes Hindsight retain queue before sessionManager.close", async () => {
 		const order: string[] = [];
 		const flushGate = deferred();

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -21,6 +21,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
 import * as mnemopiEmbedClientModule from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
 import { MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+import * as tinyTitleClientModule from "@oh-my-pi/pi-coding-agent/tiny/title-client";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -301,6 +302,38 @@ describe("AgentSession dispose parallelization", () => {
 		session = undefined;
 		const elapsed = performance.now() - started;
 		expect(elapsed).toBeLessThan(3_000);
+	});
+
+	it("shuts down the shared tiny-model client after mnemopi disposal completes", async () => {
+		const mnemopiStarted = deferred();
+		const mnemopiGate = deferred();
+		const order: string[] = [];
+		const terminateSpy = vi
+			.spyOn(tinyTitleClientModule.tinyTitleClient, "terminate")
+			.mockImplementation(async () => {
+				order.push("tiny:shutdown");
+			});
+		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		vi.spyOn(mnemopiState, "dispose").mockImplementation(async () => {
+			order.push("mnemopi:start");
+			mnemopiStarted.resolve();
+			await mnemopiGate.promise;
+			order.push("mnemopi:end");
+		});
+
+		const s = await createSession();
+		setMnemopiSessionState(s, mnemopiState);
+		const disposePromise = s.dispose();
+		try {
+			await mnemopiStarted.promise;
+			expect(terminateSpy).not.toHaveBeenCalled();
+		} finally {
+			mnemopiGate.resolve();
+			await disposePromise;
+			session = undefined;
+		}
+
+		expect(order).toEqual(["mnemopi:start", "mnemopi:end", "tiny:shutdown"]);
 	});
 
 	it("clears owned AsyncJobManager singleton when dispose rejects", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -388,6 +388,28 @@ describe("AgentSession dispose parallelization", () => {
 		expect(promptSpy).not.toHaveBeenCalled();
 	});
 
+	it("returns false when dispose interrupts a prompt during async setup", async () => {
+		const apiKeyEntered = deferred();
+		const apiKeyGate = deferred();
+		const s = await createSession();
+		const agentPromptSpy = vi.spyOn(s.agent, "prompt");
+		vi.spyOn(s.modelRegistry, "getApiKey").mockImplementation(async () => {
+			apiKeyEntered.resolve();
+			await apiKeyGate.promise;
+			return "test-key";
+		});
+
+		const promptPromise = s.prompt("prompt interrupted during setup");
+		await apiKeyEntered.promise;
+		const disposePromise = s.dispose();
+		apiKeyGate.resolve();
+
+		expect(await promptPromise).toBe(false);
+		expect(agentPromptSpy).not.toHaveBeenCalled();
+		await disposePromise;
+		session = undefined;
+	});
+
 	it("seals async-job and message admissions synchronously when dispose begins", async () => {
 		const owned = new AsyncJobManager({ onJobComplete: async () => {} });
 		const s = await createSession({ ownedAsyncJobManager: owned });

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -2,8 +2,8 @@
  * Parallelize session dispose so /exit no longer stacks subsystem
  * timeouts. Contracts:
  *  - independent Phase-B branches start before either resolves (causal, not wall-only)
- *  - post-prompt drain is bounded at 5s with the exact warn string
- *  - async-job delivery write lands before sessionManager.close
+ *  - every caller awaits post-prompt quiescence, storage close, and listener teardown
+ *  - async-result follow-up writes land before sessionManager.close
  *  - Hindsight retain flush lands before sessionManager.close
  *  - idle dispose stays under the 3s perceived-hang budget
  *  - owned AsyncJobManager singleton clears even when dispose rejects
@@ -40,6 +40,10 @@ type Deferred = {
 function deferred(): Deferred {
 	const { promise, resolve } = Promise.withResolvers<void>();
 	return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 100; i++) await Promise.resolve();
 }
 
 function hindsightFlushStub(flush: () => Promise<void>): HindsightSessionState {
@@ -287,11 +291,9 @@ describe("AgentSession dispose parallelization", () => {
 		expect(order).toEqual(["async:start", "async:end", "mcp:disconnect"]);
 	});
 
-	it("keeps session storage open for a post-prompt writer past the dispose deadline", async () => {
+	it("does not resolve a programmatic dispose until a post-prompt write is persisted and storage is closed", async () => {
 		vi.useFakeTimers();
-		vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const lateWriteGate = deferred();
-		const closeCalled = deferred();
 		const order: string[] = [];
 		const s = await createSession({ persist: true });
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -301,7 +303,7 @@ describe("AgentSession dispose parallelization", () => {
 		const lateWrite = lateWriteGate.promise.then(() => {
 			s.sessionManager.appendMessage({
 				role: "assistant",
-				content: [{ type: "text", text: "late-write" }],
+				content: [{ type: "text", text: "programmatic-dispose-late-write" }],
 				api: model.api,
 				provider: model.provider,
 				model: model.id,
@@ -323,45 +325,137 @@ describe("AgentSession dispose parallelization", () => {
 		s.sessionManager.close = async () => {
 			order.push("close");
 			await originalClose();
+		};
+
+		const disposePromise = s.dispose().then(() => {
+			order.push("dispose:resolved");
+		});
+		try {
+			vi.advanceTimersByTime(5_000);
+			await flushMicrotasks();
+			expect(order).toEqual([]);
+		} finally {
+			lateWriteGate.resolve();
+			await disposePromise;
+			session = undefined;
+		}
+
+		expect(order).toEqual(["write", "close", "dispose:resolved"]);
+		expect(fs.readFileSync(sessionFile, "utf8")).toContain("programmatic-dispose-late-write");
+	});
+
+	it("shares one full finalization promise across concurrent dispose callers", async () => {
+		const taskGate = deferred();
+		const s = await createSession();
+		s.trackPostPromptTaskForTests(taskGate.promise);
+		let closeCalls = 0;
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			closeCalls++;
+			await originalClose();
+		};
+
+		const first = s.dispose();
+		const second = s.dispose();
+		expect(second).toBe(first);
+		taskGate.resolve();
+		await Promise.all([first, second]);
+		session = undefined;
+
+		expect(closeCalls).toBe(1);
+	});
+
+	it("invalidates a deferred hidden prompt still in setup when dispose starts", async () => {
+		const apiKeyEntered = deferred();
+		const apiKeyGate = deferred();
+		const s = await createSession();
+		const promptSpy = vi.spyOn(s.agent, "prompt");
+		vi.spyOn(s.modelRegistry, "getApiKey").mockImplementation(async () => {
+			apiKeyEntered.resolve();
+			await apiKeyGate.promise;
+			return "test-key";
+		});
+		s.queueDeferredMessage({
+			role: "custom",
+			customType: "dispose-hidden-follow-up",
+			content: "must not start a provider turn during dispose",
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now(),
+		});
+		await apiKeyEntered.promise;
+
+		const disposePromise = s.dispose();
+		apiKeyGate.resolve();
+		await disposePromise;
+		session = undefined;
+
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
+	it("keeps the agent event subscription until a late continuation has drained", async () => {
+		vi.useFakeTimers();
+		const continueGate = deferred();
+		const closeCalled = deferred();
+		const s = await createSession({ persist: true });
+		const userMessage = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "continue after dispose starts" }],
+			timestamp: Date.now(),
+		};
+		s.agent.appendMessage(userMessage);
+		s.sessionManager.appendMessage(userMessage);
+		const model = s.model;
+		if (!model) throw new Error("expected session model");
+		const lateAssistant = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "late-continue-event" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop" as const,
+			timestamp: Date.now(),
+		};
+		vi.spyOn(s.agent, "continue").mockImplementation(async () => {
+			s.agent.appendMessage(lateAssistant);
+			s.agent.emitExternalEvent({ type: "message_start", message: lateAssistant });
+			s.agent.emitExternalEvent({ type: "message_end", message: lateAssistant });
+			await flushMicrotasks();
+		});
+		const lateContinue = continueGate.promise.then(() => s.agent.continue());
+		s.trackPostPromptTaskForTests(lateContinue);
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			await originalClose();
 			closeCalled.resolve();
 		};
 
 		const disposePromise = s.dispose();
-		vi.advanceTimersByTime(5_000);
-		await disposePromise;
-		expect(order).toEqual([]);
+		try {
+			vi.advanceTimersByTime(5_000);
+			await flushMicrotasks();
+		} finally {
+			continueGate.resolve();
+			await lateContinue;
+			await disposePromise;
+			await closeCalled.promise;
+			session = undefined;
+		}
 
-		lateWriteGate.resolve();
-		await lateWrite;
-		await closeCalled.promise;
-		session = undefined;
-
-		expect(order).toEqual(["write", "close"]);
-		expect(fs.readFileSync(sessionFile, "utf8")).toContain("late-write");
+		const persistedMessages = s.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "message")
+			.map(entry => JSON.stringify(entry.message));
+		expect(persistedMessages.some(message => message.includes("late-continue-event"))).toBe(true);
 	});
-
-	it("bounds a never-settling post-prompt task at 5s and logs the exact warn", async () => {
-		// Real platform clock: withTimeout is implemented with setTimeout, and
-		// awaiting dispose under fake timers leaves the deadline timer unfired
-		// while the hang task never settles. This is the intentional 5s hang-fix.
-		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		const hang = deferred(); // intentionally never resolved
-
-		const s = await createSession();
-		s.trackPostPromptTaskForTests(hang.promise);
-		expect(s.hasPostPromptWork).toBe(true);
-
-		const started = performance.now();
-		await s.dispose();
-		session = undefined;
-		const elapsed = performance.now() - started;
-
-		expect(elapsed).toBeGreaterThanOrEqual(4_500);
-		expect(elapsed).toBeLessThan(7_000);
-		expect(warnSpy.mock.calls.some(call => call[0] === "Post-prompt tasks still draining at dispose deadline")).toBe(
-			true,
-		);
-	}, 15_000);
 
 	it("writes async-job delivery entries before sessionManager.close", async () => {
 		const order: string[] = [];
@@ -427,6 +521,61 @@ describe("AgentSession dispose parallelization", () => {
 			expect(body).toContain("delivery:writer-job:payload");
 		} else {
 			expect(hasDelivery).toBe(true);
+		}
+	});
+
+	it("persists an async-result follow-up scheduled during async-job drain before storage closes", async () => {
+		vi.useFakeTimers();
+		const order: string[] = [];
+		const deliveryGate = deferred();
+		const deliveryEntered = deferred();
+		let targetSession: AgentSession | undefined;
+		const asyncJobManager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				deliveryEntered.resolve();
+				await deliveryGate.promise;
+				targetSession?.yieldQueue.enqueue("round7-async-result", { jobId, text });
+			},
+		});
+		AsyncJobManager.setInstance(asyncJobManager);
+
+		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
+		targetSession = s;
+		s.yieldQueue.register<{ jobId: string; text: string }>("round7-async-result", {
+			build: entries => ({
+				role: "custom",
+				customType: "async-result",
+				content: entries.map(entry => `${entry.jobId}:${entry.text}`).join("\n"),
+				display: true,
+				attribution: "agent",
+				timestamp: Date.now(),
+			}),
+		});
+		const originalAppendCustom = s.sessionManager.appendCustomMessageEntry.bind(s.sessionManager);
+		s.sessionManager.appendCustomMessageEntry = (customType, content, display, details, attribution) => {
+			if (customType === "async-result") order.push("async-result-write");
+			return originalAppendCustom(customType, content, display, details, attribution);
+		};
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			order.push("close");
+			await originalClose();
+		};
+
+		asyncJobManager.register("bash", "follow-up job", async () => "payload", {
+			id: "follow-up-job",
+			ownerId: "Main",
+		});
+		await deliveryEntered.promise;
+		const disposePromise = s.dispose();
+		deliveryGate.resolve();
+		try {
+			await disposePromise;
+			expect(order).toEqual(["async-result-write", "close"]);
+		} finally {
+			vi.advanceTimersByTime(10);
+			await flushMicrotasks();
+			session = undefined;
 		}
 	});
 

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -48,10 +48,10 @@ async function flushMicrotasks(): Promise<void> {
 	for (let i = 0; i < 100; i++) await Promise.resolve();
 }
 
-function hindsightFlushStub(flush: () => Promise<void>): HindsightSessionState {
+function hindsightFlushStub(flush: () => Promise<void>, dispose: () => void = () => {}): HindsightSessionState {
 	const stub = {
 		flushRetainQueue: flush,
-		dispose: () => {},
+		dispose,
 	};
 	return stub as HindsightSessionState;
 }
@@ -768,6 +768,44 @@ describe("AgentSession dispose parallelization", () => {
 		const closeAt = order.indexOf("close");
 		expect(flushEndAt).toBeGreaterThanOrEqual(0);
 		expect(closeAt).toBeGreaterThan(flushEndAt);
+	});
+
+	it("flushes Hindsight retains enqueued while post-prompt work drains", async () => {
+		const firstFlushEntered = deferred();
+		const postPromptGate = deferred();
+		const order: string[] = [];
+		let flushCalls = 0;
+		let pendingRetains = 0;
+		const s = await createSession();
+		s.setHindsightSessionState(
+			hindsightFlushStub(
+				async () => {
+					flushCalls++;
+					if (flushCalls === 1) firstFlushEntered.resolve();
+					if (pendingRetains > 0) {
+						pendingRetains = 0;
+						order.push("retain:flush");
+					}
+				},
+				() => order.push("queue:dispose"),
+			),
+		);
+		s.trackPostPromptTaskForTests(
+			postPromptGate.promise.then(() => {
+				pendingRetains++;
+				order.push("retain:enqueue");
+			}),
+		);
+
+		const disposePromise = s.dispose();
+		await firstFlushEntered.promise;
+		postPromptGate.resolve();
+		await disposePromise;
+		session = undefined;
+
+		expect(flushCalls).toBe(2);
+		expect(pendingRetains).toBe(0);
+		expect(order).toEqual(["retain:enqueue", "retain:flush", "queue:dispose"]);
 	});
 
 	it("idle dispose completes under the 3s status budget", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -89,6 +89,7 @@ describe("AgentSession dispose parallelization", () => {
 
 	async function createSession(options?: {
 		ownedAsyncJobManager?: AsyncJobManager;
+		asyncJobManager?: AsyncJobManager;
 		disconnectOwnedMcpManager?: () => Promise<void>;
 		persist?: boolean;
 		sideStreamFn?: StreamFn;
@@ -115,6 +116,7 @@ describe("AgentSession dispose parallelization", () => {
 			settings: Settings.isolated(),
 			modelRegistry,
 			ownedAsyncJobManager: options?.ownedAsyncJobManager,
+			asyncJobManager: options?.asyncJobManager,
 			disconnectOwnedMcpManager: options?.disconnectOwnedMcpManager,
 			sideStreamFn: options?.sideStreamFn,
 			agentId: "Main",
@@ -401,6 +403,7 @@ describe("AgentSession dispose parallelization", () => {
 		expect(() =>
 			capturedManager.register("task", "too late", async () => "late", {
 				ownerId: "Main",
+				admissionScope: s,
 			}),
 		).toThrow("session disposal is in progress");
 		const peerJobId = capturedManager.register("task", "peer remains admitted", async () => "ok", {
@@ -423,6 +426,33 @@ describe("AgentSession dispose parallelization", () => {
 
 		await s.dispose();
 		session = undefined;
+	});
+
+	it("admits jobs from a revived session instance that reuses a disposed agent id", async () => {
+		const sharedManager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const prior = await createSession({ asyncJobManager: sharedManager });
+
+		prior.beginDispose();
+		expect(() =>
+			sharedManager.register("task", "prior instance is sealed", async () => "late", {
+				ownerId: "Main",
+				admissionScope: prior,
+			}),
+		).toThrow("session disposal is in progress");
+		await prior.dispose();
+		session = undefined;
+
+		const revived = await createSession({ asyncJobManager: sharedManager });
+		const revivedJobId = sharedManager.register("task", "revived instance is live", async () => "ok", {
+			ownerId: "Main",
+			admissionScope: revived,
+		});
+		await sharedManager.waitForAll();
+
+		expect(sharedManager.getJob(revivedJobId)?.status).toBe("completed");
+		await revived.dispose();
+		session = undefined;
+		await sharedManager.dispose({ timeoutMs: 1_000 });
 	});
 
 	it("invalidates a deferred hidden prompt still in setup when dispose starts", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -1,9 +1,10 @@
 /**
- * Workstream D: parallelize session dispose so /exit no longer stacks subsystem
+ * Parallelize session dispose so /exit no longer stacks subsystem
  * timeouts. Contracts:
  *  - independent Phase-B branches start before either resolves (causal, not wall-only)
  *  - post-prompt drain is bounded at 5s with the exact warn string
  *  - async-job delivery write lands before sessionManager.close
+ *  - Hindsight retain flush lands before sessionManager.close
  *  - idle dispose stays under the 3s perceived-hang budget
  *  - owned AsyncJobManager singleton clears even when dispose rejects
  *  - mnemopi embed shutdown runs even when state.dispose rejects
@@ -12,17 +13,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
 import * as mnemopiEmbedClientModule from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
-import {
-	type MnemopiSessionState,
-	setMnemopiSessionState,
-} from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+import { MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -46,7 +44,7 @@ function hindsightFlushStub(flush: () => Promise<void>): HindsightSessionState {
 	return stub as HindsightSessionState;
 }
 
-describe("AgentSession dispose parallelization (WS-D)", () => {
+describe("AgentSession dispose parallelization", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
 	let session: AgentSession | undefined;
@@ -159,32 +157,28 @@ describe("AgentSession dispose parallelization (WS-D)", () => {
 		expect(hindsightStartAt).toBeLessThan(firstEnd);
 	});
 
-	it(
-		"bounds a never-settling post-prompt task at 5s and logs the exact warn",
-		async () => {
-			// Real platform clock: withTimeout is implemented with setTimeout, and
-			// awaiting dispose under fake timers leaves the deadline timer unfired
-			// while the hang task never settles. This is the intentional 5s hang-fix.
-			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-			const hang = deferred(); // intentionally never resolved
+	it("bounds a never-settling post-prompt task at 5s and logs the exact warn", async () => {
+		// Real platform clock: withTimeout is implemented with setTimeout, and
+		// awaiting dispose under fake timers leaves the deadline timer unfired
+		// while the hang task never settles. This is the intentional 5s hang-fix.
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const hang = deferred(); // intentionally never resolved
 
-			const s = await createSession();
-			s.trackPostPromptTaskForTests(hang.promise);
-			expect(s.hasPostPromptWork).toBe(true);
+		const s = await createSession();
+		s.trackPostPromptTaskForTests(hang.promise);
+		expect(s.hasPostPromptWork).toBe(true);
 
-			const started = performance.now();
-			await s.dispose();
-			session = undefined;
-			const elapsed = performance.now() - started;
+		const started = performance.now();
+		await s.dispose();
+		session = undefined;
+		const elapsed = performance.now() - started;
 
-			expect(elapsed).toBeGreaterThanOrEqual(4_500);
-			expect(elapsed).toBeLessThan(7_000);
-			expect(
-				warnSpy.mock.calls.some(call => call[0] === "Post-prompt tasks still draining at dispose deadline"),
-			).toBe(true);
-		},
-		15_000,
-	);
+		expect(elapsed).toBeGreaterThanOrEqual(4_500);
+		expect(elapsed).toBeLessThan(7_000);
+		expect(warnSpy.mock.calls.some(call => call[0] === "Post-prompt tasks still draining at dispose deadline")).toBe(
+			true,
+		);
+	}, 15_000);
 
 	it("writes async-job delivery entries before sessionManager.close", async () => {
 		const order: string[] = [];
@@ -199,13 +193,7 @@ describe("AgentSession dispose parallelization (WS-D)", () => {
 				await deliveryGate.promise;
 				const manager = session?.sessionManager;
 				if (!manager) throw new Error("session missing during delivery");
-				manager.appendCustomMessageEntry(
-					"async-result",
-					`delivery:${jobId}:${text}`,
-					true,
-					{ jobId },
-					"agent",
-				);
+				manager.appendCustomMessageEntry("async-result", `delivery:${jobId}:${text}`, true, { jobId }, "agent");
 				order.push("delivery-write");
 			},
 		});
@@ -259,6 +247,49 @@ describe("AgentSession dispose parallelization (WS-D)", () => {
 		}
 	});
 
+	it("flushes Hindsight retain queue before sessionManager.close", async () => {
+		const order: string[] = [];
+		const flushGate = deferred();
+		const flushEntered = deferred();
+
+		const s = await createSession({ persist: true });
+		s.setHindsightSessionState(
+			hindsightFlushStub(async () => {
+				order.push("hindsight-flush:start");
+				flushEntered.resolve();
+				await flushGate.promise;
+				order.push("hindsight-flush:end");
+			}),
+		);
+
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			order.push("close");
+			await originalClose();
+		};
+
+		const disposePromise = s.dispose();
+		try {
+			// Hang the Phase-B Hindsight writer across dispose start: while the
+			// flush pends the allSettled barrier cannot settle, so Phase C close
+			// must not be observed. Deterministic — close only runs post-barrier.
+			await flushEntered.promise;
+			expect(order).toContain("hindsight-flush:start");
+			expect(order).not.toContain("close");
+		} finally {
+			// Resolve even on assertion failure so the unbounded flush cannot
+			// wedge this dispose or the afterEach re-dispose.
+			flushGate.resolve();
+		}
+		await disposePromise;
+		session = undefined;
+
+		const flushEndAt = order.indexOf("hindsight-flush:end");
+		const closeAt = order.indexOf("close");
+		expect(flushEndAt).toBeGreaterThanOrEqual(0);
+		expect(closeAt).toBeGreaterThan(flushEndAt);
+	});
+
 	it("idle dispose completes under the 3s status budget", async () => {
 		// Integration wall-clock check against the real platform clock: the
 		// perceived-hang status arms at 3s, and empty/idle dispose must finish
@@ -274,18 +305,8 @@ describe("AgentSession dispose parallelization (WS-D)", () => {
 
 	it("clears owned AsyncJobManager singleton when dispose rejects", async () => {
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		const owned = {
-			dispose: async (_opts?: { timeoutMs?: number }) => {
-				throw new Error("owned async dispose boom");
-			},
-			// #cancelOwnAsyncJobs calls cancelAll on the scoped manager before dispose.
-			cancelAll: () => {},
-			getDeliveryState: () => ({
-				queued: 0,
-				delivering: false,
-				pendingJobIds: [] as string[],
-			}),
-		} as AsyncJobManager;
+		const owned = new AsyncJobManager({ onJobComplete: () => {} });
+		vi.spyOn(owned, "dispose").mockRejectedValue(new Error("owned async dispose boom"));
 		AsyncJobManager.setInstance(owned);
 
 		const s = await createSession({ ownedAsyncJobManager: owned });
@@ -297,9 +318,7 @@ describe("AgentSession dispose parallelization (WS-D)", () => {
 			warnSpy.mock.calls.some(
 				call =>
 					call[0] === "Session dispose subsystem failed during parallel teardown" &&
-					String((call[1] as { error?: unknown } | undefined)?.error ?? "").includes(
-						"owned async dispose boom",
-					),
+					String((call[1] as { error?: unknown } | undefined)?.error ?? "").includes("owned async dispose boom"),
 			),
 		).toBe(true);
 	});
@@ -313,12 +332,11 @@ describe("AgentSession dispose parallelization (WS-D)", () => {
 			.mockResolvedValue(undefined);
 
 		const order: string[] = [];
-		const rejectingState = {
-			dispose: async (_opts?: { timeoutMs?: number; consolidate?: boolean }) => {
-				order.push("mnemopi:dispose");
-				throw new Error("mnemopi dispose boom");
-			},
-		} as MnemopiSessionState;
+		const rejectingState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		vi.spyOn(rejectingState, "dispose").mockImplementation(async () => {
+			order.push("mnemopi:dispose");
+			throw new Error("mnemopi dispose boom");
+		});
 
 		const s = await createSession();
 		setMnemopiSessionState(s, rejectingState);

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -663,14 +663,14 @@ describe("AgentSession dispose parallelization", () => {
 			onJobComplete: async (jobId, text) => {
 				deliveryEntered.resolve();
 				await deliveryGate.promise;
-				targetSession?.yieldQueue.enqueue("round7-async-result", { jobId, text });
+				targetSession?.yieldQueue.enqueue("async-result", { jobId, text });
 			},
 		});
 		AsyncJobManager.setInstance(asyncJobManager);
 
 		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
 		targetSession = s;
-		s.yieldQueue.register<{ jobId: string; text: string }>("round7-async-result", {
+		s.yieldQueue.register<{ jobId: string; text: string }>("async-result", {
 			build: entries => ({
 				role: "custom",
 				customType: "async-result",
@@ -718,14 +718,14 @@ describe("AgentSession dispose parallelization", () => {
 			onJobComplete: async (jobId, text) => {
 				deliveryEntered.resolve();
 				await deliveryGate.promise;
-				targetSession?.yieldQueue.enqueue("late-async-result", { jobId, text });
+				targetSession?.yieldQueue.enqueue("async-result", { jobId, text });
 			},
 		});
 		AsyncJobManager.setInstance(asyncJobManager);
 
 		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
 		targetSession = s;
-		s.yieldQueue.register<{ jobId: string; text: string }>("late-async-result", {
+		s.yieldQueue.register<{ jobId: string; text: string }>("async-result", {
 			build: entries => ({
 				role: "custom",
 				customType: "async-result",
@@ -737,7 +737,7 @@ describe("AgentSession dispose parallelization", () => {
 		});
 		const originalAppendCustom = s.sessionManager.appendCustomMessageEntry.bind(s.sessionManager);
 		s.sessionManager.appendCustomMessageEntry = (customType, content, display, details, attribution) => {
-			if (customType === "async-result") order.push("late-async-result-write");
+			if (customType === "async-result") order.push("async-result-write");
 			return originalAppendCustom(customType, content, display, details, attribution);
 		};
 		const originalClose = s.sessionManager.close.bind(s.sessionManager);
@@ -763,7 +763,7 @@ describe("AgentSession dispose parallelization", () => {
 		await disposePromise;
 		session = undefined;
 
-		expect(order).toEqual(["late-async-result-write", "close"]);
+		expect(order).toEqual(["async-result-write", "close"]);
 	});
 
 	it("flushes Hindsight retain queue before sessionManager.close", async () => {
@@ -998,5 +998,106 @@ describe("AgentSession dispose parallelization", () => {
 					String((call[1] as { error?: unknown } | undefined)?.error ?? "").includes("mnemopi dispose boom"),
 			),
 		).toBe(true);
+	});
+	it("completes dispose promptly when the delivery callback throws synchronously every time", async () => {
+		let attempts = 0;
+		const asyncJobManager = new AsyncJobManager({
+			onJobComplete: () => {
+				attempts += 1;
+				throw new Error("delivery boom");
+			},
+		});
+		AsyncJobManager.setInstance(asyncJobManager);
+
+		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
+		asyncJobManager.register("bash", "always-fails", async () => "payload", { id: "fail-job", ownerId: "Main" });
+		await asyncJobManager.waitForAll();
+		// Let the first attempt fail before dispose so a retry with backoff is
+		// already queued — the historical hang chased that retry loop forever.
+		const deadline = Date.now() + 2_000;
+		while (attempts === 0) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for first delivery attempt");
+			await Bun.sleep(5);
+		}
+
+		let timer: Timer | undefined;
+		const completed = await Promise.race([
+			s.dispose().then(() => true),
+			new Promise<boolean>(resolve => {
+				timer = setTimeout(() => resolve(false), 2_000);
+			}),
+		]).finally(() => clearTimeout(timer));
+		session = undefined;
+
+		expect(completed).toBe(true);
+		// Exactly one terminal re-attempt during the dispose drain; never retried after.
+		const attemptsAtDispose = attempts;
+		await Bun.sleep(50);
+		expect(attempts).toBe(attemptsAtDispose);
+	});
+
+	it("drops queued MCP notifications instead of persisting them at shutdown", async () => {
+		const s = await createSession({ persist: true });
+		s.yieldQueue.register<{ serverName: string; uri: string }>("mcp-notification", {
+			build: entries => ({
+				role: "user",
+				content: [{ type: "text", text: `[MCP notification] ${entries.length} resource(s) updated` }],
+				attribution: "agent",
+				timestamp: Date.now(),
+			}),
+		});
+		s.yieldQueue.enqueue("mcp-notification", { serverName: "srv", uri: "mcp://srv/resource" });
+
+		await s.dispose();
+		session = undefined;
+
+		const persistedMessages = s.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "message")
+			.map(entry => JSON.stringify(entry.message));
+		expect(persistedMessages.some(message => message.includes("MCP notification"))).toBe(false);
+	});
+
+	it("keeps a hub-acknowledged async-result suppressed through dispose", async () => {
+		let targetSession: AgentSession | undefined;
+		const asyncJobManager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				if (asyncJobManager.isDeliverySuppressed(jobId)) return;
+				targetSession?.yieldQueue.enqueue("async-result", { jobId, text });
+			},
+		});
+		AsyncJobManager.setInstance(asyncJobManager);
+
+		const s = await createSession({ ownedAsyncJobManager: asyncJobManager, persist: true });
+		targetSession = s;
+		// Mirror the SDK registration: staleness defers to the manager's
+		// suppression sets, which must stay authoritative through dispose.
+		s.yieldQueue.register<{ jobId: string; text: string }>("async-result", {
+			isStale: entry => asyncJobManager.isDeliverySuppressed(entry.jobId),
+			build: entries => ({
+				role: "custom",
+				customType: "async-result",
+				content: entries.map(entry => `${entry.jobId}:${entry.text}`).join("\n"),
+				display: true,
+				attribution: "agent",
+				timestamp: Date.now(),
+			}),
+		});
+
+		asyncJobManager.register("bash", "acked job", async () => "payload", { id: "acked-job", ownerId: "Main" });
+		await asyncJobManager.waitForAll();
+		await asyncJobManager.drainDeliveries({ timeoutMs: 2_000 });
+		// The follow-up entry is already queued; the hub acknowledgement arrives
+		// before dispose, so the queued entry must be dropped as stale, not
+		// re-persisted by the dispose-time flush.
+		asyncJobManager.acknowledgeDeliveries(["acked-job"]);
+
+		await s.dispose();
+		session = undefined;
+
+		const persistedAsyncResults = s.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "custom_message" && entry.customType === "async-result");
+		expect(persistedAsyncResults).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -386,6 +386,45 @@ describe("AgentSession dispose parallelization", () => {
 		expect(promptSpy).not.toHaveBeenCalled();
 	});
 
+	it("seals async-job and message admissions synchronously when dispose begins", async () => {
+		const owned = new AsyncJobManager({ onJobComplete: async () => {} });
+		const s = await createSession({ ownedAsyncJobManager: owned });
+		const capturedManager = s.asyncJobManager;
+		if (!capturedManager) throw new Error("expected session-scoped async manager");
+		const steerSpy = vi.spyOn(s.agent, "steer");
+		const followUpSpy = vi.spyOn(s.agent, "followUp");
+		const appendCustomSpy = vi.spyOn(s.sessionManager, "appendCustomMessageEntry");
+
+		s.beginDispose();
+
+		expect(s.asyncJobManager).toBeUndefined();
+		expect(() =>
+			capturedManager.register("task", "too late", async () => "late", {
+				ownerId: "Main",
+			}),
+		).toThrow("session disposal is in progress");
+		const peerJobId = capturedManager.register("task", "peer remains admitted", async () => "ok", {
+			ownerId: "Peer",
+		});
+		await capturedManager.waitForAll();
+		expect(capturedManager.getJob(peerJobId)?.status).toBe("completed");
+		await s.steer("too late");
+		await s.followUp("too late");
+		expect(
+			await s.sendCustomMessage({
+				customType: "dispose-admission",
+				content: "too late",
+				display: false,
+			}),
+		).toBe(false);
+		expect(steerSpy).not.toHaveBeenCalled();
+		expect(followUpSpy).not.toHaveBeenCalled();
+		expect(appendCustomSpy).not.toHaveBeenCalled();
+
+		await s.dispose();
+		session = undefined;
+	});
+
 	it("invalidates a deferred hidden prompt still in setup when dispose starts", async () => {
 		const apiKeyEntered = deferred();
 		const apiKeyGate = deferred();

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -21,10 +21,10 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
 import * as mnemopiEmbedClientModule from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
 import { MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
-import * as tinyTitleClientModule from "@oh-my-pi/pi-coding-agent/tiny/title-client";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as tinyTitleClientModule from "@oh-my-pi/pi-coding-agent/tiny/title-client";
 import { logger, TempDir } from "@oh-my-pi/pi-utils";
 
 type Deferred = {
@@ -308,11 +308,9 @@ describe("AgentSession dispose parallelization", () => {
 		const mnemopiStarted = deferred();
 		const mnemopiGate = deferred();
 		const order: string[] = [];
-		const terminateSpy = vi
-			.spyOn(tinyTitleClientModule.tinyTitleClient, "terminate")
-			.mockImplementation(async () => {
-				order.push("tiny:shutdown");
-			});
+		const terminateSpy = vi.spyOn(tinyTitleClientModule.tinyTitleClient, "terminate").mockImplementation(async () => {
+			order.push("tiny:shutdown");
+		});
 		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
 		vi.spyOn(mnemopiState, "dispose").mockImplementation(async () => {
 			order.push("mnemopi:start");

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -376,6 +376,16 @@ describe("AgentSession dispose parallelization", () => {
 		expect(closeCalls).toBe(1);
 	});
 
+	it("reports that no agent turn started when prompting a disposed session", async () => {
+		const s = await createSession();
+		const promptSpy = vi.spyOn(s.agent, "prompt");
+		await s.dispose();
+		session = undefined;
+
+		expect(await s.prompt("too late")).toBe(false);
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+
 	it("invalidates a deferred hidden prompt still in setup when dispose starts", async () => {
 		const apiKeyEntered = deferred();
 		const apiKeyGate = deferred();

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -63,6 +63,7 @@ describe("AgentSession dispose parallelization", () => {
 		if (current) {
 			await current.dispose();
 		}
+		vi.useRealTimers();
 		authStorage?.close();
 		AsyncJobManager.resetForTests();
 		vi.restoreAllMocks();
@@ -71,6 +72,7 @@ describe("AgentSession dispose parallelization", () => {
 
 	async function createSession(options?: {
 		ownedAsyncJobManager?: AsyncJobManager;
+		disconnectOwnedMcpManager?: () => Promise<void>;
 		persist?: boolean;
 	}): Promise<AgentSession> {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -95,6 +97,7 @@ describe("AgentSession dispose parallelization", () => {
 			settings: Settings.isolated(),
 			modelRegistry,
 			ownedAsyncJobManager: options?.ownedAsyncJobManager,
+			disconnectOwnedMcpManager: options?.disconnectOwnedMcpManager,
 			agentId: "Main",
 		});
 		return session;
@@ -157,6 +160,129 @@ describe("AgentSession dispose parallelization", () => {
 		expect(hindsightStartAt).toBeGreaterThanOrEqual(0);
 		expect(asyncStartAt).toBeLessThan(firstEnd);
 		expect(hindsightStartAt).toBeLessThan(firstEnd);
+	});
+
+	it("waits for async-job drain before disposing shared mnemopi state", async () => {
+		const asyncStarted = deferred();
+		const asyncGate = deferred();
+		const order: string[] = [];
+		const owned = {
+			dispose: async (_opts?: { timeoutMs?: number }) => {
+				order.push("async:start");
+				asyncStarted.resolve();
+				await asyncGate.promise;
+				order.push("async:end");
+				return true;
+			},
+			cancelAll: () => {},
+			getDeliveryState: () => ({ queued: 0, delivering: false, pendingJobIds: [] as string[] }),
+		} as AsyncJobManager;
+		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		vi.spyOn(mnemopiState, "dispose").mockImplementation(async () => {
+			order.push("mnemopi:dispose");
+		});
+
+		const s = await createSession({ ownedAsyncJobManager: owned });
+		setMnemopiSessionState(s, mnemopiState);
+		const disposePromise = s.dispose();
+		try {
+			await asyncStarted.promise;
+			expect(order).toEqual(["async:start"]);
+		} finally {
+			asyncGate.resolve();
+		}
+		await disposePromise;
+		session = undefined;
+
+		expect(order).toEqual(["async:start", "async:end", "mnemopi:dispose"]);
+	});
+
+	it("waits for async-job drain before disconnecting the shared MCP manager", async () => {
+		const asyncStarted = deferred();
+		const asyncGate = deferred();
+		const order: string[] = [];
+		const owned = {
+			dispose: async (_opts?: { timeoutMs?: number }) => {
+				order.push("async:start");
+				asyncStarted.resolve();
+				await asyncGate.promise;
+				order.push("async:end");
+				return true;
+			},
+			cancelAll: () => {},
+			getDeliveryState: () => ({ queued: 0, delivering: false, pendingJobIds: [] as string[] }),
+		} as AsyncJobManager;
+
+		const s = await createSession({
+			ownedAsyncJobManager: owned,
+			disconnectOwnedMcpManager: async () => {
+				order.push("mcp:disconnect");
+			},
+		});
+		const disposePromise = s.dispose();
+		try {
+			await asyncStarted.promise;
+			expect(order).toEqual(["async:start"]);
+		} finally {
+			asyncGate.resolve();
+		}
+		await disposePromise;
+		session = undefined;
+
+		expect(order).toEqual(["async:start", "async:end", "mcp:disconnect"]);
+	});
+
+	it("keeps session storage open for a post-prompt writer past the dispose deadline", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const lateWriteGate = deferred();
+		const closeCalled = deferred();
+		const order: string[] = [];
+		const s = await createSession({ persist: true });
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected bundled anthropic model");
+		const sessionFile = s.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("expected persisted session file");
+		const lateWrite = lateWriteGate.promise.then(() => {
+			s.sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "late-write" }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			});
+			order.push("write");
+		});
+		s.trackPostPromptTaskForTests(lateWrite);
+		const originalClose = s.sessionManager.close.bind(s.sessionManager);
+		s.sessionManager.close = async () => {
+			order.push("close");
+			await originalClose();
+			closeCalled.resolve();
+		};
+
+		const disposePromise = s.dispose();
+		vi.advanceTimersByTime(5_000);
+		await disposePromise;
+		expect(order).toEqual([]);
+
+		lateWriteGate.resolve();
+		await lateWrite;
+		await closeCalled.promise;
+		session = undefined;
+
+		expect(order).toEqual(["write", "close"]);
+		expect(fs.readFileSync(sessionFile, "utf8")).toContain("late-write");
 	});
 
 	it("bounds a never-settling post-prompt task at 5s and logs the exact warn", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -8,6 +8,7 @@
  *  - idle dispose stays under the 3s perceived-hang budget
  *  - owned AsyncJobManager singleton clears even when dispose rejects
  *  - mnemopi embed shutdown runs even when state.dispose rejects
+ *  - detached mnemopi consolidation keeps the shared tiny worker alive
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
@@ -312,11 +313,12 @@ describe("AgentSession dispose parallelization", () => {
 			order.push("tiny:shutdown");
 		});
 		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
-		vi.spyOn(mnemopiState, "dispose").mockImplementation(async () => {
+		vi.spyOn(mnemopiState, "dispose").mockImplementation(async options => {
 			order.push("mnemopi:start");
 			mnemopiStarted.resolve();
 			await mnemopiGate.promise;
 			order.push("mnemopi:end");
+			await options?.onConsolidationSettled?.();
 		});
 
 		const s = await createSession();
@@ -332,6 +334,36 @@ describe("AgentSession dispose parallelization", () => {
 		}
 
 		expect(order).toEqual(["mnemopi:start", "mnemopi:end", "tiny:shutdown"]);
+	});
+
+	it("keeps the tiny-model client alive while timed-out consolidation continues detached", async () => {
+		const mnemopiStarted = deferred();
+		const consolidationGate = deferred();
+		const detachedCleanupSettled = deferred();
+		const terminateSpy = vi.spyOn(tinyTitleClientModule.tinyTitleClient, "terminate").mockResolvedValue();
+		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		vi.spyOn(mnemopiState, "dispose").mockImplementation(async options => {
+			mnemopiStarted.resolve();
+			void consolidationGate.promise.then(async () => {
+				await options?.onConsolidationSettled?.();
+				detachedCleanupSettled.resolve();
+			});
+		});
+
+		const s = await createSession();
+		setMnemopiSessionState(s, mnemopiState);
+		const disposePromise = s.dispose({ mnemopiConsolidateTimeoutMs: 1 });
+		try {
+			await mnemopiStarted.promise;
+			await disposePromise;
+			session = undefined;
+			expect(terminateSpy).not.toHaveBeenCalled();
+		} finally {
+			consolidationGate.resolve();
+			await detachedCleanupSettled.promise;
+		}
+
+		expect(terminateSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("clears owned AsyncJobManager singleton when dispose rejects", async () => {

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -343,8 +343,9 @@ describe("AgentSession dispose parallelization", () => {
 		AsyncJobManager.setInstance(owned);
 
 		const s = await createSession({ ownedAsyncJobManager: owned });
-		await s.dispose();
+		const disposePromise = s.dispose();
 		session = undefined;
+		await expect(disposePromise).rejects.toThrow("Session dispose subsystem failures");
 
 		expect(AsyncJobManager.instance()).toBeUndefined();
 		expect(
@@ -373,8 +374,9 @@ describe("AgentSession dispose parallelization", () => {
 
 		const s = await createSession();
 		setMnemopiSessionState(s, rejectingState);
-		await s.dispose();
+		const disposePromise = s.dispose();
 		session = undefined;
+		await expect(disposePromise).rejects.toThrow("Session dispose subsystem failures");
 
 		order.push("after-dispose");
 		expect(order).toEqual(["mnemopi:dispose", "after-dispose"]);

--- a/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-parallel.test.ts
@@ -56,6 +56,13 @@ function hindsightFlushStub(flush: () => Promise<void>): HindsightSessionState {
 	return stub as HindsightSessionState;
 }
 
+function setMnemopiProviderLlm(state: MnemopiSessionState, llm: object | false): void {
+	Object.defineProperty(state, "config", {
+		value: { providerOptions: { llm } },
+		configurable: true,
+	});
+}
+
 describe("AgentSession dispose parallelization", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -774,6 +781,7 @@ describe("AgentSession dispose parallelization", () => {
 			order.push("tiny:shutdown");
 		});
 		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		setMnemopiProviderLlm(mnemopiState, { complete: async () => null });
 		vi.spyOn(mnemopiState, "dispose").mockImplementation(async options => {
 			order.push("mnemopi:start");
 			mnemopiStarted.resolve();
@@ -803,6 +811,7 @@ describe("AgentSession dispose parallelization", () => {
 		const detachedCleanupSettled = deferred();
 		const terminateSpy = vi.spyOn(tinyTitleClientModule.tinyTitleClient, "terminate").mockResolvedValue();
 		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		setMnemopiProviderLlm(mnemopiState, { complete: async () => null });
 		vi.spyOn(mnemopiState, "dispose").mockImplementation(async options => {
 			mnemopiStarted.resolve();
 			void consolidationGate.promise.then(async () => {
@@ -824,6 +833,29 @@ describe("AgentSession dispose parallelization", () => {
 			await detachedCleanupSettled.promise;
 		}
 
+		expect(terminateSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("shuts down the tiny client promptly when remote consolidation remains detached", async () => {
+		const terminateSpy = vi.spyOn(tinyTitleClientModule.tinyTitleClient, "terminate").mockResolvedValue();
+		const mnemopiState: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		setMnemopiProviderLlm(mnemopiState, {
+			baseUrl: "https://memory.example.invalid",
+			model: "remote-memory-model",
+		});
+		let deferredCleanup: (() => void | Promise<void>) | undefined;
+		vi.spyOn(mnemopiState, "dispose").mockImplementation(async options => {
+			// Model MnemopiSessionState.dispose returning on timeout while remote
+			// consolidation and its optional settled callback remain detached.
+			deferredCleanup = options?.onConsolidationSettled;
+		});
+
+		const s = await createSession();
+		setMnemopiSessionState(s, mnemopiState);
+		await s.dispose({ mnemopiConsolidateTimeoutMs: 1 });
+		session = undefined;
+
+		expect(deferredCleanup).toBeUndefined();
 		expect(terminateSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -292,6 +292,39 @@ describe("AsyncJobManager", () => {
 		expect(manager.getAllJobs()).toHaveLength(0);
 	});
 
+	test("dispose delivers a backoff-pending retry immediately instead of waiting out the backoff", async () => {
+		let attempts = 0;
+		const completions: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (_jobId, text) => {
+				attempts += 1;
+				if (attempts === 1) throw new Error("first delivery fails");
+				completions.push(text);
+			},
+		});
+
+		manager.register("bash", "retry-then-succeed", async () => "payload");
+		await manager.waitForAll();
+		// Wait until the failed first attempt has been requeued with its
+		// exponential backoff (>= 500ms out).
+		const deadline = Date.now() + 2_000;
+		while (!(attempts >= 1 && manager.hasPendingDeliveries())) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for requeued delivery");
+			await Bun.sleep(5);
+		}
+
+		const startedAt = Date.now();
+		const clean = await manager.dispose({ timeoutMs: 3_000 });
+		const elapsedMs = Date.now() - startedAt;
+
+		// The terminal drain ignores nextAttemptAt: well under the 500ms+ backoff.
+		expect(elapsedMs).toBeLessThan(400);
+		expect(clean).toBe(true);
+		expect(attempts).toBe(2);
+		expect(completions).toEqual(["payload"]);
+		expect(manager.hasPendingDeliveries()).toBe(false);
+	});
+
 	test("scoped delivery drain returns once matching owner deliveries finish", async () => {
 		let mainJobId = "";
 		let releaseMainDelivery = (): void => {};

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Workstream D: InteractiveMode.shutdown arms a 3s "Still closing…" status
+ * before signal teardown and always clears the timer in finally.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
+
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("InteractiveMode.shutdown still-closing status (WS-D)", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-still-closing-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+		// Avoid real terminal drain during unit test.
+		mode.ui.terminal.drainInput = async () => {};
+		vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+	});
+
+	afterEach(async () => {
+		vi.useRealTimers();
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("shows Still closing… after 3s while teardown is still pending, then clears timer", async () => {
+		vi.useFakeTimers();
+		const statuses: string[] = [];
+		vi.spyOn(mode, "showStatus").mockImplementation((message: string) => {
+			statuses.push(message);
+		});
+
+		const teardownGate = Promise.withResolvers<void>();
+		// Force the fallback dispose path (no #signalTeardown) so we control settle.
+		vi.spyOn(session, "dispose").mockImplementation(async () => {
+			await teardownGate.promise;
+		});
+
+		const shutdownPromise = mode.shutdown();
+		await flushMicrotasks();
+		expect(statuses).toEqual(["Closing session…"]);
+
+		vi.advanceTimersByTime(2_999);
+		await flushMicrotasks();
+		expect(statuses).toEqual(["Closing session…"]);
+
+		vi.advanceTimersByTime(1);
+		await flushMicrotasks();
+		expect(statuses).toEqual([
+			"Closing session…",
+			"Still closing… (flushing memory backend / network)",
+		]);
+
+		teardownGate.resolve();
+		await shutdownPromise;
+
+		// Timer must be cleared: advancing further must not re-fire status.
+		const after = statuses.length;
+		vi.advanceTimersByTime(10_000);
+		await flushMicrotasks();
+		expect(statuses.length).toBe(after);
+	});
+
+	it("clears the still-closing timer when teardown finishes under 3s", async () => {
+		vi.useFakeTimers();
+		const statuses: string[] = [];
+		vi.spyOn(mode, "showStatus").mockImplementation((message: string) => {
+			statuses.push(message);
+		});
+		vi.spyOn(session, "dispose").mockResolvedValue(undefined);
+
+		await mode.shutdown();
+		expect(statuses).toEqual(["Closing session…"]);
+
+		vi.advanceTimersByTime(5_000);
+		await flushMicrotasks();
+		expect(statuses).toEqual(["Closing session…"]);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -125,5 +125,4 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 			error: String(disposeError),
 		});
 	});
-
 });

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -156,7 +156,6 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 
 		const shutdownPromise = mode.shutdown();
 		vi.advanceTimersByTime(5_000);
-		await session.dispose();
 		await flushMicrotasks();
 		expect(postmortem.quit).not.toHaveBeenCalled();
 
@@ -164,26 +163,6 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 		await shutdownPromise;
 
 		expect(order).toEqual(["write", "close", "quit"]);
-	});
-
-	it("bounds the deferred session finalization wait before /exit quits", async () => {
-		vi.useFakeTimers();
-		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		session.trackPostPromptTaskForTests(new Promise<void>(() => {}));
-
-		const shutdownPromise = mode.shutdown();
-		vi.advanceTimersByTime(5_000);
-		await session.dispose();
-		await flushMicrotasks();
-		expect(postmortem.quit).not.toHaveBeenCalled();
-
-		vi.advanceTimersByTime(5_000);
-		await shutdownPromise;
-
-		expect(postmortem.quit).toHaveBeenCalledWith(0);
-		expect(warnSpy).toHaveBeenCalledWith("Session storage still finalizing at interactive shutdown deadline", {
-			error: "Error: Timed out finalizing session storage during interactive shutdown",
-		});
 	});
 
 	it("completes /exit when session disposal rejects", async () => {

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -1,5 +1,5 @@
 /**
- * Workstream D: InteractiveMode.shutdown arms a 3s "Still closing…" status
+ * InteractiveMode.shutdown arms a 3s "Still closing…" status
  * before signal teardown and always clears the timer in finally.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
@@ -20,7 +20,7 @@ async function flushMicrotasks(): Promise<void> {
 	await Promise.resolve();
 }
 
-describe("InteractiveMode.shutdown still-closing status (WS-D)", () => {
+describe("InteractiveMode.shutdown still-closing status", () => {
 	let authStorage: AuthStorage;
 	let mode: InteractiveMode;
 	let session: AgentSession;
@@ -85,10 +85,7 @@ describe("InteractiveMode.shutdown still-closing status (WS-D)", () => {
 
 		vi.advanceTimersByTime(1);
 		await flushMicrotasks();
-		expect(statuses).toEqual([
-			"Closing session…",
-			"Still closing… (flushing memory backend / network)",
-		]);
+		expect(statuses).toEqual(["Closing session…", "Still closing… (flushing memory backend / network)"]);
 
 		teardownGate.resolve();
 		await shutdownPromise;

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -165,7 +165,7 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 		expect(order).toEqual(["write", "close", "quit"]);
 	});
 
-	it("completes /exit when session disposal rejects", async () => {
+	it("tolerates the expected Phase-B aggregate after session cleanup", async () => {
 		const disposeError = new AggregateError([new Error("phase B boom")], "Session dispose subsystem failures");
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		vi.spyOn(session, "dispose").mockRejectedValue(disposeError);
@@ -175,6 +175,18 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 		expect(postmortem.quit).toHaveBeenCalledWith(0);
 		expect(warnSpy).toHaveBeenCalledWith("Failed to dispose interactive session during shutdown", {
 			error: String(disposeError),
+		});
+	});
+	it("exits non-zero when session storage close fails", async () => {
+		const closeError = new Error("storage close failed");
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		vi.spyOn(session, "dispose").mockRejectedValue(closeError);
+
+		await expect(mode.shutdown()).resolves.toBeUndefined();
+
+		expect(postmortem.quit).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith("Failed to close interactive session storage during shutdown", {
+			error: String(closeError),
 		});
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -12,7 +12,7 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
+import { logger, postmortem, TempDir } from "@oh-my-pi/pi-utils";
 
 async function flushMicrotasks(): Promise<void> {
 	await Promise.resolve();
@@ -112,4 +112,18 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 		await flushMicrotasks();
 		expect(statuses).toEqual(["Closing session…"]);
 	});
+
+	it("completes /exit when session disposal rejects", async () => {
+		const disposeError = new AggregateError([new Error("phase B boom")], "Session dispose subsystem failures");
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		vi.spyOn(session, "dispose").mockRejectedValue(disposeError);
+
+		await expect(mode.shutdown()).resolves.toBeUndefined();
+
+		expect(postmortem.quit).toHaveBeenCalledWith(0);
+		expect(warnSpy).toHaveBeenCalledWith("Failed to dispose interactive session during shutdown", {
+			error: String(disposeError),
+		});
+	});
+
 });

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -3,6 +3,7 @@
  * before signal teardown and always clears the timer in finally.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -41,7 +42,7 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 
 		session = new AgentSession({
 			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
-			sessionManager: SessionManager.inMemory(tempDir.path()),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
 			settings: Settings.isolated(),
 			modelRegistry,
 		});
@@ -111,6 +112,78 @@ describe("InteractiveMode.shutdown still-closing status", () => {
 		vi.advanceTimersByTime(5_000);
 		await flushMicrotasks();
 		expect(statuses).toEqual(["Closing session…"]);
+	});
+
+	it("persists a late post-prompt write before /exit quits", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const lateWriteGate = Promise.withResolvers<void>();
+		const order: string[] = [];
+		const sessionFile = session.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("expected persisted session file");
+		const model = session.model;
+		if (!model) throw new Error("expected session model");
+		const lateWrite = lateWriteGate.promise.then(() => {
+			session.sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "late-write-before-quit" }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			});
+			order.push("write");
+		});
+		session.trackPostPromptTaskForTests(lateWrite);
+		const originalClose = session.sessionManager.close.bind(session.sessionManager);
+		session.sessionManager.close = async () => {
+			await originalClose();
+			order.push("close");
+		};
+		vi.spyOn(postmortem, "quit").mockImplementation(async () => {
+			expect(fs.readFileSync(sessionFile, "utf8")).toContain("late-write-before-quit");
+			order.push("quit");
+		});
+
+		const shutdownPromise = mode.shutdown();
+		vi.advanceTimersByTime(5_000);
+		await session.dispose();
+		await flushMicrotasks();
+		expect(postmortem.quit).not.toHaveBeenCalled();
+
+		lateWriteGate.resolve();
+		await shutdownPromise;
+
+		expect(order).toEqual(["write", "close", "quit"]);
+	});
+
+	it("bounds the deferred session finalization wait before /exit quits", async () => {
+		vi.useFakeTimers();
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		session.trackPostPromptTaskForTests(new Promise<void>(() => {}));
+
+		const shutdownPromise = mode.shutdown();
+		vi.advanceTimersByTime(5_000);
+		await session.dispose();
+		await flushMicrotasks();
+		expect(postmortem.quit).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(5_000);
+		await shutdownPromise;
+
+		expect(postmortem.quit).toHaveBeenCalledWith(0);
+		expect(warnSpy).toHaveBeenCalledWith("Session storage still finalizing at interactive shutdown deadline", {
+			error: "Error: Timed out finalizing session storage during interactive shutdown",
+		});
 	});
 
 	it("completes /exit when session disposal rejects", async () => {

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -590,10 +590,12 @@ describe("Mnemopi backend lifecycle", () => {
 			await flushStall.promise;
 		});
 		const closeSpy = vi.spyOn(retainMemory, "close");
+		const cleanupSettled = Promise.withResolvers<void>();
+		const onConsolidationSettled = vi.fn(() => cleanupSettled.resolve());
 
 		const BUDGET_MS = 100;
 		const start = Bun.nanoseconds();
-		await state.dispose({ timeoutMs: BUDGET_MS });
+		await state.dispose({ timeoutMs: BUDGET_MS, onConsolidationSettled });
 		const elapsedMs = (Bun.nanoseconds() - start) / 1_000_000;
 
 		// Dispose must surrender within the budget (plus a generous slack); the
@@ -604,12 +606,15 @@ describe("Mnemopi backend lifecycle", () => {
 		expect(flushCalls).toBe(1);
 		// `close()` is deferred so SQLite writes don't race a closed handle.
 		expect(closeSpy).not.toHaveBeenCalled();
+		expect(onConsolidationSettled).not.toHaveBeenCalled();
 
-		// Release the stall and confirm the deferred close runs once consolidate
-		// settles — i.e. the SQLite handle still ends up released eventually.
+		// Release the stall and confirm close plus dependent cleanup run once
+		// consolidation settles.
 		flushStall.resolve();
-		await Bun.sleep(50);
+		await cleanupSettled.promise;
 		expect(closeSpy).toHaveBeenCalledTimes(1);
+		expect(onConsolidationSettled).toHaveBeenCalledTimes(1);
+		expect(closeSpy.mock.invocationCallOrder[0]).toBeLessThan(onConsolidationSettled.mock.invocationCallOrder[0]);
 
 		registeredMnemopiState = undefined;
 	});

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
-import type { AsyncJobRegisterOptions } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { AsyncJobManager, type AsyncJobRegisterOptions } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { TanCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/tan-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
@@ -171,6 +171,29 @@ describe("TanCommandController", () => {
 		expect(harness.ctx.showStatus).toHaveBeenCalledWith("Usage: /tan <work>");
 	});
 
+	it("rejects a new tan job when the parent session has sealed admissions", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const register = manager.register.bind(manager);
+		const harness = createContext({
+			register: (_run, options) => register("task", "tan admission probe", async () => "", options),
+		});
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(harness.cloneManager);
+		manager.closeAdmissions(harness.ctx.session);
+
+		try {
+			await new TanCommandController(harness.ctx).start("check disposal");
+
+			expect(harness.capturedOptions?.admissionScope).toBe(harness.ctx.session);
+			expect(harness.ctx.showError).toHaveBeenCalledWith(
+				"Background jobs are unavailable while session disposal is in progress (Main)",
+			);
+			expect(harness.ctx.session.sendCustomMessage).not.toHaveBeenCalled();
+			expect(manager.getRunningJobs()).toHaveLength(0);
+		} finally {
+			await manager.dispose({ timeoutMs: 1000 });
+		}
+	});
+
 	it("dispatches without disturbing an in-flight turn while streaming", async () => {
 		const harness = createContext({ isStreaming: true });
 		const forkSpy = vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(harness.cloneManager);
@@ -207,6 +230,7 @@ describe("TanCommandController", () => {
 		expect(harness.register).toHaveBeenCalledWith("task", "/tan write the release note", expect.any(Function), {
 			ownerId: MAIN_AGENT_ID,
 			agentId: expect.stringMatching(/^Tan-/) as unknown as string,
+			admissionScope: harness.ctx.session,
 		});
 		expect(harness.capturedOptions?.ownerId).toBe(MAIN_AGENT_ID);
 		expect(harness.sequence).toEqual(["register", "sendCustomMessage"]);

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -194,6 +194,24 @@ describe("vibe session registry", () => {
 		AgentRegistry.resetGlobalForTests();
 	});
 
+	it("rejects a new turn job when the owning session has sealed admissions", async () => {
+		const manager = createManager();
+		const session = createSession({ manager });
+		const register = manager.register.bind(manager);
+		let admissionScope: object | undefined;
+		vi.spyOn(manager, "register").mockImplementation((type, label, _run, options) => {
+			admissionScope = options?.admissionScope;
+			return register(type, label, async () => "", options);
+		});
+		manager.closeAdmissions(session);
+
+		await expect(
+			VibeSessionRegistry.global().spawn(session, { cli: "fast", name: "Sealed", prompt: "Do not start." }),
+		).rejects.toThrow("Background jobs are unavailable while session disposal is in progress (Main)");
+		expect(admissionScope).toBe(session);
+		expect(manager.getRunningJobs()).toHaveLength(0);
+	});
+
 	it("spawn returns immediately and self-delivers a turn result with activity trace + response", async () => {
 		const gate = deferred();
 		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {


### PR DESCRIPTION
## What

Restructures `AgentSession#doDispose` into ordered Phase A / Phase B / Phase C teardown: bound the post-prompt drain, run independent subsystem flushes under one `Promise.allSettled` barrier, and only then close the session manager. Interactive shutdown also arms a 3s "Still closing…" status while dispose is still pending.

## Why

Sequential dispose made `/exit` wall-clock the sum of independent subsystem timeouts and left post-prompt drain unbounded after abort. Parallel Phase B keeps each branch's existing timeout/log behavior while preserving writers-before-`sessionManager.close()` ordering.

Fixes #5932

### Exact mechanism / invariants

`packages/coding-agent/src/session/agent-session.ts` (`#doDispose`):

Phase A (sequential):

1. `beginDispose()`, exit recording, optional `session_shutdown` extension emit.
2. Abort in-flight post-prompt work: `abortRetry()`, `abortCompaction()`, `#cancelPostPromptTasks()`, `agent.abort()`.
3. Await the post-prompt drain under `withTimeout(..., 5_000, "Timed out draining post-prompt tasks during dispose")`. On that timeout only, log `Post-prompt tasks still draining at dispose deadline` and continue (hang-fix, not silent flush drop). Other errors rethrow.
4. Capture Hindsight state, browser owner id, and mnemopi state (pointer cleared before Phase B so concurrent branches cannot observe half-disposed mnemopi state).

Phase B (independent branches under one `Promise.allSettled`):

1. Async jobs: `#cancelOwnAsyncJobs()`, owned `AsyncJobManager.dispose({ timeoutMs: 3_000 })`, and identity `finally` that clears the process-global singleton when `AsyncJobManager.instance() === ownedAsyncManager` even if dispose rejects.
2. Eval: `#prepareEvalExecutionsForDispose()`, then `Promise.all` of Python/Ruby/Julia `dispose*KernelSessionsByOwner`.
3. Browser: `releaseTabsForOwner(..., { kill: true })` under a 3s timeout.
4. `shutdownTinyTitleClient()`.
5. Owned MCP disconnect under a 3s timeout (best-effort; never throws out of dispose).
6. Await the advisor recorder close promise captured at `beginDispose()`.
7. Hindsight `flushRetainQueue()` (unbounded; must finish while the session still exposes that state identity to `#doFlush`).
8. Mnemopi: `state.dispose({ timeoutMs })` then `finally` `shutdownMnemopiEmbedClient()` so embed shutdown still runs when dispose rejects (consolidate-on-dispose may embed first).

Rejected Phase B results that were not already branch-logged are warned as `Session dispose subsystem failed during parallel teardown` without making dispose throw for expected subsystem failures.

Phase C (sequential, after the barrier):

1. Power-assertion release and empty-move session cleanup.
2. `sessionManager.close()` (writers-before-close: post-prompt drain, async-job delivery drain, Hindsight flush, and mnemopi dispose have already settled under Phase A/B).
3. Provider session close, Hindsight pointer clear + `dispose()`, agent disconnect, append-only/model-role unsubscribes, listener clear.

`packages/coding-agent/src/modes/interactive-mode.ts` (`shutdown`):

- Still shows `Closing session…` before teardown.
- Arms a 3s timer that refreshes status to `Still closing… (flushing memory backend / network)`.
- Always `clearTimeout` in `finally` so a fast exit never re-fires the status.

Test-only helper: `trackPostPromptTaskForTests` (Bun-test runtime only) to register a never-settling post-prompt promise without driving a full agent turn.

### Risks / tradeoffs

- Concurrent Phase B means subsystem logs may interleave; failures are still logged per branch or via the allSettled sweep.
- Hindsight retain flush remains unbounded by design (no data-loss race with the session pointer). That branch can still dominate exit if the backend is slow; parallelization only prevents it from serializing after unrelated work.
- Post-prompt 5s bound is a hang-fix: tasks already aborted may still run detached past the deadline.
- Idle empty-session dispose is a non-regression budget against the 3s status arm, not a multi-subsystem load proof. Concurrency and ordering are covered by causal tests, not by the idle median alone.

## Testing

Focused commands (not campaign-wide suite totals):

```bash
bun test packages/coding-agent/test/agent-session-dispose-parallel.test.ts
bun test packages/coding-agent/test/interactive-mode-still-closing.test.ts
bun run packages/coding-agent/bench/session-dispose.bench.ts
```

`packages/coding-agent/test/agent-session-dispose-parallel.test.ts`:

- Starts independent Phase B branches (owned async dispose + Hindsight flush) before either resolves (causal barrier; start order between branches is not fixed).
- Bounds a never-settling post-prompt task at ~5s and asserts the exact warn `Post-prompt tasks still draining at dispose deadline`.
- Asserts async-job delivery custom-message write lands before `sessionManager.close`.
- Idle dispose completes under the 3s status budget.
- Owned `AsyncJobManager` singleton clears when dispose rejects (identity-finally).
- Mnemopi embed client still shuts down when `state.dispose` rejects (dispose/shutdown finally). Failure fixtures use real `AsyncJobManager` / prototype-backed `MnemopiSessionState` instances.

`packages/coding-agent/test/interactive-mode-still-closing.test.ts`:

- Shows `Still closing… (flushing memory backend / network)` only after 3s of pending teardown, then clears the timer.
- Fast teardown under 3s never arms the still-closing status.

Benchmark (idle non-regression only):

`packages/coding-agent/bench/session-dispose.bench.ts` measures empty in-memory `AgentSession.dispose` with no pending network flush / multi-subsystem load.

- Before (idle dispose smoke n=5): median 6.998 ms, stddev 2.770 ms
- After (`session.dispose.idle_ms`, n=24 samples in the primary change): median 0.3252 ms, stddev 0.0515 ms
- Acceptance on the bench: median `< 3000` ms (InteractiveMode still-closing budget). This number is not the stacked-timeout win proof; the causal Phase B / writers-before-close tests are.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
