### PR TITLE
fix(providers): suppress Bearer N/A header for keyless auth providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible providers configured with `auth: none` still sending `Authorization: Bearer N/A`, which broke custom endpoints that authenticate via their own headers (e.g. `headers.x-api-key`) and reject the bogus bearer. The keyless sentinel now suppresses the `Authorization` injection in `resolveOpenAIRequestSetup`, matching the existing guards on the `google-vertex` and `amazon-bedrock` transports ([#6188](https://github.com/can1357/oh-my-pi/issues/6188)).
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/ai/src/providers/__tests__/keyless-auth-header.test.ts
+++ b/packages/ai/src/providers/__tests__/keyless-auth-header.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { NO_AUTH_SENTINEL, resolveOpenAIRequestSetup } from "../openai-shared";
+
+describe("resolveOpenAIRequestSetup keyless auth", () => {
+	test("omits Authorization for the keyless (auth: none) sentinel, keeping custom headers", () => {
+		const setup = resolveOpenAIRequestSetup(
+			{
+				provider: "qwen",
+				id: "Qwen3.6-35B-A3B",
+				baseUrl: "http://localhost:8788",
+				headers: { "x-api-key": "real-key" },
+			},
+			{ apiKey: NO_AUTH_SENTINEL, messages: [] },
+		);
+		expect(setup.headers.Authorization).toBeUndefined();
+		expect(setup.headers["x-api-key"]).toBe("real-key");
+	});
+
+	test("still injects Bearer for a real key", () => {
+		const setup = resolveOpenAIRequestSetup(
+			{ provider: "custom", id: "m", baseUrl: "http://localhost:8788" },
+			{ apiKey: "sk-real", messages: [] },
+		);
+		expect(setup.headers.Authorization).toBe("Bearer sk-real");
+	});
+
+	test("caller-supplied Authorization in model.headers is preserved even when keyless", () => {
+		const setup = resolveOpenAIRequestSetup(
+			{
+				provider: "qwen",
+				id: "m",
+				baseUrl: "http://localhost:8788",
+				headers: { Authorization: "Bearer custom-token" },
+			},
+			{ apiKey: NO_AUTH_SENTINEL, messages: [] },
+		);
+		expect(setup.headers.Authorization).toBe("Bearer custom-token");
+	});
+});

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -101,6 +101,16 @@ import type {
 import { transformMessages } from "./transform-messages";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
 
+/**
+ * Keyless-provider sentinel. Custom providers configured with `auth: none`
+ * (models.yml) have no credential, so the coding-agent resolves their API key
+ * to this literal instead of a real secret. Providers must treat it as "no
+ * credential" and suppress any credential-bearing header (e.g. `Authorization:
+ * Bearer …`) rather than forwarding the sentinel on the wire. See #6188; the
+ * google-vertex and amazon-bedrock transports apply the same guard inline.
+ */
+export const NO_AUTH_SENTINEL = "N/A";
+
 export interface OpenAIModelIdentity {
 	provider: string;
 	id: string;
@@ -279,7 +289,15 @@ export function resolveOpenAIRequestSetup(
 		baseUrl = baseUrl ?? ($env.OPENAI_BASE_URL?.trim() || options.defaultBaseUrl);
 	}
 	const requestHeaders = { ...headers };
-	headers.Authorization ??= `Bearer ${apiKey}`;
+	// A keyless provider (`auth: none` in models.yml) resolves to the `N/A`
+	// sentinel rather than a real key. Injecting `Authorization: Bearer N/A`
+	// breaks custom endpoints that authenticate via their own headers (e.g.
+	// `headers.x-api-key`) and reject the bogus bearer — mirror the sentinel
+	// guards in google-vertex / amazon-bedrock and send no Authorization here
+	// (#6188). A caller-supplied Authorization in `model.headers` still wins.
+	if (apiKey !== NO_AUTH_SENTINEL) {
+		headers.Authorization ??= `Bearer ${apiKey}`;
+	}
 	return { copilotPremiumRequests, baseUrl, headers, query, requestHeaders };
 }
 


### PR DESCRIPTION
## Repro
A custom OpenAI-compatible provider declared with `auth: none` in `models.yml` (authenticating via `headers.x-api-key`) still receives an `Authorization: Bearer N/A` header on every request, which such backends reject. Minimal reproduction against the request-setup helper:

```
resolveOpenAIRequestSetup(
  { provider: "qwen", id: "Qwen3.6-35B-A3B", baseUrl: "http://localhost:8788", headers: { "x-api-key": "real-key" } },
  { apiKey: "N/A", messages: [] },
)
// => headers: {"x-api-key":"real-key","Authorization":"Bearer N/A"}
```

## Cause
Keyless providers (`auth: none`) resolve their API key to the sentinel `N/A` (`kNoAuth` in `packages/coding-agent/src/config/model-registry.ts`). `resolveOpenAIRequestSetup` in `packages/ai/src/providers/openai-shared.ts` then ran `headers.Authorization ??= ` + "`Bearer ${apiKey}`" unconditionally, forwarding the sentinel as `Bearer N/A`. The `google-vertex` and `amazon-bedrock` transports already guard this sentinel; the OpenAI-compatible path did not.

## Fix
- Add an exported `NO_AUTH_SENTINEL` constant in `openai-shared.ts` documenting the keyless-provider contract.
- Guard the `Authorization` injection in `resolveOpenAIRequestSetup` so it is skipped when the resolved key is the sentinel; a caller-supplied `Authorization` in `model.headers` still wins.
- Add a regression test covering: sentinel omits `Authorization` while keeping custom headers, a real key still yields `Bearer <key>`, and a caller-supplied `Authorization` is preserved under keyless.

## Verification
`bun test packages/ai/src/providers/__tests__/keyless-auth-header.test.ts` → 3 pass. The failing pre-fix reproduction (`Bearer N/A`) now returns no `Authorization` header. Fixes #6188