### PR TITLE
fix(coding-agent): export file mutation queue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Fixed the legacy Pi coding-agent root to export the per-path mutation queue required by `pi-codex-image-gen` and other Pi 0.80 extensions.
 - Fixed `xd://` mount notices triggering unsolicited model turns by deferring hidden notices until the next user prompt.
 - Fixed `xd://` device tools appearing in the direct tool inventory and prompting invalid function calls ([#5797](https://github.com/can1357/oh-my-pi/issues/5797)).
 - Fixed `history://` read selectors being treated as part of the agent id instead of paging the transcript ([#5806](https://github.com/can1357/oh-my-pi/issues/5806)).

--- a/packages/coding-agent/src/tools/file-mutation-queue.ts
+++ b/packages/coding-agent/src/tools/file-mutation-queue.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, isEnotdir } from "@oh-my-pi/pi-utils";
+
+const mutationQueues = new Map<string, Promise<void>>();
+let registrationQueue = Promise.resolve();
+
+async function canonicalizeFilePath(filePath: string): Promise<string> {
+	try {
+		return await fs.realpath(filePath);
+	} catch (error) {
+		if (isEnoent(error) || isEnotdir(error)) return path.resolve(filePath);
+		throw error;
+	}
+}
+
+/** Serialize file mutations per canonical path while allowing unrelated paths to proceed independently. */
+export async function withFileMutationQueue<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+	const canonicalPath = await canonicalizeFilePath(filePath);
+	const registration = Promise.withResolvers<void>();
+	const previousRegistration = registrationQueue;
+	registrationQueue = registration.promise;
+
+	await previousRegistration;
+	const previousMutation = mutationQueues.get(canonicalPath) ?? Promise.resolve();
+	const currentMutation = Promise.withResolvers<void>();
+	mutationQueues.set(canonicalPath, currentMutation.promise);
+	registration.resolve();
+
+	await previousMutation;
+	try {
+		return await fn();
+	} finally {
+		currentMutation.resolve();
+		if (mutationQueues.get(canonicalPath) === currentMutation.promise) {
+			mutationQueues.delete(canonicalPath);
+		}
+	}
+}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -77,6 +77,7 @@ export * from "./debug";
 export * from "./essential-tools";
 export * from "./eval";
 export * from "./eval-backends";
+export * from "./file-mutation-queue";
 export * from "./gh";
 export * from "./glob";
 export * from "./grep";

--- a/packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts
+++ b/packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts
@@ -10,6 +10,7 @@ const currentPiExtensionsPath = Bun.resolveSync("@oh-my-pi/pi-coding-agent/exten
 describe("issue #973: legacy Pi plugin imports", () => {
 	let projectDir: TempDir;
 	let extensionPath: string;
+	let imageExtensionPath: string;
 
 	beforeEach(() => {
 		projectDir = TempDir.createSync("@issue-973-");
@@ -42,6 +43,79 @@ describe("issue #973: legacy Pi plugin imports", () => {
 				"}",
 			].join("\n"),
 		);
+
+		const imagePluginDir = path.join(projectDir.path(), "pi-codex-image-gen");
+		imageExtensionPath = path.join(imagePluginDir, "dist", "extension.ts");
+		fs.mkdirSync(path.dirname(imageExtensionPath), { recursive: true });
+		fs.writeFileSync(
+			path.join(imagePluginDir, "package.json"),
+			JSON.stringify({
+				name: "pi-codex-image-gen",
+				version: "0.1.11",
+				pi: {
+					extensions: ["./dist/extension.ts"],
+				},
+			}),
+		);
+		fs.writeFileSync(
+			imageExtensionPath,
+			[
+				'import * as path from "node:path";',
+				'import { StringEnum } from "@earendil-works/pi-ai";',
+				'import { getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";',
+				'import { Type } from "typebox";',
+				"",
+				"const parameters = Type.Object({",
+				'\tprompt: Type.String({ description: "Image prompt" }),',
+				'\tmode: StringEnum(["generate"] as const),',
+				"});",
+				"",
+				"export default function(pi) {",
+				"\tpi.registerTool({",
+				'\t\tname: "codex_generate_image",',
+				'\t\tlabel: "Generate image",',
+				'\t\tdescription: "Plugin-shaped compatibility probe",',
+				"\t\tparameters,",
+				"\t\texecute: async (toolCallId) => {",
+				"\t\t\tconst events = [];",
+				'\t\t\tconst pathA = path.join(getAgentDir(), "codex-image-gen-a-" + toolCallId);',
+				'\t\t\tconst pathB = path.join(getAgentDir(), "codex-image-gen-b-" + toolCallId);',
+				"\t\t\tconst firstAStarted = Promise.withResolvers();",
+				"\t\t\tconst releaseFirstA = Promise.withResolvers();",
+				"\t\t\tconst firstA = withFileMutationQueue(pathA, async () => {",
+				'\t\t\t\tevents.push("a1-start");',
+				"\t\t\t\tfirstAStarted.resolve();",
+				"\t\t\t\tawait releaseFirstA.promise;",
+				'\t\t\t\tevents.push("a1-end");',
+				"\t\t\t});",
+				"\t\t\tawait firstAStarted.promise;",
+				"\t\t\tconst secondA = withFileMutationQueue(pathA, async () => {",
+				'\t\t\t\tevents.push("a2");',
+				"\t\t\t});",
+				"\t\t\tawait withFileMutationQueue(pathB, async () => {",
+				'\t\t\t\tevents.push("b");',
+				"\t\t\t});",
+				'\t\t\tif (events.includes("a2")) throw new Error("same-path mutation overlapped");',
+				"\t\t\treleaseFirstA.resolve();",
+				"\t\t\tawait Promise.all([firstA, secondA]);",
+				"\t\t\ttry {",
+				"\t\t\t\tawait withFileMutationQueue(pathA, async () => {",
+				'\t\t\t\t\tevents.push("throw");',
+				'\t\t\t\t\tthrow new Error("expected queue rejection");',
+				"\t\t\t\t});",
+				'\t\t\t\tthrow new Error("queue callback did not reject");',
+				"\t\t\t} catch (error) {",
+				'\t\t\t\tif (!(error instanceof Error) || error.message !== "expected queue rejection") throw error;',
+				"\t\t\t}",
+				"\t\t\tawait withFileMutationQueue(pathA, async () => {",
+				'\t\t\t\tevents.push("after-throw");',
+				"\t\t\t});",
+				'\t\t\treturn { content: [{ type: "text", text: events.join(",") }] };',
+				"\t\t},",
+				"\t});",
+				"}",
+			].join("\n"),
+		);
 	});
 
 	afterEach(() => {
@@ -55,5 +129,26 @@ describe("issue #973: legacy Pi plugin imports", () => {
 		expect(result.errors).toEqual([]);
 		expect(extension).toBeDefined();
 		expect(extension?.commands.has("legacy-pi-ext")).toBe(true);
+	});
+
+	it("loads pi-codex-image-gen imports and preserves per-path queue behavior", async () => {
+		const result = await loadExtensions([imageExtensionPath], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === imageExtensionPath);
+		const tool = extension?.tools.get("codex_generate_image");
+
+		expect(result.errors).toEqual([]);
+		expect(extension).toBeDefined();
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("codex_generate_image fixture tool was not registered");
+
+		const toolResult = await tool.definition.execute(
+			"fixture-call",
+			{ prompt: "draw a deterministic probe", mode: "generate" },
+			undefined,
+			undefined,
+			undefined as never,
+		);
+
+		expect(toolResult.content).toEqual([{ type: "text", text: "a1-start,b,a1-end,a2,throw,after-throw" }]);
 	});
 });


### PR DESCRIPTION
## Summary

- export a Pi 0.80-compatible `withFileMutationQueue` helper from the coding-agent root
- serialize mutations by canonical path while preserving concurrency across different paths
- cover the legacy `pi-codex-image-gen` import surface, queue ordering, and rejection cleanup with a plugin-shaped fixture

## Verification

- `bun test --parallel=1 packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts`
- `bun --cwd packages/coding-agent check`

A live image-generation request is not part of the automated gate because it requires an active Codex login and network access; the deterministic extension fixture covers the repository-owned compatibility boundary.