### PR TITLE
fix(ai): qualify auth-gateway model IDs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `auth-gateway` model listings exposing duplicate, ambiguous bare IDs by advertising one provider-qualified routing ID per upstream model ([#6170](https://github.com/can1357/oh-my-pi/issues/6170)).
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -726,13 +726,19 @@ async function handleCredentialsCheck(storage: AuthStorage, signal: AbortSignal)
 }
 
 function handleModelsList(opts: AuthGatewayBootOptions): Response {
-	const list = opts.listModels ? Array.from(opts.listModels()) : [];
-	const data = list.map(model => ({
-		id: model.id,
-		object: "model" as const,
-		owned_by: model.provider,
-		api: model.api,
-	}));
+	const seen = new Set<string>();
+	const data: Array<{ id: string; object: "model"; owned_by: string; api: Api }> = [];
+	for (const model of opts.listModels?.() ?? []) {
+		const id = `${model.provider}/${model.id}`;
+		if (seen.has(id)) continue;
+		seen.add(id);
+		data.push({
+			id,
+			object: "model",
+			owned_by: model.provider,
+			api: model.api,
+		});
+	}
 	return json(200, { object: "list", data });
 }
 

--- a/packages/ai/test/auth-gateway-model-list.test.ts
+++ b/packages/ai/test/auth-gateway-model-list.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
+import { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+
+test("model listing exposes one provider-qualified route per upstream model", async () => {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gw-model-list-"));
+	const storage = await AuthStorage.create(path.join(dir, "auth.db"));
+	const anthropic = createMockModel({ provider: "anthropic", id: "shared-model" });
+	const devin = createMockModel({ provider: "devin", id: "shared-model" });
+	const handle = startAuthGateway({
+		bind: "127.0.0.1:0",
+		bearerTokens: [],
+		storage,
+		resolveModel: () => undefined,
+		listModels: () => [anthropic, anthropic, devin, devin],
+		version: "test",
+	});
+
+	try {
+		const response = await fetch(`${handle.url}/v1/models`);
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			object: "list",
+			data: [
+				{ id: "anthropic/shared-model", object: "model", owned_by: "anthropic", api: "mock" },
+				{ id: "devin/shared-model", object: "model", owned_by: "devin", api: "mock" },
+			],
+		});
+	} finally {
+		await handle.close();
+		storage.close();
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Repro
Starting `startAuthGateway` with Anthropic and Devin entries sharing `shared-model`—including the duplicate values produced by the resolver map—and fetching `GET /v1/models` returned four rows, all advertised as the ambiguous bare `shared-model` ID. Reproduced with `bun -e '<start gateway with duplicate shared models; fetch /v1/models>'`.

## Cause
`handleModelsList` in `packages/ai/src/auth-gateway/server.ts` mapped every resolver-map value directly to `model.id`; it neither surfaced the existing `${provider}/${id}` routing key nor removed the second reference to bare-key winners.

## Fix
- Build each advertised ID from the model provider and model ID.
- Deduplicate entries by that provider-qualified routing ID while preserving catalog order.
- Add HTTP-level regression coverage for colliding IDs and duplicate resolver-map values.
- Document the fix in the pi-ai changelog.

## Verification
`bun test packages/ai/test/auth-gateway-model-list.test.ts` passed (1 test, 2 assertions). The manual gateway reproduction now returns exactly `anthropic/shared-model` and `devin/shared-model`. `bun check` passed across all packages.

Fixes #6170