### PR TITLE
fix(ai): honor Moonshot base URL during login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/login moonshot` validating China-platform API keys against the international host instead of honoring `MOONSHOT_BASE_URL` ([#5981](https://github.com/can1357/oh-my-pi/issues/5981)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/ai/src/registry/api-key-login.ts
+++ b/packages/ai/src/registry/api-key-login.ts
@@ -31,7 +31,7 @@ type AnthropicMessagesValidation = {
 type ModelsEndpointValidation = {
 	kind: "models-endpoint";
 	provider: string;
-	modelsUrl: string;
+	modelsUrl: string | (() => string);
 	headers?: Record<string, string> | (() => Record<string, string> | undefined);
 };
 
@@ -99,7 +99,10 @@ export function createApiKeyLogin(config: ApiKeyLoginConfig): (options: OAuthCon
 				await validateApiKeyAgainstModelsEndpoint({
 					provider: config.validation.provider,
 					apiKey: trimmed,
-					modelsUrl: config.validation.modelsUrl,
+					modelsUrl:
+						typeof config.validation.modelsUrl === "function"
+							? config.validation.modelsUrl()
+							: config.validation.modelsUrl,
 					headers: config.validation.headers,
 					signal: options.signal,
 					fetch: options.fetch,

--- a/packages/ai/src/registry/moonshot.ts
+++ b/packages/ai/src/registry/moonshot.ts
@@ -1,6 +1,12 @@
+import { $env } from "@oh-my-pi/pi-utils";
 import { createApiKeyLogin } from "./api-key-login";
 import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+function resolveMoonshotModelsUrl(): string {
+	const baseUrl = $env.MOONSHOT_BASE_URL?.trim() || "https://api.moonshot.ai/v1";
+	return `${baseUrl.replace(/\/+$/, "")}/models`;
+}
 
 export const loginMoonshot = createApiKeyLogin({
 	providerLabel: "Moonshot",
@@ -11,7 +17,7 @@ export const loginMoonshot = createApiKeyLogin({
 	validation: {
 		kind: "models-endpoint",
 		provider: "moonshot",
-		modelsUrl: "https://api.moonshot.ai/v1/models",
+		modelsUrl: resolveMoonshotModelsUrl,
 	},
 });
 

--- a/packages/ai/test/issue-2883-moonshot-base-url.test.ts
+++ b/packages/ai/test/issue-2883-moonshot-base-url.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import { resolveOpenAIRequestSetup } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import { loginMoonshot } from "@oh-my-pi/pi-ai/registry/moonshot";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 
 const ORIGINAL_MOONSHOT_BASE_URL = Bun.env.MOONSHOT_BASE_URL;
 
@@ -40,6 +42,23 @@ describe("Moonshot China base URL override (issue #2883)", () => {
 			messages: [],
 		});
 		expect(setup.baseUrl).toBe("https://api.moonshot.ai/v1");
+	});
+
+	test("validates login against the configured Moonshot endpoint", async () => {
+		Bun.env.MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1/";
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request) => {
+			const url = typeof input === "string" ? input : input.toString();
+			expect(url).toBe("https://api.moonshot.cn/v1/models");
+			return new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 });
+		});
+
+		const apiKey = await loginMoonshot({
+			onPrompt: async () => " sk-china-key ",
+			fetch: fetchMock,
+		});
+
+		expect(apiKey).toBe("sk-china-key");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	test("does not redirect other openai-completions providers", () => {


### PR DESCRIPTION
## Repro
Set `MOONSHOT_BASE_URL=https://api.moonshot.cn/v1`, run `omp`, then select `/login moonshot` and paste a China-platform API key. The login validator sent `GET https://api.moonshot.ai/v1/models` instead of the configured China endpoint and failed with `401 Invalid Authentication`.

## Cause
`packages/ai/src/registry/moonshot.ts` hardcoded the international models endpoint in `loginMoonshot`, while request setup and model discovery already honored `MOONSHOT_BASE_URL`. `createApiKeyLogin` also accepted only a static `modelsUrl`, so the validator could not resolve the environment-dependent endpoint when login ran.

## Fix
- Allow model-endpoint login validators to resolve their URL lazily.
- Derive Moonshot's validation URL from `MOONSHOT_BASE_URL`, retaining the international default and normalizing trailing slashes.
- Extend the existing Moonshot China endpoint regression coverage and document the fix in the AI changelog.

## Verification
`bun test packages/ai/test/issue-2883-moonshot-base-url.test.ts` passed: 4 tests, 0 failures. A direct login-flow smoke run with `MOONSHOT_BASE_URL=https://api.moonshot.cn/v1/` called `https://api.moonshot.cn/v1/models` and returned the trimmed API key. The pre-publish `bun run fix` and `bun check` gate passed before push and PR creation.

Fixes #5981