### PR TITLE
feat: add FriendliAI as built-in provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added FriendliAI provider with API key login and model validation ([#4770](https://github.com/can1357/oh-my-pi/discussions/4770))
 - Added Synthetic (synthetic.new) usage provider: `/usage` now reports the rolling 5-hour request limit and weekly credit quota via `GET /v2/quotas`, including per-tick regeneration rates in the window labels.
 - Added optional `UsageWindow.resetLabel` so rolling windows can render their countdown with an accurate verb (e.g. "tick in 12m" / "regen in 51m" instead of "resets in") — both quota windows on Synthetic regenerate incrementally rather than hard-resetting.
 

--- a/packages/ai/src/registry/friendli.ts
+++ b/packages/ai/src/registry/friendli.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginFriendli = createApiKeyLogin({
+	providerLabel: "FriendliAI",
+	authUrl: "https://friendli.ai/suite/~/setting/keys",
+	instructions: "Copy your Personal API key from Friendli Suite",
+	promptMessage: "Paste your FriendliAI API key",
+	placeholder: "flp_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "FriendliAI",
+		modelsUrl: "https://api.friendli.ai/serverless/v1/models",
+	},
+});
+
+export const friendliProvider = {
+	id: "friendli",
+	name: "FriendliAI",
+	login: (cb: OAuthLoginCallbacks) => loginFriendli(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -13,6 +13,7 @@ import { deepseekProvider } from "./deepseek";
 import { devinProvider } from "./devin";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
+import { friendliProvider } from "./friendli";
 import { githubCopilotProvider } from "./github-copilot";
 import { gitlabDuoProvider } from "./gitlab-duo";
 import { gitLabDuoWorkflowProvider } from "./gitlab-duo-workflow";
@@ -109,6 +110,7 @@ const ALL = [
 	cerebrasProvider,
 	basetenProvider,
 	fireworksProvider,
+	friendliProvider,
 	togetherProvider,
 	nvidiaProvider,
 	novitaProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added FriendliAI provider with dynamic model discovery ([#4770](https://github.com/can1357/oh-my-pi/discussions/4770))
+
 ### Changed
 
 - Renamed `codex-auto-review` model to `GPT-5.3 Codex Spark` with updated pricing and capabilities

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -262,6 +262,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const isCerebras = modelMatchesHost(hostModel, "cerebras");
 	const isZai = modelMatchesHost(hostModel, "zai");
 	const isZhipu = modelMatchesHost(hostModel, "zhipu");
+	const isFriendli = modelMatchesHost(hostModel, "friendli");
 	const supportsZaiReasoningEffort = (isZai || isZhipu) && isGlm52ReasoningEffortModelId(spec.id);
 	const isKilo = modelMatchesHost(hostModel, "kilo");
 	const isKimiModel = isKimiModelId(spec.id);
@@ -337,6 +338,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		isMoonshotNative ||
 		isZai ||
 		isZhipu ||
+		isFriendli ||
 		hostMatchesUrl(baseUrl, "chutes") ||
 		hostMatchesUrl(baseUrl, "fireworks") ||
 		isDirectDeepseekApi;

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -50,6 +50,7 @@ export const KNOWN_HOSTS = {
 	baseten: { providers: ["baseten"], urlMarkers: ["baseten.co"] },
 	/** URL-only on purpose: the `fireworks`/`firepass` providers route per-model and not every model is Fireworks-shaped. */
 	fireworks: { urlMarkers: ["fireworks.ai"] },
+	friendli: { providers: ["friendli"], urlMarkers: ["api.friendli.ai"] },
 	groq: { providers: ["groq"], urlMarkers: ["api.groq.com"] },
 	minimax: {
 		providers: ["minimax", "minimax-code", "minimax-code-cn"],

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -16993,6 +16993,7 @@
 			}
 		}
 	},
+	"friendli": {},
 	"github-copilot": {
 		"claude-fable-5": {
 			"id": "claude-fable-5",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -19,6 +19,7 @@ import {
 	deepseekModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
+	friendliModelManagerOptions,
 	githubCopilotModelManagerOptions,
 	groqModelManagerOptions,
 	huggingfaceModelManagerOptions,
@@ -147,6 +148,14 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["FIREWORKS_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => fireworksModelManagerOptions(config),
 		catalogDiscovery: { label: "Fireworks" },
+	},
+	{
+		id: "friendli",
+		defaultModel: "zai-org/GLM-5.2",
+		envVars: ["FRIENDLI_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => friendliModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: { label: "FriendliAI" },
 	},
 	{
 		id: "github-copilot",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1843,6 +1843,64 @@ export function fireworksModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// 7.55 FriendliAI
+// ---------------------------------------------------------------------------
+
+export interface FriendliModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+const FRIENDLI_DEFAULT_BASE_URL = "https://api.friendli.ai/serverless/v1";
+
+export function friendliModelManagerOptions(
+	config?: FriendliModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? FRIENDLI_DEFAULT_BASE_URL;
+	const resolveReference = createReferenceResolver(createBundledReferenceMap<"openai-completions">("friendli"));
+	return {
+		providerId: "friendli",
+		dynamicModelsAuthoritative: true,
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "friendli",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = resolveReference(defaults.id);
+						const raw = entry as Record<string, unknown> & {
+							context_length?: unknown;
+							max_completion_tokens?: unknown;
+						};
+
+						const contextWindow = toPositiveNumber(
+							raw.context_length,
+							reference?.contextWindow ?? defaults.contextWindow,
+						);
+						const maxTokens = toPositiveNumber(
+							raw.max_completion_tokens,
+							reference?.maxTokens ?? defaults.maxTokens,
+						);
+
+						const baseModel = mapWithBundledReference(entry, defaults, reference);
+
+						return {
+							...baseModel,
+							contextWindow,
+							maxTokens,
+						};
+					},
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 7.6 Fire Pass (Fireworks Kimi K2.6 Turbo subscription)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds FriendliAI (`friendli`) as a built-in OpenAI-compatible provider. Users can authenticate with `FRIENDLI_API_KEY` and use Friendli-hosted models directly.

- Registry: `packages/ai/src/registry/friendli.ts` — API key login with validation against `/serverless/v1/models`
- Catalog: `friendliModelManagerOptions` in `openai-compat.ts` — dynamic model discovery with global reference resolution
- Catalog: `CATALOG_PROVIDERS` entry with `FRIENDLI_API_KEY` env var, default model `zai-org/GLM-5.2`
- Registry: `friendliProvider` registered in `ALL` array
- Models: empty `friendli` entry in `models.json` for type resolution
- Host: `friendli` entry in `hosts.ts` with `max_tokens` field for chat-completions compat

## Why

FriendliAI runs a fully OpenAI-compatible API at `https://api.friendli.ai/serverless/v1`. The endpoint hosts popular open models and supports streaming, tool calling, reasoning_content, structured outputs, and vision. Adding it as a built-in provider means users just paste their API key and go.

A previous attempt (#5322) got auto-closed because I wasn't vouched yet. That's sorted now — vouched in discussion #4770. This resubmission also addresses two review points from the earlier PR:

- The bundled reference slice is empty, so `createBundledReferenceMap(\"friendli\")` returned nothing and the default model came through as non-reasoning with zero cost. Switched to `createReferenceResolver` so it falls back to cross-provider references and keeps reasoning/thinking metadata intact.
- Friendli's chat-completions endpoint expects `max_tokens`, not `max_completion_tokens`. Registered the host and added it to the `useMaxTokens` list so capped requests don't get rejected.

Friendli-specific reasoning params (`parse_reasoning`, `include_reasoning`) aren't forwarded yet — that needs `extra_body` passthrough support which doesn't exist currently. Not blocking.

## Testing

- `bun check` passes across all packages
- Registry and catalog completeness checks satisfied
- Runtime model discovery will be validated once a `FRIENDLI_API_KEY` is configured

---

- [x] `bun check` passes
- [ ] Tested locally
- [x] CHANGELOG updated (if user-facing)