### PR TITLE
fix(coding-agent): parallelize session teardown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/exit` hanging on post-prompt work and stacking independent subsystem teardown delays by bounding the aborted-work drain, disposing independent session resources concurrently, and keeping long shutdown waits visible ([#5932](https://github.com/can1357/oh-my-pi/issues/5932)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -208,6 +208,8 @@ import type {
 } from "./types";
 import { UiHelpers } from "./utils/ui-helpers";
 
+const STILL_CLOSING_DELAY_MS = 3_000;
+
 const HINT_SHIMMER_PALETTE: ShimmerPalette = {
 	low: "dim",
 	mid: "muted",
@@ -3746,10 +3748,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		// first runs the work, the other awaits the same settled promise.
 		// The teardown is registered lazily in `init()` — a `/exit` reached
 		// before `init()` completed falls back to a direct dispose.
-		if (this.#signalTeardown) {
-			await this.#signalTeardown();
-		} else {
-			await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+		const stillClosingTimer = setTimeout(() => {
+			this.showStatus("Still closing… (flushing memory backend / network)");
+		}, STILL_CLOSING_DELAY_MS);
+		try {
+			if (this.#signalTeardown) {
+				await this.#signalTeardown();
+			} else {
+				await this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
+			}
+		} finally {
+			clearTimeout(stillClosingTimer);
 		}
 
 		// Do not force a final render during teardown: disposed session/UI state can

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6714,6 +6714,83 @@ export class AgentSession {
 		return this.#disposeCall;
 	}
 
+	async #disposeOwnedAsyncJobs(): Promise<void> {
+		this.#cancelOwnAsyncJobs();
+		const manager = this.#ownedAsyncJobManager;
+		if (!manager) return;
+
+		try {
+			const drained = await manager.dispose({ timeoutMs: 3_000 });
+			const deliveryState = manager.getDeliveryState();
+			if (drained === false && deliveryState) {
+				logger.warn("Async job completion deliveries still pending during dispose", { ...deliveryState });
+			}
+		} finally {
+			if (AsyncJobManager.instance() === manager) {
+				AsyncJobManager.setInstance(undefined);
+			}
+		}
+	}
+
+	async #disposeEvalKernels(): Promise<void> {
+		const settled = await this.#prepareEvalExecutionsForDispose();
+		if (!settled) {
+			logger.warn("Detaching retained eval-kernel ownership during dispose while eval execution is still active");
+		}
+
+		const results = await Promise.allSettled([
+			disposeKernelSessionsByOwner(this.#evalKernelOwnerId),
+			disposeRubyKernelSessionsByOwner(this.#evalKernelOwnerId),
+			disposeJuliaKernelSessionsByOwner(this.#evalKernelOwnerId),
+		]);
+		const errors: unknown[] = [];
+		for (const result of results) {
+			if (result.status === "rejected") errors.push(result.reason);
+		}
+		if (errors.length > 0) throw new AggregateError(errors, "Failed to dispose one or more eval kernels");
+	}
+
+	async #releaseOwnedBrowserTabs(ownerId: string | undefined): Promise<void> {
+		if (!ownerId) return;
+		try {
+			const released = await withTimeout(
+				releaseTabsForOwner(ownerId, { kill: true }),
+				3_000,
+				"Timed out releasing owned browser tabs during dispose",
+			);
+			if (released > 0) {
+				logger.debug("Released owned browser tabs during dispose", { ownerId, released });
+			}
+		} catch (error) {
+			logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
+		}
+	}
+
+	async #disconnectOwnedMcp(): Promise<void> {
+		if (!this.#disconnectOwnedMcpManager) return;
+		try {
+			await withTimeout(
+				this.#disconnectOwnedMcpManager(),
+				3_000,
+				"Timed out disconnecting owned MCP manager during dispose",
+			);
+		} catch (error) {
+			logger.warn("Failed to disconnect owned MCP manager during dispose", { error: String(error) });
+		}
+	}
+
+	async #disposeMnemopi(
+		state: MnemopiSessionState | undefined,
+		consolidateTimeoutMs: number | undefined,
+	): Promise<void> {
+		try {
+			await state?.dispose({ timeoutMs: consolidateTimeoutMs });
+		} finally {
+			// Consolidation may embed final memories, so terminate its worker only afterward.
+			await shutdownMnemopiEmbedClient();
+		}
+	}
+
 	async #doDispose(options: AgentSessionDisposeOptions = {}): Promise<void> {
 		this.beginDispose();
 		this.#recordSessionExit(options.reason ?? "dispose");
@@ -6726,124 +6803,50 @@ export class AgentSession {
 		} catch (error) {
 			logger.warn("Failed to emit session_shutdown event", { error: String(error) });
 		}
-		// Clear any timers extensions scheduled via `ctx.setInterval`/`ctx.setTimeout`
-		// so their background work does not outlive the session (issue #5664).
-		// Optional-called: hosts and tests may inject partial runner facades that
-		// implement only the dispatch surface.
+
+		// Stop extension timers before aborting deferred work they could enqueue.
 		this.#extensionRunner?.clearManagedTimers?.();
 		this.#fallbackExtensionTimers?.clearAll();
-		// Abort post-prompt work so the drain below can complete. Without this, a
-		// deferred-handoff task that has already advanced into
-		// `await this.handoff(...) → generateHandoff(...)` keeps awaiting a live LLM stream
-		// — Promise.allSettled() in #cancelPostPromptTasks then waits forever, freezing
-		// /exit and Ctrl+C-double-tap. The post-prompt task's own AbortSignal does not
-		// propagate into the inner handoff/compaction controllers, so we abort them
-		// explicitly. agent.abort() is needed for an agent.continue() that may have
-		// raced the deferred handoff (its streaming loop is awaited by the wrapper IIFE).
-		//
-		// Tool work (bash/eval/python) is NOT aborted here — those have their own
-		// dispose paths and shared kernels are contractually allowed to survive a
-		// session's dispose.
 		this.abortRetry();
 		this.abortCompaction();
 		const postPromptDrain = this.#cancelPostPromptTasks();
 		this.agent.abort();
-		await postPromptDrain;
+		try {
+			await withTimeout(postPromptDrain, 5_000, "Timed out draining post-prompt tasks during dispose");
+		} catch (error) {
+			logger.warn("Post-prompt tasks still draining at dispose deadline", { error: String(error) });
+		}
 		await this.#drainAutolearnCapture();
-		// Cancel jobs this agent registered so a subagent's teardown doesn't
-		// leak its background bash/task work into the parent's manager. Only
-		// the session that owns the manager goes on to dispose it (which itself
-		// nukes any leftover jobs and pending deliveries).
-		this.#cancelOwnAsyncJobs();
-		const ownedAsyncManager = this.#ownedAsyncJobManager;
-		if (ownedAsyncManager) {
-			const drained = await ownedAsyncManager.dispose({ timeoutMs: 3_000 });
-			const deliveryState = ownedAsyncManager.getDeliveryState();
-			if (drained === false && deliveryState) {
-				logger.warn("Async job completion deliveries still pending during dispose", { ...deliveryState });
-			}
-			if (AsyncJobManager.instance() === ownedAsyncManager) {
-				AsyncJobManager.setInstance(undefined);
-			}
-		}
-		const evalExecutionsSettled = await this.#prepareEvalExecutionsForDispose();
-		if (!evalExecutionsSettled) {
-			logger.warn("Detaching retained eval-kernel ownership during dispose while eval execution is still active");
-		}
-		await disposeKernelSessionsByOwner(this.#evalKernelOwnerId);
-		await disposeRubyKernelSessionsByOwner(this.#evalKernelOwnerId);
-		await disposeJuliaKernelSessionsByOwner(this.#evalKernelOwnerId);
-		// Release headless / spawned Chromium and worker tabs this session
-		// opened via the browser tool. The tool's `tabs`/`browsers` maps are
-		// module-global — subagents and future sessions share them — so we
-		// walk by `ownerSessionId` (assigned at `acquireTab` creation, never on
-		// reuse) and touch only what THIS session created. Bounded so a broken
-		// CDP close cannot stall `/exit`; mirrors the async-job/MCP pattern.
-		// (Issue #3963.)
-		const browserOwnerId = this.sessionManager.getSessionId();
-		if (browserOwnerId) {
-			try {
-				const released = await withTimeout(
-					releaseTabsForOwner(browserOwnerId, { kill: true }),
-					3_000,
-					"Timed out releasing owned browser tabs during dispose",
-				);
-				if (released > 0) {
-					logger.debug("Released owned browser tabs during dispose", { ownerId: browserOwnerId, released });
-				}
-			} catch (error) {
-				logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
+
+		const hindsightState = this.getHindsightSessionState();
+		const mnemopiState = setMnemopiSessionState(this, undefined);
+		const advisorRecorderClosed = this.#advisorRecorderClosed;
+		const results = await Promise.allSettled([
+			this.#disposeOwnedAsyncJobs(),
+			this.#disposeEvalKernels(),
+			this.#releaseOwnedBrowserTabs(this.sessionManager.getSessionId()),
+			shutdownTinyTitleClient(),
+			this.#disconnectOwnedMcp(),
+			advisorRecorderClosed,
+			hindsightState?.flushRetainQueue() ?? Promise.resolve(),
+			this.#disposeMnemopi(mnemopiState, options.mnemopiConsolidateTimeoutMs),
+		]);
+		for (const result of results) {
+			if (result.status === "rejected") {
+				logger.warn("Session dispose subsystem failed during parallel teardown", {
+					error: String(result.reason),
+				});
 			}
 		}
-		await shutdownTinyTitleClient();
+
 		this.#releasePowerAssertion();
-		// Clean up an empty session created by this session's /move so it doesn't accumulate.
 		await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
 		this.#movedFromEmptySessionFile = undefined;
+		// All teardown branches that can append session entries have settled.
 		await this.sessionManager.close();
-		// beginDispose() stopped the advisor and captured its recorder close; await
-		// it so the final advisor turn is flushed before the process may exit.
-		await this.#advisorRecorderClosed;
 		this.#closeAllProviderSessions("dispose");
-		// Disconnect the MCP manager this session OWNS so its stdio servers are
-		// not orphaned at exit. Best-effort: a failure here must never throw out
-		// of dispose. Only owning (top-level) sessions provide this callback;
-		// subagents reuse a parent's manager and must not tear it down. Idempotent
-		// with the deferred-discovery disconnect in `createAgentSession`.
-		//
-		// BOUNDED: an owned manager may hold an HTTP/SSE server whose session-
-		// termination DELETE blocks up to the MCP request timeout (30s default,
-		// unbounded when OMP_MCP_TIMEOUT_MS=0), so awaiting `disconnectAll()`
-		// unbounded would stall /exit and print-mode shutdown on a broken remote
-		// endpoint. Race it against a short deadline — stdio close (the subprocess
-		// reap this targets) completes well within the bound; a slow transport
-		// close is left to finish detached. Mirrors the bounded async-job teardown.
-		if (this.#disconnectOwnedMcpManager) {
-			try {
-				await withTimeout(
-					this.#disconnectOwnedMcpManager(),
-					3_000,
-					"Timed out disconnecting owned MCP manager during dispose",
-				);
-			} catch (error) {
-				logger.warn("Failed to disconnect owned MCP manager during dispose", { error: String(error) });
-			}
-		}
-		// Flush the retain queue BEFORE clearing the session's pointer so
-		// `HindsightRetainQueue.#doFlush` still sees `session.getHindsightSessionState() === state`.
-		// Reversed, the spliced batch survives just long enough to fail the
-		// identity check and get dropped with a `session vanished` warning.
-		const hindsightState = this.getHindsightSessionState();
-		await hindsightState?.flushRetainQueue();
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();
-		const mnemopiState = setMnemopiSessionState(this, undefined);
-		await mnemopiState?.dispose({ timeoutMs: options.mnemopiConsolidateTimeoutMs });
-		// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
-		// consolidate-on-dispose may still call `embed()` to store the final
-		// memories, and that round-trips through the worker we are about to
-		// hard-kill (issue #3031).
-		await shutdownMnemopiEmbedClient();
 		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();
@@ -7693,6 +7696,12 @@ export class AgentSession {
 	 */
 	get hasPostPromptWork(): boolean {
 		return this.#postPromptTasks.size > 0;
+	}
+
+	/** Register post-prompt work in tests without driving a full agent turn. */
+	trackPostPromptTaskForTests(task: Promise<unknown>): void {
+		if (!isBunTestRuntime()) throw new Error("trackPostPromptTaskForTests is test-only");
+		this.#trackPostPromptTask(task);
 	}
 
 	/** All messages including custom types like BashExecutionMessage */

--- a/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-concurrent.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
+import { MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
+
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("AgentSession concurrent disposal", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@omp-dispose-concurrent-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		vi.useRealTimers();
+		const current = session;
+		session = undefined;
+		if (current) await current.dispose();
+		authStorage.close();
+		AsyncJobManager.resetForTests();
+		vi.restoreAllMocks();
+		tempDir.removeSync();
+	});
+
+	function createSession(ownedAsyncJobManager?: AsyncJobManager): AgentSession {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected bundled model");
+		const mock = createMockModel({ handler: () => ({ content: ["ok"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml")),
+			ownedAsyncJobManager,
+			agentId: "Main",
+		});
+		return session;
+	}
+
+	it("starts independent writers together and closes persistence after their barrier", async () => {
+		const owned = new AsyncJobManager({ maxRunningJobs: 1, retentionMs: 1_000, onJobComplete: () => {} });
+		const asyncGate = Promise.withResolvers<void>();
+		const hindsightGate = Promise.withResolvers<void>();
+		const mnemopiGate = Promise.withResolvers<void>();
+		const asyncStarted = Promise.withResolvers<void>();
+		const order: string[] = [];
+		vi.spyOn(owned, "dispose").mockImplementation(async () => {
+			order.push("async:start");
+			asyncStarted.resolve();
+			await asyncGate.promise;
+			order.push("async:end");
+			return true;
+		});
+
+		const current = createSession(owned);
+		const hindsight: HindsightSessionState = Object.create(HindsightSessionState.prototype);
+		vi.spyOn(hindsight, "flushRetainQueue").mockImplementation(async () => {
+			order.push("hindsight:start");
+			await hindsightGate.promise;
+			order.push("hindsight:end");
+		});
+		vi.spyOn(hindsight, "dispose").mockImplementation(() => {});
+		current.setHindsightSessionState(hindsight);
+
+		const mnemopi: MnemopiSessionState = Object.create(MnemopiSessionState.prototype);
+		vi.spyOn(mnemopi, "dispose").mockImplementation(async () => {
+			order.push("mnemopi:start");
+			await mnemopiGate.promise;
+			order.push("mnemopi:end");
+		});
+		setMnemopiSessionState(current, mnemopi);
+
+		let persistenceClosed = false;
+		vi.spyOn(current.sessionManager, "close").mockImplementation(async () => {
+			persistenceClosed = true;
+			order.push("session:close");
+		});
+
+		const dispose = current.dispose();
+		try {
+			await asyncStarted.promise;
+			await Promise.resolve();
+			expect(order).toContain("hindsight:start");
+			expect(order).toContain("mnemopi:start");
+			expect(order).not.toContain("async:end");
+			expect(order).not.toContain("hindsight:end");
+			expect(order).not.toContain("mnemopi:end");
+			expect(persistenceClosed).toBe(false);
+		} finally {
+			asyncGate.resolve();
+			hindsightGate.resolve();
+			mnemopiGate.resolve();
+		}
+		await dispose;
+		session = undefined;
+
+		const closeAt = order.indexOf("session:close");
+		expect(closeAt).toBeGreaterThan(order.indexOf("async:end"));
+		expect(closeAt).toBeGreaterThan(order.indexOf("hindsight:end"));
+		expect(closeAt).toBeGreaterThan(order.indexOf("mnemopi:end"));
+	});
+
+	it("bounds post-prompt work that ignores abort", async () => {
+		vi.useFakeTimers();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const current = createSession();
+		const hangingTask = Promise.withResolvers<void>();
+		current.trackPostPromptTaskForTests(hangingTask.promise);
+
+		const dispose = current.dispose();
+		await flushMicrotasks();
+		vi.advanceTimersByTime(5_000);
+		await flushMicrotasks();
+		await dispose;
+		session = undefined;
+
+		expect(warn).toHaveBeenCalledWith(
+			"Post-prompt tasks still draining at dispose deadline",
+			expect.objectContaining({ error: "Error: Timed out draining post-prompt tasks during dispose" }),
+		);
+	});
+
+	it("clears the owned async manager when its dispose rejects", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const owned = new AsyncJobManager({ maxRunningJobs: 1, retentionMs: 1_000, onJobComplete: () => {} });
+		vi.spyOn(owned, "dispose").mockRejectedValue(new Error("async dispose failed"));
+		AsyncJobManager.setInstance(owned);
+		const current = createSession(owned);
+
+		await current.dispose();
+		session = undefined;
+
+		expect(AsyncJobManager.instance()).toBeUndefined();
+		expect(warn).toHaveBeenCalledWith("Session dispose subsystem failed during parallel teardown", {
+			error: "Error: async dispose failed",
+		});
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-still-closing.test.ts
+++ b/packages/coding-agent/test/interactive-mode-still-closing.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
+
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("InteractiveMode long shutdown status", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@omp-still-closing-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected bundled model");
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+		mode.ui.terminal.drainInput = async () => {};
+		vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+	});
+
+	afterEach(async () => {
+		vi.useRealTimers();
+		mode.stop();
+		vi.restoreAllMocks();
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("refreshes the existing status while teardown remains pending", async () => {
+		vi.useFakeTimers();
+		const statuses: string[] = [];
+		vi.spyOn(mode, "showStatus").mockImplementation(message => {
+			statuses.push(message);
+		});
+		const teardown = Promise.withResolvers<void>();
+		vi.spyOn(session, "dispose").mockImplementation(() => teardown.promise);
+
+		const shutdown = mode.shutdown();
+		await flushMicrotasks();
+		expect(statuses).toEqual(["Closing session…"]);
+
+		vi.advanceTimersByTime(2_999);
+		await flushMicrotasks();
+		expect(statuses).toEqual(["Closing session…"]);
+		vi.advanceTimersByTime(1);
+		await flushMicrotasks();
+		expect(statuses).toEqual(["Closing session…", "Still closing… (flushing memory backend / network)"]);
+
+		teardown.resolve();
+		await shutdown;
+		vi.advanceTimersByTime(10_000);
+		await flushMicrotasks();
+		expect(statuses).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## Repro
`bun test packages/coding-agent/test/repro-5932.test.ts` reproduced the serialized teardown: the causal order was `async:start -> async:end -> hindsight:start -> hindsight:end`, and the concurrent-start assertion failed (`Expected: true`, `Received: false`). Inspection also showed `AgentSession.#doDispose` awaiting `#cancelPostPromptTasks()` without a deadline.

## Cause
`AgentSession.#doDispose` in `packages/coding-agent/src/session/agent-session.ts` awaited each independent owner cleanup in sequence, so async jobs, eval kernels, browser tabs, the tiny client, MCP, advisor recording, Hindsight, and mnemopi contributed additive latency. Its post-prompt cancellation drain used an unbounded `Promise.allSettled`, while `InteractiveMode.shutdown` only rendered the initial closing status.

## Fix
- Bound the aborted post-prompt drain at five seconds, preserving a warning when work ignores abort.
- Start independent subsystem disposals together under `Promise.allSettled`, with eval-language cleanup settled as a group and mnemopi embedding shutdown ordered after consolidation.
- Keep async-job delivery, Hindsight, mnemopi, and normal post-prompt writers ahead of `SessionManager.close()`.
- Refresh the existing interactive status after three seconds when teardown is still pending.
- Add causal concurrency, persistence-barrier, bounded-drain, failed-manager cleanup, and delayed-status regression coverage plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/agent-session-dispose-concurrent.test.ts packages/coding-agent/test/interactive-mode-still-closing.test.ts` — 4 passed, 0 failed. `bun test packages/coding-agent/test/agent-session-dispose-concurrent.test.ts packages/coding-agent/test/interactive-mode-still-closing.test.ts packages/coding-agent/test/mcp-dispose-disconnect-bounded.test.ts packages/coding-agent/test/tools/browser-dispose-timeout.test.ts packages/coding-agent/test/agent-session-title-generation-dispose.test.ts packages/coding-agent/test/status-line-dispose-async-leak.test.ts` — 10 passed, 0 failed. `bun check` passed. Fixes #5932