### PR TITLE
fix(ai): recover empty Antigravity responses across endpoints

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini Flash Cloud Code Assist responses containing only intercepted planning-leak JSON being counted as meaningful output, so fully discarded leaks now use the existing empty-response retry path while visible suffixes and native structured tool calls remain successful.
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Gemini Flash Cloud Code Assist responses containing only intercepted planning-leak JSON being counted as meaningful output, so fully discarded leaks now use the existing empty-response retry path while visible suffixes and native structured tool calls remain successful.
+- Fixed Antigravity auto endpoint routing stopping after the daily endpoint exhausted its empty-stream retries, allowing retryable pre-content provider failures to fail over to the sandbox endpoint without replaying partial output or retrying content blocks.
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -815,9 +815,6 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 									if (isBuffering) {
 										const buffered = consumePlanningBuffer(textBuffer, toolNames);
 										if (buffered.kind !== "incomplete") {
-											if (buffered.kind === "leak") {
-												sawLeak = true;
-											}
 											const visibleSignature = bufferedTextSignature;
 											isBuffering = false;
 											textBuffer = "";
@@ -896,9 +893,6 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 
 				if (isBuffering && textBuffer !== "") {
 					const buffered = consumePlanningBuffer(textBuffer, toolNames, true);
-					if (buffered.kind === "leak") {
-						sawLeak = true;
-					}
 					if (buffered.kind !== "incomplete") {
 						feedVisibleText(buffered.visibleText, bufferedTextSignature);
 					}
@@ -910,11 +904,10 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				flushVisibleText(bufferedTextSignature);
 				endCurrentBlock();
 
-				return hasMeaningfulGoogleContent(output) || sawLeak;
+				return hasMeaningfulGoogleContent(output);
 			};
 
 			let receivedContent = false;
-			let sawLeak = false;
 
 			for (let i = 0; i < endpoints.length; i++) {
 				const endpoint = endpoints[i];

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -893,6 +893,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 
 				if (isBuffering && textBuffer !== "") {
 					const buffered = consumePlanningBuffer(textBuffer, toolNames, true);
+
 					if (buffered.kind !== "incomplete") {
 						feedVisibleText(buffered.visibleText, bufferedTextSignature);
 					}
@@ -1048,10 +1049,15 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					break;
 				} catch (error) {
 					const status = extractHttpStatusFromError(error);
-					if (AIError.isTransientStatus(status)) {
-						if (!isLastEndpoint && !started) {
-							continue;
-						}
+					if (
+						!isLastEndpoint &&
+						!started &&
+						(AIError.isTransientStatus(status) ||
+							(status === undefined &&
+								!(error instanceof AIError.ProviderResponseError && error.kind === "output") &&
+								AIError.retriable(AIError.classify(error))))
+					) {
+						continue;
 					}
 					throw error;
 				}

--- a/packages/ai/test/google-empty-response-retry.test.ts
+++ b/packages/ai/test/google-empty-response-retry.test.ts
@@ -235,6 +235,49 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 		void events;
 	});
 
+	it("retries after discarding a planning leak and delivers one structured function call", async () => {
+		let calls = 0;
+		const fetchMock: FetchImpl = async () => {
+			calls += 1;
+			const response =
+				calls === 1
+					? sse(ccaChunk('{\n  "thought": "inspect the project",\n  "call": "lookup"\n}'))
+					: sse({
+						response: {
+							candidates: [
+								{
+									content: {
+										parts: [{ functionCall: { name: "lookup", args: { q: "x" }, id: "call_1" } }],
+									},
+									finishReason: "STOP",
+								},
+							],
+						},
+					});
+			Object.defineProperty(response, "url", { value: "https://example.com/v1internal:streamGenerateContent" });
+			return response;
+		};
+
+		const stream = streamGoogleGeminiCli(cliModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			fetch: fetchMock,
+		});
+		const { events, starts } = await drain(stream);
+		const result = await stream.result();
+
+		expect(calls).toBe(2);
+		expect(starts).toBe(1);
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0]).toMatchObject({
+			type: "toolCall",
+			id: "call_1",
+			name: "lookup",
+			arguments: { q: "x" },
+		});
+		expect(events.filter(e => e.type === "toolcall_start")).toHaveLength(1);
+	});
+
 	it("does not coalesce function-call thought signatures into the preceding text block", async () => {
 		const chunks = [
 			{ response: { candidates: [{ content: { parts: [{ text: "Done" }] } }] } },

--- a/packages/ai/test/google-empty-response-retry.test.ts
+++ b/packages/ai/test/google-empty-response-retry.test.ts
@@ -81,6 +81,25 @@ const cliModel: Model<"google-gemini-cli"> = buildModel({
 	maxTokens: 32_000,
 });
 
+const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
+const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+
+const antigravityModel: Model<"google-gemini-cli"> = buildModel({
+	...cliModel,
+	provider: "google-antigravity",
+	baseUrl: ANTIGRAVITY_DAILY_ENDPOINT,
+});
+
+function withResponseUrl(response: Response, endpoint: string): Response {
+	Object.defineProperty(response, "url", { value: `${endpoint}/v1internal:streamGenerateContent?alt=sse` });
+	return response;
+}
+
+function endpointFromInput(input: Parameters<FetchImpl>[0]): string {
+	const url = input instanceof Request ? input.url : input.toString();
+	return url.startsWith(ANTIGRAVITY_SANDBOX_ENDPOINT) ? ANTIGRAVITY_SANDBOX_ENDPOINT : ANTIGRAVITY_DAILY_ENDPOINT;
+}
+
 describe("Google empty-response retry (public + Vertex path)", () => {
 	it("retries a STOP-with-empty-text response and delivers the real follow-up content", async () => {
 		let calls = 0;
@@ -243,17 +262,17 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 				calls === 1
 					? sse(ccaChunk('{\n  "thought": "inspect the project",\n  "call": "lookup"\n}'))
 					: sse({
-						response: {
-							candidates: [
-								{
-									content: {
-										parts: [{ functionCall: { name: "lookup", args: { q: "x" }, id: "call_1" } }],
+							response: {
+								candidates: [
+									{
+										content: {
+											parts: [{ functionCall: { name: "lookup", args: { q: "x" }, id: "call_1" } }],
+										},
+										finishReason: "STOP",
 									},
-									finishReason: "STOP",
-								},
-							],
-						},
-					});
+								],
+							},
+						});
 			Object.defineProperty(response, "url", { value: "https://example.com/v1internal:streamGenerateContent" });
 			return response;
 		};
@@ -276,6 +295,164 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 			arguments: { q: "x" },
 		});
 		expect(events.filter(e => e.type === "toolcall_start")).toHaveLength(1);
+	});
+
+	it("fails over to the sandbox endpoint after daily returns only empty successful streams", async () => {
+		const requestedEndpoints: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const endpoint = endpointFromInput(input);
+			requestedEndpoints.push(endpoint);
+			const response = endpoint === ANTIGRAVITY_SANDBOX_ENDPOINT ? sse(ccaChunk("Recovered.")) : sse(ccaChunk(""));
+			return withResponseUrl(response, endpoint);
+		};
+
+		const stream = streamGoogleGeminiCli(antigravityModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			antigravityEndpointMode: "auto",
+			fetch: fetchMock,
+		});
+		const { starts } = await drain(stream);
+		const result = await stream.result();
+
+		expect(requestedEndpoints).toEqual([
+			ANTIGRAVITY_DAILY_ENDPOINT,
+			ANTIGRAVITY_DAILY_ENDPOINT,
+			ANTIGRAVITY_DAILY_ENDPOINT,
+			ANTIGRAVITY_SANDBOX_ENDPOINT,
+		]);
+		expect(starts).toBe(1);
+		expect(result.stopReason).toBe("stop");
+		expect(textOf(result)).toBe("Recovered.");
+	});
+
+	for (const { mode, endpoint } of [
+		{ mode: "production", endpoint: ANTIGRAVITY_DAILY_ENDPOINT },
+		{ mode: "sandbox", endpoint: ANTIGRAVITY_SANDBOX_ENDPOINT },
+	] as const) {
+		it(`keeps empty-response retries on the selected ${mode} endpoint`, async () => {
+			const requestedEndpoints: string[] = [];
+			const fetchMock: FetchImpl = async input => {
+				const requestedEndpoint = endpointFromInput(input);
+				requestedEndpoints.push(requestedEndpoint);
+				return withResponseUrl(sse(ccaChunk("")), requestedEndpoint);
+			};
+
+			const stream = streamGoogleGeminiCli(antigravityModel, context, {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				antigravityEndpointMode: mode,
+				fetch: fetchMock,
+			});
+			const result = await stream.result();
+
+			expect(requestedEndpoints).toEqual([endpoint, endpoint, endpoint]);
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toContain("empty response");
+		});
+	}
+
+	for (const { name, chunk, errorText } of [
+		{
+			name: "SAFETY finish",
+			chunk: { response: { candidates: [{ content: { parts: [] }, finishReason: "SAFETY" }] } },
+			errorText: "SAFETY",
+		},
+		{
+			name: "MALFORMED_FUNCTION_CALL finish",
+			chunk: {
+				response: { candidates: [{ content: { parts: [] }, finishReason: "MALFORMED_FUNCTION_CALL" }] },
+			},
+			errorText: "MALFORMED_FUNCTION_CALL",
+		},
+		{
+			name: "PROHIBITED_CONTENT block",
+			chunk: {
+				response: {
+					candidates: [],
+					promptFeedback: { blockReason: "PROHIBITED_CONTENT", blockReasonMessage: "policy blocked" },
+				},
+			},
+			errorText: "PROHIBITED_CONTENT",
+		},
+	] as const) {
+		it(`does not fail over after a terminal ${name}`, async () => {
+			const requestedEndpoints: string[] = [];
+			const fetchMock: FetchImpl = async input => {
+				const endpoint = endpointFromInput(input);
+				requestedEndpoints.push(endpoint);
+				return withResponseUrl(sse(chunk), endpoint);
+			};
+
+			const stream = streamGoogleGeminiCli(antigravityModel, context, {
+				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+				antigravityEndpointMode: "auto",
+				fetch: fetchMock,
+			});
+			const result = await stream.result();
+
+			expect(requestedEndpoints).toEqual([ANTIGRAVITY_DAILY_ENDPOINT]);
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toContain(errorText);
+		});
+	}
+
+	it("does not fail over after an account-verification HTTP 403", async () => {
+		const requestedEndpoints: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const endpoint = endpointFromInput(input);
+			requestedEndpoints.push(endpoint);
+			return new Response(
+				JSON.stringify({
+					error: {
+						code: 403,
+						status: "PERMISSION_DENIED",
+						details: [
+							{
+								"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+								reason: "VALIDATION_REQUIRED",
+								metadata: { validation_url: "https://accounts.google.com/verify" },
+							},
+						],
+					},
+				}),
+				{ status: 403 },
+			);
+		};
+
+		const stream = streamGoogleGeminiCli(antigravityModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			antigravityEndpointMode: "auto",
+			fetch: fetchMock,
+		});
+		const result = await stream.result();
+
+		expect(requestedEndpoints).toEqual([ANTIGRAVITY_DAILY_ENDPOINT]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Account verification required");
+	});
+
+	it("does not fail over after partial output has started", async () => {
+		const requestedEndpoints: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const endpoint = endpointFromInput(input);
+			requestedEndpoints.push(endpoint);
+			return withResponseUrl(
+				sse({ response: { candidates: [{ content: { parts: [{ text: "partial" }] } }] } }),
+				endpoint,
+			);
+		};
+
+		const stream = streamGoogleGeminiCli(antigravityModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			antigravityEndpointMode: "auto",
+			fetch: fetchMock,
+		});
+		const { starts } = await drain(stream);
+		const result = await stream.result();
+
+		expect(requestedEndpoints).toEqual([ANTIGRAVITY_DAILY_ENDPOINT]);
+		expect(starts).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(textOf(result)).toBe("partial");
 	});
 
 	it("does not coalesce function-call thought signatures into the preceding text block", async () => {

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -557,18 +557,26 @@ describe("Google Gemini CLI alignment", () => {
 	});
 
 	describe("planning leak interception", () => {
-		it("intercepts fragmented planning leak and discards it", async () => {
+		it("intercepts a fragmented planning leak and retries after discarding it", async () => {
 			const sseChunks = [
 				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"{\\n"}]}}]}}\n\n',
 				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"thought\\": \\"let us do something\\",\\n"}]}}]}}\n\n',
 				'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"  \\"call\\": \\"read\\",\\n  \\"paths\\": [\\"src/main.ts\\"]\\n}"}]},"finishReason":"STOP"}]}}\n\n',
 			];
 
+			let fetchCalls = 0;
 			const fetchMock: FetchImpl = async () => {
+				fetchCalls += 1;
+				const chunks =
+					fetchCalls === 1
+						? sseChunks
+						: [
+							'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Recovered."}]},"finishReason":"STOP"}]}}\n\n',
+						];
 				const stream = new ReadableStream({
 					async start(controller) {
 						const encoder = new TextEncoder();
-						for (const chunk of sseChunks) {
+						for (const chunk of chunks) {
 							controller.enqueue(encoder.encode(chunk));
 							await Bun.sleep(5);
 						}
@@ -596,13 +604,13 @@ describe("Google Gemini CLI alignment", () => {
 			}
 			const result = await stream.result();
 
-			// A fully-discarded planning leak leaves no residual content — no empty
-			// text block survives (the central healing wrapper strips empties too).
-			expect(result.content).toHaveLength(0);
+			expect(fetchCalls).toBe(2);
+			expect(result.content).toEqual([{ type: "text", text: "Recovered." }]);
 			expect(result.stopReason).toBe("stop");
 
 			const textDeltaEvents = events.filter(e => e.type === "text_delta");
-			expect(textDeltaEvents).toHaveLength(0);
+			expect(textDeltaEvents).toHaveLength(1);
+			expect(textDeltaEvents[0].delta).toBe("Recovered.");
 		});
 
 		it("does not intercept normal JSON starting with { and releases it", async () => {

--- a/packages/ai/test/google-gemini-cli-alignment.test.ts
+++ b/packages/ai/test/google-gemini-cli-alignment.test.ts
@@ -571,8 +571,8 @@ describe("Google Gemini CLI alignment", () => {
 					fetchCalls === 1
 						? sseChunks
 						: [
-							'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Recovered."}]},"finishReason":"STOP"}]}}\n\n',
-						];
+								'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Recovered."}]},"finishReason":"STOP"}]}}\n\n',
+							];
 				const stream = new ReadableStream({
 					async start(controller) {
 						const encoder = new TextEncoder();


### PR DESCRIPTION
## What

- Retry Gemini Flash turns whose only payload is an intercepted planning-leak object.
- In Antigravity auto mode, fail over from daily to sandbox after a retryable pre-content provider failure.
- Keep terminal model errors, account-verification HTTP failures, fixed endpoint modes, and partially emitted streams non-replayable.

## Why

Gemini 3.6 Flash Tiered produced a burst of empty Cloud Code Assist responses in real OMP session history. The provider exhausted its local empty-stream retries, but the endpoint loop only advanced for transient HTTP statuses, so the same daily endpoint was retried by every outer attempt. Fully discarded planning-leak payloads also counted as successful content and could end a turn silently.

## Testing

- TDD baseline: discarded planning leak regression failed with 1 fetch instead of 2.
- TDD baseline: daily empty-response failover regression failed after 3 daily requests without reaching sandbox.
- Review regressions: MALFORMED_FUNCTION_CALL and VALIDATION_REQUIRED 403 each failed before the failover guard was tightened.
- `bun test packages/ai/test/google-empty-response-retry.test.ts packages/ai/test/google-gemini-cli-alignment.test.ts` — 44 pass, 0 fail, 170 expectations.
- LSP diagnostics clean for the provider and changed tests.
- Independent reviewer verdict: mergeable; no blocker or major issue.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)