### PR TITLE
fix(agent): preserve side-effecting hub outcomes

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Made tool interruptibility resolvable per call so unified tools can preserve side-effecting operation outcomes while allowing passive waits to yield to queued steering.
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1824,11 +1824,25 @@ async function executeToolCalls(
 		const tool =
 			tools?.find(t => t.name === toolCall.name) ??
 			tools?.find(t => t.customWireName !== undefined && t.customWireName === toolCall.name);
+		const args = toolCall.arguments as Record<string, unknown>;
+		const interruptibleMode = tool?.interruptible;
+		let interruptible = false;
+		if (typeof interruptibleMode === "function") {
+			try {
+				interruptible = interruptibleMode(args);
+			} catch {
+				// Resolver failures default to preserving the tool's outcome.
+				interruptible = false;
+			}
+		} else {
+			interruptible = interruptibleMode === true;
+		}
 		return {
 			toolCall,
 			tool,
-			args: toolCall.arguments as Record<string, unknown>,
-			signal: tool?.interruptible ? interruptibleSignal : nonInterruptibleSignal,
+			args,
+			interruptible,
+			signal: interruptible ? interruptibleSignal : nonInterruptibleSignal,
 			started: false,
 			result: undefined as AgentToolResult<any> | undefined,
 			isError: false,
@@ -2210,16 +2224,16 @@ async function executeToolCalls(
 		}
 	}
 
-	// While an interruptible tool is in flight (e.g. a `job`/`irc` wait
-	// blocking on external work), queued steering or interrupting IRC would
-	// otherwise wait out the tool's own window. Poll only non-consuming queues
-	// and abort the shared tool signal so the boundary dequeue below injects
-	// the message promptly. Gated on immediate-interrupt mode + an
-	// interruptible tool; checkSteering is idempotent (no-op once triggered).
+	// While an interruptible tool call is in flight (e.g. a `hub` wait blocking
+	// on external work), queued steering or interrupting IRC would otherwise
+	// wait out the tool's own window. Poll only non-consuming queues and abort
+	// the shared tool signal so the boundary dequeue below injects the message
+	// promptly. Gated on immediate-interrupt mode + an interruptible call;
+	// checkSteering is idempotent (no-op once triggered).
 	const watchSteeringWhileRunning =
 		shouldInterruptImmediately &&
 		(hasSteeringMessages !== undefined || hasIrcInterrupts !== undefined) &&
-		records.some(r => r.tool?.interruptible === true);
+		records.some(record => record.interruptible);
 	const steeringWatchTimer = watchSteeringWhileRunning
 		? setInterval(() => void checkSteering(), STEERING_INTERRUPT_POLL_MS)
 		: undefined;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -657,14 +657,16 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 	/** If true, argument validation errors are non-fatal: raw args are passed to execute() instead of returning an error to the LLM. */
 	lenientArgValidation?: boolean;
 	/**
-	 * If true, the agent loop may abort this tool mid-execution to deliver a
-	 * queued steering message (instead of waiting for the tool to finish on its
-	 * own). Set only on tools that purely *wait* and observe their abort signal
-	 * cleanly (e.g. the `job` poll), so the abort surfaces the tool's current
+	 * Whether the agent loop may abort this tool mid-execution to deliver a
+	 * queued steering message. A function resolves this per call from the raw,
+	 * pre-validation arguments.
+	 *
+	 * Enable only for calls that purely *wait* and observe their abort signal
+	 * cleanly (e.g. `job` poll), so the abort surfaces the tool's current
 	 * snapshot rather than corrupting a side effect. Honored only when
 	 * `interruptMode` is "immediate".
 	 */
-	interruptible?: boolean;
+	interruptible?: boolean | ((args: Partial<Static<TParameters>>) => boolean);
 	/**
 	 * Controls how the INTENT_FIELD (`i`) is handled for this tool.
 	 * - `"require"` (default): `i` is injected and required in the parameter schema.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1691,8 +1691,8 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
-	it("does not abort a non-interruptible tool mid-wait; steering still drains at the boundary", async () => {
-		const toolSchema = type({});
+	it("does not abort a tool when its interruptibility resolver rejects the call", async () => {
+		const toolSchema = type({ op: "'start' | 'wait'" });
 		let steerReady = false;
 		let drained = false;
 		let observedAbort = false;
@@ -1701,8 +1701,9 @@ describe("agentLoop with AgentMessage", () => {
 		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
 			name: "wait",
 			label: "Wait",
-			description: "Blocks on its own window (no interruptible flag)",
+			description: "Blocks on its own window (mimics a side-effecting start)",
 			parameters: toolSchema,
+			interruptible: params => params.op === "wait",
 			async execute(_toolCallId, _params, signal) {
 				steerReady = true;
 				const { promise, resolve } = Promise.withResolvers<void>();
@@ -1731,7 +1732,7 @@ describe("agentLoop with AgentMessage", () => {
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
 		const mock = createMockModel({
 			responses: [
-				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: {} }] },
+				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: { op: "start" } }] },
 				{ content: ["done"] },
 			],
 		});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed queued user steering aborting side-effecting `hub start` calls after the broker request may already have been written; only passive hub waits and followed logs are now interruptible ([#5995](https://github.com/can1357/oh-my-pi/issues/5995)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -159,7 +159,10 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 	readonly description: string;
 	readonly parameters = hubSchema;
 	readonly strict = true;
-	readonly interruptible = true;
+	readonly interruptible = (params: Partial<HubParams>): boolean => {
+		if (params.op === "wait") return true;
+		return params.op === "logs" && params.follow === true;
+	};
 	readonly loadMode = "essential";
 
 	readonly examples: readonly ToolExample<typeof hubSchema.infer>[] = [

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -601,7 +601,7 @@ describe("IRC", () => {
 			expect(text).toContain("Peer messaging is unavailable");
 		});
 
-		it("the tool is marked interruptible", () => {
+		it("only marks passive wait operations interruptible", () => {
 			const session: ToolSession = {
 				cwd: "/tmp",
 				hasUI: false,
@@ -612,7 +612,12 @@ describe("IRC", () => {
 				getAgentId: () => "0-Main",
 			};
 			const tool = new HubTool(session);
-			expect(tool.interruptible).toBe(true);
+			if (typeof tool.interruptible !== "function") throw new Error("Hub interruptibility must resolve per call");
+			expect(tool.interruptible({ op: "wait" })).toBe(true);
+			expect(tool.interruptible({ op: "logs", follow: true })).toBe(true);
+			expect(tool.interruptible({ op: "logs" })).toBe(false);
+			expect(tool.interruptible({ op: "start" })).toBe(false);
+			expect(tool.interruptible({ op: "send", await: true })).toBe(false);
 		});
 
 		it("op=list includes parked peers, unread counts, and parent ids", async () => {


### PR DESCRIPTION
## Repro
A queued user steering message aborts any tool call whose tool-wide `interruptible` flag is true. The unified `HubTool` applied that flag to every operation, including `start`; reproduced with `bun test packages/agent/test/agent-loop.test.ts packages/coding-agent/test/tools/irc.test.ts --test-name-pattern "drains queued steering by aborting an interruptible tool mid-wait|the tool is marked interruptible"` (`2 pass`, confirming both halves of the unsafe path).

## Cause
`packages/coding-agent/src/tools/hub/index.ts` declared `HubTool.interruptible = true`, while `executeToolCalls()` in `packages/agent/src/agent-loop.ts` selected the abortable signal and steering watcher solely from that tool-wide boolean. Consequently `executeLaunch(..., "start")` could lose its client-side outcome after the broker request had already been written.

## Fix
- Extend `AgentTool.interruptible` with a raw-argument predicate and resolve it once per tool call, defaulting resolver failures to non-interruptible.
- Restrict `HubTool` interruption to passive `wait` calls and `logs` calls with `follow: true`; preserve authoritative outcomes for `start`, peer/process sends, and other lifecycle operations.
- Add agent-loop and unified-hub regression coverage for per-call interruptibility.

## Verification
`bun test packages/agent/test/agent-loop.test.ts packages/coding-agent/test/tools/irc.test.ts` passed: 109 tests, 456 assertions, 0 failures. `bun check` passed across all packages. Fixes #5995