### PR TITLE
fix(auth): route smart paste into focused prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed `Ctrl+V` clipboard paste being dropped while API-key and other modal prompts own focus ([#6057](https://github.com/can1357/oh-my-pi/issues/6057)).
+
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -172,6 +172,7 @@ export class InputController {
 
 	#enhancedPaste?: EnhancedPasteController;
 	#focusedLeftTapListenerInstalled = false;
+	#focusedPasteListenerInstalled = false;
 	#btwBranchListenerInstalled = false;
 	#btwCopyListenerInstalled = false;
 	// Tap counter for the double-← gesture; reset whenever a quiet gap
@@ -262,6 +263,16 @@ export class InputController {
 				if (this.ctx.ui.getFocused() !== this.ctx.editor) return undefined;
 				if (this.ctx.editor.getText().trim()) return undefined;
 				void this.ctx.handleBtwCopyKey();
+				return { consume: true };
+			});
+		}
+		if (!this.#focusedPasteListenerInstalled) {
+			this.#focusedPasteListenerInstalled = true;
+			this.ctx.ui.addInputListener(data => {
+				const focused = this.ctx.ui.getFocused();
+				if (!focused || focused === this.ctx.editor || !hasPasteText(focused)) return undefined;
+				if (!this.ctx.keybindings.matches(data, "app.clipboard.pasteImage")) return undefined;
+				void this.handleImagePaste();
 				return { consume: true };
 			});
 		}

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, type Mock, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { type KeyId, matchesKey } from "@oh-my-pi/pi-tui";
 import manualContinuePrompt from "../src/prompts/system/manual-continue.md" with { type: "text" };
 
 type FakeEditor = {
@@ -55,11 +56,12 @@ function registeredInputListeners(addInputListener: Mock<(listener: InputListene
 
 async function createContext() {
 	let editorText = "";
-	const keyMap: Record<string, string[]> = {
+	const keyMap: Record<string, KeyId[]> = {
 		"app.display.reset": ["ctrl+l"],
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["alt+m"],
 		"app.retry": ["alt+r"],
+		"app.clipboard.pasteImage": ["ctrl+v"],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -148,6 +150,9 @@ async function createContext() {
 		keybindings: {
 			getKeys(action: string) {
 				return keyMap[action] ? [...keyMap[action]] : [];
+			},
+			matches(data: string, action: string) {
+				return keyMap[action]?.some(key => matchesKey(data, key)) ?? false;
 			},
 		} as InteractiveModeContext["keybindings"],
 		locallySubmittedUserSignatures: new Set<string>(),
@@ -412,6 +417,26 @@ describe("InputController keybinding setup", () => {
 
 		expect(result).toBeUndefined();
 		expect(spies.handleBtwBranchKey).not.toHaveBeenCalled();
+	});
+
+	it("routes the smart-paste shortcut to a focused login input", async () => {
+		const { promise: pasted, resolve: resolvePaste } = Promise.withResolvers<string>();
+		const focusedPasteText = vi.fn((text: string) => {
+			resolvePaste(text);
+		});
+		const { InputController, ctx, setFocused, spies } = await createContext();
+		setFocused({ pasteText: focusedPasteText });
+		const controller = new InputController(ctx, {
+			readImage: async () => null,
+			readText: async () => "sk-test-key",
+		});
+
+		controller.setupKeyHandlers();
+		const result = dispatchInput(registeredInputListeners(spies.addInputListener), "\x16");
+
+		expect(result).toEqual({ consume: true });
+		expect(await pasted).toBe("sk-test-key");
+		expect(focusedPasteText).toHaveBeenCalledWith("sk-test-key");
 	});
 
 	it("routes c to copy a copyable /btw panel when the editor is empty", async () => {


### PR DESCRIPTION
## Repro
On Windows, start first-time `/login`, focus the API-key prompt, and press `Ctrl+V`. The default `app.clipboard.pasteImage` shortcut reached only the main editor, so `bun /tmp/repro-6057.ts` observed `{"expected":"sk-test-key","actual":""}` and exited 1.

## Cause
`InputController.setupKeyHandlers()` in `packages/coding-agent/src/modes/controllers/input-controller.ts` registered smart paste only on `CustomEditor`. When `LoginDialogComponent` or another paste-capable modal owned TUI focus, its `Input.handleInput()` received the raw Ctrl+V control byte and discarded it before `handleImagePaste()` could read and route clipboard text.

## Fix
- Intercept the configured smart-paste action globally only when a non-editor, paste-capable component owns focus.
- Reuse `handleImagePaste()` so clipboard text reaches the focused component while image/error behavior remains unchanged.
- Add regression coverage for Ctrl+V API-key entry and document the fix.

## Verification
`bun test packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/input-controller-smart-paste.test.ts` passed: 29 tests, 0 failures. `bun check` passed across all packages.

Fixes #6057