### PR TITLE
fix(browser): isolate request interception per run

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `browser.run` leaving Puppeteer request handlers and interception state with divergent lifetimes by removing run-scoped handlers, disabling interception, and releasing held requests on every exit path ([#6004](https://github.com/can1357/oh-my-pi/issues/6004)).
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -16,6 +16,7 @@ Drives real Chromium tab; full puppeteer access via JS.
   - `tab.waitForNavigation` must start BEFORE the trigger click.
   - Navigation invalidates element ids — re-observe.
   - Stalled actions fail fast with named error, never whole-cell timeout.
+  - Raw request interception is run-scoped: run end removes `request` handlers, disables interception, releases held requests.
 
 - `app.path` → NEVER tamper with a real desktop app (no stealth patches).
 - Selectors: CSS + puppeteer `aria/…`, `text/…`, `xpath/…`, `pierce/…`. Playwright-only pseudos (`:has-text()`, `:visible`) are REJECTED.

--- a/packages/coding-agent/src/tools/browser/tab-protocol.ts
+++ b/packages/coding-agent/src/tools/browser/tab-protocol.ts
@@ -95,6 +95,8 @@ export interface RunErrorPayload {
 	stack?: string;
 	isToolError: boolean;
 	isAbort: boolean;
+	/** The worker could not restore tab-scoped browser state and must be recycled. */
+	recoverTab?: boolean;
 }
 
 export type WorkerOutbound =

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -138,6 +138,7 @@ const GRACE_MS = 750;
 // vanished instead of a bare "not alive". Cleared when the name is opened again.
 const killedTabs = new Map<string, string>();
 const DEFAULT_TAB_CLOSE_TIMEOUT_MS = 5_000;
+class RecoverableWorkerError extends ToolError {}
 
 async function waitForTabCleanup<T>(
 	tab: TabSession,
@@ -488,16 +489,23 @@ async function runInTabWithSnapshot(
 				async reason => await forceKillTab(name, reason),
 			);
 		} catch (error) {
-			if (error instanceof ToolError && error.message.startsWith("Browser code execution timed out after ")) {
+			const runTimedOut =
+				error instanceof ToolError && error.message.startsWith("Browser code execution timed out after ");
+			if (runTimedOut || error instanceof RecoverableWorkerError) {
 				try {
-					if (tab.worker.mode === "inline")
-						await forceKillTab(name, "Browser code execution timed out; tab killed");
-					else await recycleTimedOutWorkerTab(tab, opts.timeoutMs + GRACE_MS);
+					if (tab.worker.mode === "inline") {
+						const reason = runTimedOut
+							? "Browser code execution timed out; tab killed"
+							: "Browser request interception cleanup failed; tab killed";
+						await forceKillTab(name, reason);
+					} else {
+						await recycleTimedOutWorkerTab(tab, opts.timeoutMs + GRACE_MS);
+					}
 				} catch (recycleError) {
-					logger.warn("Failed to recycle timed-out browser tab worker; killing tab", {
+					logger.warn("Failed to recycle browser tab worker; killing tab", {
 						error: recycleError instanceof Error ? recycleError.message : String(recycleError),
 					});
-					await forceKillTab(name, "Browser code execution timed out; tab killed");
+					await forceKillTab(name, "Browser tab worker recovery failed; tab killed");
 				}
 			}
 			throw error;
@@ -873,11 +881,13 @@ async function targetIdForTarget(target: Target): Promise<string> {
 }
 
 function errorFromPayload(payload: RunErrorPayload): Error {
-	const error = payload.isAbort
-		? new ToolAbortError()
-		: payload.isToolError
-			? new ToolError(payload.message)
-			: new Error(payload.message);
+	const error = payload.recoverTab
+		? new RecoverableWorkerError(payload.message)
+		: payload.isAbort
+			? new ToolAbortError()
+			: payload.isToolError
+				? new ToolError(payload.message)
+				: new Error(payload.message);
 	error.name = payload.name;
 	if (payload.stack) error.stack = payload.stack;
 	return error;

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { postmortem, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
+import { postmortem, Snowflake, untilAborted, withTimeout } from "@oh-my-pi/pi-utils";
 import type { HTMLElement } from "linkedom";
 import type {
 	Browser,
@@ -155,6 +155,8 @@ const OP_DEADLINE_SLACK_MS = CELL_BUDGET_SLACK_MS;
 const ZERO_MATCH_FAIL_FAST_MS = 2_000;
 /** Poll cadence for the zero-match watchdog. */
 const ZERO_MATCH_POLL_MS = 250;
+/** Cleanup must settle inside the supervisor's 750ms post-run grace window. */
+const REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS = 500;
 
 export interface OpTimeouts {
 	/** Largest per-op deadline allowed — strictly below the cell budget. */
@@ -334,12 +336,124 @@ function redactUrlCredentials(url: string): string {
 	}
 }
 
+class RequestInterceptionCleanupError extends ToolError {}
+
+interface RunPageScope {
+	page: Page;
+	cleanup(): Promise<void>;
+}
+
+/**
+ * Expose the tab page while retaining the request handlers created by this run.
+ * Puppeteer's Page wraps an internal emitter, so `removeAllListeners("request")`
+ * would also remove its forwarding listener; the facade removes only user handlers.
+ */
+function createRunPageScope(page: Page): RunPageScope {
+	const requestHandlers: unknown[] = [];
+	const on = page.on;
+	const off = page.off;
+	const once = page.once;
+	const removeAllListeners = page.removeAllListeners;
+	const onDescriptor = Object.getOwnPropertyDescriptor(page, "on");
+	const offDescriptor = Object.getOwnPropertyDescriptor(page, "off");
+	const onceDescriptor = Object.getOwnPropertyDescriptor(page, "once");
+	const removeAllDescriptor = Object.getOwnPropertyDescriptor(page, "removeAllListeners");
+
+	Object.defineProperties(page, {
+		on: {
+			configurable: true,
+			value: (type: unknown, handler: unknown): Page => {
+				Reflect.apply(on, page, [type, handler]);
+				if (type === "request") requestHandlers.push(handler);
+				return page;
+			},
+		},
+		once: {
+			configurable: true,
+			value: (type: unknown, handler: unknown): Page => {
+				if (type !== "request" || typeof handler !== "function") {
+					Reflect.apply(once, page, [type, handler]);
+					return page;
+				}
+				const wrapper = (event: unknown): void => {
+					const index = requestHandlers.lastIndexOf(wrapper);
+					if (index >= 0) requestHandlers.splice(index, 1);
+					Reflect.apply(handler, page, [event]);
+				};
+				requestHandlers.push(wrapper);
+				Reflect.apply(on, page, [type, wrapper]);
+				return page;
+			},
+		},
+		off: {
+			configurable: true,
+			value: (type: unknown, handler?: unknown): Page => {
+				Reflect.apply(off, page, [type, handler]);
+				if (type === "request") {
+					if (handler === undefined) requestHandlers.length = 0;
+					else {
+						const index = requestHandlers.lastIndexOf(handler);
+						if (index >= 0) requestHandlers.splice(index, 1);
+					}
+				}
+				return page;
+			},
+		},
+		removeAllListeners: {
+			configurable: true,
+			value: (type?: unknown): Page => {
+				Reflect.apply(removeAllListeners, page, [type]);
+				if (type === undefined || type === "request") requestHandlers.length = 0;
+				return page;
+			},
+		},
+	});
+
+	return {
+		page,
+		async cleanup() {
+			if (onDescriptor) Object.defineProperty(page, "on", onDescriptor);
+			else Reflect.deleteProperty(page, "on");
+			if (offDescriptor) Object.defineProperty(page, "off", offDescriptor);
+			else Reflect.deleteProperty(page, "off");
+			if (onceDescriptor) Object.defineProperty(page, "once", onceDescriptor);
+			else Reflect.deleteProperty(page, "once");
+			if (removeAllDescriptor) Object.defineProperty(page, "removeAllListeners", removeAllDescriptor);
+			else Reflect.deleteProperty(page, "removeAllListeners");
+			for (const handler of requestHandlers) Reflect.apply(off, page, ["request", handler]);
+			requestHandlers.length = 0;
+			try {
+				await withTimeout(
+					page.setRequestInterception(false),
+					REQUEST_INTERCEPTION_CLEANUP_TIMEOUT_MS,
+					"Timed out clearing browser request interception",
+				);
+			} catch (error) {
+				throw new RequestInterceptionCleanupError(
+					"Failed to clear browser request interception after browser.run",
+					{
+						error: error instanceof Error ? error.message : String(error),
+					},
+				);
+			}
+		},
+	};
+}
+
 function errorPayload(error: unknown): RunErrorPayload {
+	const recoverTab = error instanceof RequestInterceptionCleanupError || undefined;
 	if (error instanceof ToolAbortError) {
 		return { name: error.name, message: error.message, stack: error.stack, isToolError: false, isAbort: true };
 	}
 	if (error instanceof ToolError) {
-		return { name: error.name, message: error.message, stack: error.stack, isToolError: true, isAbort: false };
+		return {
+			name: error.name,
+			message: error.message,
+			stack: error.stack,
+			isToolError: true,
+			isAbort: false,
+			recoverTab,
+		};
 	}
 	if (error instanceof Error) {
 		return { name: error.name, message: error.message, stack: error.stack, isToolError: false, isAbort: false };
@@ -720,6 +834,7 @@ export class WorkerCore {
 			await session.send("Page.enable").catch(() => undefined);
 			await session.send("Page.handleJavaScriptDialog", { accept: false }).catch(() => undefined);
 			await session.send("Page.stopLoading").catch(() => undefined);
+			await session.send("Fetch.disable").catch(() => undefined);
 		} catch (error) {
 			this.#log("debug", "Recovery CDP session failed; proceeding with attach", {
 				error: error instanceof Error ? error.message : String(error),
@@ -816,15 +931,19 @@ export class WorkerCore {
 			opCounter: 0,
 		};
 		this.#active = active;
+		let completed = false;
+		let returnValue: unknown;
+		let failure: { error: unknown } | undefined;
+		let runPage: RunPageScope | undefined;
 		try {
 			throwIfAborted(signal);
-			const page = this.#requirePage();
+			runPage = createRunPageScope(this.#requirePage());
 			const browser = this.#requireBrowser();
 			const tabApi = this.#createTabApi(msg.name, msg.timeoutMs, signal, msg.session, output, screenshots, active);
 			const runtime = this.#ensureRuntime(msg.session);
 			runtime.setCwd(msg.session.cwd);
 			runtime.setRunScope({
-				page,
+				page: runPage.page,
 				browser,
 				tab: tabApi,
 				assert: (cond: unknown, text?: string): void => {
@@ -879,25 +998,37 @@ export class WorkerCore {
 			try {
 				const hooks = this.#hooksForActiveRun();
 				if (!hooks) throw new ToolError("Browser runtime started without an active run");
-				const returnValue = await Promise.race([
+				returnValue = await Promise.race([
 					runtime.run(msg.code, `browser-run-${msg.id}.js`, hooks, { runId: msg.id, cwd: msg.session.cwd }),
 					cancelRejection,
 				]);
-				await this.#postReadyInfo();
-				this.#transport.send({
-					type: "result",
-					id: msg.id,
-					ok: true,
-					payload: { displays: output.finish(), returnValue: cloneSafe(returnValue), screenshots },
-				});
+				completed = true;
 			} finally {
 				signal.removeEventListener("abort", onCancel);
 			}
 		} catch (error) {
-			this.#transport.send({ type: "result", id: msg.id, ok: false, error: errorPayload(error) });
+			failure = { error };
 		} finally {
-			if (this.#active?.id === msg.id) this.#active = null;
 			runAc.abort(postmortem.markExpectedCleanupError(new ToolAbortError("Browser run ended")));
+			try {
+				await runPage?.cleanup();
+			} catch (error) {
+				failure = { error };
+			}
+			if (this.#active?.id === msg.id) this.#active = null;
+		}
+		if (failure) {
+			this.#transport.send({ type: "result", id: msg.id, ok: false, error: errorPayload(failure.error) });
+			return;
+		}
+		if (completed) {
+			await this.#postReadyInfo();
+			this.#transport.send({
+				type: "result",
+				id: msg.id,
+				ok: true,
+				payload: { displays: output.finish(), returnValue: cloneSafe(returnValue), screenshots },
+			});
 		}
 	}
 

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -378,6 +378,7 @@ function createRunPageScope(page: Page): RunPageScope {
 				const wrapper = (event: unknown): void => {
 					const index = requestHandlers.lastIndexOf(wrapper);
 					if (index >= 0) requestHandlers.splice(index, 1);
+					Reflect.apply(off, page, ["request", wrapper]);
 					Reflect.apply(handler, page, [event]);
 				};
 				requestHandlers.push(wrapper);

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -56,4 +56,113 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("browser tab evaluation", () => {
 			await tool.execute("close", { action: "close", name, kill: true });
 		}
 	}, 30_000);
+
+	it("clears request interception and held requests between runs, including thrown runs", async () => {
+		const server = Bun.serve({
+			port: 0,
+			fetch(request) {
+				const { pathname } = new URL(request.url);
+				if (pathname === "/held") return new Response("normal-held");
+				if (pathname === "/mock") return new Response("normal-mock");
+				return new Response("<title>Interception lifecycle</title>", {
+					headers: { "content-type": "text/html" },
+				});
+			},
+		});
+		const tool = new BrowserTool(makeSession());
+		const name = `interception-lifecycle-${process.pid}`;
+
+		try {
+			await tool.execute("open", {
+				action: "open",
+				name,
+				url: `http://127.0.0.1:${server.port}/`,
+			});
+			let setupError: unknown;
+			try {
+				await tool.execute("run", {
+					action: "run",
+					name,
+					code: `
+						globalThis.__requestListenerBaseline = page.listenerCount("request");
+						await page.setRequestInterception(true);
+						page.on("request", request => void request.abort());
+						throw new Error("setup failed");
+					`,
+				});
+			} catch (error) {
+				setupError = error;
+			}
+			expect(setupError).toBeInstanceOf(Error);
+			expect(setupError).toHaveProperty("message", "setup failed");
+
+			const afterThrow = await tool.execute("run", {
+				action: "run",
+				name,
+				code: `
+					return {
+						clean: page.listenerCount("request") === globalThis.__requestListenerBaseline,
+						body: await tab.evaluate(async () => await (await fetch("/mock")).text()),
+					};
+				`,
+			});
+			expect(afterThrow.content).toEqual([
+				{ type: "text", text: '{\n  "clean": true,\n  "body": "normal-mock"\n}' },
+			]);
+
+			const intercepted = await tool.execute("run", {
+				action: "run",
+				name,
+				code: `
+					let heldSeen = false;
+					await page.setRequestInterception(true);
+					page.on("request", request => {
+						const pathname = new URL(request.url()).pathname;
+						if (pathname === "/held") {
+							heldSeen = true;
+							return;
+						}
+						if (pathname === "/mock") {
+							void request.respond({ status: 200, body: "mocked" });
+							return;
+						}
+						void request.continue();
+					});
+					await tab.evaluate(() => {
+						globalThis.__heldFetch = fetch("/held").then(async response => await response.text());
+					});
+					await wait(() => heldSeen);
+					return await tab.evaluate(async () => await (await fetch("/mock")).text());
+				`,
+			});
+			expect(intercepted.content).toEqual([{ type: "text", text: "mocked" }]);
+
+			const resumed = await tool.execute("run", {
+				action: "run",
+				name,
+				code: `
+					const listeners = page.listenerCount("request");
+					if (listeners !== globalThis.__requestListenerBaseline) {
+						return { clean: false, listeners, baseline: globalThis.__requestListenerBaseline };
+					}
+					return {
+						clean: true,
+						values: await tab.evaluate(async () => [
+							await globalThis.__heldFetch,
+							await (await fetch("/mock")).text(),
+						]),
+					};
+				`,
+			});
+			expect(resumed.content).toEqual([
+				{
+					type: "text",
+					text: '{\n  "clean": true,\n  "values": [\n    "normal-held",\n    "normal-mock"\n  ]\n}',
+				},
+			]);
+		} finally {
+			await tool.execute("close", { action: "close", name, kill: true });
+			server.stop(true);
+		}
+	}, 30_000);
 });

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -165,4 +165,62 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("browser tab evaluation", () => {
 			server.stop(true);
 		}
 	}, 30_000);
+
+	it("fires a once request handler exactly once and clears it between runs", async () => {
+		const server = Bun.serve({
+			port: 0,
+			fetch(request) {
+				const { pathname } = new URL(request.url);
+				if (pathname === "/mock") return new Response("normal-mock");
+				return new Response("<title>Once interception</title>", {
+					headers: { "content-type": "text/html" },
+				});
+			},
+		});
+		const tool = new BrowserTool(makeSession());
+		const name = `once-interception-${process.pid}`;
+
+		try {
+			await tool.execute("open", {
+				action: "open",
+				name,
+				url: `http://127.0.0.1:${server.port}/`,
+			});
+			const fired = await tool.execute("run", {
+				action: "run",
+				name,
+				code: `
+					const baseline = page.listenerCount("request");
+					globalThis.__requestListenerBaseline = baseline;
+					await page.setRequestInterception(true);
+					page.once("request", request => {
+						if (new URL(request.url()).pathname === "/mock") {
+							void request.respond({ status: 200, body: "mocked-once" });
+							return;
+						}
+						void request.continue();
+					});
+					const body = await tab.evaluate(async () => await (await fetch("/mock")).text());
+					// A once handler that fired must unregister from the emitter, not just the tracker.
+					return { body, leaked: page.listenerCount("request") - baseline };
+				`,
+			});
+			expect(fired.content).toEqual([{ type: "text", text: '{\n  "body": "mocked-once",\n  "leaked": 0\n}' }]);
+
+			const resumed = await tool.execute("run", {
+				action: "run",
+				name,
+				code: `
+					return {
+						clean: page.listenerCount("request") === globalThis.__requestListenerBaseline,
+						body: await tab.evaluate(async () => await (await fetch("/mock")).text()),
+					};
+				`,
+			});
+			expect(resumed.content).toEqual([{ type: "text", text: '{\n  "clean": true,\n  "body": "normal-mock"\n}' }]);
+		} finally {
+			await tool.execute("close", { action: "close", name, kill: true });
+			server.stop(true);
+		}
+	}, 30_000);
 });


### PR DESCRIPTION
## Repro
A `browser.run` call enables `page.setRequestInterception(true)`, registers a `request` handler, fulfills one request, and leaves another held; a later run observes the added handler and cannot safely resume normal traffic. The focused repro is `bun test packages/coding-agent/test/tools/browser-tab-evaluate.test.ts` with a launchable Chromium installation.

## Cause
`WorkerCore.#run` in `packages/coding-agent/src/tools/browser/tab-worker.ts` ended only the JavaScript run scope; it neither removed request handlers registered by that run nor disabled Puppeteer interception. Timeout recycling in `packages/coding-agent/src/tools/browser/tab-supervisor.ts` then replaced the worker-side `Page` listener graph while target-level Fetch interception could remain active, splitting the two lifetimes.

## Fix
- Track `request` handlers registered during each `browser.run`, restore Puppeteer’s original event methods, disable interception, and release held requests on success, throw, abort, and timeout paths.
- Bound cleanup inside the supervisor grace period; mark cleanup failures for worker recycling and disable the Fetch domain during raw CDP recovery.
- Document the run-scoped contract and add live Chromium regression coverage for thrown setup, fulfilled requests, held-request release, and normal traffic restoration.

## Verification
`bun test packages/coding-agent/test/tools/browser-tab-evaluate.test.ts` passed 2 tests; `bun test packages/coding-agent/test/tools/browser-run-cancellation.test.ts packages/coding-agent/test/tools/browser-dispose-timeout.test.ts packages/coding-agent/test/tools/browser-tab-timeouts.test.ts` passed 27 tests; `bun check` passed all packages. Fixes #6004