### PR TITLE
fix(agent): bound OpenRouter thinking stream retries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed repeated OpenRouter Gemini reasoning-to-payload stream closures consuming the full ten-attempt retry budget; thinking-bearing `server_error: stream closed with reason: error` failures now get one recovery attempt before surfacing.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -14822,8 +14822,6 @@ export class AgentSession {
 			message.content.some(block => block.type === "thinking" && block.thinking.trim().length > 0)
 		);
 	}
-	
-	
 
 	#isClassifierRefusal(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error") return false;
@@ -15423,7 +15421,9 @@ export class AgentSession {
 		// (every rotation sets switchedCredential and skips it), so without
 		// this last resort a provider-wide usage cap never fails over to the
 		// configured chain.
-		const maxRetries = this.#isOpenRouterThinkingStreamClose(message) ? Math.min(retrySettings.maxRetries, 1) : retrySettings.maxRetries;
+		const maxRetries = this.#isOpenRouterThinkingStreamClose(message)
+			? Math.min(retrySettings.maxRetries, 1)
+			: retrySettings.maxRetries;
 		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
 
 		const errorMessage = message.errorMessage || "Unknown error";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -14810,6 +14810,21 @@ export class AgentSession {
 		return message.content.some(block => block.type === "toolCall");
 	}
 
+	/**
+	 * OpenRouter can repeatedly close Gemini streams at the reasoning-to-payload
+	 * transition. One retry covers a transient edge failure; the normal ten-retry
+	 * budget would otherwise re-run the same expensive reasoning cycle unchanged.
+	 */
+	#isOpenRouterThinkingStreamClose(message: AssistantMessage): boolean {
+		return (
+			message.provider === "openrouter" &&
+			/server_error:\s*stream closed with reason:\s*error/i.test(message.errorMessage ?? "") &&
+			message.content.some(block => block.type === "thinking" && block.thinking.trim().length > 0)
+		);
+	}
+	
+	
+
 	#isClassifierRefusal(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error") return false;
 		const stopType = message.stopDetails?.type;
@@ -15408,7 +15423,8 @@ export class AgentSession {
 		// (every rotation sets switchedCredential and skips it), so without
 		// this last resort a provider-wide usage cap never fails over to the
 		// configured chain.
-		const retryBudgetExhausted = this.#retryAttempt > retrySettings.maxRetries;
+		const maxRetries = this.#isOpenRouterThinkingStreamClose(message) ? Math.min(retrySettings.maxRetries, 1) : retrySettings.maxRetries;
+		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
 
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
@@ -15567,7 +15583,7 @@ export class AgentSession {
 		await this.#emitSessionEvent({
 			type: "auto_retry_start",
 			attempt: this.#retryAttempt,
-			maxAttempts: retrySettings.maxRetries,
+			maxAttempts: maxRetries,
 			delayMs,
 			errorMessage,
 			errorId: message.errorId,

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -1242,6 +1242,74 @@ describe("AgentSession retry delay cap", () => {
 		expect(last.stopReason).toBe("aborted");
 	});
 
+	it("caps repeated OpenRouter stream closes after streamed thinking at one retry", async () => {
+		const model = getBundledModel("openrouter", "~google/gemini-flash-latest");
+		if (!model) {
+			throw new Error("Expected bundled OpenRouter Gemini test model to exist");
+		}
+		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
+
+		const mock = createMockModel({
+			provider: "openrouter",
+			responses: [
+				{
+					content: [{ type: "thinking", thinking: "reasoning attempt 1" }],
+					stopReason: "error",
+					errorMessage: "server_error: stream closed with reason: error",
+				},
+				{
+					content: [{ type: "thinking", thinking: "reasoning attempt 2" }],
+					stopReason: "error",
+					errorMessage: "server_error: stream closed with reason: error",
+				},
+				{ content: ["must remain unused"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => mock.stream(requestedModel, context, options),
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 10,
+			"retry.modelFallback": false,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Trigger OpenRouter reasoning transition failure");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(2);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ attempt: 1, maxAttempts: 1 });
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: false, attempt: 1 });
+		expect(lastAssistant(session).errorMessage).toBe("server_error: stream closed with reason: error");
+		expect(session.isRetrying).toBe(false);
+	});
+
 	it("defaults 502 auto-retry to ten capped backoff attempts", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) {


### PR DESCRIPTION
## Summary
- detect OpenRouter `server_error: stream closed with reason: error` failures after streamed thinking
- allow one recovery attempt instead of replaying the normal ten-attempt transient budget
- preserve the existing retry policy for pre-output failures and other providers

## Screenshots
No visual change.

## Testing
- `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts` (17 passed)
- `bun --cwd=packages/coding-agent run check:types`

## Risk
- Narrow match on provider, exact failure signature, and non-empty thinking content; unrelated retry behavior is unchanged.
- The upstream OpenRouter stream failure remains outside OMP's control.

## Notes
- Live OpenRouter reproduction was not run; regression coverage simulates the reported streamed-thinking-to-error transition.

## AI Review Report
- Traced provider stream errors through AgentSession retry classification and retry-budget exhaustion.
- Isolated the patch from unrelated changes in the source checkout before committing.

## Security Audit
- No credential, persistence, network-request, or tool-execution behavior changed.
- Existing replay-unsafe tool-call protection remains unchanged.