### PR TITLE
fix(launch): prevent finite PTY start hangs

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -351,14 +351,10 @@ fn run_pty_sync(
 		.spawn_command(cmd)
 		.map_err(|err| Error::from_reason(format!("Failed to spawn PTY command: {err}")))?;
 	drop(pair.slave);
-	let child_pid = child
-		.process_id()
-		.and_then(|value| i32::try_from(value).ok());
+	let child_process_id = child.process_id();
+	let child_pid = child_process_id.and_then(|value| i32::try_from(value).ok());
 	if let Some(callback) = on_start.as_ref() {
-		let pid = child_pid
-			.and_then(|value| u32::try_from(value).ok())
-			.unwrap_or(0);
-		callback.call(Ok(pid), ThreadsafeFunctionCallMode::NonBlocking);
+		callback.call(Ok(child_process_id.unwrap_or(0)), ThreadsafeFunctionCallMode::NonBlocking);
 	}
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -132,7 +132,8 @@ impl PtySession {
 		Self { core: Arc::new(Mutex::new(None)) }
 	}
 
-	/// Start a shell command and stream output chunks via callback.
+	/// Start a shell command, stream output chunks, and report the spawned child
+	/// PID.
 	#[napi]
 	pub fn start<'env>(
 		&self,
@@ -140,6 +141,8 @@ impl PtySession {
 		options: PtyStartOptions<'env>,
 		#[napi(ts_arg_type = "((error: Error | null, chunk: string) => void) | undefined | null")]
 		on_chunk: Option<ThreadsafeFunction<String>>,
+		#[napi(ts_arg_type = "((error: Error | null, pid: number) => void) | undefined | null")]
+		on_start: Option<ThreadsafeFunction<u32>>,
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: PtyCommand::Shell { command: options.command, shell: options.shell },
@@ -148,11 +151,11 @@ impl PtySession {
 			cols:    options.cols.unwrap_or(120).clamp(20, 400),
 			rows:    options.rows.unwrap_or(40).clamp(5, 200),
 		};
-		self.start_config(env, run_config, options.timeout_ms, options.signal, on_chunk)
+		self.start_config(env, run_config, options.timeout_ms, options.signal, on_chunk, on_start)
 	}
 
-	/// Start an executable with separate arguments and stream output chunks via
-	/// callback.
+	/// Start an executable with separate arguments, stream output chunks, and
+	/// report the spawned child PID.
 	#[napi]
 	pub fn start_argv<'env>(
 		&self,
@@ -160,6 +163,8 @@ impl PtySession {
 		options: PtyArgvStartOptions<'env>,
 		#[napi(ts_arg_type = "((error: Error | null, chunk: string) => void) | undefined | null")]
 		on_chunk: Option<ThreadsafeFunction<String>>,
+		#[napi(ts_arg_type = "((error: Error | null, pid: number) => void) | undefined | null")]
+		on_start: Option<ThreadsafeFunction<u32>>,
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: PtyCommand::Argv { application: options.application, args: options.args },
@@ -168,7 +173,7 @@ impl PtySession {
 			cols:    options.cols.unwrap_or(120).clamp(20, 400),
 			rows:    options.rows.unwrap_or(40).clamp(5, 200),
 		};
-		self.start_config(env, run_config, options.timeout_ms, options.signal, on_chunk)
+		self.start_config(env, run_config, options.timeout_ms, options.signal, on_chunk, on_start)
 	}
 
 	/// Write raw input bytes to PTY stdin.
@@ -201,6 +206,7 @@ impl PtySession {
 		timeout_ms: Option<u32>,
 		signal: Option<Unknown<'env>>,
 		on_chunk: Option<ThreadsafeFunction<String>>,
+		on_start: Option<ThreadsafeFunction<u32>>,
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let ct = task::CancelToken::new(timeout_ms, signal);
 		let core = Arc::clone(&self.core);
@@ -215,9 +221,10 @@ impl PtySession {
 			*guard = Some(PtySessionCore { control_tx });
 		}
 		task::future(env, "pty.start", async move {
-			let run_result =
-				tokio::task::spawn_blocking(move || run_pty_sync(run_config, on_chunk, control_rx, ct))
-					.await;
+			let run_result = tokio::task::spawn_blocking(move || {
+				run_pty_sync(run_config, on_chunk, on_start, control_rx, ct)
+			})
+			.await;
 
 			let mut guard = core.lock();
 			*guard = None;
@@ -262,6 +269,7 @@ fn terminate_pty_processes(
 fn run_pty_sync(
 	config: PtyRunConfig,
 	on_chunk: Option<ThreadsafeFunction<String>>,
+	on_start: Option<ThreadsafeFunction<u32>>,
 	control_rx: flume::Receiver<ControlMessage>,
 	ct: task::CancelToken,
 ) -> Result<PtyRunResult> {
@@ -343,6 +351,15 @@ fn run_pty_sync(
 		.spawn_command(cmd)
 		.map_err(|err| Error::from_reason(format!("Failed to spawn PTY command: {err}")))?;
 	drop(pair.slave);
+	let child_pid = child
+		.process_id()
+		.and_then(|value| i32::try_from(value).ok());
+	if let Some(callback) = on_start.as_ref() {
+		let pid = child_pid
+			.and_then(|value| u32::try_from(value).ok())
+			.unwrap_or(0);
+		callback.call(Ok(pid), ThreadsafeFunctionCallMode::NonBlocking);
+	}
 	ct.heartbeat()
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
@@ -423,9 +440,6 @@ fn run_pty_sync(
 		let _ = reader_tx.send(ReaderEvent::Done);
 	});
 
-	let child_pid = child
-		.process_id()
-		.and_then(|value| i32::try_from(value).ok());
 	#[cfg(unix)]
 	let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
 	#[cfg(not(unix))]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `launch start` waiting for a finite PTY command to exit when the broker's PID-file handoff was unavailable; PTY startup now reports the spawned PID directly and returns an authoritative running or exited snapshot promptly ([#5996](https://github.com/can1357/oh-my-pi/issues/5996)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -537,6 +537,15 @@ class DaemonBroker {
 			if (error) record.log?.append(`PTY output error: ${error.message}\n`);
 			if (chunk) this.#onOutput(record, generation, chunk);
 		};
+		const started = Promise.withResolvers<number | undefined>();
+		const onStart = (error: Error | null, pid: number): void => {
+			if (error) {
+				record.log?.append(`PTY startup callback failed: ${error.message}\n`);
+				started.resolve(undefined);
+				return;
+			}
+			started.resolve(Number.isSafeInteger(pid) && pid > 0 ? pid : undefined);
+		};
 		let run: Promise<PtyRunResult>;
 		if (process.platform === "win32") {
 			run = session.startArgv(
@@ -546,41 +555,29 @@ class DaemonBroker {
 					...options,
 				},
 				onChunk,
+				onStart,
 			);
 		} else {
-			const pidPath = path.join(record.dir, "process.pid");
-			await fs.rm(pidPath, { force: true });
 			const argv = [record.spec.application, ...record.spec.args];
-			const command = [
-				`printf '%s' "$$" > ${quoteShellArg(pidPath)}`,
-				`exec ${argv.map(quoteShellArg).join(" ")}`,
-			].join("; ");
+			const command = `exec ${argv.map(quoteShellArg).join(" ")}`;
 			const shell = procmgr.getShellConfig().shell;
-			run = session.start({ command, shell, ...options }, onChunk);
+			run = session.start({ command, shell, ...options }, onChunk, onStart);
 		}
-		void run
-			.then(result => this.#onPtyExit(record, generation, result))
-			.catch(error =>
-				this.#settle(record, generation, undefined, error instanceof Error ? error.message : String(error)),
-			);
+		void run.then(
+			async result => {
+				await this.#onPtyExit(record, generation, result);
+				started.resolve(undefined);
+			},
+			async error => {
+				await this.#settle(record, generation, undefined, error instanceof Error ? error.message : String(error));
+				started.resolve(undefined);
+			},
+		);
 
-		if (process.platform === "win32") return;
-		const pidPath = path.join(record.dir, "process.pid");
-		const deadline = Date.now() + 5_000;
-		const pidFile = Bun.file(pidPath);
-		while (Date.now() < deadline && generation === record.generation) {
-			try {
-				const pid = Number.parseInt((await pidFile.text()).trim(), 10);
-				if (Number.isSafeInteger(pid) && pid > 0) {
-					record.snapshot.pid = pid;
-					this.#persist(record);
-					return;
-				}
-			} catch (error) {
-				if (!isEnoent(error)) throw error;
-			}
-			if (terminalState(record.snapshot.state)) return;
-			await Bun.sleep(20);
+		const pid = await started.promise;
+		if (pid !== undefined && generation === record.generation) {
+			record.snapshot.pid = pid;
+			this.#persist(record);
 		}
 	}
 

--- a/packages/coding-agent/test/tools/launch.test.ts
+++ b/packages/coding-agent/test/tools/launch.test.ts
@@ -231,6 +231,84 @@ setInterval(() => {}, 1000);
 		await startPtyDaemonWithShell(shellPath, "basic-shell", "compatible-shell");
 	}, 20_000);
 
+	it("returns promptly when a finite PTY child does not write the broker PID file", async () => {
+		if (process.platform === "win32") return;
+		const shellPath = path.join(await tempDir("omp-daemon-no-pid-shell-"), "zsh");
+		await Bun.write(
+			shellPath,
+			`#!/bin/sh
+case "$2" in
+	*process.pid*)
+		command=\${2#*; exec }
+		exec /bin/sh -c "exec $command"
+		;;
+	*)
+		exec /bin/sh "$@"
+		;;
+esac
+`,
+		);
+		await fs.chmod(shellPath, 0o755);
+		const projectDir = await tempDir("omp-daemon-finite-project-");
+		const runtimeDir = await tempDir("omp-daemon-finite-runtime-");
+		const runner = `
+			import { createDaemonBrokerClient } from "./src/launch/client";
+
+			const client = await createDaemonBrokerClient(${JSON.stringify(projectDir)}, {
+				runtimeDir: ${JSON.stringify(runtimeDir)},
+				idleGraceMs: 5_000,
+			});
+			try {
+				const startedAt = performance.now();
+				const started = await client.request({
+					op: "start",
+					spec: {
+						name: "finite-pty",
+						application: "/bin/sh",
+						args: ["-c", "sleep 5"],
+						env: {},
+						cwd: ${JSON.stringify(projectDir)},
+						pty: true,
+						restart: "no",
+						persist: false,
+						detached: false,
+					},
+				});
+				if (started.op !== "start") throw new Error("unexpected start response");
+				process.stdout.write(JSON.stringify({
+					elapsedMs: Math.round(performance.now() - startedAt),
+					state: started.daemon.state,
+					pid: started.daemon.pid,
+				}));
+				if (started.daemon.state === "running") {
+					await client.request({ op: "stop", name: "finite-pty", timeoutMs: 2_000 });
+				}
+			} finally {
+				try {
+					await client.request({ op: "shutdown" });
+				} catch {}
+				client.close();
+			}
+		`;
+		const child = Bun.spawn([process.execPath, "--eval", runner], {
+			cwd: path.resolve(import.meta.dir, "../.."),
+			env: { ...process.env, SHELL: shellPath },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+		]);
+		expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+		const started = JSON.parse(stdout) as { elapsedMs: number; state: string; pid?: number };
+		// This is cross-process startup latency; fake timers cannot drive the broker or PTY child.
+		expect(started.elapsedMs).toBeLessThan(3_000);
+		expect(started.state).toBe("running");
+		expect(started.pid).toBeGreaterThan(0);
+	}, 20_000);
+
 	it("stops non-persistent daemons after the last project omp exits", async () => {
 		const projectDir = await tempDir("omp-daemon-exit-project-");
 		const runtimeDir = await tempDir("omp-daemon-exit-runtime-");

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added optional PTY start callbacks that report the spawned child PID before command completion.
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -84,7 +84,10 @@ export declare class Process {
 /** Stateful PTY session for interactive stdin/stdout passthrough. */
 export declare class PtySession {
   constructor()
-  /** Start a shell command, stream output chunks, and report the spawned child PID. */
+  /**
+   * Start a shell command, stream output chunks, and report the spawned child
+   * PID.
+   */
   start(options: PtyStartOptions, onChunk?: ((error: Error | null, chunk: string) => void) | undefined | null, onStart?: ((error: Error | null, pid: number) => void) | undefined | null): Promise<PtyRunResult>
   /**
    * Start an executable with separate arguments, stream output chunks, and

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -84,13 +84,13 @@ export declare class Process {
 /** Stateful PTY session for interactive stdin/stdout passthrough. */
 export declare class PtySession {
   constructor()
-  /** Start a shell command and stream output chunks via callback. */
-  start(options: PtyStartOptions, onChunk?: ((error: Error | null, chunk: string) => void) | undefined | null): Promise<PtyRunResult>
+  /** Start a shell command, stream output chunks, and report the spawned child PID. */
+  start(options: PtyStartOptions, onChunk?: ((error: Error | null, chunk: string) => void) | undefined | null, onStart?: ((error: Error | null, pid: number) => void) | undefined | null): Promise<PtyRunResult>
   /**
-   * Start an executable with separate arguments and stream output chunks via
-   * callback.
+   * Start an executable with separate arguments, stream output chunks, and
+   * report the spawned child PID.
    */
-  startArgv(options: PtyArgvStartOptions, onChunk?: ((error: Error | null, chunk: string) => void) | undefined | null): Promise<PtyRunResult>
+  startArgv(options: PtyArgvStartOptions, onChunk?: ((error: Error | null, chunk: string) => void) | undefined | null, onStart?: ((error: Error | null, pid: number) => void) | undefined | null): Promise<PtyRunResult>
   /** Write raw input bytes to PTY stdin. */
   write(data: string): void
   /** Resize the active PTY. */

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -641,6 +641,35 @@ describe("pi-natives", () => {
 			expect(JSON.parse(output.trim())).toEqual(expected);
 		});
 
+		it("reports the child PID as soon as the PTY process starts", async () => {
+			const session = new PtySession();
+			const started = Promise.withResolvers<{ error: Error | null; pid: number }>();
+			const run = session.startArgv(
+				{
+					application: process.execPath,
+					args: ["-e", "process.stdin.resume()"],
+					cwd: testDir,
+					timeoutMs: 5_000,
+					cols: 80,
+					rows: 24,
+				},
+				undefined,
+				(error, pid) => started.resolve({ error, pid }),
+			);
+
+			const spawned = await started.promise;
+			let alive = false;
+			try {
+				process.kill(spawned.pid, 0);
+				alive = true;
+			} catch {}
+			expect(spawned.error).toBeNull();
+			expect(spawned.pid).toBeGreaterThan(0);
+			expect(alive).toBeTrue();
+			session.kill();
+			expect((await run).cancelled).toBeTrue();
+		});
+
 		it("should time out detached background workloads without hanging", async () => {
 			if (process.platform === "win32" || !Bun.which("bash")) {
 				return;


### PR DESCRIPTION
## Repro
Starting a finite PTY child through the daemon broker with a compatible shell that does not complete the broker’s `process.pid` handoff reproduces the stall: `SHELL=<wrapper> bun --eval '<createDaemonBrokerClient; start /bin/sh -c "sleep 2" with pty:true>'` returned only after 2496 ms with `{"state":"exited","pid":null}`, instead of returning when the child started.

## Cause
`DaemonBroker.#launchPty` in `packages/coding-agent/src/launch/broker.ts` wrapped POSIX commands with a PID-file write and synchronously polled that file before completing `start`. When the file handoff was unavailable, the RPC stayed pending until the finite child exited or the five-second polling deadline elapsed, even though `PtySession` had already spawned and supervised the child.

## Fix
- Add an optional PTY start callback in `crates/pi-natives/src/pty.rs` that reports the child PID immediately after `spawn_command` succeeds.
- Make `DaemonBroker.#launchPty` await that authoritative spawn event or terminal settlement instead of polling `process.pid`.
- Add native callback coverage and a cross-process integration regression for a finite PTY child whose shell suppresses the legacy PID-file handoff.
- Document both affected packages in their Unreleased changelogs.

## Verification
`bun test test/native.test.ts` in `packages/natives`: 49 passed, 0 failed. `bun test test/tools/launch.test.ts` in `packages/coding-agent`: 7 passed, 0 failed. `bun check`: passed. Manual rerun of the reproduction returned in 472 ms with `{"state":"running","pid":1623802}` and exited cleanly after broker stop.

Fixes #5996