### PR TITLE
fix(coding-agent): let hub cancel kill a jobless agent registration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a budget-aborted keep-alive subagent becoming an unkillable registration with no `hub`-level stop. A subagent force-stopped for exceeding its soft request budget is kept resumable (status `idle`, adopted by the lifecycle) so its context can be salvaged, but its async job row settles and is reaped after ~5 min — after which `hub cancel <id>` could only report `Background job not found` because it consulted the job manager alone. `hub cancel` now falls through to the agent registration: for an id the caller spawned that has no live job, it aborts any in-flight turn, disposes the session, and drops the registration (the interactive Agent Hub `x` and collab `kill` already did this; the model-facing `hub` did not). Cross-agent kills stay impossible and Main/advisor refs are never targeted ([#6315](https://github.com/can1357/oh-my-pi/issues/6315)).
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1692,6 +1692,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getAgentId: () => resolvedAgentId,
 			getToolByName: name => session?.getToolByName(name),
 			agentRegistry,
+			agentLifecycle: () => AgentLifecycleManager.global(),
 			getSessionSpawns: () => options.spawns ?? "*",
 			getModelString: () => (hasExplicitModel && model ? formatModelString(model) : undefined),
 			getActiveModelString,

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -283,7 +283,7 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 				if (!params.ids?.length) {
 					return hubErrorResult('`ids` is required for op="cancel".', { op: "cancel", jobs: [] });
 				}
-				return executeCancel(this.session, manager, this.#ownerId(), params.ids);
+				return await executeCancel(this.session, manager, this.#ownerId(), params.ids);
 			}
 			case "jobs": {
 				const manager = this.session.asyncJobManager;

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -12,6 +12,7 @@ import { settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { shimmerEnabled, shimmerText } from "../../modes/theme/shimmer";
 import type { Theme } from "../../modes/theme/theme";
+import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import type { ToolSession } from "..";
 import {
@@ -304,18 +305,21 @@ export function nothingToWaitForResult(session: ToolSession): AgentToolResult<Co
 }
 
 /** `cancel`: kill the named jobs; returns immediately with outcomes + snapshots. */
-export function executeCancel(
+export async function executeCancel(
 	session: ToolSession,
 	manager: AsyncJobManager,
 	ownerId: string | undefined,
 	ids: string[],
-): AgentToolResult<CoordinationDetails> {
+): Promise<AgentToolResult<CoordinationDetails>> {
 	const ownerFilter = ownerId ? { ownerId } : undefined;
 	const cancelOutcomes: CancelOutcome[] = [];
 	for (const id of ids) {
 		const existing = manager.getJob(id);
 		if (!existing || (ownerId && existing.ownerId !== ownerId)) {
-			cancelOutcomes.push({ id, status: "not_found", message: `Background job not found: ${id}` });
+			// No job by this id (or it belongs to another agent): a budget-aborted
+			// keep-alive subagent lives on as a jobless registration long after its
+			// job row is reaped, so let cancel reach the agent registration too.
+			cancelOutcomes.push(await cancelAgentRegistration(session, ownerId, id));
 			continue;
 		}
 		if (existing.status !== "running") {
@@ -334,6 +338,52 @@ export function executeCancel(
 		);
 	}
 	return buildJobResult(session, manager, "cancel", visibleJobs(manager, ids, ownerId), cancelOutcomes);
+}
+
+/**
+ * Kill a non-job-backed agent registration named by `id`: abort any in-flight
+ * turn, then release it from the lifecycle (dispose session + unregister). This
+ * is the only kill path for a keep-alive subagent that was budget-aborted, went
+ * `idle`/`parked`, and outlived its job row — otherwise it is unstoppable short
+ * of a broker restart (issue #6315). Scoped to the caller's own descendants so
+ * cross-agent kills stay impossible; a bare test/SDK caller (no owner id) may
+ * target any sub. Never touches Main, the caller, or advisor transcripts.
+ */
+async function cancelAgentRegistration(
+	session: ToolSession,
+	ownerId: string | undefined,
+	id: string,
+): Promise<CancelOutcome> {
+	const registry = session.agentRegistry;
+	const ref = registry?.get(id);
+	if (ref?.kind !== "sub") {
+		return { id, status: "not_found", message: `Background job not found: ${id}` };
+	}
+	if (id === ownerId) {
+		return { id, status: "not_found", message: `Cannot cancel yourself (${id}).` };
+	}
+	if (ownerId && ref.parentId !== ownerId) {
+		return { id, status: "not_found", message: `Agent ${id} was not spawned by you and cannot be cancelled.` };
+	}
+	const lifecycle = session.agentLifecycle?.();
+	try {
+		if (ref.status === "running" && ref.session) {
+			await ref.session.abort({ reason: USER_INTERRUPT_LABEL });
+		}
+		if (lifecycle) {
+			await lifecycle.release(id);
+		} else {
+			await ref.session?.dispose();
+			registry?.unregister(id);
+		}
+	} catch (error) {
+		return {
+			id,
+			status: "already_completed",
+			message: `Agent ${id} could not be fully cancelled: ${error instanceof Error ? error.message : String(error)}.`,
+		};
+	}
+	return { id, status: "cancelled", message: `Cancelled agent ${id} (killed session, dropped registration).` };
 }
 
 /** `jobs`: read-only snapshot of every job plus the jobless running-agent roster. */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -20,6 +20,7 @@ import { LspTool } from "../lsp";
 import type { MCPManager } from "../mcp";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import type { PlanModeState } from "../plan-mode/state";
+import type { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import type { AgentRegistry } from "../registry/agent-registry";
 import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridge } from "../session/client-bridge";
@@ -238,6 +239,8 @@ export interface ToolSession {
 	xdevRegistry?: XdevRegistry;
 	/** Agent registry for IRC routing across live sessions. */
 	agentRegistry?: AgentRegistry;
+	/** Idle→parked→revive lifecycle owner; lets the hub kill a non-job-backed agent registration. Default: AgentLifecycleManager.global(). */
+	agentLifecycle?: () => AgentLifecycleManager;
 	/** Get artifacts directory for artifact:// URLs */
 	getArtifactsDir?: () => string | null;
 	/** Get the ArtifactManager backing this session (shared across parent + subagents). */

--- a/packages/coding-agent/test/job-tool-agent-roster.test.ts
+++ b/packages/coding-agent/test/job-tool-agent-roster.test.ts
@@ -8,6 +8,7 @@
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { type CoordinationDetails, HubTool } from "../src/tools/hub";
@@ -24,6 +25,7 @@ function createToolSession(options: {
 	manager?: AsyncJobManager;
 	registry?: AgentRegistry;
 	agentId?: string;
+	lifecycle?: AgentLifecycleManager;
 }): ToolSession {
 	return {
 		cwd: process.cwd(),
@@ -36,6 +38,7 @@ function createToolSession(options: {
 		getAgentId: () => options.agentId ?? null,
 		asyncJobManager: options.manager,
 		agentRegistry: options.registry,
+		...(options.lifecycle ? { agentLifecycle: () => options.lifecycle } : {}),
 	} as unknown as ToolSession;
 }
 
@@ -155,5 +158,101 @@ describe("hub wait with no matching jobs", () => {
 		expect(text).toContain("No matching jobs found for IDs: Worker");
 		expect(text).toContain("running agent with no job entry");
 		expect(text).toContain("history://Worker");
+	});
+});
+
+describe("hub cancel of a non-job-backed agent registration (#6315)", () => {
+	function fakeSession() {
+		let aborts = 0;
+		let disposes = 0;
+		const session = {
+			abort: async () => {
+				aborts += 1;
+			},
+			dispose: async () => {
+				disposes += 1;
+			},
+		};
+		return { session, abortCalls: () => aborts, disposeCalls: () => disposes };
+	}
+
+	test("cancel kills an owned idle agent that has no backing job", async () => {
+		const registry = new AgentRegistry();
+		const lifecycle = new AgentLifecycleManager(registry);
+		const fake = fakeSession();
+		registry.register({
+			id: "Zombie",
+			displayName: "Zombie",
+			kind: "sub",
+			parentId: "Main",
+			session: fake.session as never,
+			status: "idle",
+		});
+		lifecycle.adopt("Zombie", { idleTtlMs: 0 });
+		const tool = new HubTool(createToolSession({ manager: createManager(), registry, agentId: "Main", lifecycle }));
+
+		const result = await tool.execute("call", { op: "cancel", ids: ["Zombie"] });
+
+		expect((result.details as CoordinationDetails)?.cancelled).toEqual([{ id: "Zombie", status: "cancelled" }]);
+		expect(resultText(result)).toContain("Cancelled agent Zombie");
+		// The registration is gone: dropped from the registry and lifecycle.
+		expect(registry.get("Zombie")).toBeUndefined();
+		expect(lifecycle.has("Zombie")).toBe(false);
+		expect(fake.disposeCalls()).toBe(1);
+	});
+
+	test("cancel aborts the in-flight turn of a running agent before releasing it", async () => {
+		const registry = new AgentRegistry();
+		const lifecycle = new AgentLifecycleManager(registry);
+		const fake = fakeSession();
+		registry.register({
+			id: "Runner",
+			displayName: "Runner",
+			kind: "sub",
+			parentId: "Main",
+			session: fake.session as never,
+			status: "running",
+		});
+		lifecycle.adopt("Runner", { idleTtlMs: 0 });
+		const tool = new HubTool(createToolSession({ manager: createManager(), registry, agentId: "Main", lifecycle }));
+
+		const result = await tool.execute("call", { op: "cancel", ids: ["Runner"] });
+
+		expect((result.details as CoordinationDetails)?.cancelled).toEqual([{ id: "Runner", status: "cancelled" }]);
+		expect(fake.abortCalls()).toBe(1);
+		expect(fake.disposeCalls()).toBe(1);
+		expect(registry.get("Runner")).toBeUndefined();
+	});
+
+	test("cancel refuses an agent spawned by someone else", async () => {
+		const registry = new AgentRegistry();
+		const lifecycle = new AgentLifecycleManager(registry);
+		const fake = fakeSession();
+		registry.register({
+			id: "OtherKid",
+			displayName: "OtherKid",
+			kind: "sub",
+			parentId: "SomeoneElse",
+			session: fake.session as never,
+			status: "idle",
+		});
+		const tool = new HubTool(createToolSession({ manager: createManager(), registry, agentId: "Main", lifecycle }));
+
+		const result = await tool.execute("call", { op: "cancel", ids: ["OtherKid"] });
+
+		expect((result.details as CoordinationDetails)?.cancelled).toEqual([{ id: "OtherKid", status: "not_found" }]);
+		expect(registry.get("OtherKid")).toBeDefined();
+		expect(fake.disposeCalls()).toBe(0);
+	});
+
+	test("cancel of a truly unknown id still reports not_found", async () => {
+		const registry = new AgentRegistry();
+		const lifecycle = new AgentLifecycleManager(registry);
+		const tool = new HubTool(createToolSession({ manager: createManager(), registry, agentId: "Main", lifecycle }));
+
+		const result = await tool.execute("call", { op: "cancel", ids: ["Ghost"] });
+
+		expect((result.details as CoordinationDetails)?.cancelled).toEqual([{ id: "Ghost", status: "not_found" }]);
+		expect(resultText(result)).toContain("Background job not found: Ghost");
 	});
 });


### PR DESCRIPTION
## Repro
A `scout`/`task` subagent that trips its 1.5x soft-request-budget force-stop without yielding is kept resumable so its context can be salvaged. Its async job row settles `failed` and is reaped after ~5 min, but the agent stays registered (`idle`) and revivable via hub/IRC. When a weak model then answers every wake with another `hub send`, the agent takes unbounded turns and there is no `hub`-level way to stop it: `hub cancel <id>` returns `Background job not found` (the job is gone) and nothing else short of a broker restart releases the registration. Covered by `packages/coding-agent/test/job-tool-agent-roster.test.ts` → `describe("hub cancel of a non-job-backed agent registration (#6315)")`; run with `bun test test/job-tool-agent-roster.test.ts`.

## Cause
`finalizeSubagentLifecycle` (`packages/coding-agent/src/task/executor.ts`) treats `abortKind === "budget"` on a keep-alive, non-isolated sub with a reviver as `resumableAbort`: it is never marked `aborted`, instead going `idle` and adopted by `AgentLifecycleManager`. `executeCancel` (`packages/coding-agent/src/tools/hub/jobs.ts`) only ever consulted `AsyncJobManager.getJob(id)`; once the job row is reaped there is nothing for it to target, so a live `idle`/`parked` registration has no model-facing kill. Only the interactive Agent Hub (`x`) and collab host (`kill`) could release such an agent.

## Fix
- `ToolSession` gains an optional `agentLifecycle` accessor (`src/tools/index.ts`), wired in `src/sdk.ts` to `AgentLifecycleManager.global()`.
- `executeCancel` becomes async; when an id matches no live job it falls through to `cancelAgentRegistration`, which aborts any in-flight turn (`session.abort`) then `AgentLifecycleManager.release(id)` (dispose + unregister), mirroring the existing collab-host `kill`. Reuses the `cancel` op, `ids` param, and `CancelOutcome` output — no tool-shape or prompt change.
- Guards: only a `sub` the caller spawned (`parentId === ownerId`) can be killed; never the caller itself, Main, or advisor transcripts; a bare test/SDK caller (no owner id) may target any sub. Truly unknown ids still report `not_found`.
- `hub` dispatch (`src/tools/hub/index.ts`) awaits the now-async `executeCancel`.

## Verification
`bun test test/job-tool-agent-roster.test.ts` → 11 pass (4 new: idle kill drops the registration + disposes; running-turn kill aborts then releases; cross-owner kill refused; unknown id `not_found`). `bun test test/task/executor-soft-budget.test.ts test/registry/agent-lifecycle.test.ts` → all pass. `bun check` clean (TS + biome). Fixes #6315