### PR TITLE
feat(task): allow per-call model selection

### DIFF
--- a/docs/task-agent-discovery.md
+++ b/docs/task-agent-discovery.md
@@ -122,14 +122,24 @@ In spawn execution (`TaskTool.#executeSync` → `#runSpawn`):
 
 `TaskTool.create()` builds the tool description from discovery results at initialization time. `#executeSync` rediscovers agents, so the runtime set can differ from what was listed in the earlier tool description if agent files changed mid-session. The async entry path still uses the initialization-time list to decide whether an agent is marked `blocking` before scheduling.
 
-## Structured-output guardrails and schema precedence
+## Model and structured-output precedence
 
-Runtime output schema precedence in `TaskTool.#runSpawn`:
+Runtime model precedence is resolved by `resolveEffectiveSubagentPolicy()`:
 
-1. agent frontmatter `output`
-2. parent session `outputSchema`
+1. the task item's explicit `model` selector or fallback chain
+2. `task.agentModelOverrides[agentName]`
+3. agent frontmatter `model`
+4. the parent session model fallback
 
-(`effectiveOutputSchema = effectiveAgent.output ?? this.session.outputSchema` — the task call itself never carries a schema; ad-hoc structured workflows go through the eval bridge's `agent(prompt, schema)`.)
+Reasoning suffixes such as `:high` are preserved. The task tool rejects blank, empty-array, and comma-only per-call selectors before policy resolution so they cannot bypass a configured agent override.
+
+Runtime output schema precedence is:
+
+1. the task item's explicit `outputSchema`
+2. agent frontmatter `output`
+3. parent session `outputSchema`
+
+The task item's optional `schemaMode` overrides the parent session mode; the default is `permissive`.
 
 The model-facing prompt (`src/prompts/tools/task.md`) no longer carries the old structured-output mismatch warning; it tags read-only agents and warns against offloading reasoning to `scout`/`sonic` instead.
 

--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -26,9 +26,9 @@
 
 ## Inputs
 
-The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ name?, agent?, task, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
+The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ name?, agent?, task, model?, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
 
-- **Batch shape** (`task.batch` on): `{ context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules; there is no top-level agent field. `context` is **required** shared background rendered into every spawned subagent's system prompt (`CONTEXT` section); `agent` and `isolated` are per item, so one call may mix agent types.
+- **Batch shape** (`task.batch` on): `{ context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules; there is no top-level agent field. `context` is **required** shared background rendered into every spawned subagent's system prompt (`CONTEXT` section); `agent`, `model`, and `isolated` are per item, so one call may mix agent types and models.
 - **Flat shape** (`task.batch` off): `{ ...item }` — exactly one spawn per call. Shared background goes into a `local://` file (e.g. `local://ctx.md`) that each spawn's `task` references; subagents share the parent's `local://` root.
 
 | Field | Type | Required | Description |
@@ -38,6 +38,7 @@ The wire schema is shape-swapped by `task.batch` (default on). One unit of work 
 | `name` | `string` | No | Stable agent name — becomes the registry/IRC id. Defaults to a generated AdjectiveNoun name. Uniquified per session by `AgentOutputManager`. Item field in batch shape, top-level in flat shape. |
 | `agent` | `string` | No | Agent type to run this item (e.g. `scout`). Defaults to the spawn policy's default agent (usually `task`); items in one batch call may use different agent types. Item field in batch shape, top-level in flat shape. |
 | `task` | `string` | Yes | The work — complete, self-contained instructions. Empty-after-trim is rejected. Item field in batch shape, top-level in flat shape. |
+| `model` | `string \| string[]` | No | Explicit non-empty model selector or non-empty fallback chain for this spawn. Optional `:reasoning` suffixes are preserved. Takes precedence over `task.agentModelOverrides` and agent frontmatter. Item field in batch shape, top-level in flat shape. |
 | `isolated` | `boolean` | No | Run in an isolated workspace and return patches. Exists only when `task.isolation.mode` is not `none`; per item in batch shape, top-level in flat shape. Isolated agents are torn down at completion — not revivable. |
 
 There is no wire label field: the one-line UI label shown in the TUI/registry is generated automatically from the `task` text by the tiny/title model (fire-and-forget), so callers never provide it.
@@ -84,7 +85,7 @@ Artifacts and side channels:
    - a mixed call registers the async jobs first, then runs its blocking items inline and returns once they settle — the text combines the inline summaries with the spawned-job listing, and the block keeps rendering the still-running background rows beside the inline results.
 5. `#executeSync(...)` runs the spawn path (`#runSpawn`), which rediscovers agents from disk, so runtime resolution can differ from the create-time description.
 6. It resolves each spawn's requested `agent` type, rejects unknown or settings-disabled agents, and enforces parent spawn policy plus `PI_BLOCKED_AGENT` self-recursion prevention.
-7. Output schema priority: agent frontmatter `output` → inherited parent session schema (the call itself never carries one).
+7. Model priority: per-call `model` → `task.agentModelOverrides` → agent frontmatter → configured task role/session fallback. Output schema priority: per-call `outputSchema` → agent frontmatter `output` → inherited parent session schema.
 8. Plan mode swaps in an `effectiveAgent` with a read-only tool subset and plan-mode prompt; `runSubprocess(...)` receives the effective agent.
 9. If `isolated`, it requires a git repo (`getRepoRoot(...)` / `captureBaseline(...)`), maps `task.isolation.mode` to a backend-kind hint (`parseIsolationMode`), and materializes the workspace via the natives PAL (`ensureIsolation` → `isoResolve`/`isoStart`), walking the candidate list when a backend is unavailable.
 10. Artifacts dir comes from the parent session file when available, otherwise a temp dir. When the session is executing an approved plan, the plan reference is handed to the subagent.

--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -26,9 +26,9 @@
 
 ## Inputs
 
-The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ name?, agent?, task, model?, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
+The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ name?, agent?, task, model?, outputSchema?, schemaMode?, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
 
-- **Batch shape** (`task.batch` on): `{ context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules; there is no top-level agent field. `context` is **required** shared background rendered into every spawned subagent's system prompt (`CONTEXT` section); `agent`, `model`, and `isolated` are per item, so one call may mix agent types and models.
+- **Batch shape** (`task.batch` on): `{ context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules; there is no top-level agent field. `context` is **required** shared background rendered into every spawned subagent's system prompt (`CONTEXT` section); `agent`, `model`, `outputSchema`, `schemaMode`, and `isolated` are per item, so one call may mix agent types, models, and output contracts.
 - **Flat shape** (`task.batch` off): `{ ...item }` — exactly one spawn per call. Shared background goes into a `local://` file (e.g. `local://ctx.md`) that each spawn's `task` references; subagents share the parent's `local://` root.
 
 | Field | Type | Required | Description |
@@ -39,13 +39,15 @@ The wire schema is shape-swapped by `task.batch` (default on). One unit of work 
 | `agent` | `string` | No | Agent type to run this item (e.g. `scout`). Defaults to the spawn policy's default agent (usually `task`); items in one batch call may use different agent types. Item field in batch shape, top-level in flat shape. |
 | `task` | `string` | Yes | The work — complete, self-contained instructions. Empty-after-trim is rejected. Item field in batch shape, top-level in flat shape. |
 | `model` | `string \| string[]` | No | Explicit non-empty model selector or non-empty fallback chain for this spawn. Optional `:reasoning` suffixes are preserved. Takes precedence over `task.agentModelOverrides` and agent frontmatter. Item field in batch shape, top-level in flat shape. |
+| `outputSchema` | JSON Schema object | No | Invocation-specific structured-output contract. Takes precedence over agent frontmatter `output` and the inherited parent session schema. Item field in batch shape, top-level in flat shape. |
+| `schemaMode` | `"permissive" \| "strict"` | No | Validation mode for the effective output schema. Overrides the parent session mode; defaults to `permissive`. Item field in batch shape, top-level in flat shape. |
 | `isolated` | `boolean` | No | Run in an isolated workspace and return patches. Exists only when `task.isolation.mode` is not `none`; per item in batch shape, top-level in flat shape. Isolated agents are torn down at completion — not revivable. |
 
 There is no wire label field: the one-line UI label shown in the TUI/registry is generated automatically from the `task` text by the tiny/title model (fire-and-forget), so callers never provide it.
 
 Runtime stays permissive: the flat form is accepted even while `task.batch` is on (internal callers such as the commit flow's `analyze_files`, and stale transcripts). The model only ever sees one shape.
 
-There is no per-call `schema` parameter. Structured output comes from the agent definition's `output` frontmatter, the inherited parent session schema, or — for ad-hoc workflows — the eval bridge's `agent(prompt, schema)`.
+There is no legacy per-call `schema` parameter. Use `outputSchema` and optional `schemaMode`; when absent, structured output falls back to the agent definition's `output` frontmatter and then the inherited parent session schema.
 
 ## Outputs
 
@@ -75,7 +77,7 @@ Artifacts and side channels:
 
 ## Flow
 1. `TaskTool.create(...)` discovers agents once per cwd through a process-level memo (`discoverAgentsForCreate`) to render the dynamic prompt description.
-2. `execute(...)` repairs raw params (`repairTaskParams`), then validates: `schema` is always rejected; `tasks`/`context` are rejected unless `task.batch` is on; batch calls need a non-empty `tasks` (a `task` per item, unique provided names), a non-empty shared `context`, and no top-level `task` alongside `tasks`; flat calls need `task`. The call is then normalized into its spawn list (`resolveSpawnItems`).
+2. `execute(...)` repairs raw params (`repairTaskParams`), then validates: `schema` is always rejected; model selectors that normalize to no patterns are rejected; `tasks`/`context` are rejected unless `task.batch` is on; batch calls need a non-empty `tasks` (a `task` per item, unique provided names), a non-empty shared `context`, and no top-level `task` alongside `tasks`; flat calls need `task`. The call is then normalized into its spawn list (`resolveSpawnItems`).
 3. Per-item execution split: items whose agent type declares `blocking: true` run inline; the rest become background jobs. The whole call runs sync when `async.enabled=false`, the session has no `AsyncJobManager` (orphaned host), or every item is blocking; inline spawns run through `#executeSync(...)` under the session-scoped semaphore.
 4. Background execution (any non-blocking item with `async.enabled=true` and an `AsyncJobManager`):
    - agent ids are allocated up front via `AgentOutputManager.allocate(...)` — each item's `name`, or a generated AdjectiveNoun name — one per spawn;
@@ -104,7 +106,7 @@ Artifacts and side channels:
   - Background job — `async.enabled=true`; non-blocking spawns go through `AsyncJobManager`.
   - Sync inline — `async.enabled=false`, no job manager, or the item's agent declares `blocking: true` (per item: a mixed call runs both modes).
 - Batch mode (`task.batch`, default on)
-  - on — `{ context, tasks[] }`: one independent spawn per item, required `context` shared across the call's spawns, `agent`/`isolated` per item. Lifecycle, revival, and concurrency semantics match N parallel single calls.
+  - on — `{ context, tasks[] }`: one independent spawn per item, required `context` shared across the call's spawns, with `agent`, `model`, `outputSchema`, `schemaMode`, and `isolated` per item. Lifecycle, revival, and concurrency semantics match N parallel single calls.
   - off — single spawn per call; `tasks`/`context` are rejected and removed from the schema.
 - Isolation mode (`task.isolation.mode`): `none`, `auto`, `apfs`, `btrfs`, `zfs`, `reflink`, `overlayfs`, `projfs`, `block-clone`, `rcopy` (legacy `worktree`, `fuse-overlay`, `fuse-projfs` accepted for back-compat); the PAL resolves the actual backend with fallback.
 - Isolation merge strategy: patch mode (capture/apply root patches) or branch mode (commit to `omp/task/<id>`, cherry-pick into parent).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added per-call `model` selection to the `task` tool, including per-item batch selectors, fallback chains, and explicit reasoning suffixes.
+
 ### Fixed
 
 - Fixed the setup wizard hiding the selected row on short terminals (e.g. 24x80): the provider sign-in, theme, and web-search lists now fit their windows to the visible height, and decorative chrome (sign-in hint, theme mock preview) yields to the list when space is tight.

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -22,6 +22,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
+  - `model`: Explicit non-empty model selector or non-empty fallback chain for this spawn. A `:reasoning` suffix is preserved. Overrides agent-specific model settings.
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
   - `schemaMode`: `"permissive"` (default) accepts a retry-exhausted invalid result with a warning; `"strict"` fails it.
 {{#if isolationEnabled}}
@@ -31,6 +32,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
 - `agent`: The agent type to spawn (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
+- `model`: Explicit non-empty model selector or non-empty fallback chain for this spawn. A `:reasoning` suffix is preserved. Overrides agent-specific model settings.
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
 - `schemaMode`: `"permissive"` (default) accepts a retry-exhausted invalid result with a warning; `"strict"` fails it.
 {{#if isolationEnabled}}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -229,6 +229,16 @@ function validateShapeParams(batchEnabled: boolean, params: TaskParams): string 
  * policy later, in `spawnParamsFor`. Returns a problem description, or
  * undefined when valid.
  */
+function hasInvalidModelSelector(model: unknown): boolean {
+	if (model === undefined) return false;
+	const selectors = typeof model === "string" ? [model] : Array.isArray(model) ? model : undefined;
+	return (
+		!selectors ||
+		selectors.length === 0 ||
+		selectors.some(selector => typeof selector !== "string" || !selector.split(",").some(pattern => pattern.trim()))
+	);
+}
+
 function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string | undefined {
 	const hasTask = typeof params.task === "string" && params.task.trim() !== "";
 	const tasks = params.tasks;
@@ -243,6 +253,9 @@ function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string 
 			const item = tasks[i];
 			if (!item || typeof item.task !== "string" || item.task.trim() === "") {
 				return `Task ${i + 1}${item?.name ? ` (\`${item.name}\`)` : ""} is missing \`task\`. Every task needs complete, self-contained instructions.`;
+			}
+			if (hasInvalidModelSelector(item.model)) {
+				return `Task ${i + 1}${item.name ? ` (\`${item.name}\`)` : ""} has an invalid \`model\`. Provide a non-empty selector or a non-empty array of non-empty selectors.`;
 			}
 		}
 		const seen = new Map<string, string>();
@@ -266,6 +279,9 @@ function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string 
 			? "Missing `tasks`. Provide a `tasks` array (one subagent per item) with a shared `context`."
 			: "Missing `task`. Provide complete, self-contained instructions for the agent.";
 	}
+	if (hasInvalidModelSelector(params.model)) {
+		return "Invalid `model`. Provide a non-empty selector or a non-empty array of non-empty selectors.";
+	}
 	return undefined;
 }
 
@@ -279,7 +295,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
 		return params.tasks;
 	}
-	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task };
+	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task, model: params.model };
 	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
 	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
 	if ("isolated" in params) item.isolated = params.isolated;
@@ -299,6 +315,7 @@ function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string
 	const spawn: TaskParams = { agent: item.agent?.trim() || defaultAgent };
 	if (item.name !== undefined) spawn.name = item.name;
 	if (item.task !== undefined) spawn.task = item.task;
+	if (item.model !== undefined) spawn.model = item.model;
 	if (params.context !== undefined) spawn.context = params.context;
 	if ("outputSchema" in item) spawn.outputSchema = item.outputSchema;
 	if ("schemaMode" in item) spawn.schemaMode = item.schemaMode;
@@ -469,6 +486,14 @@ function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
 	return pending;
 }
 
+function formatModelForApproval(model: unknown): string | undefined {
+	const selectors = typeof model === "string" ? [model] : Array.isArray(model) ? model : [];
+	const normalized = selectors.filter(
+		(selector): selector is string => typeof selector === "string" && !!selector.trim(),
+	);
+	return normalized.length > 0 ? truncateForPrompt(normalized.join(" → ")) : undefined;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Tool Class
 // ═══════════════════════════════════════════════════════════════════════════
@@ -492,6 +517,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (typeof params.name === "string" && params.name.trim()) {
 			lines.push(`Name: ${truncateForPrompt(params.name)}`);
 		}
+		const model = formatModelForApproval(params.model);
+		if (model) lines.push(`Model: ${model}`);
 		if (typeof params.task === "string") {
 			lines.push(`Task:\n${truncateForPrompt(params.task)}`);
 		}
@@ -507,6 +534,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (typeof firstTask.agent === "string" && firstTask.agent.trim()) {
 				lines.push(`Agent: ${truncateForPrompt(firstTask.agent)}`);
 			}
+			const itemModel = formatModelForApproval(firstTask.model);
+			if (itemModel) lines.push(`Model: ${itemModel}`);
 			if (typeof firstTask.task === "string") {
 				lines.push(`Task:\n${truncateForPrompt(firstTask.task)}`);
 			}
@@ -612,6 +641,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			assignment: (params.task ?? "").trim(),
 			context: this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined,
 			agent: params.agent,
+			model: params.model,
 			...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 			...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 			...("isolated" in params ? { isolation: { requested: params.isolated } } : {}),
@@ -1383,6 +1413,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				assignment,
 				context,
 				agent: params.agent,
+				model: params.model,
 				...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 				...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 				identity: { id: preAllocatedId, label: params.name },

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -232,10 +232,13 @@ function validateShapeParams(batchEnabled: boolean, params: TaskParams): string 
 function hasInvalidModelSelector(model: unknown): boolean {
 	if (model === undefined) return false;
 	const selectors = typeof model === "string" ? [model] : Array.isArray(model) ? model : undefined;
+	const materializedSelectors = selectors ? Array.from(selectors) : [];
 	return (
 		!selectors ||
-		selectors.length === 0 ||
-		selectors.some(selector => typeof selector !== "string" || !selector.split(",").some(pattern => pattern.trim()))
+		materializedSelectors.length === 0 ||
+		materializedSelectors.some(
+			selector => typeof selector !== "string" || !selector.split(",").some(pattern => pattern.trim()),
+		)
 	);
 }
 

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -113,6 +113,7 @@ export const taskItemSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
@@ -121,6 +122,7 @@ const taskItemSchemaIsolated = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
@@ -135,6 +137,8 @@ export interface TaskItem {
 	agent?: string;
 	/** The work; required by the schema. */
 	task?: string;
+	/** Explicit model selector or fallback chain for this spawn, including optional reasoning suffixes. */
+	model?: string | string[];
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
 	outputSchema?: unknown;
 	/** Validation behavior for a caller-provided or inherited output schema. */
@@ -147,6 +151,7 @@ export const taskSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
@@ -156,6 +161,7 @@ const taskSchemaNoIsolation = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
@@ -200,6 +206,7 @@ function createTaskSchema(options: {
 				"name?": "string",
 				agent,
 				task: "string",
+				"model?": "string | string[]",
 				"outputSchema?": outputSchemaInputSchema,
 				"schemaMode?": '"permissive" | "strict"',
 				"isolated?": "boolean",
@@ -215,6 +222,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
+			"model?": "string | string[]",
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
 			"+": "delete",
@@ -230,6 +238,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
+			"model?": "string | string[]",
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
 			"isolated?": "boolean",
@@ -240,6 +249,7 @@ function createTaskSchema(options: {
 		"name?": "string",
 		agent,
 		task: "string",
+		"model?": "string | string[]",
 		"outputSchema?": outputSchemaInputSchema,
 		"schemaMode?": '"permissive" | "strict"',
 		"+": "delete",
@@ -283,6 +293,8 @@ export interface TaskParams {
 	agent?: string;
 	/** The work (flat form). */
 	task?: string;
+	/** Explicit model selector or fallback chain for the spawn, including optional reasoning suffixes. */
+	model?: string | string[];
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
 	outputSchema?: unknown;
 	/** Validation behavior for a caller-provided or inherited output schema. */

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -215,17 +215,20 @@ describe("task.batch validation", () => {
 		expect(text).toContain("Missing `context`");
 	});
 
-	it("rejects an empty per-item model selector", async () => {
-		const text = await executeText(
-			{
-				context: "Background.",
-				tasks: [{ name: "Alpha", task: "Work.", model: [","] }],
-			},
-			{ "task.batch": true },
-		);
-		expect(text).toContain("Task 1 (`Alpha`) has an invalid `model`");
-		expect(text).toContain("non-empty array");
-	});
+	it.each([{ model: [","] }, { model: Array<string>(1) }])(
+		"rejects an empty per-item model selector",
+		async ({ model }) => {
+			const text = await executeText(
+				{
+					context: "Background.",
+					tasks: [{ name: "Alpha", task: "Work.", model }],
+				},
+				{ "task.batch": true },
+			);
+			expect(text).toContain("Task 1 (`Alpha`) has an invalid `model`");
+			expect(text).toContain("non-empty array");
+		},
+	);
 
 	it("rejects duplicate provided names case-insensitively", async () => {
 		const text = await executeText(

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -2,7 +2,7 @@
  * Contracts: task.batch gating (batch spawning + shared context).
  *
  * 1. The wire schema is shape-swapped by `task.batch`: `{ context, tasks[] }`
- *    when on (per-spawn fields — including `isolated`, `outputSchema`, and
+ *    when on (per-spawn fields — including `model`, `isolated`, `outputSchema`, and
  *    `schemaMode` — live in the items), the flat form exposes those fields
  *    directly. The stale `schema` field is never accepted.
  * 2. Shape validation rejects stale `schema`, `tasks`/`context` while batch
@@ -101,6 +101,7 @@ describe("task.batch schema gating", () => {
 		expect(offProperties.context).toBeUndefined();
 		expect(offProperties.task).toBeDefined();
 		expect(offProperties.name).toBeDefined();
+		expect(offProperties.model).toBeDefined();
 		expect(offProperties.outputSchema).toBeDefined();
 		expect(typeof offProperties.outputSchema).toBe("object");
 		expect(offProperties.schemaMode).toBeDefined();
@@ -114,12 +115,14 @@ describe("task.batch schema gating", () => {
 		expect(onProperties.task).toBeUndefined();
 		expect(onProperties.name).toBeUndefined();
 		expect(onProperties.agent).toBeUndefined();
+		expect(onProperties.model).toBeUndefined();
 		expect(onProperties.outputSchema).toBeUndefined();
 		expect(onProperties.schemaMode).toBeUndefined();
 		const items = (onProperties.tasks as { items?: { properties?: Record<string, unknown> } }).items;
 		expect(items?.properties?.task).toBeDefined();
 		expect(items?.properties?.name).toBeDefined();
 		expect(items?.properties?.agent).toBeDefined();
+		expect(items?.properties?.model).toBeDefined();
 		expect(items?.properties?.outputSchema).toBeDefined();
 		expect(typeof items?.properties?.outputSchema).toBe("object");
 		expect(items?.properties?.schemaMode).toBeDefined();
@@ -212,6 +215,18 @@ describe("task.batch validation", () => {
 		expect(text).toContain("Missing `context`");
 	});
 
+	it("rejects an empty per-item model selector", async () => {
+		const text = await executeText(
+			{
+				context: "Background.",
+				tasks: [{ name: "Alpha", task: "Work.", model: [","] }],
+			},
+			{ "task.batch": true },
+		);
+		expect(text).toContain("Task 1 (`Alpha`) has an invalid `model`");
+		expect(text).toContain("non-empty array");
+	});
+
 	it("rejects duplicate provided names case-insensitively", async () => {
 		const text = await executeText(
 			{
@@ -269,7 +284,7 @@ describe("task.batch spawning", () => {
 		AgentRegistry.resetGlobalForTests();
 	});
 
-	it("spawns one background job per task item and forwards independent schemas with shared context", async () => {
+	it("spawns one background job per task item and forwards independent models and schemas with shared context", async () => {
 		mockDiscovery({
 			...taskAgent,
 			output: { type: "object", properties: { staleAgentOutput: { type: "boolean" } } },
@@ -279,6 +294,7 @@ describe("task.batch spawning", () => {
 			context?: string;
 			assignment?: string;
 			parentAgentId?: string;
+			modelOverride?: string | string[];
 			outputSchema?: unknown;
 			outputSchemaMode?: "permissive" | "strict";
 			outputSchemaSource?: "caller" | "agent" | "session" | "none";
@@ -290,6 +306,7 @@ describe("task.batch spawning", () => {
 				context: options.context,
 				assignment: options.assignment,
 				parentAgentId: options.parentAgentId,
+				modelOverride: options.modelOverride,
 				outputSchema: options.outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				outputSchemaSource: options.outputSchemaSource,
@@ -307,8 +324,20 @@ describe("task.batch spawning", () => {
 		const result = await tool.execute("tc-batch", {
 			context: "# Goal\nShared background.",
 			tasks: [
-				{ name: "Alpha", task: "Do A.", outputSchema: alphaSchema, schemaMode: "strict" },
-				{ name: "Beta", task: "Do B.", outputSchema: betaSchema, schemaMode: "permissive" },
+				{
+					name: "Alpha",
+					task: "Do A.",
+					model: "openai-codex/gpt-5.6-sol:high",
+					outputSchema: alphaSchema,
+					schemaMode: "strict",
+				},
+				{
+					name: "Beta",
+					task: "Do B.",
+					model: ["anthropic/claude-sonnet-4-6:medium", "openai-codex/gpt-5.6-sol:low"],
+					outputSchema: betaSchema,
+					schemaMode: "permissive",
+				},
 			],
 		} as TaskParams);
 
@@ -333,10 +362,15 @@ describe("task.batch spawning", () => {
 			expect(spawn.outputSchemaOverridesAgent).toBe(true);
 		}
 		const byId = new Map(seen.map(spawn => [spawn.id, spawn]));
+		expect(byId.get("Alpha")?.modelOverride).toEqual(["openai-codex/gpt-5.6-sol:high"]);
 		expect(byId.get("Alpha")?.outputSchema).toEqual(alphaSchema);
 		expect(byId.get("Alpha")?.outputSchemaMode).toBe("strict");
 		expect(byId.get("Beta")?.outputSchema).toEqual(betaSchema);
 		expect(byId.get("Beta")?.outputSchemaMode).toBe("permissive");
+		expect(byId.get("Beta")?.modelOverride).toEqual([
+			"anthropic/claude-sonnet-4-6:medium",
+			"openai-codex/gpt-5.6-sol:low",
+		]);
 		expect(seen.map(spawn => spawn.assignment).sort()).toEqual(["Do A.", "Do B."]);
 		for (const spawn of seen) expect(spawn.parentAgentId).toBe("ParentA");
 	});

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -403,9 +403,14 @@ describe("task.batch spawning", () => {
 	it("accepts the flat single-spawn form at runtime under batch mode", async () => {
 		// Internal callers (e.g. the commit flow) and stale transcripts use the
 		// flat shape directly; the wire schema is batch-only but runtime is not.
-		mockDiscovery({ ...taskAgent, output: { type: "object", properties: { agent: { type: "string" } } } });
+		mockDiscovery({
+			...taskAgent,
+			model: ["anthropic/claude-sonnet-4"],
+			output: { type: "object", properties: { agent: { type: "string" } } },
+		});
 		let captured:
 			| {
+					modelOverride?: string | string[];
 					outputSchema?: unknown;
 					outputSchemaMode?: "permissive" | "strict";
 					outputSchemaSource?: "caller" | "agent" | "session" | "none";
@@ -414,6 +419,7 @@ describe("task.batch spawning", () => {
 			| undefined;
 		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
 			captured = {
+				modelOverride: options.modelOverride,
 				outputSchema: options.outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				outputSchemaSource: options.outputSchemaSource,
@@ -424,7 +430,14 @@ describe("task.batch spawning", () => {
 
 		const manager = createManager();
 		const tool = await TaskTool.create(
-			createSession({ manager, settings: { "async.enabled": true, "task.batch": true } }),
+			createSession({
+				manager,
+				settings: {
+					"async.enabled": true,
+					"task.batch": true,
+					"task.agentModelOverrides": { task: "openai/gpt-4.1-mini" },
+				},
+			}),
 		);
 
 		const callerSchema = { type: "object", properties: { caller: { type: "number" } } };
@@ -432,6 +445,7 @@ describe("task.batch spawning", () => {
 			agent: "task",
 			name: "Flat",
 			task: "Do the thing.",
+			model: ["openai-codex/gpt-5.6-sol:high", "anthropic/claude-sonnet-4:low"],
 			outputSchema: callerSchema,
 			schemaMode: "strict",
 		} as TaskParams);
@@ -440,6 +454,7 @@ describe("task.batch spawning", () => {
 		const job = manager.getJob(result.details!.async!.jobId)!;
 		await job.promise;
 		expect(job.status).toBe("completed");
+		expect(captured?.modelOverride).toEqual(["openai-codex/gpt-5.6-sol:high", "anthropic/claude-sonnet-4:low"]);
 		expect(captured?.outputSchema).toEqual(callerSchema);
 		expect(captured?.outputSchemaMode).toBe("strict");
 		expect(captured?.outputSchemaSource).toBe("caller");

--- a/packages/coding-agent/test/task/task-schema.test.ts
+++ b/packages/coding-agent/test/task/task-schema.test.ts
@@ -94,6 +94,7 @@ describe("task spawn validation", () => {
 		{ model: "," },
 		{ model: " , " },
 		{ model: [] },
+		{ model: Array<string>(1) },
 		{ model: ["openai-codex/gpt-5.6-sol:high", " "] },
 		{ model: ["openai-codex/gpt-5.6-sol:high", ","] },
 	])("rejects an empty model selector", async ({ model }) => {

--- a/packages/coding-agent/test/task/task-schema.test.ts
+++ b/packages/coding-agent/test/task/task-schema.test.ts
@@ -7,7 +7,7 @@ import { type } from "arktype";
 
 // Contract: the single-spawn schema (`task.batch: false`; the exported
 // `taskSchema` instance) carries no batch fields while accepting a caller
-// `outputSchema` and its validation mode. The batch shape (`tasks[]` + shared
+// `model`, `outputSchema`, and its validation mode. The batch shape (`tasks[]` + shared
 // `context`) is gated by the `task.batch` setting (default on, covered by
 // test/task/task-batch.test.ts).
 
@@ -30,11 +30,12 @@ describe("task schema (single-spawn)", () => {
 		expect(parsed instanceof type.errors).toBe(true);
 	});
 
-	it("retains caller outputSchema and schemaMode while stripping stale keys", () => {
+	it("retains caller model, outputSchema, and schemaMode while stripping stale keys", () => {
 		const outputSchema = { type: "object", properties: { answer: { type: "string" } } };
 		const parsed = taskSchema({
 			agent: "scout",
 			task: "Map the auth module.",
+			model: "openai-codex/gpt-5.6-sol:high",
 			outputSchema,
 			schemaMode: "strict",
 			context: "shared background",
@@ -43,6 +44,7 @@ describe("task schema (single-spawn)", () => {
 		});
 		expect(parsed instanceof type.errors).toBe(false);
 		if (!(parsed instanceof type.errors)) {
+			expect(parsed.model).toBe("openai-codex/gpt-5.6-sol:high");
 			expect(parsed.outputSchema).toEqual(outputSchema);
 			expect(parsed.schemaMode).toBe("strict");
 			expect("tasks" in parsed).toBe(false);
@@ -84,5 +86,19 @@ describe("task spawn validation", () => {
 	it("rejects a missing task", async () => {
 		const text = await executeText({ agent: "scout" });
 		expect(text).toContain("Missing `task`");
+	});
+
+	it.each([
+		{ model: "" },
+		{ model: " " },
+		{ model: "," },
+		{ model: " , " },
+		{ model: [] },
+		{ model: ["openai-codex/gpt-5.6-sol:high", " "] },
+		{ model: ["openai-codex/gpt-5.6-sol:high", ","] },
+	])("rejects an empty model selector", async ({ model }) => {
+		const text = await executeText({ agent: "scout", task: "Map the auth module.", model });
+		expect(text).toContain("Invalid `model`");
+		expect(text).toContain("non-empty selector");
 	});
 });

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -107,7 +107,7 @@ describe("task spawn routing", () => {
 
 	it("returns immediately on spawn and delivers the follow-up hint when the job completes", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
-			agents: [taskAgent],
+			agents: [{ ...taskAgent, model: ["anthropic/claude-sonnet-4"] }],
 			projectAgentsDir: null,
 		});
 		const gate = deferred();
@@ -117,12 +117,15 @@ describe("task spawn routing", () => {
 		});
 
 		const manager = createManager();
-		const tool = await TaskTool.create(createSession({ manager }));
+		const tool = await TaskTool.create(
+			createSession({ manager, settings: { "task.agentModelOverrides": { task: "openai/gpt-4.1-mini" } } }),
+		);
 
 		const result = await tool.execute("tc-spawn", {
 			agent: "task",
 			name: "Spawnling",
 			task: "Do the thing.",
+			model: "openai-codex/gpt-5.6-sol:high",
 		} as TaskParams);
 
 		// Tool returned while the job body is still gated on the deferred.
@@ -143,6 +146,7 @@ describe("task spawn routing", () => {
 		expect(job!.resultText).toContain("message it via `hub` to follow up");
 		expect(job!.resultText).toContain("history://Spawnling");
 		expect(runSpy).toHaveBeenCalledTimes(1);
+		expect(runSpy.mock.calls[0]?.[0].modelOverride).toEqual(["openai-codex/gpt-5.6-sol:high"]);
 	});
 
 	it("bounds concurrent job bodies with the session spawn semaphore", async () => {

--- a/packages/coding-agent/test/task/wire-schema.test.ts
+++ b/packages/coding-agent/test/task/wire-schema.test.ts
@@ -118,15 +118,17 @@ describe("task approval details surface the dispatch", () => {
 		} as unknown as ToolSession);
 	}
 
-	it("surfaces agent, name, and task for a flat spawn", async () => {
+	it("surfaces agent, name, model, and task for a flat spawn", async () => {
 		const tool = await makeTool();
 		const lines = tool.formatApprovalDetails({
 			agent: "reviewer",
 			name: "ReviewAuth",
+			model: "openai-codex/gpt-5.6-sol:high",
 			task: "audit the auth module",
 		});
 		expect(lines).toContain("Agent: reviewer");
 		expect(lines).toContain("Name: ReviewAuth");
+		expect(lines).toContain("Model: openai-codex/gpt-5.6-sol:high");
 		expect(lines).toContain("Task:\naudit the auth module");
 	});
 
@@ -134,11 +136,20 @@ describe("task approval details surface the dispatch", () => {
 		const tool = await makeTool();
 		const lines = tool.formatApprovalDetails({
 			context: "shared background",
-			tasks: [{ name: "DbMigrator", agent: "sonic", task: "migrate the schema" }, { task: "second item" }],
+			tasks: [
+				{
+					name: "DbMigrator",
+					agent: "sonic",
+					model: ["anthropic/claude-sonnet-4", "openai/gpt-5"],
+					task: "migrate the schema",
+				},
+				{ task: "second item" },
+			],
 		});
 		expect(lines).toContain("Context:\nshared background");
 		expect(lines).toContain("Name: DbMigrator");
 		expect(lines).toContain("Agent: sonic");
+		expect(lines).toContain("Model: anthropic/claude-sonnet-4 → openai/gpt-5");
 		expect(lines).toContain("Task:\nmigrate the schema");
 		expect(lines).toContain("+1 more task");
 	});


### PR DESCRIPTION
## What

- Adds an optional `model` field to the `task` tool's flat and per-item batch schemas.
- Routes a string selector or fallback-chain array through preflight and execution using the existing structured-subagent model resolver.
- Preserves explicit reasoning suffixes and documents precedence over agent-specific model configuration.
- Rejects selectors that normalize to no model patterns and shows the requested model in execution-approval details.
- Adds schema and async batch execution coverage, task prompt/reference documentation, and a changelog entry.

## Why

Orchestrators can carry an effect-specific model requirement, but the task wire schema currently deletes that selector and silently falls back to the configured agent model. Per-call routing lets the caller preserve that requirement without mutating session or project configuration.

> Per-call model override makes sense—Babysitter owns the execution model. Don’t pin a role that affects every task.

Related integration report: a5c-ai/babysitter#1578.

## Testing

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)

Exact exercised scenario:

- Parsed a flat task call with `model: "openai-codex/gpt-5.6-sol:high"` and verified the selector survives the wire schema.
- Executed an asynchronous two-item task batch with independent selectors (a suffixed string and a two-model fallback chain) and verified the existing subprocess boundary received the exact resolved `modelOverride` arrays for both workers.
- Focused schema, batch-routing, and approval tests: 42 passed.
- Broad task suite: 323 passed. One unrelated git-worktree fixture exceeded its fixed 5-second timeout while the Databricks pre-commit hook ran; the exact test passed on immediate targeted rerun with a 15-second timeout.
