### PR TITLE
fix(ollama): route cloud-suffixed selectors to Ollama Cloud

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy `ollama/<model>:cloud` selectors from `ollama launch omp` resolving to the local Ollama provider and failing against an unavailable localhost endpoint; they now route to the matching `ollama-cloud` model when it is available.
+
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -414,6 +414,21 @@ export function resolveProviderModelReference(
 	}
 
 	const index = getProviderModelIndex(availableModels);
+	// `ollama launch omp` historically emits `ollama/<id>:cloud` selectors.
+	// The `:cloud` suffix is transport metadata, not part of the Ollama Cloud
+	// model id; resolve it before an identically named local discovery entry can
+	// capture the request and send it to localhost.
+	if (normalizedProvider === "ollama" && normalizedModelId.endsWith(":cloud")) {
+		const cloudModelId = normalizedModelId.slice(0, -":cloud".length);
+		const cloud = index.get(`ollama-cloud\u0000${cloudModelId}`);
+		if (cloud === null) {
+			return undefined;
+		}
+		if (cloud !== undefined) {
+			return cloud;
+		}
+	}
+
 	const exact = index.get(`${normalizedProvider}\u0000${normalizedModelId}`);
 	if (exact === null) {
 		return undefined; // ambiguous
@@ -1243,6 +1258,11 @@ export function resolveModelFromString(
 	available: Model<Api>[],
 	matchPreferences?: ModelMatchPreferences,
 ): Model<Api> | undefined {
+	const legacyOllamaCloud = /^ollama\/(.+):cloud$/i.exec(value.trim());
+	if (legacyOllamaCloud?.[1]) {
+		const cloud = resolveProviderModelReference("ollama", `${legacyOllamaCloud[1]}:cloud`, available);
+		if (cloud) return cloud;
+	}
 	const exact = available.find(model => `${model.provider}/${model.id}` === value);
 	if (exact) return exact;
 	const parsed = parseModelString(value, {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1611,6 +1611,43 @@ describe("resolveModelFromString", () => {
 		expect(result?.provider).toBe("example");
 		expect(result?.id).toBe("runtime:auto");
 	});
+
+	test("routes legacy ollama :cloud selectors to Ollama Cloud", () => {
+		const localAlias = buildModel({
+			id: "kimi-k2.7-code:cloud",
+			name: "kimi-k2.7-code:cloud",
+			api: "ollama-chat",
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 262144,
+			maxTokens: 32768,
+		});
+		const cloudModel = buildModel({
+			id: "kimi-k2.7-code",
+			name: "kimi-k2.7-code",
+			api: "ollama-chat",
+			provider: "ollama-cloud",
+			baseUrl: "https://ollama.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 262144,
+			maxTokens: 32768,
+		});
+
+		const result = resolveModelFromString("ollama/kimi-k2.7-code:cloud", [localAlias, cloudModel]);
+
+		expect(result?.provider).toBe("ollama-cloud");
+		expect(result?.id).toBe("kimi-k2.7-code");
+		expect(result?.baseUrl).toBe("https://ollama.com");
+		expect(parseModelPattern("ollama/kimi-k2.7-code:cloud", [localAlias, cloudModel]).model?.provider).toBe(
+			"ollama-cloud",
+		);
+		expect(resolveModelFromString("ollama/kimi-k2.7-code:cloud", [localAlias])?.provider).toBe("ollama");
+	});
 });
 
 describe("expandRoleAlias", () => {


### PR DESCRIPTION
## Summary
- route legacy `ollama/<model>:cloud` selectors emitted by `ollama launch omp` to the matching `ollama-cloud/<model>` catalog entry
- preserve local Ollama resolution when no matching cloud model exists
- cover direct and pattern-based model resolution

## Screenshots
No visual change.

## Testing
- `bun test packages/coding-agent/test/model-resolver.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/config/model-resolver.ts packages/coding-agent/test/model-resolver.test.ts`
- `bun packages/coding-agent/src/cli.ts -p --no-tools --no-session --model ollama/kimi-k2.7-code:cloud --max-time 30 "Respond with exactly OK."`

## Risk
- Low. The compatibility path only applies to explicit `ollama/*:cloud` selectors and only redirects when the corresponding `ollama-cloud` model is available.

## Notes
- Diagnosed from a session where the selector resolved to provider `ollama` and attempted the unavailable local endpoint instead of Ollama Cloud.

## AI Review Report
- Checked exact selector resolution, parser resolution, and the local-only fallback.
- Focused regression suite: 140 passing tests, 424 assertions.

## Security Audit
- No credential handling, persistence, or request payload changes.
- Routing uses the existing authenticated `ollama-cloud` provider entry.