### PR TITLE
fix(tui): surface provider errors above plan review

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed turn-ending Codex rate-limit errors remaining hidden behind the fullscreen Plan Review overlay and leaving its approval promise pending ([#6086](https://github.com/can1357/oh-my-pi/issues/6086)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -560,6 +560,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#planModeHasEntered = false;
 	#planReviewOverlay: PlanReviewOverlay | undefined;
 	#planReviewOverlayHandle: OverlayHandle | undefined;
+	#planReviewCancel: (() => void) | undefined;
 	readonly lspServers: LspStartupServerInfo[] | undefined = undefined;
 	mcpManager?: MCPManager;
 	readonly #toolUiContextSetter: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
@@ -2632,6 +2633,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			settled = true;
 			resolve(choice);
 		};
+		this.#planReviewCancel = () => finish(undefined);
 		const overlay = new PlanReviewOverlay(
 			planContent,
 			{
@@ -2668,9 +2670,17 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	#hidePlanReview(): void {
+		this.#planReviewCancel = undefined;
 		this.#planReviewOverlayHandle?.hide();
 		this.#planReviewOverlayHandle = undefined;
 		this.#planReviewOverlay = undefined;
+	}
+
+	#dismissPlanReview(): void {
+		const cancel = this.#planReviewCancel;
+		this.#planReviewCancel = undefined;
+		cancel?.();
+		this.#hidePlanReview();
 	}
 
 	#getEditorTerminalPath(): string | null {
@@ -3921,6 +3931,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	showPinnedError(message: string): void {
+		this.#dismissPlanReview();
 		this.errorBannerContainer.clear();
 		this.errorBannerContainer.addChild(new ErrorBannerComponent(message));
 		this.ui.requestRender();

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -355,6 +355,20 @@ describe("InteractiveMode plan review rendering", () => {
 		await expect(choice).resolves.toBeUndefined();
 	});
 
+	it("dismisses Plan Review and restores input when a provider error is pinned", async () => {
+		mode.ui.setFocus(mode.editor);
+		const choice = mode.showPlanReview("# Plan\n\nReady for approval.", "Plan mode - next step", ["Approve"]);
+
+		expect(mode.ui.hasOverlay()).toBe(true);
+
+		mode.showPinnedError("Codex rate limit reached");
+
+		expect(mode.ui.hasOverlay()).toBe(false);
+		expect(mode.ui.getFocused()).toBe(mode.editor);
+		expect(mode.errorBannerContainer.render(80).join("\n")).toContain("Codex rate limit reached");
+		await expect(choice).resolves.toBeUndefined();
+	});
+
 	it("copies the overlay's current edited plan markdown from the real plan review overlay", async () => {
 		let capturedOverlay: PlanReviewOverlay | undefined;
 		const overlayHandle = { hide: vi.fn() };


### PR DESCRIPTION
## Repro
Open fullscreen Plan Review, then deliver a turn-ending provider error such as a Codex rate-limit failure; `showPinnedError()` adds the banner beneath the overlay while Plan Review retains focus. Reproduced with `bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts -t "dismisses Plan Review and restores input when a provider error is pinned"`, which failed with `Expected: false, Received: true` for `mode.ui.hasOverlay()`.

## Cause
`InteractiveMode.showPinnedError()` in `packages/coding-agent/src/modes/interactive-mode.ts` populated `errorBannerContainer` without dismissing the fullscreen overlay created by `showPlanReview()`. The overlay therefore covered the error, retained keyboard focus, and left the review promise pending.

## Fix
- Track the active Plan Review cancellation callback and settle it when a pinned provider error arrives.
- Hide the fullscreen overlay before rendering the pinned error so TUI focus returns to the editor.
- Add regression coverage for overlay dismissal, focus restoration, visible error text, and promise settlement.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts packages/coding-agent/test/event-controller-error-banner.test.ts` passed: 68 tests, 201 assertions. `bun check` passed across all packages. Skipped the automated pre-publish formatter on the final push/open because `bun run fix` rewrites the unrelated, pre-existing `packages/coding-agent/src/prompts/system/workflow-notice.md` on `main`; the formatter change was excluded from this PR.

Fixes #6086