### PR TITLE
fix(coding-agent): preserve model when resuming plan mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Fixed resuming an active plan session replacing its journal-restored model with the current `modelRoles.plan` setting ([#6015](https://github.com/can1357/oh-my-pi/issues/6015)).
 - Fixed `--model <role>` resolving a bare configured `modelRoles` key.
 - Browser tool selectors now accept bare snapshot refs (`tab.click("e501")`, `@e501`) everywhere `aria-ref=e501` works — previously the tab-worker backend fell through to a CSS tag selector that could never match, burning the 2s zero-match watchdog with a misleading "matches no elements" hint. `tab.select`, `tab.uploadFile`, `tab.press({ selector })`, `tab.screenshot({ selector })`, and `tab.drag` now resolve refs too. Unknown/stale refs fail immediately with the "refresh refs" error.
 - `tab.select` no longer double-reports the previously selected option of a single `<select>`: the returned selection is read back after the full assignment pass instead of mid-loop.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2325,7 +2325,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (sessionContext.mode === "plan") {
 			const planFilePath = sessionContext.modeData?.planFilePath as string | undefined;
-			await this.#enterPlanMode({ planFilePath });
+			await this.#enterPlanMode({ planFilePath, preserveRestoredModel: true });
 		} else if (sessionContext.mode === "plan_paused") {
 			this.planModePaused = true;
 			this.#planModeHasEntered = true;
@@ -2333,7 +2333,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async #enterPlanMode(options?: { planFilePath?: string; workflow?: "parallel" | "iterative" }): Promise<void> {
+	async #enterPlanMode(options?: {
+		planFilePath?: string;
+		workflow?: "parallel" | "iterative";
+		preserveRestoredModel?: boolean;
+	}): Promise<void> {
 		if (this.planModeEnabled) {
 			return;
 		}
@@ -2385,7 +2389,12 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.session.sendPlanModeContext({ deliverAs: "steer" });
 		}
 		this.#planModeHasEntered = true;
-		await this.#applyPlanModeModel();
+		// Session loading already restored the model recorded in the journal.
+		// Reapplying today's plan role here would replace a CLI/session-specific
+		// selection with current config during --resume or an in-process switch.
+		if (!options?.preserveRestoredModel) {
+			await this.#applyPlanModeModel();
+		}
 		this.#updatePlanModeStatus();
 		this.sessionManager.appendModeChange("plan", { planFilePath });
 		this.showStatus(`Plan mode enabled. Plan file: ${planFilePath}`);

--- a/packages/coding-agent/src/prompts/tools/debug.md
+++ b/packages/coding-agent/src/prompts/tools/debug.md
@@ -1,3 +1,3 @@
 Debugger access. Prefer over bash for program state, breakpoints, stepping, or thread inspection.
-Only one active session at a time. `program` is a target path, not a shell command. 
+Only one active session at a time. `program` is a target path, not a shell command.
 Directories need a directory-capable adapter (e.g. `dlv`).

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -247,6 +247,23 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(session?.getPlanModeState()).toBeUndefined();
 	});
 
+	it("preserves the restored model when resuming an active plan session", async () => {
+		const created = createHarness(
+			Settings.isolated({
+				"compaction.enabled": false,
+				modelRoles: { plan: "anthropic/claude-sonnet-4-6" },
+			}),
+		);
+		created.sessionManager.appendModelChange("anthropic/claude-sonnet-4-5");
+		created.sessionManager.appendModeChange("plan", { planFilePath: "local://PLAN.md" });
+		created.sessionManager.appendMessage({ role: "user", content: "prior plan turn", timestamp: Date.now() });
+
+		await created.init({ suppressWelcomeIntro: true });
+
+		expect(created.planModeEnabled).toBe(true);
+		expect(session?.model?.id).toBe("claude-sonnet-4-5");
+	});
+
 	it("enters plan mode for a fresh session that carries only startup metadata", async () => {
 		// createAgentSession appends model_change / thinking_level_change for a
 		// brand-new session before init(); those are not conversation history, so


### PR DESCRIPTION
## Repro
Enable plan mode at startup, launch a session with a CLI-selected model, leave the session in plan mode, then resume it: `omp config set plan.defaultOnStartup true`, `omp --model openai-codex/gpt-5.4-mini --plan openai-codex/gpt-5.4-mini`, and `omp --resume <session-id>`. A focused regression reproduced the reset by restoring `claude-sonnet-4-5` from the session journal while current configuration selected `claude-sonnet-4-6` for `modelRoles.plan`; interactive initialization incorrectly ended on `claude-sonnet-4-6`.

## Cause
`InteractiveMode.#reconcileModeFromSession()` restored an active `plan` mode by calling `#enterPlanMode()`. That normal entry path always called `#applyPlanModeModel()`, so the model already restored by `createAgentSession()` from the session journal was overwritten with the current `modelRoles.plan` value. CLI `--plan` overrides are process-local, making the resumed role value especially likely to differ.

## Fix
- Mark plan-mode entry from session reconciliation as preserving the journal-restored model.
- Keep normal fresh `/plan` and `plan.defaultOnStartup` entries applying the configured plan role.
- Add a regression covering a restored plan session whose current configured plan role differs.
- Document the fix in the coding-agent changelog.

## Verification
`bun test test/interactive-mode-default-plan-mode.test.ts test/agent-session-model-persistence.test.ts test/interactive-mode-plan-review.test.ts` — 87 passed, 0 failed. `gh_push_branch` also completed `bun run fix` and `bun check` successfully. Fixes #6015