### PR TITLE
fix(tui): reset cursor-key and keypad mode on terminal teardown

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -312,6 +312,7 @@ export function emergencyTerminalRestore(): void {
 			process.stdout.write(
 				"\x1b[?2026l" + // End synchronized output
 					"\x1b[?7h" + // Restore autowrap
+					"\x1b[?1l\x1b>" + // Restore normal cursor-key + keypad mode (rmkx, #6374)
 					"\x1b[?2004l" + // Disable bracketed paste
 					"\x1b[?2031l" + // Disable Mode 2031 appearance notifications
 					"\x1b[?2048l" + // Disable in-band resize notifications
@@ -624,6 +625,15 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		this.#safeWrite("\x1b[?2004h");
+
+		// Force normal cursor-key (DECCKM) and numeric-keypad mode (terminfo
+		// `rmkx` = "\x1b[?1l\x1b>"). omp decodes both CSI ("\x1b[A") and SS3
+		// ("\x1bOA") arrow encodings, so it never enables application mode
+		// itself — but a prior program that left the TTY in application-cursor-
+		// keys mode makes arrows arrive as SS3. Normalizing on entry keeps input
+		// in the predictable default state; stop() restores the same on exit.
+		// See #6374.
+		this.#safeWrite("\x1b[?1l\x1b>");
 
 		// Set up resize handler immediately. The OS refreshes process.stdout
 		// dimensions before firing `resize`, so it is authoritative for geometry:
@@ -1375,6 +1385,13 @@ export class ProcessTerminal implements Terminal {
 		// Leave paint-time terminal modes even if the process exits between the
 		// begin/end halves of a frame. Safe no-ops on terminals that ignored them.
 		this.#safeWrite("\x1b[?2026l\x1b[?7h");
+
+		// Restore normal cursor-key (DECCKM) and numeric-keypad mode (terminfo
+		// `rmkx`). Symmetric with the normalize in start(): a TTY-sharing child
+		// can leave the terminal in application-cursor-keys mode, and without
+		// this reset the parent shell inherits SS3 arrows so Up/Down history
+		// navigation stays broken after omp exits (#6374).
+		this.#safeWrite("\x1b[?1l\x1b>");
 
 		// Disable bracketed paste mode
 		this.#safeWrite("\x1b[?2004l");

--- a/packages/tui/test/process-terminal-headless.test.ts
+++ b/packages/tui/test/process-terminal-headless.test.ts
@@ -93,4 +93,30 @@ describe("ProcessTerminal headless suppression", () => {
 			setTerminalHeadless(previous);
 		}
 	});
+
+	// #6374: arrows stopped working inside omp and stayed broken in the shell
+	// after exit — a missing cursor-key/keypad reset. omp owns the TTY and emits
+	// a full private-mode reset menu, but never restored normal cursor-key
+	// (DECCKM) / numeric-keypad mode (terminfo `rmkx` = "\x1b[?1l\x1b>"). If the
+	// terminal was left in application-cursor-keys mode, arrows arrived as SS3
+	// and the parent shell's Up/Down history navigation broke. start() must
+	// normalize the state and stop() must restore it.
+	it("emits rmkx on start and stop to normalize/restore cursor-key + keypad mode (#6374)", () => {
+		const previous = setTerminalHeadless(false);
+		const terminal = new ProcessTerminal();
+		try {
+			terminal.start(
+				() => {},
+				() => {},
+			);
+			expect(writes.join("")).toContain("\x1b[?1l\x1b>");
+
+			writes.length = 0;
+			terminal.stop();
+			expect(writes.join("")).toContain("\x1b[?1l\x1b>");
+		} finally {
+			terminal.stop();
+			setTerminalHeadless(previous);
+		}
+	});
 });


### PR DESCRIPTION
## Repro
Arrow Up/Down stop responding inside `omp` and remain broken in the same terminal tab/pane after `omp` exits (history navigation dead), while other tabs are fine — the reporter's diagnosis of a missing TTY reset. The intermittent trigger is a terminal left in application-cursor-keys mode (DECCKM): in that mode arrows emit SS3 (`\x1bOA`/`\x1bOB`) instead of the default CSI (`\x1b[A`/`\x1b[B`). The deterministic half is provable in-process: driving `ProcessTerminal.start()`/`stop()` through the real pipeline (`setTerminalHeadless(false)`) shows that neither path ever emitted the standard cursor-key/keypad normal-mode reset, so an application-mode TTY is never normalized on entry nor restored on exit. Command: `bun test packages/tui/test/process-terminal-headless.test.ts`.

## Cause
`packages/tui/src/terminal.ts` owns the TTY and emits a comprehensive DEC private-mode reset menu on teardown (`ProcessTerminal.stop`, `emergencyTerminalRestore`), but it never touched DECCKM application-cursor-keys mode (`\x1b[?1h`/`\x1b[?1l`) or application keypad mode (`\x1b=`/`\x1b>`) — grep across `packages/` returned zero matches. The native decoder (`crates/pi-natives/src/keys.rs:171-174`) accepts both the SS3 and CSI arrow encodings, so omp never enabled application mode itself and never bothered to reset it. But a TTY-sharing program (or inherited state) can leave the terminal in application-cursor-keys mode; omp neither normalized it on startup nor restored normal mode on exit, so the state leaked into the parent shell — the terminfo `rmkx` reset (`\x1b[?1l\x1b>`) that mature TUIs emit was simply missing.

## Fix
- `ProcessTerminal.start()`: emit `\x1b[?1l\x1b>` after enabling bracketed paste — normalizes any inherited application-cursor-keys/keypad state so arrows use the predictable CSI form while omp runs.
- `ProcessTerminal.stop()`: emit `\x1b[?1l\x1b>` alongside the existing reset menu — restores normal cursor-key/keypad mode so the parent shell inherits a sane state on exit.
- `emergencyTerminalRestore()` blind-restore branch: add `\x1b[?1l\x1b>` to the concatenated reset string (the `activeTerminal` branch already routes through `stop()`, so it is covered).
- Regression test in `process-terminal-headless.test.ts` drives the real start/stop pipeline and asserts both paths emit the `rmkx` bytes.

## Verification
`bun test packages/tui/test/process-terminal-headless.test.ts` → 3 pass. Full package suite `bun test packages/tui/test/` → 1348 pass, 3 skip, 0 fail. The new test fails without the fix (`\x1b[?1l` appears nowhere else in `terminal.ts`). The intermittent within-omp trigger could not be reproduced live (no confirmed trigger/TTY here) — this closes the deterministic terminal-reset gap the reporter identified and defensively normalizes inherited state on entry. Fixes #6374