### PR TITLE
feat(ai): generic extension usage-provider registration with durable usage parity

### DIFF
--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -60,7 +60,7 @@ export interface RegisteredCustomApi {
 
 const customApiRegistry = new Map<string, RegisteredCustomApi>();
 
-function assertCustomApiName(api: string): void {
+export function assertCustomApiName(api: string): void {
 	if (BUILTIN_APIS.has(api as KnownApi)) {
 		throw new AIError.ConfigurationError(`Cannot register custom API "${api}": built-in API names are reserved.`);
 	}

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -256,18 +256,26 @@ export interface OAuthAccessSource {
 	getOAuthAccess(
 		provider: string,
 		sessionId?: string,
-		options?: { forceRefresh?: boolean; signal?: AbortSignal },
+		options?: { forceRefresh?: boolean; signal?: AbortSignal; usageScopeId?: string },
 	): Promise<OAuthAccess | undefined>;
 	rotateSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { error?: unknown; signal?: AbortSignal; apiKey?: string; credentialId?: number },
+		options?: {
+			error?: unknown;
+			signal?: AbortSignal;
+			apiKey?: string;
+			credentialId?: number;
+			usageScopeId?: string;
+		},
 	): Promise<boolean>;
 }
 
 export interface WithOAuthAccessOptions {
 	/** Session id for credential stickiness, threaded into every resolve. */
 	sessionId?: string;
+	/** Session-local extension usage-provider scope. */
+	usageScopeId?: string;
 	signal?: AbortSignal;
 	/** Override the retryable-error classifier (default {@link isAuthRetryableError}). */
 	isAuthError?: (error: unknown) => boolean;
@@ -307,9 +315,9 @@ export async function withOAuthAccess<T>(
 	opts?: WithOAuthAccessOptions,
 ): Promise<T> {
 	const isAuthError = opts?.isAuthError ?? isAuthRetryableError;
-	const { sessionId, signal } = opts ?? {};
+	const { sessionId, signal, usageScopeId } = opts ?? {};
 
-	let lastAccess = opts?.seed ?? (await storage.getOAuthAccess(provider, sessionId, { signal }));
+	let lastAccess = opts?.seed ?? (await storage.getOAuthAccess(provider, sessionId, { signal, usageScopeId }));
 	if (!lastAccess) {
 		throw new AIError.MissingApiKeyError(
 			provider,
@@ -335,7 +343,11 @@ export async function withOAuthAccess<T>(
 			if (!refreshedCurrent) {
 				refreshedCurrent = true;
 				try {
-					next = await storage.getOAuthAccess(provider, sessionId, { forceRefresh: true, signal });
+					next = await storage.getOAuthAccess(provider, sessionId, {
+						forceRefresh: true,
+						signal,
+						usageScopeId,
+					});
 				} catch {
 					next = undefined;
 				}
@@ -363,9 +375,10 @@ export async function withOAuthAccess<T>(
 				signal,
 				apiKey: lastAccess.accessToken,
 				credentialId: lastAccess.credentialId,
+				usageScopeId,
 			});
 			if (!rotated) break;
-			next = await storage.getOAuthAccess(provider, sessionId, { signal });
+			next = await storage.getOAuthAccess(provider, sessionId, { signal, usageScopeId });
 		} catch {
 			next = undefined;
 		}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
@@ -40,9 +41,10 @@ import type {
 	UsageLimit,
 	UsageLogger,
 	UsageProvider,
+	UsageProviderRegistration,
 	UsageReport,
 } from "./usage";
-import { resolveUsedFraction } from "./usage";
+import { resolveUsedFraction, UsageProviderRegistry, usageReportSchema } from "./usage";
 import { alibabaTokenPlanRankingStrategy, alibabaTokenPlanUsageProvider } from "./usage/alibaba-token-plan";
 import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { cursorUsageProvider } from "./usage/cursor";
@@ -515,6 +517,7 @@ export interface CredentialDisabledEvent {
 
 export type AuthStorageOptions = {
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
+	usageProviderRegistry?: UsageProviderRegistry;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	usageFetch?: typeof fetch;
 	usageRequestTimeoutMs?: number;
@@ -717,6 +720,7 @@ export interface ModelUsageHealthOptions {
 type UsageCacheEntry<T> = {
 	value: T;
 	expiresAt: number;
+	staleUntil?: number;
 };
 
 interface UsageCache {
@@ -730,6 +734,16 @@ type UsageRequestDescriptor = {
 	provider: Provider;
 	credential: UsageCredential;
 	baseUrl?: string;
+	usageProvider?: UsageProvider;
+	usageProviderCacheKeyVersion?: string | null;
+	usageProviderExtensionOwned?: boolean;
+};
+
+type SessionUsageProviderScope = {
+	resolve: (provider: Provider) => UsageProvider | undefined;
+	cacheKeyVersion: (provider: Provider) => string | null | undefined;
+	/** Provider ids registered in this scope; feeds usage-report enumeration for scope-only providers. */
+	providerIds: () => Iterable<string>;
 };
 
 type AuthApiKeyOptions = {
@@ -748,6 +762,8 @@ type AuthApiKeyOptions = {
 	 * that a peer/broker rotated out from under us is replaced before retrying.
 	 */
 	forceRefresh?: boolean;
+	/** Internal session scope for extension usage-provider resolution. */
+	usageScopeId?: string;
 };
 type OAuthResolutionResult = { apiKey: string; credential: OAuthCredential; credentialId?: number };
 
@@ -1017,10 +1033,17 @@ function resolveDefaultRankingStrategy(provider: Provider): CredentialRankingStr
 
 function parseUsageCacheEntry<T>(raw: string): UsageCacheEntry<T> | undefined {
 	try {
-		const parsed = JSON.parse(raw) as { value?: T; expiresAt?: unknown };
+		const parsed = JSON.parse(raw) as { value?: T; expiresAt?: unknown; staleUntil?: unknown };
 		const expiresAt = typeof parsed.expiresAt === "number" ? parsed.expiresAt : undefined;
 		if (!expiresAt || !Number.isFinite(expiresAt)) return undefined;
-		return { value: parsed.value as T, expiresAt };
+		const staleUntil =
+			typeof parsed.staleUntil === "number"
+				? parsed.staleUntil
+				: parsed.value === null
+					? expiresAt
+					: expiresAt + USAGE_LAST_GOOD_RETENTION_MS;
+		if (!Number.isFinite(staleUntil)) return undefined;
+		return { value: parsed.value as T, expiresAt, staleUntil };
 	} catch {
 		return undefined;
 	}
@@ -1107,20 +1130,25 @@ class AuthStorageUsageCache implements UsageCache {
 	get<T>(key: string): UsageCacheEntry<T> | undefined {
 		const raw = this.store.getCache(`${USAGE_CACHE_PREFIX}${key}`);
 		if (!raw) return undefined;
-		return parseUsageCacheEntry<T>(raw);
+		const entry = parseUsageCacheEntry<T>(raw);
+		return entry && entry.expiresAt > Date.now() ? entry : undefined;
 	}
 
 	getStale<T>(key: string): UsageCacheEntry<T> | undefined {
 		const raw = this.store.getCache(`${USAGE_CACHE_PREFIX}${key}`, { includeExpired: true });
 		if (!raw) return undefined;
-		return parseUsageCacheEntry<T>(raw);
+		const entry = parseUsageCacheEntry<T>(raw);
+		return entry && (entry.staleUntil ?? entry.expiresAt) > Date.now() ? entry : undefined;
 	}
 
 	set<T>(key: string, entry: UsageCacheEntry<T>): void {
-		const payload = JSON.stringify({ value: entry.value, expiresAt: entry.expiresAt });
-		const durableExpiresAt =
-			entry.value === null ? entry.expiresAt : Math.max(entry.expiresAt, Date.now() + USAGE_LAST_GOOD_RETENTION_MS);
-		this.store.setCache(`${USAGE_CACHE_PREFIX}${key}`, payload, Math.floor(durableExpiresAt / 1000));
+		const staleUntil =
+			entry.staleUntil ??
+			(entry.value === null
+				? entry.expiresAt
+				: Math.max(entry.expiresAt, Date.now() + USAGE_LAST_GOOD_RETENTION_MS));
+		const payload = JSON.stringify({ value: entry.value, expiresAt: entry.expiresAt, staleUntil });
+		this.store.setCache(`${USAGE_CACHE_PREFIX}${key}`, payload, Math.floor(staleUntil / 1000));
 	}
 
 	cleanup(): void {
@@ -1192,15 +1220,19 @@ export class AuthStorage {
 	/** Earliest time a freshly-set in-memory block may be cleared by live usage reconciliation. */
 	#credentialBackoffProbeAfter: Map<string, Map<number, number>> = new Map();
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
+	#usageProviderFallback: (provider: Provider) => UsageProvider | undefined;
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
 	#usageCacheEpoch = 0;
 	#usageRequestInFlight: Map<string, Promise<UsageReport | null>> = new Map();
 	#usageHeaderIngestAt: Map<string, number> = new Map();
 	#usageReportsInFlight: Map<string, Promise<UsageReport[] | null>> = new Map();
+	#sessionUsageProviderScopes = new Map<string, SessionUsageProviderScope>();
 	#usageFetch: typeof fetch;
 	#usageRequestTimeoutMs: number;
 	#usageLogger?: UsageLogger;
+	/** Extension usage-provider configuration owned by this AuthStorage instance. */
+	#usageProviderRegistry: UsageProviderRegistry;
 	#fallbackResolver?: (provider: string) => string | undefined;
 	#store: AuthCredentialStore;
 	#configValueResolver: (config: string) => Promise<string | undefined>;
@@ -1226,7 +1258,10 @@ export class AuthStorage {
 	constructor(store: AuthCredentialStore, options: AuthStorageOptions = {}) {
 		this.#store = store;
 		this.#configValueResolver = options.configValueResolver ?? defaultConfigValueResolver;
-		this.#usageProviderResolver = options.usageProviderResolver ?? resolveDefaultUsageProvider;
+		this.#usageProviderRegistry = options.usageProviderRegistry ?? new UsageProviderRegistry();
+		this.#usageProviderFallback = options.usageProviderResolver ?? resolveDefaultUsageProvider;
+		this.#usageProviderResolver = provider =>
+			this.#usageProviderRegistry.resolve(provider) ?? this.#usageProviderFallback(provider);
 		this.#rankingStrategyResolver = options.rankingStrategyResolver ?? resolveDefaultRankingStrategy;
 		this.#usageCache = new AuthStorageUsageCache(this.#store);
 		// Opportunistic hygiene, once per AuthStorage lifetime: drop expired
@@ -1278,6 +1313,10 @@ export class AuthStorage {
 	close(): void {
 		if (this.#closed) return;
 		this.#closed = true;
+		this.#sessionUsageProviderScopes.clear();
+		this.#usageRequestInFlight.clear();
+		this.#usageHeaderIngestAt.clear();
+		this.#usageReportsInFlight.clear();
 		this.#store.close();
 	}
 
@@ -1579,6 +1618,7 @@ export class AuthStorage {
 		const start = sessionId
 			? this.#getHashedIndex(sessionId, total)
 			: this.#getNextRoundRobinIndex(providerKey, total);
+
 		const order: number[] = [];
 		for (let i = 0; i < total; i++) {
 			order.push((start + i) % total);
@@ -1637,6 +1677,7 @@ export class AuthStorage {
 		blockScope: string | undefined = undefined,
 	): number | undefined {
 		const nowMs = Date.now();
+
 		let blockedUntil = this.#getCredentialBlockedUntilForKey(providerKey, credentialIndex, nowMs);
 		if (blockScope) {
 			const scopedBlockedUntil = this.#getCredentialBlockedUntilForKey(
@@ -2736,6 +2777,51 @@ export class AuthStorage {
 		};
 	}
 
+	#resolveSessionUsageProviderScope(scopeId?: string): SessionUsageProviderScope | undefined {
+		if (!scopeId) return undefined;
+		const exact = this.#sessionUsageProviderScopes.get(scopeId);
+		if (exact) return exact;
+		let matchedId: string | undefined;
+		let matched: SessionUsageProviderScope | undefined;
+		for (const [candidateId, candidate] of this.#sessionUsageProviderScopes) {
+			if (!scopeId.startsWith(`${candidateId}:`)) continue;
+			if (matchedId === undefined || candidateId.length > matchedId.length) {
+				matchedId = candidateId;
+				matched = candidate;
+			}
+		}
+		return matched;
+	}
+
+	#resolveUsageProviderContext(
+		provider: Provider,
+		scopeId?: string,
+	): {
+		provider: UsageProvider | undefined;
+		cacheKeyVersion?: string | null;
+		extensionOwned?: boolean;
+	} {
+		const resolvedScope = this.#resolveSessionUsageProviderScope(scopeId);
+		if (resolvedScope) {
+			const scopedProvider = resolvedScope.resolve(provider);
+			if (!scopedProvider) return { provider: this.#usageProviderFallback(provider), cacheKeyVersion: null };
+			return {
+				provider: scopedProvider,
+				cacheKeyVersion: resolvedScope.cacheKeyVersion(provider),
+				extensionOwned: true,
+			};
+		}
+		const extensionProvider = this.#usageProviderRegistry.resolve(provider);
+		if (extensionProvider) {
+			return {
+				provider: extensionProvider,
+				cacheKeyVersion: this.#usageProviderRegistry.cacheKeyVersion(provider),
+				extensionOwned: true,
+			};
+		}
+		return { provider: this.#usageProviderFallback(provider) };
+	}
+
 	#buildUsageCacheIdentity(credential: UsageCredential): string {
 		const parts: string[] = [credential.type];
 		const accountId = credential.accountId?.trim();
@@ -2768,20 +2854,30 @@ export class AuthStorage {
 		return baseUrl?.trim().replace(/\/+$/, "") ?? "";
 	}
 
+	#buildUsageProviderCacheKey(provider: Provider, extensionVersion?: string | null): string {
+		const versionOverride = USAGE_REPORT_CACHE_KEY_VERSION_OVERRIDES[provider];
+		const providerKey = versionOverride === undefined ? provider : `${versionOverride}:${provider}`;
+		const resolvedExtensionVersion =
+			extensionVersion === undefined ? this.#usageProviderRegistry.cacheKeyVersion(provider) : extensionVersion;
+		return resolvedExtensionVersion === undefined || resolvedExtensionVersion === null
+			? providerKey
+			: `${providerKey}:extension:${resolvedExtensionVersion}`;
+	}
+
 	#buildUsageReportCacheKey(request: UsageRequestDescriptor): string {
 		const baseUrl = this.#normalizeUsageBaseUrl(request.baseUrl) || "default";
 		const identity = this.#buildUsageCacheIdentity(request.credential);
-		const versionOverride = USAGE_REPORT_CACHE_KEY_VERSION_OVERRIDES[request.provider];
-		const providerKey = versionOverride === undefined ? request.provider : `${versionOverride}:${request.provider}`;
+		const providerKey = this.#buildUsageProviderCacheKey(request.provider, request.usageProviderCacheKeyVersion);
 		return `report:${providerKey}:${baseUrl}:${identity}`;
 	}
 
 	#buildUsageReportsCacheKey(requests: ReadonlyArray<UsageRequestDescriptor>): string {
 		const snapshot = requests
 			.map(request => {
-				const versionOverride = USAGE_REPORT_CACHE_KEY_VERSION_OVERRIDES[request.provider];
-				const providerKey =
-					versionOverride === undefined ? request.provider : `${versionOverride}:${request.provider}`;
+				const providerKey = this.#buildUsageProviderCacheKey(
+					request.provider,
+					request.usageProviderCacheKeyVersion,
+				);
 				return `${providerKey}:${this.#normalizeUsageBaseUrl(request.baseUrl) || "default"}:${this.#buildUsageCacheIdentity(request.credential)}`;
 			})
 			.sort()
@@ -2910,11 +3006,43 @@ export class AuthStorage {
 		});
 	}
 
-	async #fetchUsageUncached(request: UsageRequestDescriptor, timeoutMs?: number): Promise<UsageReport | null> {
-		const resolver = this.#usageProviderResolver;
-		if (!resolver) return null;
+	#usageProviderSupports(provider: UsageProvider, params: UsageFetchParams): boolean {
+		if (!provider.supports) return true;
+		try {
+			return provider.supports(params);
+		} catch (error) {
+			this.#usageLogger?.debug("Usage provider supports callback failed", {
+				provider: provider.id,
+				error: String(error),
+			});
+			return false;
+		}
+	}
 
-		const providerImpl = resolver(request.provider);
+	#validateUsageReport(
+		rawReport: unknown,
+		options: { expectedProvider?: Provider; source: string },
+	): UsageReport | null {
+		const validated = usageReportSchema(rawReport);
+		if (validated instanceof type.errors) {
+			this.#usageLogger?.debug(`${options.source} returned an invalid report`, {
+				provider: options.expectedProvider,
+				error: validated.summary,
+			});
+			return null;
+		}
+		if (options.expectedProvider !== undefined && validated.provider !== options.expectedProvider) {
+			this.#usageLogger?.debug(`${options.source} returned a report for a different provider`, {
+				provider: options.expectedProvider,
+				reportProvider: validated.provider,
+			});
+			return null;
+		}
+		return validated;
+	}
+
+	async #fetchUsageUncached(request: UsageRequestDescriptor, timeoutMs?: number): Promise<UsageReport | null> {
+		const providerImpl = request.usageProvider ?? this.#usageProviderResolver?.(request.provider);
 		if (!providerImpl) return null;
 
 		const timeoutSignal =
@@ -2922,7 +3050,9 @@ export class AuthStorage {
 				? AbortSignal.timeout(timeoutMs)
 				: undefined;
 		let params: UsageFetchParams = {
-			...request,
+			provider: request.provider,
+			credential: request.credential,
+			baseUrl: request.baseUrl,
 			accountKey: this.#buildUsageCacheIdentity(request.credential),
 			signal: timeoutSignal,
 		};
@@ -2953,8 +3083,9 @@ export class AuthStorage {
 						refreshableCredentialId,
 					);
 					params = {
-						...request,
+						provider: request.provider,
 						credential: refreshedCredential,
+						baseUrl: request.baseUrl,
 						accountKey: this.#buildUsageCacheIdentity(refreshedCredential),
 						signal: timeoutSignal,
 					};
@@ -2965,7 +3096,10 @@ export class AuthStorage {
 						// old usage report after its rotating refresh token is revoked.
 						// This changes cache state only; usage polling remains
 						// non-authoritative about the credential lifecycle.
-						this.#usageCache.set(this.#buildUsageReportCacheKey(request), { value: null, expiresAt: 0 });
+						this.#usageCache.set(this.#buildUsageReportCacheKey(request), {
+							value: null,
+							expiresAt: 0,
+						});
 					}
 					// Usage polling is advisory. A refresh can fail while the current
 					// access token remains valid inside the refresh skew, so probe with
@@ -2978,14 +3112,31 @@ export class AuthStorage {
 			}
 		}
 
-		if (providerImpl.supports && !providerImpl.supports(params)) return null;
+		if (!this.#usageProviderSupports(providerImpl, params)) return null;
 
 		try {
-			const report = await providerImpl.fetchUsage(params, {
+			const rawReport = await providerImpl.fetchUsage(params, {
 				fetch: this.#usageFetch,
 				logger: this.#usageLogger,
 				listUsageCosts: query => this.#store.listUsageCosts?.(query) ?? [],
 			});
+			if (!rawReport) return null;
+			const validatedReport = usageReportSchema(rawReport);
+			if (validatedReport instanceof type.errors) {
+				this.#usageLogger?.debug("Usage provider returned an invalid report", {
+					provider: request.provider,
+					error: validatedReport.summary,
+				});
+				return null;
+			}
+			if (validatedReport.provider !== request.provider) {
+				this.#usageLogger?.debug("Usage provider returned a report for a different provider", {
+					provider: request.provider,
+					reportProvider: validatedReport.provider,
+				});
+				return null;
+			}
+			const report = validatedReport;
 			// Attribute the report to the credential's organization. The orgId and
 			// orgName fallbacks apply independently: Claude's usage endpoint stamps
 			// orgId from the `anthropic-organization-id` response header but never
@@ -3016,14 +3167,16 @@ export class AuthStorage {
 
 	async #fetchUsageCached(request: UsageRequestDescriptor, timeoutMs?: number): Promise<UsageReport | null> {
 		const cacheKey = this.#buildUsageReportCacheKey(request);
+		const usageCache = this.#usageCache;
+		const usageRequestInFlight = this.#usageRequestInFlight;
 		const now = Date.now();
-		const cached = this.#usageCache.get<UsageReport | null>(cacheKey);
+		const cached = usageCache.get<UsageReport | null>(cacheKey);
 		// Fresh cache hit: return whatever's there (success or null fallback).
 		if (cached && cached.expiresAt > now) {
 			return cached.value;
 		}
 
-		const inFlight = this.#usageRequestInFlight.get(cacheKey);
+		const inFlight = usageRequestInFlight.get(cacheKey);
 		if (inFlight) return inFlight;
 
 		const usageCacheEpoch = this.#usageCacheEpoch;
@@ -3037,7 +3190,7 @@ export class AuthStorage {
 				// per source IP regardless of account, and synchronized 5-credential
 				// fan-out trips 429s every cycle. With ±25% jitter on TTL the refresh
 				// times decorrelate within a few cycles.
-				this.#usageCache.set(cacheKey, { value: report, expiresAt: Date.now() + USAGE_REPORT_TTL_MS + ttlJitter });
+				usageCache.set(cacheKey, { value: report, expiresAt: Date.now() + USAGE_REPORT_TTL_MS + ttlJitter });
 				this.#recordUsageHistory(request, report);
 				this.#reconcileCodexUsageBlock(request, report);
 				return report;
@@ -3046,19 +3199,18 @@ export class AuthStorage {
 			// re-hit the endpoint on every poll. Most providers serve the last good
 			// value through transient failures. Session-cookie providers can opt out
 			// so an expired login does not display stale quota indefinitely.
+			const stale = this.#usageCache.getStale<UsageReport | null>(cacheKey);
 			const retainLastGood = this.#usageProviderResolver?.(request.provider)?.retainLastGoodOnFailure !== false;
-			const lastGood = retainLastGood
-				? (this.#usageCache.getStale<UsageReport | null>(cacheKey)?.value ?? null)
-				: null;
+			const lastGood = retainLastGood ? (stale?.value ?? null) : null;
 			const backoffJitter = USAGE_FAILURE_BACKOFF_MS * (Math.random() * 0.5 - 0.25);
 			const coolDown = Date.now() + USAGE_FAILURE_BACKOFF_MS + backoffJitter;
-			this.#usageCache.set(cacheKey, { value: lastGood, expiresAt: coolDown });
+			usageCache.set(cacheKey, { value: lastGood, expiresAt: coolDown, staleUntil: stale?.staleUntil });
 			return lastGood;
 		})().finally(() => {
-			this.#usageRequestInFlight.delete(cacheKey);
+			usageRequestInFlight.delete(cacheKey);
 		});
 
-		this.#usageRequestInFlight.set(cacheKey, promise);
+		usageRequestInFlight.set(cacheKey, promise);
 		return promise;
 	}
 
@@ -3110,7 +3262,7 @@ export class AuthStorage {
 	recordUsageCost(
 		provider: Provider,
 		costUsd: number,
-		options?: { sessionId?: string; recordedAt?: number; baseUrl?: string },
+		options?: { sessionId?: string; usageScopeId?: string; recordedAt?: number; baseUrl?: string },
 	): boolean {
 		if (!Number.isFinite(costUsd) || costUsd <= 0) return false;
 		const record = this.#store.recordUsageCosts;
@@ -3125,13 +3277,17 @@ export class AuthStorage {
 		};
 		try {
 			record.call(this.#store, [entry]);
-			const cacheKey = this.#buildUsageReportCacheKey({
-				provider,
-				credential,
-				baseUrl: options?.baseUrl,
+			const usageContext = this.#resolveUsageProviderContext(provider, options?.usageScopeId);
+			const request = this.#buildUsageRequest(provider, credential, options?.baseUrl);
+			request.usageProvider = usageContext.provider;
+			request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+			request.usageProviderExtensionOwned = usageContext.extensionOwned;
+			const existing = this.#usageCache.getStale<UsageReport | null>(this.#buildUsageReportCacheKey(request));
+			this.#usageCache.set(this.#buildUsageReportCacheKey(request), {
+				value: existing?.value ?? null,
+				expiresAt: Date.now() - 1,
+				staleUntil: existing?.staleUntil,
 			});
-			const existing = this.#usageCache.getStale<UsageReport | null>(cacheKey);
-			this.#usageCache.set(cacheKey, { value: existing?.value ?? null, expiresAt: Date.now() - 1 });
 			return true;
 		} catch (error) {
 			this.#usageLogger?.debug("usage cost record failed", {
@@ -3167,27 +3323,63 @@ export class AuthStorage {
 	ingestUsageHeaders(
 		provider: Provider,
 		headers: Record<string, string>,
-		options?: { sessionId?: string; baseUrl?: string },
+		options?: {
+			sessionId?: string;
+			baseUrl?: string;
+			usageProvider?: UsageProvider;
+			usageProviderCacheKeyVersion?: string | null;
+			usageScopeId?: string;
+		},
 	): boolean {
 		if (this.#fetchUsageReportsOverride) return false;
-		const parseHeaders = this.#usageProviderResolver?.(provider)?.parseRateLimitHeaders;
+		const usageContext = this.#resolveUsageProviderContext(provider, options?.usageScopeId ?? options?.sessionId);
+		const parseHeaders =
+			options?.usageProvider?.parseRateLimitHeaders ?? usageContext.provider?.parseRateLimitHeaders;
 		if (!parseHeaders) return false;
 
 		const credential = this.#resolveActiveOAuthCredential(provider, options?.sessionId);
 		if (!credential) return false;
 
-		const cacheKey = this.#buildUsageReportCacheKey(
-			this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
-		);
+		const request = this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl);
+		request.usageProvider = options?.usageProvider ?? usageContext.provider;
+		request.usageProviderCacheKeyVersion = options?.usageProviderCacheKeyVersion ?? usageContext.cacheKeyVersion;
+		request.usageProviderExtensionOwned = usageContext.extensionOwned;
+		const cacheKey = this.#buildUsageReportCacheKey(request);
 		const now = Date.now();
-		const parsedReport = parseHeaders(headers, now);
+		let parsedReport: UsageReport | null;
+		try {
+			parsedReport = parseHeaders(headers, now);
+		} catch (error) {
+			this.#usageLogger?.debug("Usage provider header parser failed", {
+				provider,
+				error: String(error),
+			});
+			return false;
+		}
 		if (!parsedReport) return false;
+		const validatedReport = usageReportSchema(parsedReport);
+		if (validatedReport instanceof type.errors) {
+			this.#usageLogger?.debug("Usage provider header parser returned an invalid report", {
+				provider,
+				error: validatedReport.summary,
+			});
+			return false;
+		}
+		if (validatedReport.provider !== provider) {
+			this.#usageLogger?.debug("Usage provider header parser returned a report for a different provider", {
+				provider,
+				reportProvider: validatedReport.provider,
+			});
+			return false;
+		}
+		parsedReport = validatedReport;
 		// Throttled to one ingest per interval — except when a window reads
 		// exhausted: persist that snapshot immediately. A full-backed cache can
 		// then block the next getApiKey; a cold header-only snapshot first probes
 		// the usage endpoint.
 		const exhausted = parsedReport.limits.some(limit => this.#isUsageLimitExhausted(limit));
-		const last = this.#usageHeaderIngestAt.get(cacheKey);
+		const usageHeaderIngestAt = this.#usageHeaderIngestAt;
+		const last = usageHeaderIngestAt.get(cacheKey);
 		if (!exhausted && last !== undefined && now - last < USAGE_HEADER_INGEST_INTERVAL_MS) return false;
 		const metadata: Record<string, unknown> = { ...(parsedReport.metadata ?? {}) };
 		if (credential.accountId && metadata.accountId === undefined) metadata.accountId = credential.accountId;
@@ -3198,13 +3390,15 @@ export class AuthStorage {
 		const report: UsageReport = { ...parsedReport, metadata };
 
 		const storeIngest = this.#store.ingestUsageReport?.bind(this.#store);
-		if (storeIngest) {
+		if (!request.usageProviderExtensionOwned && storeIngest) {
 			const ingested = storeIngest(provider, credential, report);
-			if (ingested) this.#usageHeaderIngestAt.set(cacheKey, now);
+			if (ingested) usageHeaderIngestAt.set(cacheKey, now);
 			return ingested;
 		}
 
-		if (this.#fetchUsageReportsOverride || this.#store.fetchUsageReports) return false;
+		if (!request.usageProviderExtensionOwned && (this.#fetchUsageReportsOverride || this.#store.fetchUsageReports)) {
+			return false;
+		}
 		const priorEntry = this.#usageCache.getStale<UsageReport | null>(cacheKey);
 		const prior = priorEntry?.value;
 		let merged = report;
@@ -3249,21 +3443,40 @@ export class AuthStorage {
 
 	#collectUsageRequests(options?: {
 		baseUrlResolver?: (provider: Provider) => string | undefined;
+		usageScopeId?: string;
 	}): UsageRequestDescriptor[] {
-		const resolver = this.#usageProviderResolver;
-		if (!resolver) return [];
-
 		const requests: UsageRequestDescriptor[] = [];
+
 		const providers = new Set<string>([
 			...this.#data.keys(),
+			...this.#runtimeOverrides.keys(),
+			...this.#configOverrides.keys(),
+			...this.#usageProviderRegistry.providerIds(),
 			...DEFAULT_USAGE_PROVIDERS.map(provider => provider.id),
 		]);
+		const sessionScope = this.#resolveSessionUsageProviderScope(options?.usageScopeId);
+		if (sessionScope) {
+			for (const providerId of sessionScope.providerIds()) providers.add(providerId);
+		}
 
 		for (const providerId of providers) {
 			const provider = providerId as Provider;
-			const providerImpl = resolver(provider);
+			const usageContext = this.#resolveUsageProviderContext(provider, options?.usageScopeId);
+			const providerImpl = usageContext.provider;
 			if (!providerImpl) continue;
 			const baseUrl = options?.baseUrlResolver?.(provider);
+			const runtimeKey = this.#runtimeOverrides.get(providerId);
+			const configKey = this.#configOverrides.get(providerId);
+			const configuredKey = runtimeKey ?? configKey;
+			if (configuredKey) {
+				const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey: configuredKey }, baseUrl);
+				request.usageProvider = providerImpl;
+				request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+				request.usageProviderExtensionOwned = usageContext.extensionOwned;
+				if (this.#usageProviderSupports(providerImpl, request)) requests.push(request);
+				continue;
+			}
+
 			let entries = this.#getStoredCredentials(providerId);
 			if (entries.length > 0) {
 				const dedupedEntries = this.#pruneDuplicateStoredCredentials(providerId, entries);
@@ -3297,12 +3510,13 @@ export class AuthStorage {
 			}
 
 			if (entries.length === 0) {
-				const runtimeKey = this.#runtimeOverrides.get(providerId);
 				const envKey = getEnvApiKey(providerId);
-				const apiKey = runtimeKey ?? envKey;
-				if (!apiKey) continue;
-				const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
-				if (providerImpl.supports && !providerImpl.supports(request)) continue;
+				if (!envKey) continue;
+				const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey: envKey }, baseUrl);
+				request.usageProvider = providerImpl;
+				request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+				request.usageProviderExtensionOwned = usageContext.extensionOwned;
+				if (!this.#usageProviderSupports(providerImpl, request)) continue;
 				requests.push(request);
 				continue;
 			}
@@ -3313,7 +3527,10 @@ export class AuthStorage {
 					credential.type === "api_key"
 						? this.#buildUsageRequest(provider, { type: "api_key", apiKey: credential.key }, baseUrl)
 						: this.#buildUsageRequestForOauth(provider, credential, baseUrl);
-				if (providerImpl.supports && !providerImpl.supports(request)) continue;
+				request.usageProvider = providerImpl;
+				request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+				request.usageProviderExtensionOwned = usageContext.extensionOwned;
+				if (!this.#usageProviderSupports(providerImpl, request)) continue;
 				requests.push(request);
 			}
 		}
@@ -3506,18 +3723,20 @@ export class AuthStorage {
 	async #getUsageReport(
 		provider: Provider,
 		credential: AuthCredential,
-		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal },
+		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal; usageScopeId?: string },
 	): Promise<UsageReport | null> {
+		const usageContext = this.#resolveUsageProviderContext(provider, options?.usageScopeId);
 		// Store-level hook (e.g. `RemoteAuthCredentialStore`) is authoritative
-		// when present for OAuth: the broker already aggregates usage from a
-		// less-throttled IP, and falling back to the local per-credential fetch
-		// would defeat the point of routing through it. API-key credentials do
-		// not have a broker per-credential hook, so they use the normal cached
-		// provider fetch path.
-		if (credential.type === "oauth") {
+		// for ordinary OAuth providers: the broker already aggregates usage from
+		// a less-throttled IP. Extension providers remain authoritative and use
+		// their own cached per-credential fetch path.
+		if (credential.type === "oauth" && usageContext.extensionOwned !== true) {
 			const storeHook = this.#store.getUsageReport?.bind(this.#store);
 			if (storeHook) {
-				const report = await storeHook(provider, credential, options?.signal);
+				const report = this.#validateUsageReport(await storeHook(provider, credential, options?.signal), {
+					expectedProvider: provider,
+					source: "Usage store hook",
+				});
 				if (report) {
 					this.#reconcileCodexUsageBlock(
 						this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
@@ -3533,10 +3752,34 @@ export class AuthStorage {
 			if (!resolvedApiKey) return null;
 			usageCredential.apiKey = resolvedApiKey;
 		}
-		return this.#fetchUsageCached(
-			this.#buildUsageRequest(provider, usageCredential, options?.baseUrl),
-			options?.timeoutMs ?? this.#usageRequestTimeoutMs,
-		);
+		const request = this.#buildUsageRequest(provider, usageCredential, options?.baseUrl);
+		request.usageProvider = usageContext.provider;
+		request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+		request.usageProviderExtensionOwned = usageContext.extensionOwned;
+		return this.#fetchUsageCached(request, options?.timeoutMs ?? this.#usageRequestTimeoutMs);
+	}
+
+	/**
+	 * Atomically reconcile source-owned extension usage providers for this
+	 * AuthStorage. Registrations from inactive sources are rejected.
+	 */
+	syncExtensionUsageProviders(
+		activeSourceIds: Iterable<string>,
+		registrations: readonly UsageProviderRegistration[],
+	): void {
+		this.#usageProviderRegistry.syncRegistrations(activeSourceIds, registrations);
+	}
+
+	/**
+	 * Bind one session's extension provider set to its provider-session ID.
+	 * Derived side-channel IDs inherit the longest matching `scopeId:` prefix.
+	 */
+	registerSessionUsageProviders(scopeId: string, options: SessionUsageProviderScope): () => void {
+		this.#sessionUsageProviderScopes.set(scopeId, options);
+		return () => {
+			if (this.#sessionUsageProviderScopes.get(scopeId) !== options) return;
+			this.#sessionUsageProviderScopes.delete(scopeId);
+		};
 	}
 
 	/**
@@ -3546,8 +3789,8 @@ export class AuthStorage {
 	 * usage concept" (web-search keys, local/keyless servers, inference
 	 * providers without a usage API) — the latter never warrants a usage row.
 	 */
-	usageProviderFor(provider: Provider): UsageProvider | undefined {
-		return this.#usageProviderResolver?.(provider);
+	usageProviderFor(provider: Provider, usageScopeId?: string): UsageProvider | undefined {
+		return this.#resolveUsageProviderContext(provider, usageScopeId).provider;
 	}
 
 	/**
@@ -3723,9 +3966,13 @@ export class AuthStorage {
 
 	async fetchUsageReports(options?: {
 		baseUrlResolver?: (provider: Provider) => string | undefined;
+		/** Session provider scope registered through {@link registerSessionUsageProviders}. */
+		usageScopeId?: string;
 		/** Caller's cancel signal; only rejects this caller, never the shared upstream fetch. */
 		signal?: AbortSignal;
 	}): Promise<UsageReport[] | null> {
+		const requests = this.#collectUsageRequests(options);
+		const extensionRequests = requests.filter(request => request.usageProviderExtensionOwned === true);
 		// Caller override > store-level hook > local per-credential fan-out.
 		// `RemoteAuthCredentialStore` implements the store hook so a gateway
 		// backed by a broker automatically routes usage to the broker without
@@ -3749,13 +3996,27 @@ export class AuthStorage {
 				});
 				this.#usageReportsInFlight.set(OVERRIDE_KEY, shared);
 			}
-			const reports = await raceUsageWithSignal(shared, options?.signal);
+			const rawReports = await raceUsageWithSignal(shared, options?.signal);
+			const reports =
+				rawReports === null
+					? null
+					: rawReports
+							.map(report => this.#validateUsageReport(report, { source: "Usage reports override" }))
+							.filter((report): report is UsageReport => report !== null);
 			if (shouldReconcileStoreHookReports && reports) this.#reconcileCodexUsageBlocksFromReports(reports);
-			return reports;
+			if (extensionRequests.length === 0) return reports;
+			const extensionResults = await Promise.all(
+				extensionRequests.map(request => this.#fetchUsageCached(request, this.#usageRequestTimeoutMs)),
+			);
+			const remoteReports = (reports ?? []).filter(
+				report => this.#resolveUsageProviderContext(report.provider, options?.usageScopeId).extensionOwned !== true,
+			);
+			return this.#dedupeUsageReports([
+				...remoteReports,
+				...extensionResults.filter((report): report is UsageReport => report !== null),
+			]);
 		}
-		if (!this.#usageProviderResolver) return null;
 
-		const requests = this.#collectUsageRequests(options);
 		if (requests.length === 0) return [];
 
 		this.#usageLogger?.debug("Usage fetch requested", {
@@ -3768,8 +4029,9 @@ export class AuthStorage {
 		// accounts can be missing from one fetch and present in the next; the
 		// aggregate cache freezes whichever set landed first).
 		const cacheKey = this.#buildUsageReportsCacheKey(requests);
+		const usageReportsInFlight = this.#usageReportsInFlight;
 
-		const inFlight = this.#usageReportsInFlight.get(cacheKey);
+		const inFlight = usageReportsInFlight.get(cacheKey);
 		if (inFlight) return inFlight;
 
 		const promise = (async () => {
@@ -3808,10 +4070,10 @@ export class AuthStorage {
 			});
 			return resolved;
 		})().finally(() => {
-			this.#usageReportsInFlight.delete(cacheKey);
+			usageReportsInFlight.delete(cacheKey);
 		});
 
-		this.#usageReportsInFlight.set(cacheKey, promise);
+		usageReportsInFlight.set(cacheKey, promise);
 		return promise;
 	}
 
@@ -3938,22 +4200,31 @@ export class AuthStorage {
 			const providerImpl = resolver?.(row.provider as Provider);
 			if (!providerImpl) {
 				base.reason = `no usage probe configured for provider ${row.provider}`;
-			} else if (providerImpl.supports && !providerImpl.supports(initialRequest)) {
+			} else if (!this.#usageProviderSupports(providerImpl, initialRequest)) {
 				base.reason = `usage probe does not support ${cred.type} credentials for ${row.provider}`;
 			} else if (providerImpl.validatesCredentials === false) {
 				base.reason = `usage probe for ${row.provider} does not validate credentials`;
 			} else {
 				try {
-					const report = await providerImpl.fetchUsage(params, ctx);
-					if (report === null) {
+					const rawReport = await providerImpl.fetchUsage(params, ctx);
+					if (rawReport === null) {
 						base.reason = "usage probe returned no data for this credential";
 					} else {
+						const validated = usageReportSchema(rawReport);
+						if (validated instanceof type.errors) {
+							throw new TypeError(`usage probe returned an invalid report: ${validated.summary}`);
+						}
+						if (validated.provider !== row.provider) {
+							throw new TypeError(
+								`usage probe returned provider ${validated.provider}, expected ${row.provider}`,
+							);
+						}
 						base.ok = true;
-						const accountId = this.#getUsageReportMetadataValue(report, "accountId");
-						const email = this.#getUsageReportMetadataValue(report, "email");
+						const accountId = this.#getUsageReportMetadataValue(validated, "accountId");
+						const email = this.#getUsageReportMetadataValue(validated, "email");
 						if (accountId) base.accountId = accountId;
 						if (email) base.email = email;
-						const { raw: _raw, ...trimmed } = report;
+						const { raw: _raw, ...trimmed } = validated;
 						base.report = trimmed;
 					}
 				} catch (error) {
@@ -4046,6 +4317,7 @@ export class AuthStorage {
 			apiKey?: string;
 			credentialId?: number;
 			signal?: AbortSignal;
+			usageScopeId?: string;
 		},
 	): Promise<UsageLimitMarkResult> {
 		let sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
@@ -4074,12 +4346,17 @@ export class AuthStorage {
 		const providerKey = this.#getProviderTypeKey(provider, credentialType);
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
-		const blockScope = strategy?.blockScope?.(rankingContext);
+		const providerBlockScope = strategy?.blockScope?.(rankingContext);
+		const usageScopeId = options?.usageScopeId ?? sessionId;
 		const now = Date.now();
-		let blockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
+		const baselineBlockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
+		let blockedUntil = baselineBlockedUntil;
 
 		if (credentialType === "oauth" && target.credential.type === "oauth" && strategy) {
-			const report = await this.#getUsageReport(provider, target.credential, options);
+			const report = await this.#getUsageReport(provider, target.credential, {
+				...options,
+				usageScopeId,
+			});
 			if (report) {
 				const scopedLimits = this.#getScopedUsageLimits(strategy, report, rankingContext);
 				if (this.#isUsageLimitReached(scopedLimits)) {
@@ -4097,7 +4374,7 @@ export class AuthStorage {
 			entry => entry.id === targetCredentialId && entry.credential.type === credentialType,
 		);
 		if (targetIndex >= 0) {
-			this.#markCredentialBlocked(provider, providerKey, targetIndex, blockedUntil, blockScope);
+			this.#markCredentialBlocked(provider, providerKey, targetIndex, blockedUntil, providerBlockScope);
 		}
 
 		const remainingCredentials = this.#getCredentialsForProvider(provider)
@@ -4113,7 +4390,7 @@ export class AuthStorage {
 				provider,
 				providerKey,
 				candidate.index,
-				blockScope,
+				providerBlockScope,
 			);
 			if (candidateBlockedUntil === undefined) return { switched: true };
 			if (retryAtMs === undefined || candidateBlockedUntil < retryAtMs) retryAtMs = candidateBlockedUntil;
@@ -4366,6 +4643,7 @@ export class AuthStorage {
 		sessionId?: string,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthResolutionResult | undefined> {
+		options = { ...options, usageScopeId: options?.usageScopeId ?? sessionId };
 		const credentials = this.#getCredentialsForProvider(provider)
 			.map((credential, index) => ({ credential, index }))
 			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
@@ -5039,6 +5317,7 @@ export class AuthStorage {
 	 * 7. Fallback resolver (models.yml custom providers, last-resort)
 	 */
 	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
+		options = { ...options, usageScopeId: options?.usageScopeId ?? sessionId };
 		// Runtime override takes highest priority
 		const runtimeKey = this.#runtimeOverrides.get(provider);
 		if (runtimeKey) {
@@ -5411,20 +5690,39 @@ export class AuthStorage {
 	}
 
 	/**
+	 * Expire the exact cache keys the usage fetch path would read — for every
+	 * active session scope plus the unscoped view — so the next fetch bypasses
+	 * the 5-min cache. Optionally limited to one provider.
+	 */
+	#expireCollectedUsageRequests(options?: { provider?: string; baseUrl?: string }): void {
+		const expired = Date.now() - 1;
+		const onlyProvider = options?.provider;
+		const baseUrlResolver =
+			onlyProvider === undefined
+				? undefined
+				: (candidate: Provider) => (candidate === onlyProvider ? options?.baseUrl : undefined);
+		const scopeIds = [undefined, ...this.#sessionUsageProviderScopes.keys()];
+		for (const usageScopeId of scopeIds) {
+			for (const request of this.#collectUsageRequests({ baseUrlResolver, usageScopeId })) {
+				if (onlyProvider !== undefined && request.provider !== onlyProvider) continue;
+				const cacheKey = this.#buildUsageReportCacheKey(request);
+				const existing = this.#usageCache.getStale<UsageReport | null>(cacheKey);
+				this.#usageCache.set(cacheKey, {
+					value: existing?.value ?? null,
+					expiresAt: expired,
+					staleUntil: existing?.staleUntil,
+				});
+			}
+		}
+	}
+
+	/**
 	 * Force the next usage fetch for `provider` to bypass the 5-min cache, so
 	 * `/usage` reflects a freshly-redeemed reset instead of stale numbers.
 	 */
 	#invalidateUsageReportCache(provider: string, baseUrl?: string): void {
 		this.#usageCacheEpoch += 1;
-		const expired = Date.now() - 1;
-		for (const entry of this.#getStoredCredentials(provider)) {
-			if (entry.credential.type !== "oauth") continue;
-			const cacheKey = this.#buildUsageReportCacheKey(
-				this.#buildUsageRequestForOauth(provider, entry.credential, baseUrl),
-			);
-			const existing = this.#usageCache.getStale<UsageReport | null>(cacheKey);
-			this.#usageCache.set(cacheKey, { value: existing?.value ?? null, expiresAt: expired });
-		}
+		this.#expireCollectedUsageRequests({ provider, baseUrl });
 	}
 
 	/**
@@ -5438,20 +5736,7 @@ export class AuthStorage {
 			this.#invalidateUsageReportCache(provider);
 		} else {
 			this.#usageCacheEpoch += 1;
-			const expired = Date.now() - 1;
-			try {
-				const credentials = this.#store.listAuthCredentials();
-				for (const entry of credentials) {
-					if (entry.credential.type !== "oauth") continue;
-					const cacheKey = this.#buildUsageReportCacheKey(
-						this.#buildUsageRequestForOauth(entry.provider, entry.credential),
-					);
-					const existing = this.#usageCache.getStale<UsageReport | null>(cacheKey);
-					this.#usageCache.set(cacheKey, { value: existing?.value ?? null, expiresAt: expired });
-				}
-			} catch (err) {
-				logger.debug("Failed to list auth credentials for complete usage cache invalidation", { err });
-			}
+			this.#expireCollectedUsageRequests();
 		}
 
 		if (this.#store.invalidateUsageCache) {
@@ -5678,7 +5963,14 @@ export class AuthStorage {
 	async rotateSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { error?: unknown; modelId?: string; apiKey?: string; credentialId?: number; signal?: AbortSignal },
+		options?: {
+			error?: unknown;
+			modelId?: string;
+			apiKey?: string;
+			credentialId?: number;
+			signal?: AbortSignal;
+			usageScopeId?: string;
+		},
 	): Promise<boolean> {
 		const error = options?.error;
 		const status = AIError.status(error);
@@ -5690,6 +5982,7 @@ export class AuthStorage {
 					apiKey: options?.apiKey,
 					credentialId: options?.credentialId,
 					signal: options?.signal,
+					usageScopeId: options?.usageScopeId,
 				})
 			).switched;
 		}
@@ -5701,13 +5994,15 @@ export class AuthStorage {
 		if (!sessionCredential) return false;
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		const blockScope = strategy?.blockScope?.({ modelId: options?.modelId });
 		// Snapshot sibling availability before mutating so a soft-deleting
 		// suspect hook can't reindex the answer out from under us.
 		const hasSibling = this.#getCredentialsForProvider(provider).some(
 			(credential, index) =>
 				credential.type === sessionCredential.type &&
 				index !== sessionCredential.index &&
-				!this.#isCredentialBlocked(provider, providerKey, index),
+				!this.#isCredentialBlocked(provider, providerKey, index, blockScope),
 		);
 		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
 		const sticky = this.#getSessionCredential(provider, sessionId);
@@ -5767,11 +6062,14 @@ export class AuthStorage {
 	 * Used by web-search providers and other consumers that hold an AuthStorage
 	 * directly (no ModelRegistry in scope).
 	 */
-	resolver(provider: string, options?: { sessionId?: string; baseUrl?: string; modelId?: string }): ApiKeyResolver {
-		const { sessionId, baseUrl, modelId } = options ?? {};
+	resolver(
+		provider: string,
+		options?: { sessionId?: string; baseUrl?: string; modelId?: string; usageScopeId?: string },
+	): ApiKeyResolver {
+		const { sessionId, baseUrl, modelId, usageScopeId } = options ?? {};
 		return async ({ lastChance, error, signal, previousKey }) => {
 			if (error === undefined) {
-				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal });
+				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal, usageScopeId });
 			}
 			if (lastChance) {
 				const switched = await this.rotateSessionCredential(provider, sessionId, {
@@ -5779,6 +6077,7 @@ export class AuthStorage {
 					modelId,
 					signal,
 					apiKey: previousKey,
+					usageScopeId,
 				});
 				if (!switched) {
 					const status = AIError.status(error);
@@ -5788,9 +6087,15 @@ export class AuthStorage {
 					// because a peer may have refreshed the failed bearer.
 					if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) return undefined;
 				}
-				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal });
+				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal, usageScopeId });
 			}
-			return this.getApiKey(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+			return this.getApiKey(provider, sessionId, {
+				baseUrl,
+				modelId,
+				forceRefresh: true,
+				signal,
+				usageScopeId,
+			});
 		};
 	}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3430,12 +3430,11 @@ export class AuthStorage {
 			};
 		}
 
-		// Header ingestion merges values but never extends a cache entry's lifetime.
-		// Preserve the existing expiry (including active failure cooldowns) so full
-		// reports refetch on their original 5-minute schedule and full-payload-only
-		// rows such as extra usage stay current; headers only refresh window rows
-		// between fetches. A newly minted header-only report is durable but stale.
-		const expiresAt = Math.max(priorEntry?.expiresAt ?? now - 1, now - 1);
+		// A header-only extension report uses the same durable cache as a fetched
+		// report. Built-ins retain their existing stale-header refresh behavior.
+		const expiresAt = request.usageProviderExtensionOwned
+			? now + USAGE_REPORT_TTL_MS
+			: Math.max(priorEntry?.expiresAt ?? now - 1, now - 1);
 		this.#usageCache.set(cacheKey, { value: merged, expiresAt });
 		this.#usageHeaderIngestAt.set(cacheKey, now);
 		return true;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1036,13 +1036,8 @@ function parseUsageCacheEntry<T>(raw: string): UsageCacheEntry<T> | undefined {
 		const parsed = JSON.parse(raw) as { value?: T; expiresAt?: unknown; staleUntil?: unknown };
 		const expiresAt = typeof parsed.expiresAt === "number" ? parsed.expiresAt : undefined;
 		if (!expiresAt || !Number.isFinite(expiresAt)) return undefined;
-		const staleUntil =
-			typeof parsed.staleUntil === "number"
-				? parsed.staleUntil
-				: parsed.value === null
-					? expiresAt
-					: expiresAt + USAGE_LAST_GOOD_RETENTION_MS;
-		if (!Number.isFinite(staleUntil)) return undefined;
+		const staleUntil = typeof parsed.staleUntil === "number" ? parsed.staleUntil : undefined;
+		if (staleUntil !== undefined && !Number.isFinite(staleUntil)) return undefined;
 		return { value: parsed.value as T, expiresAt, staleUntil };
 	} catch {
 		return undefined;
@@ -1138,7 +1133,7 @@ class AuthStorageUsageCache implements UsageCache {
 		const raw = this.store.getCache(`${USAGE_CACHE_PREFIX}${key}`, { includeExpired: true });
 		if (!raw) return undefined;
 		const entry = parseUsageCacheEntry<T>(raw);
-		return entry && (entry.staleUntil ?? entry.expiresAt) > Date.now() ? entry : undefined;
+		return entry && (entry.staleUntil === undefined || entry.staleUntil > Date.now()) ? entry : undefined;
 	}
 
 	set<T>(key: string, entry: UsageCacheEntry<T>): void {
@@ -3121,22 +3116,13 @@ export class AuthStorage {
 				listUsageCosts: query => this.#store.listUsageCosts?.(query) ?? [],
 			});
 			if (!rawReport) return null;
-			const validatedReport = usageReportSchema(rawReport);
-			if (validatedReport instanceof type.errors) {
-				this.#usageLogger?.debug("Usage provider returned an invalid report", {
-					provider: request.provider,
-					error: validatedReport.summary,
-				});
-				return null;
-			}
-			if (validatedReport.provider !== request.provider) {
-				this.#usageLogger?.debug("Usage provider returned a report for a different provider", {
-					provider: request.provider,
-					reportProvider: validatedReport.provider,
-				});
-				return null;
-			}
-			const report = validatedReport;
+			const report = request.usageProviderExtensionOwned
+				? this.#validateUsageReport(rawReport, {
+						expectedProvider: request.provider,
+						source: "Usage provider",
+					})
+				: rawReport;
+			if (!report) return null;
 			// Attribute the report to the credential's organization. The orgId and
 			// orgName fallbacks apply independently: Claude's usage endpoint stamps
 			// orgId from the `anthropic-organization-id` response header but never

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3186,7 +3186,13 @@ export class AuthStorage {
 			// value through transient failures. Session-cookie providers can opt out
 			// so an expired login does not display stale quota indefinitely.
 			const stale = this.#usageCache.getStale<UsageReport | null>(cacheKey);
-			const retainLastGood = this.#usageProviderResolver?.(request.provider)?.retainLastGoodOnFailure !== false;
+			// Prefer the request's own provider over the global resolver: a provider
+			// registered only in this session owns its stale-cache policy, and asking
+			// the unscoped resolver turns an explicit `retainLastGoodOnFailure: false`
+			// (cookie/login usage that must vanish when the login dies) back into the
+			// default `true`, serving stale quota after invalidation.
+			const policyProvider = request.usageProvider ?? this.#usageProviderResolver?.(request.provider);
+			const retainLastGood = policyProvider?.retainLastGoodOnFailure !== false;
 			const lastGood = retainLastGood ? (stale?.value ?? null) : null;
 			const backoffJitter = USAGE_FAILURE_BACKOFF_MS * (Math.random() * 0.5 - 0.25);
 			const coolDown = Date.now() + USAGE_FAILURE_BACKOFF_MS + backoffJitter;
@@ -3482,14 +3488,24 @@ export class AuthStorage {
 				for (const entry of entries) {
 					if (entry.credential.type !== "oauth") continue;
 					const request = this.#buildUsageRequestForOauth(provider, entry.credential, baseUrl);
-					if (providerImpl.supports && !providerImpl.supports(request)) continue;
+					// Same usage context as every other path below: without it a session
+					// extension overriding xai-oauth passes its own `supports` check and
+					// is then fetched through the unscoped resolver, so its report and
+					// cache partition are ignored for xAI OAuth accounts.
+					request.usageProvider = providerImpl;
+					request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+					request.usageProviderExtensionOwned = usageContext.extensionOwned;
+					if (!this.#usageProviderSupports(providerImpl, request)) continue;
 					requests.push(request);
 					hasUsableStoredOAuthCredential = true;
 				}
 				const oauthToken = $env.XAI_OAUTH_TOKEN?.trim();
 				if (!hasUsableStoredOAuthCredential && oauthToken) {
 					const request = this.#buildUsageRequest(provider, { type: "oauth", accessToken: oauthToken }, baseUrl);
-					if (!providerImpl.supports || providerImpl.supports(request)) requests.push(request);
+					request.usageProvider = providerImpl;
+					request.usageProviderCacheKeyVersion = usageContext.cacheKeyVersion;
+					request.usageProviderExtensionOwned = usageContext.extensionOwned;
+					if (this.#usageProviderSupports(providerImpl, request)) requests.push(request);
 				}
 				continue;
 			}

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -308,6 +308,127 @@ export interface UsageProvider {
 	retainLastGoodOnFailure?: boolean;
 }
 
+export interface UsageProviderRegistration {
+	provider: UsageProvider;
+	sourceId: string;
+}
+
+type StoredUsageProviderRegistration = UsageProviderRegistration;
+
+function validateUsageProviderRegistration(provider: UsageProvider, sourceId: string): void {
+	if (
+		!provider ||
+		typeof provider !== "object" ||
+		typeof provider.id !== "string" ||
+		!provider.id ||
+		provider.id.length > 128 ||
+		!/^[a-z0-9][a-z0-9._-]*$/.test(provider.id) ||
+		typeof provider.fetchUsage !== "function" ||
+		(provider.supports !== undefined && typeof provider.supports !== "function") ||
+		(provider.parseRateLimitHeaders !== undefined && typeof provider.parseRateLimitHeaders !== "function") ||
+		(provider.validatesCredentials !== undefined && typeof provider.validatesCredentials !== "boolean") ||
+		typeof sourceId !== "string" ||
+		!sourceId ||
+		sourceId.length > 4_096 ||
+		/[\u0000-\u001f\u007f]/.test(sourceId)
+	) {
+		throw new TypeError("Invalid extension usage-provider registration");
+	}
+}
+
+/**
+ * Source-owned usage-provider registrations for one runtime scope. Agent
+ * sessions create independent registries even when they share AuthStorage;
+ * one-shot CLIs may synchronize a registry directly into their owned storage.
+ * For each provider, the most recently registered active source wins.
+ */
+export class UsageProviderRegistry {
+	#registrations: Map<Provider, StoredUsageProviderRegistration[]> = new Map();
+	#revisions: Map<Provider, number> = new Map();
+
+	#resolveRegistration(provider: Provider): StoredUsageProviderRegistration | undefined {
+		return this.#registrations.get(provider)?.at(-1);
+	}
+
+	#bumpRevisionIfChanged(provider: Provider, previous: StoredUsageProviderRegistration | undefined): void {
+		const current = this.#resolveRegistration(provider);
+		if (previous?.provider === current?.provider && previous?.sourceId === current?.sourceId) return;
+		this.#revisions.set(provider, (this.#revisions.get(provider) ?? 0) + 1);
+	}
+
+	register(provider: UsageProvider, sourceId: string): void {
+		validateUsageProviderRegistration(provider, sourceId);
+		const previous = this.#resolveRegistration(provider.id);
+		const registrations = this.#registrations.get(provider.id) ?? [];
+		const existingIndex = registrations.findIndex(registration => registration.sourceId === sourceId);
+		if (existingIndex !== -1) registrations.splice(existingIndex, 1);
+		registrations.push({ provider, sourceId });
+		this.#registrations.set(provider.id, registrations);
+		this.#bumpRevisionIfChanged(provider.id, previous);
+	}
+
+	clearSource(sourceId: string): void {
+		for (const [providerId, registrations] of this.#registrations) {
+			const previous = registrations.at(-1);
+			const remaining = registrations.filter(registration => registration.sourceId !== sourceId);
+			if (remaining.length === 0) this.#registrations.delete(providerId);
+			else if (remaining.length !== registrations.length) this.#registrations.set(providerId, remaining);
+			this.#bumpRevisionIfChanged(providerId, previous);
+		}
+	}
+
+	syncSources(activeSourceIds: Iterable<string>): void {
+		const activeSources = new Set(activeSourceIds);
+		for (const [providerId, registrations] of this.#registrations) {
+			const previous = registrations.at(-1);
+			const remaining = registrations.filter(registration => activeSources.has(registration.sourceId));
+			if (remaining.length === 0) this.#registrations.delete(providerId);
+			else if (remaining.length !== registrations.length) this.#registrations.set(providerId, remaining);
+			this.#bumpRevisionIfChanged(providerId, previous);
+		}
+	}
+
+	syncRegistrations(activeSourceIds: Iterable<string>, registrations: readonly UsageProviderRegistration[]): void {
+		const activeSources = new Set(activeSourceIds);
+		const next = new UsageProviderRegistry();
+		for (const { provider, sourceId } of registrations) {
+			if (!activeSources.has(sourceId)) {
+				throw new TypeError("Extension usage-provider source is not active");
+			}
+			next.register(provider, sourceId);
+		}
+		const providerIds = new Set([...this.#registrations.keys(), ...next.#registrations.keys()]);
+		for (const providerId of providerIds) {
+			const previous = this.#resolveRegistration(providerId);
+			const current = next.#resolveRegistration(providerId);
+			if (previous?.provider === current?.provider && previous?.sourceId === current?.sourceId) continue;
+			this.#revisions.set(providerId, (this.#revisions.get(providerId) ?? 0) + 1);
+		}
+		this.#registrations = next.#registrations;
+	}
+
+	providerIds(): Provider[] {
+		return [...this.#registrations.keys()];
+	}
+
+	/**
+	 * Partitions the durable cache per extension source and invalidates it on
+	 * in-process re-registration. Across restarts, staleness is bounded by the
+	 * report TTL, just like builtin providers.
+	 */
+	cacheKeyVersion(provider: Provider): string | undefined {
+		const revision = this.#revisions.get(provider);
+		if (revision === undefined) return undefined;
+		const sourceId = this.#resolveRegistration(provider)?.sourceId;
+		return sourceId === undefined ? `builtin:${revision}` : `${Bun.hash(sourceId).toString(16)}:${revision}`;
+	}
+
+	resolve(provider: Provider): UsageProvider | undefined {
+		const registrations = this.#registrations.get(provider);
+		return registrations?.at(-1)?.provider;
+	}
+}
+
 /** Request context used when ranking usage for a specific model. */
 export interface CredentialRankingContext {
 	/** Provider model id, when the caller is selecting a credential for one model. */

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -398,20 +398,24 @@ describe("withAuth", () => {
 describe("withOAuthAccess", () => {
 	type FakeStorage = OAuthAccessSource & {
 		calls: Array<{ forceRefresh: boolean | undefined } | "rotate">;
+		usageScopes: Array<string | undefined>;
 	};
 
 	function fakeStorage(tokens: { initial?: OAuthAccess; forced?: OAuthAccess; rotated?: OAuthAccess }): FakeStorage {
 		const storage: FakeStorage = {
 			calls: [],
+			usageScopes: [],
 			async getOAuthAccess(_provider, _sessionId, options) {
 				storage.calls.push({ forceRefresh: options?.forceRefresh });
+				storage.usageScopes.push(options?.usageScopeId);
 				if (options?.forceRefresh) return tokens.forced;
 				// After a rotate, the next plain resolve yields the sibling.
 				if (storage.calls.includes("rotate")) return tokens.rotated;
 				return tokens.initial;
 			},
-			async rotateSessionCredential() {
+			async rotateSessionCredential(_provider, _sessionId, options) {
 				storage.calls.push("rotate");
+				storage.usageScopes.push(options?.usageScopeId);
 				return tokens.rotated !== undefined;
 			},
 		};
@@ -428,6 +432,14 @@ describe("withOAuthAccess", () => {
 		const result = await withOAuthAccess(storage, "prov", async a => `ok:${a.accessToken}`);
 		expect(result).toBe("ok:t1");
 		expect(storage.calls).toEqual([{ forceRefresh: undefined }]);
+	});
+
+	it("forwards the session-local usage scope to OAuth resolution", async () => {
+		const storage = fakeStorage({ initial: access("t1") });
+		await withOAuthAccess(storage, "prov", async a => a.accessToken, {
+			usageScopeId: "usage-scope",
+		});
+		expect(storage.usageScopes).toEqual(["usage-scope"]);
 	});
 
 	it("uses the seed for the initial attempt and skips the initial resolve", async () => {

--- a/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
+++ b/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
@@ -642,6 +642,56 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 		expect(await authStorage.rotateSessionCredential(PROVIDER, "sess", { error: authError() })).toBe(false);
 	});
 
+	test("hard-auth rotation ignores siblings blocked only in the session usage scope", async () => {
+		store?.close();
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		const strategy: CredentialRankingStrategy = {
+			findWindowLimits: () => ({}),
+			windowDefaults: { primaryMs: 60_000, secondaryMs: 60_000 },
+		};
+		authStorage = new AuthStorage(store, {
+			rankingStrategyResolver: provider => (provider === PROVIDER ? strategy : undefined),
+		});
+		registerProvider();
+		await authStorage.set(PROVIDER, [
+			{ type: "oauth", access: "acc-A", refresh: "ref-A", expires: farExpiry() },
+			{ type: "oauth", access: "acc-B", refresh: "ref-B", expires: farExpiry() },
+		]);
+		const usageProvider: UsageProvider = {
+			id: PROVIDER,
+			fetchUsage: async () => ({ provider: PROVIDER, fetchedAt: Date.now(), limits: [] }),
+		};
+		const unregister = authStorage.registerSessionUsageProviders("usage-scope", {
+			resolve: provider => (provider === PROVIDER ? usageProvider : undefined),
+			cacheKeyVersion: () => "test:1",
+			providerIds: () => [],
+		});
+
+		try {
+			const first = await authStorage.getApiKey(PROVIDER, "sess", { usageScopeId: "usage-scope" });
+			expect(first).toBeDefined();
+			expect(
+				(
+					await authStorage.markUsageLimitReached(PROVIDER, "sess", {
+						retryAfterMs: 30_000,
+						usageScopeId: "usage-scope",
+					})
+				).switched,
+			).toBe(true);
+			const second = await authStorage.getApiKey(PROVIDER, "sess", { usageScopeId: "usage-scope" });
+			expect(second).toBeDefined();
+			expect(second).not.toBe(first);
+			expect(
+				await authStorage.rotateSessionCredential(PROVIDER, "sess", {
+					error: authError(),
+					usageScopeId: "usage-scope",
+				}),
+			).toBe(false);
+		} finally {
+			unregister();
+		}
+	});
+
 	test("rotateSessionCredential returns false when the session has no sticky credential", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 		registerProvider();

--- a/packages/ai/test/auth-storage-usage-history.test.ts
+++ b/packages/ai/test/auth-storage-usage-history.test.ts
@@ -234,6 +234,31 @@ describe("OpenCode Go usage from observed request costs", () => {
 		expect(refreshed?.limits.find(limit => limit.id === "rolling-5h")?.amount.used).toBe(3);
 	});
 
+	it("refreshes session-scoped usage after recording new observed spend", async () => {
+		const nowMs = Date.parse("2026-06-18T12:00:00Z");
+		const usageScopeId = "observed-cost-session";
+		setSystemTime(new Date(nowMs));
+		const unregister = storage.registerSessionUsageProviders(usageScopeId, {
+			resolve: provider => (provider === "opencode-go" ? opencodeGoUsage.opencodeGoUsageProvider : undefined),
+			cacheKeyVersion: () => "session:1",
+			providerIds: () => [],
+		});
+
+		try {
+			const initialReports = await storage.fetchUsageReports({ usageScopeId });
+			const initial = initialReports?.find(candidate => candidate.provider === "opencode-go");
+			expect(initial?.limits.find(limit => limit.id === "rolling-5h")?.amount.used).toBe(0);
+
+			storage.recordUsageCost("opencode-go", 3, { usageScopeId, recordedAt: nowMs });
+
+			const refreshedReports = await storage.fetchUsageReports({ usageScopeId });
+			const refreshed = refreshedReports?.find(candidate => candidate.provider === "opencode-go");
+			expect(refreshed?.limits.find(limit => limit.id === "rolling-5h")?.amount.used).toBe(3);
+		} finally {
+			unregister();
+		}
+	});
+
 	it("aggregates one key's observed spend into OpenCode Go cap windows", async () => {
 		const nowMs = Date.parse("2026-06-18T12:00:00Z");
 		setSystemTime(new Date(nowMs));

--- a/packages/ai/test/usage-provider-registry.test.ts
+++ b/packages/ai/test/usage-provider-registry.test.ts
@@ -1,0 +1,1126 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { type AuthCredentialStore, AuthStorage, type StoredAuthCredential } from "@oh-my-pi/pi-ai/auth-storage";
+import type { Provider } from "@oh-my-pi/pi-ai/types";
+import {
+	type CredentialRankingStrategy,
+	type UsageProvider,
+	UsageProviderRegistry,
+	type UsageReport,
+} from "@oh-my-pi/pi-ai/usage";
+
+function createUsageProvider(id: Provider): UsageProvider {
+	return {
+		id,
+		async fetchUsage() {
+			return null;
+		},
+	};
+}
+
+function createStore(rows: StoredAuthCredential[] = []): AuthCredentialStore {
+	const cache = new Map<string, { value: string; expiresAtSec: number }>();
+	return {
+		close() {},
+		listAuthCredentials(provider) {
+			return provider === undefined ? rows : rows.filter(row => row.provider === provider);
+		},
+		updateAuthCredential() {},
+		deleteAuthCredential() {},
+		tryDisableAuthCredentialIfMatches() {
+			return false;
+		},
+		replaceAuthCredentialsForProvider() {
+			return rows;
+		},
+		upsertAuthCredentialForProvider() {
+			return rows;
+		},
+		deleteAuthCredentialsForProvider() {},
+		getCache(key, options) {
+			const entry = cache.get(key);
+			if (!entry || (!options?.includeExpired && entry.expiresAtSec * 1_000 <= Date.now())) return null;
+			return entry.value;
+		},
+		setCache(key, value, expiresAtSec) {
+			cache.set(key, { value, expiresAtSec });
+		},
+		cleanExpiredCache() {},
+	};
+}
+
+describe("UsageProviderRegistry", () => {
+	it("uses the most recently registered source for a provider", () => {
+		const registry = new UsageProviderRegistry();
+		const first = createUsageProvider("anthropic");
+		const latest = createUsageProvider("anthropic");
+
+		registry.register(first, "extension:first");
+		registry.register(latest, "extension:latest");
+
+		expect(registry.resolve("anthropic")).toBe(latest);
+	});
+
+	it("replaces and promotes a registration from the same source", () => {
+		const registry = new UsageProviderRegistry();
+		const first = createUsageProvider("anthropic");
+		const otherSource = createUsageProvider("anthropic");
+		const replacement = createUsageProvider("anthropic");
+
+		registry.register(first, "extension:first");
+		registry.register(otherSource, "extension:other");
+		registry.register(replacement, "extension:first");
+
+		expect(registry.resolve("anthropic")).toBe(replacement);
+	});
+
+	it("restores active registrations when sources are cleared or synchronized", () => {
+		const registry = new UsageProviderRegistry();
+		const fallback = createUsageProvider("anthropic");
+		const override = createUsageProvider("anthropic");
+
+		registry.register(fallback, "extension:fallback");
+		registry.register(override, "extension:override");
+		registry.clearSource("extension:override");
+		expect(registry.resolve("anthropic")).toBe(fallback);
+
+		registry.register(override, "extension:override");
+		registry.syncSources(["extension:fallback", "extension:fallback"]);
+		expect(registry.resolve("anthropic")).toBe(fallback);
+	});
+
+	it("keeps registrations isolated by registry instance", () => {
+		const firstRegistry = new UsageProviderRegistry();
+		const secondRegistry = new UsageProviderRegistry();
+		const first = createUsageProvider("anthropic");
+		const second = createUsageProvider("anthropic");
+
+		firstRegistry.register(first, "extension:first");
+		secondRegistry.register(second, "extension:second");
+
+		expect(firstRegistry.resolve("anthropic")).toBe(first);
+		expect(secondRegistry.resolve("anthropic")).toBe(second);
+	});
+});
+
+describe("AuthStorage usage provider registry", () => {
+	it("uses its own registry, falls back to built-ins, and restores them after an override", () => {
+		const storage = new AuthStorage(createStore());
+		const extensionProvider = createUsageProvider("ollama");
+
+		try {
+			const builtInProvider = storage.usageProviderFor("ollama");
+			expect(builtInProvider).toBeDefined();
+
+			storage.syncExtensionUsageProviders(
+				["extension:override"],
+				[{ provider: extensionProvider, sourceId: "extension:override" }],
+			);
+			expect(storage.usageProviderFor("ollama")).toBe(extensionProvider);
+
+			storage.syncExtensionUsageProviders([], []);
+			expect(storage.usageProviderFor("ollama")).toBe(builtInProvider);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps default AuthStorage instances isolated", () => {
+		const firstStorage = new AuthStorage(createStore());
+		const secondStorage = new AuthStorage(createStore());
+		const extensionProvider = createUsageProvider("ollama");
+
+		try {
+			firstStorage.syncExtensionUsageProviders(
+				["extension:first"],
+				[{ provider: extensionProvider, sourceId: "extension:first" }],
+			);
+			expect(firstStorage.usageProviderFor("ollama")).toBe(extensionProvider);
+			expect(secondStorage.usageProviderFor("ollama")).not.toBe(extensionProvider);
+		} finally {
+			firstStorage.close();
+			secondStorage.close();
+		}
+	});
+
+	it("rejects the whole registration batch without changing the active provider", () => {
+		const storage = new AuthStorage(createStore());
+		const current = createUsageProvider("anthropic");
+		const replacement = createUsageProvider("anthropic");
+
+		try {
+			storage.syncExtensionUsageProviders(
+				["extension:current"],
+				[{ provider: current, sourceId: "extension:current" }],
+			);
+
+			expect(() =>
+				storage.syncExtensionUsageProviders(
+					["extension:next"],
+					[
+						{ provider: replacement, sourceId: "extension:next" },
+						{
+							provider: { id: "invalid", fetchUsage: null } as unknown as UsageProvider,
+							sourceId: "extension:next",
+						},
+					],
+				),
+			).toThrow("Invalid extension usage-provider registration");
+			expect(storage.usageProviderFor("anthropic")).toBe(current);
+
+			expect(() =>
+				storage.syncExtensionUsageProviders(
+					["extension:next"],
+					[
+						{
+							provider: {
+								...replacement,
+								validatesCredentials: "yes",
+							} as unknown as UsageProvider,
+							sourceId: "extension:next",
+						},
+					],
+				),
+			).toThrow("Invalid extension usage-provider registration");
+			expect(storage.usageProviderFor("anthropic")).toBe(current);
+
+			expect(() =>
+				storage.syncExtensionUsageProviders(
+					["extension:next"],
+					[{ provider: replacement, sourceId: "extension:inactive" }],
+				),
+			).toThrow("Extension usage-provider source is not active");
+			expect(storage.usageProviderFor("anthropic")).toBe(current);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps extension registrations ahead of an explicit fallback resolver", () => {
+		const registry = new UsageProviderRegistry();
+		const registered = createUsageProvider("anthropic");
+		const explicit = createUsageProvider("anthropic");
+		const storage = new AuthStorage(createStore(), {
+			usageProviderRegistry: registry,
+			usageProviderResolver: provider => (provider === "anthropic" ? explicit : undefined),
+		});
+
+		try {
+			expect(storage.usageProviderFor("anthropic")).toBe(explicit);
+			registry.register(registered, "extension:override");
+			expect(storage.usageProviderFor("anthropic")).toBe(registered);
+			registry.clearSource("extension:override");
+			expect(storage.usageProviderFor("anthropic")).toBe(explicit);
+		} finally {
+			storage.close();
+		}
+	});
+	it("does not reuse cached reports after the active registration changes", async () => {
+		const providerId = "runtime-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]));
+		let firstCalls = 0;
+		let secondCalls = 0;
+		const report = (label: string): UsageReport => ({
+			provider: providerId,
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: `${providerId}:window`,
+					label,
+					scope: { provider: providerId, windowId: "window" },
+					window: { id: "window", label: "Window" },
+					amount: { usedFraction: 0.25, unit: "percent" },
+					status: "ok",
+				},
+			],
+		});
+		const firstProvider: UsageProvider = {
+			id: providerId,
+			async fetchUsage() {
+				firstCalls += 1;
+				return report("First");
+			},
+		};
+		const secondProvider: UsageProvider = {
+			id: providerId,
+			async fetchUsage() {
+				secondCalls += 1;
+				return report("Second");
+			},
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:first"],
+				[{ provider: firstProvider, sourceId: "extension:first" }],
+			);
+			expect((await storage.fetchUsageReports())?.[0]?.limits[0]?.label).toBe("First");
+			expect((await storage.fetchUsageReports())?.[0]?.limits[0]?.label).toBe("First");
+			expect(firstCalls).toBe(1);
+
+			storage.syncExtensionUsageProviders(
+				["extension:second"],
+				[{ provider: secondProvider, sourceId: "extension:second" }],
+			);
+			expect((await storage.fetchUsageReports())?.[0]?.limits[0]?.label).toBe("Second");
+			expect(secondCalls).toBe(1);
+		} finally {
+			storage.close();
+		}
+	});
+	it("uses caller-scoped providers without leaking shared registrations", async () => {
+		const providerId = "runtime-scoped-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]));
+		const sharedProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({ provider: providerId, fetchedAt: 1, limits: [] }),
+		};
+		const localProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({ provider: providerId, fetchedAt: 2, limits: [] }),
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:shared"],
+				[{ provider: sharedProvider, sourceId: "extension:shared" }],
+			);
+			expect((await storage.fetchUsageReports())?.[0]?.fetchedAt).toBe(1);
+			const unregisterLocal = storage.registerSessionUsageProviders("local-session", {
+				resolve: provider => (provider === providerId ? localProvider : undefined),
+				cacheKeyVersion: provider => (provider === providerId ? "local:1" : null),
+				providerIds: () => [],
+			});
+			const unregisterEmpty = storage.registerSessionUsageProviders("empty-session", {
+				resolve: () => undefined,
+				cacheKeyVersion: () => null,
+				providerIds: () => [],
+			});
+			try {
+				expect(
+					(await storage.fetchUsageReports({ usageScopeId: "local-session:side-channel" }))?.[0]?.fetchedAt,
+				).toBe(2);
+				expect(await storage.fetchUsageReports({ usageScopeId: "empty-session" })).toEqual([]);
+			} finally {
+				unregisterEmpty();
+				unregisterLocal();
+			}
+			expect((await storage.fetchUsageReports())?.[0]?.fetchedAt).toBe(1);
+		} finally {
+			storage.close();
+		}
+	});
+	it("isolates a scoped built-in fallback from a global extension cache", async () => {
+		const providerId = "scoped-fallback-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		let builtInCalls = 0;
+		let extensionCalls = 0;
+		const builtInProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({ provider: providerId, fetchedAt: ++builtInCalls, limits: [] }),
+		};
+		const extensionProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({ provider: providerId, fetchedAt: 100 + ++extensionCalls, limits: [] }),
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]), {
+			usageProviderResolver: provider => (provider === providerId ? builtInProvider : undefined),
+		});
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:global"],
+				[{ provider: extensionProvider, sourceId: "extension:global" }],
+			);
+			expect((await storage.fetchUsageReports())?.[0]?.fetchedAt).toBe(101);
+
+			const unregister = storage.registerSessionUsageProviders("scoped-session", {
+				resolve: () => undefined,
+				cacheKeyVersion: () => null,
+				providerIds: () => [],
+			});
+			try {
+				expect((await storage.fetchUsageReports({ usageScopeId: "scoped-session" }))?.[0]?.fetchedAt).toBe(1);
+				expect(builtInCalls).toBe(1);
+				expect(extensionCalls).toBe(1);
+			} finally {
+				unregister();
+			}
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("enumerates scope-only provider ids so env-backed extension providers are fetched", async () => {
+		const providerId = "groq";
+		const storage = new AuthStorage(createStore([]));
+		const scopedProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({ provider: providerId, fetchedAt: 7, limits: [] }),
+		};
+		const previousEnv = Bun.env.GROQ_API_KEY;
+		Bun.env.GROQ_API_KEY = "groq-env-key";
+		try {
+			await storage.reload();
+			const unregister = storage.registerSessionUsageProviders("env-session", {
+				resolve: provider => (provider === providerId ? scopedProvider : undefined),
+				cacheKeyVersion: provider => (provider === providerId ? "env:1" : null),
+				providerIds: () => [providerId],
+			});
+			try {
+				const scoped = await storage.fetchUsageReports({ usageScopeId: "env-session" });
+				expect(scoped?.map(report => report.provider)).toContain(providerId);
+			} finally {
+				unregister();
+			}
+			// Without the scope registration, the id is not enumerated anywhere.
+			const unscoped = await storage.fetchUsageReports();
+			expect(unscoped?.map(report => report.provider) ?? []).not.toContain(providerId);
+		} finally {
+			if (previousEnv === undefined) delete Bun.env.GROQ_API_KEY;
+			else Bun.env.GROQ_API_KEY = previousEnv;
+			storage.close();
+		}
+	});
+	it("expires extension-versioned cache keys on all-provider invalidation", async () => {
+		const providerId = "invalidate-scoped-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]));
+		let fetches = 0;
+		const scopedProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				fetches += 1;
+				return { provider: providerId, fetchedAt: fetches, limits: [] };
+			},
+		};
+
+		try {
+			await storage.reload();
+			const unregister = storage.registerSessionUsageProviders("local-session", {
+				resolve: provider => (provider === providerId ? scopedProvider : undefined),
+				cacheKeyVersion: () => "local:1",
+				providerIds: () => [providerId],
+			});
+			const fetchedAt = async () =>
+				(await storage.fetchUsageReports({ usageScopeId: "local-session" }))?.find(
+					report => report.provider === providerId,
+				)?.fetchedAt;
+			try {
+				expect(await fetchedAt()).toBe(1);
+				// Cached: no refetch within TTL.
+				expect(await fetchedAt()).toBe(1);
+				await storage.invalidateUsageCache();
+				// All-provider invalidation must also expire the extension-versioned key.
+				expect(await fetchedAt()).toBe(2);
+			} finally {
+				unregister();
+			}
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("expires scope-only env-backed cache keys on all-provider invalidation", async () => {
+		const providerId = "groq";
+		const storage = new AuthStorage(createStore([]));
+		let fetches = 0;
+		const scopedProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				fetches += 1;
+				return { provider: providerId, fetchedAt: fetches, limits: [] };
+			},
+		};
+		const previousEnv = Bun.env.GROQ_API_KEY;
+		Bun.env.GROQ_API_KEY = "groq-env-key";
+		try {
+			await storage.reload();
+			const unregister = storage.registerSessionUsageProviders("env-session", {
+				resolve: provider => (provider === providerId ? scopedProvider : undefined),
+				cacheKeyVersion: provider => (provider === providerId ? "env:1" : null),
+				providerIds: () => [providerId],
+			});
+			const fetchedAt = async () =>
+				(await storage.fetchUsageReports({ usageScopeId: "env-session" }))?.find(
+					report => report.provider === providerId,
+				)?.fetchedAt;
+			try {
+				expect(await fetchedAt()).toBe(1);
+				// Cached within TTL: no refetch.
+				expect(await fetchedAt()).toBe(1);
+				await storage.invalidateUsageCache();
+				// The provider has no stored credential; the env-backed api-key cache
+				// key must still be expired by an all-provider invalidation.
+				expect(await fetchedAt()).toBe(2);
+			} finally {
+				unregister();
+			}
+		} finally {
+			if (previousEnv === undefined) delete Bun.env.GROQ_API_KEY;
+			else Bun.env.GROQ_API_KEY = previousEnv;
+			storage.close();
+		}
+	});
+
+	it("merges a session-scoped provider over remote store usage", async () => {
+		const providerId = "remote-scoped-usage";
+		const accountId = "account-1";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId,
+		};
+		const store: AuthCredentialStore = {
+			...createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]),
+			fetchUsageReports: async () => [
+				{ provider: providerId, fetchedAt: 1, limits: [], metadata: { accountId, remoteOnly: true } },
+			],
+		};
+		const storage = new AuthStorage(store);
+		const scopedProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({
+				provider: providerId,
+				fetchedAt: 2,
+				limits: [],
+				metadata: { accountId },
+			}),
+		};
+
+		try {
+			await storage.reload();
+			const unregister = storage.registerSessionUsageProviders("local-session", {
+				resolve: provider => (provider === providerId ? scopedProvider : undefined),
+				cacheKeyVersion: () => "local:1",
+				providerIds: () => [],
+			});
+			try {
+				expect((await storage.fetchUsageReports())?.[0]?.fetchedAt).toBe(1);
+				expect((await storage.fetchUsageReports({ usageScopeId: "local-session" }))?.[0]?.fetchedAt).toBe(2);
+				expect(
+					(await storage.fetchUsageReports({ usageScopeId: "local-session" }))?.[0]?.metadata?.remoteOnly,
+				).toBeUndefined();
+			} finally {
+				unregister();
+			}
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("fetches global extension providers alongside remote store usage", async () => {
+		const providerId = "global-remote-usage";
+		const credential = { type: "api_key" as const, key: "test-key" };
+		const store: AuthCredentialStore = {
+			...createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]),
+			fetchUsageReports: async () => [
+				{ provider: providerId, fetchedAt: 1, limits: [], metadata: { remoteOnly: true } },
+			],
+		};
+		const storage = new AuthStorage(store);
+		const extensionProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => ({ provider: providerId, fetchedAt: 2, limits: [] }),
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:global-remote"],
+				[{ provider: extensionProvider, sourceId: "extension:global-remote" }],
+			);
+			expect(await storage.fetchUsageReports()).toEqual([{ provider: providerId, fetchedAt: 2, limits: [] }]);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps a global extension provider authoritative over a per-credential store hook", async () => {
+		const providerId = "global-remote-oauth";
+		const credential = {
+			type: "oauth" as const,
+			access: "extension-access",
+			refresh: "extension-refresh",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		let storeFetches = 0;
+		let extensionFetches = 0;
+		const secondCredential = { ...credential, access: "extension-access-2", accountId: "account-2" };
+		const store: AuthCredentialStore = {
+			...createStore([
+				{ id: 1, provider: providerId, credential, disabledCause: null },
+				{ id: 2, provider: providerId, credential: secondCredential, disabledCause: null },
+			]),
+			getUsageReport: async () => {
+				storeFetches += 1;
+				return { provider: providerId, fetchedAt: 1, limits: [] };
+			},
+		};
+		const strategy: CredentialRankingStrategy = {
+			findWindowLimits: () => ({}),
+			windowDefaults: { primaryMs: 60_000, secondaryMs: 60_000 },
+		};
+		const storage = new AuthStorage(store, { rankingStrategyResolver: () => strategy });
+		const extensionProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				extensionFetches += 1;
+				return { provider: providerId, fetchedAt: 2, limits: [] };
+			},
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:global-oauth"],
+				[{ provider: extensionProvider, sourceId: "extension:global-oauth" }],
+			);
+			expect(["extension-access", "extension-access-2"]).toContain(
+				(await storage.getApiKey(providerId, "session-1")) ?? "",
+			);
+			expect(extensionFetches).toBe(2);
+			expect(storeFetches).toBe(0);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("rejects malformed reports from a store override", async () => {
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const store: AuthCredentialStore = {
+			...createStore([{ id: 1, provider: "anthropic", credential, disabledCause: null }]),
+			fetchUsageReports: async () =>
+				[
+					{ provider: "anthropic", fetchedAt: 1 },
+					{ provider: "anthropic", fetchedAt: 3, limits: [] },
+				] as UsageReport[],
+		};
+		const storage = new AuthStorage(store);
+
+		try {
+			await storage.reload();
+			expect(await storage.fetchUsageReports()).toEqual([{ provider: "anthropic", fetchedAt: 3, limits: [] }]);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("collects configured API keys for custom extension providers", async () => {
+		const providerId = "configured-extension-usage";
+		const storage = new AuthStorage(
+			createStore([
+				{
+					id: 1,
+					provider: providerId,
+					credential: { type: "api_key", key: "stored-key" },
+					disabledCause: null,
+				},
+			]),
+		);
+		const extensionProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async params => ({
+				provider: providerId,
+				fetchedAt: params.credential.type === "api_key" && params.credential.apiKey === "config-key" ? 2 : 1,
+				limits: [],
+			}),
+		};
+
+		try {
+			await storage.reload();
+			storage.setConfigApiKey(providerId, "config-key");
+			storage.syncExtensionUsageProviders(
+				["extension:configured"],
+				[{ provider: extensionProvider, sourceId: "extension:configured" }],
+			);
+			expect((await storage.fetchUsageReports())?.[0]?.fetchedAt).toBe(2);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("bounds last-good retention for persistent and session-scoped caches", async () => {
+		const now = spyOn(Date, "now");
+		let caseStart = 1_800_000_000_000;
+		now.mockReturnValue(caseStart);
+
+		const exerciseCache = async (usageScopeId?: string): Promise<void> => {
+			caseStart += 100_000_000;
+			now.mockReturnValue(caseStart);
+			const providerId = usageScopeId ? "memory-stale-usage" : "persistent-stale-usage";
+			const storage = new AuthStorage(
+				createStore([
+					{
+						id: 1,
+						provider: providerId,
+						credential: { type: "api_key", key: "test-key" },
+						disabledCause: null,
+					},
+				]),
+			);
+			let fail = false;
+			let fetchCalls = 0;
+			const provider: UsageProvider = {
+				id: providerId,
+				fetchUsage: async () => {
+					fetchCalls += 1;
+					return fail ? null : { provider: providerId, fetchedAt: caseStart, limits: [] };
+				},
+			};
+			let unregister: (() => void) | undefined;
+
+			try {
+				await storage.reload();
+				if (usageScopeId) {
+					unregister = storage.registerSessionUsageProviders(usageScopeId, {
+						resolve: candidate => (candidate === providerId ? provider : undefined),
+						cacheKeyVersion: () => "test:1",
+						providerIds: () => [],
+					});
+				} else {
+					storage.syncExtensionUsageProviders(["extension:stale"], [{ provider, sourceId: "extension:stale" }]);
+				}
+				const options = usageScopeId ? { usageScopeId } : undefined;
+				expect((await storage.fetchUsageReports(options))?.[0]?.fetchedAt).toBe(caseStart);
+				expect(fetchCalls).toBe(1);
+				fail = true;
+				now.mockReturnValue(caseStart + 24 * 3_600_000 - 1_000);
+				expect((await storage.fetchUsageReports(options))?.[0]?.fetchedAt).toBe(caseStart);
+				expect(fetchCalls).toBe(2);
+				now.mockReturnValue(caseStart + 24 * 3_600_000 + 1_000);
+				expect(await storage.fetchUsageReports(options)).toEqual([]);
+				expect(fetchCalls).toBe(3);
+			} finally {
+				unregister?.();
+				storage.close();
+			}
+		};
+
+		try {
+			await exerciseCache();
+			await exerciseCache("session-scope");
+		} finally {
+			now.mockRestore();
+		}
+	});
+
+	it("coalesces concurrent reports across session scopes with the same durable cache key", async () => {
+		const providerId = "concurrent-scoped-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]));
+		let firstCalls = 0;
+		let secondCalls = 0;
+		const { promise: firstStarted, resolve: markFirstStarted } = Promise.withResolvers<void>();
+		const { promise: firstCanFinish, resolve: releaseFirst } = Promise.withResolvers<void>();
+		const firstProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				firstCalls += 1;
+				markFirstStarted();
+				await firstCanFinish;
+				return { provider: providerId, fetchedAt: 1, limits: [] };
+			},
+		};
+		const secondProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				secondCalls += 1;
+				return { provider: providerId, fetchedAt: 2, limits: [] };
+			},
+		};
+		const firstScope = {
+			resolve: () => firstProvider,
+			cacheKeyVersion: () => "same-source:1",
+			providerIds: () => [],
+		};
+		const secondScope = {
+			resolve: () => secondProvider,
+			cacheKeyVersion: () => "same-source:1",
+			providerIds: () => [],
+		};
+
+		try {
+			await storage.reload();
+			const unregisterFirst = storage.registerSessionUsageProviders("first-session", firstScope);
+			const unregisterSecond = storage.registerSessionUsageProviders("second-session", secondScope);
+			try {
+				const firstPromise = storage.fetchUsageReports({ usageScopeId: "first-session" });
+				await firstStarted;
+				const secondPromise = storage.fetchUsageReports({ usageScopeId: "second-session" });
+				releaseFirst();
+				const [first, second] = await Promise.all([firstPromise, secondPromise]);
+				expect(first?.[0]?.fetchedAt).toBe(1);
+				expect(second?.[0]?.fetchedAt).toBe(1);
+				expect(firstCalls).toBe(1);
+				expect(secondCalls).toBe(0);
+			} finally {
+				unregisterSecond();
+				unregisterFirst();
+			}
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("ingests headers through a globally registered extension provider", async () => {
+		const providerId = "header-global-usage";
+		const report: UsageReport = { provider: providerId, fetchedAt: Date.now(), limits: [] };
+		let storeIngests = 0;
+		let fetchCalls = 0;
+		const store: AuthCredentialStore = {
+			...createStore([
+				{
+					id: 1,
+					credential: {
+						type: "oauth",
+						access: "access-token",
+						refresh: "refresh-token",
+						expires: Date.now() + 3_600_000,
+					},
+					provider: providerId,
+					disabledCause: null,
+				},
+			]),
+			ingestUsageReport() {
+				storeIngests += 1;
+				return true;
+			},
+		};
+		const registry = new UsageProviderRegistry();
+		registry.register(
+			{
+				id: providerId,
+				parseRateLimitHeaders: () => report,
+				fetchUsage: async () => {
+					fetchCalls += 1;
+					return report;
+				},
+			},
+			"extension:header-global",
+		);
+		const storage = new AuthStorage(store, { usageProviderRegistry: registry });
+
+		try {
+			await storage.reload();
+			expect(storage.ingestUsageHeaders(providerId, {})).toBe(true);
+			expect(storeIngests).toBe(0);
+			expect((await storage.fetchUsageReports())?.[0]?.provider).toBe(providerId);
+			expect(fetchCalls).toBe(0);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps extension header reports in the durable cache and records fetched history", async () => {
+		const providerId = "header-scoped-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const report: UsageReport = {
+			provider: providerId,
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: `${providerId}:window`,
+					label: "Scoped",
+					scope: { provider: providerId, windowId: "window" },
+					window: { id: "window", label: "Window" },
+					amount: { usedFraction: 0.25, unit: "percent" },
+					status: "ok",
+				},
+			],
+		};
+		let storeIngests = 0;
+		let recordedEntries = 0;
+		let fetchCalls = 0;
+		const store: AuthCredentialStore = {
+			...createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]),
+			ingestUsageReport() {
+				storeIngests += 1;
+				return true;
+			},
+			recordUsageSnapshots(entries) {
+				recordedEntries += entries.length;
+			},
+		};
+		const storage = new AuthStorage(store);
+		const provider: UsageProvider = {
+			id: providerId,
+			parseRateLimitHeaders: () => report,
+			fetchUsage: async () => {
+				fetchCalls += 1;
+				return report;
+			},
+		};
+		const unregister = storage.registerSessionUsageProviders("header-session", {
+			resolve: () => provider,
+			cacheKeyVersion: () => "header-source:1",
+			providerIds: () => [],
+		});
+
+		try {
+			await storage.reload();
+			expect(
+				storage.ingestUsageHeaders(
+					providerId,
+					{},
+					{
+						sessionId: "header-session",
+						usageScopeId: "header-session",
+					},
+				),
+			).toBe(true);
+			expect(storeIngests).toBe(0);
+			expect((await storage.fetchUsageReports({ usageScopeId: "header-session" }))?.[0]?.limits[0]?.label).toBe(
+				"Scoped",
+			);
+			expect(fetchCalls).toBe(0);
+			expect(recordedEntries).toBe(0);
+
+			await storage.invalidateUsageCache(providerId);
+			expect((await storage.fetchUsageReports({ usageScopeId: "header-session" }))?.[0]?.limits[0]?.label).toBe(
+				"Scoped",
+			);
+			expect(fetchCalls).toBe(1);
+			expect(recordedEntries).toBe(1);
+		} finally {
+			unregister();
+			storage.close();
+		}
+	});
+
+	it("reuses durable cache entries across process restart until the report TTL expires", async () => {
+		const providerId = "reloaded-extension-usage";
+		const store = createStore([
+			{
+				id: 1,
+				provider: providerId,
+				credential: { type: "api_key", key: "runtime-key" },
+				disabledCause: null,
+			},
+		]);
+		let firstCalls = 0;
+		let secondCalls = 0;
+		const firstProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				firstCalls += 1;
+				return { provider: providerId, fetchedAt: 1, limits: [] };
+			},
+		};
+		const secondProvider: UsageProvider = {
+			id: providerId,
+			fetchUsage: async () => {
+				secondCalls += 1;
+				return { provider: providerId, fetchedAt: 2, limits: [] };
+			},
+		};
+		const firstStorage = new AuthStorage(store);
+		await firstStorage.reload();
+		firstStorage.syncExtensionUsageProviders(
+			["extension:reload"],
+			[{ provider: firstProvider, sourceId: "extension:reload" }],
+		);
+		expect((await firstStorage.fetchUsageReports())?.[0]?.fetchedAt).toBe(1);
+		firstStorage.close();
+
+		const secondStorage = new AuthStorage(store);
+		try {
+			await secondStorage.reload();
+			secondStorage.syncExtensionUsageProviders(
+				["extension:reload"],
+				[{ provider: secondProvider, sourceId: "extension:reload" }],
+			);
+			expect((await secondStorage.fetchUsageReports())?.[0]?.fetchedAt).toBe(1);
+			expect(firstCalls).toBe(1);
+			expect(secondCalls).toBe(0);
+		} finally {
+			secondStorage.close();
+		}
+	});
+
+	it("contains throwing extension supports callbacks", async () => {
+		const providerId = "throwing-supports-usage";
+		const storage = new AuthStorage(
+			createStore([
+				{
+					id: 1,
+					provider: providerId,
+					credential: { type: "api_key", key: "runtime-key" },
+					disabledCause: null,
+				},
+			]),
+		);
+		let fetchCalls = 0;
+		const provider: UsageProvider = {
+			id: providerId,
+			supports() {
+				throw new Error("supports failed");
+			},
+			async fetchUsage() {
+				fetchCalls += 1;
+				return { provider: providerId, fetchedAt: 1, limits: [] };
+			},
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:throwing-supports"],
+				[{ provider, sourceId: "extension:throwing-supports" }],
+			);
+			expect(await storage.fetchUsageReports()).toEqual([]);
+			expect(fetchCalls).toBe(0);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("contains throwing extension header parsers", async () => {
+		const providerId = "throwing-header-parser";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]));
+		const provider: UsageProvider = {
+			id: providerId,
+			async fetchUsage() {
+				return null;
+			},
+			parseRateLimitHeaders() {
+				throw new Error("parser failed");
+			},
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:throwing-parser"],
+				[{ provider, sourceId: "extension:throwing-parser" }],
+			);
+			await storage.getApiKey(providerId, "header-session");
+			expect(storage.ingestUsageHeaders(providerId, {}, { sessionId: "header-session" })).toBe(false);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("rejects malformed and cross-provider usage reports", async () => {
+		const providerId = "malformed-usage";
+		const credential = {
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+			accountId: "account-1",
+		};
+		const storage = new AuthStorage(createStore([{ id: 1, provider: providerId, credential, disabledCause: null }]));
+		const provider: UsageProvider = {
+			id: providerId,
+			async fetchUsage() {
+				return { provider: providerId, fetchedAt: 1 } as unknown as UsageReport;
+			},
+			parseRateLimitHeaders() {
+				return { provider: "wrong-provider", fetchedAt: 1, limits: [] };
+			},
+		};
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(["extension:malformed"], [{ provider, sourceId: "extension:malformed" }]);
+			expect(await storage.fetchUsageReports()).toEqual([]);
+			await storage.getApiKey(providerId, "header-session");
+			expect(storage.ingestUsageHeaders(providerId, {}, { sessionId: "header-session" })).toBe(false);
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps an observed usage-limit retry block credential-wide with extension providers", async () => {
+		const providerId = "global-extension-block";
+		const storage = new AuthStorage(
+			createStore([
+				{
+					id: 1,
+					provider: providerId,
+					credential: { type: "api_key", key: "first-key" },
+					disabledCause: null,
+				},
+				{
+					id: 2,
+					provider: providerId,
+					credential: { type: "api_key", key: "second-key" },
+					disabledCause: null,
+				},
+			]),
+		);
+		const provider = createUsageProvider(providerId);
+
+		try {
+			await storage.reload();
+			storage.syncExtensionUsageProviders(
+				["extension:global-block"],
+				[{ provider, sourceId: "extension:global-block" }],
+			);
+			await storage.markUsageLimitReached(providerId, "first-session", {
+				credentialId: 1,
+				retryAfterMs: 60_000,
+			});
+			expect(await storage.getApiKey(providerId, "sibling-session")).toBe("second-key");
+		} finally {
+			storage.close();
+		}
+	});
+});

--- a/packages/ai/test/usage-provider-registry.test.ts
+++ b/packages/ai/test/usage-provider-registry.test.ts
@@ -742,6 +742,52 @@ describe("AuthStorage usage provider registry", () => {
 		}
 	});
 
+	it("honors a session-scoped provider's stale-cache opt-out on failure", async () => {
+		const now = spyOn(Date, "now");
+		const start = 1_900_000_000_000;
+		now.mockReturnValue(start);
+		const providerId = "scoped-optout-usage";
+		const storage = new AuthStorage(
+			createStore([
+				{ id: 1, provider: providerId, credential: { type: "api_key", key: "test-key" }, disabledCause: null },
+			]),
+		);
+		let fail = false;
+		const provider: UsageProvider = {
+			id: providerId,
+			// Cookie/login-style usage: when the login dies the quota must disappear
+			// rather than keep displaying the last good value.
+			retainLastGoodOnFailure: false,
+			fetchUsage: async () => (fail ? null : { provider: providerId, fetchedAt: start, limits: [] }),
+		};
+		let unregister: (() => void) | undefined;
+
+		try {
+			await storage.reload();
+			// Registered ONLY in the session scope, so the global resolver knows
+			// nothing about this provider — which is why the retention policy has to
+			// be read off the request rather than re-resolved unscoped.
+			unregister = storage.registerSessionUsageProviders("optout-session", {
+				resolve: candidate => (candidate === providerId ? provider : undefined),
+				cacheKeyVersion: () => "optout:1",
+				providerIds: () => [providerId],
+			});
+			const options = { usageScopeId: "optout-session" };
+			expect((await storage.fetchUsageReports(options))?.[0]?.fetchedAt).toBe(start);
+
+			// Same window the default-retention case uses to prove a refetch happens
+			// and last-good is still inside its retention bound; the opt-out is what
+			// must drop the report instead of serving the stale value.
+			fail = true;
+			now.mockReturnValue(start + 24 * 3_600_000 - 1_000);
+			expect(await storage.fetchUsageReports(options)).toEqual([]);
+		} finally {
+			unregister?.();
+			storage.close();
+			now.mockRestore();
+		}
+	});
+
 	it("coalesces concurrent reports across session scopes with the same durable cache key", async () => {
 		const providerId = "concurrent-scoped-usage";
 		const credential = {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed advisor tools losing any member exposed through a class prototype when bound to a per-advisor identity. Eval, Edit and Task build their `parameters` schema behind a getter, so the own-descriptor clone dropped it and `normalizeTools` handed `undefined` to `toolWireSchema`, failing the advisor turn before any tool ran. Inherited accessors are now re-published as delegating getters, which also keeps getters backed by `#private` state working.
+- Fixed session credential resolution bypassing the session usage-provider scope on several paths, so an extension-registered usage provider was ignored by ephemeral `/btw` and `/omfg` turns, branch summaries, main-turn key validation, scoped-model availability checks, and the unexpected-stop classifier.
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -11,13 +11,14 @@
  * `ls`/`find` use the cache when fresh (`online-if-uncached`); only `refresh`
  * forces the network (`online`).
  */
-import type { Api, Effort, Model } from "@oh-my-pi/pi-ai";
+import { type Api, type Effort, type Model, UsageProviderRegistry } from "@oh-my-pi/pi-ai";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
 import {
+	collectExtensionUsageProviderRegistrations,
 	discoverAndLoadExtensions,
 	ExtensionRunner,
 	emitSessionShutdownEvent,
@@ -325,8 +326,13 @@ export async function runModelsListing(options: RunModelsListingOptions): Promis
 			process.stderr.write(`Failed to load extension: ${extPath}: ${error}\n`);
 		}
 
-		// Mirror sdk.ts: drain pending provider registrations into the registry.
+		// Validate every pending registration before changing either durable registry.
 		const activeSources = extensionsResult.extensions.map(extension => extension.path);
+		const usageRegistrations = collectExtensionUsageProviderRegistrations(extensionsResult.extensions);
+		new UsageProviderRegistry().syncRegistrations(activeSources, usageRegistrations);
+		for (const { name, config } of extensionsResult.runtime.pendingProviderRegistrations) {
+			modelRegistry.validateProviderRegistration(name, config);
+		}
 		modelRegistry.syncExtensionSources(activeSources);
 		for (const sourceId of new Set(activeSources)) {
 			modelRegistry.clearSourceRegistrations(sourceId);
@@ -335,7 +341,7 @@ export async function runModelsListing(options: RunModelsListingOptions): Promis
 			modelRegistry.registerProvider(name, config, sourceId);
 		}
 		extensionsResult.runtime.pendingProviderRegistrations = [];
-		// Discover runtime (extension) provider catalogs now that they are registered.
+		modelRegistry.authStorage.syncExtensionUsageProviders(activeSources, usageRegistrations);
 		await modelRegistry.refreshRuntimeProviders(action === "refresh" ? "online" : "online-if-uncached");
 
 		renderProviderModels(modelRegistry, action, pattern, json);

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -15,10 +15,11 @@ import {
 	type UsageReport,
 	type UsageUnit,
 } from "@oh-my-pi/pi-ai";
-import { formatDuration, formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, formatNumber, getProjectDir, sanitizeText } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { ModelRegistry } from "../config/model-registry";
-import { discoverAuthStorage } from "../sdk";
+import { Settings } from "../config/settings";
+import { discoverAuthStorage, loadCliExtensionProviders } from "../sdk";
 
 const BAR_WIDTH = 28;
 
@@ -27,10 +28,27 @@ export interface UsageCommandArgs {
 	json?: boolean;
 	provider?: string;
 	redact?: boolean;
+	extensions?: string[];
+	noExtensions?: boolean;
+	config?: string[];
 	/** Show recorded usage-limit history instead of a live snapshot. */
 	history?: boolean;
 	/** History window in days (with `history`). */
 	days?: number;
+}
+
+export interface UsageCommandDependencies {
+	discoverAuthStorage?: () => Promise<AuthStorage>;
+	prepareModelRegistry?: (modelRegistry: ModelRegistry, command: UsageCommandArgs) => Promise<void>;
+}
+
+async function prepareUsageModelRegistry(modelRegistry: ModelRegistry, command: UsageCommandArgs): Promise<void> {
+	const cwd = getProjectDir();
+	const settings = await Settings.init({ cwd, configFiles: command.config });
+	await loadCliExtensionProviders(modelRegistry, settings, cwd, {
+		additionalExtensionPaths: command.extensions,
+		disableExtensionDiscovery: command.noExtensions,
+	});
 }
 
 /** Identity slice of a stored credential, for "every account" coverage. */
@@ -813,10 +831,15 @@ function redactReportForJson(
 	return { ...report, metadata, limits };
 }
 
-export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
-	const authStorage = await discoverAuthStorage();
+export async function runUsageCommand(
+	cmd: UsageCommandArgs,
+	dependencies: UsageCommandDependencies = {},
+): Promise<void> {
+	const authStorage = await (dependencies.discoverAuthStorage ?? discoverAuthStorage)();
 	try {
 		if (cmd.action === "invalidate") {
+			const modelRegistry = new ModelRegistry(authStorage);
+			await (dependencies.prepareModelRegistry ?? prepareUsageModelRegistry)(modelRegistry, cmd);
 			const provider = cmd.provider?.toLowerCase();
 			await authStorage.invalidateUsageCache(provider);
 			if (provider) {
@@ -858,6 +881,7 @@ export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
 			return;
 		}
 		const modelRegistry = new ModelRegistry(authStorage);
+		await (dependencies.prepareModelRegistry ?? prepareUsageModelRegistry)(modelRegistry, cmd);
 		const reports =
 			(await authStorage.fetchUsageReports({
 				baseUrlResolver: provider => modelRegistry.getProviderBaseUrl(provider),

--- a/packages/coding-agent/src/commands/usage.ts
+++ b/packages/coding-agent/src/commands/usage.ts
@@ -28,6 +28,18 @@ export default class Usage extends Command {
 			default: false,
 		}),
 		days: Flags.integer({ char: "d", description: "History window in days (with --history)", default: 7 }),
+		extension: Flags.string({
+			char: "e",
+			description: "Load an extension file before fetching usage (repeatable)",
+			multiple: true,
+		}),
+		"no-extensions": Flags.boolean({
+			description: "Disable extension discovery (explicit -e paths still work)",
+		}),
+		config: Flags.string({
+			description: "Load an extra config.yml-style overlay for this run (repeatable)",
+			multiple: true,
+		}),
 	};
 
 	static examples = [
@@ -36,6 +48,7 @@ export default class Usage extends Command {
 		"# Redact account identifiers for screenshots\n  omp usage --redact",
 		"# Machine-readable output\n  omp usage --json",
 		"# Usage-limit trend over the last 30 days\n  omp usage --history --days 30",
+		"# Fetch usage from a source-shipped extension\n  omp usage -e ./packages/provider/src/extension.ts",
 		"# Invalidate cached usage reports for all providers\n  omp usage invalidate",
 		"# Invalidate cached usage reports for a specific provider\n  omp usage invalidate --provider anthropic",
 	];
@@ -49,6 +62,9 @@ export default class Usage extends Command {
 			redact: flags.redact,
 			history: flags.history,
 			days: flags.days,
+			extensions: flags.extension,
+			noExtensions: flags["no-extensions"],
+			config: flags.config,
 		});
 	}
 }

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -7,6 +7,8 @@ export type ApiKeyResolverModel = Pick<Model<Api>, "provider" | "baseUrl" | "id"
 export interface ApiKeyResolverOptions {
 	/** Session id for credential stickiness; read at resolve time by the caller. */
 	sessionId?: string;
+	/** Owning AgentSession id for extension usage-provider lookup and session-local quota state. */
+	usageScopeId?: string;
 	/** Provider base URL hint forwarded to the auth-storage cascade. */
 	baseUrl?: string;
 	/** Provider model id forwarded to model-scoped usage ranking/backoff. */
@@ -22,7 +24,13 @@ export interface ApiKeyResolverRegistry {
 	getApiKeyForProvider(
 		provider: string,
 		sessionId?: string,
-		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
+		options?: {
+			baseUrl?: string;
+			modelId?: string;
+			forceRefresh?: boolean;
+			signal?: AbortSignal;
+			usageScopeId?: string;
+		},
 	): Promise<string | undefined>;
 	authStorage: Pick<AuthStorage, "rotateSessionCredential">;
 	/**
@@ -37,7 +45,7 @@ export interface ApiKeyResolverRegistry {
 	 * `resolveApiKeyOnce(resolver)`.
 	 */
 	resolver(provider: string, options?: ApiKeyResolverOptions): ApiKeyResolver;
-	resolver(model: ApiKeyResolverModel, sessionId?: string): ApiKeyResolver;
+	resolver(model: ApiKeyResolverModel, options?: string | ApiKeyResolverOptions): ApiKeyResolver;
 }
 
 /**
@@ -49,10 +57,10 @@ export function createApiKeyResolver(
 	provider: string,
 	options: ApiKeyResolverOptions = {},
 ): ApiKeyResolver {
-	const { sessionId, baseUrl, modelId } = options;
+	const { sessionId, usageScopeId, baseUrl, modelId } = options;
 	return async ({ lastChance, error, signal, previousKey }) => {
 		if (error === undefined) {
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, usageScopeId });
 		}
 		if (lastChance) {
 			// Account constraint (401 / usage / account-rate-limit): rotate to a
@@ -65,6 +73,7 @@ export function createApiKeyResolver(
 				modelId,
 				signal,
 				apiKey: previousKey,
+				usageScopeId,
 			});
 			if (!switched) {
 				const status = AIError.status(error);
@@ -74,8 +83,14 @@ export function createApiKeyResolver(
 				// auth decline can instead mean a peer refreshed the bearer.
 				if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) return undefined;
 			}
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, usageScopeId });
 		}
-		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+		return registry.getApiKeyForProvider(provider, sessionId, {
+			baseUrl,
+			modelId,
+			forceRefresh: true,
+			signal,
+			usageScopeId,
+		});
 	};
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import * as path from "node:path";
-import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { assertCustomApiName, registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import type {
 	Api,
 	Context,
@@ -2180,7 +2180,7 @@ export class ModelRegistry {
 	async getApiKey(
 		model: Model<Api>,
 		sessionId?: string,
-		options?: { signal?: AbortSignal },
+		options?: { signal?: AbortSignal; usageScopeId?: string } | string,
 	): Promise<string | undefined> {
 		const commandKey = this.#resolveCommandBackedApiKey(model.provider);
 		if (commandKey.configured) return commandKey.value;
@@ -2190,7 +2190,8 @@ export class ModelRegistry {
 		return this.authStorage.getApiKey(model.provider, sessionId, {
 			baseUrl: model.baseUrl,
 			modelId: model.id,
-			signal: options?.signal,
+			signal: typeof options === "string" ? undefined : options?.signal,
+			usageScopeId: typeof options === "string" ? options : options?.usageScopeId,
 		});
 	}
 
@@ -2204,7 +2205,13 @@ export class ModelRegistry {
 	async getApiKeyForProvider(
 		provider: string,
 		sessionId?: string,
-		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
+		options?: {
+			baseUrl?: string;
+			modelId?: string;
+			forceRefresh?: boolean;
+			signal?: AbortSignal;
+			usageScopeId?: string;
+		},
 	): Promise<string | undefined> {
 		const commandKey = this.#resolveCommandBackedApiKey(provider);
 		if (commandKey.configured) return commandKey.value;
@@ -2216,18 +2223,18 @@ export class ModelRegistry {
 			modelId: options?.modelId,
 			forceRefresh: options?.forceRefresh,
 			signal: options?.signal,
+			usageScopeId: options?.usageScopeId,
 		});
 	}
 
 	/**
 	 * Build an {@link ApiKeyResolver} implementing the central a/b/c auth-retry
-	 * policy. Accepts a provider id with options, or a model with an optional
-	 * session id (`resolver(model, sessionId)`) which derives `baseUrl`/`modelId`
-	 * from the model. Callers that need the initial key for a guard can call
-	 * `resolveApiKeyOnce(resolver)`.
+	 * policy. Accepts a provider id with options, or a model with a session id
+	 * or full resolver options. Callers that need the initial key for a guard
+	 * can call `resolveApiKeyOnce(resolver)`.
 	 */
 	resolver(provider: string, options?: ApiKeyResolverOptions): ApiKeyResolver;
-	resolver(model: ApiKeyResolverModel, sessionId?: string): ApiKeyResolver;
+	resolver(model: ApiKeyResolverModel, options?: string | ApiKeyResolverOptions): ApiKeyResolver;
 	resolver(target: string | ApiKeyResolverModel, optionsOrSessionId?: ApiKeyResolverOptions | string): ApiKeyResolver {
 		const options = typeof optionsOrSessionId === "string" ? { sessionId: optionsOrSessionId } : optionsOrSessionId;
 		if (typeof target === "string") {
@@ -2300,19 +2307,14 @@ export class ModelRegistry {
 		}
 	}
 
-	/**
-	 * Register a provider dynamically (from extensions).
-	 *
-	 * If provider has models: replaces all existing models for this provider.
-	 * If provider has only baseUrl/headers: overrides existing models' URLs.
-	 * If provider has streamSimple: registers a custom API streaming function.
-	 * If provider has oauth: registers OAuth provider for /login support.
-	 */
-	registerProvider(providerName: string, config: ProviderConfigInput, sourceId?: string): void {
+	/** Validate a dynamic provider before mutating any shared registry state. */
+	validateProviderRegistration(providerName: string, config: ProviderConfigInput): void {
 		if (config.streamSimple && !config.api) {
 			throw new Error(`Provider ${providerName}: "api" is required when registering streamSimple.`);
 		}
-
+		if (config.streamSimple && config.api) {
+			assertCustomApiName(config.api);
+		}
 		validateProviderConfiguration(
 			providerName,
 			{
@@ -2325,6 +2327,18 @@ export class ModelRegistry {
 			},
 			"runtime-register",
 		);
+	}
+
+	/**
+	 * Register a provider dynamically (from extensions).
+	 *
+	 * If provider has models: replaces all existing models for this provider.
+	 * If provider has only baseUrl/headers: overrides existing models' URLs.
+	 * If provider has streamSimple: registers a custom API streaming function.
+	 * If provider has oauth: registers OAuth provider for /login support.
+	 */
+	registerProvider(providerName: string, config: ProviderConfigInput, sourceId?: string): void {
+		this.validateProviderRegistration(providerName, config);
 
 		if (config.streamSimple && config.api) {
 			const streamSimple = config.streamSimple;

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -86,6 +86,10 @@ export interface CustomToolContext {
 	sessionManager: ReadonlySessionManager;
 	/** Model registry - use for API key resolution and model retrieval */
 	modelRegistry: ModelRegistry;
+	/** Provider-facing credential stickiness id for this AgentSession. */
+	providerSessionId?: string;
+	/** Session-local extension usage-provider scope. */
+	usageProviderScopeId?: string;
 	/** Current model (may be undefined if no model is selected yet) */
 	model: Model | undefined;
 	/** Whether the agent is idle (not streaming) */

--- a/packages/coding-agent/src/extensibility/extensions/index.ts
+++ b/packages/coding-agent/src/extensibility/extensions/index.ts
@@ -4,6 +4,7 @@
 
 export type { SlashCommandInfo, SlashCommandLocation, SlashCommandSource } from "../slash-commands";
 export {
+	collectExtensionUsageProviderRegistrations,
 	discoverAndLoadExtensions,
 	discoverExtensionPaths,
 	ExtensionRuntimeNotInitializedError,

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -13,6 +13,8 @@ import type {
 	ServiceTierFamily,
 	TextContent,
 	TSchema,
+	UsageProvider,
+	UsageProviderRegistration,
 } from "@oh-my-pi/pi-ai";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { hasFsCode, isEacces, isEnoent, logger } from "@oh-my-pi/pi-utils";
@@ -291,6 +293,11 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	registerProvider(name: string, config: ProviderConfig): void {
 		this.runtime.pendingProviderRegistrations.push({ name, config, sourceId: this.extension.path });
 	}
+
+	registerUsageProvider(provider: UsageProvider): void {
+		this.extension.usageProviders ??= [];
+		this.extension.usageProviders.push(provider);
+	}
 }
 
 /**
@@ -307,7 +314,17 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),
+		usageProviders: [],
 	};
+}
+
+/** Materialize source-owned usage registrations for one session or CLI invocation. */
+export function collectExtensionUsageProviderRegistrations(
+	extensions: readonly Extension[],
+): UsageProviderRegistration[] {
+	return extensions.flatMap(extension =>
+		(extension.usageProviders ?? []).map(provider => ({ provider, sourceId: extension.path })),
+	);
 }
 
 async function loadExtension(
@@ -330,9 +347,7 @@ async function loadExtension(
 
 		const extension = createExtension(extensionPath, resolvedPath);
 		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
-		await withHostGuard(async () => {
-			await factory(api);
-		});
+		await withHostGuard(async () => factory(api));
 
 		return { extension, error: null };
 	} catch (err) {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -276,13 +276,22 @@ export class ExtensionRunner {
 		private readonly runtime: ExtensionRuntime,
 		private readonly cwd: string,
 		private readonly sessionManager: SessionManager,
+
 		private readonly modelRegistry: ModelRegistry,
 		getMemory?: () => MemoryRuntimeContext | undefined,
 		private readonly settings?: Settings,
 		private readonly localProtocolOptions?: LocalProtocolOptions,
+		private readonly providerIdentity?: {
+			getProviderSessionId(): string | undefined;
+			getUsageProviderScopeId(): string | undefined;
+		},
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
+	}
+
+	getExtensions(): readonly Extension[] {
+		return this.extensions;
 	}
 
 	initialize(
@@ -556,6 +565,8 @@ export class ExtensionRunner {
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,
 			modelRegistry: this.modelRegistry,
+			providerSessionId: this.providerIdentity?.getProviderSessionId(),
+			usageProviderScopeId: this.providerIdentity?.getUsageProviderScopeId(),
 			get model() {
 				return getModel();
 			},

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -32,6 +32,7 @@ import type {
 	Static,
 	TextContent,
 	TSchema,
+	UsageProvider,
 } from "@oh-my-pi/pi-ai";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
 import type { AutocompleteItem, AutocompleteProvider, Component, EditorTheme, KeyId, TUI } from "@oh-my-pi/pi-tui";
@@ -425,6 +426,10 @@ export interface ExtensionContext {
 	sessionManager: ReadonlySessionManager;
 	/** Model registry for API key resolution */
 	modelRegistry: ModelRegistry;
+	/** Provider-facing credential stickiness id for this AgentSession. */
+	providerSessionId?: string;
+	/** Session-local extension usage-provider scope. */
+	usageProviderScopeId?: string;
 	/** Calling session's `local://` root mapping for external tool bridges. */
 	localProtocolOptions?: LocalProtocolOptions;
 	/** Current model (may be undefined) */
@@ -1297,6 +1302,9 @@ export interface ExtensionAPI {
 	 */
 	registerProvider(name: string, config: ProviderConfig): void;
 
+	/** Register a provider that fetches account usage and rate-limit information. */
+	registerUsageProvider(provider: UsageProvider): void;
+
 	/** Shared event bus for extension communication. */
 	events: EventBus;
 }
@@ -1506,6 +1514,7 @@ export interface Extension {
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;
+	usageProviders?: UsageProvider[];
 }
 
 /** Result of loading extensions. */

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -44,6 +44,7 @@ export * from "./session/auth-storage";
 export * from "./session/indexed-session-storage";
 export * from "./session/messages";
 export * from "./session/redis-session-storage";
+export { bindToolsToAsyncSessionIdentity, type ToolSessionIdentity } from "./session/session-advisors";
 export * from "./session/session-context";
 export * from "./session/session-dump-format";
 export * from "./session/session-entries";

--- a/packages/coding-agent/src/lib/xai-http.ts
+++ b/packages/coding-agent/src/lib/xai-http.ts
@@ -128,19 +128,20 @@ export function resolveXAIHttpTransport(
  */
 export async function resolveXAIHttpCredentials(
 	modelRegistry: ModelRegistry,
-	modelId?: string,
+	options?: { modelId?: string; sessionId?: string; usageScopeId?: string },
 ): Promise<XAICredentials | null> {
+	const { modelId, sessionId, usageScopeId } = options ?? {};
 	const hasDedicatedXaiOAuth =
 		modelRegistry.authStorage.hasNonEnvCredential("xai-oauth") || Boolean($env.XAI_OAUTH_TOKEN);
 	if (hasDedicatedXaiOAuth) {
-		const oauthKey = await modelRegistry.getApiKeyForProvider("xai-oauth");
+		const oauthKey = await modelRegistry.getApiKeyForProvider("xai-oauth", sessionId, { usageScopeId });
 		if (oauthKey) {
 			const baseURL = resolveXAIBaseURL(modelRegistry, "xai-oauth", modelId);
 			return { provider: "xai-oauth", apiKey: oauthKey, baseURL };
 		}
 	}
 
-	const apiKey = await modelRegistry.getApiKeyForProvider("xai");
+	const apiKey = await modelRegistry.getApiKeyForProvider("xai", sessionId, { usageScopeId });
 	if (apiKey) {
 		const baseURL = resolveXAIBaseURL(modelRegistry, "xai", modelId);
 		return { provider: "xai", apiKey, baseURL };

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -102,7 +102,13 @@ export const mnemopiBackend: MemoryBackend = {
 		}
 
 		try {
-			const config = await loadMnemopiConfigWithProviders(settings, agentDir, modelRegistry, sessionId);
+			const config = await loadMnemopiConfigWithProviders(
+				settings,
+				agentDir,
+				modelRegistry,
+				sessionId,
+				session.usageProviderScopeId,
+			);
 			await Promise.all([loadMnemopi(), loadMnemopiCore()]);
 			await installMnemopiState(session, config);
 		} catch (error) {
@@ -158,6 +164,7 @@ export const mnemopiBackend: MemoryBackend = {
 					agentDir,
 					session.modelRegistry,
 					session.sessionId,
+					session.usageProviderScopeId,
 				);
 				await Promise.all([loadMnemopi(), loadMnemopiCore()]);
 				state = await installMnemopiState(session, config);
@@ -454,9 +461,16 @@ async function loadMnemopiConfigWithProviders(
 	agentDir: string,
 	modelRegistry: ModelRegistry,
 	sessionId: string,
+	usageScopeId?: string,
 ): Promise<MnemopiBackendConfig> {
 	const config = loadMnemopiConfig(settings, agentDir);
-	config.providerOptions = await resolveMnemopiProviderOptions(config, settings, modelRegistry, sessionId);
+	config.providerOptions = await resolveMnemopiProviderOptions(
+		config,
+		settings,
+		modelRegistry,
+		sessionId,
+		usageScopeId,
+	);
 	return config;
 }
 
@@ -472,11 +486,12 @@ async function openrouterKeyResolver(
 	modelRegistry: ModelRegistry,
 	sessionId: string,
 	baseUrl: string | undefined,
+	usageScopeId?: string,
 ): Promise<ApiKeyResolver | undefined> {
 	if (baseUrl !== undefined && !hostMatchesUrl(baseUrl, "openrouter")) return undefined;
-	const key = await modelRegistry.getApiKeyForProvider("openrouter", sessionId);
+	const key = await modelRegistry.getApiKeyForProvider("openrouter", sessionId, { usageScopeId });
 	if (key === undefined || key === "") return undefined;
-	return modelRegistry.resolver("openrouter", { sessionId });
+	return modelRegistry.resolver("openrouter", { sessionId, usageScopeId });
 }
 
 async function resolveMnemopiProviderOptions(
@@ -484,6 +499,7 @@ async function resolveMnemopiProviderOptions(
 	settings: MemoryBackendStartOptions["settings"],
 	modelRegistry: ModelRegistry,
 	sessionId: string,
+	usageScopeId?: string,
 ): Promise<MnemopiProviderOptions> {
 	const base: MnemopiProviderOptions = {
 		noEmbeddings: config.providerOptions.noEmbeddings,
@@ -491,7 +507,7 @@ async function resolveMnemopiProviderOptions(
 		embeddingApiUrl: config.providerOptions.embeddingApiUrl,
 		embeddingApiKey:
 			config.providerOptions.embeddingApiKey ??
-			(await openrouterKeyResolver(modelRegistry, sessionId, config.providerOptions.embeddingApiUrl)),
+			(await openrouterKeyResolver(modelRegistry, sessionId, config.providerOptions.embeddingApiUrl, usageScopeId)),
 		llm: false,
 	};
 
@@ -521,7 +537,7 @@ async function resolveMnemopiProviderOptions(
 					config.llmApiKey ??
 					(config.llmBaseUrl === undefined
 						? undefined
-						: await openrouterKeyResolver(modelRegistry, sessionId, config.llmBaseUrl)),
+						: await openrouterKeyResolver(modelRegistry, sessionId, config.llmBaseUrl, usageScopeId)),
 				model: config.llmModel,
 			},
 		};
@@ -537,7 +553,7 @@ async function resolveMnemopiProviderOptions(
 		return {
 			...base,
 			llm: async (prompt, opts) => {
-				const hasApiKey = await modelRegistry.getApiKey(model, sessionId);
+				const hasApiKey = await modelRegistry.getApiKey(model, sessionId, usageScopeId);
 				if (!hasApiKey) {
 					logger.warn("Mnemopi: smol completion requested but no current API key is available.", {
 						provider: model.provider,
@@ -551,7 +567,7 @@ async function resolveMnemopiProviderOptions(
 						messages: [{ role: "user", content: prompt, timestamp: Date.now() }],
 					},
 					{
-						apiKey: modelRegistry.resolver(model, sessionId),
+						apiKey: modelRegistry.resolver(model, { sessionId, usageScopeId }),
 						maxTokens: opts?.maxTokens,
 						temperature: opts?.temperature,
 					},

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2501,6 +2501,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const getSessionContext = () => ({
 			sessionManager,
 			modelRegistry,
+			providerSessionId: session.sessionId,
+			usageProviderScopeId: session.usageProviderScopeId,
 			model: agent.state.model,
 			isIdle: () => !session.isStreaming,
 			hasQueuedMessages: () => session.queuedMessageCount > 0,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -9,14 +9,15 @@ import {
 	filterProviderReplayMessages,
 	type ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
-import type {
-	Context,
-	CredentialDisabledEvent,
-	Message,
-	Model,
-	ModelUsageHealth,
-	ProviderSessionState,
-	SimpleStreamOptions,
+import {
+	type Context,
+	type CredentialDisabledEvent,
+	type Message,
+	type Model,
+	type ModelUsageHealth,
+	type ProviderSessionState,
+	type SimpleStreamOptions,
+	UsageProviderRegistry,
 } from "@oh-my-pi/pi-ai";
 import type { Dialect } from "@oh-my-pi/pi-ai/dialect";
 import {
@@ -74,6 +75,7 @@ import {
 import { discoverCustomToolPaths, loadCustomTools, type ToolPathWithSource } from "./extensibility/custom-tools";
 import type { CustomTool, CustomToolContext, CustomToolSessionEvent } from "./extensibility/custom-tools/types";
 import {
+	collectExtensionUsageProviderRegistrations,
 	discoverAndLoadExtensions,
 	discoverExtensionPaths,
 	type ExtensionContext,
@@ -710,6 +712,11 @@ export async function loadCliExtensionProviders(
 	const eventBus = new EventBus();
 	const extensionsResult = await loadSessionExtensions(options, cwd, settings, eventBus);
 	const activeSources = extensionsResult.extensions.map(extension => extension.path);
+	const usageRegistrations = collectExtensionUsageProviderRegistrations(extensionsResult.extensions);
+	new UsageProviderRegistry().syncRegistrations(activeSources, usageRegistrations);
+	for (const { name, config } of extensionsResult.runtime.pendingProviderRegistrations) {
+		modelRegistry.validateProviderRegistration(name, config);
+	}
 	modelRegistry.syncExtensionSources(activeSources);
 	for (const sourceId of new Set(activeSources)) {
 		modelRegistry.clearSourceRegistrations(sourceId);
@@ -718,6 +725,7 @@ export async function loadCliExtensionProviders(
 		modelRegistry.registerProvider(name, config, sourceId);
 	}
 	extensionsResult.runtime.pendingProviderRegistrations = [];
+	modelRegistry.authStorage.syncExtensionUsageProviders(activeSources, usageRegistrations);
 	await modelRegistry.refreshRuntimeProviders();
 }
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3094,6 +3094,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Owned only when this session created the manager; subagents receive a
 		// parent's manager via `options.mcpManager` and MUST NOT disconnect it.
 		const ownedMcpManager = options.mcpManager ? undefined : mcpManager;
+		// Snapshot the runner's extension usage-provider registrations once at
+		// construction; AgentSession receives them instead of introspecting the runner.
+		const usageProviderRegistrations = collectExtensionUsageProviderRegistrations(extensionRunner.getExtensions());
 		session = new AgentSession({
 			advisorWatchdogPrompt,
 			advisorContextPrompt,
@@ -3120,6 +3123,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			promptTemplates,
 			slashCommands,
 			extensionRunner,
+			usageProviderRegistrations,
 			customCommands: customCommandsResult.commands,
 			skills,
 			skillWarnings,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -145,6 +145,7 @@ import {
 	type RetryFallbackResolutionContext,
 	resolveRetryFallbackChainKey,
 } from "./session/retry-fallback-chains";
+import { advisorToolIdentity } from "./session/session-advisors";
 import { getRestorableSessionModels } from "./session/session-context";
 import { SessionManager } from "./session/session-manager";
 import { createSettingsAwareStreamFn } from "./session/settings-stream-fn";
@@ -2490,6 +2491,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			() => (hasSession ? createSessionMemoryRuntimeContext(session, agentDir, cwd) : undefined),
 			settings,
 			localProtocolOptions,
+			// Live closures, not captured values: the runner is constructed before
+			// `session` is assigned (see `let session!` above, set once startup
+			// completes), and extensions create contexts long after that. Reading
+			// through the closure is what makes `ctx.providerSessionId` /
+			// `ctx.usageProviderScopeId` non-undefined for session-scoped usage
+			// providers instead of silently resolving in the global scope.
+			{
+				getProviderSessionId: () => (hasSession ? session.sessionId : undefined),
+				getUsageProviderScopeId: () => (hasSession ? session.usageProviderScopeId : undefined),
+			},
 		);
 
 		credentialDisabledTarget = extensionRunner;
@@ -3070,6 +3081,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			hasEditTool: true,
 			requireYieldTool: false,
 			getSessionId: () => {
+				// Roster advisors share this one toolset, so prefer the identity the
+				// running advisor bound (see `advisorToolIdentity`). The flat
+				// `<session>-advisor` id stays the fallback for tool state touched
+				// outside an advisor turn.
+				const bound = advisorToolIdentity.getStore();
+				if (bound) return bound.sessionLabel;
 				const id = sessionManager.getSessionId?.();
 				return id ? `${id}-advisor` : null;
 			},

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -99,6 +99,8 @@ export interface AgentSessionConfig {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settings: Settings;
+	/** Runtime-only usage-provider scope shared by session side channels. */
+	usageProviderScopeId?: string;
 	/** Whether the caller explicitly requested yolo/auto-approve behavior for this session. */
 	autoApprove?: boolean;
 	/** Models to cycle through with Ctrl+P (from --models flag). */

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -9,6 +9,7 @@ import type {
 	ServiceTierByFamily,
 	SimpleStreamOptions,
 	ToolChoice,
+	UsageProviderRegistration,
 } from "@oh-my-pi/pi-ai";
 import type { postmortem } from "@oh-my-pi/pi-utils";
 import type { AdvisorConfig } from "../advisor";
@@ -121,6 +122,12 @@ export interface AgentSessionConfig {
 	slashCommands?: FileSlashCommand[];
 	/** Extension runner created with wrapped tools. */
 	extensionRunner?: ExtensionRunner;
+	/**
+	 * Extension usage-provider registrations for this session's transient scope,
+	 * collected once by the SDK from the runner's loaded extensions. Defaults to
+	 * empty so AgentSession never introspects the runner for extensions.
+	 */
+	usageProviderRegistrations?: readonly UsageProviderRegistration[];
 	/** Loaded skills already discovered by the SDK. */
 	skills?: Skill[];
 	/** Skill loading warnings already captured by the SDK. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1008,6 +1008,7 @@ export class AgentSession {
 			streamingEditAbortTriggered: () => this.#streamingEditGuard.abortTriggered,
 			promptGeneration: () => this.#promptGeneration,
 			sessionId: () => this.sessionId,
+			usageScopeId: () => this.#usageProviderScopeId,
 			emitSessionEvent: event => this.#emitSessionEvent(event),
 			scheduleAgentContinue: options => this.#scheduleAgentContinue(options),
 			waitForSessionMessagePersistence: message => this.#waitForSessionMessagePersistence(message),
@@ -1027,6 +1028,7 @@ export class AgentSession {
 			sessionManager: this.sessionManager,
 			modelRegistry: this.#modelRegistry,
 			model: () => this.model,
+			usageScopeId: () => this.#usageProviderScopeId,
 			sessionId: () => this.sessionId,
 		};
 		this.#stats = new SessionStatsTracker(statsHost);
@@ -1334,6 +1336,7 @@ export class AgentSession {
 				this.#recovery.noteRetryFallbackCooldown(selector, retryAfterMs, errorMessage),
 			createCodexCompactionContext: createMaintenanceCodexCompactionContext,
 			sessionId: () => this.sessionId,
+			usageScopeId: () => this.#usageProviderScopeId,
 		};
 		this.#advisors = new SessionAdvisors(advisorsHost, {
 			enabled: this.settings.get("advisor.enabled"),
@@ -2432,6 +2435,7 @@ export class AgentSession {
 				if (assistantMsg.provider === "opencode-go") {
 					this.#modelRegistry.authStorage.recordUsageCost(assistantMsg.provider, assistantMsg.usage.cost.total, {
 						sessionId: this.#activeProviderSessionId(),
+						usageScopeId: this.#usageProviderScopeId,
 						recordedAt: assistantMsg.timestamp,
 						baseUrl: this.#modelRegistry.getProviderBaseUrl?.(assistantMsg.provider),
 					});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -128,7 +128,6 @@ import type {
 	TurnStartEvent,
 } from "../extensibility/extensions";
 import { emitSessionShutdownEvent } from "../extensibility/extensions";
-import { collectExtensionUsageProviderRegistrations } from "../extensibility/extensions/loader";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
@@ -969,28 +968,33 @@ export class AgentSession {
 		this.#promptTemplates = config.promptTemplates ?? [];
 		this.#slashCommands = config.slashCommands ?? [];
 		this.#extensionRunner = config.extensionRunner;
-		const usageProviders = collectExtensionUsageProviderRegistrations(this.#extensionRunner?.getExtensions() ?? []);
-		const usageRegistry = new UsageProviderRegistry();
-		usageRegistry.syncRegistrations(
-			[...new Set(usageProviders.map(registration => registration.sourceId))],
-			usageProviders,
-		);
-		this.#unregisterUsageProviderScope = this.#modelRegistry.authStorage.registerSessionUsageProviders(
-			this.#usageProviderScopeId,
-			{
-				resolve: provider => usageRegistry.resolve(provider),
-				cacheKeyVersion: provider => {
-					const version = usageRegistry.cacheKeyVersion(provider);
-					return version === null ? null : `${this.#usageProviderScopeId}:${version}`;
+		const usageProviders = config.usageProviderRegistrations ?? [];
+		// Only stand up the transient usage-provider scope when extensions actually
+		// registered providers; with none, builtin usage behaviour is unchanged and
+		// the session needs no scope registration or scoped credential override.
+		if (usageProviders.length > 0) {
+			const usageRegistry = new UsageProviderRegistry();
+			usageRegistry.syncRegistrations(
+				[...new Set(usageProviders.map(registration => registration.sourceId))],
+				usageProviders,
+			);
+			this.#unregisterUsageProviderScope = this.#modelRegistry.authStorage.registerSessionUsageProviders(
+				this.#usageProviderScopeId,
+				{
+					resolve: provider => usageRegistry.resolve(provider),
+					cacheKeyVersion: provider => {
+						const version = usageRegistry.cacheKeyVersion(provider);
+						return version === null ? null : `${this.#usageProviderScopeId}:${version}`;
+					},
+					providerIds: () => usageRegistry.providerIds(),
 				},
-				providerIds: () => usageRegistry.providerIds(),
-			},
-		);
-		this.agent.getApiKey = model =>
-			this.#modelRegistry.resolver(model, {
-				sessionId: this.sessionId,
-				usageScopeId: this.#usageProviderScopeId,
-			});
+			);
+			this.agent.getApiKey = model =>
+				this.#modelRegistry.resolver(model, {
+					sessionId: this.sessionId,
+					usageScopeId: this.#usageProviderScopeId,
+				});
+		}
 		this.#customCommands = config.customCommands ?? [];
 		const recoveryHost: TurnRecoveryHost = {
 			agent: this.agent,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -976,8 +976,20 @@ export class AgentSession {
 		);
 		this.#unregisterUsageProviderScope = this.#modelRegistry.authStorage.registerSessionUsageProviders(
 			this.#usageProviderScopeId,
-			usageRegistry,
+			{
+				resolve: provider => usageRegistry.resolve(provider),
+				cacheKeyVersion: provider => {
+					const version = usageRegistry.cacheKeyVersion(provider);
+					return version === null ? null : `${this.#usageProviderScopeId}:${version}`;
+				},
+				providerIds: () => usageRegistry.providerIds(),
+			},
 		);
+		this.agent.getApiKey = model =>
+			this.#modelRegistry.resolver(model, {
+				sessionId: this.sessionId,
+				usageScopeId: this.#usageProviderScopeId,
+			});
 		this.#customCommands = config.customCommands ?? [];
 		const recoveryHost: TurnRecoveryHost = {
 			agent: this.agent,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -944,6 +944,7 @@ export class AgentSession {
 			agent: this.agent,
 			settings: this.settings,
 			modelRegistry: this.#modelRegistry,
+			usageScopeId: () => this.#usageProviderScopeId,
 			sessionManager: this.sessionManager,
 			providerSessionState: this.#providerSessionState,
 			model: () => this.model,
@@ -1335,8 +1336,8 @@ export class AgentSession {
 			noteRetryFallbackCooldown: (selector, retryAfterMs, errorMessage) =>
 				this.#recovery.noteRetryFallbackCooldown(selector, retryAfterMs, errorMessage),
 			createCodexCompactionContext: createMaintenanceCodexCompactionContext,
-			sessionId: () => this.sessionId,
 			usageScopeId: () => this.#usageProviderScopeId,
+			sessionId: () => this.sessionId,
 		};
 		this.#advisors = new SessionAdvisors(advisorsHost, {
 			enabled: this.settings.get("advisor.enabled"),
@@ -1391,6 +1392,7 @@ export class AgentSession {
 			},
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
+			usageScopeId: () => this.#usageProviderScopeId,
 			rebaseAfterCompaction: () => this.#stats.rebaseAfterCompaction(),
 			getContextBreakdown: options => this.getContextBreakdown(options),
 			getContextUsage: options => this.getContextUsage(options),
@@ -1420,6 +1422,7 @@ export class AgentSession {
 			model: () => this.model,
 			thinkingLevel: () => this.thinkingLevel,
 			sessionId: () => this.sessionId,
+			usageScopeId: () => this.#usageProviderScopeId,
 			sessionFile: () => this.sessionFile,
 			baseSystemPrompt: () => this.#tools.baseSystemPrompt,
 			assertVibeSessionTransitionAllowed: action => this.#assertVibeSessionTransitionAllowed(action),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -71,7 +71,7 @@ import type {
 	ToolResultMessage,
 	UsageReport,
 } from "@oh-my-pi/pi-ai";
-import { deriveClaudeDeviceId, type Effort, streamSimple } from "@oh-my-pi/pi-ai";
+import { deriveClaudeDeviceId, type Effort, streamSimple, UsageProviderRegistry } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { resetOpenAICodexHistoryAfterCompaction } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
@@ -128,6 +128,7 @@ import type {
 	TurnStartEvent,
 } from "../extensibility/extensions";
 import { emitSessionShutdownEvent } from "../extensibility/extensions";
+import { collectExtensionUsageProviderRegistrations } from "../extensibility/extensions/loader";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
@@ -560,6 +561,8 @@ export class AgentSession {
 	#modelRegistry: ModelRegistry;
 	#usageFallbackConfirmer: ((confirmation: UsageFallbackConfirmation) => Promise<boolean>) | undefined;
 	#usageReserveApprovedSelector: string | undefined;
+	#usageProviderScopeId: string;
+	#unregisterUsageProviderScope: (() => void) | undefined;
 	#usagePreflightAbortControllers = new Set<AbortController>();
 
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
@@ -861,6 +864,7 @@ export class AgentSession {
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
 		this.#modelRegistry = config.modelRegistry;
+		this.#usageProviderScopeId = config.usageProviderScopeId ?? Bun.randomUUIDv7();
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
@@ -964,6 +968,16 @@ export class AgentSession {
 		this.#promptTemplates = config.promptTemplates ?? [];
 		this.#slashCommands = config.slashCommands ?? [];
 		this.#extensionRunner = config.extensionRunner;
+		const usageProviders = collectExtensionUsageProviderRegistrations(this.#extensionRunner?.getExtensions() ?? []);
+		const usageRegistry = new UsageProviderRegistry();
+		usageRegistry.syncRegistrations(
+			[...new Set(usageProviders.map(registration => registration.sourceId))],
+			usageProviders,
+		);
+		this.#unregisterUsageProviderScope = this.#modelRegistry.authStorage.registerSessionUsageProviders(
+			this.#usageProviderScopeId,
+			usageRegistry,
+		);
 		this.#customCommands = config.customCommands ?? [];
 		const recoveryHost: TurnRecoveryHost = {
 			agent: this.agent,
@@ -1437,6 +1451,10 @@ export class AgentSession {
 		this.#unsubscribeAppendOnly = onAppendOnlyModeChanged(_value => this.#syncAppendOnlyContext(this.model));
 		this.#unsubscribeModelRoles = onModelRolesChanged(() => this.#advisors.onModelRolesChanged());
 	}
+	get usageProviderScopeId(): string {
+		return this.#usageProviderScopeId;
+	}
+
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
 		return this.#modelRegistry;
@@ -3383,6 +3401,8 @@ export class AgentSession {
 	 */
 	beginDispose(): void {
 		this.#isDisposed = true;
+		this.#unregisterUsageProviderScope?.();
+		this.#unregisterUsageProviderScope = undefined;
 		this.#memory.cancelLocalMemoryStartup();
 		this.#titleGenerationAbortController.abort();
 		this.#abortAutolearnCapture();
@@ -5063,6 +5083,8 @@ export class AgentSession {
 			cwd: this.sessionManager.getCwd(),
 			sessionManager: this.sessionManager,
 			modelRegistry: this.#modelRegistry,
+			providerSessionId: this.sessionId,
+			usageProviderScopeId: this.#usageProviderScopeId,
 			model: this.model ?? undefined,
 			models: createExtensionModelQuery(this.#modelRegistry, this.settings, () => this.model ?? undefined),
 			isIdle: () => !this.isStreaming,
@@ -7752,6 +7774,7 @@ export class AgentSession {
 				}
 				return this.#modelRegistry.getProviderBaseUrl?.(provider);
 			},
+			usageScopeId: this.#usageProviderScopeId,
 			signal,
 		});
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3766,7 +3766,10 @@ export class AgentSession {
 			if (signal.aborted) return;
 			let apiKey: string | undefined;
 			try {
-				apiKey = await this.#modelRegistry.getApiKey(candidateModel, this.sessionId, { signal });
+				apiKey = await this.#modelRegistry.getApiKey(candidateModel, this.sessionId, {
+					signal,
+					usageScopeId: this.#usageProviderScopeId,
+				});
 			} catch {
 				if (signal.aborted) return;
 				continue;
@@ -4876,7 +4879,7 @@ export class AgentSession {
 			}
 
 			// Validate API key
-			const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
+			const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId, this.#usageProviderScopeId);
 			if (!apiKey) {
 				throw new Error(
 					`No API key found for ${this.model.provider}.\n\n` +
@@ -6766,7 +6769,10 @@ export class AgentSession {
 		const context = await this.agent.buildSideRequestContext(llmMessages);
 		const options = this.prepareSimpleStreamOptions(
 			{
-				apiKey: this.#modelRegistry.resolver(model, cacheSessionId),
+				apiKey: this.#modelRegistry.resolver(model, {
+					sessionId: cacheSessionId,
+					usageScopeId: this.#usageProviderScopeId,
+				}),
 				// Side-channel turns must not share OpenAI/Codex append-only
 				// conversation state with the main agent turn: IRC and /btw can run
 				// while the main turn is mid-tool-call. Keep the prompt-cache key
@@ -7513,14 +7519,17 @@ export class AgentSession {
 		let summaryDetails: unknown;
 		if (options.summarize && entriesToSummarize.length > 0 && !hookSummary) {
 			const model = this.model!;
-			const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
+			const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId, this.#usageProviderScopeId);
 			if (!apiKey) {
 				throw new Error(`No API key for ${model.provider}`);
 			}
 			const branchSummarySettings = this.settings.getGroup("branchSummary");
 			const result = await generateBranchSummary(entriesToSummarize, {
 				model,
-				apiKey: this.#modelRegistry.resolver(model, this.sessionId),
+				apiKey: this.#modelRegistry.resolver(model, {
+					sessionId: this.sessionId,
+					usageScopeId: this.#usageProviderScopeId,
+				}),
 				signal: this.#branchSummaryAbortController.signal,
 				customInstructions: this.#obfuscateTextForProvider(options.customInstructions),
 				reserveTokens: branchSummarySettings.reserveTokens,

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -48,6 +48,7 @@ export interface ModelControlsHost {
 	providerSessionState: Map<string, ProviderSessionState>;
 	model(): Model | undefined;
 	sessionId(): string;
+	usageScopeId(): string;
 	promptGeneration(): number;
 	resolveActiveEditMode(): EditMode;
 	syncAfterModelChange(previousEditMode: EditMode): Promise<void>;
@@ -424,7 +425,9 @@ export class ModelControls {
 		const nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 		const nextModel = availableModels[nextIndex];
 
-		const apiKey = await this.#host.modelRegistry.getApiKey(nextModel, this.#host.sessionId());
+		const apiKey = await this.#host.modelRegistry.getApiKey(nextModel, this.#host.sessionId(), {
+			usageScopeId: this.#host.usageScopeId(),
+		});
 		if (!apiKey) {
 			throw new Error(`No API key for ${nextModel.provider}/${nextModel.id}`);
 		}

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -373,7 +373,9 @@ export class ModelControls {
 			if (apiKeysByProvider.has(provider)) {
 				apiKey = apiKeysByProvider.get(provider);
 			} else {
-				apiKey = await this.#host.modelRegistry.getApiKeyForProvider(provider, this.#host.sessionId());
+				apiKey = await this.#host.modelRegistry.getApiKeyForProvider(provider, this.#host.sessionId(), {
+					usageScopeId: this.#host.usageScopeId(),
+				});
 				apiKeysByProvider.set(provider, apiKey);
 			}
 

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -227,6 +227,7 @@ export interface SessionAdvisorsHost {
 	onResponse: SimpleStreamOptions["onResponse"] | undefined;
 	onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	agentKind(): "main" | "sub";
+	usageScopeId(): string;
 	isDisposed(): boolean;
 	abortInProgress(): boolean;
 	allowAgentInitiatedTurns(): boolean;
@@ -1042,6 +1043,7 @@ export class SessionAdvisors {
 				currentModel.provider,
 				advisor.providerSessionId,
 				{
+					usageScopeId: this.#host.usageScopeId(),
 					retryAfterMs: extractRetryHint(undefined, message),
 					baseUrl: currentModel.baseUrl,
 					modelId: currentModel.id,
@@ -1073,6 +1075,7 @@ export class SessionAdvisors {
 				currentModel.provider,
 				advisor.providerSessionId,
 				{
+					usageScopeId: this.#host.usageScopeId(),
 					retryAfterMs,
 					baseUrl: currentModel.baseUrl,
 					modelId: currentModel.id,

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1,3 +1,4 @@
+import type { AsyncLocalStorage } from "node:async_hooks";
 import {
 	Agent,
 	type AgentMessage,
@@ -95,6 +96,26 @@ import { formatSessionHistoryMarkdown } from "./session-history-format";
 import type { SessionManager } from "./session-manager";
 import type { YieldQueue } from "./yield-queue";
 
+export interface ToolSessionIdentity {
+	providerSessionId: string;
+	sessionLabel: string;
+}
+
+export function bindToolsToAsyncSessionIdentity(
+	tools: AgentTool[],
+	identity: AsyncLocalStorage<ToolSessionIdentity>,
+	session: ToolSessionIdentity,
+): AgentTool[] {
+	return tools.map(tool => {
+		const bound = Object.defineProperties({}, Object.getOwnPropertyDescriptors(tool)) as AgentTool;
+		Object.defineProperty(bound, "description", {
+			enumerable: true,
+			get: () => tool.description,
+		});
+		bound.execute = (...args) => identity.run(session, () => tool.execute(...args));
+		return bound;
+	});
+}
 /** Advisor statistics for the advisor status command. */
 export interface AdvisorStats {
 	configured: boolean;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1,4 +1,4 @@
-import type { AsyncLocalStorage } from "node:async_hooks";
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
 	Agent,
 	type AgentMessage,
@@ -97,17 +97,29 @@ import type { SessionManager } from "./session-manager";
 import type { YieldQueue } from "./yield-queue";
 
 export interface ToolSessionIdentity {
-	providerSessionId: string;
+	/**
+	 * Advisor provider session id, absent until the primary session has an id.
+	 * Tool state keys on `sessionLabel`, so binding stays useful either way.
+	 */
+	providerSessionId: string | undefined;
 	sessionLabel: string;
 }
 
-export function bindToolsToAsyncSessionIdentity(
-	tools: AgentTool[],
+/**
+ * Per-advisor tool identity. The advisor toolset is built once (in `sdk.ts`) and
+ * shared by every roster advisor, so the identity their tool state is keyed on
+ * has to be dynamic rather than a baked `<session>-advisor` id: each advisor runs
+ * its tools inside this store and the advisor `ToolSession` reads it.
+ */
+export const advisorToolIdentity = new AsyncLocalStorage<ToolSessionIdentity>();
+
+export function bindToolsToAsyncSessionIdentity<T extends AgentTool<any>>(
+	tools: T[],
 	identity: AsyncLocalStorage<ToolSessionIdentity>,
 	session: ToolSessionIdentity,
-): AgentTool[] {
+): T[] {
 	return tools.map(tool => {
-		const bound = Object.defineProperties({}, Object.getOwnPropertyDescriptors(tool)) as AgentTool;
+		const bound = Object.defineProperties({}, Object.getOwnPropertyDescriptors(tool)) as T;
 		Object.defineProperty(bound, "description", {
 			enumerable: true,
 			get: () => tool.description,
@@ -600,7 +612,24 @@ export class SessionAdvisors {
 
 			const names = config.tools === undefined ? ADVISOR_DEFAULT_TOOL_NAMES : new Set(config.tools);
 			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name));
-			const advisorLoopTools: AgentTool<any>[] = [adviseTool, ...tools];
+			const primaryProviderSessionId = this.#host.sessionId();
+			const advisorSessionLabel = slug
+				? `${primaryProviderSessionId}-advisor-${slug}`
+				: `${primaryProviderSessionId}-advisor`;
+			const advisorProviderSessionId = getOrCreateAdvisorProviderSessionId(
+				this.#advisorProviderSessionIds,
+				primaryProviderSessionId,
+				slug,
+			);
+			// Bind each advisor's tools to its own identity. Tool state (snapshot,
+			// seen-lines, conflict and summary caches) is keyed on session identity, so
+			// while every roster advisor resolved to the single `<session>-advisor` id
+			// their tool state collided whenever more than one ran with tools.
+			const advisorLoopTools: AgentTool<any>[] = bindToolsToAsyncSessionIdentity(
+				[adviseTool, ...tools],
+				advisorToolIdentity,
+				{ providerSessionId: advisorProviderSessionId, sessionLabel: advisorSessionLabel },
+			);
 			const advisorToolMap = new Map<string, AgentTool<any>>();
 			const availableAdvisorToolNames = new Set<string>();
 			for (const tool of advisorLoopTools) {
@@ -614,15 +643,6 @@ export class SessionAdvisors {
 			let quarantinedAdvisorOutput: string | undefined;
 			let currentAdvisorInput = "";
 
-			const primaryProviderSessionId = this.#host.sessionId();
-			const advisorSessionLabel = slug
-				? `${primaryProviderSessionId}-advisor-${slug}`
-				: `${primaryProviderSessionId}-advisor`;
-			const advisorProviderSessionId = getOrCreateAdvisorProviderSessionId(
-				this.#advisorProviderSessionIds,
-				primaryProviderSessionId,
-				slug,
-			);
 			const appendOnlyContext = new AppendOnlyContextManager();
 
 			// Thread the primary's telemetry into the advisor loop so the advisor
@@ -680,7 +700,15 @@ export class SessionAdvisors {
 				cursorExecHandlers: advisorCursorExecHandlers,
 				cwdResolver: () => this.#host.sessionManager.getCwd(),
 				preferWebsockets: this.#host.preferWebsockets,
-				getApiKey: requestModel => this.#host.modelRegistry.resolver(requestModel, advisorProviderSessionId),
+				// The advisor's own provider-session id is a prompt-cache identity, not
+				// a usage scope. Advisor turns must resolve credentials under the
+				// owning session's scope or an extension usage provider's reports and
+				// quota blocks are ignored until some main-session path observes them.
+				getApiKey: requestModel =>
+					this.#host.modelRegistry.resolver(requestModel, {
+						sessionId: advisorProviderSessionId,
+						usageScopeId: this.#host.usageScopeId(),
+					}),
 				streamFn: this.#advisorStreamFn,
 				onPayload: this.#host.onPayload,
 				onResponse: this.#host.onResponse,
@@ -1003,7 +1031,9 @@ export class SessionAdvisors {
 		const primaryModel =
 			resolvedPrimary.model ?? this.#host.modelRegistry.find(originalSelector.provider, originalSelector.id);
 		if (!primaryModel) return;
-		const apiKey = await this.#host.modelRegistry.getApiKey(primaryModel, advisor.providerSessionId);
+		const apiKey = await this.#host.modelRegistry.getApiKey(primaryModel, advisor.providerSessionId, {
+			usageScopeId: this.#host.usageScopeId(),
+		});
 		if (!apiKey) return;
 
 		const thinkingToApply =
@@ -1096,7 +1126,9 @@ export class SessionAdvisors {
 			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
 			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
 			if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId);
+			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, {
+				usageScopeId: this.#host.usageScopeId(),
+			});
 			if (!apiKey) continue;
 
 			const originalThinkingLevel = advisor.thinkingLevel;
@@ -1269,14 +1301,19 @@ export class SessionAdvisors {
 		});
 
 		for (const candidate of candidates) {
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisorProviderSessionId);
+			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisorProviderSessionId, {
+				usageScopeId: this.#host.usageScopeId(),
+			});
 			if (!apiKey) continue;
 
 			try {
 				compactResult = await compact(
 					preparation,
 					candidate,
-					this.#host.modelRegistry.resolver(candidate, advisorProviderSessionId),
+					this.#host.modelRegistry.resolver(candidate, {
+						sessionId: advisorProviderSessionId,
+						usageScopeId: this.#host.usageScopeId(),
+					}),
 					undefined,
 					undefined,
 					{

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -120,7 +120,29 @@ export function bindToolsToAsyncSessionIdentity<T extends AgentTool<any>>(
 ): T[] {
 	return tools.map(tool => {
 		const bound = Object.defineProperties({}, Object.getOwnPropertyDescriptors(tool)) as T;
+		// Own descriptors miss everything a class-based tool exposes through its
+		// prototype - `description`, but also the `parameters` schema that Eval,
+		// Edit and Task build behind a getter. Dropping those hands `undefined` to
+		// `toolWireSchema` and fails the advisor turn before any tool runs. Each
+		// accessor is re-published as a delegating getter rather than a copied
+		// value because it may read `#private` state, which only resolves against
+		// the original instance.
+		for (
+			let proto = Object.getPrototypeOf(tool);
+			proto !== null && proto !== Object.prototype;
+			proto = Object.getPrototypeOf(proto)
+		) {
+			for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(proto))) {
+				if (key === "constructor" || descriptor.get === undefined || Object.hasOwn(bound, key)) continue;
+				Object.defineProperty(bound, key, {
+					configurable: true,
+					enumerable: true,
+					get: () => tool[key as keyof T],
+				});
+			}
+		}
 		Object.defineProperty(bound, "description", {
+			configurable: true,
 			enumerable: true,
 			get: () => tool.description,
 		});

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -41,6 +41,7 @@ export interface SessionHandoffHost {
 	model(): Model | undefined;
 	thinkingLevel(): ThinkingLevel | undefined;
 	sessionId(): string;
+	usageScopeId(): string;
 	sessionFile(): string | undefined;
 	baseSystemPrompt(): string[];
 	assertVibeSessionTransitionAllowed(action: string): void;
@@ -133,7 +134,9 @@ export class SessionHandoff {
 			if (!model) {
 				throw new Error("No model selected for handoff");
 			}
-			const apiKey = await this.#host.modelRegistry.getApiKey(model, this.#host.sessionId());
+			const apiKey = await this.#host.modelRegistry.getApiKey(model, this.#host.sessionId(), {
+				usageScopeId: this.#host.usageScopeId(),
+			});
 			if (!apiKey) {
 				throw new Error(`No API key for ${model.provider}`);
 			}
@@ -172,7 +175,10 @@ export class SessionHandoff {
 			);
 			const handoffStreamOptions = this.#host.prepareSimpleStreamOptions(
 				{
-					apiKey: this.#host.modelRegistry.resolver(model, cacheSessionId),
+					apiKey: this.#host.modelRegistry.resolver(model, {
+						sessionId: cacheSessionId,
+						usageScopeId: this.#host.usageScopeId(),
+					}),
 					sessionId: `${cacheSessionId}:side:${Snowflake.next()}`,
 					promptCacheKey: handoffPromptCacheKey,
 					preferWebsockets: false,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -185,6 +185,7 @@ export interface SessionMaintenanceHost {
 	isGeneratingHandoff(): boolean;
 	promptGeneration(): number;
 	sessionId(): string;
+	usageScopeId(): string;
 	messages(): AgentMessage[];
 	baseSystemPrompt(): string[];
 	goalModeState(): GoalModeState | undefined;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1382,7 +1382,13 @@ export class SessionMaintenance {
 		if (!candidate) return undefined;
 		if (modelsAreEqual(candidate, currentModel)) return undefined;
 		if (candidate.contextWindow == null || candidate.contextWindow <= contextWindow) return undefined;
-		const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
+		// Compaction and promotion must resolve credentials under the session's
+		// usage scope, not the provider prompt-cache id: a compaction/fallback model
+		// backed by an extension usage provider would otherwise bypass that
+		// provider's credential ranking and quota blocks.
+		const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId(), {
+			usageScopeId: this.#host.usageScopeId(),
+		});
 		if (!apiKey) return undefined;
 		return candidate;
 	}
@@ -1457,14 +1463,19 @@ export class SessionMaintenance {
 		const telemetry = resolveTelemetry(this.#host.agent.telemetry, this.#host.sessionId());
 
 		for (const candidate of candidates) {
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
+			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId(), {
+				usageScopeId: this.#host.usageScopeId(),
+			});
 			if (!apiKey) continue;
 
 			try {
 				return await compact(
 					this.#host.obfuscatePreparationForProvider(preparation),
 					candidate,
-					this.#host.modelRegistry.resolver(candidate, this.#host.sessionId()),
+					this.#host.modelRegistry.resolver(candidate, {
+						sessionId: this.#host.sessionId(),
+						usageScopeId: this.#host.usageScopeId(),
+					}),
 					this.#host.obfuscateTextForProvider(customInstructions),
 					signal,
 					{
@@ -2485,7 +2496,9 @@ export class SessionMaintenance {
 				for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
 					const candidate = candidates[candidateIndex];
 					const hasMoreCandidates = candidateIndex < candidates.length - 1;
-					const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
+					const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId(), {
+						usageScopeId: this.#host.usageScopeId(),
+					});
 					if (!apiKey) continue;
 
 					let attempt = 0;
@@ -2494,7 +2507,10 @@ export class SessionMaintenance {
 							compactResult = await compact(
 								this.#host.obfuscatePreparationForProvider(preparation),
 								candidate,
-								this.#host.modelRegistry.resolver(candidate, this.#host.sessionId()),
+								this.#host.modelRegistry.resolver(candidate, {
+									sessionId: this.#host.sessionId(),
+									usageScopeId: this.#host.usageScopeId(),
+								}),
 								undefined,
 								autoCompactionSignal,
 								{

--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -27,6 +27,7 @@ export interface SessionStatsTrackerHost {
 	modelRegistry: ModelRegistry;
 	model(): Model | undefined;
 	sessionId(): string;
+	usageScopeId(): string;
 }
 
 /** Computes session totals and tracks the in-flight context estimate. */
@@ -269,6 +270,7 @@ export class SessionStatsTracker {
 		if (!provider) return;
 		this.#host.modelRegistry.authStorage.ingestUsageHeaders(provider, response.headers, {
 			sessionId: this.#host.agent.sessionId,
+			usageScopeId: this.#host.usageScopeId(),
 			baseUrl: this.#host.modelRegistry.getProviderBaseUrl?.(provider),
 		});
 	}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -105,6 +105,7 @@ export interface TurnRecoveryHost {
 	streamingEditAbortTriggered(): boolean;
 	promptGeneration(): number;
 	sessionId(): string;
+	usageScopeId(): string;
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
 	scheduleAgentContinue(options: { delayMs?: number; generation?: number }): void;
 	waitForSessionMessagePersistence(message: AssistantMessage): Promise<void>;
@@ -1298,6 +1299,7 @@ export class TurnRecovery {
 				activeModel.provider,
 				this.#host.sessionId(),
 				{
+					usageScopeId: this.#host.usageScopeId(),
 					retryAfterMs,
 					baseUrl: activeModel.baseUrl,
 					modelId: activeModel.id,

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -553,6 +553,7 @@ export class TurnRecovery {
 				settings: this.#host.settings,
 				registry: this.#host.modelRegistry,
 				sessionId: this.#host.sessionId(),
+				usageScopeId: this.#host.usageScopeId(),
 				metadataResolver: (provider: string) => this.#host.agent.metadataForProvider(provider),
 				signal: controller.signal,
 			});

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -985,8 +985,15 @@ export class TurnRecovery {
 		if (!candidate) {
 			throw new Error(`Retry fallback model not found: ${selector.raw}`);
 		}
+		// Forwarding `options` wholesale sent no usage scope (it carries only
+		// pinFallback/apiKey/signal), so fallback auth resolved under the provider
+		// prompt-cache id and skipped session-scoped quota reports and ranking.
 		const apiKey =
-			options?.apiKey ?? (await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId(), options));
+			options?.apiKey ??
+			(await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId(), {
+				signal: options?.signal,
+				usageScopeId: this.#host.usageScopeId(),
+			}));
 		if (!apiKey) {
 			throw new Error(`No API key for retry fallback ${selector.raw}`);
 		}
@@ -1030,7 +1037,9 @@ export class TurnRecovery {
 			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
 			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
 			if (!candidate) continue;
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
+			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId(), {
+				usageScopeId: this.#host.usageScopeId(),
+			});
 			if (!apiKey) continue;
 			await this.applyRetryFallbackCandidate(role, selector, currentSelector, options);
 			return true;
@@ -1109,7 +1118,9 @@ export class TurnRecovery {
 		if (!model) return false;
 		const baseModel = this.#host.modelRegistry.find("fireworks", toFireworksBaseModelId(model.id));
 		if (!baseModel) return false;
-		const apiKey = await this.#host.modelRegistry.getApiKey(baseModel, this.#host.sessionId());
+		const apiKey = await this.#host.modelRegistry.getApiKey(baseModel, this.#host.sessionId(), {
+			usageScopeId: this.#host.usageScopeId(),
+		});
 		if (!apiKey) return false;
 		const baseSelector = formatModelStringWithRouting(baseModel);
 		this.#host.setModelWithProviderSessionReset(baseModel);
@@ -1159,7 +1170,9 @@ export class TurnRecovery {
 		const primaryModel =
 			resolvedPrimary.model ?? this.#host.modelRegistry.find(originalSelector.provider, originalSelector.id);
 		if (!primaryModel) return;
-		const apiKey = await this.#host.modelRegistry.getApiKey(primaryModel, this.#host.sessionId());
+		const apiKey = await this.#host.modelRegistry.getApiKey(primaryModel, this.#host.sessionId(), {
+			usageScopeId: this.#host.usageScopeId(),
+		});
 		if (!apiKey) return;
 
 		const currentThinkingLevel = this.#host.configuredThinkingLevel();

--- a/packages/coding-agent/src/session/unexpected-stop-classifier.ts
+++ b/packages/coding-agent/src/session/unexpected-stop-classifier.ts
@@ -28,6 +28,9 @@ export interface ClassifyUnexpectedStopDeps {
 	settings: Settings;
 	registry: ModelRegistry;
 	sessionId: string;
+	/** Session usage-provider scope, so the classifier's tiny-model call resolves
+	 *  extension-provided credentials like every other session request. */
+	usageScopeId?: string;
 	metadataResolver?: (provider: string) => Record<string, unknown> | undefined;
 	signal?: AbortSignal;
 }
@@ -72,7 +75,7 @@ async function classifyOnline(text: string, deps: ClassifyUnexpectedStopDeps): P
 	if (!model) {
 		throw new Error("unexpected-stop: no tiny/smol model available for classification");
 	}
-	const apiKey = await deps.registry.getApiKey(model, deps.sessionId);
+	const apiKey = await deps.registry.getApiKey(model, deps.sessionId, { usageScopeId: deps.usageScopeId });
 	if (!apiKey) {
 		throw new Error(`unexpected-stop: no API key for ${model.provider}/${model.id}`);
 	}
@@ -86,7 +89,7 @@ async function classifyOnline(text: string, deps: ClassifyUnexpectedStopDeps): P
 			messages: [{ role: "user", content: text, timestamp: Date.now() }],
 		},
 		{
-			apiKey: deps.registry.resolver(model, deps.sessionId),
+			apiKey: deps.registry.resolver(model, { sessionId: deps.sessionId, usageScopeId: deps.usageScopeId }),
 			maxTokens,
 			disableReasoning: true,
 			metadata,

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -479,9 +479,11 @@ function parseAntigravityCredentials(raw: string): ParsedAntigravityCredentials 
 async function findAntigravityCredentials(
 	modelRegistry: ModelRegistry,
 	sessionId?: string,
+	usageScopeId?: string,
 ): Promise<ImageApiKey | null> {
 	const apiKey = await modelRegistry.getApiKeyForProvider("google-antigravity", sessionId, {
 		modelId: DEFAULT_ANTIGRAVITY_MODEL,
+		usageScopeId,
 	});
 	if (!apiKey) return null;
 
@@ -495,9 +497,13 @@ async function findAntigravityCredentials(
 	};
 }
 
-async function findXAIImageCredentials(modelRegistry?: ModelRegistry): Promise<ImageApiKey | null> {
+async function findXAIImageCredentials(
+	modelRegistry?: ModelRegistry,
+	sessionId?: string,
+	usageScopeId?: string,
+): Promise<ImageApiKey | null> {
 	if (modelRegistry) {
-		const creds = await resolveXAIHttpCredentials(modelRegistry);
+		const creds = await resolveXAIHttpCredentials(modelRegistry, { sessionId, usageScopeId });
 		if (creds) return { provider: "xai", apiKey: creds.apiKey };
 		return null;
 	}
@@ -509,11 +515,13 @@ async function findXAIImageCredentials(modelRegistry?: ModelRegistry): Promise<I
 async function findOpenRouterImageCredentials(
 	modelRegistry?: ModelRegistry,
 	sessionId?: string,
+	usageScopeId?: string,
 ): Promise<ImageApiKey | null> {
 	if (modelRegistry) {
 		// AuthStorage.getApiKey already falls back to env keys, so this covers OPENROUTER_API_KEY too.
-		const apiKey = await modelRegistry.getApiKeyForProvider("openrouter", sessionId);
-		if (apiKey) return { provider: "openrouter", apiKey: modelRegistry.resolver("openrouter", { sessionId }) };
+		const apiKey = await modelRegistry.getApiKeyForProvider("openrouter", sessionId, { usageScopeId });
+		if (apiKey)
+			return { provider: "openrouter", apiKey: modelRegistry.resolver("openrouter", { sessionId, usageScopeId }) };
 		return null;
 	}
 	const apiKey = getEnvApiKey("openrouter");
@@ -524,12 +532,13 @@ async function findOpenRouterImageCredentials(
 async function findGeminiImageCredentials(
 	modelRegistry?: ModelRegistry,
 	sessionId?: string,
+	usageScopeId?: string,
 ): Promise<ImageApiKey | null> {
 	if (modelRegistry) {
 		// AuthStorage.getApiKey already falls back to env keys (GEMINI_API_KEY), so only
 		// GOOGLE_API_KEY needs the explicit check below.
-		const apiKey = await modelRegistry.getApiKeyForProvider("google", sessionId);
-		if (apiKey) return { provider: "gemini", apiKey: modelRegistry.resolver("google", { sessionId }) };
+		const apiKey = await modelRegistry.getApiKeyForProvider("google", sessionId, { usageScopeId });
+		if (apiKey) return { provider: "gemini", apiKey: modelRegistry.resolver("google", { sessionId, usageScopeId }) };
 	} else {
 		const envKey = getEnvApiKey("google");
 		if (envKey) return { provider: "gemini", apiKey: envKey };
@@ -543,9 +552,10 @@ async function findOpenAIHostedImageCredentials(
 	modelRegistry: ModelRegistry | undefined,
 	activeModel: Model | undefined,
 	sessionId?: string,
+	usageScopeId?: string,
 ): Promise<ImageApiKey | null> {
 	if (!modelRegistry || !isOpenAIHostedImageModel(activeModel)) return null;
-	const apiKey = await modelRegistry.getApiKey(activeModel, sessionId);
+	const apiKey = await modelRegistry.getApiKey(activeModel, sessionId, { usageScopeId });
 	if (!isAuthenticated(apiKey)) return null;
 	return {
 		provider: getOpenAIHostedImageProvider(activeModel),
@@ -580,6 +590,7 @@ async function findCodexSubscriptionImageCredentials(
 	modelRegistry: ModelRegistry | undefined,
 	activeModel: Model | undefined,
 	sessionId?: string,
+	usageScopeId?: string,
 ): Promise<ImageApiKey | null> {
 	if (!modelRegistry) return null;
 	if (isOpenAIHostedImageModel(activeModel) && getOpenAIHostedImageProvider(activeModel) === "openai-codex") {
@@ -588,11 +599,11 @@ async function findCodexSubscriptionImageCredentials(
 	// A Codex subscription credential is an OAuth JWT with an account claim. API
 	// keys stored under this provider cannot use the ChatGPT backend and must not
 	// prevent fallback providers from being selected.
-	const token = await modelRegistry.getApiKeyForProvider("openai-codex", sessionId);
+	const token = await modelRegistry.getApiKeyForProvider("openai-codex", sessionId, { usageScopeId });
 	if (!token || !getCodexAccountId(token)) return null;
 	const model = resolveDefaultCodexImageModel(modelRegistry);
 	if (!model) return null;
-	const apiKey = await modelRegistry.getApiKey(model, sessionId);
+	const apiKey = await modelRegistry.getApiKey(model, sessionId, { usageScopeId });
 	if (!isAuthenticated(apiKey) || !getCodexAccountId(apiKey)) return null;
 	return { provider: "openai-codex", apiKey, model };
 }
@@ -639,20 +650,21 @@ async function findImageApiKey(
 	modelRegistry?: ModelRegistry,
 	activeModel?: Model,
 	sessionId?: string,
+	usageScopeId?: string,
 ): Promise<ImageApiKey | null> {
 	switch (provider) {
 		case "openai":
-			return findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
+			return findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId, usageScopeId);
 		case "openai-codex":
-			return findCodexSubscriptionImageCredentials(modelRegistry, activeModel, sessionId);
+			return findCodexSubscriptionImageCredentials(modelRegistry, activeModel, sessionId, usageScopeId);
 		case "antigravity":
-			return modelRegistry ? findAntigravityCredentials(modelRegistry, sessionId) : null;
+			return modelRegistry ? findAntigravityCredentials(modelRegistry, sessionId, usageScopeId) : null;
 		case "xai":
-			return findXAIImageCredentials(modelRegistry);
+			return findXAIImageCredentials(modelRegistry, sessionId, usageScopeId);
 		case "openrouter":
-			return findOpenRouterImageCredentials(modelRegistry, sessionId);
+			return findOpenRouterImageCredentials(modelRegistry, sessionId, usageScopeId);
 		case "gemini":
-			return findGeminiImageCredentials(modelRegistry, sessionId);
+			return findGeminiImageCredentials(modelRegistry, sessionId, usageScopeId);
 	}
 }
 
@@ -1100,7 +1112,8 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 	parameters: imageGenSchema,
 	async execute(_toolCallId, params, _onUpdate, ctx, signal) {
 		return untilAborted(signal, async () => {
-			const sessionId = ctx.sessionManager.getSessionId();
+			const sessionId = ctx.providerSessionId ?? ctx.sessionManager.getSessionId();
+			const usageScopeId = ctx.usageProviderScopeId;
 			const providerOrder = imageProviderOrder(ctx.model, params.provider);
 			const cwd = ctx.sessionManager.getCwd();
 			const requestSignal = ptree.combineSignals(signal, IMAGE_TIMEOUT);
@@ -1111,7 +1124,13 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 			let resolvedImageCache: InlineImageData[] | undefined;
 
 			for (const preferredProvider of providerOrder) {
-				const apiKey = await findImageApiKey(preferredProvider, ctx.modelRegistry, ctx.model, sessionId);
+				const apiKey = await findImageApiKey(
+					preferredProvider,
+					ctx.modelRegistry,
+					ctx.model,
+					sessionId,
+					usageScopeId,
+				);
 				if (!apiKey) continue;
 				foundCredentials = true;
 				if (!resolvedImageCache) {
@@ -1345,7 +1364,11 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						if (!ctx.modelRegistry) {
 							throw new Error("Missing modelRegistry for xAI image generation");
 						}
-						const xaiCreds = await resolveXAIHttpCredentials(ctx.modelRegistry, resolvedModel);
+						const xaiCreds = await resolveXAIHttpCredentials(ctx.modelRegistry, {
+							modelId: resolvedModel,
+							sessionId,
+							usageScopeId,
+						});
 						if (!xaiCreds) {
 							throw new Error(
 								"No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok or X Premium+) or set XAI_API_KEY.",

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1170,7 +1170,12 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						}
 
 						const hostedModel = apiKey.model;
-						const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel, sessionId);
+						// Retry resolvers must carry the scope too: initial discovery above
+						// used it, but an auth/usage-limit retry rotates and marks
+						// credentials through this resolver, so without the scope the
+						// scoped provider's cache version and quota blocks are ignored
+						// from the second attempt on.
+						const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel, { sessionId, usageScopeId });
 
 						const parsed = await withAuth(
 							hostedKey,
@@ -1231,6 +1236,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const prompt = assemblePrompt(params);
 						const antigravityKey: ApiKey = ctx.modelRegistry.resolver("google-antigravity", {
 							sessionId,
+							usageScopeId,
 							modelId: DEFAULT_ANTIGRAVITY_MODEL,
 						});
 
@@ -1401,6 +1407,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 						const xaiKey: ApiKey = ctx.modelRegistry.resolver(xaiCreds.provider, {
 							sessionId,
+							usageScopeId,
 							baseUrl: xaiCreds.baseURL,
 						});
 

--- a/packages/coding-agent/src/utils/image-vision-fallback.ts
+++ b/packages/coding-agent/src/utils/image-vision-fallback.ts
@@ -52,6 +52,7 @@ export interface DescribeAttachedImagesDeps {
 	activeModelString?: string;
 	telemetryConfig?: AgentTelemetryConfig;
 	sessionId?: string;
+	usageProviderScopeId?: string;
 	/** Test seam: overrides the underlying completeSimple call. */
 	completeImpl?: typeof completeSimple;
 }
@@ -142,7 +143,13 @@ async function describeImage(
 					},
 				],
 			},
-			{ apiKey: deps.modelRegistry.resolver(visionModel, deps.sessionId), signal },
+			{
+				apiKey: deps.modelRegistry.resolver(visionModel, {
+					sessionId: deps.sessionId,
+					usageScopeId: deps.usageProviderScopeId,
+				}),
+				signal,
+			},
 			{ telemetry, oneshotKind: ONESHOT_KIND, completeImpl: deps.completeImpl },
 		);
 		if (response.stopReason === "error" || response.stopReason === "aborted") {
@@ -176,7 +183,9 @@ export async function describeAttachedImagesForTextModel(
 ): Promise<TextContent[]> {
 	const localRoot = resolveLocalRoot(deps.localProtocolOptions);
 	const visionModel = resolveVisionModel(deps);
-	const apiKey = visionModel ? await deps.modelRegistry.getApiKey(visionModel, deps.sessionId) : undefined;
+	const apiKey = visionModel
+		? await deps.modelRegistry.getApiKey(visionModel, deps.sessionId, { usageScopeId: deps.usageProviderScopeId })
+		: undefined;
 	const canDescribe = Boolean(visionModel && apiKey);
 	const telemetry = resolveTelemetry(deps.telemetryConfig, deps.sessionId);
 

--- a/packages/coding-agent/test/advisor-tool-identity-binding.test.ts
+++ b/packages/coding-agent/test/advisor-tool-identity-binding.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression: advisor tool instances are built once and shared across every
+ * roster member, then bound per invocation through an AsyncLocalStorage so the
+ * concurrent advisors each observe their OWN provider UUID and local session
+ * label. Without the async-local run, a delayed execution would read whichever
+ * identity the last binder installed, leaking one advisor's provider session
+ * into another's tool call.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { bindToolsToAsyncSessionIdentity, type ToolSessionIdentity } from "@oh-my-pi/pi-coding-agent";
+import type { Tool } from "@oh-my-pi/pi-coding-agent/tools";
+
+describe("bindToolsToAsyncSessionIdentity", () => {
+	it("keeps each concurrent binding on its own provider and label identity", async () => {
+		const identity = new AsyncLocalStorage<ToolSessionIdentity>();
+		const scheduled: Array<PromiseWithResolvers<void>> = [];
+		const observed: ToolSessionIdentity[] = [];
+
+		const sharedTool = {
+			name: "probe",
+			async execute() {
+				// Block until every peer has entered, THEN read identity after the
+				// await. AsyncLocalStorage restores the caller's store across the
+				// suspension; a mutable shared field would collapse to the last
+				// binder's identity here.
+				const gate = Promise.withResolvers<void>();
+				scheduled.push(gate);
+				await gate.promise;
+				const entry = identity.getStore();
+				if (entry) observed.push(entry);
+				return { content: [] };
+			},
+		} as unknown as Tool;
+
+		const first = bindToolsToAsyncSessionIdentity([sharedTool], identity, {
+			providerSessionId: "provider-a",
+			sessionLabel: "session-a-advisor",
+		});
+		const second = bindToolsToAsyncSessionIdentity([sharedTool], identity, {
+			providerSessionId: "provider-b",
+			sessionLabel: "session-b-advisor-reviewer",
+		});
+
+		// Binding produces a distinct per-invocation wrapper, not a mutation of the shared tool.
+		expect(first[0]).not.toBe(second[0]);
+
+		const firstDone = first[0]!.execute("call-1", {});
+		const secondDone = second[0]!.execute("call-2", {});
+
+		// Release in reverse entry order to prove the identity survives the await.
+		while (scheduled.length < 2) await Promise.resolve();
+		scheduled.pop()?.resolve();
+		scheduled.pop()?.resolve();
+		await Promise.all([firstDone, secondDone]);
+
+		expect(observed).toHaveLength(2);
+		const byProvider = new Map(observed.map(entry => [entry.providerSessionId, entry.sessionLabel]));
+		expect(byProvider.get("provider-a")).toBe("session-a-advisor");
+		expect(byProvider.get("provider-b")).toBe("session-b-advisor-reviewer");
+	});
+
+	it("preserves prototype metadata for provider-visible tool specs", () => {
+		const identity = new AsyncLocalStorage<ToolSessionIdentity>();
+		const tool = Object.assign(
+			Object.create({
+				get description(): string {
+					return "probe tool";
+				},
+			}),
+			{
+				name: "probe",
+				label: "Probe",
+				parameters: { type: "object" },
+				async execute() {
+					return { content: [] };
+				},
+			},
+		) as Tool;
+		const [bound] = bindToolsToAsyncSessionIdentity([tool], identity, {
+			providerSessionId: "provider-a",
+			sessionLabel: "session-a-advisor",
+		});
+		// The agent loop spreads the bound tool then reads description separately.
+		const spec = { ...bound!, description: bound!.description };
+		expect(spec.name).toBe("probe");
+		expect(spec.label).toBe("Probe");
+		expect(spec.description).toBe("probe tool");
+		expect(spec.parameters).toBe(tool.parameters);
+		expect(spec.execute).not.toBe(tool.execute);
+	});
+
+	it("reads branded prototype getters from the original tool instance", () => {
+		class BrandedTool {
+			#description = "private probe tool";
+			name = "private-probe";
+			label = "Private Probe";
+			parameters = { type: "object" };
+
+			get description(): string {
+				return this.#description;
+			}
+
+			async execute() {
+				return { content: [] };
+			}
+		}
+
+		const identity = new AsyncLocalStorage<ToolSessionIdentity>();
+		const tool = new BrandedTool() as unknown as Tool;
+		const [bound] = bindToolsToAsyncSessionIdentity([tool], identity, {
+			providerSessionId: "provider-a",
+			sessionLabel: "session-a-advisor",
+		});
+		const spec = { ...bound!, description: bound!.description };
+
+		expect(spec.name).toBe("private-probe");
+		expect(spec.label).toBe("Private Probe");
+		expect(spec.description).toBe("private probe tool");
+		expect(spec.parameters).toBe(tool.parameters);
+	});
+});

--- a/packages/coding-agent/test/advisor-tool-identity-binding.test.ts
+++ b/packages/coding-agent/test/advisor-tool-identity-binding.test.ts
@@ -120,4 +120,35 @@ describe("bindToolsToAsyncSessionIdentity", () => {
 		expect(spec.description).toBe("private probe tool");
 		expect(spec.parameters).toBe(tool.parameters);
 	});
+
+	it("preserves a parameter schema exposed only through a prototype getter", () => {
+		// Eval, Edit and Task build their schema behind a getter, so an own-descriptor
+		// clone drops `parameters` and normalizeTools hands undefined to
+		// toolWireSchema, failing the advisor turn before any tool runs.
+		class SchemaTool {
+			#parameters = { type: "object", properties: { path: { type: "string" } } };
+			name = "schema-probe";
+			label = "Schema Probe";
+			description = "schema probe tool";
+
+			get parameters(): unknown {
+				return this.#parameters;
+			}
+
+			async execute() {
+				return { content: [] };
+			}
+		}
+
+		const identity = new AsyncLocalStorage<ToolSessionIdentity>();
+		const tool = new SchemaTool() as unknown as Tool;
+		const [bound] = bindToolsToAsyncSessionIdentity([tool], identity, {
+			providerSessionId: "provider-a",
+			sessionLabel: "session-a-advisor",
+		});
+		const spec = { ...bound! };
+
+		expect(spec.parameters).toBe(tool.parameters);
+		expect(bound!.parameters).toBe(tool.parameters);
+	});
 });

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -406,7 +406,12 @@ describe("AgentSession message pipeline", () => {
 		expect(keys).toEqual(["old-key", "next-key"]);
 		expect(capturedOptions?.promptCacheKey).toBe(cacheSessionId);
 		expect(capturedOptions?.sessionId).toStartWith(`${cacheSessionId}:side:`);
-		expect(resolver).toHaveBeenCalledWith(model, cacheSessionId);
+		// The ephemeral turn must resolve under the session's usage scope, or /btw
+		// and /omfg silently bypass an extension's usage provider.
+		expect(resolver).toHaveBeenCalledWith(model, {
+			sessionId: cacheSessionId,
+			usageScopeId: session.usageProviderScopeId,
+		});
 	});
 
 	it("applies configured OpenRouter routing variant to ephemeral side-channel options", async () => {

--- a/packages/coding-agent/test/agent-session-usage-provider-attribution.test.ts
+++ b/packages/coding-agent/test/agent-session-usage-provider-attribution.test.ts
@@ -1,12 +1,16 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, type StreamFn } from "@oh-my-pi/pi-agent-core";
-import type { Model } from "@oh-my-pi/pi-ai";
+import type { Model, UsageProviderRegistration } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import {
+	collectExtensionUsageProviderRegistrations,
+	ExtensionRuntime,
+	loadExtensionFromFactory,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -38,6 +42,18 @@ async function scopedExtensionRunner(providerId: string, cwd: string): Promise<E
 		emit: async () => undefined,
 		emitBeforeAgentStart: async () => undefined,
 	} as unknown as ExtensionRunner;
+}
+
+/** Runner plus the registrations the SDK would collect from it, matching production DI. */
+async function scopedExtensionConfig(
+	providerId: string,
+	cwd: string,
+): Promise<{ extensionRunner: ExtensionRunner; usageProviderRegistrations: UsageProviderRegistration[] }> {
+	const extensionRunner = await scopedExtensionRunner(providerId, cwd);
+	return {
+		extensionRunner,
+		usageProviderRegistrations: collectExtensionUsageProviderRegistrations(extensionRunner.getExtensions()),
+	};
 }
 
 function createAgent(model: Model, streamFn?: StreamFn): Agent {
@@ -101,7 +117,7 @@ describe("AgentSession extension usage-provider attribution", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry,
-			extensionRunner: await scopedExtensionRunner(model.provider, tempDir.path()),
+			...(await scopedExtensionConfig(model.provider, tempDir.path())),
 		});
 		const ingestUsageHeaders = vi.spyOn(authStorage, "ingestUsageHeaders");
 
@@ -129,7 +145,7 @@ describe("AgentSession extension usage-provider attribution", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false, "retry.baseDelayMs": 0, "retry.maxRetries": 1 }),
 			modelRegistry,
-			extensionRunner: await scopedExtensionRunner(model.provider, tempDir.path()),
+			...(await scopedExtensionConfig(model.provider, tempDir.path())),
 		});
 		const markUsageLimitReached = vi
 			.spyOn(authStorage, "markUsageLimitReached")
@@ -166,7 +182,7 @@ describe("AgentSession extension usage-provider attribution", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry,
-			extensionRunner: await scopedExtensionRunner(model.provider, tempDir.path()),
+			...(await scopedExtensionConfig(model.provider, tempDir.path())),
 		});
 		const recordUsageCost = vi.spyOn(authStorage, "recordUsageCost");
 
@@ -180,5 +196,40 @@ describe("AgentSession extension usage-provider attribution", () => {
 			recordedAt: expect.any(Number),
 			baseUrl: modelRegistry.getProviderBaseUrl?.("opencode-go"),
 		});
+	});
+
+	it("skips scope registration and preserves credential resolution when no providers are registered", () => {
+		const model = requiredModel();
+		const agent = createAgent(model);
+		const originalGetApiKey = agent.getApiKey;
+		const register = vi.spyOn(authStorage, "registerSessionUsageProviders");
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+		expect(register).not.toHaveBeenCalled();
+		expect(agent.getApiKey).toBe(originalGetApiKey);
+	});
+
+	it("registers a disposable scope and scopes credential resolution when providers exist", async () => {
+		const model = requiredModel();
+		const agent = createAgent(model);
+		const originalGetApiKey = agent.getApiKey;
+		const unregister = vi.fn();
+		const register = vi.spyOn(authStorage, "registerSessionUsageProviders").mockReturnValue(unregister);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			...(await scopedExtensionConfig(model.provider, tempDir.path())),
+		});
+		expect(register).toHaveBeenCalledWith(session.usageProviderScopeId, expect.any(Object));
+		expect(agent.getApiKey).not.toBe(originalGetApiKey);
+		await session.dispose();
+		session = undefined;
+		expect(unregister).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/agent-session-usage-provider-attribution.test.ts
+++ b/packages/coding-agent/test/agent-session-usage-provider-attribution.test.ts
@@ -1,0 +1,184 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function requiredModel(provider = "anthropic"): Model {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled Anthropic model");
+	return provider === model.provider ? model : { ...model, provider, id: `${provider}-test` };
+}
+
+async function scopedExtensionRunner(providerId: string, cwd: string): Promise<ExtensionRunner> {
+	const extension = await loadExtensionFromFactory(
+		pi =>
+			pi.registerUsageProvider({
+				id: providerId,
+				fetchUsage: async () => ({ provider: providerId, fetchedAt: 1, limits: [] }),
+			}),
+		cwd,
+		new EventBus(),
+		new ExtensionRuntime(),
+		`/extensions/${providerId}.ts`,
+	);
+	return {
+		getExtensions: () => [extension],
+		hasHandlers: () => false,
+		emit: async () => undefined,
+		emitBeforeAgentStart: async () => undefined,
+	} as unknown as ExtensionRunner;
+}
+
+function createAgent(model: Model, streamFn?: StreamFn): Agent {
+	return new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		streamFn,
+	});
+}
+
+function awaitAssistantMessageEnd(agent: Agent): Promise<void> {
+	const handled = Promise.withResolvers<void>();
+	const subscribe = agent.subscribe.bind(agent);
+	agent.subscribe = listener =>
+		subscribe(event => {
+			const result = listener(event);
+			if (event.type === "message_end" && event.message.role === "assistant") {
+				Promise.resolve(result).then(handled.resolve, handled.reject);
+			}
+			return result;
+		});
+	return handled.promise;
+}
+
+describe("AgentSession extension usage-provider attribution", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-session-usage-provider-attribution-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		session = undefined;
+		vi.restoreAllMocks();
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("attributes provider usage headers to the registered extension scope", async () => {
+		const model = requiredModel();
+		const agent = createAgent(model);
+		let responseInterceptor:
+			| ((response: { headers: Headers }, responseModel?: Model) => Promise<void> | void)
+			| undefined;
+		const setProviderResponseInterceptor = agent.setProviderResponseInterceptor.bind(agent);
+		agent.setProviderResponseInterceptor = interceptor => {
+			responseInterceptor = interceptor as typeof responseInterceptor;
+			setProviderResponseInterceptor(interceptor);
+		};
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			extensionRunner: await scopedExtensionRunner(model.provider, tempDir.path()),
+		});
+		const ingestUsageHeaders = vi.spyOn(authStorage, "ingestUsageHeaders");
+
+		await responseInterceptor?.({ headers: new Headers({ "x-ratelimit-remaining": "9" }) }, model);
+
+		expect(ingestUsageHeaders).toHaveBeenCalledWith(model.provider, expect.any(Headers), {
+			sessionId: session.sessionId,
+			usageScopeId: session.usageProviderScopeId,
+			baseUrl: modelRegistry.getProviderBaseUrl?.(model.provider),
+		});
+	});
+
+	it("attributes usage-limit recovery to the registered extension scope", async () => {
+		const model = requiredModel();
+		const mock = createMockModel({
+			provider: model.provider,
+			id: model.id,
+			responses: [{ throw: "429 usage_limit_reached" }],
+		});
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const agent = createAgent(model, mock.stream);
+		const assistantMessageEnd = awaitAssistantMessageEnd(agent);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false, "retry.baseDelayMs": 0, "retry.maxRetries": 1 }),
+			modelRegistry,
+			extensionRunner: await scopedExtensionRunner(model.provider, tempDir.path()),
+		});
+		const markUsageLimitReached = vi
+			.spyOn(authStorage, "markUsageLimitReached")
+			.mockResolvedValue({ switched: false });
+
+		await session.prompt("Trigger scoped quota recovery");
+		await assistantMessageEnd;
+
+		expect(markUsageLimitReached).toHaveBeenCalledWith(model.provider, session.sessionId, {
+			usageScopeId: session.usageProviderScopeId,
+			retryAfterMs: expect.any(Number),
+			baseUrl: model.baseUrl,
+			modelId: model.id,
+		});
+	});
+
+	it("attributes opencode-go cost recording to the registered extension scope", async () => {
+		const model = requiredModel("opencode-go");
+		const mock = createMockModel({
+			provider: model.provider,
+			id: model.id,
+			responses: [
+				{
+					content: ["Recorded"],
+					usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 0.42 } },
+				},
+			],
+		});
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const agent = createAgent(model, mock.stream);
+		const assistantMessageEnd = awaitAssistantMessageEnd(agent);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			extensionRunner: await scopedExtensionRunner(model.provider, tempDir.path()),
+		});
+		const recordUsageCost = vi.spyOn(authStorage, "recordUsageCost");
+
+		await session.prompt("Record scoped cost");
+		await assistantMessageEnd;
+		expect(session.messages.at(-1)).toMatchObject({ provider: "opencode-go" });
+
+		expect(recordUsageCost).toHaveBeenCalledWith("opencode-go", 0.42, {
+			sessionId: session.sessionId,
+			usageScopeId: session.usageProviderScopeId,
+			recordedAt: expect.any(Number),
+			baseUrl: modelRegistry.getProviderBaseUrl?.("opencode-go"),
+		});
+	});
+});

--- a/packages/coding-agent/test/cli-extension-providers.test.ts
+++ b/packages/coding-agent/test/cli-extension-providers.test.ts
@@ -25,11 +25,13 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 
 let tmp: TempDir;
 let extPath: string;
+let invalidExtPath: string;
 let dbPath: string;
 
 beforeAll(async () => {
 	tmp = await TempDir.create("@cli-ext-providers-");
 	extPath = tmp.join("ext.ts");
+	invalidExtPath = tmp.join("invalid-ext.ts");
 	dbPath = tmp.join("auth.db");
 	await fs.writeFile(
 		extPath,
@@ -47,6 +49,44 @@ beforeAll(async () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		}],
+	});
+	pi.registerUsageProvider({
+		id: "bench-gw",
+		async fetchUsage() {
+			return { provider: "bench-gw", fetchedAt: 1, limits: [] };
+		},
+	});
+}
+`,
+	);
+	await fs.writeFile(
+		invalidExtPath,
+		`export default function (pi) {
+	pi.registerProvider("valid-before-invalid", {
+		baseUrl: "https://example.com/v1",
+		apiKey: "literal-test-key",
+		api: "openai-completions",
+		models: [{
+			id: "would-be-model",
+			name: "Would-be Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		}],
+	});
+	pi.registerUsageProvider({
+		id: "invalid-gw",
+		async fetchUsage() {
+			return { provider: "invalid-gw", fetchedAt: 1, limits: [] };
+		},
+	});
+	pi.registerProvider("invalid-gw", {
+		api: "openai-completions",
+		streamSimple() {
+			throw new Error("unused");
+		},
 	});
 }
 `,
@@ -83,6 +123,30 @@ test("loadCliExtensionProviders makes extension providers resolvable by selector
 		expect(after.error).toBeUndefined();
 		expect(after.model?.provider).toBe("bench-gw");
 		expect(after.model?.id).toBe("bench-model");
+		const usageProvider = authStorage.usageProviderFor("bench-gw");
+		if (!usageProvider) throw new Error("extension usage provider was not registered");
+		const report = await usageProvider.fetchUsage(
+			{ provider: "bench-gw", credential: { type: "api_key", apiKey: "test-key" } },
+			{ fetch },
+		);
+		expect(report).toEqual({ provider: "bench-gw", fetchedAt: 1, limits: [] });
+
+		await expect(
+			loadCliExtensionProviders(modelRegistry, settings, tmp.path(), {
+				disableExtensionDiscovery: true,
+				additionalExtensionPaths: [invalidExtPath],
+			}),
+		).rejects.toThrow("built-in API names are reserved");
+		expect(modelRegistry.find("bench-gw", "bench-model")).toBeDefined();
+		expect(authStorage.usageProviderFor("bench-gw")).toBe(usageProvider);
+		expect(authStorage.usageProviderFor("invalid-gw")).toBeUndefined();
+		expect(modelRegistry.find("valid-before-invalid", "would-be-model")).toBeUndefined();
+
+		await loadCliExtensionProviders(modelRegistry, settings, tmp.path(), {
+			disableExtensionDiscovery: true,
+			additionalExtensionPaths: [],
+		});
+		expect(authStorage.usageProviderFor("bench-gw")).toBeUndefined();
 	} finally {
 		authStorage.close();
 	}

--- a/packages/coding-agent/test/extension-usage-provider-registration.test.ts
+++ b/packages/coding-agent/test/extension-usage-provider-registration.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { UsageProvider } from "@oh-my-pi/pi-ai";
+import {
+	collectExtensionUsageProviderRegistrations,
+	ExtensionRuntime,
+	loadExtensionFromFactory,
+	loadExtensions,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+describe("extension usage provider registration", () => {
+	it("stores each factory's exact usage provider under its extension path", async () => {
+		const firstProvider: UsageProvider = {
+			id: "anthropic",
+			fetchUsage: async () => null,
+		};
+		const secondProvider: UsageProvider = {
+			id: "openai-codex",
+			fetchUsage: async () => null,
+		};
+		const runtime = new ExtensionRuntime();
+		const eventBus = new EventBus();
+		const firstPath = "/extensions/first.ts";
+		const secondPath = "/extensions/second.ts";
+
+		const firstExtension = await loadExtensionFromFactory(
+			pi => {
+				pi.registerUsageProvider(firstProvider);
+			},
+			"/workspace",
+			eventBus,
+			runtime,
+			firstPath,
+		);
+		const secondExtension = await loadExtensionFromFactory(
+			pi => {
+				pi.registerUsageProvider(secondProvider);
+			},
+			"/workspace",
+			eventBus,
+			runtime,
+			secondPath,
+		);
+
+		const registrations = collectExtensionUsageProviderRegistrations([firstExtension, secondExtension]);
+		expect(registrations.map(registration => registration.sourceId)).toEqual([firstPath, secondPath]);
+		expect(registrations[0]?.provider).toBe(firstProvider);
+		expect(registrations[1]?.provider).toBe(secondProvider);
+	});
+
+	it("discards usage providers when a factory fails", async () => {
+		const retainedProvider: UsageProvider = {
+			id: "anthropic",
+			fetchUsage: async () => null,
+		};
+		const leakedProvider: UsageProvider = {
+			id: "openai-codex",
+			fetchUsage: async () => null,
+		};
+		const runtime = new ExtensionRuntime();
+		const eventBus = new EventBus();
+		const retainedExtension = await loadExtensionFromFactory(
+			pi => {
+				pi.registerUsageProvider(retainedProvider);
+			},
+			"/workspace",
+			eventBus,
+			runtime,
+			"/extensions/retained.ts",
+		);
+
+		await expect(
+			loadExtensionFromFactory(
+				pi => {
+					pi.registerUsageProvider(leakedProvider);
+					throw new Error("factory failed");
+				},
+				"/workspace",
+				eventBus,
+				runtime,
+				"/extensions/failed.ts",
+			),
+		).rejects.toThrow("factory failed");
+
+		expect(collectExtensionUsageProviderRegistrations([retainedExtension])).toEqual([
+			{ provider: retainedProvider, sourceId: "/extensions/retained.ts" },
+		]);
+	});
+
+	it("continues loading after a failed path without retaining its usage provider", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "extension-usage-rollback-"));
+		const failedPath = path.join(tempDir, "failed.ts");
+		const succeedingPath = path.join(tempDir, "succeeding.ts");
+		await Bun.write(
+			failedPath,
+			`export default function (pi) {
+				pi.registerUsageProvider({ id: "failed-usage", fetchUsage: async () => null });
+				throw new Error("failed after registration");
+			}`,
+		);
+		await Bun.write(
+			succeedingPath,
+			`export default function (pi) {
+				pi.registerUsageProvider({ id: "working-usage", fetchUsage: async () => null });
+			}`,
+		);
+		try {
+			const result = await loadExtensions([failedPath, succeedingPath], tempDir, new EventBus());
+			expect(result.errors).toHaveLength(1);
+			expect(result.extensions.map(extension => extension.path)).toEqual([succeedingPath]);
+			const registrations = collectExtensionUsageProviderRegistrations(result.extensions);
+			expect(registrations).toHaveLength(1);
+			expect(registrations[0]).toMatchObject({
+				sourceId: succeedingPath,
+				provider: { id: "working-usage" },
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/issue-905-repro.test.ts
+++ b/packages/coding-agent/test/issue-905-repro.test.ts
@@ -22,15 +22,11 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 let tmp: TempDir;
 let extPath: string;
 let dbPath: string;
-let shutdownExtPath: string;
-let shutdownPath: string;
 
 beforeAll(async () => {
 	tmp = await TempDir.create("@issue-905-");
 	extPath = tmp.join("ext.ts");
 	dbPath = tmp.join("auth.db");
-	shutdownExtPath = tmp.join("shutdown-ext.ts");
-	shutdownPath = tmp.join("shutdown");
 	await fs.writeFile(
 		extPath,
 		`export default function (pi) {
@@ -47,15 +43,6 @@ beforeAll(async () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		}],
-	});
-}
-`,
-	);
-	await fs.writeFile(
-		shutdownExtPath,
-		`export default function (pi) {
-	pi.on("session_shutdown", async () => {
-		await Bun.write(${JSON.stringify(shutdownPath)}, "shutdown");
 	});
 }
 `,
@@ -99,20 +86,42 @@ test("omp models surfaces extension-registered providers (issue #905)", async ()
 	}
 });
 
-test("omp models emits extension shutdown after listing (issue #6297)", async () => {
+test("omp models does not mutate providers when usage registration validation fails", async () => {
+	const invalidExtPath = tmp.join("invalid-usage-ext.ts");
+	await fs.writeFile(
+		invalidExtPath,
+		`export default function (pi) {
+	pi.registerProvider("invalid-usage-gw", {
+		baseUrl: "https://example.com/v1",
+		apiKey: "literal-test-key",
+		api: "openai-completions",
+		models: [{
+			id: "invalid-usage-model",
+			name: "Invalid Usage Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		}],
+	});
+	pi.registerUsageProvider({ id: "invalid-usage-gw" });
+}
+`,
+	);
 	const authStorage = await AuthStorage.create(":memory:");
 	try {
 		const modelRegistry = new ModelRegistry(authStorage);
-		await runModelsListing({
-			modelRegistry,
-			cwd: tmp.path(),
-			action: "ls",
-			pattern: "issue-6297-no-models",
-			additionalExtensionPaths: [shutdownExtPath],
-			disableExtensionDiscovery: true,
-		});
-
-		expect(await Bun.file(shutdownPath).text()).toBe("shutdown");
+		await expect(
+			runModelsListing({
+				modelRegistry,
+				cwd: tmp.path(),
+				action: "ls",
+				additionalExtensionPaths: [invalidExtPath],
+				disableExtensionDiscovery: true,
+			}),
+		).rejects.toThrow();
+		expect(modelRegistry.find("invalid-usage-gw", "invalid-usage-model")).toBeUndefined();
 	} finally {
 		authStorage.close();
 	}

--- a/packages/coding-agent/test/mnemopi-provider-scope.test.ts
+++ b/packages/coding-agent/test/mnemopi-provider-scope.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as ai from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { mnemopiBackend } from "@oh-my-pi/pi-coding-agent/mnemopi/backend";
+import { getMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+
+describe("mnemopi provider credentials", () => {
+	let agentDir: string | undefined;
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (agentDir) await fs.rm(agentDir, { force: true, recursive: true });
+		agentDir = undefined;
+	});
+
+	test("resolves OpenRouter credentials in the AgentSession usage-provider scope", async () => {
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-provider-scope-"));
+		const settings = Settings.isolated({
+			"mnemopi.autoRecall": false,
+			"mnemopi.autoRetain": false,
+			"mnemopi.dbPath": path.join(agentDir, "mnemopi.db"),
+			"mnemopi.noEmbeddings": true,
+			"mnemopi.scoping": "global",
+		});
+		const resolver = vi.fn(() => async () => "openrouter-key");
+		const modelRegistry = {
+			getApiKeyForProvider: vi.fn(async () => "openrouter-key"),
+			getAvailable: vi.fn(() => []),
+			resolver,
+		};
+		const session = {
+			sessionId: "provider-session",
+			usageProviderScopeId: "usage-provider-scope",
+			settings,
+			modelRegistry,
+			sessionManager: { getCwd: () => agentDir },
+			subscribe: vi.fn(() => () => {}),
+		};
+
+		await mnemopiBackend.start({ agentDir, modelRegistry, session, settings, taskDepth: 0 } as never);
+
+		expect(modelRegistry.getApiKeyForProvider).toHaveBeenCalledWith("openrouter", "provider-session", {
+			usageScopeId: "usage-provider-scope",
+		});
+		expect(resolver).toHaveBeenCalledWith("openrouter", {
+			sessionId: "provider-session",
+			usageScopeId: "usage-provider-scope",
+		});
+		await mnemopiBackend.clear(agentDir, agentDir, session as never);
+	});
+
+	test("resolves smol LLM credentials in the AgentSession usage-provider scope", async () => {
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-provider-scope-"));
+		const settings = Settings.isolated({
+			"mnemopi.autoRecall": false,
+			"mnemopi.autoRetain": false,
+			"mnemopi.dbPath": path.join(agentDir, "mnemopi.db"),
+			"mnemopi.noEmbeddings": true,
+			"mnemopi.scoping": "global",
+			modelRoles: { tiny: "openai/smol-model" },
+		});
+		const model = {
+			contextWindow: 32_000,
+			id: "smol-model",
+			name: "Smol model",
+			provider: "openai",
+		};
+		const resolver = vi.fn(() => async () => "api-key");
+		const modelRegistry = {
+			getApiKey: vi.fn(async () => "api-key"),
+			getApiKeyForProvider: vi.fn(async () => "openrouter-key"),
+			getAvailable: vi.fn(() => [model]),
+			resolver,
+		};
+		const session = {
+			sessionId: "provider-session",
+			usageProviderScopeId: "usage-provider-scope",
+			settings,
+			modelRegistry,
+			sessionManager: { getCwd: () => agentDir },
+			subscribe: vi.fn(() => () => {}),
+		};
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			content: [{ text: "completion", type: "text" }],
+		} as never);
+
+		await mnemopiBackend.start({ agentDir, modelRegistry, session, settings, taskDepth: 0 } as never);
+		const llm = getMnemopiSessionState(session as never)?.config.providerOptions.llm;
+		if (typeof llm !== "function") throw new Error("Expected the smol LLM closure");
+		await llm("test prompt");
+
+		expect(modelRegistry.getApiKey).toHaveBeenCalledWith(model, "provider-session", "usage-provider-scope");
+		expect(resolver).toHaveBeenCalledWith(model, {
+			sessionId: "provider-session",
+			usageScopeId: "usage-provider-scope",
+		});
+		await mnemopiBackend.clear(agentDir, agentDir, session as never);
+	});
+});

--- a/packages/coding-agent/test/sdk-preloaded-extensions-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-preloaded-extensions-isolation.test.ts
@@ -11,16 +11,20 @@
  * Subagent forwarding is a separate path (`preloadedExtensionPaths`) which
  * reloads extensions per session so each session's `ExtensionAPI` is its own.
  */
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { UsageProvider } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 describe("createAgentSession preloadedExtensions isolation (issue #2190)", () => {
@@ -53,7 +57,7 @@ describe("createAgentSession preloadedExtensions isolation (issue #2190)", () =>
 		const beforeLength = preloaded.extensions.length;
 		const beforeArrayRef = preloaded.extensions;
 
-		await createAgentSession({
+		const session = await createAgentSession({
 			cwd: sharedDir,
 			agentDir: sharedDir,
 			sessionManager: SessionManager.inMemory(),
@@ -70,10 +74,207 @@ describe("createAgentSession preloadedExtensions isolation (issue #2190)", () =>
 			contextFiles: [],
 			promptTemplates: [],
 		});
+		await session.session.dispose();
 
 		// The session's own `extensionsResult` carries inline wrappers, but the
 		// caller's array (and its identity) must be untouched.
 		expect(preloaded.extensions).toBe(beforeArrayRef);
 		expect(preloaded.extensions.length).toBe(beforeLength);
+	});
+
+	it("replays source-owned usage providers when a preloaded result is reused", async () => {
+		const provider: UsageProvider = {
+			id: "reusable-usage",
+			fetchUsage: async () => ({ provider: "reusable-usage", fetchedAt: 1, limits: [] }),
+		};
+		await authStorage.set(provider.id, { type: "api_key", key: "reusable-key" });
+		const runtime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => pi.registerUsageProvider(provider),
+			sharedDir,
+			new EventBus(),
+			runtime,
+			"/extensions/reusable.ts",
+		);
+		const preloaded: LoadExtensionsResult = { extensions: [extension], errors: [], runtime };
+
+		for (let index = 0; index < 2; index++) {
+			const session = await createAgentSession({
+				cwd: sharedDir,
+				agentDir: sharedDir,
+				sessionManager: SessionManager.inMemory(),
+				modelRegistry,
+				settings: Settings.isolated(),
+				preloadedExtensions: preloaded,
+				enableLsp: false,
+				enableMCP: false,
+				skipPythonPreflight: true,
+				skills: [],
+				rules: [],
+				preloadedCustomToolPaths: [],
+				contextFiles: [],
+				promptTemplates: [],
+			});
+			expect((await session.session.fetchUsageReports())?.map(report => report.provider)).toContain(provider.id);
+			await session.session.dispose();
+		}
+		expect(authStorage.usageProviderFor(provider.id)).toBeUndefined();
+	});
+
+	it("partitions inline usage-provider cache entries by session", async () => {
+		const providerId = "inline-cache-isolated";
+		await authStorage.set(providerId, { type: "api_key", key: "inline-cache-key" });
+		let firstFetches = 0;
+		let secondFetches = 0;
+		const first = await createAgentSession({
+			cwd: sharedDir,
+			agentDir: sharedDir,
+			sessionManager: SessionManager.inMemory(),
+			modelRegistry,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			extensions: [
+				pi =>
+					pi.registerUsageProvider({
+						id: providerId,
+						fetchUsage: async () => {
+							firstFetches++;
+							return { provider: providerId, fetchedAt: 1, limits: [] };
+						},
+					}),
+			],
+			enableLsp: false,
+			enableMCP: false,
+			skipPythonPreflight: true,
+			skills: [],
+			rules: [],
+			contextFiles: [],
+			promptTemplates: [],
+		});
+		try {
+			expect(await first.session.fetchUsageReports()).toEqual([{ provider: providerId, fetchedAt: 1, limits: [] }]);
+			const second = await createAgentSession({
+				cwd: sharedDir,
+				agentDir: sharedDir,
+				sessionManager: SessionManager.inMemory(),
+				modelRegistry,
+				settings: Settings.isolated(),
+				disableExtensionDiscovery: true,
+				extensions: [
+					pi =>
+						pi.registerUsageProvider({
+							id: providerId,
+							fetchUsage: async () => {
+								secondFetches++;
+								return { provider: providerId, fetchedAt: 2, limits: [] };
+							},
+						}),
+				],
+				enableLsp: false,
+				enableMCP: false,
+				skipPythonPreflight: true,
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+			});
+			try {
+				expect(await second.session.fetchUsageReports()).toEqual([
+					{ provider: providerId, fetchedAt: 2, limits: [] },
+				]);
+				expect(firstFetches).toBe(1);
+				expect(secondFetches).toBe(1);
+			} finally {
+				await second.session.dispose();
+			}
+		} finally {
+			await first.session.dispose();
+		}
+	});
+
+	it("isolates source-owned usage providers between sessions sharing AuthStorage", async () => {
+		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) throw new Error("expected bundled anthropic default model");
+		authStorage.setRuntimeApiKey(defaultModel.provider, "test-key");
+		const parentSettings = Settings.isolated();
+		parentSettings.setModelRole("default", `${defaultModel.provider}/${defaultModel.id}`);
+		const provider: UsageProvider = {
+			id: "parent-owned-usage",
+			fetchUsage: async () => ({ provider: "parent-owned-usage", fetchedAt: 1, limits: [] }),
+		};
+		await authStorage.set(provider.id, { type: "api_key", key: "parent-key" });
+		const runtime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => pi.registerUsageProvider(provider),
+			sharedDir,
+			new EventBus(),
+			runtime,
+			"/extensions/parent.ts",
+		);
+		const parent = await createAgentSession({
+			cwd: sharedDir,
+			agentDir: sharedDir,
+			sessionManager: SessionManager.inMemory(),
+			modelRegistry,
+			settings: parentSettings,
+			providerSessionId: "shared-provider-session",
+			preloadedExtensions: { extensions: [extension], errors: [], runtime },
+			enableLsp: false,
+			enableMCP: false,
+			skipPythonPreflight: true,
+			skills: [],
+			rules: [],
+			preloadedCustomToolPaths: [],
+			contextFiles: [],
+			promptTemplates: [],
+		});
+		try {
+			const child = await createAgentSession({
+				cwd: sharedDir,
+				agentDir: sharedDir,
+				sessionManager: SessionManager.inMemory(),
+				modelRegistry,
+				settings: Settings.isolated(),
+				providerSessionId: "shared-provider-session",
+				preloadedExtensions: { extensions: [], errors: [], runtime: new ExtensionRuntime() },
+				enableLsp: false,
+				enableMCP: false,
+				skipPythonPreflight: true,
+				skills: [],
+				rules: [],
+				preloadedCustomToolPaths: [],
+				contextFiles: [],
+				promptTemplates: [],
+			});
+			try {
+				expect(parent.session.usageProviderScopeId).not.toBe(child.session.usageProviderScopeId);
+				expect((await parent.session.fetchUsageReports())?.map(report => report.provider)).toContain(provider.id);
+				expect((await child.session.fetchUsageReports())?.map(report => report.provider)).not.toContain(
+					provider.id,
+				);
+				expect((await parent.session.fetchUsageReports())?.map(report => report.provider)).toContain(provider.id);
+				expect(authStorage.usageProviderFor(provider.id)).toBeUndefined();
+				const model = parent.session.model;
+				if (!model) throw new Error("expected parent model");
+				expect(model.provider).toBe(defaultModel.provider);
+				const resolverSpy = spyOn(modelRegistry, "resolver").mockImplementation(
+					(_requestModel, options) => async () =>
+						typeof options !== "string" && options?.usageScopeId === parent.session.usageProviderScopeId
+							? "scoped-key"
+							: undefined,
+				);
+				try {
+					const key = await parent.session.agent.getApiKey?.(model);
+					if (typeof key !== "function") throw new Error("expected API key resolver");
+					expect(await key({ lastChance: false, error: undefined })).toBe("scoped-key");
+				} finally {
+					resolverSpy.mockRestore();
+				}
+			} finally {
+				await child.session.dispose();
+			}
+		} finally {
+			await parent.session.dispose();
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -95,6 +95,31 @@ describe("imageGenTool", () => {
 		);
 	});
 
+	it("attributes direct provider credential resolution to the tool's provider session and usage scope", async () => {
+		setImageProviderOrder(["antigravity"]);
+		const ctx = createAntigravityXAIContext(undefined, (async () => {
+			throw new Error("stop after credential resolution");
+		}) as unknown as typeof fetch);
+		ctx.providerSessionId = "provider-session";
+		ctx.usageProviderScopeId = "usage-scope";
+		const calls: unknown[][] = [];
+		const getApiKeyForProvider = ctx.modelRegistry.getApiKeyForProvider.bind(ctx.modelRegistry);
+		ctx.modelRegistry.getApiKeyForProvider = async (...args) => {
+			calls.push(args);
+			return await getApiKeyForProvider(...args);
+		};
+
+		await expect(
+			imageGenTool.execute("call-scoped-credentials", { subject: "a cat" }, undefined, ctx),
+		).rejects.toThrow("stop after credential resolution");
+
+		expect(calls[0]).toEqual([
+			"google-antigravity",
+			"provider-session",
+			expect.objectContaining({ usageScopeId: "usage-scope" }),
+		]);
+	});
+
 	it("e2e writes OpenAI Responses image_generation WebP output to a temp file", async () => {
 		let requestUrl: string | undefined;
 		let requestBody: unknown;

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -1,12 +1,22 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
-import type { UsageReport } from "@oh-my-pi/pi-ai";
+import {
+	type AuthCredentialStore,
+	AuthStorage,
+	type StoredAuthCredential,
+	type UsageProvider,
+	type UsageReport,
+} from "@oh-my-pi/pi-ai";
 import {
 	buildRedactionMap,
 	collectUnreportedAccounts,
 	computeProviderWindowStats,
 	formatUsageBreakdown,
 	formatUsageHistory,
+	runUsageCommand,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
 
@@ -208,23 +218,6 @@ describe("formatUsageBreakdown", () => {
 		{ provider: "cerebras", type: "api_key" },
 	];
 
-	it("renders used-only USD spend without fabricating quota data", () => {
-		const spendReport = makeReport("anthropic", "spend@example.test", [
-			{
-				id: "anthropic:extra",
-				label: "Claude Extra Usage",
-				scope: { provider: "anthropic", windowId: "extra" },
-				amount: { used: 123.45, unit: "usd" },
-			},
-		]);
-
-		const text = stripVTControlCharacters(formatUsageBreakdown([spendReport], [], Date.now()));
-
-		expect(text).toContain("$123.45 used");
-		expect(text).not.toContain("no data");
-		expect(text).not.toContain("%");
-		expect(text).not.toContain("resets");
-	});
 	it("renders every account: reported ones with limits, credential-only ones as no-data rows", () => {
 		const text = stripVTControlCharacters(formatUsageBreakdown(reports, accounts, Date.now()));
 		expect(text).toContain("dummy.primary@example.test");
@@ -479,5 +472,215 @@ describe("formatUsageHistory", () => {
 		const text = stripVTControlCharacters(formatUsageHistory(entries, SINCE, NOW, redaction));
 		expect(text).not.toContain("dummy.primary@example.test");
 		expect(text).toContain("du*");
+	});
+});
+
+describe("runUsageCommand", () => {
+	it("loads extension usage providers before fetching live reports", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "usage-cli-extension-"));
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		await authStorage.set("runtime-usage", [
+			{ type: "oauth", access: "runtime-token", refresh: "runtime-refresh", expires: Date.now() + HOUR },
+		]);
+		let prepared = false;
+		const provider: UsageProvider = {
+			id: "runtime-usage",
+			supports: ({ credential }) => credential.type === "oauth",
+			fetchUsage: async () => ({
+				provider: "runtime-usage",
+				fetchedAt: 1,
+				limits: [
+					{
+						id: "weekly",
+						label: "Weekly",
+						scope: { provider: "runtime-usage", windowId: "weekly" },
+						amount: { unit: "percent", usedFraction: 0.25 },
+					},
+				],
+			}),
+		};
+		const output: string[] = [];
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+			output.push(String(chunk));
+			return true;
+		}) as typeof process.stdout.write);
+		try {
+			await runUsageCommand(
+				{ json: true, provider: "runtime-usage" },
+				{
+					discoverAuthStorage: async () => authStorage,
+					prepareModelRegistry: async modelRegistry => {
+						prepared = true;
+						modelRegistry.authStorage.syncExtensionUsageProviders(
+							["/extensions/usage.ts"],
+							[{ provider, sourceId: "/extensions/usage.ts" }],
+						);
+					},
+				},
+			);
+		} finally {
+			writeSpy.mockRestore();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+
+		expect(prepared).toBe(true);
+		const payload = JSON.parse(output.join("")) as {
+			reports: UsageReport[];
+			accountsWithoutUsage: unknown[];
+		};
+		expect(payload.reports).toHaveLength(1);
+		expect(payload.reports[0]).toMatchObject({
+			provider: "runtime-usage",
+			limits: [{ amount: { usedFraction: 0.25 } }],
+		});
+		expect(payload.accountsWithoutUsage).toEqual([]);
+	});
+	it("loads explicit usage extensions when discovery is disabled", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "usage-cli-explicit-extension-"));
+		const extensionPath = path.join(tempDir, "usage-extension.ts");
+		await fs.writeFile(
+			extensionPath,
+			`export default function (pi) {
+				pi.registerUsageProvider({
+					id: "explicit-usage",
+					supports: ({ credential }) => credential.type === "oauth",
+					async fetchUsage() {
+						return {
+							provider: "explicit-usage",
+							fetchedAt: 1,
+							limits: [{
+								id: "weekly",
+								label: "Weekly",
+								scope: { provider: "explicit-usage", windowId: "weekly" },
+								amount: { unit: "percent", usedFraction: 0.25 }
+							}]
+						};
+					}
+				});
+			}`,
+		);
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		await authStorage.set("explicit-usage", [
+			{ type: "oauth", access: "runtime-token", refresh: "runtime-refresh", expires: Date.now() + HOUR },
+		]);
+		const output: string[] = [];
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+			output.push(String(chunk));
+			return true;
+		}) as typeof process.stdout.write);
+		try {
+			await runUsageCommand(
+				{ json: true, provider: "explicit-usage", extensions: [extensionPath], noExtensions: true },
+				{ discoverAuthStorage: async () => authStorage },
+			);
+		} finally {
+			writeSpy.mockRestore();
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+
+		const payload = JSON.parse(output.join("")) as { reports: UsageReport[] };
+		expect(payload.reports).toHaveLength(1);
+		expect(payload.reports[0]?.provider).toBe("explicit-usage");
+	});
+
+	it("loads extension usage providers before invalidating their versioned cache entries", async () => {
+		const rows: StoredAuthCredential[] = [
+			{
+				id: 1,
+				provider: "runtime-usage",
+				credential: {
+					type: "oauth",
+					access: "runtime-token",
+					refresh: "runtime-refresh",
+					expires: Date.now() + HOUR,
+				},
+				disabledCause: null,
+			},
+		];
+		const cache = new Map<string, { value: string; expiresAtSec: number }>();
+		const store: AuthCredentialStore = {
+			close() {},
+			listAuthCredentials(provider) {
+				return provider === undefined ? rows : rows.filter(row => row.provider === provider);
+			},
+			updateAuthCredential() {},
+			deleteAuthCredential() {},
+			tryDisableAuthCredentialIfMatches() {
+				return false;
+			},
+			replaceAuthCredentialsForProvider() {
+				return rows;
+			},
+			upsertAuthCredentialForProvider() {
+				return rows;
+			},
+			deleteAuthCredentialsForProvider() {},
+			getCache(key, options) {
+				const entry = cache.get(key);
+				if (!entry || (!options?.includeExpired && entry.expiresAtSec * 1_000 <= Date.now())) return null;
+				return entry.value;
+			},
+			setCache(key, value, expiresAtSec) {
+				cache.set(key, { value, expiresAtSec });
+			},
+			cleanExpiredCache() {},
+		};
+		let fetchCalls = 0;
+		const provider: UsageProvider = {
+			id: "runtime-usage",
+			supports: ({ credential }) => credential.type === "oauth",
+			fetchUsage: async () => {
+				fetchCalls += 1;
+				return {
+					provider: "runtime-usage",
+					fetchedAt: Date.now(),
+					limits: [
+						{
+							id: "weekly",
+							label: "Weekly",
+							scope: { provider: "runtime-usage", windowId: "weekly" },
+							amount: { unit: "percent", usedFraction: 0.25 },
+						},
+					],
+				};
+			},
+		};
+		const register = (storage: AuthStorage): void => {
+			storage.syncExtensionUsageProviders(
+				["/extensions/usage.ts"],
+				[{ provider, sourceId: "/extensions/usage.ts" }],
+			);
+		};
+		const createStorage = async (): Promise<AuthStorage> => {
+			const storage = new AuthStorage(store);
+			await storage.reload();
+			return storage;
+		};
+		const initialStorage = await createStorage();
+		register(initialStorage);
+		expect(await initialStorage.fetchUsageReports()).toHaveLength(1);
+		initialStorage.close();
+
+		const writeSpy = spyOn(process.stdout, "write").mockImplementation((() => true) as typeof process.stdout.write);
+		try {
+			await runUsageCommand(
+				{ action: "invalidate", provider: "runtime-usage" },
+				{
+					discoverAuthStorage: createStorage,
+					prepareModelRegistry: async modelRegistry => register(modelRegistry.authStorage),
+				},
+			);
+			const finalStorage = await createStorage();
+			try {
+				register(finalStorage);
+				expect(await finalStorage.fetchUsageReports()).toHaveLength(1);
+			} finally {
+				finalStorage.close();
+			}
+		} finally {
+			writeSpy.mockRestore();
+		}
+
+		expect(fetchCalls).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/utils/image-vision-fallback.test.ts
+++ b/packages/coding-agent/test/utils/image-vision-fallback.test.ts
@@ -109,6 +109,31 @@ describe("describeAttachedImagesForTextModel", () => {
 		expect(saved.toString("base64")).toBe(TINY_PNG_BASE64);
 	});
 
+	it("uses both provider session and usage-provider scope for vision credentials", async () => {
+		const stub = makeCompleteStub("A scoped description.");
+		const getApiKeyCalls: unknown[][] = [];
+		const resolverCalls: unknown[][] = [];
+		const deps = makeDeps(testDir, [textModel, visionModel], stub.fn);
+		deps.sessionId = "provider-session";
+		deps.usageProviderScopeId = "usage-scope";
+		deps.modelRegistry = {
+			getAvailable: () => [textModel, visionModel],
+			getApiKey: async (...args: unknown[]) => {
+				getApiKeyCalls.push(args);
+				return "test-key";
+			},
+			resolver: (...args: unknown[]) => {
+				resolverCalls.push(args);
+				return async () => "test-key";
+			},
+		} as never;
+
+		await describeAttachedImagesForTextModel([{ type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" }], deps);
+
+		expect(getApiKeyCalls).toEqual([[visionModel, "provider-session", "usage-scope"]]);
+		expect(resolverCalls).toEqual([[visionModel, { sessionId: "provider-session", usageScopeId: "usage-scope" }]]);
+	});
+
 	it("saves the image but emits a no-vision note when no vision model is available", async () => {
 		const stub = makeCompleteStub("should not be used");
 		const blocks = await describeAttachedImagesForTextModel(

--- a/packages/coding-agent/test/utils/image-vision-fallback.test.ts
+++ b/packages/coding-agent/test/utils/image-vision-fallback.test.ts
@@ -130,7 +130,7 @@ describe("describeAttachedImagesForTextModel", () => {
 
 		await describeAttachedImagesForTextModel([{ type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" }], deps);
 
-		expect(getApiKeyCalls).toEqual([[visionModel, "provider-session", "usage-scope"]]);
+		expect(getApiKeyCalls).toEqual([[visionModel, "provider-session", { usageScopeId: "usage-scope" }]]);
 		expect(resolverCalls).toEqual([[visionModel, { sessionId: "provider-session", usageScopeId: "usage-scope" }]]);
 	});
 


### PR DESCRIPTION
## What

Adds a source-owned registration seam so extensions can supply account usage / rate-limit reporting for the providers they register: `pi.registerUsageProvider(provider)`, backed by a new `UsageProviderRegistry` in `packages/ai`.

Extension usage providers get **full parity with builtins**: reports, usage history, header ingest, and credential blocks flow through the same durable usage store. What is session-scoped is provider *resolution* — which `UsageProvider` implementation a session uses — mirroring exactly how extension model providers (`pi.registerProvider`) already work.

Key pieces:

- **`packages/ai`**
  - `UsageProviderRegistry` (`src/usage.ts`): validated, source-owned registrations; most recent active source wins; removing a source restores the next registration or the built-in fallback.
  - `AuthStorage`: optional `usageProviderRegistry`; session-scoped provider resolution (`registerSessionUsageProviders`, longest-prefix match for derived side-channel ids); arktype validation of every extension-supplied `UsageReport` (fetch, header parse, probe, store hook) with provider-id match enforcement.
  - Durable cache keys include a per-source hash + registration revision, so different extensions registering the same provider id never collide, and an in-process reload invalidates that source's entries. Cross-restart staleness is bounded by the report TTL, same as builtins.
  - Extension-owned providers are authoritative for their own fetch path (a remote broker store cannot aggregate providers it does not know about); everything they produce lands in the shared durable cache/history/block state.
  - `withOAuthAccess` / `rotateSessionCredential` / `resolver` thread a `usageScopeId` end to end; defaults to the session id so behavior is unchanged for built-ins.
  - `assertCustomApiName` exported for prevalidation.
- **`packages/coding-agent`**
  - `pi.registerUsageProvider(provider)` extension API; registrations collected at load, prevalidated, synced per session (`AgentSession` owns a `usageProviderScopeId`) and per one-shot CLI.
  - `ModelRegistry.validateProviderRegistration` extracted so dynamic provider registration validates before mutating shared registry state; `getApiKey`/`resolver` accept usage-scope options.
  - Advisor tools: the prebuilt shared tool set is now bound per advisor invocation via `AsyncLocalStorage` (`bindToolsToAsyncSessionIdentity`), so concurrent roster advisors keep distinct provider session ids instead of sharing one label.
  - All side-channel consumers (web search providers, tts, image-gen, title/commit-message/compaction generation, memories/mnemopi) thread the owning session's usage scope.
  - `docs/extensions.md` documents the API, its source-owned lifecycle, and the durable-parity semantics.

## Why

Extensions can register model providers but have no way to supply usage reporting for them — `/usage`, credential ranking, and 429 handling only see built-in usage providers. A subscription-backed extension provider (e.g. an OAuth provider with plan quotas) is flying blind: no quota display, no usage-aware credential selection, no header-derived exhaustion blocks.

Design follows the `registerProvider` precedent: extensions own per-session resolution; the credential/usage store remains one shared durable substrate. No private memory-only tier. Built-in providers are untouched — with no registrations, every code path resolves exactly as before.

## Testing

- `packages/ai`: full suite green (3034 pass / 0 fail, 337 skip), including new `test/usage-provider-registry.test.ts` and extended auth-storage usage-cache/header-ingest/rotation/history tests.
- `packages/coding-agent`: touched tests green, including new `test/extension-usage-provider-registration.test.ts`, `test/advisor-tool-identity-binding.test.ts` (concurrent post-await identity isolation), `test/mnemopi-provider-scope.test.ts`, and extended `usage-cli` / sdk model-selection / preloaded-extensions-isolation tests.
- `bun check` clean in both packages.
- Known pre-existing full-suite failures on current `main` (reproduced at the merge base without this change): `test/bash-executor.test.ts` abort-on-stall 5s timeout and `test/tools.test.ts` auto-background "start" text assertion.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
