### PR TITLE
feat: add /prune command for per-tool-output context pruning

### DIFF
--- a/packages/coding-agent/src/modes/components/prune-selector.ts
+++ b/packages/coding-agent/src/modes/components/prune-selector.ts
@@ -1,0 +1,195 @@
+import { type Component, matchesKey, padding, Text, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import { replaceTabs } from "../../tools/render-utils";
+import { theme } from "../theme/theme";
+import {
+	matchesSelectCancel,
+	matchesSelectDown,
+	matchesSelectPageDown,
+	matchesSelectPageUp,
+	matchesSelectUp,
+} from "../utils/keybinding-matchers";
+import { keyHint, rawKeyHint } from "./keybinding-hints";
+import { bottomBorder, divider, row, topBorder } from "./overlay-box";
+
+/** Minimum rows reserved for the list even on short terminals. */
+const MIN_LIST_ROWS = 3;
+/** Fixed chrome rows: top border, two dividers, footer, bottom border. */
+const CHROME_ROWS = 5;
+
+export interface PruneItem {
+	id: string;
+	toolName: string;
+	tokens: number;
+	preview: string;
+}
+
+export interface PruneSelectorCallbacks {
+	/** Confirm: prune every checked id, or — if none are checked — the row under the cursor. */
+	onConfirm: (ids: string[]) => void;
+	/** The picker was dismissed without pruning anything. */
+	onCancel: () => void;
+}
+
+/**
+ * Fullscreen `/prune` picker: a flat, chronological list of every tool
+ * output currently in context, a live preview of the highlighted one, and a
+ * multi-select checkbox column. Modeled on `CopySelectorComponent` (same box
+ * chrome, preview pane, and sizing) but flat rather than tree-shaped, and
+ * checkbox-driven rather than single-pick.
+ */
+export class PruneSelectorComponent implements Component {
+	#items: PruneItem[];
+	#cursorId: string;
+	#checked = new Set<string>();
+	#lastSourceId?: string;
+	#lastSource?: string;
+	#listRows = MIN_LIST_ROWS;
+	// Reused across renders to wrap preview content to the pane width.
+	#previewText = new Text("", 0, 0);
+
+	constructor(
+		items: PruneItem[],
+		private readonly callbacks: PruneSelectorCallbacks,
+	) {
+		this.#items = items;
+		this.#cursorId = items[0]?.id ?? "";
+	}
+
+	invalidate(): void {
+		this.#lastSourceId = undefined;
+		this.#lastSource = undefined;
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesSelectCancel(keyData)) {
+			this.callbacks.onCancel();
+			return;
+		}
+
+		const items = this.#items;
+		if (items.length === 0) return;
+		const idx = Math.max(
+			0,
+			items.findIndex(n => n.id === this.#cursorId),
+		);
+
+		if (matchesSelectUp(keyData)) {
+			this.#cursorId = items[idx === 0 ? items.length - 1 : idx - 1]!.id;
+		} else if (matchesSelectDown(keyData)) {
+			this.#cursorId = items[idx === items.length - 1 ? 0 : idx + 1]!.id;
+		} else if (matchesSelectPageUp(keyData)) {
+			this.#cursorId = items[Math.max(0, idx - this.#listRows)]!.id;
+		} else if (matchesSelectPageDown(keyData)) {
+			this.#cursorId = items[Math.min(items.length - 1, idx + this.#listRows)]!.id;
+		} else if (keyData === " ") {
+			const id = items[idx]!.id;
+			if (this.#checked.has(id)) this.#checked.delete(id);
+			else this.#checked.add(id);
+		} else if (keyData === "a") {
+			if (this.#checked.size === items.length) this.#checked.clear();
+			else for (const item of items) this.#checked.add(item.id);
+		} else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const cursorId = items[idx]!.id;
+			this.callbacks.onConfirm(this.#checked.size > 0 ? [...this.#checked] : [cursorId]);
+		}
+	}
+
+	#renderList(width: number, items: PruneItem[], cursorIdx: number, rows: number): string[] {
+		const inner = Math.max(0, width - 4);
+		const start = Math.max(0, Math.min(cursorIdx - Math.floor(rows / 2), Math.max(0, items.length - rows)));
+		const out: string[] = [];
+		for (let r = 0; r < rows; r++) {
+			const i = start + r;
+			const item = items[i];
+			if (!item) {
+				out.push(row("", width));
+				continue;
+			}
+			const isSelected = i === cursorIdx;
+			const isChecked = this.#checked.has(item.id);
+
+			const box = isChecked ? theme.fg("accent", "[x] ") : "[ ] ";
+			const cursor = isSelected ? "❯ " : "  ";
+			const hint = `~${item.tokens} tok`;
+			const hintWidth = visibleWidth(hint) + 2;
+			const used = visibleWidth(box) + visibleWidth(cursor);
+			const labelPlain = truncateToWidth(item.toolName, Math.max(1, inner - used - hintWidth));
+			const left = isSelected
+				? box + theme.fg("accent", cursor) + theme.bold(theme.fg("accent", labelPlain))
+				: box + cursor + labelPlain;
+			const gap = Math.max(1, inner - used - visibleWidth(labelPlain) - visibleWidth(hint));
+			out.push(row(left + padding(gap) + theme.fg("dim", hint), width));
+		}
+		return out;
+	}
+
+	#renderPreview(width: number, item: PruneItem | undefined, rows: number): string[] {
+		const out: string[] = [];
+		out.push(row(theme.fg("dim", `Preview${item ? ` · ${item.toolName}` : ""}`), width));
+
+		const contentRows = rows - 1;
+		if (!item || contentRows <= 0) {
+			while (out.length < rows) out.push(row("", width));
+			return out;
+		}
+
+		// Tool-output previews are never code, so — unlike the copy picker —
+		// there is no syntax-highlighting branch; wrap plain text to the pane width.
+		let source: string;
+		if (item.id === this.#lastSourceId && this.#lastSource !== undefined) {
+			source = this.#lastSource;
+		} else {
+			source = replaceTabs(item.preview);
+			this.#lastSourceId = item.id;
+			this.#lastSource = source;
+		}
+		this.#previewText.setText(source);
+		const wrapped = this.#previewText.render(Math.max(1, width - 4));
+
+		const hasMore = wrapped.length > contentRows;
+		const visibleCount = hasMore ? contentRows - 1 : Math.min(wrapped.length, contentRows);
+		for (let k = 0; k < contentRows; k++) {
+			if (k < visibleCount) {
+				out.push(row(theme.fg("muted", wrapped[k]!), width));
+			} else if (k === visibleCount && hasMore) {
+				out.push(row(theme.fg("dim", `… ${wrapped.length - visibleCount} more lines`), width));
+			} else {
+				out.push(row("", width));
+			}
+		}
+		return out;
+	}
+
+	render(width: number): readonly string[] {
+		const height = process.stdout.rows || 40;
+		const items = this.#items;
+		const cursorIdx = Math.max(
+			0,
+			items.findIndex(n => n.id === this.#cursorId),
+		);
+		const selected = items[cursorIdx];
+
+		const available = Math.max(MIN_LIST_ROWS + 1, height - CHROME_ROWS);
+		const listRows = Math.max(1, Math.min(items.length, Math.floor(available / 2)));
+		this.#listRows = listRows;
+		const previewRows = Math.max(1, available - listRows);
+
+		const footer = [
+			rawKeyHint("↑↓", "move"),
+			rawKeyHint("space", "select"),
+			rawKeyHint("a", "all"),
+			keyHint("tui.select.confirm", "prune"),
+			keyHint("tui.select.cancel", "quit"),
+		].join(theme.fg("dim", " · "));
+
+		return [
+			topBorder(width, "Prune tool outputs"),
+			...this.#renderList(width, items, cursorIdx, listRows),
+			divider(width),
+			...this.#renderPreview(width, selected, previewRows),
+			divider(width),
+			row(footer, width),
+			bottomBorder(width),
+		];
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -81,6 +81,7 @@ import { ModelHubComponent, type ModelRoleSelectionScope } from "../components/m
 import { ModelPickerComponent } from "../components/model-picker";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
+import { PruneSelectorComponent } from "../components/prune-selector";
 import { ResetUsageSelectorComponent } from "../components/reset-usage-selector";
 import { renderSegmentTrack } from "../components/segment-track";
 import { SessionSelectorComponent } from "../components/session-selector";
@@ -1109,6 +1110,55 @@ export class SelectorController {
 				if (target.content === undefined) return;
 				void copyToClipboard(target.content);
 				this.ctx.showStatus(target.copyMessage ?? "Copied to clipboard");
+			},
+			onCancel: done,
+		});
+
+		overlayHandle = this.ctx.ui.showOverlay(selector, {
+			anchor: "bottom-center",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+		this.ctx.ui.setFocus(selector);
+		this.ctx.ui.requestRender();
+	}
+
+	showPruneSelector(): void {
+		const items = this.ctx.session.listPrunableToolResults();
+		if (items.length === 0) {
+			this.ctx.showStatus("No tool outputs to prune.");
+			return;
+		}
+
+		let overlayHandle: OverlayHandle | undefined;
+		const done = () => {
+			overlayHandle?.hide();
+			this.ctx.ui.requestRender();
+		};
+		const selector = new PruneSelectorComponent(items, {
+			onConfirm: async ids => {
+				done();
+				if (ids.length === 0) {
+					this.ctx.showStatus("Nothing selected to prune.");
+					return;
+				}
+				let result: { prunedCount: number; tokensFreed: number; artifactId?: string };
+				try {
+					result = await this.ctx.session.pruneToolResults(ids);
+				} catch (error) {
+					this.ctx.showError(`Prune failed: ${error instanceof Error ? error.message : String(error)}`);
+					return;
+				}
+				if (result.prunedCount === 0) {
+					this.ctx.showStatus("Nothing to prune.");
+					return;
+				}
+				this.ctx.rebuildChatFromMessages();
+				this.ctx.statusLine.invalidate();
+				this.ctx.ui.requestRender();
+				const n = result.prunedCount;
+				this.ctx.showStatus(`Pruned ${n} tool output${n === 1 ? "" : "s"} (~${result.tokensFreed} tokens freed).`);
 			},
 			onCancel: done,
 		});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4446,6 +4446,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#selectorController.showTreeSelector();
 	}
 
+	showPruneSelector(): void {
+		this.#selectorController.showPruneSelector();
+	}
+
 	showSessionSelector(): void {
 		this.#selectorController.showSessionSelector();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -371,6 +371,7 @@ export interface InteractiveModeContext {
 	showUserMessageSelector(): void;
 	showCopySelector(): void;
 	showTreeSelector(): void;
+	showPruneSelector(): void;
 	showSessionSelector(): void;
 	handleResumeSession(sessionPath: string): Promise<void>;
 	handleSessionDeleteCommand(): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -74,6 +74,7 @@ import {
 	type SummaryOptions,
 	shouldCompact,
 	shouldUseOpenAiRemoteCompaction,
+	type ToolResultShakeRegion,
 } from "@oh-my-pi/pi-agent-core/compaction";
 import {
 	DEFAULT_PRUNE_CONFIG,
@@ -81,7 +82,12 @@ import {
 	pruneToolOutputs,
 	readToolSupersedeKey,
 } from "@oh-my-pi/pi-agent-core/compaction/pruning";
-import type { ProtectedToolMatcher } from "@oh-my-pi/pi-agent-core/compaction/tool-protection";
+import {
+	collectToolCallsById,
+	isProtectedToolResult,
+	isSkillReadToolResult,
+	type ProtectedToolMatcher,
+} from "@oh-my-pi/pi-agent-core/compaction/tool-protection";
 import type {
 	AssistantMessage,
 	AssistantMessageEvent,
@@ -105,6 +111,7 @@ import type {
 	TextContent,
 	ToolCall,
 	ToolChoice,
+	ToolResultMessage,
 	Usage,
 	UsageReport,
 } from "@oh-my-pi/pi-ai";
@@ -10848,6 +10855,22 @@ export class AgentSession {
 			return { mode, toolResultsDropped: 0, blocksDropped: 0, tokensFreed: 0 };
 		}
 
+		const r = await this.#elideRegions(regions);
+		return { mode, ...r };
+	}
+
+	/**
+	 * Replace the given shake regions in place with artifact-backed elide
+	 * placeholders, persist, and replay through the agent. Shared by
+	 * {@link shake}'s `elide` mode and {@link pruneToolResults}'s per-item
+	 * selection — both just gather a different `ShakeRegion[]` up front.
+	 */
+	async #elideRegions(regions: ShakeRegion[]): Promise<{
+		toolResultsDropped: number;
+		blocksDropped: number;
+		tokensFreed: number;
+		artifactId?: string;
+	}> {
 		const artifactId = await this.#saveShakeArtifact(regions);
 		const replacements = regions.map((region, index) => this.#shakeElidePlaceholder(region, index, artifactId));
 
@@ -10873,12 +10896,79 @@ export class AgentSession {
 		this.#closeCodexProviderSessionsForHistoryRewrite();
 
 		return {
-			mode,
 			toolResultsDropped,
 			blocksDropped,
 			tokensFreed: Math.max(0, originalTokens - replacementTokens),
 			artifactId,
 		};
+	}
+
+	/**
+	 * Enumerate every tool result currently in context that is eligible for
+	 * `/prune` — unlike {@link collectShakeRegions}, this ignores shake's
+	 * size/threshold gates: every non-protected, non-empty tool result on the
+	 * branch (after the latest compaction boundary) is offered, regardless of
+	 * token size. Skill and active-plan reads are always excluded, matching
+	 * shake's always-on skill protection.
+	 */
+	#collectPrunableToolResults(): Array<{ toolCallId: string; region: ToolResultShakeRegion }> {
+		const branchEntries = this.sessionManager.getBranch();
+		const keepBoundaryId = getLatestCompactionEntry(branchEntries)?.firstKeptEntryId;
+		const boundaryIndex =
+			keepBoundaryId === undefined ? 0 : Math.max(0, branchEntries.findIndex(e => e.id === keepBoundaryId));
+		const toolCallsById = collectToolCallsById(branchEntries);
+		// Match /shake's manual behavior: never offer skill/plan reads for pruning.
+		const protectedTools = this.#withPlanProtection({ protectedTools: ["skill", isSkillReadToolResult] })
+			.protectedTools;
+		const out: Array<{ toolCallId: string; region: ToolResultShakeRegion }> = [];
+		for (let i = boundaryIndex; i < branchEntries.length; i++) {
+			const entry = branchEntries[i];
+			if (entry.type !== "message") continue;
+			const msg = entry.message as AgentMessage;
+			if (msg.role !== "toolResult") continue;
+			const tr = msg as ToolResultMessage;
+			if (tr.prunedAt !== undefined) continue;
+			if (isProtectedToolResult(tr, toolCallsById.get(tr.toolCallId), protectedTools)) continue;
+			const text = tr.content
+				.filter((b): b is TextContent => b.type === "text")
+				.map(b => b.text)
+				.join("\n");
+			if (text.length === 0) continue;
+			out.push({
+				toolCallId: tr.toolCallId,
+				region: {
+					kind: "toolResult",
+					entry: entry as SessionMessageEntry,
+					tokens: estimateTokens(tr as AgentMessage),
+					originalText: text,
+					label: tr.toolName,
+				},
+			});
+		}
+		return out;
+	}
+
+	/** Display list for the /prune picker: every tool output currently in context, chronological. */
+	listPrunableToolResults(): Array<{ id: string; toolName: string; tokens: number; preview: string }> {
+		const PREVIEW_CHARS = 4000;
+		return this.#collectPrunableToolResults().map(({ toolCallId, region }) => ({
+			id: toolCallId,
+			toolName: region.label,
+			tokens: region.tokens,
+			preview: region.originalText.slice(0, PREVIEW_CHARS),
+		}));
+	}
+
+	/** Elide the selected tool outputs (by toolCallId) in place, artifact-backed. */
+	async pruneToolResults(ids: string[]): Promise<{ prunedCount: number; tokensFreed: number; artifactId?: string }> {
+		if (ids.length === 0) return { prunedCount: 0, tokensFreed: 0 };
+		const idSet = new Set(ids);
+		const regions = this.#collectPrunableToolResults()
+			.filter(p => idSet.has(p.toolCallId))
+			.map(p => p.region);
+		if (regions.length === 0) return { prunedCount: 0, tokensFreed: 0 };
+		const r = await this.#elideRegions(regions);
+		return { prunedCount: r.toolResultsDropped, tokensFreed: r.tokensFreed, artifactId: r.artifactId };
 	}
 
 	#shakeElidePlaceholder(region: ShakeRegion, index: number, artifactId: string | undefined): string {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1502,6 +1502,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "prune",
+		description: "Pick individual tool outputs to drop from context",
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showPruneSelector();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "handoff",
 		description: "Hand off session context to a new session",
 		inlineHint: "[focus instructions]",


### PR DESCRIPTION
## Summary
Adds a builtin `/prune` slash command that opens an interactive fullscreen picker listing every tool-call result currently in context. The user multi-selects the outputs to drop; on confirm, each selected tool result is replaced in place by an artifact-backed `[shaken ... recover: artifact://...]` placeholder — the identical mechanism `/shake elide` uses — but scoped to exactly the picked items rather than everything above a size threshold.

## Changes
- `session/agent-session.ts`: extracted `#elideRegions` out of `shake()` (shared elide/persist/replay body), added `#collectPrunableToolResults` (per-item enumeration, no shake size/threshold gates, skill/plan reads always excluded), and the two public entry points `listPrunableToolResults()` / `pruneToolResults(ids)`.
- `modes/components/prune-selector.ts` (new): fullscreen picker — flat chronological list with a multi-select checkbox column and a live preview pane, modeled on `CopySelectorComponent`'s box chrome/sizing.
- `modes/controllers/selector-controller.ts`: `showPruneSelector()` overlay lifecycle, mirroring `showCopySelector()`.
- `modes/types.ts`, `modes/interactive-mode.ts`: wire `showPruneSelector` into `InteractiveModeContext`.
- `slash-commands/builtin-registry.ts`: register `/prune` (TUI-only, like `/copy` — the picker is inherently interactive, not exposed to ACP).

## Verification
- `bun run check:types` (tsgo) — clean, no new errors.
- `bun run gen:bundle` — canonical bundle build succeeds.