### PR TITLE
fix(stats): clarify overview token totals

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified overview token accounting by separating uncached input from cache reads and showing the conversation-token total used by the agent breakdown.
+
 ## [17.0.5] - 2026-07-18
 
 ### Fixed

--- a/packages/stats/src/client/data/view-models.ts
+++ b/packages/stats/src/client/data/view-models.ts
@@ -14,6 +14,18 @@ import type {
 /** Fixed display order for the agent-token-share breakdown. */
 const AGENT_TYPE_ORDER: AgentType[] = ["main", "subagent", "advisor"];
 
+export interface ConversationTokenStats {
+	totalInputTokens: number;
+	totalOutputTokens: number;
+	totalCacheReadTokens: number;
+	totalCacheWriteTokens: number;
+}
+
+/** Sum every conversation-token bucket shown by the overview. */
+export function sumConversationTokens(stats: ConversationTokenStats): number {
+	return stats.totalInputTokens + stats.totalOutputTokens + stats.totalCacheReadTokens + stats.totalCacheWriteTokens;
+}
+
 export interface AgentTokenSegment {
 	agentType: AgentType;
 	/** input + output + cache read + cache write — the displayed denominator. */
@@ -33,25 +45,21 @@ export interface AgentTokenShareView {
 /**
  * Build the "token usage by agent" breakdown: one segment per agent type that
  * appears in the data, ordered main -> subagents -> advisor, each carrying its
- * token total and share of the grand total. Token counts sum the same four
- * columns the overview renders (input + output + cache read + cache write) so a
- * segment's share never disagrees with the count beside it.
+ * token total and share of the grand total. Token counts use the same four
+ * conversation-token buckets as the overview total so the two views reconcile.
  */
 export function buildAgentTokenShare(stats: AgentTypeStats[]): AgentTokenShareView {
 	const byType = new Map<AgentType, AgentTypeStats>();
 	for (const stat of stats) byType.set(stat.agentType, stat);
 
-	const tokensOf = (stat: AgentTypeStats) =>
-		stat.totalInputTokens + stat.totalOutputTokens + stat.totalCacheReadTokens + stat.totalCacheWriteTokens;
-
 	const present = AGENT_TYPE_ORDER.map(type => byType.get(type)).filter(
 		(stat): stat is AgentTypeStats => stat !== undefined,
 	);
-	const totalTokens = present.reduce((sum, stat) => sum + tokensOf(stat), 0);
+	const totalTokens = present.reduce((sum, stat) => sum + sumConversationTokens(stat), 0);
 	const totalCost = present.reduce((sum, stat) => sum + stat.totalCost, 0);
 
 	const segments = present.map(stat => {
-		const tokens = tokensOf(stat);
+		const tokens = sumConversationTokens(stat);
 		return {
 			agentType: stat.agentType,
 			tokens,

--- a/packages/stats/src/client/routes/OverviewRoute.tsx
+++ b/packages/stats/src/client/routes/OverviewRoute.tsx
@@ -226,8 +226,8 @@ export function OverviewRoute({ active, range, refreshTrigger, onRequestClick }:
 			</AsyncBoundary>
 
 			<Panel
-				title="Token Usage by Agent"
-				subtitle="Share of tokens across the main agent, task subagents, and the advisor"
+				title="Conversation Tokens by Agent"
+				subtitle="Uncached input + cache reads + cache writes + output, grouped by agent type"
 			>
 				<AsyncBoundary loading={overviewLoading} error={overviewError} data={overview}>
 					{overview && <AgentTokenShare stats={overview.byAgentType} />}

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -581,17 +581,17 @@
 
 .stats-metric-secondary-grid {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(8, 1fr);
   gap: 12px;
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 1279px) {
   .stats-metric-secondary-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 767px) {
   .stats-metric-secondary-grid {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/packages/stats/src/client/ui/MetricCluster.tsx
+++ b/packages/stats/src/client/ui/MetricCluster.tsx
@@ -6,6 +6,7 @@ import {
 	formatPercent,
 	formatTokensPerSecond,
 } from "../data/formatters";
+import { sumConversationTokens } from "../data/view-models";
 import type { AggregatedStats } from "../types";
 
 export interface MetricClusterProps {
@@ -13,6 +14,8 @@ export interface MetricClusterProps {
 }
 
 export function MetricCluster({ stats }: MetricClusterProps) {
+	const conversationTokens = sumConversationTokens(stats);
+
 	return (
 		<div className="stats-metric-cluster">
 			<div className="stats-metric-primary-grid">
@@ -37,13 +40,21 @@ export function MetricCluster({ stats }: MetricClusterProps) {
 			</div>
 
 			<div className="stats-metric-secondary-grid">
-				<div className="stats-metric-card secondary">
-					<div className="stats-metric-label">Input Tokens</div>
+				<div className="stats-metric-card secondary" title="Conversation input not served from cache">
+					<div className="stats-metric-label">Uncached Input</div>
 					<div className="stats-metric-value">{formatCompact(stats.totalInputTokens)}</div>
+				</div>
+				<div className="stats-metric-card secondary" title="Conversation input read from the prompt cache">
+					<div className="stats-metric-label">Cache Read</div>
+					<div className="stats-metric-value">{formatCompact(stats.totalCacheReadTokens)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
 					<div className="stats-metric-label">Output Tokens</div>
 					<div className="stats-metric-value">{formatCompact(stats.totalOutputTokens)}</div>
+				</div>
+				<div className="stats-metric-card secondary" title="Uncached input + cache reads + cache writes + output">
+					<div className="stats-metric-label">Conversation Total</div>
+					<div className="stats-metric-value">{formatCompact(conversationTokens)}</div>
 				</div>
 				<div className="stats-metric-card secondary">
 					<div className="stats-metric-label">Premium Requests</div>

--- a/packages/stats/test/overview-token-labels.test.tsx
+++ b/packages/stats/test/overview-token-labels.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MetricCluster } from "../src/client/ui/MetricCluster";
+import type { AggregatedStats } from "../src/shared-types";
+
+const stats: AggregatedStats = {
+	totalRequests: 1,
+	successfulRequests: 1,
+	failedRequests: 0,
+	errorRate: 0,
+	totalInputTokens: 100,
+	totalOutputTokens: 20,
+	totalCacheReadTokens: 300,
+	totalCacheWriteTokens: 40,
+	cacheRate: 0.75,
+	totalCost: 0,
+	totalPremiumRequests: 0,
+	avgDuration: 1000,
+	avgTtft: 100,
+	avgTokensPerSecond: 20,
+	firstTimestamp: 1,
+	lastTimestamp: 1,
+};
+
+describe("overview token metrics", () => {
+	it("distinguishes uncached input and cache reads and shows their reconciled total", () => {
+		const html = renderToStaticMarkup(<MetricCluster stats={stats} />);
+
+		expect(html).toContain("Uncached Input");
+		expect(html).toContain("Cache Read");
+		expect(html).toContain("Conversation Total");
+		expect(html).toContain("Uncached input + cache reads + cache writes + output");
+		expect(html).toContain('<div class="stats-metric-value">460</div>');
+	});
+});

--- a/packages/stats/test/overview-token-labels.test.tsx
+++ b/packages/stats/test/overview-token-labels.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { formatCompact } from "../src/client/data/formatters";
 import { MetricCluster } from "../src/client/ui/MetricCluster";
 import type { AggregatedStats } from "../src/shared-types";
 
@@ -30,6 +31,13 @@ describe("overview token metrics", () => {
 		expect(html).toContain("Cache Read");
 		expect(html).toContain("Conversation Total");
 		expect(html).toContain("Uncached input + cache reads + cache writes + output");
-		expect(html).toContain('<div class="stats-metric-value">460</div>');
+
+		const expectedTotal = formatCompact(
+			stats.totalInputTokens +
+				stats.totalOutputTokens +
+				stats.totalCacheReadTokens +
+				stats.totalCacheWriteTokens,
+		);
+		expect(html).toContain(`<div class="stats-metric-value">${expectedTotal}</div>`);
 	});
 });


### PR DESCRIPTION
## What

- Rename the overview input metric to `Uncached Input`.
- Show cache-read tokens and a reconciled `Conversation Total`.
- Use one shared conversation-token calculation for the overview total and agent breakdown.
- State the four included token buckets directly above the agent breakdown.

## Why

The overview showed uncached input and output totals beside an agent breakdown that also included cache reads and cache writes. Both sets of numbers were correct, but the missing labels and total made them look contradictory—especially when cache reuse was high.

The conversation total is now defined as:

`uncached input + cache reads + cache writes + output`

## Testing

- `bun test packages/stats/test` (76 passed, 0 failed)
- `bun --cwd=packages/stats run check`
- `bun --cwd=packages/stats run build`
- Local browser check at 1246x768 confirmed the new labels, formula, total, and responsive metric layout.
- `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
