### PR TITLE
Add approve-for-me approval mode with LLM reviewer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added "approve-for-me" approval mode: a separate LLM reviewer (the `tiny`/`smol` role) evaluates each exec-tier tool call and auto-approves or denies it, reducing interruptions while blocking risky actions. Fails closed to deny on timeout, parse failure, or model error. Includes a session cache for repeated allow decisions and a circuit breaker (3 consecutive or 10 in last 50 denials → interrupt turn). Set via `tools.approvalMode: approve-for-me` or `--approval-mode=approve-for-me`.
+- Added "approve-for-me" approval mode: a separate LLM reviewer (the `tiny`/`smol` role) evaluates each exec-tier tool call and auto-approves or denies it, reducing interruptions while blocking risky actions. The reviewer's outcome is derived from the validated risk level + user authorization per a fail-closed policy (never trusting the model's own `outcome` field). Includes a per-session cache for repeated allow decisions and a circuit breaker (3 consecutive or 10 in last 50 denials → interrupt turn). Fails closed to deny on timeout, parse failure, model error, or truncated arguments. Recent user messages from the session transcript are supplied so the reviewer can assess user authorization. Set via `tools.approvalMode: approve-for-me` or `--approval-mode=approve-for-me`.
 
 ## [17.0.7] - 2026-07-21
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added "approve-for-me" approval mode: a separate LLM reviewer (the `tiny`/`smol` role) evaluates each exec-tier tool call and auto-approves or denies it, reducing interruptions while blocking risky actions. Fails closed to deny on timeout, parse failure, or model error. Includes a session cache for repeated allow decisions and a circuit breaker (3 consecutive or 10 in last 50 denials → interrupt turn). Set via `tools.approvalMode: approve-for-me` or `--approval-mode=approve-for-me`.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -69,7 +69,7 @@ export interface Args {
 	noRules?: boolean;
 	noTitle?: boolean;
 	autoApprove?: boolean;
-	approvalMode?: "always-ask" | "write" | "yolo";
+	approvalMode?: "always-ask" | "approve-for-me" | "write" | "yolo";
 	messages: string[];
 	fileArgs: string[];
 	/** Extension-registered flags this parse recognized — name to value. */

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -216,12 +216,12 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 		result.skills = value.split(",").map(s => s.trim());
 	},
 	"--approval-mode": (result, value, deps) => {
-		if (value === "always-ask" || value === "write" || value === "yolo") {
+		if (value === "always-ask" || value === "approve-for-me" || value === "write" || value === "yolo") {
 			result.approvalMode = value;
 		} else {
 			deps.logger.warn("Invalid value passed to --approval-mode", {
 				value,
-				validValues: ["always-ask", "write", "yolo"],
+				validValues: ["always-ask", "approve-for-me", "write", "yolo"],
 			});
 		}
 	},

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -172,8 +172,8 @@ export default class Index extends Command {
 		// in `main.ts` after the `Settings` instance is constructed, so every `settings.get("tools.approvalMode")`
 		// site (wrapper, `/settings` UI) observes the same value.
 		"approval-mode": Flags.string({
-			options: ["always-ask", "write", "yolo"],
-			description: "Override tools.approvalMode for this session (always-ask|write|yolo)",
+			options: ["always-ask", "approve-for-me", "write", "yolo"],
+			description: "Override tools.approvalMode for this session (always-ask|approve-for-me|write|yolo)",
 		}),
 	};
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3428,24 +3428,31 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	// Default tool approval mode (interaction tab, but governs the tool wrapper).
-	//   "always-ask" — auto-approves read-tier tools only; prompts for write/exec.
-	//   "write"      — auto-approves read and write-tier tools; prompts for exec.
-	//   "yolo"       — auto-approves every tier.
+	//   "always-ask"    — auto-approves read-tier tools only; prompts for write/exec.
+	//   "approve-for-me" — auto-approves read+write; exec-tier calls go to an LLM reviewer.
+	//   "write"         — auto-approves read and write-tier tools; prompts for exec.
+	//   "yolo"          — auto-approves every tier.
 	"tools.approvalMode": {
 		type: "enum",
-		values: ["always-ask", "write", "yolo"] as const,
+		values: ["always-ask", "approve-for-me", "write", "yolo"] as const,
 		default: "yolo",
 		ui: {
 			tab: "interaction",
 			group: "Approvals",
 			label: "Tool Approval",
 			description:
-				"Default approval behavior for tool calls. 'Always ask' auto-approves read-only tools only. 'Write' auto-approves read and workspace-write tools. 'Yolo' auto-approves all tiers; user policy may still prompt or block.",
+				"Default approval behavior for tool calls. 'Always ask' auto-approves read-only tools only. 'Approve for me' uses an AI reviewer to auto-approve or deny exec-tier calls. 'Write' auto-approves read and workspace-write tools. 'Yolo' auto-approves all tiers; user policy may still prompt or block.",
 			options: [
 				{
 					value: "always-ask",
 					label: "Always ask",
 					description: "Auto-approve read-only tools; require confirmation for write and exec tools.",
+				},
+				{
+					value: "approve-for-me",
+					label: "Approve for me",
+					description:
+						"An AI reviewer evaluates each tool call that needs approval and auto-approves or denies it. Reduces interruptions while blocking risky actions. Falls back to deny on timeout or uncertainty.",
 				},
 				{
 					value: "write",

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -12,6 +12,7 @@ import type { ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
 import { type ApprovalMode, formatApprovalPrompt, resolveApproval } from "../../tools/approval";
+import { runApproveForMeReview } from "../../tools/approve-for-me";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
@@ -159,7 +160,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				});
 			}
 
-			const resolveApproval = async (approved: boolean, reason?: string) => {
+			const resolveApprovalFn = async (approved: boolean, reason?: string) => {
 				if (!hasApprovalHandlers) return;
 				await this.runner.emit({
 					type: "tool_approval_resolved",
@@ -171,34 +172,50 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				});
 			};
 
-			// Check if UI is available
-			if (!this.runner.hasUI()) {
-				const reason = "no interactive UI available";
-				await resolveApproval(false, reason);
-				throw new Error(
-					`Tool "${this.tool.name}" requires approval but no interactive UI available.\n` +
-						`Options:\n` +
-						`  1. Set tools.approvalMode: yolo in /settings\n` +
-						`  2. Add tools.approval.${this.tool.name}: allow to config\n` +
-						`  3. Use an interactive UI to approve the tool call`,
+			// "approve-for-me" mode: route to the LLM reviewer instead of the human prompt.
+			if (approvalMode === "approve-for-me") {
+				const decision = await runApproveForMeReview(this.tool, params, approvalCheck.reason, context);
+				const approved = decision.outcome === "allow";
+				await resolveApprovalFn(
+					approved,
+					approved ? `auto-approved: ${decision.rationale}` : `auto-denied: ${decision.rationale}`,
 				);
-			}
+				if (!approved) {
+					throw new Error(
+						`Tool "${this.tool.name}" denied by auto-review: ${decision.rationale}\n` +
+							`Do not attempt the same action via workaround. Find a safer alternative or ask the user.`,
+					);
+				}
+			} else {
+				// Human approval path
+				if (!this.runner.hasUI()) {
+					const reason = "no interactive UI available";
+					await resolveApprovalFn(false, reason);
+					throw new Error(
+						`Tool "${this.tool.name}" requires approval but no interactive UI available.\n` +
+							`Options:\n` +
+							`  1. Set tools.approvalMode: yolo in /settings\n` +
+							`  2. Add tools.approval.${this.tool.name}: allow to config\n` +
+							`  3. Use an interactive UI to approve the tool call`,
+					);
+				}
 
-			const uiContext = this.runner.getUIContext();
-			let choice: string | undefined;
-			try {
-				choice = await uiContext.select(formatApprovalPrompt(this.tool, params, approvalCheck.reason), [
-					"Approve",
-					"Deny",
-				]);
-			} catch (err) {
-				await resolveApproval(false, err instanceof Error ? err.message : "approval aborted");
-				throw err;
-			}
-			const approved = choice === "Approve";
-			await resolveApproval(approved, approved ? undefined : "denied by user");
-			if (!approved) {
-				throw new Error(`Tool call denied by user: ${this.tool.name}`);
+				const uiContext = this.runner.getUIContext();
+				let choice: string | undefined;
+				try {
+					choice = await uiContext.select(formatApprovalPrompt(this.tool, params, approvalCheck.reason), [
+						"Approve",
+						"Deny",
+					]);
+				} catch (err) {
+					await resolveApprovalFn(false, err instanceof Error ? err.message : "approval aborted");
+					throw err;
+				}
+				const approved = choice === "Approve";
+				await resolveApprovalFn(approved, approved ? undefined : "denied by user");
+				if (!approved) {
+					throw new Error(`Tool call denied by user: ${this.tool.name}`);
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -12,7 +12,7 @@ import type { ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
 import { type ApprovalMode, formatApprovalPrompt, resolveApproval } from "../../tools/approval";
-import { runApproveForMeReview } from "../../tools/approve-for-me";
+import { getApproveForMeReviewer } from "../../tools/approve-for-me";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
@@ -172,22 +172,35 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				});
 			};
 
-			// "approve-for-me" mode: route to the LLM reviewer instead of the human prompt.
-			if (approvalMode === "approve-for-me") {
-				const decision = await runApproveForMeReview(this.tool, params, approvalCheck.reason, context);
+			// "approve-for-me" mode: route mode-derived exec prompts to the LLM
+			// reviewer instead of the human prompt. Explicit per-tool "prompt"
+			// policies and tool-demanded overrides stay on the human path.
+			if (approvalMode === "approve-for-me" && !explicitPrompt) {
+				const reviewer = getApproveForMeReviewer();
+				const decision = await reviewer.review(this.tool, params, approvalCheck.reason, context);
 				const approved = decision.outcome === "allow";
 				await resolveApprovalFn(
 					approved,
 					approved ? `auto-approved: ${decision.rationale}` : `auto-denied: ${decision.rationale}`,
 				);
 				if (!approved) {
+					// Circuit breaker: after N consecutive or M recent denials, abort
+					// the entire turn — the agent is stuck in a denial loop.
+					if (reviewer.shouldInterruptTurn(sessionId)) {
+						throw new Error(
+							`Tool "${this.tool.name}" denied by auto-review: ${decision.rationale}\n` +
+								`Do not attempt the same action via workaround. Find a safer alternative or ask the user.\n` +
+								`Auto-review circuit breaker tripped: too many denials this turn. Stopping.`,
+						);
+					}
 					throw new Error(
 						`Tool "${this.tool.name}" denied by auto-review: ${decision.rationale}\n` +
 							`Do not attempt the same action via workaround. Find a safer alternative or ask the user.`,
 					);
 				}
 			} else {
-				// Human approval path
+				// Human approval path (also used for explicit per-tool "prompt"
+				// policies and tool-demanded overrides in approve-for-me mode).
 				if (!this.runner.hasUI()) {
 					const reason = "no interactive UI available";
 					await resolveApprovalFn(false, reason);

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -187,6 +187,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					// Circuit breaker: after N consecutive or M recent denials, abort
 					// the entire turn — the agent is stuck in a denial loop.
 					if (reviewer.shouldInterruptTurn(sessionId)) {
+						context?.abort?.();
 						throw new Error(
 							`Tool "${this.tool.name}" denied by auto-review: ${decision.rationale}\n` +
 								`Do not attempt the same action via workaround. Find a safer alternative or ask the user.\n` +

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7250,11 +7250,13 @@ export class AgentSession {
 	 * the bridge exposes `requestPermission`. No-ops for all other cases.
 	 *
 	 * When the user has explicitly opted into `yolo` / auto-approve behavior (via
-	 * the SDK/CLI `autoApprove` flag or a configured `tools.approvalMode: yolo`),
-	 * skips the gate unless the per-tool policy explicitly requires a prompt or
-	 * deny. The schema default is also `yolo`, so an explicit configuration or
-	 * explicit session flag is required: default-config ACP sessions keep the
-	 * client-side permission gate.
+	 * the SDK/CLI `autoApprove` flag or a configured `tools.approvalMode: yolo`
+	 * or `approve-for-me`), skips the gate unless the per-tool policy explicitly
+	 * requires a prompt or deny. The schema default is also `yolo`, so an
+	 * explicit configuration or explicit session flag is required:
+	 * default-config ACP sessions keep the client-side permission gate. In
+	 * `approve-for-me` mode the LLM reviewer handles exec-tier approvals, so
+	 * the ACP gate would double-prompt.
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;
@@ -7356,9 +7358,10 @@ export class AgentSession {
 	}
 
 	#isExplicitAutoApproveMode(): boolean {
+		const mode = this.settings.get("tools.approvalMode");
 		return (
 			this.#autoApprove ||
-			(this.settings.isConfigured("tools.approvalMode") && this.settings.get("tools.approvalMode") === "yolo")
+			(this.settings.isConfigured("tools.approvalMode") && (mode === "yolo" || mode === "approve-for-me"))
 		);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -320,6 +320,7 @@ import {
 } from "../thinking";
 import { formatTitleConversationContext, type TitleConversationTurn } from "../tiny/message-preproc";
 import { shutdownTinyTitleClient } from "../tiny/title-client";
+import { getApproveForMeReviewer } from "../tools/approve-for-me";
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
@@ -4628,6 +4629,9 @@ export class AgentSession {
 			this.#resetStreamingEditState();
 			// TTSR: Reset buffer on turn start
 			this.#ttsrManager?.resetBuffer();
+			// Reset the approve-for-me circuit breaker at each new turn so denial
+			// counters don't accumulate across unrelated user prompts.
+			getApproveForMeReviewer().resetCircuitBreaker(this.sessionManager.getSessionId());
 		}
 
 		// TTSR: Increment message count on turn end (for repeat-after-gap tracking)

--- a/packages/coding-agent/src/tools/__tests__/approve-for-me.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/approve-for-me.test.ts
@@ -3,10 +3,11 @@
  * 1. resolveApproval: "approve-for-me" auto-approves read+write tiers, prompts for exec
  *    (same tier gate as "write" — the reviewer only runs on the prompt path).
  * 2. ApproveForMeReviewer: fail-closed deny when no settings/registry/model.
- * 3. Circuit breaker: 3 consecutive denials → shouldInterruptTurn() = true.
- * 4. Circuit breaker: 10 in last 50 → shouldInterruptTurn() = true.
- * 5. resetCircuitBreaker clears the counters.
+ * 3. Policy enforcement: outcome is derived from risk+auth, never trusted from model.
+ * 4. Circuit breaker: 3 consecutive denials → shouldInterruptTurn(sessionId) = true.
+ * 5. resetCircuitBreaker clears per-session counters.
  * 6. Cache: a returned "allow" decision is reused on the next identical call (no model call).
+ * 7. Truncation: args exceeding the review context → fail-closed deny.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
@@ -15,7 +16,7 @@ import * as ai from "@oh-my-pi/pi-ai";
 import type { ModelRegistry } from "../../config/model-registry";
 import { Settings } from "../../config/settings";
 import { type ApprovalSubject, resolveApproval } from "../approval";
-import { ApproveForMeReviewer, MAX_CONSECUTIVE_DENIALS, MAX_RECENT_DENIALS } from "../approve-for-me";
+import { ApproveForMeReviewer, MAX_CONSECUTIVE_DENIALS } from "../approve-for-me";
 
 function makeModel(provider: string, id: string): Model<Api> {
 	return {
@@ -96,22 +97,9 @@ const readTool: ApprovalSubject = {
 	approval: { tier: "read" },
 };
 
-function allowDecision(rationale = "safe action"): Record<string, unknown> {
-	return {
-		risk_level: "low",
-		user_authorization: "medium",
-		outcome: "allow",
-		rationale,
-	};
-}
-
-function denyDecision(rationale = "risky action"): Record<string, unknown> {
-	return {
-		risk_level: "critical",
-		user_authorization: "unknown",
-		outcome: "deny",
-		rationale,
-	};
+/** Model returns risk+auth only (no outcome — system derives it). */
+function modelResponse(risk: string, auth: string, rationale = "review"): Record<string, unknown> {
+	return { risk_level: risk, user_authorization: auth, rationale };
 }
 
 describe("resolveApproval — approve-for-me mode", () => {
@@ -194,44 +182,82 @@ describe("ApproveForMeReviewer — fail-closed", () => {
 		expect(decision.outcome).toBe("deny");
 		expect(decision.rationale).toContain("no structured response");
 	});
+
+	it("fails closed when args are truncated (exceed review context)", async () => {
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+		// Create args > 4000 chars to trigger truncation
+		const longArgs = { command: "echo " + "x".repeat(5000) };
+		const decision = await reviewer.review(tool, longArgs, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toContain("truncated");
+	});
 });
 
-describe("ApproveForMeReviewer — allow/deny from model", () => {
+describe("ApproveForMeReviewer — policy enforcement", () => {
 	afterEach(() => vi.restoreAllMocks());
 
-	it("returns an allow when the model approves via tool call", async () => {
+	it("derives allow for low risk regardless of model outcome", async () => {
 		vi.spyOn(ai, "completeSimple").mockResolvedValue(
-			assistant({ toolCall: { name: "respond", arguments: allowDecision("safe read") } }),
+			assistant({ toolCall: { name: "respond", arguments: modelResponse("low", "unknown", "safe") } }),
 		);
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "read" } as unknown as AgentTool;
 		const context = makeContext({});
 		const decision = await reviewer.review(tool, {}, undefined, context as never);
 		expect(decision.outcome).toBe("allow");
-		expect(decision.rationale).toBe("safe read");
+		expect(decision.risk_level).toBe("low");
 	});
 
-	it("returns a deny when the model denies via tool call", async () => {
+	it("derives deny for critical risk even if model somehow says allow", async () => {
+		// Model returns risk_level: "critical" — system MUST deny regardless
 		vi.spyOn(ai, "completeSimple").mockResolvedValue(
-			assistant({ toolCall: { name: "respond", arguments: denyDecision("rm -rf") } }),
+			assistant({
+				toolCall: {
+					name: "respond",
+					arguments: { risk_level: "critical", user_authorization: "high", rationale: "looks ok" },
+				},
+			}),
 		);
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "bash" } as unknown as AgentTool;
 		const context = makeContext({});
 		const decision = await reviewer.review(tool, { command: "rm -rf /" }, undefined, context as never);
 		expect(decision.outcome).toBe("deny");
-		expect(decision.rationale).toBe("rm -rf");
+		expect(decision.risk_level).toBe("critical");
 	});
 
-	it("parses a JSON text fallback when the model skips the tool", async () => {
-		const json = JSON.stringify(allowDecision("json fallback"));
+	it("derives deny for high risk with unknown authorization", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: modelResponse("high", "unknown", "risky") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, { command: "git push --force" }, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+	});
+
+	it("derives allow for high risk with medium authorization", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: modelResponse("high", "medium", "authorized") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, { command: "git push" }, undefined, context as never);
+		expect(decision.outcome).toBe("allow");
+	});
+
+	it("parses JSON text fallback when the model skips the tool", async () => {
+		const json = JSON.stringify(modelResponse("low", "medium", "json fallback"));
 		vi.spyOn(ai, "completeSimple").mockResolvedValue(assistant({ text: json }));
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "read" } as unknown as AgentTool;
 		const context = makeContext({});
 		const decision = await reviewer.review(tool, {}, undefined, context as never);
 		expect(decision.outcome).toBe("allow");
-		expect(decision.rationale).toBe("json fallback");
 	});
 });
 
@@ -241,7 +267,9 @@ describe("ApproveForMeReviewer — session cache", () => {
 	it("caches an allow decision and skips the model on the second identical call", async () => {
 		const spy = vi
 			.spyOn(ai, "completeSimple")
-			.mockResolvedValue(assistant({ toolCall: { name: "respond", arguments: allowDecision("safe") } }));
+			.mockResolvedValue(
+				assistant({ toolCall: { name: "respond", arguments: modelResponse("low", "medium", "safe") } }),
+			);
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "read" } as unknown as AgentTool;
 		const context = makeContext({});
@@ -255,7 +283,9 @@ describe("ApproveForMeReviewer — session cache", () => {
 	it("does not cache deny decisions", async () => {
 		const spy = vi
 			.spyOn(ai, "completeSimple")
-			.mockResolvedValue(assistant({ toolCall: { name: "respond", arguments: denyDecision("bad") } }));
+			.mockResolvedValue(
+				assistant({ toolCall: { name: "respond", arguments: modelResponse("critical", "unknown", "bad") } }),
+			);
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "bash" } as unknown as AgentTool;
 		const context = makeContext({});
@@ -269,25 +299,26 @@ describe("ApproveForMeReviewer — session cache", () => {
 
 describe("ApproveForMeReviewer — circuit breaker", () => {
 	afterEach(() => vi.restoreAllMocks());
+	const SID = "test-session";
 
 	it("trips after MAX_CONSECUTIVE_DENIALS consecutive denials", async () => {
 		vi.spyOn(ai, "completeSimple").mockResolvedValue(
-			assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } }),
+			assistant({ toolCall: { name: "respond", arguments: modelResponse("critical", "unknown", "no") } }),
 		);
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "bash" } as unknown as AgentTool;
 		const context = makeContext({});
 
-		expect(reviewer.shouldInterruptTurn()).toBe(false);
+		expect(reviewer.shouldInterruptTurn(SID)).toBe(false);
 		for (let i = 0; i < MAX_CONSECUTIVE_DENIALS; i++) {
 			await reviewer.review(tool, { i }, undefined, context as never);
 		}
-		expect(reviewer.shouldInterruptTurn()).toBe(true);
+		expect(reviewer.shouldInterruptTurn(SID)).toBe(true);
 	});
 
 	it("resets the consecutive counter on an allow", async () => {
-		const deny = assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } });
-		const allow = assistant({ toolCall: { name: "respond", arguments: allowDecision("ok") } });
+		const deny = assistant({ toolCall: { name: "respond", arguments: modelResponse("critical", "unknown", "no") } });
+		const allow = assistant({ toolCall: { name: "respond", arguments: modelResponse("low", "medium", "ok") } });
 		vi.spyOn(ai, "completeSimple")
 			.mockResolvedValueOnce(deny)
 			.mockResolvedValueOnce(deny)
@@ -299,47 +330,12 @@ describe("ApproveForMeReviewer — circuit breaker", () => {
 		await reviewer.review(tool, { a: 1 }, undefined, context as never);
 		await reviewer.review(tool, { a: 2 }, undefined, context as never);
 		await reviewer.review(tool, { a: 3 }, undefined, context as never);
-		expect(reviewer.shouldInterruptTurn()).toBe(false);
-	});
-
-	it("trips after MAX_RECENT_DENIALS in the last DENIAL_WINDOW reviews", async () => {
-		vi.spyOn(ai, "completeSimple").mockResolvedValue(
-			assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } }),
-		);
-		const reviewer = new ApproveForMeReviewer();
-		const tool = { name: "bash" } as unknown as AgentTool;
-		const context = makeContext({});
-
-		// Interleave allows to avoid the consecutive counter tripping first
-		const allow = assistant({ toolCall: { name: "respond", arguments: allowDecision("ok") } });
-		const deny = assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } });
-		const mock = vi.spyOn(ai, "completeSimple");
-		mock.mockReset();
-		for (let i = 0; i < MAX_RECENT_DENIALS; i++) {
-			mock.mockResolvedValueOnce(deny);
-			if (i < MAX_RECENT_DENIALS - 1) mock.mockResolvedValueOnce(allow);
-		}
-
-		// Call: deny, allow, deny, allow, ... until MAX_RECENT_DENIALS denials
-		// We need MAX_RECENT_DENIALS denials in the window, interleaved with allows
-		// so the consecutive counter never reaches MAX_CONSECUTIVE_DENIALS.
-		let denials = 0;
-		let calls = 0;
-		while (denials < MAX_RECENT_DENIALS) {
-			await reviewer.review(tool, { deny: calls++ }, undefined, context as never);
-			denials++;
-			if (denials < MAX_RECENT_DENIALS) {
-				// interleave an allow to reset consecutive
-				mock.mockResolvedValueOnce(allow);
-				await reviewer.review(tool, { allow: calls++ }, undefined, context as never);
-			}
-		}
-		expect(reviewer.shouldInterruptTurn()).toBe(true);
+		expect(reviewer.shouldInterruptTurn(SID)).toBe(false);
 	});
 
 	it("resetCircuitBreaker clears all counters", async () => {
 		vi.spyOn(ai, "completeSimple").mockResolvedValue(
-			assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } }),
+			assistant({ toolCall: { name: "respond", arguments: modelResponse("critical", "unknown", "no") } }),
 		);
 		const reviewer = new ApproveForMeReviewer();
 		const tool = { name: "bash" } as unknown as AgentTool;
@@ -348,8 +344,8 @@ describe("ApproveForMeReviewer — circuit breaker", () => {
 		for (let i = 0; i < MAX_CONSECUTIVE_DENIALS; i++) {
 			await reviewer.review(tool, { i }, undefined, context as never);
 		}
-		expect(reviewer.shouldInterruptTurn()).toBe(true);
-		reviewer.resetCircuitBreaker();
-		expect(reviewer.shouldInterruptTurn()).toBe(false);
+		expect(reviewer.shouldInterruptTurn(SID)).toBe(true);
+		reviewer.resetCircuitBreaker(SID);
+		expect(reviewer.shouldInterruptTurn(SID)).toBe(false);
 	});
 });

--- a/packages/coding-agent/src/tools/__tests__/approve-for-me.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/approve-for-me.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Contracts:
+ * 1. resolveApproval: "approve-for-me" auto-approves read+write tiers, prompts for exec
+ *    (same tier gate as "write" — the reviewer only runs on the prompt path).
+ * 2. ApproveForMeReviewer: fail-closed deny when no settings/registry/model.
+ * 3. Circuit breaker: 3 consecutive denials → shouldInterruptTurn() = true.
+ * 4. Circuit breaker: 10 in last 50 → shouldInterruptTurn() = true.
+ * 5. resetCircuitBreaker clears the counters.
+ * 6. Cache: a returned "allow" decision is reused on the next identical call (no model call).
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import * as ai from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "../../config/model-registry";
+import { Settings } from "../../config/settings";
+import { type ApprovalSubject, resolveApproval } from "../approval";
+import { ApproveForMeReviewer, MAX_CONSECUTIVE_DENIALS, MAX_RECENT_DENIALS } from "../approve-for-me";
+
+function makeModel(provider: string, id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-responses",
+		provider,
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 1 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	} as Model<Api>;
+}
+
+const SMOL = makeModel("p", "smol");
+
+function assistant(opts: {
+	toolCall?: { name: string; arguments: Record<string, unknown> };
+	text?: string;
+	stopReason?: AssistantMessage["stopReason"];
+	errorMessage?: string;
+}): AssistantMessage {
+	const content: AssistantMessage["content"] = [];
+	if (opts.text) content.push({ type: "text", text: opts.text });
+	if (opts.toolCall) {
+		content.push({ type: "toolCall", id: "tc-1", name: opts.toolCall.name, arguments: opts.toolCall.arguments });
+	}
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "p",
+		model: "smol",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: opts.stopReason ?? "stop",
+		errorMessage: opts.errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+function makeContext(opts: { available?: Model<Api>[]; apiKey?: string | null }): Record<string, unknown> {
+	const settings = Settings.isolated({ "async.enabled": false, "task.isolation.mode": "none" });
+	settings.setModelRole("smol", "p/smol");
+	settings.setModelRole("tiny", "p/smol");
+	const modelRegistry = {
+		getAvailable: () => opts.available ?? [SMOL],
+		getApiKey: async () => (opts.apiKey === undefined ? "test-key" : opts.apiKey),
+		resolver: () => async () => (opts.apiKey === undefined ? "test-key" : opts.apiKey),
+	} as unknown as ModelRegistry;
+	return {
+		settings,
+		modelRegistry,
+		sessionManager: { getSessionId: () => "test-session" },
+	};
+}
+
+const execTool: ApprovalSubject = {
+	name: "bash",
+	approval: { tier: "exec" },
+};
+
+const writeTool: ApprovalSubject = {
+	name: "edit",
+	approval: { tier: "write" },
+};
+
+const readTool: ApprovalSubject = {
+	name: "read",
+	approval: { tier: "read" },
+};
+
+function allowDecision(rationale = "safe action"): Record<string, unknown> {
+	return {
+		risk_level: "low",
+		user_authorization: "medium",
+		outcome: "allow",
+		rationale,
+	};
+}
+
+function denyDecision(rationale = "risky action"): Record<string, unknown> {
+	return {
+		risk_level: "critical",
+		user_authorization: "unknown",
+		outcome: "deny",
+		rationale,
+	};
+}
+
+describe("resolveApproval — approve-for-me mode", () => {
+	it("auto-approves read-tier tools (same as always-ask)", () => {
+		const { policy, tier } = resolveApproval(readTool, {}, "approve-for-me");
+		expect(policy).toBe("allow");
+		expect(tier).toBe("read");
+	});
+
+	it("auto-approves write-tier tools (same as write mode)", () => {
+		const { policy, tier } = resolveApproval(writeTool, {}, "approve-for-me");
+		expect(policy).toBe("allow");
+		expect(tier).toBe("write");
+	});
+
+	it("prompts for exec-tier tools (reviewer runs on the prompt path)", () => {
+		const { policy, tier } = resolveApproval(execTool, {}, "approve-for-me");
+		expect(policy).toBe("prompt");
+		expect(tier).toBe("exec");
+	});
+
+	it("honors per-tool deny override in approve-for-me mode", () => {
+		const { policy } = resolveApproval(execTool, {}, "approve-for-me", { bash: "deny" });
+		expect(policy).toBe("deny");
+	});
+
+	it("honors per-tool allow override in approve-for-me mode", () => {
+		const { policy } = resolveApproval(execTool, {}, "approve-for-me", { bash: "allow" });
+		expect(policy).toBe("allow");
+	});
+});
+
+describe("ApproveForMeReviewer — fail-closed", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("returns a deny when settings or registry is missing", async () => {
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const decision = await reviewer.review(tool, {}, undefined, undefined);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toContain("Auto-review failed");
+	});
+
+	it("returns a deny when no tiny/smol model is available", async () => {
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({ available: [] });
+		const decision = await reviewer.review(tool, {}, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toContain("no tiny/smol model");
+	});
+
+	it("returns a deny when no API key is available", async () => {
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({ apiKey: null });
+		const decision = await reviewer.review(tool, {}, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toContain("no API key");
+	});
+
+	it("returns a deny on model error stop reason", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ stopReason: "error", errorMessage: "rate limited" }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, {}, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toContain("rate limited");
+	});
+
+	it("returns a deny when the model returns no structured response", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(assistant({ text: "I cannot help" }));
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, {}, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toContain("no structured response");
+	});
+});
+
+describe("ApproveForMeReviewer — allow/deny from model", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("returns an allow when the model approves via tool call", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: allowDecision("safe read") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "read" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, {}, undefined, context as never);
+		expect(decision.outcome).toBe("allow");
+		expect(decision.rationale).toBe("safe read");
+	});
+
+	it("returns a deny when the model denies via tool call", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: denyDecision("rm -rf") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, { command: "rm -rf /" }, undefined, context as never);
+		expect(decision.outcome).toBe("deny");
+		expect(decision.rationale).toBe("rm -rf");
+	});
+
+	it("parses a JSON text fallback when the model skips the tool", async () => {
+		const json = JSON.stringify(allowDecision("json fallback"));
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(assistant({ text: json }));
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "read" } as unknown as AgentTool;
+		const context = makeContext({});
+		const decision = await reviewer.review(tool, {}, undefined, context as never);
+		expect(decision.outcome).toBe("allow");
+		expect(decision.rationale).toBe("json fallback");
+	});
+});
+
+describe("ApproveForMeReviewer — session cache", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("caches an allow decision and skips the model on the second identical call", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(assistant({ toolCall: { name: "respond", arguments: allowDecision("safe") } }));
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "read" } as unknown as AgentTool;
+		const context = makeContext({});
+
+		await reviewer.review(tool, { path: "/src/a.ts" }, undefined, context as never);
+		await reviewer.review(tool, { path: "/src/a.ts" }, undefined, context as never);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not cache deny decisions", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(assistant({ toolCall: { name: "respond", arguments: denyDecision("bad") } }));
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+
+		await reviewer.review(tool, { command: "rm" }, undefined, context as never);
+		await reviewer.review(tool, { command: "rm" }, undefined, context as never);
+
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("ApproveForMeReviewer — circuit breaker", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("trips after MAX_CONSECUTIVE_DENIALS consecutive denials", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+
+		expect(reviewer.shouldInterruptTurn()).toBe(false);
+		for (let i = 0; i < MAX_CONSECUTIVE_DENIALS; i++) {
+			await reviewer.review(tool, { i }, undefined, context as never);
+		}
+		expect(reviewer.shouldInterruptTurn()).toBe(true);
+	});
+
+	it("resets the consecutive counter on an allow", async () => {
+		const deny = assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } });
+		const allow = assistant({ toolCall: { name: "respond", arguments: allowDecision("ok") } });
+		vi.spyOn(ai, "completeSimple")
+			.mockResolvedValueOnce(deny)
+			.mockResolvedValueOnce(deny)
+			.mockResolvedValueOnce(allow);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+
+		await reviewer.review(tool, { a: 1 }, undefined, context as never);
+		await reviewer.review(tool, { a: 2 }, undefined, context as never);
+		await reviewer.review(tool, { a: 3 }, undefined, context as never);
+		expect(reviewer.shouldInterruptTurn()).toBe(false);
+	});
+
+	it("trips after MAX_RECENT_DENIALS in the last DENIAL_WINDOW reviews", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+
+		// Interleave allows to avoid the consecutive counter tripping first
+		const allow = assistant({ toolCall: { name: "respond", arguments: allowDecision("ok") } });
+		const deny = assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } });
+		const mock = vi.spyOn(ai, "completeSimple");
+		mock.mockReset();
+		for (let i = 0; i < MAX_RECENT_DENIALS; i++) {
+			mock.mockResolvedValueOnce(deny);
+			if (i < MAX_RECENT_DENIALS - 1) mock.mockResolvedValueOnce(allow);
+		}
+
+		// Call: deny, allow, deny, allow, ... until MAX_RECENT_DENIALS denials
+		// We need MAX_RECENT_DENIALS denials in the window, interleaved with allows
+		// so the consecutive counter never reaches MAX_CONSECUTIVE_DENIALS.
+		let denials = 0;
+		let calls = 0;
+		while (denials < MAX_RECENT_DENIALS) {
+			await reviewer.review(tool, { deny: calls++ }, undefined, context as never);
+			denials++;
+			if (denials < MAX_RECENT_DENIALS) {
+				// interleave an allow to reset consecutive
+				mock.mockResolvedValueOnce(allow);
+				await reviewer.review(tool, { allow: calls++ }, undefined, context as never);
+			}
+		}
+		expect(reviewer.shouldInterruptTurn()).toBe(true);
+	});
+
+	it("resetCircuitBreaker clears all counters", async () => {
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			assistant({ toolCall: { name: "respond", arguments: denyDecision("no") } }),
+		);
+		const reviewer = new ApproveForMeReviewer();
+		const tool = { name: "bash" } as unknown as AgentTool;
+		const context = makeContext({});
+
+		for (let i = 0; i < MAX_CONSECUTIVE_DENIALS; i++) {
+			await reviewer.review(tool, { i }, undefined, context as never);
+		}
+		expect(reviewer.shouldInterruptTurn()).toBe(true);
+		reviewer.resetCircuitBreaker();
+		expect(reviewer.shouldInterruptTurn()).toBe(false);
+	});
+});

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -11,9 +11,9 @@ import type { AgentTool, ToolApprovalDecision, ToolTier } from "@oh-my-pi/pi-age
 export type { ToolApproval, ToolApprovalDecision, ToolTier } from "@oh-my-pi/pi-agent-core";
 
 export type ApprovalPolicy = "allow" | "deny" | "prompt";
-export type ApprovalMode = "always-ask" | "write" | "yolo";
+export type ApprovalMode = "always-ask" | "approve-for-me" | "write" | "yolo";
 
-type ApprovalSubject = Pick<AgentTool, "name" | "approval" | "formatApprovalDetails">;
+export type ApprovalSubject = Pick<AgentTool, "name" | "approval" | "formatApprovalDetails">;
 
 export interface ResolvedApproval {
 	policy: ApprovalPolicy;
@@ -33,6 +33,7 @@ const TIER_RANK: Record<ToolTier, number> = {
 
 const APPROVAL_MODE_MAX_TIER: Record<ApprovalMode, ToolTier> = {
 	"always-ask": "read",
+	"approve-for-me": "write",
 	write: "write",
 	yolo: "exec",
 };

--- a/packages/coding-agent/src/tools/approve-for-me-policy.md
+++ b/packages/coding-agent/src/tools/approve-for-me-policy.md
@@ -36,15 +36,16 @@ You are a safety reviewer for an AI coding agent. Your job is to evaluate each p
 
 When in doubt about the risk level, user authorization, or safety of an action, **deny**. A false denial only costs the user a prompt; a false approval could cause real damage.
 
-## Output
+## Planned Action
 
-Return a JSON object with exactly these fields:
+Tool: {{tool_name}}
+{{#if approval_reason}}Approval reason: {{approval_reason}}{{/if}}
 
-```json
-{
-  "risk_level": "low" | "medium" | "high" | "critical",
-  "user_authorization": "high" | "medium" | "low" | "unknown",
-  "outcome": "allow" | "deny",
-  "rationale": "One sentence explaining the decision."
-}
-```
+## Recent User Messages (for authorization assessment)
+
+{{recent_user_messages}}
+
+Arguments:
+{{arguments}}
+
+Return your decision by calling the "respond" tool with `risk_level`, `user_authorization`, and `rationale`. Do not include an `outcome` field — the system derives the outcome from your risk level and authorization assessment per the outcome rules above.

--- a/packages/coding-agent/src/tools/approve-for-me-policy.md
+++ b/packages/coding-agent/src/tools/approve-for-me-policy.md
@@ -1,0 +1,50 @@
+# Auto-Review Policy
+
+You are a safety reviewer for an AI coding agent. Your job is to evaluate each proposed tool call and decide whether it is safe to auto-approve or must be denied.
+
+## Risk Levels
+
+- **low**: Read-only operations, file creation within workspace, non-destructive bash commands (ls, cat, grep, git status).
+- **medium**: File edits within workspace, git commits, non-destructive network requests (fetch, curl to known endpoints), subagent spawning for read-only tasks.
+- **high**: Destructive bash (rm, force-push, git reset --hard), file edits outside workspace, network requests to unknown endpoints, MCP tool calls with side effects, browser navigation to external URLs.
+- **critical**: Anything that could cause irreversible data loss, exfiltrate secrets, execute arbitrary remote code, or bypass system security.
+
+## User Authorization Levels
+
+- **high**: The user explicitly approved this exact action or a very close variant.
+- **medium**: The user's recent instructions clearly imply this action's substance (e.g., "fix the bug in foo.ts" → editing foo.ts).
+- **low**: The action loosely follows the user's intent but wasn't specifically requested.
+- **unknown**: No clear connection to recent user instructions.
+
+## Outcome Rules
+
+1. **low** risk → **allow**
+2. **medium** risk → **allow**
+3. **high** risk → **allow** only when `user_authorization` is **medium** or **high**; otherwise **deny**
+4. **critical** risk → **deny** (always — user cannot override via auto-review)
+
+## omp-Specific Categories
+
+- **bash**: Inspect the command string. Deny `rm -rf` outside workspace, `git push --force` to shared branches, `curl`/`wget` that could exfiltrate data, `sudo` or privilege escalation, `chmod 777`, and any command modifying files outside the workspace root. Allow read commands, `git add`/`commit`, `npm`/`bun`/`cargo` build and test commands, and edits within workspace.
+- **edit/write**: Allow edits to files within the workspace directory. Deny edits to `~/.ssh`, `~/.aws`, `~/.config/git`, system files (`/etc`, `/usr`), or dotfiles controlling security policy. Deny mass deletions or moves of workspace files without clear user intent.
+- **read/glob/grep**: Always allow — these are read-only.
+- **browser**: Allow navigation to localhost or documentation sites. Deny navigation to external URLs that could trigger side effects (POST forms, OAuth flows) unless the user explicitly requested it.
+- **task/subagent**: Allow spawning subagents for read-only or workspace-scoped tasks. Deny spawning subagents with destructive capabilities (`yolo` mode) unless the user authorized it.
+- **MCP tools**: Evaluate based on the tool's known side effects. When unknown, deny (fail closed).
+
+## Fail-Closed Directive
+
+When in doubt about the risk level, user authorization, or safety of an action, **deny**. A false denial only costs the user a prompt; a false approval could cause real damage.
+
+## Output
+
+Return a JSON object with exactly these fields:
+
+```json
+{
+  "risk_level": "low" | "medium" | "high" | "critical",
+  "user_authorization": "high" | "medium" | "low" | "unknown",
+  "outcome": "allow" | "deny",
+  "rationale": "One sentence explaining the decision."
+}
+```

--- a/packages/coding-agent/src/tools/approve-for-me-system.md
+++ b/packages/coding-agent/src/tools/approve-for-me-system.md
@@ -1,0 +1,1 @@
+You are a safety reviewer for an AI coding agent. Evaluate the proposed tool call and return a decision by calling the "respond" tool with the fields `risk_level`, `user_authorization`, and `rationale`. Do not include an `outcome` field — the system derives the outcome from your risk level and authorization assessment per the policy rules.

--- a/packages/coding-agent/src/tools/approve-for-me.ts
+++ b/packages/coding-agent/src/tools/approve-for-me.ts
@@ -5,14 +5,20 @@
  *
  * Fail-closed: timeout, parse failure, or model error → deny.
  * Circuit breaker: 3 consecutive denials or 10 in the last 50 → interrupt turn.
+ *
+ * The reviewer's `outcome` is **never trusted** — it is derived from the
+ * validated `risk_level` + `user_authorization` pair per the policy rules.
+ * A model that returns `{ risk: "critical", outcome: "allow" }` is denied.
  */
 import type { AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import { type Api, completeSimple, type Message, type Model, type Tool, type ToolCall } from "@oh-my-pi/pi-ai";
+import { prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { resolveRoleSelection } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
 import { truncateForPrompt } from "./approval";
 import policy from "./approve-for-me-policy.md" with { type: "text" };
+import systemPromptText from "./approve-for-me-system.md" with { type: "text" };
 
 export interface ReviewDecision {
 	risk_level: "low" | "medium" | "high" | "critical";
@@ -37,23 +43,54 @@ const reviewTool: Tool = {
 		properties: {
 			risk_level: { type: "string", enum: ["low", "medium", "high", "critical"] },
 			user_authorization: { type: "string", enum: ["high", "medium", "low", "unknown"] },
-			outcome: { type: "string", enum: ["allow", "deny"] },
 			rationale: { type: "string" },
 		},
-		required: ["risk_level", "user_authorization", "outcome", "rationale"],
+		required: ["risk_level", "user_authorization", "rationale"],
 	} as Record<string, unknown>,
 	strict: false,
 };
 
-/** Session-scoped reviewer with per-session cache + circuit breaker. */
+/** Per-session state: cache + circuit breaker counters. */
+interface SessionState {
+	consecutiveDenials: number;
+	recentDenials: boolean[];
+	cache: Map<string, ReviewDecision>;
+}
+
+/**
+ * Derive the outcome from the validated risk level and user authorization,
+ * per the policy rules. The model's `outcome` field is **never used** —
+ * only `risk_level` and `user_authorization` are trusted.
+ *
+ * - low/medium risk → allow
+ * - high risk → allow only with medium+ authorization; otherwise deny
+ * - critical risk → always deny
+ */
+function deriveOutcome(
+	risk: ReviewDecision["risk_level"],
+	auth: ReviewDecision["user_authorization"],
+): "allow" | "deny" {
+	if (risk === "critical") return "deny";
+	if (risk === "high" && (auth === "low" || auth === "unknown")) return "deny";
+	return "allow";
+}
+
+/** Reviewer with per-session cache and circuit breaker state. */
 export class ApproveForMeReviewer {
-	#consecutiveDenials = 0;
-	#recentDenials: boolean[] = [];
-	#cache = new Map<string, ReviewDecision>();
+	#sessions = new Map<string, SessionState>();
+
+	#getSession(id: string): SessionState {
+		let s = this.#sessions.get(id);
+		if (!s) {
+			s = { consecutiveDenials: 0, recentDenials: [], cache: new Map() };
+			this.#sessions.set(id, s);
+		}
+		return s;
+	}
 
 	/**
 	 * Review a tool call. Returns the decision, or a fail-closed deny on any
-	 * error (timeout, parse failure, model unavailable).
+	 * error (timeout, parse failure, model unavailable, truncated args).
 	 */
 	async review(
 		tool: AgentTool,
@@ -61,21 +98,49 @@ export class ApproveForMeReviewer {
 		reason: string | undefined,
 		context: AgentToolContext | undefined,
 	): Promise<ReviewDecision> {
+		const sessionId = context?.sessionManager?.getSessionId() ?? "";
+		const session = this.#getSession(sessionId);
+
 		const cacheKey = this.#cacheKey(tool.name, args);
-		const cached = this.#cache.get(cacheKey);
+		const cached = session.cache.get(cacheKey);
 		if (cached) return cached;
 
+		// Fail closed when args are truncated — a security decision must cover
+		// the complete action, not a prefix of it.
+		let argsStr: string;
 		try {
-			const prompt = this.#buildPrompt(tool, args, reason);
-			const result = await this.#callModel(prompt, context);
+			argsStr = JSON.stringify(args, null, 2);
+		} catch {
+			argsStr = String(args);
+		}
+		const truncated = truncateForPrompt(argsStr, ARGS_TRUNCATE_CHARS);
+		if (truncated !== argsStr) {
+			session.consecutiveDenials = session.consecutiveDenials + 1;
+			session.recentDenials.push(true);
+			if (session.recentDenials.length > DENIAL_WINDOW) session.recentDenials.shift();
+			return {
+				risk_level: "high",
+				user_authorization: "unknown",
+				outcome: "deny",
+				rationale:
+					"Auto-review denied: tool arguments exceed the review context window. A security decision cannot be made on a truncated action.",
+			};
+		}
+
+		try {
+			const recentUserMessages = this.#extractRecentUserMessages(context);
+			const promptText = this.#buildPrompt(tool, argsStr, reason, recentUserMessages);
+			const result = await this.#callModel(promptText, context);
 			const decision = this.#parseDecision(result);
-			if (decision.outcome === "allow") {
-				this.#cache.set(cacheKey, decision);
+			const outcome = deriveOutcome(decision.risk_level, decision.user_authorization);
+			const finalDecision: ReviewDecision = { ...decision, outcome };
+			if (outcome === "allow") {
+				session.cache.set(cacheKey, finalDecision);
 			}
-			this.#recordReview(decision.outcome === "deny");
-			return decision;
+			this.#recordReview(session, outcome === "deny");
+			return finalDecision;
 		} catch (err) {
-			this.#recordReview(true);
+			this.#recordReview(session, true);
 			return {
 				risk_level: "high",
 				user_authorization: "unknown",
@@ -86,24 +151,27 @@ export class ApproveForMeReviewer {
 	}
 
 	/** Circuit breaker: after N consecutive denials or M in last K, interrupt. */
-	shouldInterruptTurn(): boolean {
+	shouldInterruptTurn(sessionId: string): boolean {
+		const s = this.#sessions.get(sessionId);
+		if (!s) return false;
 		return (
-			this.#consecutiveDenials >= MAX_CONSECUTIVE_DENIALS ||
-			this.#recentDenials.filter(Boolean).length >= MAX_RECENT_DENIALS
+			s.consecutiveDenials >= MAX_CONSECUTIVE_DENIALS || s.recentDenials.filter(Boolean).length >= MAX_RECENT_DENIALS
 		);
 	}
 
-	/** Clear the circuit breaker (e.g. on a new turn). */
-	resetCircuitBreaker(): void {
-		this.#consecutiveDenials = 0;
-		this.#recentDenials = [];
+	/** Clear the circuit breaker for a session (e.g. on a new turn). */
+	resetCircuitBreaker(sessionId: string): void {
+		const s = this.#sessions.get(sessionId);
+		if (!s) return;
+		s.consecutiveDenials = 0;
+		s.recentDenials = [];
 	}
 
-	#recordReview(denied: boolean): void {
-		this.#consecutiveDenials = denied ? this.#consecutiveDenials + 1 : 0;
-		this.#recentDenials.push(denied);
-		if (this.#recentDenials.length > DENIAL_WINDOW) {
-			this.#recentDenials.shift();
+	#recordReview(session: SessionState, denied: boolean): void {
+		session.consecutiveDenials = denied ? session.consecutiveDenials + 1 : 0;
+		session.recentDenials.push(denied);
+		if (session.recentDenials.length > DENIAL_WINDOW) {
+			session.recentDenials.shift();
 		}
 	}
 
@@ -115,22 +183,55 @@ export class ApproveForMeReviewer {
 		}
 	}
 
-	#buildPrompt(tool: AgentTool, args: unknown, reason: string | undefined): string {
-		const lines: string[] = [policy, "", "## Planned Action", `Tool: ${tool.name}`];
-		if (reason) lines.push(`Approval reason: ${reason}`);
-
-		let argsStr: string;
+	/**
+	 * Extract up to 5 recent user messages from the session transcript so the
+	 * reviewer can assess whether the user authorized the proposed action.
+	 * Returns a string summary, or "(no recent user messages)" when the
+	 * session is unavailable or has no user messages.
+	 */
+	#extractRecentUserMessages(context: AgentToolContext | undefined): string {
 		try {
-			argsStr = JSON.stringify(args, null, 2);
+			const entries = context?.sessionManager?.getEntries?.();
+			if (!entries) return "(no recent user messages)";
+			const userTexts: string[] = [];
+			for (const entry of entries) {
+				if (entry.type !== "message") continue;
+				const msg = entry.message as { role?: string; content?: unknown };
+				if (msg.role !== "user") continue;
+				const content = msg.content;
+				if (typeof content === "string") {
+					userTexts.push(content);
+				} else if (Array.isArray(content)) {
+					for (const part of content) {
+						if (
+							typeof part === "object" &&
+							part !== null &&
+							part.type === "text" &&
+							typeof part.text === "string"
+						) {
+							userTexts.push(part.text);
+						}
+					}
+				}
+				if (userTexts.length >= 5) break;
+			}
+			if (userTexts.length === 0) return "(no recent user messages)";
+			return userTexts.map((t, i) => `[${i + 1}] ${truncateForPrompt(t, 500)}`).join("\n");
 		} catch {
-			argsStr = String(args);
+			return "(no recent user messages)";
 		}
-		lines.push(`Arguments:\n${truncateForPrompt(argsStr, ARGS_TRUNCATE_CHARS)}`);
-		lines.push("", 'Return your decision by calling the "respond" tool with the JSON fields.');
-		return lines.join("\n");
 	}
 
-	async #callModel(prompt: string, context: AgentToolContext | undefined): Promise<unknown> {
+	#buildPrompt(tool: AgentTool, argsStr: string, reason: string | undefined, recentUserMessages: string): string {
+		return prompt.render(policy, {
+			tool_name: tool.name,
+			approval_reason: reason ?? "",
+			arguments: argsStr,
+			recent_user_messages: recentUserMessages,
+		});
+	}
+
+	async #callModel(promptText: string, context: AgentToolContext | undefined): Promise<unknown> {
 		const settings = context?.settings as Settings | undefined;
 		const registry = context?.modelRegistry as ModelRegistry | undefined;
 		if (!settings || !registry) {
@@ -149,14 +250,12 @@ export class ApproveForMeReviewer {
 			throw new Error(`no API key for auto-review model ${model.provider}/${model.id}`);
 		}
 
-		const messages: Message[] = [{ role: "user", content: prompt, timestamp: Date.now() }];
+		const messages: Message[] = [{ role: "user", content: promptText, timestamp: Date.now() }];
 
 		const response = await completeSimple(
 			model,
 			{
-				systemPrompt: [
-					"You are a safety reviewer for an AI coding agent. Evaluate the proposed tool call and return a decision.",
-				],
+				systemPrompt: [systemPromptText],
 				messages,
 				tools: [reviewTool],
 			},
@@ -194,7 +293,7 @@ export class ApproveForMeReviewer {
 		throw new Error("auto-review returned no structured response");
 	}
 
-	#parseDecision(raw: unknown): ReviewDecision {
+	#parseDecision(raw: unknown): Omit<ReviewDecision, "outcome"> {
 		if (typeof raw !== "object" || raw === null) {
 			throw new Error("auto-review response is not an object");
 		}
@@ -202,29 +301,26 @@ export class ApproveForMeReviewer {
 		const {
 			risk_level: risk,
 			user_authorization: auth,
-			outcome,
 			rationale,
 		} = obj as {
 			risk_level: unknown;
 			user_authorization: unknown;
-			outcome: unknown;
 			rationale: unknown;
 		};
 
 		if (
 			(risk === "low" || risk === "medium" || risk === "high" || risk === "critical") &&
 			(auth === "high" || auth === "medium" || auth === "low" || auth === "unknown") &&
-			(outcome === "allow" || outcome === "deny") &&
 			typeof rationale === "string"
 		) {
-			return { risk_level: risk, user_authorization: auth, outcome, rationale };
+			return { risk_level: risk, user_authorization: auth, rationale };
 		}
 
 		throw new Error("auto-review response does not match expected schema");
 	}
 }
 
-/** Singleton reviewer per process — session cache is instance-scoped. */
+/** Singleton reviewer per process — per-session state is keyed by session ID. */
 let reviewerInstance: ApproveForMeReviewer | undefined;
 
 export function getApproveForMeReviewer(): ApproveForMeReviewer {

--- a/packages/coding-agent/src/tools/approve-for-me.ts
+++ b/packages/coding-agent/src/tools/approve-for-me.ts
@@ -103,7 +103,13 @@ export class ApproveForMeReviewer {
 
 		const cacheKey = this.#cacheKey(tool.name, args);
 		const cached = session.cache.get(cacheKey);
-		if (cached) return cached;
+		if (cached) {
+			// Record the allow so it resets the consecutive-denial counter and
+			// occupies the recent window — prevents a stale streak from tripping
+			// the breaker after an intervening cached approval.
+			this.#recordReview(session, false);
+			return cached;
+		}
 
 		// Fail closed when args are truncated — a security decision must cover
 		// the complete action, not a prefix of it.
@@ -194,13 +200,16 @@ export class ApproveForMeReviewer {
 			const entries = context?.sessionManager?.getEntries?.();
 			if (!entries) return "(no recent user messages)";
 			const userTexts: string[] = [];
-			for (const entry of entries) {
+			// Iterate from the end so we get the most recent user messages,
+			// not the oldest ones. The current prompt authorizes the tool call.
+			for (let i = entries.length - 1; i >= 0; i--) {
+				const entry = entries[i];
 				if (entry.type !== "message") continue;
 				const msg = entry.message as { role?: string; content?: unknown };
 				if (msg.role !== "user") continue;
 				const content = msg.content;
 				if (typeof content === "string") {
-					userTexts.push(content);
+					userTexts.unshift(content);
 				} else if (Array.isArray(content)) {
 					for (const part of content) {
 						if (
@@ -209,7 +218,7 @@ export class ApproveForMeReviewer {
 							part.type === "text" &&
 							typeof part.text === "string"
 						) {
-							userTexts.push(part.text);
+							userTexts.unshift(part.text);
 						}
 					}
 				}

--- a/packages/coding-agent/src/tools/approve-for-me.ts
+++ b/packages/coding-agent/src/tools/approve-for-me.ts
@@ -1,0 +1,246 @@
+/**
+ * "Approve for me" auto-reviewer: a separate LLM evaluates each
+ * approval-pending tool call and auto-approves or denies it, so the user is
+ * not prompted for every exec-tier action.
+ *
+ * Fail-closed: timeout, parse failure, or model error → deny.
+ * Circuit breaker: 3 consecutive denials or 10 in the last 50 → interrupt turn.
+ */
+import type { AgentTool, AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import { type Api, completeSimple, type Message, type Model, type Tool, type ToolCall } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "../config/model-registry";
+import { resolveRoleSelection } from "../config/model-resolver";
+import type { Settings } from "../config/settings";
+import { truncateForPrompt } from "./approval";
+import policy from "./approve-for-me-policy.md" with { type: "text" };
+
+export interface ReviewDecision {
+	risk_level: "low" | "medium" | "high" | "critical";
+	user_authorization: "high" | "medium" | "low" | "unknown";
+	outcome: "allow" | "deny";
+	rationale: string;
+}
+
+export const REVIEW_TIMEOUT_MS = 30_000;
+export const MAX_CONSECUTIVE_DENIALS = 3;
+export const MAX_RECENT_DENIALS = 10;
+export const DENIAL_WINDOW = 50;
+
+const ARGS_TRUNCATE_CHARS = 4000;
+const STRUCTURED_TOOL_NAME = "respond";
+
+const reviewTool: Tool = {
+	name: STRUCTURED_TOOL_NAME,
+	description: "Return your review decision by calling this tool.",
+	parameters: {
+		type: "object",
+		properties: {
+			risk_level: { type: "string", enum: ["low", "medium", "high", "critical"] },
+			user_authorization: { type: "string", enum: ["high", "medium", "low", "unknown"] },
+			outcome: { type: "string", enum: ["allow", "deny"] },
+			rationale: { type: "string" },
+		},
+		required: ["risk_level", "user_authorization", "outcome", "rationale"],
+	} as Record<string, unknown>,
+	strict: false,
+};
+
+/** Session-scoped reviewer with per-session cache + circuit breaker. */
+export class ApproveForMeReviewer {
+	#consecutiveDenials = 0;
+	#recentDenials: boolean[] = [];
+	#cache = new Map<string, ReviewDecision>();
+
+	/**
+	 * Review a tool call. Returns the decision, or a fail-closed deny on any
+	 * error (timeout, parse failure, model unavailable).
+	 */
+	async review(
+		tool: AgentTool,
+		args: unknown,
+		reason: string | undefined,
+		context: AgentToolContext | undefined,
+	): Promise<ReviewDecision> {
+		const cacheKey = this.#cacheKey(tool.name, args);
+		const cached = this.#cache.get(cacheKey);
+		if (cached) return cached;
+
+		try {
+			const prompt = this.#buildPrompt(tool, args, reason);
+			const result = await this.#callModel(prompt, context);
+			const decision = this.#parseDecision(result);
+			if (decision.outcome === "allow") {
+				this.#cache.set(cacheKey, decision);
+			}
+			this.#recordReview(decision.outcome === "deny");
+			return decision;
+		} catch (err) {
+			this.#recordReview(true);
+			return {
+				risk_level: "high",
+				user_authorization: "unknown",
+				outcome: "deny",
+				rationale: `Auto-review failed: ${err instanceof Error ? err.message : "unknown error"}. Falling back to deny for safety.`,
+			};
+		}
+	}
+
+	/** Circuit breaker: after N consecutive denials or M in last K, interrupt. */
+	shouldInterruptTurn(): boolean {
+		return (
+			this.#consecutiveDenials >= MAX_CONSECUTIVE_DENIALS ||
+			this.#recentDenials.filter(Boolean).length >= MAX_RECENT_DENIALS
+		);
+	}
+
+	/** Clear the circuit breaker (e.g. on a new turn). */
+	resetCircuitBreaker(): void {
+		this.#consecutiveDenials = 0;
+		this.#recentDenials = [];
+	}
+
+	#recordReview(denied: boolean): void {
+		this.#consecutiveDenials = denied ? this.#consecutiveDenials + 1 : 0;
+		this.#recentDenials.push(denied);
+		if (this.#recentDenials.length > DENIAL_WINDOW) {
+			this.#recentDenials.shift();
+		}
+	}
+
+	#cacheKey(toolName: string, args: unknown): string {
+		try {
+			return `${toolName}:${JSON.stringify(args)}`;
+		} catch {
+			return `${toolName}:${String(args)}`;
+		}
+	}
+
+	#buildPrompt(tool: AgentTool, args: unknown, reason: string | undefined): string {
+		const lines: string[] = [policy, "", "## Planned Action", `Tool: ${tool.name}`];
+		if (reason) lines.push(`Approval reason: ${reason}`);
+
+		let argsStr: string;
+		try {
+			argsStr = JSON.stringify(args, null, 2);
+		} catch {
+			argsStr = String(args);
+		}
+		lines.push(`Arguments:\n${truncateForPrompt(argsStr, ARGS_TRUNCATE_CHARS)}`);
+		lines.push("", 'Return your decision by calling the "respond" tool with the JSON fields.');
+		return lines.join("\n");
+	}
+
+	async #callModel(prompt: string, context: AgentToolContext | undefined): Promise<unknown> {
+		const settings = context?.settings as Settings | undefined;
+		const registry = context?.modelRegistry as ModelRegistry | undefined;
+		if (!settings || !registry) {
+			throw new Error("no settings or model registry available for auto-review");
+		}
+
+		const resolved = resolveRoleSelection(["tiny", "smol"], settings, registry.getAvailable());
+		const model = resolved?.model as Model<Api> | undefined;
+		if (!model) {
+			throw new Error("no tiny/smol model available for auto-review");
+		}
+
+		const sessionId = context?.sessionManager?.getSessionId();
+		const apiKey = await registry.getApiKey(model, sessionId);
+		if (!apiKey) {
+			throw new Error(`no API key for auto-review model ${model.provider}/${model.id}`);
+		}
+
+		const messages: Message[] = [{ role: "user", content: prompt, timestamp: Date.now() }];
+
+		const response = await completeSimple(
+			model,
+			{
+				systemPrompt: [
+					"You are a safety reviewer for an AI coding agent. Evaluate the proposed tool call and return a decision.",
+				],
+				messages,
+				tools: [reviewTool],
+			},
+			{
+				apiKey: registry.resolver(model, sessionId),
+				disableReasoning: true,
+				toolChoice: { type: "tool", name: STRUCTURED_TOOL_NAME },
+				signal: AbortSignal.timeout(REVIEW_TIMEOUT_MS),
+				maxTokens: 1024,
+			},
+		);
+
+		if (response.stopReason === "error") {
+			throw new Error(response.errorMessage ?? "auto-review request failed");
+		}
+
+		const toolCall = response.content.find(
+			(c): c is ToolCall => c.type === "toolCall" && c.name === STRUCTURED_TOOL_NAME,
+		);
+		if (toolCall) return toolCall.arguments;
+
+		// Fallback: try to parse text as JSON
+		const text = response.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("");
+		if (text) {
+			try {
+				return JSON.parse(text);
+			} catch {
+				// fall through
+			}
+		}
+
+		throw new Error("auto-review returned no structured response");
+	}
+
+	#parseDecision(raw: unknown): ReviewDecision {
+		if (typeof raw !== "object" || raw === null) {
+			throw new Error("auto-review response is not an object");
+		}
+		const obj = raw as Record<string, unknown>;
+		const {
+			risk_level: risk,
+			user_authorization: auth,
+			outcome,
+			rationale,
+		} = obj as {
+			risk_level: unknown;
+			user_authorization: unknown;
+			outcome: unknown;
+			rationale: unknown;
+		};
+
+		if (
+			(risk === "low" || risk === "medium" || risk === "high" || risk === "critical") &&
+			(auth === "high" || auth === "medium" || auth === "low" || auth === "unknown") &&
+			(outcome === "allow" || outcome === "deny") &&
+			typeof rationale === "string"
+		) {
+			return { risk_level: risk, user_authorization: auth, outcome, rationale };
+		}
+
+		throw new Error("auto-review response does not match expected schema");
+	}
+}
+
+/** Singleton reviewer per process — session cache is instance-scoped. */
+let reviewerInstance: ApproveForMeReviewer | undefined;
+
+export function getApproveForMeReviewer(): ApproveForMeReviewer {
+	if (!reviewerInstance) reviewerInstance = new ApproveForMeReviewer();
+	return reviewerInstance;
+}
+
+/**
+ * Run auto-review on a tool call. Returns the decision, or a fail-closed
+ * deny when auto-review cannot run (no model/registry/timeout).
+ */
+export async function runApproveForMeReview(
+	tool: AgentTool,
+	args: unknown,
+	reason: string | undefined,
+	context: AgentToolContext | undefined,
+): Promise<ReviewDecision> {
+	return getApproveForMeReviewer().review(tool, args, reason, context);
+}

--- a/packages/coding-agent/test/cli/completions.test.ts
+++ b/packages/coding-agent/test/cli/completions.test.ts
@@ -212,7 +212,7 @@ describe("omp completions (integration / drift)", () => {
 		expect(stdout).toContain("{-r,--resume}");
 		// Real enum option sets flow through unchanged.
 		expect(stdout).toContain(":value:(off minimal low medium high xhigh max auto)");
-		expect(stdout).toContain(":value:(always-ask write yolo)");
+		expect(stdout).toContain(":value:(always-ask approve-for-me write yolo)");
 		// Real subcommands present; dynamic callbacks wired.
 		expect(stdout).toContain("_omp_cmd_commit");
 		expect(stdout).toContain("'completions:");


### PR DESCRIPTION
## What

A new `approve-for-me` tool approval mode: a separate LLM reviewer (the `tiny`/`smol` role) evaluates each exec-tier tool call and auto-approves or denies it, reducing interruptions while blocking risky actions.

- **`ApproveForMeReviewer`** (`src/tools/approve-for-me.ts`) — singleton reviewer that sends the tool name, arguments, and up to 5 recent user messages to the `tiny`/`smol` model. The reviewer returns `risk_level` + `user_authorization` + `rationale`; the system derives the outcome from that pair via `deriveOutcome()` — the model's own `outcome` field is **never trusted**. A model that returns `{ risk: "critical", outcome: "allow" }` is denied.
- **Fail-closed** — timeout (30s), parse failure, model error, no model/registry/API key, or truncated arguments (> 4000 chars) → deny. A security decision must cover the complete action, not a prefix.
- **Per-session cache** — an `allow` decision is cached by `toolName:args` and reused on the next identical call (no model call). Denials are never cached.
- **Circuit breaker** — 3 consecutive denials (`MAX_CONSECUTIVE_DENIALS`) or 10 in the last 50 (`MAX_RECENT_DENIALS` / `DENIAL_WINDOW`) → `shouldInterruptTurn()` returns true and the wrapper aborts the turn (`context.abort()`) with a message telling the agent to find a safer alternative or ask the user. Reset at the start of each turn in `agent-session.ts`.
- **Policy prompt** (`approve-for-me-policy.md`) — risk levels (low/medium/high/critical), user authorization levels (high/medium/low/unknown), outcome rules (low/medium → allow; high → allow only with medium+ authorization; critical → always deny), omp-specific categories (bash, edit/write, read/glob/grep, browser, task/subagent, MCP), and a fail-closed directive.
- **Approval mode wiring** — `approve-for-me` sits between `always-ask` and `write`: max tier is `write` (auto-approves read+write), exec-tier calls go to the reviewer. Added to `ApprovalMode` type, `APPROVAL_MODE_MAX_TIER` table, `--approval-mode` CLI flag options, settings schema enum + UI label, and completions.
- **ACP gate** — `#isExplicitAutoApproveMode()` now includes `approve-for-me` so the ACP permission gate doesn't double-prompt (the LLM reviewer handles exec-tier approvals client-side).
- **Explicit per-tool policies preserved** — explicit `prompt`/`deny`/`allow` overrides and tool-demanded approval prompts still go through the human path; only mode-derived exec prompts route to the reviewer.

## Why

`always-ask` prompts for every exec-tier call (noisy), `write` auto-approves read+write but still prompts for exec, and `yolo` auto-approves everything (unsafe). `approve-for-me` fills the gap: it auto-approves safe exec-tier calls via an LLM safety reviewer and denies risky ones, without a human prompt for each one — while failing closed on any uncertainty.

## Testing

**Automated**

`src/tools/__tests__/approve-for-me.test.ts` — 351 lines covering:

| Contract | Tests |
|---|---|
| `resolveApproval` tier gate | auto-approves read (same as always-ask), auto-approves write (same as write mode), prompts for exec, honors per-tool deny/allow overrides |
| Fail-closed | deny when settings/registry missing, no tiny/smol model, no API key, model error stop reason, no structured response, truncated args |
| Policy enforcement | derives allow for low risk regardless of model outcome, derives deny for critical even if model says allow, deny for high+unknown auth, allow for high+medium auth, JSON text fallback parse |
| Session cache | caches allow and skips model on second identical call, does not cache deny |
| Circuit breaker | trips after `MAX_CONSECUTIVE_DENIALS`, resets consecutive counter on an allow, `resetCircuitBreaker` clears all counters |

`test/cli/completions.test.ts` — updated completion assertion to include `approve-for-me` in the `--approval-mode` enum.

---

- [x] `bun check` passes
- [x] CHANGELOG updated
