### PR TITLE
fix: use absolute cwd in project system prompt

### DIFF
--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -710,7 +710,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 
 	const date = formatLocalCalendarDate();
 	const dateTime = date;
-	const promptCwd = shortenPath(normalizePromptPath(resolvedCwd));
+	const promptCwd = normalizePromptPath(resolvedCwd);
 	const activeRepoContextPrompt = renderActiveRepoContextPrompt(activeRepoContext);
 
 	// Build tool metadata for system prompt rendering.


### PR DESCRIPTION
Fixes #6100.

This removes the `shortenPath` call when formatting the working directory for the project system prompt. It now passes the absolute normalized directory path instead, preventing the model from guessing incorrect base paths.