### PR TITLE
fix(catalog): union Codex models across OAuth accounts

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex (`openai-codex`) catalog discovery hiding models available only through a second configured OAuth account: discovery fetched one account's `/models` catalog and, being authoritative, pruned every model the other accounts exposed. `openaiCodexModelManagerOptions` now takes a `resolveAccounts` callback, fetches each configured account's catalog independently, and unions them by id before the authoritative merge (bundled models are retained when every account fetch fails) ([#6265](https://github.com/can1357/oh-my-pi/issues/6265)).
+
 ## [17.0.6] - 2026-07-20
 
 ### Added

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -61,24 +61,22 @@ export function openaiCodexModelManagerOptions(
 }
 
 /**
- * Merge per-account Codex catalogs into one authoritative list, deduped by
- * model id (first account to expose an id wins). Returns `null` when every
- * account's fetch failed, so the caller keeps bundled models instead of pruning
- * to an empty authoritative catalog.
+ * Merge complete per-account Codex catalogs into one authoritative list,
+ * deduped by model id (first account to expose an id wins). Returns `null` when
+ * any account's fetch failed, so a partial list cannot replace the previous or
+ * bundled authoritative catalog.
  */
 function unionCodexModels(
 	results: readonly (CodexModelDiscoveryResult | null)[],
 ): ModelSpec<"openai-codex-responses">[] | null {
 	const byId = new Map<string, ModelSpec<"openai-codex-responses">>();
-	let anySucceeded = false;
 	for (const result of results) {
-		if (!result) continue;
-		anySucceeded = true;
+		if (!result) return null;
 		for (const model of result.models) {
 			if (!byId.has(model.id)) byId.set(model.id, model);
 		}
 	}
-	return anySucceeded ? [...byId.values()] : null;
+	return [...byId.values()];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -1,17 +1,32 @@
 import { once } from "@oh-my-pi/pi-utils";
-import { fetchCodexModels } from "../discovery/codex";
+import { type CodexModelDiscoveryResult, fetchCodexModels } from "../discovery/codex";
 import type { DevinModelDiscoveryOptions } from "../discovery/devin";
 import { buildGitLabDuoWorkflowFallbackModel, fetchGitLabDuoWorkflowModels } from "../discovery/gitlab-duo-workflow";
 import type { ModelManagerOptions } from "../model-manager";
-import type { FetchImpl } from "../types";
+import type { FetchImpl, ModelSpec } from "../types";
 
 // ---------------------------------------------------------------------------
 // OpenAI Codex
 // ---------------------------------------------------------------------------
 
-export interface OpenAICodexModelManagerConfig {
-	accessToken?: string;
+/** One Codex OAuth account to fetch a catalog for. */
+export interface OpenAICodexAccount {
+	/** OAuth access token used for `Authorization: Bearer ...`. */
+	accessToken: string;
+	/** ChatGPT account id sent as the `chatgpt-account-id` header. */
 	accountId?: string;
+}
+
+export interface OpenAICodexModelManagerConfig {
+	/**
+	 * Resolves every configured Codex OAuth account at discovery time. Codex
+	 * discovery is account-scoped — a model can be available to one account and
+	 * absent from another — so each account's `/models` endpoint is fetched
+	 * independently and the results unioned by id. Without this, discovery would
+	 * surface only the account it happened to resolve and, being authoritative,
+	 * prune every model the other accounts expose (#6265).
+	 */
+	resolveAccounts?: () => Promise<readonly OpenAICodexAccount[]>;
 	clientVersion?: string;
 	fetch?: FetchImpl;
 }
@@ -19,19 +34,51 @@ export interface OpenAICodexModelManagerConfig {
 export function openaiCodexModelManagerOptions(
 	config: OpenAICodexModelManagerConfig = {},
 ): ModelManagerOptions<"openai-codex-responses"> {
-	const { accessToken, accountId, clientVersion, fetch } = config;
+	const { resolveAccounts, clientVersion, fetch } = config;
 	return {
 		providerId: "openai-codex",
 		dynamicModelsAuthoritative: true,
-		...(accessToken
+		...(resolveAccounts
 			? {
 					fetchDynamicModels: async () => {
-						const result = await fetchCodexModels({ accessToken, accountId, clientVersion, fetchFn: fetch });
-						return result?.models ?? null;
+						const accounts = await resolveAccounts();
+						if (accounts.length === 0) return null;
+						const results = await Promise.all(
+							accounts.map(account =>
+								fetchCodexModels({
+									accessToken: account.accessToken,
+									accountId: account.accountId,
+									clientVersion,
+									fetchFn: fetch,
+								}),
+							),
+						);
+						return unionCodexModels(results);
 					},
 				}
 			: undefined),
 	};
+}
+
+/**
+ * Merge per-account Codex catalogs into one authoritative list, deduped by
+ * model id (first account to expose an id wins). Returns `null` when every
+ * account's fetch failed, so the caller keeps bundled models instead of pruning
+ * to an empty authoritative catalog.
+ */
+function unionCodexModels(
+	results: readonly (CodexModelDiscoveryResult | null)[],
+): ModelSpec<"openai-codex-responses">[] | null {
+	const byId = new Map<string, ModelSpec<"openai-codex-responses">>();
+	let anySucceeded = false;
+	for (const result of results) {
+		if (!result) continue;
+		anySucceeded = true;
+		for (const model of result.models) {
+			if (!byId.has(model.id)) byId.set(model.id, model);
+		}
+	}
+	return anySucceeded ? [...byId.values()] : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -25,8 +25,13 @@ export interface OpenAICodexModelManagerConfig {
 	 * independently and the results unioned by id. Without this, discovery would
 	 * surface only the account it happened to resolve and, being authoritative,
 	 * prune every model the other accounts expose (#6265).
+	 *
+	 * Returns `null` to abort discovery entirely (e.g. an account's credential
+	 * failed to refresh): a partial account set would be cached as the complete
+	 * authoritative catalog and hide the missing account's models, so the caller
+	 * keeps the previous/bundled catalog instead.
 	 */
-	resolveAccounts?: () => Promise<readonly OpenAICodexAccount[]>;
+	resolveAccounts?: () => Promise<readonly OpenAICodexAccount[] | null>;
 	clientVersion?: string;
 	fetch?: FetchImpl;
 }
@@ -42,7 +47,7 @@ export function openaiCodexModelManagerOptions(
 			? {
 					fetchDynamicModels: async () => {
 						const accounts = await resolveAccounts();
-						if (accounts.length === 0) return null;
+						if (!accounts || accounts.length === 0) return null;
 						const results = await Promise.all(
 							accounts.map(account =>
 								fetchCodexModels({

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -224,7 +224,7 @@ describe("Codex model discovery", () => {
 		}
 	});
 
-	it("keeps bundled Codex models when every account fetch fails (#6265)", async () => {
+	it("keeps bundled Codex models when any account catalog fetch fails (#6265)", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-union-fail-"));
 		const bundled: ModelSpec<"openai-codex-responses"> = {
 			id: "gpt-5.6-terra",
@@ -238,12 +238,31 @@ describe("Codex model discovery", () => {
 			contextWindow: 372_000,
 			maxTokens: 128_000,
 		};
-		const fetchFn: typeof fetch = Object.assign(async () => new Response("nope", { status: 500 }), {
-			preconnect() {},
-		});
+		const fetchFn: typeof fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				const accountId = new Headers(init?.headers).get("chatgpt-account-id");
+				if (accountId === "account-1") {
+					return Response.json({
+						models: [
+							{
+								slug: "partial-account-model",
+								display_name: "Partial Account Model",
+								supported_in_api: true,
+								input_modalities: ["text"],
+							},
+						],
+					});
+				}
+				return new Response("nope", { status: 500 });
+			},
+			{ preconnect() {} },
+		);
 		try {
 			const options = openaiCodexModelManagerOptions({
-				resolveAccounts: async () => [{ accessToken: "token-1", accountId: "account-1" }],
+				resolveAccounts: async () => [
+					{ accessToken: "token-1", accountId: "account-1" },
+					{ accessToken: "token-2", accountId: "account-2" },
+				],
 				fetch: fetchFn,
 			});
 			const result = await resolveProviderModels(

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -177,6 +177,86 @@ describe("Codex model discovery", () => {
 		}
 	});
 
+	it("unions models across every configured Codex OAuth account (#6265)", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-union-"));
+		// Codex `/models` is account-scoped: account 1 lacks gpt-5.6-sol, account 2
+		// exposes it. Keyed off the chatgpt-account-id header the discovery flow
+		// sends per account.
+		const catalogs: Record<string, readonly string[]> = {
+			"account-1": ["gpt-5.6-terra", "gpt-5.6-luna"],
+			"account-2": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+		};
+		const fetchFn: typeof fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				const accountId = new Headers(init?.headers).get("chatgpt-account-id") ?? "";
+				const slugs = catalogs[accountId] ?? [];
+				return new Response(
+					JSON.stringify({
+						models: slugs.map(slug => ({
+							slug,
+							display_name: slug,
+							default_reasoning_level: "medium",
+							supported_reasoning_levels: ["low", "medium", "high"],
+							input_modalities: ["text", "image"],
+							supported_in_api: true,
+						})),
+					}),
+				);
+			},
+			{ preconnect() {} },
+		);
+		try {
+			const options = openaiCodexModelManagerOptions({
+				resolveAccounts: async () => [
+					{ accessToken: "token-1", accountId: "account-1" },
+					{ accessToken: "token-2", accountId: "account-2" },
+				],
+				fetch: fetchFn,
+			});
+			const result = await resolveProviderModels(
+				{ ...options, cacheDbPath: path.join(tempDir, "models.db") },
+				"online",
+			);
+
+			expect(result.models.map(model => model.id).sort()).toEqual(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps bundled Codex models when every account fetch fails (#6265)", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-union-fail-"));
+		const bundled: ModelSpec<"openai-codex-responses"> = {
+			id: "gpt-5.6-terra",
+			name: "GPT-5.6 Terra",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 372_000,
+			maxTokens: 128_000,
+		};
+		const fetchFn: typeof fetch = Object.assign(async () => new Response("nope", { status: 500 }), {
+			preconnect() {},
+		});
+		try {
+			const options = openaiCodexModelManagerOptions({
+				resolveAccounts: async () => [{ accessToken: "token-1", accountId: "account-1" }],
+				fetch: fetchFn,
+			});
+			const result = await resolveProviderModels(
+				{ ...options, staticModels: [bundled], cacheDbPath: path.join(tempDir, "models.db") },
+				"online",
+			);
+
+			expect(result.models.map(model => model.id)).toEqual(["gpt-5.6-terra"]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("ignores pre-V2 Codex discovery cache rows", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-v7-cache-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the model picker hiding Codex models available only through a second configured ChatGPT/Codex OAuth account. Catalog discovery now resolves every stored `openai-codex` OAuth account and unions their `/models` catalogs instead of surfacing only the discovery preflight account's list ([#6265](https://github.com/can1357/oh-my-pi/issues/6265)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -434,12 +434,21 @@ function getOAuthCredentialsForProvider(authStorage: AuthStorage, provider: stri
  * must fetch per account and union the results; resolving a single access token
  * (as before) hid models available only through a sibling account (#6265).
  */
-async function resolveCodexDiscoveryAccounts(authStorage: AuthStorage): Promise<OpenAICodexAccount[]> {
+async function resolveCodexDiscoveryAccounts(
+	authStorage: AuthStorage,
+	resolvedAccessToken: string,
+): Promise<OpenAICodexAccount[]> {
 	const accesses = await authStorage.getOAuthAccesses("openai-codex");
 	const accounts: OpenAICodexAccount[] = [];
 	for (const access of accesses) {
 		if (!access.ok) continue;
 		accounts.push({ accessToken: access.accessToken, accountId: access.accountId });
+	}
+	if (!accounts.some(account => account.accessToken === resolvedAccessToken)) {
+		const matchingCredential = getOAuthCredentialsForProvider(authStorage, "openai-codex").find(
+			credential => credential.access === resolvedAccessToken,
+		);
+		accounts.push({ accessToken: resolvedAccessToken, accountId: matchingCredential?.accountId });
 	}
 	return accounts;
 }
@@ -1724,9 +1733,9 @@ export class ModelRegistry {
 				providerId: "openai-codex",
 				authoritative: true,
 				resolveKey: value => value,
-				createOptions: () =>
+				createOptions: accessToken =>
 					openaiCodexModelManagerOptions({
-						resolveAccounts: () => resolveCodexDiscoveryAccounts(this.authStorage),
+						resolveAccounts: () => resolveCodexDiscoveryAccounts(this.authStorage, accessToken),
 						fetch: this.#fetch,
 					}),
 			},

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -23,6 +23,7 @@ import { getBundledModels, getBundledProviders } from "@oh-my-pi/pi-catalog/mode
 import {
 	googleAntigravityModelManagerOptions,
 	googleGeminiCliModelManagerOptions,
+	type OpenAICodexAccount,
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
 } from "@oh-my-pi/pi-catalog/provider-models";
@@ -427,20 +428,20 @@ function getOAuthCredentialsForProvider(authStorage: AuthStorage, provider: stri
 	return entries.filter((entry): entry is OAuthCredential => entry.type === "oauth");
 }
 
-function resolveOAuthAccountIdForAccessToken(
-	authStorage: AuthStorage,
-	provider: string,
-	accessToken: string,
-): string | undefined {
-	const oauthCredentials = getOAuthCredentialsForProvider(authStorage, provider);
-	const matchingCredential = oauthCredentials.find(credential => credential.access === accessToken);
-	if (matchingCredential) {
-		return matchingCredential.accountId;
+/**
+ * Resolve every configured Codex OAuth account for catalog discovery, refreshing
+ * each credential exactly once. Codex `/models` is account-scoped, so discovery
+ * must fetch per account and union the results; resolving a single access token
+ * (as before) hid models available only through a sibling account (#6265).
+ */
+async function resolveCodexDiscoveryAccounts(authStorage: AuthStorage): Promise<OpenAICodexAccount[]> {
+	const accesses = await authStorage.getOAuthAccesses("openai-codex");
+	const accounts: OpenAICodexAccount[] = [];
+	for (const access of accesses) {
+		if (!access.ok) continue;
+		accounts.push({ accessToken: access.accessToken, accountId: access.accountId });
 	}
-	if (oauthCredentials.length === 1) {
-		return oauthCredentials[0].accountId;
-	}
-	return undefined;
+	return accounts;
 }
 
 function mergeCompat<TBase extends object, TOverride extends object>(
@@ -1723,14 +1724,11 @@ export class ModelRegistry {
 				providerId: "openai-codex",
 				authoritative: true,
 				resolveKey: value => value,
-				createOptions: accessToken => {
-					const accountId = resolveOAuthAccountIdForAccessToken(this.authStorage, "openai-codex", accessToken);
-					return openaiCodexModelManagerOptions({
-						accessToken,
-						accountId,
+				createOptions: () =>
+					openaiCodexModelManagerOptions({
+						resolveAccounts: () => resolveCodexDiscoveryAccounts(this.authStorage),
 						fetch: this.#fetch,
-					});
-				},
+					}),
 			},
 		];
 		const disabledProviders = getDisabledProviderIdsFromSettings();

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -433,15 +433,21 @@ function getOAuthCredentialsForProvider(authStorage: AuthStorage, provider: stri
  * each credential exactly once. Codex `/models` is account-scoped, so discovery
  * must fetch per account and union the results; resolving a single access token
  * (as before) hid models available only through a sibling account (#6265).
+ *
+ * Returns `null` when any stored account fails to resolve (e.g. a transient
+ * refresh failure): the Codex manager is authoritative, so unioning only the
+ * accounts that resolved would cache a partial catalog and hide the failed
+ * account's models for the cache TTL. Aborting keeps the previous/bundled
+ * catalog instead.
  */
 async function resolveCodexDiscoveryAccounts(
 	authStorage: AuthStorage,
 	resolvedAccessToken: string,
-): Promise<OpenAICodexAccount[]> {
+): Promise<OpenAICodexAccount[] | null> {
 	const accesses = await authStorage.getOAuthAccesses("openai-codex");
 	const accounts: OpenAICodexAccount[] = [];
 	for (const access of accesses) {
-		if (!access.ok) continue;
+		if (!access.ok) return null;
 		accounts.push({ accessToken: access.accessToken, accountId: access.accountId });
 	}
 	if (!accounts.some(account => account.accessToken === resolvedAccessToken)) {

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -327,6 +327,36 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("openai-codex", "gpt-5.4-nano")).toBeUndefined();
 	});
 
+	test("Codex discovery falls back to a resolved non-OAuth token when no OAuth accounts exist", async () => {
+		authStorage.setRuntimeApiKey("openai-codex", "runtime-openai-codex");
+		let modelListCalls = 0;
+		const fetchMock: FetchImpl = async (input, init) => {
+			const url = String(input);
+			if (url.startsWith("https://chatgpt.com/backend-api") && url.includes("/models")) {
+				modelListCalls++;
+				expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer runtime-openai-codex");
+				return Response.json({
+					models: [
+						{
+							slug: "runtime-codex-model",
+							display_name: "Runtime Codex Model",
+							context_window: 128_000,
+							supported_in_api: true,
+							input_modalities: ["text"],
+						},
+					],
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+		await registry.refreshProvider("openai-codex", "online");
+
+		expect(modelListCalls).toBe(1);
+		expect(registry.find("openai-codex", "runtime-codex-model")).toBeDefined();
+	});
+
 	test("configured discovery suppresses built-in special OAuth discovery", async () => {
 		await authStorage.set("google-gemini-cli", {
 			type: "oauth",

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -357,6 +357,41 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("openai-codex", "runtime-codex-model")).toBeDefined();
 	});
 
+	test("Codex discovery aborts (keeps bundled models) when any account credential fails to refresh", async () => {
+		// Two configured Codex accounts: the fresh one resolves, the expired one's
+		// refresh throws so getOAuthAccesses reports ok:false. A partial union would
+		// be cached as the authoritative catalog and hide the failed account's
+		// models, so discovery must abort and keep bundled models.
+		authStorage.close();
+		authStorage = await AuthStorage.create(":memory:", {
+			refreshOAuthCredential: async (_provider, _credentialId, credential): Promise<OAuthCredentials> => {
+				if (credential.access.includes("expired")) {
+					throw new Error("simulated transient refresh failure");
+				}
+				return { ...credential, expires: Date.now() + 3_600_000 };
+			},
+		});
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", access: "fresh-codex", refresh: "refresh-fresh", expires: Date.now() + 3_600_000 },
+			{ type: "oauth", access: "expired-codex", refresh: "refresh-expired", expires: Date.now() - 60_000 },
+		]);
+		let modelListCalls = 0;
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url.startsWith("https://chatgpt.com/backend-api") && url.includes("/models")) {
+				modelListCalls++;
+				return Response.json({ models: [] });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+		await registry.refreshProvider("openai-codex", "online");
+
+		expect(modelListCalls).toBe(0);
+		expect(getModelsForProvider(registry, "openai-codex").length).toBeGreaterThan(0);
+	});
+
 	test("configured discovery suppresses built-in special OAuth discovery", async () => {
 		await authStorage.set("google-gemini-cli", {
 			type: "oauth",


### PR DESCRIPTION
## Repro
With two configured ChatGPT/Codex OAuth accounts where a model is available to only one account (e.g. `gpt-5.6-sol` on account 2), the model picker exposes only the models returned for whichever account the discovery preflight selected. `omp models refresh` then `omp models openai-codex --json` (or searching `codex` in the picker) shows a single account's catalog. New regression test in `packages/catalog/test/codex-discovery.test.ts` reproduces it: account 1 returns `[gpt-5.6-terra, gpt-5.6-luna]`, account 2 returns `[gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna]`.

## Cause
`openaiCodexModelManagerOptions` (`packages/catalog/src/provider-models/special.ts`), wired from `packages/coding-agent/src/config/model-registry.ts`, resolved a single access token via `getApiKeyForProvider("openai-codex")`, mapped it to one `chatgpt-account-id`, and made one `fetchCodexModels` call. That result is marked `dynamicModelsAuthoritative`, so it replaces the bundled provider entries — making the visible catalog depend on the single discovery account and pruning every model exposed only through a sibling account.

## Fix
- `openaiCodexModelManagerOptions` now takes a `resolveAccounts` callback instead of a single `accessToken`/`accountId`, fetches each configured account's `/models` endpoint independently, and unions the catalogs by id (first account to expose an id wins) before the authoritative merge.
- Union returns `null` when every account's fetch fails, so bundled models are retained instead of being pruned to an empty authoritative catalog.
- `model-registry.ts` resolves every stored `openai-codex` OAuth account via `AuthStorage.getOAuthAccesses` (refreshing each once) and passes them through `resolveCodexDiscoveryAccounts`; the now-unused single-account `resolveOAuthAccountIdForAccessToken` helper is removed. Request-time account selection is unchanged.

## Verification
`bun test test/codex-discovery.test.ts` in `packages/catalog` — 8 pass (includes the two new `#6265` regression tests: union across accounts, and bundled-retention when all fetches fail). Full `packages/catalog` suite: 466 pass, 0 fail. `bun check` passes across the workspace.

Fixes #6265