### PR TITLE
feat(status-line): add a balance segment for API-key provider accounts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -270,6 +270,9 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
+### Added
+
+- Added a `balance` status-line segment reporting the remaining account balance for API-key providers such as DeepSeek. It only fetches when the segment is actually configured, resolves the key against a strictly parsed `api.deepseek.com`, and owns its cache by model object so switching provider or model cannot leave a stale figure on screen ([#6361](https://github.com/can1357/oh-my-pi/pull/6361)).
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `balance` status-line segment reporting the remaining account balance for API-key providers such as DeepSeek. It only fetches when the segment is actually configured, resolves the key against a strictly parsed `api.deepseek.com`, and owns its cache by the active model plus AuthStorage's credential generation, so a provider switch, a model switch, a `/login` or a logout retires the previous account's figure ahead of the cache TTL ([#6361](https://github.com/can1357/oh-my-pi/pull/6361)).
+
 ## [17.4.0] - 2026-08-20
 
 ### Added
@@ -270,9 +274,6 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
-### Added
-
-- Added a `balance` status-line segment reporting the remaining account balance for API-key providers such as DeepSeek. It only fetches when the segment is actually configured, resolves the key against a strictly parsed `api.deepseek.com`, and owns its cache by model object so switching provider or model cannot leave a stale figure on screen ([#6361](https://github.com/can1357/oh-my-pi/pull/6361)).
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -237,6 +237,7 @@ export type StatusLineSegmentId =
 	| "cache_hit"
 	| "session_name"
 	| "usage"
+	| "balance"
 	| "collab";
 
 /** Submenu choice metadata. */

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1385,6 +1385,7 @@ export class StatusLineComponent implements Component {
 			if (this.#cachedBalance !== null) this.#cachedBalance = null;
 			return;
 		}
+		this.#balanceInFlight = true;
 		this.#balanceTimer = setTimeout(() => {
 			this.#balanceTimer = null;
 			void this.#runBalanceRefresh(session);

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1379,9 +1379,12 @@ export class StatusLineComponent implements Component {
 		if (this.#balanceFetchedAt > 0 && now - this.#balanceFetchedAt < STATUS_BALANCE_REFRESH_MS) return;
 
 		const provider = session.state.model?.provider ?? session.model?.provider;
-		if (provider !== "deepseek") return;
-
-		this.#balanceInFlight = true;
+		if (provider !== "deepseek") {
+			// Clear stale balance when switching away from DeepSeek (the
+			// session cache invalidation may fire after the next render).
+			if (this.#cachedBalance !== null) this.#cachedBalance = null;
+			return;
+		}
 		this.#balanceTimer = setTimeout(() => {
 			this.#balanceTimer = null;
 			void this.#runBalanceRefresh(session);
@@ -1418,16 +1421,20 @@ export class StatusLineComponent implements Component {
 			headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
 			signal,
 		});
-		if (!resp.ok) return null;
-
-		const json = (await resp.json()) as { balance_infos?: Array<{ total_balance?: string }> };
-		const total = parseFloat(json?.balance_infos?.[0]?.total_balance ?? "");
+		const json = (await resp.json()) as {
+			balance_infos?: Array<{ total_balance?: string; currency?: string }>;
+		};
+		const info = json?.balance_infos?.[0];
+		const total = parseFloat(info?.total_balance ?? "");
 		if (Number.isNaN(total)) return null;
+
+		const currencySymbol: Record<string, string> = { CNY: "¥", USD: "$", EUR: "€", GBP: "£" };
+		const symbol = currencySymbol[info?.currency ?? ""] ?? (info?.currency ?? "¥");
 
 		// Colour-code inline: green >50, yellow >10, red <=10
 		const G = "\x1b[32m", Y = "\x1b[33m", R = "\x1b[31m", E = "\x1b[0m";
 		const color = total > 50 ? G : total > 10 ? Y : R;
-		return `${color}¥${total.toFixed(2)}${E}`;
+		return `${color}${symbol}${total.toFixed(2)}${E}`;
 	}
 
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Model, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import {
 	type Component,
 	type ComposerStyle,
@@ -454,6 +454,7 @@ export class StatusLineComponent implements Component {
 	#onCodexResetFireworks: ((event: CodexResetFireworksEvent) => void) | undefined;
 	// API-key provider balance caching (e.g. DeepSeek)
 	#cachedBalance: string | null = null;
+	#balanceModel: Model | null = null;
 	#balanceFetchedAt = 0;
 	#balanceInFlight = false;
 	#balanceTimer: Timer | null = null;
@@ -787,6 +788,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#balanceTimer) return;
 		clearTimeout(this.#balanceTimer);
 		this.#balanceTimer = null;
+		this.#balanceInFlight = false;
 	}
 
 	invalidate(): void {
@@ -810,6 +812,7 @@ export class StatusLineComponent implements Component {
 		this.#usageFetchedAt = 0;
 		this.#usageInFlight = false;
 		this.#cachedBalance = null;
+		this.#balanceModel = null;
 		this.#balanceFetchedAt = 0;
 		this.#balanceInFlight = false;
 		this.#contextUsageCache = undefined;
@@ -1373,49 +1376,68 @@ export class StatusLineComponent implements Component {
 	 * {@link refreshUsageInBackground}.
 	 */
 	refreshBalanceInBackground(): void {
-		const now = Date.now();
 		const session = this.session;
-		if (this.#balanceInFlight || this.#balanceTimer) return;
-		if (this.#balanceFetchedAt > 0 && now - this.#balanceFetchedAt < STATUS_BALANCE_REFRESH_MS) return;
-
-		const provider = session.state.model?.provider ?? session.model?.provider;
-		if (provider !== "deepseek") {
-			// Clear stale balance when switching away from DeepSeek (the
-			// session cache invalidation may fire after the next render).
-			if (this.#cachedBalance !== null) this.#cachedBalance = null;
+		const model = session.state.model ?? session.model;
+		if (model?.provider !== "deepseek") {
+			// Model switches happen within the same session and do not invalidate
+			// these caches. Clear before the TTL guard so a fresh DeepSeek balance
+			// is never rendered under the next provider.
+			this.#clearBalanceTimer();
+			this.#cachedBalance = null;
+			this.#balanceModel = null;
+			this.#balanceFetchedAt = 0;
 			return;
 		}
+		if (this.#balanceModel !== null && this.#balanceModel !== model) {
+			this.#cachedBalance = null;
+			this.#balanceModel = null;
+			this.#balanceFetchedAt = 0;
+		}
+		if (this.#balanceInFlight || this.#balanceTimer) return;
+		const now = Date.now();
+		if (this.#balanceFetchedAt > 0 && now - this.#balanceFetchedAt < STATUS_BALANCE_REFRESH_MS) return;
+
 		this.#balanceInFlight = true;
 		this.#balanceTimer = setTimeout(() => {
 			this.#balanceTimer = null;
-			void this.#runBalanceRefresh(session);
+			void this.#runBalanceRefresh(session, model);
 		}, 0);
 	}
 
-	async #runBalanceRefresh(session: AgentSession): Promise<void> {
-		if (this.#disposed || this.session !== session) {
+	async #runBalanceRefresh(session: AgentSession, model: Model): Promise<void> {
+		if (this.#disposed || this.session !== session || (session.state.model ?? session.model) !== model) {
 			this.#balanceInFlight = false;
 			return;
 		}
 		try {
-			const balance = await this.#fetchDeepSeekBalance(session);
-			if (this.#disposed || this.session !== session) return;
+			const balance = await this.#fetchDeepSeekBalance(session, model);
+			if (this.#disposed || this.session !== session || (session.state.model ?? session.model) !== model) return;
 			this.#cachedBalance = balance;
+			this.#balanceModel = model;
 			this.#balanceFetchedAt = Date.now();
 		} catch {
-			if (this.#disposed || this.session !== session) return;
+			if (this.#disposed || this.session !== session || (session.state.model ?? session.model) !== model) return;
 			this.#balanceFetchedAt = Date.now();
 		} finally {
 			if (this.session === session) this.#balanceInFlight = false;
 		}
 	}
 
-	async #fetchDeepSeekBalance(session: AgentSession): Promise<string | null> {
-		const apiKey = await session.modelRegistry?.getApiKey(
-			session.state.model ?? session.model!,
-			session.sessionId,
-		);
-		if (!apiKey) return null;
+	async #fetchDeepSeekBalance(session: AgentSession, model: Model): Promise<string | null> {
+		// A gateway key must never be sent to DeepSeek's public balance endpoint.
+		// Empty uses the first-party default; an explicit URL must have the exact
+		// direct API hostname. Substring matching is unsafe for credential gates.
+		if (model.baseUrl) {
+			let hostname: string;
+			try {
+				hostname = new URL(model.baseUrl).hostname.toLowerCase();
+			} catch {
+				return null;
+			}
+			if (hostname !== "api.deepseek.com") return null;
+		}
+		const apiKey = await session.modelRegistry?.getApiKey(model, session.sessionId);
+		if (!apiKey || (session.state.model ?? session.model) !== model) return null;
 
 		const signal = AbortSignal.timeout(STATUS_BALANCE_FETCH_TIMEOUT_MS);
 		const resp = await fetch("https://api.deepseek.com/user/balance", {
@@ -1430,14 +1452,16 @@ export class StatusLineComponent implements Component {
 		if (Number.isNaN(total)) return null;
 
 		const currencySymbol: Record<string, string> = { CNY: "¥", USD: "$", EUR: "€", GBP: "£" };
-		const symbol = currencySymbol[info?.currency ?? ""] ?? (info?.currency ?? "¥");
+		const symbol = currencySymbol[info?.currency ?? ""] ?? info?.currency ?? "¥";
 
 		// Colour-code inline: green >50, yellow >10, red <=10
-		const G = "\x1b[32m", Y = "\x1b[33m", R = "\x1b[31m", E = "\x1b[0m";
+		const G = "\x1b[32m",
+			Y = "\x1b[33m",
+			R = "\x1b[31m",
+			E = "\x1b[0m";
 		const color = total > 50 ? G : total > 10 ? Y : R;
 		return `${color}${symbol}${total.toFixed(2)}${E}`;
 	}
-
 
 	async #raceUsageRefreshWithSignal(promise: Promise<unknown>, signal: AbortSignal): Promise<unknown> {
 		if (signal.aborted) throw signal.reason;
@@ -1694,13 +1718,16 @@ export class StatusLineComponent implements Component {
 		includePath: boolean,
 		includeGit: boolean,
 		includePr: boolean,
+		includeBalance: boolean,
 		previewTitle?: string,
 	): SegmentContext {
 		const state = this.session.state;
 
-		// Trigger background fetch (5-min TTL); render uses cached value
+		// Trigger background fetches; render uses cached values. Balance is
+		// opt-in, so default presets must not make authenticated requests that
+		// can never produce visible output.
 		this.refreshUsageInBackground();
-		this.refreshBalanceInBackground();
+		if (includeBalance) this.refreshBalanceInBackground();
 
 		// Get usage statistics
 		const aggregateUsageStats = this.session.sessionManager?.getUsageStatistics() ?? {
@@ -1866,6 +1893,8 @@ export class StatusLineComponent implements Component {
 		const plain = layout !== "box";
 		const includePath =
 			hasPathSegment(effectiveSettings.leftSegments) || hasPathSegment(effectiveSettings.rightSegments);
+		const includeBalance =
+			effectiveSettings.leftSegments.includes("balance") || effectiveSettings.rightSegments.includes("balance");
 		const gitEnabled = this.#gitEnabled();
 		const includeGit =
 			gitEnabled &&
@@ -1878,6 +1907,7 @@ export class StatusLineComponent implements Component {
 			includePath,
 			includeGit,
 			includePr,
+			includeBalance,
 			previewTitle,
 		);
 		const separatorDef = plain

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -34,6 +34,7 @@ import { getSeparator } from "./separators";
 import type {
 	CollabStatus,
 	EffectiveStatusLineSettings,
+	StatusLineBalance,
 	StatusLineSegmentId,
 	StatusLineSegmentOptions,
 	StatusLineSettings,
@@ -453,7 +454,7 @@ export class StatusLineComponent implements Component {
 	#codexResetSnapshots = new Map<string, CodexResetUsageSnapshot>();
 	#onCodexResetFireworks: ((event: CodexResetFireworksEvent) => void) | undefined;
 	// API-key provider balance caching (e.g. DeepSeek)
-	#cachedBalance: string | null = null;
+	#cachedBalance: StatusLineBalance | null = null;
 	#balanceModel: Model | null = null;
 	#balanceFetchedAt = 0;
 	#balanceInFlight = false;
@@ -1412,9 +1413,15 @@ export class StatusLineComponent implements Component {
 		try {
 			const balance = await this.#fetchDeepSeekBalance(session, model);
 			if (this.#disposed || this.session !== session || (session.state.model ?? session.model) !== model) return;
+			// Same reason as #applyUsageRefreshReports: the fetch is async, so
+			// without a repaint the segment stays blank until an unrelated event
+			// (git resolve, keystroke, agent turn) rebuilds the top border.
+			const changed =
+				this.#cachedBalance?.amount !== balance?.amount || this.#cachedBalance?.symbol !== balance?.symbol;
 			this.#cachedBalance = balance;
 			this.#balanceModel = model;
 			this.#balanceFetchedAt = Date.now();
+			if (changed) this.#onBranchChange?.();
 		} catch {
 			if (this.#disposed || this.session !== session || (session.state.model ?? session.model) !== model) return;
 			this.#balanceFetchedAt = Date.now();
@@ -1423,7 +1430,7 @@ export class StatusLineComponent implements Component {
 		}
 	}
 
-	async #fetchDeepSeekBalance(session: AgentSession, model: Model): Promise<string | null> {
+	async #fetchDeepSeekBalance(session: AgentSession, model: Model): Promise<StatusLineBalance | null> {
 		// A gateway key must never be sent to DeepSeek's public balance endpoint.
 		// Empty uses the first-party default; an explicit URL must have the exact
 		// direct API hostname. Substring matching is unsafe for credential gates.
@@ -1453,14 +1460,7 @@ export class StatusLineComponent implements Component {
 
 		const currencySymbol: Record<string, string> = { CNY: "¥", USD: "$", EUR: "€", GBP: "£" };
 		const symbol = currencySymbol[info?.currency ?? ""] ?? info?.currency ?? "¥";
-
-		// Colour-code inline: green >50, yellow >10, red <=10
-		const G = "\x1b[32m",
-			Y = "\x1b[33m",
-			R = "\x1b[31m",
-			E = "\x1b[0m";
-		const color = total > 50 ? G : total > 10 ? Y : R;
-		return `${color}${symbol}${total.toFixed(2)}${E}`;
+		return { symbol, amount: total };
 	}
 
 	async #raceUsageRefreshWithSignal(promise: Promise<unknown>, signal: AbortSignal): Promise<unknown> {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -456,6 +456,7 @@ export class StatusLineComponent implements Component {
 	// API-key provider balance caching (e.g. DeepSeek)
 	#cachedBalance: StatusLineBalance | null = null;
 	#balanceModel: Model | null = null;
+	#balanceAuthGeneration = 0;
 	#balanceFetchedAt = 0;
 	#balanceInFlight = false;
 	#balanceTimer: Timer | null = null;
@@ -815,6 +816,7 @@ export class StatusLineComponent implements Component {
 		this.#cachedBalance = null;
 		this.#balanceModel = null;
 		this.#balanceFetchedAt = 0;
+		this.#balanceAuthGeneration = 0;
 		this.#balanceInFlight = false;
 		this.#contextUsageCache = undefined;
 		this.#lastTokensPerSecond = null;
@@ -1389,7 +1391,20 @@ export class StatusLineComponent implements Component {
 			this.#balanceFetchedAt = 0;
 			return;
 		}
-		if (this.#balanceModel !== null && this.#balanceModel !== model) {
+		// The credential can change while the `Model` object stays identical:
+		// `/login deepseek` stores a key AuthStorage then prefers over an env
+		// or static one, and a logout drops it. Both bump AuthStorage's
+		// generation, so reading it is the cheap synchronous signal that the
+		// cached figure may belong to another account, and it has to precede
+		// the TTL guard or the previous account's balance stays on screen for
+		// five minutes. Credential changes AuthStorage does not own — a
+		// 401/quota sibling rotation, or a `!command` provider key
+		// re-resolving — leave the counter alone and stay TTL-bounded.
+		const authGeneration = session.modelRegistry?.authStorage.getGeneration() ?? 0;
+		if (
+			this.#balanceModel !== null &&
+			(this.#balanceModel !== model || this.#balanceAuthGeneration !== authGeneration)
+		) {
 			this.#cachedBalance = null;
 			this.#balanceModel = null;
 			this.#balanceFetchedAt = 0;
@@ -1401,11 +1416,11 @@ export class StatusLineComponent implements Component {
 		this.#balanceInFlight = true;
 		this.#balanceTimer = setTimeout(() => {
 			this.#balanceTimer = null;
-			void this.#runBalanceRefresh(session, model);
+			void this.#runBalanceRefresh(session, model, authGeneration);
 		}, 0);
 	}
 
-	async #runBalanceRefresh(session: AgentSession, model: Model): Promise<void> {
+	async #runBalanceRefresh(session: AgentSession, model: Model, authGeneration: number): Promise<void> {
 		if (this.#disposed || this.session !== session || (session.state.model ?? session.model) !== model) {
 			this.#balanceInFlight = false;
 			return;
@@ -1420,6 +1435,7 @@ export class StatusLineComponent implements Component {
 				this.#cachedBalance?.amount !== balance?.amount || this.#cachedBalance?.symbol !== balance?.symbol;
 			this.#cachedBalance = balance;
 			this.#balanceModel = model;
+			this.#balanceAuthGeneration = authGeneration;
 			this.#balanceFetchedAt = Date.now();
 			if (changed) this.#onBranchChange?.();
 		} catch {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -275,6 +275,8 @@ interface ActiveMeter {
 const EMPTY_MESSAGES: readonly AgentMessage[] = [];
 const STATUS_USAGE_START_DELAY_MS = 0;
 const STATUS_USAGE_REFRESH_TIMEOUT_MS = 2_000;
+const STATUS_BALANCE_REFRESH_MS = 5 * 60_000; // 5 min TTL
+const STATUS_BALANCE_FETCH_TIMEOUT_MS = 3_000;
 
 function isContextSegment(segment: StatusLineSegmentId): boolean {
 	return segment === "context_pct" || segment === "context_total";
@@ -450,6 +452,11 @@ export class StatusLineComponent implements Component {
 	#latestAppliedUsageRefreshSequence = 0;
 	#codexResetSnapshots = new Map<string, CodexResetUsageSnapshot>();
 	#onCodexResetFireworks: ((event: CodexResetFireworksEvent) => void) | undefined;
+	// API-key provider balance caching (e.g. DeepSeek)
+	#cachedBalance: string | null = null;
+	#balanceFetchedAt = 0;
+	#balanceInFlight = false;
+	#balanceTimer: Timer | null = null;
 	// Context-usage memo. The status line redraws on every agent event, so the
 	// hot path must not recompute context tokens unless an input changed.
 	// `getContextUsage()` anchors on the last assistant's real prompt-token
@@ -741,6 +748,7 @@ export class StatusLineComponent implements Component {
 		this.#clearUsageStartTimer();
 		this.#onCodexResetFireworks = undefined;
 		this.#codexResetSnapshots.clear();
+		this.#clearBalanceTimer();
 		this.#retireGitWatcher();
 	}
 
@@ -775,6 +783,12 @@ export class StatusLineComponent implements Component {
 		this.#usageStartTimer = null;
 	}
 
+	#clearBalanceTimer(): void {
+		if (!this.#balanceTimer) return;
+		clearTimeout(this.#balanceTimer);
+		this.#balanceTimer = null;
+	}
+
 	invalidate(): void {
 		this.#widthEpochRevision++;
 		// Generic repaint invalidation (theme change, message event, model
@@ -791,9 +805,13 @@ export class StatusLineComponent implements Component {
 	}
 	#invalidateSessionCaches(): void {
 		this.#clearUsageStartTimer();
+		this.#clearBalanceTimer();
 		this.#cachedUsage = null;
 		this.#usageFetchedAt = 0;
 		this.#usageInFlight = false;
+		this.#cachedBalance = null;
+		this.#balanceFetchedAt = 0;
+		this.#balanceInFlight = false;
 		this.#contextUsageCache = undefined;
 		this.#lastTokensPerSecond = null;
 		this.#lastTokensPerSecondTimestamp = null;
@@ -1345,6 +1363,74 @@ export class StatusLineComponent implements Component {
 			});
 	}
 
+	// ── API-key provider balance (e.g. DeepSeek) ──
+
+	/**
+	 * Fetch and cache the account balance for the active API-key provider.
+	 * Currently only DeepSeek is supported; other providers no-op.
+	 *
+	 * Runs in the background with a 5-min cache TTL, similar to
+	 * {@link refreshUsageInBackground}.
+	 */
+	refreshBalanceInBackground(): void {
+		const now = Date.now();
+		const session = this.session;
+		if (this.#balanceInFlight || this.#balanceTimer) return;
+		if (this.#balanceFetchedAt > 0 && now - this.#balanceFetchedAt < STATUS_BALANCE_REFRESH_MS) return;
+
+		const provider = session.state.model?.provider ?? session.model?.provider;
+		if (provider !== "deepseek") return;
+
+		this.#balanceInFlight = true;
+		this.#balanceTimer = setTimeout(() => {
+			this.#balanceTimer = null;
+			void this.#runBalanceRefresh(session);
+		}, 0);
+	}
+
+	async #runBalanceRefresh(session: AgentSession): Promise<void> {
+		if (this.#disposed || this.session !== session) {
+			this.#balanceInFlight = false;
+			return;
+		}
+		try {
+			const balance = await this.#fetchDeepSeekBalance(session);
+			if (this.#disposed || this.session !== session) return;
+			this.#cachedBalance = balance;
+			this.#balanceFetchedAt = Date.now();
+		} catch {
+			if (this.#disposed || this.session !== session) return;
+			this.#balanceFetchedAt = Date.now();
+		} finally {
+			if (this.session === session) this.#balanceInFlight = false;
+		}
+	}
+
+	async #fetchDeepSeekBalance(session: AgentSession): Promise<string | null> {
+		const apiKey = await session.modelRegistry?.getApiKey(
+			session.state.model ?? session.model!,
+			session.sessionId,
+		);
+		if (!apiKey) return null;
+
+		const signal = AbortSignal.timeout(STATUS_BALANCE_FETCH_TIMEOUT_MS);
+		const resp = await fetch("https://api.deepseek.com/user/balance", {
+			headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+			signal,
+		});
+		if (!resp.ok) return null;
+
+		const json = (await resp.json()) as { balance_infos?: Array<{ total_balance?: string }> };
+		const total = parseFloat(json?.balance_infos?.[0]?.total_balance ?? "");
+		if (Number.isNaN(total)) return null;
+
+		// Colour-code inline: green >50, yellow >10, red <=10
+		const G = "\x1b[32m", Y = "\x1b[33m", R = "\x1b[31m", E = "\x1b[0m";
+		const color = total > 50 ? G : total > 10 ? Y : R;
+		return `${color}¥${total.toFixed(2)}${E}`;
+	}
+
+
 	async #raceUsageRefreshWithSignal(promise: Promise<unknown>, signal: AbortSignal): Promise<unknown> {
 		if (signal.aborted) throw signal.reason;
 		const aborted = Promise.withResolvers<never>();
@@ -1537,7 +1623,6 @@ export class StatusLineComponent implements Component {
 		const effectiveTier = fiveHourTier ?? sevenDayTier ?? monthlyTier;
 		return { tier: effectiveTier, fiveHour, sevenDay, monthly };
 	}
-
 	/**
 	 * Used-tokens / context-window totals for the status-line context% segment,
 	 * memoized so the per-event redraw stays O(1) when nothing changed.
@@ -1607,6 +1692,7 @@ export class StatusLineComponent implements Component {
 
 		// Trigger background fetch (5-min TTL); render uses cached value
 		this.refreshUsageInBackground();
+		this.refreshBalanceInBackground();
 
 		// Get usage statistics
 		const aggregateUsageStats = this.session.sessionManager?.getUsageStatistics() ?? {
@@ -1699,6 +1785,7 @@ export class StatusLineComponent implements Component {
 			},
 			worktree: activeRepoCache.worktree,
 			usage: this.#cachedUsage,
+			balance: this.#cachedBalance,
 		};
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -724,16 +724,23 @@ const usageSegment: StatusLineSegment = {
 	},
 };
 
+/** Green above 50, amber above 10, red at or below 10 — same ladder as usage. */
+function pickBalanceColor(amount: number): ThemeColor {
+	if (amount > 50) return "success";
+	if (amount > 10) return "warning";
+	return "error";
+}
+
 const balanceSegment: StatusLineSegment = {
 	id: "balance",
 	render(ctx) {
 		const b = ctx.balance;
 		if (!b) return { content: "", visible: false };
-		// Balance string may contain ANSI color codes from the provider fetcher.
-		// sanitizeStatusText preserves ANSI escapes, only strips control characters.
-		const text = sanitizeStatusText(b);
+		const text = sanitizeStatusText(`${b.symbol}${b.amount.toFixed(2)}`);
 		if (!text) return { content: "", visible: false };
-		return { content: `💳 ${text}`, visible: true };
+		// theme.fg closes with `\x1b[39m`, so the status line's own background
+		// and separator styling survive the segment.
+		return { content: `💳 ${theme.fg(pickBalanceColor(b.amount), text)}`, visible: true };
 	},
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -724,6 +724,19 @@ const usageSegment: StatusLineSegment = {
 	},
 };
 
+const balanceSegment: StatusLineSegment = {
+	id: "balance",
+	render(ctx) {
+		const b = ctx.balance;
+		if (!b) return { content: "", visible: false };
+		// Balance string may contain ANSI color codes from the provider fetcher.
+		// sanitizeStatusText preserves ANSI escapes, only strips control characters.
+		const text = sanitizeStatusText(b);
+		if (!text) return { content: "", visible: false };
+		return { content: `💳 ${text}`, visible: true };
+	},
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Segment Registry
 // ═══════════════════════════════════════════════════════════════════════════
@@ -752,6 +765,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	cache_hit: cacheHitSegment,
 	session_name: sessionNameSegment,
 	usage: usageSegment,
+	balance: balanceSegment,
 	collab: collabSegment,
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -139,8 +139,19 @@ export interface SegmentContext {
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
 	} | null;
-	/** API-key provider account balance (e.g. DeepSeek). Null when unavailable or not an API-key provider. */
-	balance: string | null;
+	/**
+	 * API-key provider account balance (e.g. DeepSeek). Null when unavailable or
+	 * not an API-key provider. Carried as data, not pre-rendered text, so the
+	 * segment colours it through the theme like every other segment — a raw
+	 * `\x1b[0m` inside a segment would also clear the status line's background.
+	 */
+	balance: StatusLineBalance | null;
+}
+
+export interface StatusLineBalance {
+	/** Currency symbol resolved from the provider response (`¥`, `$`, …). */
+	symbol: string;
+	amount: number;
 }
 
 export interface RenderedSegment {

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -139,6 +139,8 @@ export interface SegmentContext {
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
 	} | null;
+	/** API-key provider account balance (e.g. DeepSeek). Null when unavailable or not an API-key provider. */
+	balance: string | null;
 }
 
 export interface RenderedSegment {

--- a/packages/coding-agent/test/status-line-balance-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-balance-refresh.test.ts
@@ -36,7 +36,7 @@ function setActiveModelForTest(session: AgentSession, model: TestModel): void {
 }
 
 function makeDeepSeekSession(
-	options: { baseUrl?: string; getApiKey?: () => Promise<string | undefined> } = {},
+	options: { baseUrl?: string; getApiKey?: () => Promise<string | undefined>; authGeneration?: () => number } = {},
 ): AgentSession {
 	const messages: unknown[] = [];
 	const model = {
@@ -51,7 +51,13 @@ function makeDeepSeekSession(
 		model,
 		isStreaming: false,
 		isFastModeActive: () => false,
-		modelRegistry: { getApiKey: options.getApiKey ?? (async () => "sk-test") },
+		modelRegistry: {
+			getApiKey: options.getApiKey ?? (async () => "sk-test"),
+			authStorage: {
+				getGeneration: options.authGeneration ?? (() => 1),
+				getOAuthAccountIdentity: () => undefined,
+			},
+		},
 		sessionManager: {
 			getUsageStatistics: () => ({
 				input: 0,
@@ -333,5 +339,55 @@ describe("StatusLineComponent balance refresh", () => {
 		const segmentText = fromGlyph.slice(0, fromGlyph.indexOf("\x1b[0m"));
 		expect(segmentText).toContain("42.00");
 		expect(segmentText).toContain("\x1b[39m");
+	});
+
+	it("re-fetches inside the TTL when the credential changes under the same model", async () => {
+		let generation = 1;
+		const session = makeDeepSeekSession({ authGeneration: () => generation });
+		const component = new StatusLineComponent(session);
+
+		await render(component);
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+		expect(component.getTopBorder(120).content).toContain("42.00");
+		expect(fetchCalls).toBe(1);
+
+		// `/login deepseek` stores a key AuthStorage then prefers over the env
+		// one. The Model object is untouched and the TTL is still fresh, so the
+		// generation bump is the only thing that can retire the old account's
+		// figure.
+		generation = 2;
+		pending = Promise.withResolvers<Response>();
+		await render(component);
+
+		expect(component.getTopBorder(120).content).not.toContain("42.00");
+		expect(fetchCalls).toBe(2);
+
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "7.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+		expect(component.getTopBorder(120).content).toContain("7.00");
+	});
+
+	it("discards a balance whose credential changed while the request was in flight", async () => {
+		let generation = 1;
+		const session = makeDeepSeekSession({ authGeneration: () => generation });
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+
+		await render(component);
+		expect(fetchCalls).toBe(1);
+
+		generation = 2;
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+
+		// The figure belongs to the previous account: it must never render, and
+		// #balanceFetchedAt must stay unstamped so the TTL cannot swallow the
+		// re-fetch on the next redraw.
+		expect(component.getTopBorder(120).content).not.toContain("42.00");
+		pending = Promise.withResolvers<Response>();
+		await render(component);
+		expect(fetchCalls).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/status-line-balance-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-balance-refresh.test.ts
@@ -275,4 +275,63 @@ describe("StatusLineComponent balance refresh", () => {
 
 		expect(component.getTopBorder(120).content).not.toContain("42.00");
 	});
+
+	it("repaints once the fetched balance lands", async () => {
+		const component = new StatusLineComponent(makeDeepSeekSession());
+		const repaint = vi.fn();
+		component.watchBranch(repaint);
+		const before = repaint.mock.calls.length;
+
+		await render(component);
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+
+		// The fetch is async. Without this notification a quiet session shows an
+		// empty segment until an unrelated event rebuilds the top border.
+		expect(repaint.mock.calls.length).toBeGreaterThan(before);
+	});
+
+	it("does not repaint when the balance is unchanged", async () => {
+		const component = new StatusLineComponent(makeDeepSeekSession());
+		const body = JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] });
+
+		await render(component);
+		pending.resolve(new Response(body));
+		await flushMicrotasks();
+
+		const repaint = vi.fn();
+		component.watchBranch(repaint);
+		const before = repaint.mock.calls.length;
+
+		// Force a second fetch past the TTL and return the identical figure.
+		vi.advanceTimersByTime(10 * 60_000);
+		pending = Promise.withResolvers<Response>();
+		await render(component);
+		pending.resolve(new Response(body));
+		await flushMicrotasks();
+
+		expect(repaint.mock.calls.length).toBe(before);
+	});
+
+	it("colours the balance without emitting a full SGR reset", async () => {
+		const component = new StatusLineComponent(makeDeepSeekSession());
+
+		await render(component);
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+
+		const content = component.getTopBorder(120).content;
+		expect(content).toContain("42.00");
+		// `#buildStatusLine` emits its own `\x1b[0m` when the segment group ends,
+		// so scope the check to the segment: everything the balance itself writes
+		// must appear before that wrapper reset, and must close with a
+		// foreground-only `\x1b[39m`. A segment-local full reset would clear the
+		// status line's background for everything that follows, and would land
+		// the amount in a slice with no `\x1b[39m` in it.
+		const fromGlyph = content.slice(content.indexOf("💳"));
+		const segmentText = fromGlyph.slice(0, fromGlyph.indexOf("\x1b[0m"));
+		expect(segmentText).toContain("42.00");
+		expect(segmentText).toContain("\x1b[39m");
+	});
 });

--- a/packages/coding-agent/test/status-line-balance-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-balance-refresh.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Contract for the DeepSeek balance segment's background refresh
+ * (`StatusLineComponent.refreshBalanceInBackground`).
+ *
+ * The status line redraws on every agent event, so the refresh must be
+ * self-deduplicating: exactly one request to `api.deepseek.com/user/balance`
+ * may be in flight at a time. `#balanceTimer` only covers the window between
+ * arming and firing — it is nulled inside the callback, while the request then
+ * runs for up to 3s with `#balanceFetchedAt` still 0. Without the
+ * `#balanceInFlight` latch every redraw inside that window re-armed the timer
+ * and fired another authenticated request.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function makeDeepSeekSession(): AgentSession {
+	const messages: unknown[] = [];
+	const model = { contextWindow: 200_000, provider: "deepseek" };
+	return {
+		sessionId: "session-1",
+		messages,
+		state: { messages, model },
+		model,
+		isStreaming: false,
+		modelRegistry: { getApiKey: async () => "sk-test" },
+		getContextUsage: () => undefined,
+		contextUsageRevision: 0,
+	} as unknown as AgentSession;
+}
+
+/** One render pass: arm the refresh, let the 0ms timer fire, drain microtasks. */
+async function render(component: StatusLineComponent): Promise<void> {
+	component.refreshBalanceInBackground();
+	vi.advanceTimersByTime(0);
+	await flushMicrotasks();
+}
+
+describe("StatusLineComponent balance refresh", () => {
+	let fetchCalls = 0;
+	let pending: PromiseWithResolvers<Response>;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme();
+		vi.useFakeTimers();
+		fetchCalls = 0;
+		pending = Promise.withResolvers<Response>();
+		vi.spyOn(globalThis, "fetch").mockImplementation(((input: unknown) => {
+			expect(String(input)).toBe("https://api.deepseek.com/user/balance");
+			fetchCalls++;
+			return pending.promise;
+		}) as typeof fetch);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("keeps a single balance request in flight across redraws", async () => {
+		const component = new StatusLineComponent(makeDeepSeekSession());
+
+		await render(component);
+		expect(fetchCalls).toBe(1);
+
+		// The request has not resolved: the timer is already null and
+		// #balanceFetchedAt is still 0, so only the in-flight latch can hold.
+		for (let i = 0; i < 5; i++) await render(component);
+		expect(fetchCalls).toBe(1);
+	});
+
+	it("refreshes again once the in-flight request settles and the TTL expires", async () => {
+		const component = new StatusLineComponent(makeDeepSeekSession());
+
+		await render(component);
+		expect(fetchCalls).toBe(1);
+
+		pending.resolve(
+			new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] }), {
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		await flushMicrotasks();
+
+		// Fresh cache: redraws stay quiet until the 5-min TTL lapses.
+		await render(component);
+		expect(fetchCalls).toBe(1);
+
+		pending = Promise.withResolvers<Response>();
+		vi.advanceTimersByTime(5 * 60_000 + 1);
+		await render(component);
+		expect(fetchCalls).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/status-line-balance-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-balance-refresh.test.ts
@@ -21,16 +21,53 @@ async function flushMicrotasks(): Promise<void> {
 	await Promise.resolve();
 }
 
-function makeDeepSeekSession(): AgentSession {
+interface TestModel {
+	contextWindow: number;
+	provider: string;
+	baseUrl: string;
+}
+
+function setActiveModelForTest(session: AgentSession, model: TestModel): void {
+	// AgentSession exposes model changes through setModel(), but these unit tests
+	// need a synchronous switch while a controlled promise remains pending.
+	const mutable = session as unknown as { model: TestModel; state: { model: TestModel } };
+	mutable.model = model;
+	mutable.state.model = model;
+}
+
+function makeDeepSeekSession(
+	options: { baseUrl?: string; getApiKey?: () => Promise<string | undefined> } = {},
+): AgentSession {
 	const messages: unknown[] = [];
-	const model = { contextWindow: 200_000, provider: "deepseek" };
+	const model = {
+		contextWindow: 200_000,
+		provider: "deepseek",
+		baseUrl: options.baseUrl ?? "",
+	};
 	return {
 		sessionId: "session-1",
 		messages,
 		state: { messages, model },
 		model,
 		isStreaming: false,
-		modelRegistry: { getApiKey: async () => "sk-test" },
+		isFastModeActive: () => false,
+		modelRegistry: { getApiKey: options.getApiKey ?? (async () => "sk-test") },
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+			getSessionName: () => "test",
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
 		getContextUsage: () => undefined,
 		contextUsageRevision: 0,
 	} as unknown as AgentSession;
@@ -100,5 +137,142 @@ describe("StatusLineComponent balance refresh", () => {
 		vi.advanceTimersByTime(5 * 60_000 + 1);
 		await render(component);
 		expect(fetchCalls).toBe(2);
+	});
+
+	it("does not resolve or send a custom gateway key to DeepSeek's public endpoint", async () => {
+		const getApiKey = vi.fn(async () => "gateway-secret");
+		const component = new StatusLineComponent(
+			makeDeepSeekSession({ baseUrl: "https://deepseek.internal.example/v1", getApiKey }),
+		);
+
+		await render(component);
+
+		expect(getApiKey).not.toHaveBeenCalled();
+		expect(fetchCalls).toBe(0);
+	});
+
+	it("allows the built-in DeepSeek model whose baseUrl is empty", async () => {
+		const getApiKey = vi.fn(async () => "sk-test");
+		const component = new StatusLineComponent(makeDeepSeekSession({ getApiKey }));
+
+		await render(component);
+
+		expect(getApiKey).toHaveBeenCalledTimes(1);
+		expect(fetchCalls).toBe(1);
+	});
+
+	it("allows the explicit first-party DeepSeek API host", async () => {
+		const getApiKey = vi.fn(async () => "sk-test");
+		const component = new StatusLineComponent(
+			makeDeepSeekSession({ baseUrl: "https://api.deepseek.com/v1", getApiKey }),
+		);
+
+		await render(component);
+
+		expect(getApiKey).toHaveBeenCalledTimes(1);
+		expect(fetchCalls).toBe(1);
+	});
+
+	it("rejects a gateway whose hostname only contains the DeepSeek marker", async () => {
+		const getApiKey = vi.fn(async () => "gateway-secret");
+		const component = new StatusLineComponent(
+			makeDeepSeekSession({ baseUrl: "https://api.deepseek.com.gateway.example/v1", getApiKey }),
+		);
+
+		await render(component);
+
+		expect(getApiKey).not.toHaveBeenCalled();
+		expect(fetchCalls).toBe(0);
+	});
+	it("does not fetch during rendering when the balance segment is absent", async () => {
+		const getApiKey = vi.fn(async () => "sk-test");
+		const component = new StatusLineComponent(makeDeepSeekSession({ getApiKey }));
+
+		component.updateSettings({ preset: "custom", leftSegments: ["model"], rightSegments: [] });
+		component.getTopBorder(120);
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(getApiKey).not.toHaveBeenCalled();
+		expect(fetchCalls).toBe(0);
+
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+		component.getTopBorder(120);
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(getApiKey).toHaveBeenCalledTimes(1);
+		expect(fetchCalls).toBe(1);
+	});
+
+	it("clears a fresh cached balance immediately when the provider changes", async () => {
+		const session = makeDeepSeekSession();
+		const component = new StatusLineComponent(session);
+
+		await render(component);
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+		expect(component.getTopBorder(120).content).toContain("42.00");
+
+		const otherModel = { contextWindow: 200_000, provider: "openai", baseUrl: "" };
+		setActiveModelForTest(session, otherModel);
+
+		expect(component.getTopBorder(120).content).not.toContain("42.00");
+	});
+
+	it("discards an old DeepSeek response that resolves after a model switch", async () => {
+		const session = makeDeepSeekSession();
+		const component = new StatusLineComponent(session);
+
+		await render(component);
+		const otherModel = { contextWindow: 200_000, provider: "openai", baseUrl: "" };
+		setActiveModelForTest(session, otherModel);
+		component.refreshBalanceInBackground();
+
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+
+		const nextDeepSeek = { contextWindow: 200_000, provider: "deepseek", baseUrl: "" };
+		setActiveModelForTest(session, nextDeepSeek);
+		pending = Promise.withResolvers<Response>();
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+
+		expect(component.getTopBorder(120).content).not.toContain("42.00");
+	});
+
+	it("can refresh again after a provider switch cancels an armed timer", async () => {
+		const session = makeDeepSeekSession();
+		const component = new StatusLineComponent(session);
+
+		component.refreshBalanceInBackground();
+		const otherModel = { contextWindow: 200_000, provider: "openai", baseUrl: "" };
+		setActiveModelForTest(session, otherModel);
+		component.refreshBalanceInBackground();
+
+		const nextDeepSeek = { contextWindow: 200_000, provider: "deepseek", baseUrl: "" };
+		setActiveModelForTest(session, nextDeepSeek);
+		component.refreshBalanceInBackground();
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(fetchCalls).toBe(1);
+	});
+
+	it("clears a fresh cached balance when switching between DeepSeek models", async () => {
+		const session = makeDeepSeekSession();
+		const component = new StatusLineComponent(session);
+
+		await render(component);
+		pending.resolve(new Response(JSON.stringify({ balance_infos: [{ total_balance: "42.00", currency: "CNY" }] })));
+		await flushMicrotasks();
+		component.updateSettings({ preset: "custom", leftSegments: ["balance"], rightSegments: [] });
+		expect(component.getTopBorder(120).content).toContain("42.00");
+
+		const nextDeepSeek = { contextWindow: 200_000, provider: "deepseek", baseUrl: "" };
+		setActiveModelForTest(session, nextDeepSeek);
+		pending = Promise.withResolvers<Response>();
+
+		expect(component.getTopBorder(120).content).not.toContain("42.00");
 	});
 });

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -48,6 +48,7 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 		worktree: null,
 		git: { branch: null, status: null, pr: null },
 		usage: null,
+		balance: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -55,6 +55,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		worktree: null,
 		git: { branch: null, status: null, pr: null },
 		usage: null,
+		balance: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -87,6 +87,7 @@ function createCtx(overrides?: {
 			pr: null,
 		},
 		usage: null,
+		balance: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -72,6 +72,7 @@ function createPathContext(): SegmentContext {
 			pr: null,
 		},
 		usage: null,
+		balance: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -70,6 +70,7 @@ function createCtx(activeMs: number): SegmentContext {
 		worktree: null,
 		git: { branch: null, status: null, pr: null },
 		usage: null,
+		balance: null,
 	};
 }
 


### PR DESCRIPTION
## Summary

Adds a `balance` status-line segment for API-key providers that have no OAuth usage API. DeepSeek is the only one wired up; for those accounts `usage` never renders anything, so the line is simply blank today.

- New `"balance"` segment id, rendered as `💳 ¥12.34` and colour-coded green >50 / yellow >10 / red ≤10. The currency symbol comes from the response (`CNY`/`USD`/`EUR`/`GBP`), falling back to the raw code.
- Fetches `GET /user/balance` with the model registry's key on a 5-minute TTL.
- Only fetches when the effective left/right segments actually include `balance`, so the default presets never make an authenticated request for output nobody sees.
- Rejects any explicit `baseUrl` whose parsed hostname is not exactly `api.deepseek.com` **before** resolving its API key, so a DeepSeek-compatible gateway credential can never be sent to the public balance endpoint.
- Owns cached results by the exact model object: a provider or model switch clears fresh data ahead of the TTL guard, a cancelled timer releases the in-flight latch, and a response arriving after a switch is discarded.

## What changed since the previous push

This branch also carried Kimi OAuth usage-window support. #8197 has since landed that, and solved it better — canonicalising the window ids in `packages/ai/src/usage/kimi.ts` rather than pattern-matching them in the status-line aggregator — so those commits are dropped and the branch is rebased onto `v17.2.15`. What remains is one logical change.

## Verification

`bun run check:ts` clean (biome + tsgo across all workspaces). `bun test test/status-line` — 164 pass.

`test/status-line-balance-refresh.test.ts` adds 11 cases covering the in-flight latch, the TTL, the hidden-segment gate, empty/official/custom/lookalike hosts, provider switches, cancelled timers, DeepSeek-to-DeepSeek cache ownership, and late responses. Each negative control was proven red by temporarily removing the guard it defends and restoring the file afterwards.

I build this branch and run it as my installed `omp`, so the render and live-fetch paths are confirmed outside CI as well.
