### PR TITLE
feat(ai): added CURSOR_API_KEY support for the cursor-agent provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `CURSOR_API_KEY` (dashboard API keys, `crsr_...`) in the `cursor-agent` provider. The raw key is transparently exchanged for a session access token before authenticating agent RPCs, matching the official Cursor CLI's API-key login path; `CURSOR_ACCESS_TOKEN` session tokens continue to be used as-is.
+
 ## [17.0.5] - 2026-07-18
 
 ### Changed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -406,10 +406,19 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 		};
 
 		try {
-			const apiKey = options?.apiKey;
-			if (!apiKey) {
+			const rawApiKey = options?.apiKey;
+			if (!rawApiKey) {
 				throw new AIError.MissingApiKeyError(undefined, "Cursor API key (access token) is required");
 			}
+			// A raw CURSOR_API_KEY (crsr_...) cannot authenticate the agent RPCs
+			// directly — exchange it for a session access token first, exactly
+			// like the official CLI's API-key login path. Session tokens (from
+			// /login or CURSOR_ACCESS_TOKEN) pass through unchanged. The OAuth
+			// module is dynamically imported so the common (already-a-session-
+			// token) path doesn't pull it into the eager registry graph.
+			const apiKey = rawApiKey.startsWith("crsr_")
+				? await (await import("../registry/oauth/cursor")).resolveCursorAccessToken(rawApiKey)
+				: rawApiKey;
 
 			const conversationId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();

--- a/packages/ai/src/registry/oauth/cursor.ts
+++ b/packages/ai/src/registry/oauth/cursor.ts
@@ -169,3 +169,54 @@ export function isCursorTokenExpiringSoon(token: string, thresholdSeconds = 300)
 		return true;
 	}
 }
+
+/**
+ * Cursor dashboard API keys (Settings → API Keys, `crsr_...`) are long-lived
+ * and cannot authenticate the agent RPCs directly — the official Cursor
+ * CLI's `CURSOR_API_KEY` login path exchanges them for a session access
+ * token via `exchange_user_api_key` before ever sending a request. Session
+ * access tokens (from `/login` or `CURSOR_ACCESS_TOKEN`) are JWTs and never
+ * carry this prefix, so it alone disambiguates the two credential shapes.
+ */
+export function isRawCursorApiKey(value: string): boolean {
+	return value.startsWith("crsr_");
+}
+
+interface CachedCursorAccessToken {
+	access: string;
+	expires: number;
+}
+
+const rawApiKeyAccessTokenCache = new Map<string, CachedCursorAccessToken>();
+const pendingRawApiKeyExchanges = new Map<string, Promise<string>>();
+
+/**
+ * Resolves any Cursor credential to a bearer usable against the agent RPCs.
+ * Session access tokens pass through unchanged; a raw `CURSOR_API_KEY` is
+ * exchanged once via {@link refreshCursorToken} and the resulting session
+ * token cached until shortly before its JWT `exp`, so a long streaming
+ * session or repeated calls don't re-exchange on every request.
+ */
+export async function resolveCursorAccessToken(apiKeyOrAccessToken: string): Promise<string> {
+	if (!isRawCursorApiKey(apiKeyOrAccessToken)) {
+		return apiKeyOrAccessToken;
+	}
+	const cached = rawApiKeyAccessTokenCache.get(apiKeyOrAccessToken);
+	if (cached && cached.expires > Date.now()) {
+		return cached.access;
+	}
+	const existing = pendingRawApiKeyExchanges.get(apiKeyOrAccessToken);
+	if (existing) {
+		return existing;
+	}
+	const pending = refreshCursorToken(apiKeyOrAccessToken)
+		.then(credentials => {
+			rawApiKeyAccessTokenCache.set(apiKeyOrAccessToken, { access: credentials.access, expires: credentials.expires });
+			return credentials.access;
+		})
+		.finally(() => {
+			pendingRawApiKeyExchanges.delete(apiKeyOrAccessToken);
+		});
+	pendingRawApiKeyExchanges.set(apiKeyOrAccessToken, pending);
+	return pending;
+}

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added automatic `CURSOR_API_KEY` exchange to Cursor model discovery (`GetUsableModels`): a raw dashboard API key is resolved to a session bearer token before the request, so discovery returns the full usable-models list instead of requiring a pre-exchanged `CURSOR_ACCESS_TOKEN`.
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -9,6 +9,7 @@ import { GetUsableModelsRequestSchema, GetUsableModelsResponseSchema } from "./c
 const CURSOR_DEFAULT_BASE_URL = "https://api2.cursor.sh";
 const CURSOR_DEFAULT_CLIENT_VERSION = "cli-2026.02.13-41ac335";
 const CURSOR_GET_USABLE_MODELS_PATH = "/agent.v1.AgentService/GetUsableModels";
+const CURSOR_API_KEY_EXCHANGE_PATH = "/auth/exchange_user_api_key";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 64_000;
@@ -67,6 +68,99 @@ export interface CursorModelDiscoveryOptions {
 }
 
 /**
+ * Cursor dashboard API keys (Settings → API Keys, `crsr_...`) are long-lived
+ * and cannot authenticate `GetUsableModels`/`Run` directly — the official
+ * Cursor CLI exchanges them for a short-lived session access token via
+ * `exchange_user_api_key` before ever sending a request. Session access
+ * tokens (from `/login` or `CURSOR_ACCESS_TOKEN`) are JWTs and never carry
+ * this prefix, so it alone disambiguates the two credential shapes.
+ */
+export function isRawCursorApiKey(value: string): boolean {
+	return value.startsWith("crsr_");
+}
+
+interface ExchangedCursorToken {
+	accessToken: string;
+	expiresAt: number;
+}
+
+const exchangedTokenCache = new Map<string, ExchangedCursorToken>();
+const pendingCursorExchanges = new Map<string, Promise<string>>();
+
+function decodeCursorAccessTokenExpiry(accessToken: string): number {
+	try {
+		const parts = accessToken.split(".");
+		if (parts.length !== 3 || !parts[1]) {
+			return Date.now() + 3600 * 1000;
+		}
+		const decoded = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+		if (decoded && typeof decoded === "object" && typeof decoded.exp === "number") {
+			return decoded.exp * 1000 - 5 * 60 * 1000;
+		}
+	} catch {
+		// Fall through to the conservative default below.
+	}
+	return Date.now() + 3600 * 1000;
+}
+
+async function exchangeCursorApiKey(
+	apiKey: string,
+	baseUrl: string,
+	fetchImpl: typeof fetch,
+): Promise<ExchangedCursorToken> {
+	const response = await fetchImpl(`${baseUrl}${CURSOR_API_KEY_EXCHANGE_PATH}`, {
+		method: "POST",
+		headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+		body: "{}",
+	});
+	if (!response.ok) {
+		const errorText = await response.text().catch(() => "");
+		throw new Error(`Cursor API key exchange failed: ${response.status} ${errorText}`);
+	}
+	const data = (await response.json()) as { accessToken?: string };
+	if (!data.accessToken) {
+		throw new Error("Cursor API key exchange response missing accessToken");
+	}
+	return { accessToken: data.accessToken, expiresAt: decodeCursorAccessTokenExpiry(data.accessToken) };
+}
+
+/**
+ * Resolves a Cursor credential to a bearer usable against the agent RPCs.
+ * Session access tokens pass through unchanged; a raw dashboard API key is
+ * exchanged once and the result cached until shortly before its JWT `exp`,
+ * so repeated discovery refreshes don't re-exchange on every call.
+ */
+export async function resolveCursorBearerToken(
+	apiKey: string,
+	options?: { baseUrl?: string; fetch?: typeof fetch },
+): Promise<string> {
+	if (!isRawCursorApiKey(apiKey)) {
+		return apiKey;
+	}
+	const baseUrl = (options?.baseUrl ?? CURSOR_DEFAULT_BASE_URL).replace(/\/+$/, "");
+	const fetchImpl = options?.fetch ?? fetch;
+	const cacheKey = `${baseUrl}\u0000${apiKey}`;
+	const cached = exchangedTokenCache.get(cacheKey);
+	if (cached && cached.expiresAt > Date.now()) {
+		return cached.accessToken;
+	}
+	const existing = pendingCursorExchanges.get(cacheKey);
+	if (existing) {
+		return existing;
+	}
+	const pending = exchangeCursorApiKey(apiKey, baseUrl, fetchImpl)
+		.then(result => {
+			exchangedTokenCache.set(cacheKey, result);
+			return result.accessToken;
+		})
+		.finally(() => {
+			pendingCursorExchanges.delete(cacheKey);
+		});
+	pendingCursorExchanges.set(cacheKey, pending);
+	return pending;
+}
+
+/**
  * Fetches Cursor models through `GetUsableModels` and normalizes them into canonical model entries.
  *
  * Returns `null` on request/decode failures.
@@ -77,13 +171,14 @@ export async function fetchCursorUsableModels(
 ): Promise<ModelSpec<"cursor-agent">[] | null> {
 	const timeoutMs = options.timeoutMs ?? 5_000;
 	try {
+		const baseUrl = (options.baseUrl ?? CURSOR_DEFAULT_BASE_URL).replace(/\/+$/, "");
+		const bearerToken = await resolveCursorBearerToken(options.apiKey, { baseUrl });
 		const requestPayload = create(GetUsableModelsRequestSchema, {
 			customModelIds: normalizeCustomModelIds(options.customModelIds),
 		});
 		const body = toBinary(GetUsableModelsRequestSchema, requestPayload);
-		const baseUrl = (options.baseUrl ?? CURSOR_DEFAULT_BASE_URL).replace(/\/+$/, "");
 
-		const responseBuffer = await fetchViaHttp2(baseUrl, body, options, timeoutMs);
+		const responseBuffer = await fetchViaHttp2(baseUrl, body, { ...options, apiKey: bearerToken }, timeoutMs);
 
 		if (!responseBuffer) {
 			return null;

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -116,7 +116,12 @@ export const CATALOG_PROVIDERS = [
 	{
 		id: "cursor",
 		defaultModel: "claude-4.6-opus-high",
-		envVars: ["CURSOR_ACCESS_TOKEN"],
+		// CURSOR_ACCESS_TOKEN is an already-exchanged session token (from `/login`
+		// or lifted from another Cursor client) and is used as-is. CURSOR_API_KEY
+		// is a long-lived dashboard key (`crsr_...`, Settings → API Keys) that the
+		// cursor-agent provider/discovery transparently exchange for a session
+		// token first — see `isRawCursorApiKey`/`resolveCursorAccessToken`.
+		envVars: ["CURSOR_ACCESS_TOKEN", "CURSOR_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => cursorModelManagerOptions(config),
 		catalogDiscovery: { label: "Cursor", envVars: ["CURSOR_API_KEY"], oauthProvider: "cursor" },
 	},

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -351,7 +351,8 @@ export function getExtraHelpText(): string {
   UMANS_WEBSEARCH_PROVIDER    - Umans gateway web search backend (native or exa)
   MINIMAX_API_KEY            - MiniMax models
   OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models
-  CURSOR_ACCESS_TOKEN        - Cursor AI models
+  CURSOR_ACCESS_TOKEN        - Cursor AI models (session token)
+  CURSOR_API_KEY             - Cursor AI models (dashboard key, auto-exchanged)
   AI_GATEWAY_API_KEY         - Vercel AI Gateway
   WAFER_SERVERLESS_API_KEY   - Wafer Serverless (pay-as-you-go)
 


### PR DESCRIPTION
## What

Adds support for Cursor **dashboard API keys** (Settings → API Keys, `crsr_...`) to the `cursor-agent` provider and its model discovery. Previously both `streamCursor` and `fetchCursorUsableModels` only accepted an already-exchanged session access token, so setting `CURSOR_API_KEY` to a raw dashboard key silently failed authentication.

The raw key is now transparently exchanged for a session access token before any agent RPC, exactly mirroring the official Cursor CLI's API-key login path (`exchange_user_api_key`), and the resulting session token is cached until shortly before its JWT `exp` so repeated calls/streams don't re-exchange every time. `CURSOR_ACCESS_TOKEN` (already a session token) is untouched — both resolvers pass anything not prefixed with `crsr_` straight through.

Changes:
- `packages/ai/src/registry/oauth/cursor.ts`: new `isRawCursorApiKey` / `resolveCursorAccessToken`, built on the existing `refreshCursorToken`.
- `packages/ai/src/providers/cursor.ts`: `streamCursor` resolves the credential through the above before issuing agent RPCs (dynamically imported so the common already-a-session-token path stays out of the eager registry graph).
- `packages/catalog/src/discovery/cursor.ts`: mirrors the same detect/exchange/cache logic locally (a `catalog` → `ai` import would be circular), so `GetUsableModels` discovery also accepts a raw key.
- `packages/catalog/src/provider-models/descriptors.ts`: lists `CURSOR_API_KEY` alongside `CURSOR_ACCESS_TOKEN` as a runtime env var fallback for the `cursor` provider.
- `packages/coding-agent/src/cli/args.ts`: mentions both env vars in `--help`.
- `CHANGELOG.md` (ai, catalog): `[Unreleased]` entries.

## Why

`CURSOR_API_KEY` (the dashboard-generated `crsr_...` key) is the credential most users actually have on hand — it's what you get from Settings → API Keys, no OAuth/PKCE dance required. `CURSOR_ACCESS_TOKEN` requires lifting an already-exchanged session token from another Cursor client, which is a much less discoverable path. Supporting the raw dashboard key directly, exchanged transparently under the hood, matches what the official `cursor-agent` CLI does and is a much better out-of-the-box experience.

## Testing

Type-checked `packages/ai`, `packages/catalog`, and `packages/coding-agent` (`bun run check:types` in each) — clean.

Verified end-to-end against the live Cursor backend with a real dashboard API key (standalone script exercising the modified functions directly, not committed):
- `isRawCursorApiKey` correctly detects the `crsr_` prefix in both `ai` and `catalog`.
- Exchange (`resolveCursorAccessToken` / `resolveCursorBearerToken`) turns the raw key into a valid session JWT; a second call hits the cache instantly instead of re-exchanging.
- `fetchCursorUsableModels` with the raw key returns the full usable-models list (189 models), matching what `cursor-agent` itself shows.
- `streamCursor` with the raw key completes a real chat turn end-to-end.
- Repeating the same `streamCursor` call with an already-exchanged session token (the `CURSOR_ACCESS_TOKEN` shape) produces identical behavior, confirming no regression for existing users.

I could not run the native Rust addon build (`bun run build:native` / `bun check:rs`) in my sandbox — it hits a nightly rustc internal compiler error unrelated to this change (reproducible on a clean checkout, looks like an sccache + incremental-compilation interaction). TypeScript-side checks and the live-key verification above are unaffected by this, since none of the touched code paths depend on the native addon.

- [x] `bun run check:ts` passes for touched packages (`ai`, `catalog`, `coding-agent`)
- [x] Tested locally (live backend calls with a real `CURSOR_API_KEY`, see above)
- [x] CHANGELOG updated

Made with [Cursor](https://cursor.com)