### PR TITLE
fix(extensions): resolve transitive CJS dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "catalog:",
         "@babel/parser": "catalog:",
+        "@babel/traverse": "catalog:",
         "@mozilla/readability": "catalog:",
         "@oh-my-pi/hashline": "catalog:",
         "@oh-my-pi/omp-stats": "catalog:",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -55,6 +55,9 @@
 - Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded.
 - Fixed `/retry` reporting "Nothing to retry" after a stream stalled or aborted mid-tool-call.
 - Fixed locally consumed extension commands triggering automatic title generation and exposing their command text to the title model.
+### Fixed
+
+- Fixed compiled binaries failing to load legacy Pi extensions with minified imports, `pi-ai/compat`, or transitive runtime dependencies. The compatibility loader now follows compact static imports, resolves transitive on-disk ESM imports and CommonJS requires with package conditions, and restores the legacy `copyToClipboard` and `decodeKittyPrintable` root exports used by `pi-vimmode` and `pi-web-access`.
 
 ## [17.0.7] - 2026-07-21
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "catalog:",
     "@babel/parser": "catalog:",
+    "@babel/traverse": "catalog:",
     "@mozilla/readability": "catalog:",
     "@oh-my-pi/hashline": "catalog:",
     "@oh-my-pi/omp-stats": "catalog:",

--- a/packages/coding-agent/scripts/legacy-pi-virtual-module.ts
+++ b/packages/coding-agent/scripts/legacy-pi-virtual-module.ts
@@ -19,7 +19,7 @@ const BUNDLED_PACKAGES: readonly BundledPackage[] = [
 	{ dir: "ai", identifier: "PiAi", rootShim: "legacy-pi-ai-shim.ts" },
 	{ dir: "coding-agent", identifier: "PiCodingAgent", rootShim: "legacy-pi-coding-agent-shim.ts" },
 	{ dir: "natives", identifier: "PiNatives", rootShim: null },
-	{ dir: "tui", identifier: "PiTui", rootShim: null },
+	{ dir: "tui", identifier: "PiTui", rootShim: "legacy-pi-tui-shim.ts" },
 	{ dir: "utils", identifier: "PiUtils", rootShim: null },
 ];
 

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1362,4 +1362,5 @@ export function getPackageDir(): string {
 
 export * from "../index";
 export { formatBytes as formatSize } from "../tools/render-utils";
+export { copyToClipboard } from "../utils/clipboard";
 export { Type } from "./typebox";

--- a/packages/coding-agent/src/extensibility/legacy-pi-tui-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-tui-shim.ts
@@ -1,0 +1,10 @@
+/**
+ * Compatibility shim for legacy extensions importing the package root of
+ * `@earendil-works/pi-tui` or `@mariozechner/pi-tui`.
+ *
+ * The historical root exported `decodeKittyPrintable`; the canonical TUI now
+ * exposes the equivalent, broader `decodePrintableKey` helper. Keep the legacy
+ * name available without reintroducing it into the canonical package surface.
+ */
+export * from "@oh-my-pi/pi-tui";
+export { decodePrintableKey as decodeKittyPrintable } from "@oh-my-pi/pi-tui";

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1,12 +1,34 @@
 /// <reference path="./legacy-pi-virtual-modules.d.ts" />
+
 import * as fs from "node:fs";
 import { createRequire, isBuiltin } from "node:module";
 import * as path from "node:path";
 import * as url from "node:url";
+import type { ParserPlugin } from "@babel/parser";
+import { parse as parseBabel } from "@babel/parser";
+import * as traverseModule from "@babel/traverse";
 import { isCompiledBinary, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
 import { registerPluginCacheInvalidator } from "../../discovery/helpers";
 
 const IS_COMPILED_BINARY = isCompiledBinary();
+
+function isBabelTraverse(value: unknown): value is typeof traverseModule.default {
+	return typeof value === "function";
+}
+
+// Bun's compiled CJS interop wraps Babel traverse's default one level deeper.
+const traverseDefault: unknown = traverseModule.default;
+const nestedTraverse =
+	traverseDefault !== null && typeof traverseDefault === "object" && "default" in traverseDefault
+		? traverseDefault.default
+		: undefined;
+const traverseCandidate = isBabelTraverse(traverseDefault) ? traverseDefault : nestedTraverse;
+if (!isBabelTraverse(traverseCandidate)) {
+	throw new TypeError(
+		`Invalid @babel/traverse export: expected function, got default=${typeof traverseDefault}, nested=${typeof nestedTraverse}`,
+	);
+}
+const traverseAst = traverseCandidate;
 
 // === Bundled host modules (issue #3423) ===
 //
@@ -40,6 +62,95 @@ interface LegacyPiResolveResult {
 interface BundledVirtualResolveResult {
 	path: string;
 	namespace: typeof BUNDLED_VIRTUAL_NAMESPACE;
+}
+
+interface ExtensionSpecifierReference {
+	readonly kind: "import" | "require";
+	readonly specifier: string;
+	readonly start: number;
+	readonly end: number;
+}
+
+function collectExtensionSpecifierReferences(source: string, importerPath: string): ExtensionSpecifierReference[] {
+	const extension = path.extname(importerPath).toLowerCase();
+	const plugins: ParserPlugin[] = ["decorators-legacy", "explicitResourceManagement"];
+	if (extension === ".ts" || extension === ".mts" || extension === ".cts" || extension === ".tsx") {
+		plugins.push("typescript");
+	}
+	if (extension === ".jsx" || extension === ".tsx") {
+		plugins.push("jsx");
+	}
+
+	const ast = (() => {
+		try {
+			return parseBabel(source, {
+				sourceType: "unambiguous",
+				allowAwaitOutsideFunction: true,
+				allowReturnOutsideFunction: true,
+				allowImportExportEverywhere: true,
+				allowNewTargetOutsideFunction: true,
+				allowSuperOutsideMethod: true,
+				allowUndeclaredExports: true,
+				errorRecovery: true,
+				plugins,
+			});
+		} catch (error) {
+			throw new Error(
+				`Failed to parse extension source for dependency rewriting: ${importerPath}: ${error instanceof Error ? error.message : String(error)}`,
+				{ cause: error },
+			);
+		}
+	})();
+
+	const references: ExtensionSpecifierReference[] = [];
+	const record = (kind: ExtensionSpecifierReference["kind"], literal: unknown): void => {
+		if (!literal || typeof literal !== "object") return;
+		const node = literal as { type?: string; value?: unknown; start?: number | null; end?: number | null };
+		if (
+			node.type === "StringLiteral" &&
+			typeof node.value === "string" &&
+			typeof node.start === "number" &&
+			typeof node.end === "number"
+		) {
+			references.push({ kind, specifier: node.value, start: node.start, end: node.end });
+		}
+	};
+	traverseAst(ast, {
+		enter(nodePath) {
+			const node = nodePath.node;
+			if (
+				node.type === "ImportDeclaration" ||
+				node.type === "ExportNamedDeclaration" ||
+				node.type === "ExportAllDeclaration"
+			) {
+				record("import", node.source);
+			} else if (node.type === "ImportExpression") {
+				record("import", node.source);
+			} else if (node.type === "CallExpression") {
+				if (node.callee.type === "Import") {
+					record("import", node.arguments[0]);
+				} else if (
+					node.callee.type === "Identifier" &&
+					node.callee.name === "require" &&
+					!nodePath.scope.hasBinding("require", true)
+				) {
+					record("require", node.arguments[0]);
+				}
+			}
+		},
+	});
+	return references;
+}
+
+function applySpecifierReplacements(
+	source: string,
+	replacements: ReadonlyArray<ExtensionSpecifierReference & { readonly replacement: string }>,
+): string {
+	let rewritten = source;
+	for (const reference of [...replacements].sort((left, right) => right.start - left.start)) {
+		rewritten = `${rewritten.slice(0, reference.start)}${JSON.stringify(reference.replacement)}${rewritten.slice(reference.end)}`;
+	}
+	return rewritten;
 }
 
 const loadedBundledModules: Record<string, BundledModule> = {};
@@ -180,6 +291,7 @@ const PI_PACKAGE_ALTERNATION = PI_PACKAGE_NAMES.join("|");
 const PI_SUBPATH_REMAPS: ReadonlyMap<string, string> = new Map<string, string>([
 	["pi-ai/utils/oauth", "pi-ai/oauth"],
 	["pi-ai/utils/oauth/", "pi-ai/oauth/"],
+	["pi-ai/compat", "pi-ai"],
 ]);
 
 function remapLegacyPiSubpath(rest: string): string {
@@ -198,18 +310,16 @@ function remapLegacyPiSubpath(rest: string): string {
 }
 
 const LEGACY_PI_SPECIFIER_FILTER = new RegExp(`^@(?:${PI_SCOPE_ALTERNATION})/(?:${PI_PACKAGE_ALTERNATION})(?:/.*)?$`);
-const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
-	`((?:from\\s+|import\\s+|import\\s*\\(\\s*)["'])(@(?:${PI_SCOPE_ALTERNATION})/(?:${PI_PACKAGE_ALTERNATION})(?:/[^"'()\\s]+)?)(["'])`,
-	"g",
-);
 const resolvedSpecifierFallbacks = new Map<string, string>();
 const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"] as const;
 const SUPPORTED_PACKAGE_IMPORT_CONDITIONS = new Set(["bun", "node", "import", "default"]);
+const SUPPORTED_PACKAGE_REQUIRE_CONDITIONS = new Set(["bun", "node", "require", "default"]);
 const packageRootCache = new Map<string, string | null>();
 const packageImportsCache = new Map<string, Record<string, unknown> | null>();
 const nodePackageRootCache = new Map<string, Promise<string | null>>();
 const packageManifestCache = new Map<string, Promise<Record<string, unknown> | null>>();
 const bareDependencyResolutionCache = new Map<string, Promise<string | null>>();
+const bareRequireResolutionCache = new Map<string, Promise<string | null>>();
 const realpathCache = new Map<string, Promise<string>>();
 const nativeAddonResolutionCache = new Map<string, Promise<string | null>>();
 const nativeAddonRequireScanCache = new Map<string, Promise<boolean>>();
@@ -222,6 +332,7 @@ function clearLegacyPiResolutionCaches(): void {
 	nodePackageRootCache.clear();
 	packageManifestCache.clear();
 	bareDependencyResolutionCache.clear();
+	bareRequireResolutionCache.clear();
 	nativeAddonResolutionCache.clear();
 	nativeAddonRequireScanCache.clear();
 	nativeAddonLoaderModulePaths.clear();
@@ -338,14 +449,21 @@ const LEGACY_PI_CODING_AGENT_SHIM_PATH = IS_COMPILED_BINARY
 	? bundledModuleVirtualSpecifier(`${CANONICAL_PI_SCOPE}/pi-coding-agent`)
 	: sourceShimPath("legacy-pi-coding-agent-shim.ts");
 
-// Package-root overrides. Shim entries (`pi-ai`, `pi-coding-agent`) always
-// replace the canonical surface so the legacy `Type` runtime and the legacy
-// helpers stay reachable. The bundled host packages (`pi-agent-core`,
-// `pi-natives`, `pi-tui`, `pi-utils`) are added only in compiled-binary mode
-// to route extensions onto the in-process module instance — in dev /
-// source-link / installed-package mode the canonical specifier resolves
-// cleanly through `Bun.resolveSync` and hardcoding a source-tree path would
-// miss installs where the bundled packages live at `node_modules/@oh-my-pi/pi-*`.
+// Legacy pi-tui exported `decodeKittyPrintable` from its package root. The
+// canonical TUI replaced it with the broader `decodePrintableKey`; route only
+// legacy root imports through a sibling shim that preserves the old name.
+const LEGACY_PI_TUI_SHIM_PATH = IS_COMPILED_BINARY
+	? bundledModuleVirtualSpecifier(`${CANONICAL_PI_SCOPE}/pi-tui`)
+	: sourceShimPath("legacy-pi-tui-shim.ts");
+
+// Package-root overrides. Shim entries (`pi-ai`, `pi-coding-agent`, `pi-tui`)
+// always replace the canonical surface so legacy helpers stay reachable. The
+// other bundled host packages (`pi-agent-core`, `pi-natives`, `pi-utils`) are
+// added only in compiled-binary mode to route extensions onto the in-process
+// module instance — in dev / source-link / installed-package mode the canonical
+// specifier resolves cleanly through `Bun.resolveSync` and hardcoding a
+// source-tree path would miss installs where bundled packages live at
+// `node_modules/@oh-my-pi/pi-*`.
 //
 // Compiled-binary entries are `omp-legacy-pi-bundled:<key>` specifiers handed
 // to the synthetic onLoad in `installLegacyPiSpecifierShim()` — bunfs paths
@@ -390,6 +508,7 @@ export function __buildLegacyPiPackageRootOverrides(
 	const candidates: Record<string, string> = {
 		[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
 		[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
+		[`${CANONICAL_PI_SCOPE}/pi-tui`]: LEGACY_PI_TUI_SHIM_PATH,
 	};
 	if (isCompiled) {
 		for (const key of bundledModuleKeys) {
@@ -473,33 +592,6 @@ function toImportSpecifier(resolvedPath: string): string {
 	return url.pathToFileURL(stripWindowsExtendedLengthPathPrefix(resolvedPath)).href;
 }
 
-function rewriteLegacyPiImports(source: string): string {
-	return source.replace(
-		LEGACY_PI_IMPORT_SPECIFIER_REGEX,
-		(match, prefix: string, specifier: string, suffix: string) => {
-			const remappedSpecifier = remapLegacyPiSpecifier(specifier);
-			if (!remappedSpecifier) {
-				return match;
-			}
-
-			try {
-				return `${prefix}${toImportSpecifier(resolveCanonicalPiSpecifier(remappedSpecifier))}${suffix}`;
-			} catch {
-				// Resolution failed — typically in compiled binary mode where
-				// Bun.resolveSync cannot walk up from /$bunfs/root to find the
-				// bundled node_modules. Leave the specifier unchanged so Bun
-				// resolves it natively against the extension's own peer deps.
-				return match;
-			}
-		},
-	);
-}
-
-// Match the bare TypeBox import specifiers (static + dynamic). Subpath imports
-// like `@sinclair/typebox/compiler` are intentionally excluded — they expose
-// TypeBox-only APIs the Zod-backed shim does not provide.
-const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(@sinclair\/typebox|typebox)(["'])/g;
-
 /**
  * Rewrite the extension-owned specifiers OMP must host-resolve — legacy
  * `@(scope)/pi-*`, bare TypeBox packages, package `imports` aliases like
@@ -508,43 +600,61 @@ const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'
  * are left untouched so Bun resolves them from the extension's real on-disk
  * location.
  *
- * When `mtimeTag` is provided, extension-owned graph specifiers (relative
- * `./`/`../`, package `#alias/*`, and extension-local bare deps) also carry a
- * `?mtime=<tag>` cache-bust so Bun rekeys them on same-process reloads. Host
- * package rewrites (legacy `@(scope)/pi-*`, TypeBox shim) always emit
- * `file://` URLs because they resolve to in-process host code that never
- * changes between reloads.
+ * When `mtimeTag` is provided, extension-owned relative graph specifiers
+ * (`./`/`../`) and, by default, resolved package `#alias/*` and extension-local
+ * bare deps also carry a `?mtime=<tag>` cache-bust so Bun rekeys them on
+ * same-process reloads. `resolvedImportMtimeTag` can disable the tag for
+ * resolved package and bare imports inside third-party dependencies, whose
+ * transitive bare imports must retain a query-free importer path for Bun's
+ * runtime `node_modules` resolution. Host package rewrites (legacy
+ * `@(scope)/pi-*`, TypeBox shim) always emit `file://` URLs because they resolve
+ * to in-process host code that never changes between reloads.
  */
 async function rewriteLegacyExtensionSource(
 	source: string,
 	importerPath: string,
 	mtimeTag: string | null = null,
+	resolvedImportMtimeTag: string | null = mtimeTag,
 ): Promise<string> {
 	// Compiled mode completes the override map from the build-supplied module
 	// keys on first use; every rewrite path must see the full map.
 	await ensureLegacyPiOverridesReady();
-	const withPi = rewriteLegacyPiImports(source);
-	// When the TypeBox shim is missing (release build dropped the entrypoint —
-	// issue #3414), leave bare specifiers untouched so Bun resolves a real
-	// `typebox` / `@sinclair/typebox` install from the extension's own
-	// `node_modules`. `resolveTypeBoxSpecifier` mirrors the fall-through.
-	const withTypeBox = TYPEBOX_SHIM_PATH
-		? withPi.replace(
-				TYPEBOX_IMPORT_SPECIFIER_REGEX,
-				(_match, prefix: string, _specifier: string, suffix: string) =>
-					`${prefix}${toImportSpecifier(TYPEBOX_SHIM_PATH)}${suffix}`,
-			)
-		: withPi;
-	const withPkg = await rewriteExtensionPackageImports(withTypeBox, importerPath, mtimeTag);
-	const withBare = await rewriteExtensionBareImports(withPkg, importerPath, mtimeTag);
-	const withNativeAddons = await rewriteExtensionNativeAddonRequires(withBare, importerPath);
-	if (!mtimeTag) {
-		return withNativeAddons;
+	const references = await collectExtensionSpecifierReferences(source, importerPath);
+	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
+	for (const reference of references) {
+		if (reference.kind !== "import") continue;
+
+		const specifier = reference.specifier;
+		let replacement: string | null = null;
+		const remappedSpecifier = remapLegacyPiSpecifier(specifier);
+		if (remappedSpecifier) {
+			try {
+				replacement = toImportSpecifier(resolveCanonicalPiSpecifier(remappedSpecifier));
+			} catch {
+				// Compiled fallback may be absent from a malformed build. Continue to
+				// the extension's on-disk peer dependency resolution below.
+			}
+		}
+		if (!replacement && TYPEBOX_SHIM_PATH && (specifier === "typebox" || specifier === "@sinclair/typebox")) {
+			replacement = toImportSpecifier(TYPEBOX_SHIM_PATH);
+		}
+		if (!replacement && specifier.startsWith("#")) {
+			const resolved = await resolvePackageImportSpecifier(specifier, importerPath);
+			if (resolved) replacement = toGraphImportSpecifier(resolved, resolvedImportMtimeTag);
+		}
+		if (!replacement && isBareExtensionDependencySpecifier(specifier)) {
+			const resolved = await resolveExtensionBareDependency(specifier, importerPath);
+			if (resolved) replacement = toGraphImportSpecifier(resolved, resolvedImportMtimeTag);
+		}
+		if (!replacement && mtimeTag && /^\.\.?\//.test(specifier) && !specifier.includes("?")) {
+			replacement = `${specifier}?mtime=${mtimeTag}`;
+		}
+		if (replacement && replacement !== specifier) {
+			replacements.push({ ...reference, replacement });
+		}
 	}
-	return withNativeAddons.replace(
-		RELATIVE_GRAPH_IMPORT_SPECIFIER_REGEX,
-		(_match, prefix: string, specifier: string, suffix: string) => `${prefix}${specifier}?mtime=${mtimeTag}${suffix}`,
-	);
+	const withImports = applySpecifierReplacements(source, replacements);
+	return rewriteExtensionBareRequires(withImports, importerPath);
 }
 
 /** Test seam for compiled-binary legacy extension source rewriting. */
@@ -552,14 +662,10 @@ export async function __rewriteLegacyExtensionSourceForTests(
 	source: string,
 	importerPath: string,
 	mtimeTag: string | null = null,
+	resolvedImportMtimeTag: string | null = mtimeTag,
 ): Promise<string> {
-	return rewriteLegacyExtensionSource(source, importerPath, mtimeTag);
+	return rewriteLegacyExtensionSource(source, importerPath, mtimeTag, resolvedImportMtimeTag);
 }
-
-// Match relative graph specifiers so their `./foo.ts` /`../foo` targets get a
-// `?mtime=<tag>` cache-bust suffix without disturbing already-rewritten
-// `file://` URLs or bare/host specifiers.
-const RELATIVE_GRAPH_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(\.\.?\/[^"'?\s]*)(["'])/g;
 
 /**
  * Build the import specifier for a graph-resolved absolute path. POSIX
@@ -672,7 +778,10 @@ async function readPackageImports(packageRoot: string): Promise<Record<string, u
 type PackageImportTargetSelection = string | typeof PACKAGE_IMPORT_EXCLUDED | null;
 type ResolvedPackageImportTargetSelection = string | typeof PACKAGE_IMPORT_EXCLUDED;
 
-function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection {
+function selectPackageImportTarget(
+	entry: unknown,
+	conditions: ReadonlySet<string> = SUPPORTED_PACKAGE_IMPORT_CONDITIONS,
+): PackageImportTargetSelection {
 	if (entry === null) {
 		return PACKAGE_IMPORT_EXCLUDED;
 	}
@@ -681,7 +790,7 @@ function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection
 	}
 	if (Array.isArray(entry)) {
 		for (const item of entry) {
-			const target = selectPackageImportTarget(item);
+			const target = selectPackageImportTarget(item, conditions);
 			if (target !== null) return target;
 		}
 		return null;
@@ -690,10 +799,10 @@ function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection
 		return null;
 	}
 	for (const [condition, value] of Object.entries(entry)) {
-		if (!SUPPORTED_PACKAGE_IMPORT_CONDITIONS.has(condition)) {
+		if (!conditions.has(condition)) {
 			continue;
 		}
-		const target = selectPackageImportTarget(value);
+		const target = selectPackageImportTarget(value, conditions);
 		if (target !== null) return target;
 	}
 	return null;
@@ -764,38 +873,6 @@ async function resolvePackageImportSpecifier(specifier: string, importerPath: st
 	}
 	return resolvePackageImportTarget(packageRoot, bestMatch.target, bestMatch.wildcard);
 }
-
-const PACKAGE_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(#[^"'()\s]+)(["'])/g;
-
-async function rewriteExtensionPackageImports(
-	source: string,
-	importerPath: string,
-	mtimeTag: string | null = null,
-): Promise<string> {
-	let rewritten = "";
-	let lastIndex = 0;
-	for (const match of source.matchAll(PACKAGE_IMPORT_SPECIFIER_REGEX)) {
-		const matchIndex = match.index;
-		if (matchIndex === undefined) continue;
-
-		const [fullMatch, prefix, specifier, suffix] = match;
-		if (!prefix || !specifier || !suffix) continue;
-
-		const resolved = await resolvePackageImportSpecifier(specifier, importerPath);
-		if (!resolved) continue;
-
-		rewritten += source.slice(lastIndex, matchIndex);
-		rewritten += `${prefix}${toGraphImportSpecifier(resolved, mtimeTag)}${suffix}`;
-		lastIndex = matchIndex + fullMatch.length;
-	}
-
-	if (lastIndex === 0) {
-		return source;
-	}
-	return `${rewritten}${source.slice(lastIndex)}`;
-}
-
-const BARE_EXTENSION_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
 
 function isBareExtensionDependencySpecifier(specifier: string): boolean {
 	if (
@@ -888,9 +965,10 @@ async function resolveNodePackageExport(
 	packageRoot: string,
 	subpath: string | null,
 	manifest: Record<string, unknown>,
+	conditions: ReadonlySet<string> = SUPPORTED_PACKAGE_IMPORT_CONDITIONS,
 ): Promise<string | null> {
 	const exportsField = manifest.exports;
-	const rootTarget = subpath === null ? selectPackageImportTarget(exportsField) : null;
+	const rootTarget = subpath === null ? selectPackageImportTarget(exportsField, conditions) : null;
 	if (rootTarget !== null && rootTarget !== PACKAGE_IMPORT_EXCLUDED) {
 		return resolvePackageExportTarget(packageRoot, rootTarget, null);
 	}
@@ -899,30 +977,41 @@ async function resolveNodePackageExport(
 	}
 
 	const exactKey = subpath === null ? "." : `./${subpath}`;
-	const exactTarget = selectPackageImportTarget(exportsField[exactKey]);
-	if (exactTarget !== null && exactTarget !== PACKAGE_IMPORT_EXCLUDED) {
-		return resolvePackageExportTarget(packageRoot, exactTarget, null);
+	if (Object.hasOwn(exportsField, exactKey)) {
+		const exactTarget = selectPackageImportTarget(exportsField[exactKey], conditions);
+		return exactTarget !== null && exactTarget !== PACKAGE_IMPORT_EXCLUDED
+			? resolvePackageExportTarget(packageRoot, exactTarget, null)
+			: null;
 	}
 
+	let bestMatch: {
+		keyLength: number;
+		prefixLength: number;
+		target: PackageImportTargetSelection;
+		wildcard: string;
+	} | null = null;
 	for (const [key, entry] of Object.entries(exportsField)) {
 		const starIndex = key.indexOf("*");
-		if (starIndex === -1 || subpath === null) continue;
+		if (starIndex === -1 || subpath === null || !key.startsWith("./")) continue;
 		const prefix = key.slice(2, starIndex);
 		const suffix = key.slice(starIndex + 1);
-		if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) {
-			continue;
+		if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) continue;
+		if (
+			!bestMatch ||
+			prefix.length > bestMatch.prefixLength ||
+			(prefix.length === bestMatch.prefixLength && key.length > bestMatch.keyLength)
+		) {
+			bestMatch = {
+				keyLength: key.length,
+				prefixLength: prefix.length,
+				target: selectPackageImportTarget(entry, conditions),
+				wildcard: subpath.slice(prefix.length, subpath.length - suffix.length),
+			};
 		}
-		const target = selectPackageImportTarget(entry);
-		if (target === null || target === PACKAGE_IMPORT_EXCLUDED) {
-			continue;
-		}
-		return resolvePackageExportTarget(
-			packageRoot,
-			target,
-			subpath.slice(prefix.length, subpath.length - suffix.length),
-		);
 	}
-	return null;
+	return bestMatch?.target && bestMatch.target !== PACKAGE_IMPORT_EXCLUDED
+		? resolvePackageExportTarget(packageRoot, bestMatch.target, bestMatch.wildcard)
+		: null;
 }
 
 async function resolveNodePackageFallback(
@@ -950,10 +1039,29 @@ async function resolveNodePackageDependency(specifier: string, importerPath: str
 	if (!packageRoot) return null;
 	const manifest = await readPackageManifest(packageRoot);
 	if (!manifest) return null;
-	return (
-		(await resolveNodePackageExport(packageRoot, parsed.subpath, manifest)) ??
-		(await resolveNodePackageFallback(packageRoot, parsed.subpath, manifest))
-	);
+	return Object.hasOwn(manifest, "exports")
+		? resolveNodePackageExport(packageRoot, parsed.subpath, manifest)
+		: resolveNodePackageFallback(packageRoot, parsed.subpath, manifest);
+}
+
+async function resolveNodePackageRequire(specifier: string, importerPath: string): Promise<string | null> {
+	const parsed = splitBarePackageSpecifier(specifier);
+	if (!parsed) return null;
+	const packageRoot = await findNodePackageRoot(parsed.name, importerPath);
+	if (!packageRoot) return null;
+	const manifest = await readPackageManifest(packageRoot);
+	if (!manifest) return null;
+
+	if (Object.hasOwn(manifest, "exports")) {
+		return resolveNodePackageExport(packageRoot, parsed.subpath, manifest, SUPPORTED_PACKAGE_REQUIRE_CONDITIONS);
+	}
+	if (parsed.subpath !== null) {
+		return resolveSourceModuleFile(path.join(packageRoot, parsed.subpath));
+	}
+	const main = manifest.main;
+	return typeof main === "string"
+		? await resolveSourceModuleFile(path.resolve(packageRoot, main))
+		: await resolveSourceModuleFile(path.join(packageRoot, "index"));
 }
 
 async function resolveExtensionBareDependency(specifier: string, importerPath: string): Promise<string | null> {
@@ -971,6 +1079,13 @@ async function resolveExtensionBareDependency(specifier: string, importerPath: s
 }
 
 async function resolveExtensionBareDependencyUncached(specifier: string, importerPath: string): Promise<string | null> {
+	// Resolve against the runtime package manifest first. Besides working in a
+	// compiled binary, this preserves the package's ESM `import` condition when
+	// the absolute target is later loaded outside normal package resolution.
+	const packageResolved = await resolveNodePackageDependency(specifier, importerPath);
+	if (packageResolved) {
+		return packageResolved;
+	}
 	try {
 		const resolved = Bun.resolveSync(specifier, path.dirname(importerPath));
 		if (resolved && resolved !== specifier && !resolved.startsWith("node:") && !resolved.startsWith("bun:")) {
@@ -979,15 +1094,10 @@ async function resolveExtensionBareDependencyUncached(specifier: string, importe
 	} catch {
 		// Compiled binaries do not reliably resolve runtime extension node_modules.
 	}
-	return resolveNodePackageDependency(specifier, importerPath);
+	return null;
 }
 
 const NATIVE_ADDON_EXTENSION = ".node";
-
-// Match CommonJS require calls so bare native-addon specifiers can be pinned
-// to absolute paths. Only requires whose resolution lands on a `.node` addon
-// are rewritten; everything else stays on Bun's native resolver.
-const NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX = /(\brequire\s*\(\s*["'])([^"'()\s]+)(["']\s*\))/g;
 
 /**
  * Resolve a bare specifier whose target is a native `.node` addon — either a
@@ -1031,42 +1141,63 @@ async function resolveExtensionNativeAddonUncached(specifier: string, importerPa
 	return realpathOrSelf(target);
 }
 
+async function resolveExtensionBareRequire(specifier: string, importerPath: string): Promise<string | null> {
+	if (!isBareExtensionDependencySpecifier(specifier)) {
+		return null;
+	}
+
+	const cacheKey = `${specifier}\0${path.resolve(path.dirname(importerPath))}`;
+	const cached = bareRequireResolutionCache.get(cacheKey);
+	if (cached) return cached;
+
+	const resolution = (async () => {
+		const nativeAddon = await resolveExtensionNativeAddon(specifier, importerPath);
+		if (nativeAddon) {
+			return nativeAddon;
+		}
+		const packageResolved = await resolveNodePackageRequire(specifier, importerPath);
+		if (packageResolved) {
+			return realpathOrSelf(packageResolved);
+		}
+		try {
+			const resolved = createRequire(importerPath).resolve(specifier);
+			return resolved === specifier || resolved.startsWith("node:") || resolved.startsWith("bun:")
+				? null
+				: await realpathOrSelf(resolved);
+		} catch {
+			return null;
+		}
+	})();
+	bareRequireResolutionCache.set(cacheKey, resolution);
+	return resolution;
+}
+
 /**
- * Rewrite bare `require()` specifiers that resolve to native `.node` addons
- * into absolute-path requires. In `bun build --compile` binaries, Bun's bare
- * resolution fails for packages whose `main` is a `.node` addon ("Cannot find
- * module '@scope/pkg-<platform>'") even when the package sits in the
- * extension's own node_modules; requiring the addon by absolute path works.
+ * Rewrite bare `require()` specifiers into absolute-path requires. In
+ * `bun build --compile` binaries, runtime resolution fails even when the
+ * package sits in the extension's own node_modules. Manifest resolution
+ * preserves CommonJS `require` export conditions and native-addon entrypoints;
+ * relative and builtin requires remain untouched.
  */
-async function rewriteExtensionNativeAddonRequires(source: string, importerPath: string): Promise<string> {
-	let rewritten = "";
-	let lastIndex = 0;
-	for (const match of source.matchAll(NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX)) {
-		const matchIndex = match.index;
-		if (matchIndex === undefined) continue;
-
-		const [fullMatch, prefix, specifier, suffix] = match;
-		if (!prefix || !specifier || !suffix) continue;
-
-		const resolved = await resolveExtensionNativeAddon(specifier, importerPath);
+async function rewriteExtensionBareRequires(source: string, importerPath: string): Promise<string> {
+	const references = await collectExtensionSpecifierReferences(source, importerPath);
+	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
+	for (const reference of references) {
+		if (reference.kind !== "require") continue;
+		const resolved = await resolveExtensionBareRequire(reference.specifier, importerPath);
 		if (!resolved) continue;
-
-		rewritten += source.slice(lastIndex, matchIndex);
-		// Forward slashes keep Windows paths valid inside single- or double-quoted literals.
-		rewritten += `${prefix}${stripWindowsExtendedLengthPathPrefix(resolved).replaceAll("\\", "/")}${suffix}`;
-		lastIndex = matchIndex + fullMatch.length;
+		replacements.push({
+			...reference,
+			replacement: stripWindowsExtendedLengthPathPrefix(resolved).replaceAll("\\", "/"),
+		});
 	}
-
-	if (lastIndex === 0) {
-		return source;
-	}
-	return `${rewritten}${source.slice(lastIndex)}`;
+	return applySpecifierReplacements(source, replacements);
 }
 
 /**
  * Whether a module's source contains a bare require that resolves to a native
  * `.node` addon — i.e. a napi-rs style loader that must be hooked into the
- * extension graph so {@link rewriteExtensionNativeAddonRequires} can pin its
+ * extension graph so {@link rewriteExtensionBareRequires} can pin its
  * platform-package requires to absolute paths.
  */
 async function moduleRequiresNativeAddon(modulePath: string): Promise<boolean> {
@@ -1085,61 +1216,29 @@ async function moduleRequiresNativeAddonUncached(modulePath: string): Promise<bo
 	} catch {
 		return false;
 	}
-	for (const match of source.matchAll(NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX)) {
-		const specifier = match[2];
-		if (specifier && (await resolveExtensionNativeAddon(specifier, modulePath))) {
+	for (const reference of await collectExtensionSpecifierReferences(source, modulePath)) {
+		if (reference.kind === "require" && (await resolveExtensionNativeAddon(reference.specifier, modulePath))) {
 			return true;
 		}
 	}
 	return false;
 }
 
-async function rewriteExtensionBareImports(
-	source: string,
-	importerPath: string,
-	mtimeTag: string | null = null,
-): Promise<string> {
-	let rewritten = "";
-	let lastIndex = 0;
-	for (const match of source.matchAll(BARE_EXTENSION_IMPORT_SPECIFIER_REGEX)) {
-		const matchIndex = match.index;
-		if (matchIndex === undefined) continue;
-
-		const [fullMatch, prefix, specifier, suffix] = match;
-		if (!prefix || !specifier || !suffix) continue;
-
-		const resolved = await resolveExtensionBareDependency(specifier, importerPath);
-		if (!resolved) continue;
-
-		rewritten += source.slice(lastIndex, matchIndex);
-		rewritten += `${prefix}${toGraphImportSpecifier(resolved, mtimeTag)}${suffix}`;
-		lastIndex = matchIndex + fullMatch.length;
-	}
-
-	if (lastIndex === 0) {
-		return source;
-	}
-	return `${rewritten}${source.slice(lastIndex)}`;
-}
-
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Match source modules in an extension graph: relative imports, package
-// `imports` aliases such as `#src/*`, and extension-local bare dependency
-// entries. Bare imports inside node_modules dependencies remain native Bun
-// resolutions; once the dependency entry is hooked, its relative children are
-// still collected and rewritten with the reload mtime tag. `require()` calls
-// are scanned too so CJS entries and napi-rs loaders reached without an
-// import statement still join the graph.
-const EXTENSION_GRAPH_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
+// Source modules in an extension graph are discovered from parsed static,
+// dynamic, re-export, and direct CommonJS require specifiers. Parsing keeps
+// import-looking text in strings, templates, regex literals, and comments out
+// of dependency resolution.
 
 // Extension source realpaths already covered by an installed load-time hook for
 // each entry. `Bun.plugin()` registrations are process-global and permanent, so
 // reloads install supplemental hooks only for modules added to the graph since
 // the previous load.
 const extensionGraphHookModules = new Map<string, Set<string>>();
+const extensionGraphCacheBustResolvedImportModules = new Map<string, Set<string>>();
 const commonJsModuleSources = new Map<string, string>();
 const commonJsFallbackModulePaths = new Map<string, string>();
 const COMMONJS_REQUIRE_GLOBAL = "__ompLegacyPiRequireGraphModule";
@@ -1234,22 +1333,27 @@ async function realpathOrSelfUncached(p: string): Promise<string> {
 	}
 }
 
+interface ExtensionModuleGraph {
+	readonly modules: Map<string, string>;
+	readonly cacheBustResolvedImportModules: Set<string>;
+}
+
 /**
  * Walk the extension's import graph starting at `entryRealPath`, returning the
  * realpath of every reachable source module OMP must rewrite at load time.
- * Relative imports and package `imports` aliases are always graph-owned.
- * Extension-local bare dependency entries are also included so their relative
- * children receive the reload mtime tag; bare imports inside those dependencies
- * remain native Bun resolutions to avoid taking over full third-party graphs.
+ * Relative imports, package `imports` aliases, and ESM bare dependencies are
+ * graph-owned recursively because compiled Bun cannot resolve runtime
+ * `node_modules` from those modules. Resolved imports inside third-party
+ * dependencies omit the reload tag so their importer paths stay query-free.
  * CommonJS modules reached through `require()` stay on Bun's native loader
  * unless they resolve native addons. CommonJS reached through ESM imports stays
  * graph-owned so the load hook can expose its exports through an ESM default.
  */
-async function collectExtensionModules(entryRealPath: string): Promise<Map<string, string>> {
+async function collectExtensionModules(entryRealPath: string): Promise<ExtensionModuleGraph> {
 	const modules = new Map<string, string>();
-	const queuedFollowBareDependencies = new Map<string, boolean>([[entryRealPath, true]]);
-	const queue: Array<{ file: string; followBareDependencies: boolean }> = [
-		{ file: entryRealPath, followBareDependencies: true },
+	const queuedCacheBustResolvedImports = new Map<string, boolean>([[entryRealPath, true]]);
+	const queue: Array<{ file: string; cacheBustResolvedImports: boolean }> = [
+		{ file: entryRealPath, cacheBustResolvedImports: true },
 	];
 	while (queue.length > 0) {
 		const item = queue.pop();
@@ -1257,7 +1361,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 			continue;
 		}
 		const file = item.file;
-		const followBareDependencies = queuedFollowBareDependencies.get(file) ?? item.followBareDependencies;
+		const cacheBustResolvedImports = queuedCacheBustResolvedImports.get(file) ?? item.cacheBustResolvedImports;
 		if (modules.has(file)) {
 			continue;
 		}
@@ -1269,22 +1373,13 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 		}
 		modules.set(file, source);
 		const dir = path.dirname(file);
-		const specifiers = new Set<string>();
-		const requiredSpecifiers = new Set<string>();
-		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
-			if (match[2]) specifiers.add(match[2]);
-		}
-		for (const match of source.matchAll(NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX)) {
-			if (match[2]) {
-				specifiers.add(match[2]);
-				requiredSpecifiers.add(match[2]);
-			}
-		}
-		for (const specifier of specifiers) {
+		const references = await collectExtensionSpecifierReferences(source, file);
+		for (const reference of references) {
+			const specifier = reference.specifier;
 			try {
 				let resolved: string | null = null;
-				let nextFollowsBareDependencies = followBareDependencies;
-				const isRequired = requiredSpecifiers.has(specifier);
+				let nextCacheBustResolvedImports = cacheBustResolvedImports;
+				const isRequired = reference.kind === "require";
 				if (specifier.startsWith(".")) {
 					const candidate = Bun.resolveSync(specifier, dir);
 					if (
@@ -1299,7 +1394,6 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 						resolved = candidate;
 					}
 				} else if (
-					followBareDependencies &&
 					isBareExtensionDependencySpecifier(specifier) &&
 					!remapLegacyPiSpecifier(specifier) &&
 					specifier !== "typebox" &&
@@ -1309,11 +1403,27 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 					const packageRoot = parsed ? await findNodePackageRoot(parsed.name, file) : null;
 					const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
 					const dependencyEntry = manifest ? await resolveExtensionBareDependency(specifier, file) : null;
+					const declaredModuleEntry =
+						packageRoot && parsed?.subpath === null && typeof manifest?.module === "string"
+							? await resolveSourceModuleFile(path.resolve(packageRoot, manifest.module))
+							: null;
 					const dependencyExtension = dependencyEntry ? path.extname(dependencyEntry) : null;
+					const modulePackageRoot =
+						dependencyEntry && (dependencyExtension === ".js" || dependencyExtension === ".jsx")
+							? await findPackageRoot(dependencyEntry)
+							: null;
+					const moduleManifest = modulePackageRoot ? await readPackageManifest(modulePackageRoot) : null;
+					const selectedDeclaredModule = Boolean(
+						dependencyEntry &&
+							declaredModuleEntry &&
+							path.resolve(dependencyEntry) === path.resolve(declaredModuleEntry),
+					);
 					const isCommonJsEntry =
 						dependencyExtension === ".cjs" ||
 						dependencyExtension === ".cts" ||
-						((dependencyExtension === ".js" || dependencyExtension === ".jsx") && manifest?.type !== "module");
+						((dependencyExtension === ".js" || dependencyExtension === ".jsx") &&
+							moduleManifest?.type !== "module" &&
+							!selectedDeclaredModule);
 					const isHookableEntry = Boolean(dependencyEntry && hasSourceModuleExtension(dependencyEntry));
 					const hookCommonJsEntry =
 						isHookableEntry && isCommonJsEntry && dependencyEntry
@@ -1325,16 +1435,18 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 					if (resolved && hookCommonJsEntry) {
 						nativeAddonLoaderModulePaths.add(resolved);
 					}
-					nextFollowsBareDependencies = false;
+					nextCacheBustResolvedImports = false;
 				}
 				if (resolved && isRequired) {
 					nativeAddonLoaderModulePaths.add(resolved);
 				}
-				if (resolved && !modules.has(resolved)) {
-					const queuedFollowsBareDependencies = queuedFollowBareDependencies.get(resolved) ?? false;
-					const mergedFollowsBareDependencies = queuedFollowsBareDependencies || nextFollowsBareDependencies;
-					queuedFollowBareDependencies.set(resolved, mergedFollowsBareDependencies);
-					queue.push({ file: resolved, followBareDependencies: mergedFollowsBareDependencies });
+				if (resolved) {
+					const queuedCacheBust = queuedCacheBustResolvedImports.get(resolved) ?? false;
+					const mergedCacheBust = queuedCacheBust || nextCacheBustResolvedImports;
+					queuedCacheBustResolvedImports.set(resolved, mergedCacheBust);
+					if (!modules.has(resolved)) {
+						queue.push({ file: resolved, cacheBustResolvedImports: mergedCacheBust });
+					}
 				}
 			} catch {
 				// Unresolvable import (e.g. a type-only path); skip it.
@@ -1344,10 +1456,17 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 	for (const modulePath of nativeAddonLoaderModulePaths) {
 		const source = modules.get(modulePath);
 		if (source !== undefined) {
-			modules.set(modulePath, await rewriteExtensionNativeAddonRequires(source, modulePath));
+			modules.set(modulePath, await rewriteExtensionBareRequires(source, modulePath));
 		}
 	}
-	return modules;
+	return {
+		modules,
+		cacheBustResolvedImportModules: new Set(
+			[...queuedCacheBustResolvedImports]
+				.filter(([modulePath, enabled]) => enabled && modules.has(modulePath))
+				.map(([modulePath]) => modulePath),
+		),
+	};
 }
 
 /**
@@ -1436,6 +1555,7 @@ async function installExtensionGraphHook(
 	entryRealPath: string,
 	modules: Map<string, string>,
 	commonJsPaths: Set<string>,
+	cacheBustResolvedImportModules: ReadonlySet<string>,
 ): Promise<{ asyncModules: Map<string, string>; syncSourceModules: Map<string, string> }> {
 	const asyncModules = new Map<string, string>();
 	const syncSourceModules = new Map<string, string>();
@@ -1472,8 +1592,9 @@ async function installExtensionGraphHook(
 					} else {
 						raw = await Bun.file(sourcePath).text();
 					}
+					const resolvedImportMtimeTag = cacheBustResolvedImportModules.has(sourcePath) ? mtimeTag : null;
 					return {
-						contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag),
+						contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag, resolvedImportMtimeTag),
 						loader: getLoader(sourcePath),
 					};
 				});
@@ -1537,7 +1658,16 @@ async function installExtensionGraphHook(
  * during the initial load; `undefined` when no new modules were discovered.
  */
 async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(): void } | undefined> {
-	const currentModules = await collectExtensionModules(entryRealPath);
+	const { modules: currentModules, cacheBustResolvedImportModules: discoveredCacheBustModules } =
+		await collectExtensionModules(entryRealPath);
+	let cacheBustResolvedImportModules = extensionGraphCacheBustResolvedImportModules.get(entryRealPath);
+	if (!cacheBustResolvedImportModules) {
+		cacheBustResolvedImportModules = new Set<string>();
+		extensionGraphCacheBustResolvedImportModules.set(entryRealPath, cacheBustResolvedImportModules);
+	}
+	for (const modulePath of discoveredCacheBustModules) {
+		cacheBustResolvedImportModules.add(modulePath);
+	}
 	const commonJsPaths = new Set<string>();
 	for (const [modulePath, source] of currentModules) {
 		const extension = path.extname(modulePath);
@@ -1573,6 +1703,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			entryRealPath,
 			pendingModules,
 			pendingCommonJsPaths,
+			cacheBustResolvedImportModules,
 		));
 		for (const modulePath of pendingModules.keys()) {
 			hookedModules.add(modulePath);

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import { createRequire, isBuiltin } from "node:module";
 import * as path from "node:path";
 import * as url from "node:url";
-import type { ParserPlugin } from "@babel/parser";
+import type { ParseResult, ParserPlugin } from "@babel/parser";
 import { parse as parseBabel } from "@babel/parser";
 import * as traverseModule from "@babel/traverse";
 import { isCompiledBinary, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
@@ -71,7 +71,7 @@ interface ExtensionSpecifierReference {
 	readonly end: number;
 }
 
-function collectExtensionSpecifierReferences(source: string, importerPath: string): ExtensionSpecifierReference[] {
+function parseExtensionSource(source: string, importerPath: string): ParseResult {
 	const extension = path.extname(importerPath).toLowerCase();
 	const plugins: ParserPlugin[] = ["decorators-legacy", "explicitResourceManagement"];
 	if (extension === ".ts" || extension === ".mts" || extension === ".cts" || extension === ".tsx") {
@@ -81,27 +81,31 @@ function collectExtensionSpecifierReferences(source: string, importerPath: strin
 		plugins.push("jsx");
 	}
 
-	const ast = (() => {
-		try {
-			return parseBabel(source, {
-				sourceType: "unambiguous",
-				allowAwaitOutsideFunction: true,
-				allowReturnOutsideFunction: true,
-				allowImportExportEverywhere: true,
-				allowNewTargetOutsideFunction: true,
-				allowSuperOutsideMethod: true,
-				allowUndeclaredExports: true,
-				errorRecovery: true,
-				plugins,
-			});
-		} catch (error) {
-			throw new Error(
-				`Failed to parse extension source for dependency rewriting: ${importerPath}: ${error instanceof Error ? error.message : String(error)}`,
-				{ cause: error },
-			);
-		}
-	})();
+	try {
+		return parseBabel(source, {
+			sourceType: "unambiguous",
+			allowAwaitOutsideFunction: true,
+			allowReturnOutsideFunction: true,
+			allowImportExportEverywhere: true,
+			allowNewTargetOutsideFunction: true,
+			allowSuperOutsideMethod: true,
+			allowUndeclaredExports: true,
+			errorRecovery: true,
+			plugins,
+		});
+	} catch (error) {
+		throw new Error(
+			`Failed to parse extension source for dependency rewriting: ${importerPath}: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error },
+		);
+	}
+}
 
+function collectExtensionSpecifierReferences(
+	source: string,
+	importerPath: string,
+	ast: ParseResult = parseExtensionSource(source, importerPath),
+): ExtensionSpecifierReference[] {
 	const references: ExtensionSpecifierReference[] = [];
 	const record = (kind: ExtensionSpecifierReference["kind"], literal: unknown): void => {
 		if (!literal || typeof literal !== "object") return;
@@ -604,9 +608,9 @@ function toImportSpecifier(resolvedPath: string): string {
  * (`./`/`../`) and, by default, resolved package `#alias/*` and extension-local
  * bare deps also carry a `?mtime=<tag>` cache-bust so Bun rekeys them on
  * same-process reloads. `resolvedImportMtimeTag` can disable the tag for
- * resolved package and bare imports inside third-party dependencies, whose
- * transitive bare imports must retain a query-free importer path for Bun's
- * runtime `node_modules` resolution. Host package rewrites (legacy
+ * resolved package and bare ESM imports inside third-party dependencies, whose
+ * transitive ESM imports retain a query-free importer path for Bun's runtime
+ * `node_modules` resolution. Host package rewrites (legacy
  * `@(scope)/pi-*`, TypeBox shim) always emit `file://` URLs because they resolve
  * to in-process host code that never changes between reloads.
  */
@@ -619,7 +623,7 @@ async function rewriteLegacyExtensionSource(
 	// Compiled mode completes the override map from the build-supplied module
 	// keys on first use; every rewrite path must see the full map.
 	await ensureLegacyPiOverridesReady();
-	const references = await collectExtensionSpecifierReferences(source, importerPath);
+	const references = collectExtensionSpecifierReferences(source, importerPath);
 	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
 	for (const reference of references) {
 		if (reference.kind !== "import") continue;
@@ -654,7 +658,7 @@ async function rewriteLegacyExtensionSource(
 		}
 	}
 	const withImports = applySpecifierReplacements(source, replacements);
-	return rewriteExtensionBareRequires(withImports, importerPath);
+	return rewriteExtensionSpecifiers(withImports, importerPath);
 }
 
 /** Test seam for compiled-binary legacy extension source rewriting. */
@@ -732,6 +736,33 @@ async function resolveSourceModuleFile(basePath: string): Promise<string | null>
 		if (resolved) return resolved;
 	}
 	return null;
+}
+
+function isPathInsideRoot(rootPath: string, candidatePath: string): boolean {
+	const relative = path.relative(rootPath, candidatePath);
+	return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+async function resolvePackageSourceTarget(packageRoot: string, targetPath: string): Promise<string | null> {
+	const candidate = path.resolve(targetPath);
+	if (!isPathInsideRoot(path.resolve(packageRoot), candidate)) {
+		return null;
+	}
+	const resolved = await resolveSourceModuleFile(candidate);
+	if (!resolved) {
+		return null;
+	}
+	const realPackageRoot = await realpathOrSelf(packageRoot);
+	return isPathInsideRoot(realPackageRoot, resolved) ? resolved : null;
+}
+
+async function resolvePackageFileTarget(packageRoot: string, targetPath: string): Promise<string | null> {
+	const candidate = path.resolve(targetPath);
+	if (!isPathInsideRoot(path.resolve(packageRoot), candidate) || !(await pathExists(candidate))) {
+		return null;
+	}
+	const [realPackageRoot, resolved] = await Promise.all([realpathOrSelf(packageRoot), realpathOrSelf(candidate)]);
+	return isPathInsideRoot(realPackageRoot, resolved) ? resolved : null;
 }
 
 async function findPackageRoot(importerPath: string): Promise<string | null> {
@@ -817,7 +848,7 @@ async function resolvePackageImportTarget(
 		return null;
 	}
 	const substituted = wildcard === null ? target : target.replaceAll("*", wildcard);
-	return resolveSourceModuleFile(path.resolve(packageRoot, substituted));
+	return resolvePackageSourceTarget(packageRoot, path.resolve(packageRoot, substituted));
 }
 
 async function resolvePackageImportSpecifier(specifier: string, importerPath: string): Promise<string | null> {
@@ -949,6 +980,58 @@ async function readPackageManifestUncached(packageRoot: string): Promise<Record<
 	}
 }
 
+type ExtensionModuleKind = "commonjs" | "esm";
+class ExtensionModuleKindConflictError extends Error {}
+
+async function isCommonJsModulePath(
+	modulePath: string,
+	sourceType?: "script" | "module",
+	inheritedKind?: ExtensionModuleKind,
+): Promise<boolean> {
+	const extension = path.extname(modulePath).toLowerCase();
+	if (extension === ".cjs" || extension === ".cts") {
+		return true;
+	}
+	if (extension !== ".js" && extension !== ".jsx") {
+		return false;
+	}
+
+	const packageRoot = await findPackageRoot(modulePath);
+	const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
+	if (manifest?.type === "module") {
+		return false;
+	}
+	if (manifest?.type === "commonjs") {
+		return true;
+	}
+	const parsedSourceType =
+		sourceType ?? parseExtensionSource(await Bun.file(modulePath).text(), modulePath).program.sourceType;
+	if (parsedSourceType === "module") {
+		return false;
+	}
+	if (inheritedKind) {
+		return inheritedKind === "commonjs";
+	}
+	const declaredModuleEntry =
+		packageRoot && typeof manifest?.module === "string"
+			? await resolvePackageSourceTarget(packageRoot, path.resolve(packageRoot, manifest.module))
+			: null;
+	return !declaredModuleEntry || path.resolve(modulePath) !== path.resolve(declaredModuleEntry);
+}
+
+async function isGraphOwnedCommonJsModule(
+	modulePath: string,
+	entryRealPath: string,
+	sourceType?: "script" | "module",
+	inheritedKind?: ExtensionModuleKind,
+): Promise<boolean> {
+	const extension = path.extname(modulePath).toLowerCase();
+	if (modulePath === entryRealPath && extension !== ".cjs" && extension !== ".cts") {
+		return false;
+	}
+	return isCommonJsModulePath(modulePath, sourceType, inheritedKind);
+}
+
 async function resolvePackageExportTarget(
 	packageRoot: string,
 	target: string,
@@ -958,7 +1041,7 @@ async function resolvePackageExportTarget(
 		return null;
 	}
 	const substituted = wildcard === null ? target : target.replaceAll("*", wildcard);
-	return resolveSourceModuleFile(path.resolve(packageRoot, substituted));
+	return resolvePackageSourceTarget(packageRoot, path.resolve(packageRoot, substituted));
 }
 
 async function resolveNodePackageExport(
@@ -1020,16 +1103,16 @@ async function resolveNodePackageFallback(
 	manifest: Record<string, unknown>,
 ): Promise<string | null> {
 	if (subpath !== null) {
-		return resolveSourceModuleFile(path.join(packageRoot, subpath));
+		return resolvePackageSourceTarget(packageRoot, path.join(packageRoot, subpath));
 	}
 	for (const field of ["module", "main"]) {
 		const target = manifest[field];
 		if (typeof target === "string") {
-			const resolved = await resolveSourceModuleFile(path.resolve(packageRoot, target));
+			const resolved = await resolvePackageSourceTarget(packageRoot, path.resolve(packageRoot, target));
 			if (resolved) return resolved;
 		}
 	}
-	return resolveSourceModuleFile(path.join(packageRoot, "index"));
+	return resolvePackageSourceTarget(packageRoot, path.join(packageRoot, "index"));
 }
 
 async function resolveNodePackageDependency(specifier: string, importerPath: string): Promise<string | null> {
@@ -1056,12 +1139,56 @@ async function resolveNodePackageRequire(specifier: string, importerPath: string
 		return resolveNodePackageExport(packageRoot, parsed.subpath, manifest, SUPPORTED_PACKAGE_REQUIRE_CONDITIONS);
 	}
 	if (parsed.subpath !== null) {
-		return resolveSourceModuleFile(path.join(packageRoot, parsed.subpath));
+		return resolvePackageSourceTarget(packageRoot, path.join(packageRoot, parsed.subpath));
 	}
 	const main = manifest.main;
 	return typeof main === "string"
-		? await resolveSourceModuleFile(path.resolve(packageRoot, main))
-		: await resolveSourceModuleFile(path.join(packageRoot, "index"));
+		? await resolvePackageSourceTarget(packageRoot, path.resolve(packageRoot, main))
+		: await resolvePackageSourceTarget(packageRoot, path.join(packageRoot, "index"));
+}
+
+async function validateResolvedBarePackagePath(
+	specifier: string,
+	importerPath: string,
+	resolvedPath: string,
+): Promise<string | null> {
+	const parsed = splitBarePackageSpecifier(specifier);
+	const packageRoot = parsed ? await findNodePackageRoot(parsed.name, importerPath) : null;
+	return packageRoot ? resolvePackageFileTarget(packageRoot, resolvedPath) : null;
+}
+
+async function isSelectedNoTypeEsmPackageBranch(
+	specifier: string,
+	importerPath: string,
+	resolvedPath: string,
+): Promise<boolean> {
+	const parsed = splitBarePackageSpecifier(specifier);
+	const packageRoot = parsed ? await findNodePackageRoot(parsed.name, importerPath) : null;
+	const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
+	if (!packageRoot || !manifest || manifest.type !== undefined) {
+		return false;
+	}
+	if (parsed?.subpath === null && typeof manifest.module === "string") {
+		const moduleEntry = await resolvePackageSourceTarget(packageRoot, path.resolve(packageRoot, manifest.module));
+		if (moduleEntry && path.resolve(moduleEntry) === path.resolve(resolvedPath)) {
+			return true;
+		}
+	}
+	if (!Object.hasOwn(manifest, "exports")) {
+		return false;
+	}
+	const importTarget = await resolveNodePackageExport(packageRoot, parsed?.subpath ?? null, manifest);
+	const requireTarget = await resolveNodePackageExport(
+		packageRoot,
+		parsed?.subpath ?? null,
+		manifest,
+		SUPPORTED_PACKAGE_REQUIRE_CONDITIONS,
+	);
+	return Boolean(
+		importTarget &&
+			path.resolve(importTarget) === path.resolve(resolvedPath) &&
+			(!requireTarget || path.resolve(requireTarget) !== path.resolve(importTarget)),
+	);
 }
 
 async function resolveExtensionBareDependency(specifier: string, importerPath: string): Promise<string | null> {
@@ -1089,7 +1216,7 @@ async function resolveExtensionBareDependencyUncached(specifier: string, importe
 	try {
 		const resolved = Bun.resolveSync(specifier, path.dirname(importerPath));
 		if (resolved && resolved !== specifier && !resolved.startsWith("node:") && !resolved.startsWith("bun:")) {
-			return resolved;
+			return validateResolvedBarePackagePath(specifier, importerPath, resolved);
 		}
 	} catch {
 		// Compiled binaries do not reliably resolve runtime extension node_modules.
@@ -1135,10 +1262,10 @@ async function resolveExtensionNativeAddonUncached(specifier: string, importerPa
 		target =
 			typeof main === "string" && main.endsWith(NATIVE_ADDON_EXTENSION) ? path.resolve(packageRoot, main) : null;
 	}
-	if (!target || !(await pathExists(target))) {
+	if (!target) {
 		return null;
 	}
-	return realpathOrSelf(target);
+	return resolvePackageFileTarget(packageRoot, target);
 }
 
 async function resolveExtensionBareRequire(specifier: string, importerPath: string): Promise<string | null> {
@@ -1163,7 +1290,7 @@ async function resolveExtensionBareRequire(specifier: string, importerPath: stri
 			const resolved = createRequire(importerPath).resolve(specifier);
 			return resolved === specifier || resolved.startsWith("node:") || resolved.startsWith("bun:")
 				? null
-				: await realpathOrSelf(resolved);
+				: await validateResolvedBarePackagePath(specifier, importerPath, resolved);
 		} catch {
 			return null;
 		}
@@ -1172,24 +1299,74 @@ async function resolveExtensionBareRequire(specifier: string, importerPath: stri
 	return resolution;
 }
 
+async function resolveExtensionCommonJsRequire(specifier: string, importerPath: string): Promise<string | null> {
+	const remappedSpecifier = remapLegacyPiSpecifier(specifier);
+	if (remappedSpecifier) {
+		try {
+			const resolved = resolveCanonicalPiSpecifier(remappedSpecifier);
+			if (isBundledVirtualSpecifier(resolved)) {
+				const moduleKey = resolved.slice(BUNDLED_VIRTUAL_SCHEME.length);
+				if (!(moduleKey in loadedBundledModules)) {
+					await loadBundledModule(moduleKey);
+				}
+			}
+			return resolved;
+		} catch {
+			// A malformed compiled registry can still fall through to an
+			// extension-installed legacy peer dependency.
+		}
+	}
+	return resolveExtensionBareRequire(specifier, importerPath);
+}
+
 /**
- * Rewrite bare `require()` specifiers into absolute-path requires. In
- * `bun build --compile` binaries, runtime resolution fails even when the
- * package sits in the extension's own node_modules. Manifest resolution
- * preserves CommonJS `require` export conditions and native-addon entrypoints;
- * relative and builtin requires remain untouched.
+ * Rewrite CommonJS graph specifiers that cannot resolve from the bridge's
+ * generated function: bare `require()` calls and, for graph-owned CommonJS
+ * sources, import specifiers. Resolved targets are retained for synchronous
+ * lazy hydration after load-time source caches clear.
  */
-async function rewriteExtensionBareRequires(source: string, importerPath: string): Promise<string> {
-	const references = await collectExtensionSpecifierReferences(source, importerPath);
+async function rewriteExtensionSpecifiers(
+	source: string,
+	importerPath: string,
+	rewriteImports = false,
+): Promise<string> {
+	const references = collectExtensionSpecifierReferences(source, importerPath);
+	const resolvedSpecifierTargets = new Map<string, string>();
 	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
 	for (const reference of references) {
-		if (reference.kind !== "require") continue;
-		const resolved = await resolveExtensionBareRequire(reference.specifier, importerPath);
+		let resolved: string | null = null;
+		if (reference.kind === "require") {
+			resolved = await resolveExtensionCommonJsRequire(reference.specifier, importerPath);
+		} else if (rewriteImports) {
+			if (reference.specifier.startsWith(".")) {
+				const candidate = Bun.resolveSync(reference.specifier, path.dirname(importerPath));
+				resolved = hasSourceModuleExtension(candidate) ? await realpathOrSelf(candidate) : null;
+			} else if (reference.specifier.startsWith("#")) {
+				resolved = await resolvePackageImportSpecifier(reference.specifier, importerPath);
+			} else {
+				resolved = await resolveExtensionBareDependency(reference.specifier, importerPath);
+			}
+		}
 		if (!resolved) continue;
-		replacements.push({
-			...reference,
-			replacement: stripWindowsExtendedLengthPathPrefix(resolved).replaceAll("\\", "/"),
-		});
+		const replacement = stripWindowsExtendedLengthPathPrefix(resolved).replaceAll("\\", "/");
+		resolvedSpecifierTargets.set(`${reference.kind}\0${reference.specifier}`, replacement);
+		replacements.push({ ...reference, replacement });
+	}
+	extensionSynchronousSpecifierTargets.set(importerPath, resolvedSpecifierTargets);
+	return applySpecifierReplacements(source, replacements);
+}
+
+function rewriteExtensionSpecifiersFromCache(source: string, importerPath: string): string {
+	const resolvedSpecifierTargets = extensionSynchronousSpecifierTargets.get(importerPath);
+	if (!resolvedSpecifierTargets || resolvedSpecifierTargets.size === 0) {
+		return source;
+	}
+	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
+	for (const reference of collectExtensionSpecifierReferences(source, importerPath)) {
+		const replacement = resolvedSpecifierTargets.get(`${reference.kind}\0${reference.specifier}`);
+		if (replacement) {
+			replacements.push({ ...reference, replacement });
+		}
 	}
 	return applySpecifierReplacements(source, replacements);
 }
@@ -1197,7 +1374,7 @@ async function rewriteExtensionBareRequires(source: string, importerPath: string
 /**
  * Whether a module's source contains a bare require that resolves to a native
  * `.node` addon — i.e. a napi-rs style loader that must be hooked into the
- * extension graph so {@link rewriteExtensionBareRequires} can pin its
+ * extension graph so {@link rewriteExtensionSpecifiers} can pin its
  * platform-package requires to absolute paths.
  */
 async function moduleRequiresNativeAddon(modulePath: string): Promise<boolean> {
@@ -1216,7 +1393,7 @@ async function moduleRequiresNativeAddonUncached(modulePath: string): Promise<bo
 	} catch {
 		return false;
 	}
-	for (const reference of await collectExtensionSpecifierReferences(source, modulePath)) {
+	for (const reference of collectExtensionSpecifierReferences(source, modulePath)) {
 		if (reference.kind === "require" && (await resolveExtensionNativeAddon(reference.specifier, modulePath))) {
 			return true;
 		}
@@ -1241,6 +1418,8 @@ const extensionGraphHookModules = new Map<string, Set<string>>();
 const extensionGraphCacheBustResolvedImportModules = new Map<string, Set<string>>();
 const commonJsModuleSources = new Map<string, string>();
 const commonJsFallbackModulePaths = new Map<string, string>();
+const extensionSynchronousSpecifierTargets = new Map<string, Map<string, string>>();
+const commonJsGraphModulePaths = new Set<string>();
 const COMMONJS_REQUIRE_GLOBAL = "__ompLegacyPiRequireGraphModule";
 const commonJsModuleDefinitions = new Map<string, { source: string; filename: string; dirname: string }>();
 const commonJsModuleCache = new Map<
@@ -1261,7 +1440,13 @@ function evaluateGraphCommonJs(modulePath: string): unknown {
 	if (cached) {
 		return cached.exports;
 	}
-	const definition = commonJsModuleDefinitions.get(modulePath);
+	let definition = commonJsModuleDefinitions.get(modulePath);
+	if (!definition && commonJsGraphModulePaths.has(modulePath)) {
+		const targetPath = commonJsFallbackModulePaths.get(modulePath) ?? modulePath;
+		const source = rewriteExtensionSpecifiersFromCache(fs.readFileSync(targetPath, "utf8"), modulePath);
+		synthesizeCommonJsDefaultModule(modulePath, source, targetPath);
+		definition = commonJsModuleDefinitions.get(modulePath);
+	}
 	if (!definition) {
 		throw new Error(`Missing graph-owned CommonJS definition: ${modulePath}`);
 	}
@@ -1278,6 +1463,14 @@ function evaluateGraphCommonJs(modulePath: string): unknown {
 	commonJsModuleCache.set(modulePath, module);
 	const graphRequire: NodeJS.Require = Object.assign(
 		(specifier: string) => {
+			if (isBundledVirtualSpecifier(specifier)) {
+				const moduleKey = specifier.slice(BUNDLED_VIRTUAL_SCHEME.length);
+				const bundledModule = loadedBundledModules[moduleKey];
+				if (!bundledModule) {
+					throw new Error(`Missing bundled CommonJS host module: ${moduleKey}`);
+				}
+				return bundledModule;
+			}
 			const resolved = nativeRequire.resolve(specifier);
 			let graphPath = resolved;
 			try {
@@ -1285,7 +1478,7 @@ function evaluateGraphCommonJs(modulePath: string): unknown {
 			} catch {
 				// Builtins and virtual modules have no filesystem realpath.
 			}
-			return commonJsModuleDefinitions.has(graphPath) ? evaluateGraphCommonJs(graphPath) : nativeRequire(specifier);
+			return commonJsGraphModulePaths.has(graphPath) ? evaluateGraphCommonJs(graphPath) : nativeRequire(specifier);
 		},
 		{
 			resolve: nativeRequire.resolve,
@@ -1336,6 +1529,7 @@ async function realpathOrSelfUncached(p: string): Promise<string> {
 interface ExtensionModuleGraph {
 	readonly modules: Map<string, string>;
 	readonly cacheBustResolvedImportModules: Set<string>;
+	readonly commonJsPaths: Set<string>;
 }
 
 /**
@@ -1343,18 +1537,23 @@ interface ExtensionModuleGraph {
  * realpath of every reachable source module OMP must rewrite at load time.
  * Relative imports, package `imports` aliases, and ESM bare dependencies are
  * graph-owned recursively because compiled Bun cannot resolve runtime
- * `node_modules` from those modules. Resolved imports inside third-party
- * dependencies omit the reload tag so their importer paths stay query-free.
- * CommonJS modules reached through `require()` stay on Bun's native loader
- * unless they resolve native addons. CommonJS reached through ESM imports stays
- * graph-owned so the load hook can expose its exports through an ESM default.
+ * `node_modules` from those modules. Graph-owned CommonJS modules also own
+ * their relative and bare CommonJS descendants, which are evaluated by the
+ * synchronous bridge. Resolved ESM imports inside third-party dependencies
+ * omit the reload tag so their importer paths stay query-free.
  */
 async function collectExtensionModules(entryRealPath: string): Promise<ExtensionModuleGraph> {
 	const modules = new Map<string, string>();
+	const commonJsPaths = new Set<string>();
 	const queuedCacheBustResolvedImports = new Map<string, boolean>([[entryRealPath, true]]);
-	const queue: Array<{ file: string; cacheBustResolvedImports: boolean }> = [
-		{ file: entryRealPath, cacheBustResolvedImports: true },
-	];
+	const queuedModuleKinds = new Map<string, ExtensionModuleKind>([[entryRealPath, "esm"]]);
+	const queuedEsmBranchPaths = new Set<string>();
+	const queue: Array<{
+		file: string;
+		cacheBustResolvedImports: boolean;
+		moduleKind?: ExtensionModuleKind;
+		esmBranch?: boolean;
+	}> = [{ file: entryRealPath, cacheBustResolvedImports: true, moduleKind: "esm" }];
 	while (queue.length > 0) {
 		const item = queue.pop();
 		if (!item) {
@@ -1362,6 +1561,8 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 		}
 		const file = item.file;
 		const cacheBustResolvedImports = queuedCacheBustResolvedImports.get(file) ?? item.cacheBustResolvedImports;
+		const inheritedModuleKind = queuedModuleKinds.get(file) ?? item.moduleKind;
+		const esmBranch = queuedEsmBranchPaths.has(file) || item.esmBranch === true;
 		if (modules.has(file)) {
 			continue;
 		}
@@ -1372,26 +1573,70 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 			continue;
 		}
 		modules.set(file, source);
+		const ast = parseExtensionSource(source, file);
+		const sourceIsCommonJs = await isGraphOwnedCommonJsModule(
+			file,
+			entryRealPath,
+			ast.program.sourceType,
+			inheritedModuleKind,
+		);
+		if (sourceIsCommonJs) {
+			commonJsPaths.add(file);
+		}
 		const dir = path.dirname(file);
-		const references = await collectExtensionSpecifierReferences(source, file);
+		const references = collectExtensionSpecifierReferences(source, file, ast);
 		for (const reference of references) {
 			const specifier = reference.specifier;
 			try {
 				let resolved: string | null = null;
 				let nextCacheBustResolvedImports = cacheBustResolvedImports;
+				let resolvedModuleKind: ExtensionModuleKind | undefined;
+				let resolvedEsmBranch = false;
+				let requiresNativeAddonRewrite = false;
 				const isRequired = reference.kind === "require";
 				if (specifier.startsWith(".")) {
 					const candidate = Bun.resolveSync(specifier, dir);
-					if (
-						hasSourceModuleExtension(candidate) &&
-						(!isRequired || (await moduleRequiresNativeAddon(candidate)))
-					) {
-						resolved = await realpathOrSelf(candidate);
+					if (hasSourceModuleExtension(candidate)) {
+						const inheritedTargetKind = isRequired
+							? sourceIsCommonJs
+								? "commonjs"
+								: undefined
+							: sourceIsCommonJs
+								? "commonjs"
+								: esmBranch
+									? "esm"
+									: undefined;
+						const targetIsCommonJs = await isCommonJsModulePath(candidate, undefined, inheritedTargetKind);
+						const isCommonJsDescendant = isRequired && sourceIsCommonJs && targetIsCommonJs;
+						requiresNativeAddonRewrite =
+							isRequired && !isCommonJsDescendant && (await moduleRequiresNativeAddon(candidate));
+						if (!isRequired || isCommonJsDescendant || requiresNativeAddonRewrite) {
+							resolved = await realpathOrSelf(candidate);
+							resolvedModuleKind = targetIsCommonJs ? "commonjs" : "esm";
+							resolvedEsmBranch = !targetIsCommonJs && esmBranch;
+						}
 					}
 				} else if (specifier.startsWith("#")) {
 					const candidate = await resolvePackageImportSpecifier(specifier, file);
-					if (candidate && (!isRequired || (await moduleRequiresNativeAddon(candidate)))) {
-						resolved = candidate;
+					if (candidate) {
+						const inheritedTargetKind = isRequired
+							? sourceIsCommonJs
+								? "commonjs"
+								: undefined
+							: sourceIsCommonJs
+								? "commonjs"
+								: esmBranch
+									? "esm"
+									: undefined;
+						const targetIsCommonJs = await isCommonJsModulePath(candidate, undefined, inheritedTargetKind);
+						const isCommonJsDescendant = isRequired && sourceIsCommonJs && targetIsCommonJs;
+						requiresNativeAddonRewrite =
+							isRequired && !isCommonJsDescendant && (await moduleRequiresNativeAddon(candidate));
+						if (!isRequired || isCommonJsDescendant || requiresNativeAddonRewrite) {
+							resolved = candidate;
+							resolvedModuleKind = targetIsCommonJs ? "commonjs" : "esm";
+							resolvedEsmBranch = !targetIsCommonJs && esmBranch;
+						}
 					}
 				} else if (
 					isBareExtensionDependencySpecifier(specifier) &&
@@ -1399,68 +1644,85 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 					specifier !== "typebox" &&
 					specifier !== "@sinclair/typebox"
 				) {
-					const parsed = splitBarePackageSpecifier(specifier);
-					const packageRoot = parsed ? await findNodePackageRoot(parsed.name, file) : null;
-					const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
-					const dependencyEntry = manifest ? await resolveExtensionBareDependency(specifier, file) : null;
-					const declaredModuleEntry =
-						packageRoot && parsed?.subpath === null && typeof manifest?.module === "string"
-							? await resolveSourceModuleFile(path.resolve(packageRoot, manifest.module))
-							: null;
-					const dependencyExtension = dependencyEntry ? path.extname(dependencyEntry) : null;
-					const modulePackageRoot =
-						dependencyEntry && (dependencyExtension === ".js" || dependencyExtension === ".jsx")
-							? await findPackageRoot(dependencyEntry)
-							: null;
-					const moduleManifest = modulePackageRoot ? await readPackageManifest(modulePackageRoot) : null;
-					const selectedDeclaredModule = Boolean(
-						dependencyEntry &&
-							declaredModuleEntry &&
-							path.resolve(dependencyEntry) === path.resolve(declaredModuleEntry),
-					);
-					const isCommonJsEntry =
-						dependencyExtension === ".cjs" ||
-						dependencyExtension === ".cts" ||
-						((dependencyExtension === ".js" || dependencyExtension === ".jsx") &&
-							moduleManifest?.type !== "module" &&
-							!selectedDeclaredModule);
+					const dependencyEntry = isRequired
+						? await resolveExtensionBareRequire(specifier, file)
+						: await resolveExtensionBareDependency(specifier, file);
 					const isHookableEntry = Boolean(dependencyEntry && hasSourceModuleExtension(dependencyEntry));
-					const hookCommonJsEntry =
-						isHookableEntry && isCommonJsEntry && dependencyEntry
-							? await moduleRequiresNativeAddon(dependencyEntry)
+					const selectedEsmBranch =
+						!isRequired &&
+						isHookableEntry &&
+						dependencyEntry !== null &&
+						(await isSelectedNoTypeEsmPackageBranch(specifier, file, dependencyEntry));
+					const inheritedTargetKind = isRequired
+						? sourceIsCommonJs
+							? "commonjs"
+							: undefined
+						: selectedEsmBranch
+							? "esm"
+							: undefined;
+					const isCommonJsEntry =
+						isHookableEntry && dependencyEntry
+							? await isCommonJsModulePath(dependencyEntry, undefined, inheritedTargetKind)
 							: false;
-					if (isHookableEntry && dependencyEntry && ((!isRequired && !isCommonJsEntry) || hookCommonJsEntry)) {
+					if (isHookableEntry && dependencyEntry && (!isRequired || (sourceIsCommonJs && isCommonJsEntry))) {
 						resolved = await realpathOrSelf(dependencyEntry);
+					} else if (isHookableEntry && dependencyEntry && isRequired) {
+						requiresNativeAddonRewrite = await moduleRequiresNativeAddon(dependencyEntry);
+						if (requiresNativeAddonRewrite) {
+							resolved = await realpathOrSelf(dependencyEntry);
+						}
 					}
-					if (resolved && hookCommonJsEntry) {
-						nativeAddonLoaderModulePaths.add(resolved);
+					if (resolved) {
+						resolvedModuleKind = isCommonJsEntry ? "commonjs" : "esm";
+						resolvedEsmBranch = selectedEsmBranch && !isCommonJsEntry;
 					}
 					nextCacheBustResolvedImports = false;
 				}
-				if (resolved && isRequired) {
+				if (resolved && requiresNativeAddonRewrite) {
 					nativeAddonLoaderModulePaths.add(resolved);
 				}
 				if (resolved) {
 					const queuedCacheBust = queuedCacheBustResolvedImports.get(resolved) ?? false;
 					const mergedCacheBust = queuedCacheBust || nextCacheBustResolvedImports;
 					queuedCacheBustResolvedImports.set(resolved, mergedCacheBust);
+					const queuedModuleKind = queuedModuleKinds.get(resolved);
+					if (queuedModuleKind && resolvedModuleKind && queuedModuleKind !== resolvedModuleKind) {
+						throw new ExtensionModuleKindConflictError(
+							`Conflicting extension module kinds for ${resolved}: ${queuedModuleKind} and ${resolvedModuleKind}`,
+						);
+					}
+					const mergedModuleKind = queuedModuleKind ?? resolvedModuleKind;
+					if (mergedModuleKind) {
+						queuedModuleKinds.set(resolved, mergedModuleKind);
+					}
+					if (resolvedEsmBranch) {
+						queuedEsmBranchPaths.add(resolved);
+					}
 					if (!modules.has(resolved)) {
-						queue.push({ file: resolved, cacheBustResolvedImports: mergedCacheBust });
+						queue.push({
+							file: resolved,
+							cacheBustResolvedImports: mergedCacheBust,
+							moduleKind: mergedModuleKind,
+							esmBranch: resolvedEsmBranch,
+						});
 					}
 				}
-			} catch {
+			} catch (error) {
+				if (error instanceof ExtensionModuleKindConflictError) {
+					throw error;
+				}
 				// Unresolvable import (e.g. a type-only path); skip it.
 			}
 		}
 	}
-	for (const modulePath of nativeAddonLoaderModulePaths) {
-		const source = modules.get(modulePath);
-		if (source !== undefined) {
-			modules.set(modulePath, await rewriteExtensionBareRequires(source, modulePath));
+	for (const [modulePath, source] of modules) {
+		if (commonJsPaths.has(modulePath) || nativeAddonLoaderModulePaths.has(modulePath)) {
+			modules.set(modulePath, await rewriteExtensionSpecifiers(source, modulePath, commonJsPaths.has(modulePath)));
 		}
 	}
 	return {
 		modules,
+		commonJsPaths,
 		cacheBustResolvedImportModules: new Set(
 			[...queuedCacheBustResolvedImports]
 				.filter(([modulePath, enabled]) => enabled && modules.has(modulePath))
@@ -1473,23 +1735,168 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
  * Discovers CommonJS export names Bun normally exposes to ESM importers. The
  * bridge must declare them statically because its default export is synthetic.
  */
-function collectCommonJsNamedExports(source: string): string[] {
-	const names = new Set<string>();
-	const assignmentPattern = /(?:^|[;\n])\s*(?:exports|module\.exports)\.([A-Za-z_$][\w$]*)\s*=/gm;
-	for (const match of source.matchAll(assignmentPattern)) {
-		const name = match[1];
-		if (name && name !== "default") {
-			names.add(name);
-		}
+const COMMONJS_NAMED_EXPORT_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+function collectCommonJsNamedExports(source: string, modulePath: string, visited = new Set<string>()): string[] {
+	let realModulePath = modulePath;
+	try {
+		realModulePath = fs.realpathSync(modulePath);
+	} catch {
+		// The caller's path remains the stable cycle key when realpath fails.
 	}
-	const objectPattern = /module\.exports\s*=\s*\{([\s\S]*?)\}/g;
-	for (const objectMatch of source.matchAll(objectPattern)) {
-		const propertyPattern = /(?:^|,)\s*(?:([A-Za-z_$][\w$]*)\s*(?=[:,]|$)|["']([A-Za-z_$][\w$]*)["']\s*:)/g;
-		for (const propertyMatch of objectMatch[1]?.matchAll(propertyPattern) ?? []) {
-			const name = propertyMatch[1] ?? propertyMatch[2];
-			if (name && name !== "default") {
+	if (visited.has(realModulePath)) {
+		return [];
+	}
+	visited.add(realModulePath);
+
+	const names = new Set<string>();
+
+	const reexportSpecifiers = new Set<string>();
+	const ast = parseExtensionSource(source, modulePath);
+	traverseAst(ast, {
+		enter(nodePath) {
+			const node = nodePath.node;
+			if (node.type === "CallExpression") {
+				const definePropertyCall =
+					node.callee.type === "MemberExpression" &&
+					!node.callee.computed &&
+					node.callee.object.type === "Identifier" &&
+					node.callee.object.name === "Object" &&
+					node.callee.property.type === "Identifier" &&
+					node.callee.property.name === "defineProperty" &&
+					!nodePath.scope.hasBinding("Object", true);
+				if (definePropertyCall) {
+					const target = node.arguments[0];
+					const property = node.arguments[1];
+					const targetsExports =
+						(target?.type === "Identifier" &&
+							target.name === "exports" &&
+							!nodePath.scope.hasBinding("exports", true)) ||
+						(target?.type === "MemberExpression" &&
+							!target.computed &&
+							target.object.type === "Identifier" &&
+							target.object.name === "module" &&
+							target.property.type === "Identifier" &&
+							target.property.name === "exports" &&
+							!nodePath.scope.hasBinding("module", true));
+					if (
+						targetsExports &&
+						property?.type === "StringLiteral" &&
+						property.value !== "default" &&
+						COMMONJS_NAMED_EXPORT_IDENTIFIER.test(property.value)
+					) {
+						names.add(property.value);
+					}
+					return;
+				}
+				if (node.callee.type === "Identifier" && node.callee.name === "__exportStar") {
+					const source = node.arguments[0];
+					const target = node.arguments[1];
+					const targetsExports =
+						(target?.type === "Identifier" &&
+							target.name === "exports" &&
+							!nodePath.scope.hasBinding("exports", true)) ||
+						(target?.type === "MemberExpression" &&
+							!target.computed &&
+							target.object.type === "Identifier" &&
+							target.object.name === "module" &&
+							target.property.type === "Identifier" &&
+							target.property.name === "exports" &&
+							!nodePath.scope.hasBinding("module", true));
+					if (
+						targetsExports &&
+						source?.type === "CallExpression" &&
+						source.callee.type === "Identifier" &&
+						source.callee.name === "require" &&
+						!nodePath.scope.hasBinding("require", true)
+					) {
+						const argument = source.arguments[0];
+						if (argument?.type === "StringLiteral") {
+							reexportSpecifiers.add(argument.value);
+						}
+					}
+					return;
+				}
+			}
+			if (node.type !== "AssignmentExpression" || node.operator !== "=" || node.left.type !== "MemberExpression") {
+				return;
+			}
+			const left = node.left;
+			const propertyName =
+				!left.computed && left.property.type === "Identifier"
+					? left.property.name
+					: left.computed && left.property.type === "StringLiteral"
+						? left.property.value
+						: null;
+			const object = left.object;
+			const assignsExportsProperty =
+				propertyName !== null &&
+				((object.type === "Identifier" &&
+					object.name === "exports" &&
+					!nodePath.scope.hasBinding("exports", true)) ||
+					(object.type === "MemberExpression" &&
+						!object.computed &&
+						object.object.type === "Identifier" &&
+						object.object.name === "module" &&
+						object.property.type === "Identifier" &&
+						object.property.name === "exports" &&
+						!nodePath.scope.hasBinding("module", true)));
+			if (assignsExportsProperty) {
+				if (propertyName !== "default" && COMMONJS_NAMED_EXPORT_IDENTIFIER.test(propertyName)) {
+					names.add(propertyName);
+				}
+				return;
+			}
+			const assignsModuleExports =
+				!left.computed &&
+				left.object.type === "Identifier" &&
+				left.object.name === "module" &&
+				left.property.type === "Identifier" &&
+				left.property.name === "exports" &&
+				!nodePath.scope.hasBinding("module", true);
+			if (!assignsModuleExports) return;
+
+			const right = node.right;
+			if (right.type === "ObjectExpression") {
+				for (const property of right.properties) {
+					if ((property.type !== "ObjectProperty" && property.type !== "ObjectMethod") || property.computed) {
+						continue;
+					}
+					const name =
+						property.key.type === "Identifier"
+							? property.key.name
+							: property.key.type === "StringLiteral"
+								? property.key.value
+								: null;
+					if (name && name !== "default" && COMMONJS_NAMED_EXPORT_IDENTIFIER.test(name)) {
+						names.add(name);
+					}
+				}
+				return;
+			}
+			if (
+				right.type === "CallExpression" &&
+				right.callee.type === "Identifier" &&
+				right.callee.name === "require" &&
+				!nodePath.scope.hasBinding("require", true)
+			) {
+				const argument = right.arguments[0];
+				if (argument?.type === "StringLiteral") {
+					reexportSpecifiers.add(argument.value);
+				}
+			}
+		},
+	});
+	const nativeRequire = createRequire(modulePath);
+	for (const specifier of reexportSpecifiers) {
+		try {
+			const resolved = fs.realpathSync(nativeRequire.resolve(specifier));
+			const reexportedSource = rewriteExtensionSpecifiersFromCache(fs.readFileSync(resolved, "utf8"), resolved);
+			for (const name of collectCommonJsNamedExports(reexportedSource, resolved, visited)) {
 				names.add(name);
 			}
+		} catch {
+			// Native modules and non-source re-exports do not expose analyzable names.
 		}
 	}
 	return [...names];
@@ -1516,7 +1923,7 @@ function synthesizeCommonJsDefaultModule(modulePath: string, source: string, tar
 	});
 	commonJsModuleCache.delete(modulePath);
 	const exportsBinding = "__ompLegacyPiCommonJsExports";
-	const namedExports = collectCommonJsNamedExports(executableSource)
+	const namedExports = collectCommonJsNamedExports(executableSource, targetPath)
 		.map(
 			(name, index) =>
 				`const __ompLegacyPiCommonJsExport${index} = ${exportsBinding}[${JSON.stringify(name)}]; export { __ompLegacyPiCommonJsExport${index} as ${name} };`,
@@ -1547,9 +1954,9 @@ async function prepareCommonJsDefaultModule(modulePath: string, source: string):
 
 /**
  * Install exact-path load hooks for the current extension graph. ESM/TS source
- * retains the async rewrite path. CommonJS wrappers and native-addon loaders
- * stay synchronous because Bun rejects `require()` targets backed by async
- * `onLoad` callbacks.
+ * retains the async rewrite path. Graph-owned CommonJS modules and native-addon
+ * loaders stay synchronous because Bun rejects `require()` targets backed by
+ * async `onLoad` callbacks.
  */
 async function installExtensionGraphHook(
 	entryRealPath: string,
@@ -1560,12 +1967,10 @@ async function installExtensionGraphHook(
 	const asyncModules = new Map<string, string>();
 	const syncSourceModules = new Map<string, string>();
 	for (const [modulePath, source] of modules) {
-		const extension = path.extname(modulePath);
-		if (extension === ".cjs" || extension === ".cts") {
-			if (!commonJsPaths.has(modulePath)) {
-				throw new Error(`Missing CommonJS compatibility source: ${modulePath}`);
-			}
-		} else if (nativeAddonLoaderModulePaths.has(modulePath)) {
+		if (commonJsPaths.has(modulePath)) {
+			continue;
+		}
+		if (nativeAddonLoaderModulePaths.has(modulePath)) {
 			syncSourceModules.set(modulePath, source);
 		} else {
 			asyncModules.set(modulePath, source);
@@ -1612,13 +2017,12 @@ async function installExtensionGraphHook(
 				build.onLoad({ filter, namespace: "file" }, args => {
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
-					const source =
-						commonJsModuleSources.get(sourcePath) ??
-						synthesizeCommonJsDefaultModule(
-							sourcePath,
-							fs.readFileSync(commonJsFallbackModulePaths.get(sourcePath) ?? sourcePath, "utf8"),
-							commonJsFallbackModulePaths.get(sourcePath) ?? sourcePath,
-						);
+					let source = commonJsModuleSources.get(sourcePath);
+					if (source === undefined) {
+						const targetPath = commonJsFallbackModulePaths.get(sourcePath) ?? sourcePath;
+						const raw = rewriteExtensionSpecifiersFromCache(fs.readFileSync(targetPath, "utf8"), sourcePath);
+						source = synthesizeCommonJsDefaultModule(sourcePath, raw, targetPath);
+					}
 					return { contents: source, loader: getLoader(sourcePath) };
 				});
 			},
@@ -1658,8 +2062,11 @@ async function installExtensionGraphHook(
  * during the initial load; `undefined` when no new modules were discovered.
  */
 async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(): void } | undefined> {
-	const { modules: currentModules, cacheBustResolvedImportModules: discoveredCacheBustModules } =
-		await collectExtensionModules(entryRealPath);
+	const {
+		modules: currentModules,
+		commonJsPaths,
+		cacheBustResolvedImportModules: discoveredCacheBustModules,
+	} = await collectExtensionModules(entryRealPath);
 	let cacheBustResolvedImportModules = extensionGraphCacheBustResolvedImportModules.get(entryRealPath);
 	if (!cacheBustResolvedImportModules) {
 		cacheBustResolvedImportModules = new Set<string>();
@@ -1668,12 +2075,10 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	for (const modulePath of discoveredCacheBustModules) {
 		cacheBustResolvedImportModules.add(modulePath);
 	}
-	const commonJsPaths = new Set<string>();
 	for (const [modulePath, source] of currentModules) {
-		const extension = path.extname(modulePath);
-		if (extension === ".cjs" || extension === ".cts") {
+		if (commonJsPaths.has(modulePath)) {
 			commonJsModuleSources.set(modulePath, await prepareCommonJsDefaultModule(modulePath, source));
-			commonJsPaths.add(modulePath);
+			commonJsGraphModulePaths.add(modulePath);
 		}
 	}
 	let hookedModules = extensionGraphHookModules.get(entryRealPath);

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -69,6 +69,25 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 		expect(loaded.schema.safeParse({ name: "ok", extra: 1 }).success).toBe(false);
 	});
 
+	it("redirects the legacy pi-ai compat entrypoint through the root compatibility shim", async () => {
+		const entry = await writeFixtureExtension(
+			[
+				'import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";',
+				'export const schema = StringEnum(["red", "green"] as const);',
+				"export const completeType = typeof complete;",
+				"export type LegacyModel = Model;",
+			].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as {
+			schema: { safeParse: (input: unknown) => { success: boolean } };
+			completeType: string;
+		};
+		expect(loaded.schema.safeParse("red").success).toBe(true);
+		expect(loaded.schema.safeParse("blue").success).toBe(false);
+		expect(loaded.completeType).toBe("function");
+	});
+
 	it('redirects `import { Type } from "@oh-my-pi/pi-ai"` for plugins published against the canonical scope', async () => {
 		const entry = await writeFixtureExtension(
 			['import { Type } from "@oh-my-pi/pi-ai";', "export const probe = Type;"].join("\n"),
@@ -206,6 +225,30 @@ describe("legacy pi package root remaps (issue #1474)", () => {
 
 		const loaded = (await loadLegacyPiModule(entry)) as { loadedVersion: string };
 		expect(loaded.loadedVersion).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	it("loads pi-vimmode's minified legacy imports", async () => {
+		const entry = await writeFixtureExtension(
+			[
+				'import{CustomEditor,copyToClipboard}from"@earendil-works/pi-coding-agent";',
+				'import{CURSOR_MARKER,decodeKittyPrintable,matchesKey,parseKey,truncateToWidth,visibleWidth}from"@earendil-works/pi-tui";',
+				"export const apiTypes=[typeof CustomEditor,typeof copyToClipboard,typeof CURSOR_MARKER,typeof decodeKittyPrintable,typeof matchesKey,typeof parseKey,typeof truncateToWidth,typeof visibleWidth];",
+				'export const printable=decodeKittyPrintable("\\x1b[97u");',
+			].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as { apiTypes: string[]; printable: string };
+		expect(loaded.apiTypes).toEqual([
+			"function",
+			"function",
+			"string",
+			"function",
+			"function",
+			"function",
+			"function",
+			"function",
+		]);
+		expect(loaded.printable).toBe("a");
 	});
 
 	it("preserves legacy defineTool root imports and usable coding tools", async () => {

--- a/packages/coding-agent/test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts
@@ -120,10 +120,17 @@ process.stdout.write(JSON.stringify([
 		const overrides = __buildLegacyPiPackageRootOverrides(true, bundledModuleKeys);
 		const missing: string[] = [];
 		for (const key of bundledModuleKeys) {
-			// pi-ai/pi-coding-agent roots intentionally use the legacy compat shims
-			// (they re-attach `Type`, `defineTool`, etc. dropped from the canonical
-			// package surface); typebox is served via TYPEBOX_SHIM_PATH.
-			if (key === "@oh-my-pi/pi-ai" || key === "@oh-my-pi/pi-coding-agent" || key === "typebox") continue;
+			// pi-ai/pi-coding-agent/pi-tui roots intentionally use the legacy compat
+			// shims (they re-attach `Type`, `defineTool`, `decodeKittyPrintable`, etc.
+			// dropped from the canonical package surfaces); typebox is served via
+			// TYPEBOX_SHIM_PATH.
+			if (
+				key === "@oh-my-pi/pi-ai" ||
+				key === "@oh-my-pi/pi-coding-agent" ||
+				key === "@oh-my-pi/pi-tui" ||
+				key === "typebox"
+			)
+				continue;
 			if (overrides[key] !== `omp-legacy-pi-bundled:${key}`) {
 				missing.push(key);
 			}
@@ -131,7 +138,7 @@ process.stdout.write(JSON.stringify([
 		expect(missing).toEqual([]);
 	});
 
-	it("keeps pi-ai/pi-coding-agent roots routed to their compat shims in compiled mode", () => {
+	it("keeps pi-ai/pi-coding-agent/pi-tui roots routed to their compat shims in compiled mode", () => {
 		// The shim entries themselves resolve to virtual bundled specifiers in
 		// compiled mode (the shim files are bundled under their own registry
 		// keys); the test asserts only that the roots stay distinct from the
@@ -141,6 +148,7 @@ process.stdout.write(JSON.stringify([
 		expect(overrides["@oh-my-pi/pi-ai"]).toBeDefined();
 		expect(overrides["@oh-my-pi/pi-ai"]).not.toBe("omp-legacy-pi-bundled:@oh-my-pi/pi-ai/oauth");
 		expect(overrides["@oh-my-pi/pi-coding-agent"]).toBeDefined();
+		expect(overrides["@oh-my-pi/pi-tui"]).toBeDefined();
 	});
 
 	it("does not register subpath overrides in dev/install mode", () => {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -330,6 +330,34 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(second.depValue).toBe("dep-v2");
 	});
 
+	it("keeps transitive bare dependency importer paths query-free", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "transitive-bare-dep-ext", version: "1.0.0", type: "module" }),
+			"node_modules/directdep/package.json": JSON.stringify({
+				name: "directdep",
+				version: "1.0.0",
+				type: "module",
+				exports: "./index.js",
+			}),
+			"node_modules/directdep/index.js": 'export { nestedUrl } from "nesteddep";\n',
+			"node_modules/nesteddep/package.json": JSON.stringify({
+				name: "nesteddep",
+				version: "1.0.0",
+				type: "module",
+				exports: "./index.js",
+			}),
+			"node_modules/nesteddep/index.js": "export const nestedUrl = import.meta.url;\n",
+			"index.ts": 'export { nestedUrl } from "directdep";\nexport default function (pi) { void pi; }\n',
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { nestedUrl: string };
+		const expectedNestedUrl = url.pathToFileURL(
+			await fs.realpath(path.join(dir, "node_modules/nesteddep/index.js")),
+		).href;
+
+		expect(mod.nestedUrl).toBe(expectedNestedUrl);
+	});
+
 	it("reloads modules added to the relative import graph after the first load", async () => {
 		const entrySource = (version: string, includeHelper: boolean): string =>
 			[
@@ -607,7 +635,7 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 			[
 				'import * as path from "node:path";',
 				'import { value } from "esmdep/value";',
-				'import { rootValue } from "rootdep";',
+				'import{rootValue}from"rootdep";',
 				"export const loaded = value + rootValue;",
 			].join("\n"),
 			importer,
@@ -626,9 +654,52 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(rewritten).toContain('from "node:path"');
 	});
 
-	it("pins native-addon package requires to absolute extension paths", async () => {
+	it("honors export pattern specificity and package encapsulation", async () => {
 		const dir = await writePackage({
-			"package.json": JSON.stringify({ name: "native-require-ext", version: "1.0.0" }),
+			"package.json": JSON.stringify({ name: "exports-contract-ext", version: "1.0.0", type: "module" }),
+			"node_modules/pattern-dep/package.json": JSON.stringify({
+				name: "pattern-dep",
+				version: "1.0.0",
+				type: "module",
+				exports: { "./*": "./fallback/*.js", "./feature/*": "./features/*.js" },
+			}),
+			"node_modules/pattern-dep/fallback/feature/x.js": "export const selected = 'fallback';",
+			"node_modules/pattern-dep/features/x.js": "export const selected = 'specific';",
+			"node_modules/blocked-dep/package.json": JSON.stringify({
+				name: "blocked-dep",
+				version: "1.0.0",
+				main: "./legacy.cjs",
+				exports: { ".": { import: "./esm.js" }, "./private": null },
+			}),
+			"node_modules/blocked-dep/esm.js": "export default {};",
+			"node_modules/blocked-dep/legacy.cjs": "module.exports = {};",
+			"node_modules/blocked-dep/private.js": "export default {};",
+			"index.ts": "",
+		});
+		const importer = path.join(dir, "index.ts");
+		const rewritten = await __rewriteLegacyExtensionSourceForTests(
+			[
+				'import { selected } from "pattern-dep/feature/x";',
+				'import privateValue from "blocked-dep/private";',
+				'const privateRequire = require("blocked-dep/private");',
+				'const rootRequire = require("blocked-dep");',
+			].join("\n"),
+			importer,
+		);
+
+		const specificUrl = url.pathToFileURL(
+			await fs.realpath(path.join(dir, "node_modules/pattern-dep/features/x.js")),
+		).href;
+		expect(rewritten).toContain(specificUrl);
+		expect(rewritten).not.toContain("fallback/feature/x.js");
+		expect(rewritten).toContain('from "blocked-dep/private"');
+		expect(rewritten).toContain('require("blocked-dep/private")');
+		expect(rewritten).toContain('require("blocked-dep")');
+	});
+
+	it("pins bare package requires to absolute extension paths", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "bare-require-ext", version: "1.0.0" }),
 			"node_modules/@fixture/native-platform/package.json": JSON.stringify({
 				name: "@fixture/native-platform",
 				version: "1.0.0",
@@ -641,6 +712,13 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 				main: "index.js",
 			}),
 			"node_modules/plain-dep/index.js": "module.exports = {};",
+			"node_modules/condition-dep/package.json": JSON.stringify({
+				name: "condition-dep",
+				version: "1.0.0",
+				exports: { import: "./esm.js", require: "./cjs.cjs" },
+			}),
+			"node_modules/condition-dep/esm.js": "export default {};",
+			"node_modules/condition-dep/cjs.cjs": "module.exports = {};",
 			"index.ts": "",
 		});
 		const importer = path.join(dir, "index.ts");
@@ -648,16 +726,28 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 			[
 				'const binding = require("@fixture/native-platform");',
 				'const plain = require("plain-dep");',
+				'const conditional = require("condition-dep");',
 				'const local = require("./local.node");',
-				"export { binding, plain, local };",
+				'const member = loader.require("plain-dep");',
+				'const importText = `from"plain-dep"`;',
+				'const importPattern = /from"typebox"/;',
+				'function shadowed(require) { return require("plain-dep"); }',
+				"export { binding, conditional, importPattern, importText, local, member, plain, shadowed };",
 			].join("\n"),
 			importer,
 		);
 
 		const addon = await fs.realpath(path.join(dir, "node_modules/@fixture/native-platform/binding.node"));
+		const plainDep = await fs.realpath(path.join(dir, "node_modules/plain-dep/index.js"));
+		const conditionalDep = await fs.realpath(path.join(dir, "node_modules/condition-dep/cjs.cjs"));
 		expect(rewritten).toContain(`require("${addon.replaceAll("\\", "/")}")`);
-		expect(rewritten).toContain('require("plain-dep")');
+		expect(rewritten).toContain(`require("${plainDep.replaceAll("\\", "/")}")`);
+		expect(rewritten).toContain(`require("${conditionalDep.replaceAll("\\", "/")}")`);
 		expect(rewritten).toContain('require("./local.node")');
+		expect(rewritten).toContain('loader.require("plain-dep")');
+		expect(rewritten).toContain('`from"plain-dep"`');
+		expect(rewritten).toContain('/from"typebox"/');
+		expect(rewritten).toContain('function shadowed(require) { return require("plain-dep"); }');
 	});
 
 	it("preserves native-addon rewrites inside wrapped CommonJS dependencies", async () => {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -78,6 +78,44 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(mod.value).toBe("config-ok");
 	});
 
+	it("loads a relative CommonJS helper imported by a TypeScript extension", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "relative-cjs-import-ext", version: "1.0.0" }),
+			"helper.js": "module.exports = { value: 42 };\n",
+			"index.ts": [
+				'import helper from "./helper.js";',
+				"export const value = helper.value;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { value: number };
+
+		expect(mod.value).toBe(42);
+	});
+
+	it("remaps legacy Pi requires in graph-owned CommonJS packages to the host shim", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "cjs-legacy-pi-require-ext", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js": 'module.exports = require("@mariozechner/pi-ai").Type;\n',
+			"index.ts": [
+				'import { Type } from "@oh-my-pi/pi-ai";',
+				'import requiredType from "direct";',
+				"export const sharesHostType = requiredType === Type;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { sharesHostType: boolean };
+
+		expect(mod.sharesHostType).toBe(true);
+	});
+
 	it("loads a default import from linkedom's CommonJS canvas fallback", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "linkedom-consumer", version: "1.0.0", type: "module" }),
@@ -356,6 +394,280 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		).href;
 
 		expect(mod.nestedUrl).toBe(expectedNestedUrl);
+	});
+
+	it("preserves named re-exports from relative ESM children in a no-type dual package", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "dual-package-ext", version: "1.0.0", type: "module" }),
+			"node_modules/dual-package/package.json": JSON.stringify({
+				name: "dual-package",
+				version: "1.0.0",
+				main: "lib/commonjs/index.js",
+				module: "lib/es/index.js",
+			}),
+			"node_modules/dual-package/lib/commonjs/index.js": `exports.stringify = value => \`cjs:\${value}\`;\n`,
+			"node_modules/dual-package/lib/es/index.js":
+				'import "./setup.js";\nexport { stringify } from "./stringify.js";\n',
+			"node_modules/dual-package/lib/es/stringify.js": `export const stringify = value => \`esm:\${value}\`;\n`,
+			"node_modules/dual-package/lib/es/setup.js": "await Promise.resolve();\n",
+			"index.ts": [
+				'import { stringify } from "dual-package";',
+				'export const result = stringify("value");',
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { result: string };
+
+		expect(mod.result).toBe("esm:value");
+	});
+
+	it("keeps a syntax-ambiguous conditional import target on its ESM branch", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "conditional-esm-ext", version: "1.0.0", type: "module" }),
+			"node_modules/conditional/package.json": JSON.stringify({
+				name: "conditional",
+				version: "1.0.0",
+				exports: {
+					".": {
+						import: "./esm.js",
+						require: "./cjs.js",
+					},
+				},
+			}),
+			"node_modules/conditional/esm.js": "await Promise.resolve();\n",
+			"node_modules/conditional/cjs.js": 'throw new Error("require branch loaded");\n',
+			"index.ts": [
+				'import "conditional";',
+				"export const loaded = true;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { loaded: boolean };
+
+		expect(mod.loaded).toBe(true);
+	});
+
+	it("reloads a hoisted CommonJS dependency required by a relative CommonJS child", async () => {
+		const entrySource = (version: string): string =>
+			[
+				'import dependency from "directdep";',
+				"export const dependencyValue = dependency.value;",
+				`export const entryVersion = ${JSON.stringify(version)};`,
+				"export default function (pi) { void pi; }",
+			].join("\n");
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "relative-transitive-cjs-ext", version: "1.0.0", type: "module" }),
+			"node_modules/directdep/package.json": JSON.stringify({
+				name: "directdep",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/directdep/index.js": 'module.exports = require("./child.js");\n',
+			"node_modules/directdep/child.js": [
+				"void 'export { ignored } from \"ignored\";';",
+				'// import ignored from "ignored";',
+				'module.exports = require("transitive-dependency");',
+			].join("\n"),
+			"node_modules/transitive-dependency/package.json": JSON.stringify({
+				name: "transitive-dependency",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/transitive-dependency/index.js": 'module.exports = { value: "dep-v1" };\n',
+			"index.ts": entrySource("v1"),
+		});
+		const entry = path.join(dir, "index.ts");
+		const transitiveDependency = path.join(dir, "node_modules", "transitive-dependency", "index.js");
+
+		const first = (await loadLegacyPiModule(entry)) as { entryVersion: string; dependencyValue: string };
+		expect(first.entryVersion).toBe("v1");
+		expect(first.dependencyValue).toBe("dep-v1");
+
+		const firstEntryStat = await fs.stat(entry);
+		const firstDependencyStat = await fs.stat(transitiveDependency);
+		await fs.writeFile(entry, entrySource("v2"), "utf8");
+		await fs.writeFile(transitiveDependency, 'module.exports = { value: "dep-v2" };\n', "utf8");
+		const bumpedEntryMtime = new Date(Math.ceil(firstEntryStat.mtimeMs) + 2_000);
+		const bumpedDependencyMtime = new Date(Math.ceil(firstDependencyStat.mtimeMs) + 2_000);
+		await fs.utimes(entry, bumpedEntryMtime, bumpedEntryMtime);
+		await fs.utimes(transitiveDependency, bumpedDependencyMtime, bumpedDependencyMtime);
+
+		const second = (await loadLegacyPiModule(entry)) as { entryVersion: string; dependencyValue: string };
+		expect(second.entryVersion).toBe("v2");
+		expect(second.dependencyValue).toBe("dep-v2");
+	});
+
+	it("preserves named imports through CommonJS package re-exports", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "named-cjs-reexport-ext", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js": 'module.exports = require("middle");\n',
+			"node_modules/middle/package.json": JSON.stringify({
+				name: "middle",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/middle/index.js": 'module.exports = require("leaf");\n',
+			"node_modules/leaf/package.json": JSON.stringify({
+				name: "leaf",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/leaf/index.js": [
+				'module.exports = require("direct");',
+				'module.exports.value = "named-reexport-ok";',
+			].join("\n"),
+			"index.ts": [
+				'import { value } from "direct";',
+				"export { value };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { value: string };
+
+		expect(mod.value).toBe("named-reexport-ok");
+	});
+
+	it("preserves named imports from CommonJS defineProperty and exportStar patterns", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "cjs-export-helper-ext", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js": [
+				'Object.defineProperty(exports, "local", { enumerable: true, get: () => "local-ok" });',
+				"const __exportStar = (mod, target) => {",
+				"  for (const key in mod) {",
+				'    if (key !== "default" && !Object.prototype.hasOwnProperty.call(target, key)) {',
+				"      Object.defineProperty(target, key, { enumerable: true, get: () => mod[key] });",
+				"    }",
+				"  }",
+				"};",
+				'__exportStar(require("leaf"), exports);',
+			].join("\n"),
+			"node_modules/leaf/package.json": JSON.stringify({
+				name: "leaf",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/leaf/index.js": 'module.exports = { value: "star-ok" };\n',
+			"index.ts": [
+				'import { local, value } from "direct";',
+				"export { local, value };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as {
+			local: string;
+			value: string;
+		};
+
+		expect(mod.local).toBe("local-ok");
+		expect(mod.value).toBe("star-ok");
+	});
+
+	it("keeps dynamic-import children of a CommonJS package on its CommonJS branch", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "dynamic-cjs-child-ext", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js":
+				'module.exports = { load: () => import("./child.js").then(mod => mod.default.value) };\n',
+			"node_modules/direct/child.js": 'module.exports = { value: "dynamic-child-ok" };\n',
+			"index.ts": [
+				'import direct from "direct";',
+				"export const result = await direct.load();",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { result: string };
+
+		expect(mod.result).toBe("dynamic-child-ok");
+	});
+
+	it("preserves default imports from CommonJS objects with non-identifier keys", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "hyphenated-cjs-export-ext", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js": 'module.exports = { "foo-bar": true, value: "default-ok" };\n',
+			"index.ts": [
+				'import direct from "direct";',
+				"export const result = direct.value;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { result: string };
+
+		expect(mod.result).toBe("default-ok");
+	});
+
+	it("reloads a lazily imported CommonJS package re-export", async () => {
+		const entrySource = (version: string): string =>
+			[
+				'export const loadValue = () => import("direct").then(mod => mod.default.value);',
+				`export const entryVersion = ${JSON.stringify(version)};`,
+				"export default function (pi) { void pi; }",
+			].join("\n");
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "lazy-cjs-reexport-ext", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js": 'module.exports = require("leaf");\n',
+			"node_modules/leaf/package.json": JSON.stringify({
+				name: "leaf",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/leaf/index.js": 'module.exports = { value: "lazy-v1" };\n',
+			"index.ts": entrySource("v1"),
+		});
+		const entry = path.join(dir, "index.ts");
+		const leaf = path.join(dir, "node_modules", "leaf", "index.js");
+
+		const first = (await loadLegacyPiModule(entry)) as {
+			entryVersion: string;
+			loadValue(): Promise<string>;
+		};
+		expect(first.entryVersion).toBe("v1");
+		expect(await first.loadValue()).toBe("lazy-v1");
+
+		const firstEntryStat = await fs.stat(entry);
+		const firstLeafStat = await fs.stat(leaf);
+		await fs.writeFile(entry, entrySource("v2"), "utf8");
+		await fs.writeFile(leaf, 'module.exports = { value: "lazy-v2" };\n', "utf8");
+		const bumpedEntryMtime = new Date(Math.ceil(firstEntryStat.mtimeMs) + 2_000);
+		const bumpedLeafMtime = new Date(Math.ceil(firstLeafStat.mtimeMs) + 2_000);
+		await fs.utimes(entry, bumpedEntryMtime, bumpedEntryMtime);
+		await fs.utimes(leaf, bumpedLeafMtime, bumpedLeafMtime);
+
+		const second = (await loadLegacyPiModule(entry)) as {
+			entryVersion: string;
+			loadValue(): Promise<string>;
+		};
+		expect(second.entryVersion).toBe("v2");
+		expect(await second.loadValue()).toBe("lazy-v2");
 	});
 
 	it("reloads modules added to the relative import graph after the first load", async () => {
@@ -695,6 +1007,61 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(rewritten).toContain('from "blocked-dep/private"');
 		expect(rewritten).toContain('require("blocked-dep/private")');
 		expect(rewritten).toContain('require("blocked-dep")');
+	});
+
+	it("rejects package resolutions that escape the package root", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "package-boundary-ext", version: "1.0.0", type: "module" }),
+			"node_modules/main-escape/package.json": JSON.stringify({
+				name: "main-escape",
+				version: "1.0.0",
+				main: "../outside/index.js",
+			}),
+			"node_modules/exports-escape/package.json": JSON.stringify({
+				name: "exports-escape",
+				version: "1.0.0",
+				exports: { "./*": "./../outside/*.js" },
+			}),
+			"node_modules/subpath-escape/package.json": JSON.stringify({
+				name: "subpath-escape",
+				version: "1.0.0",
+			}),
+			"node_modules/native-escape/package.json": JSON.stringify({
+				name: "native-escape",
+				version: "1.0.0",
+			}),
+			"node_modules/outside/index.js": "export default {};",
+			"node_modules/outside/value.js": "export default {};",
+			"node_modules/outside/addon.node": "native fixture",
+			"index.ts": "",
+			"node_modules/symlink-escape/package.json": JSON.stringify({
+				name: "symlink-escape",
+				version: "1.0.0",
+				exports: { "./value": "./link.js" },
+			}),
+		});
+		await fs.symlink(
+			path.join(dir, "node_modules", "outside", "value.js"),
+			path.join(dir, "node_modules", "symlink-escape", "link.js"),
+		);
+		const importer = path.join(dir, "index.ts");
+		const rewritten = await __rewriteLegacyExtensionSourceForTests(
+			[
+				'import mainEscape from "main-escape";',
+				'import exportsEscape from "exports-escape/value";',
+				'import subpathEscape from "subpath-escape/../outside";',
+				'import symlinkEscape from "symlink-escape/value";',
+				'const nativeEscape = require("native-escape/../outside/addon.node");',
+				"export { exportsEscape, mainEscape, nativeEscape, subpathEscape, symlinkEscape };",
+			].join("\n"),
+			importer,
+		);
+
+		expect(rewritten).toContain('from "main-escape"');
+		expect(rewritten).toContain('from "exports-escape/value"');
+		expect(rewritten).toContain('from "subpath-escape/../outside"');
+		expect(rewritten).toContain('require("native-escape/../outside/addon.node")');
+		expect(rewritten).toContain('from "symlink-escape/value"');
 	});
 
 	it("pins bare package requires to absolute extension paths", async () => {

--- a/packages/coding-agent/test/extensibility/typebox-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-remap.test.ts
@@ -73,4 +73,16 @@ describe("legacy-pi TypeBox remap", () => {
 			required: ["path"],
 		});
 	});
+
+	it("redirects minified bare typebox imports without whitespace around from", async () => {
+		const entry = await writeFixtureExtension(
+			'import{Type}from"typebox";export const schema=Type.Object({name:Type.String()});',
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as {
+			schema: { safeParse: (input: unknown) => { success: boolean } };
+		};
+		expect(loaded.schema.safeParse({ name: "ok" }).success).toBe(true);
+		expect(loaded.schema.safeParse({}).success).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary

- preserve and rebase the original compiled-extension loader work from #6256
- resolve transitive CommonJS dependencies from plugin-owned `node_modules`
- keep mixed ESM/CommonJS package branches, reload behavior, and package boundaries correct

## Root cause

The compiled OMP binary cannot use Bun's normal runtime package walk to resolve bare dependencies from an installed extension. The existing compatibility loader rewrote the extension entry graph, but CommonJS descendants still reached unresolved hoisted packages through runtime `require()` calls. That made `@mjasnikovs/pi-task` fail first at `qrcode -> dijkstrajs`, then at deeper dependencies as each shallow failure was bypassed.

## Fix

- parse and rewrite static extension imports without changing comments or strings
- collect the complete reachable ESM/CommonJS graph and pre-resolve CommonJS `require()` targets
- evaluate graph-owned CommonJS modules with cycle-safe caching and reload-aware synchronous hydration
- preserve default and statically discoverable named exports across assignments, `defineProperty`, export-star helpers, and recursive CommonJS re-exports
- track ESM/CommonJS provenance for no-type dual packages, conditional exports, relative imports, and dynamic imports
- remap legacy Pi packages required by wrapped CommonJS modules back to the host's canonical compatibility registry
- reject package import/export targets that escape their package root lexically or through symlinks
- keep rewritten topology metadata available to permanent Bun hooks while refreshing source and evaluation state between loads

## Verification

- `bun --cwd=packages/coding-agent run check`
- 66 related tests passed across:
  - `legacy-pi-inplace-load.test.ts`
  - `legacy-pi-ai-type-remap.test.ts`
  - `legacy-pi-bundled-subpath-overrides.test.ts`
  - `typebox-remap.test.ts`
- built the macOS arm64 compiled binary successfully
- launched the rebuilt binary with the real installed `@mjasnikovs/pi-task@0.17.11`; it exited 0 and emitted no extension-load or `ResolveMessage` warning

## Credit

This retains Comic Chang's original commit and implementation from #6256, then extends it with the recursive graph, mixed-module, reload, export-interop, and containment fixes required by the real plugin dependency tree.

Closes #6173
Supersedes #6256
