### PR TITLE
fix(task): detach isolated worktree git dir from parent checkout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed isolated `task` subagents mutating the parent checkout and stacking parallel task branches. Copy isolation backends (reflink/apfs/btrfs/zfs/block-clone/rcopy) materialise the worktree by duplicating its `.git` verbatim; when the parent is a linked git worktree its `.git` is a pointer file, so the isolation shared the parent's HEAD/index/ref namespace and a task's `git checkout`/`commit` moved the parent's branch (and the rcopy `git worktree add` path leaked task branches into the shared namespace so a second task committed on top of the first). `ensureIsolation` now runs a new `git.detachGitDir` after `isoStart`: each isolation becomes a standalone repo with a frozen HEAD/refs/index snapshot that borrows the source object database through `objects/info/alternates`, so isolated git operations stay private, every task branch is parented on the requested base, and patch/branch capture (`git fetch <merged>`) still resolves objects. ([#6003](https://github.com/can1357/oh-my-pi/issues/6003))
+
 ## [17.0.4] - 2026-07-18
 
 ### Fixed

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -414,6 +414,8 @@ export async function ensureIsolation(
 	preferred?: IsoBackendKind,
 ): Promise<IsolationHandle> {
 	const repoRoot = await getRepoRoot(baseCwd);
+	const repository = await git.repo.resolve(repoRoot);
+	const sourceCommonDir = repository?.commonDir ?? path.join(repoRoot, ".git");
 	const baseDir = getWorktreeDir(getTaskIsolationSegment(repoRoot, id));
 	const mergedDir = path.join(baseDir, TASK_ISOLATION_MOUNT_DIR);
 	const resolution = natives.isoResolve(preferred ?? null);
@@ -424,6 +426,14 @@ export async function ensureIsolation(
 		await fs.rm(baseDir, { recursive: true, force: true });
 		try {
 			await natives.isoStart(candidate, repoRoot, mergedDir);
+			// Sever the isolation's git metadata from the source checkout. Copy
+			// backends duplicate `repoRoot`'s `.git` verbatim — a linked-worktree
+			// pointer file (or the rcopy `git worktree add` registration) leaves
+			// the isolation sharing the source's HEAD/index/ref namespace, so a
+			// task's git operations would mutate the parent checkout and stack
+			// parallel task branches. Detaching gives each isolation a private,
+			// frozen repo that still borrows the source object DB via alternates.
+			await git.detachGitDir(mergedDir, sourceCommonDir);
 			return {
 				mergedDir,
 				backend: candidate,

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -637,6 +637,10 @@ async function readOptionalText(filePath: string): Promise<string | null> {
 	return retryOnEintr(async () => await Bun.file(filePath).text());
 }
 
+async function readOptionalBytes(filePath: string): Promise<Uint8Array | null> {
+	return retryOnEintr(async () => await Bun.file(filePath).bytes());
+}
+
 function parseGitDirPointer(content: string): string | null {
 	const match = /^gitdir:\s*(.+)\s*$/iu.exec(content.trim());
 	return match?.[1] ?? null;
@@ -1444,7 +1448,6 @@ export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string
 	// history reads keep resolving after the source moves on.
 	const headSha = (await tryText(worktreeRoot, ["rev-parse", "HEAD"], { readOnly: true }))?.trim() ?? "";
 	const headRef = (await tryText(worktreeRoot, ["symbolic-ref", "-q", "HEAD"], { readOnly: true }))?.trim() ?? "";
-	const stagedTree = (await runText(worktreeRoot, ["write-tree"], {})).trim();
 	const refDump = headSha
 		? (
 				await runText(worktreeRoot, ["for-each-ref", "--format=%(objectname) %(refname)"], {
@@ -1456,6 +1459,28 @@ export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string
 		(await tryText(worktreeRoot, ["rev-parse", "--show-object-format"], { readOnly: true }))?.trim() || "sha1";
 	const userName = await config.get(worktreeRoot, "user.name");
 	const userEmail = await config.get(worktreeRoot, "user.email");
+
+	// Preserve the index verbatim rather than round-tripping through
+	// write-tree/read-tree: the raw index carries skip-worktree bits (sparse
+	// checkout), assume-unchanged flags, and exact stage entries. A rebuilt
+	// index drops skip-worktree, so files intentionally absent from a sparse
+	// working tree would read as deletions and delta capture would apply those
+	// deletions back to the parent. Sparse config + patterns are carried too so
+	// later git operations in the isolation keep honouring the sparse view.
+	const indexPath = (
+		await runText(worktreeRoot, ["rev-parse", "--path-format=absolute", "--git-path", "index"], {
+			readOnly: true,
+		})
+	).trim();
+	const indexBytes = await readOptionalBytes(indexPath);
+	const sparseCheckout = await config.get(worktreeRoot, "core.sparseCheckout");
+	const sparseCone = await config.get(worktreeRoot, "core.sparseCheckoutCone");
+	const sparsePatternPath = (
+		await runText(worktreeRoot, ["rev-parse", "--path-format=absolute", "--git-path", "info/sparse-checkout"], {
+			readOnly: true,
+		})
+	).trim();
+	const sparsePatterns = await readOptionalText(sparsePatternPath);
 
 	// A pointer `.git` file whose worktree-admin dir back-references this exact
 	// tree is the rcopy `git worktree add` registration. Remove that admin entry
@@ -1521,8 +1546,26 @@ export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string
 	// Carry the source identity so isolated commits have an author.
 	if (userName) await config.set(worktreeRoot, "user.name", userName);
 	if (userEmail) await config.set(worktreeRoot, "user.email", userEmail);
-	// Restore the staged index without touching the working tree.
-	await readTree(worktreeRoot, stagedTree);
+
+	// Restore sparse-checkout state before the index so skip-worktree entries
+	// keep resolving against the carried patterns.
+	if (sparseCheckout) await config.set(worktreeRoot, "core.sparseCheckout", sparseCheckout);
+	if (sparseCone) await config.set(worktreeRoot, "core.sparseCheckoutCone", sparseCone);
+	if (sparsePatterns !== null) {
+		const infoDir = path.join(gitEntry, "info");
+		await fs.promises.mkdir(infoDir, { recursive: true });
+		await Bun.write(path.join(infoDir, "sparse-checkout"), sparsePatterns);
+	}
+
+	// Restore the index verbatim (skip-worktree, assume-unchanged, exact stage
+	// entries) so the working tree's dirty set — including sparse-excluded files
+	// — matches the source. Fall back to rebuilding from HEAD only when the
+	// source had no index (a bare-ish/never-staged checkout).
+	if (indexBytes) {
+		await Bun.write(path.join(gitEntry, "index"), indexBytes);
+	} else if (headSha) {
+		await readTree(worktreeRoot, headSha);
+	}
 	return "detached";
 }
 

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1438,17 +1438,20 @@ export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string
 	if (isoCommon !== parentCommon) return "independent";
 
 	// Snapshot the state the standalone repo must preserve. HEAD may be a branch
-	// ref (normal checkout) or detached; refs are frozen so `baseSha..branch`
-	// ranges and history reads keep resolving after the source moves on.
+	// ref (normal checkout), detached, or unborn (a fresh/orphan branch with no
+	// commits — a linked worktree still shares the parent ref namespace, so it
+	// must be severed too). Refs are frozen so `baseSha..branch` ranges and
+	// history reads keep resolving after the source moves on.
 	const headSha = (await tryText(worktreeRoot, ["rev-parse", "HEAD"], { readOnly: true }))?.trim() ?? "";
-	if (!headSha) return "independent"; // unborn HEAD: no shared state to sever
 	const headRef = (await tryText(worktreeRoot, ["symbolic-ref", "-q", "HEAD"], { readOnly: true }))?.trim() ?? "";
 	const stagedTree = (await runText(worktreeRoot, ["write-tree"], {})).trim();
-	const refDump = (
-		await runText(worktreeRoot, ["for-each-ref", "--format=%(objectname) %(refname)"], {
-			readOnly: true,
-		})
-	).trim();
+	const refDump = headSha
+		? (
+				await runText(worktreeRoot, ["for-each-ref", "--format=%(objectname) %(refname)"], {
+					readOnly: true,
+				})
+			).trim()
+		: "";
 	const objectFormat =
 		(await tryText(worktreeRoot, ["rev-parse", "--show-object-format"], { readOnly: true }))?.trim() || "sha1";
 	const userName = await config.get(worktreeRoot, "user.name");
@@ -1472,7 +1475,13 @@ export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string
 	await fs.promises.rm(gitEntry, { recursive: true, force: true });
 	if (ownWorktreeAdmin) await fs.promises.rm(ownWorktreeAdmin, { recursive: true, force: true });
 
-	await runEffect(worktreeRoot, ["init", "--object-format", objectFormat, "-q"]);
+	// Preserve the checked-out branch name so an unborn HEAD (fresh/orphan
+	// branch with no commits) keeps its symbolic ref after `init` rather than
+	// snapping to the init default; born HEADs get the ref rewritten below anyway.
+	const initArgs = ["init", "--object-format", objectFormat, "-q"];
+	const initialBranch = headRef.startsWith(LOCAL_BRANCH_PREFIX) ? headRef.slice(LOCAL_BRANCH_PREFIX.length) : "";
+	if (initialBranch) initArgs.push("-b", initialBranch);
+	await runEffect(worktreeRoot, initArgs);
 	const objectsInfo = path.join(gitEntry, "objects", "info");
 	await fs.promises.mkdir(objectsInfo, { recursive: true });
 	const alternates = [path.join(parentCommon, "objects")];
@@ -1486,21 +1495,28 @@ export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string
 	}
 	await Bun.write(path.join(objectsInfo, "alternates"), `${alternates.join("\n")}\n`);
 
-	// Freeze refs. Point HEAD at the raw SHA first so `update-ref` writes land
-	// even for the branch HEAD currently names, then restore the symbolic HEAD.
-	await Bun.write(path.join(gitEntry, "HEAD"), `${headSha}\n`);
-	if (refDump) {
-		const commands = refDump
-			.split("\n")
-			.filter(Boolean)
-			.map(line => {
-				const sep = line.indexOf(" ");
-				return `create ${line.slice(sep + 1)} ${line.slice(0, sep)}`;
-			})
-			.join("\n");
-		await runEffect(worktreeRoot, ["update-ref", "--stdin"], { stdin: `${commands}\n` });
+	// Freeze refs when HEAD is born. Point HEAD at the raw SHA first so
+	// `update-ref` writes land even for the branch HEAD currently names, then
+	// restore the symbolic HEAD. An unborn HEAD has no refs to freeze; `init -b`
+	// above already set the symbolic HEAD to the unborn branch.
+	if (headSha) {
+		await Bun.write(path.join(gitEntry, "HEAD"), `${headSha}\n`);
+		if (refDump) {
+			const commands = refDump
+				.split("\n")
+				.filter(Boolean)
+				.map(line => {
+					const sep = line.indexOf(" ");
+					return `create ${line.slice(sep + 1)} ${line.slice(0, sep)}`;
+				})
+				.join("\n");
+			await runEffect(worktreeRoot, ["update-ref", "--stdin"], { stdin: `${commands}\n` });
+		}
+		if (headRef) await Bun.write(path.join(gitEntry, "HEAD"), `ref: ${headRef}\n`);
+	} else if (headRef && !initialBranch) {
+		// Unborn detached HEAD (no branch, no commit) — restore the raw ref target.
+		await Bun.write(path.join(gitEntry, "HEAD"), `ref: ${headRef}\n`);
 	}
-	if (headRef) await Bun.write(path.join(gitEntry, "HEAD"), `ref: ${headRef}\n`);
 
 	// Carry the source identity so isolated commits have an author.
 	if (userName) await config.set(worktreeRoot, "user.name", userName);

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1380,6 +1380,137 @@ export async function writeTree(cwd: string, options: Pick<CommandOptions, "env"
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// API: worktree isolation
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Outcome of {@link detachGitDir}. */
+export type DetachGitDirResult =
+	/** `worktreeRoot` had no `.git`; nothing to detach. */
+	| "no-git"
+	/** `.git` already resolves to an independent object DB — left untouched. */
+	| "independent"
+	/** Detached into a standalone repo borrowing `sourceCommonDir`'s objects. */
+	| "detached";
+
+/**
+ * Sever a copied/mounted working tree from the git metadata it shares with a
+ * source checkout, turning it into a standalone repository that borrows the
+ * source object database through `objects/info/alternates`.
+ *
+ * Isolation backends (reflink/apfs/btrfs/rcopy…) materialise `merged` by
+ * copying `worktreeRoot` byte-for-byte. When `worktreeRoot` is a **linked git
+ * worktree** its `.git` is a pointer file (`gitdir: …/worktrees/<name>`), so
+ * the copy still resolves HEAD/index/refs through the source repo — a task's
+ * `git checkout`/`commit` inside the isolation then mutates the *parent*
+ * checkout. The rcopy `git worktree add` path leaks the other way: task
+ * branches land in the shared ref namespace and stack on each other.
+ *
+ * After detaching, the working tree keeps its files verbatim while:
+ * - HEAD, refs, and the index are frozen to the snapshot at call time;
+ * - all commits/branches the task creates stay private to the isolation;
+ * - objects resolve against `sourceCommonDir` via alternates, so history reads
+ *   and later `git fetch <merged>` object transfer keep working;
+ * - the source checkout's HEAD, branch, index, and working tree are untouched.
+ *
+ * A full-copy `.git` (non-worktree source) already owns its object DB and is
+ * returned as `"independent"` without modification. `worktreeRoot` without a
+ * `.git` yields `"no-git"`.
+ */
+export async function detachGitDir(worktreeRoot: string, sourceCommonDir: string): Promise<DetachGitDirResult> {
+	ensureAvailable();
+	const gitEntry = path.join(worktreeRoot, ".git");
+	let entryStat: fs.Stats;
+	try {
+		entryStat = await fs.promises.lstat(gitEntry);
+	} catch (err) {
+		if (isEnoent(err)) return "no-git";
+		throw err;
+	}
+	const parentCommon = path.resolve(sourceCommonDir);
+	const isoCommon = path.resolve(
+		(
+			await runText(worktreeRoot, ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+				readOnly: true,
+			})
+		).trim(),
+	);
+	// A full-copy `.git` already resolves to its own object DB — leave it alone.
+	if (isoCommon !== parentCommon) return "independent";
+
+	// Snapshot the state the standalone repo must preserve. HEAD may be a branch
+	// ref (normal checkout) or detached; refs are frozen so `baseSha..branch`
+	// ranges and history reads keep resolving after the source moves on.
+	const headSha = (await tryText(worktreeRoot, ["rev-parse", "HEAD"], { readOnly: true }))?.trim() ?? "";
+	if (!headSha) return "independent"; // unborn HEAD: no shared state to sever
+	const headRef = (await tryText(worktreeRoot, ["symbolic-ref", "-q", "HEAD"], { readOnly: true }))?.trim() ?? "";
+	const stagedTree = (await runText(worktreeRoot, ["write-tree"], {})).trim();
+	const refDump = (
+		await runText(worktreeRoot, ["for-each-ref", "--format=%(objectname) %(refname)"], {
+			readOnly: true,
+		})
+	).trim();
+	const objectFormat =
+		(await tryText(worktreeRoot, ["rev-parse", "--show-object-format"], { readOnly: true }))?.trim() || "sha1";
+	const userName = await config.get(worktreeRoot, "user.name");
+	const userEmail = await config.get(worktreeRoot, "user.email");
+
+	// A pointer `.git` file whose worktree-admin dir back-references this exact
+	// tree is the rcopy `git worktree add` registration. Remove that admin entry
+	// so the source repo's worktree list stops tracking the isolation. A pointer
+	// referencing the *source's* admin (a copied linked-worktree `.git`) is not
+	// ours to delete — only the local pointer file is discarded.
+	let ownWorktreeAdmin: string | undefined;
+	if (entryStat.isFile()) {
+		const pointer = parseGitDirPointer((await readOptionalText(gitEntry)) ?? "");
+		if (pointer) {
+			const adminDir = path.resolve(path.dirname(gitEntry), pointer);
+			const backRef = (await readOptionalText(path.join(adminDir, "gitdir")))?.trim();
+			if (backRef && path.resolve(backRef) === path.resolve(gitEntry)) ownWorktreeAdmin = adminDir;
+		}
+	}
+
+	await fs.promises.rm(gitEntry, { recursive: true, force: true });
+	if (ownWorktreeAdmin) await fs.promises.rm(ownWorktreeAdmin, { recursive: true, force: true });
+
+	await runEffect(worktreeRoot, ["init", "--object-format", objectFormat, "-q"]);
+	const objectsInfo = path.join(gitEntry, "objects", "info");
+	await fs.promises.mkdir(objectsInfo, { recursive: true });
+	const alternates = [path.join(parentCommon, "objects")];
+	const chained = await readOptionalText(path.join(parentCommon, "objects", "info", "alternates"));
+	if (chained) {
+		for (const line of chained.split("\n")) {
+			const entry = line.trim();
+			if (!entry) continue;
+			alternates.push(path.isAbsolute(entry) ? entry : path.resolve(parentCommon, "objects", entry));
+		}
+	}
+	await Bun.write(path.join(objectsInfo, "alternates"), `${alternates.join("\n")}\n`);
+
+	// Freeze refs. Point HEAD at the raw SHA first so `update-ref` writes land
+	// even for the branch HEAD currently names, then restore the symbolic HEAD.
+	await Bun.write(path.join(gitEntry, "HEAD"), `${headSha}\n`);
+	if (refDump) {
+		const commands = refDump
+			.split("\n")
+			.filter(Boolean)
+			.map(line => {
+				const sep = line.indexOf(" ");
+				return `create ${line.slice(sep + 1)} ${line.slice(0, sep)}`;
+			})
+			.join("\n");
+		await runEffect(worktreeRoot, ["update-ref", "--stdin"], { stdin: `${commands}\n` });
+	}
+	if (headRef) await Bun.write(path.join(gitEntry, "HEAD"), `ref: ${headRef}\n`);
+
+	// Carry the source identity so isolated commits have an author.
+	if (userName) await config.set(worktreeRoot, "user.name", userName);
+	if (userEmail) await config.set(worktreeRoot, "user.email", userEmail);
+	// Restore the staged index without touching the working tree.
+	await readTree(worktreeRoot, stagedTree);
+	return "detached";
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // API: show
 // ════════════════════════════════════════════════════════════════════════════
 

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -682,6 +682,34 @@ describe("detachGitDir", () => {
 		expect(await runGit(wt, ["branch", "--format=%(refname:short)"])).not.toContain("feature/a");
 	});
 
+	it("preserves sparse-checkout state so excluded files are not captured as deletions", async () => {
+		const { main, wt, commonDir } = await makeLinkedWorktree();
+		// Add a second directory to the source, then sparse-checkout only `keep/`
+		// in the linked worktree so `drop/` is intentionally absent from disk.
+		await fs.mkdir(path.join(main, "keep"), { recursive: true });
+		await fs.mkdir(path.join(main, "drop"), { recursive: true });
+		await fs.writeFile(path.join(main, "keep", "k.txt"), "keep\n");
+		await fs.writeFile(path.join(main, "drop", "d.txt"), "drop\n");
+		await runGit(main, ["add", "keep", "drop"]);
+		await runGit(main, ["commit", "-q", "-m", "add keep/drop"]);
+		await runGit(wt, ["merge", "-q", "main"]);
+		await runGit(wt, ["sparse-checkout", "init", "--cone"]);
+		await runGit(wt, ["sparse-checkout", "set", "keep"]);
+		// Sparse working tree is clean and `drop/` is not materialised.
+		expect(await runGit(wt, ["status", "--porcelain=v1"])).toBe("");
+		expect(await Bun.file(path.join(wt, "drop", "d.txt")).exists()).toBe(false);
+
+		const iso = await copyTree(wt);
+		expect(await git.detachGitDir(iso, commonDir)).toBe("detached");
+
+		// The detached isolation still honours sparse checkout: `drop/d.txt` keeps
+		// its skip-worktree bit and is NOT reported as a deletion (which delta
+		// capture would otherwise apply back to the parent).
+		expect(await runGit(iso, ["status", "--porcelain=v1"])).toBe("");
+		expect(await runGit(iso, ["ls-files", "-t", "drop/d.txt"])).toBe("S drop/d.txt");
+		expect(await runGit(iso, ["config", "core.sparseCheckout"])).toBe("true");
+	});
+
 	it("keeps ensureIsolation from mutating a linked-worktree parent (rcopy backend)", async () => {
 		const { wt, baseSha } = await makeLinkedWorktree();
 		vi.spyOn(natives, "isoResolve").mockReturnValue({

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -556,6 +556,134 @@ describe("getRepoRoot", () => {
 	});
 });
 
+describe("detachGitDir", () => {
+	// Build a source checkout whose `.git` is a linked-worktree pointer file —
+	// the exact shape (`gitdir: …/worktrees/<name>`) that makes copy backends
+	// leak into the parent. Returns the linked worktree root plus its shared
+	// common dir and base SHA.
+	async function makeLinkedWorktree(): Promise<{ main: string; wt: string; commonDir: string; baseSha: string }> {
+		const main = await fs.mkdtemp(path.join(os.tmpdir(), "omp-detach-main-"));
+		tempDirs.push(main);
+		await runGit(main, ["init", "-q", "-b", "main"]);
+		await runGit(main, ["config", "user.email", "src@example.com"]);
+		await runGit(main, ["config", "user.name", "Source User"]);
+		await fs.writeFile(path.join(main, "file.txt"), "base\n");
+		await runGit(main, ["add", "file.txt"]);
+		await runGit(main, ["commit", "-q", "-m", "base"]);
+		const wt = path.join(main, "..", `${path.basename(main)}-wt`);
+		tempDirs.push(wt);
+		await runGit(main, ["worktree", "add", "-q", wt, "-b", "feature/parent", "HEAD"]);
+		const commonDir = path.resolve(
+			(await runGit(main, ["rev-parse", "--path-format=absolute", "--git-common-dir"])).trim(),
+		);
+		const baseSha = await runGit(wt, ["rev-parse", "HEAD"]);
+		return { main, wt, commonDir, baseSha };
+	}
+
+	// Mimic a copy isolation backend (reflink/apfs/rcopy): a verbatim tree copy,
+	// including the `.git` pointer file, into a fresh isolation directory.
+	async function copyTree(source: string): Promise<string> {
+		const iso = await fs.mkdtemp(path.join(os.tmpdir(), "omp-detach-iso-"));
+		tempDirs.push(iso);
+		await fs.cp(source, iso, { recursive: true });
+		return iso;
+	}
+
+	it("severs a copied linked-worktree from the parent so task git ops stay isolated", async () => {
+		const { wt, commonDir, baseSha } = await makeLinkedWorktree();
+		// Dirty the source worktree: staged, unstaged, and untracked changes.
+		await fs.writeFile(path.join(wt, "staged.txt"), "staged\n");
+		await runGit(wt, ["add", "staged.txt"]);
+		await fs.writeFile(path.join(wt, "file.txt"), "unstaged\n");
+		await fs.writeFile(path.join(wt, "untracked.txt"), "untracked\n");
+		const iso = await copyTree(wt);
+		const statusBefore = await runGit(iso, ["status", "--porcelain=v1"]);
+
+		const result = await git.detachGitDir(iso, commonDir);
+
+		expect(result).toBe("detached");
+		// Working tree (staged/unstaged/untracked) is preserved verbatim.
+		expect(await runGit(iso, ["status", "--porcelain=v1"])).toBe(statusBefore);
+		// The isolation now owns an independent common dir.
+		const isoCommon = path.resolve(
+			(await runGit(iso, ["rev-parse", "--path-format=absolute", "--git-common-dir"])).trim(),
+		);
+		expect(isoCommon).not.toBe(commonDir);
+
+		// A task creates its own branch from the requested base and commits.
+		await runGit(iso, ["checkout", "-q", "-b", "feature/a", baseSha]);
+		await fs.writeFile(path.join(iso, "a.txt"), "task a\n");
+		await runGit(iso, ["add", "a.txt"]);
+		await runGit(iso, ["commit", "-q", "-m", "task a"]);
+		const taskCommit = await runGit(iso, ["rev-parse", "HEAD"]);
+		const taskParent = await runGit(iso, ["rev-parse", "HEAD^"]);
+
+		// The parent worktree is untouched: same branch, no leaked task branch.
+		expect(await runGit(wt, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("feature/parent");
+		expect(await runGit(wt, ["branch", "--format=%(refname:short)"])).not.toContain("feature/a");
+		// The task commit is parented on the requested base, not on parent state.
+		expect(taskParent).toBe(baseSha);
+		// Objects still resolve through the borrowed source ODB: the parent can
+		// fetch the task branch (proving the alternates link is intact).
+		await runGit(wt, ["fetch", iso, "feature/a:refs/heads/omp-fetched"]);
+		expect(await runGit(wt, ["rev-parse", "omp-fetched"])).toBe(taskCommit);
+	});
+
+	it("leaves an already-independent full-copy checkout untouched", async () => {
+		const src = await fs.mkdtemp(path.join(os.tmpdir(), "omp-detach-src-"));
+		tempDirs.push(src);
+		await runGit(src, ["init", "-q", "-b", "main"]);
+		await runGit(src, ["config", "user.email", "src@example.com"]);
+		await runGit(src, ["config", "user.name", "Source User"]);
+		await fs.writeFile(path.join(src, "file.txt"), "base\n");
+		await runGit(src, ["add", "file.txt"]);
+		await runGit(src, ["commit", "-q", "-m", "base"]);
+		const srcCommon = path.resolve(
+			(await runGit(src, ["rev-parse", "--path-format=absolute", "--git-common-dir"])).trim(),
+		);
+		const iso = await copyTree(src); // full `.git` directory copied — its own ODB
+
+		expect(await git.detachGitDir(iso, srcCommon)).toBe("independent");
+		// Its objects are self-contained: no alternates file was written.
+		expect(await Bun.file(path.join(iso, ".git", "objects", "info", "alternates")).exists()).toBe(false);
+	});
+
+	it("keeps ensureIsolation from mutating a linked-worktree parent (rcopy backend)", async () => {
+		const { wt, baseSha } = await makeLinkedWorktree();
+		vi.spyOn(natives, "isoResolve").mockReturnValue({
+			kind: natives.IsoBackendKind.Rcopy,
+			candidates: [natives.IsoBackendKind.Rcopy],
+			fellBack: false,
+			reason: undefined,
+		});
+		const worktreeBase = await fs.mkdtemp(path.join(os.tmpdir(), "omp-detach-wtbase-"));
+		tempDirs.push(worktreeBase);
+		const originalWorktreeDir = process.env.OMP_WORKTREE_DIR;
+		delete process.env.OMP_WORKTREE_DIR;
+		setWorktreesDir(worktreeBase);
+		try {
+			const handle = await ensureIsolation(wt, "parent-isolation-guard");
+			await runGit(handle.mergedDir, ["checkout", "-q", "-b", "feature/a", baseSha]);
+			await fs.writeFile(path.join(handle.mergedDir, "a.txt"), "task a\n");
+			await runGit(handle.mergedDir, ["add", "a.txt"]);
+			await runGit(handle.mergedDir, ["commit", "-q", "-m", "task a"]);
+
+			// Parent branch, HEAD, and worktree list are all unchanged.
+			expect(await runGit(wt, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("feature/parent");
+			expect(await runGit(wt, ["branch", "--format=%(refname:short)"])).not.toContain("feature/a");
+			const worktrees = (await runGit(wt, ["worktree", "list", "--porcelain"]))
+				.split("\n")
+				.filter(line => line.startsWith("worktree "));
+			expect(worktrees).toHaveLength(2); // main + the linked parent only
+			expect(await runGit(handle.mergedDir, ["rev-parse", "HEAD^"])).toBe(baseSha);
+		} finally {
+			setWorktreesDir(undefined);
+			if (originalWorktreeDir === undefined) delete process.env.OMP_WORKTREE_DIR;
+			else process.env.OMP_WORKTREE_DIR = originalWorktreeDir;
+		}
+	});
+});
+
 describe("applyNestedPatches", () => {
 	let parentRepo: string;
 	let nestedRel: string;

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -648,6 +648,40 @@ describe("detachGitDir", () => {
 		expect(await Bun.file(path.join(iso, ".git", "objects", "info", "alternates")).exists()).toBe(false);
 	});
 
+	it("severs a copied linked-worktree whose HEAD is unborn (no commits on the branch)", async () => {
+		const { wt, commonDir } = await makeLinkedWorktree();
+		// Switch the linked worktree to a fresh orphan branch: HEAD is now unborn
+		// (a symbolic ref with no commit) yet still resolves through the shared
+		// common dir, so a task's first commit would otherwise land in the parent.
+		await runGit(wt, ["checkout", "--orphan", "fresh-orphan"]);
+		await runGit(wt, ["rm", "-rf", "--cached", "."]);
+		await fs.rm(path.join(wt, "file.txt"), { force: true });
+		await fs.writeFile(path.join(wt, "staged.txt"), "staged\n");
+		await runGit(wt, ["add", "staged.txt"]);
+		const iso = await copyTree(wt);
+		const statusBefore = await runGit(iso, ["status", "--porcelain=v1"]);
+
+		expect(await git.detachGitDir(iso, commonDir)).toBe("detached");
+		// The unborn branch name is preserved and the common dir is now private.
+		expect(await runGit(iso, ["symbolic-ref", "HEAD"])).toBe("refs/heads/fresh-orphan");
+		const isoCommon = path.resolve(
+			(await runGit(iso, ["rev-parse", "--path-format=absolute", "--git-common-dir"])).trim(),
+		);
+		expect(isoCommon).not.toBe(commonDir);
+		// Staged state survives.
+		expect(await runGit(iso, ["status", "--porcelain=v1"])).toBe(statusBefore);
+
+		// The task makes its first branch + commit.
+		await runGit(iso, ["checkout", "-q", "-b", "feature/a"]);
+		await fs.writeFile(path.join(iso, "a.txt"), "task a\n");
+		await runGit(iso, ["add", "a.txt"]);
+		await runGit(iso, ["commit", "-q", "-m", "task a"]);
+
+		// The parent worktree keeps its unborn orphan HEAD; no task branch leaked.
+		expect(await runGit(wt, ["symbolic-ref", "HEAD"])).toBe("refs/heads/fresh-orphan");
+		expect(await runGit(wt, ["branch", "--format=%(refname:short)"])).not.toContain("feature/a");
+	});
+
 	it("keeps ensureIsolation from mutating a linked-worktree parent (rcopy backend)", async () => {
 		const { wt, baseSha } = await makeLinkedWorktree();
 		vi.spyOn(natives, "isoResolve").mockReturnValue({


### PR DESCRIPTION
## Repro
On a git-backed workspace whose parent checkout is a **linked git worktree**, running an isolated `task` (`isolated: true`) mutates the parent. Two parallel isolated tasks that each `git checkout -b feature/<x> BASE`, edit disjoint files, and commit end up: (1) moving the parent checkout onto an agent-created branch, and (2) stacking the second task's commit on top of the first (its first-parent is the other task's commit, not `BASE`). Reproduced by calling `natives.isoStart(kind, <linked-worktree>, merged)` then running `git checkout -b feature/a BASE` + commit inside `merged`:

```
[reflink] parentHEAD=feature/a status=[D a.txt] branches=[* feature/a,feature/parent,+ master] => LEAKED
[rcopy]   parentHEAD=feature/parent branches=[+ feature/a,* feature/parent,+ master] => LEAKED
```

## Cause
Isolation copy backends (`reflink`/`apfs`/`btrfs`/`zfs`/`block-clone`, and the `rcopy` recursive-copy path) materialise the isolation by duplicating the source tree — including its `.git` — byte-for-byte (`crates/pi-iso/src/*.rs`). A linked worktree's `.git` is a pointer file (`gitdir: …/worktrees/<name>`), so the copied pointer still resolves HEAD, the index, and the ref namespace through the **source** repo. A task's `git` operations inside the isolation therefore mutate the parent checkout. The `rcopy` git path (`git worktree add`) leaks the other way: task branches register in the shared ref namespace of the source repo, so parallel tasks stack. `packages/coding-agent/src/task/worktree.ts#ensureIsolation` started the backend but never severed this shared metadata.

## Fix
- Added `git.detachGitDir(worktreeRoot, sourceCommonDir)` in `packages/coding-agent/src/utils/git.ts`: when the isolation's `--git-common-dir` still points at the source's, it rebuilds a private `.git` (`git init` with the source's object format), borrows the source object DB via `objects/info/alternates` (chained alternates preserved), freezes a snapshot of HEAD/refs (`for-each-ref` → `update-ref --stdin`) and the staged index (`write-tree`/`read-tree`), carries the source `user.name`/`user.email`, and removes the rcopy `git worktree add` registration when the pointer's admin dir back-references this tree. A full-copy `.git` (non-worktree source) already owns its object DB and is returned as `"independent"` untouched.
- `ensureIsolation` now calls `git.detachGitDir(mergedDir, sourceCommonDir)` immediately after a successful `natives.isoStart`, for every backend.

## Verification
`bun test test/task/worktree.test.ts test/task/isolation-runner.test.ts` — 48 pass, 0 fail. Added three `detachGitDir` regression tests (linked-worktree sever with staged/unstaged/untracked preservation + object-borrow `git fetch`; independent full-copy no-op; end-to-end `ensureIsolation` parent-isolation guard on the rcopy backend). Confirmed all three fail when the detach call is neutralized and pass with it restored. Also ran the git-linked-worktree/reftable/clone/eisdir suites (20 pass, 5 skip). `bun check` clean. Fixes #6003