### PR TITLE
feat(coding-agent): add Moonshot web search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 
-- Added a distinct `moonshot` web search provider using Moonshot's built-in `$web_search` tool function over standard Open Platform credentials (`MOONSHOT_API_KEY` or stored `moonshot` auth) ([#5765](https://github.com/can1357/oh-my-pi/issues/5765)).
+- Added a distinct `moonshot` web search provider using Moonshot's official `moonshot/web-search:latest` Formula over standard Open Platform credentials (`MOONSHOT_API_KEY` or stored `moonshot` auth) ([#5765](https://github.com/can1357/oh-my-pi/issues/5765)).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added a distinct `moonshot` web search provider using Moonshot's built-in `$web_search` tool function over standard Open Platform credentials (`MOONSHOT_API_KEY` or stored `moonshot` auth) ([#5765](https://github.com/can1357/oh-my-pi/issues/5765)).
+
 ### Fixed
 
 - Fixed the setup wizard hiding the selected row on short terminals (e.g. 24x80): the provider sign-in, theme, and web-search lists now fit their windows to the visible height, and decorative chrome (sign-in hint, theme mock preview) yields to the list when space is tight.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4469,6 +4469,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Model ID for Gemini Google Search grounding. Defaults to gemini-2.5-flash.",
 		},
 	},
+	"providers.webSearchMoonshotModel": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Moonshot web_search model",
+			description: "Model ID for Moonshot $web_search tool loop. Defaults to kimi-k3.",
+		},
+	},
 	"providers.antigravityEndpoint": {
 		type: "enum",
 		values: ["auto", "production", "sandbox"] as const,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4476,7 +4476,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "providers",
 			group: "Services",
 			label: "Moonshot web_search model",
-			description: "Model ID for Moonshot $web_search tool loop. Defaults to kimi-k3.",
+			description: "Model ID for the Moonshot web-search Formula tool loop. Defaults to kimi-k3.",
 		},
 	},
 	"providers.antigravityEndpoint": {

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -159,6 +159,12 @@ async function executeSearch(
 	} catch {
 		geminiModel = undefined;
 	}
+	let moonshotModel: string | undefined;
+	try {
+		moonshotModel = settings.get("providers.webSearchMoonshotModel");
+	} catch {
+		moonshotModel = undefined;
+	}
 
 	const failures: Array<{ provider: Pick<SearchProvider, "id" | "label">; error: unknown }> = [];
 	let availableProviderCount = 0;
@@ -196,6 +202,7 @@ async function executeSearch(
 				sessionId,
 				antigravityEndpointMode,
 				geminiModel,
+				moonshotModel,
 			});
 
 			if (!hasRenderableSearchContent(response)) {

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -94,6 +94,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.kimi,
 		load: async () => new (await import("./providers/kimi")).KimiProvider(),
 	},
+	moonshot: {
+		id: "moonshot",
+		label: SEARCH_PROVIDER_LABELS.moonshot,
+		load: async () => new (await import("./providers/moonshot")).MoonshotProvider(),
+	},
 	parallel: {
 		id: "parallel",
 		label: SEARCH_PROVIDER_LABELS.parallel,

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -56,6 +56,7 @@ export interface SearchParams {
 	sessionId?: string;
 	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	geminiModel?: string;
+	moonshotModel?: string;
 }
 
 /** Base class for web search providers. */

--- a/packages/coding-agent/src/web/search/providers/moonshot.ts
+++ b/packages/coding-agent/src/web/search/providers/moonshot.ts
@@ -1,8 +1,8 @@
 /**
  * Moonshot Open Platform Web Search Provider
  *
- * Uses Moonshot's built-in $web_search tool function via Open Platform
- * (/v1/chat/completions).
+ * Executes the official `moonshot/web-search:latest` Formula, then lets Kimi
+ * consume the Formula's protected output and synthesize the answer.
  */
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
 import { $env } from "@oh-my-pi/pi-utils";
@@ -14,6 +14,7 @@ import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const DEFAULT_MODEL = "kimi-k3";
 const DEFAULT_BASE_URL = "https://api.moonshot.ai/v1";
+const FORMULA_URI = "moonshot/web-search:latest";
 const MAX_STEPS = 5;
 
 export interface MoonshotSearchParams extends SearchParams {
@@ -68,7 +69,30 @@ interface MoonshotChatResponse {
 	};
 }
 
-/** Execute Moonshot web search using the $web_search built-in tool loop. */
+interface MoonshotTool {
+	type: string;
+	function: {
+		name: string;
+		description?: string;
+		parameters?: Record<string, unknown>;
+	};
+}
+
+interface MoonshotToolsResponse {
+	tools?: MoonshotTool[];
+}
+
+interface MoonshotFiberResponse {
+	status?: string;
+	context?: {
+		output?: string;
+		encrypted_output?: string;
+		error?: unknown;
+	};
+	error?: unknown;
+}
+
+/** Execute Moonshot web search using the official Formula tool loop. */
 export async function searchMoonshot(params: MoonshotSearchParams): Promise<SearchResponse> {
 	const apiKey = await params.authStorage.getApiKey("moonshot", params.sessionId, { signal: params.signal });
 	if (!apiKey) {
@@ -78,6 +102,29 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 	const baseUrl = resolveBaseUrl();
 	const model = resolveMoonshotSearchModel(params.moonshotModel);
 	const fetchImpl: FetchImpl = params.fetch ?? fetch;
+	const authorization = `Bearer ${apiKey}`;
+	const searchSignal = withHardTimeout(params.signal);
+
+	const toolsResponse = await fetchImpl(`${baseUrl}/formulas/${FORMULA_URI}/tools`, {
+		headers: { Authorization: authorization },
+		signal: searchSignal,
+	});
+	if (!toolsResponse.ok) {
+		const errorText = await toolsResponse.text();
+		const classified = classifyProviderHttpError("moonshot", toolsResponse.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError(
+			"moonshot",
+			`Moonshot Formula tools API error (${toolsResponse.status}): ${errorText}`,
+			toolsResponse.status,
+		);
+	}
+
+	const toolsData = (await toolsResponse.json()) as MoonshotToolsResponse;
+	const tools = toolsData.tools ?? [];
+	if (tools.length === 0) {
+		throw new SearchProviderError("moonshot", "Moonshot Formula returned no web-search tool declaration.", 502);
+	}
 
 	const messages: Array<Record<string, unknown>> = [];
 	if (params.systemPrompt) {
@@ -85,18 +132,10 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 	}
 	messages.push({ role: "user", content: params.query });
 
-	const tools = [
-		{
-			type: "builtin_function",
-			function: {
-				name: "$web_search",
-			},
-		},
-	];
-
 	let step = 0;
 	let finalAnswer: string | undefined;
 	let modelUsed = model;
+	let requestId: string | undefined;
 	let usageTotal: SearchUsage | undefined;
 	const searchQueries: string[] = [];
 	const sources: SearchSource[] = [];
@@ -108,6 +147,10 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 			messages,
 			tools,
 		};
+		// K3 defaults to max reasoning, which can spend tens of seconds before a search-only tool decision.
+		if (model.startsWith("kimi-k3")) {
+			body.reasoning_effort = "low";
+		}
 		if (params.maxOutputTokens !== undefined) {
 			body.max_tokens = params.maxOutputTokens;
 		}
@@ -120,10 +163,10 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
+				Authorization: authorization,
 			},
 			body: JSON.stringify(body),
-			signal: withHardTimeout(params.signal),
+			signal: searchSignal,
 		});
 
 		if (!response.ok) {
@@ -132,13 +175,13 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 			if (classified) throw classified;
 			throw new SearchProviderError(
 				"moonshot",
-				`Moonshot API error (${response.status}): ${errorText}`,
+				`Moonshot chat API error (${response.status}): ${errorText}`,
 				response.status,
 			);
 		}
 
 		const data = (await response.json()) as MoonshotChatResponse;
-
+		requestId = data.id ?? requestId;
 		if (data.model) {
 			modelUsed = data.model;
 		}
@@ -152,63 +195,89 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 
 		const choice = data.choices?.[0];
 		if (!choice) {
-			throw new SearchProviderError("moonshot", "Moonshot API returned empty choices.", 500);
+			throw new SearchProviderError("moonshot", "Moonshot API returned empty choices.", 502);
 		}
 
 		const message = choice.message;
-		const finishReason = choice.finish_reason;
-
-		if (finishReason === "tool_calls" && message?.tool_calls && message.tool_calls.length > 0) {
-			// Moonshot emits "builtin_function", but raw replay rejects it with "tokenization failed"; normalize to "function".
-			const formattedMessage = {
-				...message,
-				tool_calls: message.tool_calls.map(tc => ({
-					...tc,
-					type: tc.type === "builtin_function" ? "function" : (tc.type ?? "function"),
-				})),
-			};
-			messages.push(formattedMessage as unknown as Record<string, unknown>);
+		if (choice.finish_reason === "tool_calls" && message?.tool_calls && message.tool_calls.length > 0) {
+			messages.push(message as unknown as Record<string, unknown>);
 
 			for (const toolCall of message.tool_calls) {
-				const toolName = toolCall.function?.name;
 				let argsObj: Record<string, unknown> | undefined;
-				if (toolCall.function?.arguments) {
-					try {
-						argsObj = JSON.parse(toolCall.function.arguments);
-					} catch {
-						// Pass raw string if unparseable
+				try {
+					argsObj = JSON.parse(toolCall.function.arguments);
+				} catch {
+					// The Formula endpoint still receives the original encoded arguments unchanged.
+				}
+				if (toolCall.function.name === "web_search") {
+					const searchQuery = argsObj?.query;
+					if (typeof searchQuery === "string" && !searchQueries.includes(searchQuery)) {
+						searchQueries.push(searchQuery);
 					}
 				}
 
-				if (toolName === "$web_search") {
-					if (typeof argsObj?.query === "string" && !searchQueries.includes(argsObj.query)) {
-						searchQueries.push(argsObj.query);
-					}
+				const fiberResponse = await fetchImpl(`${baseUrl}/formulas/${FORMULA_URI}/fibers`, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: authorization,
+					},
+					body: JSON.stringify(toolCall.function),
+					signal: searchSignal,
+				});
+				if (!fiberResponse.ok) {
+					const errorText = await fiberResponse.text();
+					const classified = classifyProviderHttpError("moonshot", fiberResponse.status, errorText);
+					if (classified) throw classified;
+					throw new SearchProviderError(
+						"moonshot",
+						`Moonshot Formula fiber API error (${fiberResponse.status}): ${errorText}`,
+						fiberResponse.status,
+					);
 				}
 
-				const toolResult = argsObj ?? toolCall.function?.arguments ?? {};
+				const fiber = (await fiberResponse.json()) as MoonshotFiberResponse;
+				if (fiber.status !== "succeeded") {
+					const rawError = fiber.error ?? fiber.context?.error;
+					const detail =
+						typeof rawError === "string"
+							? rawError
+							: rawError === undefined
+								? `status ${fiber.status ?? "unknown"}`
+								: JSON.stringify(rawError);
+					throw new SearchProviderError("moonshot", `Moonshot Formula fiber failed: ${detail}`, 502);
+				}
+
+				const toolResult = fiber.context?.output ?? fiber.context?.encrypted_output;
+				if (typeof toolResult !== "string" || toolResult.length === 0) {
+					throw new SearchProviderError("moonshot", "Moonshot Formula fiber returned no output.", 502);
+				}
 				messages.push({
 					role: "tool",
 					tool_call_id: toolCall.id,
-					name: toolName,
-					content: typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult),
+					content: toolResult,
 				});
 			}
-		} else {
-			finalAnswer = message?.content ?? undefined;
-			if (Array.isArray(message?.annotations)) {
-				for (const item of message.annotations) {
-					if (item && typeof item.url === "string") {
-						sources.push({
-							title: item.title ?? item.url,
-							url: item.url,
-							snippet: item.text ?? item.cited_text ?? undefined,
-						});
-					}
+			continue;
+		}
+
+		finalAnswer = message?.content ?? undefined;
+		if (Array.isArray(message?.annotations)) {
+			for (const item of message.annotations) {
+				if (item && typeof item.url === "string") {
+					sources.push({
+						title: item.title ?? item.url,
+						url: item.url,
+						snippet: item.text ?? item.cited_text ?? undefined,
+					});
 				}
 			}
-			break;
 		}
+		break;
+	}
+
+	if (step === MAX_STEPS && !finalAnswer) {
+		throw new SearchProviderError("moonshot", `Moonshot Formula exceeded ${MAX_STEPS} tool-call steps.`, 502);
 	}
 
 	return {
@@ -218,6 +287,7 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 		searchQueries: searchQueries.length > 0 ? searchQueries : undefined,
 		model: modelUsed,
 		usage: usageTotal,
+		requestId,
 	};
 }
 

--- a/packages/coding-agent/src/web/search/providers/moonshot.ts
+++ b/packages/coding-agent/src/web/search/providers/moonshot.ts
@@ -159,7 +159,7 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 		const finishReason = choice.finish_reason;
 
 		if (finishReason === "tool_calls" && message?.tool_calls && message.tool_calls.length > 0) {
-			// Append assistant message with type mapped to "function" for OpenAI-compat replay
+			// Moonshot emits "builtin_function", but raw replay rejects it with "tokenization failed"; normalize to "function".
 			const formattedMessage = {
 				...message,
 				tool_calls: message.tool_calls.map(tc => ({

--- a/packages/coding-agent/src/web/search/providers/moonshot.ts
+++ b/packages/coding-agent/src/web/search/providers/moonshot.ts
@@ -1,0 +1,237 @@
+/**
+ * Moonshot Open Platform Web Search Provider
+ *
+ * Uses Moonshot's built-in $web_search tool function via Open Platform
+ * (/v1/chat/completions).
+ */
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { $env } from "@oh-my-pi/pi-utils";
+import type { SearchCitation, SearchResponse, SearchSource, SearchUsage } from "../types";
+import { SearchProviderError } from "../types";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const DEFAULT_MODEL = "kimi-k3";
+const DEFAULT_BASE_URL = "https://api.moonshot.ai/v1";
+const MAX_STEPS = 5;
+
+export interface MoonshotSearchParams extends SearchParams {
+	moonshotModel?: string;
+}
+
+function resolveBaseUrl(): string {
+	return ($env.MOONSHOT_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function resolveMoonshotSearchModel(configuredModel: string | undefined): string {
+	return $env.MOONSHOT_SEARCH_MODEL?.trim() || configuredModel?.trim() || DEFAULT_MODEL;
+}
+
+interface MoonshotChoiceMessage {
+	role?: string;
+	content?: string | null;
+	reasoning_content?: string | null;
+	tool_calls?: Array<{
+		id: string;
+		type?: string;
+		function: {
+			name: string;
+			arguments: string;
+		};
+	}>;
+	annotations?: Array<{
+		type?: string;
+		url?: string;
+		title?: string;
+		text?: string;
+		cited_text?: string;
+	}>;
+}
+
+interface MoonshotChoice {
+	index?: number;
+	message?: MoonshotChoiceMessage;
+	finish_reason?: string;
+}
+
+interface MoonshotChatResponse {
+	id?: string;
+	model?: string;
+	choices?: MoonshotChoice[];
+	usage?: {
+		prompt_tokens?: number;
+		completion_tokens?: number;
+		total_tokens?: number;
+		input_tokens?: number;
+		output_tokens?: number;
+	};
+}
+
+/** Execute Moonshot web search using the $web_search built-in tool loop. */
+export async function searchMoonshot(params: MoonshotSearchParams): Promise<SearchResponse> {
+	const apiKey = await params.authStorage.getApiKey("moonshot", params.sessionId, { signal: params.signal });
+	if (!apiKey) {
+		throw new SearchProviderError("moonshot", "Moonshot API key not configured.", 401);
+	}
+
+	const baseUrl = resolveBaseUrl();
+	const model = resolveMoonshotSearchModel(params.moonshotModel);
+	const fetchImpl: FetchImpl = params.fetch ?? fetch;
+
+	const messages: Array<Record<string, unknown>> = [];
+	if (params.systemPrompt) {
+		messages.push({ role: "system", content: params.systemPrompt });
+	}
+	messages.push({ role: "user", content: params.query });
+
+	const tools = [
+		{
+			type: "builtin_function",
+			function: {
+				name: "$web_search",
+			},
+		},
+	];
+
+	let step = 0;
+	let finalAnswer: string | undefined;
+	let modelUsed = model;
+	let usageTotal: SearchUsage | undefined;
+	const searchQueries: string[] = [];
+	const sources: SearchSource[] = [];
+	const citations: SearchCitation[] = [];
+
+	while (step < MAX_STEPS) {
+		step++;
+		const body: Record<string, unknown> = {
+			model,
+			messages,
+			tools,
+		};
+		if (params.maxOutputTokens !== undefined) {
+			body.max_tokens = params.maxOutputTokens;
+		}
+		if (params.temperature !== undefined && params.temperature === 1) {
+			body.temperature = 1;
+		}
+
+		const response = await fetchImpl(`${baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify(body),
+			signal: withHardTimeout(params.signal),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			const classified = classifyProviderHttpError("moonshot", response.status, errorText);
+			if (classified) throw classified;
+			throw new SearchProviderError(
+				"moonshot",
+				`Moonshot API error (${response.status}): ${errorText}`,
+				response.status,
+			);
+		}
+
+		const data = (await response.json()) as MoonshotChatResponse;
+
+		if (data.model) {
+			modelUsed = data.model;
+		}
+		if (data.usage) {
+			const inputTokens = data.usage.prompt_tokens ?? data.usage.input_tokens;
+			const outputTokens = data.usage.completion_tokens ?? data.usage.output_tokens;
+			if (inputTokens !== undefined || outputTokens !== undefined) {
+				usageTotal = { inputTokens, outputTokens };
+			}
+		}
+
+		const choice = data.choices?.[0];
+		if (!choice) {
+			throw new SearchProviderError("moonshot", "Moonshot API returned empty choices.", 500);
+		}
+
+		const message = choice.message;
+		const finishReason = choice.finish_reason;
+
+		if (finishReason === "tool_calls" && message?.tool_calls && message.tool_calls.length > 0) {
+			// Append assistant message with type mapped to "function" for OpenAI-compat replay
+			const formattedMessage = {
+				...message,
+				tool_calls: message.tool_calls.map(tc => ({
+					...tc,
+					type: tc.type === "builtin_function" ? "function" : (tc.type ?? "function"),
+				})),
+			};
+			messages.push(formattedMessage as unknown as Record<string, unknown>);
+
+			for (const toolCall of message.tool_calls) {
+				const toolName = toolCall.function?.name;
+				let argsObj: Record<string, unknown> | undefined;
+				if (toolCall.function?.arguments) {
+					try {
+						argsObj = JSON.parse(toolCall.function.arguments);
+					} catch {
+						// Pass raw string if unparseable
+					}
+				}
+
+				if (toolName === "$web_search") {
+					if (typeof argsObj?.query === "string" && !searchQueries.includes(argsObj.query)) {
+						searchQueries.push(argsObj.query);
+					}
+				}
+
+				const toolResult = argsObj ?? toolCall.function?.arguments ?? {};
+				messages.push({
+					role: "tool",
+					tool_call_id: toolCall.id,
+					name: toolName,
+					content: typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult),
+				});
+			}
+		} else {
+			finalAnswer = message?.content ?? undefined;
+			if (Array.isArray(message?.annotations)) {
+				for (const item of message.annotations) {
+					if (item && typeof item.url === "string") {
+						sources.push({
+							title: item.title ?? item.url,
+							url: item.url,
+							snippet: item.text ?? item.cited_text ?? undefined,
+						});
+					}
+				}
+			}
+			break;
+		}
+	}
+
+	return {
+		provider: "moonshot",
+		answer: finalAnswer,
+		sources,
+		citations: citations.length > 0 ? citations : undefined,
+		searchQueries: searchQueries.length > 0 ? searchQueries : undefined,
+		model: modelUsed,
+		usage: usageTotal,
+	};
+}
+
+/** Search provider for Moonshot Open Platform web search. */
+export class MoonshotProvider extends SearchProvider {
+	readonly id = "moonshot" as const;
+	readonly label = "Moonshot";
+
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("moonshot");
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchMoonshot(params);
+	}
+}

--- a/packages/coding-agent/src/web/search/providers/moonshot.ts
+++ b/packages/coding-agent/src/web/search/providers/moonshot.ts
@@ -6,7 +6,7 @@
  */
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
 import { $env } from "@oh-my-pi/pi-utils";
-import type { SearchCitation, SearchResponse, SearchSource, SearchUsage } from "../types";
+import type { SearchResponse, SearchSource, SearchUsage } from "../types";
 import { SearchProviderError } from "../types";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
@@ -100,7 +100,6 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 	let usageTotal: SearchUsage | undefined;
 	const searchQueries: string[] = [];
 	const sources: SearchSource[] = [];
-	const citations: SearchCitation[] = [];
 
 	while (step < MAX_STEPS) {
 		step++;
@@ -112,7 +111,8 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 		if (params.maxOutputTokens !== undefined) {
 			body.max_tokens = params.maxOutputTokens;
 		}
-		if (params.temperature !== undefined && params.temperature === 1) {
+		// Kimi K3 accepts only temperature 1; omit other tool-supplied values so the API uses its required default.
+		if (params.temperature === 1) {
 			body.temperature = 1;
 		}
 
@@ -215,7 +215,6 @@ export async function searchMoonshot(params: MoonshotSearchParams): Promise<Sear
 		provider: "moonshot",
 		answer: finalAnswer,
 		sources,
-		citations: citations.length > 0 ? citations : undefined,
 		searchQueries: searchQueries.length > 0 ? searchQueries : undefined,
 		model: modelUsed,
 		usage: usageTotal,

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -48,7 +48,7 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{
 		value: "moonshot",
 		label: "Moonshot",
-		description: "Moonshot Open Platform ($web_search built-in tool via standard MOONSHOT_API_KEY)",
+		description: "Moonshot Open Platform's official web-search Formula (requires MOONSHOT_API_KEY)",
 	},
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -45,6 +45,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 		description:
 			"Kimi Code search (requires a Kimi Code Console key via KIMI_SEARCH_API_KEY/MOONSHOT_SEARCH_API_KEY or /login kimi-code; not MOONSHOT_API_KEY)",
 	},
+	{
+		value: "moonshot",
+		label: "Moonshot",
+		description: "Moonshot Open Platform ($web_search built-in tool via standard MOONSHOT_API_KEY)",
+	},
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },

--- a/packages/coding-agent/test/web/search/moonshot.test.ts
+++ b/packages/coding-agent/test/web/search/moonshot.test.ts
@@ -72,7 +72,7 @@ describe("Moonshot web search provider", () => {
 										tool_calls: [
 											{
 												id: "call_search_1",
-												type: "function",
+												type: "builtin_function",
 												function: {
 													name: "$web_search",
 													arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
@@ -129,6 +129,7 @@ describe("Moonshot web search provider", () => {
 			systemPrompt: "You are a web search helper.",
 			authStorage,
 			fetch: fetchImpl,
+			temperature: 0,
 		});
 
 		expect(capturedRequests).toHaveLength(2);
@@ -141,11 +142,22 @@ describe("Moonshot web search provider", () => {
 				function: { name: "$web_search" },
 			},
 		]);
+		expect(capturedRequests[0]?.body.temperature).toBeUndefined();
 
 		// Verify turn 2 request carried assistant reasoning and tool result
 		const step2Messages = capturedRequests[1]?.body.messages as Array<Record<string, unknown>>;
 		expect(step2Messages).toHaveLength(4); // system, user, assistant (tool_calls), tool
 		expect(step2Messages[2]?.reasoning_content).toBe("Thinking about searching Moonshot caching...");
+		expect(step2Messages[2]?.tool_calls).toEqual([
+			{
+				id: "call_search_1",
+				type: "function",
+				function: {
+					name: "$web_search",
+					arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
+				},
+			},
+		]);
 		expect(step2Messages[3]).toEqual({
 			role: "tool",
 			tool_call_id: "call_search_1",

--- a/packages/coding-agent/test/web/search/moonshot.test.ts
+++ b/packages/coding-agent/test/web/search/moonshot.test.ts
@@ -35,9 +35,22 @@ afterEach(() => {
 });
 
 describe("Moonshot web search provider", () => {
-	it("executes the $web_search built-in tool loop and returns normalized SearchResponse", async () => {
+	it("executes the Formula fiber loop and returns normalized SearchResponse", async () => {
 		const capturedRequests: CapturedRequest[] = [];
-		let stepCount = 0;
+		let chatStep = 0;
+		const encryptedOutput = "----MOONSHOT ENCRYPTED BEGIN----protected----MOONSHOT ENCRYPTED END----";
+		const toolDeclaration = {
+			type: "function",
+			function: {
+				name: "web_search",
+				description: "Search the web for information",
+				parameters: {
+					type: "object",
+					properties: { query: { type: "string" } },
+					required: ["query"],
+				},
+			},
+		};
 
 		const fetchImpl: FetchImpl = (input, init) => {
 			const url = typeof input === "string" ? input : input.toString();
@@ -51,71 +64,75 @@ describe("Moonshot web search provider", () => {
 						? new TextDecoder().decode(rawBody)
 						: String(rawBody ?? "");
 			const body = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
-
 			capturedRequests.push({ url, method, headers, body });
-			stepCount++;
 
-			if (stepCount === 1) {
-				// Turn 1: model returns tool_calls for $web_search
+			if (url.endsWith("/tools")) {
+				return Promise.resolve(Response.json({ object: "list", tools: [toolDeclaration] }));
+			}
+			if (url.endsWith("/fibers")) {
 				return Promise.resolve(
-					new Response(
-						JSON.stringify({
-							id: "chatcmpl-step1",
-							model: "kimi-k3",
-							choices: [
-								{
-									index: 0,
-									finish_reason: "tool_calls",
-									message: {
-										role: "assistant",
-										reasoning_content: "Thinking about searching Moonshot caching...",
-										tool_calls: [
-											{
-												id: "call_search_1",
-												type: "builtin_function",
-												function: {
-													name: "$web_search",
-													arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
-												},
-											},
-										],
-									},
-								},
-							],
-							usage: { prompt_tokens: 15, completion_tokens: 10, total_tokens: 25 },
-						}),
-						{ status: 200, headers: { "Content-Type": "application/json" } },
-					),
+					Response.json({
+						status: "succeeded",
+						context: { encrypted_output: encryptedOutput },
+					}),
 				);
 			}
 
-			// Turn 2: model produces final answer
-			return Promise.resolve(
-				new Response(
-					JSON.stringify({
-						id: "chatcmpl-step2",
+			chatStep++;
+			if (chatStep === 1) {
+				return Promise.resolve(
+					Response.json({
+						id: "chatcmpl-step1",
 						model: "kimi-k3",
 						choices: [
 							{
 								index: 0,
-								finish_reason: "stop",
+								finish_reason: "tool_calls",
 								message: {
 									role: "assistant",
-									content: "Moonshot AI Context Caching optimizes repeated prompt tokens.",
-									annotations: [
+									content: "",
+									reasoning_content: "Thinking about searching Moonshot caching...",
+									tool_calls: [
 										{
-											url: "https://platform.kimi.ai/docs",
-											title: "Kimi Docs",
-											text: "Context caching documentation",
+											id: "call_search_1",
+											type: "function",
+											function: {
+												name: "web_search",
+												arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
+											},
 										},
 									],
 								},
 							},
 						],
-						usage: { prompt_tokens: 120, completion_tokens: 25, total_tokens: 145 },
+						usage: { prompt_tokens: 15, completion_tokens: 10, total_tokens: 25 },
 					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				),
+				);
+			}
+
+			return Promise.resolve(
+				Response.json({
+					id: "chatcmpl-step2",
+					model: "kimi-k3",
+					choices: [
+						{
+							index: 0,
+							finish_reason: "stop",
+							message: {
+								role: "assistant",
+								content: "Moonshot AI Context Caching optimizes repeated prompt tokens.",
+								annotations: [
+									{
+										url: "https://platform.kimi.ai/docs",
+										title: "Kimi Docs",
+										text: "Context caching documentation",
+									},
+								],
+							},
+						},
+					],
+					usage: { prompt_tokens: 120, completion_tokens: 25, total_tokens: 145 },
+				}),
 			);
 		};
 
@@ -132,28 +149,31 @@ describe("Moonshot web search provider", () => {
 			temperature: 0,
 		});
 
-		expect(capturedRequests).toHaveLength(2);
-		expect(capturedRequests[0]?.url).toBe("https://api.moonshot.ai/v1/chat/completions");
-		expect(capturedRequests[0]?.headers.get("Authorization")).toBe("Bearer sk-moonshot-test-key");
-		expect(capturedRequests[0]?.body.model).toBe("kimi-k3");
-		expect(capturedRequests[0]?.body.tools).toEqual([
-			{
-				type: "builtin_function",
-				function: { name: "$web_search" },
-			},
+		expect(capturedRequests.map(request => `${request.method} ${request.url}`)).toEqual([
+			"GET https://api.moonshot.ai/v1/formulas/moonshot/web-search:latest/tools",
+			"POST https://api.moonshot.ai/v1/chat/completions",
+			"POST https://api.moonshot.ai/v1/formulas/moonshot/web-search:latest/fibers",
+			"POST https://api.moonshot.ai/v1/chat/completions",
 		]);
-		expect(capturedRequests[0]?.body.temperature).toBeUndefined();
+		expect(capturedRequests[0]?.headers.get("Authorization")).toBe("Bearer sk-moonshot-test-key");
+		expect(capturedRequests[1]?.body.model).toBe("kimi-k3");
+		expect(capturedRequests[1]?.body.tools).toEqual([toolDeclaration]);
+		expect(capturedRequests[1]?.body.reasoning_effort).toBe("low");
+		expect(capturedRequests[1]?.body.temperature).toBeUndefined();
+		expect(capturedRequests[2]?.body).toEqual({
+			name: "web_search",
+			arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
+		});
 
-		// Verify turn 2 request carried assistant reasoning and tool result
-		const step2Messages = capturedRequests[1]?.body.messages as Array<Record<string, unknown>>;
-		expect(step2Messages).toHaveLength(4); // system, user, assistant (tool_calls), tool
+		const step2Messages = capturedRequests[3]?.body.messages as Array<Record<string, unknown>>;
+		expect(step2Messages).toHaveLength(4);
 		expect(step2Messages[2]?.reasoning_content).toBe("Thinking about searching Moonshot caching...");
 		expect(step2Messages[2]?.tool_calls).toEqual([
 			{
 				id: "call_search_1",
 				type: "function",
 				function: {
-					name: "$web_search",
+					name: "web_search",
 					arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
 				},
 			},
@@ -161,8 +181,7 @@ describe("Moonshot web search provider", () => {
 		expect(step2Messages[3]).toEqual({
 			role: "tool",
 			tool_call_id: "call_search_1",
-			name: "$web_search",
-			content: JSON.stringify({ query: "Moonshot AI Context Caching" }),
+			content: encryptedOutput,
 		});
 
 		expect(response.answer).toBe("Moonshot AI Context Caching optimizes repeated prompt tokens.");
@@ -176,29 +195,32 @@ describe("Moonshot web search provider", () => {
 			},
 		]);
 		expect(response.usage).toEqual({ inputTokens: 120, outputTokens: 25 });
+		expect(response.requestId).toBe("chatcmpl-step2");
 	});
 
 	it("honors MOONSHOT_BASE_URL and MOONSHOT_SEARCH_MODEL overrides", async () => {
 		Bun.env.MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1/";
 		Bun.env.MOONSHOT_SEARCH_MODEL = "kimi-k2.6";
 
-		let capturedUrl = "";
-		let capturedModel = "";
-
+		const capturedUrls: string[] = [];
+		let capturedBody: Record<string, unknown> | undefined;
 		const fetchImpl: FetchImpl = (input, init) => {
-			capturedUrl = typeof input === "string" ? input : input.toString();
-			const bodyText = typeof init?.body === "string" ? init.body : "";
-			const body = JSON.parse(bodyText) as { model: string };
-			capturedModel = body.model;
-
-			return Promise.resolve(
-				new Response(
-					JSON.stringify({
-						model: "kimi-k2.6",
-						choices: [{ finish_reason: "stop", message: { content: "Done" } }],
+			const url = typeof input === "string" ? input : input.toString();
+			capturedUrls.push(url);
+			if (url.endsWith("/tools")) {
+				return Promise.resolve(
+					Response.json({
+						tools: [{ type: "function", function: { name: "web_search" } }],
 					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				),
+				);
+			}
+			const bodyText = typeof init?.body === "string" ? init.body : "";
+			capturedBody = JSON.parse(bodyText) as Record<string, unknown>;
+			return Promise.resolve(
+				Response.json({
+					model: "kimi-k2.6",
+					choices: [{ finish_reason: "stop", message: { content: "Done" } }],
+				}),
 			);
 		};
 
@@ -214,8 +236,12 @@ describe("Moonshot web search provider", () => {
 			fetch: fetchImpl,
 		});
 
-		expect(capturedUrl).toBe("https://api.moonshot.cn/v1/chat/completions");
-		expect(capturedModel).toBe("kimi-k2.6");
+		expect(capturedUrls).toEqual([
+			"https://api.moonshot.cn/v1/formulas/moonshot/web-search:latest/tools",
+			"https://api.moonshot.cn/v1/chat/completions",
+		]);
+		expect(capturedBody?.model).toBe("kimi-k2.6");
+		expect(capturedBody?.reasoning_effort).toBeUndefined();
 		expect(response.answer).toBe("Done");
 	});
 

--- a/packages/coding-agent/test/web/search/moonshot.test.ts
+++ b/packages/coding-agent/test/web/search/moonshot.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { MoonshotProvider, searchMoonshot } from "@oh-my-pi/pi-coding-agent/web/search/providers/moonshot";
+import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
+
+interface CapturedRequest {
+	url: string;
+	method: string;
+	headers: Headers;
+	body: Record<string, unknown>;
+}
+
+const ORIGINAL_MOONSHOT_BASE_URL = Bun.env.MOONSHOT_BASE_URL;
+const ORIGINAL_MOONSHOT_SEARCH_MODEL = Bun.env.MOONSHOT_SEARCH_MODEL;
+const ORIGINAL_MOONSHOT_API_KEY = Bun.env.MOONSHOT_API_KEY;
+
+afterEach(() => {
+	if (ORIGINAL_MOONSHOT_BASE_URL === undefined) {
+		delete Bun.env.MOONSHOT_BASE_URL;
+	} else {
+		Bun.env.MOONSHOT_BASE_URL = ORIGINAL_MOONSHOT_BASE_URL;
+	}
+
+	if (ORIGINAL_MOONSHOT_SEARCH_MODEL === undefined) {
+		delete Bun.env.MOONSHOT_SEARCH_MODEL;
+	} else {
+		Bun.env.MOONSHOT_SEARCH_MODEL = ORIGINAL_MOONSHOT_SEARCH_MODEL;
+	}
+
+	if (ORIGINAL_MOONSHOT_API_KEY === undefined) {
+		delete Bun.env.MOONSHOT_API_KEY;
+	} else {
+		Bun.env.MOONSHOT_API_KEY = ORIGINAL_MOONSHOT_API_KEY;
+	}
+});
+
+describe("Moonshot web search provider", () => {
+	it("executes the $web_search built-in tool loop and returns normalized SearchResponse", async () => {
+		const capturedRequests: CapturedRequest[] = [];
+		let stepCount = 0;
+
+		const fetchImpl: FetchImpl = (input, init) => {
+			const url = typeof input === "string" ? input : input.toString();
+			const method = init?.method ?? "GET";
+			const headers = new Headers(init?.headers);
+			const rawBody = init?.body;
+			const bodyText =
+				typeof rawBody === "string"
+					? rawBody
+					: rawBody instanceof Uint8Array
+						? new TextDecoder().decode(rawBody)
+						: String(rawBody ?? "");
+			const body = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
+
+			capturedRequests.push({ url, method, headers, body });
+			stepCount++;
+
+			if (stepCount === 1) {
+				// Turn 1: model returns tool_calls for $web_search
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							id: "chatcmpl-step1",
+							model: "kimi-k3",
+							choices: [
+								{
+									index: 0,
+									finish_reason: "tool_calls",
+									message: {
+										role: "assistant",
+										reasoning_content: "Thinking about searching Moonshot caching...",
+										tool_calls: [
+											{
+												id: "call_search_1",
+												type: "function",
+												function: {
+													name: "$web_search",
+													arguments: JSON.stringify({ query: "Moonshot AI Context Caching" }),
+												},
+											},
+										],
+									},
+								},
+							],
+							usage: { prompt_tokens: 15, completion_tokens: 10, total_tokens: 25 },
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			}
+
+			// Turn 2: model produces final answer
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						id: "chatcmpl-step2",
+						model: "kimi-k3",
+						choices: [
+							{
+								index: 0,
+								finish_reason: "stop",
+								message: {
+									role: "assistant",
+									content: "Moonshot AI Context Caching optimizes repeated prompt tokens.",
+									annotations: [
+										{
+											url: "https://platform.kimi.ai/docs",
+											title: "Kimi Docs",
+											text: "Context caching documentation",
+										},
+									],
+								},
+							},
+						],
+						usage: { prompt_tokens: 120, completion_tokens: 25, total_tokens: 145 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+		};
+
+		const authStorage = {
+			getApiKey: () => Promise.resolve("sk-moonshot-test-key"),
+			hasAuth: () => true,
+		} as unknown as AuthStorage;
+
+		const response = await searchMoonshot({
+			query: "Tell me about Moonshot context caching",
+			systemPrompt: "You are a web search helper.",
+			authStorage,
+			fetch: fetchImpl,
+		});
+
+		expect(capturedRequests).toHaveLength(2);
+		expect(capturedRequests[0]?.url).toBe("https://api.moonshot.ai/v1/chat/completions");
+		expect(capturedRequests[0]?.headers.get("Authorization")).toBe("Bearer sk-moonshot-test-key");
+		expect(capturedRequests[0]?.body.model).toBe("kimi-k3");
+		expect(capturedRequests[0]?.body.tools).toEqual([
+			{
+				type: "builtin_function",
+				function: { name: "$web_search" },
+			},
+		]);
+
+		// Verify turn 2 request carried assistant reasoning and tool result
+		const step2Messages = capturedRequests[1]?.body.messages as Array<Record<string, unknown>>;
+		expect(step2Messages).toHaveLength(4); // system, user, assistant (tool_calls), tool
+		expect(step2Messages[2]?.reasoning_content).toBe("Thinking about searching Moonshot caching...");
+		expect(step2Messages[3]).toEqual({
+			role: "tool",
+			tool_call_id: "call_search_1",
+			name: "$web_search",
+			content: JSON.stringify({ query: "Moonshot AI Context Caching" }),
+		});
+
+		expect(response.answer).toBe("Moonshot AI Context Caching optimizes repeated prompt tokens.");
+		expect(response.model).toBe("kimi-k3");
+		expect(response.searchQueries).toEqual(["Moonshot AI Context Caching"]);
+		expect(response.sources).toEqual([
+			{
+				title: "Kimi Docs",
+				url: "https://platform.kimi.ai/docs",
+				snippet: "Context caching documentation",
+			},
+		]);
+		expect(response.usage).toEqual({ inputTokens: 120, outputTokens: 25 });
+	});
+
+	it("honors MOONSHOT_BASE_URL and MOONSHOT_SEARCH_MODEL overrides", async () => {
+		Bun.env.MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1/";
+		Bun.env.MOONSHOT_SEARCH_MODEL = "kimi-k2.6";
+
+		let capturedUrl = "";
+		let capturedModel = "";
+
+		const fetchImpl: FetchImpl = (input, init) => {
+			capturedUrl = typeof input === "string" ? input : input.toString();
+			const bodyText = typeof init?.body === "string" ? init.body : "";
+			const body = JSON.parse(bodyText) as { model: string };
+			capturedModel = body.model;
+
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						model: "kimi-k2.6",
+						choices: [{ finish_reason: "stop", message: { content: "Done" } }],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+		};
+
+		const authStorage = {
+			getApiKey: () => Promise.resolve("sk-china-key"),
+			hasAuth: () => true,
+		} as unknown as AuthStorage;
+
+		const response = await searchMoonshot({
+			query: "test override",
+			systemPrompt: "sys",
+			authStorage,
+			fetch: fetchImpl,
+		});
+
+		expect(capturedUrl).toBe("https://api.moonshot.cn/v1/chat/completions");
+		expect(capturedModel).toBe("kimi-k2.6");
+		expect(response.answer).toBe("Done");
+	});
+
+	it("throws 401 SearchProviderError when API key is missing", async () => {
+		delete Bun.env.MOONSHOT_API_KEY;
+		const authStorage = {
+			getApiKey: () => Promise.resolve(undefined),
+			hasAuth: () => false,
+		} as unknown as AuthStorage;
+
+		await expect(
+			searchMoonshot({
+				query: "test",
+				systemPrompt: "sys",
+				authStorage,
+			}),
+		).rejects.toThrow(SearchProviderError);
+	});
+
+	it("classifies HTTP 401 errors using classifyProviderHttpError", async () => {
+		const fetchImpl: FetchImpl = () =>
+			Promise.resolve(new Response("Unauthorized key", { status: 401, headers: { "Content-Type": "text/plain" } }));
+
+		const authStorage = {
+			getApiKey: () => Promise.resolve("invalid-key"),
+			hasAuth: () => true,
+		} as unknown as AuthStorage;
+
+		try {
+			await searchMoonshot({
+				query: "test 401",
+				systemPrompt: "sys",
+				authStorage,
+				fetch: fetchImpl,
+			});
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(SearchProviderError);
+			expect((err as SearchProviderError).status).toBe(401);
+			expect((err as SearchProviderError).message).toContain("401 unauthorized");
+		}
+	});
+
+	it("MoonshotProvider delegates isAvailable to authStorage.hasAuth('moonshot')", () => {
+		const provider = new MoonshotProvider();
+		const hasAuthMock = vi.fn((prov: string) => prov === "moonshot");
+		const authStorage = { hasAuth: hasAuthMock } as unknown as AuthStorage;
+
+		expect(provider.isAvailable(authStorage)).toBe(true);
+		expect(hasAuthMock).toHaveBeenCalledWith("moonshot");
+	});
+});


### PR DESCRIPTION
## Summary

- add a distinct `moonshot` web-search provider backed by Moonshot Open Platform's official `moonshot/web-search:latest` Formula
- fetch the Formula tool declaration, execute returned calls through `/fibers`, and replay protected output unchanged for Kimi synthesis
- keep Moonshot Open Platform credentials and model configuration separate from Kimi Code search
- use low K3 reasoning effort for search routing and one 60-second deadline across the complete Formula loop

## Testing

- `bun check:ts`
- `bun test packages/coding-agent/test/web/search/` (59 passed)
- live Open Platform `/tools` → chat tool calls → `/fibers` → encrypted output replay → final answer
- `bun run dev` cmux smoke test with `providers.webSearch: moonshot`; Moonshot returned the current Bun release successfully

Closes #5765