### PR TITLE
fix(settings): merge global model roles per-role on save

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed global `setModelRole` persisting the entire stale in-memory `modelRoles` record, which clobbered concurrent/external per-role edits to `config.yml` (roles reverted, added keys vanished) when a process with a stale global snapshot made one global model switch. Global saves now merge only the changed role into the re-read file, mirroring the project save path ([#6260](https://github.com/can1357/oh-my-pi/issues/6260)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -330,6 +330,8 @@ export class Settings {
 	#modified = new Set<string>();
 	/** Individual project model roles modified during this session */
 	#modifiedProjectModelRoles = new Set<string>();
+	/** Individual global model roles modified during this session (for partial save) */
+	#modifiedGlobalModelRoles = new Set<string>();
 	/**
 	 * Original process-wide model-role overrides captured before a project edit
 	 * temporarily replaced them via `#updateRuntimeModelRoleOverride`. Restored
@@ -551,7 +553,7 @@ export class Settings {
 		if (this.#projectSavePromise) {
 			await this.#projectSavePromise;
 		}
-		if (this.#modified.size > 0) {
+		if (this.#modified.size > 0 || this.#modifiedGlobalModelRoles.size > 0) {
 			await this.#saveNow();
 		}
 		if (this.#modifiedProjectModelRoles.size > 0) {
@@ -833,13 +835,22 @@ export class Settings {
 	 * stale skip in place.
 	 */
 	setModelRole(role: ModelRole | string, modelId: string | undefined): void {
+		const prev = this.get("modelRoles");
 		const current = this.#modelRolesFromLayer(this.#global);
 		if (modelId === undefined) {
 			delete current[role];
 		} else {
 			current[role] = modelId;
 		}
-		this.set("modelRoles", current);
+		// Persist per-role rather than marking the whole `modelRoles` path
+		// modified: #saveNow merges only the changed role into the re-read
+		// file, so a concurrent external edit to a sibling role is not
+		// clobbered by this process's stale in-memory snapshot.
+		setByPath(this.#global, ["modelRoles"], current);
+		this.#modifiedGlobalModelRoles.add(role);
+		this.#rebuildMerged();
+		this.#queueSave();
+		this.#fireEffectiveSettingChanged("modelRoles", this.get("modelRoles"), prev);
 		if (this.isProjectModelRoleRuntimeOverrideActive(role)) {
 			return;
 		}
@@ -1634,22 +1645,42 @@ export class Settings {
 	}
 
 	async #saveNow(): Promise<void> {
-		if (!this.#persist || !this.#configPath || this.#modified.size === 0) return;
+		if (!this.#persist || !this.#configPath) return;
+		if (this.#modified.size === 0 && this.#modifiedGlobalModelRoles.size === 0) return;
 
 		const configPath = this.#configPath;
 		const modifiedPaths = [...this.#modified];
+		const modifiedModelRoles = [...this.#modifiedGlobalModelRoles];
 		this.#modified.clear();
+		this.#modifiedGlobalModelRoles.clear();
 
 		try {
 			await withFileLock(configPath, async () => {
 				// Re-read to preserve external changes
 				const current = await this.#loadYaml(configPath);
 
-				// Apply only our modified paths
+				// Apply only our modified whole-value paths
 				for (const modPath of modifiedPaths) {
 					const segments = modPath.split(".");
 					const value = getByPath(this.#global, segments);
 					setByPath(current, segments, value);
+				}
+
+				// Merge only the model roles we changed, so a concurrent
+				// external edit to a sibling role survives instead of being
+				// clobbered by our stale whole-map snapshot.
+				if (modifiedModelRoles.length > 0) {
+					const globalRoles = this.#modelRolesFromLayer(this.#global);
+					const currentRoles = getByPath(current, ["modelRoles"]);
+					const mergedRoles: Record<string, unknown> = isRecord(currentRoles) ? { ...currentRoles } : {};
+					for (const role of modifiedModelRoles) {
+						if (Object.hasOwn(globalRoles, role)) {
+							mergedRoles[role] = globalRoles[role];
+						} else {
+							delete mergedRoles[role];
+						}
+					}
+					setByPath(current, ["modelRoles"], mergedRoles);
 				}
 
 				// Update our global with any external changes we preserved
@@ -1661,6 +1692,9 @@ export class Settings {
 			// Re-add failed paths for retry
 			for (const p of modifiedPaths) {
 				this.#modified.add(p);
+			}
+			for (const role of modifiedModelRoles) {
+				this.#modifiedGlobalModelRoles.add(role);
 			}
 		}
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1630,7 +1630,8 @@ export class Settings {
 		clearTimeout(this.#saveTimer);
 		this.#saveTimer = setTimeout(() => {
 			this.#saveTimer = undefined;
-			const savePromise = this.#saveNow();
+			const previousSave = this.#savePromise;
+			const savePromise = previousSave ? previousSave.then(() => this.#saveNow()) : this.#saveNow();
 			this.#savePromise = savePromise;
 			savePromise
 				.catch(err => {
@@ -1705,6 +1706,15 @@ export class Settings {
 				// Update our global with any external changes we preserved
 				this.#global = current;
 				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				// These pending roles were included in this write. Remove each
+				// only if no newer local change arrived while Bun.write was in
+				// flight; a newer value still needs the queued follow-up save.
+				const globalRolesAfterWrite = this.#modelRolesFromLayer(this.#global);
+				for (const role of rolesToPreserve) {
+					if (latestGlobalRoles[role] === globalRolesAfterWrite[role]) {
+						this.#modifiedGlobalModelRoles.delete(role);
+					}
+				}
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1651,6 +1651,7 @@ export class Settings {
 		const configPath = this.#configPath;
 		const modifiedPaths = [...this.#modified];
 		const modifiedModelRoles = [...this.#modifiedGlobalModelRoles];
+		const globalRolesAtStart = this.#modelRolesFromLayer(this.#global);
 		this.#modified.clear();
 		this.#modifiedGlobalModelRoles.clear();
 
@@ -1666,16 +1667,34 @@ export class Settings {
 					setByPath(current, segments, value);
 				}
 
-				// Merge only the model roles we changed, so a concurrent
-				// external edit to a sibling role survives instead of being
-				// clobbered by our stale whole-map snapshot.
-				if (modifiedModelRoles.length > 0) {
-					const globalRoles = this.#modelRolesFromLayer(this.#global);
+				// Merge only the model roles captured by this save. Then retain
+				// any role changed while the async read/lock was pending before
+				// replacing #global, so the follow-up save still sees its value.
+				const latestGlobalRoles = this.#modelRolesFromLayer(this.#global);
+				const rolesToPreserve = new Set(this.#modifiedGlobalModelRoles);
+				for (const role in globalRolesAtStart) {
+					if (globalRolesAtStart[role] !== latestGlobalRoles[role]) {
+						rolesToPreserve.add(role);
+					}
+				}
+				for (const role in latestGlobalRoles) {
+					if (globalRolesAtStart[role] !== latestGlobalRoles[role]) {
+						rolesToPreserve.add(role);
+					}
+				}
+				if (modifiedModelRoles.length > 0 || rolesToPreserve.size > 0) {
 					const currentRoles = getByPath(current, ["modelRoles"]);
 					const mergedRoles: Record<string, unknown> = isRecord(currentRoles) ? { ...currentRoles } : {};
 					for (const role of modifiedModelRoles) {
-						if (Object.hasOwn(globalRoles, role)) {
-							mergedRoles[role] = globalRoles[role];
+						if (Object.hasOwn(globalRolesAtStart, role)) {
+							mergedRoles[role] = globalRolesAtStart[role];
+						} else {
+							delete mergedRoles[role];
+						}
+					}
+					for (const role of rolesToPreserve) {
+						if (Object.hasOwn(latestGlobalRoles, role)) {
+							mergedRoles[role] = latestGlobalRoles[role];
 						} else {
 							delete mergedRoles[role];
 						}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -422,6 +422,41 @@ describe("Settings", () => {
 			expect(settings.getModelRole("smol")).toBe("anthropic/claude-haiku-4-5");
 		});
 
+		it("preserves concurrent external per-role edits when saving one global role", async () => {
+			await writeSettings({
+				modelRoles: { default: "anthropic/claude-sonnet-4-5", advisor: "moonshot/kimi-k2" },
+			});
+
+			// Process loads its #global snapshot.
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			// External edit (another omp instance / manual edit): changes advisor,
+			// adds vision. This process's #global is now stale.
+			await writeSettings({
+				modelRoles: {
+					default: "anthropic/claude-sonnet-4-5",
+					advisor: "moonshot/kimi-k3:max",
+					vision: "anthropic/claude-haiku-4-5",
+				},
+			});
+
+			// This process makes one global-scope role switch and flushes.
+			settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+			await settings.flush();
+
+			const savedSettings = await readSettings();
+			// The role we changed lands…
+			expect((savedSettings.modelRoles as Record<string, string>).smol).toBe("anthropic/claude-haiku-4-5");
+			// …and the concurrent external per-role edits survive rather than
+			// being clobbered by our stale whole-map snapshot.
+			expect(savedSettings.modelRoles).toEqual({
+				default: "anthropic/claude-sonnet-4-5",
+				advisor: "moonshot/kimi-k3:max",
+				vision: "anthropic/claude-haiku-4-5",
+				smol: "anthropic/claude-haiku-4-5",
+			});
+		});
+
 		it("restores persisted model roles after clearing runtime overrides", async () => {
 			await writeSettings({
 				modelRoles: { default: "anthropic/claude-sonnet-4-5" },

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-ai";
@@ -18,6 +18,7 @@ import {
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
+import * as fileLock from "../src/config/file-lock";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
 
 function context(): Context {
@@ -62,6 +63,7 @@ describe("Settings", () => {
 	};
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		clearCustomApis();
 		__providerInFlightForTesting.setRoot(undefined);
 		AgentStorage.resetInstance();
@@ -454,6 +456,34 @@ describe("Settings", () => {
 				advisor: "moonshot/kimi-k3:max",
 				vision: "anthropic/claude-haiku-4-5",
 				smol: "anthropic/claude-haiku-4-5",
+			});
+		});
+
+		it("preserves a global role changed while an earlier save is pending", async () => {
+			await writeSettings({
+				modelRoles: { default: "anthropic/claude-sonnet-4-5" },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const firstSaveEntered = Promise.withResolvers<void>();
+			const releaseFirstSave = Promise.withResolvers<void>();
+			const withFileLock = fileLock.withFileLock;
+			vi.spyOn(fileLock, "withFileLock").mockImplementation(async (filePath, fn, options) => {
+				firstSaveEntered.resolve();
+				await releaseFirstSave.promise;
+				return withFileLock(filePath, fn, options);
+			});
+
+			settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
+			await firstSaveEntered.promise;
+			settings.setModelRole("advisor", "moonshot/kimi-k3:max");
+			releaseFirstSave.resolve();
+			await settings.flush();
+
+			expect(settings.getGlobalModelRole("advisor")).toBe("moonshot/kimi-k3:max");
+			expect((await readSettings()).modelRoles).toEqual({
+				default: "anthropic/claude-sonnet-4-5",
+				smol: "anthropic/claude-haiku-4-5",
+				advisor: "moonshot/kimi-k3:max",
 			});
 		});
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -459,31 +459,48 @@ describe("Settings", () => {
 			});
 		});
 
-		it("preserves a global role changed while an earlier save is pending", async () => {
+		it("does not replay a preserved role after the save writes it", async () => {
 			await writeSettings({
 				modelRoles: { default: "anthropic/claude-sonnet-4-5" },
 			});
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			const firstSaveEntered = Promise.withResolvers<void>();
 			const releaseFirstSave = Promise.withResolvers<void>();
+			const firstSaveFinished = Promise.withResolvers<void>();
 			const withFileLock = fileLock.withFileLock;
 			vi.spyOn(fileLock, "withFileLock").mockImplementation(async (filePath, fn, options) => {
 				firstSaveEntered.resolve();
 				await releaseFirstSave.promise;
-				return withFileLock(filePath, fn, options);
+				const result = await withFileLock(filePath, fn, options);
+				firstSaveFinished.resolve();
+				return result;
 			});
 
 			settings.setModelRole("smol", "anthropic/claude-haiku-4-5");
 			await firstSaveEntered.promise;
 			settings.setModelRole("advisor", "moonshot/kimi-k3:max");
 			releaseFirstSave.resolve();
-			await settings.flush();
+			await firstSaveFinished.promise;
 
-			expect(settings.getGlobalModelRole("advisor")).toBe("moonshot/kimi-k3:max");
 			expect((await readSettings()).modelRoles).toEqual({
 				default: "anthropic/claude-sonnet-4-5",
 				smol: "anthropic/claude-haiku-4-5",
 				advisor: "moonshot/kimi-k3:max",
+			});
+
+			await writeSettings({
+				modelRoles: {
+					default: "anthropic/claude-sonnet-4-5",
+					smol: "anthropic/claude-haiku-4-5",
+					advisor: "external/new-advisor",
+				},
+			});
+			await settings.flush();
+
+			expect((await readSettings()).modelRoles).toEqual({
+				default: "anthropic/claude-sonnet-4-5",
+				smol: "anthropic/claude-haiku-4-5",
+				advisor: "external/new-advisor",
 			});
 		});
 


### PR DESCRIPTION
## Repro
When a process loads its global `#global` snapshot, an external edit changes `config.yml` `modelRoles` (another omp instance or a manual edit), and this process then makes one global-scope model switch (`setModelRole`) and flushes, the flush wrote back the process's stale whole `modelRoles` map — reverting the externally-changed roles and deleting externally-added keys. Only `modelRoles` reverted; sibling top-level keys survived.

Reproduced with a regression test in `packages/coding-agent/test/settings-manager.test.ts` (`preserves concurrent external per-role edits when saving one global role`): seed `default`+`advisor`, load `Settings`, external-edit to change `advisor` and add `vision`, then `setModelRole("smol", …)` + `flush()`. Before the fix, `advisor` reverted and `vision` vanished.

```
bun test test/settings-manager.test.ts -t "preserves concurrent external per-role edits"
```

## Cause
`Settings.setModelRole` (`packages/coding-agent/src/config/settings.ts`) read the entire in-memory `modelRoles` map via `#modelRolesFromLayer(this.#global)`, mutated one role, then called `this.set("modelRoles", current)`, marking the whole `modelRoles` path in `#modified`. `#saveNow` re-reads the disk file to preserve external changes but then `setByPath(current, ["modelRoles"], staleMap)` overwrote the entire re-read record with the stale in-memory map, defeating the preservation for any role it did not itself change. The project save path (`#setProjectModelRoleValue` + `#saveProjectNow`) already tracked per-role granularity via `#modifiedProjectModelRoles`; the global path did not.

## Fix
- Added `#modifiedGlobalModelRoles: Set<string>`, parallel to `#modifiedProjectModelRoles`.
- `setModelRole` now writes the updated map into `#global`, records only the changed role in `#modifiedGlobalModelRoles`, rebuilds/queues save, and fires the `modelRoles` change signal — without marking the whole `modelRoles` path in `#modified`.
- `#saveNow` merges only the recorded roles into the re-read file's `modelRoles` record (set when present in `#global`, delete when cleared), leaving sibling roles from concurrent external edits intact; failed saves re-queue the roles for retry.
- `flush` and the `#saveNow` guard now trigger when only global model roles are pending.

## Verification
`bun test test/settings-manager.test.ts` — 60 pass, 0 fail (includes the new regression test and the existing model-role/external-edit-preservation tests). `bun check` passed via the pre-publish gate. The unrelated `selector-settings-side-effects.test.ts` failure in this worktree is a missing build-generated artifact (`src/export/html/tool-views.generated.js`, produced by `gen:tool-views`/`prepack`), not caused by this diff.

Fixes #6260