### PR TITLE
feat(btw): carry last 3 /btw Q&As as context into subsequent /btw prompts

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -931,6 +931,17 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
  * Run the update command.
  */
 export async function runUpdateCommand(opts: { force: boolean; check: boolean }): Promise<void> {
+	// Locally patched build: replacing this binary with a stock release would
+	// silently drop the local patches. A `<binary>.patched` sentinel next to
+	// the executable opts it out of self-update.
+	const patchSentinel = `${process.execPath}.patched`;
+	if (fs.existsSync(patchSentinel)) {
+		console.log(chalk.yellow(`This ${APP_NAME} is a locally patched build (${patchSentinel} exists).`));
+		console.log(chalk.yellow("Run `omp-rebuild` to update: it rebases the patch onto latest upstream and rebuilds."));
+		console.log(chalk.dim(`To force a stock update anyway, remove ${patchSentinel} and re-run.`));
+		return;
+	}
+
 	console.log(chalk.dim(`Current version: ${VERSION}`));
 
 	// Check for updates

--- a/packages/coding-agent/src/modes/controllers/btw-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/btw-controller.ts
@@ -12,6 +12,13 @@ interface BtwRequest {
 	leafId: string | null;
 }
 
+interface BtwHistoryEntry {
+	question: string;
+	answer: string;
+}
+
+const BTW_HISTORY_LIMIT = 3;
+
 function assistantMessageWithReplyText(assistantMessage: AssistantMessage, replyText: string): AssistantMessage {
 	const content: AssistantMessage["content"] = [];
 	let replacedText = false;
@@ -42,6 +49,7 @@ export class BtwController {
 	#branchInFlight = false;
 	#lastCopyText: string | undefined;
 	#copyInFlight = false;
+	#history: BtwHistoryEntry[] = [];
 
 	constructor(private readonly ctx: InteractiveModeContext) {}
 
@@ -133,7 +141,10 @@ export class BtwController {
 
 	async #runRequest(request: BtwRequest): Promise<void> {
 		try {
-			const promptText = prompt.render(btwUserPrompt, { question: request.question });
+			const promptText = prompt.render(btwUserPrompt, {
+				question: request.question,
+				previousQAs: this.#history.length > 0 ? this.#history : undefined,
+			});
 			const { replyText, assistantMessage } = await this.ctx.session.runEphemeralTurn({
 				promptText,
 				onTextDelta: delta => {
@@ -149,6 +160,12 @@ export class BtwController {
 			}
 			request.component.setAnswer(replyText);
 			request.component.markComplete();
+			if (replyText.trim()) {
+				this.#history.push({ question: request.question, answer: replyText });
+				if (this.#history.length > BTW_HISTORY_LIMIT) {
+					this.#history.splice(0, this.#history.length - BTW_HISTORY_LIMIT);
+				}
+			}
 			const copyText = request.component.getCopyText();
 			if (copyText !== undefined) {
 				this.#lastQuestion = request.question;

--- a/packages/coding-agent/src/prompts/system/btw-user.md
+++ b/packages/coding-agent/src/prompts/system/btw-user.md
@@ -3,6 +3,15 @@ This is an ephemeral side question for the current interactive session.
 Answer briefly and directly using the conversation context already provided.
 NEVER use tools.
 NEVER ask follow-up questions.
+{{#if previousQAs}}
+Earlier /btw exchanges from this session (context only — answer just the new question):
+{{#each previousQAs}}
+<btw-prior>
+Q: {{this.question}}
+A: {{this.answer}}
+</btw-prior>
+{{/each}}
+{{/if}}
 Question:
 {{question}}
 </btw>

--- a/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
@@ -127,6 +127,66 @@ describe("BtwController", () => {
 		expect(controller.hasActiveRequest()).toBe(true);
 	});
 
+	it("injects prior /btw Q&As into subsequent prompts, capped at three", async () => {
+		let counter = 0;
+		const runEphemeralTurn = vi.fn(async (_args: RunEphemeralTurnArgs) => {
+			counter++;
+			return {
+				replyText: `Answer ${counter}`,
+				assistantMessage: createAssistantMessage(`Answer ${counter}`),
+			};
+		});
+		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
+		const controller = new BtwController(ctx);
+
+		await controller.start("Q1?");
+		await drainBtwRequest();
+		// First prompt has no prior context.
+		expect(runEphemeralTurn.mock.calls[0]?.[0]?.promptText).not.toContain("<btw-prior>");
+
+		await controller.start("Q2?");
+		await drainBtwRequest();
+		const secondPrompt = runEphemeralTurn.mock.calls[1]?.[0]?.promptText ?? "";
+		expect(secondPrompt).toContain("<btw-prior>");
+		expect(secondPrompt).toContain("Q: Q1?");
+		expect(secondPrompt).toContain("A: Answer 1");
+
+		await controller.start("Q3?");
+		await drainBtwRequest();
+		await controller.start("Q4?");
+		await drainBtwRequest();
+		await controller.start("Q5?");
+		await drainBtwRequest();
+		// Fifth prompt sees only the last three exchanges: Q2..Q4.
+		const fifthPrompt = runEphemeralTurn.mock.calls[4]?.[0]?.promptText ?? "";
+		expect(fifthPrompt).not.toContain("Q: Q1?");
+		expect(fifthPrompt).toContain("Q: Q2?");
+		expect(fifthPrompt).toContain("Q: Q3?");
+		expect(fifthPrompt).toContain("Q: Q4?");
+	});
+
+	it("keeps prior /btw context after the panel is dismissed via Escape", async () => {
+		const runEphemeralTurn = vi
+			.fn<(args: RunEphemeralTurnArgs) => Promise<RunEphemeralTurnResult>>()
+			.mockResolvedValueOnce({ replyText: "First answer", assistantMessage: createAssistantMessage("First answer") })
+			.mockResolvedValueOnce({
+				replyText: "Second answer",
+				assistantMessage: createAssistantMessage("Second answer"),
+			});
+		const ctx = makeCtx(makeFakeSession(runEphemeralTurn));
+		const controller = new BtwController(ctx);
+
+		await controller.start("First?");
+		await drainBtwRequest();
+		expect(controller.handleEscape()).toBe(true);
+
+		await controller.start("Second?");
+		await drainBtwRequest();
+		const secondPrompt = runEphemeralTurn.mock.calls[1]?.[0]?.promptText ?? "";
+		expect(secondPrompt).toContain("Q: First?");
+		expect(secondPrompt).toContain("A: First answer");
+	});
+
 	it("renders completed /btw answers with copy and branch affordances", async () => {
 		const runEphemeralTurn = vi.fn(async () => ({
 			replyText: "Answer",


### PR DESCRIPTION
## What

`/btw` answers are ephemeral — each new question starts from a blank slate on top of the main session history. This makes short follow-up chains ("btw what does X do?" → "btw and how is it wired into Y?") lose the thread.

This PR keeps a rolling history of the last **3** completed `/btw` Q&As in `BtwController` and injects them as text into the next `/btw` prompt via a new optional `{{previousQAs}}` section in `btw-user.md` (rendered as `<btw-prior>` blocks). Since `runEphemeralTurn` takes a single `promptText`, the history is injected as text — same pattern as the existing `<btw>` wrapper.

## Details

- `#history` is separate from the single-shot branch/copy state, so it survives `#clearCompletedState()` (Escape, new requests) — it only dies with the controller (session teardown).
- Empty/whitespace-only replies are not recorded.
- Aborted/errored requests are not recorded (the push happens after `markComplete()`).
- Capped at 3 entries, oldest dropped.

Second commit (optional, can drop): `omp update` skips self-update when a `<binary>.patched` sentinel sits next to the executable, so locally patched builds aren't silently clobbered by a stock release.

## Tests

Two new cases in `btw-controller.test.ts`:
- prior Q&As appear in subsequent prompts and cap at 3
- history survives Escape dismissal

`bun test test/modes/controllers/btw-controller.test.ts` → 24 pass, `test/slash-commands/btw.test.ts` → 3 pass.