### PR TITLE
Add firecrawl keyless mode support

### DIFF
--- a/packages/coding-agent/src/web/search/providers/firecrawl.ts
+++ b/packages/coding-agent/src/web/search/providers/firecrawl.ts
@@ -4,7 +4,14 @@
  * Calls Firecrawl's search API and maps web results into the unified
  * SearchResponse shape used by the web search tool.
  */
-import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
+import {
+	type AuthStorage,
+	type FetchImpl,
+	getEnvApiKey,
+	resolveApiKeyOnce,
+	seedApiKeyResolver,
+	withAuth,
+} from "@oh-my-pi/pi-ai";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { clampNumResults } from "../utils";
@@ -66,7 +73,10 @@ function buildRequestBody(params: FirecrawlSearchParams): Record<string, unknown
 	return body;
 }
 
-async function callFirecrawlSearch(apiKey: string | undefined, params: FirecrawlSearchParams): Promise<FirecrawlSearchResponse> {
+async function callFirecrawlSearch(
+	apiKey: string | undefined,
+	params: FirecrawlSearchParams,
+): Promise<FirecrawlSearchResponse> {
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 	};
@@ -103,24 +113,17 @@ export async function searchFirecrawl(params: SearchParams): Promise<SearchRespo
 		signal: params.signal,
 		fetch: params.fetch,
 	};
-	const keyOrResolver: ApiKey = params.authStorage.resolver("firecrawl", {
+	const keyResolver = params.authStorage.resolver("firecrawl", {
 		sessionId: params.sessionId,
 	});
 	const numResults = clampNumResults(firecrawlParams.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
 
-	/** Resolve the API key; may be undefined (keyless mode). */
-	async function resolveApiKey(): Promise<string | undefined> {
-		if (typeof keyOrResolver === "function") {
-			return keyOrResolver({ lastChance: false, error: undefined, signal: params.signal });
-		}
-		return keyOrResolver;
-	}
-
-	const resolvedKey = await resolveApiKey();
+	const resolvedKey = await resolveApiKeyOnce(keyResolver, params.signal);
 	let data: FirecrawlSearchResponse;
 	if (resolvedKey) {
-		// Authenticated mode
-		data = await withAuth(keyOrResolver, key => callFirecrawlSearch(key, firecrawlParams), {
+		// Reuse the preflight credential for the initial authenticated attempt.
+		const seededResolver = seedApiKeyResolver(resolvedKey, keyResolver);
+		data = await withAuth(seededResolver, key => callFirecrawlSearch(key, firecrawlParams), {
 			signal: params.signal,
 		});
 	} else {

--- a/packages/coding-agent/src/web/search/providers/firecrawl.ts
+++ b/packages/coding-agent/src/web/search/providers/firecrawl.ts
@@ -149,6 +149,8 @@ export async function searchFirecrawl(params: SearchParams): Promise<SearchRespo
 		authMode: resolvedKey ? "api_key" : "keyless",
 	};
 }
+
+/** Search provider for Firecrawl web search. */
 export class FirecrawlProvider extends SearchProvider {
 	readonly id = "firecrawl";
 	readonly label = "Firecrawl";

--- a/packages/coding-agent/src/web/search/providers/firecrawl.ts
+++ b/packages/coding-agent/src/web/search/providers/firecrawl.ts
@@ -66,13 +66,16 @@ function buildRequestBody(params: FirecrawlSearchParams): Record<string, unknown
 	return body;
 }
 
-async function callFirecrawlSearch(apiKey: string, params: FirecrawlSearchParams): Promise<FirecrawlSearchResponse> {
+async function callFirecrawlSearch(apiKey: string | undefined, params: FirecrawlSearchParams): Promise<FirecrawlSearchResponse> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (apiKey) {
+		headers.Authorization = `Bearer ${apiKey}`;
+	}
 	const response = await (params.fetch ?? fetch)(FIRECRAWL_SEARCH_URL, {
 		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${apiKey}`,
-		},
+		headers,
 		body: JSON.stringify(buildRequestBody(params)),
 		signal: withHardTimeout(params.signal),
 	});
@@ -105,11 +108,26 @@ export async function searchFirecrawl(params: SearchParams): Promise<SearchRespo
 	});
 	const numResults = clampNumResults(firecrawlParams.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
 
-	const data = await withAuth(keyOrResolver, key => callFirecrawlSearch(key, firecrawlParams), {
-		signal: params.signal,
-		missingKeyMessage:
-			'Firecrawl credentials not found. Set FIRECRAWL_API_KEY or configure an API key for provider "firecrawl".',
-	});
+	/** Resolve the API key; may be undefined (keyless mode). */
+	async function resolveApiKey(): Promise<string | undefined> {
+		if (typeof keyOrResolver === "function") {
+			return keyOrResolver({ lastChance: false, error: undefined, signal: params.signal });
+		}
+		return keyOrResolver;
+	}
+
+	const resolvedKey = await resolveApiKey();
+	let data: FirecrawlSearchResponse;
+	if (resolvedKey) {
+		// Authenticated mode
+		data = await withAuth(keyOrResolver, key => callFirecrawlSearch(key, firecrawlParams), {
+			signal: params.signal,
+		});
+	} else {
+		// Keyless mode — omit Authorization header
+		data = await callFirecrawlSearch(undefined, firecrawlParams);
+	}
+
 	const sources: SearchSource[] = [];
 
 	for (const result of data.data?.web ?? []) {
@@ -125,17 +143,27 @@ export async function searchFirecrawl(params: SearchParams): Promise<SearchRespo
 		provider: "firecrawl",
 		sources: sources.slice(0, numResults),
 		requestId: data.id ?? undefined,
-		authMode: "api_key",
+		authMode: resolvedKey ? "api_key" : "keyless",
 	};
 }
-
-/** Search provider for Firecrawl web search. */
 export class FirecrawlProvider extends SearchProvider {
 	readonly id = "firecrawl";
 	readonly label = "Firecrawl";
 
+	/**
+	 * Auto-chain admission: requires a credential so an unconfigured Firecrawl
+	 * doesn't displace other providers that the user has set up with API keys.
+	 */
 	isAvailable(authStorage: AuthStorage): boolean {
 		return authStorage.hasAuth("firecrawl") || !!getEnvApiKey("firecrawl");
+	}
+
+	/**
+	 * Firecrawl supports keyless mode, so an explicit user selection
+	 * (`webSearch: firecrawl`) works without any credential configured.
+	 */
+	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+		return true;
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -37,7 +37,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "jina", label: "Jina", description: "Requires JINA_API_KEY" },
 	{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY and Kagi Search API beta access" },
 	{ value: "tavily", label: "Tavily", description: "Requires TAVILY_API_KEY" },
-	{ value: "firecrawl", label: "Firecrawl", description: "Uses Firecrawl API when FIRECRAWL_API_KEY is set; falls back to keyless mode" },
+	{
+		value: "firecrawl",
+		label: "Firecrawl",
+		description: "Uses Firecrawl API when FIRECRAWL_API_KEY is set; falls back to keyless mode",
+	},
 	{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
 	{
 		value: "kimi",

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -37,7 +37,7 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "jina", label: "Jina", description: "Requires JINA_API_KEY" },
 	{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY and Kagi Search API beta access" },
 	{ value: "tavily", label: "Tavily", description: "Requires TAVILY_API_KEY" },
-	{ value: "firecrawl", label: "Firecrawl", description: "Requires FIRECRAWL_API_KEY" },
+	{ value: "firecrawl", label: "Firecrawl", description: "Uses Firecrawl API when FIRECRAWL_API_KEY is set; falls back to keyless mode" },
 	{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
 	{
 		value: "kimi",

--- a/packages/coding-agent/test/tools/web-search-firecrawl.test.ts
+++ b/packages/coding-agent/test/tools/web-search-firecrawl.test.ts
@@ -105,6 +105,35 @@ describe("Firecrawl web search provider", () => {
 		});
 	});
 
+	it("uses the initially resolved credential for the first authenticated request", async () => {
+		let resolutionCount = 0;
+		const authStorage = {
+			resolver(provider: string, options?: { sessionId?: string }) {
+				expect(provider).toBe("firecrawl");
+				expect(options?.sessionId).toBe("session-firecrawl-test");
+				return async () => {
+					resolutionCount += 1;
+					return resolutionCount === 1 ? "initial-firecrawl-key" : undefined;
+				};
+			},
+		} as unknown as AuthStorage;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			expect(getHeader(init?.headers, "Authorization")).toBe("Bearer initial-firecrawl-key");
+			return new Response(JSON.stringify({ data: { web: [] } }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const response = await searchFirecrawl({
+			...makeParams("credential reuse", authStorage),
+			fetch: fetchMock,
+		});
+
+		expect(response.authMode).toBe("api_key");
+		expect(resolutionCount).toBe(1);
+	});
+
 	it.each([
 		[401, "firecrawl: 401 unauthorized"],
 		[402, "firecrawl: 402 credits exhausted"],

--- a/packages/coding-agent/test/tools/web-search-firecrawl.test.ts
+++ b/packages/coding-agent/test/tools/web-search-firecrawl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
-import { searchFirecrawl } from "@oh-my-pi/pi-coding-agent/web/search/providers/firecrawl";
+import { FirecrawlProvider, searchFirecrawl } from "@oh-my-pi/pi-coding-agent/web/search/providers/firecrawl";
 import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
 const TEST_KEY = "test-firecrawl-key";
@@ -134,6 +134,44 @@ describe("Firecrawl web search provider", () => {
 		expect(resolutionCount).toBe(1);
 	});
 
+	it("retries with a rotated credential after the seeded key is rejected", async () => {
+		const resolvedKeys = ["initial-firecrawl-key", "rotated-firecrawl-key"] as const;
+		let resolutionCount = 0;
+		const authStorage = {
+			resolver(provider: string, options?: { sessionId?: string }) {
+				expect(provider).toBe("firecrawl");
+				expect(options?.sessionId).toBe("session-firecrawl-test");
+				return async () => resolvedKeys[resolutionCount++];
+			},
+		} as unknown as AuthStorage;
+		const authorizationHeaders: Array<string | null> = [];
+		const fetchMock: FetchImpl = async (_input, init) => {
+			authorizationHeaders.push(getHeader(init?.headers, "Authorization"));
+			if (authorizationHeaders.length === 1) {
+				return new Response("credential rejected", { status: 401 });
+			}
+			if (authorizationHeaders.length === 2) {
+				return new Response(JSON.stringify({ id: "rotated-firecrawl-request", data: { web: [] } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error("unexpected Firecrawl request");
+		};
+
+		const response = await searchFirecrawl({
+			...makeParams("credential rotation", authStorage),
+			fetch: fetchMock,
+		});
+
+		expect(authorizationHeaders).toEqual(["Bearer initial-firecrawl-key", "Bearer rotated-firecrawl-key"]);
+		expect(resolutionCount).toBe(2);
+		expect(response).toMatchObject({
+			requestId: "rotated-firecrawl-request",
+			authMode: "api_key",
+		});
+	});
+
 	it.each([
 		[401, "firecrawl: 401 unauthorized"],
 		[402, "firecrawl: 402 credits exhausted"],
@@ -146,6 +184,21 @@ describe("Firecrawl web search provider", () => {
 		} catch (error) {
 			expect(error).toBeInstanceOf(SearchProviderError);
 			expect(error).toMatchObject({ provider: "firecrawl", status, message });
+		}
+	});
+
+	it("keeps keyless Firecrawl out of auto selection while allowing explicit selection", () => {
+		const originalApiKey = process.env.FIRECRAWL_API_KEY;
+		delete process.env.FIRECRAWL_API_KEY;
+		try {
+			const provider = new FirecrawlProvider();
+			const authStorage = makeAuthStorage(undefined);
+
+			expect(provider.isAvailable(authStorage)).toBe(false);
+			expect(provider.isExplicitlyAvailable(authStorage)).toBe(true);
+		} finally {
+			if (originalApiKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+			else process.env.FIRECRAWL_API_KEY = originalApiKey;
 		}
 	});
 

--- a/packages/coding-agent/test/tools/web-search-firecrawl.test.ts
+++ b/packages/coding-agent/test/tools/web-search-firecrawl.test.ts
@@ -120,19 +120,50 @@ describe("Firecrawl web search provider", () => {
 		}
 	});
 
-	it("throws a clear error when Firecrawl credentials are missing", async () => {
-		const fetchMock: FetchImpl = async () => {
-			throw new Error("fetch should not be called without credentials");
+	it("uses keyless mode when no API key is configured (no Authorization header)", async () => {
+		const captured: { url?: string; init?: RequestInit; body?: unknown } = {};
+
+		const fetchMock: FetchImpl = async (input, init) => {
+			captured.url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			captured.init = init;
+			captured.body = JSON.parse(String(init?.body ?? "null")) as unknown;
+			return new Response(
+				JSON.stringify({
+					id: "keyless-request-456",
+					data: {
+						web: [
+							{
+								title: "Keyless result",
+								url: "https://example.com/keyless",
+								description: "Result from keyless Firecrawl",
+							},
+						],
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
 		};
 
-		try {
-			await searchFirecrawl({ ...makeParams("missing creds", makeAuthStorage(undefined)), fetch: fetchMock });
-			expect.unreachable("expected searchFirecrawl to throw");
-		} catch (error) {
-			expect(error).toBeInstanceOf(Error);
-			expect((error as Error).message).toBe(
-				'Firecrawl credentials not found. Set FIRECRAWL_API_KEY or configure an API key for provider "firecrawl".',
-			);
-		}
+		const response = await searchFirecrawl({
+			...makeParams("keyless query", makeAuthStorage(undefined)),
+			fetch: fetchMock,
+		});
+
+		expect(captured.url).toBe("https://api.firecrawl.dev/v2/search");
+		expect(captured.init?.method).toBe("POST");
+		expect(getHeader(captured.init?.headers, "Authorization")).toBeNull();
+		expect(getHeader(captured.init?.headers, "Content-Type")).toBe("application/json");
+		expect(response).toEqual({
+			provider: "firecrawl",
+			sources: [
+				{
+					title: "Keyless result",
+					url: "https://example.com/keyless",
+					snippet: "Result from keyless Firecrawl",
+				},
+			],
+			requestId: "keyless-request-456",
+			authMode: "keyless",
+		});
 	});
 });


### PR DESCRIPTION
## What

- Add support for the official Firecrawl Keyless REST mode when no `FIRECRAWL_API_KEY` or stored credential is available.
- Call the Firecrawl REST API without an `Authorization` header for keyless requests.
- Keep Firecrawl credential-gated in the automatic provider chain while allowing explicit Firecrawl selection to use keyless mode.
- Reuse the credential selected during auth preflight in the first authenticated request, while preserving resolver-based retry and credential rotation.
- Update the provider description and add regression coverage for authenticated, keyless, and preflight credential-reuse behavior.

## Why

Firecrawl supports keyless search, but the provider previously failed before making a request when no API key was configured. This prevented users from explicitly selecting Firecrawl without credentials.

The automatic provider chain remains credential-gated so an unconfigured Firecrawl provider does not displace another configured provider.

Fixes [#4332](https://github.com/can1357/oh-my-pi/issues/4332)

## Testing

- `bun test packages/coding-agent/test/tools/web-search-firecrawl.test.ts` — 7 passed
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/web/search/providers/firecrawl.ts packages/coding-agent/src/web/search/types.ts packages/coding-agent/test/tools/web-search-firecrawl.test.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
