### PR TITLE
fix(sdk): resolve configured default for discovery-only local providers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the configured default model for discovery-only local providers (LM Studio, Ollama, llama.cpp) being ignored on a cache-cold interactive launch, surfacing as "No models available" even though `omp models` listed them. Startup now awaits one cache-aware discovery pass and retries resolution when the initial fallback finds no model and discoverable providers exist ([#6114](https://github.com/can1357/oh-my-pi/issues/6114)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the configured default model for discovery-only local providers (LM Studio, Ollama, llama.cpp) being ignored on a cache-cold interactive launch, surfacing as "No models available" even though `omp models` listed them. Startup now awaits one cache-aware discovery pass and retries resolution when the initial fallback finds no model and discoverable providers exist ([#6114](https://github.com/can1357/oh-my-pi/issues/6114)).
+- Fixed the configured `modelRoles.default` for a discovery-only provider (local runtimes LM Studio/Ollama/llama.cpp and gateways like LiteLLM) being ignored on a cache-cold interactive launch. Those providers ship no bundled models, so the configured default couldn't resolve against the static+cached catalog at startup — surfacing either as "No models available" or, when another authed provider was present, as a silent start on that provider's bundled default. Startup now awaits one cache-aware discovery pass and retries resolution whenever the configured default role is unresolved ([#6114](https://github.com/can1357/oh-my-pi/issues/6114)).
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -47,7 +47,7 @@ For independent per-item chains (review → verify, fetch → extract → score)
             schema: FINDINGS_SCHEMA,
         });
         return await parallel(found.findings.map((f) => async () => ({
-            ...f,
+            …f,
             verdict: await agent(
                 `Refute if you can (default refuted when unsure): ${f.title}`,
                 { label: `verify:${f.file}`, schema: VERDICT_SCHEMA },
@@ -57,8 +57,6 @@ For independent per-item chains (review → verify, fetch → extract → score)
     phase("Review");
     const results = await parallel(DIMENSIONS.map((d) => async () => reviewAndVerify(d)));
     const confirmed = results.flat().filter((f) => f.verdict.is_real);
-
-
 Reach for `pipeline()` only when a stage genuinely needs ALL of the previous stage first — dedup/merge across the whole set, early-exit on zero, or "compare against the other findings" — because its inter-stage barrier makes every item wait for the slowest peer:
 
 **Python (`eval`, Python backend):**
@@ -80,8 +78,6 @@ Reach for `pipeline()` only when a stage genuinely needs ALL of the previous sta
     const verdicts = await parallel(findings.map((f) => async () =>
         await agent(verifyPrompt(f), { schema: VERDICT_SCHEMA }),
     ));
-
-
 Use ordinary code between calls to flatten/map/filter; don't add a barrier just for that. Nested `parallel()` pools each cap independently, so keep total fan-out sane.
 </structure>
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2202,50 +2202,69 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// path-scoped `enabledModels` allow-list when configured. Skip when the
 		// user explicitly requested a model via --model that wasn't found.
 		if (!model && deferredModelPatterns.length === 0) {
-			// Re-resolve the allowed set: extension factories above may have
-			// registered providers/models that weren't visible at startup.
-			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+			// Resolve a startup model from the current registry catalog: retry the
+			// configured default role, then fall back to the first authed default.
+			// Factored so it can run again after an on-demand discovery pass below.
+			const resolveFallbackModel = async (): Promise<Model | undefined> => {
+				// Re-resolve the allowed set: extension factories above may have
+				// registered providers/models that weren't visible at startup.
+				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
 
-			// Retry the default-role lookup against the post-extension allowed
-			// set. Extension factories register providers AFTER the early
-			// `defaultRoleSpec` resolution, so a role pointing at an extension
-			// model (e.g. an openai-compat plugin's `posthog/claude-opus-4-8`)
-			// returned `undefined` there. Without this retry the next step's
-			// `pickDefaultAvailableModel` happily replaces the user's configured
-			// default with a bundled provider's default whenever a stray
-			// `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is in the environment.
-			// (issue #3569)
-			if (!hasExplicitModel && !defaultRoleSpec.model) {
-				const reResolvedRoleSpec = resolveModelRoleValue(settings.getModelRole("default"), fallbackCandidates, {
-					settings,
-					matchPreferences: modelMatchPreferences,
-				});
-				if (reResolvedRoleSpec.model) {
-					defaultRoleSpec = reResolvedRoleSpec;
-					const resolvedDefaultModel = reResolvedRoleSpec.model;
-					model = resolvedDefaultModel;
-					modelFallbackMessage = undefined;
-					// Recompute the thinking level against the now-real model.
-					// `pickInitialThinkingLevel` closes over `defaultRoleSpec`,
-					// so the role's explicit selector (e.g. `:max`) now applies.
-					thinkingLevel = pickInitialThinkingLevel(resolvedDefaultModel);
-					autoThinking = thinkingLevel === AUTO_THINKING;
-					effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
-					effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
-						autoThinking
-							? resolveProvisionalAutoLevel(resolvedDefaultModel)
-							: resolveThinkingLevelForModel(resolvedDefaultModel, effectiveThinkingLevel),
-					);
-					preconnectModelHost(resolvedDefaultModel.baseUrl);
+				// Retry the default-role lookup against the post-extension allowed
+				// set. Extension factories register providers AFTER the early
+				// `defaultRoleSpec` resolution, so a role pointing at an extension
+				// model (e.g. an openai-compat plugin's `posthog/claude-opus-4-8`)
+				// returned `undefined` there. Without this retry the next step's
+				// `pickDefaultAvailableModel` happily replaces the user's configured
+				// default with a bundled provider's default whenever a stray
+				// `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is in the environment.
+				// (issue #3569)
+				if (!hasExplicitModel && !defaultRoleSpec.model) {
+					const reResolvedRoleSpec = resolveModelRoleValue(settings.getModelRole("default"), fallbackCandidates, {
+						settings,
+						matchPreferences: modelMatchPreferences,
+					});
+					if (reResolvedRoleSpec.model) {
+						defaultRoleSpec = reResolvedRoleSpec;
+						const resolvedDefaultModel = reResolvedRoleSpec.model;
+						modelFallbackMessage = undefined;
+						// Recompute the thinking level against the now-real model.
+						// `pickInitialThinkingLevel` closes over `defaultRoleSpec`,
+						// so the role's explicit selector (e.g. `:max`) now applies.
+						thinkingLevel = pickInitialThinkingLevel(resolvedDefaultModel);
+						autoThinking = thinkingLevel === AUTO_THINKING;
+						effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
+						effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
+							autoThinking
+								? resolveProvisionalAutoLevel(resolvedDefaultModel)
+								: resolveThinkingLevelForModel(resolvedDefaultModel, effectiveThinkingLevel),
+						);
+						preconnectModelHost(resolvedDefaultModel.baseUrl);
+						return resolvedDefaultModel;
+					}
 				}
+
+				return pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
+			};
+
+			model = await resolveFallbackModel();
+
+			// Cold start against a discovery-only local provider (lm-studio, ollama,
+			// llama.cpp): those ship no bundled models, so the static+cached catalog
+			// resolved nothing above. The background discovery in main.ts fires only
+			// AFTER createAgentSession returns, so on a cache-cold boot nothing has
+			// populated the catalog yet and a configured local default silently
+			// degrades to "No models available" — even though `omp models` (which
+			// awaits discovery) lists them. Await one cache-aware discovery pass and
+			// retry resolution, matching `omp models`. Gated on the already-failed
+			// resolution and the presence of discoverable providers, so the common
+			// path (a bundled provider's key resolves a model above) never pays for
+			// it. (issue #6114)
+			if (!model && !hasExplicitModel && modelRegistry.getDiscoverableProviders().length > 0) {
+				await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
+				model = await resolveFallbackModel();
 			}
 
-			if (!model) {
-				const defaultModel = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
-				if (defaultModel) {
-					model = defaultModel;
-				}
-			}
 			if (model) {
 				if (modelFallbackMessage) {
 					modelFallbackMessage += `. Using ${model.provider}/${model.id}`;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2249,18 +2249,30 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 			model = await resolveFallbackModel();
 
-			// Cold start against a discovery-only local provider (lm-studio, ollama,
-			// llama.cpp): those ship no bundled models, so the static+cached catalog
-			// resolved nothing above. The background discovery in main.ts fires only
-			// AFTER createAgentSession returns, so on a cache-cold boot nothing has
-			// populated the catalog yet and a configured local default silently
-			// degrades to "No models available" — even though `omp models` (which
-			// awaits discovery) lists them. Await one cache-aware discovery pass and
-			// retry resolution, matching `omp models`. Gated on the already-failed
-			// resolution and the presence of discoverable providers, so the common
-			// path (a bundled provider's key resolves a model above) never pays for
-			// it. (issue #6114)
-			if (!model && !hasExplicitModel && modelRegistry.getDiscoverableProviders().length > 0) {
+			// Retry the resolution once against freshly-discovered models when a
+			// configured default role can't be satisfied by the static+cached
+			// catalog. Discovery-only providers ship no bundled models — local
+			// runtimes (lm-studio, ollama, llama.cpp) and built-in-discovered
+			// gateways (litellm, openai-compat plugins) alike — so on a cache-cold
+			// boot the configured default resolves to nothing above. Two failure
+			// shapes:
+			//   1. No other authed provider → `model` is undefined and startup
+			//      prints "No models available" even though `omp models` (which
+			//      awaits discovery) lists them.
+			//   2. Another authed provider exists (e.g. a stray OPENAI/codex key) →
+			//      `pickDefaultAvailableModel` masks the miss with that provider's
+			//      bundled default, so the session silently ignores the configured
+			//      default role.
+			// The background discovery in main.ts fires only AFTER
+			// createAgentSession returns, so neither case sees the discovered
+			// catalog. Await one cache-aware discovery pass (bounded to at most one
+			// fetch per cache TTL, matching `omp models`) and retry — but only when
+			// the configured default role is genuinely unresolved, so the common
+			// path (default role satisfied on the first pass) never pays for it.
+			// (issues #6114, #3569)
+			const defaultRoleUnresolved = !defaultRoleSpec.model && Boolean(settings.getModelRole("default")?.trim());
+			const canDiscover = defaultRoleUnresolved || modelRegistry.getDiscoverableProviders().length > 0;
+			if (!hasExplicitModel && (!model || defaultRoleUnresolved) && canDiscover) {
 				await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
 				model = await resolveFallbackModel();
 			}

--- a/packages/coding-agent/test/sdk-default-role-discovery-local-provider.test.ts
+++ b/packages/coding-agent/test/sdk-default-role-discovery-local-provider.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression: issue #6114.
+ *
+ * `modelRoles.default` set to a discovery-only local provider model (LM Studio,
+ * Ollama, llama.cpp) was ignored on fresh interactive launches, surfacing as
+ * "No models available". Those providers ship no bundled models, so the
+ * static+cached catalog the SDK resolves against at startup is empty on a
+ * cache-cold boot; the online discovery pass in `main.ts` runs only AFTER
+ * `createAgentSession` returns. `omp models` (which awaits discovery) listed the
+ * models, but the interactive session degraded. The SDK now awaits one
+ * cache-aware discovery pass and retries resolution when the initial fallback
+ * fails and discoverable providers exist.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("issue #6114 fresh launch default role from discovery-only local provider", () => {
+	let tempDir: string;
+	let originalLmStudioBaseUrl: string | undefined;
+	const authStoragesToClose: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-sdk-default-role-local-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		originalLmStudioBaseUrl = Bun.env.LM_STUDIO_BASE_URL;
+		delete Bun.env.LM_STUDIO_BASE_URL;
+	});
+
+	afterEach(() => {
+		for (const authStorage of authStoragesToClose) {
+			authStorage.close();
+		}
+		authStoragesToClose.length = 0;
+		if (originalLmStudioBaseUrl === undefined) {
+			delete Bun.env.LM_STUDIO_BASE_URL;
+		} else {
+			Bun.env.LM_STUDIO_BASE_URL = originalLmStudioBaseUrl;
+		}
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	/** LM Studio `/v1/models`; native metadata probe (`/api/v0/models`) 404s. */
+	function mockLmStudio(models: string[], baseUrl = "http://127.0.0.1:1234/v1"): FetchImpl {
+		return async input => {
+			const url = String(input);
+			if (url === `${baseUrl}/models`) {
+				return Response.json({ data: models.map(id => ({ id })) });
+			}
+			return new Response("not found", { status: 404 });
+		};
+	}
+
+	test("selects the configured LM Studio default on a cache-cold boot", async () => {
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStoragesToClose.push(authStorage);
+		// Fresh registry: no cached lm-studio catalog on disk, so the static
+		// catalog the SDK resolves against at startup is empty for the provider.
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"), {
+			fetch: mockLmStudio(["qwen3-coder-30b"]),
+		});
+
+		const settings = Settings.isolated();
+		settings.setModelRole("default", "lm-studio/qwen3-coder-30b");
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("lm-studio");
+			expect(session.model?.id).toBe("qwen3-coder-30b");
+		} finally {
+			await session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-default-role-discovery-local-provider.test.ts
+++ b/packages/coding-agent/test/sdk-default-role-discovery-local-provider.test.ts
@@ -97,4 +97,44 @@ describe("issue #6114 fresh launch default role from discovery-only local provid
 			await session.dispose();
 		}
 	});
+
+	test("applies the configured local default even when a bundled provider key is present", async () => {
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStoragesToClose.push(authStorage);
+		// Mirrors #6114 comment (pmatos): a stray key for a bundled provider makes
+		// `pickDefaultAvailableModel` fill `model` with that provider's default,
+		// masking the still-unresolved configured local default. Without the retry
+		// the session silently starts on the bundled fallback and never switches.
+		authStorage.setRuntimeApiKey("openai", "test-openai-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"), {
+			fetch: mockLmStudio(["qwen3-coder-30b"]),
+		});
+
+		const settings = Settings.isolated();
+		settings.setModelRole("default", "lm-studio/qwen3-coder-30b");
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("lm-studio");
+			expect(session.model?.id).toBe("qwen3-coder-30b");
+		} finally {
+			await session.dispose();
+		}
+	});
 });


### PR DESCRIPTION
## Repro
With LM Studio configured as the sole provider and `modelRoles.default` pointing at an LM Studio model, a fresh (cache-cold) interactive `omp` launch prints `Warning: No models available. Use /login or set an API key environment variable. Then use /model to select a model.` — even though `omp models` lists the LM Studio models and `omp config list` shows the default role. Reproduced with a cold `ModelRegistry` against a mocked LM Studio `/v1/models`: `modelRegistry.getAvailable()` returns 0 `lm-studio` models before discovery and the discovered model only after `refresh()`. Same shape applies to Ollama and llama.cpp.

## Cause
Discovery-only local providers (`lm-studio`, `ollama`, `llama.cpp`) ship zero bundled models in `packages/catalog/src/models.json`, so their catalog is populated exclusively by runtime discovery. At interactive startup, `createAgentSession` (`packages/coding-agent/src/sdk.ts`) resolves the startup model synchronously against the static + cached catalog via `resolveAllowedModels` / `resolveModelRoleValue` / `pickDefaultAvailableModel`. The online discovery pass runs only *after* the session is created — `main.ts` fires `modelRegistry.refreshInBackground()` from the `createSession` wrapper after `createAgentSession` returns. On a cache-cold boot nothing has populated the local provider's catalog yet, so the configured default can't resolve and the fallback lands on the `No models available` message. `omp models` (`runModelsCommand`) instead `await`s `modelRegistry.refresh(...)`, which is why it lists the models.

## Fix
- Factored the post-extension fallback resolution in `createAgentSession` into a `resolveFallbackModel()` helper that returns the resolved `Model | undefined` (retry configured default role, then first authed default), so it can run twice.
- Added a gated second attempt: when the first pass resolves no model, no explicit `--model` was given, and `modelRegistry.getDiscoverableProviders().length > 0`, await one cache-aware `modelRegistry.refresh("online-if-uncached")` and retry resolution — mirroring `omp models`. The common path (a bundled provider's key resolves a model on the first pass) never pays the discovery cost.

## Verification
Added `packages/coding-agent/test/sdk-default-role-discovery-local-provider.test.ts`, which drives `createAgentSession` with a cold registry + mocked LM Studio discovery and a configured `lm-studio/qwen3-coder-30b` default; it asserts `session.model` is the LM Studio model. Confirmed the test fails without the fix (`session.model` is `undefined`) and passes with it.

- `bun test test/sdk-default-role-discovery-local-provider.test.ts test/sdk-default-role-extension-provider.test.ts test/sdk-model-selection.test.ts` → 23 pass, 0 fail.
- `bun check` → clean (types + biome across the workspace).

Fixes #6114