### PR TITLE
fix(release): preserve changelog source fingerprints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed summarized changelog entries being reintroduced by stale pull-request merges and repeated in later patch release notes ([#6157](https://github.com/can1357/oh-my-pi/issues/6157)).
+
 ## [17.0.6] - 2026-07-20
 
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).

--- a/scripts/fix-changelogs.test.ts
+++ b/scripts/fix-changelogs.test.ts
@@ -3,7 +3,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
-import { collectPromotableAddedItemLines, fixChangelogContent, runChangelogFixer } from "./fix-changelogs";
+import {
+	collectPromotableAddedItemLines,
+	fixChangelogContent,
+	parseChangelog,
+	recordSummarizedItemFingerprints,
+	renderChangelog,
+	runChangelogFixer,
+} from "./fix-changelogs";
 
 describe("collectPromotableAddedItemLines", () => {
 	it("keeps new changelog item additions while ignoring moves and edits", () => {
@@ -153,6 +160,28 @@ describe("fixChangelogContent", () => {
 				"",
 			].join("\n"),
 		);
+	});
+
+	it("drops stale source bullets after summarization changes their text", () => {
+		const sourceItem =
+			"- Fixed isolated `task` subagents mutating the parent checkout and stacking parallel task branches ([#6003](https://github.com/can1357/oh-my-pi/issues/6003)).";
+		const document = parseChangelog(
+			["# Changelog", "", "## [Unreleased]", "", "### Fixed", "", sourceItem, ""].join("\n"),
+		);
+		const unreleased = document.sections.find(section => section.title === "Unreleased");
+		if (!unreleased) throw new Error("fixture is missing Unreleased");
+
+		recordSummarizedItemFingerprints(document, unreleased);
+		const summarizedItem =
+			"- Fixed isolated `task` subagents mutating the parent checkout by detaching the git directory.";
+		unreleased.subsections = [{ title: "Fixed", lines: [{ text: summarizedItem, lineNumber: 0 }] }];
+		const staleMerge = renderChangelog(document).replace(summarizedItem, `${summarizedItem}\n${sourceItem}`);
+
+		const result = fixChangelogContent(staleMerge, new Set());
+
+		expect(result.droppedReleasedDuplicates).toBe(1);
+		expect(result.content).toContain(summarizedItem);
+		expect(result.content).not.toContain(sourceItem);
 	});
 
 	it("can recover Unreleased by dropping bullets known to be historically released", () => {

--- a/scripts/fix-changelogs.ts
+++ b/scripts/fix-changelogs.ts
@@ -7,6 +7,7 @@ const CHANGELOG_GLOB = "packages/*/CHANGELOG.md";
 const ORDERED_SECTION_TITLES = ["Breaking Changes", "Added", "Changed", "Fixed", "Removed"] as const;
 const CHANGELOG_BASELINE_REF = "refs/clog";
 const CHANGELOG_BASELINE_NAME = "clog";
+const SUMMARIZED_ITEM_MARKER = /^<!-- changelog-source-item sha256:([0-9a-f]{64}) -->$/;
 
 export interface NumberedLine {
 	text: string;
@@ -277,6 +278,45 @@ function itemTextKey(itemLines: readonly string[]): string {
 	return trimBlankLines(itemLines).join("\n");
 }
 
+function itemFingerprint(itemLines: readonly string[]): string {
+	const text = itemTextKey(itemLines);
+	if (!text) return "";
+	return new Bun.CryptoHasher("sha256").update(text).digest("hex");
+}
+
+function collectRecordedItemFingerprints(lines: readonly NumberedLine[], keys: Set<string>): void {
+	for (const line of lines) {
+		const fingerprint = line.text.match(SUMMARIZED_ITEM_MARKER)?.[1];
+		if (fingerprint) keys.add(fingerprint);
+	}
+}
+
+function addItemKeys(keys: Set<string>, itemLines: readonly string[]): void {
+	const text = itemTextKey(itemLines);
+	if (text) keys.add(text);
+	const fingerprint = itemFingerprint(itemLines);
+	if (fingerprint) keys.add(fingerprint);
+}
+
+/**
+ * Records source-item fingerprints before an Unreleased section is summarized.
+ */
+export function recordSummarizedItemFingerprints(document: ChangelogDocument, section: ReleaseSection): void {
+	const recorded = new Set<string>();
+	collectRecordedItemFingerprints(document.prefixLines, recorded);
+	for (const subsection of section.subsections) {
+		for (const item of parseItems(subsection.lines)) {
+			const fingerprint = itemFingerprint(item.lines);
+			if (!fingerprint || recorded.has(fingerprint)) continue;
+			document.prefixLines.push({
+				text: `<!-- changelog-source-item sha256:${fingerprint} -->`,
+				lineNumber: 0,
+			});
+			recorded.add(fingerprint);
+		}
+	}
+}
+
 function subsectionHasItem(subsection: Subsection, itemLines: readonly string[]): boolean {
 	const wanted = itemTextKey(itemLines);
 	if (!wanted) return true;
@@ -288,12 +328,12 @@ function subsectionHasItem(subsection: Subsection, itemLines: readonly string[])
 
 function collectReleasedItemKeys(document: ChangelogDocument): Set<string> {
 	const keys = new Set<string>();
+	collectRecordedItemFingerprints(document.prefixLines, keys);
 	for (const section of document.sections) {
 		if (section.title === "Unreleased") continue;
 		for (const subsection of section.subsections) {
 			for (const item of parseItems(subsection.lines)) {
-				const key = itemTextKey(item.lines);
-				if (key) keys.add(key);
+				addItemKeys(keys, item.lines);
 			}
 		}
 	}
@@ -301,11 +341,10 @@ function collectReleasedItemKeys(document: ChangelogDocument): Set<string> {
 }
 
 /**
- * Drop items from [Unreleased] that already appear verbatim in a released
- * section — the residue of a release that copied [Unreleased] into the new
- * version section without clearing it. The released copy is authoritative, so
- * the Unreleased duplicate is removed. Runs before promotion (while parse line
- * numbers are still real) and only ever mutates the Unreleased section.
+ * Drops items from [Unreleased] that already appeared in a released section or
+ * were consumed by changelog summarization. Summarization records source
+ * fingerprints before replacing the text, so stale branches cannot reintroduce
+ * the original wording. Runs before promotion and only mutates Unreleased.
  */
 function dropUnreleasedDuplicatesOfReleased(
 	document: ChangelogDocument,
@@ -319,7 +358,11 @@ function dropUnreleasedDuplicatesOfReleased(
 
 	let dropped = 0;
 	for (const subsection of unreleased.subsections) {
-		const duplicates = parseItems(subsection.lines).filter(item => releasedKeys.has(itemTextKey(item.lines)));
+		const duplicates = parseItems(subsection.lines).filter(item => {
+			const text = itemTextKey(item.lines);
+			const fingerprint = itemFingerprint(item.lines);
+			return releasedKeys.has(text) || releasedKeys.has(fingerprint);
+		});
 		if (duplicates.length === 0) continue;
 		const linesToRemove = lineRangeSet(duplicates);
 		subsection.lines = subsection.lines.filter(line => !linesToRemove.has(line.lineNumber));
@@ -804,11 +847,12 @@ async function collectHistoricalReleaseRecovery(
 				if (recovery.sectionsByTitle.get(section.title) !== undefined) {
 					for (const subsection of section.subsections) {
 						for (const item of parseItems(subsection.lines)) {
-							recovery.itemKeys.add(itemTextKey(item.lines));
+							addItemKeys(recovery.itemKeys, item.lines);
 						}
 					}
 				}
 			}
+			if (recovery) collectRecordedItemFingerprints(document.prefixLines, recovery.itemKeys);
 		}
 	}
 
@@ -929,7 +973,7 @@ function usage(): string {
 		"Usage: bun scripts/fix-changelogs.ts [--dry-run|--check] [--since <tag>] [--recover] [--pin]",
 		"",
 		"Moves changelog items added since the baseline from released sections into [Unreleased],",
-		"drops [Unreleased] items that already appear verbatim in a released section, removes",
+		"drops [Unreleased] items already released or consumed by changelog summarization, removes",
 		"blank separators between adjacent bullet items, then removes duplicate or empty",
 		"### category headings.",
 		"",

--- a/scripts/rewrite-changelog.ts
+++ b/scripts/rewrite-changelog.ts
@@ -51,6 +51,7 @@ import {
 	parseChangelog,
 	parseItems,
 	type ReleaseSection,
+	recordSummarizedItemFingerprints,
 	renderChangelog,
 	resolveRepoRoot,
 } from "./fix-changelogs";
@@ -335,6 +336,7 @@ async function run(options: RunOptions): Promise<RunResult> {
 				.trim();
 
 			const rewritten = await requestRewrite(model, changelogPath, unreleasedBody);
+			recordSummarizedItemFingerprints(document, section);
 			applyRewrite(section, rewritten);
 			const next = renderChangelog(document);
 			if (next === content) continue;


### PR DESCRIPTION
## Repro

Compare `git show v17.0.5:packages/coding-agent/CHANGELOG.md` with `git show v17.0.6:packages/coding-agent/CHANGELOG.md`. Parsing the two tagged version sections yields 32 bullets for 17.0.5 and 106 for 17.0.6; the isolated-`task` git-detach fix is condensed in 17.0.5 without `#6003`, then appears again in its verbose source wording in 17.0.6 with `#6003`.

## Cause

`scripts/rewrite-changelog.ts` replaced each Unreleased source item with model-summarized text without retaining source identity. `dropUnreleasedDuplicatesOfReleased` in `scripts/fix-changelogs.ts` could therefore compare only exact text, so a stale branch's original bullet did not match its summarized released form and survived into the next patch.

## Fix

- Record SHA-256 fingerprints for source items in hidden changelog metadata before `applyRewrite` replaces their text.
- Include recorded fingerprints in normal and historical-recovery dedup keys, while retaining exact-text compatibility for existing tagged changelogs.
- Add a regression that summarizes the `#6003`-shaped source bullet, simulates a stale merge, and verifies the original is dropped while the summary remains.
- Document the release-note fix in the coding-agent Unreleased changelog.

## Verification

`bun test scripts/fix-changelogs.test.ts scripts/ci-release-notes.test.ts` — 18 passed, 0 failed. `bun check` — passed for all packages.

Fixes #6157