### PR TITLE
feat: optionally render MCP results as Markdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added an opt-in `mcp.renderMarkdownResults` setting that renders non-JSON MCP text results as Markdown in the terminal transcript.
+
 ### Fixed
 
 - Fixed the setup wizard hiding the selected row on short terminals (e.g. 24x80): the provider sign-in, theme, and web-search lists now fit their windows to the visible height, and decorative chrome (sign-in hint, theme mock preview) yields to the list when space is tight.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3945,6 +3945,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"mcp.renderMarkdownResults": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "MCP Markdown Results",
+			description: "Render non-JSON MCP text results as Markdown in the transcript",
+		},
+	},
+
 	"mcp.notifications": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/mcp/render.ts
+++ b/packages/coding-agent/src/mcp/render.ts
@@ -4,9 +4,10 @@
  * Provides structured display of MCP tool calls and results,
  * showing args and output in JSON tree format similar to task tool.
  */
-import type { Component } from "@oh-my-pi/pi-tui";
+import { type Component, Markdown } from "@oh-my-pi/pi-tui";
+import { settings } from "../config/settings";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
-import type { Theme } from "../modes/theme/theme";
+import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
 import {
 	formatArgsInline,
 	JSON_TREE_MAX_DEPTH_COLLAPSED,
@@ -48,6 +49,61 @@ export function renderMCPCall(args: Record<string, unknown>, theme: Theme, label
 	);
 }
 
+/** Render an MCP status/args prefix followed by Markdown-aware text output. */
+function renderMarkdownMCPResult(
+	result: { details?: MCPToolDetails; isError?: boolean },
+	trimmedOutput: string,
+	truncationWarning: string | null,
+	options: RenderResultOptions,
+	theme: Theme,
+	args?: Record<string, unknown>,
+): Component {
+	const markdown = new Markdown(trimmedOutput, 0, 0, getMarkdownTheme(), {
+		color: text => theme.fg("toolOutput", text),
+	});
+	return {
+		render(contentWidth: number): readonly string[] {
+			const lines: string[] = [];
+			const isError = result.isError ?? result.details?.isError ?? false;
+			const title = result.details ? `${result.details.serverName}/${result.details.mcpToolName}` : "MCP";
+			lines.push(
+				renderStatusLine(
+					isError ? { icon: "error", title } : { iconOverride: theme.styledSymbol("tool.mcp", "accent"), title },
+					theme,
+				),
+			);
+
+			if (options.expanded && args && Object.keys(args).length > 0) {
+				lines.push(theme.fg("dim", "Args"));
+				const tree = renderJsonTreeLines(
+					args,
+					theme,
+					JSON_TREE_MAX_DEPTH_EXPANDED,
+					JSON_TREE_MAX_LINES_EXPANDED,
+					JSON_TREE_SCALAR_LEN_EXPANDED,
+				);
+				lines.push(...tree.lines);
+				if (tree.truncated) lines.push(theme.fg("dim", "…"));
+				lines.push("");
+			}
+
+			const rendered = markdown.render(Math.max(1, contentWidth));
+			const maxOutputLines = options.expanded ? 12 : 4;
+			lines.push(...rendered.slice(0, maxOutputLines));
+			if (rendered.length > maxOutputLines) {
+				lines.push(
+					`${theme.fg("dim", `… ${rendered.length - maxOutputLines} more lines`)} ${formatExpandHint(theme, options.expanded, true)}`,
+				);
+			} else if (!options.expanded) {
+				lines.push(formatExpandHint(theme, options.expanded, true));
+			}
+			if (truncationWarning) lines.push(truncationWarning);
+			return lines;
+		},
+		invalidate(): void {},
+	};
+}
+
 /**
  * Render MCP tool result.
  */
@@ -58,6 +114,24 @@ export function renderMCPResult(
 	args?: Record<string, unknown>,
 ): Component {
 	const { expanded } = options;
+	const textContent = result.content?.find(c => c.type === "text")?.text ?? "";
+	const trimmedOutput = stripOutputNotice(textContent, result.details?.meta).trimEnd();
+	const truncationWarning = result.details?.meta?.truncation
+		? formatStyledTruncationWarning(result.details.meta, theme)
+		: null;
+	let parsedOutput: unknown;
+	let isJsonOutput = false;
+	if (trimmedOutput.startsWith("{") || trimmedOutput.startsWith("[")) {
+		try {
+			parsedOutput = JSON.parse(trimmedOutput);
+			isJsonOutput = true;
+		} catch {
+			// Non-JSON text beginning with a bracket is still eligible for Markdown.
+		}
+	}
+	if (trimmedOutput && settings.get("mcp.renderMarkdownResults") && !isJsonOutput) {
+		return renderMarkdownMCPResult(result, trimmedOutput, truncationWarning, options, theme, args);
+	}
 	return new WidthAwareText(
 		contentWidth => {
 			const lines: string[] = [];
@@ -86,46 +160,31 @@ export function renderMCPResult(
 				lines.push(""); // Blank line before output
 			}
 
-			// Output section
-			const textContent = result.content?.find(c => c.type === "text")?.text ?? "";
-			// Strip the LLM-facing spill notice before parsing/rendering: a spilled
-			// result appends `[Showing… artifact://N]` to the body, which would break
-			// JSON detection and bury the recovery link. Surface it as a styled warning
-			// instead, mirroring the built-in read/bash/ssh/browser renderers.
-			const trimmedOutput = stripOutputNotice(textContent, result.details?.meta).trimEnd();
-			const truncationWarning = result.details?.meta?.truncation
-				? formatStyledTruncationWarning(result.details.meta, theme)
-				: null;
+			// Output section. The body and spill metadata are normalized before
+			// component selection so the opt-in Markdown path can use its own renderer.
 
 			if (!trimmedOutput) {
 				lines.push(theme.fg("dim", "(no output)"));
 				return lines.join("\n");
 			}
 
-			// Try to parse as JSON for structured display
-			if (trimmedOutput.startsWith("{") || trimmedOutput.startsWith("[")) {
-				try {
-					const parsed = JSON.parse(trimmedOutput);
-					const maxDepth = expanded ? JSON_TREE_MAX_DEPTH_EXPANDED : JSON_TREE_MAX_DEPTH_COLLAPSED;
-					const maxLines = expanded ? JSON_TREE_MAX_LINES_EXPANDED : JSON_TREE_MAX_LINES_COLLAPSED;
-					const maxScalarLen = expanded ? JSON_TREE_SCALAR_LEN_EXPANDED : JSON_TREE_SCALAR_LEN_COLLAPSED;
-					const tree = renderJsonTreeLines(parsed, theme, maxDepth, maxLines, maxScalarLen);
+			// Preserve the existing structured JSON renderer regardless of the
+			// Markdown preference; JSON trees remain more useful than styled source.
+			if (isJsonOutput) {
+				const maxDepth = expanded ? JSON_TREE_MAX_DEPTH_EXPANDED : JSON_TREE_MAX_DEPTH_COLLAPSED;
+				const maxLines = expanded ? JSON_TREE_MAX_LINES_EXPANDED : JSON_TREE_MAX_LINES_COLLAPSED;
+				const maxScalarLen = expanded ? JSON_TREE_SCALAR_LEN_EXPANDED : JSON_TREE_SCALAR_LEN_COLLAPSED;
+				const tree = renderJsonTreeLines(parsedOutput, theme, maxDepth, maxLines, maxScalarLen);
 
-					if (tree.lines.length > 0) {
-						for (const line of tree.lines) {
-							lines.push(line);
-						}
-						// Always show expand hint when collapsed (expanded view shows longer values and deeper nesting)
-						if (!expanded) {
-							lines.push(formatExpandHint(theme, expanded, true));
-						} else if (tree.truncated) {
-							lines.push(theme.fg("dim", "…"));
-						}
-						if (truncationWarning) lines.push(truncationWarning);
-						return lines.join("\n");
+				if (tree.lines.length > 0) {
+					lines.push(...tree.lines);
+					if (!expanded) {
+						lines.push(formatExpandHint(theme, expanded, true));
+					} else if (tree.truncated) {
+						lines.push(theme.fg("dim", "…"));
 					}
-				} catch {
-					// Fall through to raw output
+					if (truncationWarning) lines.push(truncationWarning);
+					return lines.join("\n");
 				}
 			}
 

--- a/packages/coding-agent/src/modes/components/tool-execution.test.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.test.ts
@@ -1,7 +1,9 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
-import { Settings } from "../../config/settings";
+import { Settings, settings } from "../../config/settings";
+import { renderMCPResult } from "../../mcp/render";
+import type { MCPToolDetails } from "../../mcp/tool-bridge";
 import { getThemeByName, setThemeInstance, theme } from "../theme/theme";
 import { ToolExecutionComponent, type ToolExecutionUi } from "./tool-execution";
 
@@ -24,6 +26,10 @@ describe("ToolExecutionComponent custom renderer failures", () => {
 		const loaded = await getThemeByName("dark");
 		if (!loaded) throw new Error("theme unavailable");
 		setThemeInstance(loaded);
+	});
+
+	afterEach(() => {
+		settings.set("mcp.renderMarkdownResults", false);
 	});
 
 	it("falls back to the custom tool label when a renderCall child component throws during render", () => {
@@ -97,5 +103,60 @@ describe("ToolExecutionComponent custom renderer failures", () => {
 			text = visibleText(component.render(80));
 		}).not.toThrow();
 		expect(text).toContain(rawResultText);
+	});
+});
+
+describe("MCP result Markdown rendering", () => {
+	const details: MCPToolDetails = {
+		serverName: "context-mode",
+		mcpToolName: "ctx_search",
+	};
+
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("theme unavailable");
+		setThemeInstance(loaded);
+	});
+
+	afterEach(() => {
+		settings.set("mcp.renderMarkdownResults", false);
+	});
+
+	it("keeps Markdown syntax literal by default", () => {
+		const component = renderMCPResult(
+			{ content: [{ type: "text", text: "**bold result**" }], details },
+			{ expanded: true, isPartial: false },
+			theme,
+		);
+
+		expect(visibleText(component.render(80))).toContain("**bold result**");
+	});
+
+	it("renders inline Markdown when the opt-in setting is enabled", () => {
+		settings.set("mcp.renderMarkdownResults", true);
+		const component = renderMCPResult(
+			{ content: [{ type: "text", text: "**bold result** and `code`" }], details },
+			{ expanded: true, isPartial: false },
+			theme,
+		);
+		const rendered = visibleText(component.render(80));
+
+		expect(rendered).toContain("bold result and code");
+		expect(rendered).not.toContain("**bold result**");
+		expect(rendered).not.toContain("`code`");
+	});
+
+	it("preserves structured JSON rendering when Markdown is enabled", () => {
+		settings.set("mcp.renderMarkdownResults", true);
+		const component = renderMCPResult(
+			{ content: [{ type: "text", text: '{"status":"**ok**"}' }], details },
+			{ expanded: true, isPartial: false },
+			theme,
+		);
+		const rendered = visibleText(component.render(80));
+
+		expect(rendered).toContain("status");
+		expect(rendered).toContain("**ok**");
 	});
 });


### PR DESCRIPTION
## What

Add an opt-in `mcp.renderMarkdownResults` setting. When enabled, non-JSON MCP text results render through OMP's Markdown component while retaining the existing MCP status header, expanded arguments, line caps, expand hint, and spill warning. Structured JSON continues to use the JSON tree renderer.

## Why

This was observed while heavily using the [context-mode](https://github.com/mksglu/context-mode) MCP server: its search and execution tools intentionally return Markdown-formatted summaries, but OMP currently displays the source markers literally. The issue applies generally to MCP servers that return Markdown. Keeping this disabled by default preserves current behavior while allowing users who trust their MCP output formatting to enable richer transcript rendering.

## Testing

- `bun test packages/coding-agent/src/modes/components/tool-execution.test.ts` — 5 passed
- `bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit`
- `bunx biome check packages/coding-agent/src/mcp/render.ts packages/coding-agent/src/config/settings-schema.ts packages/coding-agent/src/modes/components/tool-execution.test.ts`
- Regression coverage verifies default literal output, opt-in inline Markdown rendering, and unchanged JSON tree rendering.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)