### PR TITLE
fix(ai): SuperGrok usage for unified billing accounts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed outbound credential-pattern redaction (`[github_token_redacted]` & co.) running unconditionally: it is now opt-in via `configureCredentialRedaction` and disabled by default, so credential-shaped strings the user deliberately pastes reach the provider unmodified unless the host enables redaction.
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
+- Fixed SuperGrok (`xai-oauth`) `/usage` showing "no usage data" for unified-billing accounts: when `?format=credits` lacks `creditUsagePercent` (or marks `isUnifiedBillingUser`), fall back to / merge the default monthly `monthlyLimit`/`used` payload.
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts
+++ b/packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts
@@ -136,6 +136,7 @@ describe("xAI OAuth helpers", () => {
 	it("builds the billing URL and CLI-aligned headers", () => {
 		expect(buildXAICliBillingUrl()).toBe("https://cli-chat-proxy.grok.com/v1/billing?format=credits");
 		expect(buildXAICliBillingUrl("tokens")).toBe("https://cli-chat-proxy.grok.com/v1/billing?format=tokens");
+		expect(buildXAICliBillingUrl("")).toBe("https://cli-chat-proxy.grok.com/v1/billing");
 		expect(getXAICliBillingHeaders({ accessToken: "access-token" })).toEqual({
 			Authorization: "Bearer access-token",
 			Accept: "application/json",

--- a/packages/ai/src/registry/oauth/xai-oauth.ts
+++ b/packages/ai/src/registry/oauth/xai-oauth.ts
@@ -256,10 +256,10 @@ async function withXAIOAuthIdentity(
 	};
 }
 
-/** Build the SuperGrok CLI billing URL. */
+/** Build the SuperGrok CLI billing URL. Pass `""` to omit `format` (unified monthly payload). */
 export function buildXAICliBillingUrl(format: string = XAI_CLI_BILLING_FORMAT): string {
 	const url = new URL(XAI_CLI_BILLING_PATH, XAI_CLI_BILLING_BASE_URL);
-	url.searchParams.set("format", format);
+	if (format) url.searchParams.set("format", format);
 	return validateXAIBillingEndpoint(url.toString());
 }
 

--- a/packages/ai/src/usage/xai-oauth.ts
+++ b/packages/ai/src/usage/xai-oauth.ts
@@ -1,9 +1,12 @@
 /**
  * SuperGrok (`xai-oauth`) subscription usage provider.
  *
- * Reads weekly credit and product utilization from the Grok CLI billing
- * endpoint. Only OAuth access credentials are accepted; paid API keys are a
- * separate product and must never be sent here.
+ * Reads utilization from the Grok CLI billing endpoint. Prefer the legacy
+ * weekly `format=credits` payload (creditUsagePercent / productUsage). When
+ * xAI marks the account as unified billing and omits those fields, fall back
+ * to the default monthly included-quota shape (`monthlyLimit` / `used`).
+ * Only OAuth access credentials are accepted; paid API keys are a separate
+ * product and must never be sent here.
  */
 
 import {
@@ -27,6 +30,8 @@ import { toNumber } from "./shared";
 
 const PROVIDER_ID = "xai-oauth";
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const BILLING_SOURCE = "cli-chat-proxy.grok.com/v1/billing";
 
 interface XaiBillingPeriod {
 	start: string;
@@ -39,13 +44,32 @@ interface XaiProductUsage {
 	usagePercent: number;
 }
 
-interface XaiBillingConfig {
+/** Legacy SuperGrok weekly credits (`?format=credits`). */
+interface XaiWeeklyBillingConfig {
+	kind: "weekly";
 	currentPeriod: XaiBillingPeriod;
 	creditUsagePercent: number;
 	productUsage: XaiProductUsage[];
 	onDemandCap?: number;
 	onDemandUsed?: number;
 }
+
+/**
+ * Unified-billing monthly included quota.
+ * Live `isUnifiedBillingUser` accounts omit creditUsagePercent on
+ * `?format=credits` and expose monthlyLimit/used on the default billing URL.
+ */
+interface XaiMonthlyBillingConfig {
+	kind: "monthly";
+	periodStart: string;
+	periodEnd: string;
+	used: number;
+	limit: number;
+	onDemandCap?: number;
+	onDemandUsed?: number;
+}
+
+type XaiBillingConfig = XaiWeeklyBillingConfig | XaiMonthlyBillingConfig;
 
 function parseIsoMs(value: string): number | undefined {
 	const parsed = Date.parse(value);
@@ -98,9 +122,22 @@ function buildPeriodWindow(period: XaiBillingPeriod): UsageWindow {
 	};
 }
 
-function parseBillingConfig(payload: unknown): XaiBillingConfig | null {
-	if (!isRecord(payload) || !isRecord(payload.config)) return null;
-	const raw = payload.config;
+function buildMonthlyWindow(periodStart: string, periodEnd: string): UsageWindow | undefined {
+	const startMs = parseIsoMs(periodStart);
+	const endMs = parseIsoMs(periodEnd);
+	if (startMs === undefined || endMs === undefined || endMs <= startMs) return undefined;
+	// ponytail: real calendar months vary; use observed period length from the API
+	const durationMs = endMs - startMs;
+	const approxDays = Math.max(1, Math.round(durationMs / DAY_MS));
+	return {
+		id: "1mo",
+		label: approxDays === 30 || approxDays === 31 ? "Monthly" : `${approxDays}d`,
+		durationMs,
+		resetsAt: endMs,
+	};
+}
+
+function parseWeeklyBillingConfig(raw: Record<string, unknown>): XaiWeeklyBillingConfig | null {
 	if (!isRecord(raw.currentPeriod)) return null;
 
 	const start = typeof raw.currentPeriod.start === "string" ? parseIsoMs(raw.currentPeriod.start) : undefined;
@@ -129,6 +166,7 @@ function parseBillingConfig(payload: unknown): XaiBillingConfig | null {
 	}
 
 	return {
+		kind: "weekly",
 		currentPeriod: {
 			start: raw.currentPeriod.start as string,
 			end: raw.currentPeriod.end as string,
@@ -141,62 +179,145 @@ function parseBillingConfig(payload: unknown): XaiBillingConfig | null {
 	};
 }
 
-function buildLimits(config: XaiBillingConfig, accountId: string | undefined): UsageLimit[] {
-	const window = buildPeriodWindow(config.currentPeriod);
-	const scope = {
-		provider: PROVIDER_ID,
-		...(accountId ? { accountId } : {}),
-		windowId: window.id,
-		shared: true as const,
+function parseMonthlyBillingConfig(raw: Record<string, unknown>): XaiMonthlyBillingConfig | null {
+	const periodStart = typeof raw.billingPeriodStart === "string" ? raw.billingPeriodStart : "";
+	const periodEnd = typeof raw.billingPeriodEnd === "string" ? raw.billingPeriodEnd : "";
+	const startMs = parseIsoMs(periodStart);
+	const endMs = parseIsoMs(periodEnd);
+	if (!periodStart || !periodEnd || startMs === undefined || endMs === undefined || endMs <= startMs) {
+		return null;
+	}
+
+	const limit = parseOnDemandAmount(raw.monthlyLimit);
+	const used = parseOnDemandAmount(raw.used);
+	// Require a positive included quota; zero/missing is not a usable report.
+	if (limit === undefined || limit <= 0 || used === undefined) return null;
+
+	return {
+		kind: "monthly",
+		periodStart,
+		periodEnd,
+		used,
+		limit,
+		onDemandCap: parseOnDemandAmount(raw.onDemandCap),
+		onDemandUsed: parseOnDemandAmount(raw.onDemandUsed),
 	};
-	const overall = buildPercentAmount(config.creditUsagePercent);
+}
+
+function buildOnDemandLimit(
+	onDemandCap: number | undefined,
+	onDemandUsed: number | undefined,
+	accountId: string | undefined,
+): UsageLimit | undefined {
+	if (onDemandCap === undefined || onDemandCap <= 0 || onDemandUsed === undefined) return undefined;
+	const usedFraction = Math.min(onDemandUsed / onDemandCap, 1);
+	return {
+		id: `${PROVIDER_ID}:on-demand`,
+		label: "On-demand",
+		scope: {
+			provider: PROVIDER_ID,
+			...(accountId ? { accountId } : {}),
+			shared: true,
+		},
+		amount: {
+			used: onDemandUsed,
+			limit: onDemandCap,
+			remaining: Math.max(0, onDemandCap - onDemandUsed),
+			usedFraction,
+			remainingFraction: 1 - usedFraction,
+			unit: "unknown",
+		},
+		status: buildUsageStatus(usedFraction),
+	};
+}
+
+function buildLimits(config: XaiBillingConfig, accountId: string | undefined): UsageLimit[] {
+	if (config.kind === "weekly") {
+		const window = buildPeriodWindow(config.currentPeriod);
+		const scope = {
+			provider: PROVIDER_ID,
+			...(accountId ? { accountId } : {}),
+			windowId: window.id,
+			shared: true as const,
+		};
+		const overall = buildPercentAmount(config.creditUsagePercent);
+		const limits: UsageLimit[] = [
+			{
+				id: `${PROVIDER_ID}:credits:1w`,
+				label: "SuperGrok Weekly Credits",
+				scope,
+				window,
+				amount: overall,
+				status: buildUsageStatus(overall.usedFraction ?? 0),
+			},
+		];
+
+		for (const item of config.productUsage) {
+			const amount = buildPercentAmount(item.usagePercent);
+			const slug = slugifyProduct(item.product);
+			if (!slug) continue;
+			limits.push({
+				id: `${PROVIDER_ID}:product:${slug}:1w`,
+				label: `${item.product === "GrokBuild" ? "Grok Build" : item.product === "Api" ? "API" : item.product} (Weekly)`,
+				scope,
+				window,
+				amount,
+				status: buildUsageStatus(amount.usedFraction ?? 0),
+			});
+		}
+		const onDemand = buildOnDemandLimit(config.onDemandCap, config.onDemandUsed, accountId);
+		if (onDemand) limits.push(onDemand);
+		return limits;
+	}
+
+	const window = buildMonthlyWindow(config.periodStart, config.periodEnd);
+	if (!window) return [];
+	const usedFraction = Math.min(config.used / config.limit, 1);
 	const limits: UsageLimit[] = [
 		{
-			id: `${PROVIDER_ID}:credits:1w`,
-			label: "SuperGrok Weekly Credits",
-			scope,
-			window,
-			amount: overall,
-			status: buildUsageStatus(overall.usedFraction ?? 0),
-		},
-	];
-
-	for (const item of config.productUsage) {
-		const amount = buildPercentAmount(item.usagePercent);
-		const slug = slugifyProduct(item.product);
-		if (!slug) continue;
-		limits.push({
-			id: `${PROVIDER_ID}:product:${slug}:1w`,
-			label: `${item.product === "GrokBuild" ? "Grok Build" : item.product === "Api" ? "API" : item.product} (Weekly)`,
-			scope,
-			window,
-			amount,
-			status: buildUsageStatus(amount.usedFraction ?? 0),
-		});
-	}
-	if (config.onDemandCap !== undefined && config.onDemandCap > 0 && config.onDemandUsed !== undefined) {
-		const usedFraction = Math.min(config.onDemandUsed / config.onDemandCap, 1);
-		limits.push({
-			id: `${PROVIDER_ID}:on-demand`,
-			label: "On-demand",
+			id: `${PROVIDER_ID}:included:1mo`,
+			label: "SuperGrok Monthly Included",
 			scope: {
 				provider: PROVIDER_ID,
 				...(accountId ? { accountId } : {}),
+				windowId: window.id,
 				shared: true,
 			},
+			window,
 			amount: {
-				used: config.onDemandUsed,
-				limit: config.onDemandCap,
-				remaining: Math.max(0, config.onDemandCap - config.onDemandUsed),
+				used: config.used,
+				limit: config.limit,
+				remaining: Math.max(0, config.limit - config.used),
 				usedFraction,
 				remainingFraction: 1 - usedFraction,
+				// ponytail: xAI does not label the unit; amounts match dashboard dollars-ish quota points
 				unit: "unknown",
 			},
 			status: buildUsageStatus(usedFraction),
-		});
-	}
-
+		},
+	];
+	const onDemand = buildOnDemandLimit(config.onDemandCap, config.onDemandUsed, accountId);
+	if (onDemand) limits.push(onDemand);
 	return limits;
+}
+
+async function fetchBillingPayload(
+	url: string,
+	accessToken: string,
+	ctx: UsageFetchContext,
+	signal: AbortSignal | undefined,
+): Promise<unknown | null> {
+	try {
+		const response = await ctx.fetch(url, {
+			headers: getXAICliBillingHeaders({ accessToken }),
+			redirect: "error",
+			signal,
+		});
+		if (!response.ok) return null;
+		return await response.json();
+	} catch {
+		return null;
+	}
 }
 
 export const xaiOauthUsageProvider: UsageProvider = {
@@ -224,33 +345,69 @@ export const xaiOauthUsageProvider: UsageProvider = {
 			}
 		}
 
-		const url = buildXAICliBillingUrl();
-		let payload: unknown;
-		try {
-			const response = await ctx.fetch(url, {
-				headers: getXAICliBillingHeaders({ accessToken }),
-				redirect: "error",
-				signal: params.signal,
-			});
-			if (!response.ok) return null;
-			payload = await response.json();
-		} catch {
-			return null;
+		// Always probe weekly credits first (legacy SuperGrok shape).
+		const creditsUrl = buildXAICliBillingUrl();
+		const monthlyUrl = buildXAICliBillingUrl("");
+		const creditsPayload = await fetchBillingPayload(creditsUrl, accessToken, ctx, params.signal);
+		const weekly =
+			creditsPayload && isRecord(creditsPayload) && isRecord(creditsPayload.config)
+				? parseWeeklyBillingConfig(creditsPayload.config)
+				: null;
+		const creditsLooksUnified =
+			!!creditsPayload &&
+			isRecord(creditsPayload) &&
+			isRecord(creditsPayload.config) &&
+			creditsPayload.config.isUnifiedBillingUser === true;
+
+		// Unified accounts expose a separate monthly included-quota payload on the
+		// default billing URL. Fetch it when credits is missing/unusable, or when
+		// credits itself marks the account unified (even if weekly percents exist —
+		// live responses sometimes include both shapes).
+		let monthlyPayload: unknown | null = null;
+		let monthly: XaiMonthlyBillingConfig | null = null;
+		if (!weekly || creditsLooksUnified) {
+			monthlyPayload = await fetchBillingPayload(monthlyUrl, accessToken, ctx, params.signal);
+			monthly =
+				monthlyPayload && isRecord(monthlyPayload) && isRecord(monthlyPayload.config)
+					? parseMonthlyBillingConfig(monthlyPayload.config)
+					: null;
 		}
 
-		const config = parseBillingConfig(payload);
-		if (!config) return null;
+		if (!weekly && !monthly) return null;
+
+		const limits: UsageLimit[] = [];
+		if (weekly) limits.push(...buildLimits(weekly, accountId));
+		if (monthly) limits.push(...buildLimits(monthly, accountId));
+		// Deduplicate on-demand if both shapes carried the same cap (keep first).
+		const seen = new Set<string>();
+		const deduped = limits.filter(limit => {
+			if (seen.has(limit.id)) return false;
+			seen.add(limit.id);
+			return true;
+		});
+		if (deduped.length === 0) return null;
+
+		const billingKind = weekly && monthly ? "unified" : weekly ? "weekly" : "monthly";
+		const endpoint = weekly && monthly ? `${creditsUrl} + ${monthlyUrl}` : weekly ? creditsUrl : monthlyUrl;
+		const raw =
+			weekly && monthly
+				? { credits: creditsPayload, monthly: monthlyPayload }
+				: weekly
+					? creditsPayload
+					: monthlyPayload;
+
 		return {
 			provider: PROVIDER_ID,
 			fetchedAt: Date.now(),
-			limits: buildLimits(config, accountId),
+			limits: deduped,
 			metadata: {
-				endpoint: url,
-				source: "cli-chat-proxy.grok.com/v1/billing",
+				endpoint,
+				source: BILLING_SOURCE,
+				billingKind,
 				...(accountId ? { accountId } : {}),
 				...(email ? { email } : {}),
 			},
-			raw: payload,
+			raw,
 		};
 	},
 };

--- a/packages/ai/test/xai-oauth-usage.test.ts
+++ b/packages/ai/test/xai-oauth-usage.test.ts
@@ -32,6 +32,41 @@ function makeBillingPayload(overrides?: Record<string, unknown>) {
 	};
 }
 
+/** Live unified-billing `?format=credits` body: weekly period, no percents. */
+function makeUnifiedCreditsPayload() {
+	return {
+		config: {
+			currentPeriod: {
+				type: "USAGE_PERIOD_TYPE_WEEKLY",
+				start: "2026-07-23T11:11:10.769917+00:00",
+				end: "2026-07-30T11:11:10.769917+00:00",
+			},
+			onDemandCap: { val: 0 },
+			onDemandUsed: { val: 0 },
+			isUnifiedBillingUser: true,
+			prepaidBalance: { val: 0 },
+			topUpMethod: "TOP_UP_METHOD_SAVED_PAYMENT_METHOD",
+			billingPeriodStart: "2026-07-23T11:11:10.769917+00:00",
+			billingPeriodEnd: "2026-07-30T11:11:10.769917+00:00",
+		},
+	};
+}
+
+/** Default billing URL body for unified accounts (monthly included quota). */
+function makeUnifiedMonthlyPayload(overrides?: Record<string, unknown>) {
+	return {
+		config: {
+			monthlyLimit: { val: 15000 },
+			used: { val: 10548 },
+			onDemandCap: { val: 0 },
+			billingPeriodStart: "2026-07-01T00:00:00+00:00",
+			billingPeriodEnd: "2026-08-01T00:00:00+00:00",
+			history: [],
+			...overrides,
+		},
+	};
+}
+
 function makeCredential(overrides?: Partial<UsageFetchParams["credential"]>): UsageFetchParams["credential"] {
 	return {
 		type: "oauth",
@@ -71,6 +106,33 @@ function capturingFetch(payload: unknown): {
 	return { fetch, calls };
 }
 
+/** Route credits vs default billing URLs to different live-shaped payloads. */
+function dualBillingFetch(
+	creditsPayload: unknown,
+	monthlyPayload: unknown,
+): {
+	fetch: FetchImpl;
+	calls: Array<{ url: string }>;
+} {
+	const calls: Array<{ url: string }> = [];
+	const fetch: FetchImpl = async input => {
+		const url = String(input);
+		calls.push({ url });
+		if (url.includes("/oauth2/userinfo")) {
+			return new Response(JSON.stringify({ sub: USER_ID, email: "user@example.com" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}
+		const payload = url.includes("format=credits") ? creditsPayload : monthlyPayload;
+		return new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+	};
+	return { fetch, calls };
+}
+
 describe("xai-oauth usage provider", () => {
 	it("accepts stored OAuth credentials but never shared API-key fallbacks", () => {
 		expect(xaiOauthUsageProvider.supports?.({ provider: "xai-oauth", credential: makeCredential() })).toBe(true);
@@ -97,6 +159,7 @@ describe("xai-oauth usage provider", () => {
 		expect(report?.limits[0]?.amount.usedFraction).toBeCloseTo(0.18, 5);
 		expect(report?.metadata?.accountId).toBe(USER_ID);
 		expect(report?.metadata?.email).toBe("user@example.com");
+		expect(report?.metadata?.billingKind).toBe("weekly");
 
 		const billingCall = calls.find(call => call.url.includes("/v1/billing"));
 		expect(billingCall?.url).toBe(buildXAICliBillingUrl());
@@ -106,6 +169,8 @@ describe("xai-oauth usage provider", () => {
 			"x-xai-token-auth": "xai-grok-cli",
 		});
 		expect(billingCall?.redirect).toBe("error");
+		// Non-unified weekly path must not issue a second default-format probe.
+		expect(calls.filter(call => call.url.includes("/v1/billing"))).toHaveLength(1);
 	});
 
 	it("uses a stored email without an extra userinfo request", async () => {
@@ -158,6 +223,91 @@ describe("xai-oauth usage provider", () => {
 
 		expect(report?.limits[0]?.id).toBe("xai-oauth:credits:1w");
 		expect(report?.limits[0]?.window?.resetsAt).toBe(Date.parse(periodEnd));
+	});
+
+	it("falls back to monthly included quota when credits has no percent fields", async () => {
+		const { fetch, calls } = dualBillingFetch(makeUnifiedCreditsPayload(), makeUnifiedMonthlyPayload());
+		const report = await xaiOauthUsageProvider.fetchUsage(
+			{
+				provider: "xai-oauth",
+				credential: makeCredential({ accountId: "stored-account", email: "stored@example.com" }),
+			},
+			{ fetch },
+		);
+
+		expect(calls.map(call => call.url)).toEqual([buildXAICliBillingUrl(), buildXAICliBillingUrl("")]);
+		expect(report?.metadata?.billingKind).toBe("monthly");
+		expect(report?.metadata?.endpoint).toBe(buildXAICliBillingUrl(""));
+		expect(report?.metadata?.accountId).toBe("stored-account");
+		expect(report?.metadata?.email).toBe("stored@example.com");
+		expect(report?.limits.map(limit => limit.id)).toEqual(["xai-oauth:included:1mo"]);
+
+		const included = report?.limits[0];
+		expect(included?.label).toBe("SuperGrok Monthly Included");
+		expect(included?.amount.used).toBe(10548);
+		expect(included?.amount.limit).toBe(15000);
+		expect(included?.amount.remaining).toBe(4452);
+		expect(included?.amount.usedFraction).toBeCloseTo(10548 / 15000, 5);
+		expect(included?.window?.id).toBe("1mo");
+		expect(included?.window?.label).toBe("Monthly");
+		expect(included?.window?.resetsAt).toBe(Date.parse("2026-08-01T00:00:00+00:00"));
+		expect(included?.status).toBe("ok");
+	});
+
+	it("merges weekly credits with monthly included when unified account returns both", async () => {
+		const creditsBoth = {
+			config: {
+				...makeUnifiedCreditsPayload().config,
+				creditUsagePercent: 2,
+				productUsage: [{ product: "Api", usagePercent: 2 }],
+			},
+		};
+		const { fetch, calls } = dualBillingFetch(creditsBoth, makeUnifiedMonthlyPayload());
+		const report = await xaiOauthUsageProvider.fetchUsage(
+			{ provider: "xai-oauth", credential: makeCredential({ email: "stored@example.com" }) },
+			{ fetch },
+		);
+
+		expect(calls.map(call => call.url)).toEqual([buildXAICliBillingUrl(), buildXAICliBillingUrl("")]);
+		expect(report?.metadata?.billingKind).toBe("unified");
+		expect(report?.limits.map(limit => limit.id)).toEqual([
+			"xai-oauth:credits:1w",
+			"xai-oauth:product:api:1w",
+			"xai-oauth:included:1mo",
+		]);
+		expect(report?.limits[0]?.amount.usedFraction).toBeCloseTo(0.02, 5);
+		expect(report?.limits[2]?.amount.used).toBe(10548);
+		expect(report?.limits[2]?.amount.limit).toBe(15000);
+	});
+
+	it("maps unified monthly on-demand when the included quota payload carries a positive cap", async () => {
+		const report = await xaiOauthUsageProvider.fetchUsage(
+			{ provider: "xai-oauth", credential: makeCredential() },
+			{
+				fetch: dualBillingFetch(
+					makeUnifiedCreditsPayload(),
+					makeUnifiedMonthlyPayload({ onDemandCap: { val: 100 }, onDemandUsed: { val: 25 } }),
+				).fetch,
+			},
+		);
+
+		expect(report?.limits.map(limit => limit.id)).toEqual(["xai-oauth:included:1mo", "xai-oauth:on-demand"]);
+		const onDemand = report?.limits.find(limit => limit.id === "xai-oauth:on-demand");
+		expect(onDemand?.amount.used).toBe(25);
+		expect(onDemand?.amount.limit).toBe(100);
+		expect(onDemand?.amount.usedFraction).toBeCloseTo(0.25, 5);
+	});
+
+	it("returns null when both credits and monthly billing shapes are unusable", async () => {
+		const report = await xaiOauthUsageProvider.fetchUsage(
+			{ provider: "xai-oauth", credential: makeCredential() },
+			{
+				fetch: dualBillingFetch(makeUnifiedCreditsPayload(), {
+					config: { isUnifiedBillingUser: true, monthlyLimit: { val: 0 }, used: { val: 0 } },
+				}).fetch,
+			},
+		);
+		expect(report).toBeNull();
 	});
 
 	it("skips expired OAuth tokens and returns null for rejected billing", async () => {


### PR DESCRIPTION
## Summary

- Follow-up to #4874 / #5065: SuperGrok `xai-oauth` usage still showed **no usage data** for unified-billing OAuth accounts.
- Live `GET cli-chat-proxy.grok.com/v1/billing?format=credits` for these accounts either:
  - omits `creditUsagePercent` / `productUsage`, or
  - sets `isUnifiedBillingUser: true` (sometimes with sparse weekly percents).
- The default billing URL (`/v1/billing` without `format`) returns a usable monthly included quota: `monthlyLimit.val` + `used.val` + billing period bounds.
- This PR:
  1. still prefers the legacy weekly credits shape when present
  2. falls back to monthly when credits is unusable
  3. **merges both** when credits marks the account unified (live accounts can expose weekly *and* monthly windows)

## Live verification (unified SuperGrok OAuth)

```text
billingKind: unified
- SuperGrok Weekly Credits  2.0%
- API (Weekly)              2.0%
- SuperGrok Monthly Included 10635 / 15000 (70.9%)
```

## Test plan

- [x] `bun test packages/ai/test/xai-oauth-usage.test.ts packages/ai/src/registry/oauth/__tests__/xai-oauth.test.ts` (29 pass)
- [x] Live OAuth probe against `cli-chat-proxy.grok.com` unified account
- [x] Legacy non-unified weekly fixture still single-request / same limit ids