### PR TITLE
fix(coding-agent): serialize MuPDF initialization

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 
 - Fixed Portkey/gateway custom models whose ids start with `@` (e.g. `@modal/GLM-5-2-FP8`) being rewritten to unrelated bundled wire ids (e.g. `glm-5-2`), which caused `400` responses requiring `x-portkey-config` or `x-portkey-provider`.
+### Fixed
+- Fixed concurrent PDF conversions racing MuPDF's WASM initialization; callers now share the in-flight load and retry after an initialization failure.
 
 ## [17.0.6] - 2026-07-20
 
@@ -36,8 +38,6 @@
 - Rendered `read xd://` calls in the compact grouped read view instead of a full tool-execution card; other internal URLs (`skill://`, `agent://`, …) still render full so their resolved content stays visible.
 
 ### Fixed
-- Fixed concurrent PDF conversions racing MuPDF's WASM initialization; callers now share the in-flight load and retry after an initialization failure.
-
 
 - Fixed the interactive `!`/`!!` shell shortcut spawning fish as a login shell (`fish -l -c …`), which fired `status is-login` blocks in user config (agent/keychain setup, PATH mutation) on every command. fish is now started with `-i` instead — interactive shells source the same `config.fish`/`conf.d` files (so aliases and functions from #1816 keep working) without login-shell side effects. zsh behavior (`-l -i`) is unchanged.
 - Fixed the status-line `tok/s` badge ignoring vibe worker sessions: in `/vibe` mode the director is often idle while workers stream, so the badge showed a stale/zero rate while parallel work was actively generating tokens. The rate now aggregates the main session's live tok/s with every live vibe worker's tok/s, and falls back to the main session's own cached rate when no workers are streaming.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Rendered `read xd://` calls in the compact grouped read view instead of a full tool-execution card; other internal URLs (`skill://`, `agent://`, …) still render full so their resolved content stays visible.
 
 ### Fixed
+- Fixed concurrent PDF conversions racing MuPDF's WASM initialization; callers now share the in-flight load and retry after an initialization failure.
+
 
 - Fixed the interactive `!`/`!!` shell shortcut spawning fish as a login shell (`fish -l -c …`), which fired `status is-login` blocks in user config (agent/keychain setup, PATH mutation) on every command. fish is now started with `-i` instead — interactive shells source the same `config.fish`/`conf.d` files (so aliases and functions from #1816 keep working) without login-shell side effects. zsh behavior (`-l -i`) is unchanged.
 - Fixed the status-line `tok/s` badge ignoring vibe worker sessions: in `/vibe` mode the director is often idle while workers stream, so the badge showed a stale/zero rate while parallel work was actively generating tokens. The rate now aggregates the main session's live tok/s with every live vibe worker's tok/s, and falls back to the main session's own cached rate when no workers are streaming.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concurrent PDF conversions racing MuPDF's WASM initialization; callers now share the in-flight load and retry after an initialization failure.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed
 
 - Fixed Portkey/gateway custom models whose ids start with `@` (e.g. `@modal/GLM-5-2-FP8`) being rewritten to unrelated bundled wire ids (e.g. `glm-5-2`), which caused `400` responses requiring `x-portkey-config` or `x-portkey-provider`.
-### Fixed
-- Fixed concurrent PDF conversions racing MuPDF's WASM initialization; callers now share the in-flight load and retry after an initialization failure.
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/coding-agent/src/markit/converters/pdf/extract.ts
+++ b/packages/coding-agent/src/markit/converters/pdf/extract.ts
@@ -19,10 +19,24 @@ import type { ImageRegion, PageContent, Segment, TextBox } from "./types";
 // exposing the converter classes before their module-level consts initialize
 // (e.g. `EXTENSIONS` reads as undefined). Importing mupdf lazily keeps the chunk
 // init synchronous and also keeps the ~10MB wasm off non-PDF conversions.
-let mupdfModule: typeof mupdf | undefined;
-async function loadMupdf(): Promise<typeof mupdf> {
+let mupdfModule: Promise<typeof mupdf> | undefined;
+
+async function importMupdf(): Promise<typeof mupdf> {
+	const module = await import("mupdf");
+	// Bun can expose an ESM namespace while MuPDF's top-level WASM await is still
+	// running. Touch an export declared after that await before sharing it.
+	void module.Document;
+	return module;
+}
+
+function loadMupdf(): Promise<typeof mupdf> {
 	if (!mupdfModule) {
-		mupdfModule = await import("mupdf");
+		let initializing: Promise<typeof mupdf>;
+		initializing = importMupdf().catch(error => {
+			if (mupdfModule === initializing) mupdfModule = undefined;
+			throw error;
+		});
+		mupdfModule = initializing;
 	}
 	return mupdfModule;
 }

--- a/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
+++ b/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import fs from "node:fs/promises";
+import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
+import * as os from "node:os";
+import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { convertBufferWithMarkit } from "@oh-my-pi/pi-coding-agent/utils/markit";
 import { logger } from "@oh-my-pi/pi-utils";
+import { getAddonFilenames } from "../../../natives/native/loader-state.js";
 
 function warningPdf(): Uint8Array {
 	const objects: string[] = [];
@@ -43,15 +44,38 @@ function warningPdf(): Uint8Array {
 	return new TextEncoder().encode(pdf);
 }
 
+async function resolveNativeAddonPath({
+	nativeDir,
+	platform,
+	arch,
+}: {
+	nativeDir: string;
+	platform: string;
+	arch: string;
+}): Promise<string> {
+	const filenames = getAddonFilenames({
+		tag: `${platform}-${arch}`,
+		arch,
+		variant: arch === "x64" ? "modern" : null,
+	});
+	for (const filename of filenames) {
+		const addonPath = path.join(nativeDir, filename);
+		if (await Bun.file(addonPath).exists()) return addonPath;
+	}
+	throw new Error(`No native addon found in ${nativeDir}; tried: ${filenames.join(", ")}`);
+}
+
 async function convertWithCompiledMarkit(): Promise<string> {
 	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mupdf-compiled-"));
 	const entry = path.join(root, "convert.ts");
 	const output = path.join(root, "convert");
 	const markitPath = fileURLToPath(new URL("../../src/utils/markit.ts", import.meta.url));
 	const mupdfWasmPath = path.join(path.dirname(createRequire(import.meta.url).resolve("mupdf")), "mupdf-wasm.wasm");
-	const nativeAddonPath = fileURLToPath(
-		new URL(`../../../natives/native/pi_natives.${process.platform}-${process.arch}.node`, import.meta.url),
-	);
+	const nativeAddonPath = await resolveNativeAddonPath({
+		nativeDir: fileURLToPath(new URL("../../../natives/native", import.meta.url)),
+		platform: process.platform,
+		arch: process.arch,
+	});
 	try {
 		await fs.writeFile(
 			entry,
@@ -103,6 +127,27 @@ describe("markit MuPDF warnings", () => {
 
 	it("initializes MuPDF once in a compiled binary under concurrent PDF conversions", async () => {
 		expect(await convertWithCompiledMarkit()).toBe("compiled conversion succeeded");
+	});
+
+	it("selects Linux x64 variant-only artifacts in native loader order", async () => {
+		const nativeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-native-variants-"));
+		try {
+			const modern = "pi_natives.linux-x64-modern.node";
+			const baseline = "pi_natives.linux-x64-baseline.node";
+			await Bun.write(path.join(nativeDir, baseline), "");
+			await Bun.write(path.join(nativeDir, modern), "");
+
+			expect(path.basename(await resolveNativeAddonPath({ nativeDir, platform: "linux", arch: "x64" }))).toBe(
+				modern,
+			);
+
+			await fs.rm(path.join(nativeDir, modern));
+			expect(path.basename(await resolveNativeAddonPath({ nativeDir, platform: "linux", arch: "x64" }))).toBe(
+				baseline,
+			);
+		} finally {
+			await fs.rm(nativeDir, { force: true, recursive: true });
+		}
 	});
 
 	it("routes recoverable PDF warnings to the file logger", async () => {

--- a/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
+++ b/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
@@ -43,6 +43,19 @@ describe("markit MuPDF warnings", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("initializes MuPDF once for concurrent PDF conversions", async () => {
+		const results = await Promise.all(
+			Array.from({ length: 16 }, () =>
+				convertBufferWithMarkit(warningPdf(), ".pdf", undefined, { useCache: false }),
+			),
+		);
+
+		for (const result of results) {
+			expect(result.ok).toBe(true);
+			expect(result.content).toContain("Tagged PDF repro text");
+		}
+	});
+
 	it("routes recoverable PDF warnings to the file logger", async () => {
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
 		const debug = vi.spyOn(logger, "debug").mockImplementation(() => undefined);

--- a/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
+++ b/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { convertBufferWithMarkit } from "@oh-my-pi/pi-coding-agent/utils/markit";
 import { logger } from "@oh-my-pi/pi-utils";
 
@@ -38,22 +43,66 @@ function warningPdf(): Uint8Array {
 	return new TextEncoder().encode(pdf);
 }
 
+async function convertWithCompiledMarkit(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mupdf-compiled-"));
+	const entry = path.join(root, "convert.ts");
+	const output = path.join(root, "convert");
+	const markitPath = fileURLToPath(new URL("../../src/utils/markit.ts", import.meta.url));
+	const mupdfWasmPath = path.join(path.dirname(createRequire(import.meta.url).resolve("mupdf")), "mupdf-wasm.wasm");
+	const nativeAddonPath = fileURLToPath(
+		new URL(`../../../natives/native/pi_natives.${process.platform}-${process.arch}.node`, import.meta.url),
+	);
+	try {
+		await fs.writeFile(
+			entry,
+			`import { readFileSync } from "node:fs";
+import wasmPath from ${JSON.stringify(mupdfWasmPath)} with { type: "file" };
+globalThis.$libmupdf_wasm_Module = { wasmBinary: readFileSync(wasmPath) };
+// The compiled entry must dynamically load markit so Bun lowers the lazy converter boundary.
+const { convertBufferWithMarkit } = await import(${JSON.stringify(markitPath)});
+const results = await Promise.all(
+	Array.from({ length: 16 }, () =>
+		convertBufferWithMarkit(new Uint8Array(${JSON.stringify([...warningPdf()])}), ".pdf", undefined, { useCache: false }),
+	),
+);
+for (const result of results) {
+	if (!result.ok) throw new Error(result.error);
+	if (!result.content.includes("Tagged PDF repro text")) throw new Error("missing converted text");
+}
+process.stdout.write("compiled conversion succeeded");
+`,
+		);
+		const build = await Bun.build({
+			entrypoints: [entry],
+			root: fileURLToPath(new URL("../../../..", import.meta.url)),
+			external: ["fastembed", "onnxruntime-node"],
+			compile: { outfile: output },
+			throw: false,
+		});
+		expect(build.success).toBe(true);
+		await fs.copyFile(nativeAddonPath, path.join(root, path.basename(nativeAddonPath)));
+
+		const process = Bun.spawn([output], { stdout: "pipe", stderr: "pipe" });
+		const [exitCode, stdout, stderr] = await Promise.all([
+			process.exited,
+			new Response(process.stdout).text(),
+			new Response(process.stderr).text(),
+		]);
+		if (exitCode !== 0) throw new Error(`compiled converter failed:\n${stderr}`);
+		expect(stderr).toBe("");
+		return stdout;
+	} finally {
+		await fs.rm(root, { force: true, recursive: true });
+	}
+}
+
 describe("markit MuPDF warnings", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
-	it("initializes MuPDF once for concurrent PDF conversions", async () => {
-		const results = await Promise.all(
-			Array.from({ length: 16 }, () =>
-				convertBufferWithMarkit(warningPdf(), ".pdf", undefined, { useCache: false }),
-			),
-		);
-
-		for (const result of results) {
-			expect(result.ok).toBe(true);
-			expect(result.content).toContain("Tagged PDF repro text");
-		}
+	it("initializes MuPDF once in a compiled binary under concurrent PDF conversions", async () => {
+		expect(await convertWithCompiledMarkit()).toBe("compiled conversion succeeded");
 	});
 
 	it("routes recoverable PDF warnings to the file logger", async () => {

--- a/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
+++ b/packages/coding-agent/test/utils/markit-mupdf-warnings.test.ts
@@ -44,7 +44,12 @@ function warningPdf(): Uint8Array {
 	return new TextEncoder().encode(pdf);
 }
 
-async function resolveNativeAddonPath({
+// The compiled child selects its own CPU variant at runtime (AVX2 detection /
+// `PI_NATIVE_VARIANT`), so it may request `baseline` even when a `modern` artifact
+// is present. Copy every addon file the loader could resolve — the full
+// `getAddonFilenames` candidate set that exists on disk — so whichever variant the
+// child picks is staged next to it. Returned in native loader order.
+async function resolveNativeAddonPaths({
 	nativeDir,
 	platform,
 	arch,
@@ -52,17 +57,21 @@ async function resolveNativeAddonPath({
 	nativeDir: string;
 	platform: string;
 	arch: string;
-}): Promise<string> {
+}): Promise<string[]> {
 	const filenames = getAddonFilenames({
 		tag: `${platform}-${arch}`,
 		arch,
 		variant: arch === "x64" ? "modern" : null,
 	});
+	const found: string[] = [];
 	for (const filename of filenames) {
 		const addonPath = path.join(nativeDir, filename);
-		if (await Bun.file(addonPath).exists()) return addonPath;
+		if (await Bun.file(addonPath).exists()) found.push(addonPath);
 	}
-	throw new Error(`No native addon found in ${nativeDir}; tried: ${filenames.join(", ")}`);
+	if (found.length === 0) {
+		throw new Error(`No native addon found in ${nativeDir}; tried: ${filenames.join(", ")}`);
+	}
+	return found;
 }
 
 async function convertWithCompiledMarkit(): Promise<string> {
@@ -71,7 +80,7 @@ async function convertWithCompiledMarkit(): Promise<string> {
 	const output = path.join(root, "convert");
 	const markitPath = fileURLToPath(new URL("../../src/utils/markit.ts", import.meta.url));
 	const mupdfWasmPath = path.join(path.dirname(createRequire(import.meta.url).resolve("mupdf")), "mupdf-wasm.wasm");
-	const nativeAddonPath = await resolveNativeAddonPath({
+	const nativeAddonPaths = await resolveNativeAddonPaths({
 		nativeDir: fileURLToPath(new URL("../../../natives/native", import.meta.url)),
 		platform: process.platform,
 		arch: process.arch,
@@ -104,7 +113,9 @@ process.stdout.write("compiled conversion succeeded");
 			throw: false,
 		});
 		expect(build.success).toBe(true);
-		await fs.copyFile(nativeAddonPath, path.join(root, path.basename(nativeAddonPath)));
+		for (const addonPath of nativeAddonPaths) {
+			await fs.copyFile(addonPath, path.join(root, path.basename(addonPath)));
+		}
 
 		const process = Bun.spawn([output], { stdout: "pipe", stderr: "pipe" });
 		const [exitCode, stdout, stderr] = await Promise.all([
@@ -129,7 +140,7 @@ describe("markit MuPDF warnings", () => {
 		expect(await convertWithCompiledMarkit()).toBe("compiled conversion succeeded");
 	});
 
-	it("selects Linux x64 variant-only artifacts in native loader order", async () => {
+	it("collects every Linux x64 variant artifact in native loader order", async () => {
 		const nativeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-native-variants-"));
 		try {
 			const modern = "pi_natives.linux-x64-modern.node";
@@ -137,14 +148,14 @@ describe("markit MuPDF warnings", () => {
 			await Bun.write(path.join(nativeDir, baseline), "");
 			await Bun.write(path.join(nativeDir, modern), "");
 
-			expect(path.basename(await resolveNativeAddonPath({ nativeDir, platform: "linux", arch: "x64" }))).toBe(
-				modern,
-			);
+			expect(
+				(await resolveNativeAddonPaths({ nativeDir, platform: "linux", arch: "x64" })).map(p => path.basename(p)),
+			).toEqual([modern, baseline]);
 
 			await fs.rm(path.join(nativeDir, modern));
-			expect(path.basename(await resolveNativeAddonPath({ nativeDir, platform: "linux", arch: "x64" }))).toBe(
-				baseline,
-			);
+			expect(
+				(await resolveNativeAddonPaths({ nativeDir, platform: "linux", arch: "x64" })).map(p => path.basename(p)),
+			).toEqual([baseline]);
 		} finally {
 			await fs.rm(nativeDir, { force: true, recursive: true });
 		}


### PR DESCRIPTION
## Summary
- share MuPDF's in-flight WASM initialization across concurrent PDF conversions
- clear a failed initialization promise so a later conversion can retry
- cover concurrent PDF conversion during cold initialization

## Test plan
- `cd packages/coding-agent && bun test test/utils/markit-mupdf-warnings.test.ts`
- `cd packages/coding-agent && bun check`