### PR TITLE
fix(cli): dispose model-listing extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp models` hanging after output when loaded extensions kept background resources alive; the one-shot command now emits `session_shutdown` and clears managed extension timers before returning ([#6297](https://github.com/can1357/oh-my-pi/issues/6297)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -17,8 +17,14 @@ import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
-import { discoverAndLoadExtensions, loadExtensions } from "../extensibility/extensions";
+import {
+	discoverAndLoadExtensions,
+	ExtensionRunner,
+	emitSessionShutdownEvent,
+	loadExtensions,
+} from "../extensibility/extensions";
 import { discoverAuthStorage } from "../sdk";
+import { SessionManager } from "../session/session-manager";
 import { EventBus } from "../utils/event-bus";
 
 export type ModelsAction = "ls" | "find" | "refresh";
@@ -303,25 +309,39 @@ export async function runModelsListing(options: RunModelsListingOptions): Promis
 				eventBus,
 				disabledExtensionIds,
 			);
+	const extensionRunner =
+		extensionsResult.extensions.length > 0
+			? new ExtensionRunner(
+					extensionsResult.extensions,
+					extensionsResult.runtime,
+					cwd,
+					SessionManager.inMemory(cwd),
+					modelRegistry,
+				)
+			: undefined;
 
-	for (const { path: extPath, error } of extensionsResult.errors) {
-		process.stderr.write(`Failed to load extension: ${extPath}: ${error}\n`);
-	}
+	try {
+		for (const { path: extPath, error } of extensionsResult.errors) {
+			process.stderr.write(`Failed to load extension: ${extPath}: ${error}\n`);
+		}
 
-	// Mirror sdk.ts: drain pending provider registrations into the registry.
-	const activeSources = extensionsResult.extensions.map(extension => extension.path);
-	modelRegistry.syncExtensionSources(activeSources);
-	for (const sourceId of new Set(activeSources)) {
-		modelRegistry.clearSourceRegistrations(sourceId);
-	}
-	for (const { name, config, sourceId } of extensionsResult.runtime.pendingProviderRegistrations) {
-		modelRegistry.registerProvider(name, config, sourceId);
-	}
-	extensionsResult.runtime.pendingProviderRegistrations = [];
-	// Discover runtime (extension) provider catalogs now that they are registered.
-	await modelRegistry.refreshRuntimeProviders(action === "refresh" ? "online" : "online-if-uncached");
+		// Mirror sdk.ts: drain pending provider registrations into the registry.
+		const activeSources = extensionsResult.extensions.map(extension => extension.path);
+		modelRegistry.syncExtensionSources(activeSources);
+		for (const sourceId of new Set(activeSources)) {
+			modelRegistry.clearSourceRegistrations(sourceId);
+		}
+		for (const { name, config, sourceId } of extensionsResult.runtime.pendingProviderRegistrations) {
+			modelRegistry.registerProvider(name, config, sourceId);
+		}
+		extensionsResult.runtime.pendingProviderRegistrations = [];
+		// Discover runtime (extension) provider catalogs now that they are registered.
+		await modelRegistry.refreshRuntimeProviders(action === "refresh" ? "online" : "online-if-uncached");
 
-	renderProviderModels(modelRegistry, action, pattern, json);
+		renderProviderModels(modelRegistry, action, pattern, json);
+	} finally {
+		await emitSessionShutdownEvent(extensionRunner);
+	}
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -179,17 +179,22 @@ export type SwitchSessionHandler = (sessionPath: string) => Promise<{ cancelled:
 export type ShutdownHandler = () => void;
 
 /**
- * Helper function to emit session_shutdown event to extensions.
- * Returns true if the event was emitted, false if there were no handlers.
+ * Emit `session_shutdown` and clear timers owned by an extension runner.
+ *
+ * Returns whether any shutdown handlers were present. Timer cleanup runs even
+ * when a handler fails so extension background work cannot outlive its host.
  */
 export async function emitSessionShutdownEvent(extensionRunner: ExtensionRunner | undefined): Promise<boolean> {
-	if (extensionRunner?.hasHandlers("session_shutdown")) {
+	if (!extensionRunner) return false;
+	try {
+		if (!extensionRunner.hasHandlers("session_shutdown")) return false;
 		await extensionRunner.emit({
 			type: "session_shutdown",
 		});
 		return true;
+	} finally {
+		extensionRunner.clearManagedTimers();
 	}
-	return false;
 }
 
 const noOpUIContext: ExtensionUIContext = {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -238,6 +238,7 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../extensibility/extensions";
+import { emitSessionShutdownEvent } from "../extensibility/extensions";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
@@ -6882,15 +6883,12 @@ export class AgentSession {
 		this.#cancelExitRecorder?.();
 		this.#cancelExitRecorder = undefined;
 		try {
-			if (this.#extensionRunner?.hasHandlers("session_shutdown")) {
-				await this.#extensionRunner.emit({ type: "session_shutdown" });
-			}
+			await emitSessionShutdownEvent(this.#extensionRunner);
 		} catch (error) {
 			logger.warn("Failed to emit session_shutdown event", { error: String(error) });
 		}
 
-		// Stop extension timers before aborting deferred work they could enqueue.
-		this.#extensionRunner?.clearManagedTimers?.();
+		// Stop fallback extension timers before aborting deferred work they could enqueue.
 		this.#fallbackExtensionTimers?.clearAll();
 		this.abortRetry();
 		this.abortCompaction();

--- a/packages/coding-agent/test/issue-905-repro.test.ts
+++ b/packages/coding-agent/test/issue-905-repro.test.ts
@@ -22,11 +22,15 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 let tmp: TempDir;
 let extPath: string;
 let dbPath: string;
+let shutdownExtPath: string;
+let shutdownPath: string;
 
 beforeAll(async () => {
 	tmp = await TempDir.create("@issue-905-");
 	extPath = tmp.join("ext.ts");
 	dbPath = tmp.join("auth.db");
+	shutdownExtPath = tmp.join("shutdown-ext.ts");
+	shutdownPath = tmp.join("shutdown");
 	await fs.writeFile(
 		extPath,
 		`export default function (pi) {
@@ -43,6 +47,15 @@ beforeAll(async () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		}],
+	});
+}
+`,
+	);
+	await fs.writeFile(
+		shutdownExtPath,
+		`export default function (pi) {
+	pi.on("session_shutdown", async () => {
+		await Bun.write(${JSON.stringify(shutdownPath)}, "shutdown");
 	});
 }
 `,
@@ -81,6 +94,25 @@ test("omp models surfaces extension-registered providers (issue #905)", async ()
 		const output = captured.join("");
 		expect(output).toContain("test-gw");
 		expect(output).toContain("test-model");
+	} finally {
+		authStorage.close();
+	}
+});
+
+test("omp models emits extension shutdown after listing (issue #6297)", async () => {
+	const authStorage = await AuthStorage.create(":memory:");
+	try {
+		const modelRegistry = new ModelRegistry(authStorage);
+		await runModelsListing({
+			modelRegistry,
+			cwd: tmp.path(),
+			action: "ls",
+			pattern: "issue-6297-no-models",
+			additionalExtensionPaths: [shutdownExtPath],
+			disableExtensionDiscovery: true,
+		});
+
+		expect(await Bun.file(shutdownPath).text()).toBe("shutdown");
 	} finally {
 		authStorage.close();
 	}


### PR DESCRIPTION
## Repro
A minimal extension starts a referenced interval during activation, registers a `session_shutdown` handler that clears it, and contributes one provider. `timeout 15s bun --cwd packages/coding-agent src/cli.ts models list issue-6297 --json -e /tmp/omp-6297-extension.ts` printed complete JSON on `main` but remained alive until `timeout` returned exit 124.

## Cause
`runModelsListing` in `packages/coding-agent/src/cli/models-cli.ts` loaded and activated extensions to collect provider registrations, then rendered and returned without constructing the extension lifecycle host or emitting `session_shutdown`. Cleanup handlers therefore never ran, leaving extension-owned handles alive after the one-shot command completed.

## Fix
- Construct a minimal `ExtensionRunner` for extensions loaded by `runModelsListing` and emit `session_shutdown` in a `finally` block after provider refresh/rendering.
- Centralize managed-timer cleanup in `emitSessionShutdownEvent` and route normal `AgentSession` teardown through the same lifecycle helper.
- Add regression coverage asserting model listing emits extension shutdown, plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/issue-905-repro.test.ts` — 3 passed, 0 failed. `bun run check:types` in `packages/coding-agent` — passed. Re-running the exact 15-second CLI reproduction printed the extension model and exited 0 in 1.00s instead of timing out. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #6297