### PR TITLE
fix(installer): avoid mismatched Bun architecture

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,44 @@ has_bun() {
     command -v bun >/dev/null 2>&1
 }
 
+# Resolve the host architecture even when the installer itself runs under
+# Rosetta on Apple Silicon.
+host_arch() {
+    case "$(uname -s)" in
+        Darwin)
+            if [ "$(sysctl -in hw.optional.arm64 2>/dev/null || true)" = "1" ]; then
+                echo "arm64"
+            else
+                echo "x64"
+            fi
+            ;;
+        Linux)
+            case "$(uname -m)" in
+                x86_64|amd64) echo "x64" ;;
+                arm64|aarch64) echo "arm64" ;;
+                *) echo "Unsupported architecture: $(uname -m)" >&2; return 1 ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported OS: $(uname -s)" >&2
+            return 1
+            ;;
+    esac
+}
+
+bun_arch() {
+    case "$(bun -e 'console.log(process.arch)' 2>/dev/null || true)" in
+        x64|x86_64) echo "x64" ;;
+        arm64|aarch64) echo "arm64" ;;
+        *) return 1 ;;
+    esac
+}
+
+has_compatible_bun() {
+    has_bun || return 1
+    [ "$(bun_arch)" = "$(host_arch)" ]
+}
+
 version_ge() {
     current="$1"
     minimum="$2"
@@ -187,7 +225,7 @@ install_via_bun() {
 install_binary() {
     # Detect platform
     OS="$(uname -s)"
-    ARCH="$(uname -m)"
+    ARCH="$(host_arch)"
 
     case "$OS" in
         Linux)  PLATFORM="linux" ;;
@@ -196,9 +234,8 @@ install_binary() {
     esac
 
     case "$ARCH" in
-        x86_64|amd64)  ARCH="x64" ;;
-        arm64|aarch64) ARCH="arm64" ;;
-        *)             echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        x64|arm64) ;;
+        *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
     esac
 
     BINARY="omp-${PLATFORM}-${ARCH}"
@@ -247,17 +284,24 @@ case "$MODE" in
             install_bun
         fi
         require_bun_version
+        if ! has_compatible_bun; then
+            echo "Bun is not native for this machine; install a native Bun before using --source."
+            exit 1
+        fi
         install_via_bun
         ;;
     binary)
         install_binary
         ;;
     *)
-        # Default: use bun if available, otherwise binary
-        if has_bun; then
+        # Default: use bun only when it matches the host architecture.
+        if has_compatible_bun; then
             require_bun_version
             install_via_bun
         else
+            if has_bun; then
+                echo "Existing Bun is not native for this machine; installing the prebuilt binary instead."
+            fi
             install_binary
         fi
         ;;


### PR DESCRIPTION
## Problem
On Apple Silicon, `curl -fsSL https://omp.sh/install | sh` can find an existing x86_64 Bun running under Rosetta and install an x86_64 OMP package. The result is an AVX warning and a much slower executable.

## Fix
- Detect the host architecture on macOS, including Rosetta sessions.
- Check Bun's `process.arch` before using it.
- Fall back to the matching prebuilt binary when Bun is for the wrong architecture.
- Refuse `--source` with an architecture-mismatched Bun instead of installing a broken binary.
- Use the same host-architecture detection for binary downloads.

## Verification
- `sh -n scripts/install.sh`
- `git diff --check`
- Simulated Apple Silicon + x86 Bun install selected `omp-darwin-arm64`.
- Simulated matching Bun install continued through the Bun path.