### PR TITLE
fix(thinking): persist auto selector receipt

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10344,15 +10344,16 @@ export class AgentSession {
 	}
 
 	/**
-	 * Set the thinking level. `auto` enables per-turn classification; the selector
-	 * itself is never written to the session log, but resolved concrete levels are
-	 * persisted when real user turns are classified so resumed sessions keep the
-	 * last resolved effort instead of reverting to pending auto.
+	 * Set the thinking level. `auto` enables per-turn classification. Entering
+	 * auto writes its provisional level plus `configured: "auto"` immediately,
+	 * giving external readers an authoritative selection receipt before the next
+	 * user turn. Later classifications persist only changed concrete resolutions.
 	 */
 	setThinkingLevel(level: ConfiguredThinkingLevel | undefined, persist: boolean = false): void {
 		if (level === AUTO_THINKING) {
 			const provisional = resolveProvisionalAutoLevel(this.model);
 			const wasAuto = this.#autoThinking;
+			const previousLevel = this.#thinkingLevel;
 			this.#autoThinking = true;
 			this.#autoResolvedLevel = undefined;
 			this.#thinkingLevel = provisional;
@@ -10363,7 +10364,9 @@ export class AgentSession {
 			if (persist) {
 				this.settings.set("defaultThinkingLevel", AUTO_THINKING);
 			}
-			if (!wasAuto || this.#thinkingLevel !== provisional) {
+			const isChanging = !wasAuto || previousLevel !== provisional;
+			if (isChanging) {
+				this.sessionManager.appendThinkingLevelChange(provisional, AUTO_THINKING);
 				this.#emit({ type: "thinking_level_changed", thinkingLevel: provisional, configured: AUTO_THINKING });
 			}
 			return;
@@ -10472,7 +10475,7 @@ export class AgentSession {
 
 		const effort = resolved ?? resolveProvisionalAutoLevel(model);
 		if (effort === undefined) return;
-		const shouldPersistResolution = this.#autoResolvedLevel !== effort;
+		const shouldPersistResolution = this.#thinkingLevel !== effort;
 		this.#autoResolvedLevel = effort;
 		this.#thinkingLevel = effort;
 		this.#applyThinkingLevelToAgent(effort);

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -300,6 +300,21 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.configuredThinkingLevel()).toBe(AUTO_THINKING);
 		expect(session.thinkingLevel).toBe(resolveProvisionalAutoLevel(model));
 		expect(agent.state.disableReasoning).toBe(false);
+		const autoReceipt = session.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "thinking_level_change")
+			.at(-1);
+		expect(autoReceipt).toMatchObject({
+			thinkingLevel: resolveProvisionalAutoLevel(model),
+			configured: AUTO_THINKING,
+		});
+		const autoReceiptCount = session.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "thinking_level_change").length;
+		session.setThinkingLevel(AUTO_THINKING);
+		expect(session.sessionManager.getEntries().filter(entry => entry.type === "thinking_level_change")).toHaveLength(
+			autoReceiptCount,
+		);
 		expect(session.cycleThinkingLevel()).toBe(Effort.Minimal);
 		expect(session.thinkingLevel).toBe(Effort.Minimal);
 	});
@@ -521,6 +536,9 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe(fallback);
 		expect(session.autoResolvedThinkingLevel()).toBe(fallback);
 		expect(session.agent.state.thinkingLevel).toBe(fallback);
+		expect(session.sessionManager.getEntries().filter(entry => entry.type === "thinking_level_change")).toHaveLength(
+			1,
+		);
 	});
 
 	it("skips classification for synthetic turns", async () => {


### PR DESCRIPTION
## Problem

`setThinkingLevel("auto")` changed runtime state and emitted a UI event, but wrote no session entry until the next real prompt was classified. Append-only integrations therefore could not confirm that Auto was selected and could keep cycling past it.

## Fix

- append the provisional effective level with `configured: "auto"` immediately when Auto is entered
- keep unchanged Auto reapplication idempotent
- avoid a duplicate classifier receipt when the first resolved effort equals the provisional receipt
- cover immediate persistence and both deduplication paths

## Verification

- `bun test packages/coding-agent/test/agent-session-role-thinking.test.ts packages/coding-agent/test/agent-session-model-persistence.test.ts packages/coding-agent/test/session-persistence-reasoning-dedup.test.ts` — 47 pass
- `bunx biome check packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/agent-session-role-thinking.test.ts` — OK
- `bun --cwd=packages/coding-agent run check:types` — pass
