### PR TITLE
fix(devin): count cache tokens in usage.totalTokens

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Devin (`streamDevin`) reporting `usage.totalTokens` as `input + output` only, which hid cache-read/write tokens from context accounting so auto-compaction never fired before the model window overflowed ([#6084](https://github.com/can1357/oh-my-pi/issues/6084)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Changed

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -322,7 +322,8 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 						output.usage.output = Number(msg.usage.outputTokens);
 						output.usage.cacheRead = Number(msg.usage.cacheReadTokens);
 						output.usage.cacheWrite = Number(msg.usage.cacheWriteTokens);
-						output.usage.totalTokens = output.usage.input + output.usage.output;
+						output.usage.totalTokens =
+							output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 					}
 				}
 

--- a/packages/ai/test/devin-streaming-args.test.ts
+++ b/packages/ai/test/devin-streaming-args.test.ts
@@ -7,6 +7,7 @@ import { GetChatMessageResponseSchema } from "@oh-my-pi/pi-catalog/discovery/dev
 import { GetUserJwtResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/auth_pb/auth_pb";
 import {
 	ChatToolCallSchema,
+	ModelUsageStatsSchema,
 	StopReason,
 } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/codeium_common_pb/codeium_common_pb";
 
@@ -24,6 +25,25 @@ function toolCallDelta(argumentsJson: string, stopReason = StopReason.UNSPECIFIE
 		messageId: "msg-1",
 		stopReason,
 		deltaToolCalls: [create(ChatToolCallSchema, { id: "call-1", name: "task", argumentsJson })],
+	});
+	return frameConnectMessage(toBinary(GetChatMessageResponseSchema, msg));
+}
+
+function usageFrame(usage: {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+}): Uint8Array {
+	const msg = create(GetChatMessageResponseSchema, {
+		messageId: "msg-1",
+		stopReason: StopReason.STOP_PATTERN,
+		usage: create(ModelUsageStatsSchema, {
+			inputTokens: BigInt(usage.inputTokens),
+			outputTokens: BigInt(usage.outputTokens),
+			cacheReadTokens: BigInt(usage.cacheReadTokens),
+			cacheWriteTokens: BigInt(usage.cacheWriteTokens),
+		}),
 	});
 	return frameConnectMessage(toBinary(GetChatMessageResponseSchema, msg));
 }
@@ -83,5 +103,35 @@ describe("streamDevin args streaming", () => {
 		expect(snapshots[2]).toBe(snapshots[0]);
 		expect(result.content[0]?.type).toBe("toolCall");
 		expect((result.content[0] as ToolCall).arguments).toEqual({ agent: "task", note: "initial", step: 12 });
+	});
+
+	it("counts cache read/write tokens in usage.totalTokens", async () => {
+		// Regression: cache-heavy Devin turns previously set totalTokens =
+		// input + output, hiding ~181k cache-read tokens from
+		// calculateContextTokens so auto-compaction never fired before the
+		// model window overflowed (#6084).
+		const authPayload = toBinary(GetUserJwtResponseSchema, create(GetUserJwtResponseSchema, { userJwt: "jwt" }));
+		const chunks = [
+			usageFrame({ inputTokens: 17_111, outputTokens: 666, cacheReadTokens: 181_248, cacheWriteTokens: 0 }),
+		];
+		const fetchImpl = (async (input: string | URL | Request) => {
+			const url = String(input);
+			if (url.includes("GetUserJwt")) return new Response(authPayload);
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						for (const chunk of chunks) controller.enqueue(chunk);
+						controller.close();
+					},
+				}),
+				{ status: 200 },
+			);
+		}) as typeof fetch;
+
+		const stream = streamDevin(devinModel, context, { apiKey: "token", fetch: fetchImpl });
+		const result = await stream.result();
+
+		expect(result.usage.cacheRead).toBe(181_248);
+		expect(result.usage.totalTokens).toBe(17_111 + 666 + 181_248);
 	});
 });

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -47,7 +47,7 @@ For independent per-item chains (review → verify, fetch → extract → score)
             schema: FINDINGS_SCHEMA,
         });
         return await parallel(found.findings.map((f) => async () => ({
-            ...f,
+            …f,
             verdict: await agent(
                 `Refute if you can (default refuted when unsure): ${f.title}`,
                 { label: `verify:${f.file}`, schema: VERDICT_SCHEMA },
@@ -57,8 +57,6 @@ For independent per-item chains (review → verify, fetch → extract → score)
     phase("Review");
     const results = await parallel(DIMENSIONS.map((d) => async () => reviewAndVerify(d)));
     const confirmed = results.flat().filter((f) => f.verdict.is_real);
-
-
 Reach for `pipeline()` only when a stage genuinely needs ALL of the previous stage first — dedup/merge across the whole set, early-exit on zero, or "compare against the other findings" — because its inter-stage barrier makes every item wait for the slowest peer:
 
 **Python (`eval`, Python backend):**
@@ -80,8 +78,6 @@ Reach for `pipeline()` only when a stage genuinely needs ALL of the previous sta
     const verdicts = await parallel(findings.map((f) => async () =>
         await agent(verifyPrompt(f), { schema: VERDICT_SCHEMA }),
     ));
-
-
 Use ordinary code between calls to flatten/map/filter; don't add a barrier just for that. Nested `parallel()` pools each cap independently, so keep total fan-out sane.
 </structure>
 


### PR DESCRIPTION
## Repro
With `devin/swe-1-7-lightning`, a cache-heavy tool loop exceeds the 202,752-token window without auto-compaction firing; the TUI shows >100% while the provider request fails repeatedly. Root cause is reproduced in `packages/ai/test/devin-streaming-args.test.ts` by feeding a cache-heavy Devin usage frame (input 17,111 / output 666 / cacheRead 181,248) through `streamDevin` and asserting `usage.totalTokens` includes the cache read. Command: `bun test packages/ai/test/devin-streaming-args.test.ts`. Against the pre-fix code the new test fails (`totalTokens` omits cacheRead).

## Cause
`streamDevin` assembled usage with `output.usage.totalTokens = output.usage.input + output.usage.output` (`packages/ai/src/providers/devin.ts:325`), dropping `cacheRead` and `cacheWrite`. `calculateContextTokens` (`packages/agent/src/compaction/compaction.ts:220`) prefers a nonzero `totalTokens` over the component sum, so threshold-based auto-compaction saw ~17,777 tokens instead of the ~199,000-token live context and never fired before the model window overflowed. Every other provider (anthropic, gitlab-duo, openai-shared) already includes cache tokens in the canonical `Usage.totalTokens`.

## Fix
- `packages/ai/src/providers/devin.ts`: set `totalTokens = input + output + cacheRead + cacheWrite`, matching the canonical `Usage` total.
- `packages/ai/test/devin-streaming-args.test.ts`: add a regression test that streams a cache-heavy usage frame and asserts `totalTokens` counts cache reads.
- `packages/ai/CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Verification
`bun test packages/ai/test/devin-streaming-args.test.ts` → 2 pass. Confirmed the new test fails against the pre-fix source (`Expected 199025`) and passes after the fix. `tsgo -p tsconfig.json --noEmit` for `pi-ai` clean. The opaque `invalid_argument` retry behavior is intentionally left unchanged: it is indistinguishable from a genuine transient error, and once compaction counts cache tokens it fires before the window overflows, so that retry path is no longer reached in this scenario. Fixes #6084