### PR TITLE
fix(bash): inherit SSH agent socket from tmux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored `SSH_AUTH_SOCK` from the enclosing tmux server for Bash-tool commands when a GUI or broker launch omits it, so existing SSH-agent identities remain available without interactive passphrase prompts.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -267,12 +267,39 @@ function resolveUserShellConfig(settings: Settings, baseConfig: ShellConfig): Sh
 	};
 }
 
+const SSH_AUTH_SOCK = "SSH_AUTH_SOCK";
+
+/**
+ * Restores an SSH-agent socket exported by the enclosing tmux server when the
+ * coding-agent host itself was launched without that environment variable.
+ *
+ * tmux holds the environment from the interactive shell that started it, so
+ * this covers GUI/broker launches that lose SSH_AUTH_SOCK while keeping the
+ * fallback scoped to the current user's default tmux server.
+ */
+async function resolveTmuxSshAgentEnv(): Promise<Record<string, string>> {
+	if (Bun.env[SSH_AUTH_SOCK] || process.platform === "win32") return {};
+
+	const tmux = Bun.which("tmux");
+	if (!tmux) return {};
+
+	const result = await Bun.$`${tmux} show-environment -g ${SSH_AUTH_SOCK}`.quiet().nothrow();
+	const value = result
+		.text()
+		.trim()
+		.match(new RegExp(`^${SSH_AUTH_SOCK}=(.+)$`))?.[1];
+	return value?.startsWith("/") ? { [SSH_AUTH_SOCK]: value } : {};
+}
+
 export async function executeBash(command: string, options?: BashExecutorOptions): Promise<BashResult> {
 	const settings = await Settings.init();
 	const baseShellConfig = settings.getShellConfig();
 	const shellConfig =
 		options?.useUserShell === true ? resolveUserShellConfig(settings, baseShellConfig) : baseShellConfig;
-	const { shell, args, env: shellEnv, prefix } = shellConfig;
+	const { shell, args, env: configuredShellEnv, prefix } = shellConfig;
+	const shellEnv = configuredShellEnv[SSH_AUTH_SOCK]
+		? configuredShellEnv
+		: { ...configuredShellEnv, ...(await resolveTmuxSshAgentEnv()) };
 	const bashShell = isBashShell(shell);
 	const snapshotPath = bashShell ? await getOrCreateSnapshot(shell, shellEnv) : null;
 

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -197,6 +197,47 @@ describe("executeBash", () => {
 		expect(result.output.trim()).toBe("hello");
 	});
 
+	it("inherits an SSH agent socket from tmux when the host omits it", async () => {
+		if (process.platform === "win32") return;
+
+		const originalPath = Bun.env.PATH;
+		const originalSocket = Bun.env.SSH_AUTH_SOCK;
+		const binDir = path.join(tempDir, "bin");
+		const socket = "/tmp/omp-test-ssh-agent.sock";
+		fs.mkdirSync(binDir);
+		fs.writeFileSync(
+			path.join(binDir, "tmux"),
+			`#!/bin/sh
+printf '%s\\n' 'SSH_AUTH_SOCK=${socket}'
+`,
+			{ mode: 0o755 },
+		);
+
+		try {
+			Bun.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+			delete Bun.env.SSH_AUTH_SOCK;
+			vi.spyOn(Bun, "which").mockReturnValue(path.join(binDir, "tmux"));
+			vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+				shell: "/bin/bash",
+				args: ["-c"],
+				env: { PATH: Bun.env.PATH, HOME: tempDir, SHELL: "/bin/bash" },
+				prefix: undefined,
+			});
+
+			const result = await executeBash('printf "%s" "$SSH_AUTH_SOCK"', {
+				cwd: tempDir,
+				sessionKey: `ssh-agent-${Date.now()}`,
+				timeout: 5000,
+			});
+			expect(result.output).toBe(socket);
+		} finally {
+			if (originalPath === undefined) delete Bun.env.PATH;
+			else Bun.env.PATH = originalPath;
+			if (originalSocket === undefined) delete Bun.env.SSH_AUTH_SOCK;
+			else Bun.env.SSH_AUTH_SOCK = originalSocket;
+		}
+	});
+
 	it("applies non-interactive environment defaults", async () => {
 		const result = await executeBash('echo "$GIT_TERMINAL_PROMPT:$PI_TEST_ENV"', {
 			cwd: tempDir,


### PR DESCRIPTION
## Problem

A coding-agent process started by a GUI or broker can lose `SSH_AUTH_SOCK` even while its enclosing tmux server retains it. Bash-tool SSH commands then cannot use the user’s already-unlocked identity.

## Fix

When the host and configured shell environment both lack `SSH_AUTH_SOCK`, read the value from the current user’s tmux global environment and pass it only to the Bash shell session. Existing explicit values retain precedence; Windows is unchanged.

## Verification

- `bun test packages/coding-agent/test/bash-executor.test.ts`
- `bun --cwd=packages/coding-agent run check`