### PR TITLE
fix(coding-agent/launch): wake ready waits on sticky marker not live state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `hub start`/`for:"ready"` waits blocking for the full readiness timeout when the launched process became ready and exited within one poll interval (or exited before ever becoming ready). The wait now wakes on the sticky `readyAt` marker or any terminal state instead of sampling the transient live state, and `start` reports `Process exited before readiness was observed.` for a pre-ready exit ([#6303](https://github.com/can1357/oh-my-pi/issues/6303)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -757,6 +757,11 @@ class DaemonBroker {
 			const uptime = Date.now() - record.snapshot.startedAt;
 			record.consecutiveFailures = uptime >= 30_000 ? 0 : record.consecutiveFailures + 1;
 			record.snapshot.restartCount++;
+			// Readiness belongs to the exited generation; clear it before the backoff
+			// so start / for:"ready" waits don't treat a dead service as ready during
+			// the restart window (readyAt is re-set by #launch once the child is up).
+			record.snapshot.readyAt = undefined;
+			record.snapshot.readyMatch = undefined;
 			record.snapshot.state = "restarting";
 			const delay = Math.min(1_000 * 2 ** Math.min(record.consecutiveFailures, 5), RESTART_MAX_DELAY_MS);
 			record.log?.append(

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -491,8 +491,17 @@ class DaemonBroker {
 		await this.#launch(record);
 		let readyTimedOut = false;
 		if (spec.ready && !terminalState(record.snapshot.state)) {
-			const ready = await this.#waitUntil(record, () => record.snapshot.state === "ready", spec.ready.timeoutMs);
-			readyTimedOut = !ready && !terminalState(record.snapshot.state);
+			// Wake on the sticky readyAt marker or any terminal state, not the live
+			// state: a fast process flips starting→ready→exited within one poll
+			// interval, so sampling `state === "ready"` never observes readiness even
+			// though #markReady durably recorded readyAt. A pre-ready exit must also
+			// wake the wait rather than block for the full timeout.
+			const ready = await this.#waitUntil(
+				record,
+				() => record.snapshot.readyAt !== undefined || terminalState(record.snapshot.state),
+				spec.ready.timeoutMs,
+			);
+			readyTimedOut = !ready;
 		}
 		await record.persistQueue;
 		return { op: "start", daemon: record.snapshot, readyTimedOut };
@@ -820,6 +829,10 @@ class DaemonBroker {
 				return true;
 			}
 			if (operation.for === "exit") return terminalState(record.snapshot.state);
+			// A settled daemon that flipped ready→exited within a poll interval still
+			// satisfies for:"ready" via the sticky readyAt marker; a terminal state
+			// wakes the wait so it never blocks for the full timeout.
+			if (record.snapshot.readyAt !== undefined || terminalState(record.snapshot.state)) return true;
 			return record.snapshot.state === "ready" || (record.snapshot.state === "running" && !record.spec.ready);
 		};
 		const reached = condition() || (await this.#waitUntil(record, condition, operation.timeoutMs));

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -826,6 +826,12 @@ class DaemonBroker {
 				throw new Error(`Invalid wait regex: ${error instanceof Error ? error.message : String(error)}`);
 			}
 		}
+		// Readiness was actually observed: the sticky readyAt survives a fast
+		// ready→exit, a live "ready" state, or a "running" daemon with no ready spec.
+		const readyObserved = (): boolean =>
+			record.snapshot.readyAt !== undefined ||
+			record.snapshot.state === "ready" ||
+			(record.snapshot.state === "running" && !record.spec.ready);
 		const condition = (): boolean => {
 			if (pattern) {
 				const match = pattern.exec(record.readinessBuffer);
@@ -834,14 +840,16 @@ class DaemonBroker {
 				return true;
 			}
 			if (operation.for === "exit") return terminalState(record.snapshot.state);
-			// A settled daemon that flipped ready→exited within a poll interval still
-			// satisfies for:"ready" via the sticky readyAt marker; a terminal state
-			// wakes the wait so it never blocks for the full timeout.
-			if (record.snapshot.readyAt !== undefined || terminalState(record.snapshot.state)) return true;
-			return record.snapshot.state === "ready" || (record.snapshot.state === "running" && !record.spec.ready);
+			// Wake on observed readiness or any terminal state so the wait never
+			// blocks for the full timeout; success is judged by readyObserved below.
+			return readyObserved() || terminalState(record.snapshot.state);
 		};
-		const reached = condition() || (await this.#waitUntil(record, condition, operation.timeoutMs));
-		return { op: "wait", daemon: record.snapshot, matched, timedOut: !reached };
+		const woke = condition() || (await this.#waitUntil(record, condition, operation.timeoutMs));
+		// A for:"ready" wait that woke on a terminal exit without ever observing
+		// readiness is still "not ready" — surface it as timed out so callers and the
+		// renderer don't chain work against a dead process.
+		const timedOut = operation.for === "ready" && !pattern ? !readyObserved() : !woke;
+		return { op: "wait", daemon: record.snapshot, matched, timedOut };
 	}
 
 	async #send(operation: Extract<DaemonOperation, { op: "send" }>): Promise<DaemonRpcResult> {

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -74,6 +74,9 @@ const KEY_INPUT: Record<string, string> = {
 	LEFT: "\u001b[D",
 };
 
+/** Terminal daemon lifecycle states — the process is no longer running. */
+const TERMINAL_STATES: Partial<Record<DaemonState, true>> = { exited: true, failed: true };
+
 /** Structured launch state retained for compact TUI rendering. */
 export interface LaunchToolDetails {
 	op: LaunchParams["op"];
@@ -229,6 +232,8 @@ function toolContent(result: DaemonRpcResult, params: LaunchParams): string {
 				lines.push(
 					`NOT ready — readiness timed out after ${params.ready?.timeout ?? 30}s${cause}. The process is still running (state: ${daemon.state}); follow its logs or stop it.`,
 				);
+			} else if (params.ready && daemon.readyAt === undefined && TERMINAL_STATES[daemon.state]) {
+				lines.push("Process exited before readiness was observed.");
 			}
 			return lines.join("\n");
 		}

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -442,6 +442,8 @@ export function launchRenderResult(
 								: "Readiness timed out; the process is still running.",
 						),
 					);
+				} else if (params.ready && daemon && daemon.readyAt === undefined && TERMINAL_STATES[daemon.state]) {
+					body.push(theme.fg("warning", "Process exited before readiness was observed."));
 				}
 				break;
 			}

--- a/packages/coding-agent/test/tools/launch-renderer.test.ts
+++ b/packages/coding-agent/test/tools/launch-renderer.test.ts
@@ -167,6 +167,34 @@ describe("hub launch rendering", () => {
 		expect(rendered.some(line => line.includes("spawn bun ENOENT"))).toBe(true);
 	});
 
+	it("surfaces a pre-ready exit in the interactive start result", async () => {
+		const uiTheme = await theme();
+		const rendered = lines(
+			hubToolRenderer.renderResult(
+				{
+					content: [{ type: "text", text: "Process exited before readiness was observed." }],
+					details: {
+						op: "start",
+						timedOut: false,
+						daemon: daemon({
+							state: "exited",
+							pid: undefined,
+							exitedAt: Date.now(),
+							exitCode: 0,
+							readyAt: undefined,
+						}),
+					} satisfies LaunchToolDetails,
+				},
+				{ expanded: false, isPartial: false },
+				uiTheme,
+				{ op: "start", name: "web", application: "bun", ready: { log: "LISTENING" } },
+			),
+		);
+		expect(rendered[0]).toContain("Launch start");
+		expect(rendered[0]).toContain("exited");
+		expect(rendered.some(line => line.includes("Process exited before readiness was observed."))).toBe(true);
+	});
+
 	it("names the unmet readiness condition instead of a contradictory Ready + timed-out pair", async () => {
 		const uiTheme = await theme();
 		const rendered = lines(

--- a/packages/coding-agent/test/tools/launch.test.ts
+++ b/packages/coding-agent/test/tools/launch.test.ts
@@ -478,4 +478,94 @@ esac
 			await shutdown(client);
 		}
 	}, 20_000);
+
+	// Regression: a process that flips starting→ready→exited within one 50ms poll
+	// interval used to hang `start` for the full readiness timeout, because
+	// #waitUntil sampled the live (already "exited") state instead of the sticky
+	// readyAt marker #markReady durably recorded.
+	it("returns promptly when the process becomes ready then exits within a poll", async () => {
+		const projectDir = await tempDir("omp-daemon-fast-project-");
+		const runtimeDir = await tempDir("omp-daemon-fast-runtime-");
+		const scriptPath = path.join(projectDir, "fast.ts");
+		await Bun.write(scriptPath, `process.stdout.write("done\\n");\n`);
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		try {
+			const spec: DaemonSpec = {
+				name: "fast",
+				application: process.execPath,
+				args: [scriptPath],
+				env: {},
+				cwd: projectDir,
+				pty: false,
+				ready: { log: ".+", timeoutMs: 60_000 },
+				restart: "no",
+				persist: false,
+				detached: false,
+			};
+			const t0 = Date.now();
+			const started = await client.request({ op: "start", spec });
+			const elapsed = Date.now() - t0;
+			expect(started.op).toBe("start");
+			if (started.op !== "start") throw new Error("unexpected start result");
+			// Woke on readyAt/terminal, not the full 60s timeout.
+			expect(elapsed).toBeLessThan(10_000);
+			expect(started.readyTimedOut).toBeFalse();
+			expect(started.daemon.readyAt).toBeDefined();
+		} finally {
+			await shutdown(client);
+		}
+	}, 20_000);
+
+	// Regression: a process that exits before ever becoming ready used to block the
+	// caller for the full timeout, and a for:"ready" wait on the settled daemon did
+	// the same. Terminal states now wake both waits immediately.
+	it('wakes start and for:"ready" waits when the process exits before readiness', async () => {
+		const projectDir = await tempDir("omp-daemon-preexit-project-");
+		const runtimeDir = await tempDir("omp-daemon-preexit-runtime-");
+		const scriptPath = path.join(projectDir, "preexit.ts");
+		// Exits without ever printing the ready pattern.
+		await Bun.write(scriptPath, `process.stdout.write("nope\\n"); process.exit(0);\n`);
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		try {
+			const spec: DaemonSpec = {
+				name: "preexit",
+				application: process.execPath,
+				args: [scriptPath],
+				env: {},
+				cwd: projectDir,
+				pty: false,
+				ready: { log: "LISTENING", timeoutMs: 60_000 },
+				restart: "no",
+				persist: false,
+				detached: false,
+			};
+			const t0 = Date.now();
+			const started = await client.request({ op: "start", spec });
+			const startElapsed = Date.now() - t0;
+			expect(started.op).toBe("start");
+			if (started.op !== "start") throw new Error("unexpected start result");
+			expect(startElapsed).toBeLessThan(10_000);
+			// Woke on the terminal exit rather than timing out; the readyAt marker is
+			// absent because the ready pattern never matched.
+			expect(started.readyTimedOut).toBeFalse();
+			expect(started.daemon.readyAt).toBeUndefined();
+			expect(["exited", "failed"]).toContain(started.daemon.state);
+
+			// A for:"ready" wait on the already-settled daemon must not hang either.
+			const t1 = Date.now();
+			const waited = await client.request({
+				op: "wait",
+				name: "preexit",
+				for: "ready",
+				timeoutMs: 60_000,
+			});
+			const waitElapsed = Date.now() - t1;
+			expect(waited.op).toBe("wait");
+			if (waited.op !== "wait") throw new Error("unexpected wait result");
+			expect(waitElapsed).toBeLessThan(10_000);
+			expect(waited.timedOut).toBeFalse();
+		} finally {
+			await shutdown(client);
+		}
+	}, 20_000);
 });

--- a/packages/coding-agent/test/tools/launch.test.ts
+++ b/packages/coding-agent/test/tools/launch.test.ts
@@ -568,4 +568,54 @@ esac
 			await shutdown(client);
 		}
 	}, 20_000);
+
+	// Regression (PR #6305 review): readyAt belongs to the exited generation, so a
+	// daemon in the restart backoff window must not report readiness. #settle now
+	// clears readyAt/readyMatch when entering "restarting"; without that, start and
+	// for:"ready" waits race a dead service during the backoff.
+	it("clears stale readiness while a daemon is restarting", async () => {
+		const projectDir = await tempDir("omp-daemon-restart-project-");
+		const runtimeDir = await tempDir("omp-daemon-restart-runtime-");
+		const scriptPath = path.join(projectDir, "flap.ts");
+		// Becomes ready (prints the pattern), then crashes shortly after.
+		await Bun.write(scriptPath, `process.stdout.write("READY\\n"); setTimeout(() => process.exit(1), 50);\n`);
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		try {
+			const spec: DaemonSpec = {
+				name: "flap",
+				application: process.execPath,
+				args: [scriptPath],
+				env: {},
+				cwd: projectDir,
+				pty: false,
+				ready: { log: "READY", timeoutMs: 60_000 },
+				restart: "on-failure",
+				persist: false,
+				detached: false,
+			};
+			const started = await client.request({ op: "start", spec });
+			expect(started.op).toBe("start");
+			if (started.op !== "start") throw new Error("unexpected start result");
+			expect(started.daemon.readyAt).toBeDefined();
+
+			// Catch the backoff window: once restarting, readiness must be cleared.
+			const restarting = await waitUntil(async () => {
+				const listed = await client.request({ op: "list" });
+				if (listed.op !== "list") return false;
+				const daemon = listed.daemons.find(d => d.name === "flap");
+				return daemon?.state === "restarting";
+			}, 15_000);
+			expect(restarting).toBeTrue();
+			const listed = await client.request({ op: "list" });
+			if (listed.op !== "list") throw new Error("unexpected list result");
+			const daemon = listed.daemons.find(d => d.name === "flap");
+			expect(daemon?.state).toBe("restarting");
+			expect(daemon?.readyAt).toBeUndefined();
+			expect(daemon?.readyMatch).toBeUndefined();
+
+			await client.request({ op: "stop", name: "flap", timeoutMs: 2_000 });
+		} finally {
+			await shutdown(client);
+		}
+	}, 30_000);
 });

--- a/packages/coding-agent/test/tools/launch.test.ts
+++ b/packages/coding-agent/test/tools/launch.test.ts
@@ -511,6 +511,19 @@ esac
 			expect(elapsed).toBeLessThan(10_000);
 			expect(started.readyTimedOut).toBeFalse();
 			expect(started.daemon.readyAt).toBeDefined();
+
+			// A for:"ready" wait on the settled daemon reports success via the sticky
+			// readyAt marker even though the process has already exited.
+			const waited = await client.request({
+				op: "wait",
+				name: "fast",
+				for: "ready",
+				timeoutMs: 60_000,
+			});
+			expect(waited.op).toBe("wait");
+			if (waited.op !== "wait") throw new Error("unexpected wait result");
+			expect(waited.timedOut).toBeFalse();
+			expect(waited.daemon.readyAt).toBeDefined();
 		} finally {
 			await shutdown(client);
 		}
@@ -551,7 +564,9 @@ esac
 			expect(started.daemon.readyAt).toBeUndefined();
 			expect(["exited", "failed"]).toContain(started.daemon.state);
 
-			// A for:"ready" wait on the already-settled daemon must not hang either.
+			// A for:"ready" wait on the already-settled daemon must wake immediately,
+			// but a process that never became ready is surfaced as not ready
+			// (timedOut) so callers don't chain work against a dead process.
 			const t1 = Date.now();
 			const waited = await client.request({
 				op: "wait",
@@ -563,7 +578,8 @@ esac
 			expect(waited.op).toBe("wait");
 			if (waited.op !== "wait") throw new Error("unexpected wait result");
 			expect(waitElapsed).toBeLessThan(10_000);
-			expect(waited.timedOut).toBeFalse();
+			expect(waited.timedOut).toBeTrue();
+			expect(waited.daemon.readyAt).toBeUndefined();
 		} finally {
 			await shutdown(client);
 		}


### PR DESCRIPTION
## Repro
Starting a daemon with a `ready.log` whose process becomes ready and exits within one poll interval blocks `hub start` for the full readiness timeout. Minimal case: `hub start` a process that prints one line and exits, `ready: { log: ".+", timeoutMs: 60000 }`. The broker records `readyAt`/`readyMatch` correctly, but `start` never returns. A `for:"ready"` wait on the settled daemon, and a process that exits before ever becoming ready, hang the same way. Command: `bun test packages/coding-agent/test/tools/launch.test.ts` — the two new regression tests hang to their 20s caps on the pre-fix code.

## Cause
`BrokerDaemonHost#start` waits via `#waitUntil(record, () => record.snapshot.state === "ready", …)` (`packages/coding-agent/src/launch/broker.ts`). `#waitUntil` polls every 50ms and samples the **live** state. A fast process flips `starting → ready → exited` within one interval, so the poller only ever observes `"exited"` and the `state === "ready"` condition never passes — even though `#markReady` durably set `snapshot.readyAt`. Terminal states only wake the wait while the broker is shutting down (`if (this.#shuttingDown && terminalState(...))`), so a pre-ready exit also blocks for the full timeout. `#wait` with `for: "ready"` shares the flaw on a settled daemon.

## Fix
- `#start`: wait on `record.snapshot.readyAt !== undefined || terminalState(record.snapshot.state)` instead of the transient live state; `readyTimedOut = !ready` now falls out directly.
- `#wait` (`for: "ready"`): honor the sticky `readyAt` marker or any terminal state so a settled daemon satisfies the wait immediately.
- `tools/hub/launch.ts`: add a `Process exited before readiness was observed.` result line for the pre-ready-exit case (ready spec present, no `readyAt`, terminal state).
- Two regression tests in `test/tools/launch.test.ts`: fast ready-then-exit returns promptly with `readyAt` set; pre-ready exit wakes `start` and a subsequent `for:"ready"` wait without timing out.

## Verification
`bun test packages/coding-agent/test/tools/launch.test.ts` — 9 pass, 0 fail. Both new tests complete in ~0.5s where they previously hung to their 20s caps (confirmed by reverting the broker change). `bun run fix` + `bun check` ran clean via the pre-publish gate. Fixes #6303