### PR TITLE
feat(coding-agent): add browser network recording

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -336,6 +336,9 @@
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers
+- Degraded Mnemopi extraction (missing tiny/smol model) now shows a once-per-session warning banner naming the remediation setting, plus an extraction status line in /memory stats.
+- memory_recall session entries + info-level success logs attribute every memory resurfacing to injection, tool, or compaction — capture:resurface ratios are now measurable from disk.
+- Added opt-in Puppeteer browser network recording with bounded, sanitized HAR-compatible session artifacts; CMUX is not supported in v1.
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -4,6 +4,8 @@ Drives real Chromium tab; full puppeteer access via JS.
 - Static content? `read` the URL. Browser only for JS execution, auth, interactive actions.
 - `open` → `run` — tabs survive calls and subagents, open once reuse.
 - `run` scope: `page`, `browser`, `tab`, `display`, `assert`, `wait` available. `wait(fn)` polls until truthy — use instead of polling inside `tab.evaluate`.
+- `start_recording` begins a sanitized HAR capture for an open, supported tab. Optional `domains` scopes capture to exact http(s) origins; otherwise the current tab origin is used.
+- `stop_recording` persists the capture to an `artifact://` file and returns bounded counts, never captured traffic inline.
 
 - `tab` helpers (drop to raw puppeteer `page` for anything uncovered):
   Element handles: `tab.ref("e5")` / `tab.id(n)` return a handle you call methods on directly — `(await tab.id(n)).click()`. Handles are NOT selectors: `tab.click`/`type`/`fill`/`waitFor*` take STRING selectors only. Snapshot refs work in any selector slot: `tab.click("e5")` ≡ `tab.click("aria-ref=e5")`.
@@ -21,6 +23,16 @@ Drives real Chromium tab; full puppeteer access via JS.
 - `app.path` → NEVER tamper with a real desktop app (no stealth patches).
 - Selectors: CSS + puppeteer `aria/…`, `text/…`, `xpath/…`, `pierce/…`. Playwright-only pseudos (`:has-text()`, `:visible`) are REJECTED.
 </instruction>
+
+<recording>
+Two-phase, authorized network capture:
+- Recording is opt-in and explicit: approve `start_recording` on an open supported tab, drive the flow with `run`/interactions, then approve `stop_recording` to finalize it. `run` never starts or stops a recorder.
+- `start_recording` optionally scopes capture with exact http(s) origins (`domains`); the scope is fixed at start and never widens across navigation. Reproduce the exact requests you want captured after starting.
+- `stop_recording` flushes and persists a sanitized HAR to `artifact://<id>`. Read it back with `read artifact://<id>` when you need request/response detail; the tool result itself carries only the URI plus entry/body/truncation counts — never the captured traffic inline.
+- v1 supports only Puppeteer-backed headless, spawned-app, and connected tabs; CMUX is not supported. Responses served by a service worker or synthesized from the HTTP cache may not surface as page-target Network events, so they can be absent from the HAR. Force a cache-bypassing (hard) reload or disable the service worker when such a response must be captured.
+- Headers and bodies are sanitized (secrets/PII redacted) and bounded (entry/byte caps); bodies are captured only for JSON or form-encoded content types. An over-limit capture reports `truncated`, and omitted bodies are counted.
+- Client-derivation rule: when you turn a captured request into client code, NEVER hardcode captured auth material, CSRF tokens, signed URLs, account IDs, or other PII — those are per-session and are redacted in the artifact anyway. Parameterize approved runtime credentials and derive dynamic identifiers at call time.
+</recording>
 
 <critical>
 - MUST `open` before `run`. Default to `tab.observe()`; screenshot only for appearance. `code` runs with full Node access — not sandboxed.

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -1,6 +1,8 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample } from "@oh-my-pi/pi-ai";
-import { prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { prompt, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import browserDescription from "../prompts/tools/browser.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
@@ -9,7 +11,16 @@ import { truncateForPrompt } from "./approval";
 import { resolveCmuxKind } from "./browser/cmux/rpc";
 import { acquireBrowser, type BrowserHandle, type BrowserKind, type BrowserKindTag } from "./browser/registry";
 import type { Observation, ScreenshotResult } from "./browser/tab-protocol";
-import { acquireTab, dropHeadlessTabs, getTab, releaseAllTabs, releaseTab, runInTab } from "./browser/tab-supervisor";
+import {
+	acquireTab,
+	dropHeadlessTabs,
+	getTab,
+	releaseAllTabs,
+	releaseTab,
+	runInTab,
+	startTabRecording,
+	stopTabRecording,
+} from "./browser/tab-supervisor";
 import type { OutputMeta } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
 import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
@@ -36,7 +47,7 @@ const appSchema = type({
 });
 
 const browserSchema = type({
-	action: type("'open' | 'close' | 'run'").describe("operation"),
+	action: type("'open' | 'close' | 'run' | 'start_recording' | 'stop_recording'").describe("operation"),
 	"name?": type("string").describe("tab id (default 'main')"),
 	"url?": type("string").describe("url to open"),
 	"app?": appSchema,
@@ -50,6 +61,7 @@ const browserSchema = type({
 	),
 	"dialogs?": type("'accept' | 'dismiss'").describe("auto-handle dialogs"),
 	"code?": type("string").describe("js body to run in tab"),
+	"domains?": type("string[]").describe("recording scope: exact http(s) origins (default: the tab's current origin)"),
 	"timeout?": type("number").describe("timeout in seconds"),
 	"all?": type("boolean").describe("close every tab"),
 	"kill?": type("boolean").describe("also kill spawned-app browsers"),
@@ -69,6 +81,18 @@ export interface BrowserToolDetails {
 	screenshots?: ScreenshotResult[];
 	result?: string;
 	meta?: OutputMeta;
+	/** start_recording: normalized effective recording scope (origins). */
+	scope?: readonly string[];
+	/** stop_recording: artifact id holding the sanitized HAR (`artifact://<id>`); never the HAR itself. */
+	artifactId?: string;
+	/** stop_recording: bounded capture statistics; never the captured traffic. */
+	recording?: {
+		entryCount: number;
+		capturedBodyCount: number;
+		omittedBodyCount: number;
+		totalBytes: number;
+		truncated: boolean;
+	};
 }
 
 function resolveBrowserKind(params: BrowserParams, session: ToolSession): BrowserKind {
@@ -91,10 +115,61 @@ function resolveBrowserKind(params: BrowserParams, session: ToolSession): Browse
 }
 
 /**
- * Browser tool: stateful, multi-tab. Three actions:
+ * Fields that are meaningless for each recording action. The flat schema keeps every field
+ * optional (so intent injection + OpenAI strict-mode normalization stay satisfiable), so we
+ * reject action-irrelevant fields here rather than silently ignoring them.
+ */
+const RECORDING_DISALLOWED_FIELDS = {
+	start_recording: ["url", "app", "viewport", "wait_until", "dialogs", "code", "all", "kill"],
+	stop_recording: ["url", "app", "viewport", "wait_until", "dialogs", "code", "domains", "all", "kill"],
+} as const satisfies Record<"start_recording" | "stop_recording", readonly (keyof BrowserParams)[]>;
+
+/** Format provider-controlled recording origins without echoing invalid or secret-bearing input. */
+export function formatRecordingScopeForDisplay(domains: readonly unknown[]): string {
+	return domains
+		.map(domain => {
+			if (typeof domain !== "string") return "(invalid origin)";
+			try {
+				const url = new URL(domain);
+				if (
+					(url.protocol !== "http:" && url.protocol !== "https:") ||
+					url.username ||
+					url.password ||
+					url.pathname !== "/" ||
+					url.search ||
+					url.hash ||
+					url.hostname.includes("*")
+				) {
+					return "(invalid origin)";
+				}
+				return url.origin.toLowerCase();
+			} catch {
+				return "(invalid origin)";
+			}
+		})
+		.join(", ");
+}
+
+function assertBrowserParams(params: BrowserParams): void {
+	if (params.action !== "start_recording" && params.domains !== undefined) {
+		throw new ToolError('Field domains is only accepted for action "start_recording".');
+	}
+	assertRecordingParams(params);
+}
+function assertRecordingParams(params: BrowserParams): void {
+	if (params.action !== "start_recording" && params.action !== "stop_recording") return;
+	const disallowed = RECORDING_DISALLOWED_FIELDS[params.action].filter(field => params[field] !== undefined);
+	if (disallowed.length > 0) {
+		throw new ToolError(`Action ${JSON.stringify(params.action)} does not accept: ${disallowed.join(", ")}`);
+	}
+}
+
+/**
+ * Browser tool: stateful, multi-tab. Five actions:
  * - `open`  → acquire/create a named tab on a browser kind (headless | spawned | connected) and optionally goto a url.
  * - `close` → release a named tab (or all tabs); dispose browser when refcount hits 0.
  * - `run`   → execute JS code against an existing tab with `page`/`browser`/`tab` helpers in scope.
+ * - `start_recording` / `stop_recording` → capture the tab's sanitized network traffic to an `artifact://` HAR.
  */
 export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolDetails> {
 	readonly name = "browser";
@@ -110,11 +185,25 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 		if (typeof params.code === "string" && params.code.length > 0) {
 			lines.push(`Code:\n${truncateForPrompt(params.code)}`);
 		}
+		if (params.action === "start_recording") {
+			if (Array.isArray(params.domains) && params.domains.length > 0) {
+				lines.push(`Scope: ${truncateForPrompt(formatRecordingScopeForDisplay(params.domains))}`);
+			}
+			lines.push(
+				"Records this tab's network requests and responses. These may contain account or personal data " +
+					"(auth tokens, cookies, emails, account IDs) and will be sanitized and persisted to a bounded artifact file.",
+			);
+		} else if (params.action === "stop_recording") {
+			lines.push(
+				"Finalizes this tab's recording, persists the sanitized HAR to a bounded artifact file, and returns only its URI and summary counts.",
+			);
+		}
 		return lines;
 	};
 	readonly label = "Browser";
 	readonly loadMode = "discoverable";
-	readonly summary = "Control a headless browser to navigate and interact with web pages";
+	readonly summary =
+		"Control a headless browser to navigate, interact, and record network traffic to sanitized HAR artifacts";
 	readonly parameters = browserSchema;
 	readonly strict = true;
 
@@ -167,6 +256,14 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 			caption: "Close every tab and kill spawned-app processes",
 			call: { action: "close", all: true, kill: true },
 		},
+		{
+			caption: "Start a scoped sanitized network recording",
+			call: { action: "start_recording", name: "docs", domains: ["https://example.com"] },
+		},
+		{
+			caption: "Stop recording and persist its HAR artifact",
+			call: { action: "stop_recording", name: "docs" },
+		},
 	];
 
 	constructor(private readonly session: ToolSession) {}
@@ -194,7 +291,7 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 			const timeoutMs = timeoutSeconds * 1000;
 			const name = params.name ?? DEFAULT_TAB_NAME;
 			const details: BrowserToolDetails = { action: params.action, name };
-
+			assertBrowserParams(params);
 			switch (params.action) {
 				case "open":
 					return await this.#open(name, params, details, timeoutMs, signal);
@@ -202,6 +299,10 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 					return await this.#close(name, params, details, timeoutMs, signal);
 				case "run":
 					return await this.#run(name, params, details, timeoutMs, signal);
+				case "start_recording":
+					return await this.#startRecording(name, params, details, timeoutMs, signal);
+				case "stop_recording":
+					return await this.#stopRecording(name, details, timeoutMs, signal);
 				default:
 					throw new ToolError(`Unsupported action: ${(params as BrowserParams).action}`);
 			}
@@ -350,6 +451,74 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 		}
 		return toolResult(details).content(content).done();
 	}
+
+	async #startRecording(
+		name: string,
+		params: BrowserParams,
+		details: BrowserToolDetails,
+		timeoutMs: number,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<BrowserToolDetails>> {
+		const result = await startTabRecording(name, { domains: params.domains, timeoutMs, signal });
+		details.browser = result.backend;
+		const tab = getTab(name);
+		if (tab) details.url = tab.info.url;
+		details.scope = result.scope;
+
+		const scopeText = result.scope.length > 0 ? result.scope.join(", ") : "(current origin)";
+		const lines = [
+			`Recording network traffic on tab ${JSON.stringify(name)} (${result.backend})`,
+			`Scope: ${scopeText}`,
+			"Requests and responses within scope may include account or personal data; the capture is sanitized and " +
+				"saved to a bounded artifact when you stop the recording.",
+		];
+		details.result = lines.join("\n");
+		return toolResult(details).text(details.result).done();
+	}
+
+	async #stopRecording(
+		name: string,
+		details: BrowserToolDetails,
+		timeoutMs: number,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<BrowserToolDetails>> {
+		const result = await stopTabRecording(name, { timeoutMs, signal });
+		details.browser = result.backend;
+		const tab = getTab(name);
+		if (tab) details.url = tab.info.url;
+
+		// Persist the HAR to an artifact before surfacing anything: the captured
+		// traffic must never enter the tool text/details. Require both id and path,
+		// and never serialize the HAR when the slot is unavailable.
+		const alloc = await this.session.allocateOutputArtifact?.("browser-har");
+		if (!alloc?.id || !alloc.path) {
+			throw new ToolError(
+				`Recording on tab ${JSON.stringify(name)} stopped, but no artifact slot is available to persist the HAR.`,
+			);
+		}
+		try {
+			await writeHarArtifact(alloc.path, result.har);
+		} catch (error) {
+			throw new ToolError("Failed to persist browser recording artifact.", { cause: error });
+		}
+		details.artifactId = alloc.id;
+		details.recording = {
+			entryCount: result.entryCount,
+			capturedBodyCount: result.capturedBodyCount,
+			omittedBodyCount: result.omittedBodyCount,
+			totalBytes: result.totalBytes,
+			truncated: result.truncated,
+		};
+		const lines = [
+			`Stopped recording on tab ${JSON.stringify(name)} (${result.backend})`,
+			`Sanitized HAR saved to artifact://${alloc.id}`,
+			`Entries: ${result.entryCount} (bodies captured: ${result.capturedBodyCount}, omitted: ${result.omittedBodyCount})`,
+			`Approx sanitized bytes: ${result.totalBytes}${result.truncated ? " (truncated at capture limit)" : ""}`,
+			`Read it with: read artifact://${alloc.id}`,
+		];
+		details.result = lines.join("\n");
+		return toolResult(details).text(details.result).done();
+	}
 }
 
 /** Persist over-cap browser run output as a session artifact; mirrors the bash minimizer's save path. */
@@ -361,6 +530,87 @@ async function saveBrowserOutputArtifact(session: ToolSession, fullText: string)
 		return alloc.id;
 	} catch {
 		return undefined;
+	}
+}
+
+/**
+ * Injectable IO seam for {@link writeHarArtifact}. Defaults to real `node:fs/promises`
+ * primitives; a test may override any subset (e.g. force `EXDEV` on rename, or a size
+ * mismatch on stat) to exercise the cross-device and cleanup paths without `mock.module`.
+ */
+export interface HarArtifactIo {
+	writeExclusive0600(target: string, content: string, onCreated?: () => void): Promise<void>;
+	rename(from: string, to: string): Promise<void>;
+	stat(target: string): Promise<{ size: number }>;
+	rm(target: string): Promise<void>;
+}
+
+const defaultHarArtifactIo: HarArtifactIo = {
+	async writeExclusive0600(target, content, onCreated) {
+		// Exclusive create at 0600, write, flush to disk, close.
+		const handle = await fs.open(target, "wx", 0o600);
+		try {
+			onCreated?.();
+			await handle.writeFile(content);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	},
+	async rename(from, to) {
+		await fs.rename(from, to);
+	},
+	async stat(target) {
+		return { size: (await fs.stat(target)).size };
+	},
+	async rm(target) {
+		await fs.rm(target, { force: true });
+	},
+};
+
+let harArtifactIo: HarArtifactIo = defaultHarArtifactIo;
+
+/** Test-only: override the atomic HAR write primitives; pass `undefined` to restore the real fs seam. */
+export function setHarArtifactIoForTest(overrides: Partial<HarArtifactIo> | undefined): void {
+	harArtifactIo = overrides ? { ...defaultHarArtifactIo, ...overrides } : defaultHarArtifactIo;
+}
+
+/**
+ * Persist the sanitized HAR to `finalPath` atomically at 0600, matching the
+ * artifact manager's hidden-temp convention. Stage the JSON at a leading-dot
+ * random sibling, open it exclusively at 0600, fsync + close, then atomically
+ * rename. On `EXDEV` (cross-device rename), write the final path directly
+ * (exclusive, 0600), fsync, verify its byte size, then drop the sibling. Any
+ * failure removes the hidden/partial files, so no incomplete or
+ * over-permissioned artifact is ever left behind.
+ */
+async function writeHarArtifact(finalPath: string, har: Record<string, unknown>): Promise<void> {
+	const json = JSON.stringify(har);
+	const expectedBytes = Buffer.byteLength(json, "utf8");
+	const dir = path.dirname(finalPath);
+	const tmpPath = path.join(dir, `.${path.basename(finalPath)}.${Snowflake.next()}.tmp`);
+	let ownsFinalPath = false;
+	try {
+		await harArtifactIo.writeExclusive0600(tmpPath, json);
+		try {
+			await harArtifactIo.rename(tmpPath, finalPath);
+			ownsFinalPath = true;
+		} catch (renameError) {
+			const crossDevice = renameError instanceof Error && "code" in renameError && renameError.code === "EXDEV";
+			if (!crossDevice) throw renameError;
+			await harArtifactIo.writeExclusive0600(finalPath, json, () => {
+				ownsFinalPath = true;
+			});
+			const { size } = await harArtifactIo.stat(finalPath);
+			if (size !== expectedBytes) {
+				throw new ToolError(`HAR artifact verification failed: wrote ${size} of ${expectedBytes} bytes`);
+			}
+			await harArtifactIo.rm(tmpPath).catch(() => {});
+		}
+	} catch (error) {
+		await harArtifactIo.rm(tmpPath).catch(() => {});
+		if (ownsFinalPath) await harArtifactIo.rm(finalPath).catch(() => {});
+		throw error;
 	}
 }
 

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -367,6 +367,25 @@ function resolvePageClient(page: Page): PuppeteerCdpClient | null {
 	return typeof pageWithClient._client === "function" ? pageWithClient._client() : pageWithClient._client;
 }
 
+/**
+ * A page-scoped CDP session for network recording, or `null` when the page is no longer live.
+ * Puppeteer's private `_client()` is not stable across target lifecycle transitions, so use the
+ * public Page.createCDPSession() API instead.
+ */
+export interface PageCdpClientHandle {
+	readonly client: CDPSession;
+	readonly dispose: () => Promise<void>;
+}
+
+export async function pageCdpClient(page: Page): Promise<PageCdpClientHandle | null> {
+	try {
+		const client = await page.createCDPSession();
+		return { client, dispose: () => client.detach() };
+	} catch {
+		return null;
+	}
+}
+
 const patchedClients = new WeakSet<object>();
 
 function patchSourceUrl(page: Page): void {

--- a/packages/coding-agent/src/tools/browser/network-recorder.ts
+++ b/packages/coding-agent/src/tools/browser/network-recorder.ts
@@ -1,0 +1,568 @@
+const REDACTED = "[REDACTED]";
+const MAX_REDACTION_DEPTH = 8;
+
+export interface RecordingLimits {
+	readonly bodyContentTypes: ReadonlySet<string>;
+	readonly maxEntries: number;
+	readonly maxBodyBytes: number;
+	readonly maxTotalBytes: number;
+	readonly maxBodyWaitMs: number;
+}
+
+export interface NetworkRecorderOptions extends RecordingLimits {
+	readonly origins: ReadonlySet<string>;
+}
+
+export const DEFAULT_RECORDING_LIMITS: RecordingLimits = {
+	bodyContentTypes: new Set(["application/json", "application/x-www-form-urlencoded"]),
+	maxEntries: 500,
+	maxBodyBytes: 64 * 1024,
+	maxTotalBytes: 2 * 1024 * 1024,
+	maxBodyWaitMs: 1_000,
+};
+
+export interface RecordedRequest {
+	readonly requestId: string;
+	readonly url: string;
+	readonly method: string;
+	readonly headers: Readonly<Record<string, string>>;
+	readonly postData?: string;
+	/** CDP monotonic timestamp (seconds); used for elapsed timing. */
+	readonly timestamp: number;
+	/** CDP wall-clock time (epoch seconds); used for `startedDateTime`. */
+	readonly wallTime?: number;
+}
+
+export interface RecordedResponse {
+	readonly requestId: string;
+	readonly url: string;
+	readonly method?: string;
+	readonly status: number;
+	readonly statusText: string;
+	readonly headers: Readonly<Record<string, string>>;
+	readonly contentType?: string;
+	readonly timestamp: number;
+}
+
+export interface RecordingSummary {
+	readonly har: Record<string, unknown>;
+	readonly entryCount: number;
+	readonly capturedBodyCount: number;
+	readonly omittedBodyCount: number;
+	readonly totalBytes: number;
+	readonly truncated: boolean;
+}
+
+type BodyOmissionReason = "content-type" | "size" | "unavailable" | "timeout" | "correlation";
+type Header = { name: string; value: string };
+type SafeContent = { mimeType: string; size: number; text?: string };
+type Entry = {
+	requestId: string;
+	requestReceived: boolean;
+	requestUrl: string;
+	requestMethod: string;
+	requestHeaders: Header[];
+	requestPostData?: { mimeType: string; text: string };
+	requestTimestamp: number;
+	startedWallTime: number;
+	responseUrl: string;
+	responseStatus: number;
+	responseStatusText: string;
+	responseHeaders: Header[];
+	responseMimeType: string;
+	responseTimestamp: number;
+	responseReceived: boolean;
+	responseContent?: SafeContent;
+	bodyState: "pending" | "captured" | "omitted";
+	bodyOmission?: BodyOmissionReason;
+	requestBodyOmission?: BodyOmissionReason;
+};
+
+const SENSITIVE_KEY =
+	/^(?:authorization|proxy-authorization|cookie|set-cookie|token|access[_-]?token|refresh[_-]?token|id[_-]?token|code|state|nonce|code[_-]?verifier|code[_-]?challenge|assertion|api[_-]?key|apikey|x-api-key|key|client[_-]?secret|secret|sig|signature|session|auth|csrf|password|account(?:id)?|user(?:id)|email|org(?:id)?|customer(?:id)?|client[_-]?id|credential|bearer)$/i;
+const SENSITIVE_HEADER =
+	/(?:authorization|proxy-authorization|cookie|set-cookie|api[-_]?key|token|secret|password|signature|bearer|credential|x-goog-api-key|x-api-key|x-amzn-trace-id|x-ms-request-id|x-user-email|x-user-id|x-account-id|x-customer-id|x-org-id|cf-connecting-ip|x-forwarded-for)/i;
+const JWT_SHAPED = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const EMAIL_SHAPED = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const SENSITIVE_TOKEN =
+	/^(?:authorization|cookie|token|secret|password|passwd|pwd|passphrase|session|csrf|xsrf|credential|credentials|bearer|signature|assertion|nonce|apikey|jwt|email|auth|otp|totp|mfa)$/;
+const CREDENTIAL_VALUE = /^(?:bearer|basic|digest|negotiate|token|apikey)\s+[A-Za-z0-9+/_=.~-]{8,}$/i;
+// High-signal provider credential shapes (bounded lengths) that leak under benign key names or
+// header/body values and are missed by the JWT/email/scheme checks. Case-sensitive: the prefixes are literal.
+const CREDENTIAL_PATTERN =
+	/gh[pousr]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{60,}|sk_(?:live|test)_[A-Za-z0-9]{16,}|xox[baprse]-[0-9A-Za-z-]{10,}|(?:AKIA|ASIA)[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|npm_[A-Za-z0-9]{36}|-----BEGIN[A-Z0-9 ]*PRIVATE KEY-----/;
+const RELATIVE_URL_BASE = "http://redacted.invalid";
+const SAFE_PATH_SEGMENTS = new Set([
+	"api",
+	"v1",
+	"v2",
+	"items",
+	"item",
+	"cart",
+	"oauth",
+	"authorize",
+	"token",
+	"reset",
+	"verify",
+	"recovery",
+	"users",
+	"user",
+	"accounts",
+	"account",
+]);
+const TOKEN_PATH_PREFIXES: Record<string, true> = { reset: true, verify: true, recovery: true };
+// Plural PII collection parents whose immediate child is a per-subject identifier (numeric or short ID).
+const PII_ID_PARENTS: Record<string, true> = { users: true, accounts: true, customers: true, orgs: true };
+
+function byteLength(value: string): number {
+	return Buffer.byteLength(value, "utf8");
+}
+
+function normalizeOrigin(value: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		throw new Error("Recording origin could not be parsed as an absolute URL");
+	}
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new Error("Recording origin must use the http or https scheme");
+	}
+	if (parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash) {
+		throw new Error("Recording origin must be a bare http(s) origin without credentials, path, query, or fragment");
+	}
+	return parsed.origin.toLowerCase();
+}
+
+export function normalizeRecordingOrigins(origins: Iterable<string>): ReadonlySet<string> {
+	const normalized = new Set<string>();
+	for (const origin of origins) normalized.add(normalizeOrigin(origin));
+	return normalized;
+}
+
+function isInScope(value: string, origins: ReadonlySet<string>): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		return false;
+	}
+	return (parsed.protocol === "http:" || parsed.protocol === "https:") && origins.has(parsed.origin.toLowerCase());
+}
+
+function sensitiveKey(key: string): boolean {
+	const tokens = key
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.split(/[\s._-]+/)
+		.filter(Boolean)
+		.map(token => token.toLowerCase());
+	if (tokens.length === 0) return false;
+	if (tokens.some(token => SENSITIVE_TOKEN.test(token))) return true;
+	return SENSITIVE_KEY.test(tokens.join("")) || SENSITIVE_KEY.test(tokens.join("-"));
+}
+
+function sensitiveValue(value: string): boolean {
+	return (
+		JWT_SHAPED.test(value) ||
+		EMAIL_SHAPED.test(value) ||
+		CREDENTIAL_VALUE.test(value) ||
+		CREDENTIAL_PATTERN.test(value)
+	);
+}
+
+function redactValue(value: string, key?: string): string {
+	return (key && sensitiveKey(key)) || sensitiveValue(value) ? REDACTED : value;
+}
+
+function redactAny(value: unknown, depth = 0, key?: string): unknown {
+	if (depth > MAX_REDACTION_DEPTH) return REDACTED;
+	if (typeof value === "string") return redactValue(value, key);
+	if (Array.isArray(value)) return value.map(item => redactAny(item, depth + 1));
+	if (value && typeof value === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [childKey, childValue] of Object.entries(value)) {
+			result[childKey] = sensitiveKey(childKey) ? REDACTED : redactAny(childValue, depth + 1, childKey);
+		}
+		return result;
+	}
+	return value;
+}
+
+function redactUrl(raw: string): string {
+	let parsed: URL;
+	let relative = false;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		try {
+			parsed = new URL(raw, RELATIVE_URL_BASE);
+			relative = true;
+		} catch {
+			return REDACTED;
+		}
+	}
+	parsed.username = "";
+	parsed.password = "";
+	parsed.search = "";
+	parsed.hash = "";
+	const segments = parsed.pathname.split("/");
+	// Matrix/path parameters (`;key=value`, e.g. jsessionid) can carry secrets; drop them like the query.
+	for (let index = 0; index < segments.length; index++) {
+		const semicolon = segments[index].indexOf(";");
+		if (semicolon !== -1) segments[index] = segments[index].slice(0, semicolon);
+	}
+	for (let index = 0; index < segments.length; index++) {
+		const segment = segments[index];
+		if (!segment) continue;
+		let decoded: string;
+		let previous: string;
+		try {
+			decoded = decodeURIComponent(segment);
+			previous = segments[index - 1] ? decodeURIComponent(segments[index - 1]).toLowerCase() : "";
+		} catch {
+			segments[index] = REDACTED;
+			continue;
+		}
+		const opaque = decoded.length > 16 && /^[A-Za-z0-9_-]+$/.test(decoded);
+		if (
+			sensitiveKey(decoded) ||
+			sensitiveKey(previous) ||
+			sensitiveValue(decoded) ||
+			TOKEN_PATH_PREFIXES[previous] === true ||
+			// A short/numeric per-subject ID directly under a plural PII collection parent (users/accounts/customers/orgs).
+			(PII_ID_PARENTS[previous] === true &&
+				(/^\d+$/.test(decoded) ||
+					(decoded.length <= 24 && /\d/.test(decoded) && /^[A-Za-z0-9_.-]+$/.test(decoded)))) ||
+			(opaque && !SAFE_PATH_SEGMENTS.has(decoded.toLowerCase()))
+		) {
+			segments[index] = REDACTED;
+		}
+	}
+	parsed.pathname = segments.join("/");
+	return relative ? parsed.pathname : parsed.toString();
+}
+
+const URL_VALUE_HEADERS: Record<string, true> = { referer: true, location: true, "content-location": true };
+
+function normalizeHeaders(headers: Readonly<Record<string, string>>): Header[] {
+	const result: Header[] = [];
+	for (const [name, rawValue] of Object.entries(headers)) {
+		const lowerName = name.toLowerCase();
+		let value: string;
+		if (SENSITIVE_HEADER.test(lowerName)) value = REDACTED;
+		else if (URL_VALUE_HEADERS[lowerName] === true) value = redactUrl(rawValue);
+		// Link: `<url>; rel=...` (repeatable) — redact each angle-bracketed target.
+		else if (lowerName === "link")
+			value = rawValue.replace(/<([^>]*)>/g, (_match, url: string) => `<${redactUrl(url)}>`);
+		// Refresh: `<seconds>; url=<target>` — redact only the target, keep the delay.
+		else if (lowerName === "refresh") {
+			value = rawValue.replace(
+				/(\burl\s*=\s*)(["']?)(.*?)\2\s*$/i,
+				(_match, prefix: string, quote: string, target: string) => `${prefix}${quote}${redactUrl(target)}${quote}`,
+			);
+		} else value = redactValue(rawValue);
+		result.push({ name: lowerName, value });
+	}
+	return result;
+}
+
+function contentType(headers: Readonly<Record<string, string>>, explicit?: string): string {
+	const value = explicit ?? Object.entries(headers).find(([name]) => name.toLowerCase() === "content-type")?.[1] ?? "";
+	return value.split(";", 1)[0].trim().toLowerCase();
+}
+
+function sanitizeBody(raw: string, mimeType: string): string {
+	if (mimeType === "application/x-www-form-urlencoded") {
+		const values: Record<string, unknown> = {};
+		for (const [key, value] of new URLSearchParams(raw))
+			values[key] = sensitiveKey(key) ? REDACTED : redactValue(value, key);
+		return JSON.stringify(values);
+	}
+	try {
+		return JSON.stringify(redactAny(JSON.parse(raw)));
+	} catch {
+		return sensitiveValue(raw) ? REDACTED : raw;
+	}
+}
+
+function makeHarEntry(entry: Entry): Record<string, unknown> {
+	const request: Record<string, unknown> = {
+		method: entry.requestMethod,
+		url: redactUrl(entry.requestUrl),
+		headers: entry.requestHeaders,
+	};
+	if (entry.requestPostData)
+		request.postData = { mimeType: entry.requestPostData.mimeType, text: entry.requestPostData.text };
+	const elapsed = Math.max(0, (entry.responseTimestamp - entry.requestTimestamp) * 1000);
+	return {
+		startedDateTime: new Date(entry.startedWallTime * 1000).toISOString(),
+		time: elapsed,
+		request,
+		response: {
+			status: entry.responseStatus,
+			statusText: entry.responseStatusText,
+			headers: entry.responseHeaders,
+			content: entry.responseContent ?? { mimeType: entry.responseMimeType, size: 0 },
+		},
+		timings: { send: 0, wait: elapsed, receive: 0 },
+	};
+}
+
+function makeHar(entries: readonly Entry[]): Record<string, unknown> {
+	return { log: { version: "1.2", creator: { name: "oh-my-pi", version: "1" }, entries: entries.map(makeHarEntry) } };
+}
+
+function mergeHeaderList(base: Header[], overlay: Header[]): Header[] {
+	const byName = new Map<string, string>();
+	for (const header of base) byName.set(header.name, header.value);
+	for (const header of overlay) byName.set(header.name, header.value);
+	return [...byName].map(([name, value]) => ({ name, value }));
+}
+
+export class NetworkRecorder {
+	#entries = new Map<string, Entry>();
+	#pendingBodies = new Map<string, string>();
+	#pendingBodyBytes = 0;
+	#pendingOmissions = new Map<string, BodyOmissionReason>();
+	#omittedBodyCount = 0;
+	#truncated = false;
+	#disposed = false;
+	#finished: RecordingSummary | undefined;
+	readonly #options: NetworkRecorderOptions;
+
+	constructor(options: NetworkRecorderOptions) {
+		const minimumBytes = byteLength(JSON.stringify(makeHar([])));
+		if (options.maxTotalBytes < minimumBytes)
+			throw new Error("maxTotalBytes is smaller than the minimal HAR envelope");
+		this.#options = { ...options, origins: normalizeRecordingOrigins(options.origins) };
+	}
+
+	#assertActive(): void {
+		if (this.#disposed) throw new Error("Network recorder has been disposed");
+		if (this.#finished) throw new Error("Network recorder has finished");
+	}
+
+	recordRequest(request: RecordedRequest): void {
+		this.#assertActive();
+		if (!isInScope(request.url, this.#options.origins)) return;
+		if (this.#entries.has(request.requestId)) return;
+		if (this.#entries.size >= this.#options.maxEntries) {
+			this.#truncated = true;
+			return;
+		}
+		const mimeType = contentType(request.headers);
+		const entry: Entry = {
+			requestId: request.requestId,
+			requestReceived: true,
+			requestUrl: request.url,
+			requestMethod: request.method,
+			requestHeaders: normalizeHeaders(request.headers),
+			requestTimestamp: request.timestamp,
+			startedWallTime: request.wallTime ?? Date.now() / 1000,
+			responseUrl: request.url,
+			responseStatus: 0,
+			responseStatusText: "",
+			responseHeaders: [],
+			responseMimeType: mimeType,
+			responseTimestamp: request.timestamp,
+			responseReceived: false,
+			bodyState: "pending",
+		};
+		if (request.postData !== undefined) {
+			if (!this.#options.bodyContentTypes.has(mimeType)) this.#omitRequestBody(entry, "content-type");
+			else if (byteLength(request.postData) > this.#options.maxBodyBytes) this.#omitRequestBody(entry, "size");
+			else entry.requestPostData = { mimeType, text: sanitizeBody(request.postData, mimeType) };
+		}
+		this.#entries.set(request.requestId, entry);
+		const pendingOmission = this.#pendingOmissions.get(request.requestId);
+		if (pendingOmission !== undefined) {
+			this.#pendingOmissions.delete(request.requestId);
+			this.#omit(entry, pendingOmission, true);
+		}
+	}
+
+	recordResponse(response: RecordedResponse): void {
+		this.#assertActive();
+		if (!isInScope(response.url, this.#options.origins)) return;
+		let entry = this.#entries.get(response.requestId);
+		if (!entry) {
+			if (this.#entries.size >= this.#options.maxEntries) {
+				this.#truncated = true;
+				return;
+			}
+			entry = {
+				requestId: response.requestId,
+				requestReceived: false,
+				requestUrl: response.url,
+				requestMethod: response.method ?? "UNKNOWN",
+				requestHeaders: [],
+				requestTimestamp: response.timestamp,
+				startedWallTime: Date.now() / 1000,
+				responseUrl: response.url,
+				responseStatus: response.status,
+				responseStatusText: response.statusText,
+				responseHeaders: normalizeHeaders(response.headers),
+				responseMimeType: contentType(response.headers, response.contentType),
+				responseTimestamp: response.timestamp,
+				responseReceived: true,
+				bodyState: "pending",
+			};
+			this.#entries.set(response.requestId, entry);
+			const pendingOmission = this.#pendingOmissions.get(response.requestId);
+			if (pendingOmission !== undefined) {
+				this.#pendingOmissions.delete(response.requestId);
+				this.#omit(entry, pendingOmission, true);
+			} else {
+				this.#omit(entry, "correlation");
+			}
+		} else {
+			entry.responseUrl = response.url;
+			entry.responseStatus = response.status;
+			entry.responseStatusText = response.statusText;
+			entry.responseHeaders = normalizeHeaders(response.headers);
+			entry.responseMimeType = contentType(response.headers, response.contentType);
+			entry.responseTimestamp = response.timestamp;
+			entry.responseReceived = true;
+			if (response.method) entry.requestMethod = response.method;
+		}
+		const pendingBody = this.#pendingBodies.get(response.requestId);
+		if (pendingBody !== undefined) {
+			this.#pendingBodies.delete(response.requestId);
+			this.#pendingBodyBytes -= byteLength(pendingBody);
+			this.#attachBody(entry, pendingBody);
+		}
+	}
+
+	recordRequestExtraHeaders(requestId: string, headers: Readonly<Record<string, string>>): boolean {
+		this.#assertActive();
+		const entry = this.#entries.get(requestId);
+		if (!entry?.requestReceived) return false;
+		entry.requestHeaders = mergeHeaderList(entry.requestHeaders, normalizeHeaders(headers));
+		return true;
+	}
+
+	recordResponseExtraHeaders(requestId: string, headers: Readonly<Record<string, string>>): boolean {
+		this.#assertActive();
+		const entry = this.#entries.get(requestId);
+		if (!entry?.responseReceived) return false;
+		entry.responseHeaders = mergeHeaderList(entry.responseHeaders, normalizeHeaders(headers));
+		return true;
+	}
+
+	recordResponseBody(requestId: string, body: string): void {
+		this.#assertActive();
+		const entry = this.#entries.get(requestId);
+		if (!entry?.responseReceived) {
+			this.#storePendingBody(requestId, body);
+			return;
+		}
+		this.#attachBody(entry, body);
+	}
+	recordBodyOmitted(requestId: string, reason: BodyOmissionReason): void {
+		this.#assertActive();
+		const entry = this.#entries.get(requestId);
+		if (entry) {
+			this.#omit(entry, reason);
+			return;
+		}
+		if (!this.#pendingOmissions.has(requestId) && !this.#pendingBodies.has(requestId)) {
+			this.#pendingOmissions.set(requestId, reason);
+			this.#omittedBodyCount++;
+		}
+	}
+
+	#storePendingBody(requestId: string, body: string): void {
+		if (this.#pendingOmissions.has(requestId) || this.#pendingBodies.has(requestId)) return;
+		const bodyBytes = byteLength(body);
+		const minimumBytes = byteLength(JSON.stringify(makeHar([])));
+		const availableBytes = this.#options.maxTotalBytes - minimumBytes;
+		if (
+			bodyBytes > this.#options.maxBodyBytes ||
+			bodyBytes > availableBytes ||
+			this.#pendingBodies.size >= this.#options.maxEntries ||
+			this.#pendingBodyBytes + bodyBytes > availableBytes
+		) {
+			this.#pendingOmissions.set(
+				requestId,
+				this.#pendingBodies.size >= this.#options.maxEntries ? "correlation" : "size",
+			);
+			this.#omittedBodyCount++;
+			return;
+		}
+		this.#pendingBodies.set(requestId, body);
+		this.#pendingBodyBytes += bodyBytes;
+	}
+
+	#omit(entry: Entry, reason: BodyOmissionReason, alreadyCounted = false): void {
+		if (entry.bodyState === "captured" || entry.bodyState === "omitted") return;
+		entry.bodyState = "omitted";
+		entry.bodyOmission = reason;
+		if (!alreadyCounted) this.#omittedBodyCount++;
+	}
+	#omitRequestBody(entry: Entry, reason: BodyOmissionReason): void {
+		if (entry.requestBodyOmission) return;
+		entry.requestBodyOmission = reason;
+		this.#omittedBodyCount++;
+	}
+
+	#attachBody(entry: Entry, body: string): void {
+		if (entry.bodyState === "omitted" || entry.bodyState === "captured") return;
+		if (!this.#options.bodyContentTypes.has(entry.responseMimeType)) {
+			this.#omit(entry, "content-type");
+			return;
+		}
+		if (byteLength(body) > this.#options.maxBodyBytes) {
+			this.#truncated = true;
+			this.#omit(entry, "size");
+			return;
+		}
+		entry.responseContent = {
+			mimeType: entry.responseMimeType,
+			size: byteLength(body),
+			text: sanitizeBody(body, entry.responseMimeType),
+		};
+		entry.bodyState = "captured";
+	}
+	finish(): RecordingSummary {
+		if (this.#finished) return this.#finished;
+		if (this.#disposed) throw new Error("Network recorder has been disposed");
+		for (const requestId of this.#pendingBodies.keys()) if (!this.#entries.has(requestId)) this.#omittedBodyCount++;
+		this.#pendingBodies.clear();
+		this.#pendingBodyBytes = 0;
+		for (const entry of this.#entries.values()) if (entry.bodyState === "pending") this.#omit(entry, "unavailable");
+		const allEntries = [...this.#entries.values()];
+		let selected = allEntries;
+		let har = makeHar(selected);
+		let serialized = JSON.stringify(redactAny(har)) as string;
+		while (byteLength(serialized) > this.#options.maxTotalBytes && selected.length > 0) {
+			this.#truncated = true;
+			selected = selected.slice(0, -1);
+			har = makeHar(selected);
+			serialized = JSON.stringify(redactAny(har)) as string;
+		}
+		const droppedBodyCount = allEntries.slice(selected.length).filter(entry => entry.bodyState === "captured").length;
+		this.#omittedBodyCount += droppedBodyCount;
+		const capturedBodyCount = selected.filter(entry => entry.bodyState === "captured").length;
+		this.#finished = {
+			har: JSON.parse(serialized) as Record<string, unknown>,
+			entryCount: selected.length,
+			capturedBodyCount,
+			omittedBodyCount: this.#omittedBodyCount,
+			totalBytes: byteLength(serialized),
+			truncated: this.#truncated || selected.length !== allEntries.length,
+		};
+		this.#entries.clear();
+		this.#pendingBodies.clear();
+		this.#pendingBodyBytes = 0;
+		this.#pendingOmissions.clear();
+		return this.#finished;
+	}
+
+	dispose(): void {
+		this.#disposed = true;
+		this.#entries.clear();
+		this.#pendingBodies.clear();
+		this.#pendingBodyBytes = 0;
+		this.#pendingOmissions.clear();
+	}
+}

--- a/packages/coding-agent/src/tools/browser/render.ts
+++ b/packages/coding-agent/src/tools/browser/render.ts
@@ -11,16 +11,18 @@ import type { RenderResultOptions } from "../../extensibility/custom-tools/types
 import type { Theme } from "../../modes/theme/theme";
 import { Hasher, isFramedBlockComponent, markFramedBlockComponent, renderCodeCell, renderStatusLine } from "../../tui";
 import type { BrowserToolDetails } from "../browser";
+import { formatRecordingScopeForDisplay } from "../browser";
 import { formatStyledTruncationWarning, stripOutputNotice } from "../output-meta";
-import { replaceTabs, shortenPath } from "../render-utils";
+import { replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../render-utils";
 
 const BROWSER_DEFAULT_PREVIEW_LINES = 10;
 
 interface BrowserRenderArgs {
-	action?: "open" | "close" | "run";
+	action?: "open" | "close" | "run" | "start_recording" | "stop_recording";
 	name?: string;
 	url?: string;
 	code?: string;
+	domains?: string[];
 	all?: boolean;
 	kill?: boolean;
 	app?: { path?: string; cdp_url?: string; target?: string; cmux?: boolean; surface?: string };
@@ -179,6 +181,44 @@ function renderOpenOrCloseLine(
 	return new Text([header, ...outputLines].join("\n"), 0, 0);
 }
 
+function renderRecordingLine(
+	args: BrowserRenderArgs,
+	details: BrowserToolDetails | undefined,
+	isPartial: boolean,
+	isError: boolean,
+	output: string,
+	theme: Theme,
+): Component {
+	const action = details?.action ?? args.action;
+	const status = cellStatus(isPartial, isError);
+	const icon =
+		status === "complete" ? "done" : status === "error" ? "error" : status === "running" ? "running" : "pending";
+
+	const verb = action === "stop_recording" ? "Stop recording" : "Start recording";
+	const title = `${verb} ${tabLabel(args, details)}`;
+
+	const meta: string[] = [];
+	const browserDesc = describeBrowser(args, details);
+	if (browserDesc) meta.push(browserDesc);
+	if (action === "stop_recording") {
+		if (details?.artifactId) meta.push(`artifact://${details.artifactId}`);
+	} else {
+		// Provider-controlled domains are normalized or replaced with a generic marker before rendering.
+		const scope = details?.scope ?? args.domains;
+		if (scope && scope.length > 0) {
+			meta.push(truncateToWidth(replaceTabs(formatRecordingScopeForDisplay(scope)), TRUNCATE_LENGTHS.CONTENT));
+		}
+	}
+
+	const header =
+		status === "complete"
+			? renderStatusLine({ iconOverride: theme.styledSymbol("tool.browser", "accent"), title, meta }, theme)
+			: renderStatusLine({ icon, title, meta }, theme);
+	if (!output) return new Text(header, 0, 0);
+	const outputLines = output.split("\n").map(line => theme.fg("toolOutput", replaceTabs(line)));
+	return new Text([header, ...outputLines].join("\n"), 0, 0);
+}
+
 function extractTextOutput(content: Array<{ type: string; text?: string }> | undefined): string {
 	if (!content) return "";
 	const text = content
@@ -195,6 +235,9 @@ export const browserToolRenderer = {
 		const action = args.action;
 		if (action === "run") {
 			return renderRunCell(args, undefined, options, "", false, theme);
+		}
+		if (action === "start_recording" || action === "stop_recording") {
+			return renderRecordingLine(args, undefined, options.isPartial, false, "", theme);
 		}
 		return renderOpenOrCloseLine(args, undefined, options.isPartial, false, "", theme);
 	},
@@ -217,6 +260,9 @@ export const browserToolRenderer = {
 				: undefined;
 			component = appendLine(component, truncationWarning);
 			return component;
+		}
+		if (action === "start_recording" || action === "stop_recording") {
+			return renderRecordingLine(argsObj, details, options.isPartial, isError, output, theme);
 		}
 		return renderOpenOrCloseLine(argsObj, details, options.isPartial, isError, output, theme);
 	},

--- a/packages/coding-agent/src/tools/browser/tab-protocol.ts
+++ b/packages/coding-agent/src/tools/browser/tab-protocol.ts
@@ -1,4 +1,5 @@
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { RecordingLimits, RecordingSummary } from "./network-recorder";
 
 export type Transferable = Bun.Transferable;
 
@@ -74,6 +75,9 @@ export type WorkerInbound =
 	| { type: "run"; id: string; name: string; code: string; timeoutMs: number; session: SessionSnapshot }
 	| { type: "abort"; id: string; expectedCleanup?: boolean }
 	| { type: "tool-reply"; id: string; reply: ToolReply }
+	| { type: "recording-start"; id: string; domains?: readonly string[]; limits?: Partial<RecordingLimits> }
+	| { type: "recording-stop"; id: string; timeoutMs: number }
+	| { type: "recording-cancel"; id: string }
 	| { type: "close" };
 
 export interface ReadyInfo {
@@ -106,6 +110,10 @@ export type WorkerOutbound =
 	| { type: "result"; id: string; ok: false; error: RunErrorPayload }
 	| { type: "tool-call"; id: string; runId: string; name: string; args: unknown }
 	| { type: "log"; level: "debug" | "warn" | "error"; msg: string; meta?: Record<string, unknown> }
+	| { type: "recording-started"; id: string; scope: string[]; limits: RecordingLimits }
+	| { type: "recording-stopped"; id: string; summary: RecordingSummary }
+	| { type: "recording-canceled"; id: string }
+	| { type: "recording-error"; id: string; error: RunErrorPayload }
 	| { type: "closed" };
 
 export interface Transport {

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -9,6 +9,7 @@ import { pickElectronTarget } from "./attach";
 import { CmuxTab, runCmuxCode } from "./cmux/cmux-tab";
 import { mapWaitUntil } from "./cmux/rpc";
 import { DEFAULT_VIEWPORT } from "./launch";
+import type { RecordingLimits, RecordingSummary } from "./network-recorder";
 import {
 	type BrowserHandle,
 	type BrowserKindTag,
@@ -32,7 +33,7 @@ import type {
 // Coding-agent binary/bundle workers route through the CLI entrypoint with a
 // hidden argv mode, so compiled/npm builds only need one JavaScript entry.
 
-interface WorkerHandle {
+export interface WorkerHandle {
 	send(msg: WorkerInbound, transferList?: Transferable[]): void;
 	onMessage(handler: (msg: WorkerOutbound) => void): () => void;
 	onError(handler: (error: Error) => void): () => void;
@@ -60,6 +61,21 @@ export interface PendingRun {
 	closeAc?: AbortController;
 }
 
+/** Phase of a tab's single active network recording; undefined means no recording. */
+export type TabRecordingPhase = "starting" | "active" | "stopping";
+
+/**
+ * A recording control op (start/stop/cancel) awaiting its worker reply. Bound to the exact
+ * worker instance + generation that issued it so a reply from a superseded worker (after a
+ * recycle/replacement/kill) can never settle it or corrupt the current recording.
+ */
+interface PendingControl {
+	resolve(msg: WorkerOutbound): void;
+	reject(error: unknown): void;
+	worker: WorkerHandle;
+	generation: number;
+}
+
 interface TabSessionBase<TBrowser extends BrowserHandle = BrowserHandle> {
 	name: string;
 	browser: TBrowser;
@@ -81,6 +97,15 @@ interface TabSessionBase<TBrowser extends BrowserHandle = BrowserHandle> {
 export interface WorkerTabSession extends TabSessionBase<PuppeteerBrowserHandle> {
 	backend: "worker";
 	worker: WorkerHandle;
+	/** Phase of this tab's single active/in-flight network recording, if any. */
+	recording?: TabRecordingPhase;
+}
+
+interface ManagedWorkerTabSession extends WorkerTabSession {
+	/** Monotonic counter bumped on every worker replacement/teardown; see {@link PendingControl}. */
+	workerGeneration: number;
+	/** Pending recording control ops keyed by controlId (`recording-<snowflake>`). */
+	controls: Map<string, PendingControl>;
 }
 
 export interface CmuxTabSession extends TabSessionBase<CmuxBrowserHandle> {
@@ -127,7 +152,7 @@ export interface ReleaseTabOptions {
 	timeoutMs?: number;
 }
 
-const tabs = new Map<string, TabSession>();
+const tabs = new Map<string, ManagedWorkerTabSession | CmuxTabSession>();
 // Per-name acquisition chain: serializes concurrent `acquireTab` calls for the
 // same tab name so the existence check and `tabs.set` (separated by several
 // awaits) cannot interleave and leak a worker + browser refCount.
@@ -298,7 +323,7 @@ async function acquireTabImpl(
 
 	holdBrowser(browser);
 	if (tempHold) await releaseBrowser(browser, { kill: false });
-	const tab: WorkerTabSession = {
+	const tab: ManagedWorkerTabSession = {
 		name,
 		browser,
 		targetId: info.targetId,
@@ -310,8 +335,10 @@ async function acquireTabImpl(
 		dialogPolicy: opts.dialogs,
 		kindTag: browser.kind.kind,
 		ownerSessionId: opts.ownerSessionId,
+		workerGeneration: 0,
+		controls: new Map(),
 	};
-	worker.onMessage(msg => handleTabMessage(tab, msg));
+	attachLongLivedHandlers(tab, worker);
 	tabs.set(name, tab);
 	return { tab, created: true };
 }
@@ -525,6 +552,13 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 	const wasAlive = tab.state === "alive";
 	tab.state = "dead";
 	const closeError = postmortem.markExpectedCleanupError(new ToolError(`Tab ${JSON.stringify(name)} was closed`));
+	if (tab.backend === "worker") {
+		// Retire the worker generation and settle recording controls BEFORE the worker instance is
+		// terminated, so no late reply can resolve a control or revive recording state (issue INV-579).
+		bumpWorkerGeneration(tab);
+		tab.recording = undefined;
+		settleAllControlOps(tab, closeError);
+	}
 	for (const [id, pending] of tab.pending) {
 		if (tab.backend === "worker") {
 			try {
@@ -660,6 +694,377 @@ export function getTabsMapForTest(): ReadonlyMap<string, TabSession> {
 	return tabs;
 }
 
+// ---------------------------------------------------------------------------
+// Network recording control (INV-579)
+// ---------------------------------------------------------------------------
+
+/** Bound on the `recording-cancel` handshake after a control op is abandoned. */
+const RECORDING_CANCEL_MS = 250;
+
+export interface StartRecordingOptions {
+	domains?: readonly string[];
+	limits?: Partial<RecordingLimits>;
+	signal?: AbortSignal;
+	timeoutMs: number;
+}
+
+export interface StopRecordingOptions {
+	signal?: AbortSignal;
+	timeoutMs: number;
+}
+
+export interface StartRecordingResult {
+	scope: readonly string[];
+	backend: BrowserKindTag;
+	tabName: string;
+}
+
+export interface StopRecordingResult extends RecordingSummary {
+	backend: BrowserKindTag;
+	tabName: string;
+}
+
+/** Register both long-lived worker handlers (message dispatch + failure) for a tab's worker. */
+function attachLongLivedHandlers(tab: ManagedWorkerTabSession, worker: WorkerHandle): void {
+	worker.onMessage(msg => handleTabMessage(tab, worker, msg));
+	worker.onError(error => onWorkerFailure(tab, worker, error));
+}
+
+/**
+ * Long-lived worker `error`/`closed` handler. A worker that dies or closes outside an
+ * intentional release makes the tab unusable: settle every pending control, discard the
+ * active recording, and mark the tab dead so future runs/starts reject until it is
+ * reacquired. Messages from a superseded worker instance are ignored.
+ */
+function onWorkerFailure(tab: ManagedWorkerTabSession, sourceWorker: WorkerHandle, error: unknown): void {
+	if (sourceWorker !== tab.worker) return;
+	settleAllControlOps(tab, error);
+	tab.recording = undefined;
+	tab.state = "dead";
+}
+
+/** Reject and clear every pending recording control on a tab. */
+function settleAllControlOps(tab: ManagedWorkerTabSession, error: unknown): void {
+	if (tab.controls.size === 0) return;
+	const controls = [...tab.controls.values()];
+	tab.controls.clear();
+	for (const control of controls) control.reject(error);
+}
+
+/** Reject and clear only the controls at or below `generation` — the retired worker's ops. */
+function settleControlsUpToGeneration(tab: ManagedWorkerTabSession, generation: number, error: unknown): void {
+	const stale = [...tab.controls].filter(([, control]) => control.generation <= generation);
+	if (stale.length === 0) return;
+	for (const [id] of stale) tab.controls.delete(id);
+	for (const [, control] of stale) control.reject(error);
+}
+
+function bumpWorkerGeneration(tab: ManagedWorkerTabSession): void {
+	tab.workerGeneration += 1;
+}
+
+function requireWorkerTab(name: string): ManagedWorkerTabSession {
+	const tab = tabs.get(name);
+	if (!tab || tab.state === "dead") {
+		const killed = killedTabs.get(name);
+		throw new ToolError(
+			killed
+				? `Tab ${JSON.stringify(name)} was killed: ${killed}. Reopen it.`
+				: `Tab ${JSON.stringify(name)} is not alive. Open it first with action:"open".`,
+		);
+	}
+	if (tab.backend !== "worker") {
+		throw new ToolError(`Network recording is not supported for the ${tab.kindTag} browser backend`);
+	}
+	return tab;
+}
+
+/**
+ * Validate an explicit recording domain as an exact HTTP(S) origin: reject credentials,
+ * paths, queries, fragments, wildcards, and non-HTTP(S)/opaque schemes. Returns the
+ * normalized (lowercased) origin. Omitted domains are resolved live by the worker instead.
+ */
+function validateRecordingOrigin(raw: string, index: number): string {
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new ToolError(`Invalid recording domain at index ${index}: expected an http(s) origin`);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new ToolError(`Recording domain at index ${index} must use an http(s) scheme`);
+	}
+	if (url.username || url.password) {
+		throw new ToolError(`Recording domain at index ${index} must not include credentials`);
+	}
+	if (url.pathname !== "/") {
+		throw new ToolError(`Recording domain at index ${index} must not include a path`);
+	}
+	if (url.search) {
+		throw new ToolError(`Recording domain at index ${index} must not include a query string`);
+	}
+	if (url.hash) {
+		throw new ToolError(`Recording domain at index ${index} must not include a fragment`);
+	}
+	if (url.hostname.includes("*")) {
+		throw new ToolError(`Recording domain at index ${index} must not use wildcards`);
+	}
+	return url.origin.toLowerCase();
+}
+
+function validateRecordingDomains(domains: readonly string[]): string[] {
+	return domains.map((domain, index) => validateRecordingOrigin(domain, index));
+}
+
+/**
+ * Start a network recording on a worker-backed tab. Serializes via the per-tab `recording`
+ * sentinel: a start while `starting`/`active`/`stopping` rejects without disturbing the
+ * existing recording. Explicit domains are validated here; omitted domains are resolved live
+ * by the worker from `page.url()` (the cached `tab.info.url` is only used to fail fast when the
+ * tab has never left `about:blank`). Active state is retained only after `recording-started`.
+ */
+export async function startTabRecording(name: string, options: StartRecordingOptions): Promise<StartRecordingResult> {
+	const tab = requireWorkerTab(name);
+	if (tab.recording) throw new ToolError(`Tab ${JSON.stringify(name)} is already recording`);
+
+	let domains: string[] | undefined;
+	if (options.domains && options.domains.length > 0) {
+		domains = validateRecordingDomains(options.domains);
+	} else {
+		// `tab.info.url` is only an about:blank UX preflight here — never the recording scope source
+		// (the worker resolves scope live from page.url()); scope is never derived from this cached URL.
+		const url = tab.info.url;
+		if (!url || url === "about:blank") {
+			throw new ToolError(
+				`Tab ${JSON.stringify(name)} has no page to record; open a URL first or pass domains explicitly`,
+			);
+		}
+		domains = undefined;
+	}
+
+	// Install the starting sentinel BEFORE sending so a concurrent start observes it and rejects.
+	tab.recording = "starting";
+	try {
+		const reply = await runRecordingControl(
+			tab,
+			{ type: "recording-start", id: `recording-${Snowflake.next()}`, domains, limits: options.limits },
+			options.timeoutMs,
+			options.signal,
+		);
+		if (reply.type !== "recording-started") throw new ToolError(`Unexpected recording reply ${reply.type} for start`);
+		tab.recording = "active";
+		return { scope: reply.scope, backend: tab.kindTag, tabName: name };
+	} finally {
+		// Retain "active" only on success; discard any lingering "starting" on failure.
+		if (tab.recording === "starting") tab.recording = undefined;
+	}
+}
+
+/**
+ * Stop the active recording and return its summary. Rejects when nothing is active
+ * (`undefined`/`starting`) or a stop is already in flight (`already stopping`). The worker
+ * drains for `timeoutMs`; the supervisor allows an extra grace before abandoning the control.
+ */
+export async function stopTabRecording(name: string, options: StopRecordingOptions): Promise<StopRecordingResult> {
+	const tab = requireWorkerTab(name);
+	if (tab.recording === "stopping")
+		throw new ToolError(`Tab ${JSON.stringify(name)} is already stopping its recording`);
+	if (tab.recording !== "active") throw new ToolError(`Tab ${JSON.stringify(name)} is not recording`);
+
+	tab.recording = "stopping";
+	try {
+		const reply = await runRecordingControl(
+			tab,
+			{ type: "recording-stop", id: `recording-${Snowflake.next()}`, timeoutMs: options.timeoutMs },
+			options.timeoutMs + GRACE_MS,
+			options.signal,
+		);
+		if (reply.type !== "recording-stopped") throw new ToolError(`Unexpected recording reply ${reply.type} for stop`);
+		return { ...reply.summary, backend: tab.kindTag, tabName: name };
+	} finally {
+		if (tab.recording === "stopping") tab.recording = undefined;
+	}
+}
+
+function sendRecordingControl(
+	tab: ManagedWorkerTabSession,
+	msg: Extract<WorkerInbound, { type: "recording-start" | "recording-stop" | "recording-cancel" }>,
+): void {
+	if (tab.state !== "alive") throw new ToolError("Recording control worker unreachable: tab is not alive");
+	try {
+		tab.worker.send(msg);
+	} catch (error) {
+		throw new ToolError(
+			`Recording control worker unreachable: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+/**
+ * Register a pending control, send its message, and race the worker reply against a wall-clock
+ * deadline and the caller's abort signal. A worker-delivered settle (resolve or reject) returns
+ * or throws directly; a deadline/abort abandons the control and drives the bounded cancel +
+ * recycle/kill cleanup before rethrowing the interrupt error.
+ */
+async function runRecordingControl(
+	tab: ManagedWorkerTabSession,
+	msg: Extract<WorkerInbound, { type: "recording-start" | "recording-stop" }>,
+	deadlineMs: number,
+	signal: AbortSignal | undefined,
+): Promise<WorkerOutbound> {
+	const controlId = msg.id;
+	const worker = tab.worker;
+	const generation = tab.workerGeneration;
+	const { promise, resolve, reject } = Promise.withResolvers<WorkerOutbound>();
+	void promise.catch(() => undefined);
+	tab.controls.set(controlId, { resolve, reject, worker, generation });
+	try {
+		if (tab.state !== "alive" || tab.worker !== worker || tab.workerGeneration !== generation) {
+			throw new ToolError("Recording control worker unreachable: worker changed before send");
+		}
+		sendRecordingControl(tab, msg);
+	} catch (error) {
+		tab.controls.delete(controlId);
+		reject(error);
+		throw error;
+	}
+
+	const { promise: interrupt, reject: interruptReject } = Promise.withResolvers<never>();
+	const timer = setTimeout(() => {
+		const label = msg.type === "recording-start" ? "start" : "stop";
+		interruptReject(new ToolError(`Recording ${label} timed out after ${deadlineMs}ms`));
+	}, deadlineMs);
+	const onAbort = (): void => interruptReject(new ToolAbortError("Recording operation aborted"));
+	if (signal) {
+		if (signal.aborted) onAbort();
+		else signal.addEventListener("abort", onAbort, { once: true });
+	}
+	try {
+		return await Promise.race([promise, interrupt]);
+	} catch (error) {
+		if (tab.controls.has(controlId)) await abandonRecording(tab, error, deadlineMs, worker, generation);
+		throw error;
+	} finally {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
+/**
+ * Abandon a timed-out/aborted control: retire the worker generation and settle only the controls
+ * from that retired generation, then run a bounded `recording-cancel` handshake. The recording
+ * sentinel stays set (the start/stop caller's `finally` clears it) so a concurrent start/stop
+ * rejects instead of registering a fresh control mid-handshake — and a fresh control that did slip
+ * in lives at the new generation and is never settled here. A rejected or timed-out cancel recycles
+ * (or, for inline workers, kills) the worker; a recycle/kill then settles every remaining control.
+ */
+async function abandonRecording(
+	tab: ManagedWorkerTabSession,
+	reason: unknown,
+	timeoutMs: number,
+	expectedWorker: WorkerHandle,
+	expectedGeneration: number,
+): Promise<void> {
+	if (tab.state !== "alive" || tab.worker !== expectedWorker || tab.workerGeneration !== expectedGeneration) {
+		settleControlsUpToGeneration(tab, expectedGeneration, reason);
+		return;
+	}
+	const retiredGeneration = tab.workerGeneration;
+	bumpWorkerGeneration(tab);
+	settleControlsUpToGeneration(tab, retiredGeneration, reason);
+	try {
+		await cancelWorkerRecording(tab, expectedWorker);
+	} catch (cancelError) {
+		if (
+			tab.state !== "alive" ||
+			tab.worker !== expectedWorker ||
+			(cancelError instanceof ToolError && /worker unreachable/i.test(cancelError.message))
+		) {
+			return;
+		}
+		logger.warn("Recording cancel was rejected or timed out; recycling browser tab worker", {
+			error: cancelError instanceof Error ? cancelError.message : String(cancelError),
+		});
+		await recycleOrKillTab(tab, timeoutMs, "Recording control was not acknowledged; tab recycled");
+	}
+}
+
+/**
+ * Send `recording-cancel` and wait, bounded by {@link RECORDING_CANCEL_MS}, for the worker's reply.
+ * `recording-canceled` resolves cleanly; `recording-error` rejects (the worker could not cancel) and
+ * a missed deadline throws — both propagate so {@link abandonRecording} recycles/kills rather than
+ * treating a failed cancel as an acknowledgement.
+ */
+async function cancelWorkerRecording(tab: ManagedWorkerTabSession, expectedWorker?: WorkerHandle): Promise<void> {
+	if (tab.state !== "alive") throw new ToolError("Recording control worker unreachable: tab is not alive");
+	const worker = expectedWorker ?? tab.worker;
+	const generation = tab.workerGeneration;
+	if (tab.worker !== worker) throw new ToolError("Recording control worker unreachable: worker changed before cancel");
+	const { promise, resolve, reject } = Promise.withResolvers<WorkerOutbound>();
+	const controlId = `recording-${Snowflake.next()}`;
+	tab.controls.set(controlId, { resolve, reject, worker, generation });
+	void promise.catch(() => undefined);
+	try {
+		if (tab.worker !== worker || tab.workerGeneration !== generation) {
+			throw new ToolError("Recording control worker unreachable: worker changed before cancel");
+		}
+		sendRecordingControl(tab, { type: "recording-cancel", id: controlId });
+	} catch (error) {
+		tab.controls.delete(controlId);
+		reject(error);
+		throw error;
+	}
+	await raceWithTimeout(promise, RECORDING_CANCEL_MS, "Recording cancel was not acknowledged in time");
+}
+
+/** Recycle a timed-out worker-backed tab (or force-kill an inline one) after a failed cancel. */
+async function recycleOrKillTab(tab: ManagedWorkerTabSession, timeoutMs: number, reason: string): Promise<void> {
+	if (tab.worker.mode === "inline") {
+		await forceKillTab(tab.name, reason);
+		return;
+	}
+	try {
+		await recycleTimedOutWorkerTab(tab, timeoutMs + GRACE_MS);
+	} catch {
+		await forceKillTab(tab.name, reason);
+	}
+}
+
+/** Test-only: install a worker-backed tab with an injected {@link WorkerHandle}. */
+export function registerWorkerTabForTest(options: {
+	name: string;
+	worker: WorkerHandle;
+	browser: PuppeteerBrowserHandle;
+	url?: string;
+	ownerSessionId?: string;
+	dialogPolicy?: DialogPolicy;
+}): WorkerTabSession {
+	const info: ReadyInfo = {
+		url: options.url ?? "https://example.test/",
+		viewport: { width: 1280, height: 800 },
+		targetId: `test-target-${options.name}`,
+	};
+	const tab: ManagedWorkerTabSession = {
+		name: options.name,
+		browser: options.browser,
+		targetId: info.targetId,
+		backend: "worker",
+		worker: options.worker,
+		state: "alive",
+		info,
+		pending: new Map(),
+		dialogPolicy: options.dialogPolicy,
+		kindTag: options.browser.kind.kind,
+		ownerSessionId: options.ownerSessionId,
+		workerGeneration: 0,
+		controls: new Map(),
+	};
+	holdBrowser(options.browser);
+	attachLongLivedHandlers(tab, options.worker);
+	tabs.set(options.name, tab);
+	return tab;
+}
+
 function isLastSurfaceCloseError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : String(err);
 	return /last/i.test(message);
@@ -692,31 +1097,48 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 	};
 }
 
-function handleTabMessage(tab: WorkerTabSession, msg: WorkerOutbound): void {
-	if (msg.type === "result") {
-		const pending = tab.pending.get(msg.id);
-		if (!pending) return;
-		tab.pending.delete(msg.id);
-		if (msg.ok) {
-			pending.resolve(msg.payload);
+function handleTabMessage(tab: ManagedWorkerTabSession, sourceWorker: WorkerHandle, msg: WorkerOutbound): void {
+	switch (msg.type) {
+		case "recording-started":
+		case "recording-stopped":
+		case "recording-canceled":
+		case "recording-error": {
+			// Ignore recording replies from a superseded worker before any control or state mutation.
+			if (sourceWorker !== tab.worker) return;
+			const control = tab.controls.get(msg.id);
+			if (!control || control.worker !== sourceWorker) return;
+			tab.controls.delete(msg.id);
+			if (msg.type === "recording-error") control.reject(errorFromPayload(msg.error));
+			else control.resolve(msg);
 			return;
 		}
-		pending.reject(errorFromPayload(msg.error));
-		return;
+		case "closed":
+			// An unexpected worker close (not driven by releaseTab, which bumps the generation first)
+			// leaves the tab unusable: settle controls, discard recording, and mark it dead.
+			onWorkerFailure(tab, sourceWorker, new ToolError(`Tab ${JSON.stringify(tab.name)} worker closed`));
+			return;
+		case "result": {
+			const pending = tab.pending.get(msg.id);
+			if (!pending) return;
+			tab.pending.delete(msg.id);
+			if (msg.ok) pending.resolve(msg.payload);
+			else pending.reject(errorFromPayload(msg.error));
+			return;
+		}
+		case "ready":
+			tab.info = msg.info;
+			return;
+		case "tool-call":
+			void dispatchToolCall(tab, msg);
+			return;
+		case "log":
+			logWorkerMessage(msg);
+			return;
 	}
-	if (msg.type === "ready") {
-		tab.info = msg.info;
-		return;
-	}
-	if (msg.type === "tool-call") {
-		void dispatchToolCall(tab, msg);
-		return;
-	}
-	if (msg.type === "log") logWorkerMessage(msg);
 }
 
 async function dispatchToolCall(
-	tab: WorkerTabSession,
+	tab: ManagedWorkerTabSession,
 	msg: Extract<WorkerOutbound, { type: "tool-call" }>,
 ): Promise<void> {
 	const pending = tab.pending.get(msg.runId);
@@ -754,7 +1176,7 @@ async function dispatchToolCall(
 	}
 }
 
-function safeSend(tab: WorkerTabSession, msg: WorkerInbound): void {
+function safeSend(tab: ManagedWorkerTabSession, msg: WorkerInbound): void {
 	if (tab.state !== "alive") return;
 	try {
 		tab.worker.send(msg);
@@ -776,7 +1198,19 @@ function toErrorPayload(error: unknown): RunErrorPayload {
 	return { name: "Error", message: String(error), isAbort: false, isToolError: false };
 }
 
-async function recycleTimedOutWorkerTab(tab: WorkerTabSession, timeoutMs: number): Promise<void> {
+async function recycleTimedOutWorkerTab(tab: ManagedWorkerTabSession, timeoutMs: number): Promise<void> {
+	// A recycle retires the current worker: capture its generation, bump, and settle only the
+	// controls at/below the retired generation before the instance is torn down. A control that
+	// registers against the fresh (post-bump) worker survives; late replies from the old worker
+	// are ignored by the generation/instance guard.
+	const retiredGeneration = tab.workerGeneration;
+	bumpWorkerGeneration(tab);
+	settleControlsUpToGeneration(
+		tab,
+		retiredGeneration,
+		postmortem.markExpectedCleanupError(new ToolError("Browser tab worker recycled")),
+	);
+	tab.recording = undefined;
 	const oldWorker = tab.worker;
 	await oldWorker.terminate().catch(() => undefined);
 	const browserWSEndpoint = tab.browser.browser.wsEndpoint();
@@ -797,7 +1231,7 @@ async function recycleTimedOutWorkerTab(tab: WorkerTabSession, timeoutMs: number
 		tab.worker = worker;
 		tab.info = info;
 		tab.state = "alive";
-		worker.onMessage(msg => handleTabMessage(tab, msg));
+		attachLongLivedHandlers(tab, worker);
 	} catch (error) {
 		await worker.terminate().catch(() => undefined);
 		worker = await spawnInlineWorker();
@@ -806,7 +1240,7 @@ async function recycleTimedOutWorkerTab(tab: WorkerTabSession, timeoutMs: number
 			tab.worker = worker;
 			tab.info = info;
 			tab.state = "alive";
-			worker.onMessage(msg => handleTabMessage(tab, msg));
+			attachLongLivedHandlers(tab, worker);
 		} catch (inlineError) {
 			await worker.terminate().catch(() => undefined);
 			const finalError = new ToolError(
@@ -824,6 +1258,11 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 	killedTabs.set(name, reason);
 	tab.state = "dead";
 	const error = postmortem.markExpectedCleanupError(new ToolError(reason));
+	if (tab.backend === "worker") {
+		bumpWorkerGeneration(tab);
+		tab.recording = undefined;
+		settleAllControlOps(tab, error);
+	}
 	for (const pending of tab.pending.values()) pending.reject(error);
 	tab.pending.clear();
 	if (tab.backend === "cmux") {
@@ -837,7 +1276,7 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 	tabs.delete(name);
 }
 
-async function closeOrphanTarget(tab: WorkerTabSession): Promise<void> {
+async function closeOrphanTarget(tab: ManagedWorkerTabSession): Promise<void> {
 	for (const target of tab.browser.browser.targets()) {
 		if ((await targetIdForTarget(target).catch(() => "")) !== tab.targetId) continue;
 		const page = await target.page().catch(() => null);
@@ -846,7 +1285,7 @@ async function closeOrphanTarget(tab: WorkerTabSession): Promise<void> {
 	}
 }
 
-async function waitForClosed(tab: WorkerTabSession): Promise<void> {
+async function waitForClosed(tab: ManagedWorkerTabSession): Promise<void> {
 	const { promise, resolve } = Promise.withResolvers<void>();
 	const unsubscribe = tab.worker.onMessage(msg => {
 		if (msg.type === "closed") resolve();
@@ -919,7 +1358,17 @@ async function raceWithTimeout<T>(
 	}
 }
 
+/**
+ * Test-only override for the tab-worker factory. Lets a hermetic recycle test substitute an
+ * injected {@link WorkerHandle} for the real Bun worker without a parallel spawn path.
+ */
+let tabWorkerFactoryForTest: (() => Promise<WorkerHandle>) | undefined;
+export function setTabWorkerFactoryForTest(factory: (() => Promise<WorkerHandle>) | undefined): void {
+	tabWorkerFactoryForTest = factory;
+}
+
 async function spawnTabWorker(): Promise<WorkerHandle> {
+	if (tabWorkerFactoryForTest) return tabWorkerFactoryForTest();
 	try {
 		const hostEntry = workerHostEntry();
 		const worker = hostEntry

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -14,6 +14,7 @@ import type {
 	ImageFormat,
 	KeyInput,
 	Page,
+	Protocol,
 	SerializedAXNode,
 	Target,
 } from "puppeteer-core";
@@ -35,7 +36,14 @@ import {
 	BROWSER_PROTOCOL_TIMEOUT_MS,
 	DEFAULT_VIEWPORT,
 	loadPuppeteerInWorker,
+	pageCdpClient,
 } from "./launch";
+import {
+	DEFAULT_RECORDING_LIMITS,
+	NetworkRecorder,
+	normalizeRecordingOrigins,
+	type RecordingLimits,
+} from "./network-recorder";
 import { extractReadableFromHtml, type ReadableFormat } from "./readable";
 import {
 	bindBrowserRunFacade,
@@ -736,6 +744,86 @@ export function describeInflight(inflight: Map<number, InflightOp>): string {
 		.join(", ");
 }
 
+/**
+ * CDP client shape accepted from the injected `#pageCdpClient`. Unlike the exported owned
+ * `PageCdpClientHandle` (in ./launch), which always owns the session and REQUIRES `dispose`, an
+ * injected client may borrow a shared session, so here `dispose` is optional — its absence means
+ * the recorder does not own (and must not detach) the session.
+ */
+type MaybeOwnedCdpClientHandle = {
+	readonly client: CDPSession;
+	readonly dispose?: () => Promise<void> | void;
+};
+type PageCdpClientResult = CDPSession | MaybeOwnedCdpClientHandle | null;
+function isMaybeOwnedCdpClientHandle(value: PageCdpClientResult): value is MaybeOwnedCdpClientHandle {
+	return typeof value === "object" && value !== null && "client" in value;
+}
+
+/** Injected only by the in-process contract test; production construction passes nothing. */
+export interface WorkerCoreDependencies {
+	readonly page?: Page;
+	readonly browser?: Browser;
+	readonly targetId?: string;
+	readonly pageCdpClient?: (page: Page) => PageCdpClientResult | Promise<PageCdpClientResult>;
+}
+
+/** Poll cadence for the stop drain's liveness/deadline checks; completion itself wakes the drain via a signal. */
+const RECORDING_DRAIN_POLL_MS = 25;
+
+/**
+ * Live network-recording session state. `recorder`/`client`/`cleanup` are null only during the
+ * pre-`Network.enable` `starting` window; once `phase` is `active` they are set for the session's life.
+ */
+interface RecordingState {
+	id: string;
+	phase: "starting" | "active" | "stopping";
+	canceled: boolean;
+	closed: boolean;
+	stopping: boolean;
+	limits: RecordingLimits;
+	origins: ReadonlySet<string>;
+	recorder: NetworkRecorder | null;
+	client: CDPSession | null;
+	disposeClient: (() => Promise<void> | void) | null;
+	cleanup: (() => void) | null;
+	pendingRequests: Set<string>;
+	pendingReqExtra: Map<string, Record<string, string>>;
+	pendingResExtra: Map<string, Record<string, string>>;
+	requestUrls: Map<string, string>;
+	bodyReads: Set<Promise<void>>;
+	abort: AbortController;
+	cutoff: ReadonlySet<string> | null;
+	drain: PromiseWithResolvers<void> | null;
+}
+
+// ponytail: NetworkRecorder keeps its scope check private and is a frozen Task-1 file, so the
+// worker re-derives the identical exact-origin test here rather than widen that module's API.
+function inRecordingScope(url: string, origins: ReadonlySet<string>): boolean {
+	try {
+		const parsed = new URL(url);
+		return (parsed.protocol === "http:" || parsed.protocol === "https:") && origins.has(parsed.origin.toLowerCase());
+	} catch {
+		return false;
+	}
+}
+
+/** Merge a base CDP header map with an optional (ExtraInfo) overlay, lowercasing every key. */
+function mergeHeaderMaps(base: Protocol.Network.Headers, extra?: Protocol.Network.Headers): Record<string, string> {
+	const merged: Record<string, string> = {};
+	for (const [name, value] of Object.entries(base)) merged[name.toLowerCase()] = value;
+	if (extra) for (const [name, value] of Object.entries(extra)) merged[name.toLowerCase()] = value;
+	return merged;
+}
+
+/** Origin only — no path, query, fragment, or credentials — for safe failure logging. */
+function safeOrigin(url: string): string {
+	try {
+		return new URL(url).origin;
+	} catch {
+		return "[unparsable-url]";
+	}
+}
+
 export class WorkerCore {
 	#transport: Transport;
 	#browser?: Browser;
@@ -750,9 +838,15 @@ export class WorkerCore {
 	#dialogPolicy?: DialogPolicy;
 	#dialogHandler?: (dialog: Dialog) => void;
 	#openDialog?: OpenDialogInfo;
+	#pageCdpClient: (page: Page) => PageCdpClientResult | Promise<PageCdpClientResult>;
+	#recording?: RecordingState;
 
-	constructor(transport: Transport) {
+	constructor(transport: Transport, dependencies?: WorkerCoreDependencies) {
 		this.#transport = transport;
+		if (dependencies?.page) this.#page = dependencies.page;
+		if (dependencies?.browser) this.#browser = dependencies.browser;
+		if (dependencies?.targetId) this.#targetId = dependencies.targetId;
+		this.#pageCdpClient = dependencies?.pageCdpClient ?? pageCdpClient;
 		this.#unsub = this.#transport.onMessage(msg => {
 			void this.#handleMessage(msg as WorkerInbound);
 		});
@@ -785,6 +879,15 @@ export class WorkerCore {
 				return;
 			case "tool-reply":
 				this.#deliverToolReply(msg.id, msg.reply);
+				return;
+			case "recording-start":
+				await this.#startRecording(msg);
+				return;
+			case "recording-stop":
+				await this.#stopRecording(msg);
+				return;
+			case "recording-cancel":
+				await this.#cancelRecording(msg);
 				return;
 			case "close":
 				await this.#close();
@@ -1838,8 +1941,393 @@ export class WorkerCore {
 		}
 	}
 
+	async #startRecording(msg: Extract<WorkerInbound, { type: "recording-start" }>): Promise<void> {
+		if (this.#recording) {
+			this.#transport.send({
+				type: "recording-error",
+				id: msg.id,
+				error: errorPayload(new ToolError("A recording is already active")),
+			});
+			return;
+		}
+		const limits: RecordingLimits = { ...DEFAULT_RECORDING_LIMITS, ...(msg.limits ?? {}) };
+		const state: RecordingState = {
+			id: msg.id,
+			phase: "starting",
+			canceled: false,
+			closed: false,
+			stopping: false,
+			limits,
+			origins: new Set(),
+			recorder: null,
+			client: null,
+			disposeClient: null,
+			cleanup: null,
+			pendingRequests: new Set(),
+			pendingReqExtra: new Map(),
+			pendingResExtra: new Map(),
+			requestUrls: new Map(),
+			bodyReads: new Set(),
+			abort: new AbortController(),
+			cutoff: null,
+			drain: null,
+		};
+		// Sentinel installed before the first await so a concurrent start/stop/cancel cannot race in.
+		this.#recording = state;
+		try {
+			const page = this.#page;
+			if (!page || page.isClosed()) throw new ToolError("Recording requires a live page");
+			const acquired = await this.#pageCdpClient(page);
+			if (!acquired) throw new ToolError("Recording requires a page CDP session");
+			const client = isMaybeOwnedCdpClientHandle(acquired) ? acquired.client : acquired;
+			state.disposeClient = isMaybeOwnedCdpClientHandle(acquired) ? (acquired.dispose ?? null) : null;
+			const origins =
+				msg.domains && msg.domains.length > 0
+					? normalizeRecordingOrigins(msg.domains)
+					: normalizeRecordingOrigins([new URL(page.url()).origin]);
+			state.origins = origins;
+			state.client = client;
+			state.recorder = new NetworkRecorder({ ...limits, origins });
+			if (state.canceled || this.#recording !== state) {
+				await this.#disposeClient(state);
+				return;
+			}
+			try {
+				await client.send("Network.enable");
+			} catch (error) {
+				throw new ToolError("Failed to enable network capture for recording", { cause: error });
+			}
+			// A concurrent cancel/stop/close superseded this attempt: it already ran #disposeRecording
+			// (recorder disposed, state cleared), so bail silently — that operation owns the single
+			// terminal message and this start must not emit a late recording-started.
+			if (state.canceled || this.#recording !== state) {
+				await this.#disposeClient(state);
+				return;
+			}
+			state.cleanup = this.#installRecordingListeners(state, client);
+			state.phase = "active";
+			this.#transport.send({ type: "recording-started", id: msg.id, scope: [...origins], limits });
+		} catch (error) {
+			if (this.#recording === state) this.#recording = undefined;
+			await this.#disposeRecording(state);
+			this.#transport.send({ type: "recording-error", id: msg.id, error: errorPayload(error) });
+		}
+	}
+
+	#installRecordingListeners(state: RecordingState, client: CDPSession): () => void {
+		const onRequest = (event: Protocol.Network.RequestWillBeSentEvent): void =>
+			this.#onRequestWillBeSent(state, event);
+		const onRequestExtra = (event: Protocol.Network.RequestWillBeSentExtraInfoEvent): void =>
+			this.#onRequestExtraInfo(state, event);
+		const onResponse = (event: Protocol.Network.ResponseReceivedEvent): void =>
+			this.#onResponseReceived(state, event);
+		const onResponseExtra = (event: Protocol.Network.ResponseReceivedExtraInfoEvent): void =>
+			this.#onResponseExtraInfo(state, event);
+		const onFinished = (event: Protocol.Network.LoadingFinishedEvent): void => this.#onLoadingFinished(state, event);
+		const onFailed = (event: Protocol.Network.LoadingFailedEvent): void => this.#onLoadingFailed(state, event);
+		client.on("Network.requestWillBeSent", onRequest);
+		client.on("Network.requestWillBeSentExtraInfo", onRequestExtra);
+		client.on("Network.responseReceived", onResponse);
+		client.on("Network.responseReceivedExtraInfo", onResponseExtra);
+		client.on("Network.loadingFinished", onFinished);
+		client.on("Network.loadingFailed", onFailed);
+		return () => {
+			client.off("Network.requestWillBeSent", onRequest);
+			client.off("Network.requestWillBeSentExtraInfo", onRequestExtra);
+			client.off("Network.responseReceived", onResponse);
+			client.off("Network.responseReceivedExtraInfo", onResponseExtra);
+			client.off("Network.loadingFinished", onFinished);
+			client.off("Network.loadingFailed", onFailed);
+		};
+	}
+
+	#onRequestWillBeSent(state: RecordingState, event: Protocol.Network.RequestWillBeSentEvent): void {
+		const recorder = state.recorder;
+		if (!recorder || state.stopping) return;
+		const url = event.request.url;
+		if (!inRecordingScope(url, state.origins)) return;
+		const extra = state.pendingReqExtra.get(event.requestId);
+		if (extra) state.pendingReqExtra.delete(event.requestId);
+		recorder.recordRequest({
+			requestId: event.requestId,
+			url,
+			method: event.request.method,
+			headers: mergeHeaderMaps(event.request.headers, extra),
+			postData: event.request.postData,
+			timestamp: event.timestamp,
+			wallTime: event.wallTime,
+		});
+		state.requestUrls.set(event.requestId, url);
+		state.pendingRequests.add(event.requestId);
+	}
+
+	#onRequestExtraInfo(state: RecordingState, event: Protocol.Network.RequestWillBeSentExtraInfoEvent): void {
+		// Cookie data (`associatedCookies`) is intentionally dropped; only raw headers are retained.
+		if (state.stopping && !state.cutoff?.has(event.requestId)) return;
+		// A pre-cutoff request already recorded merges the late raw headers directly; otherwise the
+		// overlay is buffered until its base requestWillBeSent arrives.
+		if (state.recorder?.recordRequestExtraHeaders(event.requestId, event.headers)) return;
+		if (state.pendingReqExtra.size >= state.limits.maxEntries && !state.pendingReqExtra.has(event.requestId)) return;
+		state.pendingReqExtra.set(event.requestId, event.headers);
+	}
+
+	#onResponseReceived(state: RecordingState, event: Protocol.Network.ResponseReceivedEvent): void {
+		const recorder = state.recorder;
+		if (!recorder) return;
+		if (state.stopping && !state.cutoff?.has(event.requestId)) return;
+		const url = event.response.url;
+		if (!inRecordingScope(url, state.origins)) return;
+		const extra = state.pendingResExtra.get(event.requestId);
+		if (extra) state.pendingResExtra.delete(event.requestId);
+		recorder.recordResponse({
+			requestId: event.requestId,
+			url,
+			status: event.response.status,
+			statusText: event.response.statusText,
+			headers: mergeHeaderMaps(event.response.headers, extra),
+			contentType: event.response.mimeType,
+			timestamp: event.timestamp,
+		});
+		state.requestUrls.set(event.requestId, url);
+		if (!state.stopping) state.pendingRequests.add(event.requestId);
+	}
+
+	#onResponseExtraInfo(state: RecordingState, event: Protocol.Network.ResponseReceivedExtraInfoEvent): void {
+		// Set-Cookie only ever arrives as a redactable single-string header here; the recorder scrubs it.
+		if (state.stopping && !state.cutoff?.has(event.requestId)) return;
+		// Merge into an already-recorded response; otherwise buffer until responseReceived fires.
+		if (state.recorder?.recordResponseExtraHeaders(event.requestId, event.headers)) return;
+		if (state.pendingResExtra.size >= state.limits.maxEntries && !state.pendingResExtra.has(event.requestId)) return;
+		state.pendingResExtra.set(event.requestId, event.headers);
+	}
+
+	#onLoadingFinished(state: RecordingState, event: Protocol.Network.LoadingFinishedEvent): void {
+		const recorder = state.recorder;
+		if (!recorder || !state.pendingRequests.has(event.requestId)) return;
+		const url = state.requestUrls.get(event.requestId) ?? "";
+		this.#clearPendingRequest(state, event.requestId);
+		if (event.encodedDataLength > state.limits.maxBodyBytes) {
+			recorder.recordBodyOmitted(event.requestId, "size");
+			this.#settleDrain(state);
+			return;
+		}
+		const task = this.#readResponseBody(state, event.requestId, url);
+		state.bodyReads.add(task);
+		void task.finally(() => {
+			state.bodyReads.delete(task);
+			this.#settleDrain(state);
+		});
+	}
+
+	#onLoadingFailed(state: RecordingState, event: Protocol.Network.LoadingFailedEvent): void {
+		const recorder = state.recorder;
+		if (!recorder || !state.pendingRequests.has(event.requestId)) return;
+		this.#clearPendingRequest(state, event.requestId);
+		recorder.recordBodyOmitted(event.requestId, "unavailable");
+		this.#settleDrain(state);
+	}
+
+	#clearPendingRequest(state: RecordingState, requestId: string): void {
+		state.pendingRequests.delete(requestId);
+		state.pendingReqExtra.delete(requestId);
+		state.pendingResExtra.delete(requestId);
+		state.requestUrls.delete(requestId);
+	}
+
+	/**
+	 * Fetch one response body under a settled worker-side race against `maxBodyWaitMs`: a timeout
+	 * records a single omission and ignores the late CDP result; a late success cannot double-count;
+	 * an abort (cancel/close) silences the read. Failures log only requestId, origin (no path), and error name.
+	 */
+	#readResponseBody(state: RecordingState, requestId: string, url: string): Promise<void> {
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const client = state.client;
+		const recorder = state.recorder;
+		if (!client || !recorder) {
+			resolve();
+			return promise;
+		}
+		let settled = false;
+		const finish = (action?: () => void): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			state.abort.signal.removeEventListener("abort", onAbort);
+			if (action && !state.closed) {
+				try {
+					action();
+				} catch {
+					// Recorder finished/disposed under a concurrent stop or cancel: drop silently.
+				}
+			}
+			resolve();
+		};
+		const onAbort = (): void => finish();
+		const timer = setTimeout(
+			() => finish(() => recorder.recordBodyOmitted(requestId, "timeout")),
+			state.limits.maxBodyWaitMs,
+		);
+		state.abort.signal.addEventListener("abort", onAbort, { once: true });
+		void client.send("Network.getResponseBody", { requestId }).then(
+			result => {
+				const body = result as Protocol.Network.GetResponseBodyResponse | undefined;
+				finish(() => {
+					if (body && !body.base64Encoded && typeof body.body === "string") {
+						recorder.recordResponseBody(requestId, body.body);
+					} else {
+						recorder.recordBodyOmitted(requestId, "unavailable");
+					}
+				});
+			},
+			(error: unknown) => {
+				finish(() => {
+					this.#log("debug", "recording response body read failed", {
+						requestId,
+						origin: safeOrigin(url),
+						reason: "unavailable",
+						error: error instanceof Error ? error.name : "Error",
+					});
+					recorder.recordBodyOmitted(requestId, "unavailable");
+				});
+			},
+		);
+		return promise;
+	}
+
+	#settleDrain(state: RecordingState): void {
+		if (state.stopping && state.drain && state.pendingRequests.size === 0 && state.bodyReads.size === 0) {
+			state.drain.resolve();
+		}
+	}
+
+	async #stopRecording(msg: Extract<WorkerInbound, { type: "recording-stop" }>): Promise<void> {
+		const state = this.#recording;
+		if (state && state.phase === "starting") {
+			// Stop raced the start's Network.enable: settle the starting state so the resuming start
+			// suppresses its recording-started, and report a single terminal (nothing was captured yet).
+			await this.#disposeRecording(state);
+			this.#transport.send({
+				type: "recording-error",
+				id: msg.id,
+				error: errorPayload(new ToolError("Recording is still starting; nothing to stop")),
+			});
+			return;
+		}
+		if (state?.phase !== "active" || !state.recorder || !state.cleanup) {
+			this.#transport.send({
+				type: "recording-error",
+				id: msg.id,
+				error: errorPayload(new ToolError("No active recording to stop")),
+			});
+			return;
+		}
+		state.phase = "stopping";
+		state.stopping = true;
+		state.cutoff = new Set(state.pendingRequests);
+		state.drain = Promise.withResolvers<void>();
+		this.#settleDrain(state);
+		try {
+			await this.#drainRecording(state, msg.timeoutMs);
+			// A cancel or worker close during the drain already emitted the single terminal and cleared
+			// state; never follow it with a recording-stopped/HAR.
+			if (this.#recording !== state) return;
+			state.cleanup();
+			state.closed = true;
+			await Promise.allSettled([...state.bodyReads]);
+			await this.#disposeClient(state);
+			const summary = state.recorder.finish();
+			this.#recording = undefined;
+			this.#transport.send({ type: "recording-stopped", id: msg.id, summary });
+		} catch (error) {
+			// Superseded by cancel/close during the drain: that path owns the terminal, so stay silent.
+			if (this.#recording !== state) return;
+			await this.#disposeRecording(state);
+			this.#transport.send({ type: "recording-error", id: msg.id, error: errorPayload(error) });
+		}
+	}
+
+	/**
+	 * Wait, under the remaining stop deadline, until every pre-cutoff request has completed and every
+	 * in-flight body read has settled. Completion wakes the drain via `#settleDrain`; the poll only
+	 * bounds the deadline and runs a same-session liveness probe so a dead page cannot hang the drain.
+	 */
+	async #drainRecording(state: RecordingState, timeoutMs: number): Promise<void> {
+		const client = state.client;
+		const drain = state.drain;
+		if (!client || !drain) return;
+		const deadline = Date.now() + Math.max(0, timeoutMs);
+		// A cancel/close during the drain aborts this signal; racing it lets the loop exit promptly
+		// (via the `!state.closed` guard) instead of blocking to the deadline.
+		const superseded = this.#abortSignalPromise(state.abort.signal);
+		while (!state.closed && (state.pendingRequests.size > 0 || state.bodyReads.size > 0)) {
+			const remaining = deadline - Date.now();
+			if (remaining <= 0) throw new ToolError(`Recording stop drain timed out after ${timeoutMs}ms`);
+			try {
+				await client.send("Page.getFrameTree");
+			} catch (error) {
+				if (state.closed) return;
+				throw new ToolError("Recording page session is no longer reachable", { cause: error });
+			}
+			await Promise.race([drain.promise, superseded, Bun.sleep(Math.min(remaining, RECORDING_DRAIN_POLL_MS))]);
+		}
+	}
+
+	#abortSignalPromise(signal: AbortSignal): Promise<void> {
+		if (signal.aborted) return Promise.resolve();
+		const { promise, resolve } = Promise.withResolvers<void>();
+		signal.addEventListener("abort", () => resolve(), { once: true });
+		return promise;
+	}
+
+	async #cancelRecording(msg: Extract<WorkerInbound, { type: "recording-cancel" }>): Promise<void> {
+		const state = this.#recording;
+		if (!state) {
+			this.#transport.send({
+				type: "recording-error",
+				id: msg.id,
+				error: errorPayload(new ToolError("No active recording to cancel")),
+			});
+			return;
+		}
+		const reads = [...state.bodyReads];
+		await this.#disposeRecording(state);
+		await Promise.allSettled(reads);
+		this.#transport.send({ type: "recording-canceled", id: msg.id });
+	}
+	/** Dispose the recording CDP session exactly once when the dependency owns it. */
+	async #disposeClient(state: RecordingState): Promise<void> {
+		const dispose = state.disposeClient;
+		state.disposeClient = null;
+		if (dispose) await Promise.resolve(dispose()).catch(() => undefined);
+	}
+
+	/** Shared teardown for cancel, drain failure, and worker close. */
+	async #disposeRecording(state: RecordingState): Promise<void> {
+		state.canceled = true;
+		state.closed = true;
+		state.stopping = true;
+		state.abort.abort();
+		state.cleanup?.();
+		state.recorder?.dispose();
+		await this.#disposeClient(state);
+		if (this.#recording === state) this.#recording = undefined;
+	}
+
 	async #close(): Promise<void> {
 		this.#unsub();
+		if (this.#recording) {
+			const state = this.#recording;
+			const reads = [...state.bodyReads];
+			await this.#disposeRecording(state);
+			// Let the aborted in-flight body reads settle before signalling closed so nothing races
+			// the transport teardown.
+			await Promise.allSettled(reads);
+			this.#transport.send({
+				type: "recording-error",
+				id: state.id,
+				error: errorPayload(new ToolError("Tab worker closed during an active recording")),
+			});
+		}
 		this.#clearElementCache();
 		const page = this.#page;
 		if (this.#dialogHandler && page && !page.isClosed()) page.off("dialog", this.#dialogHandler);

--- a/packages/coding-agent/test/tools/browser-network-recorder.test.ts
+++ b/packages/coding-agent/test/tools/browser-network-recorder.test.ts
@@ -1,0 +1,484 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DEFAULT_RECORDING_LIMITS,
+	NetworkRecorder,
+	type NetworkRecorderOptions,
+	normalizeRecordingOrigins,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/network-recorder";
+
+const options: NetworkRecorderOptions = {
+	...DEFAULT_RECORDING_LIMITS,
+	origins: new Set(["https://shop.test"]),
+};
+
+function request(overrides: Partial<Parameters<NetworkRecorder["recordRequest"]>[0]> = {}) {
+	return {
+		requestId: "r1",
+		url: "https://shop.test/api/items",
+		method: "GET",
+		headers: { "content-type": "application/json" },
+		timestamp: 1,
+		...overrides,
+	};
+}
+
+function response(overrides: Partial<Parameters<NetworkRecorder["recordResponse"]>[0]> = {}) {
+	return {
+		requestId: "r1",
+		url: "https://shop.test/api/items",
+		method: "GET",
+		status: 200,
+		statusText: "OK",
+		headers: { "content-type": "application/json" },
+		contentType: "application/json",
+		timestamp: 2,
+		...overrides,
+	};
+}
+
+describe("NetworkRecorder", () => {
+	it("redacts URL, header, nested-body, and cookie secrets in the safe HAR subset", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest({
+			requestId: "r1",
+			url: "https://shop.test/api/cart?access_token=url-secret&item=42#code=fragment-secret",
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: "Bearer header-secret",
+				cookie: "session=cookie-secret; theme=dark",
+			},
+			postData: '{"user":{"password":"body-secret","accountId":"account-secret"},"itemId":"42"}',
+			timestamp: 1,
+		});
+		recorder.recordResponse({
+			requestId: "r1",
+			url: "https://shop.test/api/cart",
+			method: "POST",
+			status: 200,
+			statusText: "OK",
+			headers: { "content-type": "application/json", "set-cookie": "session=response-secret; Secure" },
+			contentType: "application/json",
+			timestamp: 2,
+		});
+		recorder.recordResponseBody("r1", '{"ok":true,"refresh_token":"response-body-secret"}');
+
+		const result = recorder.finish();
+		const serialized = JSON.stringify(result.har);
+		expect(serialized).not.toContain("url-secret");
+		expect(serialized).not.toContain("fragment-secret");
+		expect(serialized).not.toContain("header-secret");
+		expect(serialized).not.toContain("cookie-secret");
+		expect(serialized).not.toContain("body-secret");
+		expect(serialized).not.toContain("response-secret");
+		expect(serialized).not.toContain("response-body-secret");
+		expect(serialized).toContain('\\"itemId\\":\\"42\\"');
+	});
+
+	it("filters to exact HTTP origins and keeps safe paths", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(request({ requestId: "out", url: "https://shop.test.evil/api" }));
+		recorder.recordResponse(response({ requestId: "out", url: "https://shop.test.evil/api" }));
+		recorder.recordRequest(request({ requestId: "http", url: "https://shop.test/api/v1/items" }));
+		recorder.recordResponse(response({ requestId: "http", url: "https://shop.test/api/v1/items" }));
+		recorder.recordRequest(request({ requestId: "opaque", url: "https://shop.test/reset/abcdef0123456789abcdef" }));
+		recorder.recordResponse(response({ requestId: "opaque", url: "https://shop.test/reset/abcdef0123456789abcdef" }));
+		recorder.recordRequest(request({ requestId: "letters", url: "https://shop.test/recovery/abcdefghijklmnopqrs" }));
+		recorder.recordResponse(
+			response({ requestId: "letters", url: "https://shop.test/recovery/abcdefghijklmnopqrs" }),
+		);
+		const result = recorder.finish();
+		expect(result.entryCount).toBe(3);
+		expect(JSON.stringify(result.har)).toContain("/api/v1/items");
+		expect(JSON.stringify(result.har)).not.toContain("abcdef0123456789abcdef");
+		expect(JSON.stringify(result.har)).not.toContain("abcdefghijklmnopqrs");
+	});
+
+	it("redacts OAuth, JWT, account, and PII values in URLs and nested JSON/form bodies", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(
+			request({
+				url: "https://shop.test/oauth?state=state-secret&nonce=nonce-secret&code_verifier=verifier-secret&code_challenge=challenge-secret&assertion=assertion-secret&email=e@example.test&accountId=acct-secret",
+				method: "POST",
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					"x-goog-api-key": "goog-secret",
+					"x-api-key": "api-secret",
+					"x-amzn-trace-id": "trace-secret",
+					"x-ms-request-id": "ms-secret",
+					"x-user-email": "email-secret",
+					"x-user-id": "user-secret",
+					"x-account-id": "account-secret",
+					"x-customer-id": "customer-secret",
+					"x-org-id": "org-secret",
+					"cf-connecting-ip": "ip-secret",
+					"x-forwarded-for": "forwarded-secret",
+				},
+				postData: "grant_type=password&password=hunter2&userId=alice&safe=value",
+			}),
+		);
+		recorder.recordResponse(response({ url: "https://shop.test/oauth", method: "POST" }));
+		recorder.recordResponseBody(
+			"r1",
+			JSON.stringify({
+				nested: { nonce: "secret", account: { email: "x@y.test" } },
+				safe: "ok",
+				jwt: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature",
+			}),
+		);
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const secret of [
+			"state-secret",
+			"nonce-secret",
+			"verifier-secret",
+			"challenge-secret",
+			"assertion-secret",
+			"e@example.test",
+			"acct-secret",
+			"goog-secret",
+			"api-secret",
+			"trace-secret",
+			"ms-secret",
+			"email-secret",
+			"user-secret",
+			"account-secret",
+			"customer-secret",
+			"org-secret",
+			"ip-secret",
+			"forwarded-secret",
+			"hunter2",
+			"alice",
+			"eyJhbGciOiJIUzI1NiJ9",
+		]) {
+			expect(serialized).not.toContain(secret);
+		}
+		expect(serialized).toContain('\\"grant_type\\":\\"password\\"');
+	});
+
+	it("preserves response-only metadata and counts correlation omissions", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordResponse(response({ requestId: "missing", method: undefined }));
+		const result = recorder.finish();
+		expect(result.entryCount).toBe(1);
+		expect(result.omittedBodyCount).toBe(1);
+		expect(JSON.stringify(result.har)).toContain('"method":"UNKNOWN"');
+	});
+
+	it("handles body-before-response, omitted reasons, and unknown body correlation", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(request({ method: "POST" }));
+		recorder.recordResponseBody("r1", '{"ok":true}');
+		recorder.recordResponse(response({ method: "POST" }));
+		recorder.recordBodyOmitted("r1", "timeout");
+		recorder.recordBodyOmitted("missing", "correlation");
+		const result = recorder.finish();
+		expect(result.capturedBodyCount).toBe(1);
+		expect(result.omittedBodyCount).toBe(1);
+	});
+
+	it("enforces entry, body, and total-byte limits and reports truncation", () => {
+		const recorder = new NetworkRecorder({ ...options, maxEntries: 1, maxBodyBytes: 4, maxTotalBytes: 1200 });
+		recorder.recordRequest(request({ method: "POST", postData: "12345" }));
+		recorder.recordResponse(response({ method: "POST" }));
+		recorder.recordResponseBody("r1", "{}");
+		recorder.recordRequest(request({ requestId: "r2", url: "https://shop.test/second" }));
+		recorder.recordResponse(response({ requestId: "r2", url: "https://shop.test/second" }));
+		const result = recorder.finish();
+		expect(result.entryCount).toBe(1);
+		expect(result.capturedBodyCount).toBe(1);
+		expect(result.truncated).toBe(true);
+		expect(result.totalBytes).toBeLessThanOrEqual(1200);
+	});
+
+	it("bounds body-before-response storage and counts each rejected body once", () => {
+		const recorder = new NetworkRecorder({ ...options, maxEntries: 1, maxBodyBytes: 4, maxTotalBytes: 1200 });
+		recorder.recordResponseBody("too-large", "12345");
+		recorder.recordResponseBody("too-large", "67890");
+		recorder.recordResponseBody("pending", "{}");
+		recorder.recordResponseBody("over-capacity", "{}");
+		const result = recorder.finish();
+		expect(result.capturedBodyCount).toBe(0);
+		expect(result.omittedBodyCount).toBe(3);
+	});
+
+	it("finish is idempotent and dispose rejects capture", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(request());
+		const first = recorder.finish();
+		expect(recorder.finish()).toEqual(first);
+		recorder.dispose();
+		expect(() => recorder.recordRequest(request({ requestId: "r2" }))).toThrow();
+	});
+	it("rejects opaque about:blank and invalid recording origins during normalization", () => {
+		expect(() => normalizeRecordingOrigins(["about:blank"])).toThrow();
+		expect(() => normalizeRecordingOrigins(["https://shop.test/path"])).toThrow();
+		expect(normalizeRecordingOrigins(["HTTPS://SHOP.TEST"])).toEqual(new Set(["https://shop.test"]));
+		expect(() => new NetworkRecorder({ ...options, maxTotalBytes: 1 })).toThrow(/maxTotalBytes/);
+	});
+
+	it("counts an uncorrelated late body exactly once", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordResponseBody("missing", '{"ok":true}');
+		recorder.recordBodyOmitted("missing", "timeout");
+		expect(recorder.finish().omittedBodyCount).toBe(1);
+	});
+
+	it("redacts normalized camel/snake/kebab sensitive keys and scheme credential values", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(
+			request({
+				method: "POST",
+				postData: JSON.stringify({
+					sessionToken: "camel-token-secret",
+					account_id: "snake-account-secret",
+					csrfToken: "csrf-secret",
+					emailAddress: "person@corp.test",
+					note: "Bearer eyJhbGciOiJIUzI1NiJ9payload0123456789",
+					basicAuth: "Basic dXNlcjpwYXNzd29yZA==",
+					itemCount: 42,
+				}),
+			}),
+		);
+		recorder.recordResponse(response({ method: "POST" }));
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const secret of [
+			"camel-token-secret",
+			"snake-account-secret",
+			"csrf-secret",
+			"person@corp.test",
+			"eyJhbGciOiJIUzI1NiJ9payload0123456789",
+			"dXNlcjpwYXNzd29yZA==",
+		]) {
+			expect(serialized).not.toContain(secret);
+		}
+		expect(serialized).toContain("itemCount");
+	});
+
+	it("sanitizes URL-bearing response headers including Location, Content-Location, Link, and Refresh", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(request());
+		recorder.recordResponse(
+			response({
+				status: 302,
+				headers: {
+					"content-type": "application/json",
+					location: "https://shop.test/callback?token=loc-query-secret#frag-secret",
+					"content-location": "/reset/abcdef0123456789abcdef?code=cl-secret",
+					link: '</next?token=link-secret>; rel="next"',
+					refresh: "5; url=https://shop.test/go?token=refresh-secret",
+				},
+			}),
+		);
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const secret of [
+			"loc-query-secret",
+			"frag-secret",
+			"cl-secret",
+			"link-secret",
+			"refresh-secret",
+			"abcdef0123456789abcdef",
+		]) {
+			expect(serialized).not.toContain(secret);
+		}
+		expect(serialized).toContain("shop.test/callback");
+	});
+
+	it("counts a pre-response body exactly once when response metadata never arrives", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(request({ method: "POST" }));
+		recorder.recordResponseBody("r1", '{"ok":true}');
+		const result = recorder.finish();
+		expect(result.capturedBodyCount).toBe(0);
+		expect(result.omittedBodyCount).toBe(1);
+	});
+
+	it("redacts the complete Refresh url= target across path-parameter, quoted, and relative forms", () => {
+		const cases: Record<string, string[]> = {
+			"5; url=https://shop.test/go;session=matrix-secret?token=query-secret": ["matrix-secret", "query-secret"],
+			"3; url='https://shop.test/go?token=quoted-secret'": ["quoted-secret"],
+			'2; url="https://shop.test/go?token=dquoted-secret"': ["dquoted-secret"],
+			"0; url=/reset/abcdef0123456789abcdef?token=relative-secret": ["relative-secret", "abcdef0123456789abcdef"],
+		};
+		let index = 0;
+		for (const [refresh, secrets] of Object.entries(cases)) {
+			const recorder = new NetworkRecorder(options);
+			const requestId = `refresh-${index++}`;
+			recorder.recordRequest(request({ requestId }));
+			recorder.recordResponse(
+				response({ requestId, status: 302, headers: { "content-type": "application/json", refresh } }),
+			);
+			const serialized = JSON.stringify(recorder.finish().har);
+			for (const secret of secrets) expect(serialized).not.toContain(secret);
+			// The delay prefix survives so the header stays meaningful.
+			expect(serialized).toContain("url=");
+		}
+	});
+
+	it("preserves benign compound keys that only share a token with a sensitive word", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(
+			request({
+				method: "POST",
+				postData: JSON.stringify({
+					statusCode: 200,
+					productCode: "SKU-123",
+					sortKey: "created_at",
+					zipCode: "94107",
+				}),
+			}),
+		);
+		recorder.recordResponse(response({ method: "POST" }));
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const kept of ["statusCode", "productCode", "SKU-123", "sortKey", "created_at", "zipCode", "94107"]) {
+			expect(serialized).toContain(kept);
+		}
+	});
+
+	it("never echoes the raw invalid origin in normalization errors", () => {
+		const cases = [
+			"not a url",
+			"ftp://secret-host.example",
+			"https://user:sup3r-secret-pw@shop.test/leak-path?token=leak-query",
+		];
+		for (const raw of cases) {
+			expect(() => normalizeRecordingOrigins([raw])).toThrow();
+			let message = "";
+			try {
+				normalizeRecordingOrigins([raw]);
+			} catch (error) {
+				message = (error as Error).message;
+			}
+			expect(message).not.toContain(raw);
+		}
+		let credentialMessage = "";
+		try {
+			normalizeRecordingOrigins(["https://user:sup3r-secret-pw@shop.test/leak-path?token=leak-query"]);
+		} catch (error) {
+			credentialMessage = (error as Error).message;
+		}
+		expect(credentialMessage).not.toContain("sup3r-secret-pw");
+		expect(credentialMessage).not.toContain("leak-query");
+	});
+
+	it("redacts high-signal credential prefixes hidden under benign JSON, form, and header values", () => {
+		const paymentCredential = ["sk", "live", "0123456789abcdefABCDEFGH"].join("_");
+		const chatCredential = ["xoxb", "1234567890", "abcdefghijklmnop"].join("-");
+		const formCredential = ["sk", "test", "51H8xabcdefghij0123456789"].join("_");
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(
+			request({
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"x-trace-note": "ref ghp_0123456789abcdefghijABCDEFGHIJ012345",
+				},
+				postData: JSON.stringify({
+					note: "token is ghp_0123456789abcdefghijABCDEFGHIJ012345",
+					fineGrained: "github_pat_11ABCDEFG0abcdefghijkl_0123456789abcdefghij0123456789abcdefghij0123456789",
+					payment: paymentCredential,
+					chat: chatCredential,
+					cloud: "AKIAIOSFODNN7EXAMPLE",
+					maps: "AIzaSyA0123456789abcdefghijklmnopqrstuv",
+					registry: "npm_0123456789abcdefghijABCDEFGHIJ012345",
+					pem: "-----BEGIN RSA PRIVATE KEY-----MIIabc",
+				}),
+			}),
+		);
+		recorder.recordResponse(response({ method: "POST" }));
+		recorder.recordRequest(
+			request({
+				requestId: "form",
+				url: "https://shop.test/api/form",
+				method: "POST",
+				headers: { "content-type": "application/x-www-form-urlencoded" },
+				postData: `note=${formCredential}&keep=plain`,
+			}),
+		);
+		recorder.recordResponse(response({ requestId: "form", url: "https://shop.test/api/form", method: "POST" }));
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const secret of [
+			"ghp_0123456789abcdefghijABCDEFGHIJ012345",
+			"github_pat_11ABCDEFG0abcdefghijkl",
+			paymentCredential,
+			chatCredential,
+			"AKIAIOSFODNN7EXAMPLE",
+			"AIzaSyA0123456789abcdefghijklmnopqrstuv",
+			"npm_0123456789abcdefghijABCDEFGHIJ012345",
+			"BEGIN RSA PRIVATE KEY",
+			formCredential,
+		]) {
+			expect(serialized).not.toContain(secret);
+		}
+		expect(serialized).toContain('\\"keep\\":\\"plain\\"');
+	});
+
+	it("keeps benign values that only resemble credential tokens", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordRequest(
+			request({
+				method: "POST",
+				postData: JSON.stringify({
+					shortPat: "ghp_short",
+					username: "ghost_writer_1234567890",
+					plan: "sk_learning_path_2024",
+					board: "skateboard",
+					awsish: "AKIASHORT",
+					upper: "PLEASEKEEPTHISVALUE1",
+					mapsish: "AIza_no",
+					sku: "SKU-123",
+					zip: "94107",
+				}),
+			}),
+		);
+		recorder.recordResponse(response({ method: "POST" }));
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const kept of [
+			"ghp_short",
+			"ghost_writer_1234567890",
+			"sk_learning_path_2024",
+			"skateboard",
+			"AKIASHORT",
+			"PLEASEKEEPTHISVALUE1",
+			"AIza_no",
+			"SKU-123",
+			"94107",
+		]) {
+			expect(serialized).toContain(kept);
+		}
+	});
+
+	it("redacts short and numeric IDs after plural PII path parents but keeps named sub-resources", () => {
+		const recorder = new NetworkRecorder(options);
+		const redactedIds: [string, string][] = [
+			["users", "10203040"],
+			["accounts", "50607080"],
+			["customers", "cus10203040"],
+			["orgs", "70809010"],
+		];
+		const keptSegments: [string, string][] = [
+			["users", "settings"],
+			["accounts", "preferences"],
+			["orgs", "acmeco"],
+			["orders", "99887766"],
+		];
+		let index = 0;
+		for (const [parent, segment] of [...redactedIds, ...keptSegments]) {
+			const requestId = `pii-${index++}`;
+			const url = `https://shop.test/${parent}/${segment}`;
+			recorder.recordRequest(request({ requestId, url }));
+			recorder.recordResponse(response({ requestId, url }));
+		}
+		const serialized = JSON.stringify(recorder.finish().har);
+		for (const [, segment] of redactedIds) expect(serialized).not.toContain(segment);
+		for (const [, segment] of keptSegments) expect(serialized).toContain(segment);
+	});
+
+	it("consumes a pending omission exactly once when a response-only entry is created", () => {
+		const recorder = new NetworkRecorder(options);
+		recorder.recordBodyOmitted("resp-only", "timeout");
+		recorder.recordResponse(response({ requestId: "resp-only" }));
+		const result = recorder.finish();
+		expect(result.entryCount).toBe(1);
+		expect(result.omittedBodyCount).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-recording-worker.test.ts
+++ b/packages/coding-agent/test/tools/browser-recording-worker.test.ts
@@ -1,0 +1,878 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_RECORDING_LIMITS } from "@oh-my-pi/pi-coding-agent/tools/browser/network-recorder";
+import type { Transport, WorkerInbound, WorkerOutbound } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-protocol";
+import { WorkerCore } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-worker";
+import type { CDPSession, Page } from "puppeteer-core";
+
+// The worker recording channel is exercised through its real inbound-message handler
+// (a `Transport`) and an injected CDP transport, so every assertion is a genuine
+// observable contract: an emitted outbound message or a HAR the worker produced.
+
+type CdpHandler = (payload: unknown) => void;
+
+type HarEntry = {
+	time: number;
+	startedDateTime: string;
+	request: {
+		method: string;
+		url: string;
+		headers: Array<{ name: string; value: string }>;
+		postData?: { mimeType: string; text: string };
+	};
+	response: {
+		status: number;
+		headers: Array<{ name: string; value: string }>;
+		content: { mimeType: string; size: number; text?: string };
+	};
+};
+type Har = { log: { entries: HarEntry[] } };
+
+class TestTransport implements Transport {
+	readonly sent: WorkerOutbound[] = [];
+	#handler: ((msg: WorkerInbound) => void) | null = null;
+	#waiters = new Set<{ match: (m: WorkerOutbound) => boolean; resolve: (m: WorkerOutbound) => void }>();
+
+	send(msg: WorkerOutbound | WorkerInbound): void {
+		const out = msg as WorkerOutbound;
+		this.sent.push(out);
+		for (const waiter of [...this.#waiters]) {
+			if (waiter.match(out)) {
+				this.#waiters.delete(waiter);
+				waiter.resolve(out);
+			}
+		}
+	}
+
+	onMessage(handler: (msg: WorkerOutbound | WorkerInbound) => void): () => void {
+		this.#handler = handler as (msg: WorkerInbound) => void;
+		return () => {
+			this.#handler = null;
+		};
+	}
+
+	close(): void {}
+
+	deliver(msg: WorkerInbound): void {
+		if (!this.#handler) throw new Error("worker is not listening on the transport");
+		this.#handler(msg);
+	}
+
+	byType<T extends WorkerOutbound["type"]>(type: T): Array<Extract<WorkerOutbound, { type: T }>> {
+		return this.sent.filter((m): m is Extract<WorkerOutbound, { type: T }> => m.type === type);
+	}
+
+	next<T extends WorkerOutbound["type"]>(
+		type: T,
+		match?: (m: Extract<WorkerOutbound, { type: T }>) => boolean,
+	): Promise<Extract<WorkerOutbound, { type: T }>> {
+		const predicate = (m: WorkerOutbound): m is Extract<WorkerOutbound, { type: T }> =>
+			m.type === type && (!match || match(m as Extract<WorkerOutbound, { type: T }>));
+		const existing = this.sent.find(predicate);
+		if (existing) return Promise.resolve(existing);
+		const { promise, resolve } = Promise.withResolvers<Extract<WorkerOutbound, { type: T }>>();
+		this.#waiters.add({ match: predicate, resolve: resolve as (m: WorkerOutbound) => void });
+		return promise;
+	}
+}
+
+class FakeCdpSession {
+	readonly commands: Array<{ method: string; params?: Record<string, unknown> }> = [];
+	detachCount = 0;
+	networkDisableCount = 0;
+	networkEnableError: Error | null = null;
+	frameTreeError: Error | null = null;
+	networkEnableGate: Promise<void> | null = null;
+	#handlers = new Map<string, Set<CdpHandler>>();
+	#bodies = new Map<string, PromiseWithResolvers<{ body: string; base64Encoded: boolean }>>();
+
+	on(event: string, handler: CdpHandler): this {
+		let set = this.#handlers.get(event);
+		if (!set) {
+			set = new Set();
+			this.#handlers.set(event, set);
+		}
+		set.add(handler);
+		return this;
+	}
+
+	off(event: string, handler: CdpHandler): this {
+		this.#handlers.get(event)?.delete(handler);
+		return this;
+	}
+
+	emit(event: string, payload: unknown): void {
+		for (const handler of [...(this.#handlers.get(event) ?? [])]) handler(payload);
+	}
+
+	totalListeners(): number {
+		let count = 0;
+		for (const set of this.#handlers.values()) count += set.size;
+		return count;
+	}
+
+	#bodyResolver(requestId: string): PromiseWithResolvers<{ body: string; base64Encoded: boolean }> {
+		let entry = this.#bodies.get(requestId);
+		if (!entry) {
+			entry = Promise.withResolvers();
+			this.#bodies.set(requestId, entry);
+		}
+		return entry;
+	}
+
+	resolveBody(requestId: string, body: string, base64Encoded = false): void {
+		this.#bodyResolver(requestId).resolve({ body, base64Encoded });
+	}
+
+	rejectBody(requestId: string, error: Error): void {
+		this.#bodyResolver(requestId).reject(error);
+	}
+
+	async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+		this.commands.push({ method, params });
+		if (method === "Network.enable") {
+			if (this.networkEnableGate) await this.networkEnableGate;
+			if (this.networkEnableError) throw this.networkEnableError;
+			return {};
+		}
+		if (method === "Network.disable") {
+			this.networkDisableCount++;
+			return {};
+		}
+		if (method === "Page.getFrameTree") {
+			if (this.frameTreeError) throw this.frameTreeError;
+			return { frameTree: { frame: { id: "frame", url: "https://shop.test/" }, childFrames: [] } };
+		}
+		if (method === "Network.getResponseBody") {
+			return this.#bodyResolver(String(params?.requestId ?? "")).promise;
+		}
+		return {};
+	}
+
+	async detach(): Promise<void> {
+		this.detachCount++;
+	}
+}
+
+function fakePage(url = "https://shop.test/products"): Page {
+	return { url: () => url, isClosed: () => false } as unknown as Page;
+}
+
+function makeWorker(
+	session: FakeCdpSession,
+	page = fakePage(),
+	dispose?: () => Promise<void> | void,
+	acquire?: Promise<void>,
+): { transport: TestTransport; core: WorkerCore } {
+	const transport = new TestTransport();
+	const core = new WorkerCore(transport, {
+		page,
+		targetId: "target-1",
+		pageCdpClient: async () => {
+			if (acquire) await acquire;
+			return dispose ? { client: session as unknown as CDPSession, dispose } : (session as unknown as CDPSession);
+		},
+	});
+	return { transport, core };
+}
+
+let idSeq = 0;
+const nextId = (): string => `rec-${++idSeq}`;
+
+function requestWillBeSent(
+	requestId: string,
+	url: string,
+	headers: Record<string, string> = { "content-type": "application/json" },
+	postData?: string,
+) {
+	return {
+		requestId,
+		request: { url, method: postData ? "POST" : "GET", headers, postData },
+		wallTime: 1_700_000_000,
+		timestamp: 100,
+	};
+}
+
+function requestExtraInfo(requestId: string, headers: Record<string, string>) {
+	return {
+		requestId,
+		headers,
+		associatedCookies: [{ cookie: { name: "sid", value: "top-secret-cookie" }, blockedReasons: [] }],
+	};
+}
+
+function responseReceived(
+	requestId: string,
+	url: string,
+	headers: Record<string, string> = { "content-type": "application/json" },
+	status = 200,
+	mimeType = "application/json",
+) {
+	return {
+		requestId,
+		response: { url, status, statusText: "OK", headers, mimeType, encodedDataLength: 0 },
+		timestamp: 101,
+	};
+}
+
+function loadingFinished(requestId: string, encodedDataLength = 20) {
+	return { requestId, timestamp: 102, encodedDataLength };
+}
+
+function loadingFailed(requestId: string) {
+	return { requestId, timestamp: 102, type: "Fetch", errorText: "net::ERR_FAILED", canceled: false };
+}
+
+function har(stopped: Extract<WorkerOutbound, { type: "recording-stopped" }>): Har {
+	return stopped.summary.har as unknown as Har;
+}
+
+describe("WorkerCore recording control", () => {
+	it("populates omitted limits with defaults and scopes to the live page origin", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session, fakePage("https://shop.test/products?ref=1"));
+
+		const started = transport.next("recording-started");
+		transport.deliver({ type: "recording-start", id: nextId() });
+		const msg = await started;
+
+		expect(msg.scope).toEqual(["https://shop.test"]);
+		expect(msg.limits).toEqual(DEFAULT_RECORDING_LIMITS);
+		expect(session.commands.some(c => c.method === "Network.enable")).toBe(true);
+	});
+
+	it("emits only recording-started on start and only recording-stopped on stop", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+
+		const startId = nextId();
+		const started = transport.next("recording-started");
+		transport.deliver({ type: "recording-start", id: startId });
+		expect((await started).id).toBe(startId);
+		expect(transport.byType("recording-error")).toHaveLength(0);
+
+		const stopId = nextId();
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: stopId, timeoutMs: 1_000 });
+		const stopMsg = await stopped;
+
+		expect(stopMsg.id).toBe(stopId);
+		expect(stopMsg.summary.entryCount).toBe(0);
+		expect(transport.byType("recording-stopped")).toHaveLength(1);
+		expect(transport.byType("recording-error")).toHaveLength(0);
+	});
+
+	it("never routes a recording reply onto the run result channel", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+		await stopped;
+
+		expect(transport.sent.every(m => m.type.startsWith("recording-") || m.type === "log")).toBe(true);
+		expect(transport.byType("result")).toHaveLength(0);
+	});
+
+	it("cancels without a HAR and leaves a clean follow-up start", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+
+		const cancelId = nextId();
+		const canceled = transport.next("recording-canceled");
+		transport.deliver({ type: "recording-cancel", id: cancelId });
+		const cancelMsg = await canceled;
+		expect(cancelMsg.id).toBe(cancelId);
+		expect("summary" in cancelMsg).toBe(false);
+		expect("har" in cancelMsg).toBe(false);
+
+		// State was cleared: a fresh start succeeds immediately.
+		const startId = nextId();
+		const started = transport.next("recording-started", m => m.id === startId);
+		transport.deliver({ type: "recording-start", id: startId });
+		expect((await started).id).toBe(startId);
+	});
+
+	it("captures a delayed response body before stop resolves", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/items";
+		const rid = "req-body";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		// The body arrives only after stop began draining; stop must wait for it.
+		session.resolveBody(rid, '{"result":"ok"}');
+		const stopMsg = await stopped;
+
+		expect(stopMsg.summary.capturedBodyCount).toBe(1);
+		const entry = har(stopMsg).log.entries[0];
+		expect(entry.request.url).toBe(url);
+		expect(entry.response.content.mimeType).toBe("application/json");
+		expect(entry.response.content.text).toBe('{"result":"ok"}');
+	});
+
+	it("omits the body on a read timeout and still resolves the stop", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/slow";
+		const rid = "req-timeout";
+
+		transport.deliver({ type: "recording-start", id: nextId(), limits: { maxBodyWaitMs: 5 } });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+
+		// getResponseBody is never resolved: the worker-side maxBodyWaitMs race must win.
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		const stopMsg = await stopped;
+
+		expect(stopMsg.summary.capturedBodyCount).toBe(0);
+		expect(stopMsg.summary.omittedBodyCount).toBeGreaterThanOrEqual(1);
+		expect(har(stopMsg).log.entries).toHaveLength(1);
+	});
+
+	it("omits the body and drains when a request fails to load", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/fail";
+		const rid = "req-fail";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+		session.emit("Network.responseReceived", responseReceived(rid, url, { "content-type": "application/json" }, 500));
+		session.emit("Network.loadingFailed", loadingFailed(rid));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		const stopMsg = await stopped;
+
+		expect(stopMsg.summary.capturedBodyCount).toBe(0);
+		expect(har(stopMsg).log.entries).toHaveLength(1);
+	});
+
+	it("drains a pre-cutoff request whose completion arrives after stop", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/late";
+		const rid = "req-late";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+
+		// Stop while the request is still in flight; its completion is queued afterwards.
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+		session.resolveBody(rid, '{"late":true}');
+		const stopMsg = await stopped;
+
+		expect(har(stopMsg).log.entries).toHaveLength(1);
+		expect(har(stopMsg).log.entries[0].request.url).toBe(url);
+		expect(stopMsg.summary.capturedBodyCount).toBe(1);
+	});
+
+	it("excludes requests that begin after the stop cutoff", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const preUrl = "https://shop.test/api/one";
+		const postUrl = "https://shop.test/api/two";
+		const pre = "req-pre";
+		const post = "req-post";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(pre, preUrl));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		// A brand-new request after the cutoff must never widen the capture.
+		session.emit("Network.requestWillBeSent", requestWillBeSent(post, postUrl));
+		session.emit("Network.responseReceived", responseReceived(post, postUrl));
+		session.emit("Network.loadingFinished", loadingFinished(post));
+		// The pre-cutoff request finishes and is included.
+		session.emit("Network.responseReceived", responseReceived(pre, preUrl));
+		session.emit("Network.loadingFinished", loadingFinished(pre));
+		session.resolveBody(pre, '{"pre":true}');
+		const stopMsg = await stopped;
+
+		const urls = har(stopMsg).log.entries.map(e => e.request.url);
+		expect(urls).toContain(preUrl);
+		expect(urls).not.toContain(postUrl);
+		expect(har(stopMsg).log.entries).toHaveLength(1);
+	});
+
+	it("merges request ExtraInfo headers that arrive before the base event and drops cookies", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/extra";
+		const rid = "req-extra";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		// ExtraInfo precedes the base request event.
+		session.emit(
+			"Network.requestWillBeSentExtraInfo",
+			requestExtraInfo(rid, { "X-Merged": "yes", cookie: "session=top-secret" }),
+		);
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url, { "content-type": "application/json" }));
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		session.resolveBody(rid, '{"ok":true}');
+		const stopMsg = await stopped;
+
+		const entry = har(stopMsg).log.entries[0];
+		const headers = new Map(entry.request.headers.map(h => [h.name, h.value]));
+		expect(headers.get("x-merged")).toBe("yes");
+		expect(headers.get("cookie")).toBe("[REDACTED]");
+		expect(JSON.stringify(stopMsg.summary.har)).not.toContain("top-secret");
+	});
+
+	it("emits recording-error and clears state when there is no page CDP client", async () => {
+		const transport = new TestTransport();
+		new WorkerCore(transport, { page: fakePage(), targetId: "t", pageCdpClient: () => null });
+
+		const errored = transport.next("recording-error");
+		transport.deliver({ type: "recording-start", id: nextId() });
+		const err = await errored;
+		expect(err.error.message).toContain("CDP session");
+		expect(transport.byType("recording-started")).toHaveLength(0);
+
+		// State was cleared: stopping now reports "no active recording" rather than a stale HAR.
+		const stopErr = transport.next("recording-error");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+		expect((await stopErr).error).toBeDefined();
+	});
+	it("disposes an owned CDP session exactly once on normal stop and repeated cycles", async () => {
+		const session = new FakeCdpSession();
+		let disposeCount = 0;
+		const { transport } = makeWorker(session, fakePage(), () => {
+			disposeCount++;
+		});
+		for (let cycle = 0; cycle < 2; cycle++) {
+			const started = transport.next("recording-started");
+			transport.deliver({ type: "recording-start", id: nextId() });
+			await started;
+			const stopped = transport.next("recording-stopped");
+			transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+			await stopped;
+		}
+		expect(disposeCount).toBe(2);
+	});
+
+	it("disposes an owned CDP session exactly once when canceled", async () => {
+		const session = new FakeCdpSession();
+		let disposeCount = 0;
+		const { transport } = makeWorker(session, fakePage(), () => {
+			disposeCount++;
+		});
+		const started = transport.next("recording-started");
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await started;
+		const canceled = transport.next("recording-canceled");
+		transport.deliver({ type: "recording-cancel", id: nextId() });
+		await canceled;
+		expect(disposeCount).toBe(1);
+	});
+
+	it("disposes an owned CDP session exactly once when Network.enable fails", async () => {
+		const session = new FakeCdpSession();
+		session.networkEnableError = new Error("boom");
+		let disposeCount = 0;
+		const { transport } = makeWorker(session, fakePage(), () => {
+			disposeCount++;
+		});
+		const errored = transport.next("recording-error");
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await errored;
+		expect(disposeCount).toBe(1);
+	});
+
+	it("emits recording-error without disabling the session when Network.enable fails", async () => {
+		const session = new FakeCdpSession();
+		session.networkEnableError = new Error("boom raw cdp detail");
+		const { transport } = makeWorker(session);
+
+		const errored = transport.next("recording-error");
+		transport.deliver({ type: "recording-start", id: nextId() });
+		const err = await errored;
+
+		expect(err.error.message).not.toContain("boom raw cdp detail");
+		expect(session.networkDisableCount).toBe(0);
+		expect(session.detachCount).toBe(0);
+	});
+
+	it("aborts a start whose Network.enable is still in flight when canceled", async () => {
+		const session = new FakeCdpSession();
+		const gate = Promise.withResolvers<void>();
+		session.networkEnableGate = gate.promise;
+		const { transport } = makeWorker(session);
+
+		const startId = nextId();
+		transport.deliver({ type: "recording-start", id: startId });
+		const cancelId = nextId();
+		const canceled = transport.next("recording-canceled");
+		transport.deliver({ type: "recording-cancel", id: cancelId });
+		expect((await canceled).id).toBe(cancelId);
+
+		// Release the in-flight enable; the aborted start must not emit a late recording-started.
+		gate.resolve();
+
+		const secondStart = nextId();
+		const started = transport.next("recording-started", m => m.id === secondStart);
+		transport.deliver({ type: "recording-start", id: secondStart });
+		await started;
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+		await stopped;
+
+		expect(transport.byType("recording-started")).toHaveLength(1);
+		expect(transport.byType("recording-started")[0].id).toBe(secondStart);
+	});
+	it("disposes an owned session when stop supersedes delayed CDP acquisition", async () => {
+		const session = new FakeCdpSession();
+		const acquisition = Promise.withResolvers<void>();
+		const disposed = Promise.withResolvers<void>();
+		let disposeCount = 0;
+		const { transport } = makeWorker(
+			session,
+			fakePage(),
+			() => {
+				disposeCount++;
+				disposed.resolve();
+			},
+			acquisition.promise,
+		);
+		transport.deliver({ type: "recording-start", id: nextId() });
+		const stopError = transport.next("recording-error");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+		await stopError;
+		acquisition.resolve();
+		await disposed.promise;
+		expect(disposeCount).toBe(1);
+		expect(transport.byType("recording-started")).toHaveLength(0);
+	});
+
+	it("disposes an owned session when cancel supersedes delayed CDP acquisition", async () => {
+		const session = new FakeCdpSession();
+		const acquisition = Promise.withResolvers<void>();
+		const disposed = Promise.withResolvers<void>();
+		let disposeCount = 0;
+		const { transport } = makeWorker(
+			session,
+			fakePage(),
+			() => {
+				disposeCount++;
+				disposed.resolve();
+			},
+			acquisition.promise,
+		);
+		transport.deliver({ type: "recording-start", id: nextId() });
+		const canceled = transport.next("recording-canceled");
+		transport.deliver({ type: "recording-cancel", id: nextId() });
+		await canceled;
+		acquisition.resolve();
+		await disposed.promise;
+		expect(disposeCount).toBe(1);
+		expect(transport.byType("recording-started")).toHaveLength(0);
+	});
+
+	it("disposes an owned session when close supersedes delayed CDP acquisition", async () => {
+		const session = new FakeCdpSession();
+		const acquisition = Promise.withResolvers<void>();
+		const disposed = Promise.withResolvers<void>();
+		let disposeCount = 0;
+		const { transport } = makeWorker(
+			session,
+			fakePage(),
+			() => {
+				disposeCount++;
+				disposed.resolve();
+			},
+			acquisition.promise,
+		);
+		transport.deliver({ type: "recording-start", id: nextId() });
+		const closed = transport.next("closed");
+		transport.deliver({ type: "close" });
+		await closed;
+		acquisition.resolve();
+		await disposed.promise;
+		expect(disposeCount).toBe(1);
+		expect(transport.byType("recording-started")).toHaveLength(0);
+	});
+
+	it("logs only requestId + origin (no path/query) when the body read fails", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		// A sensitive account id sits in the PATH (and a token in the query): neither may reach the log.
+		const url = "https://shop.test/accounts/SECRET-ACCOUNT-9f3a2b/orders?token=leak-marker";
+		const rid = "req-err";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+		session.rejectBody(rid, new Error("raw cdp secret payload"));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		const stopMsg = await stopped;
+
+		expect(stopMsg.summary.capturedBodyCount).toBe(0);
+		const failureLog = transport.byType("log").find(m => m.meta && "reason" in (m.meta ?? {}));
+		expect(failureLog).toBeDefined();
+		const meta = failureLog?.meta ?? {};
+		// Origin only — no path, query, or full URL.
+		expect(meta.origin).toBe("https://shop.test");
+		expect(meta.url).toBeUndefined();
+		expect(meta.reason).toBe("unavailable");
+		expect(meta.requestId).toBe(rid);
+		// The whole emitted log carries no sensitive path/query segment nor the raw CDP error text.
+		const serialized = JSON.stringify(failureLog);
+		expect(serialized).not.toContain("SECRET-ACCOUNT-9f3a2b");
+		expect(serialized).not.toContain("/accounts/");
+		expect(serialized).not.toContain("token=leak-marker");
+		expect(serialized).not.toContain("raw cdp secret payload");
+	});
+
+	it("reports recording-error when the page session dies during the stop drain", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const rid = "req-dead";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, "https://shop.test/api/hang"));
+
+		session.frameTreeError = new Error("Session closed");
+		const errored = transport.next("recording-error");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		const err = await errored;
+
+		expect(err.error.message).not.toContain("Session closed");
+		expect(session.networkDisableCount).toBe(0);
+		expect(session.detachCount).toBe(0);
+		expect(transport.byType("recording-stopped")).toHaveLength(0);
+	});
+
+	it("never disables or detaches the shared page session across stop and cancel", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const rid = "req-share";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, "https://shop.test/api/x"));
+		session.emit("Network.responseReceived", responseReceived(rid, "https://shop.test/api/x"));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+		session.resolveBody(rid, '{"ok":1}');
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		await stopped;
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started", () => transport.byType("recording-started").length === 2);
+		const canceled = transport.next("recording-canceled");
+		transport.deliver({ type: "recording-cancel", id: nextId() });
+		await canceled;
+
+		expect(session.networkDisableCount).toBe(0);
+		expect(session.detachCount).toBe(0);
+		expect(session.totalListeners()).toBe(0);
+	});
+
+	it("settles a start still enabling when stop races in, with one terminal and no late start", async () => {
+		const session = new FakeCdpSession();
+		const gate = Promise.withResolvers<void>();
+		session.networkEnableGate = gate.promise;
+		const { transport } = makeWorker(session);
+
+		const startId = nextId();
+		transport.deliver({ type: "recording-start", id: startId });
+		const stopId = nextId();
+		const errored = transport.next("recording-error", m => m.id === stopId);
+		transport.deliver({ type: "recording-stop", id: stopId, timeoutMs: 1_000 });
+		expect((await errored).id).toBe(stopId);
+
+		// Release the in-flight enable; the superseded start must not emit a late recording-started.
+		gate.resolve();
+
+		// Fence: a fresh start/stop cycle flushes the resumed start and proves state was cleared.
+		const secondStart = nextId();
+		const started = transport.next("recording-started", m => m.id === secondStart);
+		transport.deliver({ type: "recording-start", id: secondStart });
+		await started;
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+		await stopped;
+
+		expect(transport.byType("recording-started").map(m => m.id)).toEqual([secondStart]);
+		expect(transport.byType("recording-error").map(m => m.id)).toEqual([stopId]);
+	});
+
+	it("emits only recording-canceled when cancel arrives during an in-flight stop drain", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const rid = "req-drain-cancel";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, "https://shop.test/api/hang"));
+
+		// Stop begins draining and blocks on the never-completing request.
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 5_000 });
+		const cancelId = nextId();
+		const canceled = transport.next("recording-canceled", m => m.id === cancelId);
+		transport.deliver({ type: "recording-cancel", id: cancelId });
+		expect((await canceled).id).toBe(cancelId);
+
+		// Fence: a fresh start/stop cycle proves the superseded drain resolved silently.
+		const secondStart = nextId();
+		const started = transport.next("recording-started", m => m.id === secondStart);
+		transport.deliver({ type: "recording-start", id: secondStart });
+		await started;
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 1_000 });
+		await stopped;
+
+		expect(transport.byType("recording-error")).toHaveLength(0);
+		expect(transport.byType("recording-canceled").map(m => m.id)).toEqual([cancelId]);
+		expect(transport.byType("recording-stopped")).toHaveLength(1);
+	});
+
+	it("excludes non-HTTP and out-of-scope origins from the capture", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session, fakePage("https://shop.test/products"));
+		const keep = "req-keep";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		// In-scope request is captured.
+		session.emit("Network.requestWillBeSent", requestWillBeSent(keep, "https://shop.test/api/keep"));
+		session.emit("Network.responseReceived", responseReceived(keep, "https://shop.test/api/keep"));
+		session.emit("Network.loadingFinished", loadingFinished(keep));
+		// Out-of-scope origin (e.g. after a cross-origin navigation) must never widen scope.
+		session.emit("Network.requestWillBeSent", requestWillBeSent("req-cross", "https://evil.test/api/steal"));
+		session.emit("Network.responseReceived", responseReceived("req-cross", "https://evil.test/api/steal"));
+		session.emit("Network.loadingFinished", loadingFinished("req-cross"));
+		// Non-HTTP schemes are never in scope.
+		session.emit("Network.requestWillBeSent", requestWillBeSent("req-ws", "ws://shop.test/socket"));
+		session.emit("Network.requestWillBeSent", requestWillBeSent("req-about", "about:blank"));
+		session.emit("Network.requestWillBeSent", requestWillBeSent("req-data", "data:text/plain,hi"));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		session.resolveBody(keep, '{"kept":true}');
+		const stopMsg = await stopped;
+
+		expect(har(stopMsg).log.entries.map(e => e.request.url)).toEqual(["https://shop.test/api/keep"]);
+		const serialized = JSON.stringify(stopMsg.summary.har);
+		expect(serialized).not.toContain("evil.test");
+		expect(serialized).not.toContain("ws://");
+		expect(serialized).not.toContain("data:text");
+	});
+
+	it("derives HAR timing from the monotonic clock while startedDateTime keeps epoch wall time", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/timing";
+		const rid = "req-timing";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		// wallTime is epoch seconds; timestamp is the monotonic CDP clock. Elapsed time must use the
+		// monotonic delta (101 - 100 = 1s), not the epoch/monotonic mix that clamps duration to zero.
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		session.resolveBody(rid, '{"ok":true}');
+		const stopMsg = await stopped;
+
+		const entry = har(stopMsg).log.entries[0];
+		expect(entry.time).toBeCloseTo(1_000, 5);
+		expect(entry.startedDateTime).toBe(new Date(1_700_000_000_000).toISOString());
+	});
+
+	it("merges delayed request ExtraInfo for a pre-cutoff request during the stop drain", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/delayed";
+		const rid = "req-delayed-extra";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		// The request is captured before stop, but its raw-header ExtraInfo has not arrived yet.
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url, { "content-type": "application/json" }));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		// ExtraInfo (raw headers, incl. cookie) arrives only after the cutoff; a pre-cutoff id must
+		// still merge it before the drain completes.
+		session.emit(
+			"Network.requestWillBeSentExtraInfo",
+			requestExtraInfo(rid, { "x-delayed-extra": "present", cookie: "session=late-cookie-secret" }),
+		);
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+		session.resolveBody(rid, '{"ok":true}');
+		const stopMsg = await stopped;
+
+		const entry = har(stopMsg).log.entries[0];
+		const headers = new Map(entry.request.headers.map(h => [h.name, h.value]));
+		expect(headers.get("x-delayed-extra")).toBe("present");
+		expect(headers.get("cookie")).toBe("[REDACTED]");
+		expect(JSON.stringify(stopMsg.summary.har)).not.toContain("late-cookie-secret");
+	});
+
+	it("merges delayed response ExtraInfo (Set-Cookie) for a pre-cutoff request during the stop drain", async () => {
+		const session = new FakeCdpSession();
+		const { transport } = makeWorker(session);
+		const url = "https://shop.test/api/set-cookie";
+		const rid = "req-res-extra";
+
+		transport.deliver({ type: "recording-start", id: nextId() });
+		await transport.next("recording-started");
+		session.emit("Network.requestWillBeSent", requestWillBeSent(rid, url));
+
+		const stopped = transport.next("recording-stopped");
+		transport.deliver({ type: "recording-stop", id: nextId(), timeoutMs: 2_000 });
+		// responseReceived is recorded during the drain, then its raw ExtraInfo (Set-Cookie + a
+		// custom header) arrives late; a pre-cutoff id must still merge it after the base event.
+		session.emit("Network.responseReceived", responseReceived(rid, url));
+		session.emit("Network.responseReceivedExtraInfo", {
+			requestId: rid,
+			headers: { "x-res-extra": "present", "set-cookie": "session=late-set-cookie-secret; Secure" },
+		});
+		session.emit("Network.loadingFinished", loadingFinished(rid));
+		session.resolveBody(rid, '{"ok":true}');
+		const stopMsg = await stopped;
+
+		const entry = har(stopMsg).log.entries[0];
+		const headers = new Map(entry.response.headers.map(h => [h.name, h.value]));
+		expect(headers.get("x-res-extra")).toBe("present");
+		expect(headers.get("set-cookie")).toBe("[REDACTED]");
+		expect(JSON.stringify(stopMsg.summary.har)).not.toContain("late-set-cookie-secret");
+	});
+});

--- a/packages/coding-agent/test/tools/browser-recording.test.ts
+++ b/packages/coding-agent/test/tools/browser-recording.test.ts
@@ -1,0 +1,1328 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { registerArtifactsDir } from "@oh-my-pi/pi-coding-agent/internal-urls/registry-helpers";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { BrowserTool, type BrowserToolDetails, setHarArtifactIoForTest } from "@oh-my-pi/pi-coding-agent/tools/browser";
+import { ensureChromiumExecutable } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+import {
+	DEFAULT_RECORDING_LIMITS,
+	type RecordingSummary,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/network-recorder";
+import { getBrowsersMapForTest, type PuppeteerBrowserHandle } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+import { browserToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/browser/render";
+import type { RunResultOk, WorkerInbound, WorkerOutbound } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-protocol";
+import {
+	getTabsMapForTest,
+	registerWorkerTabForTest,
+	releaseTab,
+	releaseTabsForOwner,
+	setTabWorkerFactoryForTest,
+	startTabRecording,
+	stopTabRecording,
+	type WorkerHandle,
+	type WorkerTabSession,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+
+// The supervisor recording lifecycle is exercised through an injectable worker
+// transport: a `FakeWorker` stands in for the real Bun worker and deterministically
+// replays the frozen Task-2 worker protocol (recording-started/-stopped/-canceled/
+// -error, closed) so every assertion is an observable supervisor contract — a
+// resolved/rejected control op, a settled state transition, or a cleanup guarantee.
+//
+// The supervisor registers each control op and mutates recording state synchronously
+// (before its first await), so these tests read state immediately after the call with
+// no artificial yield. Only the deadline/cancel/recycle tests use a small real timeout,
+// because the supervisor's wall-clock deadline is exactly the contract under test.
+
+type RecordingReaction = "ack" | "silent";
+
+interface ResponderOptions {
+	start?: RecordingReaction;
+	stop?: RecordingReaction;
+	cancel?: RecordingReaction;
+	scope?: string[];
+	summary?: RecordingSummary;
+}
+
+function emptyRun(): RunResultOk {
+	return { displays: [], returnValue: undefined, screenshots: [] };
+}
+
+function makeSummary(entryCount = 1): RecordingSummary {
+	return {
+		har: { log: { version: "1.2", entries: [] } },
+		entryCount,
+		capturedBodyCount: 0,
+		omittedBodyCount: 0,
+		totalBytes: 0,
+		truncated: false,
+	};
+}
+
+class FakeWorker implements WorkerHandle {
+	readonly mode: "worker" | "inline";
+	readonly sent: WorkerInbound[] = [];
+	terminated = false;
+	#respond?: (msg: WorkerInbound, worker: FakeWorker) => void;
+	#throwOnSend: boolean;
+	#messageHandlers = new Set<(msg: WorkerOutbound) => void>();
+	#errorHandlers = new Set<(error: Error) => void>();
+
+	constructor(
+		opts: {
+			mode?: "worker" | "inline";
+			respond?: (msg: WorkerInbound, worker: FakeWorker) => void;
+			throwOnSend?: boolean;
+		} = {},
+	) {
+		this.mode = opts.mode ?? "worker";
+		this.#respond = opts.respond;
+		this.#throwOnSend = opts.throwOnSend ?? false;
+	}
+
+	send(msg: WorkerInbound): void {
+		if (this.#throwOnSend) throw new Error("transport unavailable");
+		this.sent.push(msg);
+		this.#respond?.(msg, this);
+	}
+
+	onMessage(handler: (msg: WorkerOutbound) => void): () => void {
+		this.#messageHandlers.add(handler);
+		return () => this.#messageHandlers.delete(handler);
+	}
+
+	onError(handler: (error: Error) => void): () => void {
+		this.#errorHandlers.add(handler);
+		return () => this.#errorHandlers.delete(handler);
+	}
+
+	async terminate(): Promise<void> {
+		this.terminated = true;
+	}
+
+	emit(msg: WorkerOutbound): void {
+		for (const handler of [...this.#messageHandlers]) handler(msg);
+	}
+
+	emitError(error: Error): void {
+		for (const handler of [...this.#errorHandlers]) handler(error);
+	}
+
+	lastSent<T extends WorkerInbound["type"]>(type: T): Extract<WorkerInbound, { type: T }> | undefined {
+		for (let i = this.sent.length - 1; i >= 0; i--) {
+			const msg = this.sent[i];
+			if (msg.type === type) return msg as Extract<WorkerInbound, { type: T }>;
+		}
+		return undefined;
+	}
+}
+
+function responder(opts: ResponderOptions = {}): (msg: WorkerInbound, worker: FakeWorker) => void {
+	const start = opts.start ?? "ack";
+	const stop = opts.stop ?? "ack";
+	const cancel = opts.cancel ?? "ack";
+	// Real workers deliver replies asynchronously via postMessage; mirror that with queueMicrotask so
+	// `waitForClosed` (which subscribes only after the close is sent) observes the `closed` reply.
+	return (msg, worker) => {
+		const reply = (out: WorkerOutbound): void => queueMicrotask(() => worker.emit(out));
+		switch (msg.type) {
+			case "close":
+				reply({ type: "closed" });
+				return;
+			case "run":
+				reply({ type: "result", id: msg.id, ok: true, payload: emptyRun() });
+				return;
+			case "init":
+				reply({
+					type: "ready",
+					info: { url: "https://shop.test/", viewport: { width: 1280, height: 800 }, targetId: "recycled-target" },
+				});
+				return;
+			case "recording-start":
+				if (start === "ack") {
+					const scope =
+						opts.scope ?? (msg.domains && msg.domains.length > 0 ? [...msg.domains] : ["https://shop.test"]);
+					reply({ type: "recording-started", id: msg.id, scope, limits: DEFAULT_RECORDING_LIMITS });
+				}
+				return;
+			case "recording-stop":
+				if (stop === "ack")
+					reply({ type: "recording-stopped", id: msg.id, summary: opts.summary ?? makeSummary() });
+				return;
+			case "recording-cancel":
+				if (cancel === "ack") reply({ type: "recording-canceled", id: msg.id });
+				return;
+		}
+	};
+}
+
+let browserSeq = 0;
+function makeBrowser(): PuppeteerBrowserHandle {
+	browserSeq += 1;
+	return {
+		key: `test-recording-browser-${browserSeq}`,
+		kind: { kind: "connected", cdpUrl: `ws://127.0.0.1/devtools/browser/test-${browserSeq}` },
+		refCount: 0,
+		browser: {
+			connected: false,
+			wsEndpoint: () => "ws://127.0.0.1/devtools/browser/fake",
+		} as unknown as PuppeteerBrowserHandle["browser"],
+		stealth: { browserSession: null, override: null },
+	};
+}
+
+type ManagedTestTab = WorkerTabSession & {
+	workerGeneration: number;
+	controls: Map<string, unknown>;
+};
+
+let tabSeq = 0;
+function register(
+	opts: { worker: WorkerHandle; url?: string; ownerSessionId?: string } = { worker: new FakeWorker() },
+): { name: string; tab: ManagedTestTab; worker: WorkerHandle } {
+	tabSeq += 1;
+	const name = `rec-tab-${tabSeq}`;
+	const tab = registerWorkerTabForTest({
+		name,
+		worker: opts.worker,
+		browser: makeBrowser(),
+		url: opts.url ?? "https://shop.test/",
+		ownerSessionId: opts.ownerSessionId,
+	});
+	return { name, tab: tab as ManagedTestTab, worker: opts.worker };
+}
+
+afterEach(async () => {
+	// Unconditional guard: a failed test must never leak the module-level worker factory.
+	setTabWorkerFactoryForTest(undefined);
+	for (const name of [...getTabsMapForTest().keys()]) {
+		await releaseTab(name, { kill: false }).catch(() => undefined);
+	}
+});
+
+describe("startTabRecording / stopTabRecording state machine", () => {
+	it("rejects an overlapping start and resolves stop with the first recording", async () => {
+		const { name } = register({ worker: new FakeWorker({ respond: responder() }) });
+
+		const first = startTabRecording(name, { timeoutMs: 1_000 });
+		const second = startTabRecording(name, { timeoutMs: 1_000 });
+		await expect(second).rejects.toThrow("already recording");
+
+		const started = await first;
+		expect(started.scope).toEqual(["https://shop.test"]);
+
+		const stopped = await stopTabRecording(name, { timeoutMs: 1_000 });
+		expect(stopped.entryCount).toBe(1);
+	});
+
+	it("rejects a second start while active and while stopping", async () => {
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ stop: "silent" }) }) });
+		await startTabRecording(name, { timeoutMs: 1_000 });
+
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("already recording");
+
+		const stopping = stopTabRecording(name, { timeoutMs: 30_000 });
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("already recording");
+
+		void stopping.catch(() => undefined);
+	});
+
+	it("rejects stop when not recording and when already stopping", async () => {
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ stop: "silent" }) }) });
+
+		await expect(stopTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("not recording");
+
+		await startTabRecording(name, { timeoutMs: 1_000 });
+		const stopping = stopTabRecording(name, { timeoutMs: 30_000 });
+		await expect(stopTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("already stopping");
+
+		void stopping.catch(() => undefined);
+	});
+
+	it("allows a fresh start only after the prior recording finished", async () => {
+		const { name, tab } = register({ worker: new FakeWorker({ respond: responder() }) });
+		await startTabRecording(name, { timeoutMs: 1_000 });
+		await stopTabRecording(name, { timeoutMs: 1_000 });
+		expect(tab.recording).toBeUndefined();
+
+		const again = await startTabRecording(name, { timeoutMs: 1_000 });
+		expect(again.scope).toEqual(["https://shop.test"]);
+		expect(tab.recording).toBe("active");
+	});
+
+	it("clears state and permits a retry after the worker rejects a start", async () => {
+		const worker = new FakeWorker({
+			respond: (msg, w) => {
+				if (msg.type === "recording-start") {
+					w.emit({
+						type: "recording-error",
+						id: msg.id,
+						error: {
+							name: "ToolError",
+							message: "A recording is already active",
+							isToolError: true,
+							isAbort: false,
+						},
+					});
+				} else if (msg.type === "close") {
+					queueMicrotask(() => w.emit({ type: "closed" }));
+				}
+			},
+		});
+		const { name, tab } = register({ worker });
+
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("A recording is already active");
+		expect(tab.recording).toBeUndefined();
+		expect(tab.controls.size).toBe(0);
+	});
+});
+
+describe("startTabRecording validation and scope", () => {
+	it("rejects recording on a tab that is not open", async () => {
+		await expect(startTabRecording("no-such-tab", { timeoutMs: 1_000 })).rejects.toThrow("not alive");
+	});
+
+	it("rejects recording on an unsupported (cmux) backend", async () => {
+		// A minimal cmux-backed tab: recording is a Puppeteer-only feature and must be
+		// rejected before any worker message.
+		const map = getTabsMapForTest() as Map<string, WorkerTabSession>;
+		const cmuxTab = {
+			name: "cmux-rec",
+			state: "alive",
+			backend: "cmux",
+			kindTag: "cmux",
+		} as unknown as WorkerTabSession;
+		map.set("cmux-rec", cmuxTab);
+		try {
+			await expect(startTabRecording("cmux-rec", { timeoutMs: 1_000 })).rejects.toThrow(
+				/not supported|unsupported/i,
+			);
+		} finally {
+			map.delete("cmux-rec");
+		}
+	});
+
+	it("rejects omitted domains on an about:blank tab with a friendly error and sends nothing", async () => {
+		const worker = new FakeWorker({ respond: responder() });
+		const { name } = register({ worker, url: "about:blank" });
+
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow(
+			"open a URL first or pass domains explicitly",
+		);
+		expect(worker.sent.filter(m => m.type === "recording-start")).toHaveLength(0);
+	});
+
+	it.each([
+		["shop.test", /http/i],
+		["ftp://shop.test", /http/i],
+		["javascript:alert(1)", /http/i],
+		["https://user:pass@shop.test", /credential/i],
+		["https://shop.test/path", /path/i],
+		["https://shop.test/?token=super-secret", /query/i],
+		["https://shop.test/#fragment-secret", /fragment/i],
+		["https://*.shop.test", /wildcard/i],
+	])("rejects the invalid domain %s without echoing provider input", async (domain, pattern) => {
+		const { name } = register({ worker: new FakeWorker({ respond: responder() }) });
+		const error = await startTabRecording(name, { timeoutMs: 1_000, domains: [domain] }).catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(Error);
+		const message = error instanceof Error ? error.message : String(error);
+		expect(message).toMatch(pattern);
+		expect(message).not.toContain(domain);
+		expect(message).not.toContain("pass");
+		expect(message).not.toContain("super-secret");
+		expect(message).not.toContain("fragment-secret");
+	});
+
+	it("forwards normalized explicit origins to the worker and returns their scope", async () => {
+		const worker = new FakeWorker({ respond: responder() });
+		const { name } = register({ worker });
+
+		const started = await startTabRecording(name, {
+			timeoutMs: 1_000,
+			domains: ["https://SHOP.test", "https://api.shop.test:8443/"],
+		});
+		expect(started.scope).toEqual(["https://shop.test", "https://api.shop.test:8443"]);
+
+		const sent = worker.lastSent("recording-start");
+		expect(sent?.domains).toEqual(["https://shop.test", "https://api.shop.test:8443"]);
+	});
+
+	it("fixes recording scope at start and never re-derives or widens it across navigation", async () => {
+		const worker = new FakeWorker({ respond: responder() });
+		const { name, tab } = register({ worker, url: "https://shop.test/" });
+
+		const started = await startTabRecording(name, { timeoutMs: 1_000 });
+		expect(started.scope).toEqual(["https://shop.test"]);
+		const firstStarts = worker.sent.filter(m => m.type === "recording-start");
+		expect(firstStarts).toHaveLength(1);
+		// Omitted domains are resolved live by the worker, never derived from the cached URL.
+		expect((firstStarts[0] as Extract<WorkerInbound, { type: "recording-start" }>).domains).toBeUndefined();
+
+		// Same-target same-origin navigation, then a cross-origin navigation, refresh the tab's known
+		// URL. The supervisor must not send another recording-start or widen the fixed scope — a
+		// later-origin request is excluded because scope was pinned at start.
+		tab.info = { ...tab.info, url: "https://shop.test/cart" };
+		tab.info = { ...tab.info, url: "https://other.test/landing" };
+		expect(worker.sent.filter(m => m.type === "recording-start")).toHaveLength(1);
+		expect(tab.recording).toBe("active");
+
+		const stopped = await stopTabRecording(name, { timeoutMs: 1_000 });
+		expect(stopped.entryCount).toBe(1);
+	});
+});
+
+describe("recording control deadlines, cancel, and recycle", () => {
+	// These four tests use a small real timeout because the supervisor's wall-clock
+	// deadline (and its bounded cancel handshake) is the exact behavior under test;
+	// no injectable clock exists and adding one would be a parallel convention.
+	it("cancels and discards state when a start times out but the worker acknowledges the cancel", async () => {
+		const worker = new FakeWorker({ respond: responder({ start: "silent", cancel: "ack" }) });
+		const { name, tab } = register({ worker });
+
+		await expect(startTabRecording(name, { timeoutMs: 20 })).rejects.toThrow(/timed out/i);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.controls.size).toBe(0);
+		expect(tab.workerGeneration).toBe(1);
+		expect(worker.lastSent("recording-cancel")).toBeDefined();
+		// A clean cancel-ack must not tear the tab down.
+		expect(worker.terminated).toBe(false);
+		expect(getTabsMapForTest().has(name)).toBe(true);
+	});
+
+	it("kills the tab when a timed-out start's cancel is never acknowledged", async () => {
+		const worker = new FakeWorker({ mode: "inline", respond: responder({ start: "silent", cancel: "silent" }) });
+		const { name } = register({ worker });
+
+		await expect(startTabRecording(name, { timeoutMs: 20 })).rejects.toThrow(/timed out/i);
+		expect(getTabsMapForTest().has(name)).toBe(false);
+		expect(worker.terminated).toBe(true);
+		// A killed tab reports the kill on the next attempt.
+		await expect(startTabRecording(name, { timeoutMs: 20 })).rejects.toThrow(/killed|not alive/i);
+	});
+
+	it("aborts a pending start promptly on signal and cancels the recording", async () => {
+		const worker = new FakeWorker({ respond: responder({ start: "silent", cancel: "ack" }) });
+		const { name, tab } = register({ worker });
+		const controller = new AbortController();
+
+		const start = startTabRecording(name, { timeoutMs: 60_000, signal: controller.signal });
+		controller.abort();
+
+		await expect(start).rejects.toBeInstanceOf(ToolAbortError);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.controls.size).toBe(0);
+		expect(worker.lastSent("recording-cancel")).toBeDefined();
+	});
+
+	it("cancels and discards state when a stop times out", async () => {
+		const worker = new FakeWorker({ respond: responder({ stop: "silent", cancel: "ack" }) });
+		const { name, tab } = register({ worker });
+		await startTabRecording(name, { timeoutMs: 1_000 });
+
+		await expect(stopTabRecording(name, { timeoutMs: 20 })).rejects.toThrow(/timed out/i);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.controls.size).toBe(0);
+		expect(worker.lastSent("recording-cancel")).toBeDefined();
+	});
+
+	it("serializes a concurrent start issued during an abandoned start's cancel handshake", async () => {
+		const cancelSeen = Promise.withResolvers<void>();
+		let releaseCancel: (() => void) | undefined;
+		let startCount = 0;
+		const worker = new FakeWorker({
+			respond: (msg, w) => {
+				if (msg.type === "close") queueMicrotask(() => w.emit({ type: "closed" }));
+				else if (msg.type === "recording-start") {
+					startCount += 1;
+					// The first start is silent (times out); a later start acknowledges.
+					if (startCount > 1) {
+						queueMicrotask(() =>
+							w.emit({
+								type: "recording-started",
+								id: msg.id,
+								scope: ["https://shop.test"],
+								limits: DEFAULT_RECORDING_LIMITS,
+							}),
+						);
+					}
+				} else if (msg.type === "recording-cancel") {
+					const { id } = msg;
+					releaseCancel = () => queueMicrotask(() => w.emit({ type: "recording-canceled", id }));
+					cancelSeen.resolve();
+				}
+			},
+		});
+		const { name, tab } = register({ worker });
+
+		const start1 = startTabRecording(name, { timeoutMs: 20 });
+		void start1.catch(() => undefined);
+		await cancelSeen.promise; // abandonment has reached (and is holding) the cancel handshake
+
+		// The recording sentinel is still held, so a concurrent start rejects rather than registering
+		// a fresh control that the abandon could wrongly settle.
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("already recording");
+		expect(tab.controls.size).toBe(1); // only the in-flight cancel control
+
+		releaseCancel?.(); // ack the cancel -> abandonment completes
+		await expect(start1).rejects.toThrow(/timed out/i);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.controls.size).toBe(0);
+
+		// A fresh start now succeeds on the recovered worker with its own control intact.
+		const started = await startTabRecording(name, { timeoutMs: 1_000 });
+		expect(started.scope).toEqual(["https://shop.test"]);
+	});
+
+	it("kills the tab when the worker rejects the cancel after a timed-out start", async () => {
+		const worker = new FakeWorker({
+			mode: "inline",
+			respond: (msg, w) => {
+				if (msg.type === "close") queueMicrotask(() => w.emit({ type: "closed" }));
+				else if (msg.type === "recording-cancel") {
+					// A recording-error on cancel means the worker could NOT cancel — never a clean ack.
+					queueMicrotask(() =>
+						w.emit({
+							type: "recording-error",
+							id: msg.id,
+							error: { name: "ToolError", message: "cancel failed", isToolError: true, isAbort: false },
+						}),
+					);
+				}
+				// recording-start stays silent so the start deadline fires.
+			},
+		});
+		const { name } = register({ worker });
+
+		await expect(startTabRecording(name, { timeoutMs: 20 })).rejects.toThrow(/timed out/i);
+		expect(getTabsMapForTest().has(name)).toBe(false);
+		expect(worker.terminated).toBe(true);
+	});
+
+	it("recycles a worker-mode tab with a fresh worker when a timed-out start's cancel is unacknowledged", async () => {
+		const w1 = new FakeWorker({ respond: responder({ start: "silent", cancel: "silent" }) });
+		const w2 = new FakeWorker({ respond: responder() });
+		setTabWorkerFactoryForTest(async () => w2);
+		try {
+			const { name, tab } = register({ worker: w1 });
+			const genBefore = tab.workerGeneration;
+
+			await expect(startTabRecording(name, { timeoutMs: 20 })).rejects.toThrow(/timed out/i);
+
+			expect(w1.terminated).toBe(true);
+			expect(tab.worker).toBe(w2);
+			expect(tab.state).toBe("alive");
+			expect(tab.recording).toBeUndefined();
+			expect(tab.controls.size).toBe(0);
+			expect(tab.workerGeneration).toBe(genBefore + 2); // abandon bump + recycle bump
+
+			// The replacement worker is live and usable.
+			const started = await startTabRecording(name, { timeoutMs: 1_000 });
+			expect(started.scope).toEqual(["https://shop.test"]);
+		} finally {
+			setTabWorkerFactoryForTest(undefined);
+		}
+	});
+
+	it("recycle rejects retired-generation controls but preserves a control registered mid-recycle", async () => {
+		const spawnReached = Promise.withResolvers<void>();
+		const spawnGate = Promise.withResolvers<void>();
+		// start silent (times out); cancel replies recording-error so abandon recycles immediately.
+		const w1 = new FakeWorker({
+			respond: (msg, w) => {
+				if (msg.type === "close") queueMicrotask(() => w.emit({ type: "closed" }));
+				else if (msg.type === "recording-cancel") {
+					queueMicrotask(() =>
+						w.emit({
+							type: "recording-error",
+							id: msg.id,
+							error: { name: "ToolError", message: "cancel failed", isToolError: true, isAbort: false },
+						}),
+					);
+				}
+			},
+		});
+		const w2 = new FakeWorker({ respond: responder() });
+		setTabWorkerFactoryForTest(async () => {
+			spawnReached.resolve();
+			await spawnGate.promise; // pause recycle at the spawn step, after its generation-scoped settle
+			return w2;
+		});
+		const { name, tab } = register({ worker: w1 });
+
+		const start1 = startTabRecording(name, { timeoutMs: 20 });
+		void start1.catch(() => undefined);
+		await spawnReached.promise; // recycle has bumped and settled retired-generation controls
+
+		// The abandoned start + cancel controls (retired generations) were rejected before the spawn.
+		expect(tab.controls.size).toBe(0);
+		const recycleGeneration = tab.workerGeneration;
+
+		// A control registered mid-recycle lives at the fresh (post-bump) generation and must survive.
+		const start2 = startTabRecording(name, { timeoutMs: 60_000 });
+		void start2.catch(() => undefined);
+		expect(tab.controls.size).toBe(1);
+		const freshControlId = [...tab.controls.keys()][0];
+
+		spawnGate.resolve(); // let recycle install the replacement worker
+		await expect(start1).rejects.toThrow(/timed out/i);
+
+		expect(tab.worker).toBe(w2);
+		expect(w1.terminated).toBe(true);
+		expect(tab.workerGeneration).toBe(recycleGeneration); // no extra bump; recycle settled once, pre-spawn
+		expect(tab.controls.has(freshControlId)).toBe(true); // fresh (post-bump) control survived recycle
+	});
+});
+
+describe("long-lived worker failure cleanup", () => {
+	it("settles a pending control and disables further starts when the worker errors", async () => {
+		const worker = new FakeWorker({ respond: responder({ start: "silent" }) });
+		const { name, tab } = register({ worker });
+
+		const start = startTabRecording(name, { timeoutMs: 60_000 });
+		expect(tab.controls.size).toBe(1);
+
+		worker.emitError(new Error("worker crashed"));
+
+		await expect(start).rejects.toThrow("worker crashed");
+		expect(tab.controls.size).toBe(0);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.state).toBe("dead");
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow("not alive");
+	});
+
+	it("settles a pending control when the worker reports it closed", async () => {
+		const worker = new FakeWorker({ respond: responder({ start: "silent" }) });
+		const { name, tab } = register({ worker });
+
+		const start = startTabRecording(name, { timeoutMs: 60_000 });
+		expect(tab.controls.size).toBe(1);
+
+		worker.emit({ type: "closed" });
+
+		await expect(start).rejects.toThrow();
+		expect(tab.controls.size).toBe(0);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.state).toBe("dead");
+	});
+	it("fails a recording start immediately when the tab is already dead without recycling", async () => {
+		const worker = new FakeWorker({ respond: responder() });
+		const { name, tab } = register({ worker });
+		tab.state = "dead";
+
+		const startedAt = performance.now();
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow(/not alive/i);
+		expect(performance.now() - startedAt).toBeLessThan(250);
+		expect(worker.sent).toHaveLength(0);
+		expect(worker.terminated).toBe(false);
+	});
+
+	it("fails a recording start immediately when worker transport throws", async () => {
+		const worker = new FakeWorker({ throwOnSend: true });
+		const { name, tab } = register({ worker });
+
+		await expect(startTabRecording(name, { timeoutMs: 1_000 })).rejects.toThrow(
+			/worker unreachable|transport unavailable/i,
+		);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.controls.size).toBe(0);
+		expect(worker.terminated).toBe(false);
+	});
+
+	it("ignores recording messages from a superseded worker", async () => {
+		const w1 = new FakeWorker({ respond: responder({ start: "silent" }) });
+		const { name, tab } = register({ worker: w1 });
+
+		const start = startTabRecording(name, { timeoutMs: 60_000 });
+		void start.catch(() => undefined);
+		expect(tab.controls.size).toBe(1);
+		const controlId = [...tab.controls.keys()][0];
+
+		// Simulate the supervisor swapping in a fresh worker (as recycle does).
+		const w2 = new FakeWorker({ respond: responder() });
+		tab.worker = w2;
+		tab.workerGeneration += 1;
+
+		// A late message from the retired worker — even a recording-error — must be
+		// ignored before it can settle a control or mutate recording state.
+		w1.emit({
+			type: "recording-error",
+			id: controlId,
+			error: { name: "Error", message: "stale boom", isToolError: false, isAbort: false },
+		});
+
+		expect(tab.controls.size).toBe(1);
+		expect(tab.recording).toBe("starting");
+		expect(tab.state).toBe("alive");
+	});
+});
+it("keeps WorkerTabSession constructible without recording internals", () => {
+	const worker = new FakeWorker();
+	const browser = makeBrowser();
+	const legacy: WorkerTabSession = {
+		name: "legacy",
+		browser,
+		targetId: "legacy-target",
+		backend: "worker",
+		worker,
+		state: "alive",
+		info: { url: "https://shop.test/", viewport: { width: 1280, height: 800 }, targetId: "legacy-target" },
+		pending: new Map(),
+		kindTag: "connected",
+	};
+	expect(legacy.backend).toBe("worker");
+});
+
+describe("release and disposal discard recording state", () => {
+	it("rejects an in-flight stop, clears controls, and bumps generation on releaseTab", async () => {
+		const worker = new FakeWorker({ respond: responder({ stop: "silent" }) });
+		const { name, tab } = register({ worker });
+		await startTabRecording(name, { timeoutMs: 1_000 });
+
+		const stopping = stopTabRecording(name, { timeoutMs: 30_000 });
+		// releaseTab settles the stop control mid-flight; guard the rejection before that happens.
+		void stopping.catch(() => undefined);
+		expect(tab.controls.size).toBe(1);
+		expect(tab.recording).toBe("stopping");
+
+		const genBefore = tab.workerGeneration;
+		await releaseTab(name, { kill: false });
+		await expect(stopping).rejects.toThrow(/closed/i);
+		expect(tab.controls.size).toBe(0);
+		expect(tab.recording).toBeUndefined();
+		expect(tab.workerGeneration).toBe(genBefore + 1);
+		expect(getTabsMapForTest().has(name)).toBe(false);
+	});
+
+	it("tears down an owned recording tab on session disposal", async () => {
+		const worker = new FakeWorker({ respond: responder({ start: "silent" }) });
+		const { name, tab } = register({ worker, ownerSessionId: "session-rec" });
+		const start = startTabRecording(name, { timeoutMs: 30_000 });
+		void start.catch(() => undefined);
+		expect(tab.controls.size).toBe(1);
+
+		const released = await releaseTabsForOwner("session-rec", { kill: false });
+		expect(released).toBe(1);
+		await expect(start).rejects.toThrow(/closed/i);
+		expect(tab.controls.size).toBe(0);
+		expect(getTabsMapForTest().has(name)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// INV-579 Task 4: public tool actions, approval disclosure, artifact, renderer
+// ---------------------------------------------------------------------------
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text")
+		.map(c => c.text)
+		.join("\n");
+}
+
+function makeRecordingSession(artifactDir: string, allocate = true): ToolSession {
+	let seq = 0;
+	return {
+		cwd: "/tmp/test",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => artifactDir,
+		settings: Settings.isolated({ "browser.headless": true }),
+		allocateOutputArtifact: async (toolType: string) => {
+			if (!allocate) return {};
+			const id = String(seq++);
+			return { id, path: path.join(artifactDir, `${id}.${toolType}.log`) };
+		},
+	} as unknown as ToolSession;
+}
+
+// A recognizable string buried in the captured HAR: it must reach the artifact
+// file verbatim but never the tool text, details, or any error message.
+const HAR_MARKER = "secret-marker-do-not-leak-xyz";
+function markedSummary(): RecordingSummary {
+	return {
+		har: {
+			log: {
+				version: "1.2",
+				creator: { name: "oh-my-pi", version: "1" },
+				entries: [{ request: { method: "GET", url: `https://shop.test/${HAR_MARKER}` } }],
+			},
+		},
+		entryCount: 3,
+		capturedBodyCount: 1,
+		omittedBodyCount: 2,
+		totalBytes: 4096,
+		truncated: true,
+	};
+}
+
+async function chromiumCanLaunch(): Promise<boolean> {
+	try {
+		const executable = await ensureChromiumExecutable();
+		if (!executable) return false;
+		return Bun.spawnSync([executable, "--version"], { stdout: "ignore", stderr: "ignore" }).exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+const REAL_BROWSER_AVAILABLE = await chromiumCanLaunch();
+
+function startRecordingFixture(): Bun.Server<undefined> {
+	const server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		async fetch(request) {
+			const url = new URL(request.url);
+			if (url.pathname === "/api/cart") {
+				const body = (await request.json()) as { itemId?: string };
+				return Response.json({ ok: true, itemId: body.itemId });
+			}
+			if (url.pathname === "/pixel.png") {
+				return new Response(Uint8Array.from([137, 80, 78, 71]), {
+					headers: { "content-type": "image/png" },
+				});
+			}
+			if (url.pathname === "/next") {
+				return new Response("<!doctype html><title>next</title><p>done</p>", {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
+			}
+			if (url.pathname === "/reset/path-secret") {
+				return new Response('<!doctype html><title>fixture</title><img src="/pixel.png">', {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		},
+	});
+	return server;
+}
+
+describe.skipIf(!REAL_BROWSER_AVAILABLE)("BrowserTool recording local browser smoke", () => {
+	it("records, sanitizes, reads, and cleans up a real browser lifecycle twice", async () => {
+		const server = startRecordingFixture();
+		const artifactDir = await fs.mkdtemp(path.join(os.tmpdir(), "browser-har-real-"));
+		const unregisterArtifacts = registerArtifactsDir(artifactDir);
+		const session = makeRecordingSession(artifactDir);
+		const tool = new BrowserTool(session);
+		const origin = `http://127.0.0.1:${server.port}`;
+		try {
+			for (let iteration = 0; iteration < 2; iteration++) {
+				const name = `recording-smoke-${process.pid}-${iteration}`;
+				let recording = false;
+				try {
+					await tool.execute("open", {
+						action: "open",
+						name,
+						url: `${origin}/reset/path-secret`,
+						wait_until: "networkidle0",
+					});
+					await tool.execute("start_recording", {
+						action: "start_recording",
+						name,
+						domains: [origin],
+					});
+					recording = true;
+					await tool.execute("run", {
+						action: "run",
+						name,
+						code: `return await tab.evaluate(async () => {
+								const response = await fetch("/api/cart?query-secret", {
+									method: "POST",
+									headers: { "content-type": "application/json", authorization: "Bearer local-secret" },
+									body: JSON.stringify({ credentials: { password: "nested-secret" }, accountId: "account-secret", itemId: "42" }),
+								});
+								await response.json();
+								return response.status;
+							});`,
+					});
+					await tool.execute("navigate", {
+						action: "run",
+						name,
+						code: `await tab.goto("${origin}/next", { waitUntil: "networkidle0" }); return await tab.url();`,
+					});
+					await tool.execute("flush-events", {
+						action: "run",
+						name,
+						code: "await wait(100); return await tab.url();",
+					});
+					const stopped = await tool.execute("stop_recording", { action: "stop_recording", name });
+					recording = false;
+					const artifactId = stopped.details?.artifactId;
+					expect(artifactId).toMatch(/^\d+$/);
+					const artifactUri = `artifact://${artifactId}`;
+					const readResult = await new ReadTool(session).execute(`read-${iteration}`, {
+						path: `${artifactUri}:raw`,
+					});
+					const document = JSON.parse(textOf(readResult)) as {
+						log: {
+							entries: Array<{
+								request: { url: string; postData?: { text?: string } };
+								response: { content?: { text?: string } };
+							}>;
+						};
+					};
+					const serialized = JSON.stringify(document);
+					const cartEntry = document.log.entries.find(entry => entry.request.url.endsWith("/api/cart"));
+					expect(cartEntry).toBeDefined();
+					expect(cartEntry?.request.postData?.text).toContain('"itemId":"42"');
+					expect(cartEntry?.response.content?.text).toContain('"itemId":"42"');
+					const navigationEntry = document.log.entries.find(entry => entry.request.url.endsWith("/next"));
+					expect(navigationEntry).toBeDefined();
+					expect(navigationEntry?.response.content?.text).toBeUndefined();
+					expect(serialized).not.toContain("Bearer local-secret");
+					expect(serialized).not.toContain("query-secret");
+					expect(serialized).not.toContain("nested-secret");
+					expect(serialized).toContain('\\"itemId\\":\\"42\\"');
+					expect(serialized).not.toContain("account-secret");
+					expect(serialized).not.toContain("path-secret");
+					expect(stopped.details?.recording?.capturedBodyCount).toBeGreaterThan(0);
+					expect(stopped.details?.recording?.omittedBodyCount).toBeGreaterThan(0);
+					expect(textOf(stopped)).toContain(artifactUri);
+					expect(textOf(stopped)).not.toContain("Bearer local-secret");
+					expect(JSON.stringify(stopped.details)).not.toContain("nested-secret");
+				} finally {
+					if (recording)
+						await tool.execute("stop-cleanup", { action: "stop_recording", name }).catch(() => undefined);
+					await tool.execute("close-cleanup", { action: "close", name, kill: true }).catch(() => undefined);
+					expect(getTabsMapForTest().has(name)).toBe(false);
+				}
+				expect(getBrowsersMapForTest().size).toBe(0);
+			}
+		} finally {
+			unregisterArtifacts();
+			server.stop(true);
+			await fs.rm(artifactDir, { recursive: true, force: true });
+		}
+	}, 60_000);
+});
+
+describe("BrowserTool recording actions", () => {
+	let artifactDir: string;
+	beforeEach(async () => {
+		artifactDir = await fs.mkdtemp(path.join(os.tmpdir(), "browser-har-"));
+	});
+	afterEach(async () => {
+		setHarArtifactIoForTest(undefined);
+		await fs.rm(artifactDir, { recursive: true, force: true }).catch(() => undefined);
+	});
+
+	it("start_recording requires an open supported tab and reports the normalized effective scope", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const { name } = register({ worker: new FakeWorker({ respond: responder() }) });
+
+		const result = await tool.execute("rec-start", {
+			action: "start_recording",
+			name,
+			domains: ["https://SHOP.test"],
+		});
+
+		expect(result.isError).toBeFalsy();
+		expect(result.details?.scope).toEqual(["https://shop.test"]);
+		expect(textOf(result)).toContain("https://shop.test");
+	});
+
+	it("start_recording on a tab that is not open surfaces an explicit error", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		await expect(tool.execute("rec-start", { action: "start_recording", name: "no-such-tab" })).rejects.toThrow(
+			/not alive|Open it first/,
+		);
+	});
+
+	it("start_recording on an unsupported cmux backend fails explicitly", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const map = getTabsMapForTest() as Map<string, WorkerTabSession>;
+		const cmuxTab = {
+			name: "cmux-pub",
+			state: "alive",
+			backend: "cmux",
+			kindTag: "cmux",
+		} as unknown as WorkerTabSession;
+		map.set("cmux-pub", cmuxTab);
+		try {
+			await expect(tool.execute("rec-start", { action: "start_recording", name: "cmux-pub" })).rejects.toThrow(
+				/not supported|unsupported/i,
+			);
+		} finally {
+			map.delete("cmux-pub");
+		}
+	});
+
+	it("start_recording approval discloses personal-data capture into a bounded sanitized artifact", () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const lines = tool.formatApprovalDetails?.({ action: "start_recording", name: "docs" });
+		const text = (Array.isArray(lines) ? lines.join("\n") : String(lines ?? "")).toLowerCase();
+		expect(text).toContain("account or personal data");
+		expect(text).toContain("sanitized");
+		expect(text).toContain("bounded");
+		expect(text).toContain("artifact");
+	});
+	it("does not expose invalid recording domains in approval details", () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const secret = "https://user:secret@example.test/reset?token=super-secret#fragment";
+		const lines = tool.formatApprovalDetails?.({ action: "start_recording", name: "docs", domains: [secret] });
+		const text = Array.isArray(lines) ? lines.join("\n") : String(lines ?? "");
+		expect(text).toContain("(invalid origin)");
+		expect(text).not.toContain(secret);
+		expect(text).not.toContain("secret");
+		expect(text).not.toContain("token=super-secret");
+	});
+
+	it("stop_recording approval discloses finalization and sanitized artifact persistence", () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const lines = tool.formatApprovalDetails?.({ action: "stop_recording", name: "docs" });
+		const text = (Array.isArray(lines) ? lines.join("\n") : String(lines ?? "")).toLowerCase();
+		expect(text).toContain("finalizes");
+		expect(text).toContain("persists");
+		expect(text).toContain("sanitized");
+		expect(text).toContain("artifact");
+	});
+
+	it("advertises network recording and HAR artifacts in the discoverable summary", () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		expect(tool.summary.toLowerCase()).toContain("record");
+		expect(tool.summary.toLowerCase()).toContain("network");
+		expect(tool.summary.toLowerCase()).toContain("har");
+	});
+
+	it("stop_recording writes valid HAR JSON to an artifact and returns only URI/count/truncation metadata", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const summary = markedSummary();
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+
+		const result = await tool.execute("rec-stop", { action: "stop_recording", name });
+		expect(result.isError).toBeFalsy();
+
+		const artifactId = result.details?.artifactId;
+		expect(typeof artifactId).toBe("string");
+
+		// The full HAR is persisted verbatim to the artifact file.
+		const harPath = path.join(artifactDir, `${artifactId}.browser-har.log`);
+		const parsed = JSON.parse(await fs.readFile(harPath, "utf8")) as { log: { version: string } };
+		expect(parsed.log.version).toBe("1.2");
+		expect(JSON.stringify(parsed)).toContain(HAR_MARKER);
+
+		// ...but only bounded metadata reaches the tool text + details — never the HAR body.
+		const text = textOf(result);
+		expect(text).toContain(`artifact://${artifactId}`);
+		expect(text).toContain("3");
+		expect(text).not.toContain(HAR_MARKER);
+		expect(JSON.stringify(result.details)).not.toContain(HAR_MARKER);
+		expect(result.details?.recording).toEqual({
+			entryCount: 3,
+			capturedBodyCount: 1,
+			omittedBodyCount: 2,
+			totalBytes: 4096,
+			truncated: true,
+		});
+	});
+
+	it("stop_recording persists the artifact at 0600 with no hidden staging leftovers", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary: markedSummary() }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+		const result = await tool.execute("rec-stop", { action: "stop_recording", name });
+
+		const harPath = path.join(artifactDir, `${result.details?.artifactId}.browser-har.log`);
+		const stat = await fs.stat(harPath);
+		expect(stat.mode & 0o777).toBe(0o600);
+		const hidden = (await fs.readdir(artifactDir)).filter(f => f.startsWith("."));
+		expect(hidden).toEqual([]);
+	});
+
+	it("stop_recording fails without serializing the HAR when no artifact slot is available", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir, false));
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary: markedSummary() }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+
+		const error = await tool.execute("rec-stop", { action: "stop_recording", name }).catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(Error);
+		const message = error instanceof Error ? error.message : String(error);
+		expect(message).not.toContain(HAR_MARKER);
+	});
+
+	it("start_recording rejects fields that belong to other actions", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const { name } = register({ worker: new FakeWorker({ respond: responder() }) });
+		for (const bad of [{ code: "return 1;" }, { all: true }, { kill: true }, { url: "https://x.test" }]) {
+			await expect(tool.execute("rec-start", { action: "start_recording", name, ...bad })).rejects.toThrow(
+				/does not accept/,
+			);
+		}
+		// No recording-start was ever sent for the rejected calls.
+		const tab = getTabsMapForTest().get(name) as WorkerTabSession | undefined;
+		expect(tab?.recording).toBeUndefined();
+	});
+
+	it("stop_recording rejects domains and other irrelevant fields", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const { name } = register({ worker: new FakeWorker({ respond: responder() }) });
+		for (const bad of [
+			{ domains: ["https://x.test"] },
+			{ code: "x" },
+			{ url: "https://x.test" },
+			{ all: true },
+			{ kill: true },
+		]) {
+			await expect(tool.execute("rec-stop", { action: "stop_recording", name, ...bad })).rejects.toThrow(
+				/does not accept|only accepted/,
+			);
+		}
+	});
+	it("rejects domains on open, close, and run instead of silently ignoring them", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		for (const action of ["open", "close", "run"] as const) {
+			await expect(
+				tool.execute(`browser-${action}-domains`, {
+					action,
+					name: "docs",
+					domains: ["https://secret.example.test"],
+					...(action === "run" ? { code: "return 1;" } : {}),
+				}),
+			).rejects.toThrow(/domains.*start_recording|does not accept/i);
+		}
+	});
+
+	it("stop_recording writes a 0600 final artifact and removes the temp when rename hits EXDEV", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		setHarArtifactIoForTest({
+			rename: async () => {
+				throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+			},
+		});
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary: markedSummary() }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+
+		const result = await tool.execute("rec-stop", { action: "stop_recording", name });
+		expect(result.isError).toBeFalsy();
+
+		const harPath = path.join(artifactDir, `${result.details?.artifactId}.browser-har.log`);
+		const stat = await fs.stat(harPath);
+		expect(stat.mode & 0o777).toBe(0o600);
+		expect(JSON.parse(await fs.readFile(harPath, "utf8"))).toMatchObject({ log: { version: "1.2" } });
+		// The hidden staging sibling was cleaned up after the direct-write fallback.
+		const hidden = (await fs.readdir(artifactDir)).filter(f => f.startsWith("."));
+		expect(hidden).toEqual([]);
+	});
+	it("preserves a foreign final artifact when EXDEV fallback hits EEXIST", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		const foreign = "foreign-artifact";
+		await fs.writeFile(path.join(artifactDir, "0.browser-har.log"), foreign, { mode: 0o600 });
+		setHarArtifactIoForTest({
+			writeExclusive0600: async (target, content) => {
+				if (target.endsWith(".browser-har.log")) {
+					throw Object.assign(new Error("already exists"), { code: "EEXIST" });
+				}
+				await fs.writeFile(target, content, { flag: "wx", mode: 0o600 });
+			},
+			rename: async () => {
+				throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+			},
+		});
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary: markedSummary() }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+
+		await expect(tool.execute("rec-stop", { action: "stop_recording", name })).rejects.toThrow(
+			"Failed to persist browser recording artifact.",
+		);
+		expect(await fs.readFile(path.join(artifactDir, "0.browser-har.log"), "utf8")).toBe(foreign);
+	});
+
+	it("removes temp and partial final and leaks no HAR when the EXDEV direct-write fails verification", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		setHarArtifactIoForTest({
+			rename: async () => {
+				throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+			},
+			// Force the post-write verification to mismatch so the failure-cleanup path runs.
+			stat: async () => ({ size: 1 }),
+		});
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary: markedSummary() }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+
+		const error = await tool.execute("rec-stop", { action: "stop_recording", name }).catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(Error);
+		const message = error instanceof Error ? error.message : String(error);
+		expect(message).toBe("Failed to persist browser recording artifact.");
+		expect(message).not.toContain(artifactDir);
+		expect(message).not.toContain(HAR_MARKER);
+		// No temp and no partial final artifact are left behind.
+		expect(await fs.readdir(artifactDir)).toEqual([]);
+	});
+	it("removes temp and partial final when EXDEV direct-write fails after creating the final", async () => {
+		const tool = new BrowserTool(makeRecordingSession(artifactDir));
+		setHarArtifactIoForTest({
+			writeExclusive0600: async (target, content, onCreated) => {
+				if (target.endsWith(".browser-har.log")) {
+					await fs.writeFile(target, content, { flag: "wx", mode: 0o600 });
+					onCreated?.();
+					throw new Error(`write failed at ${target}: ${HAR_MARKER}`);
+				}
+				await fs.writeFile(target, content, { flag: "wx", mode: 0o600 });
+			},
+			rename: async () => {
+				throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+			},
+		});
+		const { name } = register({ worker: new FakeWorker({ respond: responder({ summary: markedSummary() }) }) });
+		await tool.execute("rec-start", { action: "start_recording", name });
+
+		const error = await tool.execute("rec-stop", { action: "stop_recording", name }).catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(Error);
+		const message = error instanceof Error ? error.message : String(error);
+		expect(message).toBe("Failed to persist browser recording artifact.");
+		expect(message).not.toContain(artifactDir);
+		expect(message).not.toContain(HAR_MARKER);
+		expect(await fs.readdir(artifactDir)).toEqual([]);
+	});
+});
+
+describe("browser recording renderer", () => {
+	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme();
+	});
+	afterAll(() => {
+		resetSettingsForTest();
+	});
+
+	function renderResultLines(
+		details: BrowserToolDetails,
+		output: string,
+		args: Parameters<typeof browserToolRenderer.renderResult>[3],
+	): string {
+		const component = browserToolRenderer.renderResult(
+			{ content: [{ type: "text", text: output }], details },
+			{ expanded: true, isPartial: false } as Parameters<typeof browserToolRenderer.renderResult>[1],
+			theme,
+			args,
+		);
+		return stripVTControlCharacters((component.render(120) as readonly string[]).join("\n"));
+	}
+
+	it("labels start_recording and stop_recording as recording actions, not open or close", () => {
+		const startLines = renderResultLines(
+			{ action: "start_recording", name: "docs", browser: "headless", scope: ["https://shop.test"] },
+			'Recording network traffic on tab "docs" (headless)',
+			{ action: "start_recording", name: "docs" },
+		);
+		expect(startLines.toLowerCase()).toContain("recording");
+		expect(startLines).not.toContain("Open ");
+		expect(startLines).not.toContain("Close ");
+
+		const stopLines = renderResultLines(
+			{ action: "stop_recording", name: "docs", browser: "headless", artifactId: "7" },
+			'Stopped recording on tab "docs"',
+			{ action: "stop_recording", name: "docs" },
+		);
+		expect(stopLines.toLowerCase()).toContain("recording");
+		expect(stopLines).not.toContain("Open ");
+		expect(stopLines).not.toContain("Close ");
+		expect(stopLines).toContain("artifact://7");
+	});
+
+	it("renders the recording action label while the call is pending approval", () => {
+		const component = browserToolRenderer.renderCall(
+			{ action: "start_recording", name: "docs" },
+			{ isPartial: true } as Parameters<typeof browserToolRenderer.renderCall>[1],
+			theme,
+		);
+		const lines = stripVTControlCharacters((component.render(120) as readonly string[]).join("\n"));
+		expect(lines.toLowerCase()).toContain("recording");
+	});
+	it("does not render invalid secret-bearing domains on pending or result paths", () => {
+		const secret = "https://user:secret@example.test/reset?token=super-secret#fragment";
+		const callLines = stripVTControlCharacters(
+			(
+				browserToolRenderer
+					.renderCall(
+						{ action: "start_recording", name: "docs", domains: [secret] },
+						{ isPartial: true } as Parameters<typeof browserToolRenderer.renderCall>[1],
+						theme,
+					)
+					.render(120) as readonly string[]
+			).join("\n"),
+		);
+		expect(callLines).toContain("(invalid origin)");
+		expect(callLines).not.toContain("secret");
+		expect(callLines).not.toContain("reset");
+		expect(callLines).not.toContain("token");
+
+		const resultLines = renderResultLines(
+			{ action: "start_recording", name: "docs", browser: "headless", scope: [secret] },
+			"Recording network traffic",
+			{ action: "start_recording", name: "docs" },
+		);
+		expect(resultLines).toContain("(invalid origin)");
+		expect(resultLines).not.toContain("secret");
+		expect(resultLines).not.toContain("reset");
+		expect(resultLines).not.toContain("token");
+	});
+
+	it("sanitizes tabs and width-truncates provider-controlled recording domains on both paths", () => {
+		const overlong = `https://${"a".repeat(400)}.example.com`;
+		const tabbed = "https://tab\ttab.example.com";
+
+		// Pending/live path: scope comes straight from raw provider-controlled args.domains.
+		const callLines = stripVTControlCharacters(
+			(
+				browserToolRenderer
+					.renderCall(
+						{ action: "start_recording", name: "docs", domains: [tabbed, overlong] },
+						{ isPartial: true } as Parameters<typeof browserToolRenderer.renderCall>[1],
+						theme,
+					)
+					.render(120) as readonly string[]
+			).join("\n"),
+		);
+		expect(callLines).not.toContain("\t");
+		expect(callLines).not.toContain("a".repeat(85));
+
+		// Result/transcript path: details.scope is truncated + tab-sanitized too.
+		const resultLines = renderResultLines(
+			{ action: "start_recording", name: "docs", browser: "headless", scope: [tabbed, overlong] },
+			"Recording network traffic",
+			{ action: "start_recording", name: "docs" },
+		);
+		expect(resultLines).not.toContain("\t");
+		expect(resultLines).not.toContain("a".repeat(85));
+	});
+
+	it("keeps the recording header a single bounded line under adversarial long/tab-heavy domains", () => {
+		// Adversarial provider-controlled domain: real visible content (so it is not filtered as a
+		// blank meta) wrapped around a huge tab run. Without the CONTENT-width truncation the
+		// metadata expands to ~900 chars and wraps the single-line status header; rendered at a
+		// generous width (200) a correctly bounded header is exactly one line.
+		const pathological = `https://evil${"\t".repeat(300)}x.example.com`;
+
+		// Pending/live path (renderCall): scope = raw provider-controlled args.domains.
+		const callComponent = browserToolRenderer.renderCall(
+			{ action: "start_recording", name: "d", domains: [pathological] },
+			{ isPartial: true } as Parameters<typeof browserToolRenderer.renderCall>[1],
+			theme,
+		);
+		expect(callComponent.render(200).length).toBe(1);
+
+		// Result/transcript path (renderResult): details.scope, header only (empty output).
+		const resultComponent = browserToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "" }],
+				details: { action: "start_recording", name: "d", scope: [pathological] },
+			},
+			{ expanded: true, isPartial: false } as Parameters<typeof browserToolRenderer.renderResult>[1],
+			theme,
+			{ action: "start_recording", name: "d" },
+		);
+		expect(resultComponent.render(200).length).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-schema.test.ts
+++ b/packages/coding-agent/test/tools/browser-schema.test.ts
@@ -111,6 +111,66 @@ describe("browser tool schema", () => {
 				wait_until: null,
 				dialogs: null,
 				code: "return 1;",
+				domains: null,
+				timeout: null,
+				all: null,
+				kill: null,
+			}).success,
+		).toBe(true);
+	});
+
+	// INV-579 Task 4: the two recording actions join the closed action enum. The
+	// object stays closed (additionalProperties: false), so unknown fields and
+	// unknown actions are rejected while both recording variants validate.
+	it("accepts the recording actions and rejects unknown actions or fields", () => {
+		const tool = new BrowserTool(makeSession());
+		const wire = toolWireSchema(tool);
+		expect(
+			validateJsonSchemaValue(wire, {
+				action: "start_recording",
+				name: "docs",
+				domains: ["https://example.com"],
+			}).success,
+		).toBe(true);
+		expect(validateJsonSchemaValue(wire, { action: "stop_recording", name: "docs" }).success).toBe(true);
+		expect(validateJsonSchemaValue(wire, { action: "pause_recording", name: "docs" }).success).toBe(false);
+		expect(validateJsonSchemaValue(wire, { action: "start_recording", bogus: 1 }).success).toBe(false);
+	});
+
+	// Intent injection must keep both recording variants satisfiable, and the
+	// OpenAI strict-mode adaptation must stay compatible with the extended enum
+	// and the new `domains` field.
+	it("keeps the recording actions satisfiable under intent tracing and strict-mode enforcement", () => {
+		const normalized = normalizeTools([new BrowserTool(makeSession())], true)?.[0];
+		const schema = normalized?.parameters as Record<string, unknown>;
+
+		expect(
+			validateJsonSchemaValue(schema as TSchema, {
+				[INTENT_FIELD]: "Recording checkout traffic",
+				action: "start_recording",
+				name: "docs",
+				domains: ["https://shop.example"],
+			}).success,
+		).toBe(true);
+
+		const strict = adaptSchemaForStrict(schema, true);
+		expect(strict.strict).toBe(true);
+		const enforcement = validateStrictSchemaEnforcement(schema, strict);
+		expect(enforcement.compatible).toBe(true);
+		expect(enforcement.violations).toEqual([]);
+
+		expect(
+			validateJsonSchemaValue(strict.schema, {
+				[INTENT_FIELD]: "Persisting the HAR",
+				action: "stop_recording",
+				name: "docs",
+				url: null,
+				app: null,
+				viewport: null,
+				wait_until: null,
+				dialogs: null,
+				code: null,
+				domains: null,
 				timeout: null,
 				all: null,
 				kill: null,


### PR DESCRIPTION
## Summary
- add `browser.start_recording` and `browser.stop_recording` actions that emit bounded, sanitized HAR-compatible artifacts
- manage per-tab CDP recording lifecycle with generation-scoped controls, deterministic drain/cancel behavior, and owned-session cleanup
- document the workflow, render approval/recording status safely, and cover the public schema plus real Chromium smoke path

## Verification
- changed-file Biome checks — passed
- `bun run check:types` — passed
- focused recorder/worker/public/schema suite — 111 passed, 0 failed
- real Chromium recording suite repeated — 57 passed, 0 failed
- full package suite reached an unrelated pre-existing order-dependent Bun resolver failure in three security-profile tests (`NameTooLong` from `file:file:…`); all three pass in isolation, and the same sdk-test + security-test reproduction fails on the base workspace

Linear: https://linear.app/zoopone/issue/INV-579/add-browser-network-recording