### PR TITLE
fix(coding-agent): align bundled task prewalk display

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/agents` showing prewalk as off for the bundled `task` agent when `task.prewalk` enables its runtime default ([#6306](https://github.com/can1357/oh-my-pi/issues/6306)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -49,6 +49,7 @@ import agentCreationArchitectPrompt from "../../prompts/system/agent-creation-ar
 import agentCreationUserPrompt from "../../prompts/system/agent-creation-user.md" with { type: "text" };
 import { createAgentSession } from "../../sdk";
 import { discoverAgents } from "../../task/discovery";
+import { resolveAgentPrewalkDefault } from "../../task/prewalk";
 import type { AgentDefinition, AgentSource } from "../../task/types";
 import { shortenPath } from "../../tools/render-utils";
 import { getEditorTheme, theme } from "../theme/theme";
@@ -602,7 +603,7 @@ export class AgentDashboard extends Container {
 		this.#persistPrewalkOverrides();
 		const pattern = resolveAgentPrewalkPattern({
 			settingsOverride: selected.prewalkOverride,
-			agentPrewalk: selected.prewalk,
+			agentPrewalk: resolveAgentPrewalkDefault(selected, this.#settingsManager?.get("task.prewalk") ?? false),
 		});
 		const state = selected.prewalkOverride ?? "agent default";
 		this.#notice = `Prewalk for ${selected.name}: ${state}${pattern ? ` (into ${pattern})` : ""}`;
@@ -1081,7 +1082,10 @@ export class AgentDashboard extends Container {
 			const prewalkPattern = selected
 				? resolveAgentPrewalkPattern({
 						settingsOverride: selected.prewalkOverride,
-						agentPrewalk: selected.prewalk,
+						agentPrewalk: resolveAgentPrewalkDefault(
+							selected,
+							this.#settingsManager?.get("task.prewalk") ?? false,
+						),
 					})
 				: undefined;
 			const prewalkResolution = prewalkPattern ? this.#resolvePatterns([prewalkPattern]) : undefined;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -55,6 +55,7 @@ import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
 import { generateTaskLabel } from "./label";
+import { resolveAgentPrewalkDefault } from "./prewalk";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import {
 	type AgentDefinition,
@@ -2451,11 +2452,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// frontmatter default; the `task.prewalk` toggle (default off) arms it.
 			// Resolution failures skip prewalk instead of failing the spawn.
 			let prewalk: Prewalk | undefined;
-			const genericTaskPrewalk =
-				agent.source === "bundled" && agent.name === "task" && settings.get("task.prewalk") ? true : undefined;
 			const prewalkPattern = resolveAgentPrewalkPattern({
 				settingsOverride: settings.get("task.agentPrewalk")[agent.name],
-				agentPrewalk: agent.prewalk ?? genericTaskPrewalk,
+				agentPrewalk: resolveAgentPrewalkDefault(agent, settings.get("task.prewalk")),
 			});
 			if (prewalkPattern) {
 				const resolvedPrewalk = resolveModelOverride([prewalkPattern], modelRegistry, settings);

--- a/packages/coding-agent/src/task/prewalk.ts
+++ b/packages/coding-agent/src/task/prewalk.ts
@@ -1,0 +1,6 @@
+import type { AgentDefinition } from "./types";
+
+/** Resolve an agent's prewalk default, including the bundled task opt-in. */
+export function resolveAgentPrewalkDefault(agent: AgentDefinition, taskPrewalk: boolean): boolean | string | undefined {
+	return agent.prewalk ?? (taskPrewalk && agent.source === "bundled" && agent.name === "task" ? true : undefined);
+}

--- a/packages/coding-agent/test/agent-dashboard-create-editor.test.ts
+++ b/packages/coding-agent/test/agent-dashboard-create-editor.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentDashboard } from "@oh-my-pi/pi-coding-agent/modes/components/agent-dashboard";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import * as discovery from "@oh-my-pi/pi-coding-agent/task/discovery";
@@ -234,5 +234,21 @@ describe("AgentDashboard tab navigation", () => {
 		} finally {
 			geo.restore();
 		}
+	});
+});
+
+describe("AgentDashboard prewalk", () => {
+	test("shows the bundled task prewalk default when task.prewalk is enabled", async () => {
+		await initTheme(false);
+		vi.spyOn(discovery, "discoverAgents").mockResolvedValue({
+			projectAgentsDir: null,
+			agents: [{ name: "task", description: "Generic task agent", systemPrompt: "", source: "bundled" }],
+		});
+		const settings = Settings.isolated({ "task.prewalk": true });
+		const dashboard = await AgentDashboard.create(await makeTempCwd(), settings, 24, {});
+		const rendered = dashboard.render(100).join("\n").replace(ANSI_PATTERN, "");
+
+		expect(rendered).toContain("Prewalk: on");
+		expect(rendered).not.toContain("Prewalk: off");
 	});
 });


### PR DESCRIPTION
## Repro
With `task.prewalk: true`, ran `bun -e` to construct `AgentDashboard` with `Settings.isolated({ "task.prewalk": true })`, filter to the bundled `task` agent, and print the inspector's `Prewalk:` line. Before the fix it printed `Prewalk: off` and exited 1.

## Cause
`packages/coding-agent/src/task/executor.ts` supplied a bundled-`task` fallback to `resolveAgentPrewalkPattern`, but `packages/coding-agent/src/modes/components/agent-dashboard.ts` passed only frontmatter and per-agent overrides. The two consumers therefore resolved the same settings differently.

## Fix
- Added `resolveAgentPrewalkDefault` as the shared bundled-`task` fallback.
- Used it in both executor and Agent Control Center render/cycle paths.
- Added dashboard regression coverage and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/agent-dashboard-create-editor.test.ts` — 9 passed. `bun test packages/coding-agent/test/task/executor-prewalk.test.ts` — 11 passed. The original dashboard one-liner now prints `Prewalk: on @smol → (unresolved)` and exits 0. `bun check` passed.

Fixes #6306