### PR TITLE
fix(installer): avoid mismatched bun architecture on apple silicon

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `scripts/install.sh` installing an x86_64 build on Apple Silicon when an x86_64 `bun` runs under Rosetta. The default path only checked whether `bun` existed; it now compares `bun`'s `process.arch` to the host (detected via `sysctl -in hw.optional.arm64` so Rosetta can't spoof it) and falls back to the prebuilt native binary on a mismatch, while `--source` errors with an actionable message. `install_binary` also derives the arch from the real host instead of the Rosetta-translated `uname -m` ([#6268](https://github.com/can1357/oh-my-pi/issues/6268)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,38 @@ has_bun() {
     command -v bun >/dev/null 2>&1
 }
 
+# Normalized host architecture (x64|arm64). On macOS this uses
+# `sysctl hw.optional.arm64` so it stays correct inside a Rosetta session,
+# where `uname -m` reports the translated x86_64.
+host_arch() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if [ "$(sysctl -in hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            echo "arm64"
+        else
+            echo "x64"
+        fi
+        return
+    fi
+    case "$(uname -m)" in
+        x86_64|amd64)  echo "x64" ;;
+        arm64|aarch64) echo "arm64" ;;
+        *)             uname -m ;;
+    esac
+}
+
+# Bun's own architecture (x64|arm64), or empty when it can't be determined.
+bun_arch() {
+    bun -e 'process.stdout.write(process.arch)' 2>/dev/null
+}
+
+# True when Bun's architecture matches the host. If Bun's arch can't be read,
+# assume a match rather than block the install.
+bun_arch_matches_host() {
+    ba="$(bun_arch)"
+    [ -z "$ba" ] && return 0
+    [ "$ba" = "$(host_arch)" ]
+}
+
 version_ge() {
     current="$1"
     minimum="$2"
@@ -187,7 +219,7 @@ install_via_bun() {
 install_binary() {
     # Detect platform
     OS="$(uname -s)"
-    ARCH="$(uname -m)"
+    ARCH="$(host_arch)"
 
     case "$OS" in
         Linux)  PLATFORM="linux" ;;
@@ -196,9 +228,8 @@ install_binary() {
     esac
 
     case "$ARCH" in
-        x86_64|amd64)  ARCH="x64" ;;
-        arm64|aarch64) ARCH="arm64" ;;
-        *)             echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        x64|arm64) ;;
+        *)         echo "Unsupported architecture: $ARCH"; exit 1 ;;
     esac
 
     BINARY="omp-${PLATFORM}-${ARCH}"
@@ -247,17 +278,28 @@ case "$MODE" in
             install_bun
         fi
         require_bun_version
+        if ! bun_arch_matches_host; then
+            echo "Error: bun reports architecture '$(bun_arch)' but this host is '$(host_arch)'."
+            echo "Installing from source with this bun would produce a mismatched binary"
+            echo "(e.g. x86_64 under Rosetta on Apple Silicon), causing slow startup and AVX warnings."
+            echo "Install a native bun for your architecture, or re-run without --source to fetch the prebuilt $(host_arch) binary."
+            exit 1
+        fi
         install_via_bun
         ;;
     binary)
         install_binary
         ;;
     *)
-        # Default: use bun if available, otherwise binary
-        if has_bun; then
+        # Default: use bun only when it matches the host architecture, otherwise
+        # fall back to the prebuilt binary so Rosetta bun can't force an x86_64 build.
+        if has_bun && bun_arch_matches_host; then
             require_bun_version
             install_via_bun
         else
+            if has_bun; then
+                echo "Detected bun with architecture '$(bun_arch)' on a '$(host_arch)' host; using the prebuilt binary instead."
+            fi
             install_binary
         fi
         ;;


### PR DESCRIPTION
## Repro
On an Apple Silicon Mac with an x86_64 `bun` present (e.g. installed under Rosetta), `curl -fsSL https://omp.sh/install | sh` takes the default path and installs an x86_64 OMP — `file ~/.local/bin/omp` reports `Mach-O 64-bit executable x86_64`, startup prints `CPU lacks AVX support, strange crashes may occur`, and cold start is ~11s versus ~0.3s for the native ARM64 build. Simulated by stubbing an arm64 host (`sysctl -in hw.optional.arm64` = `1`) with a `bun` reporting `process.arch` = `x64`: the default-mode decision selects the source install.

```
host arch: arm64
bun  arch: x64
DECISION: install via bun (x86_64 OMP) -> AVX warning, slow startup
```

## Cause
In `scripts/install.sh`, the default `MODE` branch gated the source install solely on `has_bun` (`command -v bun`), never comparing Bun's architecture to the host. Additionally `install_binary` derived the download arch from `uname -m`, which reports the translated `x86_64` inside a Rosetta session, so even the binary path could pick the wrong artifact.

## Fix
- Add `host_arch()`: normalizes to `x64`/`arm64`, and on macOS reads `sysctl -in hw.optional.arm64` so a Rosetta session is still reported as `arm64` (rather than trusting `uname -m`).
- Add `bun_arch()` (`bun -e 'process.stdout.write(process.arch)'`) and `bun_arch_matches_host()` (assumes a match when Bun's arch can't be read, so it never blocks a valid install).
- Default `MODE` now uses Bun only when `has_bun && bun_arch_matches_host`; otherwise it prints a notice and falls back to `install_binary`.
- Explicit `--source` errors with an actionable message when Bun's arch mismatches the host.
- `install_binary` now derives the arch from `host_arch()` instead of `uname -m`.

## Verification
Syntax checked with `sh -n scripts/install.sh` (OK). Exercised the helper functions in an isolated `env -i` shell with stubbed `uname`/`sysctl`/`bun`:
- Apple Silicon + Rosetta bun (`sysctl`=1, bun=x64) → `host_arch=arm64`, mismatch → binary fallback.
- Native arm64 mac (bun=arm64) → match → source install.
- Linux x86_64 (bun=x64, no sysctl) → match → source install.
- Unreadable bun arch → assumed match, install not blocked.

Fixes #6268