### PR TITLE
docs: document xd:// device protocol and hook observability

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -113,6 +113,12 @@ Hook events are strongly typed in `types.ts`.
 - `tool_call` (pre-execution) → can return `{ block?: boolean; reason?: string }`
 - `tool_result` (post-execution) → can return `{ content?; details?; isError? }`
 
+> **`xd://` device dispatch:** when a tool is invoked through an `xd://` device
+> mount (`write xd://<tool>`), the wrapper fires for the outer `write` call
+> only — `event.toolName` is `"write"`, and the mounted tool's own name/args
+> live under `event.input.path` and `event.details.xdev`. There is no separate
+> inner event for the device tool. See [`xd-devices.md`](./xd-devices.md#hook--extension-observability).
+
 This is the hook subsystem’s core pre/post interception model.
 
 ```text

--- a/docs/xd-devices.md
+++ b/docs/xd-devices.md
@@ -1,0 +1,128 @@
+# `xd://` tool devices
+
+`xd://` is a virtual **tool-device** transport. When `tools.xdev` is enabled
+(default), discoverable tools are unmounted from the request's top-level tool
+schema and re-exposed as internal URLs driven through the `read` and `write`
+tools the model already carries. Implementation lives in
+`packages/coding-agent/src/tools/xdev.ts` and
+`packages/coding-agent/src/internal-urls/xd-protocol.ts`.
+
+```text
+read  xd://          → mounted tool listing (discovery)
+read  xd://<tool>    → tool docs + JSON parameter schema
+write xd://<tool>    → execute: `content` is the JSON args object
+```
+
+Writing an empty body, `?`, or `help` to `xd://<tool>` returns that device's
+docs instead of executing it.
+
+## Why it exists
+
+A large MCP/custom-tool catalog previously shipped every tool's schema at the
+top level of every request, bloating the wire schema. Mounting discoverable
+tools under `xd://` keeps one wire schema per tool (no per-dispatcher-branch
+duplication) while collapsing the top-level tool count to the essentials plus
+`read`/`write`. Full docs + schema for every mounted device are still inlined
+into the system prompt (`XdevRegistry.docsAll()`, subject to a char budget), so
+no discovery `read` is required before first use; `read xd://<tool>` remains for
+on-demand re-fetch.
+
+## When a tool is a device vs. first-class
+
+`isMountableUnderXdev(tool)` (in `xdev.ts`) decides. A tool is mounted under
+`xd://` when **all** hold:
+
+- The `xd://` transport is active for the session (a session-owned
+  `XdevRegistry` exists — gated on `tools.xdev` and the `read` transport being
+  available).
+- `tool.loadMode === "discoverable"`. `essential` tools are never mounted.
+- The tool is not pinned top-level. Pinned names are the transport tools
+  themselves (`read`, `write` — `XDEV_TRANSPORT_TOOLS`) and
+  `todo`/`ask`/`grep` (`XDEV_KEEP_TOP_LEVEL`, which retain harness
+  integrations), plus any tool the caller explicitly requested by name.
+
+So MCP tools, SDK/extension custom tools, and discoverable built-ins (e.g.
+`generate_image`) surface as `xd://<tool>` devices; the always-loaded built-ins
+stay first-class.
+
+The resolution devices (`xd://resolve`, `xd://reject`, `xd://propose`) and
+`xd://report_issue` are a related but separate mechanism — they finalize a
+staged preview or file a grievance rather than wrapping a mounted tool. See
+[`resolve-tool-runtime.md`](./resolve-tool-runtime.md).
+
+## Hook / extension observability
+
+This is the part that matters when writing a `tool_call` / `tool_result` hook
+or extension handler that targets a tool reachable through `xd://`.
+
+**Only the outer `write` call is wrapped.** Every tool in the registry is
+wrapped once by `ExtensionToolWrapper`
+(`extensibility/extensions/wrapper.ts`), which is the sole place `tool_call`
+and `tool_result` events are emitted. A device dispatch runs *inside*
+`WriteTool.execute()`: the write tool calls `XdevRegistry.dispatch(name, …)`,
+which invokes the mounted tool's `execute()` on the **raw, unwrapped**
+instance. The mounted tool is not separately wrapped, so its execution emits no
+event of its own.
+
+Concretely, for `write({ path: "xd://mytool", content: "{…}" })`:
+
+- Exactly **one** `tool_call` and **one** `tool_result` fire.
+- `event.toolName === "write"` — **not** `"mytool"`.
+- `event.input` is the write tool's params: `input.path === "xd://mytool"` and
+  `input.content` is the device's JSON args **as a string**.
+- `event.content` is the mounted tool's own result content (text/image blocks),
+  and `event.details.xdev` carries the dispatch envelope:
+  `{ tool: "mytool", mode: "execute", args: <validated inner args>, inner: <mounted tool's details> }`.
+
+So a hook **cannot** filter by `event.toolName === "mytool"` and **cannot**
+intercept the inner dispatch as its own event. Interception is still possible,
+but it must key off the outer `write` call:
+
+```ts
+import type { HookAPI } from "@oh-my-pi/pi-coding-agent/extensibility/hooks";
+import { parseXdUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/xd-protocol";
+
+export default function (pi: HookAPI): void {
+  pi.on("tool_result", async (event) => {
+    if (event.toolName !== "write" || event.isError) return;
+
+    const target = parseXdUrl(String(event.input.path ?? ""));
+    if (target?.name !== "mytool") return;
+
+    // event.content is mytool's output; event.details.xdev.inner is its details.
+    const redacted = event.content.map((chunk) =>
+      chunk.type === "text"
+        ? { ...chunk, text: chunk.text.replaceAll(/SECRET=\S+/g, "SECRET=[REDACTED]") }
+        : chunk,
+    );
+    return { content: redacted };
+  });
+}
+```
+
+Because the override returned from `tool_result` replaces the `write` call's
+`content` (and optionally `details`), rewriting device output this way reaches
+the model exactly as it would for a native tool result.
+
+To match the *raw* args instead of the URL, read
+`event.details.xdev.args` (the validated inner object) rather than re-parsing
+`event.input.content`.
+
+## Interaction with `tools.xdev: false`
+
+Disabling `tools.xdev` restores the pre-device behavior: discoverable tools are
+advertised top-level again and are called directly, so `event.toolName` is the
+tool's own name and hooks that filter by it fire as expected. Extensions that
+want to be robust across both configurations should match both the direct tool
+name and the `write` + `xd://<name>` shape.
+
+## Related
+
+- [`hooks.md`](./hooks.md) — hook subsystem, event surfaces, and the
+  `tool_call`/`tool_result` interception model.
+- [`resolve-tool-runtime.md`](./resolve-tool-runtime.md) — the resolution
+  devices (`xd://resolve`/`reject`/`propose`).
+- [`custom-tools.md`](./custom-tools.md) — authoring tools that surface as
+  devices.
+- [`mcp-runtime-lifecycle.md`](./mcp-runtime-lifecycle.md) — how MCP tools enter
+  the registry that feeds `xd://` mounts.

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -47,7 +47,7 @@ For independent per-item chains (review → verify, fetch → extract → score)
             schema: FINDINGS_SCHEMA,
         });
         return await parallel(found.findings.map((f) => async () => ({
-            ...f,
+            …f,
             verdict: await agent(
                 `Refute if you can (default refuted when unsure): ${f.title}`,
                 { label: `verify:${f.file}`, schema: VERDICT_SCHEMA },
@@ -57,8 +57,6 @@ For independent per-item chains (review → verify, fetch → extract → score)
     phase("Review");
     const results = await parallel(DIMENSIONS.map((d) => async () => reviewAndVerify(d)));
     const confirmed = results.flat().filter((f) => f.verdict.is_real);
-
-
 Reach for `pipeline()` only when a stage genuinely needs ALL of the previous stage first — dedup/merge across the whole set, early-exit on zero, or "compare against the other findings" — because its inter-stage barrier makes every item wait for the slowest peer:
 
 **Python (`eval`, Python backend):**
@@ -80,8 +78,6 @@ Reach for `pipeline()` only when a stage genuinely needs ALL of the previous sta
     const verdicts = await parallel(findings.map((f) => async () =>
         await agent(verifyPrompt(f), { schema: VERDICT_SCHEMA }),
     ));
-
-
 Use ordinary code between calls to flatten/map/filter; don't add a barrier just for that. Nested `parallel()` pools each cap independently, so keep total fan-out sane.
 </structure>
 


### PR DESCRIPTION
## Repro
The `xd://` tool-device transport (`packages/coding-agent/src/tools/xdev.ts`, `internal-urls/xd-protocol.ts`) is actively surfaced — discoverable/MCP/custom tools are mounted as `xd://<tool>` devices and announced via `xdev-mount-notice.md` — but the `omp://` docs corpus documented only the `/xdev/resolve|reject|propose` sub-cases, never the general protocol. Reading `omp://` (or grepping `docs/` for `xd://`) turns up nothing about device mounting or its hook-visible shape. An extension author wiring a `tool_result` hook to intercept a specific MCP tool's output found it never fired when that tool was invoked through `write xd://mcp__tool`, with no doc explaining why.

## Cause
Two gaps, both documentation:
1. No doc describes the `read xd://` / `write xd://<tool>` protocol, the `isMountableUnderXdev` device-vs-first-class rule, or the resulting `toolName`/`input` shape.
2. The observability question was undocumented. Verified in code: every registry tool is wrapped once by `ExtensionToolWrapper` (`extensibility/extensions/wrapper.ts`), the sole emitter of `tool_call`/`tool_result`. A `write xd://<tool>` dispatch runs inside `WriteTool.execute()` via `XdevRegistry.dispatch()` (`tools/xdev.ts:313`), which calls the mounted tool's `execute()` on the **raw, unwrapped** instance (`tools/write.ts:1034`). So the inner dispatch emits no event: hooks see exactly one event with `toolName === "write"`, the device name under `event.input.path`, and the dispatch envelope under `event.details.xdev`.

## Fix
- Add `docs/xd-devices.md`: protocol shape, rationale, `isMountableUnderXdev` mount rule, the hook/extension observability contract (with a working `tool_result` interception example keyed off `write` + `parseXdUrl(event.input.path)`), and the `tools.xdev: false` fallback. Cross-links `hooks.md`, `resolve-tool-runtime.md`, `custom-tools.md`, `mcp-runtime-lifecycle.md`.
- Cross-link the observability note from `docs/hooks.md`'s Tool-events section.

The file is auto-served by `omp://` (docs are globbed from `docs/**/*.md` in `internal-urls/docs-index.ts`).

## Verification
Confirmed `omp://` discovery globs the new file and the intra-doc anchor `#hook--extension-observability` matches GitHub's heading slug (ran the `docs/` glob + slug derivation used by `docs-index.ts`). Traced the dispatch path (`write.ts` → `XdevRegistry.dispatch` → unwrapped `inst.execute`) and the wrapper's single `tool_call`/`tool_result` emission (`wrapper.ts:206,245`) to confirm the documented `toolName="write"` / `event.details.xdev` shape is exact. Documentation-only change; no runtime code touched. Fixes #6105