### PR TITLE
Add profile-aware Anthropic Cowork OAuth support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a separate Anthropic Cowork OAuth login profile with Cowork-scoped credentials and request fingerprinting. Claude Code and Cowork credentials are retained independently, with the most recently completed login selecting the active profile for account selection and rotation.
+
 ## [17.0.6] - 2026-07-20
 
 ### Fixed

--- a/packages/ai/src/auth-broker/client.ts
+++ b/packages/ai/src/auth-broker/client.ts
@@ -7,8 +7,10 @@
  */
 import { readSseEvents } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
-import type { AuthCredential } from "../auth-storage";
+import type { AuthCredential, OAuthClientProfile } from "../auth-storage";
 import type {
+	ActiveOAuthClientProfileRequest,
+	ActiveOAuthClientProfileResponse,
 	CredentialBlockRequest,
 	CredentialBlockResponse,
 	CredentialBlocksDeleteResponse,
@@ -24,6 +26,7 @@ import type {
 	UsageStaleResponse,
 } from "./types";
 import {
+	activeOAuthClientProfileResponseSchema,
 	credentialBlockResponseSchema,
 	credentialBlocksDeleteResponseSchema,
 	credentialDisableResponseSchema,
@@ -276,6 +279,18 @@ export class AuthBrokerClient {
 		return this.#request<CredentialUploadResponse>("POST", "/v1/credential", {
 			body,
 			schema: credentialUploadResponseSchema,
+			signal,
+		});
+	}
+	async setActiveOAuthClientProfile(
+		provider: string,
+		profile: OAuthClientProfile | undefined,
+		signal?: AbortSignal,
+	): Promise<ActiveOAuthClientProfileResponse> {
+		const body: ActiveOAuthClientProfileRequest = { provider, profile };
+		return this.#request<ActiveOAuthClientProfileResponse>("POST", "/v1/active-oauth-client-profile", {
+			body,
+			schema: activeOAuthClientProfileResponseSchema,
 			signal,
 		});
 	}

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -13,6 +13,7 @@ import {
 	type AuthCredential,
 	type AuthCredentialSnapshotEntry,
 	type AuthCredentialStore,
+	type OAuthClientProfile,
 	type OAuthCredential,
 	REMOTE_REFRESH_SENTINEL,
 	type StoredAuthCredential,
@@ -121,6 +122,7 @@ function emptySnapshot(): SnapshotResponse {
 			skewMs: 0,
 			nextSweepInMs: Number.MAX_SAFE_INTEGER,
 		},
+		activeOAuthClientProfiles: {},
 		credentials: [],
 	};
 }
@@ -258,7 +260,11 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		const credentials = snapshot.credentials.map(entry => this.#normalizeSnapshotEntryBlocks(entry, nowMs));
 		if (snapshotBlocksChanged(previousCredentials, credentials)) this.#invalidateUsageCache();
 		if (protectNewBlocks) this.#protectNewSnapshotBlocks(previousCredentials, credentials, nowMs);
-		this.#snapshot = { ...snapshot, credentials };
+		this.#snapshot = {
+			...snapshot,
+			activeOAuthClientProfiles: snapshot.activeOAuthClientProfiles ?? {},
+			credentials,
+		};
 		this.#generation = generation;
 		this.#snapshotReceivedAt = nowMs;
 		const onSnapshot = this.#onSnapshot;
@@ -412,6 +418,15 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		const result = await this.#client.fetchSnapshot();
 		if (result.status === 200) this.#applySnapshot(result.snapshot, result.generation);
 		return this.#snapshot;
+	}
+
+	getActiveOAuthClientProfile(provider: string): OAuthClientProfile | undefined {
+		return this.#snapshot.activeOAuthClientProfiles?.[provider];
+	}
+
+	async setActiveOAuthClientProfileRemote(provider: string, profile: OAuthClientProfile | undefined): Promise<void> {
+		const { snapshot } = await this.#client.setActiveOAuthClientProfile(provider, profile);
+		this.#applySnapshot(snapshot, snapshot.generation);
 	}
 
 	listAuthCredentials(provider?: string): StoredAuthCredential[] {

--- a/packages/ai/src/auth-broker/server.ts
+++ b/packages/ai/src/auth-broker/server.ts
@@ -15,6 +15,7 @@ import type { AuthStorage, StoredCredentialBlock } from "../auth-storage";
 import { parseBind } from "../utils/parse-bind";
 import { AuthBrokerRefresher, type AuthBrokerRefresherSchedule } from "./refresher";
 import type {
+	ActiveOAuthClientProfileResponse,
 	CredentialBlockResponse,
 	CredentialBlockSnapshot,
 	CredentialBlocksDeleteResponse,
@@ -37,6 +38,7 @@ import {
 	DEFAULT_STREAM_KEEPALIVE_MS,
 } from "./types";
 import {
+	activeOAuthClientProfileRequestSchema,
 	credentialBlockRequestSchema,
 	credentialDisableRequestSchema,
 	credentialUploadRequestSchema,
@@ -319,6 +321,7 @@ function buildSnapshot(storage: AuthStorage, refresher: AuthBrokerRefresher | un
 		generatedAt: base.generatedAt,
 		serverNowMs,
 		refresher: wire,
+		activeOAuthClientProfiles: base.activeOAuthClientProfiles ?? {},
 		credentials,
 	};
 }
@@ -412,6 +415,7 @@ function serveSnapshotStream(
 	let pendingBumps = 0;
 	let closed = false;
 	let lastGeneration = -1;
+	let lastActiveProfilesFingerprint = "";
 
 	const cleanup = (): void => {
 		if (closed) return;
@@ -471,6 +475,9 @@ function serveSnapshotStream(
 					});
 				}
 				lastGeneration = snapshot.generation;
+				const activeProfilesFingerprint = JSON.stringify(snapshot.activeOAuthClientProfiles ?? {});
+				const activeProfilesChanged = activeProfilesFingerprint !== lastActiveProfilesFingerprint;
+				if (activeProfilesChanged) lastActiveProfilesFingerprint = activeProfilesFingerprint;
 				const seenIds = new Set<number>();
 				for (const entry of snapshot.credentials) {
 					seenIds.add(entry.id);
@@ -505,6 +512,10 @@ function serveSnapshotStream(
 					if (!write(sseEvent("removed", payload))) return;
 					logger.debug("auth-broker stream removed", { peer, id, generation: snapshot.generation });
 				}
+				if (activeProfilesChanged) {
+					const payload: SnapshotStreamSnapshotEvent = { kind: "snapshot", ...snapshot };
+					if (!write(sseEvent("snapshot", payload))) return;
+				}
 			} while (pendingBumps > 0 && !closed);
 		} finally {
 			processing = false;
@@ -517,6 +528,7 @@ function serveSnapshotStream(
 			await storage.reload();
 			const initial = buildSnapshot(storage, refresher);
 			lastGeneration = initial.generation;
+			lastActiveProfilesFingerprint = JSON.stringify(initial.activeOAuthClientProfiles ?? {});
 			for (const entry of initial.credentials) lastByCredId.set(entry.id, fingerprintEntry(entry));
 			const initialEvent: SnapshotStreamSnapshotEvent = { kind: "snapshot", ...initial };
 			if (!write(sseEvent("snapshot", initialEvent))) return;
@@ -707,6 +719,26 @@ export function startAuthBroker(opts: AuthBrokerServerOptions): AuthBrokerServer
 						return json(status, { error: message });
 					}
 				}
+				if (req.method === "POST" && pathname === "/v1/active-oauth-client-profile") {
+					const parsed = await parseBody(req, activeOAuthClientProfileRequestSchema);
+					if (!parsed.ok) return parsed.response;
+					try {
+						await opts.storage.setActiveOAuthClientProfile(parsed.data.provider, parsed.data.profile);
+						const response: ActiveOAuthClientProfileResponse = {
+							snapshot: buildSnapshot(opts.storage, refresher),
+						};
+						return json(200, response);
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						logger.warn("auth-broker active OAuth client profile update failed", {
+							provider: parsed.data.provider,
+							peer,
+							error: message,
+						});
+						return json(500, { error: message });
+					}
+				}
+
 				if (req.method === "POST" && pathname === "/v1/credential") {
 					const parsed = await parseBody(req, credentialUploadRequestSchema);
 					if (!parsed.ok) return parsed.response;

--- a/packages/ai/src/auth-broker/types.ts
+++ b/packages/ai/src/auth-broker/types.ts
@@ -10,6 +10,7 @@ import type {
 	AuthCredential,
 	AuthCredentialSnapshot,
 	AuthCredentialSnapshotEntry,
+	OAuthClientProfile,
 	StoredCredentialBlock,
 } from "../auth-storage";
 import type { UsageReport } from "../usage";
@@ -92,6 +93,14 @@ export interface CredentialUploadRequest {
 /** POST /v1/credential response body — redacted snapshot of the provider's rows after upsert. */
 export interface CredentialUploadResponse {
 	entries: AuthCredentialSnapshotEntry[];
+}
+export interface ActiveOAuthClientProfileRequest {
+	provider: string;
+	profile?: OAuthClientProfile;
+}
+
+export interface ActiveOAuthClientProfileResponse {
+	snapshot: SnapshotResponse;
 }
 
 /**

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -34,6 +34,7 @@ export const oauthCredentialSchema = type({
 	"accountId?": "string",
 	"orgId?": "string",
 	"orgName?": "string",
+	"clientProfile?": "'claude-code' | 'cowork'",
 });
 
 /** OAuth credential as it appears in broker snapshots — refresh replaced with sentinel. */
@@ -49,6 +50,7 @@ export const remoteOauthCredentialSchema = type({
 	"accountId?": "string",
 	"orgId?": "string",
 	"orgName?": "string",
+	"clientProfile?": "'claude-code' | 'cowork'",
 });
 
 export const apiKeyCredentialSchema = type({
@@ -106,6 +108,7 @@ export const snapshotResponseSchema = type({
 	generatedAt: "number",
 	serverNowMs: "number",
 	refresher: refresherScheduleSchema,
+	"activeOAuthClientProfiles?": { "[string]": "'claude-code' | 'cowork'" },
 	credentials: snapshotEntrySchema.array(),
 });
 
@@ -118,6 +121,7 @@ export const snapshotStreamSnapshotEventSchema = type({
 	generatedAt: "number",
 	serverNowMs: "number",
 	refresher: refresherScheduleSchema,
+	"activeOAuthClientProfiles?": { "[string]": "'claude-code' | 'cowork'" },
 	credentials: snapshotEntrySchema.array(),
 	kind: "'snapshot'",
 });
@@ -279,4 +283,14 @@ export const credentialUploadRequestSchema = type({
 export const credentialUploadResponseSchema = type({
 	"+": "reject",
 	entries: credentialSnapshotEntrySchema.array(),
+});
+export const activeOAuthClientProfileRequestSchema = type({
+	"+": "reject",
+	provider: type("string").atLeastLength(1),
+	"profile?": "'claude-code' | 'cowork'",
+});
+
+export const activeOAuthClientProfileResponseSchema = type({
+	"+": "reject",
+	snapshot: snapshotResponseSchema,
 });

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -19,11 +19,15 @@ import { getProviderDefinition, PASTE_CODE_LOGIN_PROVIDERS } from "./registry";
 import { getOAuthApiKey, getOAuthProvider, refreshOAuthToken } from "./registry/oauth";
 import type {
 	OAuthAuthInfo,
+	OAuthClientProfile,
 	OAuthController,
 	OAuthCredentials,
 	OAuthProvider,
 	OAuthProviderId,
 } from "./registry/oauth/types";
+
+export type { OAuthClientProfile } from "./registry/oauth/types";
+
 import { getEnvApiKey, getEnvApiKeyName } from "./stream";
 import type { Provider } from "./types";
 import type {
@@ -320,6 +324,7 @@ export interface AuthCredentialSnapshot {
 	generation: number;
 	generatedAt: number;
 	credentials: AuthCredentialSnapshotEntry[];
+	activeOAuthClientProfiles?: Record<string, OAuthClientProfile>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -345,6 +350,9 @@ export interface AuthCredentialStore {
 	/** Optional hook to notify the underlying store that usage report cache is stale. */
 	invalidateUsageCache?(signal?: AbortSignal): Promise<void>;
 	listAuthCredentials(provider?: string): StoredAuthCredential[];
+	/** Explicit provider-level OAuth client profile activation. */
+	getActiveOAuthClientProfile?(provider: string): OAuthClientProfile | undefined;
+	setActiveOAuthClientProfile?(provider: string, profile: OAuthClientProfile | undefined): void;
 	updateAuthCredential(id: number, credential: AuthCredential): void;
 	deleteAuthCredential(id: number, disabledCause: string): void;
 	tryDisableAuthCredentialIfMatches(
@@ -488,6 +496,8 @@ export interface AuthCredentialStore {
 	 * of the sync `deleteAuthCredentialsForProvider`.
 	 */
 	deleteAuthCredentialsRemote?(provider: string, disabledCause: string): Promise<void>;
+	/** Optional remote mutation hook for provider-level OAuth client profile activation. */
+	setActiveOAuthClientProfileRemote?(provider: string, profile: OAuthClientProfile | undefined): Promise<void>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1046,7 +1056,8 @@ function authCredentialEquals(left: AuthCredential, right: AuthCredential): bool
 		left.accountId === right.accountId &&
 		left.email === right.email &&
 		left.projectId === right.projectId &&
-		left.enterpriseUrl === right.enterpriseUrl
+		left.enterpriseUrl === right.enterpriseUrl &&
+		left.clientProfile === right.clientProfile
 	);
 }
 
@@ -1096,6 +1107,24 @@ class AuthStorageUsageCache implements UsageCache {
 // ─────────────────────────────────────────────────────────────────────────────
 // In-memory representation
 // ─────────────────────────────────────────────────────────────────────────────
+function normalizeOAuthClientProfile(provider: string, credential: OAuthCredential): OAuthClientProfile | undefined {
+	if (provider !== "anthropic") return credential.clientProfile;
+	return credential.clientProfile === "cowork" ? "cowork" : "claude-code";
+}
+
+function withOAuthClientProfileIdentity(
+	provider: string,
+	identityKey: string | null,
+	credential: OAuthCredential,
+): string | null {
+	if (identityKey === null || provider !== "anthropic") return identityKey;
+	return `${identityKey}|client-profile:${normalizeOAuthClientProfile(provider, credential)}`;
+}
+
+function withoutOAuthClientProfileIdentity(provider: string, identityKey: string | null): string | null {
+	if (identityKey === null || provider !== "anthropic") return identityKey;
+	return identityKey.replace(/\|client-profile:(?:claude-code|cowork)$/, "");
+}
 
 type StoredCredential = { id: number; credential: AuthCredential };
 type CredentialSelection<T extends AuthCredential> = { credential: T; index: number };
@@ -1377,6 +1406,21 @@ export class AuthStorage {
 			}
 		}
 
+		const anthropicEntries = dedupedGrouped.get("anthropic");
+		if (anthropicEntries?.some(entry => entry.credential.type === "oauth")) {
+			const activeProfile = this.#store.getActiveOAuthClientProfile?.("anthropic");
+			if (activeProfile === undefined) {
+				const initialProfile: OAuthClientProfile = anthropicEntries.some(
+					entry =>
+						entry.credential.type === "oauth" &&
+						normalizeOAuthClientProfile("anthropic", entry.credential) === "claude-code",
+				)
+					? "claude-code"
+					: "cowork";
+				this.#store.setActiveOAuthClientProfile?.("anthropic", initialProfile);
+			}
+		}
+
 		const removedProviders = new Set(this.#data.keys());
 		for (const [provider, entries] of dedupedGrouped) {
 			this.#setStoredCredentials(provider, entries);
@@ -1394,6 +1438,24 @@ export class AuthStorage {
 	 */
 	#getStoredCredentials(provider: string): StoredCredential[] {
 		return this.#data.get(provider) ?? [];
+	}
+	#getActiveProfileForSelection(provider: string): OAuthClientProfile | undefined {
+		if (provider !== "anthropic") return undefined;
+		const persisted = this.#store.getActiveOAuthClientProfile?.(provider);
+		if (persisted !== undefined) return persisted;
+		const oauth = this.#getStoredCredentials(provider).filter(
+			(entry): entry is StoredCredential & { credential: OAuthCredential } => entry.credential.type === "oauth",
+		);
+		if (oauth.some(entry => normalizeOAuthClientProfile(provider, entry.credential) === "claude-code")) {
+			return "claude-code";
+		}
+		return oauth.length > 0 ? "cowork" : undefined;
+	}
+
+	#isOAuthCredentialInActiveProfile(provider: string, credential: OAuthCredential): boolean {
+		if (provider !== "anthropic") return true;
+		const activeProfile = this.#getActiveProfileForSelection(provider);
+		return activeProfile !== undefined && normalizeOAuthClientProfile(provider, credential) === activeProfile;
 	}
 
 	/**
@@ -1419,6 +1481,32 @@ export class AuthStorage {
 			this.#data.delete(provider);
 		} else {
 			this.#data.set(provider, credentials);
+		}
+		if (provider === "anthropic") {
+			const activeProfile = this.#store.getActiveOAuthClientProfile?.(provider);
+			if (
+				activeProfile !== undefined &&
+				!credentials.some(
+					entry =>
+						entry.credential.type === "oauth" &&
+						normalizeOAuthClientProfile(provider, entry.credential) === activeProfile,
+				)
+			) {
+				const fallbackProfile: OAuthClientProfile | undefined = credentials.some(
+					entry =>
+						entry.credential.type === "oauth" &&
+						normalizeOAuthClientProfile(provider, entry.credential) === "claude-code",
+				)
+					? "claude-code"
+					: credentials.some(
+								entry =>
+									entry.credential.type === "oauth" &&
+									normalizeOAuthClientProfile(provider, entry.credential) === "cowork",
+							)
+						? "cowork"
+						: undefined;
+				this.#store.setActiveOAuthClientProfile?.(provider, fallbackProfile);
+			}
 		}
 		this.#bumpGeneration("credentials");
 	}
@@ -1798,6 +1886,12 @@ export class AuthStorage {
 			.map((credential, index) => ({ credential, index }))
 			.filter((entry): entry is { credential: Extract<AuthCredential, { type: T }>; index: number } => {
 				if (entry.credential.type !== type) return false;
+				if (
+					entry.credential.type === "oauth" &&
+					!this.#isOAuthCredentialInActiveProfile(provider, entry.credential)
+				) {
+					return false;
+				}
 				return filter?.(entry.credential) ?? true;
 			});
 
@@ -2137,20 +2231,29 @@ export class AuthStorage {
 	}
 
 	/**
-	 * List stored credential rows, optionally filtered by provider.
+	 * List stored credential rows, optionally filtered by provider and OAuth
+	 * client profile. Anthropic credentials written before profiles existed are
+	 * exposed as Claude Code credentials for filtering.
 	 */
-	listStoredCredentials(provider?: string): StoredAuthCredential[] {
+	listStoredCredentials(provider?: string, options?: { clientProfile?: OAuthClientProfile }): StoredAuthCredential[] {
+		const matchesProfile = (storedProvider: string, credential: AuthCredential): boolean =>
+			options?.clientProfile === undefined ||
+			(credential.type === "oauth" &&
+				normalizeOAuthClientProfile(storedProvider, credential) === options.clientProfile);
 		if (provider !== undefined) {
-			return this.#getStoredCredentials(provider).map(entry => ({
-				id: entry.id,
-				provider,
-				credential: entry.credential,
-				disabledCause: null,
-			}));
+			return this.#getStoredCredentials(provider)
+				.filter(entry => matchesProfile(provider, entry.credential))
+				.map(entry => ({
+					id: entry.id,
+					provider,
+					credential: entry.credential,
+					disabledCause: null,
+				}));
 		}
 		const rows: StoredAuthCredential[] = [];
 		for (const [storedProvider, entries] of this.#data) {
 			for (const entry of entries) {
+				if (!matchesProfile(storedProvider, entry.credential)) continue;
 				rows.push({
 					id: entry.id,
 					provider: storedProvider,
@@ -2160,6 +2263,27 @@ export class AuthStorage {
 			}
 		}
 		return rows;
+	}
+
+	getActiveOAuthClientProfile(provider: string): OAuthClientProfile | undefined {
+		return this.#getActiveProfileForSelection(provider);
+	}
+
+	hasOAuthClientProfile(provider: string, profile: OAuthClientProfile): boolean {
+		return this.#getStoredCredentials(provider).some(
+			entry =>
+				entry.credential.type === "oauth" && normalizeOAuthClientProfile(provider, entry.credential) === profile,
+		);
+	}
+
+	async setActiveOAuthClientProfile(provider: string, profile: OAuthClientProfile | undefined): Promise<void> {
+		if (this.#store.setActiveOAuthClientProfileRemote) {
+			await this.#store.setActiveOAuthClientProfileRemote(provider, profile);
+		} else {
+			this.#store.setActiveOAuthClientProfile?.(provider, profile);
+		}
+		this.#resetProviderAssignments(provider);
+		this.#bumpGeneration("active-oauth-client-profile");
 	}
 
 	/**
@@ -2391,6 +2515,19 @@ export class AuthStorage {
 		);
 		this.#resetProviderAssignments(provider);
 	}
+	async #reconcileOAuthClientProfileAfterRemoval(provider: string, removedCredential: AuthCredential): Promise<void> {
+		if (provider !== "anthropic" || removedCredential.type !== "oauth") return;
+		const removedProfile = normalizeOAuthClientProfile(provider, removedCredential);
+		if (removedProfile === undefined) return;
+		if (this.getActiveOAuthClientProfile(provider) !== removedProfile) return;
+		if (this.hasOAuthClientProfile(provider, removedProfile)) return;
+		const fallbackProfile: OAuthClientProfile | undefined = this.hasOAuthClientProfile(provider, "claude-code")
+			? "claude-code"
+			: this.hasOAuthClientProfile(provider, "cowork")
+				? "cowork"
+				: undefined;
+		await this.setActiveOAuthClientProfile(provider, fallbackProfile);
+	}
 
 	/**
 	 * Remove credential for a provider.
@@ -2402,7 +2539,7 @@ export class AuthStorage {
 			this.#store.deleteAuthCredentialsForProvider(provider, "deleted by user");
 		}
 		this.#setStoredCredentials(provider, []);
-		this.#resetProviderAssignments(provider);
+		await this.setActiveOAuthClientProfile(provider, undefined);
 	}
 
 	/**
@@ -2424,6 +2561,7 @@ export class AuthStorage {
 			entries.filter((_entry, entryIndex) => entryIndex !== index),
 		);
 		this.#resetProviderAssignments(provider);
+		await this.#reconcileOAuthClientProfileAfterRemoval(provider, entries[index]!.credential);
 		return true;
 	}
 
@@ -2507,13 +2645,16 @@ export class AuthStorage {
 	 */
 	getOAuthCredential(provider: string): OAuthCredential | undefined {
 		return this.#getCredentialsForProvider(provider).find(
-			(credential): credential is OAuthCredential => credential.type === "oauth",
+			(credential): credential is OAuthCredential =>
+				credential.type === "oauth" && this.#isOAuthCredentialInActiveProfile(provider, credential),
 		);
 	}
 
 	#resolveActiveOAuthCredential(provider: string, sessionId?: string): OAuthCredential | undefined {
 		const allCredentials = this.#getCredentialsForProvider(provider);
-		const oauthCredentials = allCredentials.filter((c): c is OAuthCredential => c.type === "oauth");
+		const oauthCredentials = allCredentials.filter(
+			(c): c is OAuthCredential => c.type === "oauth" && this.#isOAuthCredentialInActiveProfile(provider, c),
+		);
 		if (oauthCredentials.length === 0) return undefined;
 
 		// Runtime / config overrides bypass OAuth account_uuid attribution — the
@@ -2538,7 +2679,9 @@ export class AuthStorage {
 		// filtered array would be off-by-N when any non-OAuth credential precedes the
 		// OAuth ones (e.g. [api_key, oauth_A, oauth_B] stored order).
 		const stickyCredential = sessionPref?.type === "oauth" ? allCredentials[sessionPref.index] : undefined;
-		return stickyCredential?.type === "oauth" ? stickyCredential : oauthCredentials[0];
+		return stickyCredential?.type === "oauth" && this.#isOAuthCredentialInActiveProfile(provider, stickyCredential)
+			? stickyCredential
+			: oauthCredentials[0];
 	}
 
 	/**
@@ -2657,7 +2800,14 @@ export class AuthStorage {
 		// Use #upsertOAuthCredential to upsert the new credential.
 		// Any legacy api_key rows from older versions will be cleaned up so they do not
 		// shadow the new OAuth row, while preserving other active OAuth credentials.
-		await this.#upsertOAuthCredential(def.storeCredentialsAs ?? provider, newCredential);
+		const storedProvider = def.storeCredentialsAs ?? provider;
+		await this.#upsertOAuthCredential(storedProvider, newCredential);
+		if (storedProvider === "anthropic") {
+			await this.setActiveOAuthClientProfile(
+				storedProvider,
+				normalizeOAuthClientProfile(storedProvider, newCredential),
+			);
+		}
 		return {
 			type: "oauth",
 			email: newCredential.email,
@@ -3773,12 +3923,23 @@ export class AuthStorage {
 			const stored = this.#getStoredCredentials(provider);
 			const index = stored.findIndex(entry => entry.id === options.credentialId);
 			const entry = index === -1 ? undefined : stored[index];
-			if (entry) return { type: entry.credential.type, index, explicit: true };
+			if (
+				entry &&
+				(entry.credential.type !== "oauth" || this.#isOAuthCredentialInActiveProfile(provider, entry.credential))
+			) {
+				return { type: entry.credential.type, index, explicit: true };
+			}
 		}
 		if (options?.apiKey !== undefined) {
 			const stored = this.#getStoredCredentials(provider);
 			for (let index = 0; index < stored.length; index++) {
 				const entry = stored[index];
+				if (
+					entry?.credential.type === "oauth" &&
+					!this.#isOAuthCredentialInActiveProfile(provider, entry.credential)
+				) {
+					continue;
+				}
 				if (entry && (await this.#credentialMatchesApiKey(entry.credential, options.apiKey))) {
 					return { type: entry.credential.type, index, explicit: true };
 				}
@@ -3786,7 +3947,12 @@ export class AuthStorage {
 		}
 		if (explicit) return undefined;
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
-		return sessionCredential ? { ...sessionCredential, explicit: false } : undefined;
+		if (!sessionCredential) return undefined;
+		const storedCredential = this.#getStoredCredentials(provider)[sessionCredential.index]?.credential;
+		if (storedCredential?.type === "oauth" && !this.#isOAuthCredentialInActiveProfile(provider, storedCredential)) {
+			return undefined;
+		}
+		return { ...sessionCredential, explicit: false };
 	}
 
 	/**
@@ -3821,7 +3987,10 @@ export class AuthStorage {
 				credentialId === undefined
 					? -1
 					: this.#getStoredCredentials(provider).findIndex(
-							entry => entry.id === credentialId && entry.credential.type === "oauth",
+							entry =>
+								entry.id === credentialId &&
+								entry.credential.type === "oauth" &&
+								this.#isOAuthCredentialInActiveProfile(provider, entry.credential),
 						);
 			if (index >= 0) sessionCredential = { type: "oauth", index, explicit: true };
 		}
@@ -3864,7 +4033,10 @@ export class AuthStorage {
 			.map((credential, index) => ({ credential, index }))
 			.filter(
 				(entry): entry is { credential: AuthCredential; index: number } =>
-					entry.credential.type === credentialType && entry.index !== targetIndex,
+					entry.credential.type === credentialType &&
+					(entry.credential.type !== "oauth" ||
+						this.#isOAuthCredentialInActiveProfile(provider, entry.credential)) &&
+					entry.index !== targetIndex,
 			);
 
 		let retryAtMs: number | undefined;
@@ -4128,7 +4300,10 @@ export class AuthStorage {
 	): Promise<OAuthResolutionResult | undefined> {
 		const credentials = this.#getCredentialsForProvider(provider)
 			.map((credential, index) => ({ credential, index }))
-			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
+			.filter(
+				(entry): entry is { credential: OAuthCredential; index: number } =>
+					entry.credential.type === "oauth" && this.#isOAuthCredentialInActiveProfile(provider, entry.credential),
+			);
 
 		if (credentials.length === 0) return undefined;
 
@@ -4623,6 +4798,7 @@ export class AuthStorage {
 				apiEndpoint: result.newCredentials.apiEndpoint ?? selection.credential.apiEndpoint,
 				orgId: result.newCredentials.orgId ?? selection.credential.orgId,
 				orgName: result.newCredentials.orgName ?? selection.credential.orgName,
+				clientProfile: result.newCredentials.clientProfile ?? selection.credential.clientProfile,
 			};
 			if (credentialId !== undefined) {
 				const idx = this.#replaceCredentialById(provider, credentialId, updated);
@@ -4720,7 +4896,12 @@ export class AuthStorage {
 					await this.reload();
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
-				if (this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")) {
+				if (
+					this.#getCredentialsForProvider(provider).some(
+						credential =>
+							credential.type === "oauth" && this.#isOAuthCredentialInActiveProfile(provider, credential),
+					)
+				) {
 					if (allowFallback) return this.#resolveOAuthSelection(provider, sessionId, options);
 				}
 			} else {
@@ -4900,7 +5081,10 @@ export class AuthStorage {
 	#getStoredOAuthSelections(provider: string): StoredOAuthSelection[] {
 		return this.#getStoredCredentials(provider)
 			.map((entry, index) => ({ credentialId: entry.id, credential: entry.credential, index }))
-			.filter((entry): entry is StoredOAuthSelection => entry.credential.type === "oauth");
+			.filter(
+				(entry): entry is StoredOAuthSelection =>
+					entry.credential.type === "oauth" && this.#isOAuthCredentialInActiveProfile(provider, entry.credential),
+			);
 	}
 
 	/** Refresh one stored OAuth selection and shape it as an {@link OAuthAccessResolution}. */
@@ -5437,6 +5621,7 @@ export class AuthStorage {
 		const hasSibling = this.#getCredentialsForProvider(provider).some(
 			(credential, index) =>
 				credential.type === sessionCredential.type &&
+				(credential.type !== "oauth" || this.#isOAuthCredentialInActiveProfile(provider, credential)) &&
 				index !== sessionCredential.index &&
 				!this.#isCredentialBlocked(provider, providerKey, index),
 		);
@@ -5550,7 +5735,17 @@ export class AuthStorage {
 				});
 			}
 		}
-		return { generation: this.#generation, generatedAt: Date.now(), credentials: entries };
+		const activeOAuthClientProfiles: Record<string, OAuthClientProfile> = {};
+		for (const provider of this.#data.keys()) {
+			const profile = this.#store.getActiveOAuthClientProfile?.(provider);
+			if (profile !== undefined) activeOAuthClientProfiles[provider] = profile;
+		}
+		return {
+			generation: this.#generation,
+			generatedAt: Date.now(),
+			credentials: entries,
+			activeOAuthClientProfiles,
+		};
 	}
 
 	/**
@@ -5643,6 +5838,7 @@ export class AuthStorage {
 				apiEndpoint: refreshed.apiEndpoint ?? attempted.apiEndpoint,
 				orgId: refreshed.orgId ?? attempted.orgId,
 				orgName: refreshed.orgName ?? attempted.orgName,
+				clientProfile: refreshed.clientProfile ?? attempted.clientProfile,
 			};
 			// Persist by id: the array may have been reordered/shrunk while the
 			// refresh was in flight, so the pre-await positional index is unsafe. A
@@ -5673,6 +5869,23 @@ export class AuthStorage {
 			this.#store.deleteAuthCredential(id, disabledCause);
 			const next = entries.filter((_value, idx) => idx !== index);
 			this.#setStoredCredentials(provider, next);
+			const removedCredential = entries[index]!.credential;
+			if (
+				provider === "anthropic" &&
+				removedCredential.type === "oauth" &&
+				this.getActiveOAuthClientProfile(provider) === normalizeOAuthClientProfile(provider, removedCredential) &&
+				!this.hasOAuthClientProfile(
+					provider,
+					normalizeOAuthClientProfile(provider, removedCredential) ?? "claude-code",
+				)
+			) {
+				const fallbackProfile: OAuthClientProfile | undefined = this.hasOAuthClientProfile(provider, "claude-code")
+					? "claude-code"
+					: this.hasOAuthClientProfile(provider, "cowork")
+						? "cowork"
+						: undefined;
+				this.#store.setActiveOAuthClientProfile?.(provider, fallbackProfile);
+			}
 			this.#resetProviderAssignments(provider);
 			this.#emitCredentialDisabled({ provider, disabledCause });
 			return true;
@@ -5938,7 +6151,8 @@ function resolveProviderCredentialIdentityKey(provider: string, identifiers: str
 
 function resolveCredentialIdentityKey(provider: string, credential: AuthCredential): string | null {
 	if (credential.type === "api_key") return null;
-	return resolveProviderCredentialIdentityKey(provider, extractOAuthCredentialIdentifiers(credential));
+	const identityKey = resolveProviderCredentialIdentityKey(provider, extractOAuthCredentialIdentifiers(credential));
+	return withOAuthClientProfileIdentity(provider, identityKey, credential);
 }
 
 function resolveRowCredentialIdentityKey(provider: string, row: AuthRow): string | null {
@@ -5958,11 +6172,16 @@ function matchesReplacementCredential(
 	if (incoming.type === "api_key") {
 		return existing.type === "api_key" && existing.key === incoming.key;
 	}
+	if (provider === "anthropic" && existing.type === "oauth") {
+		if (normalizeOAuthClientProfile(provider, existing) !== normalizeOAuthClientProfile(provider, incoming))
+			return false;
+	}
 	const incomingIdentifiers = extractOAuthCredentialIdentifiers(incoming);
 	const incomingIdentityKey = resolveProviderCredentialIdentityKey(provider, incomingIdentifiers);
 	if (incomingIdentityKey === null) return false;
-	if (incomingIdentityKey === existingIdentityKey) return true;
-	if (existingIdentityKey === null) return false;
+	const existingBaseIdentityKey = withoutOAuthClientProfileIdentity(provider, existingIdentityKey);
+	if (incomingIdentityKey === existingBaseIdentityKey) return true;
+	if (existingBaseIdentityKey === null) return false;
 	// One-way upgrade, applied only when the INCOMING identity key carries the
 	// org qualifier (only anthropic and openai-codex keys do, so other
 	// providers never reach the checks below). An org-scoped login `org:<o>`
@@ -5985,9 +6204,9 @@ function matchesReplacementCredential(
 	const orgIdentifier = incomingIdentifiers.find(identifier => identifier.startsWith("org:"));
 	if (orgIdentifier === undefined) return false;
 	if (incomingIdentityKey !== orgIdentifier && !incomingIdentityKey.endsWith(`|${orgIdentifier}`)) return false;
-	if (existingIdentityKey === orgIdentifier) return true;
+	if (existingBaseIdentityKey === orgIdentifier) return true;
 	const existingIdentifiers =
-		existing.type === "oauth" && existingIdentityKey.endsWith(`|${orgIdentifier}`)
+		existing.type === "oauth" && existingBaseIdentityKey.endsWith(`|${orgIdentifier}`)
 			? extractOAuthCredentialIdentifiers(existing)
 			: null;
 	// A base identifier that merely repeats the org qualifier's id carries no
@@ -6000,8 +6219,8 @@ function matchesReplacementCredential(
 			identifier.startsWith("email:") || identifier.startsWith("account:") || identifier.startsWith("project:");
 		if (!isBase) continue;
 		if (identifier.slice(identifier.indexOf(":") + 1) === orgQualifierId) continue;
-		if (existingIdentityKey === identifier) return true;
-		if (existingIdentityKey === `${identifier}|${orgIdentifier}`) return true;
+		if (existingBaseIdentityKey === identifier) return true;
+		if (existingBaseIdentityKey === `${identifier}|${orgIdentifier}`) return true;
 		if (existingIdentifiers?.includes(identifier)) return true;
 	}
 	return false;
@@ -6329,6 +6548,10 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			);
 			CREATE INDEX IF NOT EXISTS idx_usage_cost_history_lookup ON usage_cost_history(provider, account_key, recorded_at);
 			CREATE INDEX IF NOT EXISTS idx_usage_history_recorded ON usage_history(recorded_at);
+			CREATE TABLE IF NOT EXISTS auth_provider_state (
+				provider TEXT PRIMARY KEY,
+				active_oauth_client_profile TEXT
+			);
 		`);
 
 		if (!this.#authCredentialsTableExists()) {
@@ -6341,6 +6564,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 
 		const recordedVersion = this.#readAuthSchemaVersion();
 		const schemaVersion = recordedVersion ?? this.#inferAuthSchemaVersion();
+
 		if (schemaVersion > AUTH_SCHEMA_VERSION) {
 			logger.warn("SqliteAuthCredentialStore schema version mismatch", {
 				current: schemaVersion,
@@ -6572,7 +6796,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 
 	#backfillCredentialIdentityKeys(): void {
 		const selectRowsStmt = this.#db.prepare(
-			"SELECT id, provider, credential_type, data, disabled_cause, identity_key FROM auth_credentials WHERE identity_key IS NULL ORDER BY id ASC",
+			`SELECT id, provider, credential_type, data, disabled_cause, identity_key
+			 FROM auth_credentials
+			 WHERE identity_key IS NULL
+			    OR (provider = 'anthropic' AND identity_key NOT LIKE '%|client-profile:claude-code'
+			        AND identity_key NOT LIKE '%|client-profile:cowork')
+			 ORDER BY id ASC`,
 		);
 		let rows: AuthRow[];
 		try {
@@ -6612,6 +6841,34 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			results.push(toStoredAuthCredential(row, credential));
 		}
 		return results;
+	}
+	getActiveOAuthClientProfile(provider: string): OAuthClientProfile | undefined {
+		const stmt = this.#db.prepare("SELECT active_oauth_client_profile FROM auth_provider_state WHERE provider = ?");
+		try {
+			const row = stmt.get(provider) as { active_oauth_client_profile?: unknown } | undefined;
+			return row?.active_oauth_client_profile === "claude-code" || row?.active_oauth_client_profile === "cowork"
+				? row.active_oauth_client_profile
+				: undefined;
+		} finally {
+			stmt.finalize();
+		}
+	}
+
+	setActiveOAuthClientProfile(provider: string, profile: OAuthClientProfile | undefined): void {
+		const stmt =
+			profile === undefined
+				? this.#db.prepare("DELETE FROM auth_provider_state WHERE provider = ?")
+				: this.#db.prepare(
+						`INSERT INTO auth_provider_state (provider, active_oauth_client_profile)
+						 VALUES (?, ?)
+						 ON CONFLICT(provider) DO UPDATE SET active_oauth_client_profile = excluded.active_oauth_client_profile`,
+					);
+		try {
+			if (profile === undefined) stmt.run(provider);
+			else stmt.run(provider, profile);
+		} finally {
+			stmt.finalize();
+		}
 	}
 
 	replaceAuthCredentialsForProvider(provider: string, credentials: AuthCredential[]): StoredAuthCredential[] {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -95,13 +95,15 @@ export type AnthropicHeaderOptions = {
 	baseUrl?: string;
 	isOAuth?: boolean;
 	extraBetas?: string[];
+	claudeCodeBetas?: readonly string[];
 	stream?: boolean;
 	modelHeaders?: Record<string, string>;
-	isCloudflareAiGateway?: boolean;
 	claudeCodeSessionId?: string;
-	claudeCodeBetas?: readonly string[];
-	/** Allow explicit fingerprint headers to replace OAuth defaults on non-official endpoints. */
+	isCloudflareAiGateway?: boolean;
+	/** Allow caller-provided headers to replace enforced OAuth defaults on non-official endpoints. */
 	allowAnthropicHeaderOverrides?: boolean;
+	/** Parsed client identity for callers that already resolved a structured credential. */
+	clientProfile?: AnthropicClientProfile;
 };
 
 export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
@@ -148,6 +150,32 @@ const claudeCodeAgentBetaDefaults = [
 ] as const;
 const extendedCacheTtlBeta = "extended-cache-ttl-2025-04-11";
 const claudeCodeAgentPostEffortBetas = [extendedCacheTtlBeta] as const;
+const coworkUtilityBetaDefaults = [
+	"claude-code-20250219",
+	"oauth-2025-04-20",
+	"context-1m-2025-08-07",
+	"interleaved-thinking-2025-05-14",
+	"thinking-token-count-2026-05-13",
+	contextManagementBeta,
+	"prompt-caching-scope-2026-01-05",
+	midConversationSystemBeta,
+	"advisor-tool-2026-03-01",
+	"effort-2025-11-24",
+	structuredOutputsBeta,
+] as const;
+const coworkAgentBetaDefaults = [
+	"claude-code-20250219",
+	"oauth-2025-04-20",
+	"context-1m-2025-08-07",
+	"interleaved-thinking-2025-05-14",
+	"thinking-token-count-2026-05-13",
+	contextManagementBeta,
+	"prompt-caching-scope-2026-01-05",
+	midConversationSystemBeta,
+	"advisor-tool-2026-03-01",
+	"effort-2025-11-24",
+	extendedCacheTtlBeta,
+] as const;
 const fineGrainedToolStreamingBeta = "fine-grained-tool-streaming-2025-05-14";
 const interleavedThinkingBeta = "interleaved-thinking-2025-05-14";
 // Asks the API to redact thinking blocks from responses. Only sent when the
@@ -179,6 +207,10 @@ function buildClaudeCodeBetas(
 	return betas;
 }
 
+function buildCoworkBetas(agentRequest: boolean): readonly string[] {
+	return agentRequest ? coworkAgentBetaDefaults : coworkUtilityBetaDefaults;
+}
+
 function getHeaderCaseInsensitive(headers: Record<string, string> | undefined, headerName: string): string | undefined {
 	if (!headers) return undefined;
 	const normalizedName = headerName.toLowerCase();
@@ -193,6 +225,36 @@ function isClaudeCodeClientUserAgent(userAgent: string | undefined): userAgent i
 	return userAgent.toLowerCase().startsWith("claude-cli");
 }
 
+export type AnthropicClientProfile = "claude-code" | "cowork";
+
+interface StructuredAnthropicCredential {
+	token: string;
+	clientProfile: AnthropicClientProfile;
+}
+
+function parseStructuredAnthropicCredential(apiKey: string): StructuredAnthropicCredential | undefined {
+	if (!apiKey.startsWith("{")) return undefined;
+	try {
+		const value = JSON.parse(apiKey) as Record<string, unknown>;
+		if (
+			typeof value.token === "string" &&
+			(value.clientProfile === "claude-code" || value.clientProfile === "cowork")
+		) {
+			return { token: value.token, clientProfile: value.clientProfile };
+		}
+	} catch {}
+	return undefined;
+}
+
+export function resolveAnthropicClientProfile(apiKey: string): AnthropicClientProfile | undefined {
+	return parseStructuredAnthropicCredential(apiKey)?.clientProfile;
+}
+
+function isAnthropicCredentialOAuth(apiKey: string): boolean {
+	const credential = parseStructuredAnthropicCredential(apiKey);
+	return credential !== undefined || isAnthropicOAuthToken(apiKey);
+}
+
 const sharedHeaders = {
 	"Accept-Encoding": "gzip, deflate, br, zstd",
 	Connection: "keep-alive",
@@ -203,8 +265,17 @@ const sharedHeaders = {
 };
 
 export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<string, string> {
-	const oauthToken = options.isOAuth ?? isAnthropicOAuthToken(options.apiKey);
-	const extraBetas = options.extraBetas ?? [];
+	const structuredCredential = parseStructuredAnthropicCredential(options.apiKey);
+	const apiKey = structuredCredential?.token ?? options.apiKey;
+	const clientProfile = options.clientProfile ?? structuredCredential?.clientProfile ?? "claude-code";
+	const oauthToken = options.isOAuth ?? isAnthropicCredentialOAuth(apiKey);
+	const baseBetas =
+		options.claudeCodeBetas ??
+		(oauthToken
+			? clientProfile === "cowork"
+				? buildCoworkBetas(false)
+				: buildClaudeCodeBetas(true, true, false)
+			: []);
 	const stream = options.stream ?? false;
 	// `enforcedHeaderKeys` strips User-Agent / X-Api-Key / Authorization out of
 	// modelHeaders so a case-insensitive spread can't produce duplicate keys; each
@@ -221,10 +292,7 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 	// Claude Code betas (oauth-2025-04-20, claude-code-20250219, …) are part of
 	// the OAuth fingerprint; API-key requests default to extras only, matching
 	// the streaming path (buildAnthropicClientOptions passes [] for non-OAuth).
-	const betaHeader = buildBetaHeader(
-		options.claudeCodeBetas ?? (oauthToken ? buildClaudeCodeBetas(true, true, false) : []),
-		extraBetas,
-	);
+	const betaHeader = buildBetaHeader(baseBetas, options.extraBetas ?? []);
 	const acceptHeader = oauthToken ? "application/json" : stream ? "text/event-stream" : "application/json";
 	const isCloudflare = options.isCloudflareAiGateway ?? false;
 	const honorAuthorization = !oauthToken && !isCloudflare;
@@ -280,18 +348,21 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 	}
 
 	if (oauthToken) {
+		const fingerprintHeaders = clientProfile === "cowork" ? coworkHeaders : claudeCodeHeaders;
 		const userAgent = isClaudeCodeClientUserAgent(incomingUserAgent)
 			? incomingUserAgent
-			: `claude-cli/${claudeCodeVersion} (external, local-agent, agent-sdk/${claudeAgentSdkVersion})`;
+			: clientProfile === "cowork"
+				? `claude-cli/${coworkClaudeCodeVersion} (external, local-agent)`
+				: `claude-cli/${claudeCodeVersion} (external, local-agent, agent-sdk/${claudeAgentSdkVersion})`;
 		const headers = {
 			...modelHeaders,
-			...claudeCodeHeaders,
+			...fingerprintHeaders,
 			Accept: acceptHeader,
-			Authorization: `Bearer ${options.apiKey}`,
+			Authorization: `Bearer ${apiKey}`,
 			...sharedHeaders,
 			...(betaHeader ? { "anthropic-beta": betaHeader } : {}),
 			...(options.claudeCodeSessionId ? { "X-Claude-Code-Session-Id": options.claudeCodeSessionId } : {}),
-			"x-client-request-id": nodeCrypto.randomUUID(),
+			...(clientProfile === "claude-code" ? { "x-client-request-id": nodeCrypto.randomUUID() } : {}),
 			"User-Agent": userAgent,
 			...(incomingApiKey ? { "X-Api-Key": incomingApiKey } : {}),
 		};
@@ -463,6 +534,7 @@ function getCacheControl(
 
 // Stealth mode: mimic Claude Code's request fingerprint.
 export const claudeCodeVersion = "2.1.165";
+export const coworkClaudeCodeVersion = "2.1.217";
 export const claudeAgentSdkVersion = "0.3.165";
 export const claudeClientVersion = "1.11187.4";
 export const claudeToolPrefix: string = "_";
@@ -518,9 +590,21 @@ export const claudeCodeHeaders = {
 	"anthropic-client-version": claudeClientVersion,
 };
 
+export const coworkHeaders = {
+	"X-Stainless-Retry-Count": "0",
+	"X-Stainless-Runtime-Version": "v26.3.0",
+	"X-Stainless-Package-Version": "0.94.0",
+	"X-Stainless-Runtime": "node",
+	"X-Stainless-Lang": "js",
+	"X-Stainless-Arch": mapStainlessArch(process.arch),
+	"X-Stainless-OS": mapStainlessOs(process.platform),
+	"X-Stainless-Timeout": "600",
+};
+
 const enforcedHeaderKeys = new Set(
 	[
 		...Object.keys(claudeCodeHeaders),
+		...Object.keys(coworkHeaders),
 		"Accept",
 		"Accept-Encoding",
 		"Connection",
@@ -544,19 +628,16 @@ const overridableAnthropicHeaderKeys = new Set(
 
 const CLAUDE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:";
 
-function createClaudeBillingHeader(firstUserMessageText: string): string {
+function createClaudeBillingHeader(firstUserMessageText: string, clientProfile: AnthropicClientProfile): string {
+	const version = clientProfile === "cowork" ? coworkClaudeCodeVersion : claudeCodeVersion;
 	// Fingerprint: SHA256(salt + msg[4] + msg[7] + msg[20] + version)[:3]
 	// Matches CC's computeFingerprint in utils/fingerprint.ts.
 	// Uses chars from the first user message (not the system prompt).
 	const k = [4, 7, 20].map(i => firstUserMessageText[i] ?? "0").join("");
-	const versionSuffix = nodeCrypto
-		.createHash("sha256")
-		.update(`59cf53e54c78${k}${claudeCodeVersion}`)
-		.digest("hex")
-		.slice(0, 3);
+	const versionSuffix = nodeCrypto.createHash("sha256").update(`59cf53e54c78${k}${version}`).digest("hex").slice(0, 3);
 	// cch=00000: placeholder replaced with the real attestation hash by wrapFetchForCch
 	// before the request hits the wire (see below).
-	return `${CLAUDE_BILLING_HEADER_PREFIX} cc_version=${claudeCodeVersion}.${versionSuffix}; cc_entrypoint=local-agent; ${CCH_PLACEHOLDER_STR};`;
+	return `${CLAUDE_BILLING_HEADER_PREFIX} cc_version=${version}.${versionSuffix}; cc_entrypoint=local-agent; ${CCH_PLACEHOLDER_STR};`;
 }
 
 // cch attestation: XXHash64(body_with_placeholder, seed) low-20-bits, 5 hex chars.
@@ -1789,6 +1870,7 @@ const streamAnthropicOnce = (
 				output.usage.premiumRequests = copilotDynamicHeaders.premiumRequests;
 			}
 			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
+			const clientProfile = parseStructuredAnthropicCredential(apiKey)?.clientProfile ?? "claude-code";
 			const baseUrl = resolveAnthropicBaseUrl(model, apiKey) ?? "https://api.anthropic.com";
 			const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
 			const providerSessionState = getAnthropicProviderSessionState(
@@ -1888,7 +1970,7 @@ const streamAnthropicOnce = (
 				// already carry it in the Claude Code beta list, and utility
 				// requests must not deviate from CC's header fingerprint.
 				if (
-					!(options?.isOAuth ?? isAnthropicOAuthToken(apiKey)) &&
+					!(options?.isOAuth ?? isAnthropicCredentialOAuth(apiKey)) &&
 					getCacheControl(model, options?.cacheRetention, false).cacheControl?.ttl === "1h" &&
 					!extraBetas.includes(extendedCacheTtlBeta)
 				) {
@@ -1943,6 +2025,7 @@ const streamAnthropicOnce = (
 					forceDemoteUnsignedThinking,
 					supportsEagerToolInputStreaming,
 					fallbacks,
+					clientProfile,
 				});
 				if (disableStrictTools) {
 					dropAnthropicStrictTools(nextParams);
@@ -2685,6 +2768,7 @@ type SystemBlockOptions = {
 	/** Text of the first user message — used as fingerprint seed for the billing header. */
 	firstUserMessageText?: string;
 	cacheControl?: AnthropicCacheControl;
+	clientProfile?: AnthropicClientProfile;
 };
 
 function applyClaudeCodeSystemCache(
@@ -2702,14 +2786,20 @@ export function buildAnthropicSystemBlocks(
 	systemPrompt: readonly string[] | undefined,
 	options: SystemBlockOptions = {},
 ): AnthropicSystemBlock[] | undefined {
-	const { includeClaudeCodeInstruction = false, extraInstructions = [], firstUserMessageText, cacheControl } = options;
+	const {
+		includeClaudeCodeInstruction = false,
+		extraInstructions = [],
+		firstUserMessageText,
+		cacheControl,
+		clientProfile = "claude-code",
+	} = options;
 	const sanitizedPrompts = normalizeSystemPrompts(systemPrompt);
 	const trimmedInstructions = extraInstructions.map(instruction => instruction.trim()).filter(Boolean);
 	const hasBillingHeader = sanitizedPrompts.some(prompt => prompt.startsWith(CLAUDE_BILLING_HEADER_PREFIX));
 
 	if (includeClaudeCodeInstruction && !hasBillingHeader) {
 		const blocks: AnthropicSystemBlock[] = [
-			{ type: "text", text: createClaudeBillingHeader(firstUserMessageText ?? "") },
+			{ type: "text", text: createClaudeBillingHeader(firstUserMessageText ?? "", clientProfile) },
 			{ type: "text", text: claudeCodeSystemInstruction },
 		];
 
@@ -2760,11 +2850,13 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		claudeCodeSessionId,
 		disableStrictTools: disableStrictToolsOverride,
 	} = args;
+	const structuredCredential = parseStructuredAnthropicCredential(apiKey);
+	const bearer = structuredCredential?.token ?? apiKey;
 	const compat = model.compat;
 	const disableStrictTools = disableStrictToolsOverride ?? compat.disableStrictTools;
 	const needsInterleavedBeta = interleavedThinking && !model.thinking?.supportsDisplay;
-	const oauthToken = isOAuth ?? isAnthropicOAuthToken(apiKey);
-	const baseUrl = resolveAnthropicBaseUrl(model, apiKey);
+	const oauthToken = isOAuth ?? isAnthropicOAuthToken(bearer);
+	const baseUrl = resolveAnthropicBaseUrl(model, bearer);
 	const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
 	const needsFineGrainedToolStreamingBeta =
 		hasTools && isOfficialAnthropicApiUrl(baseUrl) && !supportsEagerToolInputStreaming;
@@ -2835,12 +2927,14 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		allowAnthropicHeaderOverrides: model.compat.allowAnthropicHeaderOverrides,
 		claudeCodeSessionId,
 		claudeCodeBetas: oauthToken
-			? buildClaudeCodeBetas(
-					hasTools || thinkingEnabled,
-					thinkingEnabled,
-					thinkingDisplay === "omitted",
-					disableStrictTools,
-				)
+			? structuredCredential?.clientProfile === "cowork"
+				? buildCoworkBetas(hasTools || thinkingEnabled)
+				: buildClaudeCodeBetas(
+						hasTools || thinkingEnabled,
+						thinkingEnabled,
+						thinkingDisplay === "omitted",
+						disableStrictTools,
+					)
 			: [],
 	});
 
@@ -2900,7 +2994,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	return {
 		isOAuthToken: oauthToken,
 		apiKey: oauthToken || shouldSuppressClientApiKey ? null : apiKey,
-		authToken: oauthToken ? apiKey : undefined,
+		authToken: oauthToken ? bearer : undefined,
 		baseURL: baseUrl,
 		maxRetries: 5,
 		defaultHeaders,
@@ -3218,6 +3312,7 @@ type AnthropicParamBuildOptions = {
 	supportsEagerToolInputStreaming: boolean;
 	/** Sanitized server-side fallback entries; defaults to `options?.fallbacks` when omitted. */
 	fallbacks?: AnthropicOptions["fallbacks"];
+	clientProfile: AnthropicClientProfile;
 };
 
 function buildParams(
@@ -3233,6 +3328,7 @@ function buildParams(
 		forceDemoteUnsignedThinking,
 		supportsEagerToolInputStreaming,
 		fallbacks = options?.fallbacks,
+		clientProfile,
 	} = buildOptions;
 	// A session-scoped auto-demote (learned from a live signing 400) clones the
 	// resolved compat with `replayUnsignedThinking: false` so every subsequent
@@ -3252,6 +3348,7 @@ function buildParams(
 	const systemBlocks = buildAnthropicSystemBlocks(context.systemPrompt, {
 		includeClaudeCodeInstruction: shouldInjectClaudeCodeInstruction,
 		firstUserMessageText,
+		clientProfile,
 	});
 
 	// Pre-compute tools.

--- a/packages/ai/src/registry/anthropic.ts
+++ b/packages/ai/src/registry/anthropic.ts
@@ -1,5 +1,6 @@
 import { $pickenv } from "@oh-my-pi/pi-utils";
 import { isFoundryEnabled } from "../utils/foundry";
+import { loginAnthropic, loginAnthropicCowork, refreshAnthropicToken } from "./oauth/anthropic";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
 
@@ -11,16 +12,20 @@ export const anthropicProvider = {
 		isFoundryEnabled()
 			? $pickenv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
 			: $pickenv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
-	login: async (cb: OAuthLoginCallbacks) => {
-		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
-		const { loginAnthropic } = await import("./oauth/anthropic");
-		return loginAnthropic(cb);
-	},
-	refreshToken: async (credentials: OAuthCredentials) => {
-		// Lazy import: keep heavy OAuth flow modules out of the eager registry graph.
-		const { refreshAnthropicToken } = await import("./oauth/anthropic");
-		return refreshAnthropicToken(credentials.refresh);
-	},
+	login: async (cb: OAuthLoginCallbacks) => loginAnthropic(cb),
+	refreshToken: async (credentials: OAuthCredentials) =>
+		refreshAnthropicToken(credentials.refresh, undefined, credentials.clientProfile ?? "claude-code"),
+	callbackPort: 54545,
+	pasteCodeFlow: true,
+} as const satisfies ProviderDefinition;
+
+export const anthropicCoworkProvider = {
+	id: "anthropic-cowork",
+	name: "Anthropic (Cowork)",
+	login: async (cb: OAuthLoginCallbacks) => loginAnthropicCowork(cb),
+	refreshToken: async (credentials: OAuthCredentials) =>
+		refreshAnthropicToken(credentials.refresh, undefined, "cowork"),
+	storeCredentialsAs: "anthropic",
 	callbackPort: 54545,
 	pasteCodeFlow: true,
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/oauth/anthropic.ts
+++ b/packages/ai/src/registry/oauth/anthropic.ts
@@ -3,26 +3,36 @@
  */
 
 import * as AIError from "../../error";
-import { claudeCodeVersion } from "../../providers/anthropic";
 import type { FetchImpl } from "../../types";
 import { OAuthCallbackFlow } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthController, OAuthCredentials } from "./types";
 
 const decode = (s: string) => atob(s);
-const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
+const CLAUDE_CODE_CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
+const COWORK_CLIENT_ID = decode("YTQ3M2Q3YmItMTdhYy00M2E3LWFiYzAtYTEzNDNkN2MyODA1");
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://api.anthropic.com/v1/oauth/token";
 const BOOTSTRAP_URL = "https://api.anthropic.com/api/claude_cli/bootstrap";
 const CLAUDE_CODE_BOOTSTRAP_MODEL = "claude-opus-4-8";
-const CLAUDE_CODE_BOOTSTRAP_USER_AGENT = `claude-code/${claudeCodeVersion}`;
+const CLAUDE_CODE_BOOTSTRAP_USER_AGENT = "claude-code/2.1.165";
 const CALLBACK_PORT = 54545;
 const CALLBACK_PATH = "/callback";
+const COWORK_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
 // Scopes required for direct OAuth-token inference (user:inference) plus account/session management.
 // platform.claude.com/oauth/authorize issues console tokens (org:create_api_key only) and does not
 // grant user:inference — the claude.ai endpoint is required for direct inference access.
-const SCOPES =
+const CLAUDE_CODE_SCOPES =
 	"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+const COWORK_SCOPES = "user:inference user:file_upload user:profile";
+
+type AnthropicOAuthProfile = "claude-code" | "cowork";
+
+function oauthProfileConfig(profile: AnthropicOAuthProfile): { clientId: string; scopes: string } {
+	return profile === "cowork"
+		? { clientId: COWORK_CLIENT_ID, scopes: COWORK_SCOPES }
+		: { clientId: CLAUDE_CODE_CLIENT_ID, scopes: CLAUDE_CODE_SCOPES };
+}
 
 function formatErrorDetails(error: unknown): string {
 	if (error instanceof Error) {
@@ -205,10 +215,23 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 	#verifier: string = "";
 	#challenge: string = "";
 	#fetch: FetchImpl;
+	#profile: AnthropicOAuthProfile;
 
-	constructor(ctrl: OAuthController) {
-		super(ctrl, CALLBACK_PORT, CALLBACK_PATH);
+	constructor(ctrl: OAuthController, profile: AnthropicOAuthProfile = "claude-code") {
+		super(
+			ctrl,
+			profile === "cowork"
+				? {
+						preferredPort: CALLBACK_PORT,
+						callbackPath: CALLBACK_PATH,
+						redirectUri: COWORK_REDIRECT_URI,
+						manualInputOnly: true,
+					}
+				: CALLBACK_PORT,
+			CALLBACK_PATH,
+		);
 		this.#fetch = ctrl.fetch ?? fetch;
+		this.#profile = profile;
 	}
 
 	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
@@ -216,12 +239,13 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 		this.#verifier = pkce.verifier;
 		this.#challenge = pkce.challenge;
 
+		const config = oauthProfileConfig(this.#profile);
 		const authParams = new URLSearchParams({
 			code: "true",
-			client_id: CLIENT_ID,
+			client_id: config.clientId,
 			response_type: "code",
 			redirect_uri: redirectUri,
-			scope: SCOPES,
+			scope: config.scopes,
 			code_challenge: this.#challenge,
 			code_challenge_method: "S256",
 			state,
@@ -231,11 +255,14 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 		return {
 			url,
 			instructions:
-				"Complete login in your browser. If the browser cannot reach this machine, paste the final redirect URL or authorization code when prompted.",
+				this.#profile === "cowork"
+					? "Complete login in your browser, then paste the authorization code or final redirect URL when prompted."
+					: "Complete login in your browser. If the browser cannot reach this machine, paste the final redirect URL or authorization code when prompted.",
 		};
 	}
 
 	async exchangeToken(code: string, state: string, redirectUri: string): Promise<OAuthCredentials> {
+		const config = oauthProfileConfig(this.#profile);
 		let exchangeCode = code;
 		let exchangeState = state;
 		const codeFragmentIndex = code.indexOf("#");
@@ -253,7 +280,7 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 				TOKEN_URL,
 				{
 					grant_type: "authorization_code",
-					client_id: CLIENT_ID,
+					client_id: config.clientId,
 					code: exchangeCode,
 					state: exchangeState,
 					redirect_uri: redirectUri,
@@ -281,6 +308,7 @@ export class AnthropicOAuthFlow extends OAuthCallbackFlow {
 			email,
 			orgId,
 			orgName,
+			clientProfile: this.#profile,
 		};
 	}
 }
@@ -293,21 +321,28 @@ export async function loginAnthropic(ctrl: OAuthController): Promise<OAuthCreden
 	return flow.login();
 }
 
+export async function loginAnthropicCowork(ctrl: OAuthController): Promise<OAuthCredentials> {
+	const flow = new AnthropicOAuthFlow(ctrl, "cowork");
+	return flow.login();
+}
+
 /**
  * Refresh Anthropic OAuth token
  */
 export async function refreshAnthropicToken(
 	refreshToken: string,
 	fetchOverride?: FetchImpl,
+	profile: AnthropicOAuthProfile = "claude-code",
 ): Promise<OAuthCredentials> {
 	const fetchImpl = fetchOverride ?? fetch;
+	const config = oauthProfileConfig(profile);
 	let responseBody: string;
 	try {
 		responseBody = await postJson(
 			TOKEN_URL,
 			{
 				grant_type: "refresh_token",
-				client_id: CLIENT_ID,
+				client_id: config.clientId,
 				refresh_token: refreshToken,
 			},
 			fetchImpl,
@@ -340,5 +375,6 @@ export async function refreshAnthropicToken(
 		expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
 		accountId,
 		email,
+		clientProfile: profile,
 	};
 }

--- a/packages/ai/src/registry/oauth/index.ts
+++ b/packages/ai/src/registry/oauth/index.ts
@@ -144,24 +144,31 @@ export async function getOAuthApiKey(
 			{ kind: "validation", provider },
 		);
 	}
-	// For providers that need request-time credential metadata, return JSON.
+	// Anthropic Cowork only needs the bearer and request-fingerprint profile at
+	// request time. Keep the refresh token inside AuthStorage/the broker instead
+	// of copying it into the API-key value handed to provider and discovery code.
+	const isAnthropicCowork = provider === "anthropic" && creds.clientProfile === "cowork";
 	const needsStructuredApiKey =
+		isAnthropicCowork ||
 		provider === "github-copilot" ||
 		provider === "google-gemini-cli" ||
 		provider === "google-antigravity" ||
 		provider === "alibaba-coding-plan";
-	const apiKey = needsStructuredApiKey
-		? JSON.stringify({
-				apiEndpoint: creds.apiEndpoint,
-				token: creds.access,
-				enterpriseUrl: creds.enterpriseUrl,
-				projectId: creds.projectId,
-				refreshToken: creds.refresh,
-				expiresAt: creds.expires,
-				email: creds.email,
-				accountId: creds.accountId,
-			})
-		: creds.access;
+	const apiKey = isAnthropicCowork
+		? JSON.stringify({ token: creds.access, clientProfile: creds.clientProfile })
+		: needsStructuredApiKey
+			? JSON.stringify({
+					apiEndpoint: creds.apiEndpoint,
+					token: creds.access,
+					enterpriseUrl: creds.enterpriseUrl,
+					projectId: creds.projectId,
+					refreshToken: creds.refresh,
+					expiresAt: creds.expires,
+					email: creds.email,
+					accountId: creds.accountId,
+					clientProfile: creds.clientProfile,
+				})
+			: creds.access;
 	return { newCredentials: creds, apiKey };
 }
 

--- a/packages/ai/src/registry/oauth/types.ts
+++ b/packages/ai/src/registry/oauth/types.ts
@@ -1,6 +1,8 @@
 import type { FetchImpl } from "../../types";
 import type { OAuthProviderUnion } from "../registry";
 
+export type OAuthClientProfile = "claude-code" | "cowork";
+
 export type OAuthCredentials = {
 	refresh: string;
 	access: string;
@@ -19,6 +21,8 @@ export type OAuthCredentials = {
 	orgId?: string;
 	/** Human-readable organization name for display (may embed the email). */
 	orgName?: string;
+	/** Request-fingerprint profile associated with this credential. */
+	clientProfile?: OAuthClientProfile;
 };
 
 export type OAuthProvider = OAuthProviderUnion;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -2,7 +2,7 @@ import type { KnownProvider } from "@oh-my-pi/pi-catalog";
 import { aimlApiProvider } from "./aimlapi";
 import { alibabaCodingPlanProvider } from "./alibaba-coding-plan";
 import { amazonBedrockProvider } from "./amazon-bedrock";
-import { anthropicProvider } from "./anthropic";
+import { anthropicCoworkProvider, anthropicProvider } from "./anthropic";
 import { azureProvider } from "./azure";
 import { basetenProvider } from "./baseten";
 import { cerebrasProvider } from "./cerebras";
@@ -79,6 +79,7 @@ const ALL = [
 	azureProvider,
 	openaiCodexProvider,
 	anthropicProvider,
+	anthropicCoworkProvider,
 	zaiProvider,
 	kimiCodeProvider,
 	openrouterProvider,

--- a/packages/ai/src/registry/types.ts
+++ b/packages/ai/src/registry/types.ts
@@ -30,8 +30,8 @@ export type KeyResolver = string | (() => string | undefined);
  * - `callbackPort` present ⇒ entry in the auth-broker `CALLBACK_PORTS` map.
  * - `pasteCodeFlow` ⇒ member of `PASTE_CODE_LOGIN_PROVIDERS`.
  *
- * Heavy OAuth flow modules MUST be reached through dynamic-import thunks in
- * `login`/`refreshToken` so they stay out of the eager startup graph.
+ * Provider modules MUST use top-level imports; inline and dynamic imports are
+ * prohibited by the repository-wide module conventions.
  */
 export interface ProviderDefinition {
 	readonly id: string;

--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -10,8 +10,10 @@
  */
 import { $env } from "@oh-my-pi/pi-utils";
 import {
+	type AnthropicClientProfile,
 	buildAnthropicHeaders as buildProviderAnthropicHeaders,
 	normalizeAnthropicBaseUrl,
+	resolveAnthropicClientProfile,
 	resolveAnthropicCustomHeadersForBaseUrl,
 } from "../providers/anthropic";
 import { isFoundryEnabled } from "./foundry";
@@ -21,6 +23,7 @@ export interface AnthropicAuthConfig {
 	apiKey: string;
 	baseUrl: string;
 	isOAuth: boolean;
+	clientProfile?: AnthropicClientProfile;
 }
 
 const DEFAULT_BASE_URL = "https://api.anthropic.com";
@@ -43,7 +46,14 @@ export function resolveAnthropicBaseUrlFromEnv(): string | undefined {
  * Checks if a token is an OAuth token by looking for sk-ant-oat prefix.
  */
 export function isOAuthToken(apiKey: string): boolean {
-	return apiKey.includes("sk-ant-oat");
+	if (apiKey.includes("sk-ant-oat")) return true;
+	if (!apiKey.startsWith("{")) return false;
+	try {
+		const credential = JSON.parse(apiKey) as Record<string, unknown>;
+		return credential.clientProfile === "cowork" && typeof credential.token === "string";
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -62,6 +72,7 @@ export function buildAnthropicAuthConfig(apiKey: string, baseUrl?: string): Anth
 		apiKey,
 		baseUrl: normalizeBaseUrl(baseUrl) ?? resolveAnthropicBaseUrlFromEnv() ?? DEFAULT_BASE_URL,
 		isOAuth: isOAuthToken(apiKey),
+		clientProfile: resolveAnthropicClientProfile(apiKey),
 	};
 }
 
@@ -77,6 +88,7 @@ export function buildAnthropicSearchHeaders(auth: AnthropicAuthConfig): Record<s
 		apiKey: auth.apiKey,
 		baseUrl: auth.baseUrl,
 		isOAuth: auth.isOAuth,
+		clientProfile: auth.clientProfile,
 		extraBetas: ["web-search-2025-03-05"],
 		stream: false,
 		modelHeaders: resolveAnthropicCustomHeadersForBaseUrl(auth.baseUrl),

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -13,6 +13,7 @@ import {
 	claudeCodeSystemInstruction,
 	claudeCodeVersion,
 	claudeToolPrefix,
+	coworkClaudeCodeVersion,
 	deriveClaudeDeviceId,
 	generateClaudeCloakingUserId,
 	isClaudeCloakingUserId,
@@ -196,6 +197,35 @@ describe("Anthropic request fingerprint alignment", () => {
 		);
 		expect(headers["X-Claude-Code-Session-Id"]).toBe(sessionId);
 		expect(headers["x-client-request-id"]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+	});
+
+	it("uses the Cowork local-agent fingerprint for Cowork credentials", () => {
+		const headers = buildAnthropicHeaders({
+			apiKey: JSON.stringify({ token: "sk-ant-oat-cowork", clientProfile: "cowork" }),
+			stream: true,
+			claudeCodeSessionId: "167ec5b4-e711-4169-879f-84fa52679d9c",
+		});
+
+		expect(headers.Authorization).toBe("Bearer sk-ant-oat-cowork");
+		expect(headers["User-Agent"]).toBe(`claude-cli/${coworkClaudeCodeVersion} (external, local-agent)`);
+		expect(headers["X-Stainless-Runtime-Version"]).toBe("v26.3.0");
+		expect(headers["X-Stainless-Timeout"]).toBe("600");
+		expect(headers["anthropic-client-platform"]).toBeUndefined();
+		expect(headers["anthropic-client-version"]).toBeUndefined();
+		expect(headers["x-client-request-id"]).toBeUndefined();
+		expect(headers["anthropic-beta"]?.split(",")).toEqual([
+			"claude-code-20250219",
+			"oauth-2025-04-20",
+			"context-1m-2025-08-07",
+			"interleaved-thinking-2025-05-14",
+			"thinking-token-count-2026-05-13",
+			"context-management-2025-06-27",
+			"prompt-caching-scope-2026-01-05",
+			"mid-conversation-system-2026-04-07",
+			"advisor-tool-2026-03-01",
+			"effort-2025-11-24",
+			"structured-outputs-2025-12-15",
+		]);
 	});
 
 	it("sends redact-thinking beta only when thinking display is omitted", () => {

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { getOAuthApiKey } from "@oh-my-pi/pi-ai/registry/oauth";
 import { AnthropicOAuthFlow, refreshAnthropicToken } from "@oh-my-pi/pi-ai/registry/oauth/anthropic";
 import {
 	buildAnthropicAuthConfig,
@@ -28,6 +29,16 @@ describe("anthropic oauth alignment", () => {
 		expect(authUrl.searchParams.get("state")).toBe(state);
 		expect(authUrl.searchParams.get("redirect_uri")).toBe(redirectUri);
 		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+	});
+
+	it("generates the Cowork client authorization contract", async () => {
+		const flow = new AnthropicOAuthFlow({}, "cowork");
+		const { url } = await flow.generateAuthUrl("cowork-state", flow.redirectUri ?? "");
+		const authUrl = new URL(url);
+
+		expect(authUrl.searchParams.get("client_id")).toBe("a473d7bb-17ac-43a7-abc0-a1343d7c2805");
+		expect(authUrl.searchParams.get("scope")).toBe("user:inference user:file_upload user:profile");
+		expect(authUrl.searchParams.get("redirect_uri")).toBe("https://console.anthropic.com/oauth/code/callback");
 	});
 
 	it("uses api.anthropic.com token URL for code exchange", async () => {
@@ -119,13 +130,31 @@ describe("anthropic oauth alignment", () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
-	it("uses api.anthropic.com token URL and CC headers for refresh", async () => {
+	it.each([
+		{
+			name: "Claude Code",
+			profile: "claude-code" as const,
+			clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+		},
+		{
+			name: "Cowork",
+			profile: "cowork" as const,
+			clientId: "a473d7bb-17ac-43a7-abc0-a1343d7c2805",
+		},
+	])("uses the exact $name refresh contract", async ({ profile, clientId }) => {
 		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 			expect(typeof input === "string" ? input : input.toString()).toBe("https://api.anthropic.com/v1/oauth/token");
 			expect(init?.method).toBe("POST");
-			const headers = init?.headers as Record<string, string> | undefined;
-			expect(headers?.["anthropic-beta"]).toBe("oauth-2025-04-20");
-			expect(headers?.["User-Agent"]).toBe("anthropic-sdk-typescript/0.94.0 userOAuthProvider");
+			expect(init?.headers).toEqual({
+				"anthropic-beta": "oauth-2025-04-20",
+				"User-Agent": "anthropic-sdk-typescript/0.94.0 userOAuthProvider",
+				"Content-Type": "application/json",
+			});
+			expect(JSON.parse(String(init?.body))).toEqual({
+				grant_type: "refresh_token",
+				client_id: clientId,
+				refresh_token: "refresh-123",
+			});
 			return new Response(
 				JSON.stringify({
 					access_token: "new-access-token",
@@ -140,10 +169,11 @@ describe("anthropic oauth alignment", () => {
 			);
 		});
 
-		const result = await refreshAnthropicToken("refresh-123", fetchMock as unknown as typeof fetch);
+		const result = await refreshAnthropicToken("refresh-123", fetchMock as unknown as typeof fetch, profile);
 
 		expect(result.access).toBe("new-access-token");
 		expect(result.refresh).toBe("new-refresh-token");
+		expect(result.clientProfile).toBe(profile);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
@@ -268,6 +298,23 @@ describe("anthropic oauth alignment", () => {
 		expect(result.accountId).toBeUndefined();
 		expect(result.email).toBeUndefined();
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+	it("keeps the Cowork refresh token out of the request-facing structured credential", async () => {
+		const result = await getOAuthApiKey("anthropic", {
+			anthropic: {
+				access: "sk-ant-oat-cowork",
+				refresh: "cowork-refresh-secret",
+				expires: Date.now() + 60_000,
+				clientProfile: "cowork",
+			},
+		});
+
+		expect(result).not.toBeNull();
+		expect(JSON.parse(result!.apiKey)).toEqual({
+			token: "sk-ant-oat-cowork",
+			clientProfile: "cowork",
+		});
+		expect(result!.apiKey).not.toContain("cowork-refresh-secret");
 	});
 });
 

--- a/packages/ai/test/auth-broker-remote-store.test.ts
+++ b/packages/ai/test/auth-broker-remote-store.test.ts
@@ -110,6 +110,27 @@ describe("RemoteAuthCredentialStore SSE integration", () => {
 		expect(remote!.snapshot.credentials[0].id).not.toBe(bId);
 	});
 
+	test("round-trips active OAuth client profiles through snapshots, operations, and SSE", async () => {
+		storage!.upsertCredential("anthropic", {
+			...mintOAuthCredential("cowork", Date.now() + 120_000),
+			clientProfile: "cowork",
+		});
+		const client = new AuthBrokerClient({ url: handle!.url, token });
+		remote = new RemoteAuthCredentialStore({ client });
+		await waitUntil(() => remote!.snapshot.credentials.length === 2);
+		expect(remote.getActiveOAuthClientProfile("anthropic")).toBe("claude-code");
+
+		await remote.setActiveOAuthClientProfileRemote("anthropic", "cowork");
+		expect(remote.getActiveOAuthClientProfile("anthropic")).toBe("cowork");
+		expect(storage!.getActiveOAuthClientProfile("anthropic")).toBe("cowork");
+		const fetched = await client.fetchSnapshot();
+		if (fetched.status !== 200) throw new Error("expected active-profile snapshot");
+		expect(fetched.snapshot.activeOAuthClientProfiles).toEqual({ anthropic: "cowork" });
+
+		await storage!.setActiveOAuthClientProfile("anthropic", "claude-code");
+		await waitUntil(() => remote!.getActiveOAuthClientProfile("anthropic") === "claude-code");
+	});
+
 	test("calls onSnapshot for broker snapshots but not the constructor snapshot", async () => {
 		const client = new AuthBrokerClient({ url: handle!.url, token });
 		const initialResult = await client.fetchSnapshot();

--- a/packages/ai/test/auth-broker-snapshot-cache.test.ts
+++ b/packages/ai/test/auth-broker-snapshot-cache.test.ts
@@ -23,6 +23,7 @@ function makeSnapshot(generatedAt: number): SnapshotResponse {
 			skewMs: 300_000,
 			nextSweepInMs: 10_000,
 		},
+		activeOAuthClientProfiles: {},
 		credentials: [
 			{
 				id: 1,

--- a/packages/ai/test/auth-storage-account-identity.test.ts
+++ b/packages/ai/test/auth-storage-account-identity.test.ts
@@ -112,6 +112,35 @@ describe("AuthStorage.getOAuthAccountIdentity", () => {
 		expect(rotatedIdentity?.accountId).toBe(retryKey === "access-a" ? "acc-a" : "acc-b");
 	});
 
+	test("preserves the Anthropic Cowork profile across repeated credential resolution", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+		await storage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "sk-ant-oat-cowork",
+				refresh: "refresh-cowork",
+				expires: Date.now() + 60 * 60_000,
+				accountId: "cowork-account",
+				email: "cowork@example.com",
+				clientProfile: "cowork",
+			},
+		]);
+
+		const first = await storage.getApiKey("anthropic", "cowork-session");
+		const second = await storage.getApiKey("anthropic", "cowork-session");
+
+		expect(JSON.parse(first ?? "{}")).toMatchObject({
+			token: "sk-ant-oat-cowork",
+			clientProfile: "cowork",
+		});
+		expect(JSON.parse(second ?? "{}")).toMatchObject({
+			token: "sk-ant-oat-cowork",
+			clientProfile: "cowork",
+		});
+		expect(storage.getOAuthCredential("anthropic")?.clientProfile).toBe("cowork");
+	});
+
 	test("config override suppresses OAuth identity attribution", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 		await authStorage.set(PROVIDER, [

--- a/packages/ai/test/auth-storage-client-profile.test.ts
+++ b/packages/ai/test/auth-storage-client-profile.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { removeWithRetries } from "../../utils/src/temp";
+
+function anthropicCredential(profile: "claude-code" | "cowork", suffix: string): OAuthCredential {
+	return {
+		type: "oauth",
+		access: `access-${suffix}`,
+		refresh: `refresh-${suffix}`,
+		expires: Date.now() + 60 * 60_000,
+		accountId: "same-account",
+		email: "same@example.com",
+		orgId: "same-org",
+		clientProfile: profile,
+	};
+}
+
+describe("AuthStorage Anthropic client profile activation", () => {
+	let tempDir = "";
+	let store: SqliteAuthCredentialStore | undefined;
+	let storage: AuthStorage | undefined;
+
+	afterEach(async () => {
+		storage?.close();
+		storage = undefined;
+		store = undefined;
+		if (tempDir) await removeWithRetries(tempDir);
+		unregisterOAuthProviders("auth-client-profile-test");
+		tempDir = "";
+	});
+
+	async function open(): Promise<{ dbPath: string; auth: AuthStorage }> {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auth-client-profile-"));
+		const dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store);
+		await storage.reload();
+		return { dbPath, auth: storage };
+	}
+
+	test("retains the same Anthropic identity once per client profile", async () => {
+		const { auth } = await open();
+		auth.upsertCredential("anthropic", anthropicCredential("claude-code", "code"));
+		auth.upsertCredential("anthropic", anthropicCredential("cowork", "cowork"));
+
+		expect(auth.listStoredCredentials("anthropic")).toHaveLength(2);
+		expect(auth.listStoredCredentials("anthropic", { clientProfile: "claude-code" })).toHaveLength(1);
+		expect(auth.listStoredCredentials("anthropic", { clientProfile: "cowork" })).toHaveLength(1);
+	});
+
+	test("successful alias login activates its profile and survives reload", async () => {
+		const { dbPath, auth } = await open();
+		for (const profile of ["claude-code", "cowork"] as const) {
+			registerOAuthProvider({
+				id: `test-anthropic-${profile}`,
+				name: `Test Anthropic ${profile}`,
+				sourceId: "auth-client-profile-test",
+				storeCredentialsAs: "anthropic",
+				async login() {
+					return anthropicCredential(profile, profile);
+				},
+			});
+		}
+		const ctrl = { onAuth: () => {}, onPrompt: async () => "" };
+		await auth.login("test-anthropic-claude-code", ctrl);
+		await auth.login("test-anthropic-cowork", ctrl);
+		expect(auth.getActiveOAuthClientProfile("anthropic")).toBe("cowork");
+		expect(auth.listStoredCredentials("anthropic")).toHaveLength(2);
+
+		auth.close();
+		storage = undefined;
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store);
+		await storage.reload();
+		expect(storage.getActiveOAuthClientProfile("anthropic")).toBe("cowork");
+	});
+
+	test("persists last activation and selection never crosses profiles", async () => {
+		const { dbPath, auth } = await open();
+		await auth.set("anthropic", [
+			anthropicCredential("claude-code", "code"),
+			anthropicCredential("cowork", "cowork"),
+		]);
+		await auth.setActiveOAuthClientProfile("anthropic", "cowork");
+		expect(auth.getOAuthCredential("anthropic")?.access).toBe("access-cowork");
+		expect((await auth.getOAuthAccess("anthropic", "cowork-session"))?.accessToken).toBe("access-cowork");
+		expect(await auth.peekApiKey("anthropic")).toBe("access-cowork");
+
+		auth.close();
+		storage = undefined;
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store);
+		await storage.reload();
+
+		expect(storage.getActiveOAuthClientProfile("anthropic")).toBe("cowork");
+		expect((await storage.getOAuthAccess("anthropic", "reloaded-session"))?.accessToken).toBe("access-cowork");
+		expect(
+			await storage.rotateSessionCredential("anthropic", "reloaded-session", {
+				error: new Error("401 unauthorized"),
+			}),
+		).toBe(false);
+	});
+
+	test("does not treat an inactive profile as a rotation sibling", async () => {
+		const { auth } = await open();
+		await auth.set("anthropic", [
+			anthropicCredential("claude-code", "code"),
+			anthropicCredential("cowork", "cowork"),
+		]);
+		await auth.setActiveOAuthClientProfile("anthropic", "cowork");
+		const coworkId = auth.listStoredCredentials("anthropic", { clientProfile: "cowork" })[0]!.id;
+
+		const result = await auth.markUsageLimitReached("anthropic", undefined, {
+			credentialId: coworkId,
+			retryAfterMs: 60_000,
+		});
+
+		expect(result.switched).toBe(false);
+	});
+
+	test("inactive removal preserves activation while active-profile exhaustion falls back then clears", async () => {
+		const { auth } = await open();
+		await auth.set("anthropic", [
+			anthropicCredential("claude-code", "code"),
+			anthropicCredential("cowork", "cowork"),
+		]);
+		await auth.setActiveOAuthClientProfile("anthropic", "cowork");
+		const codeId = auth.listStoredCredentials("anthropic", { clientProfile: "claude-code" })[0]!.id;
+		const coworkId = auth.listStoredCredentials("anthropic", { clientProfile: "cowork" })[0]!.id;
+
+		await auth.removeCredential("anthropic", codeId);
+		expect(auth.getActiveOAuthClientProfile("anthropic")).toBe("cowork");
+
+		await auth.set("anthropic", [
+			anthropicCredential("claude-code", "code-2"),
+			anthropicCredential("cowork", "cowork"),
+		]);
+		await auth.removeCredential("anthropic", coworkId);
+		expect(auth.getActiveOAuthClientProfile("anthropic")).toBe("claude-code");
+		const remainingId = auth.listStoredCredentials("anthropic", { clientProfile: "claude-code" })[0]!.id;
+		await auth.removeCredential("anthropic", remainingId);
+		expect(auth.getActiveOAuthClientProfile("anthropic")).toBeUndefined();
+	});
+});

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -401,7 +401,7 @@ describe("AuthStorage openai-codex email dedupe", () => {
 			const migratedStore = await SqliteAuthCredentialStore.open(legacyDbPath);
 			try {
 				expect(readStoredIdentityRows(legacyDbPath, "anthropic")).toEqual([
-					{ identity_key: "email:legacy-anthropic@example.com", disabled_cause: null },
+					{ identity_key: "email:legacy-anthropic@example.com|client-profile:claude-code", disabled_cause: null },
 				]);
 			} finally {
 				migratedStore.close();

--- a/packages/ai/test/auth-storage-org-scoped-identity.test.ts
+++ b/packages/ai/test/auth-storage-org-scoped-identity.test.ts
@@ -92,8 +92,8 @@ describe("anthropic org-scoped credential identity", () => {
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "max", orgId: MAX_ORG }));
 
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 
 		// Same-org re-login: replaces the matching row instead of adding a third.
@@ -102,8 +102,8 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "team-renewed", orgId: TEAM_ORG }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 		const teamRow = rows.find(row => row.credential.type === "oauth" && row.credential.orgId === TEAM_ORG);
 		expect(teamRow?.credential.type).toBe("oauth");
@@ -116,11 +116,13 @@ describe("anthropic org-scoped credential identity", () => {
 		if (!store) throw new Error("test setup failed");
 
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "legacy" }));
-		expect(readIdentityRows(dbPath)).toEqual([{ identity_key: `email:${EMAIL}`, disabled_cause: null }]);
+		expect(readIdentityRows(dbPath)).toEqual([
+			{ identity_key: `email:${EMAIL}|client-profile:claude-code`, disabled_cause: null },
+		]);
 
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "max", orgId: MAX_ORG }));
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 	});
 
@@ -132,9 +134,9 @@ describe("anthropic org-scoped credential identity", () => {
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "orgless" }));
 
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}`, disabled_cause: null },
-			{ identity_key: `email:${EMAIL}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|client-profile:claude-code`, disabled_cause: null },
 		]);
 	});
 
@@ -152,8 +154,8 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "max", orgId: MAX_ORG, omitEmail: true }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `account:account-shared|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `account:account-shared|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 
 		// Same-org no-email re-login still replaces its own row in place.
@@ -172,9 +174,9 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "claimed", orgId: "org-third-3333", omitEmail: true }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `account:account-shared|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `account:account-shared|org:${MAX_ORG}`, disabled_cause: null },
-			{ identity_key: "account:account-shared|org:org-third-3333", disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: "account:account-shared|org:org-third-3333|client-profile:claude-code", disabled_cause: null },
 		]);
 	});
 
@@ -186,13 +188,15 @@ describe("anthropic org-scoped credential identity", () => {
 			"anthropic",
 			orgCredential({ suffix: "anon", orgId: TEAM_ORG, omitEmail: true, omitAccountId: true }),
 		);
-		expect(readIdentityRows(dbPath)).toEqual([{ identity_key: `org:${TEAM_ORG}`, disabled_cause: null }]);
+		expect(readIdentityRows(dbPath)).toEqual([
+			{ identity_key: `org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+		]);
 
 		// Same org, identity recovered: claims the org-only row in place instead
 		// of duplicating the subscription.
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "named", orgId: TEAM_ORG }));
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 
 		// One-way: a later org-only login of the same org must not claim the now
@@ -202,8 +206,8 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "anon-again", orgId: TEAM_ORG, omitEmail: true, omitAccountId: true }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `org:${TEAM_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 	});
 
@@ -229,8 +233,8 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "team-with-email", orgId: TEAM_ORG }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `account:account-shared|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 		const teamRow = rows.find(row => row.credential.type === "oauth" && row.credential.orgId === TEAM_ORG);
 		expect(teamRow?.credential.type).toBe("oauth");
@@ -244,13 +248,15 @@ describe("anthropic org-scoped credential identity", () => {
 
 		// Pre-org row, email never recovered: keyed by the bare account.
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "legacy", omitEmail: true }));
-		expect(readIdentityRows(dbPath)).toEqual([{ identity_key: "account:account-shared", disabled_cause: null }]);
+		expect(readIdentityRows(dbPath)).toEqual([
+			{ identity_key: "account:account-shared|client-profile:claude-code", disabled_cause: null },
+		]);
 
 		// Org-scoped login carrying the same account AND an email: the key is
 		// email-based, but the shared account still claims the legacy row.
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "upgraded", orgId: TEAM_ORG }));
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 	});
 
@@ -268,9 +274,9 @@ describe("anthropic org-scoped credential identity", () => {
 		// the bare account row via the shared account base.
 		store.upsertAuthCredentialForProvider("anthropic", orgCredential({ suffix: "orgless" }));
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `account:account-shared|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: "account:account-shared", disabled_cause: null },
-			{ identity_key: `email:${EMAIL}`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: "account:account-shared|client-profile:claude-code", disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|client-profile:claude-code`, disabled_cause: null },
 		]);
 	});
 
@@ -291,8 +297,8 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "team-lost-email", orgId: TEAM_ORG, omitEmail: true }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `account:account-shared|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 		const teamRow = rows.find(row => row.credential.type === "oauth" && row.credential.orgId === TEAM_ORG);
 		expect(teamRow?.credential.type).toBe("oauth");
@@ -314,8 +320,8 @@ describe("anthropic org-scoped credential identity", () => {
 			orgCredential({ suffix: "max-lost-email", orgId: MAX_ORG, omitEmail: true }),
 		);
 		expect(readIdentityRows(dbPath)).toEqual([
-			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}`, disabled_cause: null },
-			{ identity_key: `account:account-shared|org:${MAX_ORG}`, disabled_cause: null },
+			{ identity_key: `email:${EMAIL}|org:${TEAM_ORG}|client-profile:claude-code`, disabled_cause: null },
+			{ identity_key: `account:account-shared|org:${MAX_ORG}|client-profile:claude-code`, disabled_cause: null },
 		]);
 	});
 });

--- a/packages/ai/test/provider-registry.test.ts
+++ b/packages/ai/test/provider-registry.test.ts
@@ -75,6 +75,7 @@ describe("provider registry auth surface", () => {
 		expect([...PASTE_CODE_LOGIN_PROVIDERS].sort()).toEqual(
 			[
 				"anthropic",
+				"anthropic-cowork",
 				"devin",
 				"gitlab-duo",
 				"gitlab-duo-agent",
@@ -94,7 +95,7 @@ describe("provider registry auth surface", () => {
 		const refreshed: OAuthCredentials = { refresh: "r2", access: "a2", expires: Date.now() + 120_000 };
 		const spy = vi.spyOn(anthropicOauth, "refreshAnthropicToken").mockResolvedValue(refreshed);
 		expect(await refreshOAuthToken("anthropic", creds)).toBe(refreshed);
-		expect(spy).toHaveBeenCalledWith("r");
+		expect(spy).toHaveBeenCalledWith("r", undefined, "claude-code");
 
 		await expect(refreshOAuthToken("nonexistent-provider" as OAuthProvider, creds)).rejects.toThrow(
 			"Unknown OAuth provider",

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -348,6 +348,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 			streamSnapshots: false,
 			initialSnapshot,
 		});
+		expect(remoteStore.snapshot.activeOAuthClientProfiles).toEqual({});
 		try {
 			const first = await remoteStore.fetchUsageReports();
 			expect(fetchUsageSpy).toHaveBeenCalledTimes(1);
@@ -462,6 +463,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 
 		expect(validated).not.toBeInstanceOf(type.errors);
 		if (validated instanceof type.errors) throw new Error("expected valid snapshot");
+		expect(validated.activeOAuthClientProfiles).toBeUndefined();
 		expect(validated.credentials[0]!.blocks).toBeUndefined();
 		expect(validated.credentials[1]!.blocks).toEqual([
 			{ providerKey: "anthropic:oauth", blockScope: "tier:fable", blockedUntilMs: futureBlock },

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic model discovery to unwrap profile-aware OAuth credentials before constructing authorization headers.
+
 ## [17.0.6] - 2026-07-20
 
 ### Added

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -144,7 +144,27 @@ function mapAnthropicModelsDev(payload: unknown, baseUrl: string): ModelSpec<"an
 	return models;
 }
 
-function buildAnthropicDiscoveryHeaders(apiKey: string): Record<string, string> {
+type StructuredAnthropicCredential = {
+	token?: unknown;
+	clientProfile?: unknown;
+};
+
+function unwrapAnthropicCredential(apiKey: string): string {
+	if (!apiKey.startsWith("{")) return apiKey;
+	try {
+		const credential = JSON.parse(apiKey) as StructuredAnthropicCredential;
+		if (
+			typeof credential.token === "string" &&
+			(credential.clientProfile === "claude-code" || credential.clientProfile === "cowork")
+		) {
+			return credential.token;
+		}
+	} catch {}
+	return apiKey;
+}
+
+function buildAnthropicDiscoveryHeaders(apiKeyRaw: string): Record<string, string> {
+	const apiKey = unwrapAnthropicCredential(apiKeyRaw);
 	const oauthToken = isAnthropicOAuthToken(apiKey);
 	const headers: Record<string, string> = {
 		"anthropic-version": "2023-06-01",

--- a/packages/catalog/test/anthropic-provider.test.ts
+++ b/packages/catalog/test/anthropic-provider.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { anthropicModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+type AnthropicDiscoveryCall = {
+	authorization: string | null;
+	apiKey: string | null;
+};
+
+function createDiscoveryFetch(calls: AnthropicDiscoveryCall[]): FetchImpl {
+	return async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input);
+		if (url === "https://models.dev/api.json") {
+			return Response.json({ anthropic: { models: {} } });
+		}
+
+		const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
+		calls.push({
+			authorization: headers.get("authorization"),
+			apiKey: headers.get("x-api-key"),
+		});
+		return Response.json({
+			data: [{ id: "claude-test", display_name: "Claude Test", type: "model" }],
+		});
+	};
+}
+
+describe("Anthropic provider discovery", () => {
+	test("unwraps Cowork credentials before OAuth classification and authorization", async () => {
+		const calls: AnthropicDiscoveryCall[] = [];
+		const credential = JSON.stringify({ token: "sk-ant-oat-cowork-token", clientProfile: "cowork" });
+		const options = anthropicModelManagerOptions({
+			apiKey: credential,
+			fetch: createDiscoveryFetch(calls),
+		});
+
+		await options.fetchDynamicModels?.();
+
+		expect(calls).toEqual([
+			{
+				authorization: "Bearer sk-ant-oat-cowork-token",
+				apiKey: null,
+			},
+		]);
+		expect(calls[0]?.authorization).not.toContain(credential);
+	});
+
+	test("preserves ordinary OAuth authentication", async () => {
+		const calls: AnthropicDiscoveryCall[] = [];
+		const options = anthropicModelManagerOptions({
+			apiKey: "sk-ant-oat-ordinary-token",
+			fetch: createDiscoveryFetch(calls),
+		});
+
+		await options.fetchDynamicModels?.();
+
+		expect(calls).toEqual([
+			{
+				authorization: "Bearer sk-ant-oat-ordinary-token",
+				apiKey: null,
+			},
+		]);
+	});
+
+	test("preserves API-key authentication", async () => {
+		const calls: AnthropicDiscoveryCall[] = [];
+		const options = anthropicModelManagerOptions({
+			apiKey: "sk-ant-api-key",
+			fetch: createDiscoveryFetch(calls),
+		});
+
+		await options.fetchDynamicModels?.();
+
+		expect(calls).toEqual([
+			{
+				authorization: null,
+				apiKey: "sk-ant-api-key",
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added profile-aware Anthropic login and logout handling so Claude Code and Cowork credentials can coexist while the most recently logged-in profile remains active.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -14,6 +14,7 @@ import { settings } from "../../config/settings";
 import { theme } from "../../modes/theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { AuthStorage, CredentialOriginKind } from "../../session/auth-storage";
+import { resolveOAuthProviderStorage } from "../oauth-provider-storage";
 import { DynamicBorder } from "./dynamic-border";
 
 const OAUTH_SELECTOR_MAX_VISIBLE = 10;
@@ -112,7 +113,21 @@ export class OAuthSelectorComponent extends Container {
 		this.#stopSpinner();
 	}
 	#hasSelectableAuth(providerId: string): boolean {
-		return this.#mode === "logout" ? this.#authStorage.has(providerId) : this.#authStorage.hasAuth(providerId);
+		const target = resolveOAuthProviderStorage(providerId);
+		if (target.clientProfile) {
+			return this.#authStorage.hasOAuthClientProfile(target.provider, target.clientProfile);
+		}
+		return this.#mode === "logout"
+			? this.#authStorage.has(target.provider)
+			: this.#authStorage.hasAuth(target.provider);
+	}
+
+	#isActiveProfile(providerId: string): boolean {
+		const target = resolveOAuthProviderStorage(providerId);
+		return (
+			target.clientProfile === undefined ||
+			this.#authStorage.getActiveOAuthClientProfile(target.provider) === target.clientProfile
+		);
 	}
 
 	#loadProviders(): void {
@@ -143,7 +158,7 @@ export class OAuthSelectorComponent extends Container {
 
 		let pending = 0;
 		for (const provider of this.#allProviders) {
-			if (!this.#hasSelectableAuth(provider.id)) {
+			if (!this.#hasSelectableAuth(provider.id) || !this.#isActiveProfile(provider.id)) {
 				this.#authState.delete(provider.id);
 				continue;
 			}
@@ -201,7 +216,13 @@ export class OAuthSelectorComponent extends Container {
 	 * the list distinguishes a real login from an env var aliasing the provider.
 	 */
 	#getSourceLabel(providerId: string): string {
-		const origin = this.#authStorage.getCredentialOrigin(providerId);
+		const target = resolveOAuthProviderStorage(providerId);
+		if (target.clientProfile) {
+			return this.#authStorage.hasOAuthClientProfile(target.provider, target.clientProfile)
+				? theme.fg("muted", ` (${ORIGIN_LABELS.oauth})`)
+				: "";
+		}
+		const origin = this.#authStorage.getCredentialOrigin(target.provider);
 		if (!origin) return "";
 		const detail = origin.kind === "env" && origin.envVar ? `env: ${origin.envVar}` : ORIGIN_LABELS[origin.kind];
 		return theme.fg("muted", ` (${detail})`);
@@ -221,9 +242,9 @@ export class OAuthSelectorComponent extends Container {
 		if (state === "valid") {
 			return theme.fg("success", ` ${theme.status.enabled} logged in`) + source;
 		}
-		return this.#hasSelectableAuth(providerId)
-			? theme.fg("success", ` ${theme.status.enabled} logged in`) + source
-			: "";
+		if (!this.#hasSelectableAuth(providerId)) return "";
+		const label = this.#isActiveProfile(providerId) ? "logged in" : "stored";
+		return theme.fg("success", ` ${theme.status.enabled} ${label}`) + source;
 	}
 
 	#isSearchEnabled(): boolean {
@@ -242,10 +263,17 @@ export class OAuthSelectorComponent extends Container {
 
 	#getProviderSearchText(provider: OAuthProviderInfo): string {
 		let text = `${provider.name} ${provider.id}`;
-		const origin = this.#authStorage.getCredentialOrigin(provider.id);
-		if (origin) {
-			text += ` logged in authenticated ${ORIGIN_LABELS[origin.kind]}`;
-			if (origin.envVar) text += ` ${origin.envVar}`;
+		const target = resolveOAuthProviderStorage(provider.id);
+		if (target.clientProfile) {
+			if (this.#authStorage.hasOAuthClientProfile(target.provider, target.clientProfile)) {
+				text += ` stored authenticated ${ORIGIN_LABELS.oauth}`;
+			}
+		} else {
+			const origin = this.#authStorage.getCredentialOrigin(target.provider);
+			if (origin) {
+				text += ` logged in authenticated ${ORIGIN_LABELS[origin.kind]}`;
+				if (origin.envVar) text += ` ${origin.envVar}`;
+			}
 		}
 		if (!provider.available) {
 			text += " unavailable";

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -89,6 +89,7 @@ import { ToolExecutionComponent } from "../components/tool-execution";
 import { TranscriptBlock } from "../components/transcript-container";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
+import { resolveOAuthProviderStorage } from "../oauth-provider-storage";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import { buildCopyTargets } from "../utils/copy-targets";
 
@@ -107,11 +108,13 @@ export class SelectorController {
 	}
 
 	async #refreshOAuthProviderAuthState(): Promise<void> {
-		const oauthProviders = getOAuthProviders();
+		const storageProviders = new Set(
+			getOAuthProviders().map(provider => resolveOAuthProviderStorage(provider.id).provider),
+		);
 		await Promise.all(
-			oauthProviders.map(provider =>
+			[...storageProviders].map(provider =>
 				this.ctx.session.modelRegistry
-					.getApiKeyForProvider(provider.id, this.ctx.session.sessionId)
+					.getApiKeyForProvider(provider, this.ctx.session.sessionId)
 					.catch(() => undefined),
 			),
 		);
@@ -1485,14 +1488,11 @@ export class SelectorController {
 				// focus (#5339).
 				onManualCodeInput: useManualInput ? () => dialog.showManualInput(MANUAL_LOGIN_PROMPT) : undefined,
 			});
-			// Scope the post-login refresh to the just-authenticated provider with an
-			// `online` strategy: the default all-provider `online-if-uncached` reuses
-			// a fresh authoritative cache row (e.g. an empty result fetched before
-			// login), so newly persisted credentials would never re-run discovery and
-			// models would stay unavailable in-session (#5780). Unrelated providers
-			// are left untouched. `refreshProvider` swallows discovery failures, so
-			// awaiting cannot reject the login.
-			await this.ctx.session.modelRegistry.refreshProvider(providerId, "online");
+			// Scope the post-login refresh to the credential's canonical storage
+			// provider. Login aliases such as Anthropic Cowork and headless Codex
+			// do not have their own model registry namespace.
+			const target = resolveOAuthProviderStorage(providerId);
+			await this.ctx.session.modelRegistry.refreshProvider(target.provider, "online");
 			const block = new TranscriptBlock();
 			// Name the account (and Anthropic organization) that was stored so a
 			// login that lands on an unintended account/subscription is visible
@@ -1526,7 +1526,8 @@ export class SelectorController {
 	async #handleCredentialLogout(providerId: string, account: LogoutAccount): Promise<void> {
 		try {
 			const authStorage = this.ctx.session.modelRegistry.authStorage;
-			const removed = await authStorage.removeCredential(providerId, account.credentialId);
+			const target = resolveOAuthProviderStorage(providerId);
+			const removed = await authStorage.removeCredential(target.provider, account.credentialId);
 			if (!removed) {
 				this.ctx.showError(`Logout skipped: ${account.label} is no longer stored for ${providerId}.`);
 				return;
@@ -1537,7 +1538,7 @@ export class SelectorController {
 			// default all-provider `online-if-uncached` would reuse the fresh
 			// authoritative cache row and keep showing models the credential
 			// unlocked (#5780). Other providers are left untouched.
-			await this.ctx.session.modelRegistry.refreshProvider(providerId, "online");
+			await this.ctx.session.modelRegistry.refreshProvider(target.provider, "online");
 			const block = new TranscriptBlock();
 			block.addChild(
 				new Text(
@@ -1550,7 +1551,10 @@ export class SelectorController {
 				),
 			);
 			block.addChild(new Text(theme.fg("dim", `Credential removed from ${getAgentDbPath()}`), 1, 0));
-			const remainingSource = authStorage.describeCredentialSource(providerId, this.ctx.session.sessionId);
+			const remainingSource =
+				target.clientProfile === undefined
+					? authStorage.describeCredentialSource(target.provider, this.ctx.session.sessionId)
+					: undefined;
 			if (remainingSource) {
 				block.addChild(
 					new Text(theme.fg("warning", `${providerId} is still authenticated via ${remainingSource}`), 1, 0),
@@ -1573,12 +1577,29 @@ export class SelectorController {
 			return;
 		}
 		const provider = getOAuthProviders().find(candidate => candidate.id === providerId);
-		const accounts = toLogoutAccounts(providerId, authStorage.listStoredCredentials(providerId), {
-			activeIdentity: authStorage.getOAuthAccountIdentity(providerId, this.ctx.session.sessionId),
-			activeApiKey: authStorage.getCredentialOrigin(providerId)?.kind === "api_key",
-		});
+		const target = resolveOAuthProviderStorage(providerId);
+		const activeProfile = target.clientProfile ? authStorage.getActiveOAuthClientProfile(target.provider) : undefined;
+		const accounts = toLogoutAccounts(
+			providerId,
+			authStorage.listStoredCredentials(
+				target.provider,
+				target.clientProfile ? { clientProfile: target.clientProfile } : undefined,
+			),
+			{
+				activeIdentity:
+					target.clientProfile === undefined || activeProfile === target.clientProfile
+						? authStorage.getOAuthAccountIdentity(target.provider, this.ctx.session.sessionId)
+						: undefined,
+				activeApiKey:
+					target.clientProfile === undefined &&
+					authStorage.getCredentialOrigin(target.provider)?.kind === "api_key",
+			},
+		);
 		if (accounts.length === 0) {
-			const source = authStorage.describeCredentialSource(providerId, this.ctx.session.sessionId);
+			const source =
+				target.clientProfile === undefined
+					? authStorage.describeCredentialSource(target.provider, this.ctx.session.sessionId)
+					: undefined;
 			const suffix = source ? ` Current auth comes from ${source}; remove that source to log out.` : "";
 			this.ctx.showError(`Logout skipped: no stored credentials for ${providerId}.${suffix}`);
 			return;
@@ -1614,9 +1635,12 @@ export class SelectorController {
 		if (mode === "logout") {
 			await this.#refreshOAuthProviderAuthState();
 			const oauthProviders = getOAuthProviders();
-			const loggedInProviders = oauthProviders.filter(provider =>
-				this.ctx.session.modelRegistry.authStorage.has(provider.id),
-			);
+			const loggedInProviders = oauthProviders.filter(provider => {
+				const target = resolveOAuthProviderStorage(provider.id);
+				return target.clientProfile
+					? this.ctx.session.modelRegistry.authStorage.hasOAuthClientProfile(target.provider, target.clientProfile)
+					: this.ctx.session.modelRegistry.authStorage.has(target.provider);
+			});
 			if (loggedInProviders.length === 0) {
 				this.ctx.showStatus("No stored provider credentials to log out. Remove env or config auth at its source.");
 				return;
@@ -1644,8 +1668,18 @@ export class SelectorController {
 				},
 				{
 					validateAuth: async (selectedProviderId: string) => {
+						const target = resolveOAuthProviderStorage(selectedProviderId);
+						if (
+							target.clientProfile &&
+							!this.ctx.session.modelRegistry.authStorage.hasOAuthClientProfile(
+								target.provider,
+								target.clientProfile,
+							)
+						) {
+							return false;
+						}
 						const apiKey = await this.ctx.session.modelRegistry.getApiKeyForProvider(
-							selectedProviderId,
+							target.provider,
 							this.ctx.session.sessionId,
 						);
 						return !!apiKey;

--- a/packages/coding-agent/src/modes/oauth-provider-storage.ts
+++ b/packages/coding-agent/src/modes/oauth-provider-storage.ts
@@ -1,0 +1,19 @@
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
+import type { OAuthClientProfile } from "@oh-my-pi/pi-ai/oauth/types";
+
+export interface OAuthProviderStorageTarget {
+	provider: string;
+	clientProfile?: OAuthClientProfile;
+}
+
+/** Resolve a login-facing provider id to its persisted credential namespace. */
+export function resolveOAuthProviderStorage(providerId: string): OAuthProviderStorageTarget {
+	if (providerId === "anthropic") {
+		return { provider: "anthropic", clientProfile: "claude-code" };
+	}
+	if (providerId === "anthropic-cowork") {
+		return { provider: "anthropic", clientProfile: "cowork" };
+	}
+	const provider = getOAuthProviders().find(candidate => candidate.id === providerId);
+	return { provider: provider?.storeCredentialsAs ?? providerId };
+}

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -64,6 +64,7 @@ function getModel(): string {
 function buildSystemBlocks(
 	auth: AnthropicAuthConfig,
 	model: string,
+	firstUserMessageText: string,
 	systemPrompt?: string,
 ): AnthropicSystemBlock[] | undefined {
 	// Match the streaming path: the CC billing header + system instruction are
@@ -74,6 +75,8 @@ function buildSystemBlocks(
 	return buildAnthropicSystemBlocks(systemPrompt ? [systemPrompt] : undefined, {
 		includeClaudeCodeInstruction: includeClaudeCode,
 		extraInstructions,
+		firstUserMessageText,
+		clientProfile: auth.clientProfile,
 		cacheControl: { type: "ephemeral" },
 	});
 }
@@ -102,7 +105,7 @@ async function callSearch(
 	const url = buildAnthropicUrl(auth);
 	const headers = buildAnthropicSearchHeaders(auth);
 
-	const systemBlocks = buildSystemBlocks(auth, model, systemPrompt);
+	const systemBlocks = buildSystemBlocks(auth, model, query, systemPrompt);
 
 	const body: Record<string, unknown> = {
 		model,

--- a/packages/coding-agent/test/modes/components/oauth-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/oauth-selector.test.ts
@@ -12,6 +12,7 @@ beforeAll(async () => {
 const authStorage = {
 	has: (_providerId: string) => false,
 	hasAuth: (_providerId: string) => false,
+	hasOAuthClientProfile: (_providerId: string, _profile: string) => false,
 	getCredentialOrigin: (_providerId: string) => undefined,
 } as unknown as AuthStorage;
 
@@ -56,6 +57,7 @@ describe("OAuthSelectorComponent", () => {
 			{
 				has: (_providerId: string) => false,
 				hasAuth: (providerId: string) => providerId === "opencode-go" || providerId === "opencode-zen",
+				hasOAuthClientProfile: (_providerId: string, _profile: string) => false,
 				getCredentialOrigin: (_providerId: string) => undefined,
 			} as unknown as AuthStorage,
 			providerId => selected.push(providerId),
@@ -83,6 +85,7 @@ describe("OAuthSelectorComponent", () => {
 			{
 				has: (providerId: string) => providerId === "opencode-go",
 				hasAuth: (providerId: string) => providerId === "opencode-go",
+				hasOAuthClientProfile: (_providerId: string, _profile: string) => false,
 				getCredentialOrigin: (_providerId: string) => undefined,
 			} as unknown as AuthStorage,
 			providerId => selected.push(providerId),
@@ -102,6 +105,34 @@ describe("OAuthSelectorComponent", () => {
 
 		component.handleInput("\n");
 		expect(selected).toEqual(["opencode-go"]);
+	});
+
+	it("shows Anthropic profiles independently from canonical stored credentials", () => {
+		const profiles: Record<string, true> = { "claude-code": true, cowork: true };
+		const profileStorage = {
+			has: (providerId: string) => providerId === "anthropic",
+			hasAuth: (providerId: string) => providerId === "anthropic",
+			hasOAuthClientProfile: (providerId: string, profile: string) =>
+				providerId === "anthropic" && profile in profiles,
+			getActiveOAuthClientProfile: (providerId: string) => (providerId === "anthropic" ? "cowork" : undefined),
+			getCredentialOrigin: (providerId: string) => (providerId === "anthropic" ? { kind: "oauth" } : undefined),
+		} as unknown as AuthStorage;
+
+		const component = new OAuthSelectorComponent(
+			"logout",
+			profileStorage,
+			() => {},
+			() => {},
+		);
+		const rendered = component
+			.render(100)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+
+		expect(rendered).toContain("Anthropic (Claude Pro/Max)");
+		expect(rendered).toContain("Anthropic (Cowork)");
+		expect(rendered).toMatch(/Cowork\).*logged in/);
+		expect(rendered).toMatch(/Claude Pro\/Max\).*stored/);
 	});
 
 	describe("disabledProviders", () => {
@@ -172,6 +203,7 @@ describe("OAuthSelectorComponent", () => {
 				{
 					has: (providerId: string) => providerId === "opencode-go",
 					hasAuth: (providerId: string) => providerId === "opencode-go",
+					hasOAuthClientProfile: (_providerId: string, _profile: string) => false,
 					getCredentialOrigin: (_providerId: string) => undefined,
 				} as unknown as AuthStorage,
 				providerId => selected.push(providerId),

--- a/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
 });
 
 describe("SelectorController login", () => {
-	it("awaits a provider-scoped online refresh, then presents OAuth success", async () => {
+	it("refreshes canonical Anthropic after a Cowork login, then presents success", async () => {
 		const loginSaved = Promise.withResolvers<void>();
 		const presentedBlocks: unknown[] = [];
 		const authStorage = {
@@ -60,17 +60,16 @@ describe("SelectorController login", () => {
 		} as unknown as InteractiveModeContext;
 		const controller = new SelectorController(ctx);
 
-		void controller.showOAuthSelector("login", "xai-oauth");
+		void controller.showOAuthSelector("login", "anthropic-cowork");
 		await loginSaved.promise;
 		// Let the awaited refreshProvider settle before the success block is presented.
 		await Promise.resolve();
 		await Promise.resolve();
 
-		expect(renderPresented(presentedBlocks)).toContain("Successfully logged in to xai-oauth");
-		// Post-login refresh is scoped to the just-authenticated provider with the
-		// `online` strategy (#5780) — not the all-provider default refresh.
+		expect(renderPresented(presentedBlocks)).toContain("Successfully logged in to anthropic-cowork");
+		// Cowork credentials are stored and consumed under canonical Anthropic.
 		expect(refreshProvider).toHaveBeenCalledTimes(1);
-		expect(refreshProvider).toHaveBeenCalledWith("xai-oauth", "online");
+		expect(refreshProvider).toHaveBeenCalledWith("anthropic", "online");
 		expect(refresh).not.toHaveBeenCalled();
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/modes/controllers/selector-controller-logout.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-logout.test.ts
@@ -23,7 +23,12 @@ function createEditorContainer(): TestEditorContainer {
 	};
 }
 
-function createStoredCredential(id: number, email: string, accountId: string): StoredAuthCredential {
+function createStoredCredential(
+	id: number,
+	email: string,
+	accountId: string,
+	clientProfile: "claude-code" | "cowork",
+): StoredAuthCredential {
 	return {
 		id,
 		provider: "anthropic",
@@ -35,6 +40,7 @@ function createStoredCredential(id: number, email: string, accountId: string): S
 			expires: Date.now() + 60_000,
 			email,
 			accountId,
+			clientProfile,
 		},
 	};
 }
@@ -44,11 +50,12 @@ beforeAll(async () => {
 });
 
 describe("SelectorController logout", () => {
-	it("opens an account picker and removes only the selected credential", async () => {
+	it("Cowork logout lists and removes only Cowork credentials", async () => {
 		const editorContainer = createEditorContainer();
 		const credentials = [
-			createStoredCredential(21, "a@example.com", "acct-a"),
-			createStoredCredential(22, "b@example.com", "acct-b"),
+			createStoredCredential(20, "claude@example.com", "acct-claude", "claude-code"),
+			createStoredCredential(21, "cowork-a@example.com", "acct-cowork-a", "cowork"),
+			createStoredCredential(22, "cowork-b@example.com", "acct-cowork-b", "cowork"),
 		];
 		const removeCredential = vi.fn(async (_provider: string, credentialId: number) => {
 			const index = credentials.findIndex(row => row.id === credentialId);
@@ -58,10 +65,15 @@ describe("SelectorController logout", () => {
 		});
 		const authStorage = {
 			reload: vi.fn(async () => undefined),
-			listStoredCredentials: (_provider?: string) => credentials,
-			getOAuthAccountIdentity: (_provider: string, _sessionId?: string) => ({ accountId: "acct-a" }),
+			listStoredCredentials: (_provider?: string, options?: { clientProfile?: "claude-code" | "cowork" }) =>
+				options?.clientProfile
+					? credentials.filter(
+							row => row.credential.type === "oauth" && row.credential.clientProfile === options.clientProfile,
+						)
+					: credentials,
+			getActiveOAuthClientProfile: (_provider: string) => "cowork",
+			getOAuthAccountIdentity: (_provider: string, _sessionId?: string) => ({ accountId: "acct-cowork-a" }),
 			getCredentialOrigin: (_provider: string) => ({ kind: "oauth" }),
-			describeCredentialSource: (_provider: string, _sessionId?: string) => undefined,
 			removeCredential,
 		} as unknown as AuthStorage;
 		const refreshProvider = vi.fn(async (_providerId: string, _mode: string) => undefined);
@@ -87,18 +99,25 @@ describe("SelectorController logout", () => {
 		} as unknown as InteractiveModeContext;
 		const controller = new SelectorController(ctx);
 
-		await controller.showOAuthSelector("logout", "anthropic");
+		await controller.showOAuthSelector("logout", "anthropic-cowork");
 
 		const selector = editorContainer.children[0];
 		if (!(selector instanceof LogoutAccountSelectorComponent)) {
 			throw new Error("Expected logout account selector");
 		}
+		const rendered = selector
+			.render(100)
+			.map(line => Bun.stripANSI(line))
+			.join("\n");
+		expect(rendered).toContain("cowork-a@example.com");
+		expect(rendered).toContain("cowork-b@example.com");
+		expect(rendered).not.toContain("claude@example.com");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\n");
 		await presented.promise;
 
 		expect(removeCredential).toHaveBeenCalledWith("anthropic", 22);
-		expect(credentials.map(row => row.id)).toEqual([21]);
+		expect(credentials.map(row => row.id)).toEqual([20, 21]);
 		expect(refreshProvider).toHaveBeenCalledWith("anthropic", "online");
 		expect(ctx.showError).not.toHaveBeenCalled();
 		expect(ctx.present).toHaveBeenCalled();

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -26,6 +26,8 @@ describe("SignInTab", () => {
 		const authStorage = {
 			has: (_providerId: string) => false,
 			hasAuth: (_providerId: string) => false,
+			hasOAuthClientProfile: (_providerId: string, _profile: "claude-code" | "cowork") => false,
+			getActiveOAuthClientProfile: (_providerId: string) => undefined,
 			getCredentialOrigin: (_providerId: string) => undefined,
 			async login(_provider: OAuthProviderId, ctrl: OAuthLoginCallbacks): Promise<void> {
 				ctrl.onAuth({ url });
@@ -98,6 +100,8 @@ describe("SignInTab", () => {
 		const authStorage = {
 			has: (_providerId: string) => false,
 			hasAuth: (_providerId: string) => false,
+			hasOAuthClientProfile: (_providerId: string, _profile: "claude-code" | "cowork") => false,
+			getActiveOAuthClientProfile: (_providerId: string) => undefined,
 			getCredentialOrigin: (_providerId: string) => undefined,
 			async login(_provider: OAuthProviderId, ctrl: OAuthLoginCallbacks): Promise<void> {
 				ctrl.onAuth({ url });

--- a/packages/coding-agent/test/web/search/anthropic.test.ts
+++ b/packages/coding-agent/test/web/search/anthropic.test.ts
@@ -5,13 +5,19 @@ import { AuthStorage as CodingAuthStorage } from "@oh-my-pi/pi-coding-agent/sess
 import { searchAnthropic } from "@oh-my-pi/pi-coding-agent/web/search/providers/anthropic";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
-function makeCaptureFetch(): { fetch: FetchImpl; body: () => Record<string, unknown> | undefined } {
-	let captured: Record<string, unknown> | undefined;
+function makeCaptureFetch(): {
+	fetch: FetchImpl;
+	body: () => Record<string, unknown> | undefined;
+	headers: () => Headers | undefined;
+} {
+	let capturedBody: Record<string, unknown> | undefined;
+	let capturedHeaders: Headers | undefined;
 	const fetch: FetchImpl = async (_input, init) => {
 		const raw = init?.body;
 		const text =
 			typeof raw === "string" ? raw : raw instanceof Uint8Array ? new TextDecoder().decode(raw) : String(raw);
-		captured = JSON.parse(text);
+		capturedBody = JSON.parse(text);
+		capturedHeaders = new Headers(init?.headers);
 		return new Response(
 			JSON.stringify({
 				id: "msg_test",
@@ -22,7 +28,7 @@ function makeCaptureFetch(): { fetch: FetchImpl; body: () => Record<string, unkn
 			{ status: 200, headers: { "Content-Type": "application/json" } },
 		);
 	};
-	return { fetch, body: () => captured };
+	return { fetch, body: () => capturedBody, headers: () => capturedHeaders };
 }
 
 describe("Anthropic search request body", () => {
@@ -74,5 +80,44 @@ describe("Anthropic search request body", () => {
 		expect(userId.session_id).toBe("session-2295");
 		expect(userId.account_uuid).toBe(accountUuid);
 		expect(userId.device_id).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("uses the Cowork OAuth wire fingerprint for web search", async () => {
+		const coworkCredential = JSON.stringify({
+			token: "sk-ant-oat-cowork-search",
+			clientProfile: "cowork",
+		});
+		const oauthAuthStorage = {
+			resolver: () => () => Promise.resolve(coworkCredential),
+			getOAuthAccountId: () => undefined,
+			hasAuth: () => true,
+		} as unknown as AuthStorage;
+
+		const cap = makeCaptureFetch();
+		await searchAnthropic({
+			query: "cowork web search fingerprint",
+			authStorage: oauthAuthStorage,
+			fetch: cap.fetch,
+		});
+
+		expect(cap.headers()?.get("authorization")).toBe("Bearer sk-ant-oat-cowork-search");
+		expect(cap.headers()?.get("user-agent")).toBe("claude-cli/2.1.217 (external, local-agent)");
+		expect(cap.headers()?.get("anthropic-beta")?.split(",")).toEqual([
+			"claude-code-20250219",
+			"oauth-2025-04-20",
+			"context-1m-2025-08-07",
+			"interleaved-thinking-2025-05-14",
+			"thinking-token-count-2026-05-13",
+			"context-management-2025-06-27",
+			"prompt-caching-scope-2026-01-05",
+			"mid-conversation-system-2026-04-07",
+			"advisor-tool-2026-03-01",
+			"effort-2025-11-24",
+			"structured-outputs-2025-12-15",
+			"web-search-2025-03-05",
+		]);
+
+		const system = cap.body()?.system as Array<{ text?: string }> | undefined;
+		expect(system?.[0]?.text).toContain("x-anthropic-billing-header: cc_version=2.1.217.");
 	});
 });


### PR DESCRIPTION
## Summary

- Add Anthropic Cowork as a separate OAuth login profile with Cowork-compatible request fingerprinting.
- Retain Claude Code and Cowork credentials independently under the canonical `anthropic` provider.
- Persist the active Anthropic client profile, with the most recently completed login becoming active.
- Make login, logout, credential selection, rotation, model discovery, and web search profile-aware.
- Prevent request-facing Cowork credentials and model discovery from exposing OAuth refresh tokens.

## Motivation and Open Questions

Claude Cowork currently provides doubled usage within its 5-hour usage window through August 5, 2026. Supporting the Cowork OAuth profile allows eligible subscribers to use that increased allowance from OMP while preserving their existing Claude Code login.

Right now this is setup to have both Cowork and Claude Code as login-able provider options, with the most recently logged in provider being active for Anthropic models. But perhaps it would be better to just have Cowork OAuth replace Claude Code OAuth for as long as this promotion is running, to not confuse users with two Claude plan providers. Except, while the Cowork OAuth works, it is not tested at a large scale and could introduce ToS risks.

## Implementation

Claude Code and Cowork use different OAuth clients and request fingerprints, but both authenticate requests to the Anthropic API.

Treating the profiles as independent storage providers would duplicate the Anthropic model namespace, while storing them as an indistinguishable credential would cause one login to overwrite the other or use the wrong request fingerprint.

This change keeps both credential profiles under `anthropic`, retains them independently, and persists which profile is currently active.

### Credential storage and selection

- Add a client-profile discriminator for `claude-code` and `cowork`.
- Include the client profile in Anthropic credential identity keys so the same account and organization can retain one credential for each profile.
- Persist the active profile in SQLite provider state.
- Make the last successful login select its profile as active.
- Restrict OAuth selection, peeking, ranking, session stickiness, rotation, usage-limit retry, and account resolution to the active profile.
- Preserve inactive credentials without allowing them to participate in active request routing.
- Fall back to the remaining profile when the final credential in the active profile is removed.

### Auth broker

- Include active OAuth client profiles in broker snapshots.
- Add a broker mutation for changing the active profile.
- Propagate profile changes through snapshot streaming.
- Keep snapshot decoding compatible with brokers that do not yet include active-profile state.

### OAuth and request alignment

- Add the Cowork OAuth client, scopes, redirect flow, and profile metadata.
- Send the exact refresh-token payload without a `scope` field.
- Apply Cowork-specific runtime headers, beta lists, user agent, timeout, and billing fingerprint version.
- Use the first user message when constructing the Cowork web-search billing fingerprint.
- Replace newly introduced dynamic OAuth imports with top-level imports.

### Login and logout UX

- Resolve `anthropic-cowork` to the canonical `anthropic` credential namespace.
- Display Claude Code and Cowork authentication state independently.
- Distinguish the active profile from a retained inactive profile.
- Filter logout account selection by profile.
- Refresh the canonical Anthropic model provider after alias login or logout.

### Credential safety and model discovery

- Unwrap profile-aware Anthropic credentials before constructing model-discovery authorization headers.
- Send only the raw bearer token to `/v1/models`.
- Limit request-facing Cowork structured credentials to the access token and client profile; the refresh token remains inside `AuthStorage` or the auth broker.

## Testing

- `packages/ai`: 3,033 passed, 337 skipped, 0 failed
- `packages/catalog`: 467 passed, 0 failed
- Focused coding-agent login, logout, selector, setup-wizard, and Anthropic search tests passed
- Type checks passed for `packages/ai`, `packages/catalog`, and `packages/coding-agent`
- Biome checks passed for all modified and added files
- `git diff --check` passed

The full sequential coding-agent suite completed with 9,716 passed, 390 skipped, and 4 daemon startup timing failures in `test/tools/launch.test.ts`. Running that file from an isolated, unchanged `HEAD` worktree produced the identical 3-pass/4-fail result, confirming those four failures are pre-existing environment/baseline failures rather than regressions from this change.