### PR TITLE
feat(collab): list active local host sessions

### DIFF
--- a/docs/collab.md
+++ b/docs/collab.md
@@ -37,8 +37,26 @@ The guest's previous session is restored on `/leave` (or when the host stops).
 | `/collab view` | Start sharing read-only (or re-print the link/QR when already hosting) |
 | `/collab status` | Show link + participants |
 | `/collab stop` | Stop sharing |
+| `/collab list` | List every active local Collab host with its write-capable browser URL |
+| `/collab list view` | Same hosts, view-only browser URLs |
 | `/join <link>` | Join a shared session as a guest |
 | `/leave` | Leave (guest) or stop sharing (host) |
+
+### Listing active local hosts
+
+`omp collab list` (and `/collab list` inside a TUI) enumerates every live Collab host on the local machine under the same omp configuration root — across terminals, projects, and profiles — and prints one browser URL per host:
+
+```
+omp collab list          # write-capable URLs (labeled `write`)
+omp collab list --view   # same hosts, view-only URLs (labeled `view`)
+omp collab list --json   # deterministic machine-readable output
+```
+
+Each row shows the session name/ID, working directory, PID, age, guest count, access mode, and URL. Hosts are sorted by start time, then PID. An empty result ("No active Collab hosts.") is a successful outcome, not an error.
+
+**The default output is secret-bearing**: a write URL grants full control of the host agent, and redirecting the output persists it. Use `--view` to deliberately share read-only access; `--view` changes only the link capability, never which hosts are listed.
+
+How it works: each host publishes a private per-process IPC endpoint (a Unix domain socket on macOS/Linux, a named pipe on Windows — never a TCP port) after its relay connection succeeds. Full-control and view-only URLs, the room key, and the write token stay in the host process's memory; disk holds only owner-only discovery metadata (protocol version, PID, endpoint, creation time, and a random bearer token). Listing queries every live host concurrently, skips unresponsive or foreign-version entries, and prunes metadata left behind by crashed hosts. Stopped rooms disappear immediately and cannot be recovered — the feature keeps no history, lists no guests or remote hosts, and requires no relay change.
 
 ## Link format
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `omp collab list` (with `--view` and `--json`) and `/collab list [view]` to list every active local Collab host and recover its browser URL from a runtime host registry over Unix sockets/named pipes, without persisting room keys, write tokens, or URLs to disk ([#6099](https://github.com/can1357/oh-my-pi/issues/6099))
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -19,6 +19,7 @@ export const commands: CommandEntry[] = [
 	{ name: "agents", load: () => import("./commands/agents").then(m => m.default) },
 	{ name: "bench", load: () => import("./commands/bench").then(m => m.default) },
 	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
+	{ name: "collab", load: () => import("./commands/collab").then(m => m.default) },
 	{ name: "completions", load: () => import("./commands/completions").then(m => m.default) },
 	{ name: "__complete", load: () => import("./commands/complete").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },

--- a/packages/coding-agent/src/cli/collab-cli.ts
+++ b/packages/coding-agent/src/cli/collab-cli.ts
@@ -1,0 +1,75 @@
+/**
+ * CLI handler for `omp collab list` — enumerate live local Collab hosts.
+ *
+ * Queries the runtime host registry (`src/collab/registry.ts`); never touches
+ * the relay and never reads room secrets from disk (hosts return their URLs
+ * over authenticated local IPC). Default output prints write-capable URLs.
+ */
+import { formatAge } from "@oh-my-pi/pi-utils";
+import chalk from "chalk";
+import {
+	COLLAB_REGISTRY_VERSION,
+	type CollabAccessMode,
+	type CollabHostSnapshot,
+	type CollabListOptions,
+	listCollabHosts,
+} from "../collab/registry";
+import { shortenPath } from "../tools/render-utils";
+
+export interface CollabListCommandArgs {
+	/** Request view-only URLs instead of write-capable URLs. */
+	view: boolean;
+	/** Emit deterministic machine-readable JSON. */
+	json: boolean;
+	/** Registry overrides (tests). */
+	registry?: CollabListOptions;
+}
+
+/** Versioned top-level JSON shape for `omp collab list --json`. */
+export interface CollabListJsonOutput {
+	version: number;
+	mode: CollabAccessMode;
+	hosts: CollabHostSnapshot[];
+}
+
+export async function runCollabListCommand(
+	args: CollabListCommandArgs,
+	print: (line: string) => void = line => console.log(line),
+): Promise<void> {
+	const mode: CollabAccessMode = args.view ? "view" : "write";
+	const hosts = await listCollabHosts({ ...args.registry, mode });
+
+	if (args.json) {
+		const output: CollabListJsonOutput = { version: COLLAB_REGISTRY_VERSION, mode, hosts };
+		print(JSON.stringify(output, null, 2));
+		return;
+	}
+
+	if (hosts.length === 0) {
+		print(chalk.dim("No active Collab hosts."));
+		return;
+	}
+
+	const plural = hosts.length === 1 ? "host" : "hosts";
+	print(
+		mode === "write"
+			? chalk.dim(
+					`${hosts.length} active Collab ${plural}. URLs below are write-capable: anyone with one can prompt and control the host agent.`,
+				)
+			: chalk.dim(`${hosts.length} active Collab ${plural}. URLs below are view-only.`),
+	);
+	for (const host of hosts) {
+		const label = host.mode === "write" ? chalk.yellow("write") : chalk.green("view ");
+		const session = host.sessionName ? `${host.sessionName} (${host.sessionId})` : host.sessionId;
+		const guests = host.participants - 1;
+		const details = [
+			`pid ${host.pid}`,
+			`started ${formatAge(Math.round((Date.now() - host.startedAt) / 1000)) || "just now"}`,
+			`${guests} ${guests === 1 ? "guest" : "guests"}`,
+		].join(" · ");
+		print("");
+		print(`${label}  ${session}  ${chalk.dim(shortenPath(host.cwd))}`);
+		print(`       ${chalk.dim(details)}`);
+		print(`       ${host.url}`);
+	}
+}

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -43,6 +43,12 @@ import {
 	generateRoomId,
 	parseCollabLink,
 } from "./protocol";
+import {
+	type CollabAccessMode,
+	type CollabHostPublication,
+	type CollabHostSnapshot,
+	publishCollabHost,
+} from "./registry";
 import { CollabSocket } from "./relay-client";
 import { shrinkForReplication } from "./replication-shrink";
 
@@ -127,6 +133,8 @@ export class CollabHost {
 	#webViewLink = "";
 	#writeToken: Uint8Array | null = null;
 	#sessionId = "";
+	#startedAt = 0;
+	#registryPublication: CollabHostPublication | null = null;
 	#unsubscribe?: () => void;
 	#peers = new Map<number, { name: string; canWrite: boolean }>();
 	#uiReqSeq = 0;
@@ -266,6 +274,18 @@ export class CollabHost {
 			clearTimeout(timeout);
 		}
 
+		this.#startedAt = Date.now();
+		// Publish to the local host registry only after the relay connection
+		// succeeded. Publication failure warns but never breaks hosting (#6099).
+		try {
+			this.#registryPublication = await publishCollabHost(mode => this.#registrySnapshot(mode));
+		} catch (err) {
+			logger.warn("Collab host registry publication failed", { error: String(err) });
+			this.#ctx.showStatus("Collab host discovery unavailable (omp collab list will not show this session)", {
+				dim: true,
+			});
+		}
+
 		this.#unsubscribe = this.#ctx.session.subscribe(event => {
 			if (isWireAgentEvent(event)) this.#broadcast({ t: "event", event: shrinkForReplication(event) });
 			this.#onEventForState(event);
@@ -296,6 +316,15 @@ export class CollabHost {
 	async #teardown(): Promise<void> {
 		if (this.#stopped) return;
 		this.#stopped = true;
+		const publication = this.#registryPublication;
+		this.#registryPublication = null;
+		if (publication) {
+			// close() removes discovery metadata synchronously before awaiting the
+			// server shutdown, so a stopped room disappears from lists immediately.
+			void publication
+				.close()
+				.catch(err => logger.warn("Collab host registry withdrawal failed", { error: String(err) }));
+		}
 		this.#ctx.sessionManager.onEntryAppended = undefined;
 		this.#unsubscribe?.();
 		this.#unsubscribe = undefined;
@@ -317,6 +346,19 @@ export class CollabHost {
 		this.#ctx.collabHost = undefined;
 		this.#ctx.statusLine.setCollabStatus(null);
 		this.#ctx.ui.requestRender();
+	}
+
+	/** Live snapshot served over the registry IPC; `view` never sees the write URL. */
+	#registrySnapshot(mode: CollabAccessMode): Omit<CollabHostSnapshot, "mode"> {
+		return {
+			sessionId: this.#sessionId,
+			sessionName: this.#ctx.session.sessionName ?? null,
+			cwd: this.#ctx.sessionManager.getCwd(),
+			pid: process.pid,
+			startedAt: this.#startedAt,
+			participants: this.participants.length,
+			url: mode === "view" ? this.#webViewLink : this.#webLink,
+		};
 	}
 
 	#broadcast(frame: CollabFrame): void {

--- a/packages/coding-agent/src/collab/registry.ts
+++ b/packages/coding-agent/src/collab/registry.ts
@@ -1,0 +1,432 @@
+/**
+ * Runtime local Collab host registry.
+ *
+ * Every successfully connected Collab host publishes a private, per-process
+ * IPC endpoint (Unix domain socket on POSIX, named pipe on Windows) so that a
+ * separate local process can discover live hosts and retrieve a shareable URL.
+ * Full-control and view-only URLs, room keys, and write tokens stay in host
+ * memory; disk carries only ephemeral discovery metadata (protocol version,
+ * PID, endpoint, creation time, random bearer token) with owner-only
+ * permissions. Endpoints die with the host process, so a crash leaves at most
+ * stale metadata that the next list operation prunes best-effort.
+ *
+ * Transport follows the launch daemon broker conventions: node `net` servers,
+ * newline-delimited JSON envelopes, per-request bearer authentication, and
+ * bounded buffers. Guests never publish; this registry is host-only.
+ */
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as path from "node:path";
+import { getBaseConfigRoot, isEnoent, logger } from "@oh-my-pi/pi-utils";
+
+/** Discovery metadata / IPC protocol version. Mixed omp versions fail safely. */
+export const COLLAB_REGISTRY_VERSION = 1;
+
+/** Reject request lines beyond this size; a valid request is <200 bytes. */
+const MAX_REQUEST_BYTES = 4 * 1024;
+/** Reject snapshot responses beyond this size. */
+const MAX_RESPONSE_BYTES = 64 * 1024;
+/** Per-entry connect+response deadline during listing. */
+const DEFAULT_QUERY_TIMEOUT_MS = 1_500;
+/** Concurrency bound for querying discovery entries. */
+const LIST_CONCURRENCY = 8;
+
+export type CollabAccessMode = "write" | "view";
+
+/** Live host state, computed by the host process at query time. */
+export interface CollabHostSnapshot {
+	/** Session ID of the hosted conversation. */
+	sessionId: string;
+	/** Human-readable session name, when one is set. */
+	sessionName: string | null;
+	/** Host working directory. */
+	cwd: string;
+	/** Host process ID. */
+	pid: number;
+	/** Epoch milliseconds when the host connected to the relay. */
+	startedAt: number;
+	/** Current participant count, including the host. */
+	participants: number;
+	/** Access mode the returned URL grants. */
+	mode: CollabAccessMode;
+	/** Browser URL for the requested access mode. `view` requests never carry the write URL. */
+	url: string;
+}
+
+/** Computes one live snapshot per request; called by the IPC server. */
+export type CollabHostSnapshotProvider = (mode: CollabAccessMode) => Omit<CollabHostSnapshot, "mode">;
+
+/** Handle returned by {@link publishCollabHost}; closing withdraws the host. */
+export interface CollabHostPublication {
+	/** Endpoint the host listens on (test/diagnostic use; not secret). */
+	readonly endpoint: string;
+	/** Stop serving snapshots and remove the discovery metadata. Idempotent. */
+	close(): Promise<void>;
+}
+
+export interface CollabRegistryOptions {
+	/** Override the discovery metadata directory (tests). */
+	dir?: string;
+}
+
+export interface CollabListOptions extends CollabRegistryOptions {
+	/** URL capability to request from each host. Defaults to `write`. */
+	mode?: CollabAccessMode;
+	/** Per-entry query deadline in milliseconds. */
+	timeoutMs?: number;
+}
+
+/**
+ * Discovery metadata directory. Deliberately under the profile-independent
+ * config root (`~/.omp/run/collab-hosts`) — unlike the launch broker's
+ * profile-scoped runtime dir — so hosts started under any profile are
+ * discoverable from any other (issue #6099 user story 18).
+ */
+export function collabHostsRuntimeDir(): string {
+	return path.join(getBaseConfigRoot(), "run", "collab-hosts");
+}
+
+interface DiscoveryMetadata {
+	version: number;
+	pid: number;
+	endpoint: string;
+	createdAt: number;
+	token: string;
+}
+
+function parseDiscoveryMetadata(text: string): DiscoveryMetadata | null {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	if (typeof raw !== "object" || raw === null) return null;
+	const meta = raw as Record<string, unknown>;
+	if (typeof meta.version !== "number") return null;
+	if (typeof meta.pid !== "number" || !Number.isInteger(meta.pid) || meta.pid <= 0) return null;
+	if (typeof meta.endpoint !== "string" || meta.endpoint.length === 0) return null;
+	if (typeof meta.createdAt !== "number") return null;
+	if (typeof meta.token !== "string" || meta.token.length === 0) return null;
+	return {
+		version: meta.version,
+		pid: meta.pid,
+		endpoint: meta.endpoint,
+		createdAt: meta.createdAt,
+		token: meta.token,
+	};
+}
+
+function tokenMatches(expected: string, presented: unknown): boolean {
+	if (typeof presented !== "string") return false;
+	const a = Buffer.from(expected, "utf8");
+	const b = Buffer.from(presented, "utf8");
+	if (a.length !== b.length) return false;
+	return crypto.timingSafeEqual(a, b);
+}
+
+function parseSnapshot(raw: unknown, mode: CollabAccessMode): CollabHostSnapshot | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const host = raw as Record<string, unknown>;
+	if (typeof host.sessionId !== "string") return null;
+	if (host.sessionName !== null && typeof host.sessionName !== "string") return null;
+	if (typeof host.cwd !== "string") return null;
+	if (typeof host.pid !== "number" || !Number.isInteger(host.pid)) return null;
+	if (typeof host.startedAt !== "number") return null;
+	if (typeof host.participants !== "number") return null;
+	if (typeof host.url !== "string" || host.url.length === 0) return null;
+	return {
+		sessionId: host.sessionId,
+		sessionName: host.sessionName,
+		cwd: host.cwd,
+		pid: host.pid,
+		startedAt: host.startedAt,
+		participants: host.participants,
+		mode,
+		url: host.url,
+	};
+}
+
+/** One request per connection: authenticate, snapshot, respond, close. */
+function handleConnection(socket: net.Socket, token: string, provider: CollabHostSnapshotProvider): void {
+	let buffer = "";
+	let handled = false;
+	const respond = (payload: object): void => {
+		handled = true;
+		socket.end(`${JSON.stringify(payload)}\n`);
+	};
+	socket.setEncoding("utf8");
+	socket.on("error", () => socket.destroy());
+	socket.on("data", chunk => {
+		if (handled) return;
+		buffer += chunk;
+		if (Buffer.byteLength(buffer, "utf8") > MAX_REQUEST_BYTES) {
+			socket.destroy();
+			return;
+		}
+		const newline = buffer.indexOf("\n");
+		if (newline < 0) return;
+		const line = buffer.slice(0, newline).trim();
+		let request: unknown;
+		try {
+			request = JSON.parse(line);
+		} catch {
+			respond({ ok: false, error: "malformed request" });
+			return;
+		}
+		if (typeof request !== "object" || request === null) {
+			respond({ ok: false, error: "malformed request" });
+			return;
+		}
+		const { v, token: presented, mode } = request as Record<string, unknown>;
+		if (v !== COLLAB_REGISTRY_VERSION) {
+			respond({ ok: false, error: "unsupported protocol version" });
+			return;
+		}
+		if (!tokenMatches(token, presented)) {
+			respond({ ok: false, error: "authentication failed" });
+			return;
+		}
+		if (mode !== "write" && mode !== "view") {
+			respond({ ok: false, error: "invalid access mode" });
+			return;
+		}
+		try {
+			// A `view` request receives only the view-only URL; the provider never
+			// serializes the full-control URL for it.
+			const snapshot = provider(mode);
+			respond({ ok: true, v: COLLAB_REGISTRY_VERSION, host: { ...snapshot, mode } });
+		} catch {
+			// Never let provider errors (or URLs) leak into the wire error.
+			respond({ ok: false, error: "snapshot unavailable" });
+		}
+	});
+}
+
+/**
+ * Publish a live Collab host to the local registry.
+ *
+ * Creates the owner-only runtime dir, starts a private IPC endpoint backed by
+ * `provider`, and writes discovery metadata (never URLs or room secrets).
+ * Call {@link CollabHostPublication.close} on every teardown path; a process
+ * exit hook removes the on-disk state for normal shutdown, and the OS closing
+ * the endpoint covers crashes.
+ */
+export async function publishCollabHost(
+	provider: CollabHostSnapshotProvider,
+	options?: CollabRegistryOptions,
+): Promise<CollabHostPublication> {
+	const dir = options?.dir ?? collabHostsRuntimeDir();
+	await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+
+	// Unpredictable instance ID: names the endpoint and the metadata file, so
+	// PID reuse cannot attach stale metadata to an unrelated process.
+	const instanceId = crypto.randomBytes(8).toString("hex");
+	const token = crypto.randomBytes(32).toString("hex");
+	const endpoint =
+		process.platform === "win32" ? `\\\\.\\pipe\\omp-collab-${instanceId}` : path.join(dir, `${instanceId}.sock`);
+	const metaPath = path.join(dir, `${instanceId}.json`);
+
+	const liveSockets = new Set<net.Socket>();
+	const server = net.createServer(socket => {
+		liveSockets.add(socket);
+		socket.once("close", () => liveSockets.delete(socket));
+		handleConnection(socket, token, provider);
+	});
+	const listening = Promise.withResolvers<void>();
+	server.once("error", err => listening.reject(err));
+	server.listen(endpoint, () => listening.resolve());
+	try {
+		await listening.promise;
+		if (process.platform !== "win32") await fs.promises.chmod(endpoint, 0o600);
+		const meta: DiscoveryMetadata = {
+			version: COLLAB_REGISTRY_VERSION,
+			pid: process.pid,
+			endpoint,
+			createdAt: Date.now(),
+			token,
+		};
+		const handle = await fs.promises.open(metaPath, "wx", 0o600);
+		try {
+			await handle.writeFile(JSON.stringify(meta), "utf8");
+		} finally {
+			await handle.close();
+		}
+	} catch (err) {
+		server.close();
+		if (process.platform !== "win32") fs.rmSync(endpoint, { force: true });
+		throw err;
+	}
+
+	const removeArtifactsSync = (): void => {
+		try {
+			fs.rmSync(metaPath, { force: true });
+			if (process.platform !== "win32") fs.rmSync(endpoint, { force: true });
+		} catch {
+			// Best-effort; a survivor is pruned by the next list.
+		}
+	};
+	// Normal process shutdown without an explicit stop still withdraws the host.
+	process.once("exit", removeArtifactsSync);
+
+	let closed = false;
+	return {
+		endpoint,
+		async close(): Promise<void> {
+			if (closed) return;
+			closed = true;
+			process.off("exit", removeArtifactsSync);
+			const done = Promise.withResolvers<void>();
+			server.close(() => done.resolve());
+			// Sever any lingering clients so close() cannot hang on an open socket.
+			for (const socket of liveSockets) socket.destroy();
+			removeArtifactsSync();
+			await done.promise;
+		},
+	};
+}
+
+/** Query one endpoint: connect, authenticate, read one bounded response line. */
+function querySnapshot(
+	meta: DiscoveryMetadata,
+	mode: CollabAccessMode,
+	timeoutMs: number,
+): Promise<{ status: "ok"; host: CollabHostSnapshot } | { status: "dead" } | { status: "skip" }> {
+	const { promise, resolve } = Promise.withResolvers<
+		{ status: "ok"; host: CollabHostSnapshot } | { status: "dead" } | { status: "skip" }
+	>();
+	let buffer = "";
+	const socket = net.createConnection({ path: meta.endpoint });
+	const timer = setTimeout(() => finish({ status: "skip" }), timeoutMs);
+	const finish = (
+		result: { status: "ok"; host: CollabHostSnapshot } | { status: "dead" } | { status: "skip" },
+	): void => {
+		clearTimeout(timer);
+		socket.destroy();
+		resolve(result);
+	};
+	socket.setEncoding("utf8");
+	socket.once("error", () => {
+		// Endpoints die with their host process: connection failure means the
+		// host is gone (even if the PID was reused), so the entry is stale.
+		finish({ status: "dead" });
+	});
+	socket.once("connect", () => {
+		socket.write(`${JSON.stringify({ v: COLLAB_REGISTRY_VERSION, token: meta.token, mode })}\n`);
+	});
+	socket.on("data", chunk => {
+		buffer += chunk;
+		if (Buffer.byteLength(buffer, "utf8") > MAX_RESPONSE_BYTES) {
+			finish({ status: "skip" });
+			return;
+		}
+		const newline = buffer.indexOf("\n");
+		if (newline < 0) return;
+		let response: unknown;
+		try {
+			response = JSON.parse(buffer.slice(0, newline));
+		} catch {
+			finish({ status: "skip" });
+			return;
+		}
+		if (typeof response !== "object" || response === null || (response as Record<string, unknown>).ok !== true) {
+			// Authentication failure or structured error: an unrelated endpoint
+			// cannot satisfy stale metadata without the matching token.
+			finish({ status: "skip" });
+			return;
+		}
+		const host = parseSnapshot((response as Record<string, unknown>).host, mode);
+		finish(host ? { status: "ok", host } : { status: "skip" });
+	});
+	socket.once("close", () => finish({ status: "skip" }));
+	return promise;
+}
+
+function pidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function pruneEntry(dir: string, name: string, meta: DiscoveryMetadata | null): Promise<void> {
+	try {
+		await fs.promises.rm(path.join(dir, name), { force: true });
+		if (meta && process.platform !== "win32" && meta.endpoint.startsWith(dir + path.sep)) {
+			await fs.promises.rm(meta.endpoint, { force: true });
+		}
+	} catch {
+		// Best-effort cleanup only.
+	}
+}
+
+async function listEntry(
+	dir: string,
+	name: string,
+	mode: CollabAccessMode,
+	timeoutMs: number,
+): Promise<CollabHostSnapshot | null> {
+	let text: string;
+	try {
+		text = await Bun.file(path.join(dir, name)).text();
+	} catch (err) {
+		if (isEnoent(err)) return null;
+		return null;
+	}
+	const meta = parseDiscoveryMetadata(text);
+	if (!meta) {
+		// Malformed metadata can never become listable; remove it.
+		await pruneEntry(dir, name, null);
+		return null;
+	}
+	if (meta.version !== COLLAB_REGISTRY_VERSION) {
+		// A different omp version owns this entry. Never show it; prune only
+		// once the owning process is gone so newer versions keep their state.
+		if (!pidAlive(meta.pid)) await pruneEntry(dir, name, meta);
+		return null;
+	}
+	const result = await querySnapshot(meta, mode, timeoutMs);
+	if (result.status === "ok") return result.host;
+	if (result.status === "dead") await pruneEntry(dir, name, meta);
+	return null;
+}
+
+/**
+ * List live Collab hosts under this config root.
+ *
+ * Reads every discovery entry, queries the live hosts concurrently (bounded,
+ * short independent deadlines), prunes stale or malformed entries
+ * best-effort, and returns healthy hosts sorted by start time then PID.
+ * Unreachable, unauthenticated, malformed, or version-mismatched entries are
+ * omitted without failing the listing.
+ */
+export async function listCollabHosts(options?: CollabListOptions): Promise<CollabHostSnapshot[]> {
+	const dir = options?.dir ?? collabHostsRuntimeDir();
+	const mode = options?.mode ?? "write";
+	const timeoutMs = options?.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS;
+	let names: string[];
+	try {
+		names = await fs.promises.readdir(dir);
+	} catch (err) {
+		if (isEnoent(err)) return [];
+		logger.warn("Collab registry listing failed", { error: String(err) });
+		return [];
+	}
+	const entries = names.filter(name => name.endsWith(".json")).sort();
+	const hosts: CollabHostSnapshot[] = [];
+	// Bounded worker pool: LIST_CONCURRENCY entries in flight at once.
+	let next = 0;
+	const worker = async (): Promise<void> => {
+		while (next < entries.length) {
+			const name = entries[next++];
+			const host = await listEntry(dir, name, mode, timeoutMs);
+			if (host) hosts.push(host);
+		}
+	};
+	await Promise.all(Array.from({ length: Math.min(LIST_CONCURRENCY, entries.length) }, worker));
+	hosts.sort((a, b) => a.startedAt - b.startedAt || a.pid - b.pid);
+	return hosts;
+}

--- a/packages/coding-agent/src/commands/collab.ts
+++ b/packages/coding-agent/src/commands/collab.ts
@@ -1,0 +1,37 @@
+/**
+ * List active local Collab host sessions.
+ */
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { runCollabListCommand } from "../cli/collab-cli";
+
+export default class Collab extends Command {
+	static description =
+		"List active local Collab host sessions.\n\n" +
+		"By default each row prints the write-capable browser URL: anyone who obtains it " +
+		"can prompt and control the host agent, so treat the output (and anything you " +
+		"redirect it into) as secret. Use --view for view-only URLs.";
+
+	static args = {
+		action: Args.string({
+			description: "list (default)",
+			required: false,
+			options: ["list"],
+			default: "list",
+		}),
+	};
+
+	static flags = {
+		view: Flags.boolean({
+			description: "Print view-only URLs instead of write-capable URLs (same hosts, weaker capability)",
+			default: false,
+		}),
+		json: Flags.boolean({ char: "j", description: "Emit deterministic machine-readable JSON", default: false }),
+	};
+
+	static examples = ["omp collab list", "omp collab list --view", "omp collab list --json"];
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(Collab);
+		await runCollabListCommand({ view: flags.view ?? false, json: flags.json ?? false });
+	}
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -7,6 +7,7 @@ import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
+import { listCollabHosts } from "../collab/registry";
 import { expandRoleAlias, getModelMatchPreferences, resolveCliModel } from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import type { SettingPath, SettingValue } from "../config/settings";
@@ -36,6 +37,7 @@ import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
+import { shortenPath } from "../tools/render-utils";
 import { urlHyperlinkAlways } from "../tui";
 import {
 	getChangelogPath,
@@ -690,9 +692,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "collab",
 		description: "Share this session live via a relay",
-		inlineHint: "[start|view|stop|status] [relayUrl]",
+		inlineHint: "[start|view|list|stop|status] [relayUrl]",
 		subcommands: [
 			{ name: "view", description: "Share a read-only link (guests can watch, not prompt)" },
+			{ name: "list", description: "List active local Collab hosts (write URLs; `list view` for view-only)" },
 			{ name: "status", description: "Show link + participants" },
 			{ name: "stop", description: "Stop sharing" },
 		],
@@ -734,6 +737,37 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				} else {
 					ctx.showStatus("Not in a collab session");
 				}
+				return;
+			}
+			if (verb === "list") {
+				// Same registry and access-mode semantics as `omp collab list`:
+				// `list view` returns the same hosts with view-only URLs.
+				const viewList = rest.trim().toLowerCase() === "view";
+				const hosts = await listCollabHosts({ mode: viewList ? "view" : "write" });
+				if (hosts.length === 0) {
+					ctx.showStatus("No active Collab hosts");
+					return;
+				}
+				const bullet = theme.fg("accent", theme.format.bullet);
+				const plural = hosts.length === 1 ? "" : "s";
+				const lines = [
+					theme.fg(
+						"dim",
+						viewList
+							? `${hosts.length} active local Collab host${plural} (view-only URLs)`
+							: `${hosts.length} active local Collab host${plural} — write URLs: anyone with one can prompt and control that host`,
+					),
+				];
+				for (const host of hosts) {
+					const session = host.sessionName ? `${host.sessionName} (${host.sessionId})` : host.sessionId;
+					const guests = host.participants - 1;
+					const detail = `pid ${host.pid}, ${guests} guest${guests === 1 ? "" : "s"}, ${shortenPath(host.cwd)}`;
+					lines.push(
+						` ${bullet} ${session} ${theme.fg("muted", `— ${detail}`)}`,
+						`   ${host.mode}: ${collabWebLinkClickable(host.url)}`,
+					);
+				}
+				ctx.showStatus(lines.join("\n"), { dim: false });
 				return;
 			}
 			if (ctx.collabGuest) {

--- a/packages/coding-agent/test/cli/collab-list.test.ts
+++ b/packages/coding-agent/test/cli/collab-list.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runCollabListCommand } from "@oh-my-pi/pi-coding-agent/cli/collab-cli";
+import {
+	COLLAB_REGISTRY_VERSION,
+	type CollabHostPublication,
+	publishCollabHost,
+} from "@oh-my-pi/pi-coding-agent/collab/registry";
+import Collab from "@oh-my-pi/pi-coding-agent/commands/collab";
+
+interface HostFixture {
+	sessionId: string;
+	sessionName: string | null;
+	cwd: string;
+	pid: number;
+	startedAt: number;
+	participants: number;
+	writeUrl: string;
+	viewUrl: string;
+}
+
+const ALPHA: HostFixture = {
+	sessionId: "sess-alpha",
+	sessionName: "Alpha Session",
+	cwd: "/tmp/work/alpha",
+	pid: 111,
+	startedAt: 1_700_000_000_000,
+	participants: 3, // 2 guests
+	writeUrl: "https://collab.test/#alpha-WRITE-url",
+	viewUrl: "https://collab.test/#alpha-VIEW-url",
+};
+
+const BRAVO: HostFixture = {
+	sessionId: "sess-bravo",
+	sessionName: null,
+	cwd: "/tmp/work/bravo",
+	pid: 222,
+	startedAt: 1_700_000_100_000,
+	participants: 1, // 0 guests
+	writeUrl: "https://collab.test/#bravo-WRITE-url",
+	viewUrl: "https://collab.test/#bravo-VIEW-url",
+};
+
+const publications: CollabHostPublication[] = [];
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-collab-cli-"));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+async function publish(dir: string, fixture: HostFixture): Promise<CollabHostPublication> {
+	const pub = await publishCollabHost(
+		mode => ({
+			sessionId: fixture.sessionId,
+			sessionName: fixture.sessionName,
+			cwd: fixture.cwd,
+			pid: fixture.pid,
+			startedAt: fixture.startedAt,
+			participants: fixture.participants,
+			url: mode === "view" ? fixture.viewUrl : fixture.writeUrl,
+		}),
+		{ dir },
+	);
+	publications.push(pub);
+	return pub;
+}
+
+function collector(): { print: (line: string) => void; plain: () => string; calls: string[] } {
+	const calls: string[] = [];
+	return {
+		print: line => calls.push(line),
+		plain: () => Bun.stripANSI(calls.join("\n")),
+		calls,
+	};
+}
+
+afterEach(async () => {
+	await Promise.all(publications.splice(0).map(pub => pub.close()));
+	for (const dir of tmpDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("runCollabListCommand", () => {
+	it("reports no active hosts against an empty registry", async () => {
+		const dir = makeTmpDir();
+		const out = collector();
+
+		await runCollabListCommand({ view: false, json: false, registry: { dir } }, out.print);
+
+		expect(out.plain()).toBe("No active Collab hosts.");
+	});
+
+	it("renders write rows ordered by startedAt then pid with URLs, pids and guest counts", async () => {
+		const dir = makeTmpDir();
+		// Publish out of order to prove the command sorts, not the filesystem.
+		await publish(dir, BRAVO);
+		await publish(dir, ALPHA);
+		const out = collector();
+
+		await runCollabListCommand({ view: false, json: false, registry: { dir } }, out.print);
+
+		const text = out.plain();
+		expect(text).toContain("write");
+		expect(text).toContain("pid 111");
+		expect(text).toContain("pid 222");
+		expect(text).toContain("2 guests");
+		expect(text).toContain("0 guests");
+		expect(text).toContain("Alpha Session (sess-alpha)");
+		expect(text).toContain("sess-bravo");
+		expect(text).toContain(ALPHA.writeUrl);
+		expect(text).toContain(BRAVO.writeUrl);
+		// Alpha (older startedAt) precedes Bravo.
+		expect(text.indexOf(ALPHA.writeUrl)).toBeLessThan(text.indexOf(BRAVO.writeUrl));
+	});
+
+	it("renders view rows with view URLs and never leaks write URLs", async () => {
+		const dir = makeTmpDir();
+		await publish(dir, ALPHA);
+		await publish(dir, BRAVO);
+		const out = collector();
+
+		await runCollabListCommand({ view: true, json: false, registry: { dir } }, out.print);
+
+		const text = out.plain();
+		expect(text).toContain("view");
+		expect(text).toContain(ALPHA.viewUrl);
+		expect(text).toContain(BRAVO.viewUrl);
+		expect(text).not.toContain(ALPHA.writeUrl);
+		expect(text).not.toContain(BRAVO.writeUrl);
+	});
+
+	it("emits deterministic write-mode JSON carrying only write URLs", async () => {
+		const dir = makeTmpDir();
+		await publish(dir, BRAVO);
+		await publish(dir, ALPHA);
+		const out = collector();
+
+		await runCollabListCommand({ view: false, json: true, registry: { dir } }, out.print);
+
+		// A single print call carries the full JSON document.
+		expect(out.calls).toHaveLength(1);
+		const parsed = JSON.parse(out.calls[0]!);
+		expect(parsed).toEqual({
+			version: COLLAB_REGISTRY_VERSION,
+			mode: "write",
+			hosts: [
+				{
+					sessionId: ALPHA.sessionId,
+					sessionName: ALPHA.sessionName,
+					cwd: ALPHA.cwd,
+					pid: ALPHA.pid,
+					startedAt: ALPHA.startedAt,
+					participants: ALPHA.participants,
+					mode: "write",
+					url: ALPHA.writeUrl,
+				},
+				{
+					sessionId: BRAVO.sessionId,
+					sessionName: BRAVO.sessionName,
+					cwd: BRAVO.cwd,
+					pid: BRAVO.pid,
+					startedAt: BRAVO.startedAt,
+					participants: BRAVO.participants,
+					mode: "write",
+					url: BRAVO.writeUrl,
+				},
+			],
+		});
+		// The view URL never appears anywhere in write-mode output.
+		expect(out.calls[0]).not.toContain(ALPHA.viewUrl);
+		expect(out.calls[0]).not.toContain(BRAVO.viewUrl);
+
+		// Repeated invocation yields byte-identical JSON.
+		const again = collector();
+		await runCollabListCommand({ view: false, json: true, registry: { dir } }, again.print);
+		expect(again.calls[0]).toBe(out.calls[0]);
+	});
+
+	it("emits view-mode JSON carrying only view URLs", async () => {
+		const dir = makeTmpDir();
+		await publish(dir, ALPHA);
+		const out = collector();
+
+		await runCollabListCommand({ view: true, json: true, registry: { dir } }, out.print);
+
+		const parsed = JSON.parse(out.calls[0]!);
+		expect(parsed.mode).toBe("view");
+		expect(parsed.hosts[0].url).toBe(ALPHA.viewUrl);
+		expect(parsed.hosts[0].mode).toBe("view");
+		expect(out.calls[0]).not.toContain(ALPHA.writeUrl);
+	});
+});
+
+describe("Collab command contract", () => {
+	it("warns that default output prints write-capable URLs granting host control", () => {
+		const description = Collab.description.toLowerCase();
+		expect(description).toContain("write-capable");
+		expect(description).toContain("control");
+		expect(description).toContain("view");
+	});
+
+	it("exposes view and json flags", () => {
+		expect(Collab.flags).toHaveProperty("view");
+		expect(Collab.flags).toHaveProperty("json");
+	});
+});

--- a/packages/coding-agent/test/collab/helpers/registry-host-process.ts
+++ b/packages/coding-agent/test/collab/helpers/registry-host-process.ts
@@ -1,0 +1,49 @@
+/**
+ * Standalone Bun process that publishes a single fixture Collab host to the
+ * local registry and then stays alive until killed. Used by the real
+ * two-process smoke test (`registry-smoke.test.ts`) — it is spawned, never
+ * imported. It exercises the same public {@link publishCollabHost} entry point
+ * a real host uses, so the parent test observes cross-process discovery,
+ * mode-scoped URLs, crash cleanup, and the full CLI path end to end.
+ *
+ * argv[2]  metadata dir override; empty/absent → default `~/.omp/run/collab-hosts`.
+ * argv[3]  marker string embedded in the fixture URLs (falls back to
+ *          `OMP_SMOKE_MARKER` env, then "smoke").
+ *
+ * Emits `READY\n` to stdout once publish resolves. SIGTERM closes the
+ * publication cleanly and exits 0.
+ */
+import { publishCollabHost } from "../../../src/collab/registry";
+
+const dirArg = process.argv[2];
+const marker = process.argv[3] ?? process.env.OMP_SMOKE_MARKER ?? "smoke";
+const dir = dirArg && dirArg.length > 0 ? dirArg : undefined;
+
+const startedAt = Date.now();
+
+const publication = await publishCollabHost(
+	mode => ({
+		sessionId: `session-${marker}`,
+		sessionName: `Smoke ${marker}`,
+		cwd: process.cwd(),
+		pid: process.pid,
+		startedAt,
+		participants: 1,
+		url: mode === "view" ? `https://collab.example/view/${marker}` : `https://collab.example/write/${marker}`,
+	}),
+	dir ? { dir } : undefined,
+);
+
+const shutdown = (): void => {
+	publication.close().then(
+		() => process.exit(0),
+		() => process.exit(0),
+	);
+};
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
+process.stdout.write("READY\n");
+
+// Stay alive until a signal arrives (or the parent SIGKILLs us).
+await new Promise<never>(() => {});

--- a/packages/coding-agent/test/collab/host-registry.test.ts
+++ b/packages/coding-agent/test/collab/host-registry.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Contract: the CollabHost wires its lifetime to the local host registry
+ * (#6099). It publishes exactly once — and only after the relay connection
+ * succeeds — withdraws on every teardown path (explicit stop, session switch,
+ * terminal relay close), keeps hosting when publication fails, and guests
+ * joining through the relay never add a registry entry.
+ *
+ * The in-memory relay harness (./helpers/in-memory-relay) replaces the real
+ * WebSocket so a real CollabHost/CollabSocket run unchanged; a per-test spy on
+ * the `publishCollabHost` export redirects discovery metadata into a temp dir,
+ * so the registry's real Unix-socket IPC is exercised without touching ~/.omp.
+ */
+import { afterEach, beforeEach, describe, expect, it, type Mock, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { COLLAB_PROTO, parseCollabLink } from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import * as registry from "@oh-my-pi/pi-coding-agent/collab/registry";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { FakeWebSocket, installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+const RELAY_URL = "ws://localhost:8788";
+const WEB_URL = "https://collab.example";
+
+/** Mutable, observable surface of a host context fixture. */
+interface HostContextState {
+	sessionId: string;
+	showStatus: string[];
+	subscribed: ((event: { type: string; [k: string]: unknown }) => void) | null;
+}
+
+/**
+ * Minimal InteractiveModeContext the host needs to `start()` and serve a
+ * registry snapshot, plus the handles a test drives: the mutable session id,
+ * captured `showStatus` messages, and the session-event subscriber callback.
+ */
+function makeHostContext(): { ctx: InteractiveModeContext; state: HostContextState } {
+	const state: HostContextState = {
+		sessionId: `sess-${crypto.randomUUID()}`,
+		showStatus: [],
+		subscribed: null,
+	};
+	const ctx = {
+		settings: { get: () => "" },
+		sessionManager: {
+			getSessionId: () => state.sessionId,
+			getCwd: () => "/tmp/collab-registry-test",
+			snapshotForReplication: () => ({
+				header: {
+					type: "session",
+					id: state.sessionId,
+					timestamp: "2026-07-20T00:00:00Z",
+					cwd: "/tmp/collab-registry-test",
+				},
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			queuedMessageCount: 0,
+			sessionName: "registry-test",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: (cb: HostContextState["subscribed"]) => {
+				state.subscribed = cb;
+				return () => {};
+			},
+			emitNotice: () => {},
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: (message: string) => {
+			state.showStatus.push(message);
+		},
+		collabHost: undefined,
+	};
+	return { ctx: ctx as unknown as InteractiveModeContext, state };
+}
+
+let tmp: string;
+let publishSpy: Mock<typeof registry.publishCollabHost>;
+let capturedSockets: FakeWebSocket[] = [];
+let host: CollabHost | undefined;
+const guestCleanups: (() => void)[] = [];
+
+beforeEach(async () => {
+	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-hostreg-"));
+	installInMemoryRelay();
+	// Record every fake socket the host/guests construct so a test can drive a
+	// terminal close on the host's transport directly.
+	capturedSockets = [];
+	const Capturing = class extends FakeWebSocket {
+		constructor(url: string) {
+			super(url);
+			capturedSockets.push(this);
+		}
+	};
+	globalThis.WebSocket = Capturing as unknown as typeof WebSocket;
+	// Redirect publication into the temp dir. Captured before the spy so the
+	// implementation calls the genuine registry (real Unix-socket IPC).
+	const real = registry.publishCollabHost;
+	publishSpy = spyOn(registry, "publishCollabHost").mockImplementation(provider => real(provider, { dir: tmp }));
+	host = undefined;
+});
+
+afterEach(async () => {
+	for (const cleanup of guestCleanups.splice(0).reverse()) cleanup();
+	if (host) await host.stop("test cleanup").catch(() => {});
+	uninstallInMemoryRelay();
+	publishSpy?.mockRestore();
+	await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("collab host registry lifecycle (#6099)", () => {
+	it("publishes exactly one host only after the relay connection succeeds", async () => {
+		const { ctx, state } = makeHostContext();
+		host = new CollabHost(ctx);
+
+		// Constructing the host publishes nothing; the registry is empty.
+		expect(publishSpy).toHaveBeenCalledTimes(0);
+		expect(await registry.listCollabHosts({ dir: tmp })).toEqual([]);
+
+		await host.start(RELAY_URL, WEB_URL);
+
+		// Sanity: the spy on the same module host.ts resolves was actually hit,
+		// exactly once, by the host after the relay connected.
+		expect(publishSpy).toHaveBeenCalledTimes(1);
+
+		const write = await registry.listCollabHosts({ dir: tmp });
+		expect(write).toHaveLength(1);
+		expect(write[0]!.mode).toBe("write");
+		expect(write[0]!.url).toBe(host.webLink);
+		expect(write[0]!.sessionId).toBe(state.sessionId);
+		expect(write[0]!.participants).toBeGreaterThanOrEqual(1);
+
+		// A view-mode query gets the read-only URL, never the write link.
+		const view = await registry.listCollabHosts({ dir: tmp, mode: "view" });
+		expect(view).toHaveLength(1);
+		expect(view[0]!.mode).toBe("view");
+		expect(view[0]!.url).toBe(host.webViewLink);
+	});
+
+	it("withdraws from the registry on explicit stop", async () => {
+		const { ctx } = makeHostContext();
+		host = new CollabHost(ctx);
+		await host.start(RELAY_URL, WEB_URL);
+		expect(await registry.listCollabHosts({ dir: tmp })).toHaveLength(1);
+
+		await host.stop("host stopped");
+
+		expect(await registry.listCollabHosts({ dir: tmp })).toEqual([]);
+	});
+
+	it("withdraws when the underlying session is switched out", async () => {
+		const { ctx, state } = makeHostContext();
+		host = new CollabHost(ctx);
+		await host.start(RELAY_URL, WEB_URL);
+		expect(await registry.listCollabHosts({ dir: tmp })).toHaveLength(1);
+		if (!state.subscribed) throw new Error("host never subscribed to session events");
+
+		// The active session changed; the next broadcast detects the mismatch
+		// and tears the host down.
+		state.sessionId = `sess-switched-${Date.now()}`;
+		state.subscribed({ type: "notice", level: "info", message: "switched", source: "test" });
+
+		expect(await registry.listCollabHosts({ dir: tmp })).toEqual([]);
+	});
+
+	it("withdraws on a terminal (non-reconnecting) relay close", async () => {
+		const { ctx } = makeHostContext();
+		host = new CollabHost(ctx);
+		await host.start(RELAY_URL, WEB_URL);
+		expect(await registry.listCollabHosts({ dir: tmp })).toHaveLength(1);
+
+		const hostSocket = capturedSockets.find(s => s.role === "host");
+		if (!hostSocket) throw new Error("host transport socket was never created");
+		// Code 4001 ("room closed") is classified fatal/non-reconnecting by
+		// relay-client, so the host tears down instead of retrying.
+		hostSocket.onclose?.({ code: 4001, reason: "room closed" });
+
+		expect(await registry.listCollabHosts({ dir: tmp })).toEqual([]);
+	});
+
+	it("keeps hosting when publication fails, surfacing a discovery warning", async () => {
+		const { ctx, state } = makeHostContext();
+		// Publication rejects; start() must still resolve and hosting continue.
+		publishSpy.mockImplementation(() => Promise.reject(new Error("registry write failed")));
+		host = new CollabHost(ctx);
+
+		await host.start(RELAY_URL, WEB_URL);
+
+		expect(host.link.length).toBeGreaterThan(0);
+		expect(host.webLink.length).toBeGreaterThan(0);
+		expect(host.participants.length).toBeGreaterThanOrEqual(1);
+		// The failure is surfaced to the user via the fixture-observable seam.
+		expect(state.showStatus.some(m => /discovery unavailable/i.test(m))).toBe(true);
+
+		// Teardown is still clean even though nothing was published.
+		await host.stop("done");
+		expect(await registry.listCollabHosts({ dir: tmp })).toEqual([]);
+	});
+
+	it("never publishes for guests joining through the relay", async () => {
+		const { ctx } = makeHostContext();
+		host = new CollabHost(ctx);
+		await host.start(RELAY_URL, WEB_URL);
+
+		const parsed = parseCollabLink(host.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+		const writeToken = parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined;
+		const key = await importRoomKey(parsed.key);
+		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+		guestCleanups.push(() => socket.close());
+
+		const joined = Promise.withResolvers<void>();
+		socket.onFrame = frame => {
+			if (frame.t === "welcome") joined.resolve();
+		};
+		socket.onOpen = () => socket.send({ t: "hello", proto: COLLAB_PROTO, name: "guest", writeToken });
+		socket.connect();
+		await joined.promise;
+
+		// The guest is a real relay peer, but joining published nothing extra:
+		// only the host's single entry exists.
+		expect(host.participants.length).toBeGreaterThanOrEqual(2);
+		expect(publishSpy).toHaveBeenCalledTimes(1);
+		const jsonFiles = (await fs.readdir(tmp)).filter(name => name.endsWith(".json"));
+		expect(jsonFiles).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/collab/registry-smoke.test.ts
+++ b/packages/coding-agent/test/collab/registry-smoke.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Real two-process smoke test for the local Collab host registry (issue #6099).
+ *
+ * Unlike the unit tests, nothing here is stubbed: a genuine child Bun process
+ * publishes a live host over a real Unix socket / named pipe, and the parent
+ * discovers it through {@link listCollabHosts} and through the shipped
+ * `omp collab list` CLI. This defends the cross-process contracts that in-process
+ * tests cannot reach:
+ *   - a separately-spawned host is discoverable with its real PID and
+ *     mode-scoped URLs;
+ *   - a hard-killed (SIGKILL) host is pruned from the registry on the next list;
+ *   - the end-user CLI emits the documented versioned JSON for live hosts.
+ *
+ * All writes are confined to temp dirs (including a fake $HOME for the CLI path),
+ * so the suite is full-suite safe and never touches the real `~/.omp`.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { listCollabHosts } from "@oh-my-pi/pi-coding-agent/collab/registry";
+
+const HELPER_PATH = path.resolve(import.meta.dir, "helpers/registry-host-process.ts");
+const CLI_PATH = path.resolve(import.meta.dir, "../../src/cli.ts");
+const READY_TIMEOUT_MS = 15_000;
+const CLEANUP_TIMEOUT_MS = 15_000;
+const CLI_TIMEOUT_MS = 60_000;
+
+const cleanupDirs: string[] = [];
+const liveChildren: { kill(signal?: NodeJS.Signals): void; exited: Promise<number> }[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	cleanupDirs.push(dir);
+	return dir;
+}
+
+// Cross-process integration: fake timers cannot advance a real OS process.
+async function waitUntil(condition: () => boolean | Promise<boolean>, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await condition()) return true;
+		await Bun.sleep(50);
+	}
+	return condition();
+}
+
+/** Read `stream` until `needle` appears or `timeoutMs` elapses. */
+async function readUntil(stream: ReadableStream<Uint8Array>, needle: string, timeoutMs: number): Promise<boolean> {
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const scan = (async () => {
+		for await (const chunk of stream) {
+			buffer += decoder.decode(chunk, { stream: true });
+			if (buffer.includes(needle)) return true;
+		}
+		return false;
+	})();
+	return Promise.race([scan, Bun.sleep(timeoutMs).then(() => false)]);
+}
+
+interface Helper {
+	child: Bun.Subprocess<"ignore", "pipe", "pipe">;
+	/** Snapshot of everything the helper has written to stderr so far. */
+	stderr(): string;
+}
+
+function spawnHelper(args: string[], env?: Record<string, string | undefined>): Helper {
+	const child = Bun.spawn([process.execPath, HELPER_PATH, ...args], {
+		cwd: path.resolve(import.meta.dir, "../.."),
+		env: env ?? process.env,
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	liveChildren.push(child);
+	// Drain stderr continuously: reading it to completion would block until the
+	// (long-lived) helper exits, so accumulate chunks in the background instead.
+	let stderrText = "";
+	const decoder = new TextDecoder();
+	void (async () => {
+		for await (const chunk of child.stderr) stderrText += decoder.decode(chunk, { stream: true });
+	})().catch(() => {});
+	return { child, stderr: () => stderrText };
+}
+
+afterEach(async () => {
+	for (const child of liveChildren.splice(0)) {
+		try {
+			child.kill("SIGKILL");
+			await child.exited;
+		} catch {
+			// Already gone.
+		}
+	}
+	while (cleanupDirs.length > 0) {
+		const dir = cleanupDirs.pop();
+		if (dir) await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("collab host registry (two-process smoke)", () => {
+	it("discovers a separately-spawned host and prunes it after a crash", async () => {
+		const dir = await tempDir("omp-collab-smoke-seam-");
+		const marker = `seam-${Date.now().toString(36)}`;
+		const { child, stderr } = spawnHelper([dir, marker]);
+
+		const ready = await readUntil(child.stdout, "READY", READY_TIMEOUT_MS);
+		expect({ ready, stderr: stderr() }).toEqual({ ready: true, stderr: "" });
+
+		const hosts = await listCollabHosts({ dir });
+		expect(hosts).toHaveLength(1);
+		expect(hosts[0]?.pid).toBe(child.pid);
+		expect(hosts[0]?.mode).toBe("write");
+		expect(hosts[0]?.url).toBe(`https://collab.example/write/${marker}`);
+		expect(hosts[0]?.sessionId).toBe(`session-${marker}`);
+
+		const viewHosts = await listCollabHosts({ dir, mode: "view" });
+		expect(viewHosts).toHaveLength(1);
+		expect(viewHosts[0]?.mode).toBe("view");
+		expect(viewHosts[0]?.url).toBe(`https://collab.example/view/${marker}`);
+
+		// Hard kill: no chance to run cleanup handlers, so the next list must
+		// prune the now-dead endpoint (crash-cleanup contract across processes).
+		child.kill("SIGKILL");
+		await child.exited;
+
+		const pruned = await waitUntil(async () => {
+			const remaining = await listCollabHosts({ dir });
+			if (remaining.length !== 0) return false;
+			const entries = await fs.readdir(dir);
+			return !entries.some(name => name.endsWith(".json"));
+		}, CLEANUP_TIMEOUT_MS);
+		expect(pruned).toBe(true);
+	}, 40_000);
+
+	it("lists a live host through the real `collab list` CLI under a fake HOME", async () => {
+		const home = await tempDir("omp-collab-smoke-home-");
+		const marker = `cli-${Date.now().toString(36)}`;
+		// Force the default registry dir (~/.omp/run/collab-hosts) to resolve
+		// under the fake HOME by clearing every override that would redirect it.
+		const env: Record<string, string | undefined> = {
+			...process.env,
+			HOME: home,
+			USERPROFILE: home,
+			NO_COLOR: "1",
+			// Marker travels via env because argv[2] must stay empty (default dir).
+			OMP_SMOKE_MARKER: marker,
+		};
+		delete env.PI_CONFIG_DIR;
+		delete env.PI_PROFILE;
+		delete env.OMP_PROFILE;
+		delete env.PI_CODING_AGENT_DIR;
+
+		// No dir argv → publishes to the default dir under the fake HOME.
+		const { child, stderr } = spawnHelper([], env);
+		const ready = await readUntil(child.stdout, "READY", READY_TIMEOUT_MS);
+		expect({ ready, helperStderr: stderr() }).toEqual({ ready: true, helperStderr: "" });
+
+		const runCli = async (extraArgs: string[]): Promise<{ code: number; json: unknown; stderr: string }> => {
+			const cli = Bun.spawn([process.execPath, CLI_PATH, "collab", "list", "--json", ...extraArgs], {
+				cwd: path.resolve(import.meta.dir, "../.."),
+				env,
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [code, stdout, cliStderr] = await Promise.all([
+				cli.exited,
+				new Response(cli.stdout).text(),
+				new Response(cli.stderr).text(),
+			]);
+			const brace = stdout.indexOf("{");
+			if (brace < 0) {
+				throw new Error(`CLI produced no JSON object (exit ${code}).\nstdout:\n${stdout}\nstderr:\n${cliStderr}`);
+			}
+			return { code, json: JSON.parse(stdout.slice(brace)), stderr: cliStderr };
+		};
+
+		const write = await runCli([]);
+		expect(write.code).toBe(0);
+		const writeJson = write.json as { version: number; mode: string; hosts: { pid: number; url: string }[] };
+		expect(writeJson.version).toBe(1);
+		expect(writeJson.mode).toBe("write");
+		expect(writeJson.hosts).toHaveLength(1);
+		expect(writeJson.hosts[0]?.pid).toBe(child.pid);
+		expect(writeJson.hosts[0]?.url).toBe(`https://collab.example/write/${marker}`);
+
+		const view = await runCli(["--view"]);
+		expect(view.code).toBe(0);
+		const viewJson = view.json as { mode: string; hosts: { url: string }[] };
+		expect(viewJson.mode).toBe("view");
+		expect(viewJson.hosts).toHaveLength(1);
+		expect(viewJson.hosts[0]?.url).toBe(`https://collab.example/view/${marker}`);
+
+		// Clean withdrawal: SIGTERM lets the host close its publication, so a
+		// subsequent CLI list reports zero hosts.
+		child.kill("SIGTERM");
+		await child.exited;
+
+		const afterStop = await waitUntil(async () => {
+			const { json } = await runCli([]);
+			return (json as { hosts: unknown[] }).hosts.length === 0;
+		}, CLI_TIMEOUT_MS);
+		expect(afterStop).toBe(true);
+	}, 120_000);
+});

--- a/packages/coding-agent/test/collab/registry.test.ts
+++ b/packages/coding-agent/test/collab/registry.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	COLLAB_REGISTRY_VERSION,
+	type CollabHostPublication,
+	type CollabHostSnapshotProvider,
+	listCollabHosts,
+	publishCollabHost,
+} from "@oh-my-pi/pi-coding-agent/collab/registry";
+
+const cleanupDirs: string[] = [];
+const openPublications: CollabHostPublication[] = [];
+const openServers: net.Server[] = [];
+
+afterEach(async () => {
+	for (const pub of openPublications.splice(0)) {
+		try {
+			await pub.close();
+		} catch {
+			// best-effort
+		}
+	}
+	for (const server of openServers.splice(0)) {
+		const closed = Promise.withResolvers<void>();
+		server.close(() => closed.resolve());
+		await closed.promise;
+	}
+	for (const dir of cleanupDirs.splice(0)) {
+		await fsp.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function tempDir(prefix = "omp-collab-registry-"): Promise<string> {
+	const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+	cleanupDirs.push(dir);
+	return dir;
+}
+
+interface Fixture {
+	sessionId: string;
+	sessionName: string | null;
+	cwd: string;
+	pid: number;
+	startedAt: number;
+	participants: number;
+	roomKey: string;
+	writeToken: string;
+	writeUrl: string;
+	viewUrl: string;
+}
+
+function makeFixture(over: Partial<Fixture> = {}): Fixture {
+	const roomKey = over.roomKey ?? `ROOMKEY-${crypto.randomBytes(6).toString("hex")}`;
+	const writeToken = over.writeToken ?? `WRITETOKEN-${crypto.randomBytes(6).toString("hex")}`;
+	return {
+		sessionId: over.sessionId ?? `sess-${crypto.randomBytes(4).toString("hex")}`,
+		sessionName: over.sessionName ?? "Fixture Session",
+		cwd: over.cwd ?? "/tmp/fixture-cwd",
+		pid: over.pid ?? 4242,
+		startedAt: over.startedAt ?? 1_700_000_000_000,
+		participants: over.participants ?? 3,
+		roomKey,
+		writeToken,
+		writeUrl: over.writeUrl ?? `https://collab.example/#room=${roomKey}&k=${writeToken}`,
+		viewUrl: over.viewUrl ?? `https://collab.example/#room=${roomKey}&view=1`,
+	};
+}
+
+function providerFor(f: Fixture): CollabHostSnapshotProvider {
+	return mode => ({
+		sessionId: f.sessionId,
+		sessionName: f.sessionName,
+		cwd: f.cwd,
+		pid: f.pid,
+		startedAt: f.startedAt,
+		participants: f.participants,
+		url: mode === "write" ? f.writeUrl : f.viewUrl,
+	});
+}
+
+async function publish(dir: string, f: Fixture): Promise<CollabHostPublication> {
+	const pub = await publishCollabHost(providerFor(f), { dir });
+	openPublications.push(pub);
+	return pub;
+}
+
+/** Reads the discovery token from the single metadata file in `dir`. */
+async function readSoleToken(dir: string): Promise<string> {
+	const names = (await fsp.readdir(dir)).filter(n => n.endsWith(".json"));
+	expect(names.length).toBe(1);
+	const meta = JSON.parse(await fsp.readFile(path.join(dir, names[0]!), "utf8"));
+	return meta.token as string;
+}
+
+/** Connects to `endpoint`, sends one JSON request line, returns the raw response line. */
+function rawRequest(endpoint: string, request: object): Promise<string> {
+	const { promise, resolve, reject } = Promise.withResolvers<string>();
+	let buffer = "";
+	const socket = net.createConnection({ path: endpoint });
+	const done = (fn: () => void): void => {
+		socket.destroy();
+		fn();
+	};
+	socket.setEncoding("utf8");
+	socket.once("error", err => done(() => reject(err)));
+	socket.once("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+	socket.on("data", chunk => {
+		buffer += chunk;
+		const nl = buffer.indexOf("\n");
+		// Endpoints answer with one line synchronously; no wall-clock guard needed.
+		if (nl >= 0) done(() => resolve(buffer.slice(0, nl)));
+	});
+	return promise;
+}
+
+function auxEndpoint(dir: string, label: string): string {
+	const id = crypto.randomBytes(4).toString("hex");
+	return process.platform === "win32"
+		? `\\\\.\\pipe\\omp-collab-test-${label}-${id}`
+		: path.join(dir, `${label}-${id}.sock`);
+}
+
+function writeMetadata(dir: string, name: string, meta: Record<string, unknown>): void {
+	fs.writeFileSync(path.join(dir, name), JSON.stringify(meta), { mode: 0o600 });
+}
+
+function freshDeadPid(): number {
+	// The child has already exited by the time spawnSync returns: a real, dead PID.
+	return Bun.spawnSync(["bun", "-e", ""]).pid;
+}
+
+function collectRegularFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...collectRegularFiles(full));
+		else if (entry.isFile()) out.push(full);
+	}
+	return out;
+}
+
+describe("collab registry", () => {
+	it("round-trips a published host through list for both access modes", async () => {
+		const dir = await tempDir();
+		const f = makeFixture({ sessionName: "Round Trip", cwd: "/work/project", pid: 1234, participants: 5 });
+		await publish(dir, f);
+
+		const write = await listCollabHosts({ dir });
+		expect(write.length).toBe(1);
+		const host = write[0]!;
+		expect(host.mode).toBe("write");
+		expect(host.url).toBe(f.writeUrl);
+		expect(host.sessionId).toBe(f.sessionId);
+		expect(host.sessionName).toBe("Round Trip");
+		expect(host.cwd).toBe("/work/project");
+		expect(host.pid).toBe(1234);
+		expect(host.startedAt).toBe(f.startedAt);
+		expect(host.participants).toBe(5);
+
+		const view = await listCollabHosts({ dir, mode: "view" });
+		expect(view.length).toBe(1);
+		expect(view[0]!.sessionId).toBe(f.sessionId);
+		expect(view[0]!.mode).toBe("view");
+		expect(view[0]!.url).toBe(f.viewUrl);
+		expect(view[0]!.url).not.toContain(f.writeToken);
+	});
+
+	it("never transmits the write URL to a view request on the wire", async () => {
+		const dir = await tempDir();
+		const f = makeFixture();
+		const pub = await publish(dir, f);
+		const token = await readSoleToken(dir);
+
+		const line = await rawRequest(pub.endpoint, { v: COLLAB_REGISTRY_VERSION, token, mode: "view" });
+		expect(line).toContain(f.viewUrl);
+		expect(line).not.toContain(f.writeUrl);
+		expect(line).not.toContain(f.writeToken);
+		const parsed = JSON.parse(line);
+		expect(parsed.ok).toBe(true);
+		expect(parsed.host.mode).toBe("view");
+		expect(parsed.host.url).toBe(f.viewUrl);
+	});
+
+	it("keeps URLs and secrets off disk while published", async () => {
+		const dir = await tempDir();
+		const f = makeFixture();
+		await publish(dir, f);
+		// Exercise both modes so any URL caching would surface on disk.
+		await listCollabHosts({ dir });
+		await listCollabHosts({ dir, mode: "view" });
+
+		const files = collectRegularFiles(dir);
+		expect(files.length).toBeGreaterThan(0);
+		for (const file of files) {
+			const content = fs.readFileSync(file, "utf8");
+			expect(content).not.toContain(f.writeUrl);
+			expect(content).not.toContain(f.viewUrl);
+			expect(content).not.toContain(f.roomKey);
+			expect(content).not.toContain(f.writeToken);
+		}
+	});
+
+	it("rejects a wrong token without leaking a host or URL", async () => {
+		const dir = await tempDir();
+		const f = makeFixture();
+		const pub = await publish(dir, f);
+
+		const line = await rawRequest(pub.endpoint, {
+			v: COLLAB_REGISTRY_VERSION,
+			token: "not-the-real-token",
+			mode: "write",
+		});
+		const parsed = JSON.parse(line);
+		expect(parsed.ok).toBe(false);
+		expect(parsed.host).toBeUndefined();
+		expect(line).not.toContain(f.writeUrl);
+		expect(line).not.toContain(f.viewUrl);
+		expect(line).not.toContain(f.roomKey);
+	});
+
+	it("sorts hosts by startedAt then pid regardless of publish order", async () => {
+		const dir = await tempDir();
+		const early = makeFixture({ sessionId: "early", startedAt: 900, pid: 99 });
+		const tieHigh = makeFixture({ sessionId: "tie-high", startedAt: 1000, pid: 50 });
+		const tieLow = makeFixture({ sessionId: "tie-low", startedAt: 1000, pid: 30 });
+
+		// Publish out of expected order.
+		await publish(dir, tieHigh);
+		await publish(dir, early);
+		await publish(dir, tieLow);
+
+		const hosts = await listCollabHosts({ dir });
+		expect(hosts.map(h => h.sessionId)).toEqual(["early", "tie-low", "tie-high"]);
+	});
+
+	it("returns only the healthy host and prunes stale entries on partial failure", async () => {
+		const dir = await tempDir();
+		const healthy = makeFixture({ sessionId: "healthy" });
+		await publish(dir, healthy);
+
+		// (b) malformed JSON.
+		fs.writeFileSync(path.join(dir, "garbage.json"), "{not json", { mode: 0o600 });
+
+		// (c) version mismatch with a dead PID -> pruned.
+		writeMetadata(dir, "version-mismatch.json", {
+			version: 99,
+			pid: freshDeadPid(),
+			endpoint: auxEndpoint(dir, "vmismatch"),
+			createdAt: Date.now(),
+			token: crypto.randomBytes(16).toString("hex"),
+		});
+
+		// (d) stale: nonexistent socket + dead PID -> connection error -> pruned.
+		writeMetadata(dir, "stale.json", {
+			version: COLLAB_REGISTRY_VERSION,
+			pid: freshDeadPid(),
+			endpoint: auxEndpoint(dir, "stale-missing"),
+			createdAt: Date.now(),
+			token: crypto.randomBytes(16).toString("hex"),
+		});
+
+		// (e) unresponsive: accepts connections, never answers -> skipped, not pruned.
+		const unresponsiveEndpoint = auxEndpoint(dir, "unresponsive");
+		const unresponsive = net.createServer(() => {
+			/* accept and hang */
+		});
+		openServers.push(unresponsive);
+		const listening = Promise.withResolvers<void>();
+		unresponsive.once("error", err => listening.reject(err));
+		unresponsive.listen(unresponsiveEndpoint, () => listening.resolve());
+		await listening.promise;
+		writeMetadata(dir, "unresponsive.json", {
+			version: COLLAB_REGISTRY_VERSION,
+			pid: process.pid,
+			endpoint: unresponsiveEndpoint,
+			createdAt: Date.now(),
+			token: crypto.randomBytes(16).toString("hex"),
+		});
+
+		const hosts = await listCollabHosts({ dir, timeoutMs: 250 });
+		expect(hosts.map(h => h.sessionId)).toEqual(["healthy"]);
+
+		expect(fs.existsSync(path.join(dir, "garbage.json"))).toBe(false);
+		expect(fs.existsSync(path.join(dir, "version-mismatch.json"))).toBe(false);
+		expect(fs.existsSync(path.join(dir, "stale.json"))).toBe(false);
+		// No prune on timeout: the unresponsive entry survives.
+		expect(fs.existsSync(path.join(dir, "unresponsive.json"))).toBe(true);
+	});
+
+	it("removes on-disk state and disappears from listings after close", async () => {
+		const dir = await tempDir();
+		const f = makeFixture();
+		const pub = await publish(dir, f);
+		expect((await listCollabHosts({ dir })).length).toBe(1);
+
+		await pub.close();
+
+		expect(await listCollabHosts({ dir })).toEqual([]);
+		const remainingJson = (await fsp.readdir(dir)).filter(n => n.endsWith(".json"));
+		expect(remainingJson).toEqual([]);
+		if (process.platform !== "win32") {
+			expect(fs.existsSync(pub.endpoint)).toBe(false);
+		}
+	});
+
+	it("treats endpoint death as authoritative over a reused PID", async () => {
+		const dir = await tempDir();
+		// Alive PID (simulating PID reuse) but nothing listens on the endpoint.
+		const forgedFile = "reused-pid.json";
+		writeMetadata(dir, forgedFile, {
+			version: COLLAB_REGISTRY_VERSION,
+			pid: process.pid,
+			endpoint: auxEndpoint(dir, "reused"),
+			createdAt: Date.now(),
+			token: crypto.randomBytes(16).toString("hex"),
+		});
+
+		expect(await listCollabHosts({ dir })).toEqual([]);
+		expect(fs.existsSync(path.join(dir, forgedFile))).toBe(false);
+	});
+
+	it("hides a forged entry pointing at a real endpoint with a wrong token", async () => {
+		const dir = await tempDir();
+		const f = makeFixture({ sessionId: "genuine" });
+		const pub = await publish(dir, f);
+
+		// Second metadata entry aims at B's real endpoint but with a different token.
+		writeMetadata(dir, "forged.json", {
+			version: COLLAB_REGISTRY_VERSION,
+			pid: process.pid,
+			endpoint: pub.endpoint,
+			createdAt: Date.now(),
+			token: crypto.randomBytes(16).toString("hex"),
+		});
+
+		const hosts = await listCollabHosts({ dir });
+		expect(hosts.length).toBe(1);
+		expect(hosts[0]!.sessionId).toBe("genuine");
+		expect(hosts[0]!.url).toBe(f.writeUrl);
+	});
+
+	it("creates owner-only permissions on unix", async () => {
+		if (process.platform === "win32") return;
+		const dir = await tempDir();
+		const f = makeFixture();
+		const pub = await publish(dir, f);
+
+		expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+
+		const jsonNames = (await fsp.readdir(dir)).filter(n => n.endsWith(".json"));
+		expect(jsonNames.length).toBe(1);
+		expect(fs.statSync(path.join(dir, jsonNames[0]!)).mode & 0o777).toBe(0o600);
+
+		expect(fs.statSync(pub.endpoint).mode & 0o777).toBe(0o600);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/collab-list.test.ts
+++ b/packages/coding-agent/test/slash-commands/collab-list.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { CollabHostSnapshot } from "@oh-my-pi/pi-coding-agent/collab/registry";
+import * as registry from "@oh-my-pi/pi-coding-agent/collab/registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import {
+	type BuiltinSlashCommandRuntime,
+	executeBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function snapshot(mode: "write" | "view"): CollabHostSnapshot {
+	return {
+		sessionId: "sess-tui",
+		sessionName: "TUI Session",
+		cwd: "/tmp/work/tui",
+		pid: 42,
+		startedAt: 1_700_000_000_000,
+		participants: 2,
+		mode,
+		url: mode === "view" ? "https://collab.test/#view-fixture" : "https://collab.test/#write-fixture",
+	};
+}
+
+function createHarness() {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const showError = vi.fn();
+	const ctx = {
+		editor: { setText },
+		showStatus,
+		showError,
+		settings: { get: () => "" },
+	} as unknown as InteractiveModeContext;
+	return { ctx, setText, showStatus, showError, runtime: { ctx } as BuiltinSlashCommandRuntime };
+}
+
+describe("/collab list slash command", () => {
+	it("requests write-mode hosts and renders their write URL and pid", async () => {
+		const listSpy = vi.spyOn(registry, "listCollabHosts").mockResolvedValue([snapshot("write")]);
+		const harness = createHarness();
+
+		const handled = await executeBuiltinSlashCommand("/collab list", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(listSpy).toHaveBeenCalledWith({ mode: "write" });
+		const text = Bun.stripANSI(String(harness.showStatus.mock.calls.at(-1)?.[0] ?? ""));
+		expect(text).toContain("collab.test/#write-fixture");
+		expect(text).toContain("pid 42");
+		expect(text).toContain("TUI Session (sess-tui)");
+	});
+
+	it("requests view-mode hosts and renders the view URL only", async () => {
+		const listSpy = vi.spyOn(registry, "listCollabHosts").mockResolvedValue([snapshot("view")]);
+		const harness = createHarness();
+
+		const handled = await executeBuiltinSlashCommand("/collab list view", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(listSpy).toHaveBeenCalledWith({ mode: "view" });
+		const text = Bun.stripANSI(String(harness.showStatus.mock.calls.at(-1)?.[0] ?? ""));
+		expect(text).toContain("collab.test/#view-fixture");
+		expect(text).not.toContain("collab.test/#write-fixture");
+	});
+
+	it("shows an empty-state message when no hosts are active", async () => {
+		vi.spyOn(registry, "listCollabHosts").mockResolvedValue([]);
+		const harness = createHarness();
+
+		const handled = await executeBuiltinSlashCommand("/collab list", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(Bun.stripANSI(String(harness.showStatus.mock.calls.at(-1)?.[0] ?? ""))).toContain(
+			"No active Collab hosts",
+		);
+	});
+});

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -103,7 +103,8 @@ function readProfileFromEnvSafe(): string | undefined {
 	}
 }
 
-function getBaseConfigRoot(): string {
+/** Profile-independent config root (~/.omp), shared by every omp profile. */
+export function getBaseConfigRoot(): string {
 	return path.join(os.homedir(), getConfigDirName());
 }
 


### PR DESCRIPTION
Closes #6099

## Summary

Adds a runtime local Collab host registry plus a canonical `omp collab list` command, so every active local Collab host is discoverable and its shareable URL recoverable from a separate process — without persisting room secrets.

### Registry (`packages/coding-agent/src/collab/registry.ts`)

- Deep module with two externally meaningful operations: `publishCollabHost(provider)` (returns a close/dispose handle) and `listCollabHosts()`.
- Each host publishes a private per-process IPC endpoint — Unix domain socket on macOS/Linux, named pipe on Windows — following the launch daemon broker conventions (node `net`, newline-delimited JSON, per-request bearer auth, bounded buffers). No TCP listener, no localhost HTTP, no relay/wire/link/encryption change.
- Disk metadata is limited to protocol version, PID, endpoint, creation time, and a per-publication random bearer token, under an owner-only (`0700`/`0600`) runtime area shared across profiles (`~/.omp/run/collab-hosts`). Full-control and view-only URLs, room keys, and write tokens stay in host memory only.
- The IPC protocol is versioned and size-bounded; `view` requests never serialize the full-control URL; token comparison is timing-safe; URLs never appear in errors or logs.
- Listing queries all discovery entries concurrently (bounded, short independent deadlines), returns healthy hosts sorted deterministically by start time then PID, and prunes stale/malformed metadata best-effort. Unresponsive hosts are skipped without blocking other results; foreign-version entries are hidden and pruned only once their owner PID is dead.

### Host lifecycle (`src/collab/host.ts`)

- Publishes only after the initial relay connection succeeds; the host stays authoritative for its live snapshot (session ID/name, cwd, PID, start time, participant count, mode-selected URL computed at query time).
- Explicit stop, terminal relay close, session switch, and teardown all withdraw the publication; a process-exit hook removes on-disk state on normal shutdown; crashes are covered by endpoint death + next-list pruning.
- Publication failure warns (`logger.warn` + status line) but never breaks hosting. Guests never publish.

### CLI / TUI

- `omp collab list` — one write-capable browser URL per active local host, labeled `write`; help text warns the output is secret-bearing.
- `omp collab list --view` — same hosts, view-only URLs only, labeled `view`.
- `omp collab list --json` — deterministic versioned JSON (`{version, mode, hosts}`), containing only the selected access-mode URL.
- `/collab list` and `/collab list view` — thin TUI adapters over the same registry interface.
- Docs: new "Listing active local hosts" section in `docs/collab.md`; changelog entry under `[Unreleased]`.

## Testing

- `test/collab/registry.test.ts` — publish/list/close over real local IPC: security contract (no URL/room-key/write-token at rest), wrong-token authorization, view-never-transmits-write-URL raw-wire assertion, multi-host deterministic ordering, partial-failure matrix (healthy + malformed + unsupported-version + stale + unresponsive) with best-effort pruning, lifecycle close, PID-reuse/forged-endpoint cases, Unix `0700`/`0600` permission checks (win32-gated).
- `test/collab/host-registry.test.ts` — in-memory relay integration: publishes only after relay connect succeeds; withdraws on explicit stop, terminal relay close, and session switch; publication failure warns but hosting works; guests never publish.
- `test/cli/collab-list.test.ts` + `test/slash-commands/collab-list.test.ts` — empty/rows/labels/order/JSON schema/help-text contracts; TUI adapters delegate to the same registry with the right access mode.
- `test/collab/registry-smoke.test.ts` — **real two-process smoke**: a spawned publisher process is discovered by PID/URL via the registry from the parent, SIGKILL leads to prune; and the shipped CLI (`bun src/cli.ts collab list --json` / `--view`) run under an isolated HOME returns the live host and empties after clean shutdown.
- `bun check` (TS + biome) green; `bun test test/collab/ test/cli/collab-list.test.ts test/slash-commands/collab-list.test.ts` → 96 pass / 0 fail; `test/tools/launch.test.ts` (broker) and `packages/utils` suites unaffected (7 and 468 pass).

## Out of scope (unchanged)

Relay endpoints, Collab wire frames, link format, AES-256-GCM encryption, guest permission model, `/collab status`, session persistence, and collab-web.
