### PR TITLE
fix(session): persist terminal empty error turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a terminal non-retryable provider error (zero content blocks, `stopReason: "error"`) after a failed tool result being silently dropped from the session: the `isEmptyErrorTurn` persistence gate skipped it and the run relied on a live pinned render that never fires when the main session's UI subscription is detached (e.g. while focused on a subagent transcript), so the failure vanished with no durable record. The empty error turn is now persisted on the terminal fall-through — matching the existing retry-budget/delay-cap paths — so unfocus/reload rebuilds keep the provider `errorMessage` ([#6250](https://github.com/can1357/oh-my-pi/issues/6250)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5081,6 +5081,14 @@ export class AgentSession {
 			if (this.#isClassifierRefusal(msg)) {
 				this.#prunedTerminalRefusal = msg;
 				this.#removeAssistantMessageFromActiveContext(msg);
+			} else {
+				// Terminal non-retryable provider error: persist a content-less
+				// error turn so the run leaves a durable record of why it stopped.
+				// The retry-lifecycle caps already persist here; the plain
+				// fall-through did not, so a zero-content error dropped silently
+				// whenever the live pinned render was unreachable — e.g. focused on
+				// a subagent transcript (#6250). No-op unless the turn is empty.
+				await this.#persistEmptyErrorTurn(msg);
 			}
 			this.#resolveRetry();
 
@@ -11988,7 +11996,17 @@ export class AgentSession {
 		this.#pendingRecoveredRetryErrors = [];
 	}
 
-	async #persistRetryLifecycleErrorMessage(message: AssistantMessage): Promise<void> {
+	/**
+	 * Durably record a content-less `stopReason: "error"` turn (an empty
+	 * provider-rejection) that {@link #persistSessionMessageIfMissing} skips via
+	 * {@link isEmptyErrorTurn}. Called on every terminal exit of such a turn —
+	 * retry-budget/delay caps AND the plain non-retryable fall-through (#6250) —
+	 * so the run always leaves a record of why it stopped instead of relying on
+	 * the live pinned render, which never fires when the main UI subscription is
+	 * detached (e.g. while a subagent transcript is focused). No-op for turns
+	 * that carried real content (they persist normally) or are already on disk.
+	 */
+	async #persistEmptyErrorTurn(message: AssistantMessage): Promise<void> {
 		await this.#waitForSessionMessagePersistence(message);
 		if (!isEmptyErrorTurn(message)) return;
 		if (this.#sessionMessageAlreadyPersisted(message)) return;
@@ -12030,7 +12048,7 @@ export class AgentSession {
 		id: number,
 		options: { switchedCredential: boolean; switchedModel: boolean; delayMs: number },
 	): Promise<void> {
-		await this.#persistRetryLifecycleErrorMessage(message);
+		await this.#persistEmptyErrorTurn(message);
 		const persistenceKey = sessionMessagePersistenceKey(message);
 		if (!persistenceKey) return;
 		let branchEntry: SessionEntry | undefined;
@@ -15501,7 +15519,7 @@ export class AgentSession {
 		}
 		if (retryBudgetExhausted) {
 			if (!switchedModel) {
-				await this.#persistRetryLifecycleErrorMessage(message);
+				await this.#persistEmptyErrorTurn(message);
 				// Max retries exceeded and no fallback model to switch to: emit
 				// final failure and reset.
 				await this.#emitSessionEvent({
@@ -15548,7 +15566,7 @@ export class AgentSession {
 		// can act on it.
 		const maxDelayMs = retrySettings.maxDelayMs;
 		if (maxDelayMs > 0 && delayMs > maxDelayMs && !switchedCredential && !switchedModel) {
-			await this.#persistRetryLifecycleErrorMessage(message);
+			await this.#persistEmptyErrorTurn(message);
 			const attempt = this.#retryAttempt;
 			this.#retryAttempt = 0;
 			await this.#emitSessionEvent({

--- a/packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-terminal-error-persistence.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import * as aiStream from "@oh-my-pi/pi-ai/stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+/**
+ * Contract (issue #6250): when a tool returns `isError: true` and the follow-up
+ * provider turn ends with a non-retryable `stopReason: "error"` carrying zero
+ * content blocks, the terminal error turn MUST be persisted to the session so a
+ * durable record of why the run stopped survives — instead of being silently
+ * dropped by the `isEmptyErrorTurn` persistence gate. The pre-fix flow only
+ * surfaced this error "live (pinned)", which vanishes when the main UI
+ * subscription is detached (e.g. while a subagent transcript is focused).
+ */
+describe("AgentSession terminal empty error persistence", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+	let sessionManager: SessionManager | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-terminal-error-persist-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		vi.spyOn(aiStream, "getEnvApiKey").mockReturnValue(undefined);
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		if (sessionManager) {
+			await sessionManager.close();
+			sessionManager = undefined;
+		}
+		authStorage.close();
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	it("persists a non-retryable zero-content error turn after a failed tool result", async () => {
+		const model = getBundledModel("openai", "gpt-5");
+		if (!model) {
+			throw new Error("Expected bundled OpenAI test model to exist");
+		}
+
+		const failingTool: AgentTool = {
+			name: "eval",
+			label: "Eval",
+			description: "Mock eval tool that rejects invalid input",
+			parameters: type({ "code?": "string" }),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "SyntaxError: Unexpected token '{'." }],
+				isError: true,
+			}),
+		};
+
+		// First turn calls the tool; the tool fails; the follow-up continuation
+		// throws a generic (non-retryable) provider error with no content.
+		const mock = createMockModel({
+			provider: "openai",
+			id: model.id,
+			responses: [
+				{ content: [{ type: "toolCall", id: "tc-0", name: "eval", arguments: { code: "import {" } }] },
+				{ throw: "Provider rejected the request (400 invalid continuation)" },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [failingTool], messages: [] },
+			convertToLlm,
+			streamFn: (requestedModel, context, options) => mock.stream(requestedModel, context, options),
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"todo.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 100,
+			"retry.modelFallback": false,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		sessionManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[failingTool.name, failingTool]]),
+		});
+
+		await session.prompt("run eval");
+		await session.waitForIdle();
+		await sessionManager.flush();
+
+		// The continuation ended terminally with a zero-content error.
+		const last = session.agent.state.messages.at(-1);
+		expect(last?.role).toBe("assistant");
+		expect((last as AssistantMessage).stopReason).toBe("error");
+		expect((last as AssistantMessage).content).toHaveLength(0);
+
+		// The terminal error turn is now durably recorded: a rebuild from
+		// persisted entries (what a focus/unfocus rebuild reads) shows it,
+		// preserving the provider errorMessage instead of losing it.
+		const persistedErrorTurns = sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "message" && entry.message.role === "assistant")
+			.map(entry => entry.type === "message" && (entry.message as AssistantMessage))
+			.filter((message): message is AssistantMessage => !!message && message.stopReason === "error");
+		expect(persistedErrorTurns).toHaveLength(1);
+		expect(persistedErrorTurns[0]?.errorMessage).toContain("invalid continuation");
+	});
+});


### PR DESCRIPTION
## Repro
A tool returns `isError: true`, then the follow-up main-session continuation ends with a generic non-retryable provider error carrying zero content blocks (`stopReason: "error"`). Before this change the terminal error turn was the last in-memory assistant message but was never written to the session file, so a focus/unfocus or reload rebuild — which reads only persisted entries — lost it entirely. Captured live in session `019f8741-b654-7000-b71f-2d032c8a0680` (macOS, `omp/17.0.7`). Regression harness: `bun test test/agent-session-terminal-error-persistence.test.ts` (asserts one persisted `stopReason: "error"` entry after a failed tool call — fails pre-fix with `Received length: 0`).

## Cause
`AgentSession.#persistSessionMessageIfMissing` (`packages/coding-agent/src/session/agent-session.ts`) deliberately skips any `isEmptyErrorTurn` message — a `stopReason: "error"` turn with no text/thinking/tool-call content — to avoid replaying an empty provider-rejection on reload, on the assumption that such errors are always "surfaced live (pinned)". But the `agent_end` maintenance-routing terminal fall-through (`#processAgentEvent`) neither retried the turn (a generic error isn't in `RETRIABLE_KINDS`, `packages/ai/src/error/flags.ts`) nor persisted it. When `SessionFocusController.#attach` detaches the main session's UI subscription while a subagent transcript is focused, the live pinned render never fires — and with nothing on disk, the rebuild silently drops the error and its `errorMessage`. Only the retry-budget and delay-cap paths persisted empty error turns (via `#persistRetryLifecycleErrorMessage`); the plain non-retryable exit did not.

## Fix
- Renamed `#persistRetryLifecycleErrorMessage` to `#persistEmptyErrorTurn` and broadened its doc to cover every terminal exit of a content-less error turn (it already no-ops for non-empty or already-persisted turns).
- Persist the empty error turn on the maintenance-routing terminal fall-through, in the `else` branch of the existing classifier-refusal check so deliberately-pruned refusals stay unpersisted.
- Added `test/agent-session-terminal-error-persistence.test.ts` covering the failed-tool-then-non-retryable-error path.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/agent-session-terminal-error-persistence.test.ts test/agent-session-retry-cap.test.ts test/agent-session-retry-recovery.test.ts test/agent-session-retry-fallback.test.ts test/session/empty-error-turn.test.ts test/agent-session-manual-retry.test.ts test/agent-session-silent-abort.test.ts test/agent-session-empty-stop-guard.test.ts test/agent-session-unexpected-stop-guard.test.ts test/agent-session-session-stop-will-continue.test.ts test/agent-session-prune-persistence.test.ts test/session-focus-controller.test.ts` — 90 pass, 0 fail. `bun check` clean. Fixes #6250