### PR TITLE
fix(ai): scope latest-turn thinking-signature exemption to same-issuer

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed outbound credential-pattern redaction (`[github_token_redacted]` & co.) running unconditionally: it is now opt-in via `configureCredentialRedaction` and disabled by default, so credential-shaped strings the user deliberately pastes reach the provider unmodified unless the host enables redaction.
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
+- Fixed a session wedge (`400 Invalid signature in thinking block`) when switching into a signing Anthropic endpoint while the latest surviving assistant turn was produced by a different `anthropic-messages` provider: `transformMessages` now scopes its latest-turn byte-for-byte signature exemption to same-issuer (same-provider) replays, stripping a foreign provider's unverifiable signature like any prior cross-issuer turn so the encoder applies its `replayUnsignedThinking` policy ([#6379](https://github.com/can1357/oh-my-pi/issues/6379)).
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -524,6 +524,18 @@ export function transformMessages<TApi extends Api>(
 			// session-level model swaps (#2257).
 			const isAnthropicReplay = isAnthropicTarget && assistantMsg.api === "anthropic-messages";
 			const isLatestSurvivingAssistant = index === latestSurvivingAssistantIndex;
+			// Anthropic's byte-for-byte rule — thinking blocks from its most
+			// recent response must be replayed unmodified — only protects
+			// Anthropic's OWN latest turn, i.e. one issued by the SAME provider
+			// (the anthropic-prefill pin keeps the outgoing model aligned across
+			// a same-provider id switch). A latest turn minted by a DIFFERENT
+			// provider carries a signature the target can never verify, so it
+			// must be stripped like any prior cross-issuer turn instead of riding
+			// the wire and wedging the session on a 400 `Invalid signature in
+			// thinking block` (#6379). Scope every latest-turn signature
+			// exemption to same-issuer replays.
+			const isLatestByteForByteAnthropic =
+				isLatestSurvivingAssistant && isAnthropicReplay && assistantMsg.provider === model.provider;
 			// Signature policy is a second axis. Anthropic cryptographically
 			// binds reasoning signatures to its key+session+model, so cross-model
 			// signatures must be stripped whenever a signing Anthropic endpoint
@@ -623,18 +635,24 @@ export function transformMessages<TApi extends Api>(
 							? { ...block, thinkingSignature: undefined }
 							: block;
 					if (isAnthropicReplay) {
-						// Latest abandoned turn: Anthropic's byte-for-byte rule forbids
-						// even stripping a signature on the latest message.
-						if (isLatestSurvivingAssistant && abandonedToolUse) return block;
-						// Cross-model prior turns crossing an official Anthropic endpoint
-						// must strip the source signature so the downstream encoder
-						// applies its `replayUnsignedThinking` policy (unsigned thinking
-						// is emitted natively on Anthropic-compatible reasoning endpoints
-						// and demoted to text on official Anthropic). 3p ↔ 3p replays
-						// keep the signature so the reasoning chain stays signed on
-						// continuation (#2265).
+						// Latest same-issuer abandoned turn: Anthropic's byte-for-byte
+						// rule forbids even stripping a signature on its own latest
+						// message. A foreign-provider latest turn is not covered — fall
+						// through so its unverifiable signature is stripped (#6379).
+						if (isLatestByteForByteAnthropic && abandonedToolUse) return block;
+						// Cross-model turns crossing a signing Anthropic endpoint must
+						// strip the source signature so the downstream encoder applies
+						// its `replayUnsignedThinking` policy (unsigned thinking is
+						// emitted natively on Anthropic-compatible reasoning endpoints
+						// and demoted to text on official Anthropic). This covers the
+						// latest surviving turn too: Anthropic's byte-for-byte rule only
+						// protects its OWN latest response (same-issuer, exempted above),
+						// so a foreign latest turn's signature is stripped like any
+						// prior cross-issuer turn (#6379). 3p ↔ 3p replays keep the
+						// signature so the reasoning chain stays signed on continuation
+						// (#2265).
 						if (
-							!isLatestSurvivingAssistant &&
+							!isLatestByteForByteAnthropic &&
 							!isSameModel &&
 							signingAnthropicInvolved &&
 							sanitized.thinkingSignature
@@ -708,14 +726,15 @@ export function transformMessages<TApi extends Api>(
 
 				if (block.type === "redactedThinking") {
 					// Redacted thinking is native-only. Keep it for same-model
-					// signed replay, the latest byte-for-byte Anthropic turn, or
+					// signed replay, a same-issuer byte-for-byte latest turn, or
 					// compatible targets that will also emit sibling unsigned
 					// thinking natively. Drop it when the matching visible thinking
-					// was discarded, or when visible thinking was cross-model
-					// stripped and will be demoted to text.
+					// was discarded, when visible thinking was cross-model stripped and
+					// will be demoted to text, or when a foreign latest turn's block
+					// would otherwise ride to a signing endpoint (#6379).
 					if (isAnthropicReplay) {
 						if (dropsAllSameModelVisibleThinking) return [];
-						if (isSameModel || isLatestSurvivingAssistant || replaysUnsignedAnthropicThinking) return block;
+						if (isSameModel || isLatestByteForByteAnthropic || replaysUnsignedAnthropicThinking) return block;
 						return [];
 					}
 					if (isSameModel) return block;

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -637,4 +637,101 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		const wireBlobs = JSON.stringify(priorBlocks);
 		expect(wireBlobs).not.toContain("sig_sonnet");
 	});
+
+	it("strips a foreign anthropic-messages LATEST turn's signature on a signing Anthropic target (#6379)", () => {
+		// The latest surviving assistant was minted by a DIFFERENT provider on
+		// the anthropic-messages API (e.g. kimi-code/k3). Switching the target
+		// to a signing Anthropic model replayed that turn's foreign signature
+		// verbatim, wedging the session on `400 Invalid signature in thinking
+		// block`. Anthropic's byte-for-byte rule only protects its own latest
+		// response, so the foreign latest turn must be stripped like any prior
+		// cross-issuer turn.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-fable-5",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const messages: Message[] = [
+			makeUser("which is larger, 17^3 or 3^17?"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "compare magnitudes", thinkingSignature: "kimi_foreign_sig" },
+					{ type: "text", text: "3^17 is larger." },
+				],
+				{ provider: "kimi-code", model: "k3", stopReason: "stop" },
+			),
+			makeUser("double-check with logarithms"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const blocks = assistants[assistants.length - 1].content as WireBlock[];
+		// No native thinking block replays the unverifiable foreign signature.
+		expect(blocks.find(b => b.type === "thinking")).toBeUndefined();
+		const wire = JSON.stringify(params);
+		expect(wire).not.toContain("kimi_foreign_sig");
+		// The reasoning survives, demoted to bare Claude-dialect prose.
+		expect(wire).toContain(renderDemotedThinking(target.id, "compare magnitudes"));
+		expect(wire).toContain("3^17 is larger.");
+	});
+
+	it("strips a foreign abandoned tool-use LATEST turn's signature on a signing Anthropic target (#6379)", () => {
+		// Same class, abandoned-tool-use variant: the unconditional latest-turn
+		// exemption used to `return block` (original, still-signed) for a
+		// foreign latest turn. It must fall through and strip instead.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-fable-5",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const messages: Message[] = [
+			makeUser("read the file"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "abandoned reasoning", thinkingSignature: "foreign_abandoned_sig" },
+					{ type: "toolCall", id: "toolu_x", name: "read", arguments: { path: "x" } },
+				],
+				{ provider: "kimi-code", model: "k3", stopReason: "stop" },
+			),
+			toolResult("toolu_x", "placeholder"),
+			makeUser("continue"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const wire = JSON.stringify(params);
+		expect(wire).not.toContain("foreign_abandoned_sig");
+		const assistants = params.filter(p => p.role === "assistant");
+		const blocks = assistants[assistants.length - 1].content as WireBlock[];
+		expect(blocks.find(b => b.type === "thinking")).toBeUndefined();
+		const toolUse = blocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+		expect(toolUse?.id).toBe("toolu_x");
+	});
+
+	it("keeps a same-model LATEST turn's signature on a signing Anthropic target (#6379 guard)", () => {
+		// The fix scopes the latest-turn exemption to same-model replays; it
+		// must NOT over-strip Anthropic's own byte-for-byte latest response.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-fable-5",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const messages: Message[] = [
+			makeUser("q"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "own reasoning", thinkingSignature: "sig_own" },
+					{ type: "text", text: "answer" },
+				],
+				{ provider: "anthropic", model: "claude-fable-5", stopReason: "stop" },
+			),
+			makeUser("continue"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const blocks = assistants[assistants.length - 1].content as WireBlock[];
+		const thinking = blocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking?.thinking).toBe("own reasoning");
+		expect(thinking?.signature).toBe("sig_own");
+	});
 });


### PR DESCRIPTION
## Repro
Switching a session's model into a signing Anthropic endpoint while the latest surviving assistant turn was produced by a *different* `anthropic-messages` provider replays that turn's foreign thinking signature verbatim, and Anthropic rejects it with `400 messages.1.content.0: Invalid \`signature\` in \`thinking\` block`, wedging the session onto its fallback model. Deterministic against `convertAnthropicMessages`: a foreign-provider (`provider: kimi-code`, `api: anthropic-messages`) signed `[thinking, text]` turn as the latest surviving assistant, then a target of `anthropic/claude-fable-5` (`compat.signingEndpoint: true`, `replayUnsignedThinking: false`) — the wire carries `{"type":"thinking",...,"signature":"kimi_foreign_sig"}`.

## Cause
In `packages/ai/src/providers/transform-messages.ts`, the cross-issuer thinking-signature strip was gated on `!isLatestSurvivingAssistant` and the abandoned-tool-use latest-turn exemption (`return block`) was unconditional. Anthropic's byte-for-byte rule only protects its *own* most recent response (same issuer); a latest turn minted by another provider is not that, so its unverifiable signature rode the wire through the `isAnthropicReplay` path (`return sanitized`) and the encoder emitted it natively. Non-latest foreign turns were already stripped, which is why sessions self-heal once a fallback turn completes.

## Fix
- Added `isLatestByteForByteAnthropic = isLatestSurvivingAssistant && isAnthropicReplay && assistantMsg.provider === model.provider` — the latest-turn exemption is now issuer-scoped (same provider), matching the anthropic-prefill pin that keeps same-provider id switches byte-for-byte.
- Gated the abandoned-tool-use latest exemption on `isLatestByteForByteAnthropic` so a foreign latest turn falls through and gets stripped.
- Added `!isLatestByteForByteAnthropic` to the visible-thinking signature strip so a foreign latest turn is stripped like any prior cross-issuer turn; the encoder then applies its `replayUnsignedThinking` policy (unsigned native on 3p, demoted to text on signing Anthropic).
- Extended the `redactedThinking` keep predicate to `isSameModel || isLatestByteForByteAnthropic || replaysUnsignedAnthropicThinking` so a foreign latest turn's redacted sibling drops on signing targets while a same-issuer latest turn keeps it.

## Verification
`cd packages/ai && bun test test/anthropic-prior-turn-thinking.test.ts test/anthropic-prefill.test.ts test/transform-messages-thinking-dialect.test.ts test/anthropic-abandoned-tooluse-replay.test.ts test/anthropic-copilot-checkpoint-thinking-signature.test.ts test/anthropic-zenmux-checkpoint-thinking-signature.test.ts` → 56 pass, 0 fail, including three new `#6379` regression cases (foreign latest turn stripped+demoted; foreign abandoned-tool-use latest turn stripped; same-model latest turn preserved) and the pre-existing same-provider prefill-pin test (`preserves latest Anthropic thinking blocks even when model id changes`). Full `bun test` for `packages/ai` is green except `proxy.test.ts` (`PI_PROXY_*` env pollution, passes in isolation, unrelated to this diff). `bun check` (TS + Rust) clean.

Fixes #6379