### PR TITLE
fix(rm): reject empty operand instead of deleting cwd

### DIFF
--- a/crates/vendor/uu-rm/src/rm.rs
+++ b/crates/vendor/uu-rm/src/rm.rs
@@ -595,6 +595,19 @@ pub fn remove(files: &[&OsStr], options: &Options) -> bool {
 	for filename in files {
 		let file = Path::new(filename);
 
+		// An empty operand can never name a real file. Guard it before
+		// `pi_uutils_ctx::resolve`, which joins "" onto the shell's working
+		// directory — without this, `rm -rf ""` resolves to the cwd and
+		// recursively deletes it. GNU rm reports ENOENT for an empty operand
+		// (and `rm -f` stays silent), so mirror that here.
+		if filename.is_empty() {
+			if !options.force {
+				show_error!("{}", RmError::CannotRemoveNoSuchFile(filename.to_os_string()));
+				had_err = true;
+			}
+			continue;
+		}
+
 		// Check if the path (potentially with trailing slash) resolves to root
 		// This needs to happen before symlink_metadata to catch cases like "rootlink/"
 		// where rootlink is a symlink to root.
@@ -1105,5 +1118,58 @@ mod tests {
 		let path = Path::new("/////");
 
 		assert_eq!(Path::new("/"), clean_trailing_slashes(path));
+	}
+
+	/// Regression: `rm -rf ""` must never delete the shell working directory.
+	///
+	/// An empty operand used to reach `pi_uutils_ctx::resolve`, which joins ""
+	/// onto the cwd and yields the cwd itself, so `-rf` recursively removed it
+	/// (issue #6287). The builtin now rejects the empty operand before
+	/// resolution, leaving the cwd and its contents intact.
+	#[test]
+	fn empty_operand_does_not_delete_cwd() {
+		use std::{
+			collections::HashMap,
+			ffi::OsString,
+			sync::{
+				Arc,
+				atomic::{AtomicBool, AtomicU32, Ordering},
+			},
+			time::{SystemTime, UNIX_EPOCH},
+		};
+
+		use pi_uutils_ctx::{ScopeIo, scope};
+
+		// Unique disposable working directory with a sentinel file inside it.
+		static COUNTER: AtomicU32 = AtomicU32::new(0);
+		let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+		let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+		let cwd = std::env::temp_dir()
+			.join(format!("omp-rm-empty-{}-{}-{}", std::process::id(), nanos, seq));
+		std::fs::create_dir_all(&cwd).unwrap();
+		let sentinel = cwd.join("sentinel");
+		std::fs::write(&sentinel, b"keep me").unwrap();
+
+		let io = ScopeIo {
+			stdin:                 Box::new(std::io::empty()),
+			stdin_fd:              None,
+			stdin_is_search_input: false,
+			stdout:                Box::new(std::io::sink()),
+			stderr:                Box::new(std::io::sink()),
+			cwd:                   cwd.clone(),
+			env:                   HashMap::new(),
+			cancel:                Arc::new(AtomicBool::new(false)),
+		};
+
+		let args =
+			vec![OsString::from("rm"), OsString::from("-rf"), OsString::new()];
+		let code = scope(io, || crate::run(args));
+
+		// `rm -f` swallows the empty-operand error, matching GNU rm's exit 0.
+		assert_eq!(code, 0, "rm -rf \"\" should exit 0 under --force");
+		assert!(cwd.is_dir(), "working directory must survive rm -rf \"\"");
+		assert!(sentinel.is_file(), "sentinel must survive rm -rf \"\"");
+
+		std::fs::remove_dir_all(&cwd).ok();
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the in-process `rm` builtin treating an empty path operand as the shell working directory, so `rm -rf ""` recursively deleted the current directory instead of rejecting the operand. An empty operand reached `pi_uutils_ctx::resolve`, which joins `""` onto the cwd and yields the cwd itself; the builtin now rejects empty operands before resolution, matching GNU `rm` (ENOENT, silent under `-f`) and leaving the cwd untouched ([#6287](https://github.com/can1357/oh-my-pi/issues/6287)).
+
 ## [17.0.5] - 2026-07-18
 
 ### Added


### PR DESCRIPTION
## Repro
Inside `omp shell` (or any embedding using the in-process `rm` builtin), `rm -rf ""` recursively deletes the shell working directory instead of rejecting the empty operand. This bites a common cleanup idiom: when a failed command substitution leaves a variable empty (e.g. a second `mktemp` fails after its parent dir was already removed), the following `rm -rf "$VAR"` runs as `rm -rf ""` and wipes the cwd. Reproduced with an in-process test driving `uu_rm::run` under a `pi_uutils_ctx` scope whose cwd is a fresh temp dir containing a `sentinel` file: `cargo test -p uu_rm empty_operand_does_not_delete_cwd`. With the guard removed the test fails (`working directory must survive rm -rf ""`), demonstrating the deletion.

## Cause
`remove()` in `crates/vendor/uu-rm/src/rm.rs` passes each operand straight into `pi_uutils_ctx::resolve` (`crates/pi-uutils-ctx/src/lib.rs:171`). For `Path::new("")`, `resolve` takes the non-absolute branch and returns `cwd().join("")`, which is the cwd unchanged. `symlink_metadata()` then reports a directory, and under `-r` the builtin recursively removes it. Platform `rm` instead reports ENOENT for an empty operand and never touches the cwd.

## Fix
- Guard empty operands at the top of the `remove()` loop in `crates/vendor/uu-rm/src/rm.rs`, before `pi_uutils_ctx::resolve` can turn `""` into the cwd. `rm ""` reports `cannot remove '': No such file or directory` and exits 1; `rm -f ""` / `rm -rf ""` stay silent and exit 0 — matching GNU `rm`. The cwd is untouched in every case.
- Add regression test `empty_operand_does_not_delete_cwd` that runs the actual builtin `rm -rf ""` in a scoped temp cwd and asserts the cwd and a sentinel file survive.
- Changelog entry under `packages/natives/CHANGELOG.md` `[Unreleased]`.

## Verification
`cargo test -p uu_rm empty_operand_does_not_delete_cwd` passes with the fix and fails without it (verified by temporarily disabling the guard). `bun check` passes via the pre-publish gate. Fixes #6287