### PR TITLE
fix(tools): keep web_search top-level under xdev

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `web_search` being unreachable under default config: with `tools.xdev: true`, the discoverable `web_search` tool was mounted under `xd://` and dropped from the top-level toolset, so models calling it directly got "Tool web_search not found". It is now pinned top-level via `XDEV_KEEP_TOP_LEVEL` while other discoverable tools keep mounting under `xd://` ([#5973](https://github.com/can1357/oh-my-pi/issues/5973)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -38,11 +38,18 @@ import { ToolError } from "./tool-errors";
 /**
  * Discoverable built-ins that must stay top-level even when xdev mounting is
  * active: `todo` feeds the todo prelude/prewalk machinery, `ask` is the
- * model's user-interaction affordance, and `grep` is the redirect target of
- * the bash interceptor rules — each loses its harness integration if hidden
- * behind dispatch.
+ * model's user-interaction affordance, `grep` is the redirect target of the
+ * bash interceptor rules, and `web_search` is invoked directly by most models
+ * (which have no notion of the `xd://` protocol) so hiding it behind dispatch
+ * makes it unreachable in practice (issue #5973) — each loses its harness
+ * integration or usability if hidden behind dispatch.
  */
-export const XDEV_KEEP_TOP_LEVEL: Record<string, true> = { todo: true, ask: true, grep: true };
+export const XDEV_KEEP_TOP_LEVEL: Record<string, true> = {
+	todo: true,
+	ask: true,
+	grep: true,
+	web_search: true,
+};
 
 /**
  * Tools that carry the `xd://` transport itself and therefore can never be

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -206,3 +206,22 @@ describe("read and write route xd:// device URLs", () => {
 		}
 	});
 });
+
+describe("web_search stays top-level under xdev", () => {
+	it("keeps web_search a direct tool and off the xd:// registry with default config", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "write-xdev-websearch-"));
+		try {
+			const session = xdevSession(tempDir);
+			// Default config: tools.xdev is on.
+			expect(session.settings.get("tools.xdev")).toBe(true);
+			const tools = await createTools(session);
+			// Regression for #5973: models call web_search directly, so it must
+			// remain a top-level function and never mount behind the xd:// device.
+			expect(tools.some(entry => entry.name === "web_search")).toBe(true);
+			const mounted = session.xdevRegistry ? [...session.xdevRegistry.list()].map(t => t.name) : [];
+			expect(mounted).not.toContain("web_search");
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With default config (`tools.xdev: true`), asking the agent to run a web search fails: the model calls `web_search` directly and gets "Tool web_search not found", even though the system prompt lists it. Building the toolset via `createTools(session)` with `Settings.isolated({})` shows `web_search` is not top-level and instead mounted under `xd://`:
```
tools.xdev default: true
web_search top-level? false
web_search mounted under xd://? true
```

## Cause
`isMountableUnderXdev` in `packages/coding-agent/src/tools/xdev.ts` mounts any tool with `loadMode: "discoverable"` under `xd://` unless it is pinned in `XDEV_KEEP_TOP_LEVEL`. `WebSearchTool` (`packages/coding-agent/src/web/search/index.ts`) declares `loadMode = "discoverable"` and was not pinned, so `createTools` moved it into the session `XdevRegistry` and out of the top-level toolset. The only working path became `write xd://web_search`, which most models never attempt.

## Fix
- Add `web_search` to `XDEV_KEEP_TOP_LEVEL` in `packages/coding-agent/src/tools/xdev.ts` so it stays a direct-callable top-level tool while every other discoverable tool keeps mounting under `xd://`.
- Add a regression test in `packages/coding-agent/test/write-xdev-dispatch.test.ts` asserting `web_search` is top-level and absent from the `xd://` registry under default config.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/write-xdev-dispatch.test.ts` → 6 pass / 0 fail. Manually reconfirmed via `createTools` that `web_search` is now top-level (`web_search top-level? true`, `mounted under xd://? false`). Fixes #5973