### PR TITLE
fix(tui): lock plan review overlay after a choice commits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the fullscreen Plan Review overlay staying interactive with no feedback after a choice was picked: while the approval ran slow async work (e.g. context compaction) the overlay remained mounted, arrow keys still moved the cursor, and repeat Enter/Esc were silently swallowed, so users on Ghostty and macOS Terminal thought `/plan` was frozen. The overlay now locks input and shows a "submitting…" indicator the moment a choice commits ([#5926](https://github.com/can1357/oh-my-pi/issues/5926)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/plan-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/plan-review-overlay.ts
@@ -152,6 +152,14 @@ export class PlanReviewOverlay implements Component {
 	 *  motion mouse reports and cleared when the pointer leaves the option rows. */
 	#hoveredOption: number | undefined;
 
+	// Once a choice fires, the promise-based caller resolves but keeps this
+	// overlay mounted while it runs slow async approval work (e.g. context
+	// compaction). Lock input and switch to a "submitting" indicator so the
+	// overlay stops looking interactive and repeat Enter/Esc are not silently
+	// swallowed with zero feedback (#5926).
+	#committed = false;
+	/** Label of the committed choice, shown while the async approval settles. */
+	#committedLabel: string | undefined;
 	#annotating = false;
 	#input: Input;
 
@@ -283,11 +291,14 @@ export class PlanReviewOverlay implements Component {
 	#confirmSelection(): void {
 		const index = this.#selectedIndex;
 		if (index >= 0 && index < this.#options.length && !this.#disabled.has(index)) {
+			this.#committed = true;
+			this.#committedLabel = this.#options[index]!;
 			this.callbacks.onPick(this.#options[index]!);
 		}
 	}
 
 	handleInput(keyData: string): void {
+		if (this.#committed) return;
 		if (keyData.startsWith("\x1b[<") && this.#handleMouse(keyData)) return;
 		if (this.#annotating) {
 			if (this.callbacks.onAnnotationExternalEditor && matchesAppExternalEditor(keyData)) {
@@ -300,6 +311,7 @@ export class PlanReviewOverlay implements Component {
 			return;
 		}
 		if (matchesSelectCancel(keyData)) {
+			this.#committed = true;
 			this.callbacks.onCancel();
 			return;
 		}
@@ -838,10 +850,14 @@ export class PlanReviewOverlay implements Component {
 		const innerWidth = Math.max(1, width - 4);
 		const bodyContentWidth = sidebarShown ? splitBodyWidth(width, sidebarWidth) : innerWidth;
 
-		const sliderLines = this.#renderSliderLines();
-		const optionLines = this.#renderOptionLines();
+		const committed = this.#committed;
+		const sliderLines = committed ? [] : this.#renderSliderLines();
+		const submittingLabel = this.#committedLabel ? `${this.#committedLabel} — submitting…` : "Submitting…";
+		const optionLines = committed ? [theme.bold(theme.fg("accent", submittingLabel))] : this.#renderOptionLines();
 		const promptLines = this.#promptTitle ? [theme.bold(theme.fg("accent", this.#promptTitle))] : [];
-		const footerLines = this.#renderFooterLines(innerWidth);
+		const footerLines = committed
+			? [theme.fg("dim", "Applying your selection — this can take a moment while context is prepared.")]
+			: this.#renderFooterLines(innerWidth);
 
 		// Chrome rows: top border, two dividers, bottom border, plus the
 		// prompt/slider/option/footer rows between them.
@@ -884,7 +900,7 @@ export class PlanReviewOverlay implements Component {
 		for (const line of promptLines) out.push(row(line, width));
 		for (const line of sliderLines) out.push(row(line, width));
 		for (let i = 0; i < optionLines.length; i++) {
-			this.#optionClickRows.set(out.length, i);
+			if (!committed) this.#optionClickRows.set(out.length, i);
 			out.push(row(optionLines[i]!, width));
 		}
 		out.push(divider(width));

--- a/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
@@ -75,7 +75,7 @@ describe("PlanReviewOverlay", () => {
 		expect(onPick).toHaveBeenCalledWith("Approve and execute");
 	});
 
-	it("moves the option cursor with up/down and confirms the new target", () => {
+	it("moves the option cursor with down and confirms the new target", () => {
 		const onPick = vi.fn();
 		const overlay = new PlanReviewOverlay(
 			"plan",
@@ -85,11 +85,42 @@ describe("PlanReviewOverlay", () => {
 		overlay.handleInput(DOWN);
 		overlay.handleInput(ENTER);
 		expect(onPick).toHaveBeenCalledWith("Approve and compact context");
+	});
 
-		onPick.mockClear();
+	it("confirms the up-moved target from a lower start", () => {
+		const onPick = vi.fn();
+		const overlay = new PlanReviewOverlay(
+			"plan",
+			{ promptTitle: "next", options: APPROVAL_OPTIONS, initialIndex: 1 },
+			{ onPick, onCancel: vi.fn() },
+		);
 		overlay.handleInput(UP);
 		overlay.handleInput(ENTER);
 		expect(onPick).toHaveBeenCalledWith("Approve and execute");
+	});
+
+	it("locks input and shows a submitting indicator after a pick, ignoring repeat keys", () => {
+		const onPick = vi.fn();
+		const onCancel = vi.fn();
+		const overlay = new PlanReviewOverlay(
+			"plan",
+			{ promptTitle: "next", options: APPROVAL_OPTIONS },
+			{ onPick, onCancel },
+		);
+		overlay.handleInput(ENTER);
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onPick).toHaveBeenCalledWith("Approve and execute");
+
+		const committed = stripVTControlCharacters(overlay.render(80).join("\n"));
+		expect(committed).toContain("Approve and execute — submitting…");
+
+		// The async approval window keeps the overlay mounted; further keys must
+		// not fire a second callback or move the cursor (#5926).
+		overlay.handleInput(DOWN);
+		overlay.handleInput(ENTER);
+		overlay.handleInput("\x1b");
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onCancel).not.toHaveBeenCalled();
 	});
 
 	it("skips disabled options and never confirms them", () => {
@@ -654,14 +685,14 @@ describe("PlanReviewOverlay", () => {
 		expect(hoverRow(overlay, "Approve and keep context")).toBe(true);
 		expect(optionLineRaw(overlay, "Approve and keep context")).toContain(selectedBg);
 
+		// Pointer onto the top border (a non-option row) drops the highlight.
+		overlay.handleInput("\x1b[<35;6;1M");
+		expect(optionLineRaw(overlay, "Approve and keep context")).not.toContain(selectedBg);
+
 		// Hover is visual only: the keyboard cursor stays on index 0, so Enter still
 		// confirms the first option rather than the hovered one.
 		overlay.handleInput(ENTER);
 		expect(onPick).toHaveBeenCalledWith("Approve and execute");
-
-		// Pointer onto the top border (a non-option row) drops the highlight.
-		overlay.handleInput("\x1b[<35;6;1M");
-		expect(optionLineRaw(overlay, "Approve and keep context")).not.toContain(selectedBg);
 	});
 
 	it("never hovers a disabled option", () => {


### PR DESCRIPTION
## Repro
After picking an option in the fullscreen Plan Review overlay (`/plan` → approve), the overlay keeps looking interactive while a slow async approval runs (e.g. "Approve and compact context", which triggers context compaction). Arrow keys still move the cursor, `c` still copies, and a repeat Enter/Esc does nothing — with no indication the choice was accepted and the fullscreen buffer hiding all progress underneath. Reporters on Ghostty 1.3.2-main, macOS Terminal, and Alacritty+WSL all read this as "`/plan` is frozen" (#5926). Reproduced with a harness that mirrors `showPlanReview`'s `finish()` — commit a pick, then keep feeding keys while the overlay stays mounted: before the fix the cursor still moved and no "submitting" indicator rendered; after the fix input is frozen and the indicator shows.

## Cause
`InteractiveMode.showPlanReview` (`packages/coding-agent/src/modes/interactive-mode.ts`) resolves its choice promise via `finish()` but deliberately does **not** hide the overlay — the hide is deferred to `#approvePlan` (line ~2980), guarded to avoid stale-buffer flicker and premature focus restoration (#5688 / #5319 / #5689). Between the pick and that deferred hide, `#approvePlan` awaits slow work (tool-set restore, model transition, `handleCompactCommand`). Throughout that window the overlay is still the focused component, so `PlanReviewOverlay.handleInput` keeps processing navigation, and a second Enter/Esc is silently swallowed by the caller's `settled` dedup flag. The overlay had no notion of "already committed".

## Fix
- `packages/coding-agent/src/modes/components/plan-review-overlay.ts`: add a `#committed` / `#committedLabel` state. `#confirmSelection` and the cancel path set it as they fire their callback.
- `handleInput` early-returns once `#committed` — no further navigation, picks, or cancels register during the async approval window.
- `render` switches to a committed presentation when locked: the options collapse to a bold `"<choice> — submitting…"` line, the slider is hidden, and the footer reads "Applying your selection — this can take a moment while context is prepared." Click hit-testing for options is skipped while committed.
- The deferred-hide timing in `interactive-mode.ts` is untouched, so the #5688/#5319/#5689 stale-buffer and focus guards stay intact.
- Tests: reworked two `plan-review-overlay.test.ts` cases that reused one overlay for sequential picks (now impossible by design) into single-shot contracts, and added a case asserting the overlay locks input and renders the submitting indicator after a pick.

## Verification
`bun test packages/coding-agent/test/modes/components/plan-review-overlay.test.ts packages/coding-agent/test/interactive-mode-plan-review.test.ts` → 85 pass, 0 fail. `bun check` (biome + full typecheck) passes. Manual harness confirms navigation is frozen and the "submitting…" indicator renders after a pick, and that a second Enter/Esc fires no additional callback. Fixes #5926