### PR TITLE
fix(coding-agent): render ask option previews inline

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed rich ask options showing preview content only for the highlighted choice; every option now renders its preview inline, with pageable long content and accurate configured paging and cancel hints ([#5988](https://github.com/can1357/oh-my-pi/pull/5988) by [@metaphorics](https://github.com/metaphorics)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -4,7 +4,6 @@ import {
 	Markdown,
 	type MarkdownTheme,
 	matchesKey,
-	padding,
 	renderInlineMarkdown,
 	replaceTabs,
 	ScrollView,
@@ -13,7 +12,6 @@ import {
 	Text,
 	type TUI,
 	truncateToWidth,
-	visibleWidth,
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
 import type {
@@ -23,8 +21,15 @@ import type {
 } from "../../extensibility/extensions";
 import { getTabBarTheme } from "../shared";
 import { getMarkdownTheme, highlightCode, theme } from "../theme/theme";
-import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
+import {
+	matchesSelectCancel,
+	matchesSelectDown,
+	matchesSelectPageDown,
+	matchesSelectPageUp,
+	matchesSelectUp,
+} from "../utils/keybinding-matchers";
 import { CountdownTimer } from "./countdown-timer";
+import { editorKey } from "./keybinding-hints";
 import { bottomBorder, divider, row, topBorder } from "./overlay-box";
 import { handleTabSwitchKey } from "./selector-helpers";
 
@@ -38,9 +43,6 @@ const SUBMIT_OPTION = "Submit";
 const DIALOG_HEIGHT_RATIO = 0.7;
 const MIN_DIALOG_ROWS = 12;
 const MIN_BODY_ROWS = 5;
-const PREVIEW_MIN_WIDTH = 40;
-const SIDE_BY_SIDE_LIST_MIN_WIDTH = 30;
-const SIDE_BY_SIDE_GAP_WIDTH = 3;
 const MAX_HEADER_CHIP_WIDTH = 16;
 /** Maximum number of title lines shown in the prompt editor overlay, so a
  *  long or multi-line question cannot push the input row off-screen. Mirrors
@@ -90,6 +92,7 @@ interface QuestionState {
 	noteRowKey: string | undefined;
 	cursorIndex: number;
 	scrollOffset: number;
+	manualScroll: boolean;
 	timedOut: boolean;
 }
 
@@ -113,6 +116,8 @@ interface PreviewSegment {
 	text: string;
 	language: string | undefined;
 }
+
+type PreviewRenderCache = Map<string, Map<number, readonly string[]>>;
 
 function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(value, max));
@@ -211,6 +216,26 @@ function renderPreviewContent(preview: string, width: number): string[] {
 	return out;
 }
 
+function renderCachedPreview(cache: PreviewRenderCache, preview: string, width: number): readonly string[] {
+	let byWidth = cache.get(preview);
+	if (!byWidth) {
+		byWidth = new Map();
+		cache.set(preview, byWidth);
+	}
+	let rendered = byWidth.get(width);
+	if (!rendered) {
+		rendered = renderPreviewContent(preview, width).map(line => `      ${theme.fg("border", "│")} ${line}`);
+		byWidth.set(width, rendered);
+	}
+	return rendered;
+}
+
+function pageKeysLabel(): string {
+	const pageUp = editorKey("tui.select.pageUp");
+	const pageDown = editorKey("tui.select.pageDown");
+	return `${pageUp === "pageup" ? "PgUp" : pageUp}/${pageDown === "pagedown" ? "PgDn" : pageDown}`;
+}
+
 function normalizedInlineInput(input: string): string {
 	return replaceTabs(input).replace(/\s+/g, " ").trim();
 }
@@ -260,6 +285,7 @@ function renderRowLabel(
 	state: QuestionState,
 	selected: boolean,
 	mdTheme: MarkdownTheme,
+	previewCache: PreviewRenderCache,
 	width: number,
 ): string[] {
 	const isOption = rowItem.kind === "option";
@@ -283,6 +309,10 @@ function renderRowLabel(
 				lines.push(`      ${truncateToWidth(line, Math.max(1, width - 6), Ellipsis.Unicode)}`);
 			}
 		}
+		if (option?.preview?.trim()) {
+			const previewWidth = Math.max(1, width - 8);
+			lines.push(...renderCachedPreview(previewCache, option.preview, previewWidth));
+		}
 	}
 	if (isOther && state.customInput !== undefined) {
 		const preview = replaceTabs(state.customInput).replace(/\s+/g, " ").trim();
@@ -295,6 +325,8 @@ export class AskDialogComponent implements Component {
 	#states: QuestionState[];
 	#activeTabIndex = 0;
 	#submitScrollOffset = 0;
+	#bodyRows = MIN_BODY_ROWS;
+	#questionCanPage = false;
 	#remainingSeconds: number | undefined;
 	#countdown: CountdownTimer | undefined;
 	#promptActive = false;
@@ -302,6 +334,8 @@ export class AskDialogComponent implements Component {
 	#closed = false;
 	#tabBar: TabBar | undefined;
 	#stableHeight: { key: string; total: number } | undefined;
+	#previewCache: PreviewRenderCache = new Map();
+	#overflowLayouts = new WeakMap<ExtensionAskDialogQuestion, Set<string>>();
 
 	constructor(
 		private readonly questions: ExtensionAskDialogQuestion[],
@@ -318,6 +352,7 @@ export class AskDialogComponent implements Component {
 				noteRowKey: undefined,
 				cursorIndex: clamp(recommended ?? 0, 0, maxIndex),
 				scrollOffset: 0,
+				manualScroll: false,
 				timedOut: false,
 			};
 		});
@@ -335,6 +370,8 @@ export class AskDialogComponent implements Component {
 
 	invalidate(): void {
 		this.#stableHeight = undefined;
+		this.#previewCache.clear();
+		this.#overflowLayouts = new WeakMap();
 		this.#tabBar?.invalidate();
 	}
 
@@ -377,6 +414,7 @@ export class AskDialogComponent implements Component {
 		// (PRRT_kwDOQxs0bc6OFbDY).
 		const fixedRows = 1 + headerLines.length + 1 + 1 + 1 + 1;
 		const bodyRows = Math.max(MIN_BODY_ROWS, totalRows - fixedRows);
+		this.#bodyRows = bodyRows;
 		const bodyLines = this.#isSubmitTab()
 			? this.#renderSubmitBody(innerWidth, bodyRows)
 			: this.#renderQuestionBody(innerWidth, bodyRows);
@@ -419,22 +457,11 @@ export class AskDialogComponent implements Component {
 			const listRows = (listWidth: number): number => {
 				let total = 0;
 				for (const rowItem of rowItems) {
-					total += renderRowLabel(rowItem, question, state, false, mdTheme, listWidth).length;
+					total += renderRowLabel(rowItem, question, state, false, mdTheme, this.#previewCache, listWidth).length;
 				}
 				return total;
 			};
-			let body = listRows(width);
-			const previews = question.options.filter(option => option.preview?.trim());
-			const sideBySide = width >= SIDE_BY_SIDE_LIST_MIN_WIDTH + PREVIEW_MIN_WIDTH + SIDE_BY_SIDE_GAP_WIDTH;
-			if (previews.length > 0 && sideBySide) {
-				const previewWidth = Math.max(PREVIEW_MIN_WIDTH, Math.floor(width * 0.45));
-				const listWidth = Math.max(1, width - previewWidth - SIDE_BY_SIDE_GAP_WIDTH);
-				let pane = 0;
-				for (const option of previews) {
-					pane = Math.max(pane, renderPreviewContent(option.preview ?? "", Math.max(1, previewWidth - 2)).length);
-				}
-				body = Math.max(body, listRows(listWidth), pane);
-			}
+			const body = listRows(width);
 			needed = Math.max(needed, chrome + headerRows + Math.max(MIN_BODY_ROWS, body));
 		}
 		if (this.#hasSubmitTab()) {
@@ -499,13 +526,17 @@ export class AskDialogComponent implements Component {
 	}
 
 	#footerHintText(indicator: string): string {
-		const scroll = indicator ? ` ${indicator} scroll ·` : "";
 		if (this.#isSubmitTab()) {
+			const scroll = indicator ? ` ${indicator} scroll ·` : "";
 			return `Enter submit · ↑/↓ scroll ·${scroll} Esc cancel`;
 		}
 		const question = this.questions[this.#currentQuestionIndex()];
 		const action = question?.multi ? "Space/Enter toggle · n note" : "Enter select · n note";
-		const tabs = this.#hasSubmitTab() ? " · Tab/←/→ tabs" : "";
+		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
+		if (this.#questionCanPage && indicator) {
+			return `${action} · ↑/↓${tabs} · Esc cancel · ${pageKeysLabel()} ${indicator}`;
+		}
+		const scroll = indicator ? ` ${indicator} scroll ·` : "";
 		return `${action} · ↑/↓ move${tabs} ·${scroll} Esc cancel`;
 	}
 
@@ -536,13 +567,27 @@ export class AskDialogComponent implements Component {
 		if (!active) return;
 		const { question, state } = active;
 		const rows = this.#questionRows(question);
+		if (matchesSelectPageUp(keyData)) {
+			state.scrollOffset = Math.max(0, state.scrollOffset - Math.max(1, this.#bodyRows - 1));
+			state.manualScroll = true;
+			this.#requestRender();
+			return;
+		}
+		if (matchesSelectPageDown(keyData)) {
+			state.scrollOffset += Math.max(1, this.#bodyRows - 1);
+			state.manualScroll = true;
+			this.#requestRender();
+			return;
+		}
 		if (matchesSelectUp(keyData)) {
 			state.cursorIndex = clamp(state.cursorIndex - 1, 0, Math.max(0, rows.length - 1));
+			state.manualScroll = false;
 			this.#requestRender();
 			return;
 		}
 		if (matchesSelectDown(keyData)) {
 			state.cursorIndex = clamp(state.cursorIndex + 1, 0, Math.max(0, rows.length - 1));
+			state.manualScroll = false;
 			this.#requestRender();
 			return;
 		}
@@ -672,33 +717,7 @@ export class AskDialogComponent implements Component {
 		const { question, state } = active;
 		const rowItems = this.#questionRows(question);
 		state.cursorIndex = clamp(state.cursorIndex, 0, Math.max(0, rowItems.length - 1));
-		const selectedRow = rowItems[state.cursorIndex];
-		const preview =
-			selectedRow?.kind === "option" ? question.options[selectedRow.optionIndex ?? -1]?.preview : undefined;
-		// The preview pane exists only while the highlighted option carries a
-		// preview; otherwise the list takes the full dialog width.
-		if (!preview?.trim()) return this.#renderQuestionList(question, state, rowItems, width, maxRows);
-		const sideBySide = width >= SIDE_BY_SIDE_LIST_MIN_WIDTH + PREVIEW_MIN_WIDTH + SIDE_BY_SIDE_GAP_WIDTH;
-		if (sideBySide) {
-			const previewWidth = Math.max(PREVIEW_MIN_WIDTH, Math.floor(width * 0.45));
-			const listWidth = Math.max(1, width - previewWidth - SIDE_BY_SIDE_GAP_WIDTH);
-			const list = this.#renderQuestionList(question, state, rowItems, listWidth, maxRows);
-			const previewLines = this.#renderPreviewPane(preview, previewWidth, maxRows);
-			const lines: string[] = [];
-			for (let index = 0; index < maxRows; index++) {
-				const left = truncateToWidth(list.lines[index] ?? "", listWidth, Ellipsis.Unicode);
-				const right = truncateToWidth(previewLines[index] ?? "", previewWidth, Ellipsis.Unicode);
-				const gap = padding(Math.max(1, listWidth - visibleWidth(left)) + 1);
-				lines.push(`${left}${gap}${theme.fg("border", "│")} ${right}`);
-			}
-			return { lines, scrollOffset: list.scrollOffset, indicator: list.indicator };
-		}
-		const previewLines = this.#renderPreviewPane(preview, width, Math.max(3, Math.min(8, Math.floor(maxRows * 0.4))));
-		const listRows = Math.max(3, maxRows - previewLines.length - 1);
-		const list = this.#renderQuestionList(question, state, rowItems, width, listRows);
-		const lines = [...list.lines, theme.fg("border", "─".repeat(Math.max(1, width))), ...previewLines];
-		while (lines.length < maxRows) lines.push("");
-		return { lines: lines.slice(0, maxRows), scrollOffset: list.scrollOffset, indicator: list.indicator };
+		return this.#renderQuestionList(question, state, rowItems, width, maxRows);
 	}
 
 	#renderQuestionList(
@@ -709,16 +728,51 @@ export class AskDialogComponent implements Component {
 		rows: number,
 	): RenderedList {
 		const mdTheme = getMarkdownTheme();
-		const allLines: string[] = [];
-		const lineStartByRow: number[] = [];
-		for (let index = 0; index < rowItems.length; index++) {
-			lineStartByRow.push(allLines.length);
-			const rowItem = rowItems[index];
-			if (!rowItem) continue;
-			allLines.push(...renderRowLabel(rowItem, question, state, index === state.cursorIndex, mdTheme, width));
+		const renderRows = (contentWidth: number): { allLines: string[]; lineStartByRow: number[] } => {
+			const allLines: string[] = [];
+			const lineStartByRow: number[] = [];
+			for (let index = 0; index < rowItems.length; index++) {
+				lineStartByRow.push(allLines.length);
+				const rowItem = rowItems[index];
+				if (!rowItem) continue;
+				allLines.push(
+					...renderRowLabel(
+						rowItem,
+						question,
+						state,
+						index === state.cursorIndex,
+						mdTheme,
+						this.#previewCache,
+						contentWidth,
+					),
+				);
+			}
+			return { allLines, lineStartByRow };
+		};
+		const layoutKey = `${width}:${rows}:${state.customInput === undefined ? 0 : 1}`;
+		let overflowLayouts = this.#overflowLayouts.get(question);
+		const knownOverflow = overflowLayouts?.has(layoutKey) ?? false;
+		let renderedRows = renderRows(knownOverflow && width > 1 ? width - 1 : width);
+		if (!knownOverflow && width > 1 && renderedRows.allLines.length > rows) {
+			if (!overflowLayouts) {
+				overflowLayouts = new Set();
+				this.#overflowLayouts.set(question, overflowLayouts);
+			}
+			overflowLayouts.add(layoutKey);
+			renderedRows = renderRows(width - 1);
 		}
+		const { allLines, lineStartByRow } = renderedRows;
 		const cursorStart = lineStartByRow[state.cursorIndex] ?? 0;
-		state.scrollOffset = this.#scrollOffsetForCursor(state.scrollOffset, cursorStart, rows, allLines.length);
+		const cursorEnd = lineStartByRow[state.cursorIndex + 1] ?? allLines.length;
+		this.#questionCanPage = cursorEnd - cursorStart > rows;
+		state.scrollOffset = this.#scrollOffsetForCursor(
+			state.scrollOffset,
+			cursorStart,
+			cursorEnd,
+			rows,
+			allLines.length,
+			state.manualScroll,
+		);
 		const scrollView = new ScrollView(allLines, {
 			height: rows,
 			scrollbar: "auto",
@@ -732,15 +786,6 @@ export class AskDialogComponent implements Component {
 			scrollOffset: state.scrollOffset,
 			indicator: this.#clipIndicator(state.scrollOffset, rows, allLines.length),
 		};
-	}
-
-	#renderPreviewPane(preview: string, width: number, maxRows: number): string[] {
-		const bodyWidth = Math.max(1, width - 2);
-		const content = renderPreviewContent(preview, bodyWidth);
-		if (content.length <= maxRows) return content;
-		const visibleCount = Math.max(1, maxRows - 1);
-		const hidden = content.length - visibleCount;
-		return [...content.slice(0, visibleCount), theme.fg("dim", `… ${hidden} more lines`)];
 	}
 
 	#renderSubmitBody(width: number, rows: number): RenderedList {
@@ -789,12 +834,25 @@ export class AskDialogComponent implements Component {
 		};
 	}
 
-	#scrollOffsetForCursor(currentOffset: number, cursorLine: number, rows: number, totalRows: number): number {
-		if (totalRows <= rows) return 0;
-		let nextOffset = clamp(currentOffset, 0, Math.max(0, totalRows - rows));
-		if (cursorLine < nextOffset) nextOffset = cursorLine;
-		if (cursorLine >= nextOffset + rows) nextOffset = cursorLine - rows + 1;
-		return clamp(nextOffset, 0, Math.max(0, totalRows - rows));
+	#scrollOffsetForCursor(
+		currentOffset: number,
+		cursorStart: number,
+		cursorEnd: number,
+		rows: number,
+		totalRows: number,
+		manualScroll: boolean,
+	): number {
+		const maxOffset = Math.max(0, totalRows - rows);
+		if (maxOffset === 0) return 0;
+		let nextOffset = clamp(currentOffset, 0, maxOffset);
+		const cursorRows = cursorEnd - cursorStart;
+		if (manualScroll && cursorRows > rows) {
+			if (cursorEnd <= nextOffset) nextOffset = cursorEnd - 1;
+			if (cursorStart >= nextOffset + rows) nextOffset = cursorStart - rows + 1;
+		} else if (cursorStart < nextOffset || cursorEnd > nextOffset + rows) {
+			nextOffset = cursorRows <= rows ? cursorEnd - rows : cursorStart;
+		}
+		return clamp(nextOffset, 0, maxOffset);
 	}
 
 	#clipIndicator(offset: number, rows: number, totalRows: number): string {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -236,6 +236,11 @@ function pageKeysLabel(): string {
 	return `${pageUp === "pageup" ? "PgUp" : pageUp}/${pageDown === "pagedown" ? "PgDn" : pageDown}`;
 }
 
+function cancelKeyLabel(): string {
+	const [key = ""] = editorKey("tui.select.cancel").split("/");
+	return key === "escape" ? "Esc" : key;
+}
+
 function normalizedInlineInput(input: string): string {
 	return replaceTabs(input).replace(/\s+/g, " ").trim();
 }
@@ -526,18 +531,19 @@ export class AskDialogComponent implements Component {
 	}
 
 	#footerHintText(indicator: string): string {
+		const cancel = `${cancelKeyLabel()} cancel`;
 		if (this.#isSubmitTab()) {
 			const scroll = indicator ? ` ${indicator} scroll ·` : "";
-			return `Enter submit · ↑/↓ scroll ·${scroll} Esc cancel`;
+			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
 		}
 		const question = this.questions[this.#currentQuestionIndex()];
 		const action = question?.multi ? "Space/Enter toggle · n note" : "Enter select · n note";
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		if (this.#questionCanPage && indicator) {
-			return `${action} · ↑/↓${tabs} · Esc cancel · ${pageKeysLabel()} ${indicator}`;
+			return `${action} · ↑/↓${tabs} · ${cancel} · ${pageKeysLabel()} ${indicator}`;
 		}
 		const scroll = indicator ? ` ${indicator} scroll ·` : "";
-		return `${action} · ↑/↓ move${tabs} ·${scroll} Esc cancel`;
+		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}`;
 	}
 
 	#questionRows(question: ExtensionAskDialogQuestion): QuestionRow[] {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -853,8 +853,8 @@ export class AskDialogComponent implements Component {
 		let nextOffset = clamp(currentOffset, 0, maxOffset);
 		const cursorRows = cursorEnd - cursorStart;
 		if (manualScroll && cursorRows > rows) {
-			if (cursorEnd <= nextOffset) nextOffset = cursorEnd - 1;
-			if (cursorStart >= nextOffset + rows) nextOffset = cursorStart - rows + 1;
+			// A page must not expose another option while Enter still targets this one.
+			nextOffset = clamp(nextOffset, cursorStart, cursorEnd - rows);
 		} else if (cursorStart < nextOffset || cursorEnd > nextOffset + rows) {
 			nextOffset = cursorRows <= rows ? cursorEnd - rows : cursorStart;
 		}

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -7,6 +7,9 @@ import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/mode
 import { setKeybindings } from "@oh-my-pi/pi-tui";
 
 const DOWN = "\x1b[B";
+const UP = "\x1b[A";
+const PAGE_DOWN = "\x1b[6~";
+const PAGE_UP = "\x1b[5~";
 const ENTER = "\n";
 const CANCEL = "\x07";
 const SPACE = " ";
@@ -901,33 +904,33 @@ describe("AskDialogComponent", () => {
 	});
 
 	it("scrolls question rows when cursor moves below the viewport", () => {
-		// Use many options so the rendered list overflows a small body.
-		const options = Array.from({ length: 30 }, (_, i) => ({ label: `Option ${String(i + 1).padStart(2, "0")}` }));
-		const questions: ExtensionAskDialogQuestion[] = [{ id: "q1", question: "Pick one?", options }];
+		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, value: 24 });
+		try {
+			const options = Array.from({ length: 30 }, (_, i) => ({
+				label: `Option ${String(i + 1).padStart(2, "0")}`,
+			}));
+			const questions: ExtensionAskDialogQuestion[] = [{ id: "q1", question: "Pick one?", options }];
+			const component = new AskDialogComponent(questions, {
+				onSubmit: vi.fn(),
+				onCancel: vi.fn(),
+				onPrompt: vi.fn(),
+			});
+			const renderAt = (width: number): string => stripVTControlCharacters(component.render(width).join("\n"));
 
-		const component = new AskDialogComponent(questions, {
-			onSubmit: vi.fn(),
-			onCancel: vi.fn(),
-			onPrompt: vi.fn(),
-		});
+			const initial = renderAt(60);
+			expect(initial).toContain("Option 01");
+			expect(initial).not.toContain("Option 30");
+			expect(initial).toContain("↓ scroll");
 
-		// Render at a narrow width / small height to force overflow.
-		// The body height is derived from process.stdout.rows; we render at
-		// width 60 and inspect the visible content.
-		const renderAt = (width: number): string => stripVTControlCharacters(component.render(width).join("\n"));
-
-		// Initial render: first options visible, last options not.
-		const initial = renderAt(60);
-		expect(initial).toContain("Option 01");
-		expect(initial).not.toContain("Option 30");
-
-		// Move cursor down past the viewport boundary to trigger scrolling.
-		for (let i = 0; i < 28; i++) component.handleInput(DOWN);
-
-		const scrolled = renderAt(60);
-		// After scrolling, early options should be gone and later ones visible.
-		expect(scrolled).not.toContain("Option 01");
-		expect(scrolled).toContain("Option 29");
+			for (let i = 0; i < 28; i++) component.handleInput(DOWN);
+			const scrolled = renderAt(60);
+			expect(scrolled).not.toContain("Option 01");
+			expect(scrolled).toContain("Option 29");
+		} finally {
+			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
+			else Reflect.deleteProperty(process.stdout, "rows");
+		}
 	});
 
 	it("single-question multi-select: Enter toggles instead of submitting", () => {
@@ -989,12 +992,16 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual([]);
 	});
 
-	it("shows the preview pane only while the highlighted option has a preview", () => {
+	it("renders every option's preview inline, not only the highlighted one", () => {
 		const questions: ExtensionAskDialogQuestion[] = [
 			{
 				id: "q1",
 				question: "Pick one?",
-				options: [{ label: "Plain" }, { label: "Rich", preview: "Preview body text" }],
+				options: [
+					{ label: "Alpha", preview: "PREVIEW-ALPHA" },
+					{ label: "Bravo", preview: "PREVIEW-BRAVO" },
+					{ label: "Charlie" },
+				],
 			},
 		];
 		const component = new AskDialogComponent(questions, {
@@ -1002,18 +1009,191 @@ describe("AskDialogComponent", () => {
 			onCancel: vi.fn(),
 			onPrompt: vi.fn(),
 		});
+		// Cursor defaults to option 0; both previews must be visible without navigating.
+		const out = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(out).toContain("PREVIEW-ALPHA");
+		expect(out).toContain("PREVIEW-BRAVO");
+	});
 
-		// Cursor on "Plain": no pane, no placeholder text.
-		const withoutPreview = component.render(80);
-		expect(stripVTControlCharacters(withoutPreview.join("\n"))).not.toContain("Preview body text");
-		expect(stripVTControlCharacters(withoutPreview.join("\n"))).not.toContain("No preview");
+	it("refreshes cached preview styling after theme invalidation", async () => {
+		const createComponent = (): AskDialogComponent =>
+			new AskDialogComponent(
+				[{ id: "q1", question: "Pick one?", options: [{ label: "Alpha", preview: "CACHE-PREVIEW" }] }],
+				{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+			);
+		const previewLine = (component: AskDialogComponent): string =>
+			component.render(80).find(line => line.includes("CACHE-PREVIEW")) ?? "";
+		const originalTheme = darkTheme;
+		if (!originalTheme) throw new Error("Failed to load dark theme");
+		const lightTheme = await getThemeByName("light");
+		if (!lightTheme) throw new Error("Failed to load light theme");
+		const cachedComponent = createComponent();
+		const before = previewLine(cachedComponent);
+		expect(stripVTControlCharacters(before)).toContain("│ CACHE-PREVIEW");
+		try {
+			setThemeInstance(lightTheme);
+			const stale = previewLine(cachedComponent);
+			const fresh = previewLine(createComponent());
+			expect(stripVTControlCharacters(stale)).toBe(stripVTControlCharacters(fresh));
+			expect(stale).not.toBe(fresh);
 
-		// Cursor on "Rich": the pane shows the preview content — at the same
-		// dialog height (toggling the pane never resizes the box).
-		component.handleInput(DOWN);
-		const withPreview = component.render(80);
-		expect(stripVTControlCharacters(withPreview.join("\n"))).toContain("Preview body text");
-		expect(withPreview.length).toBe(withoutPreview.length);
+			cachedComponent.invalidate();
+			expect(previewLine(cachedComponent)).toBe(fresh);
+		} finally {
+			setThemeInstance(originalTheme);
+			cachedComponent.invalidate();
+		}
+	});
+
+	it("preserves a preview line's final column across overflowing renders", () => {
+		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, value: 24 });
+		try {
+			const edgeLine = `${"X".repeat(67)}Ω`;
+			const filler = Array.from({ length: 30 }, (_, index) => `filler-${index}`).join("\n");
+			const component = new AskDialogComponent(
+				[
+					{
+						id: "q1",
+						question: "Inspect?",
+						options: [{ label: "Alpha", preview: `\`\`\`\n${edgeLine}\n${filler}\n\`\`\`` }],
+					},
+				],
+				{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+			);
+
+			expect(render(component)).toContain("Ω");
+			expect(render(component)).toContain("Ω");
+		} finally {
+			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
+			else Reflect.deleteProperty(process.stdout, "rows");
+		}
+	});
+
+	it("keeps the cancel hint visible with tabs and a tall preview", () => {
+		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, value: 24 });
+		try {
+			const preview = `\`\`\`\n${Array.from({ length: 40 }, (_, index) => `line-${index}`).join("\n")}\n\`\`\``;
+			const component = new AskDialogComponent(
+				[
+					{ id: "q1", question: "Inspect?", options: [{ label: "Alpha", preview }], multi: true },
+					{ id: "q2", question: "Continue?", options: [{ label: "Bravo" }] },
+				],
+				{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+			);
+			const out = render(component);
+
+			expect(out).toContain("PgUp/PgDn");
+			expect(out).toContain("Tab/←/→");
+			expect(out).not.toContain(" tabs");
+			expect(out).toContain("Esc cancel");
+			setKeybindings(
+				KeybindingsManager.inMemory({
+					"tui.select.cancel": "ctrl+g",
+					"tui.select.pageUp": "ctrl+u",
+					"tui.select.pageDown": "ctrl+d",
+				}),
+			);
+			const remapped = render(component);
+			expect(remapped).toContain("ctrl+u/ctrl+d");
+			expect(remapped).toContain("Esc cancel");
+		} finally {
+			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
+			else Reflect.deleteProperty(process.stdout, "rows");
+		}
+	});
+
+	it("pages through an inline preview taller than the question viewport", () => {
+		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, value: 24 });
+		try {
+			const previewLines = Array.from({ length: 80 }, (_, index) => {
+				if (index === 0) return "PREVIEW-FIRST";
+				if (index === 40) return "PREVIEW-MIDDLE";
+				if (index === 79) return "PREVIEW-LAST";
+				return `preview-line-${index}`;
+			});
+			const questions: ExtensionAskDialogQuestion[] = [
+				{
+					id: "q1",
+					question: "Inspect the preview?",
+					options: [{ label: "Plain" }, { label: "Alpha", preview: `\`\`\`\n${previewLines.join("\n")}\n\`\`\`` }],
+				},
+			];
+			const component = new AskDialogComponent(questions, {
+				onSubmit: vi.fn(),
+				onCancel: vi.fn(),
+				onPrompt: vi.fn(),
+			});
+
+			let out = render(component);
+			expect(out).toContain("PREVIEW-FIRST");
+			expect(out).not.toContain("PREVIEW-MIDDLE");
+			expect(out).not.toContain("PREVIEW-LAST");
+			expect(out).not.toContain("PgUp/PgDn");
+			expect(out).toContain("↓ scroll");
+			component.handleInput(DOWN);
+			for (let page = 0; page < 4; page++) component.handleInput(PAGE_DOWN);
+			out = render(component);
+			expect(out).toContain("PgUp/PgDn");
+			expect(out).toContain("PREVIEW-MIDDLE");
+			component.handleInput(DOWN);
+			out = render(component);
+			expect(out).toContain("Other (type your own)");
+			expect(out).not.toContain("PREVIEW-MIDDLE");
+			expect(out).not.toContain("PgUp/PgDn");
+			component.handleInput(UP);
+			out = render(component);
+			expect(out).toContain("PREVIEW-FIRST");
+			expect(out).toContain("PgUp/PgDn");
+			for (let page = 0; page < 10; page++) {
+				component.handleInput(PAGE_DOWN);
+				out = render(component);
+			}
+			expect(out).toContain("PREVIEW-LAST");
+			for (let page = 0; page < 10; page++) {
+				component.handleInput(PAGE_UP);
+				out = render(component);
+			}
+			expect(out).toContain("PREVIEW-FIRST");
+		} finally {
+			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
+			else Reflect.deleteProperty(process.stdout, "rows");
+		}
+	});
+
+	it("keeps a selected inline preview visible when its row fits the viewport", () => {
+		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, value: 24 });
+		try {
+			const options = [
+				...Array.from({ length: 8 }, (_, index) => ({ label: `Plain ${index}` })),
+				{ label: "Target", preview: "```\nPREVIEW-SHORT-FIRST\npreview-short-middle\nPREVIEW-SHORT-LAST\n```" },
+				...Array.from({ length: 8 }, (_, index) => ({ label: `After ${index}` })),
+			];
+			const component = new AskDialogComponent([{ id: "q1", question: "Pick one?", options }], {
+				onSubmit: vi.fn(),
+				onCancel: vi.fn(),
+				onPrompt: vi.fn(),
+			});
+
+			for (let index = 0; index < 8; index++) component.handleInput(DOWN);
+			let out = render(component);
+			expect(out).toContain("PREVIEW-SHORT-FIRST");
+			expect(out).toContain("PREVIEW-SHORT-LAST");
+			expect(out).not.toContain("PgUp/PgDn");
+			expect(out).toMatch(/[↓↑↕] scroll/);
+			component.handleInput(PAGE_DOWN);
+			out = render(component);
+			expect(out).toContain("PREVIEW-SHORT-FIRST");
+			expect(out).toContain("PREVIEW-SHORT-LAST");
+			expect(out).not.toContain("PgUp/PgDn");
+			expect(out).toMatch(/[↓↑↕] scroll/);
+		} finally {
+			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
+			else Reflect.deleteProperty(process.stdout, "rows");
+		}
 	});
 
 	it("does not repeat the tab chip in the question line", () => {

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1087,7 +1087,7 @@ describe("AskDialogComponent", () => {
 			expect(out).toContain("PgUp/PgDn");
 			expect(out).toContain("Tab/←/→");
 			expect(out).not.toContain(" tabs");
-			expect(out).toContain("Esc cancel");
+			expect(out).toContain("ctrl+g cancel");
 			setKeybindings(
 				KeybindingsManager.inMemory({
 					"tui.select.cancel": "ctrl+g",
@@ -1097,7 +1097,7 @@ describe("AskDialogComponent", () => {
 			);
 			const remapped = render(component);
 			expect(remapped).toContain("ctrl+u/ctrl+d");
-			expect(remapped).toContain("Esc cancel");
+			expect(remapped).toContain("ctrl+g cancel");
 		} finally {
 			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
 			else Reflect.deleteProperty(process.stdout, "rows");

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1045,7 +1045,7 @@ describe("AskDialogComponent", () => {
 		}
 	});
 
-	it("preserves a preview line's final column across overflowing renders", () => {
+	it("keeps the memoized overflowing render identical to the initial width-adjusted render", () => {
 		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
 		Object.defineProperty(process.stdout, "rows", { configurable: true, value: 24 });
 		try {
@@ -1062,8 +1062,10 @@ describe("AskDialogComponent", () => {
 				{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
 			);
 
-			expect(render(component)).toContain("Ω");
-			expect(render(component)).toContain("Ω");
+			const initial = render(component);
+			const cached = render(component);
+			expect(initial).toContain("Ω");
+			expect(cached).toBe(initial);
 		} finally {
 			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
 			else Reflect.deleteProperty(process.stdout, "rows");
@@ -1152,6 +1154,12 @@ describe("AskDialogComponent", () => {
 				out = render(component);
 			}
 			expect(out).toContain("PREVIEW-LAST");
+			expect(out).not.toContain("Other (type your own)");
+			component.handleInput(DOWN);
+			out = render(component);
+			expect(out).toContain("Other (type your own)");
+			component.handleInput(UP);
+			out = render(component);
 			for (let page = 0; page < 10; page++) {
 				component.handleInput(PAGE_UP);
 				out = render(component);


### PR DESCRIPTION
## Summary

Rich ask options now show their preview content directly beneath every option when the dialog opens. Previously, only the highlighted option's preview appeared in a separate pane, so options the user had not visited looked empty.

The question list now uses the full dialog width. Long previews remain reachable with page navigation, and the footer reports the configured paging and cancel keys without hiding the cancel action.

## Design

- Reuses the existing Markdown and code-highlighting renderer instead of introducing a second rich-content path.
- Caches themed preview output and confirmed overflow layouts while invalidating both when the dialog is refreshed.
- Keeps ordinary option navigation cursor-driven; page navigation is limited to preview rows taller than the viewport.

## Commits

| Commit | Purpose |
|---|---|
| `a741e0b38` | Render ask option previews inline and cover viewport, theme, gutter, and key-hint behavior. |
| `59b9f6568` | Show the configured cancel binding in the ask footer instead of hardcoding Escape. |
| `1570f2510` | Document the inline-preview fix in the coding-agent changelog. |
| `2300c9ff4` | Keep tall-preview paging inside the selected row and strengthen the cached-overflow regression. |

## Validation

- `bun test packages/coding-agent/test/modes/components/ask-dialog.test.ts` — 37 passed, 0 failed.
- Scoped Biome check for the changed source and test — passed.
- Scoped Biome check for `packages/coding-agent/CHANGELOG.md` — passed.
- Manual `packages/coding-agent` smoke — Alpha and Bravo previews rendered immediately, Charlie had no preview line, and no split/side pane appeared.
- `bun check` — the clean upstream baseline and this branch both report the same 10 unrelated formatting errors outside the changed files.
- `bun run check:types` in `packages/coding-agent` — the clean upstream baseline and this branch both report the same existing OpenTelemetry dependency/type errors in `src/telemetry-export.ts`.
