### PR TITLE
fix(search): honor configured Codex transport

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -3913,7 +3913,8 @@ function redactHeaders(headers: Headers): Record<string, string> {
 	return redacted;
 }
 
-function resolveCodexResponsesUrl(baseUrl: string | undefined): string {
+/** Resolve a Codex Responses endpoint exactly as the chat and compaction transports do. */
+export function resolveCodexResponsesUrl(baseUrl: string | undefined): string {
 	const raw = baseUrl && baseUrl.trim().length > 0 ? baseUrl : CODEX_BASE_URL;
 	const normalized = raw.replace(/\/+$/, "");
 	if (normalized.endsWith("/codex/responses")) return normalized;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex web search to honor configured `openai-codex` base URLs, API keys, and headers without leaking official OAuth credentials to custom endpoints; explicitly selected providers now fail closed instead of silently falling back ([#6001](https://github.com/can1357/oh-my-pi/issues/6001)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1986,6 +1986,17 @@ export class ModelRegistry {
 		);
 	}
 
+	/**
+	 * Whether the provider's configured API key is resolved from a command.
+	 *
+	 * Callers use this to distinguish the registry's command-first resolver
+	 * path from lower-priority credentials in {@link authStorage}.
+	 */
+	hasCommandBackedApiKey(provider: string): boolean {
+		const keyConfig = this.#customProviderApiKeys.get(provider);
+		return isCommandConfigValue(keyConfig);
+	}
+
 	getDiscoverableProviders(): string[] {
 		const disabledProviders = getDisabledProviderIdsFromSettings();
 		return this.#discoverableProviders

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -134,10 +134,7 @@ async function executeSearch(
 	const explicitProvider = params.provider;
 	let candidates: SearchProviderCandidate[];
 	if (explicitProvider && explicitProvider !== "auto") {
-		const provider = await getSearchProvider(explicitProvider);
-		candidates = (await provider.isExplicitlyAvailable(authStorage))
-			? [{ id: explicitProvider, explicit: true }]
-			: resolveProviderCandidates("auto");
+		candidates = [{ id: explicitProvider, explicit: true }];
 	} else if (explicitProvider === "auto") {
 		// Explicit `--provider auto` bypasses the configured preferred provider
 		// for this invocation; exclusions still apply.
@@ -175,7 +172,13 @@ async function executeSearch(
 			const available = candidate.explicit
 				? await provider.isExplicitlyAvailable(authStorage)
 				: await provider.isAvailable(authStorage);
-			if (!available) continue;
+			if (!available && !candidate.explicit) continue;
+			if (!available && candidate.explicit) {
+				throw new SearchProviderError(
+					provider.id,
+					`${provider.label} web search is unavailable. Configure its credentials or select the automatic provider chain.`,
+				);
+			}
 			availableProviderCount++;
 			lastProvider = provider;
 
@@ -213,6 +216,7 @@ async function executeSearch(
 			// summary error), masking the cancellation.
 			throwIfAborted(signal);
 			failures.push({ provider: provider ?? providerMeta, error });
+			if (candidate.explicit) break;
 		}
 	}
 

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -625,12 +625,13 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 
 	let result: CodexSearchResult;
 	if (transport.customEndpoint) {
-		// The resolver draws its bearer from the registry's own storage when a
-		// registry is supplied, so validate the credential origin against that
-		// same storage — not a caller-supplied `authStorage` that may differ.
+		// ModelRegistry resolves command-backed provider keys before consulting
+		// its AuthStorage, so a lower-priority OAuth origin is irrelevant when
+		// that command source is configured.
 		const credentialSource = params.modelRegistry?.authStorage ?? params.authStorage;
 		const credentialOrigin = credentialSource.getCredentialOrigin("openai-codex");
-		if (credentialOrigin?.kind === "oauth" || credentialOrigin?.kind === "env") {
+		const hasCommandBackedKey = params.modelRegistry?.hasCommandBackedApiKey("openai-codex") === true;
+		if (!hasCommandBackedKey && (credentialOrigin?.kind === "oauth" || credentialOrigin?.kind === "env")) {
 			throw new SearchProviderError(
 				"codex",
 				`Refusing to send official Codex OAuth credentials to custom endpoint ${transport.baseUrl}. Configure an API key for provider "openai-codex".`,

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -625,7 +625,11 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 
 	let result: CodexSearchResult;
 	if (transport.customEndpoint) {
-		const credentialOrigin = params.authStorage.getCredentialOrigin("openai-codex");
+		// The resolver draws its bearer from the registry's own storage when a
+		// registry is supplied, so validate the credential origin against that
+		// same storage — not a caller-supplied `authStorage` that may differ.
+		const credentialSource = params.modelRegistry?.authStorage ?? params.authStorage;
+		const credentialOrigin = credentialSource.getCredentialOrigin("openai-codex");
 		if (credentialOrigin?.kind === "oauth" || credentialOrigin?.kind === "env") {
 			throw new SearchProviderError(
 				"codex",

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -1,28 +1,40 @@
 /**
  * OpenAI Codex Web Search Provider
  *
- * Uses Codex's built-in web_search tool via the Responses API.
- * Auth is resolved through `AuthStorage.getOAuthAccess("openai-codex")` so the
- * broker is the sole refresh authority — this module never opens a sibling
- * SQLite store, never POSTs the broker sentinel to an OpenAI token endpoint.
+ * Uses the configured Codex Responses transport for proxy/API-key setups and
+ * the official ChatGPT backend for OAuth logins.
  */
 import * as os from "node:os";
-import { type AuthStorage, type FetchImpl, type Model, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
-import { decodeJwt } from "@oh-my-pi/pi-ai/oauth/openai-codex";
+import {
+	type AuthStorage,
+	type FetchImpl,
+	type Model,
+	type OAuthAccess,
+	withAuth,
+	withOAuthAccess,
+} from "@oh-my-pi/pi-ai";
 import { applyCodexResponsesLiteShape } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
-import { createOpenAICodexCompatibilityMetadata } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import {
+	createOpenAICodexCompatibilityMetadata,
+	resolveCodexResponsesUrl,
+} from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
-import { CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "@oh-my-pi/pi-catalog/wire/codex";
+import {
+	CODEX_BASE_URL,
+	CODEX_CLIENT_VERSION,
+	getCodexAccountId,
+	OPENAI_HEADER_VALUES,
+	OPENAI_HEADERS,
+} from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, readSseJson } from "@oh-my-pi/pi-utils";
 import packageJson from "../../../../package.json" with { type: "json" };
+import type { ModelRegistry } from "../../../config/model-registry";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
-const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
-const CODEX_RESPONSES_PATH = "/codex/responses";
 const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
 	"gpt-5.6-luna",
@@ -37,7 +49,6 @@ const DEFAULT_MODEL_PREFERENCES = [
 	"gpt-5.1-codex",
 	"gpt-5-codex-mini",
 ];
-const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const DEFAULT_INSTRUCTIONS =
 	"You are a helpful assistant with web search capabilities. Search the web to answer the user's question accurately and cite your sources.";
 
@@ -46,6 +57,21 @@ type CodexSearchModel = Model<"openai-codex-responses">;
 interface CodexModelCandidate {
 	modelId: string;
 	catalogModel?: CodexSearchModel;
+}
+
+interface CodexSearchTransport {
+	baseUrl: string;
+	url: string;
+	headers: Record<string, string>;
+	customEndpoint: boolean;
+}
+
+interface CodexSearchResult {
+	answer: string;
+	sources: SearchSource[];
+	model: string;
+	requestId: string;
+	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
 }
 
 function getBundledCodexModels(): CodexSearchModel[] {
@@ -296,18 +322,6 @@ function extractTextSources(text: string): SearchSource[] {
 }
 
 /**
- * Extracts account ID from a Codex access token.
- * @param accessToken - JWT access token
- * @returns Account ID string, or null if not found
- */
-function getAccountIdFromJwt(accessToken: string): string | null {
-	const payload = decodeJwt(accessToken);
-	const auth = payload?.[JWT_CLAIM_PATH] as { chatgpt_account_id?: string } | undefined;
-	const accountId = auth?.chatgpt_account_id;
-	return typeof accountId === "string" && accountId.length > 0 ? accountId : null;
-}
-
-/**
  * Resolve a Codex bearer + accountId through {@link AuthStorage} — the single
  * refresh authority. Returns `null` when no OAuth credential is configured,
  * when the credential cannot be refreshed (broker error, revoked token, etc.),
@@ -320,25 +334,55 @@ async function findCodexAuth(
 ): Promise<{ access: OAuthAccess; accountId: string } | null> {
 	const access = await authStorage.getOAuthAccess("openai-codex", sessionId, { signal });
 	if (!access) return null;
-	const accountId = access.accountId ?? getAccountIdFromJwt(access.accessToken);
+	const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
 	if (!accountId) return null;
 	return { access, accountId };
+}
+
+function resolveCodexSearchTransport(modelRegistry: ModelRegistry | undefined, modelId: string): CodexSearchTransport {
+	const registryModel = modelRegistry?.find("openai-codex", modelId);
+	const bundledModel = getBundledCodexModels().find(model => model.id === modelId);
+	const providerBaseUrl = modelRegistry?.getProviderBaseUrl("openai-codex");
+	let baseUrl = providerBaseUrl ?? registryModel?.baseUrl ?? CODEX_BASE_URL;
+	if (registryModel?.baseUrl && registryModel.baseUrl !== (bundledModel?.baseUrl ?? CODEX_BASE_URL)) {
+		baseUrl = registryModel.baseUrl;
+	}
+
+	const url = resolveCodexResponsesUrl(baseUrl);
+	return {
+		baseUrl,
+		url,
+		headers: {
+			...(modelRegistry?.getProviderHeaders("openai-codex") ?? {}),
+			...(registryModel?.headers ?? {}),
+		},
+		customEndpoint: url !== resolveCodexResponsesUrl(CODEX_BASE_URL),
+	};
 }
 
 /**
  * Builds HTTP headers for Codex API requests.
  */
-function buildCodexHeaders(accessToken: string, accountId: string): Record<string, string> {
-	return {
-		Authorization: `Bearer ${accessToken}`,
-		[OPENAI_HEADERS.ACCOUNT_ID]: accountId,
-		[OPENAI_HEADERS.BETA]: OPENAI_HEADER_VALUES.BETA_RESPONSES,
-		[OPENAI_HEADERS.ORIGINATOR]: OPENAI_HEADER_VALUES.ORIGINATOR_CODEX,
-		[OPENAI_HEADERS.VERSION]: CODEX_CLIENT_VERSION,
-		"User-Agent": `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`,
-		Accept: "text/event-stream",
-		"Content-Type": "application/json",
-	};
+function buildCodexHeaders(
+	accessToken: string,
+	accountId: string | undefined,
+	configuredHeaders: Record<string, string>,
+): Headers {
+	const headers = new Headers(configuredHeaders);
+	headers.delete("x-api-key");
+	headers.set("Authorization", `Bearer ${accessToken}`);
+	if (accountId) {
+		headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
+	} else {
+		headers.delete(OPENAI_HEADERS.ACCOUNT_ID);
+	}
+	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
+	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
+	headers.set(OPENAI_HEADERS.VERSION, CODEX_CLIENT_VERSION);
+	headers.set("User-Agent", `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`);
+	headers.set("Accept", "text/event-stream");
+	headers.set("Content-Type", "application/json");
+	return headers;
 }
 
 /**
@@ -348,7 +392,7 @@ function buildCodexHeaders(accessToken: string, accountId: string): Record<strin
  * overrides from the default ChatGPT-account model-selection path.
  */
 async function callCodexSearch(
-	auth: { accessToken: string; accountId: string },
+	auth: { accessToken: string; accountId?: string },
 	query: string,
 	options: {
 		signal?: AbortSignal;
@@ -357,16 +401,10 @@ async function callCodexSearch(
 		model: CodexModelCandidate;
 		sessionId?: string;
 		fetch?: FetchImpl;
+		transport: CodexSearchTransport;
 	},
-): Promise<{
-	answer: string;
-	sources: SearchSource[];
-	model: string;
-	requestId: string;
-	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
-}> {
-	const url = `${CODEX_BASE_URL}${CODEX_RESPONSES_PATH}`;
-	const headers = buildCodexHeaders(auth.accessToken, auth.accountId);
+): Promise<CodexSearchResult> {
+	const headers = buildCodexHeaders(auth.accessToken, auth.accountId, options.transport.headers);
 
 	const requestedModel = options.model.modelId;
 	const usesResponsesLite = options.model.catalogModel?.useResponsesLite === true;
@@ -397,15 +435,18 @@ async function callCodexSearch(
 			requestKind: "turn",
 			startNewTurn: true,
 		});
-		Object.assign(headers, metadata.headers);
-		headers[OPENAI_HEADERS.RESPONSES_LITE] = "true";
+		for (const name in metadata.headers) {
+			const value = metadata.headers[name];
+			if (value !== undefined) headers.set(name, value);
+		}
+		headers.set(OPENAI_HEADERS.RESPONSES_LITE, "true");
 		body.client_metadata = metadata.clientMetadata;
 		body.reasoning = { context: "all_turns" };
 		applyCodexResponsesLiteShape(body);
 	}
 
 	const fetchImpl = options.fetch ?? fetch;
-	const response = await fetchImpl(url, {
+	const response = await fetchImpl(options.transport.url, {
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
@@ -528,6 +569,39 @@ async function callCodexSearch(
 	};
 }
 
+async function runCodexSearchCandidates(options: {
+	auth: { accessToken: string; accountId?: string };
+	params: SearchParams;
+	modelCandidates: CodexModelCandidate[];
+	modelWasConfigured: boolean;
+	transport: CodexSearchTransport;
+}): Promise<CodexSearchResult> {
+	let lastError: unknown;
+	for (let index = 0; index < options.modelCandidates.length; index += 1) {
+		const candidate = options.modelCandidates[index];
+		if (!candidate) continue;
+
+		try {
+			return await callCodexSearch(options.auth, options.params.query, {
+				signal: options.params.signal,
+				systemPrompt: options.params.systemPrompt,
+				searchContextSize: "high",
+				model: candidate,
+				sessionId: options.params.sessionId,
+				fetch: options.params.fetch,
+				transport: options.transport,
+			});
+		} catch (error) {
+			lastError = error;
+			const isLastCandidate = index === options.modelCandidates.length - 1;
+			if (options.modelWasConfigured || isLastCandidate || !shouldRetryWithNextDefaultModel(error)) {
+				throw error;
+			}
+		}
+	}
+	throw lastError ?? new Error("Codex search failed without returning a result");
+}
+
 /**
  * Executes a web search using OpenAI Codex's built-in web search tool.
  *
@@ -541,55 +615,76 @@ async function callCodexSearch(
  *   rejects.
  */
 export async function searchCodex(params: SearchParams): Promise<SearchResponse> {
-	const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
-	if (!seed) {
-		throw new Error(
-			"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
-		);
-	}
-
 	const configuredModel = getConfiguredModel();
 	const modelCandidates = configuredModel ? [configuredModel] : getDefaultModelCandidates();
+	const firstCandidate = modelCandidates[0];
+	if (!firstCandidate) {
+		throw new SearchProviderError("codex", "No Codex web search model is configured.");
+	}
+	const transport = resolveCodexSearchTransport(params.modelRegistry, firstCandidate.modelId);
 
-	const result = await withOAuthAccess(
-		params.authStorage,
-		"openai-codex",
-		async access => {
-			// Derive ALL auth material from the access this attempt received —
-			// a refreshed/rotated credential carries a different bearer and
-			// ChatGPT account id than the seed.
-			const accountId = access.accountId ?? getAccountIdFromJwt(access.accessToken);
-			if (!accountId) {
-				throw new Error("Codex OAuth credential is missing a ChatGPT account id");
-			}
-			const auth = { accessToken: access.accessToken, accountId };
+	let result: CodexSearchResult;
+	if (transport.customEndpoint) {
+		const credentialOrigin = params.authStorage.getCredentialOrigin("openai-codex");
+		if (credentialOrigin?.kind === "oauth" || credentialOrigin?.kind === "env") {
+			throw new SearchProviderError(
+				"codex",
+				`Refusing to send official Codex OAuth credentials to custom endpoint ${transport.baseUrl}. Configure an API key for provider "openai-codex".`,
+			);
+		}
 
-			let lastError: unknown;
-			for (let index = 0; index < modelCandidates.length; index += 1) {
-				const candidate = modelCandidates[index];
-				if (!candidate) continue;
+		const resolverOptions = {
+			sessionId: params.sessionId,
+			baseUrl: transport.baseUrl,
+			modelId: firstCandidate.modelId,
+		};
+		const keyOrResolver = params.modelRegistry
+			? params.modelRegistry.resolver("openai-codex", resolverOptions)
+			: params.authStorage.resolver("openai-codex", resolverOptions);
+		result = await withAuth(
+			keyOrResolver,
+			accessToken =>
+				runCodexSearchCandidates({
+					auth: { accessToken },
+					params,
+					modelCandidates,
+					modelWasConfigured: configuredModel !== undefined,
+					transport,
+				}),
+			{
+				signal: params.signal,
+				missingKeyMessage: 'Codex credentials not found. Configure an API key for provider "openai-codex".',
+			},
+		);
+	} else {
+		const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
+		if (!seed) {
+			throw new Error(
+				"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
+			);
+		}
 
-				try {
-					return await callCodexSearch(auth, params.query, {
-						signal: params.signal,
-						systemPrompt: params.systemPrompt,
-						searchContextSize: "high",
-						model: candidate,
-						sessionId: params.sessionId,
-						fetch: params.fetch,
-					});
-				} catch (error) {
-					lastError = error;
-					const isLastCandidate = index === modelCandidates.length - 1;
-					if (configuredModel || isLastCandidate || !shouldRetryWithNextDefaultModel(error)) {
-						throw error;
-					}
+		result = await withOAuthAccess(
+			params.authStorage,
+			"openai-codex",
+			access => {
+				// A refreshed/rotated credential can carry a different bearer and
+				// ChatGPT account id than the seed used to select the first attempt.
+				const accountId = access.accountId ?? getCodexAccountId(access.accessToken);
+				if (!accountId) {
+					throw new Error("Codex OAuth credential is missing a ChatGPT account id");
 				}
-			}
-			throw lastError ?? new Error("Codex search failed without returning a result");
-		},
-		{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
-	);
+				return runCodexSearchCandidates({
+					auth: { accessToken: access.accessToken, accountId },
+					params,
+					modelCandidates,
+					modelWasConfigured: configuredModel !== undefined,
+					transport,
+				});
+			},
+			{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
+		);
+	}
 
 	let sources = result.sources;
 
@@ -615,14 +710,10 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 }
 
 /**
- * Checks if Codex web search is available.
+ * Checks whether Codex web search has an API key or OAuth credential.
  */
 export async function hasCodexSearch(authStorage: AuthStorage): Promise<boolean> {
-	// `isAvailable` runs before every request — keep the probe cheap.
-	// `hasOAuth(...)` is a synchronous in-memory check that returns true as soon
-	// as a Codex OAuth credential is loaded, without driving the refresh
-	// pipeline. The actual refresh happens lazily in `searchCodex`.
-	return authStorage.hasOAuth("openai-codex");
+	return authStorage.hasAuth("openai-codex");
 }
 
 /** Search provider for OpenAI Codex web search. */

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -50,6 +50,8 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 		);
 
 		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(registry.hasCommandBackedApiKey("anthropic")).toBe(true);
+		expect(registry.hasCommandBackedApiKey("openai")).toBe(false);
 		const models = registry.getAll().filter(model => model.provider === "anthropic");
 
 		expect(models.length).toBeGreaterThan(1);

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -219,6 +219,9 @@ describe("searchCodex model selection", () => {
 		getProviderHeaders() {
 			return { "X-Proxy-Tenant": "tenant-1" };
 		},
+		hasCommandBackedApiKey() {
+			return false;
+		},
 		resolver() {
 			return async () => "test-proxy-key";
 		},
@@ -322,6 +325,31 @@ describe("searchCodex model selection", () => {
 			}),
 		).rejects.toThrow("Refusing to send official Codex OAuth credentials");
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("prefers a command-backed proxy key over stored OAuth on a custom endpoint", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		const commandBackedRegistry = {
+			...proxyModelRegistry,
+			authStorage: oauthOnlyAuthStorage,
+			hasCommandBackedApiKey(provider: string) {
+				return provider === "openai-codex";
+			},
+			resolver() {
+				return async () => "command-proxy-key";
+			},
+		} as unknown as ModelRegistry;
+
+		const result = await searchCodex({
+			...makeSearchParams("command proxy key", mockCodexFetch("gpt-5.4")),
+			authStorage: oauthOnlyAuthStorage,
+			modelRegistry: commandBackedRegistry,
+		});
+
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("authorization")).toBe("Bearer command-proxy-key");
+		expect(headers.has("chatgpt-account-id")).toBe(false);
+		expect(result.answer).toBe("Codex answer");
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -303,6 +303,27 @@ describe("searchCodex model selection", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it("validates the credential origin from the registry storage that supplies the key", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		const fetchMock = vi.fn();
+		const oauthBackedRegistry = {
+			...proxyModelRegistry,
+			authStorage: oauthOnlyAuthStorage,
+			resolver() {
+				return async () => "official-oauth-token";
+			},
+		} as unknown as ModelRegistry;
+
+		await expect(
+			searchCodex({
+				...makeSearchParams("registry oauth leak", fetchMock),
+				authStorage: proxyAuthStorage,
+				modelRegistry: oauthBackedRegistry,
+			}),
+		).rejects.toThrow("Refusing to send official Codex OAuth credentials");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
 		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.6-luna")));

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import type { SearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/base";
-import { searchCodex } from "@oh-my-pi/pi-coding-agent/web/search/providers/codex";
+import { hasCodexSearch, searchCodex } from "@oh-my-pi/pi-coding-agent/web/search/providers/codex";
 
 type CapturedRequest = {
 	url: string;
@@ -185,6 +186,43 @@ describe("searchCodex model selection", () => {
 			return true;
 		},
 	} as unknown as AuthStorage;
+	const proxyAuthStorage = {
+		hasAuth(provider: string) {
+			return provider === "openai-codex";
+		},
+		getCredentialOrigin() {
+			return { kind: "config" as const };
+		},
+		resolver() {
+			return async () => "test-proxy-key";
+		},
+	} as unknown as AuthStorage;
+	const oauthOnlyAuthStorage = {
+		...proxyAuthStorage,
+		getCredentialOrigin() {
+			return { kind: "oauth" as const };
+		},
+	} as unknown as AuthStorage;
+	const proxyModelRegistry = {
+		find(_provider: string, modelId: string) {
+			return {
+				provider: "openai-codex",
+				id: modelId,
+				api: "openai-codex-responses",
+				baseUrl: "https://proxy.example/backend-api",
+				headers: { "X-Proxy-Tenant": "tenant-1" },
+			};
+		},
+		getProviderBaseUrl() {
+			return "https://proxy.example/backend-api";
+		},
+		getProviderHeaders() {
+			return { "X-Proxy-Tenant": "tenant-1" };
+		},
+		resolver() {
+			return async () => "test-proxy-key";
+		},
+	} as unknown as ModelRegistry;
 	let capturedRequest: CapturedRequest | null = null;
 
 	function makeSearchParams(query: string, fetch?: FetchImpl): SearchParams {
@@ -232,6 +270,37 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
 		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
+	});
+
+	it("uses configured Codex endpoint, API key, and headers without OAuth", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		const result = await searchCodex({
+			...makeSearchParams("proxy codex model", mockCodexFetch("gpt-5.4")),
+			authStorage: proxyAuthStorage,
+			modelRegistry: proxyModelRegistry,
+		});
+
+		expect(await hasCodexSearch(proxyAuthStorage)).toBe(true);
+		expect(capturedRequest?.url).toBe("https://proxy.example/backend-api/codex/responses");
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("authorization")).toBe("Bearer test-proxy-key");
+		expect(headers.get("x-proxy-tenant")).toBe("tenant-1");
+		expect(headers.has("chatgpt-account-id")).toBe(false);
+		expect(result.answer).toBe("Codex answer");
+	});
+
+	it("refuses to send official OAuth credentials to a configured Codex endpoint", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		const fetchMock = vi.fn();
+
+		await expect(
+			searchCodex({
+				...makeSearchParams("unsafe proxy", fetchMock),
+				authStorage: oauthOnlyAuthStorage,
+				modelRegistry: proxyModelRegistry,
+			}),
+		).rejects.toThrow("Refusing to send official Codex OAuth credentials");
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {

--- a/packages/coding-agent/test/web/search/abort-and-timeout.test.ts
+++ b/packages/coding-agent/test/web/search/abort-and-timeout.test.ts
@@ -22,7 +22,11 @@ import { searchAnthropic } from "@oh-my-pi/pi-coding-agent/web/search/providers/
 import type { SearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/base";
 import { searchBrave } from "@oh-my-pi/pi-coding-agent/web/search/providers/brave";
 import { withHardTimeout } from "@oh-my-pi/pi-coding-agent/web/search/providers/utils";
-import type { SearchProviderId, SearchResponse } from "@oh-my-pi/pi-coding-agent/web/search/types";
+import {
+	SearchProviderError,
+	type SearchProviderId,
+	type SearchResponse,
+} from "@oh-my-pi/pi-coding-agent/web/search/types";
 
 const FAKE_SESSION = {} as ToolSession;
 const fakeStorage = {
@@ -173,9 +177,9 @@ describe("executeSearch abort propagation", () => {
 		};
 	}
 
-	function mockProviderChain(providers: provider.SearchProvider[]) {
+	function mockProviderChain(providers: provider.SearchProvider[], options?: { explicitFirst?: boolean }) {
 		vi.spyOn(provider, "resolveProviderCandidates").mockReturnValue(
-			providers.map(({ id }) => ({ id, explicit: false })),
+			providers.map(({ id }, index) => ({ id, explicit: options?.explicitFirst === true && index === 0 })),
 		);
 		return vi.spyOn(provider, "getSearchProvider").mockImplementation(async id => {
 			const match = providers.find(candidate => candidate.id === id);
@@ -265,6 +269,32 @@ describe("executeSearch abort propagation", () => {
 		expect(result.details?.response.provider).toBe("exa");
 		expect(getProvider).toHaveBeenCalledTimes(1);
 		expect(getProvider).toHaveBeenCalledWith("exa");
+		expect(fallbackSearch).not.toHaveBeenCalled();
+	});
+
+	it("does not fall through after an explicitly selected provider fails", async () => {
+		const fallbackSearch = vi.fn(
+			async (): Promise<SearchResponse> => ({
+				provider: "brave",
+				sources: [{ title: "Hidden fallback", url: "https://example.com/fallback" }],
+			}),
+		);
+		const getProvider = mockProviderChain(
+			[
+				fakeProvider("codex", async () => {
+					throw new SearchProviderError("codex", "Configured Codex endpoint does not support web_search.", 400);
+				}),
+				fakeProvider("brave", fallbackSearch),
+			],
+			{ explicitFirst: true },
+		);
+
+		const tool = new WebSearchTool(FAKE_SESSION);
+		const result = await tool.execute("test-id", { query: "anything" });
+
+		expect(result.details?.error).toContain("Configured Codex endpoint does not support web_search.");
+		expect(result.details?.response.provider).toBe("codex");
+		expect(getProvider).toHaveBeenCalledTimes(1);
 		expect(fallbackSearch).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Repro
Configure `providers.openai-codex` in `models.yml` with `baseUrl: http://proxy.example/backend-api`, `auth: apiKey`, and an API key, remove the `openai-codex` OAuth credential, then run `omp search "hello" --provider codex`. Before this fix, the equivalent probe printed `available=false` and `No Codex OAuth credentials found` before fetch, so the configured proxy was never contacted.

## Cause
`packages/coding-agent/src/web/search/providers/codex.ts` built every request from hardcoded ChatGPT backend constants and `AuthStorage.getOAuthAccess()`, unlike the shared Codex chat transport; `packages/coding-agent/src/web/search/index.ts` also replaced an unavailable explicitly selected provider with the automatic candidate chain and continued that chain after explicit-provider errors.

## Fix
- Export and reuse `resolveCodexResponsesUrl()` so Codex search constructs the same Responses endpoint as chat and compaction.
- Resolve configured `openai-codex` base URLs, API keys, and headers for custom endpoints while retaining broker-managed OAuth for the official backend.
- Reject official OAuth credentials on custom endpoints and stop explicitly selected providers after unavailability or provider errors.
- Add configured-transport, OAuth-leakage, and fail-closed regression coverage plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/web-search-codex.test.ts packages/coding-agent/test/web/search/abort-and-timeout.test.ts` passed: 27 tests, 79 assertions. `bun check` passed across all TypeScript packages. Manual transport smoke used `http://proxy.example/backend-api/codex/responses`, `Bearer proxy-key`, the configured proxy header, no `chatgpt-account-id`, and returned the mocked search answer.

Fixes #6001