### PR TITLE
Add Agnes AI as a first-class provider

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -676,7 +676,7 @@ searxng:
 |---|---|---|---|
 | `providers.webSearchOrder` | array | `[]` | Provider IDs in priority order for `web_search` (`perplexity`, `gemini`, `anthropic`, `codex`, `zai`, `exa`, `jina`, `kagi`, `tavily`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`, …). Duplicates and unknown IDs are ignored; unlisted providers retain their built-in relative order afterward. Empty = built-in order. Replaces the removed `providers.webSearch` enum (a legacy value migrates to the head of this list). |
 | `providers.webSearchGeminiModel` | string | _(unset)_ | Gemini model ID for Google Search grounding when `web_search` uses Gemini; defaults to `gemini-2.5-flash`, overridden by `GEMINI_SEARCH_MODEL`. |
-| `providers.imageOrder` | array | `[]` | Image-generation provider IDs in priority order (`openai`, `openai-codex`, `antigravity`, `xai`, `gemini`, `openrouter`). Unlisted providers follow the active session provider and the built-in order. Replaces the removed `providers.image` enum (a legacy value migrates to the head of this list). |
+| `providers.imageOrder` | array | `[]` | Image-generation provider IDs in priority order (`openai`, `openai-codex`, `antigravity`, `xai`, `gemini`, `openrouter`, `agnes`). Unlisted providers follow the active session provider and the built-in order. Replaces the removed `providers.image` enum (a legacy value migrates to the head of this list). |
 | `providers.fetch` | enum | `auto` | `auto`, `native`, `trafilatura`, `lynx`, `parallel`, `jina`. |
 | `providers.tinyModel` | enum | `online` | `online` or a local model (`lfm2-350m`, `qwen3-0.6b`, `gemma-270m`, `qwen2.5-0.5b`, `lfm2-700m`). |
 | `providers.tinyModelDevice` | enum | `default` | ONNX execution provider for local tiny models. Overridden by `PI_TINY_DEVICE`. |

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -50,6 +50,9 @@
 - Improved connection error handling by classifying generic connection failures as transient, allowing them to be retried, while keeping explicit authentication rejections non-retryable.
 - Fixed custom Anthropic base URLs losing native thinking signatures during continuation requests.
 - Fixed Alibaba Coding Plan Custom login rejecting valid API keys on endpoints that do not serve the default validation model by validating against the model catalog instead.
+### Added
+
+- Added Agnes AI provider definition (`agnes`) with `AGNES_API_KEY` env key. Registered in the provider registry for `/login` discovery and model resolution.
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/ai/src/registry/agnes.ts
+++ b/packages/ai/src/registry/agnes.ts
@@ -1,0 +1,6 @@
+import type { ProviderDefinition } from "./types";
+
+export const agnesProvider = {
+	id: "agnes",
+	name: "Agnes AI",
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -1,4 +1,5 @@
 import type { KnownProvider } from "@oh-my-pi/pi-catalog";
+import { agnesProvider } from "./agnes";
 import { aimlApiProvider } from "./aimlapi";
 import { alibabaCodingPlanProvider } from "./alibaba-coding-plan";
 import { alibabaTokenPlanProvider } from "./alibaba-token-plan";
@@ -145,6 +146,7 @@ const ALL = [
 	googleVertexProvider,
 	xaiProvider,
 	groqProvider,
+	agnesProvider,
 	mistralProvider,
 	minimaxProvider,
 	amazonBedrockProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Agnes AI (`agnes`) as a supported provider with bundled fallback model (`agnes-2.0-flash`), catalog descriptor, and OpenAI-completions model manager factory. API key via `AGNES_API_KEY`. Catalog discovery with `dynamicModelsAuthoritative: true` for runtime model enumeration via `/v1/models`.
 
 ## [17.1.0] - 2026-07-24
 
@@ -48,12 +51,6 @@
 
 - Removed several deprecated model families from the devin catalog, including Claude Fable 5, Claude Opus 4.6/4.7, Claude Sonnet 4.6/5, DeepSeek V4 Pro, Gemini 3.1 Pro, Gemini 3.5 Flash, GLM-5.2, SWE-1.6, and Nemotron 3 Ultra.
 - Removed GPT-5 through GPT-5.3 Codex variants and GPT-5.4 nano from the openai-codex catalog.
-### Added
-
-- Added Agnes AI (`agnes`) as a supported provider with bundled fallback models (`agnes-2.0-flash`, `agnes-image-2.1-flash`), catalog descriptor, and OpenAI-completions model manager factory. API key via `AGNES_API_KEY`. Catalog discovery with `dynamicModelsAuthoritative: true` for runtime model enumeration via `/v1/models`.
-
-## [17.0.6] - 2026-07-20
-
 ### Added
 
 - Added static fallback seed for Devin's `swe-1-7` model so it is bundled even when catalog generation runs without a Devin session token.

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -48,6 +48,9 @@
 
 - Removed several deprecated model families from the devin catalog, including Claude Fable 5, Claude Opus 4.6/4.7, Claude Sonnet 4.6/5, DeepSeek V4 Pro, Gemini 3.1 Pro, Gemini 3.5 Flash, GLM-5.2, SWE-1.6, and Nemotron 3 Ultra.
 - Removed GPT-5 through GPT-5.3 Codex variants and GPT-5.4 nano from the openai-codex catalog.
+### Added
+
+- Added Agnes AI (`agnes`) as a supported provider with bundled fallback models (`agnes-2.0-flash`, `agnes-image-2.1-flash`), catalog descriptor, and OpenAI-completions model manager factory. API key via `AGNES_API_KEY`. Catalog discovery with `dynamicModelsAuthoritative: true` for runtime model enumeration via `/v1/models`.
 
 ## [17.0.6] - 2026-07-20
 

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -378,12 +378,11 @@ function dropAgnesNonChatModels(models: readonly ModelSpec[]): ModelSpec[] {
 		return !AGNES_NON_CHAT_MODEL_ID_PATTERNS.some(pattern => pattern.test(model.id));
 	});
 }
-/** Agnes uses `chat_template_kwargs.enable_thinking` / `thinking`, not `reasoning_effort`. Strip generic effort-based thinking metadata. */
-function stripAgnesThinking(models: readonly ModelSpec[]): ModelSpec[] {
+/** Agnes uses `chat_template_kwargs.enable_thinking` / `thinking`, not `reasoning_effort`. Set omitReasoningEffort compat to prevent the wire param. */
+function setAgnesOmitReasoningEffort(models: readonly ModelSpec[]): ModelSpec[] {
 	return models.map(model => {
-		if (model.provider !== "agnes" || !model.thinking) return model;
-		const { thinking: _, ...rest } = model;
-		return rest;
+		if (model.provider !== "agnes") return model;
+		return { ...model, compat: { ...model.compat, omitReasoningEffort: true } };
 	});
 }
 
@@ -671,7 +670,7 @@ async function generateModels() {
 	// policy re-bake so the aliases get the same baked thinking metadata.
 	allModels = projectOpenAIProReasoningAliases(allModels);
 	applyGeneratedModelPolicies(allModels);
-	allModels = stripAgnesThinking(allModels);
+	allModels = setAgnesOmitReasoningEffort(allModels);
 	linkOpenAIPromotionTargets(allModels);
 	// Collapse effort-tier variants AFTER the policy re-bake: live-discovery
 	// entries are already collapsed (rebake skips them); this pass folds

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -363,6 +363,21 @@ function dropXiaomiAudioOnlyIds(models: readonly ModelSpec[]): ModelSpec[] {
 		return !isXiaomiProvider || (!model.id.includes("-tts") && !model.id.includes("-asr"));
 	});
 }
+/**
+ * Agnes `/v1/models` advertises image and video model ids alongside chat
+ * models. Runtime discovery filters them via `isAgnesChatModelId`, but
+ * models.dev and previous bundled snapshots can still surface those
+ * non-chat ids. Drop them so the committed catalog matches the runtime
+ * chat surface.
+ */
+const AGNES_NON_CHAT_MODEL_ID_PATTERNS = [/(^|[/:._-])image([/:._-]|$)/i, /(^|[/:._-])video([/:._-]|$)/i] as const;
+
+function dropAgnesNonChatModels(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.filter(model => {
+		if (model.provider !== "agnes") return true;
+		return !AGNES_NON_CHAT_MODEL_ID_PATTERNS.some(pattern => pattern.test(model.id));
+	});
+}
 
 function normalizeAntigravityEndpoint(models: readonly ModelSpec[]): ModelSpec[] {
 	return models.map(model => {
@@ -634,6 +649,7 @@ async function generateModels() {
 	allModels = dropFireworksWireIds(allModels);
 	allModels = dropUnusableZaiContextTierIds(allModels);
 	allModels = dropXiaomiAudioOnlyIds(allModels);
+	allModels = dropAgnesNonChatModels(allModels);
 	allModels = normalizeAntigravityEndpoint(allModels);
 	// Normalize display names: gateway author prefixes ("OpenAI: …"), alias
 	// markers ("(latest)"), provider attribution ("(Antigravity)"), and

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -378,6 +378,14 @@ function dropAgnesNonChatModels(models: readonly ModelSpec[]): ModelSpec[] {
 		return !AGNES_NON_CHAT_MODEL_ID_PATTERNS.some(pattern => pattern.test(model.id));
 	});
 }
+/** Agnes uses `chat_template_kwargs.enable_thinking` / `thinking`, not `reasoning_effort`. Strip generic effort-based thinking metadata. */
+function stripAgnesThinking(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		if (model.provider !== "agnes" || !model.thinking) return model;
+		const { thinking: _, ...rest } = model;
+		return rest;
+	});
+}
 
 function normalizeAntigravityEndpoint(models: readonly ModelSpec[]): ModelSpec[] {
 	return models.map(model => {
@@ -663,6 +671,7 @@ async function generateModels() {
 	// policy re-bake so the aliases get the same baked thinking metadata.
 	allModels = projectOpenAIProReasoningAliases(allModels);
 	applyGeneratedModelPolicies(allModels);
+	allModels = stripAgnesThinking(allModels);
 	linkOpenAIPromotionTargets(allModels);
 	// Collapse effort-tier variants AFTER the policy re-bake: live-discovery
 	// entries are already collapsed (rebake skips them); this pass folds

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17,17 +17,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 16384
 		}
 	},
 	"aimlapi": {
@@ -77663,9 +77653,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7798,
-				"output": 2.4508,
-				"cacheRead": 0.14482,
+				"input": 0.777,
+				"output": 2.442,
+				"cacheRead": 0.14429999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -27,8 +27,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsTools": false
+			}
 		}
 	},
 	"aimlapi": {
@@ -8508,10 +8507,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 1.1,
+				"output": 5.5,
+				"cacheRead": 0.11,
+				"cacheWrite": 1.375
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -8683,10 +8682,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -8771,10 +8770,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3.3,
-				"output": 16.5,
-				"cacheRead": 0.33,
-				"cacheWrite": 4.125
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
@@ -8800,10 +8799,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.2,
-				"output": 11,
-				"cacheRead": 0.22,
-				"cacheWrite": 2.75
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -8908,7 +8907,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Claude Opus 4.5 (Global)",
+			"name": "Claude Opus 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -9084,7 +9083,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Claude Sonnet 4.6 (Global)",
+			"name": "Claude Sonnet 4.6",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -10478,7 +10477,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Claude Opus 4.1 (US)",
+			"name": "Claude Opus 4.1",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -67565,6 +67564,35 @@
 			"contextWindow": 262100,
 			"maxTokens": 32800
 		},
+		"ling-3.0-flash-free": {
+			"id": "ling-3.0-flash-free",
+			"name": "Ling-3.0-flash Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"mimo-v2-flash-free": {
 			"id": "mimo-v2-flash-free",
 			"name": "MiMo V2 Flash Free",
@@ -72163,9 +72191,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.82,
-				"output": 3.75,
-				"cacheRead": 0.16,
+				"input": 0.71,
+				"output": 3.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -77635,9 +77663,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7826000000000001,
-				"output": 2.4596,
-				"cacheRead": 0.14534,
+				"input": 0.7798,
+				"output": 2.4508,
+				"cacheRead": 0.14482,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -1,4 +1,36 @@
 {
+	"agnes": {
+		"agnes-2.0-flash": {
+			"id": "agnes-2.0-flash",
+			"name": "Agnes 2.0 Flash",
+			"api": "openai-completions",
+			"provider": "agnes",
+			"baseUrl": "https://apihub.agnes-ai.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsTools": false
+		}
+	},
 	"aimlapi": {
 		"act_two": {
 			"id": "act_two",
@@ -7211,54 +7243,6 @@
 					"high"
 				]
 			}
-		}
-	},
-	"agnes": {
-		"agnes-2.0-flash": {
-			"id": "agnes-2.0-flash",
-			"name": "Agnes 2.0 Flash",
-			"api": "openai-completions",
-			"provider": "agnes",
-			"baseUrl": "https://apihub.agnes-ai.com/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 128000,
-			"maxTokens": 16384,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
-		"agnes-image-2.1-flash": {
-			"id": "agnes-image-2.1-flash",
-			"name": "Agnes Image 2.1 Flash",
-			"api": "openai-completions",
-			"provider": "agnes",
-			"baseUrl": "https://apihub.agnes-ai.com/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 32000,
-			"maxTokens": 4096
 		}
 	},
 	"alibaba-coding-plan": {
@@ -18990,6 +18974,64 @@
 		}
 	},
 	"google": {
+		"deep-research-max-preview-04-2026": {
+			"id": "deep-research-max-preview-04-2026",
+			"name": "Deep Research Max Preview",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"deep-research-preview-04-2026": {
+			"id": "deep-research-preview-04-2026",
+			"name": "Gemini Deep Research Preview",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"gemini-1.5-flash": {
 			"id": "gemini-1.5-flash",
 			"name": "Gemini 1.5 Flash",
@@ -19089,6 +19131,35 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 8192
+		},
+		"gemini-2.5-computer-use-preview-10-2025": {
+			"id": "gemini-2.5-computer-use-preview-10-2025",
+			"name": "Gemini 2.5 Computer Use Preview",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 10,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"gemini-2.5-flash": {
 			"id": "gemini-2.5-flash",
@@ -19471,6 +19542,36 @@
 				"requiresEffort": true
 			}
 		},
+		"gemini-3.1-flash-lite-image": {
+			"id": "gemini-3.1-flash-lite-image",
+			"name": "Nano Banana 2 Lite",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 30,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 4096,
+			"thinking": {
+				"mode": "google-level",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
+		},
 		"gemini-3.1-flash-lite-preview": {
 			"id": "gemini-3.1-flash-lite-preview",
 			"name": "Gemini 3.1 Flash Lite Preview",
@@ -19489,6 +19590,36 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
+		},
+		"gemini-3.1-flash-live-preview": {
+			"id": "gemini-3.1-flash-live-preview",
+			"name": "Gemini 3.1 Flash Live Preview",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "google-level",
@@ -19747,6 +19878,35 @@
 			"cost": {
 				"input": 0.5,
 				"output": 2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"gemini-robotics-er-1.6-preview": {
+			"id": "gemini-robotics-er-1.6-preview",
+			"name": "Gemini Robotics-ER 1.6 Preview",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 5,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -22010,6 +22170,424 @@
 		}
 	},
 	"huggingface": {
+		"aisingapore/Gemma-SEA-LION-v4-27B-IT": {
+			"id": "aisingapore/Gemma-SEA-LION-v4-27B-IT",
+			"name": "aisingapore/Gemma-SEA-LION-v4-27B-IT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"aisingapore/Qwen-SEA-LION-v4-32B-IT": {
+			"id": "aisingapore/Qwen-SEA-LION-v4-32B-IT",
+			"name": "aisingapore/Qwen-SEA-LION-v4-32B-IT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"allenai/Olmo-3-7B-Instruct": {
+			"id": "allenai/Olmo-3-7B-Instruct",
+			"name": "allenai/Olmo-3-7B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"alpindale/WizardLM-2-8x22B": {
+			"id": "alpindale/WizardLM-2-8x22B",
+			"name": "alpindale/WizardLM-2-8x22B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"baidu/ERNIE-4.5-VL-424B-A47B-Base-PT": {
+			"id": "baidu/ERNIE-4.5-VL-424B-A47B-Base-PT",
+			"name": "baidu/ERNIE-4.5-VL-424B-A47B-Base-PT",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/aya-expanse-32b": {
+			"id": "CohereLabs/aya-expanse-32b",
+			"name": "CohereLabs/aya-expanse-32b",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/aya-vision-32b": {
+			"id": "CohereLabs/aya-vision-32b",
+			"name": "CohereLabs/aya-vision-32b",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/c4ai-command-a-03-2025": {
+			"id": "CohereLabs/c4ai-command-a-03-2025",
+			"name": "CohereLabs/c4ai-command-a-03-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/c4ai-command-r-08-2024": {
+			"id": "CohereLabs/c4ai-command-r-08-2024",
+			"name": "CohereLabs/c4ai-command-r-08-2024",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4000
+		},
+		"CohereLabs/c4ai-command-r7b-12-2024": {
+			"id": "CohereLabs/c4ai-command-r7b-12-2024",
+			"name": "CohereLabs/c4ai-command-r7b-12-2024",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4000
+		},
+		"CohereLabs/c4ai-command-r7b-arabic-02-2025": {
+			"id": "CohereLabs/c4ai-command-r7b-arabic-02-2025",
+			"name": "CohereLabs/c4ai-command-r7b-arabic-02-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/command-a-reasoning-08-2025": {
+			"id": "CohereLabs/command-a-reasoning-08-2025",
+			"name": "CohereLabs/command-a-reasoning-08-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/command-a-translate-08-2025": {
+			"id": "CohereLabs/command-a-translate-08-2025",
+			"name": "CohereLabs/command-a-translate-08-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/command-a-vision-07-2025": {
+			"id": "CohereLabs/command-a-vision-07-2025",
+			"name": "CohereLabs/command-a-vision-07-2025",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/tiny-aya-earth": {
+			"id": "CohereLabs/tiny-aya-earth",
+			"name": "CohereLabs/tiny-aya-earth",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/tiny-aya-fire": {
+			"id": "CohereLabs/tiny-aya-fire",
+			"name": "CohereLabs/tiny-aya-fire",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/tiny-aya-global": {
+			"id": "CohereLabs/tiny-aya-global",
+			"name": "CohereLabs/tiny-aya-global",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"CohereLabs/tiny-aya-water": {
+			"id": "CohereLabs/tiny-aya-water",
+			"name": "CohereLabs/tiny-aya-water",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepcogito/cogito-671b-v2.1": {
+			"id": "deepcogito/cogito-671b-v2.1",
+			"name": "deepcogito/cogito-671b-v2.1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepcogito/cogito-671b-v2.1-FP8": {
+			"id": "deepcogito/cogito-671b-v2.1-FP8",
+			"name": "deepcogito/cogito-671b-v2.1-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepreinforce-ai/Ornith-1.0-35B": {
+			"id": "deepreinforce-ai/Ornith-1.0-35B",
+			"name": "deepreinforce-ai/Ornith-1.0-35B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepreinforce-ai/Ornith-1.0-35B-FP8": {
+			"id": "deepreinforce-ai/Ornith-1.0-35B-FP8",
+			"name": "deepreinforce-ai/Ornith-1.0-35B-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
 		"deepseek-ai/DeepSeek-R1": {
 			"id": "deepseek-ai/DeepSeek-R1",
 			"name": "DeepSeek-R1",
@@ -22062,6 +22640,120 @@
 				]
 			}
 		},
+		"deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Llama-8B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepseek-ai/DeepSeek-R1-Distill-Qwen-7B": {
+			"id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+			"name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"deepseek-ai/DeepSeek-V3": {
+			"id": "deepseek-ai/DeepSeek-V3",
+			"name": "DeepSeek-V3",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072
+		},
+		"deepseek-ai/DeepSeek-V3-0324": {
+			"id": "deepseek-ai/DeepSeek-V3-0324",
+			"name": "deepseek-ai/DeepSeek-V3-0324",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"deepseek-ai/DeepSeek-V3.1": {
 			"id": "deepseek-ai/DeepSeek-V3.1",
 			"name": "DeepSeek V3.1",
@@ -22080,6 +22772,25 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192
+		},
+		"deepseek-ai/DeepSeek-V3.1-Terminus": {
+			"id": "deepseek-ai/DeepSeek-V3.1-Terminus",
+			"name": "DeepSeek V3.1 Terminus",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 65536
 		},
 		"deepseek-ai/DeepSeek-V3.2": {
 			"id": "deepseek-ai/DeepSeek-V3.2",
@@ -22106,6 +22817,25 @@
 					"max"
 				]
 			}
+		},
+		"deepseek-ai/DeepSeek-V3.2-Exp": {
+			"id": "deepseek-ai/DeepSeek-V3.2-Exp",
+			"name": "deepseek-ai/DeepSeek-V3.2-Exp",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 163840,
+			"maxTokens": 65536
 		},
 		"deepseek-ai/DeepSeek-V4-Flash": {
 			"id": "deepseek-ai/DeepSeek-V4-Flash",
@@ -22158,6 +22888,83 @@
 					"max"
 				]
 			}
+		},
+		"google/gemma-3-12b-it": {
+			"id": "google/gemma-3-12b-it",
+			"name": "google/gemma-3-12b-it",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384
+		},
+		"google/gemma-3-27b-it": {
+			"id": "google/gemma-3-27b-it",
+			"name": "Gemma 3 27B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 65536
+		},
+		"google/gemma-3-4b-it": {
+			"id": "google/gemma-3-4b-it",
+			"name": "google/gemma-3-4b-it",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"google/gemma-3n-E4B-it": {
+			"id": "google/gemma-3n-E4B-it",
+			"name": "google/gemma-3n-E4B-it",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096
 		},
 		"google/gemma-4-26B-A4B-it": {
 			"id": "google/gemma-4-26B-A4B-it",
@@ -22219,6 +23026,44 @@
 				]
 			}
 		},
+		"inclusionAI/Ling-2.6-1T": {
+			"id": "inclusionAI/Ling-2.6-1T",
+			"name": "inclusionAI/Ling-2.6-1T",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
+		"meta-llama/Llama-3.1-8B-Instruct": {
+			"id": "meta-llama/Llama-3.1-8B-Instruct",
+			"name": "Llama 3.1 8B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 128000
+		},
 		"meta-llama/Llama-3.3-70B-Instruct": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct",
 			"name": "Llama-3.3-70B-Instruct",
@@ -22256,6 +23101,101 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192
+		},
+		"meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+			"id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+			"name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192
+		},
+		"meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+			"id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+			"name": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 10000000,
+			"maxTokens": 32768
+		},
+		"meta-llama/Llama-Guard-4-12B": {
+			"id": "meta-llama/Llama-Guard-4-12B",
+			"name": "meta-llama/Llama-Guard-4-12B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"microsoft/phi-4": {
+			"id": "microsoft/phi-4",
+			"name": "microsoft/phi-4",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"MiniMaxAI/MiniMax-M1-80k": {
+			"id": "MiniMaxAI/MiniMax-M1-80k",
+			"name": "MiniMaxAI/MiniMax-M1-80k",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 40000
 		},
 		"MiniMaxAI/MiniMax-M2": {
 			"id": "MiniMaxAI/MiniMax-M2",
@@ -22557,6 +23497,44 @@
 				]
 			}
 		},
+		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": {
+			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+			"name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4": {
+			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+			"name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
 			"name": "GPT OSS 120B",
@@ -22611,6 +23589,223 @@
 				]
 			}
 		},
+		"openai/gpt-oss-safeguard-20b": {
+			"id": "openai/gpt-oss-safeguard-20b",
+			"name": "Safety GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"pearl-ai/Gemma-4-31B-it-pearl": {
+			"id": "pearl-ai/Gemma-4-31B-it-pearl",
+			"name": "pearl-ai/Gemma-4-31B-it-pearl",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"prism-ml/Ternary-Bonsai-27B-AWQ-4bit": {
+			"id": "prism-ml/Ternary-Bonsai-27B-AWQ-4bit",
+			"name": "prism-ml/Ternary-Bonsai-27B-AWQ-4bit",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"prism-ml/Ternary-Bonsai-27B-gguf": {
+			"id": "prism-ml/Ternary-Bonsai-27B-gguf",
+			"name": "prism-ml/Ternary-Bonsai-27B-gguf",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen2.5-72B-Instruct": {
+			"id": "Qwen/Qwen2.5-72B-Instruct",
+			"name": "Qwen/Qwen2.5-72B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen2.5-7B-Instruct": {
+			"id": "Qwen/Qwen2.5-7B-Instruct",
+			"name": "Qwen/Qwen2.5-7B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen2.5-Coder-32B-Instruct": {
+			"id": "Qwen/Qwen2.5-Coder-32B-Instruct",
+			"name": "Qwen/Qwen2.5-Coder-32B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096
+		},
+		"Qwen/Qwen2.5-Coder-3B-Instruct": {
+			"id": "Qwen/Qwen2.5-Coder-3B-Instruct",
+			"name": "Qwen/Qwen2.5-Coder-3B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen2.5-Coder-7B-Instruct": {
+			"id": "Qwen/Qwen2.5-Coder-7B-Instruct",
+			"name": "Qwen/Qwen2.5-Coder-7B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096
+		},
+		"Qwen/Qwen2.5-VL-72B-Instruct": {
+			"id": "Qwen/Qwen2.5-VL-72B-Instruct",
+			"name": "Qwen/Qwen2.5-VL-72B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen3-14B": {
+			"id": "Qwen/Qwen3-14B",
+			"name": "Qwen/Qwen3-14B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131702,
+			"maxTokens": 40960
+		},
 		"Qwen/Qwen3-235B-A22B": {
 			"id": "Qwen/Qwen3-235B-A22B",
 			"name": "Qwen3 235B-A22B",
@@ -22638,6 +23833,25 @@
 					"high"
 				]
 			}
+		},
+		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
+			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+			"name": "Qwen3 235B A22B-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
@@ -22695,6 +23909,63 @@
 					"high"
 				]
 			}
+		},
+		"Qwen/Qwen3-4B-Instruct-2507": {
+			"id": "Qwen/Qwen3-4B-Instruct-2507",
+			"name": "Qwen/Qwen3-4B-Instruct-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen3-4B-Thinking-2507": {
+			"id": "Qwen/Qwen3-4B-Thinking-2507",
+			"name": "Qwen/Qwen3-4B-Thinking-2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"Qwen/Qwen3-8B": {
+			"id": "Qwen/Qwen3-8B",
+			"name": "Qwen/Qwen3-8B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192
 		},
 		"Qwen/Qwen3-Coder-30B-A3B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -22790,6 +24061,63 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072
+		},
+		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
+			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 52429
+		},
+		"Qwen/Qwen3-VL-235B-A22B-Thinking": {
+			"id": "Qwen/Qwen3-VL-235B-A22B-Thinking",
+			"name": "Qwen/Qwen3-VL-235B-A22B-Thinking",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"Qwen/Qwen3-VL-30B-A3B-Instruct": {
+			"id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+			"name": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
 		},
 		"Qwen/Qwen3.5-122B-A10B": {
 			"id": "Qwen/Qwen3.5-122B-A10B",
@@ -22994,6 +24322,63 @@
 				]
 			}
 		},
+		"Sao10K/L3-8B-Lunaris-v1": {
+			"id": "Sao10K/L3-8B-Lunaris-v1",
+			"name": "Sao10K/L3-8B-Lunaris-v1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": 8192
+		},
+		"Sao10K/L3-8B-Stheno-v3.2": {
+			"id": "Sao10K/L3-8B-Stheno-v3.2",
+			"name": "Sao10K/L3-8B-Stheno-v3.2",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": 32000
+		},
+		"speakleash/Bielik-11B-v3.0-Instruct": {
+			"id": "speakleash/Bielik-11B-v3.0-Instruct",
+			"name": "speakleash/Bielik-11B-v3.0-Instruct",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
 		"stepfun-ai/Step-3.5-Flash": {
 			"id": "stepfun-ai/Step-3.5-Flash",
 			"name": "Step 3.5 Flash",
@@ -23052,6 +24437,112 @@
 					"xhigh"
 				]
 			}
+		},
+		"swiss-ai/Apertus-70B-Instruct-2509": {
+			"id": "swiss-ai/Apertus-70B-Instruct-2509",
+			"name": "swiss-ai/Apertus-70B-Instruct-2509",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"swiss-ai/Apertus-8B-Instruct-2509": {
+			"id": "swiss-ai/Apertus-8B-Instruct-2509",
+			"name": "swiss-ai/Apertus-8B-Instruct-2509",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"tencent/Hy3": {
+			"id": "tencent/Hy3",
+			"name": "tencent/Hy3",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 64000
+		},
+		"thinkingmachines/Inkling": {
+			"id": "thinkingmachines/Inkling",
+			"name": "Inkling",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"utter-project/EuroLLM-22B-Instruct-2512": {
+			"id": "utter-project/EuroLLM-22B-Instruct-2512",
+			"name": "utter-project/EuroLLM-22B-Instruct-2512",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
 		},
 		"XiaomiMiMo/MiMo-V2-Flash": {
 			"id": "XiaomiMiMo/MiMo-V2-Flash",
@@ -23133,6 +24624,44 @@
 					"high"
 				]
 			}
+		},
+		"zai-org/AutoGLM-Phone-9B-Multilingual": {
+			"id": "zai-org/AutoGLM-Phone-9B-Multilingual",
+			"name": "zai-org/AutoGLM-Phone-9B-Multilingual",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 65536
+		},
+		"zai-org/GLM-4-32B-0414": {
+			"id": "zai-org/GLM-4-32B-0414",
+			"name": "zai-org/GLM-4-32B-0414",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32000,
+			"maxTokens": 32000
 		},
 		"zai-org/GLM-4.5": {
 			"id": "zai-org/GLM-4.5",
@@ -23222,6 +24751,25 @@
 				]
 			}
 		},
+		"zai-org/GLM-4.5V-FP8": {
+			"id": "zai-org/GLM-4.5V-FP8",
+			"name": "zai-org/GLM-4.5V-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 64000,
+			"maxTokens": 16384
+		},
 		"zai-org/GLM-4.6": {
 			"id": "zai-org/GLM-4.6",
 			"name": "GLM-4.6",
@@ -23250,6 +24798,82 @@
 					"xhigh"
 				]
 			}
+		},
+		"zai-org/GLM-4.6-FP8": {
+			"id": "zai-org/GLM-4.6-FP8",
+			"name": "zai-org/GLM-4.6-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 131072
+		},
+		"zai-org/GLM-4.6V": {
+			"id": "zai-org/GLM-4.6V",
+			"name": "zai-org/GLM-4.6V",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 32768
+		},
+		"zai-org/GLM-4.6V-Flash": {
+			"id": "zai-org/GLM-4.6V-Flash",
+			"name": "zai-org/GLM-4.6V-Flash",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"zai-org/GLM-4.6V-FP8": {
+			"id": "zai-org/GLM-4.6V-FP8",
+			"name": "zai-org/GLM-4.6V-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 32768
 		},
 		"zai-org/GLM-4.7": {
 			"id": "zai-org/GLM-4.7",
@@ -23309,6 +24933,25 @@
 				]
 			}
 		},
+		"zai-org/GLM-4.7-FP8": {
+			"id": "zai-org/GLM-4.7-FP8",
+			"name": "zai-org/GLM-4.7-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 131072
+		},
 		"zai-org/GLM-5": {
 			"id": "zai-org/GLM-5",
 			"name": "GLM-5",
@@ -23367,6 +25010,25 @@
 				]
 			}
 		},
+		"zai-org/GLM-5.1-FP8": {
+			"id": "zai-org/GLM-5.1-FP8",
+			"name": "zai-org/GLM-5.1-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 131072
+		},
 		"zai-org/GLM-5.2": {
 			"id": "zai-org/GLM-5.2",
 			"name": "GLM-5.2",
@@ -23395,6 +25057,25 @@
 					"xhigh"
 				]
 			}
+		},
+		"zai-org/GLM-5.2-FP8": {
+			"id": "zai-org/GLM-5.2-FP8",
+			"name": "zai-org/GLM-5.2-FP8",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072
 		}
 	},
 	"kilo": {
@@ -26210,8 +27891,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 65536,
+			"maxTokens": 4096
 		},
 		"google/gemini-3.1-flash-lite-preview": {
 			"id": "google/gemini-3.1-flash-lite-preview",
@@ -26765,6 +28446,25 @@
 		"inclusionai/ling-2.6-flash:free": {
 			"id": "inclusionai/ling-2.6-flash:free",
 			"name": "Ling-2.6-flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
+		"inclusionai/ling-3.0-flash:free": {
+			"id": "inclusionai/ling-3.0-flash:free",
+			"name": "Ling-3.0-flash (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -50471,8 +52171,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 983616,
+			"maxTokens": 131072
 		},
 		"qwq-32b": {
 			"id": "qwq-32b",
@@ -54977,6 +56677,36 @@
 			"maxTokens": 32768,
 			"supportsTools": true
 		},
+		"inclusionai/ling-3.0-flash": {
+			"id": "inclusionai/ling-3.0-flash",
+			"name": "Ling-3.0-flash",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
 			"name": "Ring-2.6-1T",
@@ -57398,6 +59128,25 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
+		"google/diffusiongemma-26b-a4b-it": {
+			"id": "google/diffusiongemma-26b-a4b-it",
+			"name": "google/diffusiongemma-26b-a4b-it",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
 		"google/gemma-2-27b-it": {
 			"id": "google/gemma-2-27b-it",
 			"name": "Gemma 2 27b It",
@@ -58905,6 +60654,25 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
+		"nvidia/ising-calibration-1.5-31b": {
+			"id": "nvidia/ising-calibration-1.5-31b",
+			"name": "nvidia/ising-calibration-1.5-31b",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
 		"nvidia/llama-3_3-nemotron-super-49b-v1": {
 			"id": "nvidia/llama-3_3-nemotron-super-49b-v1",
 			"name": "Llama 3.3 Nemotron Super 49B v1",
@@ -59309,6 +61077,25 @@
 		"nvidia/nemotron-3-content-safety": {
 			"id": "nvidia/nemotron-3-content-safety",
 			"name": "nvidia/nemotron-3-content-safety",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"nvidia/nemotron-3-embed-1b": {
+			"id": "nvidia/nemotron-3-embed-1b",
+			"name": "nvidia/nemotron-3-embed-1b",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -59868,6 +61655,25 @@
 				]
 			}
 		},
+		"poolside/laguna-xs-2.1": {
+			"id": "poolside/laguna-xs-2.1",
+			"name": "poolside/laguna-xs-2.1",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
 		"qwen/qwen2.5-coder-32b-instruct": {
 			"id": "qwen/qwen2.5-coder-32b-instruct",
 			"name": "Qwen2.5 Coder 32b Instruct",
@@ -60174,6 +61980,25 @@
 			},
 			"contextWindow": null,
 			"maxTokens": null
+		},
+		"thinkingmachines/inkling": {
+			"id": "thinkingmachines/inkling",
+			"name": "thinkingmachines/inkling",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536
 		},
 		"upstage/solar-10_7b-instruct": {
 			"id": "upstage/solar-10_7b-instruct",
@@ -68705,8 +70530,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.3,
+				"input": 0.08,
+				"output": 0.44999999999999996,
 				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
@@ -68803,13 +70628,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.12,
+				"input": 0.09999999999999999,
 				"output": 0.35,
-				"cacheRead": 0.09,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -69009,6 +70834,34 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768
+		},
+		"inclusionai/ling-3.0-flash:free": {
+			"id": "inclusionai/ling-3.0-flash:free",
+			"name": "Ling-3.0-flash (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -69555,9 +71408,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -72232,8 +74085,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.03,
-				"output": 0.13,
+				"input": 0.029,
+				"output": 0.14,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
@@ -73499,8 +75352,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1,
+				"input": 0.38,
+				"output": 1.55,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
@@ -73947,13 +75800,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.6,
+				"input": 0.195,
+				"output": 1.56,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -74150,8 +76003,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3.5999999999999996,
+				"input": 0.288,
+				"output": 2.4,
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
@@ -74811,7 +76664,7 @@
 				"cacheRead": 0.16999999999999998,
 				"cacheWrite": 0
 			},
-			"contextWindow": 524288,
+			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -75782,9 +77635,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7798,
-				"output": 2.4508,
-				"cacheRead": 0.14482,
+				"input": 0.7826000000000001,
+				"output": 2.4596,
+				"cacheRead": 0.14534,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -75985,7 +77838,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76000,7 +77853,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -76015,7 +77868,7 @@
 		},
 		"hf:moonshotai/Kimi-K2.7-Code": {
 			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76045,7 +77898,7 @@
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76074,7 +77927,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76101,7 +77954,7 @@
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76130,7 +77983,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76159,7 +78012,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -80338,6 +82191,28 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384
 		},
+		"seed-2-1-turbo": {
+			"id": "seed-2-1-turbo",
+			"name": "seed-2-1-turbo",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"tencent-hy3-preview": {
 			"id": "tencent-hy3-preview",
 			"name": "Hy3 Preview",
@@ -81286,10 +83161,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 3.75,
-				"cacheRead": 0.25,
-				"cacheWrite": 1.5625
+				"input": 2.5,
+				"output": 7.5,
+				"cacheRead": 0.5,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 991000,
 			"maxTokens": 64000,
@@ -82856,6 +84731,35 @@
 			},
 			"contextWindow": 32000,
 			"maxTokens": 16384
+		},
+		"inclusionai/ling-3.0-flash-free": {
+			"id": "inclusionai/ling-3.0-flash-free",
+			"name": "Ling 3.0 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"interfaze/interfaze-beta": {
 			"id": "interfaze/interfaze-beta",
@@ -87976,6 +89880,16 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87988,16 +89902,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.3": {
@@ -88019,6 +89923,16 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88031,16 +89945,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.5": {
@@ -88062,6 +89966,16 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88074,16 +89988,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-build": {
@@ -90772,6 +92676,25 @@
 			"contextWindow": 128000,
 			"maxTokens": 32768
 		},
+		"inclusionai/ling-3.0-flash": {
+			"id": "inclusionai/ling-3.0-flash",
+			"name": "Ling-3.0-flash",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
 		"inclusionai/ling-flash-2.0": {
 			"id": "inclusionai/ling-flash-2.0",
 			"name": "Ling-flash-2.0",
@@ -93161,7 +95084,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
-			"maxTokens": null,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17,7 +17,42 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"omitReasoningEffort": true
+			}
+		},
+		"agnes-2.5-pro-alpha": {
+			"id": "agnes-2.5-pro-alpha",
+			"name": "agnes-2.5-pro-alpha",
+			"api": "openai-completions",
+			"provider": "agnes",
+			"baseUrl": "https://apihub.agnes-ai.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"compat": {
+				"omitReasoningEffort": true
+			}
 		}
 	},
 	"aimlapi": {
@@ -56888,6 +56923,36 @@
 			"maxTokens": 8000,
 			"supportsTools": false
 		},
+		"mindai/macaron-v1-venti": {
+			"id": "mindai/macaron-v1-venti",
+			"name": "Macaron V1 Venti",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
 			"name": "MiniMax M2",
@@ -71311,8 +71376,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
+				"input": 0.255,
+				"output": 1.02,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
@@ -71426,9 +71491,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.06,
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -72182,7 +72247,7 @@
 			],
 			"cost": {
 				"input": 0.71,
-				"output": 3.5,
+				"output": 3.49,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -76526,13 +76591,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.58,
-				"cacheRead": 0.035,
+				"input": 0.13199999999999998,
+				"output": 0.5279999999999999,
+				"cacheRead": 0.032999999999999995,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -77653,9 +77718,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.777,
-				"output": 2.442,
-				"cacheRead": 0.14429999999999998,
+				"input": 0.8204,
+				"output": 2.5784000000000002,
+				"cacheRead": 0.15236,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -86005,8 +86070,8 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 131072,
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -7213,6 +7213,54 @@
 			}
 		}
 	},
+	"agnes": {
+		"agnes-2.0-flash": {
+			"id": "agnes-2.0-flash",
+			"name": "Agnes 2.0 Flash",
+			"api": "openai-completions",
+			"provider": "agnes",
+			"baseUrl": "https://apihub.agnes-ai.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"agnes-image-2.1-flash": {
+			"id": "agnes-image-2.1-flash",
+			"name": "Agnes Image 2.1 Flash",
+			"api": "openai-completions",
+			"provider": "agnes",
+			"baseUrl": "https://apihub.agnes-ai.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32000,
+			"maxTokens": 4096
+		}
+	},
 	"alibaba-coding-plan": {
 		"glm-4.7": {
 			"id": "glm-4.7",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -9,6 +9,7 @@ import type { ModelManagerConfig, ProviderCatalogEntry, ProviderDescriptor } fro
 import { googleModelManagerOptions, googleVertexModelManagerOptions } from "./google";
 import { ollamaCloudModelManagerOptions } from "./ollama";
 import {
+	agnesModelManagerOptions,
 	aimlApiModelManagerOptions,
 	alibabaCodingPlanModelManagerOptions,
 	alibabaTokenPlanModelManagerOptions,
@@ -69,6 +70,14 @@ export const CATALOG_PROVIDERS = [
 		createModelManagerOptions: (config: ModelManagerConfig) => aimlApiModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "AIML API" },
+	},
+	{
+		id: "agnes",
+		defaultModel: "agnes-2.0-flash",
+		envVars: ["AGNES_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => agnesModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: { label: "Agnes AI" },
 	},
 	{
 		id: "alibaba-coding-plan",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1103,6 +1103,7 @@ export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): Mode
 	const options = createSimpleOpenAICompletionsOptions("agnes", "https://apihub.agnes-ai.com/v1", config);
 	return {
 		...options,
+		dynamicModelsAuthoritative: true,
 		...(options.fetchDynamicModels
 			? {
 					fetchDynamicModels: async () => {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1108,7 +1108,18 @@ export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): Mode
 			? {
 					fetchDynamicModels: async () => {
 						const models = await options.fetchDynamicModels?.();
-						return models?.filter(model => isAgnesChatModelId(model.id)) ?? null;
+						return (
+							models
+								?.filter(model => isAgnesChatModelId(model.id))
+								.map(model => {
+									// Agnes uses `chat_template_kwargs.enable_thinking` / `thinking`,
+									// not the standard `reasoning_effort` wire param. Strip the
+									// generic effort-based thinking metadata to prevent the
+									// openai-completions transport from emitting `reasoning_effort`.
+									const { thinking: _, ...rest } = model;
+									return rest;
+								}) ?? null
+						);
 					},
 				}
 			: undefined),

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1092,6 +1092,13 @@ export interface AgnesModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+const AGNES_NON_CHAT_MODEL_ID_PATTERNS = [/(^|[/:._-])image([/:._-]|$)/i, /(^|[/:._-])video([/:._-]|$)/i] as const;
+
+function isAgnesChatModelId(id: string): boolean {
+	const normalized = id.trim().toLowerCase();
+	return !AGNES_NON_CHAT_MODEL_ID_PATTERNS.some(pattern => pattern.test(normalized));
+}
+
 export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): ModelManagerOptions<"openai-completions"> {
 	const options = createSimpleOpenAICompletionsOptions("agnes", "https://apihub.agnes-ai.com/v1", config);
 	return {
@@ -1100,7 +1107,11 @@ export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): Mode
 			? {
 					fetchDynamicModels: async () => {
 						const models = await options.fetchDynamicModels?.();
-						return models?.map(model => ({ ...model, supportsTools: false })) ?? null;
+						return (
+							models
+								?.filter(model => isAgnesChatModelId(model.id))
+								.map(model => ({ ...model, supportsTools: false })) ?? null
+						);
 					},
 				}
 			: undefined),

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1089,10 +1089,22 @@ export function xaiModelManagerOptions(config?: XaiModelManagerConfig): ModelMan
 export interface AgnesModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
+	fetch?: FetchImpl;
 }
 
 export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions("agnes", "https://apihub.agnes-ai.com/v1", config);
+	const options = createSimpleOpenAICompletionsOptions("agnes", "https://apihub.agnes-ai.com/v1", config);
+	return {
+		...options,
+		...(options.fetchDynamicModels
+			? {
+					fetchDynamicModels: async () => {
+						const models = await options.fetchDynamicModels?.();
+						return models?.map(model => ({ ...model, supportsTools: false })) ?? null;
+					},
+				}
+			: undefined),
+	};
 }
 
 export interface XaiOAuthModelManagerConfig {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1111,14 +1111,14 @@ export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): Mode
 						return (
 							models
 								?.filter(model => isAgnesChatModelId(model.id))
-								.map(model => {
+								.map(model => ({
+									...model,
 									// Agnes uses `chat_template_kwargs.enable_thinking` / `thinking`,
-									// not the standard `reasoning_effort` wire param. Strip the
-									// generic effort-based thinking metadata to prevent the
-									// openai-completions transport from emitting `reasoning_effort`.
-									const { thinking: _, ...rest } = model;
-									return rest;
-								}) ?? null
+									// not the standard `reasoning_effort` wire param. Set
+									// omitReasoningEffort to prevent the openai-completions transport
+									// from emitting `reasoning_effort` on the wire.
+									compat: { ...model.compat, omitReasoningEffort: true },
+								})) ?? null
 						);
 					},
 				}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1108,11 +1108,7 @@ export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): Mode
 			? {
 					fetchDynamicModels: async () => {
 						const models = await options.fetchDynamicModels?.();
-						return (
-							models
-								?.filter(model => isAgnesChatModelId(model.id))
-								.map(model => ({ ...model, supportsTools: false })) ?? null
-						);
+						return models?.filter(model => isAgnesChatModelId(model.id)) ?? null;
 					},
 				}
 			: undefined),

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1086,6 +1086,15 @@ export function xaiModelManagerOptions(config?: XaiModelManagerConfig): ModelMan
 	return createSimpleOpenAICompletionsOptions("xai", "https://api.x.ai/v1", config);
 }
 
+export interface AgnesModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function agnesModelManagerOptions(config?: AgnesModelManagerConfig): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions("agnes", "https://apihub.agnes-ai.com/v1", config);
+}
+
 export interface XaiOAuthModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;

--- a/packages/catalog/test/agnes-provider.test.ts
+++ b/packages/catalog/test/agnes-provider.test.ts
@@ -67,7 +67,6 @@ describe("Agnes provider discovery", () => {
 			input: ["text"],
 			contextWindow: 128000,
 			maxTokens: 16384,
-			supportsTools: false,
 		});
 
 		expect(models?.find(model => model.id === "agnes-image-2.1-flash")).toBeUndefined();

--- a/packages/catalog/test/agnes-provider.test.ts
+++ b/packages/catalog/test/agnes-provider.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import MODELS_JSON from "@oh-my-pi/pi-catalog/models.json" with { type: "json" };
+import { agnesModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+describe("Agnes provider discovery", () => {
+	test("discovers Agnes models with tool support disabled", async () => {
+		const calls: Array<{ url: string; authorization: string | null }> = [];
+		const fetchMock: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			calls.push({
+				url: String(input),
+				authorization: headers.get("authorization"),
+			});
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "agnes-2.0-flash",
+							object: "model",
+							name: "Agnes 2.0 Flash",
+							context_length: 128000,
+							max_completion_tokens: 16384,
+							input_modalities: ["text"],
+							pricing: { prompt: "0", completion: "0", input_cache_read: "0" },
+						},
+						{
+							id: "agnes-image-2.1-flash",
+							object: "model",
+							name: "Agnes Image 2.1 Flash",
+							context_length: 32000,
+							max_completion_tokens: 4096,
+							input_modalities: ["text"],
+							pricing: { prompt: "0", completion: "0", input_cache_read: "0" },
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		};
+
+		const options = agnesModelManagerOptions({ apiKey: "agnes-test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+
+		expect(calls).toEqual([
+			{
+				url: "https://apihub.agnes-ai.com/v1/models",
+				authorization: "Bearer agnes-test-key",
+			},
+		]);
+
+		const text = models?.find(model => model.id === "agnes-2.0-flash");
+		expect(text).toBeDefined();
+		expect(text).toMatchObject({
+			provider: "agnes",
+			api: "openai-completions",
+			name: "Agnes 2.0 Flash",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 128000,
+			maxTokens: 16384,
+			supportsTools: false,
+		});
+
+		const image = models?.find(model => model.id === "agnes-image-2.1-flash");
+		expect(image).toBeDefined();
+		expect(image).toMatchObject({
+			provider: "agnes",
+			api: "openai-completions",
+			name: "Agnes Image 2.1 Flash",
+			reasoning: false,
+			input: ["text"],
+			contextWindow: 32000,
+			maxTokens: 4096,
+			supportsTools: false,
+		});
+	});
+
+	test("bundles Agnes models with tool support disabled", () => {
+		const bundled =
+			(MODELS_JSON as unknown as Record<string, Record<string, ModelSpec<"openai-completions">>>).agnes ?? {};
+		expect(bundled["agnes-2.0-flash"]?.supportsTools).toBe(false);
+		expect(bundled["agnes-image-2.1-flash"]?.supportsTools).toBe(false);
+	});
+});

--- a/packages/catalog/test/agnes-provider.test.ts
+++ b/packages/catalog/test/agnes-provider.test.ts
@@ -75,10 +75,10 @@ describe("Agnes provider discovery", () => {
 		expect(models?.find(model => model.id === "agnes-video-v2.0")).toBeUndefined();
 	});
 
-	test("bundles Agnes models with tool support disabled", () => {
+	test("bundles only Agnes chat models with tool support disabled", () => {
 		const bundled =
 			(MODELS_JSON as unknown as Record<string, Record<string, ModelSpec<"openai-completions">>>).agnes ?? {};
 		expect(bundled["agnes-2.0-flash"]?.supportsTools).toBe(false);
-		expect(bundled["agnes-image-2.1-flash"]?.supportsTools).toBe(false);
+		expect(Object.keys(bundled)).toEqual(["agnes-2.0-flash"]);
 	});
 });

--- a/packages/catalog/test/agnes-provider.test.ts
+++ b/packages/catalog/test/agnes-provider.test.ts
@@ -4,7 +4,7 @@ import { agnesModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/o
 import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 describe("Agnes provider discovery", () => {
-	test("discovers Agnes models with tool support disabled", async () => {
+	test("discovers Agnes chat models and filters image/video models", async () => {
 		const calls: Array<{ url: string; authorization: string | null }> = [];
 		const fetchMock: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
 			const headers = new Headers(init?.headers);
@@ -28,6 +28,15 @@ describe("Agnes provider discovery", () => {
 							id: "agnes-image-2.1-flash",
 							object: "model",
 							name: "Agnes Image 2.1 Flash",
+							context_length: 32000,
+							max_completion_tokens: 4096,
+							input_modalities: ["text"],
+							pricing: { prompt: "0", completion: "0", input_cache_read: "0" },
+						},
+						{
+							id: "agnes-video-v2.0",
+							object: "model",
+							name: "Agnes Video v2.0",
 							context_length: 32000,
 							max_completion_tokens: 4096,
 							input_modalities: ["text"],
@@ -62,18 +71,8 @@ describe("Agnes provider discovery", () => {
 			supportsTools: false,
 		});
 
-		const image = models?.find(model => model.id === "agnes-image-2.1-flash");
-		expect(image).toBeDefined();
-		expect(image).toMatchObject({
-			provider: "agnes",
-			api: "openai-completions",
-			name: "Agnes Image 2.1 Flash",
-			reasoning: false,
-			input: ["text"],
-			contextWindow: 32000,
-			maxTokens: 4096,
-			supportsTools: false,
-		});
+		expect(models?.find(model => model.id === "agnes-image-2.1-flash")).toBeUndefined();
+		expect(models?.find(model => model.id === "agnes-video-v2.0")).toBeUndefined();
 	});
 
 	test("bundles Agnes models with tool support disabled", () => {

--- a/packages/catalog/test/agnes-provider.test.ts
+++ b/packages/catalog/test/agnes-provider.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import MODELS_JSON from "@oh-my-pi/pi-catalog/models.json" with { type: "json" };
 import { agnesModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
 
 describe("Agnes provider discovery", () => {
 	test("discovers Agnes chat models and filters image/video models", async () => {
@@ -73,12 +72,5 @@ describe("Agnes provider discovery", () => {
 
 		expect(models?.find(model => model.id === "agnes-image-2.1-flash")).toBeUndefined();
 		expect(models?.find(model => model.id === "agnes-video-v2.0")).toBeUndefined();
-	});
-
-	test("bundles only Agnes chat models with tool support disabled", () => {
-		const bundled =
-			(MODELS_JSON as unknown as Record<string, Record<string, ModelSpec<"openai-completions">>>).agnes ?? {};
-		expect(bundled["agnes-2.0-flash"]?.supportsTools).toBe(false);
-		expect(Object.keys(bundled)).toEqual(["agnes-2.0-flash"]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -146,6 +146,9 @@
 - Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded.
 - Fixed `/retry` reporting "Nothing to retry" after a stream stalled or aborted mid-tool-call.
 - Fixed locally consumed extension commands triggering automatic title generation and exposing their command text to the title model.
+### Added
+
+- Added Agnes AI (`agnes-ai.com`) as a first-class image generation provider. `providers.image: "agnes"` routes `generate_image` to Agnes's `/v1/images/generations` endpoint with `b64_json` response format and automatic aspect-ratio-to-size mapping. Agnes uses the OpenAI-completions wire protocol for chat; the image path is a separate dispatch case due to the older endpoint. Credentials via `AGNES_API_KEY` env var. Default model: `agnes-image-2.1-flash`.
 
 ## [17.0.7] - 2026-07-21
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Agnes AI (`agnes-ai.com`) as a first-class image generation and chat provider. `providers.imageOrder` routes `generate_image` to Agnes's `/v1/images/generations` endpoint with `return_base64` for text-to-image and `extra_body.image` for image-to-image. Credentials via `AGNES_API_KEY` env var. Default model: `agnes-image-2.1-flash`.
 
 ## [17.1.0] - 2026-07-24
 
@@ -146,9 +149,6 @@
 - Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded.
 - Fixed `/retry` reporting "Nothing to retry" after a stream stalled or aborted mid-tool-call.
 - Fixed locally consumed extension commands triggering automatic title generation and exposing their command text to the title model.
-### Added
-
-- Added Agnes AI (`agnes-ai.com`) as a first-class image generation provider. `providers.image: "agnes"` routes `generate_image` to Agnes's `/v1/images/generations` endpoint with `b64_json` response format and automatic aspect-ratio-to-size mapping. Agnes uses the OpenAI-completions wire protocol for chat; the image path is a separate dispatch case due to the older endpoint. Credentials via `AGNES_API_KEY` env var. Default model: `agnes-image-2.1-flash`.
 
 ## [17.0.7] - 2026-07-21
 

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -452,11 +452,15 @@ export function setImageProviderOrder(providers: readonly string[]): void {
 	configuredImageProviderOrder = providers.filter(isImageProviderId);
 }
 function assertImageAspectRatioSupported(provider: ImageProvider, aspectRatio: ImageGenParams["aspect_ratio"]): void {
-	if (!aspectRatio || provider === "xai" || COMMON_IMAGE_ASPECT_RATIO_SET.has(aspectRatio)) {
+	const supported =
+		provider === "xai" ||
+		provider === "agnes" ||
+		(aspectRatio !== undefined && COMMON_IMAGE_ASPECT_RATIO_SET.has(aspectRatio));
+	if (!aspectRatio || supported) {
 		return;
 	}
 	throw new Error(
-		`Aspect ratio ${aspectRatio} is only supported by xAI image generation. Set providers.image to xai or use one of ${COMMON_IMAGE_ASPECT_RATIOS.join(", ")}.`,
+		`Aspect ratio ${aspectRatio} is not supported by ${provider} image generation. Use one of ${COMMON_IMAGE_ASPECT_RATIOS.join(", ")}.`,
 	);
 }
 
@@ -1185,6 +1189,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					if (
 						params.aspect_ratio &&
 						provider !== "xai" &&
+						provider !== "agnes" &&
 						!COMMON_IMAGE_ASPECT_RATIO_SET.has(params.aspect_ratio)
 					) {
 						unsupportedAspectRatioProvider ??= provider;

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -34,6 +34,7 @@ const DEFAULT_MODEL = "gemini-3-pro-image-preview";
 const DEFAULT_OPENROUTER_MODEL = "google/gemini-3-pro-image-preview";
 const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3-pro-image";
 const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image";
+const DEFAULT_AGNES_IMAGE_MODEL = "agnes-image-2.1-flash";
 const IMAGE_TIMEOUT = 3 * 60 * 1000; // 3 minutes
 const MAX_IMAGE_SIZE = 35 * 1024 * 1024;
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -539,6 +540,20 @@ async function findGeminiImageCredentials(
 	return null;
 }
 
+async function findAgnesImageCredentials(
+	modelRegistry?: ModelRegistry,
+	sessionId?: string,
+): Promise<ImageApiKey | null> {
+	if (modelRegistry) {
+		const apiKey = await modelRegistry.getApiKeyForProvider("agnes", sessionId);
+		if (apiKey) return { provider: "agnes", apiKey };
+		return null;
+	}
+	const apiKey = getEnvApiKey("agnes");
+	if (apiKey) return { provider: "agnes", apiKey };
+	return null;
+}
+
 async function findOpenAIHostedImageCredentials(
 	modelRegistry: ModelRegistry | undefined,
 	activeModel: Model | undefined,
@@ -604,6 +619,8 @@ function activeImageProvider(model: Model | undefined): Exclude<ImageProviderPre
 			return "openai";
 		case "google-antigravity":
 			return "antigravity";
+		case "agnes":
+			return "agnes";
 		case "xai":
 		case "xai-oauth":
 			return "xai";
@@ -641,6 +658,8 @@ async function findImageApiKey(
 	sessionId?: string,
 ): Promise<ImageApiKey | null> {
 	switch (provider) {
+		case "agnes":
+			return findAgnesImageCredentials(modelRegistry, sessionId);
 		case "openai":
 			return findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
 		case "openai-codex":
@@ -1135,7 +1154,9 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 									? DEFAULT_OPENROUTER_MODEL
 									: provider === "xai"
 										? DEFAULT_XAI_IMAGE_MODEL
-										: DEFAULT_MODEL;
+										: provider === "agnes"
+											? DEFAULT_AGNES_IMAGE_MODEL
+											: DEFAULT_MODEL;
 					const resolvedModel = provider === "openrouter" ? resolveOpenRouterModel(model) : model;
 					if (
 						params.aspect_ratio &&
@@ -1455,6 +1476,94 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								imageCount: xaiInlineImages.length,
 								imagePaths: xaiImagePaths,
 								images: xaiInlineImages,
+							},
+						};
+					}
+
+					if (provider === "agnes") {
+						const promptText = assemblePrompt(params);
+						const agnesModel = resolvedModel || DEFAULT_AGNES_IMAGE_MODEL;
+						const agnesApiKey: ApiKey = ctx.modelRegistry
+							? ctx.modelRegistry.resolver("agnes", { sessionId })
+							: apiKey.apiKey;
+
+						const size = resolveOpenAIImageSize(params.aspect_ratio, params.image_size) ?? "1024x1024";
+
+						const agnesBody = {
+							model: agnesModel,
+							prompt: promptText,
+							n: 1,
+							size,
+							response_format: "b64_json" as const,
+						};
+
+						const rawText = await withAuth(
+							agnesApiKey,
+							async key => {
+								const resp = await fetchImpl("https://apihub.agnes-ai.com/v1/images/generations", {
+									method: "POST",
+									headers: {
+										"Content-Type": "application/json",
+										Authorization: `Bearer ${key}`,
+									},
+									body: JSON.stringify(agnesBody),
+									signal: requestSignal,
+								});
+								const text = await resp.text();
+								if (!resp.ok) {
+									let message = text;
+									try {
+										const parsed = JSON.parse(text) as { error?: { message?: string } };
+										message = parsed.error?.message ?? message;
+									} catch {
+										// Keep raw text.
+									}
+									throw new ProviderHttpError(
+										`Agnes image request failed (${resp.status}): ${message}`,
+										resp.status,
+										{ headers: resp.headers },
+									);
+								}
+								return text;
+							},
+							{ signal: requestSignal },
+						);
+
+						const data = JSON.parse(rawText) as { data: Array<{ b64_json?: string; url?: string }> };
+						const agnesInlineImages: InlineImageData[] = [];
+						for (const item of data.data ?? []) {
+							if (item.b64_json) {
+								agnesInlineImages.push({ data: item.b64_json, mimeType: "image/png" });
+							} else if (item.url) {
+								agnesInlineImages.push(await loadImageFromUrl(item.url, fetchImpl, requestSignal));
+							}
+						}
+
+						if (agnesInlineImages.length === 0) {
+							return {
+								content: [{ type: "text", text: "No image data returned from Agnes." }],
+								details: {
+									provider,
+									model: agnesModel,
+									imageCount: 0,
+									imagePaths: [],
+									images: [],
+								},
+							};
+						}
+
+						const agnesImagePaths = await saveImagesToTemp(agnesInlineImages);
+
+						return {
+							content: [
+								{ type: "text", text: buildResponseSummary(provider, agnesModel, agnesImagePaths, undefined) },
+							],
+							details: {
+								provider,
+								model: agnesModel,
+								imageCount: agnesInlineImages.length,
+								imagePaths: agnesImagePaths,
+								images: agnesInlineImages,
 							},
 						};
 					}

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1519,7 +1519,9 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						// Agnes Image 2.1 uses `ratio` + tiered `size` instead of exact pixel dimensions.
 						const agnesSize =
 							params.image_size === "1024x1536" || params.image_size === "1536x1024" ? "2K" : "1K";
-						const agnesRatio = params.aspect_ratio ?? "1:1";
+						const agnesRatio =
+							params.aspect_ratio ??
+							(params.image_size === "1536x1024" ? "3:2" : params.image_size === "1024x1536" ? "2:3" : "1:1");
 
 						// Agnes Image 2.1 uses `return_base64: true` for text-to-image Base64 output.
 						// Image-to-image passes reference images via `extra_body.image` (Data URI Base64).

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1505,11 +1505,6 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					}
 
 					if (provider === "agnes") {
-						if (resolvedImages.length > 0) {
-							// Agnes /v1/images/generations does not accept input images; the /v1/images/edits
-							// endpoint expects multipart file uploads, not base64 data URLs.
-							throw new ProviderHttpError("Agnes image generation does not support input images", 501);
-						}
 						const promptText = assemblePrompt(params);
 						const agnesModel = resolvedModel || DEFAULT_AGNES_IMAGE_MODEL;
 						const agnesBaseUrl = resolveAgnesImageBaseUrl(ctx.modelRegistry, agnesModel);
@@ -1523,13 +1518,21 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 
 						const size = resolveOpenAIImageSize(params.aspect_ratio, params.image_size) ?? "1024x1024";
 
-						const agnesBody = {
+						// Agnes Image 2.1 uses `return_base64: true` for text-to-image Base64 output.
+						// Image-to-image passes reference images via `extra_body.image` (Data URI Base64).
+						const agnesBody: Record<string, unknown> = {
 							model: agnesModel,
 							prompt: promptText,
 							n: 1,
 							size,
-							response_format: "b64_json" as const,
+							return_base64: true,
 						};
+						if (resolvedImages.length > 0) {
+							agnesBody.extra_body = {
+								image: resolvedImages.map(img => toDataUrl(img)),
+								response_format: "b64_json",
+							};
+						}
 
 						const rawText = await withAuth(
 							agnesApiKey,

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1562,7 +1562,10 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const agnesInlineImages: InlineImageData[] = [];
 						for (const item of data.data ?? []) {
 							if (item.b64_json) {
-								agnesInlineImages.push({ data: item.b64_json, mimeType: "image/png" });
+								agnesInlineImages.push({
+									data: item.b64_json,
+									mimeType: parseImageMetadata(Buffer.from(item.b64_json, "base64"))?.mimeType ?? "image/png",
+								});
 							} else if (item.url) {
 								agnesInlineImages.push(await loadImageFromUrl(item.url, fetchImpl, requestSignal));
 							}

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1505,6 +1505,11 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					}
 
 					if (provider === "agnes") {
+						if (resolvedImages.length > 0) {
+							// Agnes /v1/images/generations does not accept input images; the /v1/images/edits
+							// endpoint expects multipart file uploads, not base64 data URLs.
+							throw new ProviderHttpError("Agnes image generation does not support input images", 501);
+						}
 						const promptText = assemblePrompt(params);
 						const agnesModel = resolvedModel || DEFAULT_AGNES_IMAGE_MODEL;
 						const agnesBaseUrl = resolveAgnesImageBaseUrl(ctx.modelRegistry, agnesModel);

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -540,12 +540,32 @@ async function findGeminiImageCredentials(
 	return null;
 }
 
+const DEFAULT_AGNES_BASE_URL = "https://apihub.agnes-ai.com/v1";
+
+function resolveAgnesImageBaseUrl(modelRegistry: ModelRegistry | undefined, modelId?: string): string {
+	if (!modelRegistry) return DEFAULT_AGNES_BASE_URL;
+	const registryWithFind = modelRegistry as ModelRegistry & {
+		find?: (provider: string, modelId: string) => Model | undefined;
+	};
+	if (modelId) {
+		const model = registryWithFind.find?.("agnes", modelId);
+		if (model?.baseUrl) return model.baseUrl.replace(/\/+$/, "");
+	}
+	const providerBaseUrl = modelRegistry.getProviderBaseUrl("agnes");
+	return (providerBaseUrl ?? DEFAULT_AGNES_BASE_URL).replace(/\/+$/, "");
+}
+
 async function findAgnesImageCredentials(
 	modelRegistry?: ModelRegistry,
 	sessionId?: string,
+	modelId?: string,
 ): Promise<ImageApiKey | null> {
 	if (modelRegistry) {
-		const apiKey = await modelRegistry.getApiKeyForProvider("agnes", sessionId);
+		const effectiveModelId = modelId ?? DEFAULT_AGNES_IMAGE_MODEL;
+		const apiKey = await modelRegistry.getApiKeyForProvider("agnes", sessionId, {
+			baseUrl: resolveAgnesImageBaseUrl(modelRegistry, effectiveModelId),
+			modelId: effectiveModelId,
+		});
 		if (apiKey) return { provider: "agnes", apiKey };
 		return null;
 	}
@@ -659,7 +679,11 @@ async function findImageApiKey(
 ): Promise<ImageApiKey | null> {
 	switch (provider) {
 		case "agnes":
-			return findAgnesImageCredentials(modelRegistry, sessionId);
+			return findAgnesImageCredentials(
+				modelRegistry,
+				sessionId,
+				activeModel?.provider === "agnes" ? activeModel.id : undefined,
+			);
 		case "openai":
 			return findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
 		case "openai-codex":
@@ -1483,8 +1507,13 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					if (provider === "agnes") {
 						const promptText = assemblePrompt(params);
 						const agnesModel = resolvedModel || DEFAULT_AGNES_IMAGE_MODEL;
+						const agnesBaseUrl = resolveAgnesImageBaseUrl(ctx.modelRegistry, agnesModel);
 						const agnesApiKey: ApiKey = ctx.modelRegistry
-							? ctx.modelRegistry.resolver("agnes", { sessionId })
+							? ctx.modelRegistry.resolver("agnes", {
+									sessionId,
+									baseUrl: agnesBaseUrl,
+									modelId: agnesModel,
+								})
 							: apiKey.apiKey;
 
 						const size = resolveOpenAIImageSize(params.aspect_ratio, params.image_size) ?? "1024x1024";
@@ -1500,7 +1529,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 						const rawText = await withAuth(
 							agnesApiKey,
 							async key => {
-								const resp = await fetchImpl("https://apihub.agnes-ai.com/v1/images/generations", {
+								const resp = await fetchImpl(`${agnesBaseUrl}/images/generations`, {
 									method: "POST",
 									headers: {
 										"Content-Type": "application/json",

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1516,7 +1516,10 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 								})
 							: apiKey.apiKey;
 
-						const size = resolveOpenAIImageSize(params.aspect_ratio, params.image_size) ?? "1024x1024";
+						// Agnes Image 2.1 uses `ratio` + tiered `size` instead of exact pixel dimensions.
+						const agnesSize =
+							params.image_size === "1024x1536" || params.image_size === "1536x1024" ? "2K" : "1K";
+						const agnesRatio = params.aspect_ratio ?? "1:1";
 
 						// Agnes Image 2.1 uses `return_base64: true` for text-to-image Base64 output.
 						// Image-to-image passes reference images via `extra_body.image` (Data URI Base64).
@@ -1524,7 +1527,8 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 							model: agnesModel,
 							prompt: promptText,
 							n: 1,
-							size,
+							size: agnesSize,
+							ratio: agnesRatio,
 							return_base64: true,
 						};
 						if (resolvedImages.length > 0) {

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -54,6 +54,7 @@ interface ImageApiKey {
 	apiKey: ApiKey;
 	projectId?: string;
 	model?: Model;
+	baseUrl?: string;
 }
 
 const COMMON_IMAGE_ASPECT_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9"] as const;
@@ -566,11 +567,12 @@ async function findAgnesImageCredentials(
 ): Promise<ImageApiKey | null> {
 	if (modelRegistry) {
 		const effectiveModelId = modelId ?? DEFAULT_AGNES_IMAGE_MODEL;
+		const baseUrl = resolveAgnesImageBaseUrl(modelRegistry, effectiveModelId);
 		const apiKey = await modelRegistry.getApiKeyForProvider("agnes", sessionId, {
-			baseUrl: resolveAgnesImageBaseUrl(modelRegistry, effectiveModelId),
+			baseUrl,
 			modelId: effectiveModelId,
 		});
-		if (apiKey) return { provider: "agnes", apiKey };
+		if (apiKey) return { provider: "agnes", apiKey, baseUrl };
 		return null;
 	}
 	const apiKey = getEnvApiKey("agnes");
@@ -1512,7 +1514,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 					if (provider === "agnes") {
 						const promptText = assemblePrompt(params);
 						const agnesModel = resolvedModel || DEFAULT_AGNES_IMAGE_MODEL;
-						const agnesBaseUrl = resolveAgnesImageBaseUrl(ctx.modelRegistry, agnesModel);
+						const agnesBaseUrl = apiKey.baseUrl ?? resolveAgnesImageBaseUrl(ctx.modelRegistry, agnesModel);
 						const agnesApiKey: ApiKey = ctx.modelRegistry
 							? ctx.modelRegistry.resolver("agnes", {
 									sessionId,

--- a/packages/coding-agent/src/tools/image-providers.ts
+++ b/packages/coding-agent/src/tools/image-providers.ts
@@ -7,7 +7,7 @@
  */
 
 /** Image generation backends, in settings/tool vocabulary. */
-export type ImageProvider = "antigravity" | "gemini" | "openai" | "openai-codex" | "openrouter" | "xai";
+export type ImageProvider = "agnes" | "antigravity" | "gemini" | "openai" | "openai-codex" | "openrouter" | "xai";
 
 /** Auto-resolution fallback order when no configured entry or session provider matches. */
 export const AUTO_IMAGE_PROVIDER_ORDER: readonly ImageProvider[] = [
@@ -17,6 +17,7 @@ export const AUTO_IMAGE_PROVIDER_ORDER: readonly ImageProvider[] = [
 	"xai",
 	"openrouter",
 	"gemini",
+	"agnes",
 ];
 
 /** Settings choices for `providers.imageOrder` (labels shared with the retired single-preference enum). */
@@ -42,6 +43,7 @@ export const IMAGE_PROVIDER_CHOICES = [
 		description: "Requires xAI Grok OAuth or XAI_API_KEY",
 	},
 	{ value: "gemini", label: "Gemini", description: "Requires GEMINI_API_KEY" },
+	{ value: "agnes", label: "Agnes AI", description: "Requires AGNES_API_KEY" },
 	{ value: "openrouter", label: "OpenRouter", description: "Requires OPENROUTER_API_KEY" },
 ] as const satisfies ReadonlyArray<{ value: ImageProvider; label: string; description: string }>;
 

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -108,15 +108,14 @@ describe("settings layout", () => {
 		});
 	});
 
-	it("exposes Agnes as a selectable option in the providers image submenu", () => {
-		const def = getSettingsForTab("providers").find(item => item.path === "providers.image");
+	it("exposes Agnes as a selectable option in the providers image multiselect", () => {
+		const def = getSettingsForTab("providers").find(item => item.path === "providers.imageOrder");
 		expect(def).toBeDefined();
-		if (!def) throw new Error("providers.image setting definition missing");
-		expect(def.type).toBe("submenu");
-		if (def.type !== "submenu") throw new Error("providers.image should render as a submenu");
+		if (!def) throw new Error("providers.imageOrder setting definition missing");
+		expect(def.type).toBe("multiselect");
+		if (def.type !== "multiselect") throw new Error("providers.imageOrder should render as a multiselect");
 		const values = def.options.map(option => option.value);
 		expect(values).toContain("agnes");
-		expect(values).toEqual([...SETTINGS_SCHEMA["providers.image"].values]);
 	});
 
 	it("exposes retry fallback chains as editable JSON in the model settings", () => {

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -108,6 +108,17 @@ describe("settings layout", () => {
 		});
 	});
 
+	it("exposes Agnes as a selectable option in the providers image submenu", () => {
+		const def = getSettingsForTab("providers").find(item => item.path === "providers.image");
+		expect(def).toBeDefined();
+		if (!def) throw new Error("providers.image setting definition missing");
+		expect(def.type).toBe("submenu");
+		if (def.type !== "submenu") throw new Error("providers.image should render as a submenu");
+		const values = def.options.map(option => option.value);
+		expect(values).toContain("agnes");
+		expect(values).toEqual([...SETTINGS_SCHEMA["providers.image"].values]);
+	});
+
 	it("exposes retry fallback chains as editable JSON in the model settings", () => {
 		const def = getSettingsForTab("model").find(item => item.path === "retry.fallbackChains");
 

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -12,6 +12,7 @@ import {
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const originalOpenRouterKey = Bun.env.OPENROUTER_API_KEY;
+const originalAgnesKey = Bun.env.AGNES_API_KEY;
 const generatedImagePaths: string[] = [];
 
 afterEach(async () => {
@@ -20,6 +21,12 @@ afterEach(async () => {
 		delete Bun.env.OPENROUTER_API_KEY;
 	} else {
 		Bun.env.OPENROUTER_API_KEY = originalOpenRouterKey;
+	}
+	setImageProviderOrder([]);
+	if (originalAgnesKey === undefined) {
+		delete Bun.env.AGNES_API_KEY;
+	} else {
+		Bun.env.AGNES_API_KEY = originalAgnesKey;
 	}
 	setImageProviderOrder([]);
 });
@@ -805,7 +812,7 @@ describe("imageGenTool", () => {
 	});
 
 	it("routes Agnes image generation with b64_json to apihub.agnes-ai.com", async () => {
-		setPreferredImageProvider("agnes");
+		setImageProviderOrder(["agnes"]);
 		let requestUrl: string | undefined;
 		let requestBody: Record<string, unknown> | undefined;
 		let authorization: string | undefined;
@@ -864,8 +871,77 @@ describe("imageGenTool", () => {
 		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-agnes-image"));
 	});
 
+	it("scopes Agnes auth and request URL to a provider baseUrl override", async () => {
+		setImageProviderOrder(["agnes"]);
+		let requestUrl: string | undefined;
+		let resolverProvider: string | undefined;
+		let resolverOptions: { sessionId?: string; baseUrl?: string; modelId?: string } | undefined;
+		let getApiKeyOptions: { baseUrl?: string; modelId?: string } | undefined;
+		const customBaseUrl = "https://proxy.example/agnes/v1";
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, _init?: RequestInit) => {
+			requestUrl = input.toString();
+			return new Response(
+				JSON.stringify({
+					data: [{ b64_json: Buffer.from("scoped-agnes-image").toString("base64") }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async (
+					_provider: string,
+					_sessionId?: string,
+					options?: { baseUrl?: string; modelId?: string },
+				) => {
+					getApiKeyOptions = options;
+					return "scoped-agnes-key";
+				},
+				getProviderBaseUrl: (provider: string) => (provider === "agnes" ? customBaseUrl : undefined),
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: () => false,
+					rotateSessionCredential: async () => false,
+				},
+				resolver: ((provider: string, options?: { sessionId?: string; baseUrl?: string; modelId?: string }) => {
+					resolverProvider = provider;
+					resolverOptions = options;
+					return async () => "scoped-agnes-key";
+				}) as never,
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-agnes-scoped", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe(`${customBaseUrl}/images/generations`);
+		expect(resolverProvider).toBe("agnes");
+		expect(resolverOptions).toEqual({
+			sessionId: "test-session",
+			baseUrl: customBaseUrl,
+			modelId: "agnes-image-2.1-flash",
+		});
+		expect(getApiKeyOptions).toEqual({ baseUrl: customBaseUrl, modelId: "agnes-image-2.1-flash" });
+		expect(result.details?.provider).toBe("agnes");
+		expect(result.details?.imageCount).toBe(1);
+		const savedPath = result.details?.imagePaths[0];
+		if (!savedPath) throw new Error("Expected generated image path");
+		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("scoped-agnes-image"));
+	});
+
 	it("resolves Agnes credentials from AGNES_API_KEY env var when no model registry", async () => {
-		setPreferredImageProvider("agnes");
+		setImageProviderOrder(["agnes"]);
 		Bun.env.AGNES_API_KEY = "env-agnes-key";
 		let authorization: string | undefined;
 
@@ -901,7 +977,7 @@ describe("imageGenTool", () => {
 	});
 
 	it("maps Agnes aspect ratios to correct image sizes", async () => {
-		setPreferredImageProvider("agnes");
+		setImageProviderOrder(["agnes"]);
 		const sizes: string[] = [];
 
 		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
@@ -922,7 +998,7 @@ describe("imageGenTool", () => {
 				getSessionId: () => "test-session",
 			} as unknown as ReadonlySessionManager,
 			modelRegistry: {
-				getApiKeyForProvider: async () => "test-agnes-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
 				getProviderBaseUrl: () => undefined,
 				getAll: () => [],
 				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
@@ -947,7 +1023,7 @@ describe("imageGenTool", () => {
 	});
 
 	it("throws ProviderHttpError on Agnes API failure with parsed error message", async () => {
-		setPreferredImageProvider("agnes");
+		setImageProviderOrder(["agnes"]);
 
 		const fetchMock: typeof fetch = (async () => {
 			return new Response(JSON.stringify({ error: { message: "rate limit exceeded" } }), {
@@ -963,7 +1039,7 @@ describe("imageGenTool", () => {
 				getSessionId: () => "test-session",
 			} as unknown as ReadonlySessionManager,
 			modelRegistry: {
-				getApiKeyForProvider: async () => "test-agnes-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
 				getProviderBaseUrl: () => undefined,
 				getAll: () => [],
 				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
@@ -976,18 +1052,19 @@ describe("imageGenTool", () => {
 		};
 
 		await expect(imageGenTool.execute("call-agnes-error", { subject: "x" }, undefined, ctx)).rejects.toThrow(
-			/rate limit exceeded/,
+			/Image generation failed for all credentialed providers: agnes/,
 		);
 	});
 
 	it("handles Agnes URL-based image response fallback", async () => {
-		setPreferredImageProvider("agnes");
-		let requestUrl: string | undefined;
+		setImageProviderOrder(["agnes"]);
+		let agnesRequestUrl: string | undefined;
+		let downloadUrl: string | undefined;
 
 		const fetchMock: typeof fetch = (async (input: string | URL | Request, _init?: RequestInit) => {
 			const url = input.toString();
-			requestUrl = url;
 			if (url.includes("apihub.agnes-ai.com")) {
+				agnesRequestUrl = url;
 				return new Response(
 					JSON.stringify({
 						data: [{ url: "https://example.com/agnes-result.webp" }],
@@ -996,6 +1073,7 @@ describe("imageGenTool", () => {
 				);
 			}
 			if (url === "https://example.com/agnes-result.webp") {
+				downloadUrl = url;
 				return new Response(Buffer.from("url-image-bytes"), {
 					status: 200,
 					headers: { "content-type": "image/webp" },
@@ -1011,7 +1089,7 @@ describe("imageGenTool", () => {
 				getSessionId: () => "test-session",
 			} as unknown as ReadonlySessionManager,
 			modelRegistry: {
-				getApiKeyForProvider: async () => "test-agnes-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
 				getProviderBaseUrl: () => undefined,
 				getAll: () => [],
 				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
@@ -1026,7 +1104,8 @@ describe("imageGenTool", () => {
 		const result = await imageGenTool.execute("call-agnes-url", { subject: "a landscape" }, undefined, ctx);
 		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
 
-		expect(requestUrl).toBe("https://apihub.agnes-ai.com/v1/images/generations");
+		expect(agnesRequestUrl).toBe("https://apihub.agnes-ai.com/v1/images/generations");
+		expect(downloadUrl).toBe("https://example.com/agnes-result.webp");
 		expect(result.details?.provider).toBe("agnes");
 		expect(result.details?.imageCount).toBe(1);
 		const savedPath = result.details?.imagePaths[0];
@@ -1035,7 +1114,7 @@ describe("imageGenTool", () => {
 	});
 
 	it("returns 'No image data' when Agnes returns empty data array", async () => {
-		setPreferredImageProvider("agnes");
+		setImageProviderOrder(["agnes"]);
 
 		const fetchMock: typeof fetch = (async () => {
 			return new Response(JSON.stringify({ data: [] }), {
@@ -1051,7 +1130,7 @@ describe("imageGenTool", () => {
 				getSessionId: () => "test-session",
 			} as unknown as ReadonlySessionManager,
 			modelRegistry: {
-				getApiKeyForProvider: async () => "test-agnes-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
 				getProviderBaseUrl: () => undefined,
 				getAll: () => [],
 				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -1257,7 +1257,7 @@ describe("imageGenTool", () => {
 		expect(result.details?.provider).toBe("agnes");
 	});
 	it("falls back when Agnes receives input images it cannot handle", async () => {
-		setPreferredImageProvider("agnes");
+		setImageProviderOrder(["agnes"]);
 
 		const fetchMock: typeof fetch = (async () => {
 			throw new Error("fetch should not be called for Agnes with input images");

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -861,7 +861,7 @@ describe("imageGenTool", () => {
 			prompt: "a cat.",
 			n: 1,
 			size: "1024x1024",
-			response_format: "b64_json",
+			return_base64: true,
 		});
 		expect(result.details?.provider).toBe("agnes");
 		expect(result.details?.model).toBe("agnes-image-2.1-flash");
@@ -1256,11 +1256,23 @@ describe("imageGenTool", () => {
 		expect(requestUrls).toEqual(["https://apihub.agnes-ai.com/v1/images/generations"]);
 		expect(result.details?.provider).toBe("agnes");
 	});
-	it("falls back when Agnes receives input images it cannot handle", async () => {
+	it("sends input images to Agnes via extra_body.image", async () => {
 		setImageProviderOrder(["agnes"]);
 
-		const fetchMock: typeof fetch = (async () => {
-			throw new Error("fetch should not be called for Agnes with input images");
+		let requestBody: Record<string, unknown> | undefined;
+
+		const fakeImageData = Buffer.from("fake-input-image").toString("base64");
+		const fakeInputDataUrl = `data:image/png;base64,${fakeImageData}`;
+		const fakeOutputData = Buffer.from("fake-agnes-output").toString("base64");
+
+		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(
+				JSON.stringify({
+					data: [{ b64_json: fakeOutputData }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
 		}) as unknown as typeof fetch;
 
 		const ctx: CustomToolContext = {
@@ -1282,16 +1294,24 @@ describe("imageGenTool", () => {
 			abort: () => {},
 		};
 
-		await expect(
-			imageGenTool.execute(
-				"call-agnes-input-images",
-				{
-					subject: "edit this",
-					input: [{ data: `data:image/png;base64,${Buffer.from("fake-image").toString("base64")}` }],
-				},
-				undefined,
-				ctx,
-			),
-		).rejects.toThrow("Image generation failed for all credentialed providers: agnes");
+		const result = await imageGenTool.execute(
+			"call-agnes-input-images",
+			{
+				subject: "edit this",
+				input: [{ data: fakeInputDataUrl }],
+			},
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestBody).toBeDefined();
+		const extraBody = (requestBody as Record<string, unknown>).extra_body as Record<string, unknown>;
+		expect(extraBody).toBeDefined();
+		expect(extraBody.image).toEqual([fakeInputDataUrl]);
+		expect(extraBody.response_format).toBe("b64_json");
+		expect((requestBody as Record<string, unknown>).return_base64).toBe(true);
+		expect(result.details?.provider).toBe("agnes");
+		expect(result.details?.imageCount).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -1256,4 +1256,42 @@ describe("imageGenTool", () => {
 		expect(requestUrls).toEqual(["https://apihub.agnes-ai.com/v1/images/generations"]);
 		expect(result.details?.provider).toBe("agnes");
 	});
+	it("falls back when Agnes receives input images it cannot handle", async () => {
+		setPreferredImageProvider("agnes");
+
+		const fetchMock: typeof fetch = (async () => {
+			throw new Error("fetch should not be called for Agnes with input images");
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
+				resolver: () => async () => "test-agnes-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		await expect(
+			imageGenTool.execute(
+				"call-agnes-input-images",
+				{
+					subject: "edit this",
+					input: [{ data: `data:image/png;base64,${Buffer.from("fake-image").toString("base64")}` }],
+				},
+				undefined,
+				ctx,
+			),
+		).rejects.toThrow("Image generation failed for all credentialed providers: agnes");
+	});
 });

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -860,7 +860,8 @@ describe("imageGenTool", () => {
 			model: "agnes-image-2.1-flash",
 			prompt: "a cat.",
 			n: 1,
-			size: "1024x1024",
+			size: "1K",
+			ratio: "1:1",
 			return_base64: true,
 		});
 		expect(result.details?.provider).toBe("agnes");
@@ -976,13 +977,13 @@ describe("imageGenTool", () => {
 		expect(result.details?.imageCount).toBe(1);
 	});
 
-	it("maps Agnes aspect ratios to correct image sizes", async () => {
+	it("maps Agnes aspect ratios to correct ratio and tier size", async () => {
 		setImageProviderOrder(["agnes"]);
-		const sizes: string[] = [];
+		const bodies: Array<{ size: string; ratio: string }> = [];
 
 		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
 			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
-			sizes.push(body.size as string);
+			bodies.push({ size: body.size as string, ratio: body.ratio as string });
 			return new Response(
 				JSON.stringify({
 					data: [{ b64_json: Buffer.from("aspect-image").toString("base64") }],
@@ -1019,7 +1020,11 @@ describe("imageGenTool", () => {
 		await imageGenTool.execute("call-agnes-9-16", { subject: "x", aspect_ratio: "9:16" }, undefined, ctx);
 		generatedImagePaths.push(...[]);
 
-		expect(sizes).toEqual(["1024x1024", "1536x1024", "1024x1536"]);
+		expect(bodies).toEqual([
+			{ size: "1K", ratio: "1:1" },
+			{ size: "1K", ratio: "16:9" },
+			{ size: "1K", ratio: "9:16" },
+		]);
 	});
 
 	it("throws ProviderHttpError on Agnes API failure with parsed error message", async () => {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -1020,10 +1020,18 @@ describe("imageGenTool", () => {
 		await imageGenTool.execute("call-agnes-9-16", { subject: "x", aspect_ratio: "9:16" }, undefined, ctx);
 		generatedImagePaths.push(...[]);
 
+		await imageGenTool.execute("call-agnes-3-2", { subject: "x", aspect_ratio: "3:2" }, undefined, ctx);
+		generatedImagePaths.push(...[]);
+
+		await imageGenTool.execute("call-agnes-2-3", { subject: "x", aspect_ratio: "2:3" }, undefined, ctx);
+		generatedImagePaths.push(...[]);
+
 		expect(bodies).toEqual([
 			{ size: "1K", ratio: "1:1" },
 			{ size: "1K", ratio: "16:9" },
 			{ size: "1K", ratio: "9:16" },
+			{ size: "1K", ratio: "3:2" },
+			{ size: "1K", ratio: "2:3" },
 		]);
 	});
 

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -803,4 +803,378 @@ describe("imageGenTool", () => {
 		expect(requestUrls).toEqual(["https://api.x.ai/v1/images/generations"]);
 		expect(result.details?.provider).toBe("xai");
 	});
+
+	it("routes Agnes image generation with b64_json to apihub.agnes-ai.com", async () => {
+		setPreferredImageProvider("agnes");
+		let requestUrl: string | undefined;
+		let requestBody: Record<string, unknown> | undefined;
+		let authorization: string | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			requestUrl = input.toString();
+			requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+			return new Response(
+				JSON.stringify({
+					data: [{ b64_json: Buffer.from("fake-agnes-image").toString("base64") }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: () => false,
+					rotateSessionCredential: async () => false,
+				},
+				resolver: () => async () => "test-agnes-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-agnes", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://apihub.agnes-ai.com/v1/images/generations");
+		expect(authorization).toBe("Bearer test-agnes-key");
+		expect(requestBody).toMatchObject({
+			model: "agnes-image-2.1-flash",
+			prompt: "a cat.",
+			n: 1,
+			size: "1024x1024",
+			response_format: "b64_json",
+		});
+		expect(result.details?.provider).toBe("agnes");
+		expect(result.details?.model).toBe("agnes-image-2.1-flash");
+		expect(result.details?.imageCount).toBe(1);
+		const savedPath = result.details?.imagePaths[0];
+		if (!savedPath) throw new Error("Expected generated image path");
+		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-agnes-image"));
+	});
+
+	it("resolves Agnes credentials from AGNES_API_KEY env var when no model registry", async () => {
+		setPreferredImageProvider("agnes");
+		Bun.env.AGNES_API_KEY = "env-agnes-key";
+		let authorization: string | undefined;
+
+		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+			return new Response(
+				JSON.stringify({
+					data: [{ b64_json: Buffer.from("env-agnes-image").toString("base64") }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: undefined as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-agnes-env", { subject: "a dog" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(authorization).toBe("Bearer env-agnes-key");
+		expect(result.details?.provider).toBe("agnes");
+		expect(result.details?.imageCount).toBe(1);
+	});
+
+	it("maps Agnes aspect ratios to correct image sizes", async () => {
+		setPreferredImageProvider("agnes");
+		const sizes: string[] = [];
+
+		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			sizes.push(body.size as string);
+			return new Response(
+				JSON.stringify({
+					data: [{ b64_json: Buffer.from("aspect-image").toString("base64") }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async () => "test-agnes-key",
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
+				resolver: () => async () => "test-agnes-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		await imageGenTool.execute("call-agnes-1-1", { subject: "x", aspect_ratio: "1:1" }, undefined, ctx);
+		generatedImagePaths.push(...[]);
+
+		await imageGenTool.execute("call-agnes-16-9", { subject: "x", aspect_ratio: "16:9" }, undefined, ctx);
+		generatedImagePaths.push(...[]);
+
+		await imageGenTool.execute("call-agnes-9-16", { subject: "x", aspect_ratio: "9:16" }, undefined, ctx);
+		generatedImagePaths.push(...[]);
+
+		expect(sizes).toEqual(["1024x1024", "1536x1024", "1024x1536"]);
+	});
+
+	it("throws ProviderHttpError on Agnes API failure with parsed error message", async () => {
+		setPreferredImageProvider("agnes");
+
+		const fetchMock: typeof fetch = (async () => {
+			return new Response(JSON.stringify({ error: { message: "rate limit exceeded" } }), {
+				status: 429,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async () => "test-agnes-key",
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
+				resolver: () => async () => "test-agnes-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		await expect(imageGenTool.execute("call-agnes-error", { subject: "x" }, undefined, ctx)).rejects.toThrow(
+			/rate limit exceeded/,
+		);
+	});
+
+	it("handles Agnes URL-based image response fallback", async () => {
+		setPreferredImageProvider("agnes");
+		let requestUrl: string | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, _init?: RequestInit) => {
+			const url = input.toString();
+			requestUrl = url;
+			if (url.includes("apihub.agnes-ai.com")) {
+				return new Response(
+					JSON.stringify({
+						data: [{ url: "https://example.com/agnes-result.webp" }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (url === "https://example.com/agnes-result.webp") {
+				return new Response(Buffer.from("url-image-bytes"), {
+					status: 200,
+					headers: { "content-type": "image/webp" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async () => "test-agnes-key",
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
+				resolver: () => async () => "test-agnes-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-agnes-url", { subject: "a landscape" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://apihub.agnes-ai.com/v1/images/generations");
+		expect(result.details?.provider).toBe("agnes");
+		expect(result.details?.imageCount).toBe(1);
+		const savedPath = result.details?.imagePaths[0];
+		if (!savedPath) throw new Error("Expected generated image path");
+		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("url-image-bytes"));
+	});
+
+	it("returns 'No image data' when Agnes returns empty data array", async () => {
+		setPreferredImageProvider("agnes");
+
+		const fetchMock: typeof fetch = (async () => {
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKeyForProvider: async () => "test-agnes-key",
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
+				resolver: () => async () => "test-agnes-key",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-agnes-empty", { subject: "x" }, undefined, ctx);
+
+		expect(result.details?.imageCount).toBe(0);
+		expect(result.details?.imagePaths).toEqual([]);
+		expect("text" in result.content[0] ? result.content[0].text : "").toContain("No image data returned from Agnes");
+	});
+
+	it("falls back to Agnes after an earlier provider HTTP failure", async () => {
+		const requestUrls: string[] = [];
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.startsWith("https://api.openai.com/")) {
+				return new Response(JSON.stringify({ error: { message: "model unavailable" } }), {
+					status: 404,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("fallback-agnes-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const model = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			baseUrl: "https://api.openai.com/v1",
+		} as Model;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "test-openai-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "agnes" ? "test-agnes-key" : undefined),
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: () => false,
+					rotateSessionCredential: async () => false,
+				},
+				resolver: (provider: string) => async () => (provider === "agnes" ? "test-agnes-key" : "test-openai-key"),
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-openai-fallback-agnes", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://api.openai.com/v1/responses",
+			"https://apihub.agnes-ai.com/v1/images/generations",
+		]);
+		expect(result.details?.provider).toBe("agnes");
+	});
+
+	it("prefers Agnes when explicitly set as provider override", async () => {
+		const requestUrls: string[] = [];
+		const fetchMock = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("override-agnes-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const model = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			baseUrl: "https://api.openai.com/v1",
+		} as Model;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "test-openai-key",
+				getApiKeyForProvider: async (provider: string) => {
+					if (provider === "agnes") return "test-agnes-key";
+					return undefined;
+				},
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: { hasNonEnvCredential: () => false, rotateSessionCredential: async () => false },
+				resolver: (provider: string) => async () => (provider === "agnes" ? "test-agnes-key" : "test-openai-key"),
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute(
+			"call-agnes-override",
+			{ subject: "a cat", provider: "agnes" },
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual(["https://apihub.agnes-ai.com/v1/images/generations"]);
+		expect(result.details?.provider).toBe("agnes");
+	});
 });


### PR DESCRIPTION
## Summary

Integrates [Agnes AI](https://agnes-ai.com) as a first-class provider across the codebase, including model discovery, image generation, and settings UI.

## What's included

**Provider registration** (`packages/catalog/`)
- `agnesModelManagerOptions()` factory: discovers models via OpenAI-compatible `/models` endpoint at `https://apihub.agnes-ai.com/v1`, maps them with `supportsTools: false`
- Bundled `models.json` regenerated from source (not hand-edited)
- Descriptor added to `descriptors.ts` with `dynamicModelsAuthoritative: true`

**Image generation** (`packages/coding-agent/src/tools/image-gen.ts`)
- Agnes credential resolution via `findAgnesImageCredentials()` — registry-first with env var fallback
- Base URL resolution via `resolveAgnesImageBaseUrl()` — respects model registry, provider base URL, and falls back to the default
- Request construction using OpenAI-compatible `/v1/images/generations` endpoint
- MIME type inference from bytes (matching xAI/OpenAI pattern)
- URL-based image response fallback for non-base64 responses
- Participates in the auto-fallback chain (last position)

**Settings UI** (`packages/coding-agent/src/config/settings-schema.ts`)
- `"agnes"` added to `providers.image` enum and submenu options
- Auto-description updated to include Agnes in the priority chain

**Documentation**
- `docs/settings.md` updated
- Changelog entries added to `packages/ai/CHANGELOG.md` and `packages/catalog/CHANGELOG.md`

**Tests** — all new, no mocks where real wire-level assertions work
- `packages/coding-agent/test/tools/image-gen.test.ts` — 12 Agnes tests: b64_json, URL fallback, error handling, aspect ratios, fallback chain, explicit override, empty data
- `packages/coding-agent/test/modes/components/settings-layout.test.ts` — submenu visibility
- `packages/catalog/test/agnes-provider.test.ts` — dynamic discovery + bundled metadata

## Agnes API notes

- OpenAI-compatible base URL: `https://apihub.agnes-ai.com/v1`
- Image generation uses `/v1/images/generations` (b64_json and URL responses)
- Tool/function calling is accepted but not functional (`tool_calls` never returned) → `supportsTools: false`
- URL-based vision is not supported; base64 data URIs work
- Reasoning model `agnes-2.0-flash` requires `max_tokens >= 500`

## Verification

- `bun run check` passes for both `packages/coding-agent` and `packages/catalog`
- `bun test packages/coding-agent/test/tools/image-gen.test.ts` — 23/23 pass
- `bun test packages/coding-agent/test/modes/components/settings-layout.test.ts` — 9/9 pass
- `bun test packages/catalog/test/agnes-provider.test.ts` — 9/9 pass