### PR TITLE
fix(tui): add terminal.preserveScrollback to stop ESC[3J scrollback wipes under limux

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -583,6 +583,7 @@ statusLine:
 
 terminal:
   showImages: true
+  preserveScrollback: auto   # auto, always, never
 images:
   autoResize: true
   blockImages: false
@@ -603,6 +604,7 @@ tui:
 | `statusLine.transparent` | boolean | `false` | Use the terminal background for the status line. |
 | `statusLine.showHookStatus` | boolean | `true` | Show hook status messages. |
 | `terminal.showImages` | boolean | `true` | Render images inline (when the terminal supports it). |
+| `terminal.preserveScrollback` | enum | `auto` | `auto`, `always`, `never`. Suppress destructive scrollback erases (`ESC[3J`) on full repaints (session switch, theme change, compaction collapse) so terminal history and scroll position survive. `auto` preserves scrollback inside limux; `always` everywhere; `never` keeps the destructive erase. |
 | `images.autoResize` | boolean | `true` | Resize large images for model compatibility. |
 | `images.blockImages` | boolean | `false` | Never send images to providers. |
 | `tui.hyperlinks` | enum | `auto` | `off`, `auto`, `always`. |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `terminal.preserveScrollback` setting (`auto` | `always` | `never`, default `auto`): suppresses destructive terminal scrollback erases (`ESC[3J`) on full repaints — session switch, theme change, compaction collapse, handoff — degrading them to a non-destructive full repaint so terminal history and scroll position survive. `auto` preserves scrollback when running inside limux (detected via `LIMUX_SESSION_DIR`/`LIMUX_CHANNEL`), where the erase wipes the ghostty-core scrollback, snaps the viewport to bottom, and collapses the host scrollbar; `always` preserves everywhere; `never` keeps the previous behavior.
+
 ## [17.0.6] - 2026-07-20
 
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -935,6 +935,19 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"terminal.preserveScrollback": {
+		type: "enum",
+		values: ["auto", "always", "never"] as const,
+		default: "auto",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Preserve Scrollback",
+			description:
+				"Suppress destructive scrollback erases (ED3) on full repaints such as session switch, theme change, and compaction collapse (auto: preserve inside limux, where the erase snaps the viewport to bottom and collapses the scrollbar; always: never erase scrollback; never: allow destructive erases everywhere)",
+		},
+	},
+
 	"display.shimmer": {
 		type: "enum",
 		values: ["classic", "kitt", "disabled"] as const,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -65,6 +65,7 @@ import {
 	setPreferredSearchProvider,
 } from "../../tools";
 import { shortenPath } from "../../tools/render-utils";
+import { applyPreserveScrollbackSetting } from "../../tui/preserve-scrollback";
 import { copyToClipboard } from "../../utils/clipboard";
 import { repo } from "../../utils/git";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
@@ -502,6 +503,10 @@ export class SelectorController {
 
 			case "tui.scrollbackRebuild":
 				this.ctx.ui.setScrollbackRebuild(value as boolean);
+				break;
+
+			case "terminal.preserveScrollback":
+				applyPreserveScrollbackSetting(value as "auto" | "always" | "never");
 				break;
 
 			case "tui.renderMermaid":

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -124,6 +124,7 @@ import {
 	todoMatchesAnyDescription,
 } from "../tools/todo";
 import { vocalizer } from "../tts/vocalizer";
+import { applyPreserveScrollbackSetting } from "../tui/preserve-scrollback";
 import { renderTreeList } from "../tui/tree-list";
 import { copyToClipboard } from "../utils/clipboard";
 import type { EventBus } from "../utils/event-bus";
@@ -678,6 +679,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setMaxInlineImages(settings.get("tui.maxInlineImages"));
 		this.ui.setScrollbackRebuild(settings.get("tui.scrollbackRebuild"));
+		// Destructive scrollback erases (ED3) wipe the terminal's history buffer;
+		// in limux "auto" degrades them to non-destructive full repaints so the
+		// user keeps their scroll position (see applyPreserveScrollbackSetting).
+		applyPreserveScrollbackSetting(settings.get("terminal.preserveScrollback"));
 		// OSC 66 text-sizing is Kitty-only; resolve the setting against the terminal's
 		// capability (`TERMINAL.textSizing` defaults on for Kitty) so it stays off
 		// unless the user opts in, and never emits raw escapes on other terminals.

--- a/packages/coding-agent/src/tui/index.ts
+++ b/packages/coding-agent/src/tui/index.ts
@@ -6,6 +6,7 @@ export * from "./code-cell";
 export * from "./file-list";
 export * from "./hyperlink";
 export * from "./output-block";
+export * from "./preserve-scrollback";
 export * from "./status-line";
 export * from "./tree-list";
 export * from "./types";

--- a/packages/coding-agent/src/tui/preserve-scrollback.ts
+++ b/packages/coding-agent/src/tui/preserve-scrollback.ts
@@ -1,0 +1,15 @@
+import { isInsideLimux, setPreserveScrollback } from "@oh-my-pi/pi-tui";
+import type { SettingValue } from "../config/settings-schema";
+
+/**
+ * Apply the `terminal.preserveScrollback` setting to the TUI's destructive
+ * scrollback-clear gate:
+ * - `"never"`: destructive scrollback erases (ED3, `CSI 3 J`) stay enabled.
+ * - `"always"`: full repaints never erase native scrollback — they degrade to
+ *   the non-destructive repaint path.
+ * - `"auto"`: preserve only inside limux, whose ghostty-core viewport snaps to
+ *   bottom and collapses the host scrollbar when ED3 erases history.
+ */
+export function applyPreserveScrollbackSetting(mode: SettingValue<"terminal.preserveScrollback">): void {
+	setPreserveScrollback(mode === "always" || (mode === "auto" && isInsideLimux()));
+}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -139,6 +139,20 @@ describe("Settings", () => {
 			expect(getDefault("providers.maxInFlightRequests")).toEqual({});
 		});
 
+		it("defaults preserve-scrollback to auto and accepts all three modes", () => {
+			const isolated = Settings.isolated();
+			expect(isolated.get("terminal.preserveScrollback")).toBe("auto");
+			expect(getDefault("terminal.preserveScrollback")).toBe("auto");
+			expect(getEnumValues("terminal.preserveScrollback")).toEqual(["auto", "always", "never"]);
+
+			isolated.set("terminal.preserveScrollback", "always");
+			expect(isolated.get("terminal.preserveScrollback")).toBe("always");
+			isolated.set("terminal.preserveScrollback", "never");
+			expect(isolated.get("terminal.preserveScrollback")).toBe("never");
+			isolated.set("terminal.preserveScrollback", "auto");
+			expect(isolated.get("terminal.preserveScrollback")).toBe("auto");
+		});
+
 		it("exposes all tool calling mode options", () => {
 			const values = getEnumValues("tools.format");
 			expect(values).toEqual([

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a scrollback-preservation gate: `setPreserveScrollback(enabled)` / `isPreserveScrollbackEnabled()` suppress destructive scrollback erases (ED3, `ESC[3J`) — full repaints requested with `clearScrollback: true` still replay the frame but take the non-destructive `ESC[2J` path, resizes repaint in place (multiplexer-style) instead of erasing and rewrapping history, and divergence rebuilds fall back to the repair-below path. Added `isInsideLimux()` to detect limux panes via `LIMUX_SESSION_DIR`/`LIMUX_CHANNEL`.
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -200,6 +200,20 @@ export function isInsideZellij(env: NodeJS.ProcessEnv = Bun.env): boolean {
 	return Boolean(env.ZELLIJ);
 }
 
+/**
+ * Whether the agent process is running inside a limux pane (a ghostty-core GTK
+ * terminal host). Limux exports `LIMUX_SESSION_DIR` (limux-host-linux
+ * `layout_state.rs`: `LIMUX_SESSION_DIR_ENV = "LIMUX_SESSION_DIR"`) and
+ * `LIMUX_CHANNEL` (limux-control `socket_path.rs`:
+ * `LIMUX_CHANNEL_ENV = "LIMUX_CHANNEL"`) into every hosted pane. Destructive
+ * scrollback clears (ED3, `CSI 3 J`) are hostile there: ghostty-family
+ * viewports snap to bottom and the host collapses its scrollbar when native
+ * history is erased.
+ */
+export function isInsideLimux(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	return Boolean(env.LIMUX_SESSION_DIR || env.LIMUX_CHANNEL);
+}
+
 export function isNotificationSuppressed(): boolean {
 	const value = $env.PI_NOTIFICATIONS;
 	if (!value) return false;
@@ -581,6 +595,27 @@ export function setTerminalDeccara(enabled: boolean): void {
 /** Override screen-to-scrollback clear support for targeted renderer tests. */
 export function setTerminalScreenToScrollback(enabled: boolean): void {
 	TERMINAL.supportsScreenToScrollback = enabled;
+}
+
+let preserveScrollback = false;
+
+/**
+ * Suppress destructive scrollback clears (ED3, `CSI 3 J`) at runtime. The
+ * coding-agent calls this from the `terminal.preserveScrollback` setting
+ * (`"always"`, or `"auto"` inside limux — see {@link isInsideLimux}); tests
+ * flip it directly. When enabled, gesture-driven full repaints (session
+ * replace, theme change, compaction collapse) still replay the frame — only
+ * the history erase degrades to the non-destructive `ED 2` clear, and resizes
+ * repaint in place (multiplexer-style) instead of erasing and rewrapping
+ * native history.
+ */
+export function setPreserveScrollback(enabled: boolean): void {
+	preserveScrollback = enabled;
+}
+
+/** Whether destructive scrollback clears are suppressed (see {@link setPreserveScrollback}). */
+export function isPreserveScrollbackEnabled(): boolean {
+	return preserveScrollback;
 }
 
 /**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -27,6 +27,7 @@ import {
 	encodeKittyDeleteImage,
 	ImageProtocol,
 	isInsideTerminalMultiplexer,
+	isPreserveScrollbackEnabled,
 	setCellDimensions,
 	setTerminalImageProtocol,
 	shouldEnableSynchronizedOutputByDefault,
@@ -404,12 +405,15 @@ function reportsSizeOnAltScreenToggle(): boolean {
 
 /**
  * Resize should repaint the visible window in place — no alternate-screen
- * borrow, no ED3 scrollback rewrap — for multiplexer panes and for terminals
- * that loop on alt-screen toggles. The tradeoff is identical to a multiplexer:
- * scrollback above the window keeps its old wrap instead of being re-flowed.
+ * borrow, no ED3 scrollback rewrap — for multiplexer panes, for terminals
+ * that loop on alt-screen toggles, and when scrollback preservation is active
+ * (an ED3-free geometry rebuild would replay the whole transcript below the
+ * retained history, duplicating it once per resize settle). The tradeoff is
+ * identical to a multiplexer: scrollback above the window keeps its old wrap
+ * instead of being re-flowed.
  */
 function resizeRepaintsInPlace(): boolean {
-	return isMultiplexerSession() || reportsSizeOnAltScreenToggle();
+	return isMultiplexerSession() || reportsSizeOnAltScreenToggle() || isPreserveScrollbackEnabled();
 }
 
 /**
@@ -3028,6 +3032,7 @@ export class TUI extends Container {
 		// and keep the repair-below fallback in the branches under this one.
 		const divergenceRebuild =
 			this.#scrollbackRebuildEnabled &&
+			!isPreserveScrollbackEnabled() &&
 			!firstPaint &&
 			!replaceRequested &&
 			!geometryChanged &&
@@ -3126,7 +3131,14 @@ export class TUI extends Container {
 		const intent: RenderIntent = fullPaint
 			? {
 					kind: "fullPaint",
-					clearScrollback: divergenceRebuild || ((replaceRequested || geometryRebuild) && !isMultiplexerSession()),
+					// Scrollback preservation (setPreserveScrollback, driven by the
+					// host's `terminal.preserveScrollback` setting) is the single
+					// choke point for destructive clears: the full repaint still
+					// runs, but ED3 degrades to the non-destructive ED 2 branch of
+					// #emitFullPaint so native history survives.
+					clearScrollback:
+						!isPreserveScrollbackEnabled() &&
+						(divergenceRebuild || ((replaceRequested || geometryRebuild) && !isMultiplexerSession())),
 				}
 			: { kind: "update", chunkTo, windowTop };
 		this.#logRedraw(intent, frameLength, height);

--- a/packages/tui/test/preserve-scrollback.test.ts
+++ b/packages/tui/test/preserve-scrollback.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import {
+	type Component,
+	isPreserveScrollbackEnabled,
+	setPreserveScrollback,
+	setTerminalScreenToScrollback,
+	TERMINAL,
+	TUI,
+} from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class MutableLinesComponent implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+}
+
+function rows(prefix: string, count: number): string[] {
+	return Array.from({ length: count }, (_v, i) => `${prefix}${i}`);
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	// Drain the scheduler's setImmediate hop, let the throttled render fire,
+	// then flush the virtual terminal (same cadence as render-regressions).
+	const immediate = Promise.withResolvers<void>();
+	setImmediate(immediate.resolve);
+	await immediate.promise;
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+function captureWrites(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	vi.spyOn(term, "write").mockImplementation((data: string) => {
+		writes.push(data);
+		realWrite(data);
+	});
+	return writes;
+}
+
+function visible(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.trimEnd());
+}
+
+async function withEnvPatch<T>(patch: Record<string, string | undefined>, run: () => T | Promise<T>): Promise<T> {
+	const saved: Record<string, string | undefined> = {};
+	for (const key in patch) {
+		saved[key] = Bun.env[key];
+		const value = patch[key];
+		if (value === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = value;
+		}
+	}
+	try {
+		return await run();
+	} finally {
+		for (const key in saved) {
+			const value = saved[key];
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+const DIRECT_TERMINAL_ENV = { TMUX: undefined, STY: undefined, ZELLIJ: undefined, TERM: "xterm-256color" } as const;
+
+describe("preserve scrollback", () => {
+	afterEach(() => {
+		setPreserveScrollback(false);
+		vi.restoreAllMocks();
+	});
+
+	it("degrades a clearScrollback full paint to a non-destructive repaint when preservation is active", async () => {
+		await withEnvPatch({ ...DIRECT_TERMINAL_ENV }, async () => {
+			const savedScreenToScrollback = TERMINAL.supportsScreenToScrollback;
+			setTerminalScreenToScrollback(false);
+			setPreserveScrollback(true);
+			expect(isPreserveScrollbackEnabled()).toBe(true);
+			const term = new VirtualTerminal(24, 4);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("old-session-", 6));
+			tui.addChild(component);
+			const writes = captureWrites(term);
+
+			try {
+				tui.start();
+				await settle(term);
+				writes.length = 0;
+				component.setLines(rows("resumed-", 5));
+
+				// Session replacement gesture: the caller still requests a
+				// destructive replace; only the history erase must be skipped.
+				tui.requestRender(true, { clearScrollback: true });
+				await settle(term);
+
+				const out = writes.join("");
+				expect(out).not.toContain("\x1b[3J");
+				// The repaint still happens, via the non-destructive branch.
+				expect(out).toContain("\x1b[2J\x1b[H");
+				expect(visible(term)).toEqual(["resumed-1", "resumed-2", "resumed-3", "resumed-4"]);
+			} finally {
+				tui.stop();
+				setTerminalScreenToScrollback(savedScreenToScrollback);
+			}
+		});
+	});
+
+	it("keeps the destructive ED3 replace when preservation is inactive", async () => {
+		await withEnvPatch({ ...DIRECT_TERMINAL_ENV }, async () => {
+			const savedScreenToScrollback = TERMINAL.supportsScreenToScrollback;
+			setTerminalScreenToScrollback(false);
+			setPreserveScrollback(false);
+			const term = new VirtualTerminal(24, 4);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("old-session-", 6));
+			tui.addChild(component);
+			const writes = captureWrites(term);
+
+			try {
+				tui.start();
+				await settle(term);
+				writes.length = 0;
+				component.setLines(rows("resumed-", 5));
+
+				tui.requestRender(true, { clearScrollback: true });
+				await settle(term);
+
+				const out = writes.join("");
+				expect(out).toContain("\x1b[H\x1b[3J");
+				expect(visible(term)).toEqual(["resumed-1", "resumed-2", "resumed-3", "resumed-4"]);
+			} finally {
+				tui.stop();
+				setTerminalScreenToScrollback(savedScreenToScrollback);
+			}
+		});
+	});
+});

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
 	getTerminalInfo,
 	hyperlinksUserOverride,
 	ImageProtocol,
+	isInsideLimux,
 	NotifyProtocol,
 	resolveWarpImageProtocol,
 	shouldEnableHyperlinksByDefault,
@@ -20,6 +21,20 @@ describe("detectTerminalId", () => {
 		const env = { TERM: "xterm-256color", TERM_PROGRAM: "", COLORTERM: "truecolor", VTE_VERSION: "8400" };
 
 		expect(detectTerminalId(env)).toBe("trueColor");
+	});
+});
+
+describe("isInsideLimux", () => {
+	it("detects a limux pane via either exported session marker", () => {
+		// limux-host-linux layout_state.rs: LIMUX_SESSION_DIR_ENV = "LIMUX_SESSION_DIR";
+		// limux-control socket_path.rs: LIMUX_CHANNEL_ENV = "LIMUX_CHANNEL".
+		expect(isInsideLimux({ LIMUX_SESSION_DIR: "/home/user/.local/state/limux" })).toBe(true);
+		expect(isInsideLimux({ LIMUX_CHANNEL: "preview:test" })).toBe(true);
+	});
+
+	it("returns false outside limux, including on bare ghostty", () => {
+		expect(isInsideLimux({})).toBe(false);
+		expect(isInsideLimux({ TERM: "xterm-ghostty", GHOSTTY_RESOURCES_DIR: "/usr/share/ghostty" })).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Problem

When the OMP TUI runs inside limux (a ghostty-core GTK terminal), full repaints that pass `clearScrollback: true` emit `ESC[H ESC[3J` (`#emitFullPaint`, `packages/tui/src/tui.ts`), erasing the terminal's entire scrollback. In ghostty-family terminals this snaps the viewport to bottom, collapses the scrollback total, and limux hides/pegs its GTK scrollbar — the user loses their scroll position with a visible flash.

**Diagnosis one-liner:** the discrete `clearScrollback: true` call sites (session replacement, compaction collapse, handoff, theme swap) funnel into `#emitFullPaint`'s `ESC[H ESC[3J` emission, which is a destructive history wipe on ghostty-core hosts like limux.

## Setting semantics

New setting `terminal.preserveScrollback` (enum `"auto" | "always" | "never"`, default `"auto"`):

- **`always`** — never emit destructive scrollback erases: every `clearScrollback: true` request still runs a full repaint, but takes `#emitFullPaint`'s existing non-destructive branch (`ESC[22J`-if-supported + `ESC[2J ESC[H`) instead of `ESC[3J`. No new sequence logic — the established per-line forms are reused.
- **`never`** — current behavior everywhere.
- **`auto`** — current behavior, except preserve scrollback (degrade like `always`) when running inside limux.

## Implementation

- **Limux detection** (`packages/tui/src/terminal-capabilities.ts`): `isInsideLimux()` keys on `LIMUX_SESSION_DIR` / `LIMUX_CHANNEL`, the env markers limux exports into every pane (`limux-host-linux/src/layout_state.rs` `LIMUX_SESSION_DIR_ENV`; `limux-control/src/socket_path.rs` `LIMUX_CHANNEL_ENV`).
- **TUI-level knob** (`setPreserveScrollback` / `isPreserveScrollbackEnabled`, mirroring the existing runtime setters like `setTerminalScreenToScrollback`): `packages/tui` never imports coding-agent settings — the policy is injected. Coding-agent resolves the setting + limux detection in `src/tui/preserve-scrollback.ts` (`applyPreserveScrollbackSetting`), called at interactive-mode startup and on live setting changes in the settings selector.
- **Single choke point**: the gate lives where the `fullPaint` intent's `clearScrollback` option is built in `tui.ts`, so all ED3 sources (session replace, geometry rebuild, divergence rebuild) are masked uniformly while the full repaint contract is preserved (alt-exit fusing and full-history replay still key off the caller's replace intent).
- While preservation is active, resizes repaint **in place** (multiplexer-style, same path Warp already uses) instead of ED3-rewrapping history — an ED3-free geometry rebuild would otherwise replay the whole transcript below the retained history once per resize settle. Divergence rebuilds likewise fall back to the multiplexer repair-below path ("duplication, never loss").

## Test plan

- [x] `packages/tui/test/preserve-scrollback.test.ts` — with suppression active, a `clearScrollback: true` full paint emits **no** `\x1b[3J`, takes the `\x1b[2J\x1b[H` branch, and still repaints the new frame; with suppression inactive, `\x1b[H\x1b[3J` is emitted (existing behavior preserved).
- [x] `packages/tui/test/terminal-capabilities.test.ts` — `isInsideLimux` responds to `LIMUX_SESSION_DIR` / `LIMUX_CHANNEL` and stays false on bare ghostty.
- [x] `packages/coding-agent/test/settings-manager.test.ts` — schema defaults to `auto`, exposes exactly `["auto", "always", "never"]`, and round-trips all three values.
- [x] Neighbor suites green: `render-regressions` (98 pass; the 4 failures are pre-existing on the WSL host, identical on HEAD), `issue-2088-repro`, `resize-viewport-defer`, `streaming-scrollback-defer`, `committed-prefix-resync`, `overlay-scroll`, `issue-2115-repro`, `issue-2130-repro` (85 pass, 0 fail), `settings-manager` (60 pass), `selector-settings-side-effects` (23 pass).
- [x] `tsgo --noEmit` clean for `packages/tui` and `packages/coding-agent`; `biome check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaQksnHQvvfpzNnrLX3Trg
