### PR TITLE
fix(setup): add default model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,32 @@ OpenAI-compatible `/v1/models`. Local instances skip the key.
 
 Ollama `local` · Ollama Cloud · LM Studio `local` · llama.cpp `local` · vLLM `local` · LiteLLM
 
+### Custom OpenAI-compatible providers
+
+Define custom providers in `~/.omp/agent/models.yml`:
+
+```yaml
+providers:
+  spark:
+    baseUrl: http://192.168.10.223:8000/v1
+    api: openai-completions
+    apiKey: dummy
+    models:
+      - id: minimax-m3
+        name: MiniMax M3
+        contextWindow: 100000
+        maxTokens: 32000
+```
+
+Run `omp models spark` to verify discovery. Then run `omp setup` and choose the model in the default-model step, or open `/model` in a session and assign it to the `default` role.
+
+To preconfigure the default without the picker, add the selector to `~/.omp/agent/config.yml`:
+
+```yaml
+modelRoles:
+  default: spark/minimax-m3
+```
+
 ### Four knobs that make routing useful
 
 - **Custom providers** — Declare anything that speaks `openai-completions`, `openai-responses`, `openai-codex-responses`, `azure-openai-responses`, `anthropic-messages`, `google-generative-ai`, or `google-vertex` in `~/.omp/agent/models.yml`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed onboarding omitting model selection by adding a persisted default-model step, and documented custom `models.yml` provider configuration and default-role selection ([#5979](https://github.com/can1357/oh-my-pi/issues/5979)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/modes/setup-version.ts
+++ b/packages/coding-agent/src/modes/setup-version.ts
@@ -8,4 +8,4 @@
  * the overlay component and their TUI deps. MUST equal `max(scene.minVersion)`
  * across `ALL_SCENES`; the `setup-wizard` barrel and test suite guard it.
  */
-export const CURRENT_SETUP_VERSION = 1;
+export const CURRENT_SETUP_VERSION = 2;

--- a/packages/coding-agent/src/modes/setup-wizard/index.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/index.ts
@@ -2,6 +2,7 @@ import type { Settings } from "../../config/settings";
 import { CURRENT_SETUP_VERSION } from "../setup-version";
 import type { InteractiveModeContext } from "../types";
 import { glyphSetupScene } from "./scenes/glyph";
+import { modelSetupScene } from "./scenes/model";
 import { providersSetupScene } from "./scenes/providers";
 import { themeSetupScene } from "./scenes/theme";
 import type { SetupScene } from "./scenes/types";
@@ -14,6 +15,7 @@ export { CURRENT_SETUP_VERSION };
 
 export const ALL_SCENES = [
 	providersSetupScene,
+	modelSetupScene,
 	glyphSetupScene,
 	themeSetupScene,
 ] as const satisfies readonly SetupScene[];

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
@@ -30,8 +30,10 @@ class ModelSceneController implements SetupSceneController {
 		this.#syncModels();
 	}
 
-	onMount(): void {
-		void this.#refreshModels();
+	async onMount(): Promise<void> {
+		this.#status = theme.fg("muted", "Discovering available models…");
+		this.host.requestRender();
+		await this.#refreshModels();
 	}
 
 	dispose(): void {
@@ -89,9 +91,10 @@ class ModelSceneController implements SetupSceneController {
 
 	async #refreshModels(): Promise<void> {
 		try {
-			await this.host.ctx.session.modelRegistry.refresh("offline");
+			await this.host.ctx.session.modelRegistry.refresh("online-if-uncached");
 			if (this.#disposed) return;
 			this.#syncModels();
+			this.#status = undefined;
 			this.host.requestRender();
 		} catch (error) {
 			if (this.#disposed) return;

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
@@ -109,7 +109,11 @@ class ModelSceneController implements SetupSceneController {
 		this.#status = theme.fg("muted", `Saving ${selector} as the default model…`);
 		this.host.requestRender();
 		try {
-			await this.host.ctx.session.setModel(model, "default", { selector, persist: true });
+			const projectScope = this.host.ctx.settings.get("modelRoleStorage") === "project";
+			await this.host.ctx.session.setModel(model, "default", { selector, persist: !projectScope });
+			if (projectScope) {
+				this.host.ctx.settings.setProjectModelRole("default", selector);
+			}
 			await this.host.ctx.settings.flush();
 			if (!this.#disposed) this.host.finish("done");
 		} catch (error) {

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/model.ts
@@ -1,0 +1,127 @@
+import type { Model } from "@oh-my-pi/pi-ai";
+import type { SgrMouseEvent } from "@oh-my-pi/pi-tui";
+import {
+	buildBrowserItems,
+	ModelBrowser,
+	resolveRoleAssignments,
+	sortModelItems,
+} from "../../components/model-browser";
+import { theme } from "../../theme/theme";
+import type { SetupScene, SetupSceneController, SetupSceneHost } from "./types";
+
+const MAX_VISIBLE_MODELS = 10;
+const WIZARD_SCREEN_RESERVE = 22;
+
+class ModelSceneController implements SetupSceneController {
+	title = "Choose your default model";
+	subtitle = "Search configured models and save the model used for new sessions.";
+	#browser: ModelBrowser;
+	#status: string | undefined;
+	#selecting = false;
+	#disposed = false;
+	#browserRowStart = 2;
+
+	constructor(private readonly host: SetupSceneHost) {
+		this.#browser = new ModelBrowser(host.ctx.settings);
+		this.#browser.onActivate = item => {
+			void this.#select(item.model, item.selector);
+		};
+		this.#browser.onCancel = () => host.finish("skipped");
+		this.#syncModels();
+	}
+
+	onMount(): void {
+		void this.#refreshModels();
+	}
+
+	dispose(): void {
+		this.#disposed = true;
+	}
+
+	invalidate(): void {
+		this.#browser.invalidate();
+	}
+
+	handleInput(data: string): void {
+		if (this.#selecting) return;
+		this.#browser.handleInput(data);
+	}
+
+	routeMouse(event: SgrMouseEvent, line: number): void {
+		if (this.#selecting) return;
+		this.#browser.routeMouse(event, line - this.#browserRowStart);
+	}
+
+	render(width: number): readonly string[] {
+		const visibleRows = Math.max(
+			1,
+			Math.min(MAX_VISIBLE_MODELS, this.host.ctx.ui.terminal.rows - WIZARD_SCREEN_RESERVE),
+		);
+		this.#browser.setMaxVisible(visibleRows);
+		const lines = [
+			this.#status ?? theme.fg("muted", "Type to search. Enter saves the highlighted model as your default."),
+			"",
+		];
+		this.#browserRowStart = lines.length;
+		lines.push(...this.#browser.render(width));
+		return lines;
+	}
+
+	#syncModels(): void {
+		const registry = this.host.ctx.session.modelRegistry;
+		const available = registry.getAvailable();
+		const roles = resolveRoleAssignments(this.host.ctx.settings, registry.getAll(), available);
+		const storage = this.host.ctx.settings.getStorage();
+		const items = buildBrowserItems(available);
+		sortModelItems(items, { roles, mruOrder: storage?.getModelUsageOrder() ?? [] });
+		this.#browser.setRoles(roles);
+		this.#browser.setMruOrder(storage?.getModelUsageOrder() ?? []);
+		this.#browser.setPerfStats(storage?.getModelPerf() ?? new Map());
+		this.#browser.setItems(items);
+
+		const current = this.host.ctx.session.model;
+		if (current) {
+			const selector = `${current.provider}/${current.id}`;
+			this.#browser.setCurrentSelector(selector);
+			this.#browser.selectSelector(selector);
+		}
+	}
+
+	async #refreshModels(): Promise<void> {
+		try {
+			await this.host.ctx.session.modelRegistry.refresh("offline");
+			if (this.#disposed) return;
+			this.#syncModels();
+			this.host.requestRender();
+		} catch (error) {
+			if (this.#disposed) return;
+			this.#status = theme.fg("error", error instanceof Error ? error.message : String(error));
+			this.host.requestRender();
+		}
+	}
+
+	async #select(model: Model, selector: string): Promise<void> {
+		if (this.#selecting) return;
+		this.#selecting = true;
+		this.#status = theme.fg("muted", `Saving ${selector} as the default model…`);
+		this.host.requestRender();
+		try {
+			await this.host.ctx.session.setModel(model, "default", { selector, persist: true });
+			await this.host.ctx.settings.flush();
+			if (!this.#disposed) this.host.finish("done");
+		} catch (error) {
+			if (this.#disposed) return;
+			this.#selecting = false;
+			this.#status = theme.fg("error", error instanceof Error ? error.message : String(error));
+			this.host.requestRender();
+		}
+	}
+}
+
+/** Setup step that assigns one available model to the persisted default role. */
+export const modelSetupScene: SetupScene = {
+	id: "model",
+	title: "Choose your default model",
+	minVersion: 2,
+	mount: host => new ModelSceneController(host),
+};

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -113,7 +113,7 @@ describe("setup wizard scene selection", () => {
 });
 
 describe("setup wizard model selection", () => {
-	it("saves a configured custom model as the default", async () => {
+	it("discovers and saves an uncached custom model as the default", async () => {
 		await initTheme(false, "unicode", false, "titanium", "dark");
 		const settings = Settings.isolated();
 		const model: Model = buildModel({
@@ -128,6 +128,7 @@ describe("setup wizard model selection", () => {
 			contextWindow: 100_000,
 			maxTokens: 32_000,
 		});
+		let available: Model[] = [];
 		const finished = Promise.withResolvers<string>();
 		const setModel = mock(
 			async (
@@ -147,9 +148,11 @@ describe("setup wizard model selection", () => {
 				session: {
 					model: undefined,
 					modelRegistry: {
-						getAvailable: () => [model],
-						getAll: () => [model],
-						refresh: async () => {},
+						getAvailable: () => available,
+						getAll: () => available,
+						refresh: async (strategy: string) => {
+							if (strategy === "online-if-uncached") available = [model];
+						},
 					},
 					setModel,
 				},
@@ -164,6 +167,9 @@ describe("setup wizard model selection", () => {
 		expect(scene).toBeDefined();
 
 		const controller = scene!.mount(host);
+		expect(controller.render?.(120).join("\n")).not.toContain("minimax-m3");
+		await controller.onMount?.();
+		expect(controller.render?.(120).join("\n")).toContain("minimax-m3");
 		controller.handleInput?.("\r");
 		const result = await finished.promise;
 

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -113,21 +113,21 @@ describe("setup wizard scene selection", () => {
 });
 
 describe("setup wizard model selection", () => {
-	it("discovers and saves an uncached custom model as the default", async () => {
+	const CUSTOM_MODEL: Model = buildModel({
+		id: "minimax-m3",
+		name: "MiniMax M3",
+		api: "openai-completions",
+		provider: "spark",
+		baseUrl: "http://127.0.0.1:8000/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 32_000,
+	});
+
+	async function pickModelDuringSetup(settings: Settings): Promise<string> {
 		await initTheme(false, "unicode", false, "titanium", "dark");
-		const settings = Settings.isolated();
-		const model: Model = buildModel({
-			id: "minimax-m3",
-			name: "MiniMax M3",
-			api: "openai-completions",
-			provider: "spark",
-			baseUrl: "http://127.0.0.1:8000/v1",
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 100_000,
-			maxTokens: 32_000,
-		});
 		let available: Model[] = [];
 		const finished = Promise.withResolvers<string>();
 		const setModel = mock(
@@ -151,7 +151,7 @@ describe("setup wizard model selection", () => {
 						getAvailable: () => available,
 						getAll: () => available,
 						refresh: async (strategy: string) => {
-							if (strategy === "online-if-uncached") available = [model];
+							if (strategy === "online-if-uncached") available = [CUSTOM_MODEL];
 						},
 					},
 					setModel,
@@ -171,10 +171,27 @@ describe("setup wizard model selection", () => {
 		await controller.onMount?.();
 		expect(controller.render?.(120).join("\n")).toContain("minimax-m3");
 		controller.handleInput?.("\r");
-		const result = await finished.promise;
+		return finished.promise;
+	}
 
-		expect(settings.getModelRole("default")).toBe("spark/minimax-m3");
+	it("discovers and saves an uncached custom model as the global default", async () => {
+		const settings = Settings.isolated();
+
+		const result = await pickModelDuringSetup(settings);
+
 		expect(result).toBe("done");
+		expect(settings.getGlobalModelRole("default")).toBe("spark/minimax-m3");
+		expect(settings.getProjectModelRole("default")).toBeUndefined();
+	});
+
+	it("saves to the project layer under project role storage", async () => {
+		const settings = Settings.isolated({ modelRoleStorage: "project" });
+
+		const result = await pickModelDuringSetup(settings);
+
+		expect(result).toBe("done");
+		expect(settings.getProjectModelRole("default")).toBe("spark/minimax-m3");
+		expect(settings.getGlobalModelRole("default")).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { runOnboardingSetup } from "@oh-my-pi/pi-coding-agent/commands/setup";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { SETTINGS_SCHEMA } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
@@ -107,6 +109,66 @@ describe("setup wizard scene selection", () => {
 			{ isTTY: true },
 		);
 		expect(selected.map(scene => scene.id)).toEqual(["allowed"]);
+	});
+});
+
+describe("setup wizard model selection", () => {
+	it("saves a configured custom model as the default", async () => {
+		await initTheme(false, "unicode", false, "titanium", "dark");
+		const settings = Settings.isolated();
+		const model: Model = buildModel({
+			id: "minimax-m3",
+			name: "MiniMax M3",
+			api: "openai-completions",
+			provider: "spark",
+			baseUrl: "http://127.0.0.1:8000/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 100_000,
+			maxTokens: 32_000,
+		});
+		const finished = Promise.withResolvers<string>();
+		const setModel = mock(
+			async (
+				selected: Model,
+				role: string,
+				options?: { selector?: string; persist?: boolean },
+			): Promise<{ switched: boolean }> => {
+				if (options?.persist) {
+					settings.setModelRole(role, options.selector ?? `${selected.provider}/${selected.id}`);
+				}
+				return { switched: true };
+			},
+		);
+		const host = {
+			ctx: {
+				settings,
+				session: {
+					model: undefined,
+					modelRegistry: {
+						getAvailable: () => [model],
+						getAll: () => [model],
+						refresh: async () => {},
+					},
+					setModel,
+				},
+				ui: { terminal: { rows: 30 } },
+			},
+			requestRender: () => {},
+			finish: (next: string) => finished.resolve(next),
+			setFocus: () => {},
+			restoreFocus: () => {},
+		} as unknown as SetupSceneHost;
+		const scene = ALL_SCENES.find(candidate => candidate.id === "model");
+		expect(scene).toBeDefined();
+
+		const controller = scene!.mount(host);
+		controller.handleInput?.("\r");
+		const result = await finished.promise;
+
+		expect(settings.getModelRole("default")).toBe("spark/minimax-m3");
+		expect(result).toBe("done");
 	});
 });
 


### PR DESCRIPTION
## Repro
With the reported custom provider saved in `~/.omp/agent/models.yml`, `PI_CODING_AGENT_DIR=$PWD/.tmp/repro-5979 bun packages/coding-agent/src/cli.ts models spark --json` lists `spark/minimax-m3`, while inspecting `ALL_SCENES.map(scene => scene.id)` returned only `["providers","glyph-mode","theme"]`; onboarding loaded the model but offered no way to persist it as the default.

## Cause
`packages/coding-agent/src/modes/setup-wizard/index.ts` registered provider authentication, glyph, and theme scenes only. No setup controller called `AgentSession.setModel(..., { persist: true })`, so `modelRoles.default` stayed unset and `findInitialModel` continued using automatic provider-default selection, which could select Hugging Face DeepSeek-R1.

## Fix
- Add a searchable default-model setup scene that lists available registry models, switches to the selected model, and persists it to the `default` role.
- Bump the setup version so existing 17.0.4 installations receive the new scene.
- Document custom `models.yml` providers, discovery verification, setup and `/model` selection, and direct `modelRoles.default` configuration.
- Add regression coverage for selecting a custom model during setup.

## Verification
`bun test packages/coding-agent/test/setup-wizard.test.ts packages/coding-agent/test/setup-wizard-sign-in.test.ts` — 22 passed, 0 failed. `bun check` passed across all packages. Manually exercised the scene controller with `spark/minimax-m3`; it persisted `modelRoles.default` as `spark/minimax-m3` and completed the setup step. Fixes #5979