### PR TITLE
fix(devin): sanitize foreign history during model switches

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed model switches to Devin rejecting foreign provider response IDs, reasoning signatures, and empty interrupted turns as invalid Cascade history.
+
 ## [17.0.5] - 2026-07-18
 
 ### Changed

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -45,6 +45,7 @@ import type {
 } from "../types";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
+import { isDemotedThinking } from "../utils/block-symbols";
 import { toolWireSchema } from "../utils/schema/wire";
 import { transformMessages } from "./transform-messages";
 
@@ -527,7 +528,7 @@ function buildChatMessagePrompts(
 			const toolCalls: ChatToolCall[] = [];
 			for (const part of msg.content) {
 				if (part.type === "text") {
-					promptText += part.text;
+					promptText += `${part.text}${isDemotedThinking(part) ? "\n" : ""}`;
 				} else if (part.type === "thinking") {
 					thinkingText += part.thinking;
 					if (isNativeDevinMessage && !signature && part.thinkingSignature) signature = part.thinkingSignature;

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -43,9 +43,9 @@ import type {
 	Tool,
 	ToolCall,
 } from "../types";
+import { isDemotedThinking } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { isDemotedThinking } from "../utils/block-symbols";
 import { toolWireSchema } from "../utils/schema/wire";
 import { transformMessages } from "./transform-messages";
 

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -46,6 +46,7 @@ import type {
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { toolWireSchema } from "../utils/schema/wire";
+import { transformMessages } from "./transform-messages";
 
 /** Base host for Codeium/Windsurf's Cascade chat API (Connect protocol over HTTP/1.1). */
 export const DEVIN_API_URL = "https://server.codeium.com";
@@ -442,6 +443,7 @@ function buildDevinChatRequest(
 		options?.stopSequences && options.stopSequences.length > 0
 			? [...DEVIN_DEFAULT_STOP_PATTERNS, ...options.stopSequences]
 			: DEVIN_DEFAULT_STOP_PATTERNS;
+	const messages = transformMessages(context.messages, model);
 	return create(GetChatMessageRequestSchema, {
 		metadata: create(MetadataSchema, {
 			apiKey,
@@ -453,7 +455,7 @@ function buildDevinChatRequest(
 			locale: "en",
 		}),
 		prompt: (context.systemPrompt ?? []).join("\n\n"),
-		chatMessagePrompts: buildChatMessagePrompts(context.messages, cascadeId),
+		chatMessagePrompts: buildChatMessagePrompts(messages, cascadeId, model),
 		chatModelUid: options?.chatModelUid ?? model.requestModelId ?? model.id,
 		requestType: ChatMessageRequestType.CASCADE,
 		plannerMode: ConversationalPlannerMode.DEFAULT,
@@ -485,7 +487,11 @@ function buildDevinChatRequest(
 }
 
 /** Map omp `Message` history onto Cascade `ChatMessagePrompt`s (USER / SYSTEM / TOOL channels). */
-function buildChatMessagePrompts(messages: Message[], cascadeId: string): ChatMessagePrompt[] {
+function buildChatMessagePrompts(
+	messages: Message[],
+	cascadeId: string,
+	model: Model<"devin-agent">,
+): ChatMessagePrompt[] {
 	const prompts: ChatMessagePrompt[] = [];
 	// messageId seeds are `cascadeId\0index\0role[...]` — prompt text is excluded
 	// so ids stay stable across content edits / history rebuilds.
@@ -513,6 +519,8 @@ function buildChatMessagePrompts(messages: Message[], cascadeId: string): ChatMe
 				}),
 			);
 		} else if (msg.role === "assistant") {
+			const isNativeDevinMessage =
+				msg.api === model.api && msg.provider === model.provider && msg.model === model.id;
 			let promptText = "";
 			let thinkingText = "";
 			let signature = "";
@@ -522,7 +530,7 @@ function buildChatMessagePrompts(messages: Message[], cascadeId: string): ChatMe
 					promptText += part.text;
 				} else if (part.type === "thinking") {
 					thinkingText += part.thinking;
-					if (!signature && part.thinkingSignature) signature = part.thinkingSignature;
+					if (isNativeDevinMessage && !signature && part.thinkingSignature) signature = part.thinkingSignature;
 				} else if (part.type === "toolCall") {
 					toolCalls.push(
 						create(ChatToolCallSchema, {
@@ -533,9 +541,13 @@ function buildChatMessagePrompts(messages: Message[], cascadeId: string): ChatMe
 					);
 				}
 			}
+			if (!promptText && !thinkingText && !signature && toolCalls.length === 0) continue;
 			prompts.push(
 				create(ChatMessagePromptSchema, {
-					messageId: msg.responseId ?? `bot-${deterministicUuid(`${cascadeId}\0${index}\0assistant`)}`,
+					messageId:
+						isNativeDevinMessage && msg.responseId
+							? msg.responseId
+							: `bot-${deterministicUuid(`${cascadeId}\0${index}\0assistant`)}`,
 					source: ChatMessageSource.SYSTEM,
 					prompt: promptText,
 					thinking: thinkingText,

--- a/packages/ai/test/devin-history.test.ts
+++ b/packages/ai/test/devin-history.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { gunzipSync } from "node:zlib";
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
+import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { GetChatMessageRequestSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
+import { GetUserJwtResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/auth_pb/auth_pb";
+
+const devinModel: Model<"devin-agent"> = buildModel({
+	id: "devin-test",
+	name: "Devin Test",
+	api: "devin-agent",
+	provider: "devin",
+	baseUrl: "https://server.codeium.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 64_000,
+});
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistant(overrides: Partial<AssistantMessage>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "devin-agent",
+		provider: "devin",
+		model: "devin-test",
+		usage: zeroUsage,
+		stopReason: "stop",
+		timestamp: 1,
+		...overrides,
+	};
+}
+
+async function captureRequest(context: Context) {
+	const authPayload = toBinary(GetUserJwtResponseSchema, create(GetUserJwtResponseSchema, { userJwt: "jwt" }));
+	let requestPayload: Uint8Array | undefined;
+	const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+		if (String(input).includes("GetUserJwt")) return new Response(authPayload);
+		requestPayload = new Uint8Array(init?.body as ArrayBuffer);
+		return new Response(new Uint8Array());
+	}) as typeof fetch;
+
+	await streamDevin(devinModel, context, { apiKey: "token", fetch: fetchImpl }).result();
+	if (!requestPayload) throw new Error("Devin chat request was not captured");
+	const length = new DataView(requestPayload.buffer, requestPayload.byteOffset, requestPayload.byteLength).getUint32(
+		1,
+		false,
+	);
+	const compressed = requestPayload.subarray(5, 5 + length);
+	return fromBinary(GetChatMessageRequestSchema, gunzipSync(compressed));
+}
+
+describe("streamDevin history handoff", () => {
+	it("removes foreign provider metadata and empty aborted turns", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "start", timestamp: 1 },
+				assistant({
+					api: "openai-responses",
+					provider: "openai-codex",
+					model: "gpt-5.6-sol",
+					responseId: "resp_foreign",
+					content: [
+						{ type: "thinking", thinking: "foreign reasoning", thinkingSignature: '{"type":"reasoning"}' },
+						{ type: "text", text: "foreign answer" },
+					],
+				}),
+				{ role: "user", content: "continue", timestamp: 2 },
+				assistant({
+					responseId: "bot-12345678-1234-4234-8234-123456789abc",
+					content: [{ type: "thinking", thinking: "native reasoning", thinkingSignature: "native-signature" }],
+				}),
+				{ role: "user", content: "interrupt", timestamp: 3 },
+				assistant({
+					api: "openai-responses",
+					provider: "openai-codex",
+					model: "gpt-5.6-sol",
+					stopReason: "aborted",
+				}),
+				{ role: "user", content: "resume", timestamp: 4 },
+			],
+		};
+
+		const request = await captureRequest(context);
+		const foreign = request.chatMessagePrompts[1];
+		const native = request.chatMessagePrompts[3];
+
+		expect(request.chatMessagePrompts).toHaveLength(6);
+		expect(foreign?.messageId).not.toBe("resp_foreign");
+		expect(foreign?.messageId).toMatch(/^bot-[0-9a-f-]{36}$/);
+		expect(foreign?.prompt).toContain("foreign reasoning");
+		expect(foreign?.prompt).toContain("foreign answer");
+		expect(foreign?.thinking).toBe("");
+		expect(foreign?.signature).toBe("");
+		expect(native?.messageId).toBe("bot-12345678-1234-4234-8234-123456789abc");
+		expect(native?.thinking).toBe("native reasoning");
+		expect(native?.signature).toBe("native-signature");
+	});
+});


### PR DESCRIPTION
## Summary
- normalize replayed messages through the shared cross-provider history transformer before encoding Cascade prompts
- keep Devin response IDs and reasoning signatures only for same-model native Devin turns
- omit content-empty interrupted assistant turns that Cascade rejects as invalid history

## Screenshots
No visual change.

## Testing
- `bun test packages/ai/test/devin-*.test.ts`
- `bun test --parallel` from `packages/ai` (3005 passed, 337 skipped)
- `bun run check:ts`

## Risk
- Devin now receives the same cross-provider reasoning and tool-history normalization used by other provider encoders. Native same-model Devin metadata remains unchanged.
- Live provider handoff was not verified from the isolated worktree because no Devin credential was available there; the regression decodes and asserts the actual compressed Connect protobuf request.

## Notes
- Reproduced from a Codex-to-Devin model switch where foreign `resp_*` IDs, OpenAI reasoning signatures, and empty interrupted turns produced Cascade `invalid_argument` before token generation.

## AI Review Report
- Traced the failed session through model-change and provider-error events.
- Reviewed the Devin Connect request encoder and shared history transformation rules.
- Added coverage for foreign OpenAI history, native Devin history, and an interrupted empty turn in one handoff request.

## Security Audit
- No authentication, credential storage, transport, or logging behavior changed.
- Foreign opaque reasoning signatures are no longer forwarded to Devin.