### PR TITLE
fix(coding-agent): await background discovery before default-model fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed startup model selection ignoring the configured `modelRoles.default` when it points at a `models.yml` discovery provider (e.g. a custom OpenAI-compatible endpoint with `discovery: openai-models-list`). The background model discovery was still in flight when the default-role resolution ran, so the session silently fell back to an unrelated provider's default. Startup now awaits the in-flight background refresh before retrying the default-role lookup.
+
 ## [17.0.6] - 2026-07-20
 
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2074,6 +2074,15 @@ export class ModelRegistry {
 			.map(provider => provider.provider);
 	}
 
+	/**
+	 * Await the in-flight background refresh, if any. Resolves immediately
+	 * when no refresh is running. Callers use this to wait for models.yml
+	 * discovery providers to finish before falling back to a different model.
+	 */
+	waitForBackgroundRefresh(): Promise<void> {
+		return this.#backgroundRefresh ?? Promise.resolve();
+	}
+
 	getProviderDiscoveryState(provider: string): ProviderDiscoveryState | undefined {
 		return this.#providerDiscoveryStates.get(provider);
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2204,7 +2204,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (!model && deferredModelPatterns.length === 0) {
 			// Re-resolve the allowed set: extension factories above may have
 			// registered providers/models that weren't visible at startup.
-			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+			let fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
 
 			// Retry the default-role lookup against the post-extension allowed
 			// set. Extension factories register providers AFTER the early
@@ -2215,6 +2215,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// default with a bundled provider's default whenever a stray
 			// `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is in the environment.
 			// (issue #3569)
+			// When the configured default role points at a models.yml discovery
+			// provider (e.g. `alibaba-token-plan/qwen3.8-max-preview`), the model
+			// may not exist in the registry yet — the background refresh kicked
+			// off at startup is still in flight. Wait for it so the retry below
+			// sees freshly discovered models instead of falling through to
+			// pickDefaultAvailableModel with an unrelated provider.
+			if (!hasExplicitModel && !defaultRoleSpec.model && settings.getModelRole("default")) {
+				await modelRegistry.waitForBackgroundRefresh();
+				fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+			}
+
 			if (!hasExplicitModel && !defaultRoleSpec.model) {
 				const reResolvedRoleSpec = resolveModelRoleValue(settings.getModelRole("default"), fallbackCandidates, {
 					settings,


### PR DESCRIPTION
## Problem

When `modelRoles.default` points at a `models.yml` discovery provider (e.g. a custom OpenAI-compatible endpoint with `discovery: openai-models-list`), the configured model may not exist in the registry at startup — `refreshInBackground()` is still in flight. The default-role resolution fails and `pickDefaultAvailableModel` silently replaces the user's configured default with an unrelated provider's model.

Reproduction:
1. Configure a custom provider in `~/.omp/agent/models.yml` with `discovery: openai-models-list`
2. Set `modelRoles.default: <custom-provider>/<model>` in `config.yml`
3. Start `omp` with a cold model cache (`models.db` empty)
4. Observe: startup uses a different model than configured

## Fix

- Add `ModelRegistry.waitForBackgroundRefresh()` — exposes the in-flight background refresh promise (resolves immediately when none is running).
- In the `sdk.ts` fallback path, when a default role is configured but unresolved, await the background refresh and re-resolve allowed models before retrying the role lookup.

The wait is scoped: it only triggers when `!hasExplicitModel && !defaultRoleSpec.model && settings.getModelRole("default")` — no impact on sessions without a configured default role or where the model resolved on the first pass.

## Testing

- `bun check` passes
- `model-resolver.test.ts` (139 tests), `sdk-model-selection.test.ts` (21 tests), `model-registry.test.ts` + `repro-issue-1022` (85 tests) all pass