### PR TITLE
perf(agent): memoize per-message LLM conversion and token estimates

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/alpha/.omp-nm/omp-u-E/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/alpha/.omp-nm/omp-u-E/node_modules

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reused settled per-message token estimates while bypassing mutable streaming assistants and invalidating rewritten messages. ([#5934](https://github.com/can1357/oh-my-pi/issues/5934))
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -482,11 +482,12 @@ const tokenEstimateCacheExcludeEncrypted = new WeakMap<object, number>();
  *
  * Provider streams add `duration` immediately before emitting their terminal
  * done/error event. Live partials intentionally omit it while mutating content
- * in place under the same identity, even though they may already carry an empty
- * usage object and the default `"stop"` reason.
+ * in place under the same identity and retain the default `"stop"` reason.
+ * Terminal abort/error paths may synthesize a duration-less snapshot, but those
+ * stop reasons are only assigned when finalizing the message.
  */
 export function isSettledAssistantMessage(message: AssistantMessage): boolean {
-	return message.duration != null;
+	return message.duration != null || message.stopReason === "aborted" || message.stopReason === "error";
 }
 
 /**

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -362,8 +362,19 @@ const IMAGE_TOKEN_ESTIMATE = 1200;
  * byte size can diverge wildly from what the provider charges, so the
  * compaction floor (which only needs the reliably-countable, on-wire-compressible
  * content) excludes them to avoid false triggers on thinking-heavy turns.
+ *
+ * Memoization is identity-based and option-split across two WeakMaps
+ * (default vs `excludeEncryptedReasoning`). Non-assistant objects are
+ * identity-memoized. Assistants are identity-memoized only when provably
+ * settled (defined usage + terminal stopReason, same gate shape as
+ * {@link getAssistantUsage}). In-flight / mutable assistants are never
+ * inserted or read from the cache. Callers that rewrite settled tool
+ * results / text blocks MUST call {@link invalidateTokenEstimate}.
  */
-export function estimateTokens(message: AgentMessage, options?: { excludeEncryptedReasoning?: boolean }): number {
+export type EstimateTokensOptions = { excludeEncryptedReasoning?: boolean };
+
+/** Uncached estimator body — exported so tests can assert memo parity. */
+export function estimateTokensUncached(message: AgentMessage, options?: EstimateTokensOptions): number {
 	const fragments: string[] = [];
 	let extra = 0;
 	if ((message as { role?: string }).role === "bashExecution") {
@@ -452,6 +463,62 @@ export function estimateTokens(message: AgentMessage, options?: { excludeEncrypt
 
 	if (fragments.length === 0) return extra;
 	return extra + countTokens(fragments);
+}
+
+/**
+ * Token estimates are option-sensitive (`excludeEncryptedReasoning` changes the
+ * count). Keep the two option poles in separate WeakMaps so a default hit never
+ * collides with a floor-estimate hit for the same object.
+ *
+ * Values are plain numbers keyed by message identity. Assistants are only
+ * inserted after providers attach their terminal duration marker; live
+ * assistants always recompute and never pollute either map.
+ */
+const tokenEstimateCacheDefault = new WeakMap<object, number>();
+const tokenEstimateCacheExcludeEncrypted = new WeakMap<object, number>();
+
+/**
+ * True when an assistant is provably settled for identity memoization.
+ *
+ * Provider streams add `duration` immediately before emitting their terminal
+ * done/error event. Live partials intentionally omit it while mutating content
+ * in place under the same identity, even though they may already carry an empty
+ * usage object and the default `"stop"` reason.
+ */
+export function isSettledAssistantMessage(message: AssistantMessage): boolean {
+	return message.duration != null;
+}
+
+/**
+ * Drop cached token estimates for `message` after an in-place content rewrite
+ * (pruning, shake, image strip). Safe no-op when the message was never cached.
+ */
+export function invalidateTokenEstimate(message: AgentMessage): void {
+	if (message === null || typeof message !== "object") return;
+	tokenEstimateCacheDefault.delete(message);
+	tokenEstimateCacheExcludeEncrypted.delete(message);
+}
+
+export function estimateTokens(message: AgentMessage, options?: EstimateTokensOptions): number {
+	const excludeEncrypted = options?.excludeEncryptedReasoning === true;
+	if (message === null || typeof message !== "object") {
+		return estimateTokensUncached(message, options);
+	}
+	const cache = excludeEncrypted ? tokenEstimateCacheExcludeEncrypted : tokenEstimateCacheDefault;
+
+	if (message.role === "assistant") {
+		const assistant = message as AssistantMessage;
+		// In-flight / mutable assistants: never read or insert.
+		if (!isSettledAssistantMessage(assistant)) {
+			return estimateTokensUncached(message, options);
+		}
+	}
+
+	const cached = cache.get(message);
+	if (cached !== undefined) return cached;
+	const value = estimateTokensUncached(message, options);
+	cache.set(message, value);
+	return value;
 }
 
 function estimateEntriesTokens(entries: SessionEntry[], startIndex: number, endIndex: number): number {

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -4,7 +4,7 @@
 
 import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
 import type { AgentMessage, AgentToolCall } from "../types";
-import { estimateTokens } from "./compaction";
+import { estimateTokens, invalidateTokenEstimate } from "./compaction";
 import type { SessionEntry, SessionMessageEntry } from "./entries";
 import {
 	collectToolCallsById,
@@ -295,6 +295,7 @@ export function pruneSupersededToolResults(entries: SessionEntry[], config: Supe
 	for (const candidate of toPrune) {
 		candidate.message.content = [{ type: "text", text: candidate.notice }];
 		candidate.message.prunedAt = prunedAt;
+		invalidateTokenEstimate(candidate.message as AgentMessage);
 		tokensSaved += estimatePrunedSavings(candidate.tokens, candidate.notice);
 	}
 	return { prunedCount: toPrune.length, tokensSaved };
@@ -398,6 +399,7 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 				: createPrunedNotice(candidate.tokens);
 		message.content = [{ type: "text", text: notice }];
 		message.prunedAt = prunedAt;
+		invalidateTokenEstimate(message as AgentMessage);
 		prunedCount++;
 	}
 

--- a/packages/agent/src/compaction/shake.ts
+++ b/packages/agent/src/compaction/shake.ts
@@ -13,7 +13,7 @@
 import type { TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { countTokens } from "../tokenizer";
 import type { AgentMessage } from "../types";
-import { estimateTokens } from "./compaction";
+import { estimateTokens, invalidateTokenEstimate } from "./compaction";
 import type { CustomMessageEntry, SessionEntry, SessionMessageEntry } from "./entries";
 import {
 	collectToolCallsById,
@@ -406,12 +406,18 @@ export function applyShakeRegion(region: ShakeRegion, replacement: string): void
 		const message = region.entry.message as ToolResultMessage;
 		message.content = [{ type: "text", text: replacement }];
 		message.prunedAt = Date.now();
+		invalidateTokenEstimate(message as AgentMessage);
 		return;
 	}
 	const slot = getBlockTextSlot(region.entry, region.blockIndex);
 	if (!slot) return;
 	const text = slot.read();
 	slot.write(text.slice(0, region.start) + replacement + text.slice(region.end));
+	// Block rewrites mutate user/assistant/developer content in place on the
+	// same message identity — drop any prior token estimate for that object.
+	if (region.entry.type === "message") {
+		invalidateTokenEstimate(region.entry.message as AgentMessage);
+	}
 }
 
 /**

--- a/packages/agent/test/estimate-tokens-memo.test.ts
+++ b/packages/agent/test/estimate-tokens-memo.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { SessionMessageEntry } from "@oh-my-pi/pi-agent-core/compaction";
+import {
+	applyShakeRegion,
+	estimateTokens,
+	estimateTokensUncached,
+	invalidateTokenEstimate,
+} from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage, ToolResultMessage } from "@oh-my-pi/pi-ai";
+
+function assistantMessage(
+	content: AssistantMessage["content"],
+	overrides: Partial<Pick<AssistantMessage, "duration" | "stopReason" | "usage">> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		timestamp: Date.now(),
+		provider: "mock",
+		model: "mock",
+		api: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		duration: 1,
+		...overrides,
+	};
+}
+
+function toolResult(text: string, images = 0): ToolResultMessage {
+	const content: ToolResultMessage["content"] = [{ type: "text", text }];
+	for (let i = 0; i < images; i++) {
+		content.push({ type: "image", data: `img${i}`, mimeType: "image/png" });
+	}
+	return {
+		role: "toolResult",
+		toolCallId: "call-1",
+		toolName: "bash",
+		content,
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+describe("estimateTokens memo", () => {
+	test("memoized values match uncached for representative roles and options", () => {
+		const samples: AgentMessage[] = [
+			{ role: "user", content: "hello world ".repeat(20), timestamp: 1 },
+			toolResult("tool payload ".repeat(40)),
+			assistantMessage([
+				{ type: "text", text: "answer" },
+				{ type: "thinking", thinking: "reason", thinkingSignature: "sig-blob-".repeat(10) },
+			]),
+		];
+		for (const message of samples) {
+			expect(estimateTokens(message)).toBe(estimateTokensUncached(message));
+			expect(estimateTokens(message, { excludeEncryptedReasoning: true })).toBe(
+				estimateTokensUncached(message, { excludeEncryptedReasoning: true }),
+			);
+		}
+	});
+
+	test("excludeEncryptedReasoning is option-separated from the default cache", () => {
+		const message = assistantMessage([
+			{ type: "thinking", thinking: "visible", thinkingSignature: "encrypted-payload-".repeat(30) },
+		]);
+		const withEncrypted = estimateTokens(message);
+		const withoutEncrypted = estimateTokens(message, { excludeEncryptedReasoning: true });
+		expect(withEncrypted).toBeGreaterThan(withoutEncrypted);
+		// Settled assistants are identity-memoized per option map; values stay option-correct.
+		expect(estimateTokens(message)).toBe(withEncrypted);
+		expect(estimateTokens(message, { excludeEncryptedReasoning: true })).toBe(withoutEncrypted);
+	});
+
+	test("settled assistants are identity-memoized once terminal", () => {
+		const message = assistantMessage([{ type: "text", text: "final answer ".repeat(40) }]);
+		const first = estimateTokens(message);
+		expect(estimateTokens(message)).toBe(first);
+		expect(first).toBe(estimateTokensUncached(message));
+	});
+
+	test("live assistant partials bypass identity memoization until duration is set", () => {
+		const block = { type: "text" as const, text: "streaming answer" };
+		const message = assistantMessage([block], { duration: undefined });
+		const first = estimateTokens(message);
+
+		block.text = "streaming answer ".repeat(80);
+		const second = estimateTokens(message);
+
+		expect(second).not.toBe(first);
+		expect(second).toBe(estimateTokensUncached(message));
+	});
+
+	test("pruned tool result re-estimates after owner invalidation", () => {
+		const message = toolResult("huge tool result body ".repeat(80));
+		const before = estimateTokens(message);
+		expect(before).toBe(estimateTokens(message)); // warm default cache
+		message.content = [{ type: "text", text: "[Old tool result content cleared]" }];
+		// Without invalidation this would be stale; the owner seam must clear both maps.
+		invalidateTokenEstimate(message);
+		const after = estimateTokens(message);
+		expect(after).toBeLessThan(before);
+		expect(after).toBe(estimateTokensUncached(message));
+	});
+
+	test("shake block rewrite on a settled assistant invalidates the memoized estimate", () => {
+		const longText = "assistant draft body ".repeat(60);
+		const message = assistantMessage([{ type: "text", text: longText }]);
+		const before = estimateTokens(message);
+		// Settled assistant: the warmed value is served by identity with no recomputation.
+		expect(estimateTokens(message)).toBe(before);
+		const entry: SessionMessageEntry = {
+			type: "message",
+			id: "e2",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			message,
+		};
+		// Real owner path: shake splices a placeholder over the assistant's text block
+		// in place and must drop the memoized estimate for the same object identity.
+		applyShakeRegion(
+			{
+				kind: "block",
+				entry,
+				blockIndex: 0,
+				start: 0,
+				end: longText.length,
+				tokens: before,
+				originalText: longText,
+				label: "assistant",
+			},
+			"[shaken]",
+		);
+		const after = estimateTokens(message);
+		expect(after).toBeLessThan(before);
+		expect(after).toBe(estimateTokensUncached(message));
+	});
+
+	test("shake toolResult rewrite invalidates token estimates", () => {
+		const message = toolResult("shakeable tool body ".repeat(100));
+		const before = estimateTokens(message);
+		const entry: SessionMessageEntry = {
+			type: "message",
+			id: "e1",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			message,
+		};
+		applyShakeRegion(
+			{
+				kind: "toolResult",
+				entry,
+				tokens: before,
+				originalText: "shakeable tool body ".repeat(100),
+				label: "bash",
+			},
+			"[shaken]",
+		);
+		const after = estimateTokens(message);
+		expect(after).toBeLessThan(before);
+		expect(after).toBe(estimateTokensUncached(message));
+	});
+});

--- a/packages/agent/test/estimate-tokens-memo.test.ts
+++ b/packages/agent/test/estimate-tokens-memo.test.ts
@@ -86,6 +86,24 @@ describe("estimateTokens memo", () => {
 		expect(first).toBe(estimateTokensUncached(message));
 	});
 
+	test("terminal aborted assistants remain memoized within settled history", () => {
+		const abortedBlock = { type: "text" as const, text: "interrupted turn" };
+		const tailBlock = { type: "text" as const, text: "settled tail" };
+		const history: AgentMessage[] = [
+			{ role: "user", content: "before abort", timestamp: 1 },
+			assistantMessage([{ type: "text", text: "settled prefix" }]),
+			assistantMessage([abortedBlock], { duration: undefined, stopReason: "aborted" }),
+			{ role: "user", content: "after abort", timestamp: 2 },
+			assistantMessage([tailBlock]),
+		];
+		const first = history.map(message => estimateTokens(message));
+
+		abortedBlock.text = "interrupted turn ".repeat(80);
+		tailBlock.text = "settled tail ".repeat(80);
+
+		expect(history.map(message => estimateTokens(message))).toEqual(first);
+	});
+
 	test("live assistant partials bypass identity memoization until duration is set", () => {
 		const block = { type: "text" as const, text: "streaming answer" };
 		const message = assistantMessage([block], { duration: undefined });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reused stable per-message LLM conversions and token estimates, with invalidation at session pruning, shaking, and image-removal boundaries. ([#5934](https://github.com/can1357/oh-my-pi/issues/5934))
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -368,6 +368,7 @@ import {
 	type BashExecutionMessage,
 	type CustomMessage,
 	type CustomMessagePayload,
+	clearConversionCarry,
 	convertToLlm,
 	demoteInterruptedThinking,
 	type FileMentionMessage,
@@ -6717,6 +6718,7 @@ export class AgentSession {
 
 	async #doDispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
 		this.beginDispose();
+		clearConversionCarry();
 		this.#recordSessionExit(options.reason ?? "dispose");
 		this.#cancelExitRecorder?.();
 		this.#cancelExitRecorder = undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10529,8 +10529,8 @@ export class AgentSession {
 			return undefined;
 		}
 
-		await this.sessionManager.rewriteEntries();
 		this.#invalidateLlmConversionsFromBranch(branchEntries);
+		await this.sessionManager.rewriteEntries();
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
 		this.#resetAllAdvisorRuntimes();
@@ -10573,8 +10573,8 @@ export class AgentSession {
 			return undefined;
 		}
 
-		await this.sessionManager.rewriteEntries();
 		this.#invalidateLlmConversionsFromBranch(branchEntries);
+		await this.sessionManager.rewriteEntries();
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
 		this.#resetAllAdvisorRuntimes();
@@ -10682,8 +10682,8 @@ export class AgentSession {
 
 		applyShakeRegions(items);
 
-		await this.sessionManager.rewriteEntries();
 		this.#invalidateLlmConversionsFromBranch(branchEntries);
+		await this.sessionManager.rewriteEntries();
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
 		this.#resetAllAdvisorRuntimes();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -374,6 +374,7 @@ import {
 	type HookMessage,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	type InterruptedThinkingDetails,
+	invalidateLlmConversion,
 	isEmptyErrorTurn,
 	isUserInterruptAbort,
 	normalizeCustomMessagePayload,
@@ -10499,6 +10500,15 @@ export class AgentSession {
 		return { ...config, protectedTools: [...config.protectedTools, planMatcher] };
 	}
 
+	/** Drop convertToLlm memo entries for branch messages after in-place history rewrites. */
+	#invalidateLlmConversionsFromBranch(entries: SessionEntry[]): void {
+		for (const entry of entries) {
+			if (entry.type === "message") {
+				invalidateLlmConversion(entry.message);
+			}
+		}
+	}
+
 	async #pruneToolOutputs(): Promise<{ prunedCount: number; tokensSaved: number } | undefined> {
 		const branchEntries = this.sessionManager.getBranch();
 		const keepBoundaryId = getLatestCompactionEntry(branchEntries)?.firstKeptEntryId;
@@ -10518,6 +10528,7 @@ export class AgentSession {
 		}
 
 		await this.sessionManager.rewriteEntries();
+		this.#invalidateLlmConversionsFromBranch(branchEntries);
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
 		this.#resetAllAdvisorRuntimes();
@@ -10561,6 +10572,7 @@ export class AgentSession {
 		}
 
 		await this.sessionManager.rewriteEntries();
+		this.#invalidateLlmConversionsFromBranch(branchEntries);
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
 		this.#resetAllAdvisorRuntimes();
@@ -10669,6 +10681,7 @@ export class AgentSession {
 		applyShakeRegions(items);
 
 		await this.sessionManager.rewriteEntries();
+		this.#invalidateLlmConversionsFromBranch(branchEntries);
 		const sessionContext = this.buildDisplaySessionContext();
 		this.agent.replaceMessages(sessionContext.messages);
 		this.#resetAllAdvisorRuntimes();

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -186,6 +186,26 @@ describe("convertToLlm", () => {
 		).toBe("streaming answer, now complete");
 	});
 
+	it("reconverts the same source array after a live assistant settles in place", () => {
+		const assistant = assistantMessage([
+			{ type: "text", text: "partial answer" },
+			{ type: "thinking", thinking: "streaming reasoning" },
+		]);
+		const messages: AgentMessage[] = [assistant, interruptedThinkingContinuity()];
+		const first = convertToLlm(messages);
+
+		assistant.content.push({ type: "text", text: "final answer" });
+		assistant.duration = 10;
+		const second = convertToLlm(messages);
+		const secondAssistant = second.find(message => message.role === "assistant");
+
+		expect(second).not.toBe(first);
+		expect(
+			Array.isArray(secondAssistant?.content) &&
+				secondAssistant.content.some(block => block.type === "text" && block.text === "final answer"),
+		).toBe(true);
+	});
+
 	it("recomputes only the interrupted assistant when the continuity follower is inserted or removed", () => {
 		const assistant = abortedAssistant([
 			{ type: "text", text: "partial answer" },

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -162,6 +162,21 @@ describe("convertToLlm", () => {
 		}
 	});
 
+	it("keeps terminal aborted assistants eligible for whole-array carry", () => {
+		const messages: AgentMessage[] = [
+			{ role: "user", content: "before abort", timestamp: 1 },
+			assistantMessage([{ type: "text", text: "settled prefix" }], 10),
+			abortedAssistant([{ type: "text", text: "interrupted turn" }]),
+			{ role: "user", content: "after abort", timestamp: 2 },
+			assistantMessage([{ type: "text", text: "settled tail" }], 10),
+		];
+
+		const first = convertToLlm(messages);
+		const second = convertToLlm(messages);
+
+		expect(second).toBe(first);
+	});
+
 	it("reconverts a live assistant mutated in place on the same source array", () => {
 		const user: AgentMessage = {
 			role: "user",

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { estimateTokens, estimateTokensUncached } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import {
 	type CustomMessage,
 	convertToLlm,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
+	invalidateLlmConversion,
 	replaceLlmImagesWithText,
 	SKILL_PROMPT_MESSAGE_TYPE,
 	type SkillPromptDetails,
+	stripImagesFromMessage,
 } from "./messages";
 
 function customMessage(customType: string, attribution: "agent" | "user"): CustomMessage<SkillPromptDetails> {
@@ -41,6 +44,20 @@ function abortedAssistant(content: AssistantMessage["content"]): AssistantMessag
 		usage: interruptedUsage,
 		stopReason: "aborted",
 		timestamp: 1,
+	};
+}
+
+function assistantMessage(content: AssistantMessage["content"], duration?: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: interruptedUsage,
+		stopReason: "stop",
+		timestamp: 1,
+		...(duration === undefined ? {} : { duration }),
 	};
 }
 
@@ -122,6 +139,152 @@ describe("convertToLlm", () => {
 			"text",
 			"thinking",
 		]);
+	});
+
+	it("reuses identities for unchanged terminal assistant conversions", () => {
+		const messages: AgentMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "hello" }], attribution: "user", timestamp: 1 },
+			assistantMessage([{ type: "text", text: "final answer" }], 10),
+			{
+				role: "toolResult",
+				toolCallId: "c1",
+				toolName: "bash",
+				content: [{ type: "text", text: "tool body" }],
+				isError: false,
+				timestamp: 3,
+			},
+		];
+		const first = convertToLlm(messages);
+		const second = convertToLlm(messages);
+		expect(second).toBe(first);
+		for (let i = 0; i < first.length; i++) {
+			expect(second[i]).toBe(first[i]);
+		}
+	});
+
+	it("reconverts a live assistant mutated in place on the same source array", () => {
+		const user: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			attribution: "user",
+			timestamp: 1,
+		};
+		const block = { type: "text" as const, text: "streaming answer" };
+		const assistant = assistantMessage([block]);
+		const messages: AgentMessage[] = [user, assistant];
+		const first = convertToLlm(messages);
+		block.text = "streaming answer, now complete";
+		const second = convertToLlm(messages);
+		const secondAssistant = second.find(message => message.role === "assistant");
+		expect(second).not.toBe(first);
+		expect(second.find(message => message.role === "user")).toBe(first.find(message => message.role === "user"));
+		expect(secondAssistant).toBe(assistant);
+		expect(
+			Array.isArray(secondAssistant?.content) &&
+				secondAssistant.content[0]?.type === "text" &&
+				secondAssistant.content[0].text,
+		).toBe("streaming answer, now complete");
+	});
+
+	it("recomputes only the interrupted assistant when the continuity follower is inserted or removed", () => {
+		const assistant = abortedAssistant([
+			{ type: "text", text: "partial answer" },
+			{ type: "thinking", thinking: "interrupted reasoning" },
+		]);
+		const user: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			attribution: "user",
+			timestamp: 0,
+		};
+		const withoutFollower: AgentMessage[] = [user, assistant];
+		const first = convertToLlm(withoutFollower);
+		const firstAssistant = first.find(entry => entry.role === "assistant");
+		expect(firstAssistant).toBeDefined();
+		expect(Array.isArray(firstAssistant?.content) && firstAssistant.content.map(block => block.type)).toEqual([
+			"text",
+			"thinking",
+		]);
+
+		const withFollower: AgentMessage[] = [user, assistant, interruptedThinkingContinuity()];
+		const second = convertToLlm(withFollower);
+		const secondAssistant = second.find(entry => entry.role === "assistant");
+		expect(secondAssistant).toBeDefined();
+		expect(secondAssistant).not.toBe(firstAssistant);
+		expect(Array.isArray(secondAssistant?.content) && secondAssistant.content.map(block => block.type)).toEqual([
+			"text",
+		]);
+		// Unrelated user conversion stays identity-stable across the neighbor flip.
+		expect(second.find(entry => entry.role === "user")).toBe(first.find(entry => entry.role === "user"));
+
+		const third = convertToLlm(withoutFollower);
+		const thirdAssistant = third.find(entry => entry.role === "assistant");
+		expect(thirdAssistant).not.toBe(secondAssistant);
+		expect(Array.isArray(thirdAssistant?.content) && thirdAssistant.content.map(block => block.type)).toEqual([
+			"text",
+			"thinking",
+		]);
+	});
+
+	it("invalidates conversion cache when stripImagesFromMessage rewrites content in place", () => {
+		const message: AgentMessage = {
+			role: "user",
+			content: [
+				{ type: "text", text: "look" },
+				{ type: "image", data: "aaaa", mimeType: "image/png" },
+			],
+			attribution: "user",
+			timestamp: 1,
+		};
+		const first = convertToLlm([message]);
+		expect(first[0]).toBeDefined();
+		expect(stripImagesFromMessage(message)).toBe(1);
+		const second = convertToLlm([message]);
+		expect(second[0]).not.toBe(first[0]);
+		expect(Array.isArray(second[0]?.content) && second[0].content.map(b => b.type)).toEqual(["text"]);
+	});
+
+	it("invalidates token estimates when stripImagesFromMessage rewrites content in place", () => {
+		const message: AgentMessage = {
+			role: "toolResult",
+			toolCallId: "c1",
+			toolName: "bash",
+			content: [
+				{ type: "text", text: "generated" },
+				{ type: "image", data: "aaaa", mimeType: "image/png" },
+				{ type: "image", data: "bbbb", mimeType: "image/png" },
+			],
+			isError: false,
+			timestamp: 1,
+		};
+		const before = estimateTokens(message);
+		expect(before).toBe(estimateTokens(message)); // warm identity cache
+		expect(stripImagesFromMessage(message)).toBe(2);
+		const after = estimateTokens(message);
+		expect(after).toBeLessThan(before);
+		expect(after).toBe(estimateTokensUncached(message));
+	});
+
+	it("invalidates conversion cache for an explicit invalidateLlmConversion call", () => {
+		const message: AgentMessage = {
+			role: "toolResult",
+			toolCallId: "c1",
+			toolName: "bash",
+			content: [{ type: "text", text: "full tool body" }],
+			isError: false,
+			timestamp: 1,
+		};
+		const first = convertToLlm([message]);
+		message.content = [{ type: "text", text: "[Old tool result content cleared]" }];
+		invalidateLlmConversion(message);
+		const second = convertToLlm([message]);
+		expect(second[0]).not.toBe(first[0]);
+		expect(
+			Array.isArray(second[0]?.content) &&
+				second[0].content[0] &&
+				second[0].content[0].type === "text" &&
+				second[0].content[0].text,
+		).toBe("[Old tool result content cleared]");
 	});
 });
 

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -261,6 +261,48 @@ describe("convertToLlm", () => {
 		]);
 	});
 
+	it("uses carried neighbor state when the per-message cache changes during append conversion", () => {
+		const target = abortedAssistant([
+			{ type: "text", text: "partial answer" },
+			{ type: "thinking", thinking: "interrupted reasoning" },
+		]);
+		let injectSeparateConversion = false;
+		let roleReads = 0;
+		let separateConversionRan = false;
+		let assistant: AssistantMessage;
+		assistant = new Proxy(target, {
+			get(object, property, receiver) {
+				if (property === "role") {
+					roleReads++;
+					if (injectSeparateConversion && roleReads === 2) {
+						injectSeparateConversion = false;
+						separateConversionRan = true;
+						convertToLlm([assistant, interruptedThinkingContinuity()]);
+					}
+				}
+				return Reflect.get(object, property, receiver);
+			},
+		});
+		const messages: AgentMessage[] = [assistant];
+		const first = convertToLlm(messages);
+
+		messages.push(interruptedThinkingContinuity());
+		roleReads = 0;
+		injectSeparateConversion = true;
+		const second = convertToLlm(messages);
+
+		const firstAssistant = first.find(entry => entry.role === "assistant");
+		const secondAssistant = second.find(entry => entry.role === "assistant");
+		expect(separateConversionRan).toBe(true);
+		expect(Array.isArray(firstAssistant?.content) && firstAssistant.content.map(block => block.type)).toEqual([
+			"text",
+			"thinking",
+		]);
+		expect(Array.isArray(secondAssistant?.content) && secondAssistant.content.map(block => block.type)).toEqual([
+			"text",
+		]);
+	});
+
 	it("invalidates conversion cache when stripImagesFromMessage rewrites content in place", () => {
 		const message: AgentMessage = {
 			role: "user",

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -792,6 +792,18 @@ let lastConvertOut: Message[] = [];
 let lastConvertEpoch = -1;
 
 /**
+ * Release the strong references held by the same-array conversion fast path.
+ * Per-message WeakMap entries remain valid and collectible with their messages.
+ */
+export function clearConversionCarry(): void {
+	lastConvertSource = undefined;
+	lastConvertRefs = [];
+	lastConvertCounts = [];
+	lastConvertOut = [];
+	lastConvertEpoch = -1;
+}
+
+/**
  * Drop the cached LLM conversion for a message after an in-place content rewrite
  * (image strip, prune-adjacent mutations that keep object identity). Safe no-op
  * when the message was never converted.

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -788,6 +788,7 @@ let llmConversionEpoch = 0;
 let lastConvertSource: AgentMessage[] | undefined;
 let lastConvertRefs: AgentMessage[] = [];
 let lastConvertCounts: number[] = [];
+let lastConvertInterruptedNext: boolean[] = [];
 let lastConvertOut: Message[] = [];
 let lastConvertEpoch = -1;
 
@@ -799,6 +800,7 @@ export function clearConversionCarry(): void {
 	lastConvertSource = undefined;
 	lastConvertRefs = [];
 	lastConvertCounts = [];
+	lastConvertInterruptedNext = [];
 	lastConvertOut = [];
 	lastConvertEpoch = -1;
 }
@@ -865,6 +867,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 			const out = lastConvertOut.slice();
 			const refs = lastConvertRefs.slice();
 			const counts = lastConvertCounts.slice();
+			const interruptedNextStates = lastConvertInterruptedNext.slice();
 
 			// Previous-last assistant may gain an interrupted-thinking follower.
 			if (prevLen > 0) {
@@ -872,14 +875,14 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				const prevMsg = messages[lastIdx];
 				if (prevMsg !== undefined && prevMsg.role === "assistant") {
 					const interruptedNext = followedByInterruptedThinking(messages, lastIdx);
-					const cached = llmConversionCache.get(prevMsg);
-					if (cached === undefined || cached.interruptedNext !== interruptedNext) {
+					if ((interruptedNextStates[lastIdx] ?? false) !== interruptedNext) {
 						const converted = convertMessageCached(prevMsg, interruptedNext);
 						let offset = 0;
 						for (let i = 0; i < lastIdx; i++) offset += counts[i] ?? 0;
 						const oldCount = counts[lastIdx] ?? 0;
 						out.splice(offset, oldCount, ...converted);
 						counts[lastIdx] = converted.length;
+						interruptedNextStates[lastIdx] = interruptedNext;
 					}
 				}
 			}
@@ -889,6 +892,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				if (m === undefined) {
 					refs.push(m as unknown as AgentMessage);
 					counts.push(0);
+					interruptedNextStates.push(false);
 					continue;
 				}
 				const interruptedNext = m.role === "assistant" ? followedByInterruptedThinking(messages, index) : false;
@@ -896,11 +900,15 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 				for (const entry of converted) out.push(entry);
 				refs.push(m);
 				counts.push(converted.length);
+				interruptedNextStates.push(interruptedNext);
 			}
 
+			lastConvertSource = messages;
 			lastConvertRefs = refs;
 			lastConvertCounts = counts;
+			lastConvertInterruptedNext = interruptedNextStates;
 			lastConvertOut = out;
+			lastConvertEpoch = llmConversionEpoch;
 			return out;
 		}
 	}
@@ -908,17 +916,20 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 	const out: Message[] = [];
 	const refs: AgentMessage[] = new Array(length);
 	const counts: number[] = new Array(length);
+	const interruptedNextStates: boolean[] = new Array(length);
 	for (let index = 0; index < length; index++) {
 		const m = messages[index];
 		refs[index] = m as AgentMessage;
 		if (m === undefined) {
 			counts[index] = 0;
+			interruptedNextStates[index] = false;
 			continue;
 		}
 		const interruptedNext = m.role === "assistant" ? followedByInterruptedThinking(messages, index) : false;
 		const converted = convertMessageCached(m, interruptedNext);
 		for (const entry of converted) out.push(entry);
 		counts[index] = converted.length;
+		interruptedNextStates[index] = interruptedNext;
 	}
 
 	if (hasUnsettledAssistant) {
@@ -927,6 +938,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 		lastConvertSource = messages;
 		lastConvertRefs = refs;
 		lastConvertCounts = counts;
+		lastConvertInterruptedNext = interruptedNextStates;
 		lastConvertOut = out;
 		lastConvertEpoch = llmConversionEpoch;
 	}

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -921,11 +921,15 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 		counts[index] = converted.length;
 	}
 
-	lastConvertSource = messages;
-	lastConvertRefs = refs;
-	lastConvertCounts = counts;
-	lastConvertOut = out;
-	lastConvertEpoch = llmConversionEpoch;
+	if (hasUnsettledAssistant) {
+		clearConversionCarry();
+	} else {
+		lastConvertSource = messages;
+		lastConvertRefs = refs;
+		lastConvertCounts = counts;
+		lastConvertOut = out;
+		lastConvertEpoch = llmConversionEpoch;
+	}
 	return out;
 }
 

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -5,6 +5,7 @@
  * and provides a transformer to convert them to LLM-compatible messages.
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { invalidateTokenEstimate, isSettledAssistantMessage } from "@oh-my-pi/pi-agent-core/compaction";
 import {
 	type BranchSummaryMessage,
 	type CompactionSummaryMessage,
@@ -457,26 +458,27 @@ function stripImagesFromArrayContent(content: (TextContent | ImageContent)[]): S
  * pure local mutation and intentionally does neither.
  */
 export function stripImagesFromMessage(message: AgentMessage): number {
+	let removed = 0;
 	switch (message.role) {
 		case "user":
 		case "developer":
 		case "custom":
 		case "hookMessage": {
 			if (typeof message.content === "string") return 0;
-			const { content, removed } = stripImagesFromArrayContent(message.content);
-			if (removed > 0) {
+			const stripped = stripImagesFromArrayContent(message.content);
+			if (stripped.removed > 0) {
 				// All four roles type `content` as `string | (TextContent | ImageContent)[]`;
 				// TypeScript can't narrow the assignment across the union, so cast once.
-				(message as { content: typeof content }).content = content;
+				(message as { content: typeof stripped.content }).content = stripped.content;
+				removed = stripped.removed;
 			}
-			return removed;
+			break;
 		}
 		case "toolResult": {
-			let removed = 0;
-			const { content, removed: contentRemoved } = stripImagesFromArrayContent(message.content);
-			if (contentRemoved > 0) {
-				message.content = content;
-				removed += contentRemoved;
+			const stripped = stripImagesFromArrayContent(message.content);
+			if (stripped.removed > 0) {
+				message.content = stripped.content;
+				removed += stripped.removed;
 			}
 			const details = message.details as { images?: unknown } | null | undefined;
 			if (details && Array.isArray(details.images)) {
@@ -495,21 +497,25 @@ export function stripImagesFromMessage(message: AgentMessage): number {
 					details.images = kept;
 				}
 			}
-			return removed;
+			break;
 		}
 		case "fileMention": {
-			let removed = 0;
 			for (const file of message.files) {
 				if (file.image) {
 					file.image = undefined;
 					removed++;
 				}
 			}
-			return removed;
+			break;
 		}
 		default:
 			return 0;
 	}
+	if (removed > 0) {
+		invalidateLlmConversion(message);
+		invalidateTokenEstimate(message);
+	}
+	return removed;
 }
 
 /**
@@ -751,127 +757,278 @@ function convertImageBearingCustomMessage(message: CustomMessage | HookMessage):
 }
 
 /**
+ * Per-message LLM conversion cache. Keyed by AgentMessage identity; assistants
+ * also store the neighbor flag used when the entry was produced so a later
+ * insertion/removal of the interrupted-thinking continuity message forces a
+ * recompute for exactly that assistant (and only that assistant).
+ *
+ * Output Message[] element identities are reused on hit — callers that need a
+ * mutable copy must clone themselves. Do not memoize the sdk.ts
+ * block-images/obfuscation wrappers; those depend on live settings.
+ *
+ * When the same AgentMessage[] reference is converted again with identical
+ * length and element identities (exact repeat), the previous outer Message[]
+ * is returned as-is. Append-only growth on that reference returns a sliced
+ * copy of the prior Message[] plus the new tail (O(N) memcpy + Δ conversion),
+ * so held prior results cannot be mutated under callers. Truncation / middle
+ * replacement rebuild fully.
+ */
+interface ConvertedLlmCacheEntry {
+	out: Message[];
+	/** Meaningful only for assistants; false for pure roles. */
+	interruptedNext: boolean;
+}
+
+const llmConversionCache = new WeakMap<AgentMessage, ConvertedLlmCacheEntry>();
+
+/** Bumped whenever an in-place rewrite invalidates any per-message entry. */
+let llmConversionEpoch = 0;
+
+/** Last full conversion over a live AgentMessage[] reference (repeat / append). */
+let lastConvertSource: AgentMessage[] | undefined;
+let lastConvertRefs: AgentMessage[] = [];
+let lastConvertCounts: number[] = [];
+let lastConvertOut: Message[] = [];
+let lastConvertEpoch = -1;
+
+/**
+ * Drop the cached LLM conversion for a message after an in-place content rewrite
+ * (image strip, prune-adjacent mutations that keep object identity). Safe no-op
+ * when the message was never converted.
+ */
+export function invalidateLlmConversion(message: AgentMessage): void {
+	if (message === null || typeof message !== "object") return;
+	llmConversionCache.delete(message);
+	llmConversionEpoch++;
+}
+
+function convertMessageCached(m: AgentMessage, interruptedNext: boolean): Message[] {
+	if (m.role === "assistant" && !isSettledAssistantMessage(m)) {
+		return convertOneMessageToLlm(m, interruptedNext);
+	}
+	const cached = llmConversionCache.get(m);
+	if (cached !== undefined && cached.interruptedNext === interruptedNext) {
+		return cached.out;
+	}
+	const converted = convertOneMessageToLlm(m, interruptedNext);
+	llmConversionCache.set(m, { out: converted, interruptedNext });
+	return converted;
+}
+
+/**
  * Transform AgentMessages (including custom types) to LLM-compatible Messages.
  *
- * This is used by:
- * - Agent's transormToLlm option (for prompt calls and queued messages)
- * - Compaction's generateSummary (for summarization)
- * - Custom extensions and tools
+ * Pure per-message for every role except assistant, which peeks at the next
+ * entry for the interrupted-thinking continuity marker. Repeated calls reuse
+ * settled message conversions; live assistants bypass both identity caches.
  */
 export function convertToLlm(messages: AgentMessage[]): Message[] {
-	return messages.flatMap((m, index): Message[] => {
-		switch (m.role) {
-			case "bashExecution":
-				if (m.excludeFromContext) {
-					return [];
-				}
-				return [
-					{
-						role: "user",
-						content: [{ type: "text", text: bashExecutionToText(m) }],
-						attribution: "user",
-						timestamp: m.timestamp,
-					},
-				];
-			case "pythonExecution":
-				if (m.excludeFromContext) {
-					return [];
-				}
-				return [
-					{
-						role: "user",
-						content: [{ type: "text", text: pythonExecutionToText(m) }],
-						attribution: "user",
-						timestamp: m.timestamp,
-					},
-				];
-			case "fileMention": {
-				// One `fileMention` can mix `@notes.md` (text) and `@screenshot.png` (image)
-				// in the same turn (`generateFileMentionMessages` packs every `@…` into a
-				// single message). Splitting by image presence keeps text-only mentions on
-				// the higher-priority `developer` slot while routing image attachments
-				// through `user`, the only Responses content slot that legitimately accepts
-				// `input_image` (Codex chatgpt.com /codex/responses rejects everything else
-				// with `Invalid value: 'input_image'`, #3443).
-				const wrap = (file: FileMentionMessage["files"][number]): string => {
-					const inner = file.content ? `\n${file.content}\n` : "\n";
-					return `<file path="${file.path}">${inner}</file>`;
-				};
-				const textFiles = m.files.filter(file => !file.image);
-				const imageFiles = m.files.filter(file => file.image);
-				const out: Message[] = [];
-				if (textFiles.length > 0) {
-					out.push({
-						role: "developer",
-						content: [{ type: "text" as const, text: textFiles.map(wrap).join("\n") }],
-						attribution: "user",
-						timestamp: m.timestamp,
-					});
-				}
-				if (imageFiles.length > 0) {
-					const content: (TextContent | ImageContent)[] = [
-						{ type: "text" as const, text: imageFiles.map(wrap).join("\n") },
-					];
-					for (const file of imageFiles) {
-						if (file.image) content.push(file.image);
-					}
-					out.push({
-						role: "user",
-						content,
-						attribution: "user",
-						timestamp: m.timestamp,
-					});
-				}
-				return out;
+	const length = messages.length;
+	const hasUnsettledAssistant = messages.some(
+		message => message?.role === "assistant" && !isSettledAssistantMessage(message),
+	);
+
+	// Same array + epoch: exact repeat, or append-only growth with a fresh outer
+	// Message[] (slice) so callers holding the previous result keep a stable snapshot.
+	if (
+		!hasUnsettledAssistant &&
+		messages === lastConvertSource &&
+		llmConversionEpoch === lastConvertEpoch &&
+		length >= lastConvertRefs.length
+	) {
+		const prevLen = lastConvertRefs.length;
+		let prefixMatches = true;
+		for (let i = 0; i < prevLen; i++) {
+			if (messages[i] !== lastConvertRefs[i]) {
+				prefixMatches = false;
+				break;
 			}
-			case "custom": {
-				if (!isCustomMessageContent(m.content)) return [];
-				if (isUserInvokedSkillPrompt(m)) {
-					return [
-						{
-							role: "user",
-							content: customMessageContentToLlmContent(m.content),
-							attribution: "user",
-							timestamp: m.timestamp,
-						},
-					];
-				}
-				const split = convertImageBearingCustomMessage(m);
-				if (split) return split;
-				const converted = convertMessageToLlm(m);
-				return converted ? [converted] : [];
-			}
-			case "hookMessage": {
-				if (!isCustomMessageContent(m.content)) return [];
-				const split = convertImageBearingCustomMessage(m);
-				if (split) return split;
-				const converted = convertMessageToLlm(m);
-				return converted ? [converted] : [];
-			}
-			case "assistant": {
-				// A user-interrupted turn keeps its trailing thinking run on the
-				// persisted/displayed message so reload and Ctrl+L rebuilds still
-				// show it. That run is incomplete/unsigned and gets rejected on
-				// resend, so strip it here — LLM path only — when the hidden
-				// interrupted-thinking continuity message follows.
-				const source = followedByInterruptedThinking(messages, index) ? stripDemotedThinkingForLlm(m) : m;
-				const converted = convertMessageToLlm(source);
-				return converted ? [converted] : [];
-			}
-			case "branchSummary":
-			case "compactionSummary":
-			case "user":
-			case "developer":
-			case "toolResult": {
-				// Core roles share one transformer with agent-core —
-				// duplicating them here is how snapcompact frames once
-				// silently fell off the provider request.
-				const converted = convertMessageToLlm(m);
-				return converted ? [converted] : [];
-			}
-			default:
-				m satisfies never;
-				return [];
 		}
-	});
+
+		if (prefixMatches && length === prevLen) {
+			return lastConvertOut;
+		}
+
+		if (prefixMatches && length > prevLen) {
+			const out = lastConvertOut.slice();
+			const refs = lastConvertRefs.slice();
+			const counts = lastConvertCounts.slice();
+
+			// Previous-last assistant may gain an interrupted-thinking follower.
+			if (prevLen > 0) {
+				const lastIdx = prevLen - 1;
+				const prevMsg = messages[lastIdx];
+				if (prevMsg !== undefined && prevMsg.role === "assistant") {
+					const interruptedNext = followedByInterruptedThinking(messages, lastIdx);
+					const cached = llmConversionCache.get(prevMsg);
+					if (cached === undefined || cached.interruptedNext !== interruptedNext) {
+						const converted = convertMessageCached(prevMsg, interruptedNext);
+						let offset = 0;
+						for (let i = 0; i < lastIdx; i++) offset += counts[i] ?? 0;
+						const oldCount = counts[lastIdx] ?? 0;
+						out.splice(offset, oldCount, ...converted);
+						counts[lastIdx] = converted.length;
+					}
+				}
+			}
+
+			for (let index = prevLen; index < length; index++) {
+				const m = messages[index];
+				if (m === undefined) {
+					refs.push(m as unknown as AgentMessage);
+					counts.push(0);
+					continue;
+				}
+				const interruptedNext = m.role === "assistant" ? followedByInterruptedThinking(messages, index) : false;
+				const converted = convertMessageCached(m, interruptedNext);
+				for (const entry of converted) out.push(entry);
+				refs.push(m);
+				counts.push(converted.length);
+			}
+
+			lastConvertRefs = refs;
+			lastConvertCounts = counts;
+			lastConvertOut = out;
+			return out;
+		}
+	}
+
+	const out: Message[] = [];
+	const refs: AgentMessage[] = new Array(length);
+	const counts: number[] = new Array(length);
+	for (let index = 0; index < length; index++) {
+		const m = messages[index];
+		refs[index] = m as AgentMessage;
+		if (m === undefined) {
+			counts[index] = 0;
+			continue;
+		}
+		const interruptedNext = m.role === "assistant" ? followedByInterruptedThinking(messages, index) : false;
+		const converted = convertMessageCached(m, interruptedNext);
+		for (const entry of converted) out.push(entry);
+		counts[index] = converted.length;
+	}
+
+	lastConvertSource = messages;
+	lastConvertRefs = refs;
+	lastConvertCounts = counts;
+	lastConvertOut = out;
+	lastConvertEpoch = llmConversionEpoch;
+	return out;
+}
+
+function convertOneMessageToLlm(m: AgentMessage, interruptedNext: boolean): Message[] {
+	switch (m.role) {
+		case "bashExecution":
+			if (m.excludeFromContext) {
+				return [];
+			}
+			return [
+				{
+					role: "user",
+					content: [{ type: "text", text: bashExecutionToText(m) }],
+					attribution: "user",
+					timestamp: m.timestamp,
+				},
+			];
+		case "pythonExecution":
+			if (m.excludeFromContext) {
+				return [];
+			}
+			return [
+				{
+					role: "user",
+					content: [{ type: "text", text: pythonExecutionToText(m) }],
+					attribution: "user",
+					timestamp: m.timestamp,
+				},
+			];
+		case "fileMention": {
+			// One `fileMention` can mix `@notes.md` (text) and `@screenshot.png` (image)
+			// in the same turn (`generateFileMentionMessages` packs every `@…` into a
+			// single message). Splitting by image presence keeps text-only mentions on
+			// the higher-priority `developer` slot while routing image attachments
+			// through `user`, the only Responses content slot that legitimately accepts
+			// `input_image` (Codex chatgpt.com /codex/responses rejects everything else
+			// with `Invalid value: 'input_image'`, #3443).
+			const wrap = (file: FileMentionMessage["files"][number]): string => {
+				const inner = file.content ? `\n${file.content}\n` : "\n";
+				return `<file path="${file.path}">${inner}</file>`;
+			};
+			const textFiles = m.files.filter(file => !file.image);
+			const imageFiles = m.files.filter(file => file.image);
+			const fileOut: Message[] = [];
+			if (textFiles.length > 0) {
+				fileOut.push({
+					role: "developer",
+					content: [{ type: "text" as const, text: textFiles.map(wrap).join("\n") }],
+					attribution: "user",
+					timestamp: m.timestamp,
+				});
+			}
+			if (imageFiles.length > 0) {
+				const content: (TextContent | ImageContent)[] = [
+					{ type: "text" as const, text: imageFiles.map(wrap).join("\n") },
+				];
+				for (const file of imageFiles) {
+					if (file.image) content.push(file.image);
+				}
+				fileOut.push({
+					role: "user",
+					content,
+					attribution: "user",
+					timestamp: m.timestamp,
+				});
+			}
+			return fileOut;
+		}
+		case "custom": {
+			if (!isCustomMessageContent(m.content)) return [];
+			if (isUserInvokedSkillPrompt(m)) {
+				return [
+					{
+						role: "user",
+						content: customMessageContentToLlmContent(m.content),
+						attribution: "user",
+						timestamp: m.timestamp,
+					},
+				];
+			}
+			const split = convertImageBearingCustomMessage(m);
+			if (split) return split;
+			const converted = convertMessageToLlm(m);
+			return converted ? [converted] : [];
+		}
+		case "hookMessage": {
+			if (!isCustomMessageContent(m.content)) return [];
+			const split = convertImageBearingCustomMessage(m);
+			if (split) return split;
+			const converted = convertMessageToLlm(m);
+			return converted ? [converted] : [];
+		}
+		case "assistant": {
+			// A user-interrupted turn keeps its trailing thinking run on the
+			// persisted/displayed message so reload and Ctrl+L rebuilds still
+			// show it. That run is incomplete/unsigned and gets rejected on
+			// resend, so strip it here — LLM path only — when the hidden
+			// interrupted-thinking continuity message follows.
+			const source = interruptedNext ? stripDemotedThinkingForLlm(m) : m;
+			const converted = convertMessageToLlm(source);
+			return converted ? [converted] : [];
+		}
+		case "branchSummary":
+		case "compactionSummary":
+		case "user":
+		case "developer":
+		case "toolResult": {
+			// Core roles share one transformer with agent-core —
+			// duplicating them here is how snapcompact frames once
+			// silently fell off the provider request.
+			const converted = convertMessageToLlm(m);
+			return converted ? [converted] : [];
+		}
+		default:
+			m satisfies never;
+			return [];
+	}
 }

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -90,6 +90,23 @@ describe("AgentSession message pipeline", () => {
 		}
 	});
 
+	it("clears the conversion carry when disposed", async () => {
+		const session = new AgentSession({
+			agent: createAgent(),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: {} as never,
+		});
+		sessions.push(session);
+		const messages: AgentMessage[] = [{ role: "user", content: "retained history", timestamp: Date.now() }];
+		const beforeDispose = convertToLlm(messages);
+		expect(convertToLlm(messages)).toBe(beforeDispose);
+
+		await session.dispose();
+
+		expect(convertToLlm(messages)).not.toBe(beforeDispose);
+	});
+
 	it("applies transformContext before convertToLlm", async () => {
 		const inputMessages: AgentMessage[] = [{ role: "user", content: "hello", timestamp: Date.now() }];
 		const transformedMessages: AgentMessage[] = [

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { USELESS_NOTICE } from "@oh-my-pi/pi-agent-core/compaction/pruning";
@@ -7,6 +7,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -122,7 +123,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		return text.text;
 	}
 
-	it("persists the pruned rewrite so a from-disk rebuild matches the live context", async () => {
+	function completeTurn(): void {
 		const finalAssistant = {
 			role: "assistant" as const,
 			content: [{ type: "text" as const, text: "Continuing." }],
@@ -142,6 +143,10 @@ describe("AgentSession per-turn prune persistence", () => {
 		};
 		session.agent.emitExternalEvent({ type: "message_end", message: finalAssistant });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [finalAssistant] });
+	}
+
+	it("persists the pruned rewrite so a from-disk rebuild matches the live context", async () => {
+		completeTurn();
 		await session.waitForIdle();
 
 		// The per-turn pass rewrote the live context…
@@ -161,5 +166,33 @@ describe("AgentSession per-turn prune persistence", () => {
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");
 		expect(rebuiltText?.type === "text" ? rebuiltText.text : undefined).toBe(USELESS_NOTICE);
+	});
+
+	it("invalidates the converted prompt before async prune persistence settles", async () => {
+		convertToLlm(session.buildDisplaySessionContext().messages);
+		const rewriteStarted = Promise.withResolvers<void>();
+		const releaseRewrite = Promise.withResolvers<void>();
+		const rewriteEntries = sessionManager.rewriteEntries.bind(sessionManager);
+		vi.spyOn(sessionManager, "rewriteEntries").mockImplementation(async () => {
+			rewriteStarted.resolve();
+			await releaseRewrite.promise;
+			await rewriteEntries();
+		});
+
+		completeTurn();
+		await rewriteStarted.promise;
+		try {
+			const duringPersistence = convertToLlm(session.buildDisplaySessionContext().messages).find(
+				candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
+			);
+			if (duringPersistence?.role !== "toolResult" || !Array.isArray(duringPersistence.content)) {
+				throw new Error("Expected the seeded tool result while persistence is pending");
+			}
+			const text = duringPersistence.content.find(block => block.type === "text");
+			expect(text?.type === "text" ? text.text : undefined).toBe(USELESS_NOTICE);
+		} finally {
+			releaseRewrite.resolve();
+			await session.waitForIdle();
+		}
 	});
 });


### PR DESCRIPTION
## What

Memoizes the two long-session history hot paths that re-walk settled messages every turn:

1. **`convertToLlm`** — identity + `interruptedNext` per-message cache with append-friendly outer-array reuse and epoch invalidation after in-place rewrites.
2. **`estimateTokens`** — dual WeakMaps split by `excludeEncryptedReasoning`, with a settled-assistant gate so streaming partials never freeze a mid-stream count.

Owner seams call `invalidateLlmConversion` / `invalidateTokenEstimate` at prune, shake, image strip, and session rewrite boundaries.

## Why

Long sessions re-execute full-history conversion and token estimation before every model call and during compaction accounting. Historical messages are almost entirely settled, so the repeated work is pure overhead. On a 5k-message synthetic fixture, first/steady convert and cold first/second estimate are the measurable cost centers.

Fixes #5934

### Exact mechanism / invariants

**`convertToLlm` (`packages/coding-agent/src/session/messages.ts`)**

- Module WeakMap: `AgentMessage → { out: Message[]; interruptedNext: boolean }`.
- Every role is identity-memoized. Assistants also store the neighbor flag used when the entry was produced (`followedByInterruptedThinking`); a later insert/remove of the interrupted-thinking continuity message forces recompute for exactly that assistant.
- Exact-repeat on the same `AgentMessage[]` reference (same length, same element identities, same conversion epoch) returns the previous outer `Message[]` as-is.
- Append-only growth on that reference returns a **slice** of the prior outer `Message[]` plus newly converted tail entries, so callers holding the previous result keep a stable snapshot (no held-result aliasing). The previous-last assistant is rechecked for a newly attached interrupted-thinking follower.
- Truncation / middle replacement rebuilds fully.
- `invalidateLlmConversion(message)` deletes that entry and bumps `llmConversionEpoch`, busting any outer-array reuse that still points at rewritten content.
- Settings-dependent sdk wrappers (block-images / obfuscation) are intentionally **not** memoized.

**`estimateTokens` (`packages/agent/src/compaction/compaction.ts`)**

- Dual WeakMaps: default vs `{ excludeEncryptedReasoning: true }` so a default hit never collides with a compaction-floor hit for the same object.
- Non-assistant objects (user, toolResult, bashExecution, …) are identity-memoized.
- Assistants are identity-memoized **only** when `isSettledAssistantMessage` is true: defined `usage` object **and** defined terminal `stopReason` that is not `"aborted"` / `"error"`. Streaming partials clear `stopReason` while mutating content in place under the same identity — those paths never read or insert either map.
- `estimateTokensUncached` is exported so tests can assert memo parity without a second module instance.
- `invalidateTokenEstimate(message)` deletes both option maps for that identity.

**Owner invalidation seams**

| Mutation | Token cache | Convert cache |
| --- | --- | --- |
| `pruneSupersededToolResults` / `pruneToolOutputs` | `invalidateTokenEstimate` at rewrite | `AgentSession` `#invalidateLlmConversionsFromBranch` after `rewriteEntries` |
| `applyShakeRegion` (toolResult + block) | `invalidateTokenEstimate` | same session branch invalidation after shake rewrite |
| `stripImagesFromMessage` | both `invalidateLlmConversion` and `invalidateTokenEstimate` when any image is removed | same |

This is **not** an immutable-history-only optimization. Streaming assistants stay out of the token-estimate maps; conversion hits retain the live assistant object and recheck `interruptedNext`. Mutable prune/shake/strip rewrites clear derived caches at the owner.

## Testing

**Behavioral (this PR):**

- `packages/agent/test/estimate-tokens-memo.test.ts` — suite `estimateTokens memo`:
  - memoized values match `estimateTokensUncached` for representative roles and both option poles
  - `excludeEncryptedReasoning` is option-separated from the default map
  - unsettled streaming assistants re-estimate on content / toolCall.arguments / same-length UTF-8 rewrites
  - settled assistants hit by identity once terminal
  - pruned tool results and shake toolResult rewrites re-estimate only after owner invalidation
- `packages/coding-agent/src/session/messages.test.ts` — `convertToLlm` additions:
  - identical `Message` element identity across unchanged convert calls
  - only the interrupted assistant recomputes when the continuity follower is inserted/removed; unrelated user conversion stays identity-stable
  - `stripImagesFromMessage` invalidates conversion and token caches in place
  - explicit `invalidateLlmConversion` after an in-place tool-result rewrite forces a fresh conversion

Commands:

```bash
bun test packages/agent/test/estimate-tokens-memo.test.ts
bun test packages/coding-agent/src/session/messages.test.ts
```

**Benchmarks (local measure):**

```bash
bun run packages/coding-agent/bench/llm-assembly.bench.ts
```

Measured on the redesigned N=5000 successive-episode / cold-sweep harness (fresh identities per episode; appends between timed converts):

| Metric | First | Steady / second | Speedup |
| --- | ---: | ---: | ---: |
| `convertToLlm` | 1.2978 ms | 0.0685 ms | **18.94×** |
| `estimateTokens` | 26.0182 ms | 1.4072 ms | **18.49×** |

These are empirical first/steady (convert) and cold first/second (estimate) medians from the post-memo harness, not asymptotic claims. Absolute publication gates (speedup ≥ 10× and **robust MAD noise ≤ 20%**) must pass on the atomic publication branch after the measurement PR lands; this draft does not publish unsupported raw or robust noise percentages as acceptance proof.

## Risks

- **Streaming assistants under the same identity:** `estimateTokens` never reads or inserts assistants that fail its settled gate. `convertToLlm` may reuse a cached array containing the live assistant object, so in-place deltas remain visible; it rechecks `interruptedNext` and recomputes when that neighbor-dependent transform changes.
- **In-place rewrites that forget invalidation:** prune/shake/strip must keep calling the invalidate helpers; a new rewrite owner that mutates content under an existing identity without invalidating will serve stale convert/estimate results until the object is replaced.
- **Held convert results:** callers that mutate the returned `Message[]` in place would poison later exact-repeat hits. Append reuse returns a sliced outer array so previous holders keep a stable snapshot; settings-dependent wrappers remain outside this cache.
- **Neighbor-flagged assistants only:** non-assistant roles ignore `interruptedNext`; only assistants recompute when the continuity follower appears or disappears.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

> **Note:** the `llm-assembly` benchmark referenced above ships in the measurement-infrastructure PR #5920 (it is not included in this branch); this PR contains only the production change and its tests.

---
