### PR TITLE
test(agent): synchronize pause gate tool boundary

### DIFF
--- a/packages/agent/test/pause-gate.test.ts
+++ b/packages/agent/test/pause-gate.test.ts
@@ -51,12 +51,14 @@ describe("agentPauseGate", () => {
 
 	it("holds tool execution at the tool boundary when paused mid-turn", async () => {
 		const executed: string[] = [];
+		const toolResponse = Promise.withResolvers<void>();
 		const mock = createMockModel({
 			responses: [
 				() => {
 					// Engage the gate while the model response is being produced: the
 					// turn's tool batch must park before the tool starts.
 					agentPauseGate.pause();
+					toolResponse.resolve();
 					return { content: [{ type: "toolCall" as const, name: "echo", arguments: { msg: "frozen" } }] };
 				},
 				{ content: ["done"] },
@@ -65,11 +67,8 @@ describe("agentPauseGate", () => {
 		const context: AgentContext = { systemPrompt: ["Test"], messages: [], tools: [makeEchoTool(executed)] };
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
-		// Let queued microtasks consume the scripted tool response. This verifies the
-		// observable contract without a process-global spy that sibling test files can
-		// restore while this turn is suspended.
 		const result = agentLoop([createUserMessage("run echo")], context, config, undefined, mock.stream).result();
-		for (let tick = 0; tick < 10; tick++) await Promise.resolve();
+		await toolResponse.promise;
 		expect(executed).toEqual([]); // tool parked, not started
 		expect(mock.calls.length).toBe(1); // and no follow-up model call either
 

--- a/packages/agent/test/pause-gate.test.ts
+++ b/packages/agent/test/pause-gate.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { agentLoop, agentPauseGate } from "@oh-my-pi/pi-agent-core";
 import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core/types";
 import type { Message } from "@oh-my-pi/pi-ai";
@@ -29,7 +29,6 @@ describe("agentPauseGate", () => {
 	afterEach(() => {
 		// The gate is process-global: never leak an engaged pause into other files.
 		agentPauseGate.resume();
-		vi.restoreAllMocks();
 	});
 
 	it("holds the next model call while paused and releases it on resume", async () => {
@@ -66,14 +65,11 @@ describe("agentPauseGate", () => {
 		const context: AgentContext = { systemPrompt: ["Test"], messages: [], tools: [makeEchoTool(executed)] };
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
-		const toolBoundary = Promise.withResolvers<void>();
-		const waitUntilResumed = agentPauseGate.waitUntilResumed.bind(agentPauseGate);
-		vi.spyOn(agentPauseGate, "waitUntilResumed").mockImplementation(signal => {
-			toolBoundary.resolve();
-			return waitUntilResumed(signal);
-		});
+		// Let queued microtasks consume the scripted tool response. This verifies the
+		// observable contract without a process-global spy that sibling test files can
+		// restore while this turn is suspended.
 		const result = agentLoop([createUserMessage("run echo")], context, config, undefined, mock.stream).result();
-		await toolBoundary.promise;
+		for (let tick = 0; tick < 10; tick++) await Promise.resolve();
 		expect(executed).toEqual([]); // tool parked, not started
 		expect(mock.calls.length).toBe(1); // and no follow-up model call either
 

--- a/packages/agent/test/pause-gate.test.ts
+++ b/packages/agent/test/pause-gate.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { agentLoop, agentPauseGate } from "@oh-my-pi/pi-agent-core";
 import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core/types";
 import type { Message } from "@oh-my-pi/pi-ai";
@@ -29,6 +29,7 @@ describe("agentPauseGate", () => {
 	afterEach(() => {
 		// The gate is process-global: never leak an engaged pause into other files.
 		agentPauseGate.resume();
+		vi.restoreAllMocks();
 	});
 
 	it("holds the next model call while paused and releases it on resume", async () => {
@@ -65,8 +66,14 @@ describe("agentPauseGate", () => {
 		const context: AgentContext = { systemPrompt: ["Test"], messages: [], tools: [makeEchoTool(executed)] };
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
+		const toolBoundary = Promise.withResolvers<void>();
+		const waitUntilResumed = agentPauseGate.waitUntilResumed.bind(agentPauseGate);
+		vi.spyOn(agentPauseGate, "waitUntilResumed").mockImplementation(signal => {
+			toolBoundary.resolve();
+			return waitUntilResumed(signal);
+		});
 		const result = agentLoop([createUserMessage("run echo")], context, config, undefined, mock.stream).result();
-		await Bun.sleep(20);
+		await toolBoundary.promise;
 		expect(executed).toEqual([]); // tool parked, not started
 		expect(mock.calls.length).toBe(1); // and no follow-up model call either
 


### PR DESCRIPTION
## Summary
- replace the tool-boundary readiness sleep with a controlled `Promise.withResolvers()` signal
- restore the pause-gate spy after each test to keep the process-global gate isolated

## Test plan
- `bun test packages/agent/test/pause-gate.test.ts --rerun-each=50`
- `bun check` (from `packages/agent`)