### PR TITLE
fix(coding-agent): show changelog in standalone binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/changelog` and `/changelog full` reporting no entries in standalone binaries by embedding omp's release history as the safe fallback when no package asset directory exists ([#6172](https://github.com/can1357/oh-my-pi/issues/6172)).
+
 ## [17.0.6] - 2026-07-20
 
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,4 +1,5 @@
 import { getLastChangelogVersionPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import bundledChangelog from "../../CHANGELOG.md" with { type: "text" };
 
 export interface ChangelogEntry {
 	major: number;
@@ -29,73 +30,68 @@ export interface StartupChangelogSelection {
 }
 
 /**
- * Parse changelog entries from the file at `changelogPath`. Scans for `## [x.y.z]`
- * headings and collects each block until the next heading or EOF.
+ * Parse changelog entries from omp's package asset when available, falling back
+ * to the copy embedded in compiled binaries.
  *
- * Returns `[]` when `changelogPath` is `undefined` (package directory not
- * resolvable — see `getChangelogPath`) or the file is missing. Callers MUST NOT
- * synthesize a fallback path from the host project's cwd; doing so caused issue
- * #1423 (the host project's `CHANGELOG.md` was rendered as omp's).
+ * The embedded fallback keeps standalone binaries self-contained without
+ * resolving relative to the host project's cwd, which caused issue #1423.
  */
 export async function parseChangelog(changelogPath: string | undefined): Promise<ChangelogEntry[]> {
-	if (!changelogPath) {
-		return [];
-	}
-	try {
-		const content = await Bun.file(changelogPath).text();
-		const lines = content.split("\n");
-		const entries: ChangelogEntry[] = [];
-
-		let currentLines: string[] = [];
-		let currentVersion: { major: number; minor: number; patch: number } | null = null;
-
-		for (const line of lines) {
-			// Check if this is a version header (## [x.y.z] ...)
-			if (line.startsWith("## ")) {
-				// Save previous entry if exists
-				if (currentVersion && currentLines.length > 0) {
-					entries.push({
-						...currentVersion,
-						content: currentLines.join("\n").trim(),
-					});
-				}
-
-				// Try to parse version from this line
-				const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
-				if (versionMatch) {
-					currentVersion = {
-						major: Number.parseInt(versionMatch[1], 10),
-						minor: Number.parseInt(versionMatch[2], 10),
-						patch: Number.parseInt(versionMatch[3], 10),
-					};
-					currentLines = [line];
-				} else {
-					// Reset if we can't parse version
-					currentVersion = null;
-					currentLines = [];
-				}
-			} else if (currentVersion) {
-				// Collect lines for current version
-				currentLines.push(line);
+	let content = bundledChangelog;
+	if (changelogPath) {
+		try {
+			content = await Bun.file(changelogPath).text();
+		} catch (error) {
+			if (!isEnoent(error)) {
+				logger.error(`Warning: Could not parse changelog: ${error}`);
 			}
 		}
-
-		// Save last entry
-		if (currentVersion && currentLines.length > 0) {
-			entries.push({
-				...currentVersion,
-				content: currentLines.join("\n").trim(),
-			});
-		}
-
-		return entries;
-	} catch (error) {
-		if (isEnoent(error)) {
-			return [];
-		}
-		logger.error(`Warning: Could not parse changelog: ${error}`);
-		return [];
 	}
+
+	return parseChangelogContent(content);
+}
+
+function parseChangelogContent(content: string): ChangelogEntry[] {
+	const lines = content.split("\n");
+	const entries: ChangelogEntry[] = [];
+
+	let currentLines: string[] = [];
+	let currentVersion: { major: number; minor: number; patch: number } | null = null;
+
+	for (const line of lines) {
+		if (line.startsWith("## ")) {
+			if (currentVersion && currentLines.length > 0) {
+				entries.push({
+					...currentVersion,
+					content: currentLines.join("\n").trim(),
+				});
+			}
+
+			const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
+			if (versionMatch) {
+				currentVersion = {
+					major: Number.parseInt(versionMatch[1], 10),
+					minor: Number.parseInt(versionMatch[2], 10),
+					patch: Number.parseInt(versionMatch[3], 10),
+				};
+				currentLines = [line];
+			} else {
+				currentVersion = null;
+				currentLines = [];
+			}
+		} else if (currentVersion) {
+			currentLines.push(line);
+		}
+	}
+
+	if (currentVersion && currentLines.length > 0) {
+		entries.push({
+			...currentVersion,
+			content: currentLines.join("\n").trim(),
+		});
+	}
+
+	return entries;
 }
 
 /**

--- a/packages/coding-agent/test/utils/changelog.test.ts
+++ b/packages/coding-agent/test/utils/changelog.test.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import { removeWithRetries, VERSION } from "@oh-my-pi/pi-utils";
 import {
 	type ChangelogEntry,
+	parseChangelog,
 	RECENT_CHANGELOG_ENTRY_LIMIT,
 	readLastChangelogVersion,
 	renderChangelogEntries,
@@ -148,6 +149,16 @@ describe("selectStartupChangelog", () => {
 		expect(selection.markdown).toContain(STARTUP_CHANGELOG_FULL_HINT);
 		expect(selection.markdown).not.toContain("TAIL-THREE");
 		expect(Buffer.byteLength(selection.markdown ?? "")).toBeLessThanOrEqual(STARTUP_CHANGELOG_MAX_BYTES);
+	});
+});
+
+describe("parseChangelog", () => {
+	test("reads the embedded release history when no package path is available", async () => {
+		const entries = await parseChangelog(undefined);
+		const latest = entries[0];
+
+		expect(`${latest?.major}.${latest?.minor}.${latest?.patch}`).toBe(VERSION);
+		expect(latest?.content).toContain(`## [${VERSION}]`);
 	});
 });
 


### PR DESCRIPTION
## Repro
Build the standalone executable with `bun run --cwd packages/coding-agent build`, launch `packages/coding-agent/dist/omp`, and enter `/changelog`; before this fix the panel reported `No changelog entries found.`

## Cause
`getPackageDir()` in `packages/coding-agent/src/config.ts` intentionally returns `undefined` inside Bun's compiled filesystem to avoid reading the host project's assets, and `parseChangelog()` in `packages/coding-agent/src/utils/changelog.ts` treated that unresolved path as an empty changelog.

## Fix
- Embed `packages/coding-agent/CHANGELOG.md` as text in the executable and use it when the external package asset is unavailable.
- Preserve `PI_PACKAGE_DIR` and source/npm package asset resolution as the preferred path.
- Cover the no-package-path fallback against the current packaged version.

## Verification
`bun test test/utils/changelog.test.ts` passes (9 tests); `bun run check` passes in `packages/coding-agent`; a rebuilt standalone binary now renders `Recent Changes` beginning with `[17.0.6] - 2026-07-20` for `/changelog` instead of the empty-state message.

Fixes #6172