### PR TITLE
fix(coding-agent): preserve compat overrides on model refresh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed dynamic model discovery refreshes dropping provider-level compatibility overrides from `models.yml` ([#6041](https://github.com/can1357/oh-my-pi/issues/6041)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -153,7 +153,7 @@ interface ProviderOverride {
 export function mergeDiscoveredModel<TApi extends Api>(
 	model: Model<TApi>,
 	existing: Model<Api> | undefined,
-	providerOverride?: Pick<ProviderOverride, "baseUrl" | "headers" | "remoteCompaction" | "transport">,
+	providerOverride?: Pick<ProviderOverride, "baseUrl" | "compat" | "headers" | "remoteCompaction" | "transport">,
 ): Model<TApi> {
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
@@ -167,7 +167,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 				providerOverride?.remoteCompaction,
 			),
 			...(supportsTools !== undefined ? { supportsTools } : {}),
-			compat: model.compatConfig,
+			compat: mergeCompat(model.compatConfig, providerOverride?.compat),
 		} as ModelSpec<TApi>);
 	}
 	if (providerOverride) {
@@ -180,7 +180,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 				model.remoteCompaction,
 				providerOverride.remoteCompaction,
 			),
-			compat: model.compatConfig,
+			compat: mergeCompat(model.compatConfig, providerOverride.compat),
 		} as ModelSpec<TApi>);
 	}
 	return model;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -163,6 +163,11 @@ describe("ModelRegistry", () => {
 		return model?.compatConfig as OpenAICompat | undefined;
 	}
 
+	function getReplayUnsignedThinking(model: Model | undefined): boolean | undefined {
+		const compat = model?.compat;
+		return compat && "replayUnsignedThinking" in compat ? compat.replayUnsignedThinking : undefined;
+	}
+
 	/** Create a baseUrl-only override (no custom models) */
 	function overrideConfig(baseUrl: string, headers?: Record<string, string>) {
 		return { baseUrl, ...(headers && { headers }) };
@@ -674,6 +679,32 @@ describe("ModelRegistry", () => {
 				expect(getOpenAICompat(model)?.disableReasoningOnToolChoice).toBe(true);
 				expect(getOpenAICompat(model)?.allowsSyntheticReasoningContentForToolCalls).toBe(false);
 			}
+		});
+
+		test("provider-level Anthropic compat survives dynamic discovery refresh", async () => {
+			writeRawModelsJson({
+				anthropic: {
+					baseUrl: "https://proxy.example/v1",
+					apiKey: "TEST_KEY",
+					compat: { replayUnsignedThinking: false },
+				},
+			});
+			const fetchMock: FetchImpl = async input => {
+				const url = String(input);
+				if (url === "https://models.dev/api.json") return Response.json({});
+				if (url === "https://proxy.example/v1/models") {
+					return Response.json({
+						data: [{ id: "claude-sonnet-5", display_name: "Claude Sonnet 5" }],
+					});
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			};
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+			expect(getReplayUnsignedThinking(registry.find("anthropic", "claude-sonnet-5"))).toBe(false);
+
+			await registry.refreshProvider("anthropic", "online");
+
+			expect(getReplayUnsignedThinking(registry.find("anthropic", "claude-sonnet-5"))).toBe(false);
 		});
 
 		test("provider-level compat applies to custom models", () => {


### PR DESCRIPTION
## Repro
Configure Anthropic with `compat.replayUnsignedThinking: false`, construct `ModelRegistry`, and run `refreshProvider("anthropic", "online")`. `bun test packages/coding-agent/test/model-registry.test.ts --test-name-pattern "provider-level Anthropic compat survives dynamic discovery refresh"` failed before the fix because the initial value was `false` and the post-refresh value was `true`.

## Cause
`mergeDiscoveredModel` in `packages/coding-agent/src/config/model-registry.ts` accepted and reapplied provider overrides for routing, headers, transport, and compaction, but its `ProviderOverride` projection excluded `compat`; both discovered-model branches rebuilt compatibility solely from discovered defaults.

## Fix
- Include `compat` in the provider override projection accepted by `mergeDiscoveredModel`.
- Deep-merge discovered compatibility metadata with explicit provider compatibility fields in both merge branches, keeping provider configuration authoritative.
- Add an Anthropic discovery-refresh regression and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/model-registry.test.ts --test-name-pattern "provider-level Anthropic compat survives dynamic discovery refresh"` passes (1 test); `bun test packages/coding-agent/test/model-registry.test.ts` passes (85 tests, 2,972 expectations); `bun check` passes across all packages.

Fixes #6041