### PR TITLE
Fix ST-terminated OSC 8 links in Markdown tables

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ST-terminated OSC 8 hyperlinks corrupting Markdown table column widths when linked text started with inline markup.
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2622,7 +2622,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 export function renderInlineMarkdown(text: string, mdTheme: MarkdownTheme, baseColor?: (t: string) => string): string {
 	// Guard against undefined/null during streaming — partial JSON can leave fields unpopulated.
 	if (typeof text !== "string") return (baseColor ?? (t => t))(text != null ? String(text) : "");
-	const tokens = markdownParser.lexer(text);
+	const tokens = markdownParser.lexer(normalizeOsc8Terminators(text));
 	const applyText = baseColor ?? ((t: string) => t);
 	let result = "";
 	for (const token of tokens) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -20,6 +20,16 @@ import {
 
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 
+// Marked treats the backslash in an ST-terminated OSC 8 sequence (`ESC \\`) as
+// Markdown punctuation when it is immediately followed by markup such as a
+// codespan backtick. Normalize well-formed OSC 8 prefixes to the equivalent BEL
+// terminator before lexing so the control sequence stays opaque to Markdown.
+const OSC8_ST_PREFIX_REGEX = /(\x1b\]8;[^\x07\x1b]*)\x1b\\/g;
+
+function normalizeOsc8Terminators(text: string): string {
+	return text.replace(OSC8_ST_PREFIX_REGEX, "$1\x07");
+}
+
 // OSC 66 (Kitty text-sizing) heading spans are emitted as a single indivisible
 // unit by the H1 render path. Like image-protocol lines, they must bypass
 // ANSI wrapping and width padding: re-wrapping splits/normalizes the sized span
@@ -1097,7 +1107,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		defaultTextStyle?: DefaultTextStyle,
 		codeBlockIndent: number = 2,
 	) {
-		this.#text = text;
+		this.#text = normalizeOsc8Terminators(text);
 		this.#paddingX = paddingX;
 		this.#paddingY = paddingY;
 		this.#theme = theme;
@@ -1106,6 +1116,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 	}
 
 	setText(text: string): boolean {
+		text = normalizeOsc8Terminators(text);
 		// Equality guard: streaming re-emits identical text on ticks that carried
 		// no delta (throttled provider frames, reconciled tool-execution updates).
 		// Without this, the caller-side `#cachedLines` gets thrown away and the

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -16,6 +16,16 @@ function getCellItalic(terminal: VirtualTerminal, row: number, col: number): boo
 }
 
 describe("renderInlineMarkdown", () => {
+	it("preserves ST-terminated OSC 8 links before inline lexing", () => {
+		const st = "\x1b\\";
+		const input = `\x1b]8;;file:///tmp/example.ts${st}\`example.ts\`\x1b]8;;${st}`;
+		const rendered = renderInlineMarkdown(input, defaultMarkdownTheme);
+		const plain = stripVTControlCharacters(rendered.replace(/\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/g, ""));
+
+		expect(rendered.includes("\x1b]8;;file:///tmp/example.ts\x07")).toBeTruthy();
+		expect(plain).toBe("example.ts");
+	});
+
 	it("preserves ordered list items as visible inline text", () => {
 		const rendered = renderInlineMarkdown("1. Review against a base branch (PR Style)", defaultMarkdownTheme);
 		const plain = stripVTControlCharacters(rendered);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -164,6 +164,31 @@ describe("Markdown component", () => {
 	});
 
 	describe("Tables", () => {
+		it("preserves ST-terminated OSC 8 links inside table cells", () => {
+			const st = "\x1b\\";
+			const fileLink = `\x1b]8;;file:///tmp/DisplayTypeEnum.java${st}\`DisplayTypeEnum.java\`\x1b]8;;${st}`;
+			const markdown = new Markdown(
+				`| Module | Local file | Change |
+| --- | --- | --- |
+| common | ${fileLink} | Added display type |`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const width = 80;
+			const lines = markdown.render(width);
+			const output = lines.join("\n");
+			const plainOutput = stripVTControlCharacters(output.replace(/\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/g, ""));
+
+			expect(output.includes("\x1b]8;;file:///tmp/DisplayTypeEnum.java\x07")).toBeTruthy();
+			expect(plainOutput.includes("DisplayTypeEnum.java")).toBeTruthy();
+			expect(plainOutput.includes("`DisplayTypeEnum.java`")).toBeFalsy();
+			for (const line of lines) {
+				expect(visibleWidth(line), `Line exceeds width ${width}`).toBeLessThanOrEqual(width);
+			}
+		});
+
 		it("should render simple table", () => {
 			const markdown = new Markdown(
 				`| Name | Age |


### PR DESCRIPTION
## Summary

- normalize well-formed ST-terminated OSC 8 prefixes to the equivalent BEL terminator before Markdown lexing
- preserve inline code parsing and visible-width accounting inside table cells
- add a regression test covering link visibility, backtick handling, and viewport width

## Root cause

Marked interprets the backslash in an OSC 8 ST terminator (`ESC \\`) as Markdown escape punctuation when linked text begins with a codespan backtick. That leaves the OSC sequence malformed, so the table width calculation treats the filename as hidden while the terminal still draws it across cell borders.

## Validation

- source-built OMP verified against the resumed session that originally reproduced the issue
- `bun test packages/tui/test/markdown.test.ts -t "preserves ST-terminated OSC 8 links inside table cells"`
- `bun --cwd packages/tui check`

The full Markdown test file currently has three unrelated OSC 8 wrapping failures that reproduce unchanged on clean `upstream/main`. The repository-wide check is also currently blocked by existing formatter failures in files outside this PR.

The regression fixture uses a synthetic `/tmp/DisplayTypeEnum.java` path and contains no session or user-specific data.