### PR TITLE
fix(task): avoid boolean output schema subschemas

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `task` tool schemas emitting boolean subschemas that llama.cpp grammar generation cannot parse ([#5957](https://github.com/can1357/oh-my-pi/issues/5957)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -106,11 +106,14 @@ export interface SubagentLifecyclePayload {
 /** Display cap for a normalized one-line label (roster line, registry `displayName`, prompt field). */
 export const LABEL_MAX = 80;
 
+// Keep this explicit: ArkType serializes `unknown` as a boolean subschema, which llama.cpp grammars reject.
+const outputSchemaInputSchema = type("object | boolean | string | null");
+
 export const taskItemSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
-	"outputSchema?": "unknown",
+	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
 });
@@ -118,7 +121,7 @@ const taskItemSchemaIsolated = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
-	"outputSchema?": "unknown",
+	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
 	"+": "delete",
@@ -144,7 +147,7 @@ export const taskSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
-	"outputSchema?": "unknown",
+	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
 	"+": "delete",
@@ -153,7 +156,7 @@ const taskSchemaNoIsolation = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
-	"outputSchema?": "unknown",
+	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
 });
@@ -197,7 +200,7 @@ function createTaskSchema(options: {
 				"name?": "string",
 				agent,
 				task: "string",
-				"outputSchema?": "unknown",
+				"outputSchema?": outputSchemaInputSchema,
 				"schemaMode?": '"permissive" | "strict"',
 				"isolated?": "boolean",
 				"+": "delete",
@@ -212,7 +215,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
-			"outputSchema?": "unknown",
+			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
 			"+": "delete",
 		});
@@ -227,7 +230,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
-			"outputSchema?": "unknown",
+			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
 			"isolated?": "boolean",
 			"+": "delete",
@@ -237,7 +240,7 @@ function createTaskSchema(options: {
 		"name?": "string",
 		agent,
 		task: "string",
-		"outputSchema?": "unknown",
+		"outputSchema?": outputSchemaInputSchema,
 		"schemaMode?": '"permissive" | "strict"',
 		"+": "delete",
 	});

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -102,6 +102,7 @@ describe("task.batch schema gating", () => {
 		expect(offProperties.task).toBeDefined();
 		expect(offProperties.name).toBeDefined();
 		expect(offProperties.outputSchema).toBeDefined();
+		expect(typeof offProperties.outputSchema).toBe("object");
 		expect(offProperties.schemaMode).toBeDefined();
 
 		const on = await TaskTool.create(createSession({ settings: { "task.batch": true } }));
@@ -120,6 +121,7 @@ describe("task.batch schema gating", () => {
 		expect(items?.properties?.name).toBeDefined();
 		expect(items?.properties?.agent).toBeDefined();
 		expect(items?.properties?.outputSchema).toBeDefined();
+		expect(typeof items?.properties?.outputSchema).toBe("object");
 		expect(items?.properties?.schemaMode).toBeDefined();
 	});
 


### PR DESCRIPTION
## Repro
Serializing the 17.0.3 batch task parameters with `arkToWireSchema(getTaskSchema({ isolationEnabled: false, batchEnabled: true }))` produced `properties.tasks.items.properties.outputSchema: true`; llama.cpp commit `e8f19cc0a` rejects that request schema with `Unrecognized schema: true` before inference.

## Cause
`packages/coding-agent/src/task/types.ts` declared every task `outputSchema` input as ArkType `unknown`. The provider wire conversion normalizes unconstrained ArkType schemas to the standards-valid boolean schema `true`, but llama.cpp's JSON-schema-to-grammar converter does not implement boolean subschemas.

## Fix
- Define the accepted output-schema representations explicitly as object, JSON string, boolean, or null, preserving supported task inputs while making ArkType emit an object-form `anyOf` subschema.
- Apply the same schema to flat, batch, isolation-enabled, and dynamic-default-agent task shapes.
- Assert both flat and batch wire schemas keep `outputSchema` in object form, and document the regression fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/task/task-schema.test.ts packages/coding-agent/test/task/task-batch.test.ts` — 21 passed, 0 failed. Manual wire-schema smoke check confirmed both flat and batch `outputSchema` fields serialize as object-form `anyOf` schemas with no boolean subschema. The publish gate also completed `bun run fix` and `bun check` before push.

Fixes #5957