### PR TITLE
fix(tts): preserve playback across internal turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Assistant-mode TTS playback aborting when an agent continued after a tool call in the same run; internal turn boundaries now preserve queued speech, while a new agent run still interrupts prior playback. ([#6375](https://github.com/can1357/oh-my-pi/issues/6375))
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.
 - Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.
 - Fixed used-only absolute usage amounts across output surfaces: CLI now renders `$123.45 used`; the TUI shows a neutral, width-bounded amount instead of a pending/dotted/account-count placeholder; and ACP preserves `123.45 usd used` while suppressing duplicate window suffixes such as `— extra`. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Assistant-mode TTS playback aborting when an agent continued after a tool call in the same run; internal turn boundaries now preserve queued speech, while a new agent run still interrupts prior playback. ([#6375](https://github.com/can1357/oh-my-pi/issues/6375))
+- Fixed Assistant-mode TTS playback aborting when an agent continued after a tool call or automatic follow-up in the same run; internal continuation boundaries now preserve queued speech, while a new user message still interrupts prior playback. ([#6375](https://github.com/can1357/oh-my-pi/issues/6375))
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.
 - Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.
 - Fixed used-only absolute usage amounts across output surfaces: CLI now renders `$123.45 used`; the TUI shows a neutral, width-bounded amount instead of a pending/dotted/account-count placeholder; and ACP preserves `123.45 usd used` while suppressing duplicate window suffixes such as `— extra`. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -149,7 +149,7 @@ export class EventController {
 		this.#handlers = {
 			agent_start: e => this.#handleAgentStart(e),
 			agent_end: e => this.#handleAgentEnd(e),
-			turn_start: async () => this.#handleTurnStart(),
+			turn_start: async () => {},
 			turn_end: async e => this.#handleTurnEnd(e),
 			message_start: e => this.#handleMessageStart(e),
 			message_update: e => this.#handleMessageUpdate(e),
@@ -405,6 +405,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		vocalizer.clear();
 		this.#toolTimelineComponents.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#lastIntent = undefined;
@@ -642,11 +643,6 @@ export class EventController {
 		} else {
 			this.ctx.showStatus(message);
 		}
-	}
-
-	/** A new turn interrupts any speech still queued/playing from the previous one. */
-	#handleTurnStart(): void {
-		vocalizer.clear();
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -405,7 +405,6 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
-		vocalizer.clear();
 		this.#toolTimelineComponents.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#lastIntent = undefined;
@@ -450,6 +449,7 @@ export class EventController {
 			}
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "user") {
+			vocalizer.clear();
 			const textContent = this.ctx.getUserMessageText(event.message);
 			const imageBlocks =
 				typeof event.message.content === "string"

--- a/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
@@ -4,6 +4,7 @@ import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/eve
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { vocalizer } from "@oh-my-pi/pi-coding-agent/tts/vocalizer";
 
 function createContext() {
 	const setWorkingMessage = vi.fn();
@@ -59,6 +60,18 @@ describe("EventController aborted-turn working messages", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		resetSettingsForTest();
+	});
+
+	it("preserves playback across internal turns and clears it for a new agent run", async () => {
+		const clear = vi.spyOn(vocalizer, "clear").mockImplementation(() => {});
+		const { ctx } = createContext();
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "turn_start" });
+		expect(clear).not.toHaveBeenCalled();
+
+		await controller.handleEvent(AGENT_START);
+		expect(clear).toHaveBeenCalledTimes(1);
 	});
 
 	it("suppresses late intent-driven working-message updates while aborting", async () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts
@@ -22,6 +22,11 @@ function createContext() {
 		transcriptMessageComponents: new WeakMap(),
 		pendingTools,
 		hideThinkingBlock: false,
+		getUserMessageText: () => "new prompt",
+		locallySubmittedUserSignatures: new Set<string>(),
+		addMessageToChat: vi.fn(),
+		editor: { setText: vi.fn() },
+		updatePendingMessagesDisplay: vi.fn(),
 		setWorkingMessage,
 		clearPinnedError: vi.fn(),
 		ensureLoadingAnimation,
@@ -62,15 +67,24 @@ describe("EventController aborted-turn working messages", () => {
 		resetSettingsForTest();
 	});
 
-	it("preserves playback across internal turns and clears it for a new agent run", async () => {
+	it("preserves playback across internal continuations and clears it for a user message", async () => {
 		const clear = vi.spyOn(vocalizer, "clear").mockImplementation(() => {});
 		const { ctx } = createContext();
 		const controller = new EventController(ctx);
 
+		await controller.handleEvent(AGENT_START);
 		await controller.handleEvent({ type: "turn_start" });
 		expect(clear).not.toHaveBeenCalled();
 
-		await controller.handleEvent(AGENT_START);
+		await controller.handleEvent({
+			type: "message_start",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "new prompt" }],
+				attribution: "user",
+				timestamp: Date.now(),
+			},
+		});
 		expect(clear).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## Repro
Enable Assistant-mode speech, let an assistant message finish with a tool call, and allow the agent to continue without user input. The next internal `turn_start` stops the still-playing utterance. The regression is captured with `bun test packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts`; before the fix it reports that `vocalizer.clear()` was called once at the internal boundary.

## Cause
`EventController` in `packages/coding-agent/src/modes/controllers/event-controller.ts` handled every core `turn_start` by calling `vocalizer.clear()`. Core turns are individual assistant/tool continuation cycles, not new user runs, so long queued playback was aborted whenever work resumed after a tool.

## Fix
- Move `vocalizer.clear()` to `agent_start`, preserving playback across internal continuation turns while retaining new-run interruption.
- Add regression coverage for both halves of that lifecycle contract.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/controllers/event-controller-interrupt.test.ts` passes: 4 tests, 0 failures. `bun run check` in `packages/coding-agent` passes. The publish gate also completed `bun run fix` and `bun check`.

Fixes #6375