### PR TITLE
fix(tui): show fallback models in Agent Hub

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Agent Hub fallback rows hiding routing provenance and the resolved provider/model ([#6316](https://github.com/can1357/oh-my-pi/issues/6316)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -95,21 +95,24 @@ function formatResolvedModelBadge(resolved: string, preserveProvider = false): s
  * (e.g. a parked historical agent restored from disk).
  */
 function modelBadge(ref: AgentRef, observed: ObservableSession | undefined): string | undefined {
-	const fallback = ref.session?.retryFallbackModel;
-	if (fallback) {
-		return `${theme.fg("warning", "fallback →")} ${formatResolvedModelBadge(fallback, true)}`;
+	const progress = observed?.progress;
+	// Prefer the live session's own resolved fallback selector; else honor the
+	// executor-reported fallback flag. The latter covers observer-only rows (no
+	// live session) AND live rows whose fallback armed no session retry state —
+	// e.g. the Fireworks Fast → base degrade, which emits `retry_fallback_applied`
+	// without populating `#activeRetryFallback`, so `retryFallbackModel` is undefined.
+	const fallbackSelector =
+		ref.session?.retryFallbackModel ?? (progress?.resolvedModelIsFallback ? progress.resolvedModel : undefined);
+	if (fallbackSelector) {
+		return `${theme.fg("warning", "fallback →")} ${formatResolvedModelBadge(fallbackSelector, true)}`;
 	}
 	const model = ref.session?.model;
 	if (model) {
 		const level = model.thinking ? ref.session?.thinkingLevel : undefined;
 		return formatModelBadge(model.id, level);
 	}
-	const resolved = observed?.progress?.resolvedModel;
-	if (!resolved) return undefined;
-	if (observed?.progress?.resolvedModelIsFallback) {
-		return `${theme.fg("warning", "fallback →")} ${formatResolvedModelBadge(resolved, true)}`;
-	}
-	return formatResolvedModelBadge(resolved);
+	const resolved = progress?.resolvedModel;
+	return resolved ? formatResolvedModelBadge(resolved) : undefined;
 }
 
 /** Result of one host-backed transcript read for the Agent Hub viewer. */

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -105,7 +105,11 @@ function modelBadge(ref: AgentRef, observed: ObservableSession | undefined): str
 		return formatModelBadge(model.id, level);
 	}
 	const resolved = observed?.progress?.resolvedModel;
-	return resolved ? formatResolvedModelBadge(resolved) : undefined;
+	if (!resolved) return undefined;
+	if (observed?.progress?.resolvedModelIsFallback) {
+		return `${theme.fg("warning", "fallback →")} ${formatResolvedModelBadge(resolved, true)}`;
+	}
+	return formatResolvedModelBadge(resolved);
 }
 
 /** Result of one host-backed transcript read for the Agent Hub viewer. */

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -76,26 +76,36 @@ function formatModelBadge(modelId: string, level: ThinkingLevel | undefined): st
 	return `${model} ${theme.getThinkingBorderColor(level)(display)}`;
 }
 
+/** Format a resolved selector, preserving provider identity when requested. */
+function formatResolvedModelBadge(resolved: string, preserveProvider = false): string {
+	// Model ids may themselves contain colons (`qwen3:14b`), so only treat the
+	// suffix as a thinking level when it parses as one.
+	const colon = resolved.lastIndexOf(":");
+	const level = colon >= 0 ? parseThinkingLevel(resolved.slice(colon + 1)) : undefined;
+	const selector = level !== undefined ? resolved.slice(0, colon) : resolved;
+	const label = preserveProvider ? selector : selector.slice(selector.indexOf("/") + 1);
+	return formatModelBadge(label, level);
+}
+
 /**
  * Active model + reasoning level for a hub row: live session state when the
  * agent is attached, else the executor-reported `resolvedModel` selector
- * (`provider/id`, optionally `:<level>`). Undefined when neither is known
+ * (`provider/id`, optionally `:<level>`). Active retry fallbacks retain their
+ * provider and carry an explicit marker. Undefined when no model is known
  * (e.g. a parked historical agent restored from disk).
  */
 function modelBadge(ref: AgentRef, observed: ObservableSession | undefined): string | undefined {
+	const fallback = ref.session?.retryFallbackModel;
+	if (fallback) {
+		return `${theme.fg("warning", "fallback →")} ${formatResolvedModelBadge(fallback, true)}`;
+	}
 	const model = ref.session?.model;
 	if (model) {
 		const level = model.thinking ? ref.session?.thinkingLevel : undefined;
 		return formatModelBadge(model.id, level);
 	}
 	const resolved = observed?.progress?.resolvedModel;
-	if (!resolved) return undefined;
-	// Model ids may themselves contain colons (`qwen3:14b`), so only treat the
-	// suffix as a thinking level when it parses as one.
-	const colon = resolved.lastIndexOf(":");
-	const level = colon >= 0 ? parseThinkingLevel(resolved.slice(colon + 1)) : undefined;
-	const selector = level !== undefined ? resolved.slice(0, colon) : resolved;
-	return formatModelBadge(selector.slice(selector.indexOf("/") + 1), level);
+	return resolved ? formatResolvedModelBadge(resolved) : undefined;
 }
 
 /** Result of one host-backed transcript read for the Agent Hub viewer. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6991,6 +6991,12 @@ export class AgentSession {
 		return this.agent.state.model;
 	}
 
+	/** Resolved selector while retry routing is using a fallback model. */
+	get retryFallbackModel(): string | undefined {
+		const model = this.model;
+		return this.#activeRetryFallback && model ? formatRetryFallbackSelector(model, this.thinkingLevel) : undefined;
+	}
+
 	/** Effective thinking level applied to the agent (the resolved level when `auto`). */
 	get thinkingLevel(): ThinkingLevel | undefined {
 		return this.#thinkingLevel;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1563,11 +1563,13 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			}
 			if (event.type === "retry_fallback_applied") {
 				progress.resolvedModel = event.to;
+				progress.resolvedModelIsFallback = true;
 				scheduleProgress(true);
 				return;
 			}
 			if (event.type === "retry_fallback_succeeded") {
 				progress.resolvedModel = event.model;
+				progress.resolvedModelIsFallback = true;
 				scheduleProgress(true);
 				return;
 			}
@@ -1973,6 +1975,7 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		contextWindow: progress.contextWindow,
 		modelOverride,
 		resolvedModel: progress.resolvedModel,
+		resolvedModelIsFallback: progress.resolvedModelIsFallback,
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1094,6 +1094,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							// and running counters without reverting the "running"
 							// status back to the subagent's initial "pending" snapshot.
 							progress.resolvedModel = nextProgress.resolvedModel;
+							progress.resolvedModelIsFallback = nextProgress.resolvedModelIsFallback;
 							progress.tokens = nextProgress.tokens;
 							progress.requests = nextProgress.requests;
 							progress.contextTokens = nextProgress.contextTokens;
@@ -1138,8 +1139,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					progress.retryState = undefined;
 					if (singleResult?.resolvedModel) {
 						progress.resolvedModel = singleResult.resolvedModel;
+						progress.resolvedModelIsFallback = singleResult.resolvedModelIsFallback;
 					} else {
 						delete progress.resolvedModel;
+						delete progress.resolvedModelIsFallback;
 					}
 					onSettled?.(resultFailed);
 					const statusText = resultFailed

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -419,6 +419,8 @@ export interface AgentProgress {
 	modelOverride?: string | string[];
 	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Undefined when the model could not be resolved. */
 	resolvedModel?: string;
+	/** True when {@link resolvedModel} is the target of an active retry fallback (not the originally configured model). Lets observer-only UIs (collab guests, Agent Hub rows with no live session) flag the fallback and keep the provider. */
+	resolvedModelIsFallback?: boolean;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/**
@@ -486,6 +488,8 @@ export interface SingleResult {
 	modelOverride?: string | string[];
 	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Omitted from tool-result JSON when undefined to keep wire payloads small. */
 	resolvedModel?: string;
+	/** True when {@link resolvedModel} is the target of an active retry fallback. Mirrors {@link AgentProgress.resolvedModelIsFallback} onto the settled result. */
+	resolvedModelIsFallback?: boolean;
 	error?: string;
 	aborted?: boolean;
 	abortReason?: string;

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -204,4 +204,46 @@ describe("Agent hub row ordering", () => {
 			hub.dispose();
 		}
 	});
+
+	it("flags a fallback badge for a live row whose fallback armed no session retry state", () => {
+		geometry = stubStdoutGeometry(120);
+		const agents = new AgentRegistry();
+		// Live session with a resolved model but no `retryFallbackModel` — the
+		// Fireworks Fast → base degrade emits `retry_fallback_applied` without
+		// arming `#activeRetryFallback`, so the badge must fall back to the
+		// executor-reported progress flag.
+		const session = { model: { id: "kimi-k2" }, retryFallbackModel: undefined } as unknown as AgentSession;
+		agents.register({ id: "FastAgent", displayName: "Fast Agent", kind: "sub", session });
+
+		const observers = new SessionObserverRegistry();
+		vi.spyOn(observers, "getSessions").mockReturnValue([
+			{
+				id: "FastAgent",
+				kind: "subagent",
+				label: "Subagent",
+				status: "active",
+				lastUpdate: Date.now(),
+				progress: {
+					resolvedModel: "fireworks/kimi-k2",
+					resolvedModelIsFallback: true,
+				} as never,
+			},
+		]);
+
+		const hub = new AgentHubOverlayComponent({
+			observers,
+			hubKeys: [],
+			onDone: () => {},
+			requestRender: () => {},
+			registry: agents,
+			irc: new IrcBus(agents),
+			focusAgent: async () => {},
+		});
+
+		try {
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("fallback → fireworks/kimi-k2");
+		} finally {
+			hub.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -165,4 +165,43 @@ describe("Agent hub row ordering", () => {
 
 		hub.dispose();
 	});
+
+	it("flags a fallback badge for observer-only rows with no live session", () => {
+		geometry = stubStdoutGeometry(120);
+		const agents = new AgentRegistry();
+		// A collab guest / observer-only row carries no live AgentSession, so the
+		// badge must come from the executor-reported progress instead.
+		agents.register({ id: "GuestAgent", displayName: "Guest Agent", kind: "sub", session: null });
+
+		const observers = new SessionObserverRegistry();
+		vi.spyOn(observers, "getSessions").mockReturnValue([
+			{
+				id: "GuestAgent",
+				kind: "subagent",
+				label: "Subagent",
+				status: "active",
+				lastUpdate: Date.now(),
+				progress: {
+					resolvedModel: "openai/gpt-4o",
+					resolvedModelIsFallback: true,
+				} as never,
+			},
+		]);
+
+		const hub = new AgentHubOverlayComponent({
+			observers,
+			hubKeys: [],
+			onDone: () => {},
+			requestRender: () => {},
+			registry: agents,
+			irc: new IrcBus(agents),
+			focusAgent: async () => {},
+		});
+
+		try {
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("fallback → openai/gpt-4o");
+		} finally {
+			hub.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -11,6 +11,11 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { parseModelPattern, parseModelString } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentHubOverlayComponent } from "@oh-my-pi/pi-coding-agent/modes/components/agent-hub";
+import { SessionObserverRegistry } from "@oh-my-pi/pi-coding-agent/modes/session-observer-registry";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -81,6 +86,7 @@ describe("AgentSession retry fallback", () => {
 	// mutable retry-fallback cooldown state between tests.
 	beforeAll(async () => {
 		tempDir = TempDir.createSync("@pi-retry-fallback-");
+		await initTheme();
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
 		authStorage.setRuntimeApiKey("openai", "openai-test-key");
@@ -219,6 +225,28 @@ describe("AgentSession retry fallback", () => {
 				role: "default",
 			},
 		]);
+		const registry = new AgentRegistry();
+		registry.register({
+			id: "fallback-agent",
+			displayName: "Fallback Agent",
+			kind: "sub",
+			session,
+		});
+		const hub = new AgentHubOverlayComponent({
+			observers: new SessionObserverRegistry(),
+			hubKeys: [],
+			onDone: () => {},
+			requestRender: () => {},
+			registry,
+			irc: new IrcBus(registry),
+		});
+		try {
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain(
+				`fallback → ${secondFallback.provider}/${secondFallback.id}`,
+			);
+		} finally {
+			hub.dispose();
+		}
 	});
 
 	it("applies a model-keyed fallback chain to advisor quota failures", async () => {


### PR DESCRIPTION
## Repro
Configure a retry fallback chain, force the primary provider to fail, then render the Agent Hub after the fallback succeeds. `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts --test-name-pattern "advances through a role-keyed fallback chain"` previously rendered only the bare `gpt-4o` id instead of `fallback → openai/gpt-4o`.

## Cause
`AgentHubOverlayComponent.modelBadge()` in `packages/coding-agent/src/modes/components/agent-hub.ts` read only `AgentSession.model.id`; `AgentSession` retained fallback routing state privately, so the Hub could not distinguish a fallback or retain its provider.

## Fix
- Expose the active resolved retry-fallback selector through `AgentSession.retryFallbackModel`.
- Render active fallbacks as `fallback → provider/model`, preserving explicit thinking suffixes.
- Extend the real retry-fallback test through Agent Hub rendering and document the fix in the changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts --test-name-pattern "advances through a role-keyed fallback chain"` — 1 passed.

`bun test packages/coding-agent/test/agent-hub-activate.test.ts packages/coding-agent/test/agent-hub-advisor-scroll.test.ts packages/coding-agent/test/agent-hub-ordering.test.ts` — 24 passed.

`bun run check` in `packages/coding-agent` passed; the publish gate also completed successfully.

Fixes #6316