### PR TITLE
feat(coding-agent): expose transcript presentation surfaces to extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Expanded `ExtensionAPI.pi`'s live transcript presentation surface with `ChatTranscriptBuilder`, `EventController`, and `UiHelpers`, alongside the existing assistant- and user-message constructors, so extensions can integrate without loading duplicate class instances.
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -34,8 +34,11 @@ export * from "./main";
 // Run modes for programmatic SDK usage
 export * from "./modes";
 export * from "./modes/components";
+export * from "./modes/components/chat-transcript-builder";
+export * from "./modes/controllers/event-controller";
 // Theme utilities for custom tools
 export * from "./modes/theme/theme";
+export * from "./modes/utils/ui-helpers";
 // SDK for programmatic usage
 export * from "./sdk";
 export * from "./session/agent-session";

--- a/packages/coding-agent/test/extension-loader-self-import.test.ts
+++ b/packages/coding-agent/test/extension-loader-self-import.test.ts
@@ -113,4 +113,32 @@ describe("extension loader host runtime binding", () => {
 		expect(hookResult.hooks).toHaveLength(1);
 		expect(hookResult.hooks[0].handlers.has("identity:event")).toBe(true);
 	});
+
+	it("exposes the live transcript presentation constructors to extensions", async () => {
+		expect(projectDir).toBeDefined();
+		const extensionPath = writeModule(
+			"transcript-surface-extension.ts",
+			`
+				export default function(api) {
+					const requiredConstructors = [
+						"AssistantMessageComponent",
+						"ChatTranscriptBuilder",
+						"EventController",
+						"UiHelpers",
+						"UserMessageComponent",
+					];
+					for (const name of requiredConstructors) {
+						if (typeof api.pi[name] !== "function") {
+							throw new Error(\`missing transcript presentation constructor: \${name}\`);
+						}
+					}
+				}
+			`,
+		);
+
+		const result = await loadExtensions([extensionPath], projectDir!.path());
+
+		expect(result.errors).toEqual([]);
+		expect(result.extensions).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Summary

- Export `ChatTranscriptBuilder`, `EventController`, and `UiHelpers` from the coding-agent root namespace.
- Make these live host constructors available through the existing `ExtensionAPI.pi` runtime alongside `AssistantMessageComponent` and `UserMessageComponent`.
- Add an extension-loader contract test covering all five transcript presentation constructors.
- Document the expanded extension surface in the coding-agent changelog.

## Motivation

Extensions that integrate with OMP's live transcript currently cannot access the host transcript builder, live event controller, or replay helper through `ExtensionAPI.pi`.

Deep-importing or bundling another coding-agent module instance is unsafe: prototype wrappers would target different class instances from those used by the running host. Exporting the existing constructors through the injected in-process namespace preserves constructor and prototype identity.

This does not change transcript behavior by itself and does not introduce a second module instance or a new loader mechanism.

## Test plan

- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/extension-loader-self-import.test.ts`
- Loaded a real extension through the forked runtime and confirmed all required constructors are functions on `ExtensionAPI.pi`.