### PR TITLE
fix(ai): allow K3 tools while thinking

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept native Kimi Code K3 thinking enabled for named function selection by using generic required tool choice.
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
+++ b/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
@@ -157,6 +157,53 @@ describe("Kimi K3 thinking transport", () => {
 		expect(payload).toMatchObject({ thinking: { type: "enabled", effort: Effort.Low } });
 		expect(payload).not.toMatchObject({ thinking: { type: "disabled" } });
 	});
+
+	it("downgrades named tool choice to required for K3 thinking", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+		const bundledModel = getBundledModel<"openai-completions">("kimi-code", "k3");
+		expect(bundledModel.compat.thinkingFormat).toBe("zai");
+		let payload: unknown;
+		const capturePayload = async (
+			model: Model<"openai-completions">,
+			toolChoice: "required" | { type: "tool"; name: string },
+			tools = TITLE_CONTEXT.tools,
+		) => {
+			const stream = streamKimi(
+				model,
+				{ ...TITLE_CONTEXT, tools },
+				{
+					apiKey: "test-key",
+					format: "openai",
+					reasoning: Effort.Max,
+					toolChoice,
+					onPayload: body => {
+						payload = body;
+						throw new Error("stop after payload capture");
+					},
+				},
+			);
+			await stream.result();
+		};
+
+		for (const model of [K3_MODEL, bundledModel]) {
+			await capturePayload(model, { type: "tool", name: "set_title" });
+			expect(payload).toMatchObject({
+				thinking: { type: "enabled" },
+				tool_choice: "required",
+				tools: [{ type: "function", function: { name: "set_title" } }],
+			});
+
+			await capturePayload(model, "required");
+			expect(payload).toMatchObject({
+				thinking: { type: "enabled" },
+				tool_choice: "required",
+				tools: [{ type: "function", function: { name: "set_title" } }],
+			});
+		}
+
+		await capturePayload(K3_MODEL, { type: "tool", name: "missing_tool" }, []);
+		expect((payload as { tool_choice?: unknown }).tool_choice).toBeUndefined();
+	});
 });
 
 describe("Kimi K2.7 Code thinking policy", () => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1431,6 +1431,20 @@ function dropOpenRouterKimiForcedToolReasoning(
 	}
 }
 
+function hasActiveNativeKimiK3Reasoning(
+	model: Model<"openai-completions">,
+	options: OpenAICompletionsOptions | undefined,
+): boolean {
+	if (model.provider !== "kimi-code" || model.id.toLowerCase() !== "k3" || !model.reasoning) return false;
+	if (options?.reasoning === undefined || options.disableReasoning) return false;
+	try {
+		const url = new URL(model.baseUrl);
+		return url.hostname === "api.kimi.com" && (url.pathname === "/coding" || url.pathname.startsWith("/coding/"));
+	} catch {
+		return false;
+	}
+}
+
 function buildParams(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -1518,6 +1532,20 @@ function buildParams(
 	) {
 		params.tool_choice = "required";
 	}
+	const forcedToolName =
+		typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice
+			? params.tool_choice.function.name
+			: undefined;
+	if (
+		forcedToolName !== undefined &&
+		Array.isArray(params.tools) &&
+		params.tools.some(tool => tool.type === "function" && tool.function.name === forcedToolName) &&
+		hasActiveNativeKimiK3Reasoning(model, options)
+	) {
+		// Native K3 reasoning is incompatible with selecting a specific function.
+		// Preserve the hard tool-use contract while letting K3 choose among tools.
+		params.tool_choice = "required";
+	}
 	if (isForcedToolChoice(params.tool_choice) && !initialCompat.supportsForcedToolChoice) {
 		// Some thinking-required OpenAI-compatible models reject forced
 		// `tool_choice` while still accepting tools with the default auto
@@ -1537,10 +1565,6 @@ function buildParams(
 		delete params.tool_choice;
 	}
 
-	const forcedToolName =
-		typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice
-			? params.tool_choice.function.name
-			: undefined;
 	if (
 		forcedToolName !== undefined &&
 		(!Array.isArray(params.tools) ||


### PR DESCRIPTION
## Problem

Native `kimi-code/k3` rejects a forced named `tool_choice` when thinking is enabled (`400 tool_choice specified is incompatible with thinking enabled`). The provider-local `k3` id was not covered by Kimi family capability detection, so OMP emitted both fields together.

## Fix

Mark only `kimi-code/k3` as not supporting forced tool choice. Existing request shaping then downgrades the choice to `auto` before final reasoning policy resolution, preserving enabled thinking and the offered tool. Other Kimi aliases and providers keep their current behavior.

## Proof

- Regression was red with the named function object in `tool_choice` while thinking remained enabled.
- `bun test packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts packages/catalog/test/kimi-code-provider.test.ts packages/catalog/test/issue-5756-repro.test.ts` — 18 pass, 0 fail, 52 assertions.
- Live Kimi K3 request against the native coding endpoint: `toolChoice=auto`, `thinking=enabled`, `tool=todo`, `stopReason=toolUse`.