### PR TITLE
fix(mcp): route task proxies through source tool and mark tools non-strict

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP argument-shaping parity between direct and Task/subagent tool calls: `MCPTool`/`DeferredMCPTool` now declare `strict: false` so OpenAI-family serializers preserve the explicit non-strict flag (models no longer over-fill mutually exclusive optional fields), and Task proxies (`createMCPProxyTools`) now delegate to the current source MCP tool instead of rebuilding a raw `tools/call`, so harness-intent (`i`) stripping, optional-placeholder pruning, local-URL resolution, reconnect, abort, and result metadata match the direct path. Strict servers no longer reject proxied calls with `unrecognized_keys ["i"]` ([#6208](https://github.com/can1357/oh-my-pi/issues/6208)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -332,6 +332,13 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly approval = "write" as const;
 	/** Render completed MCP calls with the result header replacing the pending call header. */
 	readonly mergeCallAndResult = true;
+	/**
+	 * MCP-backed tools opt out of strict structured-output grammar. The server
+	 * owns validation, and strict mode makes OpenAI-family models over-fill
+	 * mutually exclusive optional fields (#4336/#4340). Serializers preserve an
+	 * explicit `false`; an omitted flag would leave nothing to preserve.
+	 */
+	readonly strict = false as const;
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
 	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
@@ -418,6 +425,8 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly approval = "write" as const;
 	/** Render completed MCP calls with the result header replacing the pending call header. */
 	readonly mergeCallAndResult = true;
+	/** See {@link MCPTool.strict}: MCP servers own validation, so stay non-strict. */
+	readonly strict = false as const;
 
 	readonly #fallbackProvider: string | undefined;
 	readonly #fallbackProviderName: string | undefined;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -30,7 +30,6 @@ import { getSessionSlashCommands } from "../extensibility/extensions/get-command
 import { buildSkillPromptMessage, type Skill } from "../extensibility/skills";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
-import { callTool } from "../mcp/client";
 import type { MCPManager } from "../mcp/manager";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
@@ -729,46 +728,54 @@ function getUsageTokens(usage: unknown): number {
 
 /**
  * Create proxy tools that reuse the parent's MCP connections.
+ *
+ * Each proxy delegates to the current source `MCPTool`/`DeferredMCPTool` rather
+ * than rebuilding a raw `tools/call` request, so the Task/subagent path shares
+ * the source tool's authoritative outbound boundary: harness-intent (`i`)
+ * stripping, optional-placeholder pruning, local-URL resolution, reconnect
+ * retry, abort handling, and result/provider metadata. The source tool is
+ * re-resolved on every call by raw MCP server/tool metadata (not the normalized
+ * display name), so a reconnect that swaps the instance in `getTools()` is
+ * always honored. The proxy adds only the Task-specific 60s call timeout,
+ * combining its abort signal with the caller's around source execution.
  */
 export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
 	return mcpManager.getTools().map(tool => {
-		const mcpTool = tool as { mcpToolName?: string; mcpServerName?: string };
+		const serverName = tool.mcpServerName ?? "";
+		const mcpToolName = tool.mcpToolName ?? "";
 		return {
 			name: tool.name,
 			label: tool.label ?? tool.name,
 			description: tool.description ?? "",
 			parameters: tool.parameters,
-			execute: async (_toolCallId, params, _onUpdate, _ctx, signal) => {
+			strict: tool.strict,
+			mcpServerName: serverName,
+			mcpToolName,
+			execute: async (toolCallId, params, onUpdate, ctx, signal) => {
 				if (signal?.aborted) {
 					throw new ToolAbortError();
 				}
-				const serverName = mcpTool.mcpServerName ?? "";
-				const mcpToolName = mcpTool.mcpToolName ?? "";
+				// Re-resolve by raw MCP metadata so a reconnect that replaced the
+				// source instance is picked up; the display name alone is not enough.
+				const source = mcpManager
+					.getTools()
+					.find(t => t.mcpServerName === serverName && t.mcpToolName === mcpToolName);
+				if (!source?.execute) {
+					return {
+						content: [{ type: "text" as const, text: `MCP error: tool ${mcpToolName} no longer available` }],
+						details: { serverName, mcpToolName, isError: true },
+					};
+				}
 				try {
 					const timeoutController = new AbortController();
 					const timeoutSignal = timeoutController.signal;
 					const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
-					const result = await withAbortTimeout(
-						(async () => {
-							const connection = await untilAborted(combinedSignal, () =>
-								mcpManager.waitForConnection(serverName),
-							);
-							return callTool(connection, mcpToolName, params as Record<string, unknown>, {
-								signal: combinedSignal,
-							});
-						})(),
+					return await withAbortTimeout(
+						Promise.resolve(source.execute(toolCallId, params, onUpdate, ctx, combinedSignal)),
 						MCP_CALL_TIMEOUT_MS,
 						signal,
 						timeoutController,
 					);
-					return {
-						content: (result.content ?? []).map(item =>
-							item.type === "text"
-								? { type: "text" as const, text: item.text ?? "" }
-								: { type: "text" as const, text: JSON.stringify(item) },
-						),
-						details: { serverName, mcpToolName, isError: result.isError },
-					};
 				} catch (error) {
 					if (error instanceof ToolAbortError) {
 						throw error;

--- a/packages/coding-agent/test/task-executor-mcp-parity.test.ts
+++ b/packages/coding-agent/test/task-executor-mcp-parity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "bun:test";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+import type { CustomToolContext } from "../src/extensibility/custom-tools/types";
+import { MCPManager } from "../src/mcp/manager";
+import { DeferredMCPTool, MCPTool } from "../src/mcp/tool-bridge";
+import type { MCPServerConnection, MCPToolDefinition } from "../src/mcp/types";
+import { createMCPProxyTools } from "../src/task/executor";
+import { createMockConnection, createMockTransport } from "./mcp-test-utils";
+
+type CapturedRequest = { method: string; params: Record<string, unknown> | undefined };
+
+const unusedContext = {} as CustomToolContext;
+
+/** Strict MCP tool: `additionalProperties:false`, one required + one optional field. */
+const STRICT_TOOL: MCPToolDefinition = {
+	name: "comment",
+	description: "Post a comment",
+	inputSchema: {
+		type: "object",
+		properties: {
+			body: { type: "string" },
+			optional: { type: "string" },
+		},
+		required: ["body"],
+		additionalProperties: false,
+	},
+};
+
+function createCapturedConnection(calls: CapturedRequest[]): MCPServerConnection {
+	const transport = createMockTransport(
+		new Map([["tools/call", [{ content: [{ type: "text", text: "ok" }] }]]]),
+		(method, params) => calls.push({ method, params }),
+	);
+	return createMockConnection({ tools: {} }, transport);
+}
+
+describe("MCP tool strict declaration", () => {
+	it("declares strict:false on MCPTool", () => {
+		const tool = new MCPTool(createCapturedConnection([]), STRICT_TOOL);
+		expect(tool.strict).toBe(false);
+	});
+
+	it("declares strict:false on DeferredMCPTool", () => {
+		const connection = createCapturedConnection([]);
+		const tool = new DeferredMCPTool("srv", STRICT_TOOL, async () => connection);
+		expect(tool.strict).toBe(false);
+	});
+
+	it("propagates strict:false onto Task proxy definitions", () => {
+		const manager = new MCPManager(process.cwd());
+		vi.spyOn(manager, "getTools").mockReturnValue([new MCPTool(createCapturedConnection([]), STRICT_TOOL)]);
+		const [proxy] = createMCPProxyTools(manager);
+		expect(proxy?.strict).toBe(false);
+	});
+});
+
+describe("Task MCP proxy parity", () => {
+	const NOISY_INPUT = { body: "x", optional: "", [INTENT_FIELD]: "js prelude" };
+	const CLEAN_ARGS = { body: "x" };
+
+	it("strips harness intent and empty placeholders on the parent direct path", async () => {
+		const calls: CapturedRequest[] = [];
+		const tool = new MCPTool(createCapturedConnection(calls), STRICT_TOOL);
+
+		await tool.execute("call-1", NOISY_INPUT, undefined, unusedContext, undefined);
+
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "comment", arguments: CLEAN_ARGS } }]);
+	});
+
+	it("strips harness intent and empty placeholders through the Task proxy path", async () => {
+		const calls: CapturedRequest[] = [];
+		const manager = new MCPManager(process.cwd());
+		vi.spyOn(manager, "getTools").mockReturnValue([new MCPTool(createCapturedConnection(calls), STRICT_TOOL)]);
+
+		const [proxy] = createMCPProxyTools(manager);
+		if (!proxy?.execute) {
+			expect.unreachable("proxy tool missing execute");
+			return;
+		}
+
+		await proxy.execute("call-1", NOISY_INPUT, undefined, unusedContext, undefined);
+
+		// Identical outbound arguments to the parent path — no `i`, no empty optional.
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "comment", arguments: CLEAN_ARGS } }]);
+	});
+
+	it("preserves `i` through the Task proxy when the server declares it", async () => {
+		const calls: CapturedRequest[] = [];
+		const definition: MCPToolDefinition = {
+			name: "echo",
+			description: "Echo",
+			inputSchema: { type: "object", properties: { i: { type: "string" } }, required: ["i"] },
+		};
+		const manager = new MCPManager(process.cwd());
+		vi.spyOn(manager, "getTools").mockReturnValue([new MCPTool(createCapturedConnection(calls), definition)]);
+
+		const [proxy] = createMCPProxyTools(manager);
+		if (!proxy?.execute) {
+			expect.unreachable("proxy tool missing execute");
+			return;
+		}
+
+		await proxy.execute("call-1", { i: "hello" }, undefined, unusedContext, undefined);
+
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "echo", arguments: { i: "hello" } } }]);
+	});
+
+	it("re-resolves the source tool by MCP metadata so a reconnect replacement is honored", async () => {
+		const staleCalls: CapturedRequest[] = [];
+		const freshCalls: CapturedRequest[] = [];
+		const manager = new MCPManager(process.cwd());
+
+		const staleTool = new MCPTool(createCapturedConnection(staleCalls), STRICT_TOOL);
+		const freshTool = new MCPTool(createCapturedConnection(freshCalls), STRICT_TOOL);
+
+		const getTools = vi.spyOn(manager, "getTools").mockReturnValue([staleTool]);
+		const [proxy] = createMCPProxyTools(manager); // captured while stale tool is current
+
+		// Reconnect swaps the instance in getTools() before the proxy executes.
+		getTools.mockReturnValue([freshTool]);
+
+		if (!proxy?.execute) {
+			expect.unreachable("proxy tool missing execute");
+			return;
+		}
+		await proxy.execute("call-1", { body: "x" }, undefined, unusedContext, undefined);
+
+		expect(freshCalls).toHaveLength(1);
+		expect(staleCalls).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/task-executor-mcp-timeout.test.ts
+++ b/packages/coding-agent/test/task-executor-mcp-timeout.test.ts
@@ -1,7 +1,8 @@
 import { expect, test, vi } from "bun:test";
-import type { CustomTool, CustomToolContext } from "../src/extensibility/custom-tools/types";
+import type { CustomToolContext } from "../src/extensibility/custom-tools/types";
 import { MCPManager } from "../src/mcp/manager";
-import type { MCPRequestOptions, MCPServerConnection, MCPTransport } from "../src/mcp/types";
+import { MCPTool } from "../src/mcp/tool-bridge";
+import type { MCPRequestOptions, MCPServerConnection, MCPToolDefinition, MCPTransport } from "../src/mcp/types";
 import { createMCPProxyTools } from "../src/task/executor";
 import { ToolAbortError } from "../src/tools/tool-errors";
 
@@ -45,25 +46,21 @@ function createFakeConnection() {
 	};
 }
 
+const TOOL_DEFINITION: MCPToolDefinition = {
+	name: "test_tool",
+	description: "A test tool",
+	inputSchema: { type: "object", properties: {} },
+};
+
+/** Register a real MCPTool bound to `connection` as the sole source tool. */
+function mockSourceTool(manager: MCPManager, connection: MCPServerConnection): void {
+	vi.spyOn(manager, "getTools").mockReturnValue([new MCPTool(connection, TOOL_DEFINITION)]);
+}
+
 test("MCP proxy tool aborts underlying operation on caller abort", async () => {
 	const fake = createFakeConnection();
 	const manager = new MCPManager(process.cwd());
-
-	const toolsData: CustomTool[] = [
-		{
-			name: "test_tool",
-			label: "Test Tool",
-			description: "A test tool",
-			strict: false,
-			mcpToolName: "test_tool",
-			mcpServerName: "test-server",
-			parameters: { type: "object", properties: {} },
-			execute: async () => ({ content: [] }),
-		} as CustomTool,
-	];
-
-	vi.spyOn(manager, "getTools").mockReturnValue(toolsData);
-	vi.spyOn(manager, "waitForConnection").mockResolvedValue(fake.connection);
+	mockSourceTool(manager, fake.connection);
 
 	const tools = createMCPProxyTools(manager);
 	const proxyTool = tools[0];
@@ -90,7 +87,7 @@ test("MCP proxy tool aborts underlying operation on caller abort", async () => {
 
 	try {
 		await executePromise;
-		expect.unreachable("executePromise should throw ToolAbortError");
+		expect.unreachable("Expected ToolAbortError");
 	} catch (e: unknown) {
 		expect(e instanceof ToolAbortError).toBe(true);
 	}
@@ -103,22 +100,7 @@ test("MCP proxy tool aborts underlying operation on timeout", async () => {
 	try {
 		const fake = createFakeConnection();
 		const manager = new MCPManager(process.cwd());
-
-		const toolsData: CustomTool[] = [
-			{
-				name: "test_tool",
-				label: "Test Tool",
-				description: "A test tool",
-				strict: false,
-				mcpToolName: "test_tool",
-				mcpServerName: "test-server",
-				parameters: { type: "object", properties: {} },
-				execute: async () => ({ content: [] }),
-			} as CustomTool,
-		];
-
-		vi.spyOn(manager, "getTools").mockReturnValue(toolsData);
-		vi.spyOn(manager, "waitForConnection").mockResolvedValue(fake.connection);
+		mockSourceTool(manager, fake.connection);
 
 		const tools = createMCPProxyTools(manager);
 		const proxyTool = tools[0];


### PR DESCRIPTION
## Repro
With a strict MCP server (`additionalProperties: false`), a Task/subagent eval call like `{ body: "x", optional: "", i: "js prelude" }` reaches the server as `{ body: "x", optional: "", i: "js prelude" }` and is rejected with `-32602 Input validation error: unrecognized_keys ["i"]`. The same input on the parent direct path correctly sends `{ body: "x" }`. Separately, because MCP tools never declared `strict`, OpenAI-family models over-fill mutually exclusive optional fields (a nonempty enum paired with an empty id) that the server then rejects. Run: `bun test test/task-executor-mcp-parity.test.ts` in `packages/coding-agent`.

## Cause
`MCPTool` and `DeferredMCPTool` (`packages/coding-agent/src/mcp/tool-bridge.ts`) declared no explicit `strict` value, so the OpenAI serializers — which after #4336/#4340 only emit `strict: false` when `tool.strict === false` — had nothing to preserve. `createMCPProxyTools` (`packages/coding-agent/src/task/executor.ts`) located the connection and called the low-level `callTool(connection, name, params)` directly, bypassing `prepareOutboundArgs` in the source tool: harness-intent (`i`) stripping, optional-placeholder pruning, and local-URL resolution never ran on the Task path, and provider/result metadata + reconnect/abort behavior diverged from the direct path.

## Fix
- `MCPTool`/`DeferredMCPTool` declare `readonly strict = false as const` (documented rationale referencing #4336/#4340).
- `createMCPProxyTools` now delegates to the current source `MCPTool`/`DeferredMCPTool` — re-resolved on every call by raw MCP server/tool metadata (`mcpServerName`/`mcpToolName`), not the normalized display name, so a reconnect that swaps the instance in `getTools()` is honored — and propagates `strict` onto the proxy definition. The Task-specific 60s timeout is retained by combining its abort signal with the caller's around source execution; unused `callTool` import removed.
- Regression coverage in `test/task-executor-mcp-parity.test.ts`: `strict === false` on both tools and the proxy definition; identical outbound args from parent vs Task path for `{ body, optional:"", i }`; declared-`i` passthrough; reconnect re-resolution. `test/task-executor-mcp-timeout.test.ts` updated to delegate through a real `MCPTool` source.

## Verification
`bun test test/task-executor-mcp-parity.test.ts test/task-executor-mcp-timeout.test.ts test/mcp-tool-args.test.ts` → 15 pass / 0 fail; `bun test test/mcp-reconnect.test.ts test/mcp-server-tool-ownership.test.ts test/sdk-mcp-defer.test.ts test/mcp-tool-args.test.ts` → 41 pass / 0 fail; `bun check` → clean. Fixes #6208