### PR TITLE
fix(task): surface actionable shape error for batch calls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `task` tool rejecting a valid batch `{ context, tasks[] }` call with the misleading `task must be a string (was missing)` when `task.batch` was disabled. The flat single-spawn wire schema strips `tasks`/`context` (arktype `"+": "delete"`) and then fails on the now-missing `task` in the agent loop, preempting the tool's own actionable shape check. The tool now uses lenient argument validation so those raw args reach `execute()`, which explains the real cause (`task.batch is disabled…`) ([#6039](https://github.com/can1357/oh-my-pi/issues/6039)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -520,6 +520,17 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly summary = "Spawn subagents to complete delegated tasks";
 	readonly strict = false;
 	readonly loadMode = "essential";
+	// Arktype validates model calls against the active wire schema, but the flat
+	// single-spawn schema carries `"+": "delete"`: a batch `{ context, tasks[] }`
+	// payload has those keys stripped, then fails on the now-missing `task` with
+	// the misleading `task must be a string (was missing)`. That preempts the
+	// tool's own actionable shape checks (`validateShapeParams` /
+	// `validateSpawnParams`), which never run. Lenient validation forwards the
+	// raw args to `execute()` on any arktype failure so those checks surface the
+	// real reason ("enable task.batch, or use the flat `task` shape"). Valid
+	// calls still normalize through arktype; `execute()` resolves `agent`
+	// defaults independently, so the success path is unchanged.
+	readonly lenientArgValidation = true;
 	readonly renderResult = renderResult;
 	// Suppress the streaming call preview once a (partial or final) result exists
 	// so the task renders as ONE block that transitions in place — not a pending

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -224,6 +224,26 @@ describe("task.batch validation", () => {
 		);
 		expect(text).toContain("Duplicate task name");
 	});
+
+	it("marks lenientArgValidation so execute() surfaces the actionable shape error", async () => {
+		// Regression (#6039): the flat single-spawn wire schema carries
+		// `"+": "delete"`, so a batch `{ context, tasks[] }` payload is stripped
+		// by arktype and rejected as `task must be a string (was missing)` in the
+		// agent loop — preempting the tool's own actionable message. The lenient
+		// flag makes the loop forward the raw args to execute() on that failure.
+		mockDiscovery();
+		const tool = await TaskTool.create(createSession({ settings: { "task.batch": false } }));
+		expect(tool.lenientArgValidation).toBe(true);
+
+		// The raw batch payload the loop would forward reaches execute() and
+		// yields the actionable reason, never arktype's misleading missing-`task`.
+		const text = await executeText(
+			{ context: "Background.", tasks: [{ name: "Alpha", task: "Work." }] },
+			{ "task.batch": false },
+		);
+		expect(text).toContain("task.batch is disabled");
+		expect(text).not.toContain("was missing");
+	});
 });
 
 describe("task.batch spawning", () => {


### PR DESCRIPTION
## Repro
With `task.batch` disabled, the model emits a valid-looking batch `{ context, tasks[] }` call. The tool rejects it with `task must be a string (was missing)` (and, via the execute-time path, `Missing \`tasks\``), never naming the real problem. Reproduced deterministically by validating a 4-item `{ context, tasks[] }` payload against the flat schema:

```
bun test packages/coding-agent/test/task/task-batch.test.ts
```

Under the default `task.batch=true` the identical payload validates and executes cleanly, which is why the failure looked session-dependent (issue #6039).

## Cause
The task tool advertises one of two arktype schemas by the `task.batch` setting (`packages/coding-agent/src/task/types.ts` — `getTaskSchema`). The flat single-spawn schema carries `"+": "delete"`, so a batch payload has `tasks`/`context` silently stripped, leaving the required `task` empty. `validateToolArguments` in the agent loop (`packages/ai/src/utils/validation.ts`) then rejects with `task must be a string (was missing)` — *before* the tool's own actionable checks (`validateShapeParams` / `validateSpawnParams` in `packages/coding-agent/src/task/index.ts`), which produce `task.batch is disabled, so the task tool does not accept \`tasks\`…`, can run. Those messages were effectively dead code for real model calls.

## Fix
- `packages/coding-agent/src/task/index.ts`: mark `TaskTool` with `readonly lenientArgValidation = true`. On any arktype failure the agent loop forwards the raw arguments to `execute()`, so the tool's shape checks surface the real reason. Mirrors the existing `yield` tool pattern (`packages/coding-agent/src/tools/yield.ts`).
- `packages/coding-agent/test/task/task-batch.test.ts`: regression test asserting the flag and that a batch payload under a disabled-batch session yields `task.batch is disabled` (never `was missing`).
- `packages/coding-agent/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

Valid batch calls (`task.batch` on) still validate and normalize through arktype unchanged; `execute()` already resolves `agent` defaults independently, so the success path is untouched.

## Verification
`bun test packages/coding-agent/test/task/task-batch.test.ts` → 16 pass (including the new regression test). An end-to-end smoke confirmed arktype rejects the batch payload under the flat schema with `was missing`, while with the lenient flag `execute()` returns `task.batch is disabled`. This delivers the reporter's stated Expected: the error now names the actual cause. Fixes #6039