### PR TITLE
fix(coding-agent): run fish user shell interactively instead of as a login shell

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the interactive `!`/`!!` shell shortcut spawning fish as a login shell (`fish -l -c …`), which fired `status is-login` blocks in user config (agent/keychain setup, PATH mutation) on every command. fish is now started with `-i` instead — interactive shells source the same `config.fish`/`conf.d` files (so aliases and functions from #1816 keep working) without login-shell side effects. zsh behavior (`-l -i`) is unchanged.
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -152,7 +152,7 @@ function isBashShell(shell: string): boolean {
 
 function needsInteractiveShellArg(shell: string): boolean {
 	const basename = shellBasename(shell);
-	return basename.includes("zsh");
+	return basename.includes("zsh") || basename.includes("fish");
 }
 
 function supportsAutoUserShell(shell: string): boolean {
@@ -165,19 +165,31 @@ function hasInteractiveShellArg(args: string[]): boolean {
 }
 
 function ensureInteractiveShellArgs(shell: string, args: string[]): string[] {
-	if (!needsInteractiveShellArg(shell) || hasInteractiveShellArg(args)) return args;
+	if (!needsInteractiveShellArg(shell)) return args;
 
-	const commandIndex = args.findIndex(arg => arg === "-c" || arg === "--command");
+	// fish sources the same config files (config.fish + conf.d) for interactive
+	// shells as for login shells, so the inherited `-l` adds nothing — it only
+	// marks the shell as login, firing `status is-login` blocks in user config
+	// (agent/keychain setup, path mutation) on every `!` command. zsh keeps `-l`
+	// because .zprofile is login-only. Args originate from procmgr's
+	// getShellArgs(), so login only ever appears as a standalone `-l`/`--login`.
+	const effectiveArgs = shellBasename(shell).includes("fish")
+		? args.filter(arg => arg !== "-l" && arg !== "--login")
+		: args;
+
+	if (hasInteractiveShellArg(effectiveArgs)) return effectiveArgs;
+
+	const commandIndex = effectiveArgs.findIndex(arg => arg === "-c" || arg === "--command");
 	if (commandIndex !== -1) {
-		return [...args.slice(0, commandIndex), "-i", ...args.slice(commandIndex)];
+		return [...effectiveArgs.slice(0, commandIndex), "-i", ...effectiveArgs.slice(commandIndex)];
 	}
 
-	const compactCommandIndex = args.findIndex(arg => /^-[^-]*c[^-]*$/.test(arg));
+	const compactCommandIndex = effectiveArgs.findIndex(arg => /^-[^-]*c[^-]*$/.test(arg));
 	if (compactCommandIndex !== -1) {
-		return args.map((arg, index) => (index === compactCommandIndex ? arg.replace("c", "ic") : arg));
+		return effectiveArgs.map((arg, index) => (index === compactCommandIndex ? arg.replace("c", "ic") : arg));
 	}
 
-	return [...args, "-i"];
+	return [...effectiveArgs, "-i"];
 }
 
 function quoteShellArg(value: string): string {

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -337,8 +337,8 @@ exit 64
 			return;
 		}
 
-		const fishPath = ["/usr/bin/fish", "/bin/fish", "/usr/local/bin/fish", "/opt/homebrew/bin/fish"].find(
-			candidate => fs.existsSync(candidate),
+		const fishPath = ["/usr/bin/fish", "/bin/fish", "/usr/local/bin/fish", "/opt/homebrew/bin/fish"].find(candidate =>
+			fs.existsSync(candidate),
 		);
 		if (!fishPath) {
 			return;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -276,8 +276,10 @@ exit 64
 			expect(result.cancelled).toBe(false);
 			expect(result.exitCode).toBe(0);
 			expect(result.output.trim()).toBe("env-shell-ok");
-			expect(fs.readFileSync(marker, "utf8")).toContain("-l -c");
-			expect(fs.readFileSync(marker, "utf8")).not.toContain("-i");
+			// fish gets `-i` (interactive loads config.fish too) instead of `-l`,
+			// so `status is-login` blocks in user config don't fire on `!` commands.
+			expect(fs.readFileSync(marker, "utf8")).toContain("-i -c");
+			expect(fs.readFileSync(marker, "utf8")).not.toContain("-l");
 		} finally {
 			if (originalShell === undefined) {
 				delete Bun.env.SHELL;
@@ -325,6 +327,58 @@ exit 64
 			expect(result.cancelled).toBe(false);
 			expect(result.exitCode).toBe(0);
 			expect(result.output.trim()).toBe("zsh-alias-ok");
+		} finally {
+			removeSyncWithRetries(shellDir);
+		}
+	});
+
+	it("runs fish user-shell commands without login-shell side effects", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		const fishPath = ["/usr/bin/fish", "/bin/fish", "/usr/local/bin/fish", "/opt/homebrew/bin/fish"].find(
+			candidate => fs.existsSync(candidate),
+		);
+		if (!fishPath) {
+			return;
+		}
+
+		const shellDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-fish-shellpath-"));
+		const configDir = path.join(shellDir, ".config", "fish");
+		fs.mkdirSync(path.join(configDir, "conf.d"), { recursive: true });
+		fs.writeFileSync(path.join(configDir, "config.fish"), "function pi_fish_fn; echo fish-fn-ok; end\n");
+		// Login-gated snippet: fires only when the spawned fish is a login shell.
+		fs.writeFileSync(
+			path.join(configDir, "conf.d", "pi-login.fish"),
+			"if status is-login; echo fish-login-side-effect; end\n",
+		);
+		Settings.instance.set("shellPath", fishPath);
+
+		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+			shell: fishPath,
+			args: ["-l", "-c"],
+			env: {
+				PATH: Bun.env.PATH ?? "",
+				HOME: shellDir,
+			},
+			prefix: undefined,
+		});
+
+		try {
+			const result = await executeBash("pi_fish_fn", {
+				cwd: tempDir,
+				timeout: 5000,
+				sessionKey: "fish-shell-path",
+				useUserShell: true,
+			});
+
+			expect(result.cancelled).toBe(false);
+			expect(result.exitCode).toBe(0);
+			// config.fish must still load (#1816 contract)…
+			expect(result.output).toContain("fish-fn-ok");
+			// …but the shell must not be a login shell.
+			expect(result.output).not.toContain("fish-login-side-effect");
 		} finally {
 			removeSyncWithRetries(shellDir);
 		}


### PR DESCRIPTION
## Problem

On machines where `$SHELL` is fish, the interactive `!`/`!!` shell shortcut runs every command as a **login shell** (`fish -l -c '…'`). A login fish triggers `status is-login` blocks in user config — ssh-agent/keychain spawning, PATH mutation, greeting/motd output — on every `!` command.

Root cause chain:

1. `procmgr.getShellArgs()` defaults to `["-l", "-c"]` (bash-oriented).
2. `resolveUserShellConfig` (bash-executor.ts) whitelists fish via `supportsAutoUserShell` and swaps `$SHELL` in, but **inherits those args unchanged**.
3. `ensureInteractiveShellArgs` injected `-i` only for zsh, so fish kept exactly `-l -c`.
4. `buildUserShellCommand` then emitted `'fish' '-l' '-c' '<cmd>'` for the brush session to spawn.

The `-l` was the mechanism #1816 used to load fish user config (aliases/functions) — but it was never load-bearing: **fish sources the same `config.fish` + `conf.d/*.fish` files for interactive shells as for login shells.**

## Fix

- `needsInteractiveShellArg` now covers fish.
- `ensureInteractiveShellArgs` strips the inherited `-l`/`--login` for fish (interactive startup already covers config loading) and inserts `-i`, producing `fish -i -c '…'`.
- zsh behavior is unchanged (`-l -i -c`) — `.zprofile` is login-only, so zsh's `-l` *is* load-bearing.

Verified empirically with fish 4.1.1: `fish -i -c` reports `status is-login` = false while still resolving functions/aliases defined in `config.fish`; `fish -l -c` fires a `status is-login`-gated `conf.d` snippet, `fish -i -c` does not.

## Tests

- New regression test: `runs fish user-shell commands without login-shell side effects` — a `status is-login`-gated `conf.d` marker must not fire while a `config.fish` function must resolve (#1816 contract preserved).
- Updated `uses executable SHELL for user-shell shortcut commands` (fake `fish` binary capturing argv): previously asserted `-l -c` passthrough — i.e. it locked in the buggy behavior; now asserts `-i -c` and no `-l`.
- `bun test test/bash-executor.test.ts`: 41 pass, 0 fail.
