### PR TITLE
fix(session): persist terminal empty error turns ending the run

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a terminal provider error on the continuation turn after a failed tool result silently ending the run with no durable record of why. When retry, model fallback, and compaction all declined a `stopReason: "error"` turn with no substantive content, `#persistSessionMessageIfMissing` dropped it as an empty error turn, so the session JSONL stopped at the last tool result and the provider's `errorMessage` was lost. The non-retry terminal error tail now persists the empty error turn (mirroring the retry-lifecycle dead-ends), keeping it off the wire on reload while preserving the diagnostic ([#6249](https://github.com/can1357/oh-my-pi/issues/6249)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5081,6 +5081,13 @@ export class AgentSession {
 			if (this.#isClassifierRefusal(msg)) {
 				this.#prunedTerminalRefusal = msg;
 				this.#removeAssistantMessageFromActiveContext(msg);
+			} else {
+				// No retry, fallback, or compaction continuation fired: this errored
+				// turn ends the run. #persistSessionMessageIfMissing dropped it as an
+				// empty error turn, so record it here — otherwise the JSONL stops at
+				// the last tool result and the provider's errorMessage is lost (#6249).
+				// Idempotent and a no-op for non-empty turns.
+				await this.#persistTerminalEmptyErrorTurn(msg);
 			}
 			this.#resolveRetry();
 
@@ -11988,7 +11995,17 @@ export class AgentSession {
 		this.#pendingRecoveredRetryErrors = [];
 	}
 
-	async #persistRetryLifecycleErrorMessage(message: AssistantMessage): Promise<void> {
+	/**
+	 * Durably record a terminal empty error turn (`stopReason: "error"` with no
+	 * substantive content) that `#persistSessionMessageIfMissing` skipped, so the
+	 * session JSONL keeps a record of why the run stopped instead of ending at the
+	 * last tool result. A no-op for non-empty/non-error turns and idempotent via
+	 * the already-persisted guard; the turn is dropped from active context by the
+	 * caller (or `isProviderRefusalMessage`/`isEmptyErrorTurn` filters) so it is
+	 * never replayed on the wire. Used by the retry-lifecycle dead-ends and the
+	 * non-retry terminal error tail.
+	 */
+	async #persistTerminalEmptyErrorTurn(message: AssistantMessage): Promise<void> {
 		await this.#waitForSessionMessagePersistence(message);
 		if (!isEmptyErrorTurn(message)) return;
 		if (this.#sessionMessageAlreadyPersisted(message)) return;
@@ -12030,7 +12047,7 @@ export class AgentSession {
 		id: number,
 		options: { switchedCredential: boolean; switchedModel: boolean; delayMs: number },
 	): Promise<void> {
-		await this.#persistRetryLifecycleErrorMessage(message);
+		await this.#persistTerminalEmptyErrorTurn(message);
 		const persistenceKey = sessionMessagePersistenceKey(message);
 		if (!persistenceKey) return;
 		let branchEntry: SessionEntry | undefined;
@@ -15501,7 +15518,7 @@ export class AgentSession {
 		}
 		if (retryBudgetExhausted) {
 			if (!switchedModel) {
-				await this.#persistRetryLifecycleErrorMessage(message);
+				await this.#persistTerminalEmptyErrorTurn(message);
 				// Max retries exceeded and no fallback model to switch to: emit
 				// final failure and reset.
 				await this.#emitSessionEvent({
@@ -15548,7 +15565,7 @@ export class AgentSession {
 		// can act on it.
 		const maxDelayMs = retrySettings.maxDelayMs;
 		if (maxDelayMs > 0 && delayMs > maxDelayMs && !switchedCredential && !switchedModel) {
-			await this.#persistRetryLifecycleErrorMessage(message);
+			await this.#persistTerminalEmptyErrorTurn(message);
 			const attempt = this.#retryAttempt;
 			this.#retryAttempt = 0;
 			await this.#emitSessionEvent({

--- a/packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { z } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const failingToolSchema = z.object({ value: z.string() });
+const failingTool: AgentTool<typeof failingToolSchema, Record<string, never>> = {
+	name: "boom",
+	label: "Boom",
+	description: "Always fails",
+	parameters: failingToolSchema,
+	async execute() {
+		return { content: [{ type: "text", text: "invalid javascript" }], isError: true };
+	},
+};
+
+type Harness = { session: AgentSession; authStorage: AuthStorage; tempDir: TempDir };
+const activeHarnesses: Harness[] = [];
+
+async function createHarness(responses: MockResponse[]): Promise<Harness & { sessionManager: SessionManager }> {
+	const tempDir = TempDir.createSync("@pi-terminal-error-persistence-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("mock", "test-key");
+	const mock = createMockModel({ responses });
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"retry.enabled": false,
+		"todo.enabled": false,
+		"todo.reminders": false,
+	});
+	settings.setModelRole("default", `${mock.provider}/${mock.id}`);
+	const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+	const tools = [failingTool as AgentTool];
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model: mock, systemPrompt: ["Test"], tools, messages: [] },
+		convertToLlm,
+		streamFn: mock.stream,
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settings,
+		modelRegistry,
+		toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+	});
+	const harness = { session, authStorage, tempDir };
+	activeHarnesses.push(harness);
+	return { ...harness, sessionManager };
+}
+
+function persistedErrorTurns(sessionManager: SessionManager): AssistantMessage[] {
+	return sessionManager
+		.getEntries()
+		.filter(entry => entry.type === "message")
+		.map(entry => entry.message as AgentMessage)
+		.filter((message): message is AssistantMessage => message.role === "assistant" && message.stopReason === "error");
+}
+
+afterEach(async () => {
+	for (const harness of activeHarnesses.splice(0)) {
+		await harness.session.dispose();
+		harness.authStorage.close();
+		harness.tempDir.removeSync();
+	}
+	vi.restoreAllMocks();
+});
+
+describe("AgentSession terminal error persistence", () => {
+	// #6249: a non-retriable provider error on the continuation turn after a failed
+	// tool result ended the run, but #persistSessionMessageIfMissing dropped the
+	// empty error turn, so the session JSONL stopped at the tool result and the
+	// provider errorMessage was lost with no durable record of why the run stopped.
+	it("persists the terminal empty error turn that ends the run after a failed tool result", async () => {
+		const { session, sessionManager } = await createHarness([
+			{
+				content: [{ type: "toolCall", id: "call-1", name: "boom", arguments: { value: "x" } }],
+				stopReason: "toolUse",
+			},
+			{ content: [], stopReason: "error", errorMessage: "provider rejected the continuation" },
+		]);
+
+		await session.prompt("run the tool then fail");
+		await session.waitForIdle();
+
+		const errorTurns = persistedErrorTurns(sessionManager);
+		expect(errorTurns).toHaveLength(1);
+		expect(errorTurns[0]?.errorMessage).toBe("provider rejected the continuation");
+	});
+
+	it("records the terminal error turn without a phantom retry when retry is disabled", async () => {
+		const retryEvents: string[] = [];
+		const { session, sessionManager } = await createHarness([
+			{ content: [], stopReason: "error", errorMessage: "hard provider failure" },
+		]);
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start" || event.type === "auto_retry_end") retryEvents.push(event.type);
+		});
+
+		await session.prompt("fail immediately");
+		await session.waitForIdle();
+
+		expect(retryEvents).toHaveLength(0);
+		const errorTurns = persistedErrorTurns(sessionManager);
+		expect(errorTurns).toHaveLength(1);
+		expect(errorTurns[0]?.errorMessage).toBe("hard provider failure");
+	});
+
+	it("does not persist a terminal error turn that carried real text", async () => {
+		const { session, sessionManager } = await createHarness([
+			{
+				content: [{ type: "text", text: "partial answer before the error" }],
+				stopReason: "error",
+				errorMessage: "stream cut",
+			},
+		]);
+
+		await session.prompt("stream then error");
+		await session.waitForIdle();
+
+		// The turn streamed substantive text, so #persistSessionMessageIfMissing
+		// keeps it via the normal path (one persisted copy, not two).
+		expect(persistedErrorTurns(sessionManager)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Repro
Main session invokes a tool that returns `isError: true`; the continuation call returns a provider error (`stopReason: "error"` with an empty content block and an `errorMessage`), with retry disabled. The run stops at the failed tool result, the errored assistant turn is never written to the session JSONL, and its `errorMessage` is lost — the transcript makes the local tool error look terminal even though a continuation had started and then failed. Reproduced with `bun test packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts` (0 persisted error turns before the fix). Matches the reporter's capture: zero-content `agent_end` with `stopReason: error`, no `auto_retry` event, `session_exit` with `pendingToolCalls: 0`.

## Cause
In `AgentSession.#processAgentEvent`'s `agent_end` maintenance (`packages/coding-agent/src/session/agent-session.ts`), a `stopReason: "error"` turn with no substantive content is dropped from the JSONL by `#persistSessionMessageIfMissing` via `isEmptyErrorTurn` (`session/messages.ts`) to avoid replaying an empty turn on reload. The re-persist helper (`#persistRetryLifecycleErrorMessage`) only ran inside the retry lifecycle. When `#isRetryableError`, `#isHardErrorFallbackEligible`, and compaction all decline the turn (a generic non-retriable provider error with no configured fallback chain — the reporter's Antigravity case), control reaches the terminal error tail, which never re-persisted the turn. The empty-stop guard does not apply either (`#isEmptyAssistantStop` matches only `stop`/`toolUse`). The focus interaction is not a cause: `SessionFocusController` only retargets the UI and never touches the main run loop; Esc-while-focused was already gated to main-only by the #2819 fix.

## Fix
- Renamed `#persistRetryLifecycleErrorMessage` to `#persistTerminalEmptyErrorTurn` and documented it as a general, idempotent terminal-failure record (no-op for non-empty/non-error turns), updating the two retry-lifecycle call sites.
- In the non-retry terminal error tail, persist the empty error turn for non-classifier-refusal errors, so the JSONL keeps a durable record of why the run stopped. Classifier refusals keep their existing prune-from-context behavior.
- The persisted empty turn stays off the wire on reload via the empty-assistant filter in `packages/ai/src/providers/transform-messages.ts` (line 210), matching the already-shipped retry-exhaustion dead-ends, so context replay is unaffected.
- Added `packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts`.

## Verification
`bun test packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts` (3 pass). Regression suites green: `agent-session-empty-stop-guard`, `agent-session-retry-cap`, `agent-session-retry-recovery`, `agent-session-retry-fallback`, `session/empty-error-turn`, `agent-session-auto-compaction-queue`, `agent-session-thinking-loop-retry` (87 pass). `bun check` clean after `bun run fix`. Fixes #6249