### PR TITLE
fix(sdk): resolve configured default role over cold-cache discovery race

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a cache-cold startup race where `modelRoles.default` pointing at a `models.yml` discovery provider (e.g. a custom OpenAI-compatible endpoint with `discovery.type: openai-models-list`) was silently replaced by an unrelated authenticated provider's default. `createAgentSession` resolves the default role before background discovery populates the catalog, so on a cold `models.db` the configured provider had no models yet and the fallback went straight to `pickDefaultAvailableModel`. Startup now awaits one cache-aware discovery pass and re-resolves the configured default whenever it is still unresolved (not only when nothing resolved at all) before accepting a bundled-provider fallback ([#6162](https://github.com/can1357/oh-my-pi/issues/6162)).
+
 ## [17.0.6] - 2026-07-20
 
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2202,48 +2202,84 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// path-scoped `enabledModels` allow-list when configured. Skip when the
 		// user explicitly requested a model via --model that wasn't found.
 		if (!model && deferredModelPatterns.length === 0) {
-			// Re-resolve the allowed set: extension factories above may have
-			// registered providers/models that weren't visible at startup.
-			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
-
-			// Retry the default-role lookup against the post-extension allowed
-			// set. Extension factories register providers AFTER the early
-			// `defaultRoleSpec` resolution, so a role pointing at an extension
-			// model (e.g. an openai-compat plugin's `posthog/claude-opus-4-8`)
-			// returned `undefined` there. Without this retry the next step's
-			// `pickDefaultAvailableModel` happily replaces the user's configured
-			// default with a bundled provider's default whenever a stray
-			// `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is in the environment.
-			// (issue #3569)
-			if (!hasExplicitModel && !defaultRoleSpec.model) {
+			// Retry the configured default role against the current catalog,
+			// setting `model` (+ thinking level) when it resolves. Extension
+			// factories register providers AFTER the early `defaultRoleSpec`
+			// resolution, and configured discovery providers may still be
+			// mid-discovery, so a role pointing at such a model (an openai-compat
+			// plugin's `posthog/claude-opus-4-8`, a models.yml `openai-models-list`
+			// endpoint) returned `undefined` there. Without this retry the
+			// `pickDefaultAvailableModel` fallback below happily replaces the
+			// user's configured default with a bundled provider's default whenever
+			// a stray `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is in the environment.
+			// (issues #3569, #6162)
+			const tryResolveDefaultRole = async (): Promise<boolean> => {
+				if (hasExplicitModel) return false;
+				// Re-resolve the allowed set: extension factories and discovery
+				// refreshes above may have registered models not visible earlier.
+				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
 				const reResolvedRoleSpec = resolveModelRoleValue(settings.getModelRole("default"), fallbackCandidates, {
 					settings,
 					matchPreferences: modelMatchPreferences,
 				});
-				if (reResolvedRoleSpec.model) {
-					defaultRoleSpec = reResolvedRoleSpec;
-					const resolvedDefaultModel = reResolvedRoleSpec.model;
-					model = resolvedDefaultModel;
-					modelFallbackMessage = undefined;
-					// Recompute the thinking level against the now-real model.
-					// `pickInitialThinkingLevel` closes over `defaultRoleSpec`,
-					// so the role's explicit selector (e.g. `:max`) now applies.
-					thinkingLevel = pickInitialThinkingLevel(resolvedDefaultModel);
-					autoThinking = thinkingLevel === AUTO_THINKING;
-					effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
-					effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
-						autoThinking
-							? resolveProvisionalAutoLevel(resolvedDefaultModel)
-							: resolveThinkingLevelForModel(resolvedDefaultModel, effectiveThinkingLevel),
-					);
-					preconnectModelHost(resolvedDefaultModel.baseUrl);
-				}
-			}
+				if (!reResolvedRoleSpec.model) return false;
+				defaultRoleSpec = reResolvedRoleSpec;
+				const resolvedDefaultModel = reResolvedRoleSpec.model;
+				model = resolvedDefaultModel;
+				modelFallbackMessage = undefined;
+				// Recompute the thinking level against the now-real model.
+				// `pickInitialThinkingLevel` closes over `defaultRoleSpec`,
+				// so the role's explicit selector (e.g. `:max`) now applies.
+				thinkingLevel = pickInitialThinkingLevel(resolvedDefaultModel);
+				autoThinking = thinkingLevel === AUTO_THINKING;
+				effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
+				effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
+					autoThinking
+						? resolveProvisionalAutoLevel(resolvedDefaultModel)
+						: resolveThinkingLevelForModel(resolvedDefaultModel, effectiveThinkingLevel),
+				);
+				preconnectModelHost(resolvedDefaultModel.baseUrl);
+				return true;
+			};
+
+			await tryResolveDefaultRole();
 
 			if (!model) {
-				const defaultModel = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
-				if (defaultModel) {
-					model = defaultModel;
+				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+				let pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
+
+				// Cold-cache discovery race (issues #6114, #6162): a discovery
+				// provider (models.yml `openai-models-list`, LM Studio/Ollama/
+				// llama.cpp, or an openai-compat proxy) ships no static models, so
+				// the static+cached catalog resolved nothing above. Background
+				// discovery in main.ts fires only AFTER createAgentSession returns,
+				// so on a cache-cold boot the configured default stays unresolved
+				// and `pick` silently degrades to an unrelated authed provider's
+				// default (#6162) or "No models available" (#6114) — even though
+				// `omp models` (which awaits discovery) lists the model. Await one
+				// cache-aware discovery pass and retry when a default role is
+				// configured (must win over `pick`) or nothing resolved at all.
+				// The common path — role already resolved, or a `pick` with no
+				// configured default — never pays for it.
+				const defaultRoleConfigured = Boolean(settings.getModelRole("default"));
+				if (
+					!hasExplicitModel &&
+					(defaultRoleConfigured || !pick) &&
+					modelRegistry.getDiscoverableProviders().length > 0
+				) {
+					await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
+					if (!(await tryResolveDefaultRole()) && !model) {
+						const refreshedCandidates = await resolveAllowedModels(
+							modelRegistry,
+							settings,
+							modelMatchPreferences,
+						);
+						pick = pickDefaultAvailableModel(refreshedCandidates.filter(hasModelAuth));
+					}
+				}
+
+				if (!model && pick) {
+					model = pick;
 				}
 			}
 			if (model) {

--- a/packages/coding-agent/test/sdk-default-role-discovery-config-provider.test.ts
+++ b/packages/coding-agent/test/sdk-default-role-discovery-config-provider.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression: issue #6162.
+ *
+ * `modelRoles.default` set to a `models.yml` discovery provider model
+ * (a custom OpenAI-compatible endpoint with `discovery.type: openai-models-list`)
+ * was silently replaced on a cache-cold interactive launch by an unrelated
+ * authenticated provider's default. The configured provider ships no static
+ * models, so the static+cached catalog the SDK resolves against at startup is
+ * empty; the online discovery pass in `main.ts` runs only AFTER
+ * `createAgentSession` returns. Unlike issue #6114 (no other authed provider, so
+ * the fallback resolved nothing and the later discovery-retry gate fired), here
+ * a competing bundled provider key resolves `pickDefaultAvailableModel` first,
+ * so the `!model` discovery-retry gate never runs and the configured default is
+ * lost. The SDK now runs the discovery pass whenever the configured default role
+ * is still unresolved and discoverable providers exist, before accepting the
+ * bundled-provider fallback.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("issue #6162 fresh launch default role from models.yml discovery provider", () => {
+	let tempDir: string;
+	const authStoragesToClose: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-sdk-default-role-config-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		for (const authStorage of authStoragesToClose) {
+			authStorage.close();
+		}
+		authStoragesToClose.length = 0;
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	const baseUrl = "https://example.com/v1";
+
+	/** Custom provider `/v1/models` (openai-models-list discovery). */
+	function mockDiscovery(models: string[]): FetchImpl {
+		return async input => {
+			const url = String(input);
+			if (url === `${baseUrl}/models`) {
+				return Response.json({ data: models.map(id => ({ id })) });
+			}
+			return new Response("not found", { status: 404 });
+		};
+	}
+
+	test("selects the configured models.yml default over a competing bundled provider on cold cache", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		fs.writeFileSync(
+			modelsPath,
+			[
+				"providers:",
+				"  my-provider:",
+				`    baseUrl: ${baseUrl}`,
+				"    api: openai-completions",
+				"    apiKey: MY_API_KEY",
+				"    discovery:",
+				"      type: openai-models-list",
+				"",
+			].join("\n"),
+		);
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStoragesToClose.push(authStorage);
+		// The configured provider's key resolves the role model; a competing
+		// bundled provider key would otherwise win the startup fallback via
+		// `pickDefaultAvailableModel`.
+		authStorage.setRuntimeApiKey("my-provider", "test-provider-key");
+		authStorage.setRuntimeApiKey("openai", "test-openai-key");
+
+		// Fresh registry: no cached my-provider catalog on disk, so the static
+		// catalog the SDK resolves against at startup is empty for the provider.
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath, {
+			fetch: mockDiscovery(["some-model"]),
+		});
+
+		const settings = Settings.isolated();
+		settings.setModelRole("default", "my-provider/some-model");
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("my-provider");
+			expect(session.model?.id).toBe("some-model");
+		} finally {
+			await session.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With a custom provider in `~/.omp/agent/models.yml` using `discovery.type: openai-models-list`, `modelRoles.default: my-provider/some-model` in `config.yml`, a cold model cache (`models.db` with no cached rows for the provider), and a competing authed provider (e.g. `OPENAI_API_KEY` set), starting `omp` selects the competing provider's default instead of `my-provider/some-model`. A regression test mirroring this (`test/sdk-default-role-discovery-config-provider.test.ts`) fails on `main`:

```
bun test test/sdk-default-role-discovery-config-provider.test.ts
Expected: "my-provider"
Received: "openai"
```

## Cause
In `createAgentSession` (`packages/coding-agent/src/sdk.ts`), the post-extension fallback re-resolves `modelRoles.default` against the current catalog, but on a cold cache the discovery provider ships no static models and background discovery (`main.ts`, fired only after `createAgentSession` returns) has not populated the catalog yet. Role resolution finds nothing, so it falls through to `pickDefaultAvailableModel`, which returns the competing authed provider's default. The prior discovery-retry (PR #6228 / #6114) only ran when `!model` — but here `pickDefaultAvailableModel` already returned a model, so the retry never fired.

## Fix
- Factored the default-role retry into a `tryResolveDefaultRole()` closure that re-resolves the allowed set and sets `model` + thinking level when the configured default resolves.
- After the first `pickDefaultAvailableModel`, run one cache-aware discovery pass (`modelRegistry.refresh("online-if-uncached")`) and re-resolve whenever a default role is configured (so it wins over the bundled pick) **or** nothing resolved at all, gated on `getDiscoverableProviders().length > 0` so the common path (a bundled key resolves a model) never pays for it.
- A configured default role now takes precedence over the `pickDefaultAvailableModel` fallback even when a competing provider is authed.

## Verification
`bun test test/sdk-default-role-discovery-config-provider.test.ts` passes; `sdk-default-role-extension-provider`, `sdk-model-selection`, `model-resolver`, `sdk-session-isolation`, `model-registry-runtime-provider`, `issue-5780-repro` all green (187 tests). `bun check` clean. Fixes #6162