### PR TITLE
fix(tui): resume direct writes after ConPTY settle

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed idle Loader animations on WSL repeatedly entering render scheduling after an expired ConPTY post-paint settle window instead of resuming direct component writes ([#6024](https://github.com/can1357/oh-my-pi/issues/6024)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Changed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1967,7 +1967,7 @@ export class TUI extends Container {
 		if (
 			this.#renderRequested ||
 			this.#postFullPaintSettleTimer !== undefined ||
-			this.#postFullPaintSettleUntilMs > 0
+			this.#postFullPaintSettleDelay() > 0
 		) {
 			this.requestComponentRender(component);
 			return;
@@ -2106,6 +2106,15 @@ export class TUI extends Container {
 		this.#commit(this.#composedFrame, previousWindow, width, height, cursorControl);
 	}
 
+	#postFullPaintSettleDelay(): number {
+		const until = this.#postFullPaintSettleUntilMs;
+		if (until <= 0) return 0;
+		const remaining = until - this.#renderScheduler.now();
+		if (remaining > 0) return remaining;
+		this.#postFullPaintSettleUntilMs = 0;
+		return 0;
+	}
+
 	/** Ordinary (non-forced) scheduling shared by full and component-scoped requests. */
 	#requestOrdinaryRender(): void {
 		// Coalesce non-forced renders inside the post-full-paint ConPTY settle
@@ -2114,20 +2123,17 @@ export class TUI extends Container {
 		// catching up with the previous big paint, and each follow-up viewport
 		// repaint nudges Windows Terminal's viewport tracker further off the
 		// last row (see #2095).
-		if (this.#postFullPaintSettleUntilMs > 0) {
-			const now = this.#renderScheduler.now();
-			if (now < this.#postFullPaintSettleUntilMs) {
-				if (this.#postFullPaintSettleTimer === undefined) {
-					this.#postFullPaintSettleTimer = this.#renderScheduler.scheduleRender(() => {
-						this.#postFullPaintSettleTimer = undefined;
-						this.#postFullPaintSettleUntilMs = 0;
-						if (this.#stopped) return;
-						this.#requestOrdinaryRender();
-					}, this.#postFullPaintSettleUntilMs - now);
-				}
-				return;
+		const settleDelayMs = this.#postFullPaintSettleDelay();
+		if (settleDelayMs > 0) {
+			if (this.#postFullPaintSettleTimer === undefined) {
+				this.#postFullPaintSettleTimer = this.#renderScheduler.scheduleRender(() => {
+					this.#postFullPaintSettleTimer = undefined;
+					this.#postFullPaintSettleUntilMs = 0;
+					if (this.#stopped) return;
+					this.#requestOrdinaryRender();
+				}, settleDelayMs);
 			}
-			this.#postFullPaintSettleUntilMs = 0;
+			return;
 		}
 		if (this.#renderRequested) return;
 		this.#renderRequested = true;

--- a/packages/tui/test/issue-2095-repro.test.ts
+++ b/packages/tui/test/issue-2095-repro.test.ts
@@ -122,6 +122,51 @@ describe("issue #2095: ConPTY post-full-paint settle prevents viewport drift", (
 		}
 	});
 
+	it("resumes direct writes after an idle ConPTY settle window expires (#6024)", async () => {
+		setPlatform("linux");
+		Bun.env.WSL_DISTRO_NAME = "Ubuntu";
+		const term = new VirtualTerminal(80, 24, 4096);
+		let now = 0;
+		const immediate: (() => void)[] = [];
+		const scheduler: RenderScheduler = {
+			now: () => now,
+			scheduleImmediate: callback => {
+				immediate.push(callback);
+			},
+			scheduleRender: (): RenderTimer => ({ cancel(): void {} }),
+		};
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const status = {
+			line: "spin-0",
+			renders: 0,
+			invalidate(): void {},
+			render(): string[] {
+				this.renders++;
+				return [this.line];
+			},
+		};
+		tui.addChild(new TallContent(200));
+		tui.addChild(status);
+
+		try {
+			tui.start();
+			while (immediate.length > 0) immediate.shift()?.();
+			await term.flush();
+			tui.requestRender(true, { clearScrollback: true });
+			while (immediate.length > 0) immediate.shift()?.();
+			await term.flush();
+			now = 151;
+			const rendersAfterSettle = status.renders;
+
+			status.line = "spin-1";
+			tui.requestDirectWrite(status);
+
+			expect(status.renders).toBe(rendersAfterSettle + 1);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("does not arm the settle on a clean (non-ConPTY) linux host", async () => {
 		setPlatform("linux");
 		const term = new VirtualTerminal(80, 24, 4096);


### PR DESCRIPTION
## Repro
On a simulated WSL ConPTY host, force an overflowing full paint, advance the render clock beyond the 150 ms post-paint settle window, then request a Loader-style direct write. Before the fix, `bun test packages/tui/test/issue-2095-repro.test.ts --test-name-pattern 'resumes direct writes'` failed with `Expected: 3, Received: 2`: `requestDirectWrite()` scheduled another component render instead of rendering the changed status segment directly.

## Cause
`TUI.#armPostFullPaintSettle()` in `packages/tui/src/tui.ts` can leave `#postFullPaintSettleUntilMs` set without a trailing timer when no render was pending during the full paint. `TUI.requestDirectWrite()` treated any positive deadline as active without comparing it to the scheduler clock, so every Loader tick after the expired window fell back through `requestComponentRender()` and re-entered render scheduling on ConPTY hosts.

## Fix
- Centralize active/expired settle calculation in `TUI.#postFullPaintSettleDelay()` and clear stale deadlines.
- Let `requestDirectWrite()` resume its proportional direct component path once the settle deadline has elapsed while preserving coalescing during the live window.
- Add a deterministic WSL regression covering an overflowing full paint followed by an idle Loader update after expiry.
- Document the fix in `packages/tui/CHANGELOG.md`.

## Verification
`bun test packages/tui/test/issue-2095-repro.test.ts` passed (6 tests); `bun test packages/tui/test/loader.test.ts` passed (10 tests); `bun test packages/tui/test/component-render.test.ts` passed (14 tests); `bun run check` in `packages/tui` passed. A standalone TUI smoke probe reported `direct-write-after-expiry=true` for the simulated WSL path. Fixes #6024