### PR TITLE
fix(tui): compact committed finalized transcript history

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the transcript keeping finalized assistant blocks in the live compose walk after their rows entered native terminal scrollback, making each stream tick's `TranscriptContainer.render` depth-linear in session length. Fully committed finalized blocks are now compacted out of the local frame regardless of post-finalize version tracking; a later mutation no longer recommits on ordinary frames (no duplication) and rehydrates on the next destructive full replay (no loss). Compose cost for a live tail tick is now flat as depth grows (`bench/transcript-compose.bench.ts`: ratio(N5000/N500) 2.30 → 0.90) ([#5930](https://github.com/can1357/oh-my-pi/issues/5930)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/bench/transcript-compose.bench.ts
+++ b/packages/coding-agent/bench/transcript-compose.bench.ts
@@ -1,0 +1,131 @@
+/**
+ * Benchmark: transcript compose cost vs session depth
+ * (perf/transcript-compose-flat-after-commit)
+ *
+ * A long interactive session finalizes assistant blocks and emits their rows
+ * into native terminal scrollback. Once committed, those rows are immutable
+ * history the terminal owns; the local {@link TranscriptContainer} should drop
+ * them from its frame so a live tail mutation does not re-walk sealed history.
+ *
+ * This bench builds N finalized assistant blocks (prose + closed code fences),
+ * commits every finalized row into native scrollback, then times one pure
+ * `TranscriptContainer.render(width)` per streaming tick of a single live tail
+ * block. Depth-linear cost (ms rising with N) means sealed history is still
+ * walked and re-assembled each tick; flat cost means the committed prefix was
+ * compacted and only the live tail composes.
+ *
+ * Target after the fix: ratio(N5000/N500) <= 1.3, N5000 p95 < 10 ms.
+ */
+
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { Settings } from "../src/config/settings";
+import { AssistantMessageComponent } from "../src/modes/components/assistant-message";
+import { TranscriptContainer } from "../src/modes/components/transcript-container";
+import { initTheme } from "../src/modes/theme/theme";
+
+const WIDTH = 100;
+const SIZES = [500, 5000];
+const WARMUP = 20;
+const SAMPLES = 200;
+
+function makeMarkdownCorpus(targetGraphemes: number): string {
+	const para =
+		"The quick brown fox jumps over the lazy dog while 🚀 emoji and a `code span` " +
+		"plus **bold** and _italic_ text exercise the markdown lexer and the grapheme segmenter. ";
+	const codeBlock = "\n```ts\nconst x: number = compute(a, b) + delta;\nreturn x.toFixed(2);\n```\n\n";
+	const list = "\n- first bullet item\n- second bullet item with `inline`\n- third\n\n";
+	let out = "";
+	let i = 0;
+	while (out.length < targetGraphemes) {
+		out += `## Section ${++i}\n\n${para}${para}${codeBlock}${list}`;
+	}
+	return out.slice(0, targetGraphemes);
+}
+
+function makeTextMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "bench",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+	return sorted[idx]!;
+}
+
+/** Build N committed finalized blocks + a live tail, return per-tick render medians/p95. */
+function measure(n: number): { median: number; p95: number } {
+	const histText = makeMarkdownCorpus(240);
+	const tailCorpus = makeMarkdownCorpus(1200);
+	const container = new TranscriptContainer();
+	for (let i = 0; i < n; i++) {
+		const c = new AssistantMessageComponent();
+		c.updateContent(makeTextMessage(histText));
+		c.markTranscriptBlockFinalized();
+		container.addChild(c);
+	}
+	const tail = new AssistantMessageComponent();
+	container.addChild(tail);
+	let revealed = Math.floor(tailCorpus.length * 0.5);
+	tail.updateContent(makeTextMessage(tailCorpus.slice(0, revealed)), { transient: true });
+
+	// Warm every block's markdown L1 cache and establish the assembled frame,
+	// then commit exactly the seam the container reports (what the TUI does):
+	// every finalized-history row plus the separator before the live tail. The
+	// container compacts that committed prefix on the next render.
+	container.render(WIDTH);
+	const committed = container.getNativeScrollbackLiveRegionStart() ?? 0;
+	container.setNativeScrollbackCommittedRows(committed);
+	container.render(WIDTH);
+
+	const tick = () => {
+		revealed += 20;
+		if (revealed > tailCorpus.length) revealed = Math.floor(tailCorpus.length * 0.5);
+		tail.updateContent(makeTextMessage(tailCorpus.slice(0, revealed)), { transient: true });
+		container.render(WIDTH);
+	};
+
+	for (let i = 0; i < WARMUP; i++) tick();
+	const samples: number[] = [];
+	for (let i = 0; i < SAMPLES; i++) {
+		const start = Bun.nanoseconds();
+		tick();
+		samples.push((Bun.nanoseconds() - start) / 1e6);
+	}
+	samples.sort((a, b) => a - b);
+	return { median: percentile(samples, 50), p95: percentile(samples, 95) };
+}
+
+await Settings.init({ inMemory: true });
+await initTheme("dark");
+
+console.log(`\nBenchmark: transcript-compose (live tail tick after committed finalized history, width ${WIDTH})\n`);
+
+const results = SIZES.map(n => {
+	const r = measure(n);
+	console.log(`  N=${n}: median ${r.median.toFixed(4)}ms  p95 ${r.p95.toFixed(4)}ms`);
+	return r;
+});
+
+const small = results[0]!;
+const large = results[results.length - 1]!;
+const ratio = large.median / small.median;
+console.log(
+	`\n  ratio(N${SIZES[SIZES.length - 1]}/N${SIZES[0]}) median = ${ratio.toFixed(3)}  ` +
+		`(target <= 1.3; N${SIZES[SIZES.length - 1]} p95 = ${large.p95.toFixed(4)}ms, target < 10ms)\n`,
+);

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -19,11 +19,17 @@ interface FinalizableBlock {
 	/**
 	 * Monotonic content version for blocks that can still mutate *after*
 	 * reporting finalized (e.g. `AssistantMessageComponent`: the inline error
-	 * restored at the next turn's `agent_start`, late tool-result images). The
-	 * committed-scrollback render bypass only replays a block's previous rows
-	 * when the version is unchanged; without this signal a post-finalize
-	 * mutation would stay invisible until a global invalidation. Blocks that
-	 * never mutate post-finalize simply omit the method.
+	 * restored at the next turn's `agent_start`, late tool-result images). While
+	 * the block's rows are still on screen (not yet fully committed), the
+	 * committed-scrollback render bypass replays its previous rows only when the
+	 * version is unchanged; a bump forces a real render so the TUI's
+	 * committed-prefix audit can observe and re-anchor the change. Once the rows
+	 * fully commit to native scrollback they are dropped from the local frame
+	 * (compacted) — a later mutation no longer recommits on an ordinary frame
+	 * (immutable history the terminal owns; recommitting would duplicate it) and
+	 * instead rehydrates on the next destructive full replay
+	 * ({@link "@oh-my-pi/pi-tui".NativeScrollbackReplay}). Blocks that never
+	 * mutate post-finalize simply omit the method.
 	 */
 	getTranscriptBlockVersion?(): number;
 	/**
@@ -124,7 +130,7 @@ interface BlockSegment {
 	sep: number;
 	/** Whether the block reported finalized when this segment was rendered. */
 	finalized: boolean;
-	/** Safe to drop after commit: produced while finalized, without post-finalize version tracking. */
+	/** Safe to drop from the local frame once its rows fully commit to native scrollback: produced while finalized. */
 	compactable: boolean;
 	/** Block version observed when this segment was rendered (see {@link FinalizableBlock}). */
 	version: number | undefined;
@@ -453,7 +459,7 @@ export class TranscriptContainer
 					previous.width === width &&
 					previous.generation === this.#generation);
 			const contribution = reusable ? previous.contribution : stripPlainBlankEdges(raw);
-			const compactable = finalized && version === undefined && previous?.finalized !== false;
+			const compactable = finalized && previous?.finalized !== false;
 
 			// Empty (or stripped-to-nothing) children contribute nothing and never
 			// affect spacing. An empty still-live child still gates the commit

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -388,26 +388,34 @@ describe("TranscriptContainer", () => {
 		expect(container.render(40)).toEqual(["committed", "", "tail"]);
 		expect(committed.renderCount).toBe(2);
 	});
-	it("re-renders a committed finalized block when its version changes", () => {
+	it("compacts a committed version-tracked block and rehydrates its post-commit mutation on replay", () => {
 		const container = new TranscriptContainer();
 		const block = new VersionedFinalizedBlock(["original"]);
+		const tail = new CountingFinalizedBlock(["tail"]);
 		container.addChild(block);
+		container.addChild(tail);
 
-		expect(container.render(40)).toEqual(["original"]);
-		container.setNativeScrollbackCommittedRows(1);
-		expect(container.render(40)).toEqual(["original"]);
+		expect(container.render(40)).toEqual(["original", "", "tail"]);
+		// Commit the block plus its trailing separator: those rows are now
+		// immutable native scrollback the terminal owns, so the container drops
+		// them from the live frame instead of re-walking them every tick.
+		container.setNativeScrollbackCommittedRows(2);
+		expect(container.render(40)).toEqual(["tail"]);
 		expect(block.renderCount).toBe(1);
 
-		// Post-finalize mutation (e.g. setErrorPinned(false) restoring the inline
-		// error) must surface even though the rows sit in committed scrollback —
-		// the render is what lets the TUI's committed-prefix audit re-anchor.
+		// A post-commit mutation (setErrorPinned(false) restoring the inline
+		// error) on a compacted, scrolled-off block must NOT recommit on an
+		// ordinary frame — recommitting immutable history would duplicate it.
 		block.mutate(["original", "Error: boom"]);
-		expect(container.render(40)).toEqual(["original", "Error: boom"]);
-		expect(block.renderCount).toBe(2);
+		expect(container.render(40)).toEqual(["tail"]);
+		expect(block.renderCount).toBe(1);
 
-		// Once observed, the bypass re-engages at the new version.
+		// A destructive full replay (ED3) retires the tape and rehydrates the
+		// complete frame from each block's current render — the mutation surfaces
+		// exactly once, no loss.
+		container.prepareNativeScrollbackReplay();
 		container.setNativeScrollbackCommittedRows(2);
-		expect(container.render(40)).toEqual(["original", "Error: boom"]);
+		expect(container.render(40)).toEqual(["original", "Error: boom", "", "tail"]);
 		expect(block.renderCount).toBe(2);
 	});
 	it("renders once after a block finalizes with rows already inside committed scrollback", () => {


### PR DESCRIPTION
## Repro
In long interactive sessions the transcript keeps finalized assistant blocks in the live `TranscriptContainer` component tree after their rows have already entered native terminal scrollback, so every stream tick re-walks and re-assembles that sealed history. The new permanent fixture `packages/coding-agent/bench/transcript-compose.bench.ts` builds N committed finalized blocks + one live tail and times a pure `TranscriptContainer.render` per tick:

```
bun run bench/transcript-compose.bench.ts   # packages/coding-agent
N=500:  median 0.3120ms  p95 0.6285ms
N=5000: median 0.7165ms  p95 1.1602ms
ratio(N5000/N500) median = 2.296            (target <= 1.3)
```

Depth-linear (~2.3x for 10x N), not flat.

## Cause
In `packages/coding-agent/src/modes/components/transcript-container.ts` the committed-prefix compaction gate was `const compactable = finalized && version === undefined && previous?.finalized !== false`. `AssistantMessageComponent` always reports `getTranscriptBlockVersion()` (for post-finalize mutations: error-unpin restore, late tool-result images), so `version === undefined` is never true for assistant history. Those blocks were never compactable, `#compactedChildStart` could not advance past them, and `render()` iterated all N children every tick (N segment allocations + N-iteration assembly walk).

## Fix
- Drop the `version === undefined` term from the `compactable` gate: a fully-committed finalized block is compacted out of the local frame regardless of post-finalize version tracking, because its rows are immutable native scrollback the terminal owns. This preserves exactly-once history: a post-commit mutation on a compacted (scrolled-off) block no longer recommits on an ordinary frame (no duplication) and rehydrates from the block's current render on the next destructive full replay via `prepareNativeScrollbackReplay` (no loss). The on-screen (uncompacted) version bypass at `committedReusable` is unchanged, so a mutation to a still-visible block still forces a real render for the committed-prefix audit.
- Add the permanent `bench/transcript-compose.bench.ts` fixture the issue references (median/p95 per N, ratio + p95 target report).
- Rewrite the `TranscriptContainer` version test to defend the new contract (compact → no ordinary-frame recommit after mutation → replay rehydrates the mutation exactly once), and refresh the `getTranscriptBlockVersion` / `compactable` docs.

## Verification
`bun test test/modes/components/transcript-container.test.ts test/transcript-streaming-commit-repro.test.ts` → 54 pass, 0 fail. `bun test packages/tui/test/component-render.test.ts` → 10 pass. Pre-existing, unrelated failures on a clean tree (`user-message-keywords` missing generated `tool-views.generated.js`; `markdown` OSC 8 link balancing) confirmed by stashing this diff. Bench after fix: `N=500 median 0.216ms / N=5000 median 0.194ms, ratio 0.898 (<= 1.3), N5000 p95 0.478ms (< 10ms)`. Fixes #5930