### PR TITLE
fix(coding-agent): enable plan mode for print prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Rendered `read xd://` calls in the compact grouped read view instead of a full tool-execution card; other internal URLs (`skill://`, `agent://`, …) still render full so their resolved content stays visible.
 
 ### Fixed
+- Fixed `plan.defaultOnStartup` being ignored by headless `omp -p` sessions, so the initial prompt now runs in plan mode and the persisted session remains in plan mode for later review ([#6017](https://github.com/can1357/oh-my-pi/issues/6017)).
 
 - Fixed `--model <role>` resolving a bare configured `modelRoles` key.
 - Browser tool selectors now accept bare snapshot refs (`tab.click("e501")`, `@e501`) everywhere `aria-ref=e501` works — previously the tab-worker backend fell through to a CSS tag selector that could never match, burning the 2s zero-match watchdog with a misleading "matches no elements" hint. `tab.select`, `tab.uploadFile`, `tab.press({ selector })`, `tab.screenshot({ selector })`, and `tab.drag` now resolve refs too. Unknown/stale refs fail immediately with the "refresh refs" error.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -8,7 +8,6 @@ import {
 	type Agent,
 	AgentBusyError,
 	type AgentMessage,
-	type AgentToolResult,
 	EventLoopKeepalive,
 	ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
@@ -89,12 +88,7 @@ import {
 	MCP_CONNECTION_STATUS_EVENT_CHANNEL,
 	type McpConnectionStatusEvent,
 } from "../mcp/startup-events";
-import {
-	humanizePlanTitle,
-	type PlanApprovalDetails,
-	resolveApprovedPlan,
-	resolvePlanTitle,
-} from "../plan-mode/approved-plan";
+import { humanizePlanTitle, type PlanApprovalDetails, resolvePlanTitle } from "../plan-mode/approved-plan";
 import { resolvePlanModelTransition } from "../plan-mode/model-transition";
 import planModeApprovedPrompt from "../prompts/system/plan-mode-approved.md" with { type: "text" };
 import planModeCompactInstructionsPrompt from "../prompts/system/plan-mode-compact-instructions.md" with {
@@ -129,7 +123,6 @@ import {
 	setActiveTodoDescriptionsProvider,
 	todoMatchesAnyDescription,
 } from "../tools/todo";
-import { ToolError } from "../tools/tool-errors";
 import { vocalizer } from "../tts/vocalizer";
 import { renderTreeList } from "../tui/tree-list";
 import { copyToClipboard } from "../utils/clipboard";
@@ -2380,7 +2373,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			workflow: options?.workflow ?? "parallel",
 			reentry: this.#planModeHasEntered,
 		});
-		this.session.setPlanProposalHandler?.(title => this.#handlePlanProposal(title));
+		this.session.setPlanProposalHandler?.(title => this.session.preparePlanForReview(title));
 		if (this.session.isStreaming) {
 			await this.session.sendPlanModeContext({ deliverAs: "steer" });
 		}
@@ -2389,33 +2382,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#updatePlanModeStatus();
 		this.sessionManager.appendModeChange("plan", { planFilePath });
 		this.showStatus(`Plan mode enabled. Plan file: ${planFilePath}`);
-	}
-
-	/** Plan-proposal handler registered while plan mode is active. The agent
-	 *  submits the finalized plan by writing the chosen `<slug>`/title to
-	 *  `xd://propose`; this handler validates the plan file exists, normalizes
-	 *  the title, and shapes the payload that `event-controller` forwards to
-	 *  `handlePlanApproval`. */
-	async #handlePlanProposal(title: string): Promise<AgentToolResult<unknown>> {
-		const state = this.session.getPlanModeState?.();
-		if (!state?.enabled) {
-			throw new ToolError("Plan mode is not active.");
-		}
-		const { planFilePath, title: resolvedTitle } = await resolveApprovedPlan({
-			suppliedTitle: title,
-			statePlanFilePath: state.planFilePath,
-			readPlan: url => this.#readPlanFile(url),
-			listPlanFiles: () => this.#listLocalPlanFiles(),
-		});
-		const details: PlanApprovalDetails = {
-			planFilePath,
-			title: resolvedTitle,
-			planExists: true,
-		};
-		return {
-			content: [{ type: "text" as const, text: "Plan ready for approval." }],
-			details,
-		};
 	}
 
 	async #restorePlanPreviousModel(prev: { model: Model; thinkingLevel?: ConfiguredThinkingLevel }): Promise<void> {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -8,6 +8,7 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { resolvePlanModelTransition } from "../plan-mode/model-transition";
 import { type AgentSession, type AgentSessionEvent, SHUTDOWN_CONSOLIDATE_BUDGET_MS } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
 import { flushTelemetryExport } from "../telemetry-export";
@@ -107,6 +108,42 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			process.stderr.write(`Extension error (${err.extensionPath}): ${err.error}\n`);
 		},
 	});
+
+	// InteractiveMode applies the same startup default during TUI initialization.
+	// Print mode has no TUI bootstrap, so arm the shared session directly before
+	// the first prompt; persisting the mode_change also lets a later interactive
+	// attachment restore and review the generated plan.
+	const hasConversationContext = session.sessionManager.buildSessionContext().messages.length > 0;
+	const hasExplicitMode = session.sessionManager.getEntries().some(entry => entry.type === "mode_change");
+	if (
+		!hasConversationContext &&
+		!hasExplicitMode &&
+		session.settings.get("plan.defaultOnStartup") &&
+		session.settings.get("plan.enabled")
+	) {
+		const planFilePath = session.getPlanReferencePath() || "local://PLAN.md";
+		const previousTools = session.getEnabledToolNames();
+		const planTools = session.hasBuiltInTool("write") ? [...new Set([...previousTools, "write"])] : previousTools;
+		await session.setActiveToolsByName(planTools);
+		session.setPlanModeState({
+			enabled: true,
+			planFilePath,
+			workflow: "parallel",
+		});
+		session.sessionManager.appendModeChange("plan", { planFilePath });
+
+		const resolved = session.resolveRoleModelWithThinking("plan");
+		const transition = resolvePlanModelTransition(session.model, resolved, false);
+		if (transition.kind === "thinking") {
+			session.setThinkingLevel(transition.thinkingLevel);
+		} else if (transition.kind === "apply") {
+			try {
+				await session.setModelTemporary(transition.model, transition.thinkingLevel);
+			} catch (error) {
+				logger.warn("Failed to switch to plan model for print mode", { error: String(error) });
+			}
+		}
+	}
 
 	// Always subscribe to enable session persistence via _handleAgentEvent
 	session.subscribe(event => {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -12,6 +12,7 @@ import { resolvePlanModelTransition } from "../plan-mode/model-transition";
 import { type AgentSession, type AgentSessionEvent, SHUTDOWN_CONSOLIDATE_BUDGET_MS } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
 import { flushTelemetryExport } from "../telemetry-export";
+import { PROPOSE_DEVICE_NAME, writeDeviceDispatch } from "../tools/resolve";
 import { initializeExtensions } from "./runtime-init";
 
 /**
@@ -113,6 +114,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	// Print mode has no TUI bootstrap, so arm the shared session directly before
 	// the first prompt; persisting the mode_change also lets a later interactive
 	// attachment restore and review the generated plan.
+	let abortAfterPlanProposal = false;
 	const hasConversationContext = session.sessionManager.buildSessionContext().messages.length > 0;
 	const hasExplicitMode = session.sessionManager.getEntries().some(entry => entry.type === "mode_change");
 	if (
@@ -131,6 +133,19 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			workflow: "parallel",
 		});
 		session.sessionManager.appendModeChange("plan", { planFilePath });
+		abortAfterPlanProposal = true;
+		session.setPlanProposalHandler(async title => {
+			const result = await session.preparePlanForReview(title);
+			const details = result.details;
+			if (details) {
+				const state = session.getPlanModeState();
+				if (state?.enabled) {
+					session.setPlanModeState({ ...state, planFilePath: details.planFilePath });
+				}
+				session.sessionManager.appendModeChange("plan", { planFilePath: details.planFilePath });
+			}
+			return result;
+		});
 
 		const resolved = session.resolveRoleModelWithThinking("plan");
 		const transition = resolvePlanModelTransition(session.model, resolved, false);
@@ -147,6 +162,16 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 
 	// Always subscribe to enable session persistence via _handleAgentEvent
 	session.subscribe(event => {
+		if (abortAfterPlanProposal && event.type === "tool_execution_end" && !event.isError) {
+			const dispatch = writeDeviceDispatch(event.toolName, event.result);
+			if (dispatch?.tool === PROPOSE_DEVICE_NAME && dispatch.mode === "execute") {
+				abortAfterPlanProposal = false;
+				session.markPlanInternalAbortPending();
+				void session.abort().finally(() => {
+					session.clearPlanInternalAbortPending();
+				});
+			}
+		}
 		// In JSON mode, output all events
 		if (mode === "json") {
 			process.stdout.write(`${JSON.stringify(printableEvent(event))}\n`);

--- a/packages/coding-agent/src/prompts/tools/debug.md
+++ b/packages/coding-agent/src/prompts/tools/debug.md
@@ -1,3 +1,3 @@
 Debugger access. Prefer over bash for program state, breakpoints, stepping, or thread inspection.
-Only one active session at a time. `program` is a target path, not a shell command. 
+Only one active session at a time. `program` is a target path, not a shell command.
 Directories need a directory-capable adapter (e.g. `dlv`).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -264,7 +264,7 @@ import {
 	estimateToolSchemaTokens,
 } from "../modes/utils/context-usage";
 import { containsWorkflow, renderWorkflowNotice } from "../modes/workflow";
-import { resolveApprovedPlan } from "../plan-mode/approved-plan";
+import { type PlanApprovalDetails, resolveApprovedPlan } from "../plan-mode/approved-plan";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import advisorSystemPrompt from "../prompts/advisor/system.md" with { type: "text" };
@@ -2567,6 +2567,24 @@ export class AgentSession {
 		this.setPlanProposalHandler(title => this.#approvePlanYoloProposal(title));
 	}
 
+	/** Validate the active plan artifact and shape an `xd://propose` result for review-mode hosts. */
+	async preparePlanForReview(title: string): Promise<AgentToolResult<PlanApprovalDetails>> {
+		const state = this.getPlanModeState();
+		if (!state?.enabled) {
+			throw new ToolError("Plan mode is not active.");
+		}
+		const { planFilePath, title: resolvedTitle } = await resolveApprovedPlan({
+			suppliedTitle: title,
+			statePlanFilePath: state.planFilePath,
+			readPlan: url => this.#readPlanFile(url),
+			listPlanFiles: () => this.#listPlanFiles(),
+		});
+		return {
+			content: [{ type: "text", text: "Plan ready for review." }],
+			details: { planFilePath, title: resolvedTitle, planExists: true },
+		};
+	}
+
 	/**
 	 * Plan-proposal handler while PlanYolo's plan phase is active. Auto-approves
 	 * the instant the model writes the plan slug/title to `xd://propose` — no
@@ -2587,8 +2605,8 @@ export class AgentSession {
 		const { planFilePath, title: resolvedTitle } = await resolveApprovedPlan({
 			suppliedTitle: title,
 			statePlanFilePath: state.planFilePath,
-			readPlan: url => this.#readPlanYoloFile(url),
-			listPlanFiles: () => this.#listPlanYoloFiles(),
+			readPlan: url => this.#readPlanFile(url),
+			listPlanFiles: () => this.#listPlanFiles(),
 		});
 		this.setPlanModeState(undefined);
 		const previousTools = this.#planYoloPreviousTools;
@@ -2623,7 +2641,7 @@ export class AgentSession {
 		};
 	}
 
-	async #readPlanYoloFile(planFilePath: string): Promise<string | null> {
+	async #readPlanFile(planFilePath: string): Promise<string | null> {
 		const resolvedPath = planFilePath.startsWith("local:")
 			? resolveLocalUrlToPath(normalizeLocalScheme(planFilePath), this.#localProtocolOptions())
 			: resolveToCwd(planFilePath, this.sessionManager.getCwd());
@@ -2637,7 +2655,7 @@ export class AgentSession {
 
 	/** `local://` URLs of plan files in the session-local root, newest first —
 	 *  a fallback for `resolveApprovedPlan` when the agent dropped `extra.title`. */
-	async #listPlanYoloFiles(): Promise<string[]> {
+	async #listPlanFiles(): Promise<string[]> {
 		const localRoot = resolveLocalUrlToPath("local://", this.#localProtocolOptions());
 		try {
 			const entries = await fs.promises.readdir(localRoot, { withFileTypes: true });

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/modes/print-mode";
 import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { type PlanProposalHandler, PROPOSE_DEVICE_NAME } from "@oh-my-pi/pi-coding-agent/tools/resolve";
 
 function makeAssistantMessage(text: string): AssistantMessage {
 	const timestamp = Date.now();
@@ -36,6 +37,10 @@ interface DelayedSession {
 	resolvePrompt: () => void;
 	getPlanModeAtPrompt: () => PlanModeState | undefined;
 	getModeChanges: () => Array<{ mode: string; data?: Record<string, unknown> }>;
+	getPlanProposalHandler: () => PlanProposalHandler | undefined;
+	getCurrentPlanMode: () => PlanModeState | undefined;
+	emit: (event: AgentSessionEvent) => void;
+	getAbortCalls: () => number;
 }
 
 function createDelayedSession(
@@ -50,6 +55,9 @@ function createDelayedSession(
 	let planModeAtPrompt: PlanModeState | undefined;
 	let enabledToolNames = ["read"];
 	const modeChanges: Array<{ mode: string; data?: Record<string, unknown> }> = [];
+	let planProposalHandler: PlanProposalHandler | undefined;
+	let subscriber: ((event: AgentSessionEvent) => void) | undefined;
+	let abortCalls = 0;
 
 	const session = {
 		state: { messages },
@@ -79,13 +87,28 @@ function createDelayedSession(
 		setPlanModeState: (state: PlanModeState | undefined) => {
 			planModeState = state;
 		},
+		preparePlanForReview: async (title: string) => {
+			const details = { planFilePath: `local://${title}-plan.md`, title, planExists: true };
+			return { content: [{ type: "text" as const, text: "Plan ready for review." }], details };
+		},
+		setPlanProposalHandler: (handler: PlanProposalHandler | null) => {
+			planProposalHandler = handler ?? undefined;
+		},
 		resolveRoleModelWithThinking: () => ({
 			model: undefined,
 			thinkingLevel: undefined,
 			explicitThinkingLevel: false,
 		}),
 		extensionRunner: undefined,
-		subscribe: () => () => {},
+		markPlanInternalAbortPending: () => {},
+		clearPlanInternalAbortPending: () => {},
+		abort: async () => {
+			abortCalls++;
+		},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			subscriber = listener;
+			return () => {};
+		},
 		prompt: async () => {
 			planModeAtPrompt = planModeState;
 			if (advisorDrainPrepared) throw new Error("headless advisor delivery armed before prompt completion");
@@ -109,6 +132,10 @@ function createDelayedSession(
 		resolvePrompt,
 		getPlanModeAtPrompt: () => planModeAtPrompt,
 		getModeChanges: () => modeChanges,
+		getPlanProposalHandler: () => planProposalHandler,
+		getCurrentPlanMode: () => planModeState,
+		emit: event => subscriber?.(event),
+		getAbortCalls: () => abortCalls,
 	};
 }
 
@@ -155,6 +182,36 @@ describe("print mode working indicator", () => {
 				planFilePath: "local://PLAN.md",
 			});
 			expect(delayed.getModeChanges()).toEqual([{ mode: "plan", data: { planFilePath: "local://PLAN.md" } }]);
+			const handler = delayed.getPlanProposalHandler();
+			if (!handler) throw new Error("Expected print plan proposal handler");
+			const proposal = await handler("hello");
+			expect(proposal).toMatchObject({
+				content: [{ type: "text", text: "Plan ready for review." }],
+				details: { planFilePath: "local://hello-plan.md", title: "hello", planExists: true },
+			});
+			expect(delayed.getCurrentPlanMode()).toMatchObject({ planFilePath: "local://hello-plan.md" });
+			expect(delayed.getModeChanges()).toEqual([
+				{ mode: "plan", data: { planFilePath: "local://PLAN.md" } },
+				{ mode: "plan", data: { planFilePath: "local://hello-plan.md" } },
+			]);
+			delayed.emit({
+				type: "tool_execution_end",
+				toolCallId: "proposal",
+				toolName: "write",
+				result: {
+					content: proposal.content,
+					details: {
+						xdev: {
+							tool: PROPOSE_DEVICE_NAME,
+							mode: "execute",
+							args: { title: "hello" },
+							inner: proposal.details,
+						},
+					},
+				},
+			});
+			await Promise.resolve();
+			expect(delayed.getAbortCalls()).toBe(1);
 		} finally {
 			delayed.resolvePrompt();
 			await run;

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -5,6 +5,7 @@ import {
 	PRINT_MODE_ERROR_ADVISOR_DRAIN_TIMEOUT_MS,
 	runPrintMode,
 } from "@oh-my-pi/pi-coding-agent/modes/print-mode";
+import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 function makeAssistantMessage(text: string): AssistantMessage {
@@ -33,23 +34,60 @@ interface DelayedSession {
 	session: AgentSession;
 	promptStarted: Promise<void>;
 	resolvePrompt: () => void;
+	getPlanModeAtPrompt: () => PlanModeState | undefined;
+	getModeChanges: () => Array<{ mode: string; data?: Record<string, unknown> }>;
 }
 
-function createDelayedSession(finalMessage: AssistantMessage): DelayedSession {
+function createDelayedSession(
+	finalMessage: AssistantMessage,
+	options: { defaultPlanMode?: boolean } = {},
+): DelayedSession {
 	const messages: AssistantMessage[] = [];
 	const { promise: promptStarted, resolve: markPromptStarted } = Promise.withResolvers<void>();
 	const { promise: promptReleased, resolve: resolvePrompt } = Promise.withResolvers<void>();
 	let advisorDrainPrepared = false;
+	let planModeState: PlanModeState | undefined;
+	let planModeAtPrompt: PlanModeState | undefined;
+	let enabledToolNames = ["read"];
+	const modeChanges: Array<{ mode: string; data?: Record<string, unknown> }> = [];
 
 	const session = {
 		state: { messages },
 		getLastAssistantMessage: () => messages.findLast(message => message.role === "assistant"),
 		sessionManager: {
 			getHeader: () => undefined,
+			buildSessionContext: () => ({ messages: [] }),
+			getEntries: () => [],
+			appendModeChange: (mode: string, data?: Record<string, unknown>) => {
+				modeChanges.push({ mode, data });
+				return "mode-change";
+			},
 		},
+		settings: {
+			get: (key: string) =>
+				key === "plan.enabled" || (key === "plan.defaultOnStartup" && options.defaultPlanMode === true),
+		},
+		model: undefined,
+		isStreaming: false,
+		getPlanReferencePath: () => "",
+		getEnabledToolNames: () => enabledToolNames,
+		hasBuiltInTool: (name: string) => name === "write",
+		setActiveToolsByName: async (names: string[]) => {
+			enabledToolNames = names;
+		},
+		getPlanModeState: () => planModeState,
+		setPlanModeState: (state: PlanModeState | undefined) => {
+			planModeState = state;
+		},
+		resolveRoleModelWithThinking: () => ({
+			model: undefined,
+			thinkingLevel: undefined,
+			explicitThinkingLevel: false,
+		}),
 		extensionRunner: undefined,
 		subscribe: () => () => {},
 		prompt: async () => {
+			planModeAtPrompt = planModeState;
 			if (advisorDrainPrepared) throw new Error("headless advisor delivery armed before prompt completion");
 			markPromptStarted();
 			await promptReleased;
@@ -65,7 +103,13 @@ function createDelayedSession(finalMessage: AssistantMessage): DelayedSession {
 		dispose: async () => {},
 	} as unknown as AgentSession;
 
-	return { session, promptStarted, resolvePrompt };
+	return {
+		session,
+		promptStarted,
+		resolvePrompt,
+		getPlanModeAtPrompt: () => planModeAtPrompt,
+		getModeChanges: () => modeChanges,
+	};
 }
 
 describe("print mode working indicator", () => {
@@ -98,6 +142,23 @@ describe("print mode working indicator", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("enters default plan mode before submitting the initial prompt", async () => {
+		const delayed = createDelayedSession(makeAssistantMessage("plan ready"), { defaultPlanMode: true });
+		const run = runPrintMode(delayed.session, { mode: "text", initialMessage: "/plan hello" });
+
+		await delayed.promptStarted;
+		try {
+			expect(delayed.getPlanModeAtPrompt()).toMatchObject({
+				enabled: true,
+				planFilePath: "local://PLAN.md",
+			});
+			expect(delayed.getModeChanges()).toEqual([{ mode: "plan", data: { planFilePath: "local://PLAN.md" } }]);
+		} finally {
+			delayed.resolvePrompt();
+			await run;
+		}
 	});
 
 	it("writes a text-mode working indicator before the prompt resolves and prints the final answer afterward", async () => {
@@ -155,7 +216,12 @@ describe("print mode working indicator", () => {
 		const session = {
 			state: { messages },
 			getLastAssistantMessage: () => messages.findLast(message => message.role === "assistant"),
-			sessionManager: { getHeader: () => undefined },
+			sessionManager: {
+				getHeader: () => undefined,
+				buildSessionContext: () => ({ messages: [] }),
+				getEntries: () => [],
+			},
+			settings: { get: () => false },
 			extensionRunner: undefined,
 			subscribe: (listener: (event: AgentSessionEvent) => void) => {
 				subscriber = listener;
@@ -216,7 +282,12 @@ describe("print mode working indicator", () => {
 		const session = {
 			state: { messages },
 			getLastAssistantMessage: () => messages.findLast(message => message.role === "assistant"),
-			sessionManager: { getHeader: () => undefined },
+			sessionManager: {
+				getHeader: () => undefined,
+				buildSessionContext: () => ({ messages: [] }),
+				getEntries: () => [],
+			},
+			settings: { get: () => false },
 			extensionRunner: undefined,
 			subscribe: () => () => {},
 			prompt: async () => {


### PR DESCRIPTION
## Repro
With `plan.defaultOnStartup` enabled, run `omp --model openai-codex/gpt-5.4-mini --plan openai-codex/gpt-5.4-mini -p '/plan hello'`. Before the fix, the initial print-mode prompt was submitted while `AgentSession.getPlanModeState()` was still undefined; the focused reproduction was `bun test packages/coding-agent/test/print-mode-working-indicator.test.ts`.

## Cause
`InteractiveMode.init()` in `packages/coding-agent/src/modes/interactive-mode.ts` applied `plan.defaultOnStartup`, but `runPrintMode()` in `packages/coding-agent/src/modes/print-mode.ts` initialized extensions and immediately submitted the prompt without performing the equivalent fresh-session mode transition.

## Fix
- Enter plan mode in `runPrintMode()` before the first prompt when the session is fresh and both plan settings are enabled.
- Activate the built-in plan write tool, apply the configured plan-role model/thinking transition, and persist the `mode_change` so later interactive review restores the plan.
- Add regression coverage for the reported `-p '/plan hello'` startup path and persisted plan state.

## Verification
`bun test packages/coding-agent/test/print-mode-working-indicator.test.ts packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts` passed: 19 tests, 61 assertions. `bun check` passed across all packages. Fixes #6017