### PR TITLE
fix(launch): hide Windows daemon console windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Fixed non-PTY `launch start` daemons opening visible console windows on Windows by preserving an attached host console and using `CREATE_NO_WINDOW` only for headless hosts ([#6018](https://github.com/can1357/oh-my-pi/issues/6018)).
 - Fixed `--model <role>` resolving a bare configured `modelRoles` key.
 - Browser tool selectors now accept bare snapshot refs (`tab.click("e501")`, `@e501`) everywhere `aria-ref=e501` works — previously the tab-worker backend fell through to a CSS tag selector that could never match, burning the 2s zero-match watchdog with a misleading "matches no elements" hint. `tab.select`, `tab.uploadFile`, `tab.press({ selector })`, `tab.screenshot({ selector })`, and `tab.drag` now resolve refs too. Unknown/stale refs fail immediately with the "refresh refs" error.
 - `tab.select` no longer double-reports the previously selected option of a single `<select>`: the returned selection is read back after the full assignment pass instead of mid-loop.

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
 import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText } from "@oh-my-pi/pi-utils";
+import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
 import { workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint } from "./paths";
@@ -24,6 +25,7 @@ import {
 	parseDaemonSpec,
 	parseDaemonWireRequest,
 } from "./protocol";
+import { resolveDaemonSpawnOptions } from "./spawn-options";
 
 const DEFAULT_IDLE_GRACE_MS = 3_000;
 const MAX_REQUEST_BYTES = 1024 * 1024;
@@ -36,6 +38,10 @@ const PID_FILE = "broker.pid";
 const META_FILE = "meta.json";
 const LOG_FILE = "output.log";
 const PREVIOUS_LOG_FILE = "output.previous.log";
+const DAEMON_SPAWN_OPTIONS = resolveDaemonSpawnOptions({
+	platform: process.platform,
+	hostHasInheritableConsole: hostHasInheritableConsole(),
+});
 
 const SIGNAL_NUMBER: Record<DaemonSignal, number> = {
 	SIGINT: os.constants.signals.SIGINT,
@@ -588,7 +594,7 @@ class DaemonBroker {
 			stdin: "pipe",
 			stdout: "pipe",
 			stderr: "pipe",
-			detached: true,
+			...DAEMON_SPAWN_OPTIONS,
 		});
 		record.process = process;
 		record.input = process.stdin;
@@ -611,7 +617,7 @@ class DaemonBroker {
 				cwd: record.spec.cwd,
 				env: workerEnvFromParent(record.spec.env),
 				stdio: ["ignore", output.fd, output.fd],
-				detached: true,
+				...DAEMON_SPAWN_OPTIONS,
 			});
 			record.process = process;
 			record.snapshot.pid = process.pid;

--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -3,6 +3,7 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { isEexist, isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { resolveWorkerSpawnCmd, workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint, daemonRuntimeDir } from "./paths";
 import {
@@ -16,10 +17,15 @@ import {
 	parseDaemonRpcResult,
 	parseDaemonWireResponse,
 } from "./protocol";
+import { resolveDaemonSpawnOptions } from "./spawn-options";
 
 const CONNECT_TIMEOUT_MS = 10_000;
 const CONNECT_RETRY_MS = 50;
 const TOKEN_FILE = "broker.token";
+const BROKER_SPAWN_OPTIONS = resolveDaemonSpawnOptions({
+	platform: process.platform,
+	hostHasInheritableConsole: hostHasInheritableConsole(),
+});
 
 interface PendingRequest {
 	operation: DaemonOperation;
@@ -228,7 +234,7 @@ class SocketDaemonClient implements DaemonBrokerClient {
 			stdin: "ignore",
 			stdout: "ignore",
 			stderr: "ignore",
-			detached: true,
+			...BROKER_SPAWN_OPTIONS,
 		});
 		child.unref();
 	}

--- a/packages/coding-agent/src/launch/spawn-options.test.ts
+++ b/packages/coding-agent/src/launch/spawn-options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { resolveDaemonSpawnOptions } from "./spawn-options";
+
+describe("resolveDaemonSpawnOptions", () => {
+	it("hides Windows daemons when the host has no console", () => {
+		expect(
+			resolveDaemonSpawnOptions({
+				platform: "win32",
+				hostHasInheritableConsole: false,
+			}),
+		).toEqual({ detached: false, windowsHide: true });
+	});
+
+	it("inherits the Windows host console instead of detaching", () => {
+		expect(
+			resolveDaemonSpawnOptions({
+				platform: "win32",
+				hostHasInheritableConsole: true,
+			}),
+		).toEqual({ detached: false, windowsHide: false });
+	});
+
+	it("keeps POSIX daemons in their own session", () => {
+		expect(
+			resolveDaemonSpawnOptions({
+				platform: "linux",
+				hostHasInheritableConsole: false,
+			}),
+		).toEqual({ detached: true });
+	});
+});

--- a/packages/coding-agent/src/launch/spawn-options.ts
+++ b/packages/coding-agent/src/launch/spawn-options.ts
@@ -1,10 +1,10 @@
-/** Platform-specific options for non-PTY daemon subprocesses. */
+/** Platform-specific options for the launch broker and its non-PTY children. */
 export interface DaemonSpawnOptions {
 	detached: boolean;
 	windowsHide?: boolean;
 }
 
-/** Keep daemon subprocesses headless without discarding an inheritable Windows console. */
+/** Keep launch processes headless without discarding an inheritable Windows console. */
 export function resolveDaemonSpawnOptions(opts: {
 	platform: NodeJS.Platform;
 	hostHasInheritableConsole: boolean;

--- a/packages/coding-agent/src/launch/spawn-options.ts
+++ b/packages/coding-agent/src/launch/spawn-options.ts
@@ -1,0 +1,17 @@
+/** Platform-specific options for non-PTY daemon subprocesses. */
+export interface DaemonSpawnOptions {
+	detached: boolean;
+	windowsHide?: boolean;
+}
+
+/** Keep daemon subprocesses headless without discarding an inheritable Windows console. */
+export function resolveDaemonSpawnOptions(opts: {
+	platform: NodeJS.Platform;
+	hostHasInheritableConsole: boolean;
+}): DaemonSpawnOptions {
+	if (opts.platform !== "win32") return { detached: true };
+	return {
+		detached: false,
+		windowsHide: !opts.hostHasInheritableConsole,
+	};
+}

--- a/packages/coding-agent/src/prompts/tools/debug.md
+++ b/packages/coding-agent/src/prompts/tools/debug.md
@@ -1,3 +1,3 @@
 Debugger access. Prefer over bash for program state, breakpoints, stepping, or thread inspection.
-Only one active session at a time. `program` is a target path, not a shell command. 
+Only one active session at a time. `program` is a target path, not a shell command.
 Directories need a directory-capable adapter (e.g. `dlv`).


### PR DESCRIPTION
## Repro
On Windows, start a non-PTY console daemon with `launch start name=web application=node args=["server.js"]`; the broker currently opens a visible console window for the daemon. The broker-side trigger is reproduced with `ast-grep 'Bun.spawn($CMD, { $$$BEFORE, detached: true, $$$AFTER })' packages/coding-agent/src/launch/broker.ts`, which matched both `#launchPipe` and `#launchDetached` before the fix and showed no `windowsHide` option.

## Cause
`packages/coding-agent/src/launch/broker.ts` unconditionally passed `detached: true` in both non-PTY spawn paths. On Windows that prevents console inheritance, while omitting `windowsHide` lets console applications allocate a new visible console window.

## Fix
- Add `resolveDaemonSpawnOptions` to preserve POSIX session detachment while keeping Windows daemons attached to an inheritable host console.
- Set `windowsHide: true` only when the Windows host has no console, reusing `hostHasInheritableConsole()`.
- Apply the shared spawn policy to both pipe and detached daemon launches, with regression coverage for headless Windows, console-attached Windows, and POSIX.

## Verification
`bun test src/launch/spawn-options.test.ts` passes (3 tests); `bun run check:types` passes; `bun src/cli.ts --smoke-test` reports `smoke-test: ok`. An end-to-end broker smoke launched both pipe and detached Bun subprocesses and captured `pipe-ok` and `detached-ok` from their broker logs. Fixes #6018