### PR TITLE
fix(catalog): retain ChatGPT-only Codex models

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Fixed
 
 - Collapsed Devin's six GLM-5.2 variants into two logical entries (`glm-5-2` for 200K free, `glm-5-2-1m` for 1M paid). The 200K entry routes every thinking effort to the free `glm-5-2` wire UID — never to the quota-gated `glm-5-2-max` or `glm-5-2-none` — so GLM-5.2 works even when the weekly usage quota is exhausted.
+### Fixed
+
+- Fixed authenticated OpenAI Codex discovery dropping account-listed ChatGPT-only models such as GPT-5.3 Codex Spark when they are unavailable through the public API ([#6108](https://github.com/can1357/oh-my-pi/issues/6108)).
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -33,7 +33,7 @@ const codexModelEntrySchema = type({
 	"default_reasoning_level?": "unknown",
 	"supported_reasoning_levels?": "unknown",
 	"input_modalities?": "unknown",
-	"supported_in_api?": "unknown",
+	"visibility?": "unknown",
 	"priority?": "unknown",
 	"prefer_websockets?": "unknown",
 	"use_responses_lite?": "unknown",
@@ -217,8 +217,8 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 		return null;
 	}
 
-	const supportedInApi = toBoolean(payload.supported_in_api);
-	if (supportedInApi === false) {
+	const visibility = toNonEmptyString(payload.visibility)?.toLowerCase();
+	if (visibility === "hide" || visibility === "hidden") {
 		return null;
 	}
 

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -141,7 +141,7 @@ describe("Codex model discovery", () => {
 		expect(legacy?.contextWindow).toBe(272_000);
 	});
 
-	it("uses the discovered account catalog as authoritative", async () => {
+	it("keeps account-listed API-unsupported models while pruning hidden and absent models", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-authoritative-"));
 		const staticOnlyModel: ModelSpec<"openai-codex-responses"> = {
 			id: "unsupported-static",
@@ -155,23 +155,58 @@ describe("Codex model discovery", () => {
 			contextWindow: 272_000,
 			maxTokens: 128_000,
 		};
-		const discoveredModel: ModelSpec<"openai-codex-responses"> = {
+		const sparkModel: ModelSpec<"openai-codex-responses"> = {
 			...staticOnlyModel,
-			id: "account-supported",
-			name: "Account-supported model",
+			id: "gpt-5.3-codex-spark",
+			name: "GPT-5.3 Codex Spark",
+			contextWindow: 128_000,
 		};
+		const fetchFn: typeof fetch = Object.assign(
+			async () =>
+				new Response(
+					JSON.stringify({
+						models: [
+							{
+								slug: "gpt-5.3-codex-spark",
+								display_name: "GPT-5.3-Codex-Spark",
+								visibility: "list",
+								supported_in_api: false,
+								context_window: 128_000,
+								default_reasoning_level: "high",
+								input_modalities: ["text"],
+							},
+							{
+								slug: "hidden-model",
+								display_name: "Hidden model",
+								visibility: "hidden",
+								supported_in_api: true,
+							},
+							{
+								slug: "hide-model",
+								display_name: "Hide model",
+								visibility: "hide",
+								supported_in_api: true,
+							},
+						],
+					}),
+				),
+			{ preconnect() {} },
+		);
 		try {
 			const result = await resolveProviderModels(
 				{
-					...openaiCodexModelManagerOptions(),
-					staticModels: [staticOnlyModel],
+					...openaiCodexModelManagerOptions({ accessToken: "test-token", fetch: fetchFn }),
+					staticModels: [staticOnlyModel, sparkModel],
 					cacheDbPath: path.join(tempDir, "models.db"),
-					fetchDynamicModels: async () => [discoveredModel],
 				},
 				"online",
 			);
 
-			expect(result.models.map(model => model.id)).toEqual(["account-supported"]);
+			expect(result.models.map(model => model.id)).toEqual(["gpt-5.3-codex-spark"]);
+			expect(result.models[0]).toMatchObject({
+				contextWindow: 128_000,
+				maxTokens: 128_000,
+			});
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Repro
On current `main`, a mocked account-scoped `/codex/models` response containing `gpt-5.3-codex-spark` with `visibility: list` and `supported_in_api: false` normalized to an empty model list. Reproduced with `bun -e 'import { fetchCodexModels } from "./packages/catalog/src/discovery/codex.ts"; const result = await fetchCodexModels({ accessToken: "test-token", paths: ["/codex/models"], fetchFn: async () => new Response(JSON.stringify({ models: [{ slug: "gpt-5.3-codex-spark", visibility: "list", supported_in_api: false, context_window: 128000 }] })) }); process.stdout.write(JSON.stringify(result?.models.map(model => model.id)));'`, which printed `[]`.

## Cause
`normalizeCodexModelEntry()` in `packages/catalog/src/discovery/codex.ts` treated `supported_in_api: false` as a rejection signal even though the authenticated `openai-codex` route uses the ChatGPT backend rather than the public OpenAI API. Authoritative reconciliation then retained only the already-filtered dynamic IDs, so the bundled Spark entry could not restore the listed account model.

## Fix
- Stop using public API availability to filter account-scoped Codex discovery.
- Filter only models whose account response explicitly marks `visibility` as `hide` or `hidden`.
- Extend the authoritative discovery regression to cover list-visible Spark retention, hidden filtering, absent static pruning, and Spark's 128K limits.
- Record the fix in the catalog changelog.

## Verification
`bun test packages/catalog/test/codex-discovery.test.ts` passed 6 tests; the reproduction probe now returned `[{"id":"gpt-5.3-codex-spark","contextWindow":128000}]`; `bun test packages/ai/test/openai-codex-responses-lite.test.ts` passed 34 tests, preserving the pre-5.4 `reasoning.summary` compatibility behavior. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #6108