### PR TITLE
feat(coding-agent): add evidence-aware output packing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -221,6 +221,7 @@
 - Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded.
 - Fixed `/retry` reporting "Nothing to retry" after a stream stalled or aborted mid-tool-call.
 - Fixed locally consumed extension commands triggering automatic title generation and exposing their command text to the title model.
+- Added an opt-in evidence-aware packer for large generic tool results that keeps exact source ranges and preserves the full raw output as a recoverable artifact.
 
 ## [17.0.7] - 2026-07-21
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -713,6 +713,17 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
+	"tools.evidenceAwarePacking": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Output Limits",
+			label: "Evidence-aware Output Packing",
+			description:
+				"Experimental: select task-relevant source ranges for large generic tool results while preserving the full output as an artifact",
+		},
+	},
 	"tools.artifactTailBytes": {
 		type: "number",
 		default: 20,

--- a/packages/coding-agent/src/tools/context-packing/candidate-settings.json
+++ b/packages/coding-agent/src/tools/context-packing/candidate-settings.json
@@ -1,0 +1,12 @@
+{
+	"dedupeExactLines": true,
+	"errorWeight": 1200,
+	"headWeight": 0,
+	"neighborRadius": 0,
+	"neighborWeight": 80,
+	"pathWeight": 180,
+	"queryWeight": 140,
+	"structureWeight": 40,
+	"summaryWeight": 320,
+	"tailWeight": 0
+}

--- a/packages/coding-agent/src/tools/context-packing/candidate.ts
+++ b/packages/coding-agent/src/tools/context-packing/candidate.ts
@@ -1,0 +1,299 @@
+import candidateSettings from "./candidate-settings.json" with { type: "json" };
+import { queryTokenWeights } from "./query";
+import type { CandidateSelectionSettings, SourceUnit, ToolOutputPackRequest } from "./types";
+
+const ERROR_SUMMARY_RE =
+	/(?:\btest result\b|\btests?\s+(?:failed|passed)\b|\bcommand exited\b|\bexit code\b|\b(?:failures?|errors?):|\b\d+\s+(?:failed|passed|errors?)\b)/iu;
+
+const CANDIDATE_EVALUATIONS_PER_KIB = 32;
+const MIN_CANDIDATE_EVALUATIONS = 64;
+
+interface RankedSourceUnit {
+	id: string;
+	kind: SourceUnit["kind"];
+	lineNumber: number;
+	score: number;
+}
+
+interface SearchGroup {
+	end: number;
+	overlap: number;
+	start: number;
+}
+
+export function candidateEvaluationLimit(maxBytes: number): number {
+	return Math.max(MIN_CANDIDATE_EVALUATIONS, Math.ceil(Math.max(0, maxBytes) / 1024) * CANDIDATE_EVALUATIONS_PER_KIB);
+}
+
+function compareRanked(left: RankedSourceUnit, right: RankedSourceUnit): number {
+	return right.score - left.score || left.lineNumber - right.lineNumber;
+}
+
+function compareSearchGroups(left: SearchGroup, right: SearchGroup): number {
+	return right.overlap - left.overlap || left.start - right.start;
+}
+
+function retainBestCandidate(
+	ranked: RankedSourceUnit[],
+	id: string,
+	kind: SourceUnit["kind"],
+	lineNumber: number,
+	score: number,
+	limit: number,
+): void {
+	if (ranked.length >= limit) {
+		const worst = ranked[0];
+		const comparison = worst.score - score || lineNumber - worst.lineNumber;
+		if (comparison >= 0) return;
+	}
+	const candidate = { id, kind, lineNumber, score };
+	if (ranked.length < limit) {
+		ranked.push(candidate);
+		let index = ranked.length - 1;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (compareRanked(ranked[index], ranked[parent]) <= 0) break;
+			[ranked[index], ranked[parent]] = [ranked[parent], ranked[index]];
+			index = parent;
+		}
+		return;
+	}
+
+	ranked[0] = candidate;
+	let index = 0;
+	while (true) {
+		const left = index * 2 + 1;
+		const right = left + 1;
+		let worse = index;
+		if (left < ranked.length && compareRanked(ranked[left], ranked[worse]) > 0) worse = left;
+		if (right < ranked.length && compareRanked(ranked[right], ranked[worse]) > 0) worse = right;
+		if (worse === index) return;
+		[ranked[index], ranked[worse]] = [ranked[worse], ranked[index]];
+		index = worse;
+	}
+}
+
+function overlapScore(normalizedLine: string, tokenWeights: ReadonlyMap<string, number>): number {
+	let score = 0;
+	for (const [token, weight] of tokenWeights) {
+		if (normalizedLine.includes(token)) score += weight;
+	}
+	return score;
+}
+
+function kindWeight(unit: SourceUnit, settings: CandidateSelectionSettings): number {
+	switch (unit.kind) {
+		case "error":
+			return settings.errorWeight;
+		case "path":
+			return /(?:^|\s)\/\/\s/u.test(unit.text) ? 0 : settings.pathWeight;
+		case "summary":
+			return settings.summaryWeight;
+		case "json_key":
+		case "structure":
+		case "table_header":
+			return /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*$/u.test(unit.text) ? 0 : settings.structureWeight;
+		default:
+			return 0;
+	}
+}
+
+function fallbackRankedIds(units: readonly SourceUnit[], limit: number): string[] {
+	const ranked: string[] = [];
+	for (let head = 0, tail = units.length - 1; head <= tail && ranked.length < limit; head++, tail--) {
+		ranked.push(units[head].id);
+		if (tail !== head && ranked.length < limit) ranked.push(units[tail].id);
+	}
+	return ranked;
+}
+
+/**
+ * Editable autoresearch surface. Return source unit IDs in descending value.
+ * The fixed planner resolves dependencies, applies the byte budget, and renders
+ * exact source text, so this function cannot rewrite tool output.
+ */
+export function rankSourceUnits(
+	request: ToolOutputPackRequest,
+	units: readonly SourceUnit[],
+	settings: CandidateSelectionSettings = candidateSettings,
+): string[] {
+	const normalizedUnits = units.map(unit => unit.text.toLowerCase());
+	const tokenWeights = queryTokenWeights(request, normalizedUnits);
+	const overlaps = Float64Array.from(normalizedUnits, normalized => overlapScore(normalized, tokenWeights));
+	const lastLine = units.at(-1)?.lineNumber ?? 1;
+	const fallbackErrorLine =
+		request.isError || (request.exitCode !== undefined && request.exitCode !== 0)
+			? units.findLast(unit => unit.text.trim().length > 0)?.lineNumber
+			: undefined;
+	const neighborDistances = new Float64Array(units.length);
+	neighborDistances.fill(Number.POSITIVE_INFINITY);
+	let closestHitLine = Number.NEGATIVE_INFINITY;
+	for (let index = 0; index < units.length; index++) {
+		const unit = units[index];
+		if (overlaps[index] >= 0.5) closestHitLine = unit.lineNumber;
+		neighborDistances[index] = unit.lineNumber - closestHitLine;
+	}
+	closestHitLine = Number.POSITIVE_INFINITY;
+	for (let index = units.length - 1; index >= 0; index--) {
+		const unit = units[index];
+		if (overlaps[index] >= 0.5) closestHitLine = unit.lineNumber;
+		neighborDistances[index] = Math.min(neighborDistances[index], closestHitLine - unit.lineNumber);
+	}
+	const exhaustiveQuery = /\b(?:all|both|complete|each|entire|every|list|multiple)\b/iu.test(request.taskGoal);
+	const rankedLimit = candidateEvaluationLimit(request.maxBytes);
+	const relevantEvidence = new Uint8Array(units.length);
+	for (let index = 0; index < units.length; index++) {
+		const unit = units[index];
+		if (overlaps[index] >= 0.5 || (unit.kind === "path" && !/(?:^|\s)\/\/\s/u.test(unit.text))) {
+			relevantEvidence[index] = 1;
+		}
+	}
+	let bestTableRowOverlap = 0;
+	for (let index = 0; index < units.length; index++) {
+		if (units[index].kind === "table_row") bestTableRowOverlap = Math.max(bestTableRowOverlap, overlaps[index]);
+	}
+	const isSearchOutput =
+		request.kind === "search" || ["find", "glob", "grep", "search"].includes(request.toolName.toLowerCase());
+	let bestSearchGroupOverlap = 0;
+	const searchGroups: SearchGroup[] = [];
+	if (isSearchOutput) {
+		for (let start = 0; start < units.length; ) {
+			if (overlaps[start] < 0.5) {
+				start++;
+				continue;
+			}
+			let end = start + 1;
+			let groupOverlap = overlaps[start];
+			while (end < units.length && overlaps[end] >= 0.5 && units[end - 1].lineNumber + 1 === units[end].lineNumber) {
+				groupOverlap += overlaps[end];
+				end++;
+			}
+			bestSearchGroupOverlap = Math.max(bestSearchGroupOverlap, groupOverlap);
+			searchGroups.push({ end, overlap: groupOverlap, start });
+			// Each reserved group contributes at least one line, so only the top
+			// rankedLimit groups can ever be reserved; bounded truncation keeps
+			// dense alternating matches from accumulating unbounded group state.
+			if (searchGroups.length > rankedLimit * 2) {
+				searchGroups.sort(compareSearchGroups);
+				searchGroups.length = rankedLimit;
+			}
+			start = end;
+		}
+	}
+	const selectedSearchLines = new Set<number>();
+	if (searchGroups.length > 0) {
+		// Reserve lines from the strongest groups first so an early qualifying
+		// group cannot exhaust the cap before a later higher-overlap group.
+		searchGroups.sort(compareSearchGroups);
+		for (const group of searchGroups) {
+			const remaining = rankedLimit - selectedSearchLines.size;
+			if (remaining <= 0 || group.overlap < bestSearchGroupOverlap * 0.7) break;
+			if (group.end - group.start <= remaining) {
+				for (let index = group.start; index < group.end; index++) {
+					selectedSearchLines.add(units[index].lineNumber);
+				}
+				continue;
+			}
+			// The group overflows the reservation cap: keep its strongest rows
+			// (overlap desc, line asc) instead of the first rows in source order,
+			// so a weak prefix cannot exclude a later stronger match.
+			const strongest: RankedSourceUnit[] = [];
+			for (let index = group.start; index < group.end; index++) {
+				const unit = units[index];
+				retainBestCandidate(strongest, unit.id, unit.kind, unit.lineNumber, overlaps[index], remaining);
+			}
+			for (const row of strongest) selectedSearchLines.add(row.lineNumber);
+			break;
+		}
+	}
+
+	const structuralContext = new Uint8Array(units.length);
+	for (let index = 0; index < units.length; index++) {
+		const unit = units[index];
+		if (/^\s*@@/u.test(unit.text) && index + 1 < units.length) structuralContext[index + 1] = 1;
+		if (
+			/(?:decoder error|deseriali[sz]ation|invalid json|parseerror|syntaxerror|unexpected end)/iu.test(unit.text) &&
+			index > 0
+		) {
+			structuralContext[index - 1] = 1;
+		}
+	}
+
+	const hasRelevantEvidenceNearby = (index: number): boolean => {
+		const lineNumber = units[index].lineNumber;
+		for (let neighbor = Math.max(0, index - 2); neighbor <= Math.min(units.length - 1, index + 2); neighbor++) {
+			if (
+				neighbor !== index &&
+				relevantEvidence[neighbor] === 1 &&
+				Math.abs(units[neighbor].lineNumber - lineNumber) <= 2
+			) {
+				return true;
+			}
+		}
+		return false;
+	};
+	let hasNonStructuralRanking = false;
+	let rankedCandidateCount = 0;
+	const ranked: RankedSourceUnit[] = [];
+	const seenLines = new Set<string>();
+	for (let index = 0; index < units.length; index++) {
+		const unit = units[index];
+		const normalized = normalizedUnits[index].trim();
+		const duplicate = settings.dedupeExactLines && normalized.length > 0 && seenLines.has(normalized);
+		if (settings.dedupeExactLines && normalized.length > 0) {
+			if (duplicate) {
+				seenLines.delete(normalized);
+			} else if (seenLines.size >= rankedLimit) {
+				const oldest = seenLines.values().next().value;
+				if (oldest !== undefined) seenLines.delete(oldest);
+			}
+			seenLines.add(normalized);
+		}
+		const overlap = overlaps[index];
+		const supportsRelevantError =
+			unit.lineNumber === fallbackErrorLine ||
+			unit.kind !== "error" ||
+			exhaustiveQuery ||
+			overlap >= 0.5 ||
+			ERROR_SUMMARY_RE.test(unit.text) ||
+			hasRelevantEvidenceNearby(index);
+
+		const neighborDistance = neighborDistances[index];
+		const neighborBonus =
+			neighborDistance <= settings.neighborRadius
+				? settings.neighborWeight * (settings.neighborRadius - neighborDistance + 1)
+				: 0;
+		const edgeBonus =
+			unit.lineNumber <= 3
+				? settings.headWeight * (4 - unit.lineNumber)
+				: unit.lineNumber > lastLine - 4
+					? settings.tailWeight * (unit.lineNumber - (lastLine - 4))
+					: 0;
+		const fallbackErrorBonus = unit.lineNumber === fallbackErrorLine ? settings.errorWeight : 0;
+		const score =
+			kindWeight(unit, settings) +
+			fallbackErrorBonus +
+			overlap * settings.queryWeight +
+			neighborBonus +
+			(structuralContext[index] === 1 ? settings.neighborWeight : 0) +
+			edgeBonus -
+			(duplicate ? 500 : 0);
+		if (
+			score <= 0 ||
+			!supportsRelevantError ||
+			(isSearchOutput && !exhaustiveQuery && overlap >= 0.5 && !selectedSearchLines.has(unit.lineNumber)) ||
+			(unit.kind === "table_row" && !exhaustiveQuery && overlap < bestTableRowOverlap * 0.5)
+		) {
+			continue;
+		}
+		rankedCandidateCount++;
+		if (unit.kind !== "structure" && unit.kind !== "table_header") hasNonStructuralRanking = true;
+		retainBestCandidate(ranked, unit.id, unit.kind, unit.lineNumber, score, rankedLimit);
+	}
+	ranked.sort(compareRanked);
+	const structuralOnlyTableRanking =
+		units.some(unit => unit.kind === "table_header") && rankedCandidateCount > 0 && !hasNonStructuralRanking;
+	return rankedCandidateCount === 0 || structuralOnlyTableRanking
+		? fallbackRankedIds(units, rankedLimit)
+		: ranked.map(item => item.id);
+}

--- a/packages/coding-agent/src/tools/context-packing/index.ts
+++ b/packages/coding-agent/src/tools/context-packing/index.ts
@@ -1,0 +1,25 @@
+import { rankSourceUnits } from "./candidate";
+import { renderRankedSelection } from "./render";
+import { segmentToolOutput } from "./segment";
+import type { PackedToolOutput, ToolOutputPackRequest } from "./types";
+
+export * from "./candidate";
+export * from "./render";
+export * from "./segment";
+export * from "./types";
+
+export function packToolOutput(request: ToolOutputPackRequest): PackedToolOutput {
+	const units = segmentToolOutput(request);
+	const rankedIds = rankSourceUnits(request, units);
+	return renderRankedSelection(request, units, rankedIds);
+}
+
+export function formatToolArgumentsForPacking(value: unknown): string {
+	if (value === undefined) return "";
+	try {
+		const serialized = typeof value === "string" ? value : JSON.stringify(value);
+		return serialized.slice(0, 4096);
+	} catch {
+		return String(value).slice(0, 4096);
+	}
+}

--- a/packages/coding-agent/src/tools/context-packing/query.ts
+++ b/packages/coding-agent/src/tools/context-packing/query.ts
@@ -1,0 +1,76 @@
+import type { ToolOutputPackRequest } from "./types";
+
+const TOKEN_RE = /[\p{L}\p{N}_./:-]{2,}/gu;
+const MAX_QUERY_TOKENS = 256;
+const MAX_QUERY_LINE_COMPARISONS = 4_000_000;
+
+function appendQueryTokens(tokens: Set<string>, source: string | undefined, limit: number): void {
+	if (!source || limit <= 0) return;
+	const headLimit = Math.floor(limit / 2);
+	const tailLimit = limit - headLimit;
+	const tail: string[] = [];
+	const tailSet = new Set<string>();
+	let headAdded = 0;
+	let tailCursor = 0;
+
+	for (const match of source.toLowerCase().matchAll(TOKEN_RE)) {
+		const token = match[0];
+		if (token.length < 3 || tokens.has(token) || tailSet.has(token)) continue;
+		if (headAdded < headLimit) {
+			tokens.add(token);
+			headAdded++;
+			continue;
+		}
+		if (tail.length < tailLimit) {
+			tail.push(token);
+			tailSet.add(token);
+			continue;
+		}
+		if (tailLimit === 0) continue;
+		tailSet.delete(tail[tailCursor]);
+		tail[tailCursor] = token;
+		tailSet.add(token);
+		tailCursor = (tailCursor + 1) % tailLimit;
+	}
+
+	const tailStart = tail.length === tailLimit ? tailCursor : 0;
+	for (let offset = 0; offset < tail.length; offset++) {
+		tokens.add(tail[(tailStart + offset) % tail.length]);
+	}
+}
+
+function queryTokenLimit(unitCount: number): number {
+	return Math.max(2, Math.min(MAX_QUERY_TOKENS, Math.floor(MAX_QUERY_LINE_COMPARISONS / Math.max(1, unitCount * 2))));
+}
+
+export function boundedTaskQueryTokens(request: ToolOutputPackRequest, unitCount: number): readonly string[] {
+	const limit = queryTokenLimit(unitCount);
+	const tokens = new Set<string>();
+	appendQueryTokens(tokens, request.taskGoal, Math.min(limit, Math.max(2, Math.floor(limit * 0.75))));
+	return [...tokens];
+}
+
+export function boundedQueryTokens(request: ToolOutputPackRequest, unitCount: number): Set<string> {
+	const limit = queryTokenLimit(unitCount);
+	const tokens = new Set(boundedTaskQueryTokens(request, unitCount));
+	appendQueryTokens(tokens, request.toolArguments, limit - tokens.size);
+	appendQueryTokens(tokens, request.toolName, limit - tokens.size);
+	return tokens;
+}
+
+export function queryTokenWeights(
+	request: ToolOutputPackRequest,
+	normalizedUnits: readonly string[],
+): Map<string, number> {
+	const tokens = boundedQueryTokens(request, normalizedUnits.length);
+	const weights = new Map<string, number>();
+	for (const token of tokens) {
+		let documentFrequency = 0;
+		for (const normalized of normalizedUnits) {
+			if (normalized.includes(token)) documentFrequency++;
+		}
+		const weight = Math.log2((normalizedUnits.length + 1) / (documentFrequency + 1));
+		if (weight >= 0.5) weights.set(token, weight);
+	}
+	return weights;
+}

--- a/packages/coding-agent/src/tools/context-packing/render.ts
+++ b/packages/coding-agent/src/tools/context-packing/render.ts
@@ -1,0 +1,361 @@
+import { candidateEvaluationLimit } from "./candidate";
+import { boundedQueryTokens, boundedTaskQueryTokens } from "./query";
+import type {
+	PackedToolOutput,
+	SelectedSourceFragment,
+	SelectedSourceSpan,
+	SourceUnit,
+	ToolOutputPackRequest,
+} from "./types";
+
+function dependencyClosure(ids: ReadonlySet<string>, unitsById: ReadonlyMap<string, SourceUnit>): Set<string> {
+	const closure = new Set(ids);
+	const pending = [...ids];
+	while (pending.length > 0) {
+		const id = pending.pop();
+		if (!id) continue;
+		for (const dependency of unitsById.get(id)?.dependencies ?? []) {
+			if (closure.has(dependency)) continue;
+			closure.add(dependency);
+			pending.push(dependency);
+		}
+	}
+	return closure;
+}
+
+function hasOnlyJsonStructuralDependencies(unit: SourceUnit, unitsById: ReadonlyMap<string, SourceUnit>): boolean {
+	return (
+		unit.dependencies.length > 0 &&
+		unit.dependencies.every(dependency => {
+			const kind = unitsById.get(dependency)?.kind;
+			return kind === "json_key" || kind === "structure";
+		})
+	);
+}
+
+function createSpans(selected: ReadonlySet<string>, unitsById: ReadonlyMap<string, SourceUnit>): SelectedSourceSpan[] {
+	const lines: SourceUnit[] = [];
+	for (const id of selected) {
+		const unit = unitsById.get(id);
+		if (unit) lines.push(unit);
+	}
+	lines.sort((left, right) => left.lineNumber - right.lineNumber);
+	const spans: SelectedSourceSpan[] = [];
+	for (const unit of lines) {
+		const previous = spans.at(-1);
+		if (previous && previous.endLine + 1 === unit.lineNumber) {
+			previous.endLine = unit.lineNumber;
+			previous.text += `\n${unit.text}`;
+			continue;
+		}
+		spans.push({ endLine: unit.lineNumber, startLine: unit.lineNumber, text: unit.text });
+	}
+	return spans;
+}
+
+function renderSpans(request: ToolOutputPackRequest, spans: readonly SelectedSourceSpan[], totalLines: number): string {
+	if (spans.length === 0) return `[tool=${request.toolName}; no source lines selected]`;
+	const chunks: string[] = [];
+	let previousEnd = 0;
+	for (const span of spans) {
+		if (span.startLine > previousEnd + 1) {
+			chunks.push(`[... source lines ${previousEnd + 1}-${span.startLine - 1} omitted ...]`);
+		}
+		const range = span.startLine === span.endLine ? `${span.startLine}` : `${span.startLine}-${span.endLine}`;
+		chunks.push(`[tool=${request.toolName}; source lines ${range}]\n${span.text}`);
+		previousEnd = span.endLine;
+	}
+	if (previousEnd < totalLines) chunks.push(`[... source lines ${previousEnd + 1}-${totalLines} omitted ...]`);
+	return chunks.join("\n");
+}
+
+function renderSelection(
+	request: ToolOutputPackRequest,
+	selected: ReadonlySet<string>,
+	unitsById: ReadonlyMap<string, SourceUnit>,
+	totalLines: number,
+): { content: string; spans: SelectedSourceSpan[] } {
+	const spans = createSpans(selected, unitsById);
+	return { content: renderSpans(request, spans, totalLines), spans };
+}
+
+function utf8Head(text: string, maxBytes: number): string {
+	if (maxBytes <= 0) return "";
+	let windowEnd = Math.min(text.length, maxBytes);
+	const lastCodeUnit = text.charCodeAt(windowEnd - 1);
+	if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) windowEnd++;
+	const window = text.substring(0, windowEnd);
+	const bytes = Buffer.from(window, "utf8");
+	if (bytes.length <= maxBytes) return window;
+	let end = maxBytes;
+	while (end > 0 && (bytes[end] & 0xc0) === 0x80) end--;
+	return bytes.subarray(0, end).toString("utf8");
+}
+
+function utf8Tail(text: string, maxBytes: number): string {
+	if (maxBytes <= 0) return "";
+	let windowStart = Math.max(0, text.length - maxBytes);
+	const firstCodeUnit = text.charCodeAt(windowStart);
+	if (firstCodeUnit >= 0xdc00 && firstCodeUnit <= 0xdfff) windowStart--;
+	const window = text.substring(windowStart);
+	const bytes = Buffer.from(window, "utf8");
+	if (bytes.length <= maxBytes) return window;
+	let start = bytes.length - maxBytes;
+	while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start++;
+	return bytes.subarray(start).toString("utf8");
+}
+
+function utf8Before(text: string, end: number, maxBytes: number): string {
+	let start = Math.max(0, end - maxBytes);
+	const firstCodeUnit = text.charCodeAt(start);
+	if (firstCodeUnit >= 0xdc00 && firstCodeUnit <= 0xdfff) start--;
+	return utf8Tail(text.slice(start, end), maxBytes);
+}
+
+function utf8After(text: string, start: number, maxBytes: number): string {
+	let end = Math.min(text.length, start + maxBytes);
+	const lastCodeUnit = text.charCodeAt(end - 1);
+	if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) end++;
+	return utf8Head(text.slice(start, end), maxBytes);
+}
+
+function utf8Window(text: string, matchStart: number, matchEnd: number, maxBytes: number): SelectedSourceFragment {
+	const match = text.slice(matchStart, matchEnd);
+	const matchBytes = Buffer.byteLength(match, "utf8");
+	if (matchBytes >= maxBytes) {
+		const fragment = utf8Head(match, maxBytes);
+		return { endOffset: matchStart + fragment.length, startOffset: matchStart, text: fragment };
+	}
+	const remaining = maxBytes - matchBytes;
+	const beforeBudget = Math.floor(remaining / 2);
+	const afterBudget = remaining - beforeBudget;
+	let before = utf8Before(text, matchStart, beforeBudget);
+	let after = utf8After(text, matchEnd, afterBudget);
+	const beforeBytes = Buffer.byteLength(before, "utf8");
+	const afterBytes = Buffer.byteLength(after, "utf8");
+	if (before.length === matchStart) {
+		after = utf8After(text, matchEnd, afterBudget + beforeBudget - beforeBytes);
+	} else if (matchEnd + after.length === text.length) {
+		before = utf8Before(text, matchStart, beforeBudget + afterBudget - afterBytes);
+	}
+	return {
+		endOffset: matchEnd + after.length,
+		startOffset: matchStart - before.length,
+		text: `${before}${match}${after}`,
+	};
+}
+
+function queryMatches(
+	request: ToolOutputPackRequest,
+	unit: SourceUnit,
+	unitCount: number,
+): { end: number; start: number }[] {
+	const normalized = unit.text.toLowerCase();
+	const matches: { end: number; start: number }[] = [];
+	const seenStarts = new Set<number>();
+	const taskTokens = boundedTaskQueryTokens(request, unitCount);
+	for (let index = taskTokens.length - 1; index >= 0 && matches.length < 4; index--) {
+		const token = taskTokens[index];
+		const start = normalized.indexOf(token);
+		if (start < 0 || seenStarts.has(start)) continue;
+		seenStarts.add(start);
+		matches.push({ end: Math.min(unit.text.length, start + token.length), start });
+	}
+	if (matches.length > 0) return matches;
+
+	let best: { end: number; start: number } | undefined;
+	for (const token of boundedQueryTokens(request, unitCount)) {
+		const start = normalized.indexOf(token);
+		if (start < 0 || (best && token.length <= best.end - best.start)) continue;
+		best = { end: Math.min(unit.text.length, start + token.length), start };
+	}
+	return best ? [best] : [];
+}
+
+function mergeFragments(text: string, fragments: SelectedSourceFragment[]): SelectedSourceFragment[] {
+	fragments.sort((left, right) => left.startOffset - right.startOffset);
+	const merged: SelectedSourceFragment[] = [];
+	for (const fragment of fragments) {
+		const previous = merged.at(-1);
+		if (previous && fragment.startOffset <= previous.endOffset) {
+			previous.endOffset = Math.max(previous.endOffset, fragment.endOffset);
+			previous.text = text.slice(previous.startOffset, previous.endOffset);
+		} else {
+			merged.push(fragment);
+		}
+	}
+	return merged;
+}
+
+function renderOversizedUnit(
+	request: ToolOutputPackRequest,
+	unit: SourceUnit,
+	totalLines: number,
+	maxBytes: number,
+): { content: string; spans: SelectedSourceSpan[] } | undefined {
+	const before = unit.lineNumber > 1 ? `[... source lines 1-${unit.lineNumber - 1} omitted ...]\n` : "";
+	const header = `[tool=${request.toolName}; source line ${unit.lineNumber}; partial source-line fragments]\n`;
+	const after =
+		unit.lineNumber < totalLines ? `\n[... source lines ${unit.lineNumber + 1}-${totalLines} omitted ...]` : "";
+	const fragmentMarker = "\n[... source bytes omitted within line ...]\n";
+	const fragmentBudget = maxBytes - Buffer.byteLength(`${before}${header}${after}`, "utf8");
+	const matches = queryMatches(request, unit, totalLines);
+	const admitted: { end: number; start: number }[] = [];
+	let tokenBytes = 0;
+	for (const match of matches) {
+		const matchBytes = Buffer.byteLength(unit.text.slice(match.start, match.end), "utf8");
+		const markerBytes = admitted.length === 0 ? 0 : Buffer.byteLength(fragmentMarker, "utf8");
+		if (tokenBytes + matchBytes + markerBytes > fragmentBudget) continue;
+		admitted.push(match);
+		tokenBytes += matchBytes + markerBytes;
+	}
+
+	let fragments: SelectedSourceFragment[];
+	if (admitted.length === 0) {
+		const fragment = utf8Tail(unit.text, fragmentBudget);
+		if (fragment.length === 0) return undefined;
+		fragments = [{ endOffset: unit.text.length, startOffset: unit.text.length - fragment.length, text: fragment }];
+	} else {
+		const contextBytes = Math.max(0, fragmentBudget - tokenBytes);
+		const contextPerFragment = Math.floor(contextBytes / admitted.length);
+		fragments = mergeFragments(
+			unit.text,
+			admitted.map((match, index) =>
+				utf8Window(
+					unit.text,
+					match.start,
+					match.end,
+					Buffer.byteLength(unit.text.slice(match.start, match.end), "utf8") +
+						contextPerFragment +
+						(index === admitted.length - 1 ? contextBytes % admitted.length : 0),
+				),
+			),
+		);
+		if (fragments.length === 1) {
+			let matchStart = admitted[0].start;
+			let matchEnd = admitted[0].end;
+			for (const match of admitted) {
+				matchStart = Math.min(matchStart, match.start);
+				matchEnd = Math.max(matchEnd, match.end);
+			}
+			fragments[0] = utf8Window(unit.text, matchStart, matchEnd, fragmentBudget);
+		}
+	}
+	const fragmentText = fragments.map(fragment => fragment.text).join(fragmentMarker);
+	const content = `${before}${header}${fragmentText}${after}`;
+	if (Buffer.byteLength(content, "utf8") > maxBytes) return undefined;
+	return {
+		content,
+		spans: [
+			{
+				endLine: unit.lineNumber,
+				fragments,
+				startLine: unit.lineNumber,
+				text: fragments[0].text,
+			},
+		],
+	};
+}
+
+export function renderRankedSelection(
+	request: ToolOutputPackRequest,
+	units: readonly SourceUnit[],
+	rankedIds: readonly string[],
+): PackedToolOutput {
+	const unitsById = new Map(units.map(unit => [unit.id, unit]));
+	const rankById = new Map(rankedIds.map((id, index) => [id, index]));
+	const maxBytes = Math.max(0, request.maxBytes);
+	const totalBytes = Buffer.byteLength(request.content, "utf8");
+	let selected = new Set<string>();
+	if (totalBytes <= maxBytes) {
+		const allSelected = new Set(units.map(unit => unit.id));
+		const complete = renderSelection(request, allSelected, unitsById, units.length);
+		if (Buffer.byteLength(complete.content, "utf8") <= maxBytes) selected = allSelected;
+	}
+	let pending = selected.size === units.length ? [] : [...new Set(rankedIds)].filter(id => unitsById.has(id));
+	const maxCandidateEvaluations = candidateEvaluationLimit(maxBytes);
+	let candidateEvaluations = 0;
+	let oversizedCandidate: SourceUnit | undefined;
+	let bestAdmittedSubstantiveRank = Number.POSITIVE_INFINITY;
+	while (pending.length > 0 && candidateEvaluations < maxCandidateEvaluations) {
+		let admitted = false;
+		const deferred: string[] = [];
+		for (const id of pending) {
+			if (candidateEvaluations >= maxCandidateEvaluations) break;
+			candidateEvaluations++;
+			const unit = unitsById.get(id);
+			if (!unit) continue;
+			const proposed = dependencyClosure(new Set([...selected, id]), unitsById);
+			const rendered = renderSelection(request, proposed, unitsById, units.length);
+			if (Buffer.byteLength(rendered.content, "utf8") <= maxBytes) {
+				selected = proposed;
+				admitted = true;
+				if (unit.kind !== "structure") {
+					bestAdmittedSubstantiveRank = Math.min(bestAdmittedSubstantiveRank, rankById.get(id) ?? Infinity);
+				}
+			} else {
+				if (
+					!hasOnlyJsonStructuralDependencies(unit, unitsById) ||
+					queryMatches(request, unit, units.length).length === 0
+				) {
+					deferred.push(id);
+					continue;
+				}
+				const direct = new Set(selected).add(id);
+				const directRendered = renderSelection(request, direct, unitsById, units.length);
+				if (Buffer.byteLength(directRendered.content, "utf8") <= maxBytes) {
+					selected = direct;
+					admitted = true;
+					if (unit.kind !== "structure") {
+						bestAdmittedSubstantiveRank = Math.min(bestAdmittedSubstantiveRank, rankById.get(id) ?? Infinity);
+					}
+				} else {
+					oversizedCandidate ??= unit;
+					deferred.push(id);
+				}
+			}
+		}
+		if (!admitted) break;
+		pending = deferred;
+	}
+
+	let rendered = renderSelection(request, selected, unitsById, units.length);
+	const oversizedUnit =
+		oversizedCandidate ??
+		(selected.size === 0
+			? rankedIds
+					.map(id => unitsById.get(id))
+					.find((unit): unit is SourceUnit => unit !== undefined && unit.dependencies.length === 0)
+			: undefined);
+	const oversized = oversizedUnit && renderOversizedUnit(request, oversizedUnit, units.length, maxBytes);
+	if (oversized && oversizedUnit && (rankById.get(oversizedUnit.id) ?? Infinity) < bestAdmittedSubstantiveRank) {
+		selected = new Set([oversizedUnit.id]);
+		rendered = oversized;
+	}
+	if (Buffer.byteLength(rendered.content, "utf8") > maxBytes) {
+		selected = new Set();
+		rendered = { content: "", spans: [] };
+	}
+	const selectedUnits = units.filter(unit => selected.has(unit.id));
+	const selectedSourceBytes = rendered.spans.reduce(
+		(sum, span) =>
+			sum +
+			(span.fragments ?? [{ text: span.text }]).reduce(
+				(fragmentSum, fragment) => fragmentSum + Buffer.byteLength(fragment.text, "utf8"),
+				0,
+			),
+		0,
+	);
+	const outputBytes = Buffer.byteLength(rendered.content, "utf8");
+	return {
+		content: rendered.content,
+		estimatedTokens: Math.ceil(outputBytes / 4),
+		omittedLines: Math.max(0, units.length - selectedUnits.length),
+		outputBytes,
+		selectedLineNumbers: selectedUnits.map(unit => unit.lineNumber),
+		selectedSourceBytes,
+		spans: rendered.spans,
+		totalBytes,
+		totalLines: units.length,
+	};
+}

--- a/packages/coding-agent/src/tools/context-packing/segment.ts
+++ b/packages/coding-agent/src/tools/context-packing/segment.ts
@@ -1,0 +1,228 @@
+import type { SourceUnit, SourceUnitKind, ToolOutputKind, ToolOutputPackRequest } from "./types";
+
+const ERROR_RE =
+	/(?:^|\b)(?:error|failed|failure|fatal|panic|exception|assertionerror|traceback|segmentation fault|not found|permission denied)(?:\b|:)/iu;
+const SUMMARY_RE =
+	/(?:tests?\s+(?:failed|passed)|\d+\s+(?:failed|passed|errors?)|command exited|exit code|summary|results?:|warnings?:)/iu;
+const PATH_RE =
+	/(?:^|\s)(?:\.\.?\/|\/|[A-Za-z]:\\)[^\s:]+|\b[^\s:]+\.(?:[cm]?[jt]sx?|py|rs|go|java|json|ya?ml|toml|md):\d+/u;
+const JSON_KEY_RE = /^\s*"(?:[^"\\]|\\.)+"\s*:/u;
+const JSON_STRUCTURE_RE = /^\s*[{}[\]],?\s*$/u;
+const TABLE_SEPARATOR_RE = /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*$/u;
+const MAX_JSON_INFERENCE_CHARS = 64 * 1024;
+const MAX_TABLE_INFERENCE_LINES = 256;
+const CSV_MIN_FIELDS = 3;
+
+function isPipeTableLine(line: string): boolean {
+	return line.split("|").length - 1 >= 2;
+}
+
+/**
+ * Field count of a delimiter-structured CSV record, or 0 when the line reads
+ * like ordinary comma-separated prose. CSV records keep every field non-empty
+ * and flush against the delimiter, while prose and log clauses ("we came, we
+ * saw, we conquered") pad fields with whitespace around each comma.
+ */
+function csvFieldCount(rawLine: string): number {
+	const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+	if (!line.includes(",")) return 0;
+	const fields = line.split(",");
+	if (fields.length < CSV_MIN_FIELDS) return 0;
+	for (const field of fields) {
+		if (field.length === 0 || field !== field.trim()) return 0;
+	}
+	return fields.length;
+}
+
+/**
+ * Bounded structural table detection: two pipe-table lines anywhere in the
+ * prefix, or a header-like CSV record immediately followed by a record of the
+ * same width (`File,Status,Message` over `src/a.ts,failed,...`).
+ */
+function hasTableStructure(lines: readonly string[]): boolean {
+	const bounded = Math.min(lines.length, MAX_TABLE_INFERENCE_LINES);
+	let pipeLines = 0;
+	let previousCsvFields = 0;
+	for (let index = 0; index < bounded; index++) {
+		if (isPipeTableLine(lines[index])) {
+			pipeLines++;
+			if (pipeLines >= 2) return true;
+		}
+		const csvFields = csvFieldCount(lines[index]);
+		if (csvFields > 0 && csvFields === previousCsvFields) return true;
+		previousCsvFields = csvFields;
+	}
+	return false;
+}
+
+function hasJsonContainerBoundary(text: string): boolean {
+	return (text.startsWith("{") && text.endsWith("}")) || (text.startsWith("[") && text.endsWith("]"));
+}
+
+export function inferToolOutputKind(request: ToolOutputPackRequest): ToolOutputKind {
+	if (request.kind) return request.kind;
+	const toolName = request.toolName.toLowerCase();
+	if (toolName === "task" || toolName === "subagent") return "subagent";
+	if (["grep", "search", "glob", "find"].includes(toolName)) return "search";
+	const trimmed = request.content.trim();
+	if (hasJsonContainerBoundary(trimmed)) {
+		if (trimmed.length > MAX_JSON_INFERENCE_CHARS) return "json";
+		try {
+			JSON.parse(trimmed);
+			return "json";
+		} catch {
+			// Small malformed payloads remain generic text. Large structural
+			// payloads avoid allocating a parsed object graph during inference;
+			// segmentation still preserves their exact source text.
+		}
+	}
+	if (hasTableStructure(request.content.split("\n"))) return "table";
+	if (["bash", "python", "ssh", "eval"].includes(toolName) || ERROR_RE.test(request.content)) return "test";
+	return "text";
+}
+
+function classifyLine(
+	line: string,
+	kind: ToolOutputKind,
+	isTableLine: boolean,
+	isTableHeader: boolean,
+): SourceUnitKind {
+	if (line.length === 0 || line === "\r") return "blank";
+	if (ERROR_RE.test(line)) return "error";
+	if (SUMMARY_RE.test(line)) return "summary";
+	if (PATH_RE.test(line)) return "path";
+	if (kind === "json" && JSON_STRUCTURE_RE.test(line)) return "structure";
+	if (kind === "json" && JSON_KEY_RE.test(line)) return "json_key";
+	if (kind === "table" && isTableLine) return isTableHeader ? "table_header" : "table_row";
+	return "text";
+}
+
+function jsonDependenciesByLine(lines: readonly string[]): string[][] {
+	const frames: Array<{ closeLine: number | null; openLine: number; parentIndex: number | null }> = [];
+	const stack: number[] = [];
+	const directFrameByLine = lines.map((): number | null => null);
+	let escaped = false;
+	let inString = false;
+
+	for (let index = 0; index < lines.length; index++) {
+		const lineNumber = index + 1;
+		directFrameByLine[index] = stack.at(-1) ?? null;
+
+		for (const character of lines[index]) {
+			if (inString) {
+				if (escaped) {
+					escaped = false;
+				} else if (character === "\\") {
+					escaped = true;
+				} else if (character === '"') {
+					inString = false;
+				}
+				continue;
+			}
+			if (character === '"') {
+				inString = true;
+				continue;
+			}
+			if (character === "{" || character === "[") {
+				const frameIndex = frames.length;
+				frames.push({ closeLine: null, openLine: lineNumber, parentIndex: stack.at(-1) ?? null });
+				stack.push(frameIndex);
+				directFrameByLine[index] = frameIndex;
+				continue;
+			}
+			if (character === "}" || character === "]") {
+				const frameIndex = stack.pop();
+				if (frameIndex === undefined) continue;
+				frames[frameIndex].closeLine = lineNumber;
+			}
+		}
+	}
+
+	const dependenciesByLine = lines.map(() => new Set<string>());
+	const addFrameBoundaries = (lineIndex: number, frameIndex: number): void => {
+		const dependencies = dependenciesByLine[lineIndex];
+		const frame = frames[frameIndex];
+		const lineNumber = lineIndex + 1;
+		if (frame.openLine !== lineNumber) dependencies.add(`line:${frame.openLine}`);
+		if (frame.closeLine !== null && frame.closeLine !== lineNumber) dependencies.add(`line:${frame.closeLine}`);
+	};
+
+	for (let index = 0; index < directFrameByLine.length; index++) {
+		const frameIndex = directFrameByLine[index];
+		if (frameIndex !== null) addFrameBoundaries(index, frameIndex);
+	}
+	for (let frameIndex = 0; frameIndex < frames.length; frameIndex++) {
+		const frame = frames[frameIndex];
+		addFrameBoundaries(frame.openLine - 1, frameIndex);
+		if (frame.closeLine !== null) addFrameBoundaries(frame.closeLine - 1, frameIndex);
+		if (frame.parentIndex !== null) addFrameBoundaries(frame.openLine - 1, frame.parentIndex);
+	}
+
+	return dependenciesByLine.map(dependencies => [...dependencies]);
+}
+
+export function segmentToolOutput(request: ToolOutputPackRequest): SourceUnit[] {
+	const kind = inferToolOutputKind(request);
+	const lines = request.content.split("\n");
+	const jsonDependencies =
+		kind === "json" && request.content.length <= MAX_JSON_INFERENCE_CHARS ? jsonDependenciesByLine(lines) : [];
+	let tableHeaderLine: number | null = null;
+	let tableSeparatorId: string | null = null;
+	let tableDelimiter: "csv" | "pipe" | null = null;
+	let tableCsvFields = 0;
+
+	const units: SourceUnit[] = [];
+	for (let index = 0; index < lines.length; index++) {
+		const lineNumber = index + 1;
+		const text = lines[index];
+		const isPipeLine = kind === "table" && isPipeTableLine(text);
+		const csvFields = kind === "table" && !isPipeLine ? csvFieldCount(text) : 0;
+		const delimiter = isPipeLine ? "pipe" : csvFields > 0 ? "csv" : null;
+		const isTableLine = delimiter !== null;
+		if (delimiter !== tableDelimiter || (delimiter === "csv" && tableCsvFields > 0 && csvFields !== tableCsvFields)) {
+			// A non-table line, a delimiter change (CSV<->pipe adjacency), or a
+			// CSV width change ends the current table, so later rows depend on
+			// their own header rather than the first one.
+			tableHeaderLine = null;
+			tableSeparatorId = null;
+			tableDelimiter = null;
+			tableCsvFields = 0;
+		}
+		const isTableSeparator = isPipeLine && TABLE_SEPARATOR_RE.test(text);
+		const nextLine = index + 1 < lines.length ? lines[index + 1] : null;
+		// An adjacent pipe table announces itself with a separator directly under
+		// its header row; promote that row instead of chaining it to the old table.
+		const startsAdjacentTable =
+			isPipeLine &&
+			!isTableSeparator &&
+			tableHeaderLine !== null &&
+			nextLine !== null &&
+			isPipeTableLine(nextLine) &&
+			TABLE_SEPARATOR_RE.test(nextLine);
+		const isTableHeader = isTableLine && (tableHeaderLine === null || isTableSeparator || startsAdjacentTable);
+		if (isTableLine && (tableHeaderLine === null || startsAdjacentTable)) {
+			tableHeaderLine = lineNumber;
+			tableSeparatorId = null;
+			tableDelimiter = delimiter;
+			tableCsvFields = csvFields;
+		}
+		if (isTableSeparator) tableSeparatorId = `line:${lineNumber}`;
+
+		const unitKind = classifyLine(text, kind, isTableLine, isTableHeader);
+		const dependencies = [...(jsonDependencies[index] ?? [])];
+		if (isTableLine && !isTableHeader && tableHeaderLine !== null) {
+			dependencies.push(`line:${tableHeaderLine}`);
+			if (tableSeparatorId) dependencies.push(tableSeparatorId);
+		}
+
+		units.push({
+			byteLength: Buffer.byteLength(text, "utf8"),
+			dependencies,
+			id: `line:${lineNumber}`,
+			kind: unitKind,
+			lineNumber,
+			text,
+		});
+	}
+	return units;
+}

--- a/packages/coding-agent/src/tools/context-packing/types.ts
+++ b/packages/coding-agent/src/tools/context-packing/types.ts
@@ -1,0 +1,70 @@
+export type ToolOutputKind = "json" | "search" | "subagent" | "table" | "test" | "text";
+
+export type SourceUnitKind =
+	| "blank"
+	| "error"
+	| "json_key"
+	| "path"
+	| "structure"
+	| "summary"
+	| "table_header"
+	| "table_row"
+	| "text";
+
+export interface ToolOutputPackRequest {
+	content: string;
+	isError?: boolean;
+	exitCode?: number;
+	kind?: ToolOutputKind;
+	maxBytes: number;
+	taskGoal: string;
+	toolArguments?: string;
+	toolName: string;
+}
+
+export interface SourceUnit {
+	byteLength: number;
+	dependencies: readonly string[];
+	id: string;
+	kind: SourceUnitKind;
+	lineNumber: number;
+	text: string;
+}
+
+export interface CandidateSelectionSettings {
+	dedupeExactLines: boolean;
+	errorWeight: number;
+	headWeight: number;
+	neighborRadius: number;
+	neighborWeight: number;
+	pathWeight: number;
+	queryWeight: number;
+	structureWeight: number;
+	summaryWeight: number;
+	tailWeight: number;
+}
+
+export interface SelectedSourceFragment {
+	endOffset: number;
+	startOffset: number;
+	text: string;
+}
+
+export interface SelectedSourceSpan {
+	endLine: number;
+	startLine: number;
+	fragments?: readonly SelectedSourceFragment[];
+	text: string;
+}
+
+export interface PackedToolOutput {
+	content: string;
+	estimatedTokens: number;
+	omittedLines: number;
+	outputBytes: number;
+	selectedLineNumbers: readonly number[];
+	selectedSourceBytes: number;
+	spans: readonly SelectedSourceSpan[];
+	totalBytes: number;
+	totalLines: number;
+}

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -17,6 +17,7 @@ import { getDefault, type Settings } from "../config/settings";
 import { formatGroupedDiagnosticMessages } from "../lsp/utils";
 import type { Theme } from "../modes/theme/theme";
 import { type OutputSummary, type TruncationResult, truncateMiddle, truncateTail } from "../session/streaming-output";
+import { formatToolArgumentsForPacking, packToolOutput } from "./context-packing";
 import { formatBytes, wrapBrackets } from "./render-utils";
 import { renderError } from "./tool-errors";
 
@@ -24,8 +25,8 @@ import { renderError } from "./tool-errors";
  * Truncation metadata for the output notice.
  */
 export interface TruncationMeta {
-	direction: "head" | "tail" | "middle";
-	truncatedBy: "lines" | "bytes" | "middle";
+	direction: "head" | "tail" | "middle" | "selection";
+	truncatedBy: "lines" | "bytes" | "middle" | "selection";
 	totalLines: number;
 	totalBytes: number;
 	outputLines: number;
@@ -36,6 +37,8 @@ export interface TruncationMeta {
 	/** Head/tail line ranges shown when direction === "middle". */
 	headRange?: { start: number; end: number };
 	tailRange?: { start: number; end: number };
+	/** Exact source ranges retained by evidence-aware selection. */
+	selectedRanges?: { start: number; end: number }[];
 	/** Bytes elided from the middle. */
 	elidedBytes?: number;
 	/** Lines elided from the middle. */
@@ -445,6 +448,14 @@ export function stripGeneratedOutputNotice(text: string): string {
 export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 	let notice: string;
 
+	if (truncation.direction === "selection") {
+		const ranges = truncation.selectedRanges?.length ?? 0;
+		const elidedLines = truncation.elidedLines ?? Math.max(0, truncation.totalLines - truncation.outputLines);
+		notice = `Showing ${ranges} evidence-selected source range${ranges === 1 ? "" : "s"} from ${truncation.totalLines} lines; ${elidedLines.toLocaleString()} source line${elidedLines === 1 ? "" : "s"} elided`;
+		if (truncation.artifactId != null) notice += `. ${formatFullOutputReference(truncation.artifactId)}`;
+		return notice;
+	}
+
 	if (truncation.direction === "middle") {
 		const head = truncation.headRange;
 		const tail = truncation.tailRange;
@@ -612,14 +623,43 @@ function getSpillConfig(s: Settings | undefined) {
 		| "tools.artifactSpillThreshold"
 		| "tools.artifactTailBytes"
 		| "tools.artifactTailLines"
-		| "tools.artifactHeadBytes";
+		| "tools.artifactHeadBytes"
+		| "tools.evidenceAwarePacking";
 	const get = <P extends Path>(path: P) => s?.get(path) ?? getDefault(path);
 	return {
 		threshold: get("tools.artifactSpillThreshold") * 1024,
 		tailBytes: get("tools.artifactTailBytes") * 1024,
 		tailLines: get("tools.artifactTailLines"),
 		headBytes: get("tools.artifactHeadBytes") * 1024,
+		evidenceAwarePacking: get("tools.evidenceAwarePacking"),
 	};
+}
+
+const CONTINUATION_MESSAGE_RE =
+	/^(?:carry on|continue|do it|go ahead|go on|keep going|ok|okay|proceed|sounds good|sure|yeah|yep|yes)[.!?]*$/i;
+
+function isContinuationMessage(text: string): boolean {
+	return CONTINUATION_MESSAGE_RE.test(text.trim());
+}
+
+function latestUserTaskGoal(context: AgentToolContext | undefined): string | undefined {
+	const branch = context?.sessionManager.getBranch();
+	if (!branch) return undefined;
+	for (let index = branch.length - 1; index >= 0; index--) {
+		const entry = branch[index];
+		if (entry.type !== "message" || entry.message.role !== "user") continue;
+		const { content } = entry.message;
+		const text =
+			typeof content === "string"
+				? content
+				: content
+						.filter((block): block is TextContent => block.type === "text")
+						.map(block => block.text)
+						.join("\n");
+		const trimmed = text.trim();
+		if (trimmed && !isContinuationMessage(trimmed)) return trimmed;
+	}
+	return undefined;
 }
 
 /**
@@ -650,12 +690,13 @@ export function resolveOutputMaxColumns(s: Settings | undefined): number {
 async function spillLargeResultToArtifact(
 	result: AgentToolResult,
 	toolName: string,
+	params: unknown,
 	context: AgentToolContext | undefined,
 ): Promise<AgentToolResult> {
 	const sessionManager = context?.sessionManager;
 	if (!sessionManager) return result;
 	if (toolName === "read") return result;
-	const { threshold, tailBytes, tailLines, headBytes } = getSpillConfig(context?.settings);
+	const { threshold, tailBytes, tailLines, headBytes, evidenceAwarePacking } = getSpillConfig(context?.settings);
 
 	// Skip if tool already saved an artifact
 	const existingMeta: OutputMeta | undefined = result.details?.meta;
@@ -689,6 +730,37 @@ async function spillLargeResultToArtifact(
 			tool: toolName,
 			error: error instanceof Error ? error.message : String(error),
 		});
+	}
+
+	if (evidenceAwarePacking) {
+		const maxBytes = headBytes + tailBytes;
+		const packed = packToolOutput({
+			content: fullText,
+			isError: result.isError === true,
+			maxBytes,
+			taskGoal: latestUserTaskGoal(context) ?? toolName,
+			toolArguments: formatToolArgumentsForPacking(params),
+			toolName,
+		});
+		const newContent: (TextContent | ImageContent)[] = result.content.filter(
+			(block): block is ImageContent => block.type !== "text",
+		);
+		newContent.push({ type: "text", text: packed.content });
+		const truncationMeta: TruncationMeta = {
+			artifactId,
+			direction: "selection",
+			elidedBytes: Math.max(0, packed.totalBytes - packed.selectedSourceBytes),
+			elidedLines: packed.omittedLines,
+			maxBytes,
+			outputBytes: packed.outputBytes,
+			outputLines: packed.content.length === 0 ? 0 : packed.content.split("\n").length,
+			selectedRanges: packed.spans.map(span => ({ start: span.startLine, end: span.endLine })),
+			totalBytes: packed.totalBytes,
+			totalLines: packed.totalLines,
+			truncatedBy: "selection",
+		};
+		const newMeta: OutputMeta = { ...(existingMeta ?? {}), truncation: truncationMeta };
+		return { ...result, content: newContent, details: { ...(result.details ?? {}), meta: newMeta } };
 	}
 
 	// Truncate: middle elision when a head budget is configured, otherwise tail-only.
@@ -780,7 +852,7 @@ async function wrappedExecute(
 		let result = await originalExecute.call(this, toolCallId, params, signal, onUpdate, context);
 
 		// Spill large results to artifact, truncate to tail
-		result = await spillLargeResultToArtifact(result, this.name, context);
+		result = await spillLargeResultToArtifact(result, this.name, params, context);
 
 		// Append notices from meta
 		const meta: OutputMeta | undefined = result.details?.meta;

--- a/packages/coding-agent/test/context-packing.test.ts
+++ b/packages/coding-agent/test/context-packing.test.ts
@@ -1,0 +1,815 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { type } from "arktype";
+import { Settings } from "../src/config/settings";
+import { SessionManager } from "../src/session/session-manager";
+import { packToolOutput, rankSourceUnits, segmentToolOutput } from "../src/tools/context-packing";
+import { type OutputMeta, wrapToolWithMetaNotice } from "../src/tools/output-meta";
+
+function textContent(result: { content: readonly { text?: string; type: string }[] }): string {
+	return result.content
+		.filter(
+			(block): block is { text: string; type: "text" } => block.type === "text" && typeof block.text === "string",
+		)
+		.map(block => block.text)
+		.join("\n");
+}
+
+function createToolContext(
+	settings: Settings,
+	sessionManager: SessionManager = SessionManager.inMemory(),
+): AgentToolContext {
+	return {
+		abort: () => {},
+		hasQueuedMessages: () => false,
+		isIdle: () => true,
+		model: undefined,
+		modelRegistry: { find: () => undefined, getAll: () => [], getApiKey: async () => undefined },
+		sessionManager,
+		settings,
+	} as unknown as AgentToolContext;
+}
+
+describe("evidence-aware tool-output packing", () => {
+	it("returns deterministic exact source spans within the byte budget", () => {
+		const content = [
+			...Array.from({ length: 180 }, (_, index) => `routine line ${index}`),
+			"Error: cache checksum mismatch",
+			"src/cache/index.ts:73",
+			...Array.from({ length: 180 }, (_, index) => `later line ${index}`),
+		].join("\n");
+		const request = {
+			content,
+			maxBytes: 1024,
+			taskGoal: "Find the cache checksum error and source path",
+			toolName: "bash",
+		};
+		const first = packToolOutput(request);
+		const second = packToolOutput(request);
+
+		expect(first).toEqual(second);
+		expect(first.outputBytes).toBeLessThanOrEqual(request.maxBytes);
+		expect(first.content).toContain("Error: cache checksum mismatch");
+		expect(first.content).toContain("src/cache/index.ts:73");
+		expect(first.content).toContain("source lines");
+		expect(first.content).not.toContain("routine line 100");
+	});
+
+	it("retains trailing task intent after bounded query tokenization", () => {
+		const target = "needle-final";
+		const content = Array.from({ length: 1_000 }, (_, index) =>
+			index === 500 ? target : `opaque result ${index}`,
+		).join("\n");
+		const taskContext = Array.from({ length: 1_000 }, (_, index) => `contexttoken${index}`).join(" ");
+		const packed = packToolOutput({
+			content,
+			maxBytes: 512,
+			taskGoal: `${taskContext} Find ${target}`,
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(512);
+		expect(packed.content).toContain(target);
+	});
+
+	it("retains leading task intent at the minimum dynamic token limit", () => {
+		const target = "needle-start";
+		const content = Array.from({ length: 700_000 }, (_, index) => (index === 350_000 ? target : "x")).join("\n");
+		const taskContext = Array.from({ length: 1_000 }, (_, index) => `contexttoken${index}`).join(" ");
+		const packed = packToolOutput({
+			content,
+			maxBytes: 1_024,
+			taskGoal: `${target} ${taskContext}`,
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(1_024);
+		expect(packed.content).toContain(target);
+	}, 30_000);
+
+	it("returns an empty selection when provenance markers cannot fit the byte budget", () => {
+		const packed = packToolOutput({
+			content: "alpha\nbeta",
+			maxBytes: 1,
+			taskGoal: "Find alpha",
+			toolName: "demo",
+		});
+
+		expect(packed.content).toBe("");
+		expect(packed.outputBytes).toBe(0);
+		expect(packed.selectedLineNumbers).toEqual([]);
+		expect(packed.spans).toEqual([]);
+	});
+
+	it("retains exact evidence fragments from oversized selected lines", () => {
+		const headTarget = "needle-head";
+		const middleTarget = "needle-middle";
+		const tailTarget = "needle-😀-tail";
+		const cases = [
+			{
+				content: JSON.stringify({ target: headTarget, filler: "x".repeat(50_000) }),
+				fragmentCount: 1,
+				target: headTarget,
+				taskGoal: `Find ${headTarget}`,
+			},
+			{
+				content: JSON.stringify({
+					before: "x".repeat(25_000),
+					target: middleTarget,
+					after: "x".repeat(25_000),
+				}),
+				target: middleTarget,
+				fragmentCount: 1,
+				taskGoal: `Find ${middleTarget}`,
+			},
+			{
+				content: JSON.stringify({ filler: "😀".repeat(15_000), target: tailTarget }),
+				fragmentCount: 1,
+				target: tailTarget,
+				taskGoal: `Find ${tailTarget}`,
+			},
+			{
+				content: JSON.stringify({ investigate: "x".repeat(50_000), needle: "value" }),
+				fragmentCount: 2,
+				target: '"needle":"value"',
+				taskGoal: "Investigate needle",
+			},
+			{
+				content: JSON.stringify({ output: "x".repeat(50_000), needle: "value" }),
+				fragmentCount: 2,
+				target: '"needle":"value"',
+				taskGoal: "Find needle in output",
+			},
+		];
+
+		for (const { content, fragmentCount, target, taskGoal } of cases) {
+			const packed = packToolOutput({
+				content,
+				kind: "json",
+				maxBytes: 1_024,
+				taskGoal,
+				toolName: "custom",
+			});
+
+			expect(packed.outputBytes).toBeLessThanOrEqual(1_024);
+			expect(packed.outputBytes).toBeGreaterThan(900);
+			expect(packed.content).toContain("partial source-line fragment");
+			expect(packed.content).toContain(target);
+			expect(packed.content).not.toContain("\uFFFD");
+			expect(packed.selectedLineNumbers).toEqual([1]);
+			expect(content).toContain(packed.spans[0].text);
+			expect(packed.spans[0].fragments).toHaveLength(fragmentCount);
+			for (const fragment of packed.spans[0].fragments ?? []) {
+				expect(content.slice(fragment.startOffset, fragment.endOffset)).toBe(fragment.text);
+			}
+		}
+	});
+
+	it("fragments an oversized matching JSON leaf when its closure cannot fit", () => {
+		const target = "needle-value";
+		const content = `{\n  "${target}": "${"x".repeat(50_000)}",\n}`;
+		const packed = packToolOutput({
+			content,
+			kind: "json",
+			maxBytes: 1_024,
+			taskGoal: `Find ${target}`,
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(1_024);
+		expect(packed.content).toContain("partial source-line fragment");
+		expect(packed.content).toContain(target);
+		expect(packed.selectedLineNumbers).toEqual([2]);
+		expect(packed.spans[0].fragments).toHaveLength(1);
+	});
+
+	it("keeps higher-ranked bounded evidence over a lower-ranked oversized JSON leaf", () => {
+		const content = `{\n  "message": "Error: critical needle",\n  "needle": "${"x".repeat(50_000)}"\n}`;
+		const packed = packToolOutput({
+			content,
+			kind: "json",
+			maxBytes: 1_024,
+			taskGoal: "Find the critical needle error",
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(1_024);
+		expect(packed.content).toContain("Error: critical needle");
+		expect(packed.content).not.toContain("partial source-line fragment");
+		expect(packed.selectedLineNumbers).toContain(2);
+		expect(packed.selectedLineNumbers).not.toContain(3);
+	});
+
+	it("falls back to bounded edge spans when no evidence is ranked", () => {
+		const content = Array.from({ length: 2_000 }, (_, index) => `opaque-${index.toString().padStart(5, "0")}`).join(
+			"\n",
+		);
+		const packed = packToolOutput({
+			content,
+			maxBytes: 512,
+			taskGoal: "Inspect values",
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(512);
+		expect(packed.selectedLineNumbers.length).toBeGreaterThan(0);
+		expect(packed.content).toContain("opaque-00000");
+		expect(packed.content).toContain("opaque-01999");
+	});
+
+	it("retains the final diagnostic line for a failed tool result outside summary patterns", () => {
+		const diagnostic = "fatal signal 9";
+		const packed = packToolOutput({
+			content: [...Array.from({ length: 100 }, (_, index) => `routine output ${index}`), diagnostic].join("\n"),
+			isError: true,
+			maxBytes: 512,
+			taskGoal: "Run the command",
+			toolName: "custom",
+		});
+
+		expect(packed.content).toContain(diagnostic);
+		expect(packed.outputBytes).toBeLessThanOrEqual(512);
+	});
+
+	it("retains complete JSON source when its provenance rendering fits", () => {
+		const content = '{\r\n  "outer": {\r\n    "needle": true\r\n  }\r\n}\r\n';
+		const packed = packToolOutput({
+			content,
+			kind: "json",
+			maxBytes: 160,
+			taskGoal: "Find needle",
+			toolName: "read",
+		});
+
+		expect(packed.content).toContain('"needle": true');
+		expect(packed.omittedLines).toBe(0);
+		expect(packed.selectedLineNumbers).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(packed.selectedSourceBytes).toBe(Buffer.byteLength(content, "utf8"));
+	});
+
+	it("retains enclosing JSON boundaries for a selected nested value", () => {
+		const content = JSON.stringify(
+			{
+				routine: Array.from({ length: 100 }, (_, id) => ({ id, value: `routine-${id}` })),
+				outer: { inner: { needle: true } },
+			},
+			null,
+			2,
+		);
+		const packed = packToolOutput({
+			content,
+			kind: "json",
+			maxBytes: 300,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(300);
+		expect(packed.content).toContain('"outer": {');
+		expect(packed.content).toContain('"inner": {');
+		expect(packed.content).toContain('"needle": true');
+	});
+
+	it("bounds disjoint matching search groups to the selection limit", () => {
+		const content = Array.from({ length: 10_000 }, (_, index) =>
+			index % 2 === 0 ? `needle result ${index}` : `opaque result ${index}`,
+		).join("\n");
+		const request = {
+			content,
+			maxBytes: 1_024,
+			taskGoal: "Find needle",
+			toolName: "grep",
+		};
+		const units = segmentToolOutput(request);
+
+		const first = rankSourceUnits(request, units);
+		const second = rankSourceUnits(request, units);
+
+		expect(first).toEqual(second);
+		expect(first).toHaveLength(64);
+		expect(first.at(-1)).toBe("line:127");
+		for (const id of first) {
+			const unit = units[Number(id.slice("line:".length)) - 1];
+			expect(unit.text).toContain("needle");
+		}
+	});
+
+	it("reserves a later higher-overlap search group over an earlier qualifying group", () => {
+		const content = [
+			...Array.from({ length: 64 }, (_, index) => `alpine basalt cobalt dunes ember fjord early-${index}`),
+			"-- divider --",
+			...Array.from(
+				{ length: 64 },
+				(_, index) => `garnet harbor indigo jasper krypton lumen maple nectar late-${index}`,
+			),
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "search",
+			maxBytes: 700,
+			taskGoal: "alpine basalt cobalt dunes ember fjord garnet harbor indigo jasper krypton lumen maple nectar",
+			toolName: "grep",
+		});
+
+		expect(packed.content).toContain("late-");
+		expect(packed.content).not.toContain("early-");
+	});
+
+	it("keeps the strongest row of a contiguous search group that overflows the reservation cap", () => {
+		const content = [
+			...Array.from({ length: 64 }, (_, index) => `alpine weak-${index}`),
+			"garnet harbor indigo jasper krypton lumen maple nectar needle",
+			...Array.from({ length: 40 }, (_, index) => `opaque filler-${index}`),
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "search",
+			maxBytes: 700,
+			taskGoal: "alpine garnet harbor indigo jasper krypton lumen maple nectar",
+			toolName: "grep",
+		});
+
+		expect(packed.content).toContain("needle");
+	});
+
+	it("retains late unique errors after a bounded repeated-line cache", () => {
+		const content = Array.from({ length: 10_000 }, (_, index) => {
+			const lineNumber = index + 1;
+			if (lineNumber <= 64) return `opaque-${lineNumber}`;
+			return lineNumber === 9_000 ? "Error: critical needle" : "Error: repeated";
+		}).join("\n");
+		const request = {
+			content,
+			maxBytes: 1_024,
+			taskGoal: "Inspect failures",
+			toolName: "custom",
+		};
+		const units = segmentToolOutput(request);
+
+		const ranked = rankSourceUnits(request, units);
+
+		expect(ranked).toHaveLength(64);
+		expect(ranked).toContain("line:9000");
+	});
+
+	it("caps ranked candidates before sorting dense matching output", () => {
+		const units = Array.from({ length: 10_000 }, (_, index) => {
+			const lineNumber = index + 1;
+			const finalError = lineNumber === 10_000;
+			return {
+				byteLength: 16,
+				dependencies: [],
+				id: `line:${lineNumber}`,
+				kind: finalError ? ("error" as const) : ("summary" as const),
+				lineNumber,
+				text: finalError ? "Error: failed" : `summary-${lineNumber}`,
+			};
+		});
+		const request = {
+			content: "",
+			maxBytes: 1_024,
+			taskGoal: "Inspect summaries",
+			toolName: "custom",
+		};
+
+		const first = rankSourceUnits(request, units);
+		const second = rankSourceUnits(request, units);
+
+		expect(first).toEqual(second);
+		expect(first).toHaveLength(64);
+		expect(first).toContain("line:1");
+		expect(first).toContain("line:10000");
+	});
+	it("skips dependency graphs for oversized inferred JSON containers", () => {
+		const content = [...Array.from({ length: 17_000 }, () => "{"), ...Array.from({ length: 17_000 }, () => "}")].join(
+			"\n",
+		);
+		const units = segmentToolOutput({
+			content,
+			maxBytes: 1_024,
+			taskGoal: "Inspect payload",
+			toolName: "custom",
+		});
+
+		expect(units).toHaveLength(34_000);
+		expect(units.every(unit => unit.dependencies.length === 0)).toBe(true);
+	});
+
+	it("keeps a matching JSON leaf when its dependency closure exceeds the budget", () => {
+		const depth = 100;
+		const content = [
+			"{",
+			...Array.from({ length: depth }, (_, index) => `"level-${index}": {`),
+			'"needle": "value"',
+			...Array.from({ length: depth + 1 }, () => "}"),
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "json",
+			maxBytes: 512,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(512);
+		expect(packed.content).toContain('"needle": "value"');
+		expect(packed.selectedLineNumbers).toContain(depth + 2);
+	});
+
+	it("keeps deeply nested JSON dependencies linear", () => {
+		const depth = 512;
+		const content = [
+			...Array.from({ length: depth }, () => "["),
+			'"needle"',
+			...Array.from({ length: depth }, () => "]"),
+		].join("\n");
+		const request = {
+			content,
+			kind: "json" as const,
+			maxBytes: 16 * 1024,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		};
+		const units = segmentToolOutput(request);
+		const dependencyCount = units.reduce((sum, unit) => sum + unit.dependencies.length, 0);
+		const packed = packToolOutput(request);
+
+		expect(dependencyCount).toBeLessThanOrEqual(units.length * 4);
+		expect(packed.outputBytes).toBeLessThanOrEqual(request.maxBytes);
+		expect(packed.selectedLineNumbers).toHaveLength(units.length);
+		expect(packed.content).toContain('"needle"');
+	});
+
+	it("adds a table header whenever a selected row depends on it", () => {
+		const content = [
+			"| File | Status |",
+			"|---|---|",
+			...Array.from({ length: 80 }, (_, index) => `| routine-${index} | ok |`),
+			"| src/needle.ts:91 | failed |",
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "table",
+			maxBytes: 700,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		});
+
+		expect(packed.content).toContain("| src/needle.ts:91 | failed |");
+		expect(packed.content).toContain("| File | Status |");
+		expect(packed.content).toContain("|---|---|");
+		expect(packed.selectedLineNumbers).toContain(1);
+		expect(packed.selectedLineNumbers).toContain(2);
+	});
+
+	it("infers a table after bounded tool preamble lines", () => {
+		const content = [
+			...Array.from({ length: 20 }, (_, index) => `progress step ${index}`),
+			"| Environment | Status |",
+			"|---|---|",
+			...Array.from({ length: 80 }, (_, index) => `| routine-${index} | ok |`),
+			"| prod | failed |",
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			maxBytes: 700,
+			taskGoal: "Find the prod failure",
+			toolName: "custom",
+		});
+
+		expect(packed.content).toContain("| prod | failed |");
+		expect(packed.content).toContain("| Environment | Status |");
+		expect(packed.content).toContain("|---|---|");
+		expect(packed.selectedLineNumbers).toContain(21);
+		expect(packed.selectedLineNumbers).toContain(22);
+	});
+
+	it("does not detach a matching table row when its header exceeds the budget", () => {
+		const row = "| needle | ok |";
+		const content = [`| ${"File".repeat(300)} | Status |`, "|---|---|", row].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "table",
+			maxBytes: 512,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(512);
+		expect(packed.content).not.toContain(row);
+		expect(packed.selectedLineNumbers).not.toContain(3);
+	});
+
+	it("falls back to data rows when table ranking is structural only", () => {
+		const content = [
+			"| File | Status |",
+			"|---|---|",
+			...Array.from({ length: 200 }, (_, index) => `| routine-${index} | ok |`),
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "table",
+			maxBytes: 512,
+			taskGoal: "What is the status?",
+			toolName: "custom",
+		});
+
+		expect(packed.outputBytes).toBeLessThanOrEqual(512);
+		expect(packed.content).toContain("| File | Status |");
+		expect(packed.content).toContain("| routine-199 | ok |");
+	});
+
+	it("infers a text-only CSV table and retains the header for a selected error row", () => {
+		const content = [
+			"File,Status,Message",
+			...Array.from(
+				{ length: 80 },
+				(_, index) =>
+					`src/routine-${String.fromCharCode(97 + (index % 26))}${String.fromCharCode(97 + Math.floor(index / 26))}.ts,ok,checked`,
+			),
+			"src/needle.ts,failed,Missing header guard",
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			maxBytes: 700,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		});
+
+		expect(packed.content).toContain("src/needle.ts,failed,Missing header guard");
+		expect(packed.content).toContain("File,Status,Message");
+		expect(packed.selectedLineNumbers).toContain(1);
+	});
+
+	it("does not infer a table from ordinary comma-separated prose", () => {
+		const content = [
+			"We came, we saw, we conquered the build.",
+			"Later, after lunch, the suite ran again.",
+			"Finally, without warnings, everything passed.",
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			maxBytes: 700,
+			taskGoal: "Summarize the run",
+			toolName: "custom",
+		});
+
+		expect(
+			segmentToolOutput({ content, maxBytes: 700, taskGoal: "", toolName: "custom" }).every(
+				unit => unit.kind !== "table_row" && unit.kind !== "table_header",
+			),
+		).toBe(true);
+		expect(packed.content).toContain("we conquered");
+	});
+
+	it("selects a later table row with its own header instead of the first table's", () => {
+		const content = [
+			"| First | State |",
+			"|---|---|",
+			...Array.from({ length: 40 }, (_, index) => `| first-${index} | ok |`),
+			"",
+			"| Second | Result |",
+			"|---|---|",
+			...Array.from({ length: 40 }, (_, index) => `| second-${index} | ok |`),
+			"| needle | failed |",
+		].join("\n");
+		const packed = packToolOutput({
+			content,
+			kind: "table",
+			maxBytes: 700,
+			taskGoal: "Find needle",
+			toolName: "custom",
+		});
+
+		expect(packed.content).toContain("| needle | failed |");
+		expect(packed.content).toContain("| Second | Result |\n|---|---|");
+		expect(packed.selectedLineNumbers).toContain(44);
+		expect(packed.selectedLineNumbers).toContain(45);
+	});
+
+	it("starts a new table when a pipe table directly follows a CSV table", () => {
+		const content = [
+			"File,Status,Message",
+			...Array.from({ length: 20 }, (_, index) => `src/routine-${String.fromCharCode(97 + index)}.ts,ok,checked`),
+			"| Env | Result |",
+			"|---|---|",
+			...Array.from({ length: 20 }, (_, index) => `| env-${index} | ok |`),
+			"| needle | failed |",
+		].join("\n");
+		const request = { content, kind: "table" as const, maxBytes: 700, taskGoal: "Find needle", toolName: "custom" };
+		const needle = segmentToolOutput(request).find(unit => unit.text === "| needle | failed |");
+		expect(needle?.dependencies.toSorted()).toEqual(["line:22", "line:23"]);
+
+		const packed = packToolOutput(request);
+		expect(packed.content).toContain("| needle | failed |");
+		expect(packed.content).toContain("| Env | Result |\n|---|---|");
+		expect(packed.selectedLineNumbers).toContain(22);
+		expect(packed.selectedLineNumbers).toContain(23);
+	});
+
+	it("starts a new table when a CSV table directly follows a pipe table", () => {
+		const content = [
+			"| First | State |",
+			"|---|---|",
+			...Array.from({ length: 20 }, (_, index) => `| first-${index} | ok |`),
+			"Env,Status,Note",
+			...Array.from({ length: 20 }, (_, index) => `env-${String.fromCharCode(97 + index)},ok,checked`),
+			"prod,failed,Broken deploy",
+		].join("\n");
+		const request = {
+			content,
+			kind: "table" as const,
+			maxBytes: 700,
+			taskGoal: "Find the prod failure",
+			toolName: "custom",
+		};
+		const needle = segmentToolOutput(request).find(unit => unit.text === "prod,failed,Broken deploy");
+		expect(needle?.dependencies).toEqual(["line:23"]);
+
+		const packed = packToolOutput(request);
+		expect(packed.content).toContain("prod,failed,Broken deploy");
+		expect(packed.content).toContain("Env,Status,Note");
+		expect(packed.selectedLineNumbers).toContain(23);
+	});
+
+	it("promotes an adjacent pipe header after a separator-less first table", () => {
+		const content = [
+			"| First | State |",
+			...Array.from({ length: 20 }, (_, index) => `| first-${index} | ok |`),
+			"| Second | Result |",
+			"|---|---|",
+			...Array.from({ length: 20 }, (_, index) => `| second-${index} | ok |`),
+			"| needle | failed |",
+		].join("\n");
+		const request = { content, kind: "table" as const, maxBytes: 700, taskGoal: "Find needle", toolName: "custom" };
+		const needle = segmentToolOutput(request).find(unit => unit.text === "| needle | failed |");
+		expect(needle?.dependencies.toSorted()).toEqual(["line:22", "line:23"]);
+
+		const packed = packToolOutput(request);
+		expect(packed.content).toContain("| needle | failed |");
+		expect(packed.content).toContain("| Second | Result |\n|---|---|");
+		expect(packed.selectedLineNumbers).toContain(22);
+		expect(packed.selectedLineNumbers).toContain(23);
+	});
+
+	it("uses the opt-in packer while preserving a recoverable full-output artifact", async () => {
+		const schema = type({ command: "string" });
+		const content = [
+			...Array.from({ length: 420 }, (_, index) => `routine generated record ${index}`),
+			"needle-checksum-payload",
+			...Array.from({ length: 420 }, (_, index) => `later generated record ${index}`),
+		].join("\n");
+		const tool: AgentTool<typeof schema, { meta?: OutputMeta }> = {
+			description: "Return a large diagnostic result",
+			execute: async () => ({ content: [{ type: "text", text: content }], details: {} }),
+			label: "Diagnostic",
+			name: "diagnostic",
+			parameters: schema,
+		};
+		const wrapped = wrapToolWithMetaNotice(tool);
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({
+			role: "user",
+			content: "Find the needle-checksum-payload",
+			timestamp: Date.now(),
+		});
+		const context = createToolContext(
+			Settings.isolated({
+				"tools.artifactHeadBytes": 1,
+				"tools.artifactSpillThreshold": 1,
+				"tools.artifactTailBytes": 1,
+				"tools.evidenceAwarePacking": true,
+			}),
+			sessionManager,
+		);
+
+		const result = await wrapped.execute("call-1", { command: "bun test" }, undefined, undefined, context);
+		const output = textContent(result);
+		expect(result.details?.meta?.truncation?.direction).toBe("selection");
+		expect(result.details?.meta?.truncation?.artifactId).toBeDefined();
+		expect(output).toContain("needle-checksum-payload");
+		expect(output).toContain("evidence-selected source");
+		expect(output).not.toContain("routine generated record 200");
+	});
+
+	it("retains the prior substantive task goal after a continuation message", async () => {
+		const schema = type({ command: "string" });
+		const target = "needle-original-task";
+		const content = Array.from({ length: 840 }, (_, index) =>
+			index === 420 ? target : `routine generated record ${index}`,
+		).join("\n");
+		const tool: AgentTool<typeof schema, { meta?: OutputMeta }> = {
+			description: "Return a large diagnostic result",
+			execute: async () => ({ content: [{ type: "text", text: content }], details: {} }),
+			label: "Diagnostic",
+			name: "diagnostic",
+			parameters: schema,
+		};
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({
+			role: "user",
+			content: `Find ${target}`,
+			timestamp: Date.now(),
+		});
+		sessionManager.appendMessage({
+			role: "user",
+			content: "continue",
+			timestamp: Date.now(),
+		});
+		const context = createToolContext(
+			Settings.isolated({
+				"tools.artifactHeadBytes": 1,
+				"tools.artifactSpillThreshold": 1,
+				"tools.artifactTailBytes": 1,
+				"tools.evidenceAwarePacking": true,
+			}),
+			sessionManager,
+		);
+
+		const result = await wrapToolWithMetaNotice(tool).execute(
+			"call-continuation",
+			{ command: "generate" },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(textContent(result)).toContain(target);
+	});
+
+	it("keeps a bounded fragment for oversized single-line tool output", async () => {
+		const schema = type({ command: "string" });
+		const target = "needle-tail";
+		const content = JSON.stringify({ filler: "x".repeat(50_000), target });
+		const tool: AgentTool<typeof schema, { meta?: OutputMeta }> = {
+			description: "Return a large minified result",
+			execute: async () => ({ content: [{ type: "text", text: content }], details: {} }),
+			label: "Minified",
+			name: "minified",
+			parameters: schema,
+		};
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({
+			role: "user",
+			content: `Find ${target}`,
+			timestamp: Date.now(),
+		});
+		const context = createToolContext(
+			Settings.isolated({
+				"tools.artifactHeadBytes": 1,
+				"tools.artifactSpillThreshold": 1,
+				"tools.artifactTailBytes": 1,
+				"tools.evidenceAwarePacking": true,
+			}),
+			sessionManager,
+		);
+
+		const result = await wrapToolWithMetaNotice(tool).execute(
+			"call-oversized",
+			{ command: "generate" },
+			undefined,
+			undefined,
+			context,
+		);
+		const output = textContent(result);
+		expect(result.details?.meta?.truncation?.outputBytes).toBeLessThanOrEqual(2_048);
+		expect(output).toContain("partial source-line fragment");
+		expect(output).toContain(target);
+		expect(result.details?.meta?.truncation?.selectedRanges).toEqual([{ start: 1, end: 1 }]);
+	});
+
+	it("honors an empty inline budget and reports zero output lines", async () => {
+		const schema = type({ command: "string" });
+		const tool: AgentTool<typeof schema, { meta?: OutputMeta }> = {
+			description: "Return a large opaque result",
+			execute: async () => ({
+				content: [
+					{ type: "text", text: Array.from({ length: 1_000 }, (_, index) => `opaque-${index}`).join("\n") },
+				],
+				details: {},
+			}),
+			label: "Opaque",
+			name: "opaque",
+			parameters: schema,
+		};
+		const context = createToolContext(
+			Settings.isolated({
+				"tools.artifactHeadBytes": 0,
+				"tools.artifactSpillThreshold": 1,
+				"tools.artifactTailBytes": 0,
+				"tools.evidenceAwarePacking": true,
+			}),
+		);
+
+		const result = await wrapToolWithMetaNotice(tool).execute(
+			"call-empty",
+			{ command: "generate" },
+			undefined,
+			undefined,
+			context,
+		);
+		expect(result.details?.meta?.truncation?.maxBytes).toBe(0);
+		expect(result.details?.meta?.truncation?.outputBytes).toBe(0);
+		expect(result.details?.meta?.truncation?.outputLines).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

- Add the opt-in `tools.evidenceAwarePacking` setting for centralized large-result artifact spills.
- Select exact source ranges using tool arguments, source structure, and error signals while preserving JSON/table dependencies and the configured byte limit.
- Record selected ranges in truncation metadata and keep the full raw output recoverable through its `artifact://` reference.

## Why

Head/tail truncation can hide relevant diagnostics in the middle of large generic tool results. This adds an experimental opt-in path that keeps bounded, provenance-labeled evidence inline without changing the default spill behavior.

## Behavioral validation

Focused regression coverage exercises critical and error evidence selection, provenance metadata, JSON/table structural dependencies, deterministic output, byte-budget compliance, and oversized fragment recovery through the raw artifact reference.

This is behavior-level validation. No latency, throughput, score-improvement, or generalization claim is made.

## Testing

```bash
bun test packages/coding-agent/test/context-packing.test.ts
bun --cwd=packages/coding-agent run check
```

---

- [x] Package check passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
