### PR TITLE
fix(ai): include Devin cache usage in total tokens

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Devin total-token usage omitting cache reads and cache writes.
+
 ## [17.0.5] - 2026-07-18
 
 ### Changed

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -322,7 +322,8 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 						output.usage.output = Number(msg.usage.outputTokens);
 						output.usage.cacheRead = Number(msg.usage.cacheReadTokens);
 						output.usage.cacheWrite = Number(msg.usage.cacheWriteTokens);
-						output.usage.totalTokens = output.usage.input + output.usage.output;
+						output.usage.totalTokens =
+							output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 					}
 				}
 

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { GetChatMessageResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
+import { GetUserJwtResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/auth_pb/auth_pb";
+import {
+	ModelUsageStatsSchema,
+	StopReason,
+} from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/codeium_common_pb/codeium_common_pb";
+
+function frameConnectMessage(payload: Uint8Array): Uint8Array {
+	const out = new Uint8Array(5 + payload.length);
+	const view = new DataView(out.buffer);
+	view.setUint8(0, 0);
+	view.setUint32(1, payload.length, false);
+	out.set(payload, 5);
+	return out;
+}
+
+const devinModel: Model<"devin-agent"> = buildModel({
+	id: "devin-test",
+	name: "Devin Test",
+	api: "devin-agent",
+	provider: "devin",
+	baseUrl: "https://server.codeium.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+});
+
+const context: Context = { messages: [{ role: "user", content: "hi", timestamp: 1 }] };
+
+describe("streamDevin usage", () => {
+	it("includes cached tokens in totalTokens", async () => {
+		const authPayload = toBinary(GetUserJwtResponseSchema, create(GetUserJwtResponseSchema, { userJwt: "jwt" }));
+		const response = create(GetChatMessageResponseSchema, {
+			messageId: "msg-1",
+			stopReason: StopReason.STOP_PATTERN,
+			usage: create(ModelUsageStatsSchema, {
+				inputTokens: 11n,
+				outputTokens: 7n,
+				cacheReadTokens: 100n,
+				cacheWriteTokens: 13n,
+			}),
+		});
+		const responseFrame = frameConnectMessage(toBinary(GetChatMessageResponseSchema, response));
+		const fetchImpl = (async (input: string | URL | Request) => {
+			if (String(input).includes("GetUserJwt")) return new Response(authPayload);
+			return new Response(responseFrame);
+		}) as typeof fetch;
+
+		const result = await streamDevin(devinModel, context, { apiKey: "token", fetch: fetchImpl }).result();
+
+		expect(result.usage).toMatchObject({
+			input: 11,
+			output: 7,
+			cacheRead: 100,
+			cacheWrite: 13,
+			totalTokens: 131,
+		});
+	});
+});


### PR DESCRIPTION
## What

- Include Devin cache-read and cache-write usage in `totalTokens`.
- Add a framed protobuf response regression test covering all four usage buckets.

## Why

The shared usage contract defines `totalTokens` as input + output + cache read + cache write, but the Devin provider only added input and output.

For the regression fixture, the provider previously reported `18` total tokens for `11` input, `7` output, `100` cache-read, and `13` cache-write tokens. It now reports the correct total of `131`.

This affects newly recorded Devin responses. It does not rewrite historical transcripts or existing stats rows.

## Testing

- `bun test packages/ai/test/devin-usage.test.ts packages/ai/test/devin-frame-cap.test.ts packages/ai/test/devin-streaming-args.test.ts packages/ai/test/devin-login.test.ts` (5 passed, 0 failed)
- `bun --cwd=packages/ai test` (3,005 passed, 337 skipped, 0 failed)
- `bun --cwd=packages/ai run check`
- `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
