### PR TITLE
fix(typebox): add Type.Unsafe to OMP schema shim

### DIFF
--- a/packages/coding-agent/src/extensibility/typebox.ts
+++ b/packages/coding-agent/src/extensibility/typebox.ts
@@ -908,6 +908,26 @@ function tComposite(objects: readonly ArkSchema[], opts?: Meta): ArkSchema {
 	return applyMeta(createArkSchema(validator, { allOf: objects.map(jsonSchemaOf) }), opts);
 }
 
+/**
+ * Accept a raw JSON Schema document as a tool/extension parameter schema.
+ *
+ * Real TypeBox exposes `Type.Unsafe(...)` for this. Plugins such as
+ * `pi-mcp-adapter` pass MCP `inputSchema` objects through it. Without this
+ * entry the OMP extension loader remaps `import { Type } from "typebox"` to
+ * this shim and crashes with `Type.Unsafe is not a function`.
+ *
+ * Wire + argument validation treat the result as plain JSON Schema (see
+ * `toolWireSchema` / `validateToolArguments`); the identity validator only
+ * satisfies the shim's `safeParse` surface.
+ */
+function tUnsafe(schema: Record<string, unknown>, opts?: Meta): ArkSchema {
+	const json =
+		schema && typeof schema === "object" && !Array.isArray(schema)
+			? (schemaJsonValue(schema) as Record<string, unknown>)
+			: {};
+	return applyMeta(createArkSchema((data: unknown) => data, json), opts);
+}
+
 // ---------------------------------------------------------------------------
 // Public `Type` namespace
 // ---------------------------------------------------------------------------
@@ -937,6 +957,7 @@ export const Type = {
 	Pick: tPick,
 	Omit: tOmit,
 	Composite: tComposite,
+	Unsafe: tUnsafe,
 } as const;
 
 export type TypeBuilder = typeof Type;


### PR DESCRIPTION
## Summary
- OMP remaps `import { Type } from "typebox"` onto `packages/coding-agent/src/extensibility/typebox.ts`.
- Plugins such as `pi-mcp-adapter` call `Type.Unsafe(...)` to pass raw MCP `inputSchema` documents as tool parameters.
- The host shim previously omitted `Unsafe`, so OMP 17.0.6 failed extension load with `Type.Unsafe is not a function`.

## Change
- Add `tUnsafe` that preserves the JSON Schema document with an identity validator.
- Export it as `Type.Unsafe` so the shim matches real TypeBox for this plugin surface.
- Wire/argument validation already treats the result as plain JSON Schema via `toolWireSchema` / `validateToolArguments`.

## Test plan
- [x] Local OMP 17.0.6 with patched shim: `pi-mcp-adapter@2.11.0` loads (no `Type.Unsafe` crash).
- [x] MCP read path still works (`omniroute_get_health`).
- [ ] CI / package tests for coding-agent if available.
- [ ] Confirm extension load on clean OMP install after merge.

## Context
Found while closing harness integration for OmniRoute MCP via MCPM on OMP. Local runtime was patched first; this makes the fix upgrade-safe.