### PR TITLE
feat: add RPC collaboration controls

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -48,6 +48,7 @@ There is no envelope beyond the object shape itself.
 9. Prompt lifecycle hints (`{ type: "prompt_result", id?, agentInvoked }`) for scheduled prompts that later resolve without invoking the agent
 10. Subagent frames (`subagent_lifecycle`, `subagent_progress`, `subagent_event`), gated by `set_subagent_subscription`
 11. Builtin slash-command side channels (`command_output`, `session_info_update`, `config_update`)
+12. Collaboration lifecycle frames (`{ type: "collab_state", state, reason?, room }`) emitted when a native room starts, reconnects, stops, or fails
 
 ### Inbound frame categories (stdin)
 
@@ -94,6 +95,17 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_subagent_subscription", level: "off" | "progress" | "events" }`
 - `{ id?, type: "get_subagents" }`
 - `{ id?, type: "get_subagent_messages", subagentId?: string, sessionFile?: string, fromByte?: number }`
+
+### Collaboration
+
+- `{ id?, type: "collab_start", relayUrl?: string, webUrl?: string, displayName?: string }`
+- `{ id?, type: "collab_status" }`
+- `{ id?, type: "collab_stop" }`
+
+`collab_start` creates at most one native room per RPC process and returns that
+room unchanged on repeated calls. `relayUrl` and `webUrl` override the
+`collab.relayUrl` and `collab.webUrl` settings for the first start. Closing
+stdin or shutting down the RPC process closes the room.
 
 ### Model
 
@@ -162,6 +174,34 @@ All command results use `RpcResponse`:
 - Failure: `{ id?, type: "response", command: string, success: false, error: string }`
 
 Data payloads are command-specific and defined in `rpc-types.ts`.
+
+### Collaboration payloads and lifecycle
+
+All three collaboration commands return `RpcCollabRoomState`:
+
+```json
+{
+  "active": true,
+  "joinUrl": "relay.example/r/room.key-and-write-token",
+  "viewUrl": "relay.example/r/room.key",
+  "webUrl": "https://collab.example/#relay.example/r/room.key-and-write-token",
+  "webViewUrl": "https://collab.example/#relay.example/r/room.key",
+  "participants": [{ "name": "host", "role": "host" }]
+}
+```
+
+`joinUrl` grants writable native OMP access; `viewUrl` grants read-only access.
+The web URLs use `collab.webUrl` when configured and otherwise derive an
+HTTP(S) origin from the relay. Room lifecycle changes are unsolicited frames:
+
+```json
+{
+  "type": "collab_state",
+  "state": "started|reconnecting|stopped|failed",
+  "reason": "optional detail",
+  "room": { "active": false, "participants": [] }
+}
+```
 
 ### `prompt` payload
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added native collaboration room controls to RPC mode, including typed start/status/stop commands, join and view capability URLs, client helpers, lifecycle frames, and room teardown on RPC shutdown.
+
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/coding-agent/src/collab/display-name.ts
+++ b/packages/coding-agent/src/collab/display-name.ts
@@ -1,8 +1,8 @@
 import * as os from "node:os";
-import type { InteractiveModeContext } from "../modes/types";
+import type { Settings } from "../config/settings";
 
 /** Display name for this process's user in collab sessions. */
-export function collabDisplayName(ctx: InteractiveModeContext): string {
+export function collabDisplayName(ctx: { settings: Pick<Settings, "get"> }): string {
 	const configured = (ctx.settings.get("collab.displayName") ?? "").trim();
 	if (configured) return configured;
 	try {

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -21,15 +21,15 @@ import type {
 	AgentEvent as WireAgentEvent,
 	SessionEntry as WireSessionEntry,
 } from "@oh-my-pi/pi-wire";
-import type { InteractiveModeContext } from "../modes/types";
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import { type AgentRef, AgentRegistry } from "../registry/agent-registry";
-import type { AgentSessionEvent } from "../session/agent-session";
+import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import { stripImagesFromMessage, USER_INTERRUPT_LABEL } from "../session/messages";
 import type { SessionEntry as StoredSessionEntry } from "../session/session-entries";
+import type { SessionManager } from "../session/session-manager";
 import { TASK_SUBAGENT_LIFECYCLE_CHANNEL, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../task/types";
+import type { EventBus } from "../utils/event-bus";
 import { generateRoomKey, generateWriteToken, importRoomKey } from "./crypto";
-import { collabDisplayName } from "./display-name";
 import {
 	type AgentSnapshot,
 	COLLAB_PROMPT_MESSAGE_TYPE,
@@ -118,8 +118,45 @@ const SNAPSHOT_CHUNK_BYTES = 512 * 1024;
  */
 export type CollabGuestUiResult = { kind: "answered"; value: CollabUiResponseValue } | { kind: "unavailable" };
 
+export type CollabHostSession = Pick<
+	AgentSession,
+	| "abort"
+	| "emitNotice"
+	| "getContextUsage"
+	| "isAborting"
+	| "isStreaming"
+	| "model"
+	| "promptCustomMessage"
+	| "queuedMessageCount"
+	| "sessionName"
+	| "subscribe"
+	| "thinkingLevel"
+>;
+
+export type CollabHostSessionManager = Pick<
+	SessionManager,
+	"getCwd" | "getSessionId" | "onEntryAppended" | "snapshotForReplication"
+>;
+
+export type CollabHostEventBus = Pick<EventBus, "on">;
+
+/**
+ * Runtime dependencies for hosting a collaboration room. UI modes can attach
+ * callbacks, while RPC/headless modes provide only session state.
+ */
+export interface CollabHostContext {
+	session: CollabHostSession;
+	sessionManager: CollabHostSessionManager;
+	eventBus?: CollabHostEventBus;
+	displayName?: string;
+	onPendingMessagesChanged?(): void;
+	onParticipantsChanged?(participantCount: number): void;
+	onRelayReconnecting?(reason: string): void;
+	onStopped?(reason: string): void;
+}
+
 export class CollabHost {
-	#ctx: InteractiveModeContext;
+	#ctx: CollabHostContext;
 	#socket: CollabSocket | null = null;
 	#link = "";
 	#webLink = "";
@@ -139,7 +176,7 @@ export class CollabHost {
 	#registryUnsubscribe?: () => void;
 	#stopped = false;
 
-	constructor(ctx: InteractiveModeContext) {
+	constructor(ctx: CollabHostContext) {
 		this.#ctx = ctx;
 	}
 
@@ -163,7 +200,7 @@ export class CollabHost {
 	}
 
 	get participants(): CollabParticipant[] {
-		const list: CollabParticipant[] = [{ name: collabDisplayName(this.#ctx), role: "host" }];
+		const list: CollabParticipant[] = [{ name: this.#ctx.displayName || "anonymous", role: "host" }];
 		for (const peer of this.#peers.values()) {
 			list.push({ name: peer.name, role: "guest", readOnly: peer.canWrite ? undefined : true });
 		}
@@ -243,9 +280,9 @@ export class CollabHost {
 				return;
 			}
 			if (willReconnect) {
-				this.#ctx.showStatus(`Collab relay connection lost (${reason}), reconnecting…`, { dim: true });
+				this.#ctx.onRelayReconnecting?.(reason);
 			} else {
-				void this.#teardown();
+				void this.#teardown(reason);
 				this.#ctx.session.emitNotice("warning", `Collab ended: ${reason}`, "collab");
 			}
 		};
@@ -265,6 +302,7 @@ export class CollabHost {
 		} finally {
 			clearTimeout(timeout);
 		}
+		if (this.#stopped) throw new Error("collaboration room ended while starting");
 
 		this.#unsubscribe = this.#ctx.session.subscribe(event => {
 			if (isWireAgentEvent(event)) this.#broadcast({ t: "event", event: shrinkForReplication(event) });
@@ -283,17 +321,17 @@ export class CollabHost {
 			// guest state promptly (debounce + JSON diff dedupe).
 			this.#scheduleStateBroadcast();
 		};
-		this.#updateStatusSegment();
+		this.#notifyParticipantsChanged();
 	}
 
 	/** Broadcast a goodbye, detach all taps, and close the socket. */
 	async stop(reason: string): Promise<void> {
 		if (this.#stopped) return;
 		this.#socket?.send({ t: "bye", reason });
-		await this.#teardown();
+		await this.#teardown(reason);
 	}
 
-	async #teardown(): Promise<void> {
+	async #teardown(reason: string): Promise<void> {
 		if (this.#stopped) return;
 		this.#stopped = true;
 		this.#ctx.sessionManager.onEntryAppended = undefined;
@@ -314,9 +352,8 @@ export class CollabHost {
 		this.#peers.clear();
 		this.#socket?.close();
 		this.#socket = null;
-		this.#ctx.collabHost = undefined;
-		this.#ctx.statusLine.setCollabStatus(null);
-		this.#ctx.ui.requestRender();
+		this.#ctx.onParticipantsChanged?.(0);
+		this.#ctx.onStopped?.(reason);
 	}
 
 	#broadcast(frame: CollabFrame): void {
@@ -417,7 +454,7 @@ export class CollabHost {
 			`${cleanName} joined the collab session${canWrite ? "" : " (read-only)"}`,
 			"collab",
 		);
-		this.#updateStatusSegment();
+		this.#notifyParticipantsChanged();
 		this.#scheduleStateBroadcast();
 	}
 
@@ -476,8 +513,7 @@ export class CollabHost {
 			images && images.length > 0 ? [{ type: "text", text }, ...images] : text;
 		const details: CollabPromptDetails = { from: name };
 		if (this.#ctx.session.isStreaming) {
-			this.#ctx.updatePendingMessagesDisplay();
-			this.#ctx.ui.requestRender();
+			this.#ctx.onPendingMessagesChanged?.();
 			this.#scheduleStateBroadcast();
 		}
 		this.#ctx.session
@@ -514,17 +550,15 @@ export class CollabHost {
 		const name = this.#peers.get(peer)?.name;
 		this.#peers.delete(peer);
 		if (name) this.#ctx.session.emitNotice("info", `${name} left the collab session`, "collab");
-		this.#updateStatusSegment();
+		this.#notifyParticipantsChanged();
 		this.#scheduleStateBroadcast();
 	}
 
 	#buildState(): CollabSessionState {
 		const session = this.#ctx.session;
-		// Context numbers come from the status line's memoized breakdown so guests
-		// render exactly the same anchored, provider-real count the host's own
-		// status line shows.
-		const breakdown = this.#ctx.statusLine.getCachedContextBreakdown();
-		const tokens = breakdown.usedTokens ?? 0;
+		const usage = session.getContextUsage?.();
+		const tokens = usage?.tokens ?? 0;
+		const contextWindow = usage?.contextWindow ?? session.model?.contextWindow ?? 0;
 		return {
 			isStreaming: session.isStreaming,
 			isAborting: session.isAborting,
@@ -535,8 +569,8 @@ export class CollabHost {
 			thinkingLevel: session.thinkingLevel,
 			contextUsage: {
 				tokens,
-				contextWindow: breakdown.contextWindow,
-				percent: breakdown.contextWindow > 0 ? (tokens / breakdown.contextWindow) * 100 : 0,
+				contextWindow,
+				percent: contextWindow > 0 ? (tokens / contextWindow) * 100 : 0,
 			},
 			participants: this.participants,
 		};
@@ -682,9 +716,7 @@ export class CollabHost {
 		}, STATE_DEBOUNCE_MS);
 	}
 
-	#updateStatusSegment(): void {
-		this.#ctx.statusLine.setCollabStatus({ role: "host", participantCount: this.#peers.size + 1 });
-		this.#ctx.statusLine.invalidate();
-		this.#ctx.ui.requestRender();
+	#notifyParticipantsChanged(): void {
+		this.#ctx.onParticipantsChanged?.(this.#peers.size + 1);
 	}
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -15,6 +15,8 @@ import type { AgentSessionEvent, SessionStats } from "../../session/agent-sessio
 import type {
 	RpcAvailableCommandsUpdateFrame,
 	RpcAvailableSlashCommand,
+	RpcCollabLifecycleFrame,
+	RpcCollabRoomState,
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
@@ -67,6 +69,7 @@ export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
 export type RpcAvailableCommandsUpdateListener = (commands: RpcAvailableSlashCommand[]) => void;
+export type RpcCollabStateListener = (frame: RpcCollabLifecycleFrame) => void;
 
 export interface RpcClientToolContext<TDetails = unknown> {
 	toolCallId: string;
@@ -170,6 +173,18 @@ function isRpcAvailableCommandsUpdateFrame(value: unknown): value is RpcAvailabl
 	return value.type === "available_commands_update" && Array.isArray(value.commands);
 }
 
+function isRpcCollabLifecycleFrame(value: unknown): value is RpcCollabLifecycleFrame {
+	if (!isRecord(value) || value.type !== "collab_state" || !isRecord(value.room)) return false;
+	return (
+		(value.state === "started" ||
+			value.state === "reconnecting" ||
+			value.state === "stopped" ||
+			value.state === "failed") &&
+		typeof value.room.active === "boolean" &&
+		Array.isArray(value.room.participants)
+	);
+}
+
 function isRpcHostToolCallRequest(value: unknown): value is RpcHostToolCallRequest {
 	if (!isRecord(value)) return false;
 	return (
@@ -212,6 +227,7 @@ export class RpcClient {
 	#subagentProgressListeners = new Set<RpcSubagentProgressListener>();
 	#subagentEventListeners = new Set<RpcSubagentEventListener>();
 	#availableCommandsUpdateListeners = new Set<RpcAvailableCommandsUpdateListener>();
+	#collabStateListeners = new Set<RpcCollabStateListener>();
 	#pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
 		new Map();
 	#customTools: RpcClientCustomTool[] = [];
@@ -429,6 +445,12 @@ export class RpcClient {
 		return () => this.#availableCommandsUpdateListeners.delete(listener);
 	}
 
+	/** Subscribe to native collaboration room lifecycle changes. */
+	onCollabState(listener: RpcCollabStateListener): () => void {
+		this.#collabStateListeners.add(listener);
+		return () => this.#collabStateListeners.delete(listener);
+	}
+
 	/**
 	 * Get collected stderr output (useful for debugging).
 	 */
@@ -498,6 +520,26 @@ export class RpcClient {
 	 */
 	async getState(): Promise<RpcSessionState> {
 		const response = await this.#send({ type: "get_state" });
+		return this.#getData(response);
+	}
+
+	/** Start the native collaboration room, or return the existing room unchanged. */
+	async startCollab(
+		options: { relayUrl?: string; webUrl?: string; displayName?: string } = {},
+	): Promise<RpcCollabRoomState> {
+		const response = await this.#send({ type: "collab_start", ...options });
+		return this.#getData(response);
+	}
+
+	/** Return the native collaboration room owned by this RPC process. */
+	async getCollabStatus(): Promise<RpcCollabRoomState> {
+		const response = await this.#send({ type: "collab_status" });
+		return this.#getData(response);
+	}
+
+	/** Stop the native collaboration room without stopping the RPC process. */
+	async stopCollab(): Promise<RpcCollabRoomState> {
+		const response = await this.#send({ type: "collab_stop" });
 		return this.#getData(response);
 	}
 
@@ -911,6 +953,13 @@ export class RpcClient {
 		if (isRpcSubagentEventFrame(data)) {
 			for (const listener of this.#subagentEventListeners) {
 				listener(data.payload);
+			}
+			return;
+		}
+
+		if (isRpcCollabLifecycleFrame(data)) {
+			for (const listener of this.#collabStateListeners) {
+				listener(data);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-collab.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-collab.ts
@@ -1,0 +1,98 @@
+import {
+	CollabHost,
+	type CollabHostEventBus,
+	type CollabHostSession,
+	type CollabHostSessionManager,
+} from "../../collab/host";
+import type { RpcCollabLifecycleFrame, RpcCollabRoomState } from "./rpc-types";
+
+export interface RpcCollabHostControllerContext {
+	session: CollabHostSession;
+	sessionManager: CollabHostSessionManager;
+	eventBus?: CollabHostEventBus;
+	defaultRelayUrl?: string;
+	defaultWebUrl?: string;
+	displayName?: string;
+	output(frame: RpcCollabLifecycleFrame): void;
+}
+
+export interface RpcCollabStartOptions {
+	relayUrl?: string;
+	webUrl?: string;
+	displayName?: string;
+}
+
+/** Owns the single native collaboration room associated with one RPC process. */
+export class RpcCollabHostController {
+	readonly #context: RpcCollabHostControllerContext;
+	#host: CollabHost | undefined;
+	#stopping = false;
+
+	constructor(context: RpcCollabHostControllerContext) {
+		this.#context = context;
+	}
+
+	status(): RpcCollabRoomState {
+		const host = this.#host;
+		if (!host) return { active: false, participants: [] };
+		return {
+			active: true,
+			joinUrl: host.link,
+			viewUrl: host.viewLink,
+			...(host.webLink ? { webUrl: host.webLink } : {}),
+			...(host.webViewLink ? { webViewUrl: host.webViewLink } : {}),
+			participants: host.participants,
+		};
+	}
+
+	async start(options: RpcCollabStartOptions): Promise<RpcCollabRoomState> {
+		if (this.#host) return this.status();
+		const relayInput = options.relayUrl?.trim() || this.#context.defaultRelayUrl?.trim();
+		if (!relayInput) throw new Error("No collaboration relay configured");
+		const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
+		const webUrl = options.webUrl?.trim() || this.#context.defaultWebUrl?.trim() || "";
+		const host = new CollabHost({
+			session: this.#context.session,
+			sessionManager: this.#context.sessionManager,
+			eventBus: this.#context.eventBus,
+			displayName: options.displayName?.trim() || this.#context.displayName?.trim(),
+			onRelayReconnecting: reason => {
+				this.#context.output({ type: "collab_state", state: "reconnecting", reason, room: this.status() });
+			},
+			onStopped: reason => {
+				if (this.#host !== host) return;
+				const state = this.#stopping ? "stopped" : "failed";
+				this.#host = undefined;
+				this.#stopping = false;
+				this.#context.output({ type: "collab_state", state, reason, room: this.status() });
+			},
+		});
+		this.#host = host;
+		try {
+			await host.start(relayUrl, webUrl);
+		} catch (error) {
+			if (this.#host === host) {
+				this.#host = undefined;
+				const reason = error instanceof Error ? error.message : String(error);
+				this.#context.output({ type: "collab_state", state: "failed", reason, room: this.status() });
+			}
+			throw error;
+		}
+		if (this.#host !== host) throw new Error("Collaboration room ended while starting");
+		const room = this.status();
+		this.#context.output({ type: "collab_state", state: "started", room });
+		return room;
+	}
+
+	async stop(reason: string): Promise<RpcCollabRoomState> {
+		const host = this.#host;
+		if (!host) return this.status();
+		this.#stopping = true;
+		await host.stop(reason);
+		return this.status();
+	}
+
+	async shutdown(): Promise<void> {
+		await this.stop("RPC shutdown");
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -14,6 +14,7 @@ import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { isZodSchema, zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { $env, isRecord, readLines, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
+import { collabDisplayName } from "../../collab/display-name";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	type ExtensionUIContext,
@@ -34,6 +35,7 @@ import type { EventBus } from "../../utils/event-bus";
 import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
+import { RpcCollabHostController } from "./rpc-collab";
 import { claimRpcInput } from "./rpc-input";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
@@ -644,6 +646,15 @@ export async function runRpcMode(
 	const hostToolBridge = new RpcHostToolBridge(output);
 	const hostUriBridge = new RpcHostUriBridge(output);
 	const subagentRegistry = eventBus ? new RpcSubagentRegistry(eventBus, output) : undefined;
+	const collabController = new RpcCollabHostController({
+		session,
+		sessionManager: session.sessionManager,
+		eventBus,
+		defaultRelayUrl: session.settings.get("collab.relayUrl"),
+		defaultWebUrl: session.settings.get("collab.webUrl"),
+		displayName: collabDisplayName(session),
+		output,
+	});
 
 	// Shutdown request flag (wrapped in object to allow mutation with const)
 	const shutdownState = { requested: false };
@@ -1052,6 +1063,20 @@ export async function runRpcMode(
 				return success(id, "get_state", state);
 			}
 
+			case "collab_start": {
+				const room = await collabController.start(command);
+				return success(id, "collab_start", room);
+			}
+
+			case "collab_status": {
+				return success(id, "collab_status", collabController.status());
+			}
+
+			case "collab_stop": {
+				const room = await collabController.stop("RPC client requested stop");
+				return success(id, "collab_stop", room);
+			}
+
 			case "get_available_commands": {
 				return success(id, "get_available_commands", { commands: await getAvailableCommands() });
 			}
@@ -1358,6 +1383,7 @@ export async function runRpcMode(
 			// the process exits. dispose() also emits `session_shutdown`, so we
 			// must NOT emit it separately here or the event fires twice. Skipping
 			// dispose left OMP-owned Chromium alive after RPC shutdown (#5643).
+			await collabController.shutdown();
 			await session.dispose();
 			process.exit(0);
 		},
@@ -1412,6 +1438,7 @@ export async function runRpcMode(
 	// bounded teardown run on the stdin-EOF path too (#5643). Idempotent: a
 	// prior pi.shutdown() through the coordinator makes this await settle
 	// immediately.
+	await collabController.shutdown();
 	await session.dispose();
 	process.exit(0);
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,6 +7,7 @@
 import type { AgentMessage, AgentToolResult, ThinkingLevel, ToolLoadMode } from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
+import type { CollabParticipant } from "../../collab/protocol";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
@@ -42,6 +43,9 @@ export type RpcCommand =
 	| { id?: string; type: "set_subagent_subscription"; level: RpcSubagentSubscriptionLevel }
 	| { id?: string; type: "get_subagents" }
 	| { id?: string; type: "get_subagent_messages"; subagentId?: string; sessionFile?: string; fromByte?: number }
+	| { id?: string; type: "collab_start"; relayUrl?: string; webUrl?: string; displayName?: string }
+	| { id?: string; type: "collab_status" }
+	| { id?: string; type: "collab_stop" }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -162,6 +166,22 @@ export interface RpcSubagentMessagesResult {
 	messages: AgentMessage[];
 }
 
+export interface RpcCollabRoomState {
+	active: boolean;
+	joinUrl?: string;
+	viewUrl?: string;
+	webUrl?: string;
+	webViewUrl?: string;
+	participants: CollabParticipant[];
+}
+
+export interface RpcCollabLifecycleFrame {
+	type: "collab_state";
+	state: "started" | "reconnecting" | "stopped" | "failed";
+	reason?: string;
+	room: RpcCollabRoomState;
+}
+
 // ============================================================================
 // RPC Responses (stdout)
 // ============================================================================
@@ -209,6 +229,9 @@ export type RpcResponse =
 			success: true;
 			data: RpcSubagentMessagesResult;
 	  }
+	| { id?: string; type: "response"; command: "collab_start"; success: true; data: RpcCollabRoomState }
+	| { id?: string; type: "response"; command: "collab_status"; success: true; data: RpcCollabRoomState }
+	| { id?: string; type: "response"; command: "collab_stop"; success: true; data: RpcCollabRoomState }
 
 	// Model
 	| {
@@ -319,7 +342,7 @@ export interface RpcSubagentEventFrame {
 
 export type RpcSubagentFrame = RpcSubagentLifecycleFrame | RpcSubagentProgressFrame | RpcSubagentEventFrame;
 
-export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
+export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame | RpcCollabLifecycleFrame;
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -5,6 +5,7 @@ import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
+import { collabDisplayName } from "../collab/display-name";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
 import { expandRoleAlias, getModelMatchPreferences, resolveCliModel } from "../config/model-resolver";
@@ -762,7 +763,27 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			// Scheme-less relay args default to wss (ws:// must be spelled out for localhost).
 			const relayUrl = relayInput.includes("://") ? relayInput : `wss://${relayInput}`;
 			const webUrl = ctx.settings.get("collab.webUrl") || "";
-			const host = new CollabHost(ctx);
+			const host = new CollabHost({
+				session: ctx.session,
+				sessionManager: ctx.sessionManager,
+				eventBus: ctx.eventBus,
+				displayName: collabDisplayName(ctx),
+				onPendingMessagesChanged: () => {
+					ctx.updatePendingMessagesDisplay();
+					ctx.ui.requestRender();
+				},
+				onParticipantsChanged: participantCount => {
+					ctx.statusLine.setCollabStatus(participantCount > 0 ? { role: "host", participantCount } : null);
+					ctx.statusLine.invalidate();
+					ctx.ui.requestRender();
+				},
+				onRelayReconnecting: reason => {
+					ctx.showStatus(`Collab relay connection lost (${reason}), reconnecting…`, { dim: true });
+				},
+				onStopped: () => {
+					if (ctx.collabHost === host) ctx.collabHost = undefined;
+				},
+			});
 			try {
 				await host.start(relayUrl, webUrl);
 			} catch (err) {

--- a/packages/coding-agent/test/collab/helpers/in-memory-relay.ts
+++ b/packages/coding-agent/test/collab/helpers/in-memory-relay.ts
@@ -64,6 +64,14 @@ export class FakeWebSocket {
 		queueMicrotask(() => this.onclose?.({ code: 1000, reason: "closed" }));
 	}
 
+	/** Simulate a relay-side fatal close. */
+	fail(code: number, reason: string): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.#relay.disconnect(this);
+		queueMicrotask(() => this.onclose?.({ code, reason }));
+	}
+
 	/** Relay → this socket: a binary frame, delivered as ArrayBuffer (binaryType "arraybuffer"). */
 	deliver(bytes: Uint8Array): void {
 		if (this.readyState !== FakeWebSocket.OPEN) return;
@@ -83,10 +91,12 @@ export class InMemoryRelay {
 	#host: FakeWebSocket | null = null;
 	readonly #guests = new Map<number, FakeWebSocket>();
 	#nextPeerId = 1;
+	#failHostOnConnect: { code: number; reason: string } | undefined;
 
 	connect(ws: FakeWebSocket): void {
 		if (ws.role === "host") {
 			this.#host = ws;
+			if (this.#failHostOnConnect) ws.fail(this.#failHostOnConnect.code, this.#failHostOnConnect.reason);
 			return;
 		}
 		ws.peerId = this.#nextPeerId++;
@@ -116,6 +126,14 @@ export class InMemoryRelay {
 		}
 		this.#guests.delete(ws.peerId);
 		this.#host?.deliverControl(JSON.stringify({ t: "peer-left", peer: ws.peerId }));
+	}
+
+	failNextHostOnConnect(code: number, reason: string): void {
+		this.#failHostOnConnect = { code, reason };
+	}
+
+	failHost(code: number, reason: string): void {
+		this.#host?.fail(code, reason);
 	}
 }
 

--- a/packages/coding-agent/test/collab/mode-neutral-host.test.ts
+++ b/packages/coding-agent/test/collab/mode-neutral-host.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { CollabHost, type CollabHostContext } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+function makeHeadlessContext(events: string[]): CollabHostContext {
+	return {
+		displayName: "rpc-host",
+		sessionManager: {
+			getSessionId: () => "sess-rpc",
+			getCwd: () => "/workspace",
+			snapshotForReplication: () => ({
+				header: {
+					type: "session",
+					id: "sess-rpc",
+					timestamp: new Date().toISOString(),
+					cwd: "/workspace",
+				},
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			isAborting: false,
+			queuedMessageCount: 0,
+			sessionName: "headless",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+			getContextUsage: () => ({ tokens: 12, contextWindow: 100, percent: 12 }),
+		},
+		onParticipantsChanged: count => events.push(`participants:${count}`),
+		onStopped: () => events.push("stopped"),
+	};
+}
+
+describe("mode-neutral CollabHost context", () => {
+	beforeEach(() => installInMemoryRelay());
+	afterEach(() => uninstallInMemoryRelay());
+
+	it("hosts and stops without an InteractiveModeContext or TUI", async () => {
+		const events: string[] = [];
+		const host = new CollabHost(makeHeadlessContext(events));
+
+		await host.start("ws://localhost:8787");
+		expect(host.participants).toEqual([{ name: "rpc-host", role: "host" }]);
+		expect(events).toEqual(["participants:1"]);
+
+		await host.stop("test done");
+		expect(events).toEqual(["participants:1", "participants:0", "stopped"]);
+	});
+});

--- a/packages/coding-agent/test/rpc-collab.test.ts
+++ b/packages/coding-agent/test/rpc-collab.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	RpcCollabHostController,
+	type RpcCollabHostControllerContext,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-collab";
+import type { RpcCollabLifecycleFrame } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
+import { type InMemoryRelay, installInMemoryRelay, uninstallInMemoryRelay } from "./collab/helpers/in-memory-relay";
+
+function makeControllerContext(output: (frame: RpcCollabLifecycleFrame) => void): RpcCollabHostControllerContext {
+	return {
+		defaultRelayUrl: "ws://localhost:8787",
+		displayName: "rpc-host",
+		output,
+		sessionManager: {
+			getSessionId: () => "sess-rpc",
+			getCwd: () => "/workspace",
+			snapshotForReplication: () => ({
+				header: {
+					type: "session",
+					id: "sess-rpc",
+					timestamp: new Date().toISOString(),
+					cwd: "/workspace",
+				},
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			isAborting: false,
+			queuedMessageCount: 0,
+			sessionName: "headless",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+			getContextUsage: () => ({ tokens: 12, contextWindow: 100, percent: 12 }),
+		},
+	};
+}
+
+describe("RPC collaboration host controls", () => {
+	let relay: InMemoryRelay;
+
+	beforeEach(() => {
+		relay = installInMemoryRelay();
+	});
+	afterEach(() => uninstallInMemoryRelay());
+
+	it("starts one room idempotently, reports status, and stops it", async () => {
+		const frames: RpcCollabLifecycleFrame[] = [];
+		const controller = new RpcCollabHostController(makeControllerContext(frame => frames.push(frame)));
+
+		const started = await controller.start({});
+		expect(started).toMatchObject({ active: true, participants: [{ name: "rpc-host", role: "host" }] });
+		expect(started.joinUrl).toStartWith("ws://localhost:8787/");
+		expect(started.viewUrl).not.toBe(started.joinUrl);
+		expect(await controller.start({ relayUrl: "ws://ignored.example" })).toEqual(started);
+		expect(controller.status()).toEqual(started);
+		expect(frames.filter(frame => frame.state === "started")).toHaveLength(1);
+
+		await controller.stop("RPC client requested stop");
+		expect(controller.status()).toEqual({ active: false, participants: [] });
+		expect(frames.at(-1)).toEqual({
+			type: "collab_state",
+			state: "stopped",
+			reason: "RPC client requested stop",
+			room: { active: false, participants: [] },
+		});
+	});
+
+	it("rejects when the relay closes during startup without leaking session taps", async () => {
+		const frames: RpcCollabLifecycleFrame[] = [];
+		let subscriptions = 0;
+		const context = makeControllerContext(frame => frames.push(frame));
+		context.session.subscribe = () => {
+			subscriptions++;
+			return () => subscriptions--;
+		};
+		const controller = new RpcCollabHostController(context);
+		relay.failNextHostOnConnect(4001, "room closed during startup");
+
+		await expect(controller.start({})).rejects.toThrow("collaboration room ended while starting");
+		expect(controller.status()).toEqual({ active: false, participants: [] });
+		expect(subscriptions).toBe(0);
+		expect(frames.some(frame => frame.state === "started")).toBe(false);
+		expect(frames.filter(frame => frame.state === "failed")).toHaveLength(1);
+	});
+
+	it("emits a failed lifecycle frame when the relay closes the room", async () => {
+		const failed = Promise.withResolvers<RpcCollabLifecycleFrame>();
+		const controller = new RpcCollabHostController(
+			makeControllerContext(frame => {
+				if (frame.state === "failed") failed.resolve(frame);
+			}),
+		);
+		await controller.start({});
+
+		relay.failHost(4001, "room closed");
+
+		expect(await failed.promise).toEqual({
+			type: "collab_state",
+			state: "failed",
+			reason: "room closed",
+			room: { active: false, participants: [] },
+		});
+		expect(controller.status().active).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- extract a mode-neutral collaboration host context shared by TUI and RPC mode
- add typed RPC start/status/stop commands, client helpers, and lifecycle frames
- tear down collaboration rooms on RPC shutdown and cover startup/relay failure races

## Verification
- `bun run check:types` (`packages/coding-agent`)
- `bun test packages/coding-agent/test/rpc-collab.test.ts packages/coding-agent/test/rpc-client.test.ts packages/coding-agent/test/collab` (72 pass)
- isolated PTY smoke: source `omp join <local-capability-url>` joined a real local relay, appeared as participant 2, and `collab_stop` closed the room