### PR TITLE
fix(collab-web): prevent IME composition duplicate character on Enter

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where Korean/Japanese/Chinese IME users experienced the last character being duplicated when pressing Enter to confirm a composition in the collab composer.
+
 ## [17.0.1] - 2026-07-16
 
 ### Fixed

--- a/packages/collab-web/src/components/shell/Composer.tsx
+++ b/packages/collab-web/src/components/shell/Composer.tsx
@@ -40,6 +40,7 @@ function AskEditor({ prefill, onSubmit }: AskEditorProps): ReactNode {
 	}, [draft]);
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+		if (e.nativeEvent.isComposing) return;
 		if (e.key === "Enter" && !e.shiftKey) {
 			e.preventDefault();
 			onSubmit(draft);
@@ -96,6 +97,7 @@ export function Composer({ client, snapshot }: ComposerProps): ReactNode {
 	}, [client, live, readOnly, text]);
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+		if (e.nativeEvent.isComposing) return;
 		if (e.key === "Enter" && !e.shiftKey) {
 			e.preventDefault();
 			send();


### PR DESCRIPTION
## What

Guard both `AskEditor` and `Composer` `onKeyDown` handlers with an early return when `e.nativeEvent.isComposing` is true, preventing the composer from submitting mid-composition.

## Why

Korean/Japanese/Chinese IME users experienced the last character being duplicated when pressing Enter to confirm a composition in the collab composer. The `onKeyDown` handlers did not check `isComposing`, so the Enter keydown during active composition triggered `send()` + `setText("")`, causing a re-render that re-committed the composing character.

## Testing

- `tsc --noEmit` passes for `packages/collab-web`
- Existing `composer.test.tsx` suite passes (3/3)
- Manually verified: type Korean (e.g. `한글`) in the composer, press Enter to confirm — no duplicate character; press Enter again to send — submits correctly

---

- [x] `bun check` passes (TS portion; Rust check timed out locally due to cold cache)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)