### PR TITLE
fix(catalog): restore cached Copilot 1M models

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cached model variants that reuse a bundled request model, including GitHub Copilot `-1m` entries, being discarded after request headers were sanitized from the cache. ([#6037](https://github.com/can1357/oh-my-pi/issues/6037))
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -226,7 +226,9 @@ export function writeModelCache<TApi extends Api>(
 			for (const model of models) {
 				if (hasModelHeaders(model)) {
 					headerOmittedModelIds.push(model.id);
-					if (!headersEqual(model.headers, staticById.get(model.id)?.headers)) {
+					const staticHeaderSource =
+						staticById.get(model.id) ?? (model.requestModelId ? staticById.get(model.requestModelId) : undefined);
+					if (!headersEqual(model.headers, staticHeaderSource?.headers)) {
 						unrestorableHeaderModelIds.push(model.id);
 					}
 				}

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -108,9 +108,14 @@ interface CachedHeaderRestoreResult<TApi extends Api> {
 /**
  * Restore cache-omitted headers from the current static source.
  *
- * Header-bearing models without a same-id or `requestModelId` static source
- * cannot be reconstructed safely without persisting arbitrary credential
- * values; callers must refetch or omit them rather than return a broken model.
+ * A same-id static match is trusted only when the row did not flag the model
+ * unrestorable (its live headers matched static when cached). A synthesized
+ * variant instead recovers headers through `requestModelId`, whose static
+ * source is by construction where the variant's headers came from — this path
+ * is honoured even past a stale `unrestorable` marker written before the
+ * fallback existed. Models that resolve to no static headers cannot be rebuilt
+ * safely without persisting arbitrary credential values; callers must refetch
+ * or omit them rather than return a broken model.
  */
 function restoreCachedModelHeaders<TApi extends Api>(
 	cachedModels: readonly ModelSpec<TApi>[],
@@ -128,12 +133,9 @@ function restoreCachedModelHeaders<TApi extends Api>(
 	const unresolvedModelIds = new Set<string>();
 	const restored = models.map(model => {
 		if (!omittedIds.has(model.id)) return model;
-		if (unrestorableIds.has(model.id)) {
-			unresolvedModelIds.add(model.id);
-			return model;
-		}
 		const staticModel =
-			staticById.get(model.id) ?? (model.requestModelId ? staticById.get(model.requestModelId) : undefined);
+			(unrestorableIds.has(model.id) ? undefined : staticById.get(model.id)) ??
+			(model.requestModelId ? staticById.get(model.requestModelId) : undefined);
 		if (!staticModel?.headers) {
 			unresolvedModelIds.add(model.id);
 			return model;

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -108,9 +108,9 @@ interface CachedHeaderRestoreResult<TApi extends Api> {
 /**
  * Restore cache-omitted headers from the current static source.
  *
- * Dynamic-only header-bearing models cannot be reconstructed safely without
- * persisting arbitrary credential values; callers must refetch them online or
- * omit them from an offline result rather than return a broken model.
+ * Header-bearing models without a same-id or `requestModelId` static source
+ * cannot be reconstructed safely without persisting arbitrary credential
+ * values; callers must refetch or omit them rather than return a broken model.
  */
 function restoreCachedModelHeaders<TApi extends Api>(
 	cachedModels: readonly ModelSpec<TApi>[],
@@ -132,7 +132,8 @@ function restoreCachedModelHeaders<TApi extends Api>(
 			unresolvedModelIds.add(model.id);
 			return model;
 		}
-		const staticModel = staticById.get(model.id);
+		const staticModel =
+			staticById.get(model.id) ?? (model.requestModelId ? staticById.get(model.requestModelId) : undefined);
 		if (!staticModel?.headers) {
 			unresolvedModelIds.add(model.id);
 			return model;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot 1M-context models disappearing on restart until the model picker was manually refreshed. ([#6037](https://github.com/can1357/oh-my-pi/issues/6037))
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1139,9 +1139,14 @@ export class ModelRegistry {
 					models.push(spec);
 					continue;
 				}
-				if (unrestorableHeaderIds.has(spec.id)) continue;
+				// A same-id bundled match is trusted only when the row did not flag
+				// the model unrestorable. Synthesized variants recover through
+				// `requestModelId`, whose bundled source is where their headers
+				// came from — honoured even past a stale `unrestorable` marker
+				// written before the fallback existed.
 				const bundledHeaders = (
-					bundledById?.get(spec.id) ?? (spec.requestModelId ? bundledById?.get(spec.requestModelId) : undefined)
+					(unrestorableHeaderIds.has(spec.id) ? undefined : bundledById?.get(spec.id)) ??
+					(spec.requestModelId ? bundledById?.get(spec.requestModelId) : undefined)
 				)?.headers;
 				if (!bundledHeaders) continue;
 				models.push({ ...spec, headers: bundledHeaders });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1140,7 +1140,9 @@ export class ModelRegistry {
 					continue;
 				}
 				if (unrestorableHeaderIds.has(spec.id)) continue;
-				const bundledHeaders = bundledById?.get(spec.id)?.headers;
+				const bundledHeaders = (
+					bundledById?.get(spec.id) ?? (spec.requestModelId ? bundledById?.get(spec.requestModelId) : undefined)
+				)?.headers;
 				if (!bundledHeaders) continue;
 				models.push({ ...spec, headers: bundledHeaders });
 			}

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -302,6 +302,28 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("github-copilot", "gpt-5.6-sol-1m")?.contextWindow).toBe(1_000_000);
 	});
 
+	test("restores legacy cache rows that stale-marked request-model variants unrestorable", () => {
+		const bundledBase = getBundledModel("github-copilot", "gpt-5.6-sol");
+		if (!bundledBase?.headers) {
+			throw new Error("Expected bundled Copilot transport headers");
+		}
+		const cachedLongContextModel = buildModel({
+			...bundledBase,
+			id: "gpt-5.6-sol-1m",
+			requestModelId: "gpt-5.6-sol",
+			name: "GPT-5.6 Sol (1M)",
+			contextWindow: 1_000_000,
+		});
+		// Pre-fix writer only matched static headers by the model's own id, so
+		// the variant landed in unrestorable_header_model_ids. Reproduce that
+		// legacy row by omitting the static header source at write time.
+		writeModelCache("github-copilot", Date.now() - 60_000, [cachedLongContextModel], true, "", cacheDbPath);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(registry.find("github-copilot", "gpt-5.6-sol-1m")?.contextWindow).toBe(1_000_000);
+	});
+
 	test("online-if-uncached refreshes expired OAuth for authoritative providers even when the cache is fresh", async () => {
 		// Regression for #5364: openai-codex is authoritative, so its bundled
 		// models are pruned only when the manager is actually constructed — which

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -6,6 +6,7 @@ import { Effort, type FetchImpl, type Model } from "@oh-my-pi/pi-ai";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { OpenAICompat } from "@oh-my-pi/pi-catalog/types";
 import { applyLlamaCppQwenThinking } from "@oh-my-pi/pi-coding-agent/config/model-discovery";
 import { kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -278,6 +279,27 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(refreshCalls).toEqual([]);
 		expect(capture.modelListCalls).toBe(0);
 		expect(authStorage.getOAuthCredential("anthropic")?.access).toBe("sk-ant-oat-expired-anthropic");
+	});
+
+	test("restores cached request-model variants from bundled headers on startup", () => {
+		const bundledBase = getBundledModel("github-copilot", "gpt-5.6-sol");
+		if (!bundledBase?.headers) {
+			throw new Error("Expected bundled Copilot transport headers");
+		}
+		const cachedLongContextModel = buildModel({
+			...bundledBase,
+			id: "gpt-5.6-sol-1m",
+			requestModelId: "gpt-5.6-sol",
+			name: "GPT-5.6 Sol (1M)",
+			contextWindow: 1_000_000,
+		});
+		writeModelCache("github-copilot", Date.now() - 60_000, [cachedLongContextModel], true, "", cacheDbPath, [
+			bundledBase,
+		]);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(registry.find("github-copilot", "gpt-5.6-sol-1m")?.contextWindow).toBe(1_000_000);
 	});
 
 	test("online-if-uncached refreshes expired OAuth for authoritative providers even when the cache is fresh", async () => {


### PR DESCRIPTION
## Repro
Cache a synthesized `github-copilot/gpt-5.6-sol-1m` model, construct a fresh `ModelRegistry`, and observe that the model is absent until an online provider refresh. The regression is reproduced by `bun test packages/coding-agent/test/model-discovery.test.ts -t "restores cached request-model variants from bundled headers on startup"` against the pre-fix implementation.

## Cause
`packages/catalog/src/model-cache.ts` stripped request headers from cache rows for security, but `writeModelCache` and the restore paths in `packages/catalog/src/model-manager.ts` and `packages/coding-agent/src/config/model-registry.ts` only matched static header sources by the cached model's local ID. Synthesized `-1m` variants use a distinct local ID and carry the bundled base ID in `requestModelId`, so restart treated their known transport headers as unrestorable and discarded them.

## Fix
- Resolve safe static header sources by local model ID, then by `requestModelId`.
- Apply the same resolution in model-manager cache reads and synchronous `ModelRegistry` startup loads.
- Add a restart regression covering cached `github-copilot/gpt-5.6-sol-1m`.

## Verification
`bun test packages/catalog/test/github-copilot-model-limits.test.ts packages/catalog/test/build.test.ts packages/coding-agent/test/model-registry-cache-headers.test.ts packages/coding-agent/test/model-discovery.test.ts` passed: 113 tests, 641 assertions. A standalone startup smoke restored `gpt-5.6-sol-1m` with `requestModelId: gpt-5.6-sol`, a 1,000,000-token context window, and the bundled transport headers. The publish gate also completed `bun run fix` and `bun check`.

Fixes #6037