### PR TITLE
fix(auth): gate session credential pin on prompt-cache idle window

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session credential stickiness suppressing usage-based re-ranking indefinitely: the Anthropic session pin skipped ranking for up to 30 days (or process lifetime) even after the ≤1h prompt cache it protects had expired. The skip is now gated on time since the session's last resolve (`SESSION_STICKY_CACHE_WARM_MS`, 1h), and when ranking runs the pinned account is only a tie-break rather than an absolute front-of-queue override, restoring proactive multi-account load balancing after long idle ([#5966](https://github.com/can1357/oh-my-pi/issues/5966)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed session credential stickiness suppressing usage-based re-ranking indefinitely: the Anthropic session pin skipped ranking for up to 30 days (or process lifetime) even after the ≤1h prompt cache it protects was no longer guaranteed warm. The skip is now gated on time since the session's last resolve (`SESSION_STICKY_CACHE_WARM_MS`, 1h), and when ranking runs the pinned account is only a tie-break rather than an absolute front-of-queue override, restoring proactive multi-account load balancing after long idle ([#5966](https://github.com/can1357/oh-my-pi/issues/5966)).
+- Fixed Anthropic session credential stickiness suppressing usage-based re-ranking indefinitely: the session pin skipped ranking for up to 30 days (or process lifetime) even after the ≤1h prompt cache it protects was no longer guaranteed warm. The Anthropic skip is now gated on time since the session's last resolve (`ANTHROPIC_SESSION_STICKY_CACHE_WARM_MS`, 1h), while providers without a verified cache lifetime retain their existing stickiness. When ranking runs, the pinned account is only a tie-break rather than an absolute front-of-queue override, restoring proactive multi-account load balancing after long idle ([#5966](https://github.com/can1357/oh-my-pi/issues/5966)).
 
 ## [17.0.4] - 2026-07-18
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed session credential stickiness suppressing usage-based re-ranking indefinitely: the Anthropic session pin skipped ranking for up to 30 days (or process lifetime) even after the ≤1h prompt cache it protects had expired. The skip is now gated on time since the session's last resolve (`SESSION_STICKY_CACHE_WARM_MS`, 1h), and when ranking runs the pinned account is only a tie-break rather than an absolute front-of-queue override, restoring proactive multi-account load balancing after long idle ([#5966](https://github.com/can1357/oh-my-pi/issues/5966)).
+- Fixed session credential stickiness suppressing usage-based re-ranking indefinitely: the Anthropic session pin skipped ranking for up to 30 days (or process lifetime) even after the ≤1h prompt cache it protects was no longer guaranteed warm. The skip is now gated on time since the session's last resolve (`SESSION_STICKY_CACHE_WARM_MS`, 1h), and when ranking runs the pinned account is only a tie-break rather than an absolute front-of-queue override, restoring proactive multi-account load balancing after long idle ([#5966](https://github.com/can1357/oh-my-pi/issues/5966)).
 
 ## [17.0.4] - 2026-07-18
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -73,6 +73,16 @@ function fingerprintOAuthBearer(bearer: string): string {
 	return createHash("sha256").update(bearer).digest("base64url");
 }
 const SESSION_STICKY_CACHE_PREFIX = "session:sticky:";
+/**
+ * Idle window after which a session's pinned credential no longer suppresses
+ * usage-based re-ranking. The pin exists to preserve the server-side prompt
+ * cache — switching accounts mid-session cold-starts it — but Anthropic caps
+ * OAuth prompt-cache retention at `ttl: "1h"` (ephemeral ~5min otherwise), so
+ * once a session has gone this long without an Anthropic resolve the
+ * conversation-prefix cache the pin protects has certainly expired and ranking
+ * must run again to restore proactive multi-account load balancing.
+ */
+const SESSION_STICKY_CACHE_WARM_MS = 60 * 60_000;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Credential Types
@@ -1137,7 +1147,10 @@ export class AuthStorage {
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
-	#sessionLastCredential: Map<string, Map<string, { type: AuthCredential["type"]; index: number }>> = new Map();
+	#sessionLastCredential: Map<
+		string,
+		Map<string, { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number }>
+	> = new Map();
 	/** Recent bearer fingerprints resolved for each durable OAuth row; used only for delayed usage-limit attribution. */
 	#oauthBearerFingerprints: Map<string, Map<number, string[]>> = new Map();
 	/** Maps provider:type -> credentialIndex -> blockedUntilMs for temporary backoff. */
@@ -1685,17 +1698,18 @@ export class AuthStorage {
 		index: number,
 	): void {
 		if (!sessionId) return;
+		const nowMs = Date.now();
 		const sessionMap = this.#sessionLastCredential.get(provider) ?? new Map();
-		sessionMap.set(sessionId, { type, index });
+		sessionMap.set(sessionId, { type, index, lastUsedAtMs: nowMs });
 		this.#sessionLastCredential.set(provider, sessionMap);
 
 		try {
 			const credentialId = this.#getStoredCredentials(provider)[index]?.id;
 			if (credentialId !== undefined) {
 				const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
-				const cacheValue = JSON.stringify({ type, index, credentialId });
+				const cacheValue = JSON.stringify({ type, index, credentialId, lastUsedAtMs: nowMs });
 				// Expires in 30 days
-				const expiresAtSec = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+				const expiresAtSec = Math.floor(nowMs / 1000) + 30 * 24 * 60 * 60;
 				this.#store.setCache(cacheKey, cacheValue, expiresAtSec);
 			}
 		} catch (err) {
@@ -1707,7 +1721,7 @@ export class AuthStorage {
 	#getSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-	): { type: AuthCredential["type"]; index: number } | undefined {
+	): { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number } | undefined {
 		if (!sessionId) return undefined;
 		let sessionMap = this.#sessionLastCredential.get(provider);
 		if (sessionMap?.has(sessionId)) {
@@ -1717,7 +1731,12 @@ export class AuthStorage {
 			const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
 			const raw = this.#store.getCache(cacheKey);
 			if (raw) {
-				const val = JSON.parse(raw) as { type: AuthCredential["type"]; index: number; credentialId?: number };
+				const val = JSON.parse(raw) as {
+					type: AuthCredential["type"];
+					index: number;
+					credentialId?: number;
+					lastUsedAtMs?: number;
+				};
 
 				if (val.credentialId !== undefined) {
 					const stored = this.#getStoredCredentials(provider);
@@ -1737,7 +1756,7 @@ export class AuthStorage {
 					sessionMap = new Map();
 					this.#sessionLastCredential.set(provider, sessionMap);
 				}
-				const sessionVal = { type: val.type, index: val.index };
+				const sessionVal = { type: val.type, index: val.index, lastUsedAtMs: val.lastUsedAtMs };
 				sessionMap.set(sessionId, sessionVal);
 				return sessionVal;
 			}
@@ -4135,16 +4154,39 @@ export class AuthStorage {
 			sessionPreferredCredential !== undefined &&
 			(sessionPreferredCredential.refresh.trim().length > 0 ||
 				Date.now() + OAUTH_REFRESH_SKEW_MS < sessionPreferredCredential.expires);
-		// Skip ranking only when the session already has a working preferred credential — re-ranking
-		// mid-session causes account switches that cold-start the server-side prompt cache. New sessions
-		// (no preference) and sessions whose preferred is blocked still rank, so we pick the account
-		// with the most headroom proactively and fall back intelligently when rate-limited.
+		// Skip ranking only when the session already has a working preferred credential AND that
+		// credential is still "warm" — re-ranking mid-session causes account switches that cold-start
+		// the server-side prompt cache. New sessions (no preference), sessions whose preferred is
+		// blocked, and sessions idle past the prompt-cache TTL ({@link SESSION_STICKY_CACHE_WARM_MS})
+		// still rank, so we pick the account with the most headroom proactively and fall back
+		// intelligently when rate-limited. Legacy pins predating `lastUsedAtMs` count as warm until
+		// the next resolve rewrites the row — no worse than today.
+		const sessionPreferredLastUsedAtMs =
+			sessionCredential?.type === "oauth" ? sessionCredential.lastUsedAtMs : undefined;
+		const sessionPreferredIsWarm =
+			sessionPreferredLastUsedAtMs === undefined ||
+			Date.now() - sessionPreferredLastUsedAtMs < SESSION_STICKY_CACHE_WARM_MS;
 		const sessionPreferredIsAvailable =
 			sessionPreferredIndex !== undefined &&
 			sessionPreferredCanRefreshOrUse &&
 			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScope);
-		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || hasPlanRequirement);
-		const rankingOrder = shouldRank && sessionId ? credentials.map((_credential, index) => index) : order;
+		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || !sessionPreferredIsWarm || hasPlanRequirement);
+		// When ranking, seed the pinned credential first in the evaluation order so it wins genuine
+		// ties (the ranked comparator falls back to `orderPos`) without overriding a strictly-better
+		// sibling — this respects the residual value of a same-account shared static prefix that other
+		// workspace traffic may have kept warm, while still rotating away from a clearly-worse account.
+		const baseRankingOrder = credentials.map((_credential, index) => index);
+		let rankingOrder = shouldRank && sessionId ? baseRankingOrder : order;
+		const sessionPreferredRankingPos =
+			shouldRank && sessionId && sessionPreferredIndex !== undefined && !hasPlanRequirement
+				? credentials.findIndex(entry => entry.index === sessionPreferredIndex)
+				: -1;
+		if (sessionPreferredRankingPos > 0) {
+			rankingOrder = [
+				sessionPreferredRankingPos,
+				...baseRankingOrder.filter(index => index !== sessionPreferredRankingPos),
+			];
+		}
 		const candidates = shouldRank
 			? await this.#rankOAuthSelections({
 					providerKey,
@@ -4162,7 +4204,10 @@ export class AuthStorage {
 					.filter((selection): selection is { credential: OAuthCredential; index: number } => Boolean(selection))
 					.map(selection => ({ selection, usage: null, usageChecked: false }));
 
-		if (sessionPreferredIndex !== undefined && !hasPlanRequirement) {
+		// On the warm skip path the candidate list follows the round-robin `order`, not the pin, so
+		// hoist the pinned credential to the front to actually reuse it. When ranking ran, the pin is
+		// already a mere tie-break via `rankingOrder`; do not override the ranked result here.
+		if (!shouldRank && sessionPreferredIndex !== undefined && !hasPlanRequirement) {
 			const sessionPreferredCandidate = candidates.findIndex(
 				candidate =>
 					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScope) &&

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -79,8 +79,8 @@ const SESSION_STICKY_CACHE_PREFIX = "session:sticky:";
  * cache — switching accounts mid-session cold-starts it — but Anthropic caps
  * OAuth prompt-cache retention at `ttl: "1h"` (ephemeral ~5min otherwise), so
  * once a session has gone this long without an Anthropic resolve the
- * conversation-prefix cache the pin protects has certainly expired and ranking
- * must run again to restore proactive multi-account load balancing.
+ * conversation-prefix cache the pin protects is no longer guaranteed warm and
+ * ranking must run again to restore proactive multi-account load balancing.
  */
 const SESSION_STICKY_CACHE_WARM_MS = 60 * 60_000;
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -74,15 +74,14 @@ function fingerprintOAuthBearer(bearer: string): string {
 }
 const SESSION_STICKY_CACHE_PREFIX = "session:sticky:";
 /**
- * Idle window after which a session's pinned credential no longer suppresses
- * usage-based re-ranking. The pin exists to preserve the server-side prompt
- * cache — switching accounts mid-session cold-starts it — but Anthropic caps
- * OAuth prompt-cache retention at `ttl: "1h"` (ephemeral ~5min otherwise), so
- * once a session has gone this long without an Anthropic resolve the
- * conversation-prefix cache the pin protects is no longer guaranteed warm and
- * ranking must run again to restore proactive multi-account load balancing.
+ * Anthropic-only idle window after which a session's pinned credential no
+ * longer suppresses usage-based re-ranking. Anthropic caps OAuth prompt-cache
+ * retention at `ttl: "1h"` (ephemeral ~5min otherwise), so after this long
+ * without an Anthropic resolve the conversation-prefix cache is no longer
+ * guaranteed warm. Other providers retain indefinite stickiness until their
+ * own cache lifetimes are verified.
  */
-const SESSION_STICKY_CACHE_WARM_MS = 60 * 60_000;
+const ANTHROPIC_SESSION_STICKY_CACHE_WARM_MS = 60 * 60_000;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Credential Types
@@ -4154,18 +4153,18 @@ export class AuthStorage {
 			sessionPreferredCredential !== undefined &&
 			(sessionPreferredCredential.refresh.trim().length > 0 ||
 				Date.now() + OAUTH_REFRESH_SKEW_MS < sessionPreferredCredential.expires);
-		// Skip ranking only when the session already has a working preferred credential AND that
-		// credential is still "warm" — re-ranking mid-session causes account switches that cold-start
-		// the server-side prompt cache. New sessions (no preference), sessions whose preferred is
-		// blocked, and sessions idle past the prompt-cache TTL ({@link SESSION_STICKY_CACHE_WARM_MS})
-		// still rank, so we pick the account with the most headroom proactively and fall back
-		// intelligently when rate-limited. Legacy pins predating `lastUsedAtMs` count as warm until
-		// the next resolve rewrites the row — no worse than today.
+		// Skip ranking when the session already has a working preferred credential and its prompt
+		// cache may still be warm. Only Anthropic has a verified idle boundary here; unverified
+		// providers retain indefinite stickiness rather than risk switching while their prompt cache
+		// remains warm. New Anthropic sessions (no preference), sessions whose preferred is blocked,
+		// and sessions idle past {@link ANTHROPIC_SESSION_STICKY_CACHE_WARM_MS} still rank. Legacy
+		// pins predating `lastUsedAtMs` count as warm until the next resolve rewrites the row.
 		const sessionPreferredLastUsedAtMs =
 			sessionCredential?.type === "oauth" ? sessionCredential.lastUsedAtMs : undefined;
 		const sessionPreferredIsWarm =
+			provider !== "anthropic" ||
 			sessionPreferredLastUsedAtMs === undefined ||
-			Date.now() - sessionPreferredLastUsedAtMs < SESSION_STICKY_CACHE_WARM_MS;
+			Date.now() - sessionPreferredLastUsedAtMs < ANTHROPIC_SESSION_STICKY_CACHE_WARM_MS;
 		const sessionPreferredIsAvailable =
 			sessionPreferredIndex !== undefined &&
 			sessionPreferredCanRefreshOrUse &&

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2399,4 +2399,88 @@ describe("AuthStorage claude oauth ranking", () => {
 		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-single");
 		expect(apiKey).toBe("api-acct-solo");
 	});
+
+	test("re-ranks a session pinned to a now-worse account after >1h of Anthropic idle", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+
+		await storage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-pinned", "pinned@example.com") },
+			{ type: "oauth", ...createCredential("acct-fresh", "fresh@example.com") },
+		]);
+
+		const base = Date.now();
+		let clockOffset = 0;
+		vi.spyOn(Date, "now").mockImplementation(() => base + clockOffset);
+
+		// t0: acct-pinned is healthy; acct-fresh's 5h window is hot (>=85%),
+		// so ranking picks acct-pinned and pins the session to it.
+		const setUsage = (pinnedPrimary: number, freshPrimary: number): void => {
+			usageByAccount.set(
+				"acct-pinned",
+				createClaudeUsageReport({
+					accountId: "acct-pinned",
+					primary: { usedFraction: pinnedPrimary, resetInMs: 4 * HOUR_MS },
+					secondary: { usedFraction: 0.5, resetInMs: 5 * 24 * HOUR_MS },
+				}),
+			);
+			usageByAccount.set(
+				"acct-fresh",
+				createClaudeUsageReport({
+					accountId: "acct-fresh",
+					primary: { usedFraction: freshPrimary, resetInMs: 4 * HOUR_MS },
+					secondary: { usedFraction: 0.5, resetInMs: 5 * 24 * HOUR_MS },
+				}),
+			);
+		};
+
+		setUsage(0.2, 0.9);
+		expect(await storage.getApiKey("anthropic", "claude-idle-gating")).toBe("api-acct-pinned");
+
+		// The tables turn: acct-pinned's 5h window is now hot, acct-fresh is cool.
+		setUsage(0.9, 0.2);
+
+		// Within 1h of the last resolve the conversation prefix is plausibly warm,
+		// so the pin must hold even though it is now the worse account.
+		clockOffset = 30 * 60 * 1000;
+		expect(await storage.getApiKey("anthropic", "claude-idle-gating")).toBe("api-acct-pinned");
+
+		// After >1h of Anthropic request inactivity the prompt cache has certainly
+		// expired, so ranking must run again and rotate to the clearly-better sibling.
+		clockOffset = 30 * 60 * 1000 + 2 * HOUR_MS;
+		expect(await storage.getApiKey("anthropic", "claude-idle-gating")).toBe("api-acct-fresh");
+	});
+
+	test("keeps the pinned account after idle when siblings rank equal (tie-break)", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+
+		await storage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-a", "a@example.com") },
+			{ type: "oauth", ...createCredential("acct-b", "b@example.com") },
+		]);
+
+		const base = Date.now();
+		let clockOffset = 0;
+		vi.spyOn(Date, "now").mockImplementation(() => base + clockOffset);
+
+		for (const accountId of ["acct-a", "acct-b"]) {
+			usageByAccount.set(
+				accountId,
+				createClaudeUsageReport({
+					accountId,
+					primary: { usedFraction: 0.25, resetInMs: 4 * HOUR_MS },
+					secondary: { usedFraction: 0.25, resetInMs: 4 * 24 * HOUR_MS },
+				}),
+			);
+		}
+
+		const first = await storage.getApiKey("anthropic", "claude-idle-tie");
+		expect(first).toBeDefined();
+
+		// Past the warm window ranking runs again, but both accounts score equal,
+		// so the pin must win the tie rather than churn to the sibling.
+		clockOffset = HOUR_MS + 1;
+		expect(await storage.getApiKey("anthropic", "claude-idle-tie")).toBe(first);
+	});
 });

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -227,6 +227,48 @@ describe("AuthStorage codex oauth ranking", () => {
 		expectExclusivePreference(counts, "api-acct-near", "api-acct-far");
 	});
 
+	test("keeps a Codex session pinned after >1h idle", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+
+		await storage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-pinned", "pinned@example.com") },
+			{ type: "oauth", ...createCredential("acct-sibling", "sibling@example.com") },
+		]);
+
+		const base = Date.now();
+		let clockOffset = 0;
+		vi.spyOn(Date, "now").mockImplementation(() => base + clockOffset);
+
+		const setUsage = (pinnedPrimary: number, siblingPrimary: number): void => {
+			usageByAccount.set(
+				"acct-pinned",
+				createCodexUsageReport({
+					accountId: "acct-pinned",
+					primary: { usedFraction: pinnedPrimary, resetInMs: HOUR_MS },
+					secondary: { usedFraction: 0.5, resetInMs: 5 * 24 * HOUR_MS },
+				}),
+			);
+			usageByAccount.set(
+				"acct-sibling",
+				createCodexUsageReport({
+					accountId: "acct-sibling",
+					primary: { usedFraction: siblingPrimary, resetInMs: HOUR_MS },
+					secondary: { usedFraction: 0.5, resetInMs: 5 * 24 * HOUR_MS },
+				}),
+			);
+		};
+
+		setUsage(0.2, 0.9);
+		expect(await storage.getApiKey("openai-codex", "codex-idle-boundary")).toBe("api-acct-pinned");
+
+		// Codex long retention can preserve a prompt cache for 24h, so the
+		// Anthropic-specific 1h gate must not re-rank this still-usable pin.
+		setUsage(0.9, 0.2);
+		clockOffset = 2 * HOUR_MS;
+		expect(await storage.getApiKey("openai-codex", "codex-idle-boundary")).toBe("api-acct-pinned");
+	});
+
 	test("prefers fresh 5h ticker account at 0% usage", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2445,8 +2445,8 @@ describe("AuthStorage claude oauth ranking", () => {
 		clockOffset = 30 * 60 * 1000;
 		expect(await storage.getApiKey("anthropic", "claude-idle-gating")).toBe("api-acct-pinned");
 
-		// After >1h of Anthropic request inactivity the prompt cache has certainly
-		// expired, so ranking must run again and rotate to the clearly-better sibling.
+		// After >1h of Anthropic request inactivity the prompt cache is no longer
+		// guaranteed warm, so ranking must run again and rotate to the better sibling.
 		clockOffset = 30 * 60 * 1000 + 2 * HOUR_MS;
 		expect(await storage.getApiKey("anthropic", "claude-idle-gating")).toBe("api-acct-fresh");
 	});


### PR DESCRIPTION
## Repro
A session pins to its last-used Anthropic credential (`session:sticky:anthropic:<sessionId>`, 30-day TTL) and `#resolveOAuthSelection` skips usage-based re-ranking whenever that pin is available. The skip's stated purpose is prompt-cache locality, but the skip condition had no time/idle component, so ranking stayed suppressed long after the ≤1h prompt cache expired. Reproduced with a mocked clock in `packages/ai/test/auth-storage-codex-selection.test.ts`: pin a session to `acct-pinned` while healthy, flip usage so `acct-pinned` goes hot and `acct-fresh` becomes the clearly-better pick, advance >1h — on `main` the session stays on `acct-pinned`.

```
cd packages/ai && bun test test/auth-storage-codex-selection.test.ts -t "re-ranks a session pinned"
# main: Expected "api-acct-fresh", Received "api-acct-pinned"
```

## Cause
`#resolveOAuthSelection` (`packages/ai/src/auth-storage.ts`) built `shouldRank` from `sessionPreferredIsAvailable`, whose three inputs are all structural (exists / refreshable / unblocked). `#recordSessionCredential` wrote the pin JSON as `{type, index, credentialId}` with no timestamp, so no idle signal existed. Even when ranking did run, the pinned index was unconditionally hoisted to the front of the ranked candidates, overriding the ranked result.

## Fix
- `#recordSessionCredential` / `#getSessionCredential`: carry `lastUsedAtMs` in the in-memory `#sessionLastCredential` map and the persisted pin JSON. Legacy rows without the field read as warm until the next resolve rewrites them.
- Added `SESSION_STICKY_CACHE_WARM_MS` (1h, matching Anthropic OAuth `ttl: "1h"` retention). `shouldRank` now also fires when the pin is idle past this window (`!sessionPreferredIsWarm`).
- When ranking runs, the pinned credential is seeded first in `rankingOrder` so it wins genuine ties via the comparator's `orderPos` fallback, instead of the old absolute front-of-queue hoist. The hoist is retained only on the warm skip path (where candidates follow round-robin `order`, not the pin).

## Verification
`cd packages/ai && bun test test/auth-storage-*.test.ts` → 236 pass, 0 fail (includes the two new regression tests). `bun run check:ts` clean after `bun run fix`. Fixes #5966