### PR TITLE
fix(sdk): resolve missing role fallback chains

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--model <role>` skipping the role's ordered `retry.fallbackChains` when its configured primary is unavailable, so startup now selects the first available authenticated fallback instead of leaving the role unresolved ([#6283](https://github.com/can1357/oh-my-pi/issues/6283)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1720,7 +1720,12 @@ export function resolveCliModel(options: {
 					? `${formatModelRoleAlias(bareRoleName)}${bareRoleThinkingLevel ? `:${bareRoleThinkingLevel}` : ""}`
 					: undefined;
 		if (roleSelector) {
-			const configuredRole = getModelRoleAlias(roleSelector, settings);
+			const { base: roleAlias } = splitThinkingSuffix(
+				roleSelector,
+				modelRoleAliasPrefixLength(roleSelector) ?? -1,
+				MAX_THINKING_SUFFIX_OPTIONS,
+			);
+			const configuredRole = getModelRoleAlias(roleAlias, settings);
 			configuredPatterns = resolveConfiguredModelPatterns([roleSelector], settings);
 			const resolved = resolveModelRoleValue(roleSelector, availableModels, {
 				settings,

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1601,8 +1601,10 @@ export function filterAvailableModelsByEnabledPatterns(
 
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;
-	/** configuredPatterns is the full configured fallback chain when the selector resolves through a role. */
+	/** configuredPatterns contains the role's ordered primary candidates. */
 	configuredPatterns?: string[];
+	/** configuredRole identifies the role expanded into configuredPatterns. */
+	configuredRole?: string;
 	/** configuredPatternIndex identifies the configured role pattern that matched an available model. */
 	configuredPatternIndex?: number;
 	selector?: string;
@@ -1718,6 +1720,7 @@ export function resolveCliModel(options: {
 					? `${formatModelRoleAlias(bareRoleName)}${bareRoleThinkingLevel ? `:${bareRoleThinkingLevel}` : ""}`
 					: undefined;
 		if (roleSelector) {
+			const configuredRole = getModelRoleAlias(roleSelector, settings);
 			configuredPatterns = resolveConfiguredModelPatterns([roleSelector], settings);
 			const resolved = resolveModelRoleValue(roleSelector, availableModels, {
 				settings,
@@ -1727,6 +1730,7 @@ export function resolveCliModel(options: {
 				return {
 					model: resolved.model,
 					selector: formatModelString(resolved.model),
+					configuredRole,
 					configuredPatterns,
 					configuredPatternIndex: resolved.matchedPatternIndex,
 					thinkingLevel: resolved.thinkingLevel,
@@ -1738,6 +1742,7 @@ export function resolveCliModel(options: {
 				return {
 					model: undefined,
 					configuredPatterns,
+					configuredRole,
 					selector: undefined,
 					thinkingLevel: undefined,
 					warning: resolved.warning,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -119,7 +119,7 @@ import {
 	obfuscateProviderContext,
 	SecretObfuscator,
 } from "./secrets";
-import { AgentSession, type PlanYolo, type Prewalk } from "./session/agent-session";
+import { AgentSession, type InitialRetryFallbackState, type PlanYolo, type Prewalk } from "./session/agent-session";
 import { discoverAuthStorage as discoverAuthStorageFromConfig } from "./session/auth-broker-config";
 import type { AuthStorage } from "./session/auth-storage";
 import { createInterruptedTurnAbortMessage } from "./session/exit-diagnostics";
@@ -1387,6 +1387,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	);
 	let model = options.model;
 	let modelFallbackMessage: string | undefined;
+	let initialRetryFallback: InitialRetryFallbackState | undefined;
 	// Identify session model strings to restore in fallback order. We do an
 	// initial pass here so model-dependent setup (thinking-level resolution,
 	// host preconnect) can use the restored model; extension-registered
@@ -2085,9 +2086,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						preferences: matchPreferences,
 					});
 					if (resolved.configuredPatterns && resolved.configuredPatterns.length > 0) {
-						const primaryPatterns = resolved.configuredPatterns.map(pattern => ({
+						const primaryPatterns: Array<{
+							pattern: string;
+							retryFallback: InitialRetryFallbackState | undefined;
+						}> = resolved.configuredPatterns.map(pattern => ({
 							pattern,
-							retryFallback: false,
+							retryFallback: undefined,
 						}));
 						if (!resolved.configuredRole || !settings.get("retry.modelFallback")) {
 							return primaryPatterns;
@@ -2097,11 +2101,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 							fallbackChains[resolved.configuredRole] ??
 							(resolved.configuredRole === "default" ? undefined : fallbackChains.default);
 						if (!Array.isArray(roleFallbacks)) return primaryPatterns;
+						const originalSelector = resolved.configuredPatterns[0];
+						const parsedOriginal = parseModelString(originalSelector, {
+							allowMaxSuffix: true,
+							allowAutoAlias: true,
+							isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+						});
+						const retryFallback: InitialRetryFallbackState = {
+							role: resolved.configuredRole,
+							originalSelector,
+							originalThinkingLevel: parsedOriginal?.thinkingLevel,
+						};
 						return [
 							...primaryPatterns,
 							...roleFallbacks
 								.filter((pattern): pattern is string => typeof pattern === "string")
-								.map(pattern => ({ pattern, retryFallback: true })),
+								.map(pattern => ({ pattern, retryFallback })),
 						];
 					}
 					if (resolved.model) {
@@ -2111,13 +2126,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 									resolved.selector ?? formatModelStringWithRouting(resolved.model),
 									resolved.thinkingLevel,
 								),
-								retryFallback: false,
+								retryFallback: undefined,
 							},
 						];
 					}
 					return resolveConfiguredModelPatterns([trimmedSelector], settings).map(pattern => ({
 						pattern,
-						retryFallback: false,
+						retryFallback: undefined,
 					}));
 				}),
 			);
@@ -2197,6 +2212,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					}
 				}
 				model = selectedModel;
+				initialRetryFallback = retryFallback;
 				modelFallbackMessage = undefined;
 				if (selectedExplicitThinkingLevel) {
 					restoredSessionThinkingLevel = selectedThinkingLevel;
@@ -2941,6 +2957,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			agent,
 			pruneToolDescriptions: inlineToolDescriptors,
 			thinkingLevel: autoThinking ? AUTO_THINKING : effectiveThinkingLevel,
+			initialRetryFallback,
 			prewalk: options.prewalk,
 			planYolo: options.planYolo,
 			serviceTierByFamily: initialServiceTierByFamily,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2085,23 +2085,46 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						preferences: matchPreferences,
 					});
 					if (resolved.configuredPatterns && resolved.configuredPatterns.length > 0) {
-						return resolved.configuredPatterns;
+						const primaryPatterns = resolved.configuredPatterns.map(pattern => ({
+							pattern,
+							retryFallback: false,
+						}));
+						if (!resolved.configuredRole || !settings.get("retry.modelFallback")) {
+							return primaryPatterns;
+						}
+						const fallbackChains = settings.get("retry.fallbackChains");
+						const roleFallbacks =
+							fallbackChains[resolved.configuredRole] ??
+							(resolved.configuredRole === "default" ? undefined : fallbackChains.default);
+						if (!Array.isArray(roleFallbacks)) return primaryPatterns;
+						return [
+							...primaryPatterns,
+							...roleFallbacks
+								.filter((pattern): pattern is string => typeof pattern === "string")
+								.map(pattern => ({ pattern, retryFallback: true })),
+						];
 					}
 					if (resolved.model) {
 						return [
-							formatModelSelectorValue(
-								resolved.selector ?? formatModelStringWithRouting(resolved.model),
-								resolved.thinkingLevel,
-							),
+							{
+								pattern: formatModelSelectorValue(
+									resolved.selector ?? formatModelStringWithRouting(resolved.model),
+									resolved.thinkingLevel,
+								),
+								retryFallback: false,
+							},
 						];
 					}
-					return resolveConfiguredModelPatterns([trimmedSelector], settings);
+					return resolveConfiguredModelPatterns([trimmedSelector], settings).map(pattern => ({
+						pattern,
+						retryFallback: false,
+					}));
 				}),
 			);
 			for (let patternIndex = 0; patternIndex < expandedModelPatterns.length; patternIndex += 1) {
-				const pattern = expandedModelPatterns[patternIndex];
+				const { pattern, retryFallback } = expandedModelPatterns[patternIndex];
 				const primary = parseModelPattern(pattern, availableModels, matchPreferences);
-				if (!primary.model) continue;
+				if (!primary.model || (retryFallback && !hasModelAuth(primary.model))) continue;
 				let selectedModel = primary.model;
 				let selectedThinkingLevel = primary.thinkingLevel;
 				let selectedExplicitThinkingLevel = primary.explicitThinkingLevel;
@@ -2132,8 +2155,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					);
 					const seenSelectors = new Set<string>([primarySelector]);
 					const fallbackSelectors: string[] = [];
-					for (const fallbackPattern of expandedModelPatterns.slice(patternIndex + 1)) {
-						const fallback = parseModelPattern(fallbackPattern, availableModels, matchPreferences);
+					for (const fallbackEntry of expandedModelPatterns.slice(patternIndex + 1)) {
+						const fallback = parseModelPattern(fallbackEntry.pattern, availableModels, matchPreferences);
 						if (!fallback.model) continue;
 						const fallbackSelector = formatModelSelectorValue(
 							formatModelStringWithRouting(fallback.model),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -872,6 +872,16 @@ export interface PlanYolo {
 // Types
 // ============================================================================
 
+/** Identifies a retry fallback chain already entered during startup model resolution. */
+export interface InitialRetryFallbackState {
+	/** Role whose configured primary was unavailable. */
+	role: string;
+	/** Configured primary selector retained for restoration when it becomes available. */
+	originalSelector: string;
+	/** Thinking selector configured for the unavailable primary. */
+	originalThinkingLevel: ConfiguredThinkingLevel | undefined;
+}
+
 export interface AgentSessionConfig {
 	agent: Agent;
 	sessionManager: SessionManager;
@@ -882,6 +892,8 @@ export interface AgentSessionConfig {
 	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
 	/** Initial session thinking selector. */
 	thinkingLevel?: ConfiguredThinkingLevel;
+	/** Retry chain ownership when startup selected one of its fallback entries. */
+	initialRetryFallback?: InitialRetryFallbackState;
 	/** Prewalk from the starting model to a fast/cheap target at the first edit/write once the todo list exists. */
 	prewalk?: Prewalk;
 	/** Force read-only plan mode at start, auto-approve on the model's first
@@ -2697,6 +2709,13 @@ export class AgentSession {
 			this.#thinkingLevel = resolveProvisionalAutoLevel(this.model);
 		} else {
 			this.#thinkingLevel = config.thinkingLevel;
+		}
+		if (config.initialRetryFallback) {
+			this.#activeRetryFallback = {
+				...config.initialRetryFallback,
+				lastAppliedFallbackThinkingLevel: this.configuredThinkingLevel(),
+				pinned: false,
+			};
 		}
 		if (config.prewalk) {
 			this.#prewalk = config.prewalk;

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -221,6 +221,83 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("continues a startup-owned role fallback chain from the active fallback", async () => {
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!firstFallback || !secondFallback) {
+			throw new Error("Expected bundled fallback models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: firstFallback,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === firstFallback.provider && model.id === firstFallback.id) {
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
+				} else if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+					mock.push({ content: ["Recovered on the remaining fallback"] });
+				} else {
+					throw new Error(
+						`Unexpected model requested during startup fallback test: ${model.provider}/${model.id}`,
+					);
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		const primarySelector = "missing-provider/missing-model";
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": {
+				slow: [`${firstFallback.provider}/${firstFallback.id}`, `${secondFallback.provider}/${secondFallback.id}`],
+			},
+		});
+		settings.setModelRole("slow", primarySelector);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			initialRetryFallback: {
+				role: "slow",
+				originalSelector: primarySelector,
+				originalThinkingLevel: undefined,
+			},
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") fallbackAppliedEvents.push(event);
+		});
+
+		await session.prompt("Continue the startup fallback chain");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${secondFallback.provider}/${secondFallback.id}`,
+		]);
+		expect(session.model?.provider).toBe(secondFallback.provider);
+		expect(session.model?.id).toBe(secondFallback.id);
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${firstFallback.provider}/${firstFallback.id}`,
+				to: `${secondFallback.provider}/${secondFallback.id}`,
+				role: "slow",
+			},
+		]);
+	});
+
 	it("applies a model-keyed fallback chain to advisor quota failures", async () => {
 		const mainModel = getBundledModel("openai", "gpt-4o-mini");
 		const advisorPrimary = getBundledModel("devin", "gpt-5-6-sol");

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -352,10 +352,10 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
-	test("uses a configured role fallback when its primary model is unavailable", async () => {
+	test("uses a configured suffixed role fallback when its primary model is unavailable", async () => {
 		const settings = Settings.isolated({
 			"retry.fallbackChains": {
-				slow: ["missing-provider/missing-fallback", "runtime-provider/runtime-model"],
+				slow: ["missing-provider/missing-fallback", "runtime-provider/runtime-reasoning-model"],
 			},
 		});
 		settings.setModelRole("slow", "missing-provider/missing-model");
@@ -363,7 +363,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		authStorage.setRuntimeApiKey("runtime-provider", "test-key");
 		authStoragesToClose.push(authStorage);
 		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "missing-role-models.yml"));
-		const parsed = parseArgs(["--model", "slow"]);
+		const parsed = parseArgs(["--model", "slow:high"]);
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string | null) => {
 			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
 		});
@@ -375,7 +375,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 				modelRegistry,
 				settings,
 			);
-			expect(cliOptions.modelPattern).toBe("slow");
+			expect(cliOptions.modelPattern).toBe("slow:high");
 
 			const { session, modelFallbackMessage } = await createAgentSession({
 				...cliOptions,
@@ -397,7 +397,8 @@ describe("createAgentSession deferred model pattern resolution", () => {
 
 			try {
 				expect(session.model?.provider).toBe("runtime-provider");
-				expect(session.model?.id).toBe("runtime-model");
+				expect(session.model?.id).toBe("runtime-reasoning-model");
+				expect(session.thinkingLevel).toBe(Effort.High);
 				expect(modelFallbackMessage).toBeUndefined();
 			} finally {
 				await session.dispose();

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -352,6 +352,61 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("uses a configured role fallback when its primary model is unavailable", async () => {
+		const settings = Settings.isolated({
+			"retry.fallbackChains": {
+				slow: ["missing-provider/missing-fallback", "runtime-provider/runtime-model"],
+			},
+		});
+		settings.setModelRole("slow", "missing-provider/missing-model");
+		const authStorage = await AuthStorage.create(path.join(tempDir, "missing-role-auth.db"));
+		authStorage.setRuntimeApiKey("runtime-provider", "test-key");
+		authStoragesToClose.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "missing-role-models.yml"));
+		const parsed = parseArgs(["--model", "slow"]);
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string | null) => {
+			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
+		});
+		try {
+			const cliOptions = await buildCliSessionOptions(
+				parsed,
+				[],
+				SessionManager.inMemory(),
+				modelRegistry,
+				settings,
+			);
+			expect(cliOptions.modelPattern).toBe("slow");
+
+			const { session, modelFallbackMessage } = await createAgentSession({
+				...cliOptions,
+				cwd: tempDir,
+				agentDir: tempDir,
+				authStorage,
+				modelRegistry,
+				settings,
+				disableExtensionDiscovery: true,
+				extensions: [providerExtension],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+			});
+
+			try {
+				expect(session.model?.provider).toBe("runtime-provider");
+				expect(session.model?.id).toBe("runtime-model");
+				expect(modelFallbackMessage).toBeUndefined();
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			exitSpy.mockRestore();
+		}
+	});
+
 	test("preserves deferred bare role fallback chains", async () => {
 		const settings = Settings.isolated();
 		settings.setModelRole("task", "runtime-provider/runtime-model,runtime-provider/runtime-reasoning-model");


### PR DESCRIPTION
## Repro
Configure `modelRoles.slow` with an absent primary and `retry.fallbackChains.slow` with an available authenticated model, then start with `omp --model slow`. The regression is reproduced by `bun test packages/coding-agent/test/sdk-model-selection.test.ts -t "uses a configured role fallback"`; before the fix, `session.model` was `undefined` instead of the configured fallback.

## Cause
`resolveCliModel` in `packages/coding-agent/src/config/model-resolver.ts` expanded a bare role into only its `modelRoles` primary candidates, and the deferred startup loop in `packages/coding-agent/src/sdk.ts` never added the matching `retry.fallbackChains` candidates before resolving the session model.

## Fix
- Carry the configured role identity through CLI model resolution.
- Append that role's ordered retry fallback chain during deferred startup resolution and skip unavailable or unauthenticated fallback entries.
- Add an end-to-end CLI/session regression covering an absent primary, an absent first fallback, and an authenticated available fallback.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/sdk-model-selection.test.ts` passes: 22 tests, 0 failures. `bun check` passes for all packages.

Fixes #6283