### PR TITLE
fix(ai): preserve native thinking signatures through leaked-thinking wrapper

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom Anthropic base URLs losing native thinking signatures in the leaked-thinking recovery wrapper: the signature Anthropic delivers at `thinking_end` (after all `thinking_delta` events) was ignored, so continuations replayed the block with an empty signature and signing endpoints rejected it ([#6046](https://github.com/can1357/oh-my-pi/issues/6046)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Changed

--- a/packages/ai/src/utils/leaked-thinking-stream.ts
+++ b/packages/ai/src/utils/leaked-thinking-stream.ts
@@ -78,6 +78,11 @@ export function wrapLeakedThinkingStream(inner: AssistantMessageEventStream): As
 						projector.thinking(event.delta, block?.type === "thinking" ? block.thinkingSignature : undefined);
 						break;
 					}
+					case "thinking_end": {
+						const block = event.partial.content[event.contentIndex];
+						projector?.thinkingEnd(block?.type === "thinking" ? block.thinkingSignature : undefined);
+						break;
+					}
 					case "image_end":
 						projector ??= new LeakedThinkingProjector(out, event.partial);
 						projector.image(event.content);
@@ -108,8 +113,9 @@ export function wrapLeakedThinkingStream(inner: AssistantMessageEventStream): As
 						out.push({ type: "error", reason: event.reason, error: { ...event.error, content } });
 						return;
 					}
-					// text_start/text_end/thinking_start/thinking_end are ignored: the
-					// projector owns block boundaries (matches wrapInbandToolStream).
+					// text_start/text_end/thinking_start are ignored: the projector owns
+					// block boundaries (matches wrapInbandToolStream). thinking_end is
+					// handled to capture the signature Anthropic delivers at block close.
 				}
 			}
 			// Inner ended via end(result) without a terminal event.
@@ -165,6 +171,17 @@ class LeakedThinkingProjector {
 		block.thinking += delta;
 		if (signature !== undefined) block.thinkingSignature = signature;
 		this.#out.push({ type: "thinking_delta", contentIndex: index, delta, partial: this.#partial });
+	}
+
+	/**
+	 * Capture a native thinking block's completed signature. Anthropic delivers
+	 * it via `signature_delta` after every `thinking_delta`, so it is absent while
+	 * deltas stream and only present on the `thinking_end` partial. Stamp it onto
+	 * the open projected block so {@link finish} persists the signed block.
+	 */
+	thinkingEnd(signature: string | undefined): void {
+		if (signature === undefined || !this.#thinking) return;
+		(this.#partial.content[this.#thinking.index] as ThinkingContent).thinkingSignature = signature;
 	}
 
 	/** Forward a completed native image after releasing held text. */

--- a/packages/ai/src/utils/leaked-thinking-stream.ts
+++ b/packages/ai/src/utils/leaked-thinking-stream.ts
@@ -159,6 +159,8 @@ class LeakedThinkingProjector {
 	#toolBlocks = new Map<number, { index: number; block: StreamingToolCall }>();
 	/** Projected native thinking blocks, keyed by the inner stream's `contentIndex`. */
 	#thinkingBlocks = new Map<number, number>();
+	/** Native thinking blocks whose projected `thinking_end` awaits the source end event. */
+	#pendingThinkingEnds = new Set<number>();
 
 	constructor(out: AssistantMessageEventStream, seed: AssistantMessage) {
 		this.#out = out;
@@ -177,8 +179,10 @@ class LeakedThinkingProjector {
 	thinking(srcIndex: number, delta: string, signature: string | undefined): void {
 		let index = this.#thinkingBlocks.get(srcIndex);
 		if (index === undefined) {
+			if (this.#thinking && this.#pendingThinkingEnds.has(this.#thinking.index)) this.#closeThinking();
 			index = this.#openThinking();
 			this.#thinkingBlocks.set(srcIndex, index);
+			this.#pendingThinkingEnds.add(index);
 		}
 		const block = this.#partial.content[index] as ThinkingContent;
 		block.thinking += delta;
@@ -187,13 +191,19 @@ class LeakedThinkingProjector {
 	}
 
 	/**
-	 * Capture a native thinking block's completed signature. Source identity is
-	 * required because providers may finalize it after a later block has started.
+	 * Finalize a native thinking block by source identity. Its projected end is
+	 * deferred until this event so stream consumers observe the completed
+	 * signature before the block closes, even when later blocks started first.
 	 */
 	thinkingEnd(srcIndex: number, signature: string | undefined): void {
 		const index = this.#thinkingBlocks.get(srcIndex);
-		if (signature === undefined || index === undefined) return;
-		(this.#partial.content[index] as ThinkingContent).thinkingSignature = signature;
+		if (index === undefined) return;
+		if (signature !== undefined) {
+			(this.#partial.content[index] as ThinkingContent).thinkingSignature = signature;
+		}
+		if (!this.#pendingThinkingEnds.delete(index)) return;
+		if (this.#thinking?.index === index) this.#thinking = undefined;
+		this.#emitThinkingEnd(index);
 	}
 
 	/** Forward a completed native image after releasing held text. */
@@ -263,6 +273,10 @@ class LeakedThinkingProjector {
 	 * flush held-back fragments, close open blocks, and return the healed content.
 	 */
 	finish(message: AssistantMessage): AssistantMessage["content"] {
+		for (const [srcIndex] of this.#thinkingBlocks) {
+			const block = message.content[srcIndex];
+			this.thinkingEnd(srcIndex, block?.type === "thinking" ? block.thinkingSignature : undefined);
+		}
 		let fullText = "";
 		let tailSignature: string | undefined;
 		for (const block of message.content) {
@@ -333,13 +347,19 @@ class LeakedThinkingProjector {
 
 	#closeThinking(): void {
 		if (!this.#thinking) return;
-		const block = this.#partial.content[this.#thinking.index] as ThinkingContent;
+		const index = this.#thinking.index;
+		this.#thinking = undefined;
+		if (this.#pendingThinkingEnds.has(index)) return;
+		this.#emitThinkingEnd(index);
+	}
+
+	#emitThinkingEnd(index: number): void {
+		const block = this.#partial.content[index] as ThinkingContent;
 		this.#out.push({
 			type: "thinking_end",
-			contentIndex: this.#thinking.index,
+			contentIndex: index,
 			content: block.thinking,
 			partial: this.#partial,
 		});
-		this.#thinking = undefined;
 	}
 }

--- a/packages/ai/src/utils/leaked-thinking-stream.ts
+++ b/packages/ai/src/utils/leaked-thinking-stream.ts
@@ -75,12 +75,19 @@ export function wrapLeakedThinkingStream(inner: AssistantMessageEventStream): As
 					case "thinking_delta": {
 						projector ??= new LeakedThinkingProjector(out, event.partial);
 						const block = event.partial.content[event.contentIndex];
-						projector.thinking(event.delta, block?.type === "thinking" ? block.thinkingSignature : undefined);
+						projector.thinking(
+							event.contentIndex,
+							event.delta,
+							block?.type === "thinking" ? block.thinkingSignature : undefined,
+						);
 						break;
 					}
 					case "thinking_end": {
 						const block = event.partial.content[event.contentIndex];
-						projector?.thinkingEnd(block?.type === "thinking" ? block.thinkingSignature : undefined);
+						projector?.thinkingEnd(
+							event.contentIndex,
+							block?.type === "thinking" ? block.thinkingSignature : undefined,
+						);
 						break;
 					}
 					case "image_end":
@@ -150,6 +157,8 @@ class LeakedThinkingProjector {
 	#lastTextSignature: string | undefined;
 	/** Forwarded native tool calls, keyed by the inner stream's `contentIndex`. */
 	#toolBlocks = new Map<number, { index: number; block: StreamingToolCall }>();
+	/** Projected native thinking blocks, keyed by the inner stream's `contentIndex`. */
+	#thinkingBlocks = new Map<number, number>();
 
 	constructor(out: AssistantMessageEventStream, seed: AssistantMessage) {
 		this.#out = out;
@@ -164,9 +173,13 @@ class LeakedThinkingProjector {
 		this.#apply(this.#healer.feedEvents(delta), this.#lastTextSignature);
 	}
 
-	/** Forward a native thinking delta, preserving its signature. */
-	thinking(delta: string, signature: string | undefined): void {
-		const index = this.#openThinking();
+	/** Forward a native thinking delta, preserving its source block identity and signature. */
+	thinking(srcIndex: number, delta: string, signature: string | undefined): void {
+		let index = this.#thinkingBlocks.get(srcIndex);
+		if (index === undefined) {
+			index = this.#openThinking();
+			this.#thinkingBlocks.set(srcIndex, index);
+		}
 		const block = this.#partial.content[index] as ThinkingContent;
 		block.thinking += delta;
 		if (signature !== undefined) block.thinkingSignature = signature;
@@ -174,14 +187,13 @@ class LeakedThinkingProjector {
 	}
 
 	/**
-	 * Capture a native thinking block's completed signature. Anthropic delivers
-	 * it via `signature_delta` after every `thinking_delta`, so it is absent while
-	 * deltas stream and only present on the `thinking_end` partial. Stamp it onto
-	 * the open projected block so {@link finish} persists the signed block.
+	 * Capture a native thinking block's completed signature. Source identity is
+	 * required because providers may finalize it after a later block has started.
 	 */
-	thinkingEnd(signature: string | undefined): void {
-		if (signature === undefined || !this.#thinking) return;
-		(this.#partial.content[this.#thinking.index] as ThinkingContent).thinkingSignature = signature;
+	thinkingEnd(srcIndex: number, signature: string | undefined): void {
+		const index = this.#thinkingBlocks.get(srcIndex);
+		if (signature === undefined || index === undefined) return;
+		(this.#partial.content[index] as ThinkingContent).thinkingSignature = signature;
 	}
 
 	/** Forward a completed native image after releasing held text. */

--- a/packages/ai/test/leaked-thinking-stream.test.ts
+++ b/packages/ai/test/leaked-thinking-stream.test.ts
@@ -224,6 +224,26 @@ describe("wrapLeakedThinkingStream", () => {
 		expect(calls[0]?.thoughtSignature).toBe("tsig");
 	});
 
+	it("captures a native thinking signature delivered at thinking_end, not on the delta", async () => {
+		// Anthropic sends thinking_delta first (no signature), then signature_delta,
+		// so the completed signature only appears on the thinking_end partial.
+		const signature = `SIG_${"x".repeat(400)}`;
+		const { result } = await runWrapper(inner => {
+			inner.push({ type: "start", partial: msg() });
+			inner.push({
+				type: "thinking_delta",
+				contentIndex: 0,
+				delta: "reason",
+				partial: msg({ content: [{ type: "thinking", thinking: "reason", thinkingSignature: "" }] }),
+			});
+			const signed = msg({ content: [{ type: "thinking", thinking: "reason", thinkingSignature: signature }] });
+			inner.push({ type: "thinking_end", contentIndex: 0, content: "reason", partial: signed });
+			inner.push({ type: "done", reason: "stop", message: signed });
+		});
+
+		expect(thinks(result).map(b => b.thinkingSignature)).toEqual([signature]);
+	});
+
 	it("preserves native tool-call ids and streamed partial JSON while healing", async () => {
 		const inner = new AssistantMessageEventStream();
 		const out = wrapLeakedThinkingStream(inner);

--- a/packages/ai/test/leaked-thinking-stream.test.ts
+++ b/packages/ai/test/leaked-thinking-stream.test.ts
@@ -244,7 +244,7 @@ describe("wrapLeakedThinkingStream", () => {
 		expect(thinks(result).map(b => b.thinkingSignature)).toEqual([signature]);
 	});
 
-	it("finalizes a native thinking block by source index after later blocks start", async () => {
+	it("emits a late native thinking signature by source index after later blocks start", async () => {
 		const firstSignature = "sig-first";
 		const secondSignature = "sig-second";
 		const call: ToolCall = {
@@ -255,7 +255,7 @@ describe("wrapLeakedThinkingStream", () => {
 		};
 		const first = { type: "thinking" as const, thinking: "first", thinkingSignature: "" };
 		const second = { type: "thinking" as const, thinking: "second", thinkingSignature: "" };
-		const { result } = await runWrapper(inner => {
+		const { events, result } = await runWrapper(inner => {
 			inner.push({ type: "start", partial: msg() });
 			inner.push({
 				type: "thinking_delta",
@@ -291,6 +291,15 @@ describe("wrapLeakedThinkingStream", () => {
 			inner.push({ type: "done", reason: "stop", message: signed });
 		});
 
+		const firstEnd = events.find(event => event.type === "thinking_end" && event.contentIndex === 0);
+		if (firstEnd?.type !== "thinking_end") throw new Error("Missing first projected thinking_end");
+		expect(firstEnd.partial.content[firstEnd.contentIndex]).toEqual({
+			type: "thinking",
+			thinking: first.thinking,
+			thinkingSignature: firstSignature,
+		});
+		expect(events.indexOf(firstEnd)).toBeGreaterThan(events.findIndex(event => event.type === "toolcall_start"));
+		expect(events.filter(event => event.type === "thinking_end" && event.contentIndex === 0)).toHaveLength(1);
 		expect(thinks(result).map(block => [block.thinking, block.thinkingSignature])).toEqual([
 			["first", firstSignature],
 			["second", secondSignature],

--- a/packages/ai/test/leaked-thinking-stream.test.ts
+++ b/packages/ai/test/leaked-thinking-stream.test.ts
@@ -244,6 +244,59 @@ describe("wrapLeakedThinkingStream", () => {
 		expect(thinks(result).map(b => b.thinkingSignature)).toEqual([signature]);
 	});
 
+	it("finalizes a native thinking block by source index after later blocks start", async () => {
+		const firstSignature = "sig-first";
+		const secondSignature = "sig-second";
+		const call: ToolCall = {
+			type: "toolCall",
+			id: "call_between_thinking",
+			name: "read",
+			arguments: { path: "x" },
+		};
+		const first = { type: "thinking" as const, thinking: "first", thinkingSignature: "" };
+		const second = { type: "thinking" as const, thinking: "second", thinkingSignature: "" };
+		const { result } = await runWrapper(inner => {
+			inner.push({ type: "start", partial: msg() });
+			inner.push({
+				type: "thinking_delta",
+				contentIndex: 0,
+				delta: first.thinking,
+				partial: msg({ content: [first] }),
+			});
+			const withCall = msg({ content: [first, call] });
+			inner.push({ type: "toolcall_start", contentIndex: 1, partial: withCall });
+			inner.push({ type: "toolcall_end", contentIndex: 1, toolCall: call, partial: withCall });
+			inner.push({
+				type: "thinking_delta",
+				contentIndex: 2,
+				delta: second.thinking,
+				partial: msg({ content: [first, call, second] }),
+			});
+			const firstSigned = {
+				...first,
+				thinkingSignature: firstSignature,
+			};
+			const secondSigned = {
+				...second,
+				thinkingSignature: secondSignature,
+			};
+			inner.push({
+				type: "thinking_end",
+				contentIndex: 0,
+				content: first.thinking,
+				partial: msg({ content: [firstSigned, call, second] }),
+			});
+			const signed = msg({ content: [firstSigned, call, secondSigned] });
+			inner.push({ type: "thinking_end", contentIndex: 2, content: second.thinking, partial: signed });
+			inner.push({ type: "done", reason: "stop", message: signed });
+		});
+
+		expect(thinks(result).map(block => [block.thinking, block.thinkingSignature])).toEqual([
+			["first", firstSignature],
+			["second", secondSignature],
+		]);
+	});
+
 	it("preserves native tool-call ids and streamed partial JSON while healing", async () => {
 		const inner = new AssistantMessageEventStream();
 		const out = wrapLeakedThinkingStream(inner);


### PR DESCRIPTION
## Repro
Custom `anthropic-messages` base URLs are wrapped by `healLeakedThinking()`, which routes the stream through `wrapLeakedThinkingStream()`. Feeding a native thinking block whose signature arrives in Anthropic's real order — `thinking_delta` (no signature) followed by the completed signature on the `thinking_end` partial — persists an empty `thinkingSignature`. A regression test that pushes `thinking_delta` then `thinking_end` (partial carrying a 400-char signature) through the wrapper and asserts the final block's `thinkingSignature` fails: `Expected: "SIG_xxxx…"`, `Received: ""`. A later continuation then replays the block with `signature: ""`, which signing endpoints reject with `Invalid \`signature\` in \`thinking\` block`.

## Cause
In `packages/ai/src/providers/anthropic.ts`, `signature_delta` accumulates onto `block.thinkingSignature` (lines 2369-2376) but emits no event; the completed signature first becomes observable on the `thinking_end` partial (`finalizeStreamBlock`, line 1996). `wrapLeakedThinkingStream()` in `packages/ai/src/utils/leaked-thinking-stream.ts` explicitly ignored `thinking_end`, and `LeakedThinkingProjector.thinking()` only records the signature present on each `thinking_delta` — always empty for Anthropic. `finish()` synchronizes terminal text/`textSignature` but never a native thinking block's final `thinkingSignature`, so the projected block kept the empty value.

## Fix
- Handle `thinking_end` in the `wrapLeakedThinkingStream` event loop, forwarding the completed block's signature to the projector.
- Add `LeakedThinkingProjector.thinkingEnd(signature)` to stamp the completed signature onto the open projected thinking block.
- Add a regression test driving the real Anthropic event order (`thinking_delta` without signature → `thinking_end` partial with signature) and asserting the persisted signature.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/leaked-thinking-stream.test.ts` (packages/ai): 17 pass, 0 fail. The new regression test fails before the fix (`Received: ""`) and passes after. Fixes #6046