### PR TITLE
fix(coding-agent): preserve provider compat after discovery refresh

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -139,6 +139,9 @@ interface ProviderOverride {
  *   2. `existing.transport` (carried over from boot-time override application)
  *   3. `model.transport` (rarely set — discovery defaults omit it)
  *
+ * `compat` resolution merges the discovered model's compatibility metadata
+ * with the provider override, with explicit provider fields taking precedence.
+ *
  * Without (1), the user's override would lose to discovery; without (2)
  * preferred over (3), the bundled `api.xiaomimimo.com` would shadow the
  * tp- token-plan host and produce 401s on the first stream call.
@@ -153,7 +156,7 @@ interface ProviderOverride {
 export function mergeDiscoveredModel<TApi extends Api>(
 	model: Model<TApi>,
 	existing: Model<Api> | undefined,
-	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "remoteCompaction" | "transport">,
+	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "compat" | "remoteCompaction" | "transport">,
 ): Model<TApi> {
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
@@ -167,7 +170,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 				providerOverride?.remoteCompaction,
 			),
 			...(supportsTools !== undefined ? { supportsTools } : {}),
-			compat: model.compatConfig,
+			compat: mergeCompat(model.compatConfig, providerOverride?.compat),
 		} as ModelSpec<TApi>);
 	}
 	if (providerOverride) {
@@ -180,7 +183,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 				model.remoteCompaction,
 				providerOverride.remoteCompaction,
 			),
-			compat: model.compatConfig,
+			compat: mergeCompat(model.compatConfig, providerOverride.compat),
 		} as ModelSpec<TApi>);
 	}
 	return model;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -530,6 +530,36 @@ describe("ModelRegistry", () => {
 				expect(model.baseUrl).toBe("http://localhost:4000");
 			}
 		});
+		test("refresh keeps provider compat override on built-in Anthropic models", async () => {
+			writeRawModelsJson({
+				anthropic: {
+					baseUrl: "http://localhost:4000/v1",
+					apiKey: "proxy-token",
+					compat: {
+						replayUnsignedThinking: false,
+					},
+				},
+			});
+
+			const fetchMock: FetchImpl = async input => {
+				const url = input instanceof Request ? input.url : String(input);
+				if (url === "http://localhost:4000/v1/models") {
+					return Response.json({ data: [{ id: "claude-sonnet-5" }] });
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			};
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+			expect(registry.find("anthropic", "claude-sonnet-5")?.compat).toMatchObject({
+				replayUnsignedThinking: false,
+			});
+
+			await registry.refreshProvider("anthropic", "online");
+
+			expect(registry.find("anthropic", "claude-sonnet-5")?.compat).toMatchObject({
+				replayUnsignedThinking: false,
+			});
+		});
 	});
 
 	describe("provider compat overrides", () => {


### PR DESCRIPTION
## Summary

- preserve provider-level `compat` overrides when a discovered model replaces a bundled model during runtime refresh
- merge discovered compatibility defaults with explicit provider fields, with provider configuration taking precedence
- add regression coverage for preserving `replayUnsignedThinking: false` across an Anthropic provider refresh

## Root cause

`mergeDiscoveredModel()` reapplied provider overrides for `baseUrl`, headers, transport, and remote compaction, but dropped `providerOverride.compat`.

Dynamic discovery could therefore replace the boot-time model with a discovered row whose compatibility defaults overrode explicit provider configuration.

This is independent of the thinking-signature loss tracked in #6046. Provider compatibility fields must survive refresh regardless of why they were configured.

## Testing

- `bun test packages/coding-agent/test/model-registry.test.ts` — 85 passed, 0 failed
- `bun --cwd=packages/coding-agent run check` — passed

Fixes #6041
