### PR TITLE
fix(ai): normalize clockless usage drain ranking

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed clockless Anthropic usage windows outranking clocked sibling credentials by scoring their headroom over the full window duration ([#5960](https://github.com/can1357/oh-my-pi/issues/5960)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3886,16 +3886,15 @@ export class AuthStorage {
 	 * how fast the window's remaining quota must be consumed to fully use it
 	 * before it resets and expires. Higher = more headroom at risk of expiring
 	 * unused = ranked first, so selection chases quota that is about to be
-	 * wasted ("use it or lose it"). Without a reset clock the headroom
-	 * fraction alone is returned, degrading to most-headroom-first.
+	 * wasted ("use it or lose it"). Without a reset clock, the full window
+	 * duration is assumed to remain so clocked and clockless scores stay comparable.
 	 */
 	#computeWindowRequiredDrain(limit: UsageLimit | undefined, nowMs: number, fallbackDurationMs: number): number {
 		const headroom = 1 - this.#normalizeUsageFraction(limit);
 		if (headroom <= 0) return 0;
 		const resetAt = this.#resolveWindowResetAt(limit?.window);
-		if (resetAt === undefined) return headroom;
 		const durationMs = limit?.window?.durationMs ?? fallbackDurationMs;
-		let remainingMs = resetAt - nowMs;
+		let remainingMs = resetAt === undefined ? durationMs : resetAt - nowMs;
 		if (Number.isFinite(durationMs) && durationMs > 0) {
 			remainingMs = Math.min(remainingMs, durationMs);
 		}

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2023,7 +2023,7 @@ function createClaudeLimit(args: {
 	key: "5h" | "7d";
 	durationMs: number;
 	usedFraction: number;
-	resetInMs: number;
+	resetInMs?: number;
 	tier?: "fable";
 }): UsageLimit {
 	const clamped = Math.min(Math.max(args.usedFraction, 0), 1);
@@ -2041,7 +2041,7 @@ function createClaudeLimit(args: {
 			id: args.key,
 			label,
 			durationMs: args.durationMs,
-			resetsAt: Date.now() + args.resetInMs,
+			...(args.resetInMs === undefined ? {} : { resetsAt: Date.now() + args.resetInMs }),
 		},
 		amount: {
 			unit: "percent",
@@ -2057,9 +2057,9 @@ function createClaudeLimit(args: {
 
 function createClaudeUsageReport(args: {
 	accountId: string;
-	primary: { usedFraction: number; resetInMs: number };
-	secondary: { usedFraction: number; resetInMs: number };
-	fableSecondary?: { usedFraction: number; resetInMs: number };
+	primary: { usedFraction: number; resetInMs?: number };
+	secondary: { usedFraction: number; resetInMs?: number };
+	fableSecondary?: { usedFraction: number; resetInMs?: number };
 }): UsageReport {
 	const limits = [
 		createClaudeLimit({
@@ -2164,6 +2164,35 @@ describe("AuthStorage claude oauth ranking", () => {
 
 		const counts = await countApiKeySelections(authStorage, "anthropic", "weighted-claude-near");
 		expectExclusivePreference(counts, "api-acct-near", "api-acct-far");
+	});
+
+	test("assumes the full duration remains when ranking clockless windows", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-clockless", "clockless@example.com") },
+			{ type: "oauth", ...createCredential("acct-clocked", "clocked@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-clockless",
+			createClaudeUsageReport({
+				accountId: "acct-clockless",
+				primary: { usedFraction: 0 },
+				secondary: { usedFraction: 0 },
+			}),
+		);
+		usageByAccount.set(
+			"acct-clocked",
+			createClaudeUsageReport({
+				accountId: "acct-clocked",
+				primary: { usedFraction: 0, resetInMs: 4 * HOUR_MS },
+				secondary: { usedFraction: 0.05, resetInMs: 22 * HOUR_MS },
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-clockless");
+		expect(apiKey).toBe("api-acct-clocked");
 	});
 
 	test("resolves equal-priority accounts to one deterministic pick", async () => {


### PR DESCRIPTION
## Repro
A 0%-used Anthropic OAuth credential whose 5h and 7d usage windows omit `resetsAt` outranked a 5%-used sibling whose weekly window resets in 22h. Reproduced with `bun test packages/ai/test/auth-storage-codex-selection.test.ts --test-name-pattern "assumes the full duration remains when ranking clockless windows"`; before the fix it selected `api-acct-clockless` instead of `api-acct-clocked`.

## Cause
`AuthStorage.#computeWindowRequiredDrain` in `packages/ai/src/auth-storage.ts` returned bare headroom for clockless windows while clocked windows returned headroom divided by remaining hours. Those differently scaled scores made a freshly reset, clockless credential dominate any sibling with more than one hour remaining.

## Fix
- Treat a missing reset clock as a full window duration remaining before computing required drain.
- Cover Anthropic credential selection with clockless 5h/7d windows against a clocked weekly sibling.
- Record the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/auth-storage-codex-selection.test.ts` passed: 46 tests, 0 failures. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #5960