### PR TITLE
fix(rpc): await background model discovery in get_available_models, set_model, and deferred --model resolution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Fixed
 
 - Fixed the setup wizard hiding the selected row on short terminals (e.g. 24x80): the provider sign-in, theme, and web-search lists now fit their windows to the visible height, and decorative chrome (sign-in hint, theme mock preview) yields to the list when space is tight.
+- Fixed `get_available_models` and `set_model` RPCs racing background model discovery on cold start by awaiting the in-flight refresh before reading the registry. RPC/ACP clients that query the catalog or select a model immediately after session ready previously saw only statically-bundled models until discovery completed seconds later.
+- Fixed deferred `--model <provider>/<pattern>` CLI resolution failing on cold start with "Model not found" when the selector pointed at a discovery-backed provider (proxy / ollama / lm-studio / llama.cpp / litellm). The deferred retry now runs a cache-aware discovery pass before resolving, mirroring the default-role fallback's cold-cache race fix (issues #6114, #6162).
 
 ## [17.0.8] - 2026-07-22
 

--- a/packages/coding-agent/src/config/__tests__/model-registry.test.ts
+++ b/packages/coding-agent/src/config/__tests__/model-registry.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "../model-registry";
+
+/**
+ * Stub AuthStorage that satisfies the surface used by ModelRegistry's
+ * constructor (#loadModels → clearConfigApiKeys, constructor →
+ * setFallbackResolver). The awaiter under test never reaches auth-gated code
+ * paths, so no real credential store is required.
+ */
+function createStubAuthStorage(): AuthStorage {
+	const stub = {
+		setFallbackResolver: () => {},
+		clearConfigApiKeys: () => {},
+		hasAuth: () => false,
+	};
+	return stub as unknown as AuthStorage;
+}
+
+describe("ModelRegistry.awaitBackgroundRefresh", () => {
+	let tmpDir: string;
+	let registry: ModelRegistry;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(path.join(os.tmpdir(), "omp-reg-"));
+		// Construct with an explicit modelsPath inside the temp dir so the
+		// constructor's #loadModels read returns "not-found" rather than
+		// touching the host's ~/.omp/agent/models.yaml. isBunTestRuntime()
+		// auto-stubs #fetch in the constructor.
+		registry = new ModelRegistry(createStubAuthStorage(), path.join(tmpDir, "models.yaml"));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("resolves immediately when no background refresh is in flight", async () => {
+		// No refreshInBackground() called → #backgroundRefresh is undefined.
+		// The awaiter must settle within a single microtask, never hanging.
+		let settled = false;
+		const p = registry.awaitBackgroundRefresh().then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		await p;
+		expect(settled).toBe(true);
+	});
+
+	test("blocks until the in-flight background refresh resolves, then resolves", async () => {
+		// Drive refreshInBackground with a controlled refresh() return value so
+		// #backgroundRefresh is captured but not yet settled.
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const refreshSpy = vi.spyOn(registry, "refresh").mockReturnValue(promise);
+
+		registry.refreshInBackground();
+		expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+		let settled = false;
+		const awaitPromise = registry.awaitBackgroundRefresh().then(() => {
+			settled = true;
+		});
+
+		// Yield to the microtask queue: the awaiter must still be pending.
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		expect(settled).toBe(false);
+
+		resolve();
+
+		await awaitPromise;
+		expect(settled).toBe(true);
+	});
+
+	test("resolves even when the underlying refresh rejects (refreshInBackground swallows)", async () => {
+		// refreshInBackground wraps refresh() in .catch(...) so discovery errors
+		// never reach awaitBackgroundRefresh callers. The awaiter must resolve,
+		// not propagate the rejection.
+		const { promise, reject } = Promise.withResolvers<void>();
+		vi.spyOn(registry, "refresh").mockReturnValue(promise);
+
+		registry.refreshInBackground();
+
+		let settled = false;
+		const awaitPromise = registry.awaitBackgroundRefresh().then(() => {
+			settled = true;
+		});
+
+		reject(new Error("synthetic discovery failure"));
+
+		await awaitPromise;
+		expect(settled).toBe(true);
+	});
+
+	test("awaiter is a no-op after the in-flight refresh settles and clears #backgroundRefresh", async () => {
+		// Once refreshInBackground's promise resolves, #backgroundRefresh is
+		// cleared in the .finally. A subsequent awaitBackgroundRefresh must be
+		// an immediate no-op (microtask), not hang waiting for a stale promise
+		// or a second refresh that was never started.
+		const { promise, resolve } = Promise.withResolvers<void>();
+		vi.spyOn(registry, "refresh").mockReturnValue(promise);
+
+		registry.refreshInBackground();
+		resolve();
+		await registry.awaitBackgroundRefresh();
+
+		// Now #backgroundRefresh is cleared. A fresh await must resolve in a
+		// single microtask — measure by asserting it settles before a second
+		// microtask tick.
+		let settled = false;
+		const p = registry.awaitBackgroundRefresh().then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(true);
+		await p;
+	});
+
+	test("refreshInBackground deduplicates: a second call while in-flight starts no new refresh", async () => {
+		// The guard `if (this.#backgroundRefresh) return` at the top of
+		// refreshInBackground prevents concurrent refreshes. A second call
+		// while the first is still pending must not invoke refresh() again.
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const refreshSpy = vi.spyOn(registry, "refresh").mockReturnValue(promise);
+
+		registry.refreshInBackground();
+		registry.refreshInBackground();
+		registry.refreshInBackground();
+
+		expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+		resolve();
+		await registry.awaitBackgroundRefresh();
+
+		// After settle, #backgroundRefresh is cleared — a new call DOES start
+		// a fresh refresh.
+		const { promise: secondPromise, resolve: secondResolve } = Promise.withResolvers<void>();
+		refreshSpy.mockReturnValue(secondPromise);
+		registry.refreshInBackground();
+		expect(refreshSpy).toHaveBeenCalledTimes(2);
+
+		secondResolve();
+		await registry.awaitBackgroundRefresh();
+	});
+});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -869,6 +869,28 @@ export class ModelRegistry {
 		this.#backgroundRefresh = refreshPromise;
 	}
 
+	/**
+	 * Wait for any in-flight background model discovery to settle.
+	 *
+	 * Background discovery started by {@link refreshInBackground} is
+	 * fire-and-forget; RPC consumers (e.g. `get_available_models`,
+	 * `set_model`) and deferred `--model` resolution that read the registry
+	 * immediately after session creation can otherwise observe a partial
+	 * catalog before discovery-backed providers have populated `#models`.
+	 * Awaiting the tracked promise ensures the response reflects every
+	 * configured provider once the initial background refresh resolves.
+	 *
+	 * No-op when no refresh is in flight (`#backgroundRefresh` cleared in the
+	 * `finally` of `refreshInBackground` on completion). Resolves immediately
+	 * in that case so already-warm sessions are unaffected. Discovery errors
+	 * remain swallowed by `refreshInBackground`'s existing `.catch`.
+	 */
+	async awaitBackgroundRefresh(): Promise<void> {
+		if (this.#backgroundRefresh) {
+			await this.#backgroundRefresh;
+		}
+	}
+
 	async refreshProvider(providerId: string, strategy: ModelRefreshStrategy = "online"): Promise<void> {
 		this.#reloadStaticModels();
 		for (const selector of this.#suppressedSelectors.keys()) {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1122,8 +1122,19 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "set_model": {
-				const models = session.getAvailableModels();
-				const model = models.find(m => m.provider === command.provider && m.id === command.modelId);
+				let models = session.getAvailableModels();
+				let model = models.find(m => m.provider === command.provider && m.id === command.modelId);
+				if (!model) {
+					// Model not in the current catalog. Wait for in-flight
+					// background discovery before declaring it missing: on cold
+					// start, discovery-backed providers (proxy / ollama / etc.)
+					// populate seconds after session ready. Models already in
+					// the bundled catalog skip this await entirely so the RPC
+					// queue is not stalled behind unrelated discovery.
+					await session.modelRegistry.awaitBackgroundRefresh();
+					models = session.getAvailableModels();
+					model = models.find(m => m.provider === command.provider && m.id === command.modelId);
+				}
 				if (!model) {
 					return error(id, "set_model", `Model not found: ${command.provider}/${command.modelId}`);
 				}
@@ -1140,6 +1151,7 @@ export async function runRpcMode(
 			}
 
 			case "get_available_models": {
+				await session.modelRegistry.awaitBackgroundRefresh();
 				const models = session.getAvailableModels();
 				return success(id, "get_available_models", { models });
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2026,8 +2026,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// the background.
 		await modelRegistry.refreshRuntimeProviders("offline");
 		// Continue runtime discovery in the background (cache-aware) so startup is
-		// only blocked on local cache reads, not provider network fetches.
-		void modelRegistry.refreshRuntimeProviders().catch(error => {
+		// only blocked on local cache reads, not provider network fetches. Stash
+		// the promise so the deferred `--model` retry below can await it instead
+		// of starting a second concurrent discovery pass (the unfiltered
+		// `refresh()` also covers runtime model managers).
+		const runtimeDiscoveryPromise = modelRegistry.refreshRuntimeProviders().catch(error => {
 			logger.warn("runtime provider discovery failed", {
 				error: error instanceof Error ? error.message : String(error),
 			});
@@ -2076,6 +2079,29 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// registered. Use the same CLI resolver as the immediate path so bare role
 		// names, exact model names, and provider selectors keep one precedence rule.
 		if (!model && deferredModelPatterns.length > 0) {
+			// Deferred `--model` patterns almost always failed at the immediate
+			// path (main.ts:881) precisely because discovery-backed providers
+			// hadn't populated yet. Await the in-flight runtime discovery
+			// already kicked off above (stash + reuse avoids a second concurrent
+			// `#refreshRuntimeDiscoveries` pass for the same runtime model
+			// managers). `refreshRuntimeProviders()` only covers runtime model
+			// managers, not config-discovery providers (e.g. user-configured
+			// ollama); fall back to a full cache-aware refresh only when the
+			// runtime pass didn't surface a match. By then runtime managers
+			// short-circuit on the fresh cache written by the awaited pass,
+			// closing the double-fetch window.
+			if (modelRegistry.getDiscoverableProviders().length > 0) {
+				await logger.time("resolveModelDiscoveryDeferredRetry", () => runtimeDiscoveryPromise);
+				const availableModelsAfterRuntime = modelRegistry.getAll();
+				const runtimeResolved = deferredModelPatterns.some(pattern =>
+					availableModelsAfterRuntime.some(m => `${m.provider}/${m.id}` === pattern),
+				);
+				if (!runtimeResolved) {
+					await logger.time("resolveModelDiscoveryFallbackNonRuntime", () =>
+						modelRegistry.refresh("online-if-uncached"),
+					);
+				}
+			}
 			const availableModels = modelRegistry.getAll();
 			const matchPreferences = getModelMatchPreferences(settings);
 			const expandedModelPatterns = deferredModelPatterns.flatMap(pattern =>


### PR DESCRIPTION
## What
Fixes three cold-start read paths that queried the model registry before background discovery settled:
1. `get_available_models` RPC (`rpc-mode.ts`): returned only statically-bundled models.
2. `set_model` RPC (`rpc-mode.ts`): rejected discovery-backed selectors with "Model not found".
3. `--model <provider>/<pattern>` CLI deferred retry (`sdk.ts:2078`): exited 1 with "Model not found".

## Why
Session startup kicks off model discovery via `ModelRegistry.refreshInBackground()` (fire-and-forget) AFTER `createAgentSession` returns (main.ts:1406). Any code reading the registry before discovery settles sees a partial catalog. `omp models` CLI is unaffected because it awaits `modelRegistry.refresh()` directly before listing.

Affects any RPC/ACP consumer and any discovery-backed provider (`proxy` / `ollama` / `lm-studio` / `llama.cpp` / `litellm`).

Context: #6244

## Relationship to existing cold-cache fix (issues #6114, #6162)
The cold-cache race for the default-role fallback path (`sdk.ts:2343`) was already fixed with an inline `await modelRegistry.refresh("online-if-uncached")` call. That is correct for that path because the fallback runs INSIDE `createAgentSession`, BEFORE `main.ts` fires `refreshInBackground()`. The foreground refresh resolves before the background one starts, so they are sequential.

This PR extends the same race fix to three additional read paths that were not covered. The RPC handlers need a different mechanism because they run AFTER the background refresh is already in flight: calling `refresh()` directly would start a second refresh concurrent with the in-flight one (`refresh()` has no dedup guard; only `refreshInBackground()` does).

| Path | Runs when | Fix |
|---|---|---|
| `get_available_models` RPC | After background refresh fired | Await the in-flight promise via `awaitBackgroundRefresh()` |
| `set_model` RPC | Same as above | Same as above |
| Deferred `--model` retry (`sdk.ts:2078`) | Inside `createAgentSession`, before background fired | Inline `refresh("online-if-uncached")`, matching #6114 / #6162 |

`awaitBackgroundRefresh()` exposes the existing `#backgroundRefresh` promise already tracked and cleared by `refreshInBackground`. No second refresh is started; the RPC handler synchronizes on the discovery that `main.ts` already kicked off.

## Reproduction
Configure any discovery-backed provider in `~/.omp/agent/models.yaml`, then:

```bash
cd ~
{
  sleep 1
  printf '%s\n' '{"id":"m1","type":"get_available_models"}'
  sleep 5
} | timeout 15 omp --mode rpc-ui --approval-mode yolo 2>/dev/null \
  | grep '"id":"m1"' | jq '.data.models | {count: length, providers: ([.[].provider]|unique)}'
```

The response omits the discovery-backed provider on cold start. Increasing the pre-RPC sleep to ~8s returns the full list without the patch, confirming it is a race rather than a filter.

Same race reproduces via:

```bash
omp --mode rpc-ui --model <discovery-provider>/<model-id> --approval-mode yolo
# exits 1: "Model \"...\" not found"
```

## Behavioral characteristics
* Warm-session fast path preserved: when no refresh is in flight, `await undefined` resolves in a microtask.
* Failure isolation preserved: `refreshInBackground()` already swallows discovery errors via `.catch(...)`, so `awaitBackgroundRefresh()` resolves even when discovery fails.
* No double-refresh: RPC handlers synchronize on the in-flight promise rather than starting a second foreground refresh.
* Scoped: does not change `refreshInBackground()` semantics.

## Testing
5 unit tests in `packages/coding-agent/src/config/__tests__/model-registry.test.ts`:
* no-op when no refresh in flight
* blocks until refresh settles
* resolves when refresh rejects (error swallowed)
* no-op after refresh settles and clears
* dedup of concurrent `refreshInBackground` calls

All green. `bun run check:types` and biome clean. Independent code review surfaced no deadlocks, re-entrancy issues, or new races. One pre-existing issue noted for a separate follow-up: RPC handlers (`set_model`, `get_available_models`, `cycle_model`) serialize the full `Model` object, which can include `headers` containing credentials (e.g. `Authorization: Bearer ...`). Not introduced by this PR, but the wider catalog reach after the fix increases exposure. Out of scope here, will file separately.

## Changes (5 files, ~213 lines)
* `packages/coding-agent/src/config/model-registry.ts`: new `awaitBackgroundRefresh()` method
* `packages/coding-agent/src/modes/rpc/rpc-mode.ts`: await in `get_available_models` and `set_model`
* `packages/coding-agent/src/sdk.ts`: inline `refresh("online-if-uncached")` in deferred `--model` retry
* `packages/coding-agent/src/config/__tests__/model-registry.test.ts`: 5 unit tests
* `packages/coding-agent/CHANGELOG.md`

***
* [x] `bun check` passes
* [x] Tested locally
* [x] CHANGELOG updated
