### PR TITLE
fix(coding-agent): avoid stack overflow in deeply nested HTML exports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed HTML session exports overflowing the browser call stack when rendering valid deeply nested conversation trees.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -102,14 +102,18 @@
           }
         }
 
-        // Sort children by timestamp
-        function sortChildren(node) {
+        // Sort children by timestamp. Use an explicit stack so valid, deep
+        // conversation chains do not exhaust the browser call stack.
+        const sortStack = [...roots];
+        while (sortStack.length > 0) {
+          const node = sortStack.pop();
           node.children.sort((a, b) =>
             new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime()
           );
-          node.children.forEach(sortChildren);
+          for (let i = node.children.length - 1; i >= 0; i--) {
+            sortStack.push(node.children[i]);
+          }
         }
-        roots.forEach(sortChildren);
 
         return roots;
       }
@@ -157,17 +161,27 @@
         const result = [];
         const multipleRoots = roots.length > 1;
 
-        // Mark which subtrees contain the active leaf
+        // Mark which subtrees contain the active leaf. Use iterative post-order
+        // traversal so valid, deep conversation chains do not exhaust the
+        // browser call stack.
         const containsActive = new Map();
-        function markActive(node) {
+        const allNodes = [];
+        const activeStack = [...roots];
+        while (activeStack.length > 0) {
+          const node = activeStack.pop();
+          allNodes.push(node);
+          for (let i = node.children.length - 1; i >= 0; i--) {
+            activeStack.push(node.children[i]);
+          }
+        }
+        for (let i = allNodes.length - 1; i >= 0; i--) {
+          const node = allNodes[i];
           let has = activePathIds.has(node.entry.id);
           for (const child of node.children) {
-            if (markActive(child)) has = true;
+            if (containsActive.get(child)) has = true;
           }
           containsActive.set(node, has);
-          return has;
         }
-        roots.forEach(markActive);
 
         // Stack: [node, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild]
         const stack = [];

--- a/packages/coding-agent/test/export-html-markdown.test.ts
+++ b/packages/coding-agent/test/export-html-markdown.test.ts
@@ -8,32 +8,32 @@ const [templateHtml, templateJs] = await Promise.all([
 	Bun.file(new URL("../src/export/html/template.js", import.meta.url)).text(),
 ]);
 
-function renderMarkdown(source: string): Element {
-	const { document, window } = parseHTML(templateHtml);
-	const session = {
-		header: {
-			type: "session",
-			version: 3,
-			id: "markdown-test",
-			timestamp: "2026-01-01T00:00:00.000Z",
-			cwd: "/tmp",
-		},
-		entries: [
-			{
-				type: "message",
-				id: "message-1",
-				parentId: null,
-				timestamp: "2026-01-01T00:00:00.000Z",
-				message: {
-					role: "user",
-					content: source,
-					timestamp: 0,
-				},
-			},
-		],
-		leafId: "message-1",
+interface MinimalMessageEntry {
+	type: "message";
+	id: string;
+	parentId: string | null;
+	timestamp: string;
+	message: {
+		role: "user" | "assistant";
+		content: string | unknown[];
+		timestamp: number;
 	};
+}
 
+interface MinimalSession {
+	header: {
+		type: "session";
+		version: number;
+		id: string;
+		timestamp: string;
+		cwd: string;
+	};
+	entries: MinimalMessageEntry[];
+	leafId: string;
+}
+
+function renderSession(session: MinimalSession) {
+	const { document, window } = parseHTML(templateHtml);
 	const sessionData = document.getElementById("session-data");
 	if (!sessionData) throw new Error("Export template is missing session data");
 	sessionData.textContent = Buffer.from(JSON.stringify(session)).toBase64();
@@ -66,6 +66,73 @@ function renderMarkdown(source: string): Element {
 		clearTimeout() {},
 	});
 	vm.runInContext(templateJs, context);
+	return document;
+}
+
+function createSession(entries: MinimalMessageEntry[], leafId: string, id: string): MinimalSession {
+	return {
+		header: {
+			type: "session",
+			version: 3,
+			id,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			cwd: "/tmp",
+		},
+		entries,
+		leafId,
+	};
+}
+
+function createDeepChainSession(depth: number): MinimalSession {
+	const entries: MinimalMessageEntry[] = [
+		{
+			type: "message",
+			id: "message-0",
+			parentId: null,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			message: {
+				role: "user",
+				content: "root",
+				timestamp: 0,
+			},
+		},
+	];
+	for (let i = 1; i < depth; i++) {
+		entries.push({
+			type: "message",
+			id: `message-${i}`,
+			parentId: `message-${i - 1}`,
+			timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+			message: {
+				role: "assistant",
+				content: [],
+				timestamp: i,
+			},
+		});
+	}
+	return createSession(entries, "message-0", "deep-chain-test");
+}
+
+function renderMarkdown(source: string): Element {
+	const document = renderSession(
+		createSession(
+			[
+				{
+					type: "message",
+					id: "message-1",
+					parentId: null,
+					timestamp: "2026-01-01T00:00:00.000Z",
+					message: {
+						role: "user",
+						content: source,
+						timestamp: 0,
+					},
+				},
+			],
+			"message-1",
+			"markdown-test",
+		),
+	);
 
 	const rendered = document.querySelector(".markdown-content");
 	if (!rendered) throw new Error("Export viewer did not render Markdown content");
@@ -81,5 +148,13 @@ describe("HTML export Markdown", () => {
 		expect(rendered.querySelector("ul > li > em")?.textContent).toBe("italic");
 		expect(rendered.querySelector("ul > li > code")?.textContent).toBe("code");
 		expect(rendered.querySelector("ol > li > strong")?.textContent).toBe("nested");
+	});
+
+	test("renders a deep valid conversation tree without overflowing the call stack", () => {
+		const document = renderSession(createDeepChainSession(30_000));
+
+		expect(document.querySelectorAll(".tree-node").length).toBe(1);
+		expect(document.querySelector(".tree-node.active")?.getAttribute("data-id")).toBe("message-0");
+		expect(document.querySelector("#messages")?.textContent).toContain("root");
 	});
 });


### PR DESCRIPTION
## Problem

The failing export contains a valid, unusually deep main-session tree: 8,165 entries with a maximum parent depth of 6,481. It has no duplicate IDs, no missing parents, no self-parent entries, and no parent cycle. This is not malformed session data or a corrupted export.

OMP's in-app TUI tree selector already computes active subtrees with an explicit iterative post-order traversal. The standalone HTML viewer reimplements tree construction and flattening independently in `template.js`. That separate implementation still used two recursive traversals: `sortChildren()` sorted every node's children, then `markActive()` marked the subtrees containing the active path.

This created divergent behavior for the same valid deep session data: the in-app TUI uses iterative traversal, while opening the exported HTML consumed one browser stack frame per tree level until Chromium raised `RangeError: Maximum call stack size exceeded`. Replacing only `sortChildren()` would be incomplete, because the same data could then still overflow in `markActive()`.

## Fix

Replace both export-only recursive traversals with iterative equivalents:

- an explicit stack sorts every node's children in timestamp order;
- pre-order collection plus reverse processing computes `containsActive` with post-order semantics.

The output ordering and active-branch prioritization are unchanged. The static export now handles deep valid session trees consistently with the in-app TUI tree selector.

## Regression coverage

Add a DOM-level export-viewer test with a valid 30,000-entry parent chain. Against `origin/main`, this test fails in `sortChildren()` with `RangeError: Maximum call stack size exceeded`; with this change it renders the root message and active tree node.

## Verification

- `bun test test/export-html-markdown.test.ts`
- `bun run check`
