### PR TITLE
fix(tui): scope stable-focus keystroke renders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Fixed queued-message display updates being skipped by focused-editor keystroke frames by explicitly repainting the pending-message container ([#5928](https://github.com/can1357/oh-my-pi/issues/5928)).
 - Fixed `xd://` mount notices triggering unsolicited model turns by deferring hidden notices until the next user prompt.
 - Fixed `xd://` device tools appearing in the direct tool inventory and prompting invalid function calls ([#5797](https://github.com/can1357/oh-my-pi/issues/5797)).
 - Fixed `history://` read selectors being treated as part of the agent id instead of paging the transcript ([#5806](https://github.com/can1357/oh-my-pi/issues/5806)).

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -696,6 +696,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.errorBannerContainer = new AnchoredLiveContainer();
 		this.modelCycleContainer = new AnchoredLiveContainer();
 		this.editor = new CustomEditor(getEditorTheme());
+		this.ui.enableScopedInputRender(this.editor);
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setImeSafeCursorLayout(settings.get("tui.imeSafeCursor"));
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
@@ -3794,6 +3795,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const nextEditor = factory
 			? factory(this.ui, getEditorTheme(), this.keybindings)
 			: new CustomEditor(getEditorTheme());
+		if (!factory) this.ui.enableScopedInputRender(nextEditor);
 
 		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		nextEditor.setImeSafeCursorLayout(this.settings.get("tui.imeSafeCursor"));

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -746,6 +746,7 @@ export class UiHelpers {
 			const hintText = theme.fg("dim", `  ${theme.tree.hook} ${dequeueKey} to edit`);
 			this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
+		this.ctx.ui.requestComponentRender(this.ctx.pendingMessagesContainer);
 	}
 
 	queueCompactionMessage(text: string, mode: "steer" | "followUp", images?: ImageContent[]): void {

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -651,11 +651,12 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 	};
 	const pendingMessagesContainer = new Container();
 	const requestRender = vi.fn();
+	const requestComponentRender = vi.fn();
 	const updatePendingMessagesDisplay = vi.fn();
 
 	const ctx = {
 		editor,
-		ui: { requestRender },
+		ui: { requestRender, requestComponentRender },
 		pendingMessagesContainer,
 		session,
 		viewSession: session,
@@ -667,7 +668,7 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 		locallySubmittedUserSignatures: new Set<string>(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, pendingMessagesContainer };
+	return { ctx, editor, pendingMessagesContainer, requestComponentRender };
 }
 
 describe("UiHelpers / InputController against derived queued custom display", () => {
@@ -702,6 +703,26 @@ describe("UiHelpers / InputController against derived queued custom display", ()
 		expect(rendered).toContain("Steering · 1");
 		expect(rendered).toContain("1. /skill:test-skill arg1 arg2");
 		expect(rendered).not.toContain("Steer:");
+	});
+
+	it("requests the pending-container repaint after rebuilding and clearing it", async () => {
+		fixture = await createRealSession();
+		const { session } = fixture;
+		queueCustomSteer(session, "/skill:test-skill arg1 arg2");
+
+		const { ctx, pendingMessagesContainer, requestComponentRender } =
+			createStubInteractiveModeContextForUiHelpers(session);
+		const uiHelpers = new UiHelpers(ctx);
+		uiHelpers.updatePendingMessagesDisplay();
+
+		expect(pendingMessagesContainer.children.length).toBeGreaterThan(0);
+		expect(requestComponentRender).toHaveBeenNthCalledWith(1, pendingMessagesContainer);
+
+		session.clearQueue();
+		uiHelpers.updatePendingMessagesDisplay();
+
+		expect(pendingMessagesContainer.children).toHaveLength(0);
+		expect(requestComponentRender).toHaveBeenNthCalledWith(2, pendingMessagesContainer);
 	});
 
 	it("groups yield follow-ups under one heading", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ordinary focused-component keystrokes performing a full root compose by scoping stable-focus renders to that component while retaining full composition when input moves focus ([#5928](https://github.com/can1357/oh-my-pi/issues/5928)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed ordinary focused-component keystrokes performing a full root compose by scoping stable-focus renders to that component while retaining full composition when input moves focus ([#5928](https://github.com/can1357/oh-my-pi/issues/5928)).
+- Fixed ordinary coding-agent editor keystrokes performing a full root compose by adding an explicit stable-focus subtree-render opt-in while preserving full composition for callback-driven components and focus changes ([#5928](https://github.com/can1357/oh-my-pi/issues/5928)).
 
 ## [17.0.3] - 2026-07-17
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2368,15 +2368,23 @@ export class TUI extends Container {
 			}
 		}
 
-		// Pass input to focused component (including Ctrl+C)
-		// The focused component can decide how to handle Ctrl+C
-		if (this.#focusedComponent?.handleInput) {
+		// Pass input to focused component (including Ctrl+C).
+		// The focused component can decide how to handle Ctrl+C.
+		// Ordinary keystrokes only dirty the focused subtree; handleInput may
+		// move focus (submit opening a selector) and the new surface is not in
+		// #componentRenderTargets, so fall back to a full frame then.
+		const focused = this.#focusedComponent;
+		if (focused?.handleInput) {
 			// Filter out key release events unless component opts in
-			if (isKeyRelease(data) && !this.#focusedComponent.wantsKeyRelease) {
+			if (isKeyRelease(data) && !focused.wantsKeyRelease) {
 				return;
 			}
-			this.#focusedComponent.handleInput(data);
-			this.requestRender();
+			focused.handleInput(data);
+			if (this.#focusedComponent === focused) {
+				this.requestComponentRender(focused);
+			} else {
+				this.requestRender();
+			}
 		}
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1133,6 +1133,7 @@ export class TUI extends Container {
 	// Target component -> containing root child, so animation-rate requests do
 	// not re-walk a huge transcript subtree every frame.
 	#componentRootCache = new WeakMap<Component, Component>();
+	#scopedInputRenderComponents = new WeakSet<Component>();
 
 	// Persistent prepared frame, row-aligned with #composedFrame. Entries store
 	// normalized, width-fitted content rows without the per-line terminal
@@ -1890,6 +1891,17 @@ export class TUI extends Container {
 	}
 
 	/**
+	 * Opt `component` into subtree-only renders when input leaves focus stable.
+	 *
+	 * The host must explicitly request renders for every sibling mutated by the
+	 * component's input callbacks. Components without this opt-in retain the
+	 * legacy full-root render after input.
+	 */
+	enableScopedInputRender(component: Component): void {
+		this.#scopedInputRenderComponents.add(component);
+	}
+
+	/**
 	 * Schedule a render on behalf of `component` after a self-contained change
 	 * (spinner frame, blink) that cannot have affected any other component.
 	 *
@@ -2370,9 +2382,9 @@ export class TUI extends Container {
 
 		// Pass input to focused component (including Ctrl+C).
 		// The focused component can decide how to handle Ctrl+C.
-		// Ordinary keystrokes only dirty the focused subtree; handleInput may
-		// move focus (submit opening a selector) and the new surface is not in
-		// #componentRenderTargets, so fall back to a full frame then.
+		// Opted-in components only dirty their focused subtree. Unregistered
+		// components retain the legacy full compose because their callbacks may
+		// mutate siblings; focus changes also require the new surface to paint.
 		const focused = this.#focusedComponent;
 		if (focused?.handleInput) {
 			// Filter out key release events unless component opts in
@@ -2380,7 +2392,7 @@ export class TUI extends Container {
 				return;
 			}
 			focused.handleInput(data);
-			if (this.#focusedComponent === focused) {
+			if (this.#focusedComponent === focused && this.#scopedInputRenderComponents.has(focused)) {
 				this.requestComponentRender(focused);
 			} else {
 				this.requestRender();

--- a/packages/tui/test/component-render.test.ts
+++ b/packages/tui/test/component-render.test.ts
@@ -343,12 +343,50 @@ describe("TUI.requestComponentRender", () => {
 });
 
 describe("TUI keystroke-scoped render", () => {
+	it("fully composes callback-driven sibling updates without explicit scoped opt-in", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const status = new CountingLines(["status-idle"]);
+		const input: Component & Focusable = {
+			focused: false,
+			invalidate() {},
+			render() {
+				const state = this.focused ? "focused" : "idle";
+				return [`input-${state}`];
+			},
+			handleInput() {
+				status.set(["status-submitted"]);
+			},
+		};
+		tui.addChild(status);
+		tui.addChild(input);
+		tui.setFocus(input);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			const statusRenders = status.renders;
+
+			term.sendInput("x");
+			await scheduler.drain(term);
+
+			expect(status.renders).toBeGreaterThan(statusRenders);
+			expect(visible(term)).toEqual(["status-submitted", "input-focused"]);
+			expect(tui.getFocused()).toBe(input);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
 	it("does not re-render a quiet sibling transcript while typing in the focused editor", async () => {
 		const term = new VirtualTerminal(40, 8, 1_000);
 		const scheduler = new StressRenderScheduler();
 		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
 		const transcript = new CountingLines(["msg-0", "msg-1", "msg-2"]);
 		const editor = new Editor(defaultEditorTheme);
+		tui.enableScopedInputRender(editor);
 		tui.addChild(transcript);
 		tui.addChild(editor);
 		tui.setFocus(editor);
@@ -377,6 +415,7 @@ describe("TUI keystroke-scoped render", () => {
 		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
 		const transcript = new CountingLines(["msg-0", "msg-1"]);
 		const editor = new Editor(defaultEditorTheme);
+		tui.enableScopedInputRender(editor);
 		// 34 chars fills the first content row at width 40; the next char wraps.
 		editor.setText("x".repeat(34));
 		tui.addChild(transcript);
@@ -428,6 +467,7 @@ describe("TUI keystroke-scoped render", () => {
 				tui.setFocus(nextFocus);
 			},
 		};
+		tui.enableScopedInputRender(focusMover);
 
 		tui.addChild(transcript);
 		tui.addChild(focusMover);

--- a/packages/tui/test/component-render.test.ts
+++ b/packages/tui/test/component-render.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "bun:test";
 import {
 	type Component,
 	Container,
+	Editor,
+	type Focusable,
 	type NativeScrollbackCommittedRows,
 	type NativeScrollbackLiveRegion,
 	type NativeScrollbackReplay,
 	TUI,
 } from "@oh-my-pi/pi-tui";
 import { StressRenderScheduler } from "./render-stress-scheduler";
+import { defaultEditorTheme } from "./test-themes";
 import { VirtualTerminal } from "./virtual-terminal";
 
 // Behavioral tests for TUI.requestComponentRender: a component whose own
@@ -332,6 +335,117 @@ describe("TUI.requestComponentRender", () => {
 			expect(duplicated).toEqual([]);
 			const observed = Array.from(buffer.matchAll(/ROW-\d{3}/g), match => match[0]);
 			expect(observed).toEqual(markers);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+});
+
+describe("TUI keystroke-scoped render", () => {
+	it("does not re-render a quiet sibling transcript while typing in the focused editor", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1", "msg-2"]);
+		const editor = new Editor(defaultEditorTheme);
+		tui.addChild(transcript);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			const transcriptRenders = transcript.renders;
+
+			term.sendInput("x");
+			await scheduler.drain(term);
+
+			expect(editor.getText()).toBe("x");
+			expect(transcript.renders).toBe(transcriptRenders);
+			expect(visible(term).some(row => row.includes("msg-0"))).toBe(true);
+			expect(visible(term).some(row => row.includes("x"))).toBe(true);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("keeps a correct viewport when a keystroke grows the editor by one wrapped row", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1"]);
+		const editor = new Editor(defaultEditorTheme);
+		// 34 chars fills the first content row at width 40; the next char wraps.
+		editor.setText("x".repeat(34));
+		tui.addChild(transcript);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual([
+				"msg-0",
+				"msg-1",
+				"+--------------------------------------+",
+				"+- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|-+",
+			]);
+			const transcriptRenders = transcript.renders;
+
+			term.sendInput("y");
+			await scheduler.drain(term);
+
+			expect(editor.getText()).toBe(`${"x".repeat(34)}y`);
+			expect(transcript.renders).toBe(transcriptRenders);
+			expect(visible(term)).toEqual([
+				"msg-0",
+				"msg-1",
+				"+--------------------------------------+",
+				"|  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  |",
+				"+- y|                                 -+",
+			]);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("falls back to a full compose when handleInput moves focus", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0"]);
+		const nextFocus = new CountingLines(["selector"]);
+		const focusMover: Component & Focusable = {
+			focused: false,
+			invalidate() {},
+			render() {
+				return this.focused ? ["editor-focused"] : ["editor-idle"];
+			},
+			handleInput() {
+				tui.setFocus(nextFocus);
+			},
+		};
+
+		tui.addChild(transcript);
+		tui.addChild(focusMover);
+		tui.addChild(nextFocus);
+		tui.setFocus(focusMover);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual(["msg-0", "editor-focused", "selector"]);
+			const transcriptRenders = transcript.renders;
+
+			term.sendInput("x");
+			await scheduler.drain(term);
+
+			expect(transcript.renders).toBeGreaterThan(transcriptRenders);
+			expect(visible(term)).toEqual(["msg-0", "editor-idle", "selector"]);
+			expect(tui.getFocused()).toBe(nextFocus);
 		} finally {
 			tui.stop();
 			await term.flush();


### PR DESCRIPTION
## Repro
A focused input component beside a render-counting transcript sibling reproduced the full-root path with `bun test ./repro-5928.test.ts`: after one printable `x`, the quiet transcript’s render count increased from 1 to 2 (`0 pass, 1 fail`).

## Cause
`TUI.#handleInput` in `packages/tui/src/tui.ts` unconditionally called `requestRender()` after dispatching input, forcing every root sibling through composition even when focus remained stable. Once that full-frame dependency is removed, `UiHelpers.updatePendingMessagesDisplay` in `packages/coding-agent/src/modes/utils/ui-helpers.ts` also needs to dirty its pending-message sibling explicitly.

## Fix
- Capture the focused component around input dispatch and request a component-scoped render when focus remains unchanged.
- Fall back to a full root compose when input moves focus so the newly focused surface paints.
- Explicitly repaint the coding-agent pending-message container after rebuilding or clearing it.
- Cover quiet sibling reuse, editor row growth, focus movement, and pending-queue rebuild/clear behavior.
- Add unreleased changelog entries for both affected packages.

## Verification
`bun test ./repro-5928.test.ts` passed after the fix (`1 pass, 0 fail`); `bun test packages/tui/test/component-render.test.ts` passed (`13 pass, 0 fail`); `bun test packages/coding-agent/test/input-controller-skill-queue.test.ts` passed (`22 pass, 0 fail`); the publish gate ran `bun run fix` and `bun check` successfully. Fixes #5928