### PR TITLE
fix(cli): prefer authenticated provider for bare models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unqualified `--model` startup selection preferring an unauthenticated provider's catalog entry over the same model from a configured provider. ([#6150](https://github.com/can1357/oh-my-pi/issues/6150))
+
 ## [17.0.6] - 2026-07-20
 
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1598,6 +1598,13 @@ export function filterAvailableModelsByEnabledPatterns(
 
 	return includeSyntheticAllowedModels(available, allowedModels);
 }
+function findExactCliModel(selector: string, models: Model<Api>[]): Model<Api> | undefined {
+	const referenced = findExactModelReferenceMatch(selector, models);
+	if (referenced) return referenced;
+
+	const lower = selector.toLowerCase();
+	return models.find(model => model.id.toLowerCase() === lower || formatModelString(model).toLowerCase() === lower);
+}
 
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;
@@ -1620,17 +1627,19 @@ export function resolveCliModel(options: {
 	cliProvider?: string;
 	cliModel?: string;
 	modelRegistry: CliModelRegistry;
+	/** Authenticated models to prefer for unqualified selectors; omit to preserve catalog-order behavior. */
+	availableModels?: Model<Api>[];
 	settings?: Settings;
 	preferences?: ModelMatchPreferences;
 }): ResolveCliModelResult {
-	const { cliProvider, cliModel, modelRegistry, settings, preferences } = options;
+	const { cliProvider, cliModel, modelRegistry, settings, preferences, availableModels: preferredModels } = options;
 
 	if (!cliModel) {
 		return { model: undefined, selector: undefined, warning: undefined, error: undefined };
 	}
 
-	const availableModels = modelRegistry.getAll();
-	if (availableModels.length === 0) {
+	const allModels = modelRegistry.getAll();
+	if (allModels.length === 0) {
 		return {
 			model: undefined,
 			selector: undefined,
@@ -1639,8 +1648,9 @@ export function resolveCliModel(options: {
 		};
 	}
 
+	const availableModels = preferredModels ?? allModels;
 	const providerMap = new Map<string, string>();
-	for (const model of availableModels) {
+	for (const model of allModels) {
 		providerMap.set(model.provider.toLowerCase(), model.provider);
 	}
 
@@ -1656,18 +1666,14 @@ export function resolveCliModel(options: {
 
 	const trimmedModel = cliModel.trim();
 	if (!provider) {
-		const lower = trimmedModel.toLowerCase();
-		// When input has provider/id format (e.g. "zai/glm-5"), prefer decomposed
-		// provider+id match over flat id match. Without this, a model with id
-		// "zai/glm-5" on provider "vercel-ai-gateway" wins over provider "zai"
-		// with id "glm-5", because Array.find returns the first catalog hit.
-		let exact = findExactModelReferenceMatch(trimmedModel, availableModels);
-		if (!exact) {
-			// Flat exact id (or full selector) by catalog order: CLI resolution
-			// stays deterministic across runs regardless of usage-based ranking.
-			exact = availableModels.find(
-				model => model.id.toLowerCase() === lower || `${model.provider}/${model.id}`.toLowerCase() === lower,
-			);
+		const slashIndex = trimmedModel.indexOf("/");
+		const hasExplicitProvider =
+			slashIndex !== -1 && providerMap.has(trimmedModel.substring(0, slashIndex).toLowerCase());
+		let exact = hasExplicitProvider
+			? findExactCliModel(trimmedModel, allModels)
+			: findExactCliModel(trimmedModel, availableModels);
+		if (!exact && !hasExplicitProvider) {
+			exact = findExactCliModel(trimmedModel, allModels);
 		}
 		if (exact) {
 			return {
@@ -1684,14 +1690,11 @@ export function resolveCliModel(options: {
 			MAX_THINKING_SUFFIX_OPTIONS,
 		);
 		if (exactThinkingLevel) {
-			let exactSuffixed = findExactModelReferenceMatch(exactBase, availableModels);
-			if (!exactSuffixed) {
-				const lowerExactBase = exactBase.toLowerCase();
-				exactSuffixed = availableModels.find(
-					model =>
-						model.id.toLowerCase() === lowerExactBase ||
-						`${model.provider}/${model.id}`.toLowerCase() === lowerExactBase,
-				);
+			let exactSuffixed = hasExplicitProvider
+				? findExactCliModel(exactBase, allModels)
+				: findExactCliModel(exactBase, availableModels);
+			if (!exactSuffixed && !hasExplicitProvider) {
+				exactSuffixed = findExactCliModel(exactBase, allModels);
 			}
 			if (exactSuffixed) {
 				return {
@@ -1719,10 +1722,16 @@ export function resolveCliModel(options: {
 					: undefined;
 		if (roleSelector) {
 			configuredPatterns = resolveConfiguredModelPatterns([roleSelector], settings);
-			const resolved = resolveModelRoleValue(roleSelector, availableModels, {
+			const availableResolved = resolveModelRoleValue(roleSelector, availableModels, {
 				settings,
 				matchPreferences: preferences,
 			});
+			const resolved = availableResolved.model
+				? availableResolved
+				: resolveModelRoleValue(roleSelector, allModels, {
+						settings,
+						matchPreferences: preferences,
+					});
 			if (resolved.model) {
 				return {
 					model: resolved.model,
@@ -1767,7 +1776,7 @@ export function resolveCliModel(options: {
 	}
 
 	if (provider) {
-		const exactProviderMatch = resolveProviderModelReference(provider, pattern, availableModels);
+		const exactProviderMatch = resolveProviderModelReference(provider, pattern, allModels);
 		if (exactProviderMatch) {
 			return {
 				model: exactProviderMatch,
@@ -1779,10 +1788,16 @@ export function resolveCliModel(options: {
 		}
 	}
 
-	const candidates = provider ? availableModels.filter(model => model.provider === provider) : availableModels;
-	const { model, thinkingLevel, warning, upstream } = parseModelPattern(pattern, candidates, preferences, {
+	const candidates = provider ? allModels.filter(model => model.provider === provider) : availableModels;
+	let parsed = parseModelPattern(pattern, candidates, preferences, {
 		allowInvalidThinkingSelectorFallback: false,
 	});
+	if (!parsed.model && !provider) {
+		parsed = parseModelPattern(pattern, allModels, preferences, {
+			allowInvalidThinkingSelectorFallback: false,
+		});
+	}
+	const { model, thinkingLevel, warning, upstream } = parsed;
 
 	if (!model) {
 		const display = provider ? `${provider}/${pattern}` : cliModel;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -882,6 +882,7 @@ export async function buildSessionOptions(
 			cliProvider: parsed.provider,
 			cliModel: parsed.model,
 			modelRegistry,
+			availableModels: modelRegistry.getAvailable(),
 			settings: activeSettings,
 			preferences: modelMatchPreferences,
 		});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -992,9 +992,7 @@ describe("resolveModelOverride", () => {
 });
 describe("resolveCliModel", () => {
 	test("resolves --model provider/id without --provider", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openai/gpt-4o",
@@ -1006,10 +1004,25 @@ describe("resolveCliModel", () => {
 		expect(result.model?.id).toBe("gpt-4o");
 	});
 
-	test("resolves bare configured role names from --model", () => {
+	test("prefers an authenticated provider for an unqualified exact model id", () => {
+		const availableModels = openaiGpt55Models.filter(model => model.provider === "openai-codex");
 		const registry = {
-			getAll: () => allModels,
+			getAll: () => openaiGpt55Models,
 		};
+
+		const result = resolveCliModel({
+			cliModel: "gpt-5.5",
+			modelRegistry: registry,
+			availableModels,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openai-codex");
+		expect(result.model?.id).toBe("gpt-5.5");
+	});
+
+	test("resolves bare configured role names from --model", () => {
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { task: "openai/gpt-4o" },
 		});
@@ -1026,9 +1039,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves bare configured role names with thinking suffixes", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { task: "anthropic/claude-sonnet-4-5" },
 		});
@@ -1046,9 +1057,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("preserves configured role fallback selectors for deferred resolution", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: {
 				task: "openrouter/z-ai/glm-4.7@cerebras,anthropic/claude-sonnet-4-5",
@@ -1065,9 +1074,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("reports when a configured role matches after unresolved candidates", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: {
 				task: "runtime-provider/runtime-model,anthropic/claude-sonnet-4-5",
@@ -1086,9 +1093,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("does not fuzzy-match unresolved configured roles", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { sonnet: "runtime-provider/runtime-model" },
 		});
@@ -1105,9 +1110,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("keeps unknown --model names on the not-found path", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 
 		const result = resolveCliModel({
 			cliModel: "not-a-model",
@@ -1131,9 +1134,7 @@ describe("resolveCliModel", () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		});
-		const registry = {
-			getAll: () => [...allModels, exactModel],
-		};
+		const registry = { getAll: () => [...allModels, exactModel] };
 		const settings = Settings.isolated({
 			modelRoles: { task: "anthropic/claude-sonnet-4-5" },
 		});
@@ -1158,9 +1159,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves configured custom, legacy, and default role aliases from --model", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: {
 				default: "openai/gpt-4o",
@@ -1194,9 +1193,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("splits thinking suffixes and abbreviations off the * default alias", () => {
-		const registry = {
-			getAll: () => allModels,
-		};
+		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { default: "anthropic/claude-sonnet-4-5" },
 		});
@@ -1222,9 +1219,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves fuzzy patterns within an explicit provider", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openai",
@@ -1238,9 +1233,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("supports --model <pattern>:<thinking> (without explicit --thinking)", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "sonnet:high",
@@ -1253,9 +1246,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("prefers exact model id match over provider inference (OpenRouter-style ids)", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openai/gpt-4o:extended",
@@ -1268,9 +1259,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("does not strip invalid :suffix as thinking level in --model (fail fast)", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openai",
@@ -1283,9 +1272,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("supports provider-prefixed OpenRouter route suffixes even when the base model is cataloged without them", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openrouter/z-ai/glm-4.7-20251222:nitro",
@@ -1298,9 +1285,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("supports explicit OpenRouter provider with route suffixes that are not in the catalog", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openrouter",
@@ -1320,16 +1305,12 @@ describe("resolveCliModel", () => {
 		const baseResult = resolveCliModel({
 			cliProvider: "amazon-bedrock",
 			cliModel: profileArn,
-			modelRegistry: {
-				getAll: () => [defaultBedrockModel],
-			},
+			modelRegistry: { getAll: () => [defaultBedrockModel] },
 		});
 		const offResult = resolveCliModel({
 			cliProvider: "amazon-bedrock",
 			cliModel: `${profileArn}:off`,
-			modelRegistry: {
-				getAll: () => [defaultBedrockModel],
-			},
+			modelRegistry: { getAll: () => [defaultBedrockModel] },
 		});
 
 		expect(baseResult.error).toBeUndefined();
@@ -1348,9 +1329,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("returns a clear error when there are no models", () => {
-		const registry = {
-			getAll: () => [],
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => [] } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openai",
@@ -1363,9 +1342,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves provider-prefixed fuzzy patterns (openrouter/qwen -> openrouter model)", () => {
-		const registry = {
-			getAll: () => allModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openrouter/qwen",
@@ -1406,9 +1383,9 @@ describe("resolveCliModel", () => {
 				maxTokens: 4096,
 			}),
 		];
-		const registry = {
-			getAll: () => ambiguousModels,
-		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => ambiguousModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "zai/glm-5",


### PR DESCRIPTION
## Repro
With only one provider authenticated, resolve a bare model ID shared by that provider and an earlier unauthenticated catalog provider. `bun test packages/coding-agent/test/model-resolver.test.ts --test-name-pattern "prefers an authenticated provider for an unqualified exact model id"` failed before the fix: expected `openai-codex` (the sole available provider), received catalog-first `openai`. This is the same startup path as `omp --model glm-5.2` selecting Fireworks instead of configured Ollama Cloud.

## Cause
`resolveCliModel` in `packages/coding-agent/src/config/model-resolver.ts` resolved exact bare IDs against `ModelRegistry.getAll()` in catalog order. `buildSessionOptions` in `packages/coding-agent/src/main.ts` therefore selected an unauthenticated provider before request-time auth resolution, while `/switch` builds its choices from `getAvailable()`.

## Fix
- Pass the authenticated model snapshot from startup into `resolveCliModel`.
- Prefer that snapshot for unqualified exact IDs, role selectors, and fuzzy selectors, then fall back to the full catalog when no authenticated match exists.
- Keep explicit provider-qualified selectors authoritative and add regression coverage for shared bare IDs.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/main-model-scope-notification.test.ts packages/coding-agent/test/sdk-model-selection.test.ts packages/coding-agent/test/bench-auth-fallback.test.ts packages/coding-agent/test/issue-980-bedrock-priority.test.ts` — 178 passed, 0 failed. `bun check` passed. The pre-publish gate also completed successfully.

Fixes #6150