### PR TITLE
fix(extensibility): add Type.Unsafe to typebox shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the remapped TypeBox compatibility shim omitting `Type.Unsafe`, which crashed extensions such as `pi-mcp-adapter` when they registered tools from raw MCP input schemas ([#6221](https://github.com/can1357/oh-my-pi/issues/6221)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/typebox.ts
+++ b/packages/coding-agent/src/extensibility/typebox.ts
@@ -41,6 +41,8 @@ export type TOptional<_E extends ArkSchema> = ArkSchema;
 export type TUnion<_T extends readonly ArkSchema[] = readonly ArkSchema[]> = ArkSchema;
 export type TEnum<_T extends readonly (string | number)[] = readonly (string | number)[]> = ArkSchema;
 export type TRecord<_K extends ArkSchema, _V extends ArkSchema> = ArkSchema;
+/** TypeBox-compatible wrapper for raw JSON Schema documents. */
+export type TUnsafe<_T = unknown> = ArkSchema;
 
 // ---------------------------------------------------------------------------
 // ArkSchema wrapper — JSON Schema object with hidden validator metadata
@@ -560,18 +562,14 @@ function tNull(opts?: Meta): ArkSchema {
 	return applyMeta(createArkSchema(validator, { type: "null" }), opts);
 }
 
+const identityValidator = (data: unknown): unknown => data;
+
 function tAny(opts?: Meta): ArkSchema {
-	return applyMeta(
-		createArkSchema((data: unknown) => data, {}),
-		opts,
-	);
+	return applyMeta(createArkSchema(identityValidator, {}), opts);
 }
 
 function tUnknown(opts?: Meta): ArkSchema {
-	return applyMeta(
-		createArkSchema((data: unknown) => data, {}),
-		opts,
-	);
+	return applyMeta(createArkSchema(identityValidator, {}), opts);
 }
 
 function tNever(opts?: Meta): ArkSchema {
@@ -920,6 +918,9 @@ export const Type = {
 	Null: tNull,
 	Any: tAny,
 	Unknown: tUnknown,
+	Unsafe<T = unknown>(jsonSchema: Record<string, unknown> = {}): TUnsafe<T> {
+		return createArkSchema(identityValidator, jsonSchema);
+	},
 	Never: tNever,
 	Literal: tLiteral,
 	Union: tUnion,

--- a/packages/coding-agent/src/extensibility/typebox.ts
+++ b/packages/coding-agent/src/extensibility/typebox.ts
@@ -17,7 +17,7 @@
  * like a small validator at runtime.
  */
 
-import { areJsonValuesEqual } from "@oh-my-pi/pi-ai/utils/schema";
+import { areJsonValuesEqual, validateJsonSchemaValue } from "@oh-my-pi/pi-ai/utils/schema";
 
 // ---------------------------------------------------------------------------
 // Type aliases — exported so `import type { Static, TSchema } from "..."`
@@ -919,7 +919,15 @@ export const Type = {
 	Any: tAny,
 	Unknown: tUnknown,
 	Unsafe<T = unknown>(jsonSchema: Record<string, unknown> = {}): TUnsafe<T> {
-		return createArkSchema(identityValidator, jsonSchema);
+		const validator = (data: unknown): unknown => {
+			const result = validateJsonSchemaValue(jsonSchema, data);
+			if (result.success) return data;
+			const messages = result.issues.map(issue =>
+				issue.path.length > 0 ? `${issue.path.join(".")}: ${issue.message}` : issue.message,
+			);
+			return validationFailure(messages.join("; ") || "Invalid value");
+		};
+		return createArkSchema(validator, jsonSchema);
 	},
 	Never: tNever,
 	Literal: tLiteral,

--- a/packages/coding-agent/test/extensibility/typebox-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-remap.test.ts
@@ -57,17 +57,20 @@ describe("legacy-pi TypeBox remap", () => {
 			[
 				'import { Type } from "typebox";',
 				"export const probe = Type;",
-				"export const enumSchema = Type.Enum(['upstream', 'downstream']);",
+				"export const unsafeSchema = Type.Unsafe({ type: 'object', properties: { path: { type: 'string' } }, required: ['path'] });",
 			].join("\n"),
 		);
 
 		const loaded = (await loadLegacyPiModule(entry)) as {
 			probe: typeof TypeBoxShimType;
-			enumSchema: { safeParse: (input: unknown) => { success: boolean } };
+			unsafeSchema: Record<string, unknown>;
 		};
 
 		expect(loaded.probe).toBe(TypeBoxShimType);
-		expect(loaded.enumSchema.safeParse("upstream").success).toBe(true);
-		expect(loaded.enumSchema.safeParse("sideways").success).toBe(false);
+		expect({ ...loaded.unsafeSchema }).toEqual({
+			type: "object",
+			properties: { path: { type: "string" } },
+			required: ["path"],
+		});
 	});
 });

--- a/packages/coding-agent/test/extensibility/typebox-shim.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-shim.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
 import { isValidJsonSchema, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { validateToolArguments } from "@oh-my-pi/pi-ai/utils/validation";
 import { type TSchema, Type } from "@oh-my-pi/pi-coding-agent/extensibility/typebox";
 
 /**
@@ -23,6 +25,37 @@ describe("pi.typebox compatibility shim", () => {
 
 		expect(safeParse(schema, { path: "README.md" }).success).toBe(true);
 		expect(safeParse(schema, { path: "README.md", mode: "delete" }).success).toBe(false);
+	});
+
+	it("preserves and enforces raw JSON Schema wrapped with Type.Unsafe", () => {
+		const rawSchema = {
+			type: "object",
+			properties: { path: { type: "string" } },
+			required: ["path"],
+			additionalProperties: false,
+		};
+		const schema = Type.Unsafe<{ path: string }>(rawSchema);
+		const tool: Tool = { name: "unsafe-schema", description: "", parameters: schema };
+		const validArgs = { path: "README.md" };
+
+		expect(schema.__validator(validArgs)).toBe(validArgs);
+		expect(toolWireSchema(tool)).toEqual(rawSchema);
+		expect(
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "valid",
+				name: tool.name,
+				arguments: validArgs,
+			}),
+		).toEqual(validArgs);
+		expect(() =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "invalid",
+				name: tool.name,
+				arguments: {},
+			}),
+		).toThrow('Validation failed for tool "unsafe-schema"');
 	});
 
 	it("preserves numeric enum values from TypeScript enum objects", () => {

--- a/packages/coding-agent/test/extensibility/typebox-shim.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-shim.test.ts
@@ -39,6 +39,10 @@ describe("pi.typebox compatibility shim", () => {
 		const validArgs = { path: "README.md" };
 
 		expect(schema.__validator(validArgs)).toBe(validArgs);
+		expect(schema.safeParse({}).success).toBe(false);
+		const composed = Type.Object({ input: schema });
+		expect(composed.safeParse({ input: validArgs }).success).toBe(true);
+		expect(composed.safeParse({ input: {} }).success).toBe(false);
 		expect(toolWireSchema(tool)).toEqual(rawSchema);
 		expect(
 			validateToolArguments(tool, {


### PR DESCRIPTION
## Repro
Import the remapped TypeBox shim and invoke the API used by `pi-mcp-adapter`: `bun -e 'import { Type } from "./packages/coding-agent/src/extensibility/typebox.ts"; Type.Unsafe({ type: "object" });'`. Before the fix this exited 1 with `TypeError: Type.Unsafe is not a function`.

## Cause
`packages/coding-agent/src/extensibility/typebox.ts` implements the `Type` compatibility namespace used for bare `typebox` imports, but its builder surface omitted `Unsafe`; extension evaluation therefore failed before MCP tools could be registered.

## Fix
- Add a generic `TUnsafe` alias and `Type.Unsafe` builder that exposes the raw JSON Schema document with the shim's identity validator.
- Cover both provider/runtime schema validation and a bare-`typebox` remapped extension fixture.
- Record the extension-load fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/extensibility/typebox-shim.test.ts packages/coding-agent/test/extensibility/typebox-remap.test.ts` passed: 13 tests, 0 failures. `bun check` passed for all packages. The original one-line reproduction now exits 0 and confirms the wrapped schema retains `type: "object"`.

Fixes #6221