### PR TITLE
fix(ai): coerce boolean tool-schema subschemas for Moonshot MFJS

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Moonshot/Kimi tool calls 400ing with "tools.function.parameters is not a valid moonshot flavored json schema, details: property schema for '<name>' must be an object" whenever a tool parameter schema carried a bare boolean subschema. `normalizeSchemaForMoonshot` now coerces boolean subschemas to their object form (`true` → `{}`, `false` → `{ not: {} }`, both accepted by the live Moonshot endpoint), matching `normalizeSchemaForGoogle`/`normalizeSchemaForCCA`. This also covers the empty-`{}`-schema case, since `normalizeEmptySchemas` rewrites empty subschemas to `true` on the wire (#1179) — so the encoder itself manufactured the rejected construct even for boolean-free source schemas. `additionalProperties: true/false` (a native MFJS keyword) is preserved untouched.
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1080,6 +1080,14 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  *    `default` and `description` are MFJS Meta Data fields and are preserved.
  *  - `additionalProperties` (boolean or schema) and `type: "null"` (incl.
  *    inside `anyOf`) are kept.
+ *  - A bare boolean subschema in a subschema slot (e.g. `properties.x: true`)
+ *    is rejected — MFJS 400s with "property schema for '<name>' must be an
+ *    object". This is not hypothetical: {@link normalizeEmptySchemas} rewrites
+ *    every empty `{}` subschema to `true` upstream (issue #1179), so the wire
+ *    encoder itself manufactures the construct. Coerced to object form
+ *    (`true` -> `{}`, `false` -> `{ not: {} }`); both are accepted by the live
+ *    Moonshot endpoint. `additionalProperties: true/false` is a native MFJS
+ *    keyword (not a subschema slot) and is preserved untouched.
  *
  * Out of scope (absent from the built-in tool surface, spec-ambiguous to
  * rewrite blindly): `allOf` intersection merging, external/recursive `$ref`,
@@ -1087,6 +1095,7 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  */
 export function normalizeSchemaForMoonshot(value: unknown): unknown {
 	return normalizeSchema(value, {
+		coerceBooleanSubschemas: true,
 		unsupportedFields: isMoonshotUnsupportedSchemaField,
 		normalizeFieldNames: false,
 		collapseNullFields: false,

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -1276,11 +1276,29 @@ describe("normalizeSchemaForMoonshot", () => {
 		expect(props.limit).toEqual({ type: "integer", default: 10 });
 	});
 
-	it("preserves boolean subschemas rather than synthesizing MFJS-forbidden not", () => {
+	it("coerces bare boolean subschemas to object form (MFJS rejects booleans in subschema slots)", () => {
+		// Verified against the live Moonshot endpoint: `properties.x: true` and
+		// `properties.x: false` both 400 with "property schema for 'x' must be an
+		// object"; the coerced `{}` and `{ not: {} }` forms both return 200. The
+		// wire encoder itself manufactures these booleans via normalizeEmptySchemas
+		// (`{}` -> `true`, issue #1179), so this fires even for boolean-free sources.
+		expect(normalizeSchemaForMoonshot({ type: "object", properties: { open: true } })).toEqual({
+			type: "object",
+			properties: { open: {} },
+		});
 		expect(normalizeSchemaForMoonshot({ type: "object", properties: { forbidden: false } })).toEqual({
 			type: "object",
-			properties: { forbidden: false },
+			properties: { forbidden: { not: {} } },
 		});
+	});
+
+	it("coerces boolean subschemas inside items and combinator arrays", () => {
+		expect(normalizeSchemaForMoonshot({ type: "array", items: true }) as Record<string, unknown>).toEqual({
+			type: "array",
+			items: {},
+		});
+		const anyOf = normalizeSchemaForMoonshot({ anyOf: [true, { type: "string" }] }) as Record<string, unknown>;
+		expect(anyOf.anyOf).toEqual([{}, { type: "string" }]);
 	});
 
 	it("folds oneOf into anyOf (the only MFJS combinator)", () => {


### PR DESCRIPTION
## Problem

Moonshot/Kimi validates `tools.function.parameters` against **Moonshot Flavored JSON Schema (MFJS)**, which rejects a bare boolean in a subschema slot:

```
tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'properties.tasks.items.properties': property schema for 'outputSchema' must be an object>
```

A boolean subschema (`true` = accept anything, `false` = accept nothing) is **valid standard JSON Schema (draft-06+)**, so the request is well-formed — but Moonshot 400s the whole turn on the first request, leaving the client with an empty assistant turn and no obvious cause.

Two independent paths hit this:

1. **Third-party / built-in tool schemas** that legitimately use boolean subschemas. The built-in `task` tool emits `"outputSchema": true` nested in its parameters, so *any* Kimi model 400s the moment `task` is in scope.
2. **The wire encoder itself.** `normalizeEmptySchemas` rewrites every empty `{}` subschema to `true` for llama.cpp grammar reasons (#1179), provider-agnostically and upstream of the Moonshot normalizer. So even a schema that never contained a boolean arrives at Moonshot with the forbidden construct.

## Fix

`normalizeSchemaForGoogle` and `normalizeSchemaForCCA` already pass `coerceBooleanSubschemas: true`; `normalizeSchemaForMoonshot` did not. Add it, so bare booleans in genuine subschema slots (`properties`, `patternProperties`, `$defs`, `anyOf`/`oneOf`/`allOf`/`prefixItems`, `items`, `contains`, `if`/`then`/`else`, `not`, ...) are coerced to object form:

- `true` → `{}`
- `false` → `{ not: {} }`

`additionalProperties: true/false` is a **native MFJS keyword** (not a subschema slot per the walker's `booleanIsSubschema` gate) and is preserved untouched — the existing "keeps additionalProperties (boolean and schema)" test still passes.

## Verification

Both coercion outputs were checked against a **live Moonshot endpoint**:

| schema | result |
| --- | --- |
| `properties: { x: true }` | **400** |
| `properties: { x: {} }` | **200** |
| `properties: { x: false }` | **400** |
| `properties: { x: { not: {} } }` | **200** |
| `additionalProperties: true` | **200** |

`{ not: {} }` survives to the wire: the boolean coercion is a leaf return (`normalize.ts` ~L291) that later strip/fold passes never revisit, and the residual/fixpoint passes are off for the Moonshot option set.

This also corrects a prior test (`schema-normalization.test.ts`) whose premise — *"synthesizing MFJS-forbidden not"* — is falsified by the live endpoint accepting `{ not: {} }`. It now asserts the empirically-correct coercion for both `true` and `false`, plus `items`/`anyOf` boolean coercion.

## Tests

`bun test packages/ai/test/schema-normalization.test.ts` → 71 pass. `openai-completions-compat` → 67 pass. `biome check` + `tsgo --noEmit` clean.

## Known follow-ups (not in this PR)

- The strip-set marks `not` as unsupported for MFJS, but the live endpoint accepts it — user-authored `not` schemas are still stripped/spilled. Widening that is a separate change.
- `toolSchemaFlavor` is gated on `isMoonshotNative` (host `api.moonshot.ai`/`api.kimi.com`). Kimi served via an OpenRouter "Moonshot AI" route isn''t detected; the existing per-model `compat.toolSchemaFlavor` override is the current escape hatch. MFJS is a property of the serving stack (not the open weights), so by-model-id gating is intentionally **not** done here — it would apply a lossy transform to hosts (Groq/Fireworks/Together) that accept the raw schema.