### PR TITLE
fix(ai): normalize boolean tool schemas for Moonshot

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Coerced boolean tool-schema subschemas to MFJS object forms for native Moonshot/Kimi endpoints, preventing the task tool's `outputSchema` field from causing HTTP 400 responses ([#5952](https://github.com/can1357/oh-my-pi/issues/5952)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -29,8 +29,11 @@ import { decontaminateZodInstance } from "./zod-decontaminate";
 export type ResidualSchemaIncompatibility = "type-array" | "type-null" | "nullable" | "combiners" | "not";
 
 export interface NormalizeSchemaOptions {
-	/** Coerce JSON Schema boolean subschemas for providers whose wire cannot encode them. */
-	coerceBooleanSubschemas?: boolean;
+	/**
+	 * Coerce boolean subschemas to object forms. `standard` preserves `false`
+	 * with `not`; `permissive` uses `{}` when the provider cannot express it.
+	 */
+	coerceBooleanSubschemas?: "standard" | "permissive";
 	unsupportedFields: (key: string) => boolean;
 	normalizeFieldNames: boolean;
 	collapseNullFields: boolean;
@@ -284,12 +287,12 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 	}
 	if (typeof value === "boolean") {
 		// A bare boolean is a JSON Schema subschema only in a subschema slot.
-		// The Google/CCA protobuf Schema wire has no representation for it
-		// (issue #5604): `true` accepts anything -> `{}`, `false` accepts nothing
-		// -> `{ not: {} }`. In a keyword slot (`nullable`, `enum` entry, …) a
-		// boolean is a plain value and is left untouched.
-		if (!options.coerceBooleanSubschemas || !options.booleanIsSubschema) return value;
-		return value ? {} : { not: {} };
+		// Some provider wires have no boolean-schema representation: `true`
+		// becomes `{}`; `false` uses `not` when supported, or the permissive
+		// `{}` fallback when the provider cannot express an impossible schema.
+		const mode = options.coerceBooleanSubschemas;
+		if (!mode || !options.booleanIsSubschema) return value;
+		return value || mode === "permissive" ? {} : { not: {} };
 	}
 	if (!isJsonObject(value)) {
 		return value;
@@ -993,7 +996,7 @@ export function normalizeSchema(value: unknown, options: NormalizeSchemaOptions)
 
 export function normalizeSchemaForGoogle(value: unknown): unknown {
 	return normalizeSchema(value, {
-		coerceBooleanSubschemas: true,
+		coerceBooleanSubschemas: "standard",
 		unsupportedFields: isGoogleUnsupportedSchemaField,
 		normalizeFieldNames: true,
 		collapseNullFields: true,
@@ -1015,7 +1018,7 @@ export function normalizeSchemaForGoogle(value: unknown): unknown {
 
 export function normalizeSchemaForCCA(value: unknown): unknown {
 	return normalizeSchema(value, {
-		coerceBooleanSubschemas: true,
+		coerceBooleanSubschemas: "standard",
 		unsupportedFields: isGoogleUnsupportedSchemaField,
 		normalizeFieldNames: true,
 		collapseNullFields: false,
@@ -1080,6 +1083,9 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  *    `default` and `description` are MFJS Meta Data fields and are preserved.
  *  - `additionalProperties` (boolean or schema) and `type: "null"` (incl.
  *    inside `anyOf`) are kept.
+ *  - Boolean subschemas are object-coerced; MFJS has no exact `false` schema,
+ *    so both values become the permissive empty schema while local tool
+ *    validation remains authoritative.
  *
  * Out of scope (absent from the built-in tool surface, spec-ambiguous to
  * rewrite blindly): `allOf` intersection merging, external/recursive `$ref`,
@@ -1087,6 +1093,7 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  */
 export function normalizeSchemaForMoonshot(value: unknown): unknown {
 	return normalizeSchema(value, {
+		coerceBooleanSubschemas: "permissive",
 		unsupportedFields: isMoonshotUnsupportedSchemaField,
 		normalizeFieldNames: false,
 		collapseNullFields: false,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -2382,6 +2382,22 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 				additionalProperties: false,
 			},
 		},
+		{
+			name: "task",
+			description: "spawn task",
+			parameters: {
+				type: "object",
+				properties: {
+					tasks: {
+						type: "array",
+						items: {
+							type: "object",
+							properties: { outputSchema: true },
+						},
+					},
+				},
+			},
+		},
 	];
 
 	function toolParameters(payload: unknown, toolName: string): Record<string, unknown> {
@@ -2434,6 +2450,10 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 		const paths = probeProperty(payload, "find", "paths");
 		expect(paths.minItems).toBeUndefined();
 		expect(paths.type).toBe("array");
+		const taskProperties = toObject(
+			toObject(toObject(probeProperty(payload, "task", "tasks").items)?.properties)?.outputSchema,
+		);
+		expect(taskProperties).toEqual({});
 	});
 
 	it("leaves raw JSON Schema untouched on non-Moonshot hosts (flag-gated)", async () => {
@@ -2446,5 +2466,8 @@ describe("Moonshot Flavored JSON Schema tool normalization", () => {
 		expect(op).toEqual({ type: "string", enum: ["pr_checkout", "pr_create"], description: "github operation" });
 		const paths = probeProperty(payload, "find", "paths");
 		expect(paths.minItems).toBe(1);
+		const taskItems = toObject(probeProperty(payload, "task", "tasks").items);
+		const taskProperties = toObject(taskItems?.properties);
+		expect(taskProperties?.outputSchema).toBe(true);
 	});
 });

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -1193,6 +1193,7 @@ function assertMfjsValid(node: unknown, path = "$"): void {
 		for (const [i, entry] of node.entries()) assertMfjsValid(entry, `${path}[${i}]`);
 		return;
 	}
+	if (typeof node === "boolean") throw new Error(`MFJS requires an object schema at ${path}`);
 	if (typeof node !== "object" || node === null) return;
 	const obj = node as Record<string, unknown>;
 	for (const key of Object.keys(obj)) {
@@ -1276,11 +1277,20 @@ describe("normalizeSchemaForMoonshot", () => {
 		expect(props.limit).toEqual({ type: "integer", default: 10 });
 	});
 
-	it("preserves boolean subschemas rather than synthesizing MFJS-forbidden not", () => {
-		expect(normalizeSchemaForMoonshot({ type: "object", properties: { forbidden: false } })).toEqual({
+	it("coerces boolean subschemas to MFJS object forms without changing boolean keywords", () => {
+		expect(
+			normalizeSchemaForMoonshot({
+				type: "object",
+				properties: { allowed: true, forbidden: false },
+				additionalProperties: false,
+			}),
+		).toEqual({
 			type: "object",
-			properties: { forbidden: false },
+			properties: { allowed: {}, forbidden: {} },
+			additionalProperties: false,
 		});
+		expect(normalizeSchemaForMoonshot(true)).toEqual({});
+		expect(normalizeSchemaForMoonshot(false)).toEqual({});
 	});
 
 	it("folds oneOf into anyOf (the only MFJS combinator)", () => {


### PR DESCRIPTION
## Repro
A native Moonshot/Kimi `openai-completions` request containing the default task tool serialized `tasks.items.properties.outputSchema` as boolean `true`; `bun test packages/ai/test/openai-completions-compat.test.ts --test-name-pattern "rewrites tool schemas to MFJS"` captured that wire payload and failed because MFJS requires property schemas to be objects.

## Cause
`normalizeSchemaForMoonshot()` in `packages/ai/src/utils/schema/normalize.ts` did not enable boolean-subschema coercion, so `normalizeSchemaNode()` preserved the task tool's valid JSON Schema boolean node even though Moonshot's MFJS wire format cannot encode it.

## Fix
- Added provider-selectable standard and permissive boolean-subschema coercion modes.
- Configured Moonshot normalization to map both boolean schema values to MFJS-compatible empty object schemas while leaving keyword booleans such as `additionalProperties` unchanged.
- Added request-wire and schema-normalizer regression coverage plus the `pi-ai` changelog entry.

## Verification
`bun test packages/ai/test/schema-normalization.test.ts packages/ai/test/openai-completions-compat.test.ts` passed: 137 tests, 324 assertions, 0 failures. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #5952