### PR TITLE
Add runtime RPC plan and approval controls

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -48,6 +48,7 @@ There is no envelope beyond the object shape itself.
 9. Prompt lifecycle hints (`{ type: "prompt_result", id?, agentInvoked }`) for scheduled prompts that later resolve without invoking the agent
 10. Subagent frames (`subagent_lifecycle`, `subagent_progress`, `subagent_event`), gated by `set_subagent_subscription`
 11. Builtin slash-command side channels (`command_output`, `session_info_update`, `config_update`)
+12. Runtime mode updates (`{ type: "mode_changed", mode: "default" | "plan" }`)
 
 ### Inbound frame categories (stdin)
 
@@ -88,6 +89,8 @@ Important edge behavior from runtime:
 
 - `{ id?, type: "get_state" }`
 - `{ id?, type: "get_available_commands" }`
+- `{ id?, type: "set_mode", mode: "default" | "plan" }`
+- `{ id?, type: "set_approval_mode", mode: "always-ask" | "write" | "yolo" }`
 - `{ id?, type: "set_todos", phases: TodoPhase[] }`
 - `{ id?, type: "set_host_tools", tools: RpcHostToolDefinition[] }`
 - `{ id?, type: "set_host_uri_schemes", schemes: RpcHostUriSchemeDefinition[] }`
@@ -193,6 +196,8 @@ Local-only slash commands may emit `command_output` frames before completing via
 {
   "model": { "provider": "...", "id": "..." },
   "thinkingLevel": "off|minimal|low|medium|high|xhigh|max",
+  "mode": "default|plan",
+  "approvalMode": "always-ask|write|yolo",
   "isStreaming": false,
   "isCompacting": false,
   "steeringMode": "all|one-at-a-time",
@@ -363,6 +368,12 @@ Extension runner errors are emitted separately as:
 
 `message_update` includes streaming deltas in `assistantMessageEvent` (text/thinking/toolcall deltas).
 
+Native plan-mode transitions are emitted separately:
+
+```json
+{ "type": "mode_changed", "mode": "plan" }
+```
+
 ## Prompt/Queue Concurrency and Ordering
 
 This is the most important operational behavior.
@@ -406,6 +417,34 @@ From `packages/agent/src/agent.ts` defaults:
 - `set_interrupt_mode`
   - `"immediate"`: tool execution checks steering between tool calls; pending steering can abort remaining tool calls in the turn
   - `"wait"`: defer steering until turn completion
+
+### Runtime plan and approval controls
+
+`set_mode` changes the native coding-agent mode:
+
+- `"plan"` enables the existing read-only plan workflow and defaults its plan
+  file to `local://PLAN.md`. The normal plan write guards and `xd://propose`
+  submission path remain active.
+- Entering plan mode fails when `plan.enabled` is false or a `plan-yolo`
+  workflow is configured for the session.
+- Mode changes fail while the agent is streaming.
+- A proposal emits an `extension_ui_request` with `method: "confirm"`. Approval
+  records the plan reference and exits to `"default"`; rejection or cancellation
+  keeps plan mode active for refinement.
+- Every applied transition emits `mode_changed`. Successful `new_session`,
+  `switch_session`, and `branch` commands reset an active plan mode to
+  `"default"` and emit the same event.
+
+`set_approval_mode` replaces the in-memory `tools.approvalMode` override with
+`"always-ask"`, `"write"`, or `"yolo"`. It affects subsequent tool approval
+decisions, does not persist the setting, and does not cancel an approval already
+in flight. The command response and the next `get_state` expose the effective
+value; a `config_update` frame is also emitted.
+
+`RpcClient` exposes these commands as `setMode(...)` and
+`setApprovalMode(...)`. Clients entering plan mode must subscribe with
+`onExtensionUIRequest(...)` and answer confirmation requests with
+`sendExtensionUIResponse(...)`.
 
 ## Extension UI Sub-Protocol
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added RPC runtime controls for native plan mode and tool approval mode, including state fields and mode-change events.
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/modes/rpc/mode-control.ts
+++ b/packages/coding-agent/src/modes/rpc/mode-control.ts
@@ -1,0 +1,219 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { resolveLocalUrlToPath } from "../../internal-urls";
+import { normalizePlanTitle, type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
+import type { PlanModeState } from "../../plan-mode/state";
+import { normalizeLocalScheme } from "../../tools/path-utils";
+import type { PlanProposalHandler } from "../../tools/resolve";
+import { ToolError } from "../../tools/tool-errors";
+import type { RpcMode } from "./rpc-types";
+
+const DEFAULT_RPC_PLAN_FILE_URL = "local://PLAN.md";
+
+export interface RpcModeControllerSession {
+	settings: { get(path: "plan.enabled"): boolean };
+	sessionManager: {
+		getArtifactsDir(): string | null;
+		getSessionId(): string;
+		getCwd(): string;
+	};
+	hasPlanYoloWorkflow(): boolean;
+	getEnabledToolNames(): string[];
+	hasBuiltInTool(name: string): boolean;
+	setActiveToolsByName(toolNames: string[]): Promise<void>;
+	getPlanModeState(): PlanModeState | undefined;
+	setPlanModeState(state: PlanModeState | undefined): void;
+	setPlanProposalHandler(handler: PlanProposalHandler | null): void;
+	setPlanReferencePath(planFilePath: string): void;
+}
+export interface RpcModeControllerOptions {
+	session: RpcModeControllerSession;
+	confirm(title: string, message: string, signal: AbortSignal): Promise<boolean>;
+	onModeChanged(mode: RpcMode): void;
+}
+
+export class RpcModeController {
+	readonly #session: RpcModeControllerSession;
+	readonly #confirm: RpcModeControllerOptions["confirm"];
+	readonly #onModeChanged: RpcModeControllerOptions["onModeChanged"];
+	#previousTools: string[] | undefined;
+	#pendingProposalAbort: AbortController | undefined;
+	#ownedPlanState: PlanModeState | undefined;
+	constructor(options: RpcModeControllerOptions) {
+		this.#session = options.session;
+		this.#confirm = options.confirm;
+		this.#onModeChanged = options.onModeChanged;
+	}
+
+	get mode(): RpcMode {
+		return this.#session.getPlanModeState()?.enabled ? "plan" : "default";
+	}
+
+	get ownsPlanMode(): boolean {
+		return this.#ownedPlanState !== undefined && this.#session.getPlanModeState() === this.#ownedPlanState;
+	}
+
+	async apply(mode: RpcMode): Promise<void> {
+		if (mode === this.mode) {
+			if (mode === "plan" && !this.ownsPlanMode) {
+				throw new Error("Plan mode is managed by another workflow");
+			}
+			return;
+		}
+		if (mode === "default" && !this.ownsPlanMode) {
+			throw new Error("Plan mode is managed by another workflow");
+		}
+		if (mode === "plan") {
+			if (!this.#session.settings.get("plan.enabled")) {
+				throw new Error("Plan mode is disabled by the plan.enabled setting");
+			}
+			if (this.#session.hasPlanYoloWorkflow()) {
+				throw new Error("Cannot enter RPC plan mode while a plan-yolo workflow is configured");
+			}
+			const previousTools = this.#session.getEnabledToolNames();
+			const augmentations = this.#session.hasBuiltInTool("write") ? ["write"] : [];
+			await this.#session.setActiveToolsByName([...new Set([...previousTools, ...augmentations])]);
+			const previous = this.#session.getPlanModeState();
+			const state: PlanModeState = {
+				enabled: true,
+				planFilePath: previous?.planFilePath ?? DEFAULT_RPC_PLAN_FILE_URL,
+				workflow: previous?.workflow ?? "parallel",
+				reentry: previous !== undefined,
+			};
+			this.#previousTools = previousTools;
+			this.#session.setPlanModeState(state);
+			this.#ownedPlanState = state;
+			this.#session.setPlanProposalHandler(title => this.#handlePlanProposal(title));
+		} else {
+			this.cancelPendingProposal();
+			if (this.#previousTools) {
+				await this.#session.setActiveToolsByName(this.#previousTools);
+			}
+			this.#previousTools = undefined;
+			this.#ownedPlanState = undefined;
+			this.#session.setPlanProposalHandler(null);
+			this.#session.setPlanModeState(undefined);
+		}
+		this.#onModeChanged(mode);
+	}
+
+	cancelPendingProposal(): void {
+		this.#pendingProposalAbort?.abort();
+		this.#pendingProposalAbort = undefined;
+	}
+
+	#resolvePlanFilePath(planFilePath: string): string {
+		if (planFilePath.startsWith("local:")) {
+			const normalized = normalizeLocalScheme(planFilePath);
+			return resolveLocalUrlToPath(normalized, {
+				getArtifactsDir: () => this.#session.sessionManager.getArtifactsDir(),
+				getSessionId: () => this.#session.sessionManager.getSessionId(),
+			});
+		}
+		return path.resolve(this.#session.sessionManager.getCwd(), planFilePath);
+	}
+
+	async #readPlanFile(planFilePath: string): Promise<string | null> {
+		try {
+			return await Bun.file(this.#resolvePlanFilePath(planFilePath)).text();
+		} catch (error) {
+			if (isEnoent(error)) return null;
+			throw error;
+		}
+	}
+
+	async #listPlanFiles(): Promise<string[]> {
+		const localRoot = this.#resolvePlanFilePath("local://");
+		try {
+			const entries = await fs.readdir(localRoot, { withFileTypes: true });
+			const plans = await Promise.all(
+				entries
+					.filter(entry => entry.isFile() && /plan\.md$/i.test(entry.name))
+					.map(async entry => {
+						const stat = await fs.stat(path.join(localRoot, entry.name)).catch(() => null);
+						return { url: `local://${entry.name}`, mtime: stat?.mtimeMs ?? 0 };
+					}),
+			);
+			return plans.sort((a, b) => b.mtime - a.mtime).map(plan => plan.url);
+		} catch {
+			return [];
+		}
+	}
+
+	async #handlePlanProposal(title: string): Promise<AgentToolResult<unknown>> {
+		const state = this.#session.getPlanModeState();
+		if (!state?.enabled) {
+			throw new ToolError("Plan mode is not active.");
+		}
+		if (this.#pendingProposalAbort) {
+			throw new ToolError("A plan approval request is already pending.");
+		}
+		const approvalAbort = new AbortController();
+		this.#pendingProposalAbort = approvalAbort;
+		try {
+			const {
+				planFilePath,
+				planContent,
+				title: resolvedTitle,
+			} = await resolveApprovedPlan({
+				suppliedTitle: title,
+				statePlanFilePath: state.planFilePath,
+				readPlan: url => this.#readPlanFile(url),
+				listPlanFiles: () => this.#listPlanFiles(),
+			});
+			if (approvalAbort.signal.aborted) {
+				throw new ToolError("Plan approval was cancelled.");
+			}
+			const previewLines = planContent.split("\n");
+			const preview = previewLines.slice(0, 12).join("\n");
+			const approved = await this.#confirm(
+				"Approve plan?",
+				`Approve plan "${resolvedTitle}" and start implementation?\n\n${preview}${previewLines.length > 12 ? "\n…" : ""}`,
+				approvalAbort.signal,
+			);
+			if (approvalAbort.signal.aborted) {
+				throw new ToolError("Plan approval was cancelled.");
+			}
+			if (this.#session.getPlanModeState() !== state) {
+				throw new ToolError("Plan mode changed while approval was pending.");
+			}
+			const details: PlanApprovalDetails = {
+				planFilePath,
+				title: resolvedTitle,
+				planExists: true,
+			};
+			if (!approved) {
+				const normalizedTitle = normalizePlanTitle(resolvedTitle).title;
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Plan refinement requested. Update the plan file, then write ${normalizedTitle} to xd://propose again when ready.`,
+						},
+					],
+					details,
+				};
+			}
+			this.#session.setPlanReferencePath(planFilePath);
+			if (this.#pendingProposalAbort === approvalAbort) {
+				this.#pendingProposalAbort = undefined;
+			}
+			await this.apply("default");
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation.`,
+					},
+				],
+				details,
+			};
+		} finally {
+			if (this.#pendingProposalAbort === approvalAbort) {
+				this.#pendingProposalAbort = undefined;
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -12,10 +12,12 @@ import { isRecord, ptree, readJsonl } from "@oh-my-pi/pi-utils";
 import type { FileSink } from "bun";
 import type { BashResult } from "../../exec/bash-executor";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
+import type { ApprovalMode } from "../../tools/approval";
 import type {
 	RpcAvailableCommandsUpdateFrame,
 	RpcAvailableSlashCommand,
 	RpcCommand,
+	RpcConfigUpdateFrame,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
 	RpcHandoffResult,
@@ -24,6 +26,8 @@ import type {
 	RpcHostToolDefinition,
 	RpcHostToolResult,
 	RpcHostToolUpdate,
+	RpcMode,
+	RpcModeChangedFrame,
 	RpcResponse,
 	RpcSessionState,
 	RpcSubagentEventFrame,
@@ -62,7 +66,8 @@ export interface RpcClientOptions {
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
 export type RpcEventListener = (event: AgentEvent) => void;
-export type RpcSessionEventListener = (event: AgentSessionEvent) => void;
+export type RpcSessionEventListener = (event: AgentSessionEvent | RpcConfigUpdateFrame | RpcModeChangedFrame) => void;
+export type RpcExtensionUIRequestListener = (request: RpcExtensionUIRequest) => void;
 export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["payload"]) => void;
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
@@ -170,6 +175,15 @@ function isRpcAvailableCommandsUpdateFrame(value: unknown): value is RpcAvailabl
 	return value.type === "available_commands_update" && Array.isArray(value.commands);
 }
 
+function isRpcConfigUpdateFrame(value: unknown): value is RpcConfigUpdateFrame {
+	return isRecord(value) && value.type === "config_update";
+}
+
+function isRpcModeChangedFrame(value: unknown): value is RpcModeChangedFrame {
+	if (!isRecord(value)) return false;
+	return value.type === "mode_changed" && (value.mode === "default" || value.mode === "plan");
+}
+
 function isRpcHostToolCallRequest(value: unknown): value is RpcHostToolCallRequest {
 	if (!isRecord(value)) return false;
 	return (
@@ -217,7 +231,7 @@ export class RpcClient {
 	#customTools: RpcClientCustomTool[] = [];
 	#pendingHostToolCalls = new Map<string, { controller: AbortController }>();
 	#requestId = 0;
-	#extensionUiListeners: Set<(req: RpcExtensionUIRequest) => void> = new Set();
+	#extensionUiListeners = new Set<RpcExtensionUIRequestListener>();
 	#abortController = new AbortController();
 
 	constructor(private options: RpcClientOptions = {}) {
@@ -398,6 +412,21 @@ export class RpcClient {
 	}
 
 	/**
+	 * Subscribe to extension UI requests, including native plan approval.
+	 */
+	onExtensionUIRequest(listener: RpcExtensionUIRequestListener): () => void {
+		this.#extensionUiListeners.add(listener);
+		return () => this.#extensionUiListeners.delete(listener);
+	}
+
+	/**
+	 * Answer a request received through {@link onExtensionUIRequest}.
+	 */
+	sendExtensionUIResponse(response: RpcExtensionUIResponse): void {
+		this.#writeFrame(response);
+	}
+
+	/**
 	 * Subscribe to subagent lifecycle frames after setSubagentSubscription("progress" | "events").
 	 */
 	onSubagentLifecycle(listener: RpcSubagentLifecycleListener): () => void {
@@ -499,6 +528,22 @@ export class RpcClient {
 	async getState(): Promise<RpcSessionState> {
 		const response = await this.#send({ type: "get_state" });
 		return this.#getData(response);
+	}
+
+	/**
+	 * Change the session's behavioral mode.
+	 */
+	async setMode(mode: RpcMode): Promise<RpcMode> {
+		const response = await this.#send({ type: "set_mode", mode });
+		return this.#getData<{ mode: RpcMode }>(response).mode;
+	}
+
+	/**
+	 * Change the effective tool approval mode for future tool calls.
+	 */
+	async setApprovalMode(mode: ApprovalMode): Promise<ApprovalMode> {
+		const response = await this.#send({ type: "set_approval_mode", mode });
+		return this.#getData<{ approvalMode: ApprovalMode }>(response).approvalMode;
 	}
 
 	/**
@@ -918,6 +963,20 @@ export class RpcClient {
 		if (isRpcAvailableCommandsUpdateFrame(data)) {
 			for (const listener of this.#availableCommandsUpdateListeners) {
 				listener(data.commands);
+			}
+			return;
+		}
+
+		if (isRpcConfigUpdateFrame(data)) {
+			for (const listener of this.#sessionEventListeners) {
+				listener(data);
+			}
+			return;
+		}
+
+		if (isRpcModeChangedFrame(data)) {
+			for (const listener of this.#sessionEventListeners) {
+				listener(data);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -34,6 +34,7 @@ import type { EventBus } from "../../utils/event-bus";
 import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
+import { RpcModeController } from "./mode-control";
 import { claimRpcInput } from "./rpc-input";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
@@ -600,6 +601,7 @@ export function requestRpcEditor(
 	} as RpcExtensionUIRequest);
 	return promise;
 }
+
 /**
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
@@ -677,6 +679,12 @@ export async function runRpcMode(
 			};
 
 			const onAbort = () => {
+				this.output({
+					type: "extension_ui_request",
+					id: Snowflake.next() as string,
+					method: "cancel",
+					targetId: id,
+				} as RpcExtensionUIRequest);
 				cleanup();
 				resolve(defaultValue);
 			};
@@ -889,6 +897,12 @@ export async function runRpcMode(
 	const rpcUiContext = new RpcExtensionUIContext(pendingExtensionRequests, output);
 	setToolUIContext?.(rpcUiContext, true);
 
+	const modeController = new RpcModeController({
+		session,
+		confirm: (title, message, signal) => rpcUiContext.confirm(title, message, { signal }),
+		onModeChanged: mode => output({ type: "mode_changed", mode }),
+	});
+
 	// Set up extensions with RPC-based UI context
 	await initializeExtensions(session, {
 		reportSendError: (action, err) => {
@@ -1000,11 +1014,13 @@ export async function runRpcMode(
 			}
 
 			case "abort": {
+				modeController.cancelPendingProposal();
 				await session.abort({ reason: USER_INTERRUPT_LABEL });
 				return success(id, "abort");
 			}
 
 			case "abort_and_prompt": {
+				modeController.cancelPendingProposal();
 				await session.abort({ reason: USER_INTERRUPT_LABEL });
 				session
 					.prompt(command.message, { images: command.images })
@@ -1015,8 +1031,13 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
+				const resetMode = modeController.ownsPlanMode;
+				if (resetMode) modeController.cancelPendingProposal();
 				const result = await handleRpcSessionChange(session, command, subagentRegistry);
-				if (!result.data.cancelled) await emitAvailableCommandsUpdate();
+				if (!result.data.cancelled) {
+					if (resetMode) await modeController.apply("default");
+					await emitAvailableCommandsUpdate();
+				}
 				return success(id, result.type, result.data);
 			}
 
@@ -1028,6 +1049,8 @@ export async function runRpcMode(
 				const state: RpcSessionState = {
 					model: session.model,
 					thinkingLevel: session.thinkingLevel,
+					mode: modeController.mode,
+					approvalMode: session.settings.get("tools.approvalMode"),
 					isStreaming: session.isStreaming,
 					isCompacting: session.isCompacting,
 					steeringMode: session.steeringMode,
@@ -1050,6 +1073,36 @@ export async function runRpcMode(
 					contextUsage: session.getContextUsage(),
 				};
 				return success(id, "get_state", state);
+			}
+
+			case "set_mode": {
+				if (command.mode !== "default" && command.mode !== "plan") {
+					return error(id, "set_mode", `Unsupported mode: ${String(command.mode)}`);
+				}
+				if (session.isStreaming) {
+					return error(id, "set_mode", "Cannot change mode while the agent is streaming");
+				}
+				try {
+					await modeController.apply(command.mode);
+					return success(id, "set_mode", { mode: modeController.mode });
+				} catch (err) {
+					return error(id, "set_mode", err instanceof Error ? err.message : String(err));
+				}
+			}
+
+			case "set_approval_mode": {
+				if (command.mode !== "always-ask" && command.mode !== "write" && command.mode !== "yolo") {
+					return error(id, "set_approval_mode", `Unsupported approval mode: ${String(command.mode)}`);
+				}
+				session.settings.override("tools.approvalMode", command.mode);
+				const approvalMode = session.settings.get("tools.approvalMode");
+				output({
+					type: "config_update",
+					model: session.model,
+					thinkingLevel: session.thinkingLevel,
+					approvalMode,
+				});
+				return success(id, "set_approval_mode", { approvalMode });
 			}
 
 			case "get_available_commands": {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -18,6 +18,7 @@ import type {
 	SubagentLifecyclePayload,
 	SubagentProgressPayload,
 } from "../../task";
+import type { ApprovalMode } from "../../tools/approval";
 import type { TodoPhase } from "../../tools/todo";
 
 // ============================================================================
@@ -42,6 +43,8 @@ export type RpcCommand =
 	| { id?: string; type: "set_subagent_subscription"; level: RpcSubagentSubscriptionLevel }
 	| { id?: string; type: "get_subagents" }
 	| { id?: string; type: "get_subagent_messages"; subagentId?: string; sessionFile?: string; fromByte?: number }
+	| { id?: string; type: "set_mode"; mode: RpcMode }
+	| { id?: string; type: "set_approval_mode"; mode: ApprovalMode }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -90,9 +93,13 @@ export type RpcCommand =
 // RPC State
 // ============================================================================
 
+export type RpcMode = "default" | "plan";
+
 export interface RpcSessionState {
 	model?: Model;
 	thinkingLevel: ThinkingLevel | undefined;
+	mode: RpcMode;
+	approvalMode: ApprovalMode;
 	isStreaming: boolean;
 	isCompacting: boolean;
 	steeringMode: "all" | "one-at-a-time";
@@ -130,6 +137,18 @@ export interface RpcPromptResultFrame {
 	type: "prompt_result";
 	id?: string;
 	agentInvoked: boolean;
+}
+
+export interface RpcConfigUpdateFrame {
+	type: "config_update";
+	model?: Model;
+	thinkingLevel?: ThinkingLevel;
+	approvalMode?: ApprovalMode;
+}
+
+export interface RpcModeChangedFrame {
+	type: "mode_changed";
+	mode: RpcMode;
 }
 
 export interface RpcHandoffResult {
@@ -178,6 +197,14 @@ export type RpcResponse =
 
 	// State
 	| { id?: string; type: "response"; command: "get_state"; success: true; data: RpcSessionState }
+	| { id?: string; type: "response"; command: "set_mode"; success: true; data: { mode: RpcMode } }
+	| {
+			id?: string;
+			type: "response";
+			command: "set_approval_mode";
+			success: true;
+			data: { approvalMode: ApprovalMode };
+	  }
 	| {
 			id?: string;
 			type: "response";
@@ -319,7 +346,7 @@ export interface RpcSubagentEventFrame {
 
 export type RpcSubagentFrame = RpcSubagentLifecycleFrame | RpcSubagentProgressFrame | RpcSubagentEventFrame;
 
-export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
+export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame | RpcConfigUpdateFrame | RpcModeChangedFrame;
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8067,6 +8067,10 @@ export class AgentSession {
 		return this.#planModeState;
 	}
 
+	hasPlanYoloWorkflow(): boolean {
+		return this.#planYolo !== undefined;
+	}
+
 	/** Prewalk state, if armed and active */
 	getPrewalkState(): Prewalk | undefined {
 		return this.#prewalk;

--- a/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
+++ b/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
@@ -2,32 +2,59 @@
 /**
  * Test fixture: a stand-in for the coding-agent RPC mode.
  *
- * Emits the `ready` frame immediately, echoes each inbound command with a
- * success response, and stays alive until stdin closes or SIGTERM arrives.
- * Used by rpc-client lifecycle tests that need to exercise start/stop/start
- * without booting the full agent runtime (which requires provider credentials).
+ * Emits the `ready` frame immediately, handles a small set of control frames,
+ * echoes other inbound commands with success responses, and stays alive until
+ * stdin closes or SIGTERM arrives.
  */
-process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
+const write = (frame: Record<string, unknown>): void => {
+	process.stdout.write(`${JSON.stringify(frame)}\n`);
+};
+
+write({ type: "ready" });
 
 // Bun's `console` is an AsyncIterable over stdin lines.
 for await (const raw of console) {
 	if (!raw) continue;
 	try {
 		const frame = JSON.parse(raw) as Record<string, unknown>;
-		if (frame && typeof frame === "object" && typeof frame.type === "string") {
-			const id = typeof frame.id === "string" ? frame.id : undefined;
-			process.stdout.write(
-				`${JSON.stringify({
-					id,
-					type: "response",
-					command: frame.type,
-					success: true,
-					data: {},
-				})}\n`,
-			);
+		if (!frame || typeof frame !== "object" || typeof frame.type !== "string") continue;
+		const id = typeof frame.id === "string" ? frame.id : undefined;
+		if (frame.type === "set_mode") {
+			if (frame.mode === "plan") {
+				write({
+					type: "extension_ui_request",
+					id: "plan-confirm",
+					method: "confirm",
+					title: "Approve plan?",
+					message: "Approve the plan?",
+				});
+			}
+			write({ type: "mode_changed", mode: frame.mode });
+			write({ id, type: "response", command: frame.type, success: true, data: { mode: frame.mode } });
+			continue;
 		}
+		if (frame.type === "set_approval_mode") {
+			write({ type: "config_update", approvalMode: frame.mode });
+			write({
+				id,
+				type: "response",
+				command: frame.type,
+				success: true,
+				data: { approvalMode: frame.mode },
+			});
+			continue;
+		}
+		if (frame.type === "extension_ui_response") {
+			write({
+				type: "notice",
+				level: "info",
+				message: frame.confirmed === true ? "plan approved" : "plan rejected",
+			});
+			continue;
+		}
+		write({ id, type: "response", command: frame.type, success: true, data: {} });
 	} catch {
-		// ignore parse errors — the test harness sends well-formed frames.
+		// Ignore parse errors — the test harness sends well-formed frames.
 	}
 }
 process.exit(0);

--- a/packages/coding-agent/test/rpc-controls.test.ts
+++ b/packages/coding-agent/test/rpc-controls.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import { isRecord, readJsonl } from "@oh-my-pi/pi-utils";
+
+const MOCK_AGENT = path.join(import.meta.dir, "fixtures", "mock-rpc-agent.ts");
+
+describe("RPC runtime controls", () => {
+	test("changes plan and approval modes without restarting the session", async () => {
+		const cliPath = path.join(import.meta.dir, "..", "src", "cli.ts");
+		const child = Bun.spawn(
+			[
+				"bun",
+				cliPath,
+				"--mode",
+				"rpc",
+				"--provider",
+				"anthropic",
+				"--model",
+				"claude-sonnet-4-5",
+				"--approval-mode",
+				"write",
+			],
+			{
+				cwd: path.join(import.meta.dir, ".."),
+				env: { ...Bun.env, PI_NO_TITLE: "1" },
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+
+		const commands = [
+			{ id: "initial", type: "get_state" },
+			{ id: "approval", type: "set_approval_mode", mode: "always-ask" },
+			{ id: "plan", type: "set_mode", mode: "plan" },
+			{ id: "planned", type: "get_state" },
+			{ id: "default", type: "set_mode", mode: "default" },
+		];
+		for (const command of commands) {
+			child.stdin.write(`${JSON.stringify(command)}\n`);
+		}
+		await child.stdin.flush();
+
+		const responses: Partial<Record<string, Record<string, unknown>>> = {};
+		const modeChanges: string[] = [];
+		try {
+			for await (const frame of readJsonl<unknown>(child.stdout as ReadableStream<Uint8Array>)) {
+				if (!isRecord(frame)) continue;
+				if (frame.type === "mode_changed" && typeof frame.mode === "string") {
+					modeChanges.push(frame.mode);
+				}
+				if (frame.type === "response" && typeof frame.id === "string") {
+					responses[frame.id] = frame;
+					if (frame.id === "default") break;
+				}
+			}
+		} finally {
+			child.stdin.end();
+			child.kill();
+			await child.exited.catch(() => {});
+		}
+
+		expect(responses.initial?.data).toMatchObject({ mode: "default", approvalMode: "write" });
+		expect(responses.approval?.data).toEqual({ approvalMode: "always-ask" });
+		expect(responses.plan?.data).toEqual({ mode: "plan" });
+		expect(responses.planned?.data).toMatchObject({ mode: "plan", approvalMode: "always-ask" });
+		expect(responses.default?.data).toEqual({ mode: "default" });
+		expect(modeChanges).toEqual(["plan", "default"]);
+	}, 30000);
+
+	test("client dispatches control events and answers plan confirmation", async () => {
+		using client = new RpcClient({ cliPath: MOCK_AGENT });
+		const modeChanged = Promise.withResolvers<void>();
+		const configUpdated = Promise.withResolvers<void>();
+		const planAnswered = Promise.withResolvers<void>();
+		let observedMode: string | undefined;
+		let observedApprovalMode: string | undefined;
+		let approvalRequest: { id: string; method: string } | undefined;
+
+		client.onExtensionUIRequest(request => {
+			if (request.method !== "confirm") return;
+			approvalRequest = { id: request.id, method: request.method };
+			client.sendExtensionUIResponse({
+				type: "extension_ui_response",
+				id: request.id,
+				confirmed: true,
+			});
+		});
+		client.onSessionEvent(event => {
+			if (event.type === "mode_changed") {
+				observedMode = event.mode;
+				modeChanged.resolve();
+			} else if (event.type === "config_update") {
+				observedApprovalMode = event.approvalMode;
+				configUpdated.resolve();
+			} else if (event.type === "notice" && event.message === "plan approved") {
+				planAnswered.resolve();
+			}
+		});
+
+		await client.start();
+		expect(await client.setMode("plan")).toBe("plan");
+		await Promise.all([modeChanged.promise, planAnswered.promise]);
+		expect(await client.setApprovalMode("always-ask")).toBe("always-ask");
+		await configUpdated.promise;
+
+		expect(approvalRequest).toEqual({ id: "plan-confirm", method: "confirm" });
+		expect(observedMode).toBe("plan");
+		expect(observedApprovalMode).toBe("always-ask");
+	}, 20000);
+});

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -317,6 +317,8 @@ describe("RpcInputDispatcher", () => {
 					success: true,
 					data: {
 						thinkingLevel: undefined,
+						mode: "default",
+						approvalMode: "yolo",
 						isStreaming: false,
 						isCompacting: false,
 						steeringMode: "all",

--- a/packages/coding-agent/test/rpc-mode-control.test.ts
+++ b/packages/coding-agent/test/rpc-mode-control.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { RpcModeController, type RpcModeControllerSession } from "@oh-my-pi/pi-coding-agent/modes/rpc/mode-control";
+import type { RpcMode } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
+import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
+import type { PlanProposalHandler } from "@oh-my-pi/pi-coding-agent/tools/resolve";
+
+interface ControllerHarness {
+	controller: RpcModeController;
+	getState(): PlanModeState | undefined;
+	getHandler(): PlanProposalHandler | null;
+	getReference(): string | undefined;
+	getTools(): string[];
+	modeChanges: RpcMode[];
+	confirmCalls: Array<{ title: string; message: string }>;
+}
+
+describe("RPC mode controller", () => {
+	let cwd: string;
+
+	beforeEach(async () => {
+		cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-mode-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(cwd, { recursive: true, force: true });
+	});
+
+	function makeHarness(
+		options: {
+			planEnabled?: boolean;
+			approved?: boolean;
+			confirm?: (signal: AbortSignal) => Promise<boolean>;
+			tools?: string[];
+			builtInWrite?: boolean;
+			initialState?: PlanModeState;
+			planYolo?: boolean;
+		} = {},
+	): ControllerHarness {
+		let state: PlanModeState | undefined = options.initialState;
+		let handler: PlanProposalHandler | null = null;
+		let reference: string | undefined;
+		let enabledTools = [...(options.tools ?? ["read"])];
+		const modeChanges: RpcMode[] = [];
+		const confirmCalls: Array<{ title: string; message: string }> = [];
+		const session: RpcModeControllerSession = {
+			settings: { get: () => options.planEnabled ?? true },
+			sessionManager: {
+				getArtifactsDir: () => path.join(cwd, "artifacts"),
+				getSessionId: () => "session-1",
+				getCwd: () => cwd,
+			},
+			hasPlanYoloWorkflow: () => options.planYolo ?? false,
+			getEnabledToolNames: () => enabledTools,
+			hasBuiltInTool: name => name === "write" && (options.builtInWrite ?? true),
+			setActiveToolsByName: async next => {
+				enabledTools = [...next];
+			},
+			getPlanModeState: () => state,
+			setPlanModeState: next => {
+				state = next;
+			},
+			setPlanProposalHandler: next => {
+				handler = next;
+			},
+			setPlanReferencePath: next => {
+				reference = next;
+			},
+		};
+		const controller = new RpcModeController({
+			session,
+			confirm: (title, message, signal) => {
+				confirmCalls.push({ title, message });
+				return options.confirm?.(signal) ?? Promise.resolve(options.approved ?? false);
+			},
+			onModeChanged: mode => modeChanges.push(mode),
+		});
+		return {
+			controller,
+			getState: () => state,
+			getHandler: () => handler,
+			getReference: () => reference,
+			getTools: () => enabledTools,
+			modeChanges,
+			confirmCalls,
+		};
+	}
+
+	test("enters and exits native plan mode", async () => {
+		const harness = makeHarness();
+
+		await harness.controller.apply("plan");
+		expect(harness.controller.mode).toBe("plan");
+		expect(harness.getState()).toMatchObject({
+			enabled: true,
+			planFilePath: "local://PLAN.md",
+			workflow: "parallel",
+		});
+		expect(harness.getHandler()).toBeFunction();
+		expect(harness.getTools()).toEqual(["read", "write"]);
+
+		await harness.controller.apply("default");
+		expect(harness.controller.mode).toBe("default");
+		expect(harness.getState()).toBeUndefined();
+		expect(harness.getHandler()).toBeNull();
+		expect(harness.getTools()).toEqual(["read"]);
+		expect(harness.modeChanges).toEqual(["plan", "default"]);
+	});
+
+	test("rejects plan mode when disabled", async () => {
+		const harness = makeHarness({ planEnabled: false });
+
+		await expect(harness.controller.apply("plan")).rejects.toThrow("Plan mode is disabled");
+		expect(harness.controller.mode).toBe("default");
+		expect(harness.modeChanges).toEqual([]);
+	});
+
+	test("keeps plan mode active when approval requests refinement", async () => {
+		const planPath = path.join(cwd, "rpc-plan.md");
+		await Bun.write(planPath, "# RPC plan\n\n1. Add mode control\n2. Add approval control\n");
+		const harness = makeHarness({ approved: false });
+		await harness.controller.apply("plan");
+		harness.getState()!.planFilePath = planPath;
+
+		const result = await harness.getHandler()!("RPC controls");
+
+		expect(result.content).toEqual([
+			expect.objectContaining({ type: "text", text: expect.stringContaining("Plan refinement requested") }),
+		]);
+		expect(harness.controller.mode).toBe("plan");
+		expect(harness.getHandler()).toBeFunction();
+		expect(harness.confirmCalls).toEqual([
+			expect.objectContaining({ title: "Approve plan?", message: expect.stringContaining("# RPC plan") }),
+		]);
+		expect(harness.modeChanges).toEqual(["plan"]);
+	});
+
+	test("approval records the plan reference and returns to default mode", async () => {
+		const planPath = path.join(cwd, "rpc-plan.md");
+		await Bun.write(planPath, "# RPC plan\n\nImplement the controls.\n");
+		const harness = makeHarness({ approved: true });
+		await harness.controller.apply("plan");
+		harness.getState()!.planFilePath = planPath;
+
+		const result = await harness.getHandler()!("RPC controls");
+
+		expect(result.content).toEqual([
+			expect.objectContaining({ type: "text", text: expect.stringContaining("Plan approved") }),
+		]);
+		expect(harness.getReference()).toBe(planPath);
+		expect(harness.controller.mode).toBe("default");
+		expect(harness.getHandler()).toBeNull();
+		expect(harness.modeChanges).toEqual(["plan", "default"]);
+	});
+
+	test("rejects a stale proposal result after plan mode changes", async () => {
+		const planPath = path.join(cwd, "rpc-plan.md");
+		await Bun.write(planPath, "# RPC plan\n\nImplement the controls.\n");
+		const approval = Promise.withResolvers<boolean>();
+		const confirmationStarted = Promise.withResolvers<void>();
+		const harness = makeHarness({
+			confirm: signal => {
+				confirmationStarted.resolve();
+				signal.addEventListener("abort", () => approval.resolve(false), { once: true });
+				return approval.promise;
+			},
+		});
+		await harness.controller.apply("plan");
+		harness.getState()!.planFilePath = planPath;
+
+		const proposal = harness.getHandler()!("RPC controls");
+		await confirmationStarted.promise;
+		await harness.controller.apply("default");
+
+		await expect(proposal).rejects.toThrow("Plan approval was cancelled");
+		expect(harness.controller.mode).toBe("default");
+		expect(harness.getReference()).toBeUndefined();
+	});
+
+	test("cancels a proposal before plan resolution completes", async () => {
+		const planPath = path.join(cwd, "rpc-plan.md");
+		await Bun.write(planPath, "# RPC plan\n\nImplement the controls.\n");
+		const harness = makeHarness({ approved: true });
+		await harness.controller.apply("plan");
+		harness.getState()!.planFilePath = planPath;
+
+		const proposal = harness.getHandler()!("RPC controls");
+		harness.controller.cancelPendingProposal();
+
+		await expect(proposal).rejects.toThrow("Plan approval was cancelled");
+		expect(harness.confirmCalls).toEqual([]);
+		expect(harness.controller.mode).toBe("plan");
+	});
+	test("reapplying the active mode is idempotent", async () => {
+		const harness = makeHarness();
+
+		await harness.controller.apply("plan");
+		const state = harness.getState();
+		await harness.controller.apply("plan");
+
+		expect(harness.getState()).toBe(state);
+		expect(harness.getState()?.reentry).toBe(false);
+		expect(harness.modeChanges).toEqual(["plan"]);
+		expect(harness.getTools()).toEqual(["read", "write"]);
+	});
+
+	test("does not tear down plan mode owned by another workflow", async () => {
+		const initialState: PlanModeState = {
+			enabled: true,
+			planFilePath: "local://PLAN.md",
+			workflow: "parallel",
+			reentry: false,
+		};
+		const harness = makeHarness({ initialState, tools: ["read", "write"] });
+
+		await expect(harness.controller.apply("default")).rejects.toThrow("managed by another workflow");
+		expect(harness.getState()).toBe(initialState);
+		expect(harness.getTools()).toEqual(["read", "write"]);
+		expect(harness.modeChanges).toEqual([]);
+	});
+
+	test("rejects RPC plan mode while plan-yolo is configured", async () => {
+		const harness = makeHarness({ planYolo: true });
+
+		await expect(harness.controller.apply("plan")).rejects.toThrow("plan-yolo workflow is configured");
+		expect(harness.controller.mode).toBe("default");
+		expect(harness.getTools()).toEqual(["read"]);
+		expect(harness.modeChanges).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- add `set_mode` and `set_approval_mode` RPC commands, state fields, and config/mode update frames
- run native plan mode through guarded tool augmentation, RPC confirmation/cancellation, session resets, and plan-yolo ownership checks
- expose typed `RpcClient` control and extension-UI response APIs with protocol docs and contract coverage

## Verification
- `bun test test/rpc-mode-control.test.ts test/rpc-controls.test.ts test/rpc-input-frame.test.ts test/rpc-client.start.test.ts test/rpc-client.restart.test.ts test/rpc-subagents.test.ts` (39 pass)
- `bun check`