### PR TITLE
feat(coding-agent): add opt-in lossless re-encoding for structured tool results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -76,6 +76,9 @@
 ### Removed
 
 - Added dynamic multi-root workspace context (issue [#2569](https://github.com/can1357/oh-my-pi/issues/2569)): a session now carries an ordered list of workspace directories beyond `cwd`, managed live from the terminal. New `/add-dir <path>`, `/remove-dir <path>`, and `/dirs` slash commands let you add and remove folders mid-session; the repeatable `--add-dir <path>` CLI flag seeds them at launch, and the `workspace.additionalDirectories` setting persists defaults per project. Additional roots are persisted in the session header, survive reopen/fork/move, and are surfaced to the agent in the system prompt so it knows they exist and can `read`/`grep`/`glob` them by absolute path. Design aligns with the endorsed community implementation on `feature/session-workspace`.
+### Added
+
+- Added opt-in deterministic lossless schema+CSV re-encoding for eligible historical flat JSON-array tool results before snapcompact provider transforms ([#5338](https://github.com/can1357/oh-my-pi/issues/5338)).
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -78,7 +78,7 @@
 - Added dynamic multi-root workspace context (issue [#2569](https://github.com/can1357/oh-my-pi/issues/2569)): a session now carries an ordered list of workspace directories beyond `cwd`, managed live from the terminal. New `/add-dir <path>`, `/remove-dir <path>`, and `/dirs` slash commands let you add and remove folders mid-session; the repeatable `--add-dir <path>` CLI flag seeds them at launch, and the `workspace.additionalDirectories` setting persists defaults per project. Additional roots are persisted in the session header, survive reopen/fork/move, and are surfaced to the agent in the system prompt so it knows they exist and can `read`/`grep`/`glob` them by absolute path. Design aligns with the endorsed community implementation on `feature/session-workspace`.
 ### Added
 
-- Added opt-in deterministic lossless schema+CSV re-encoding for eligible historical flat JSON-array tool results before snapcompact provider transforms ([#5338](https://github.com/can1357/oh-my-pi/issues/5338)).
+- Added opt-in deterministic lossless schema+CSV re-encoding for eligible historical flat JSON-array tool results before snapcompact provider transforms, gated by both `reencode.losslessToolResults` and the empty-by-default per-tool `reencode.toolResultAllowlist`; the output marker discloses that values are exact while formatting and key order are normalized ([#5338](https://github.com/can1357/oh-my-pi/issues/5338)).
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Made the statusline `git` segment jj-aware: in a Jujutsu repo it shows the nearest bookmark (falling back to the short change-id) instead of git's `detached` label or nothing, and working-copy change counts come from jj where there is no `.git` to read ([#3582](https://github.com/can1357/oh-my-pi/issues/3582))
 - Added `block`/`unblock` todo operations and a `blocked` status for tasks waiting on external input; blocked tasks stay visible in the todo HUD and summary but are excluded from the incomplete-todo stop reminder, and an optional blocker note records what the task is waiting for.
 - Added a toggle-list editor in `/settings` for array-of-enum settings: `providers.webSearchOrder` and `providers.imageOrder` (ordered — Enter/Space toggles, ←/→ nudges, 1-9 splices the hovered provider into that position) and `providers.webSearchExclude` now appear under Providers → Services instead of being config-file only.
+- Added opt-in deterministic value-lossless schema+CSV re-encoding for eligible historical flat JSON-array tool results before snapcompact provider transforms, gated by both `reencode.losslessToolResults` and the empty-by-default per-tool `reencode.toolResultAllowlist`; the output marker discloses that values are exact while formatting and key order are normalized ([#5338](https://github.com/can1357/oh-my-pi/issues/5338)).
 
 ### Changed
 
@@ -76,9 +77,6 @@
 ### Removed
 
 - Added dynamic multi-root workspace context (issue [#2569](https://github.com/can1357/oh-my-pi/issues/2569)): a session now carries an ordered list of workspace directories beyond `cwd`, managed live from the terminal. New `/add-dir <path>`, `/remove-dir <path>`, and `/dirs` slash commands let you add and remove folders mid-session; the repeatable `--add-dir <path>` CLI flag seeds them at launch, and the `workspace.additionalDirectories` setting persists defaults per project. Additional roots are persisted in the session header, survive reopen/fork/move, and are surfaced to the agent in the system prompt so it knows they exist and can `read`/`grep`/`glob` them by absolute path. Design aligns with the endorsed community implementation on `feature/session-workspace`.
-### Added
-
-- Added opt-in deterministic lossless schema+CSV re-encoding for eligible historical flat JSON-array tool results before snapcompact provider transforms, gated by both `reencode.losslessToolResults` and the empty-by-default per-tool `reencode.toolResultAllowlist`; the output marker discloses that values are exact while formatting and key order are normalized ([#5338](https://github.com/can1357/oh-my-pi/issues/5338)).
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2247,6 +2247,19 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	// Experimental: deterministic lossless structured-result re-encoding (transient, per-request)
+	"reencode.losslessToolResults": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "context",
+			group: "Experimental",
+			label: "Lossless Structured Tool Results",
+			description:
+				"Experimental: re-encode eligible historical flat JSON arrays as deterministic schema+CSV in the 3K-token–50KiB band when that saves at least 10%.",
+		},
+	},
+
 	// Experimental: snapcompact inline imaging (transient, per-request; never persisted)
 	"snapcompact.systemPrompt": {
 		type: "enum",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2256,7 +2256,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Experimental",
 			label: "Lossless Structured Tool Results",
 			description:
-				"Experimental: re-encode eligible historical flat JSON arrays as deterministic schema+CSV in the 3K-token–50KiB band when that saves at least 10%.",
+				"Experimental: re-encode eligible historical flat JSON arrays as deterministic schema+CSV in the 3K-token–50KiB band when that saves at least 10% of estimated tokens without increasing bytes.",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2256,7 +2256,18 @@ export const SETTINGS_SCHEMA = {
 			group: "Experimental",
 			label: "Lossless Structured Tool Results",
 			description:
-				"Experimental: re-encode eligible historical flat JSON arrays as deterministic schema+CSV in the 3K-token–50KiB band when that saves at least 10% of estimated tokens without increasing bytes.",
+				"Experimental: enable deterministic schema+CSV re-encoding for eligible historical flat JSON-array tool results, but only for tools named in reencode.toolResultAllowlist. Enabling this alone changes nothing.",
+		},
+	},
+	"reencode.toolResultAllowlist": {
+		type: "array",
+		default: [] as string[],
+		ui: {
+			tab: "context",
+			group: "Experimental",
+			label: "Lossless Re-encode Tool Allowlist",
+			description:
+				"Tool names whose eligible historical JSON-array results may be re-encoded when Lossless Structured Tool Results is enabled. Empty by default; opt in only producers whose output is consumed as structured values because formatting and key order are normalized.",
 		},
 	},
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -126,6 +126,7 @@ import { AgentSession, type InitialRetryFallbackState, type PlanYolo, type Prewa
 import { discoverAuthStorage as discoverAuthStorageFromConfig } from "./session/auth-broker-config";
 import type { AuthStorage } from "./session/auth-storage";
 import { createInterruptedTurnAbortMessage } from "./session/exit-diagnostics";
+import { transformLosslessToolResults } from "./session/lossless-reencode";
 import {
 	type CustomMessage,
 	convertToLlm,
@@ -2795,9 +2796,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			return wrapSteeringForModel(withContext);
 		};
 		// Per-request provider-context transforms. Obfuscate FIRST so secrets are
-		// redacted from text before snapcompact rasterizes it into PNG frames, then
-		// clamp images to the active provider budget before the request is sent.
+		// redacted before lossless structured re-encoding, then let snapcompact
+		// consider only the remaining text and clamp images to the provider budget.
 		const snapcompactSystemPromptMode = settings.get("snapcompact.systemPrompt");
+		const losslessReencodeToolResults = settings.get("reencode.losslessToolResults");
 		const snapcompactInline =
 			snapcompactSystemPromptMode !== "none" || settings.get("snapcompact.toolResults")
 				? new SnapcompactInlineTransformer(
@@ -2813,6 +2815,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				: undefined;
 		const transformProviderContext = async (context: Context, transformModel: Model): Promise<Context> => {
 			let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
+			if (losslessReencodeToolResults) transformed = transformLosslessToolResults(transformed);
 			if (snapcompactInline) transformed = await snapcompactInline.transform(transformed, transformModel);
 			return clampProviderContextImages(transformed, transformModel);
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2800,6 +2800,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// consider only the remaining text and clamp images to the provider budget.
 		const snapcompactSystemPromptMode = settings.get("snapcompact.systemPrompt");
 		const losslessReencodeToolResults = settings.get("reencode.losslessToolResults");
+		const losslessReencodeToolAllowlist = settings.get("reencode.toolResultAllowlist");
 		const snapcompactInline =
 			snapcompactSystemPromptMode !== "none" || settings.get("snapcompact.toolResults")
 				? new SnapcompactInlineTransformer(
@@ -2815,7 +2816,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				: undefined;
 		const transformProviderContext = async (context: Context, transformModel: Model): Promise<Context> => {
 			let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
-			if (losslessReencodeToolResults) transformed = transformLosslessToolResults(transformed);
+			if (losslessReencodeToolResults) {
+				transformed = transformLosslessToolResults(transformed, {
+					toolAllowlist: losslessReencodeToolAllowlist,
+				});
+			}
 			if (snapcompactInline) transformed = await snapcompactInline.transform(transformed, transformModel);
 			return clampProviderContextImages(transformed, transformModel);
 		};

--- a/packages/coding-agent/src/session/lossless-reencode.ts
+++ b/packages/coding-agent/src/session/lossless-reencode.ts
@@ -247,7 +247,9 @@ class FlatJsonArrayParser {
 			const code = this.input.charCodeAt(this.#index);
 			if (code === 0x22) {
 				this.#index++;
-				return JSON.parse(this.input.slice(start, this.#index)) as string;
+				const value = JSON.parse(this.input.slice(start, this.#index)) as string;
+				if (!value.isWellFormed()) throw new Error("Ill-formed JSON string");
+				return value;
 			}
 			if (code < 0x20) throw new Error("Control character in JSON string");
 			if (code !== 0x5c) {

--- a/packages/coding-agent/src/session/lossless-reencode.ts
+++ b/packages/coding-agent/src/session/lossless-reencode.ts
@@ -1,0 +1,379 @@
+type JsonPrimitive = string | number | boolean | null;
+type FlatRow = Record<string, JsonPrimitive>;
+type ColumnType = "string" | "number" | "boolean" | "null";
+
+interface Column {
+	name: string;
+	type: ColumnType;
+	optional: boolean;
+}
+
+interface CsvCell {
+	value: string;
+	quoted: boolean;
+}
+
+const MIN_ROWS = 2;
+const SAFE_COLUMN_NAME = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
+const NUMBER_LITERAL = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+
+/**
+ * Re-encode an eligible JSON array, otherwise return the original bytes.
+ *
+ * Format v1 is deliberately conservative:
+ * - at least two flat objects with at least one shared, always-present key;
+ * - sorted ASCII-safe column names and one non-null primitive type per column;
+ * - an unquoted empty cell is absent, unquoted `null` is null, and `""` is an
+ *   empty string (the literal string `null` is quoted);
+ * - JSON number literals must already equal canonical `JSON.stringify` output,
+ *   be finite safe integers when integral, and must not be negative zero.
+ */
+export function reencodeLosslessJsonArray(input: string): string {
+	return encodeLosslessJsonTable(input) ?? input;
+}
+
+/** Encode an eligible JSON array as the deterministic v1 schema+CSV format. */
+export function encodeLosslessJsonTable(input: string): string | undefined {
+	try {
+		const rows = new FlatJsonArrayParser(input).parse();
+		const columns = inferColumns(rows);
+		if (!columns) return undefined;
+		const encoded = encodeRows(rows, columns);
+		const decoded = decodeLosslessJsonTable(encoded);
+		return decoded && equalRows(rows, decoded) ? encoded : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Decode the deterministic v1 schema+CSV format, rejecting malformed input. */
+export function decodeLosslessJsonTable(encoded: string): FlatRow[] | undefined {
+	try {
+		const newline = encoded.indexOf("\n");
+		if (newline < 0) return undefined;
+		const columns = parseHeader(encoded.slice(0, newline));
+		if (!columns) return undefined;
+		const cells = parseCsv(encoded.slice(newline + 1));
+		if (!cells || cells.length !== columns.rowCount) return undefined;
+
+		const rows: FlatRow[] = [];
+		for (const csvRow of cells) {
+			if (csvRow.length !== columns.items.length) return undefined;
+			const row: FlatRow = {};
+			for (let i = 0; i < columns.items.length; i++) {
+				const column = columns.items[i];
+				const cell = csvRow[i];
+				const decoded = decodeCell(cell, column);
+				if (!decoded.ok) return undefined;
+				if (!decoded.absent) {
+					Object.defineProperty(row, column.name, {
+						value: decoded.value,
+						enumerable: true,
+						configurable: true,
+						writable: true,
+					});
+				}
+			}
+			rows.push(row);
+		}
+		return rows;
+	} catch {
+		return undefined;
+	}
+}
+
+class FlatJsonArrayParser {
+	#index = 0;
+
+	constructor(readonly input: string) {}
+
+	parse(): FlatRow[] {
+		this.#skipWhitespace();
+		this.#expect("[");
+		this.#skipWhitespace();
+		const rows: FlatRow[] = [];
+		if (this.#peek() === "]") {
+			this.#index++;
+		} else {
+			while (true) {
+				rows.push(this.#parseObject());
+				this.#skipWhitespace();
+				const next = this.#peek();
+				if (next === "]") {
+					this.#index++;
+					break;
+				}
+				this.#expect(",");
+				this.#skipWhitespace();
+			}
+		}
+		this.#skipWhitespace();
+		if (this.#index !== this.input.length || rows.length < MIN_ROWS) throw new Error("Unsupported JSON array");
+		return rows;
+	}
+
+	#parseObject(): FlatRow {
+		this.#expect("{");
+		this.#skipWhitespace();
+		const row: FlatRow = {};
+		const keys = new Set<string>();
+		if (this.#peek() === "}") {
+			this.#index++;
+			return row;
+		}
+
+		while (true) {
+			if (this.#peek() !== '"') throw new Error("Object key must be a string");
+			const key = this.#parseString();
+			if (!SAFE_COLUMN_NAME.test(key) || keys.has(key)) throw new Error("Unsupported or duplicate key");
+			keys.add(key);
+			this.#skipWhitespace();
+			this.#expect(":");
+			this.#skipWhitespace();
+			const value = this.#parsePrimitive();
+			Object.defineProperty(row, key, {
+				value,
+				enumerable: true,
+				configurable: true,
+				writable: true,
+			});
+			this.#skipWhitespace();
+			const next = this.#peek();
+			if (next === "}") {
+				this.#index++;
+				return row;
+			}
+			this.#expect(",");
+			this.#skipWhitespace();
+		}
+	}
+
+	#parsePrimitive(): JsonPrimitive {
+		const next = this.#peek();
+		if (next === '"') return this.#parseString();
+		if (next === "t") return this.#literal("true", true);
+		if (next === "f") return this.#literal("false", false);
+		if (next === "n") return this.#literal("null", null);
+		if (next === "{" || next === "[") throw new Error("Nested values are unsupported");
+
+		NUMBER_LITERAL.lastIndex = this.#index;
+		const match = NUMBER_LITERAL.exec(this.input);
+		if (!match) throw new Error("Expected primitive value");
+		const raw = match[0];
+		this.#index += raw.length;
+		const value = Number(raw);
+		if (!isCanonicalNumber(raw, value)) throw new Error("Non-canonical number");
+		return value;
+	}
+
+	#parseString(): string {
+		const start = this.#index;
+		this.#expect('"');
+		while (this.#index < this.input.length) {
+			const code = this.input.charCodeAt(this.#index);
+			if (code === 0x22) {
+				this.#index++;
+				return JSON.parse(this.input.slice(start, this.#index)) as string;
+			}
+			if (code < 0x20) throw new Error("Control character in JSON string");
+			if (code !== 0x5c) {
+				this.#index++;
+				continue;
+			}
+			this.#index++;
+			const escapeCode = this.input[this.#index];
+			if (!escapeCode || !'"\\/bfnrtu'.includes(escapeCode)) throw new Error("Invalid JSON escape");
+			this.#index++;
+			if (escapeCode === "u") {
+				const hex = this.input.slice(this.#index, this.#index + 4);
+				if (!/^[0-9a-fA-F]{4}$/.test(hex)) throw new Error("Invalid Unicode escape");
+				this.#index += 4;
+			}
+		}
+		throw new Error("Unterminated JSON string");
+	}
+
+	#literal<T extends JsonPrimitive>(text: string, value: T): T {
+		if (!this.input.startsWith(text, this.#index)) throw new Error("Invalid literal");
+		this.#index += text.length;
+		return value;
+	}
+
+	#skipWhitespace(): void {
+		while (this.#index < this.input.length && /[\t\n\r ]/.test(this.input[this.#index])) this.#index++;
+	}
+
+	#expect(expected: string): void {
+		if (this.input[this.#index] !== expected) throw new Error(`Expected ${expected}`);
+		this.#index++;
+	}
+
+	#peek(): string | undefined {
+		return this.input[this.#index];
+	}
+}
+
+function inferColumns(rows: FlatRow[]): Column[] | undefined {
+	const names = [...new Set(rows.flatMap(row => Object.keys(row)))].sort();
+	if (names.length === 0 || !names.some(name => rows.every(row => Object.hasOwn(row, name)))) return undefined;
+
+	const columns: Column[] = [];
+	for (const name of names) {
+		let type: Exclude<ColumnType, "null"> | undefined;
+		let optional = false;
+		for (const row of rows) {
+			if (!Object.hasOwn(row, name)) {
+				optional = true;
+				continue;
+			}
+			const value = row[name];
+			if (value === null) continue;
+			const valueType = typeof value;
+			if (valueType !== "string" && valueType !== "number" && valueType !== "boolean") return undefined;
+			if (type && type !== valueType) return undefined;
+			type = valueType;
+		}
+		columns.push({ name, type: type ?? "null", optional });
+	}
+	return columns;
+}
+
+function encodeRows(rows: FlatRow[], columns: Column[]): string {
+	const header = `[${rows.length}]{${columns
+		.map(column => `${column.name}:${column.type}${column.optional ? "?" : ""}`)
+		.join(",")}}`;
+	const body = rows.map(row => columns.map(column => encodeCell(row, column)).join(",")).join("\n");
+	return `${header}\n${body}`;
+}
+
+function encodeCell(row: FlatRow, column: Column): string {
+	if (!Object.hasOwn(row, column.name)) return "";
+	const value = row[column.name];
+	if (value === null) return "null";
+	if (typeof value === "string") return encodeCsvString(value);
+	return JSON.stringify(value);
+}
+
+function encodeCsvString(value: string): string {
+	if (value === "" || value === "null" || /[",\r\n]/.test(value) || /^\s|\s$/u.test(value)) {
+		return `"${value.replaceAll('"', '""')}"`;
+	}
+	return value;
+}
+
+function parseHeader(header: string): { rowCount: number; items: Column[] } | undefined {
+	const match = /^\[(\d+)]\{(.*)}$/.exec(header);
+	if (!match) return undefined;
+	const rowCount = Number(match[1]);
+	if (!Number.isSafeInteger(rowCount) || rowCount < MIN_ROWS || match[2].length === 0) return undefined;
+
+	const items: Column[] = [];
+	const seen = new Set<string>();
+	for (const descriptor of match[2].split(",")) {
+		const column = /^([A-Za-z_][A-Za-z0-9_.-]*):(string|number|boolean|null)(\?)?$/.exec(descriptor);
+		if (!column || seen.has(column[1])) return undefined;
+		if (items.length > 0 && items[items.length - 1].name >= column[1]) return undefined;
+		seen.add(column[1]);
+		items.push({ name: column[1], type: column[2] as ColumnType, optional: column[3] === "?" });
+	}
+	return { rowCount, items };
+}
+
+function parseCsv(body: string): CsvCell[][] | undefined {
+	if (body.length === 0 || body.endsWith("\n")) return undefined;
+	const rows: CsvCell[][] = [];
+	let row: CsvCell[] = [];
+	let index = 0;
+
+	while (index < body.length) {
+		let value = "";
+		let quoted = false;
+		if (body[index] === '"') {
+			quoted = true;
+			index++;
+			let closed = false;
+			while (index < body.length) {
+				const char = body[index++];
+				if (char !== '"') {
+					value += char;
+					continue;
+				}
+				if (body[index] === '"') {
+					value += '"';
+					index++;
+					continue;
+				}
+				closed = true;
+				break;
+			}
+			if (!closed) return undefined;
+		} else {
+			const start = index;
+			while (index < body.length && body[index] !== "," && body[index] !== "\n") {
+				if (body[index] === '"' || body[index] === "\r") return undefined;
+				index++;
+			}
+			value = body.slice(start, index);
+		}
+
+		row.push({ value, quoted });
+		if (index === body.length) {
+			rows.push(row);
+			break;
+		}
+		if (body[index] === ",") {
+			index++;
+			if (index === body.length) {
+				row.push({ value: "", quoted: false });
+				rows.push(row);
+			}
+			continue;
+		}
+		if (body[index] === "\n") {
+			rows.push(row);
+			row = [];
+			index++;
+			continue;
+		}
+		return undefined;
+	}
+	return rows;
+}
+
+function decodeCell(
+	cell: CsvCell,
+	column: Column,
+): { ok: true; absent: boolean; value?: JsonPrimitive } | { ok: false } {
+	if (!cell.quoted && cell.value === "") return column.optional ? { ok: true, absent: true } : { ok: false };
+	if (!cell.quoted && cell.value === "null") return { ok: true, absent: false, value: null };
+	if (column.type === "null") return { ok: false };
+	if (column.type === "string") return { ok: true, absent: false, value: cell.value };
+	if (cell.quoted) return { ok: false };
+	if (column.type === "boolean") {
+		if (cell.value === "true") return { ok: true, absent: false, value: true };
+		if (cell.value === "false") return { ok: true, absent: false, value: false };
+		return { ok: false };
+	}
+	const value = Number(cell.value);
+	return isCanonicalNumber(cell.value, value) ? { ok: true, absent: false, value } : { ok: false };
+}
+
+function isCanonicalNumber(raw: string, value: number): boolean {
+	if (!Number.isFinite(value) || Object.is(value, -0)) return false;
+	if (Number.isInteger(value) && !Number.isSafeInteger(value)) return false;
+	return JSON.stringify(value) === raw;
+}
+
+function equalRows(left: FlatRow[], right: FlatRow[]): boolean {
+	if (left.length !== right.length) return false;
+	for (let i = 0; i < left.length; i++) {
+		const leftKeys = Object.keys(left[i]).sort();
+		const rightKeys = Object.keys(right[i]).sort();
+		if (leftKeys.length !== rightKeys.length) return false;
+		for (let k = 0; k < leftKeys.length; k++) {
+			const key = leftKeys[k];
+			if (key !== rightKeys[k] || !Object.is(left[i][key], right[i][key])) return false;
+		}
+	}
+	return true;
+}

--- a/packages/coding-agent/src/session/lossless-reencode.ts
+++ b/packages/coding-agent/src/session/lossless-reencode.ts
@@ -23,7 +23,7 @@ const NUMBER_LITERAL = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
 export const MIN_LOSSLESS_REENCODE_TOKENS = 3000;
 /** Stage 1 intentionally stops at the existing inline-result cap. */
 export const MAX_LOSSLESS_REENCODE_BYTES = 50 * 1024;
-/** Adjacent snapcompact precedent: the complete replacement must save at least 10%. */
+/** Adjacent snapcompact precedent: the complete replacement must save at least 10% of estimated tokens. */
 export const LOSSLESS_REENCODE_SAVINGS_MARGIN = 0.9;
 
 /**
@@ -120,7 +120,8 @@ export function planLosslessReencodes(messages: readonly Message[]): LosslessRee
 			const block = message.content[blockIndex];
 			if (block.type !== "text") continue;
 			const originalBytes = Buffer.byteLength(block.text, "utf8");
-			if (originalBytes > MAX_LOSSLESS_REENCODE_BYTES || countTokens(block.text) < MIN_LOSSLESS_REENCODE_TOKENS) {
+			const originalTokens = countTokens(block.text);
+			if (originalBytes > MAX_LOSSLESS_REENCODE_BYTES || originalTokens < MIN_LOSSLESS_REENCODE_TOKENS) {
 				continue;
 			}
 			const encoded = encodeLosslessJsonTable(block.text);
@@ -128,7 +129,10 @@ export function planLosslessReencodes(messages: readonly Message[]): LosslessRee
 			const marker = `[lossless-reencode v1 schema+csv; original=${originalBytes}B]`;
 			const replacement = `${marker}\n${encoded}`;
 			const replacementBytes = Buffer.byteLength(replacement, "utf8");
-			if (replacementBytes > originalBytes * LOSSLESS_REENCODE_SAVINGS_MARGIN) continue;
+			// Token savings are the goal and match snapcompact's precedent. The
+			// byte guard is independent defense against pathological wire growth.
+			if (replacementBytes > originalBytes) continue;
+			if (countTokens(replacement) > originalTokens * LOSSLESS_REENCODE_SAVINGS_MARGIN) continue;
 			swaps.push({ messageIndex, blockIndex, replacement });
 		}
 	}

--- a/packages/coding-agent/src/session/lossless-reencode.ts
+++ b/packages/coding-agent/src/session/lossless-reencode.ts
@@ -120,10 +120,9 @@ export function planLosslessReencodes(messages: readonly Message[]): LosslessRee
 			const block = message.content[blockIndex];
 			if (block.type !== "text") continue;
 			const originalBytes = Buffer.byteLength(block.text, "utf8");
+			if (originalBytes > MAX_LOSSLESS_REENCODE_BYTES) continue;
 			const originalTokens = countTokens(block.text);
-			if (originalBytes > MAX_LOSSLESS_REENCODE_BYTES || originalTokens < MIN_LOSSLESS_REENCODE_TOKENS) {
-				continue;
-			}
+			if (originalTokens < MIN_LOSSLESS_REENCODE_TOKENS) continue;
 			const encoded = encodeLosslessJsonTable(block.text);
 			if (!encoded) continue;
 			const marker = `[lossless-reencode v1 schema+csv; original=${originalBytes}B]`;

--- a/packages/coding-agent/src/session/lossless-reencode.ts
+++ b/packages/coding-agent/src/session/lossless-reencode.ts
@@ -91,6 +91,10 @@ export function decodeLosslessJsonTable(encoded: string): FlatRow[] | undefined 
 	}
 }
 
+export interface LosslessReencodeOptions {
+	toolAllowlist: readonly string[];
+}
+
 export interface LosslessReencodeSwap {
 	messageIndex: number;
 	blockIndex: number;
@@ -102,7 +106,11 @@ export interface LosslessReencodeSwap {
  * provider context. Candidates are visited oldest-first and the newest tool
  * result is a stable frontier that always remains verbatim.
  */
-export function planLosslessReencodes(messages: readonly Message[]): LosslessReencodeSwap[] {
+export function planLosslessReencodes(
+	messages: readonly Message[],
+	options: LosslessReencodeOptions,
+): LosslessReencodeSwap[] {
+	if (!Array.isArray(options.toolAllowlist) || options.toolAllowlist.length === 0) return [];
 	let newestToolResultIndex = -1;
 	for (let i = messages.length - 1; i >= 0; i--) {
 		if (messages[i].role === "toolResult") {
@@ -116,6 +124,7 @@ export function planLosslessReencodes(messages: readonly Message[]): LosslessRee
 	for (let messageIndex = 0; messageIndex < newestToolResultIndex; messageIndex++) {
 		const message = messages[messageIndex];
 		if (message.role !== "toolResult") continue;
+		if (!options.toolAllowlist.includes(message.toolName)) continue;
 		for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
 			const block = message.content[blockIndex];
 			if (block.type !== "text") continue;
@@ -125,7 +134,7 @@ export function planLosslessReencodes(messages: readonly Message[]): LosslessRee
 			if (originalTokens < MIN_LOSSLESS_REENCODE_TOKENS) continue;
 			const encoded = encodeLosslessJsonTable(block.text);
 			if (!encoded) continue;
-			const marker = `[lossless-reencode v1 schema+csv; original=${originalBytes}B]`;
+			const marker = `[lossless-reencode v1 schema+csv; values exact, formatting/key-order normalized; original=${originalBytes}B]`;
 			const replacement = `${marker}\n${encoded}`;
 			const replacementBytes = Buffer.byteLength(replacement, "utf8");
 			// Token savings are the goal and match snapcompact's precedent. The
@@ -139,8 +148,8 @@ export function planLosslessReencodes(messages: readonly Message[]): LosslessRee
 }
 
 /** Apply the pure plan to fresh message/content arrays for provider dispatch. */
-export function transformLosslessToolResults(context: Context): Context {
-	const swaps = planLosslessReencodes(context.messages);
+export function transformLosslessToolResults(context: Context, options: LosslessReencodeOptions): Context {
+	const swaps = planLosslessReencodes(context.messages, options);
 	if (swaps.length === 0) return context;
 
 	const messages = [...context.messages];

--- a/packages/coding-agent/src/session/lossless-reencode.ts
+++ b/packages/coding-agent/src/session/lossless-reencode.ts
@@ -1,3 +1,6 @@
+import { countTokens } from "@oh-my-pi/pi-agent-core";
+import type { Context, Message } from "@oh-my-pi/pi-ai";
+
 type JsonPrimitive = string | number | boolean | null;
 type FlatRow = Record<string, JsonPrimitive>;
 type ColumnType = "string" | "number" | "boolean" | "null";
@@ -16,6 +19,12 @@ interface CsvCell {
 const MIN_ROWS = 2;
 const SAFE_COLUMN_NAME = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
 const NUMBER_LITERAL = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+/** Mirrors snapcompact's token floor so both transforms classify the same input scale. */
+export const MIN_LOSSLESS_REENCODE_TOKENS = 3000;
+/** Stage 1 intentionally stops at the existing inline-result cap. */
+export const MAX_LOSSLESS_REENCODE_BYTES = 50 * 1024;
+/** Adjacent snapcompact precedent: the complete replacement must save at least 10%. */
+export const LOSSLESS_REENCODE_SAVINGS_MARGIN = 0.9;
 
 /**
  * Re-encode an eligible JSON array, otherwise return the original bytes.
@@ -80,6 +89,68 @@ export function decodeLosslessJsonTable(encoded: string): FlatRow[] | undefined 
 	} catch {
 		return undefined;
 	}
+}
+
+export interface LosslessReencodeSwap {
+	messageIndex: number;
+	blockIndex: number;
+	replacement: string;
+}
+
+/**
+ * Plan deterministic historical tool-result replacements without mutating the
+ * provider context. Candidates are visited oldest-first and the newest tool
+ * result is a stable frontier that always remains verbatim.
+ */
+export function planLosslessReencodes(messages: readonly Message[]): LosslessReencodeSwap[] {
+	let newestToolResultIndex = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i].role === "toolResult") {
+			newestToolResultIndex = i;
+			break;
+		}
+	}
+	if (newestToolResultIndex < 0) return [];
+
+	const swaps: LosslessReencodeSwap[] = [];
+	for (let messageIndex = 0; messageIndex < newestToolResultIndex; messageIndex++) {
+		const message = messages[messageIndex];
+		if (message.role !== "toolResult") continue;
+		for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
+			const block = message.content[blockIndex];
+			if (block.type !== "text") continue;
+			const originalBytes = Buffer.byteLength(block.text, "utf8");
+			if (originalBytes > MAX_LOSSLESS_REENCODE_BYTES || countTokens(block.text) < MIN_LOSSLESS_REENCODE_TOKENS) {
+				continue;
+			}
+			const encoded = encodeLosslessJsonTable(block.text);
+			if (!encoded) continue;
+			const marker = `[lossless-reencode v1 schema+csv; original=${originalBytes}B]`;
+			const replacement = `${marker}\n${encoded}`;
+			const replacementBytes = Buffer.byteLength(replacement, "utf8");
+			if (replacementBytes > originalBytes * LOSSLESS_REENCODE_SAVINGS_MARGIN) continue;
+			swaps.push({ messageIndex, blockIndex, replacement });
+		}
+	}
+	return swaps;
+}
+
+/** Apply the pure plan to fresh message/content arrays for provider dispatch. */
+export function transformLosslessToolResults(context: Context): Context {
+	const swaps = planLosslessReencodes(context.messages);
+	if (swaps.length === 0) return context;
+
+	const messages = [...context.messages];
+	for (const swap of swaps) {
+		const message = messages[swap.messageIndex];
+		if (message.role !== "toolResult") continue;
+		const content = [...message.content];
+		const block = content[swap.blockIndex];
+		if (block?.type !== "text") continue;
+		content[swap.blockIndex] = { ...block, text: swap.replacement };
+		messages[swap.messageIndex] = { ...message, content };
+	}
+	return { ...context, messages };
 }
 
 class FlatJsonArrayParser {

--- a/packages/coding-agent/test/lossless-reencode-transform.test.ts
+++ b/packages/coding-agent/test/lossless-reencode-transform.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
-import { countTokens } from "@oh-my-pi/pi-agent-core";
+import { describe, expect, it, spyOn } from "bun:test";
+import * as agentCore from "@oh-my-pi/pi-agent-core";
 import type { Context, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
@@ -116,9 +116,23 @@ describe("lossless request-time transform", () => {
 		expect(result.messages[2]).toBe(over);
 	});
 
+	it("skips oversized blocks before tokenizing", () => {
+		const oversized = "x".repeat(50 * 1024 + 1);
+		const context: Context = {
+			messages: [userMessage(), toolResult("oversized", oversized), toolResult("tail", "tail")],
+		};
+		const countTokensSpy = spyOn(agentCore, "countTokens");
+		try {
+			expect(transformLosslessToolResults(context)).toBe(context);
+			expect(countTokensSpy).not.toHaveBeenCalled();
+		} finally {
+			countTokensSpy.mockRestore();
+		}
+	});
+
 	it("requires the marked replacement to save at least 10% of estimated tokens", () => {
 		const text = highEntropyJson();
-		expect(countTokens(text)).toBeGreaterThanOrEqual(3000);
+		expect(agentCore.countTokens(text)).toBeGreaterThanOrEqual(3000);
 		expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(50 * 1024);
 		const candidate = toolResult("candidate", text);
 		const context: Context = {
@@ -149,7 +163,9 @@ describe("lossless request-time transform", () => {
 		expect(Buffer.byteLength(replacement, "utf8")).toBeLessThanOrEqual(
 			originalBytes * LOSSLESS_REENCODE_SAVINGS_MARGIN,
 		);
-		expect(countTokens(replacement)).toBeGreaterThan(countTokens(text) * LOSSLESS_REENCODE_SAVINGS_MARGIN);
+		expect(agentCore.countTokens(replacement)).toBeGreaterThan(
+			agentCore.countTokens(text) * LOSSLESS_REENCODE_SAVINGS_MARGIN,
+		);
 
 		const candidate = toolResult("candidate", text);
 		const context: Context = {
@@ -223,7 +239,7 @@ describe("lossless request-time transform", () => {
 
 	it("deterministically removes a compacted result from downstream snapcompact eligibility", async () => {
 		const original = structuredJson();
-		expect(countTokens(original)).toBeGreaterThanOrEqual(3000);
+		expect(agentCore.countTokens(original)).toBeGreaterThanOrEqual(3000);
 		const context: Context = {
 			messages: [userMessage(), toolResult("candidate", original), toolResult("tail", "tail")],
 		};
@@ -238,7 +254,7 @@ describe("lossless request-time transform", () => {
 
 		const reencoded = transformLosslessToolResults(context);
 		const compactedText = encodedText(reencoded.messages[1]);
-		expect(countTokens(compactedText)).toBeLessThan(3000);
+		expect(agentCore.countTokens(compactedText)).toBeLessThan(3000);
 		const combined = await snapcompact.transform(reencoded, makeVisionModel());
 
 		expect(combined).toBe(reencoded);

--- a/packages/coding-agent/test/lossless-reencode-transform.test.ts
+++ b/packages/coding-agent/test/lossless-reencode-transform.test.ts
@@ -4,6 +4,8 @@ import type { Context, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	decodeLosslessJsonTable,
+	encodeLosslessJsonTable,
+	LOSSLESS_REENCODE_SAVINGS_MARGIN,
 	transformLosslessToolResults,
 } from "@oh-my-pi/pi-coding-agent/session/lossless-reencode";
 import { SnapcompactInlineTransformer } from "@oh-my-pi/pi-coding-agent/session/snapcompact-inline";
@@ -114,7 +116,7 @@ describe("lossless request-time transform", () => {
 		expect(result.messages[2]).toBe(over);
 	});
 
-	it("requires the marked replacement to be at least 10% smaller", () => {
+	it("requires the marked replacement to save at least 10% of estimated tokens", () => {
 		const text = highEntropyJson();
 		expect(countTokens(text)).toBeGreaterThanOrEqual(3000);
 		expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(50 * 1024);
@@ -127,6 +129,33 @@ describe("lossless request-time transform", () => {
 
 		expect(result).toBe(context);
 		expect(result.messages[1]).toBe(candidate);
+	});
+
+	it("rejects a byte-saving replacement that misses the token margin at the estimator rounding boundary", () => {
+		// In tests countTokens is ceil(UTF-8 bytes / 4), but the ceiling still
+		// makes byte and token margins non-equivalent. Production can additionally
+		// select the accurate native tokenizer via PI_TOKENIZER_ACCURATE=1.
+		const text = JSON.stringify(
+			Array.from({ length: 89 }, (_, id) => ({
+				id,
+				payload: "x".repeat(158),
+			})),
+		);
+		const encoded = encodeLosslessJsonTable(text);
+		if (!encoded) throw new Error("Expected eligible rounding fixture");
+		const originalBytes = Buffer.byteLength(text, "utf8");
+		const replacement = `[lossless-reencode v1 schema+csv; original=${originalBytes}B]\n${encoded}`;
+
+		expect(Buffer.byteLength(replacement, "utf8")).toBeLessThanOrEqual(
+			originalBytes * LOSSLESS_REENCODE_SAVINGS_MARGIN,
+		);
+		expect(countTokens(replacement)).toBeGreaterThan(countTokens(text) * LOSSLESS_REENCODE_SAVINGS_MARGIN);
+
+		const candidate = toolResult("candidate", text);
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
+		};
+		expect(transformLosslessToolResults(context)).toBe(context);
 	});
 
 	it("marks the format and exact original UTF-8 size", () => {

--- a/packages/coding-agent/test/lossless-reencode-transform.test.ts
+++ b/packages/coding-agent/test/lossless-reencode-transform.test.ts
@@ -6,6 +6,7 @@ import {
 	decodeLosslessJsonTable,
 	encodeLosslessJsonTable,
 	LOSSLESS_REENCODE_SAVINGS_MARGIN,
+	type LosslessReencodeOptions,
 	transformLosslessToolResults,
 } from "@oh-my-pi/pi-coding-agent/session/lossless-reencode";
 import { SnapcompactInlineTransformer } from "@oh-my-pi/pi-coding-agent/session/snapcompact-inline";
@@ -64,6 +65,10 @@ function encodedBody(marked: string): string {
 	return marked.slice(newline + 1);
 }
 
+function allowlisted(options: Omit<LosslessReencodeOptions, "toolAllowlist"> = {}): LosslessReencodeOptions {
+	return { toolAllowlist: ["read"], ...options };
+}
+
 function makeVisionModel() {
 	return buildModel({
 		id: "test-model",
@@ -86,7 +91,7 @@ describe("lossless request-time transform", () => {
 		const newest = toolResult("newest", structuredJson());
 		const context: Context = { messages: [userMessage(), first, second, newest] };
 
-		const result = transformLosslessToolResults(context);
+		const result = transformLosslessToolResults(context, allowlisted());
 
 		expect(result).not.toBe(context);
 		for (const [index, source] of [
@@ -94,11 +99,49 @@ describe("lossless request-time transform", () => {
 			[2, second],
 		] as const) {
 			const text = encodedText(result.messages[index]);
-			expect(text).toMatch(/^\[lossless-reencode v1 schema\+csv; original=\d+B]\n/);
+			expect(text).toMatch(
+				/^\[lossless-reencode v1 schema\+csv; values exact, formatting\/key-order normalized; original=\d+B]\n/,
+			);
 			expect(decodeLosslessJsonTable(encodedBody(text))).toEqual(JSON.parse(encodedText(source)));
 		}
 		expect(result.messages[3]).toBe(newest);
 		expect(encodedText(newest)).toBe(structuredJson());
+	});
+
+	it("leaves eligible results untouched when the tool name is not allowlisted", () => {
+		const candidate = { ...toolResult("candidate", structuredJson()), toolName: "bash" };
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", "tail")],
+		};
+
+		const result = transformLosslessToolResults(context, allowlisted());
+
+		expect(result).toBe(context);
+		expect(result.messages[1]).toBe(candidate);
+	});
+
+	it("is inert when the tool allowlist is empty", () => {
+		const candidate = toolResult("candidate", structuredJson());
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", "tail")],
+		};
+
+		const result = transformLosslessToolResults(context, { toolAllowlist: [] });
+
+		expect(result).toBe(context);
+		expect(result.messages[1]).toBe(candidate);
+	});
+
+	it("leaves eligible results untouched when the tool name is unresolvable", () => {
+		const candidate = { ...toolResult("candidate", structuredJson()), toolName: "" };
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", "tail")],
+		};
+
+		const result = transformLosslessToolResults(context, allowlisted());
+
+		expect(result).toBe(context);
+		expect(result.messages[1]).toBe(candidate);
 	});
 
 	it("uses the exact 3k-token lower gate and 50 KiB UTF-8 upper gate", () => {
@@ -109,7 +152,7 @@ describe("lossless request-time transform", () => {
 		const tail = toolResult("tail", '[{"id":1},{"id":2}]');
 		const context: Context = { messages: [userMessage(), below, over, tail] };
 
-		const result = transformLosslessToolResults(context);
+		const result = transformLosslessToolResults(context, allowlisted());
 
 		expect(result).toBe(context);
 		expect(result.messages[1]).toBe(below);
@@ -123,7 +166,7 @@ describe("lossless request-time transform", () => {
 		};
 		const countTokensSpy = spyOn(agentCore, "countTokens");
 		try {
-			expect(transformLosslessToolResults(context)).toBe(context);
+			expect(transformLosslessToolResults(context, allowlisted())).toBe(context);
 			expect(countTokensSpy).not.toHaveBeenCalled();
 		} finally {
 			countTokensSpy.mockRestore();
@@ -139,7 +182,7 @@ describe("lossless request-time transform", () => {
 			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
 		};
 
-		const result = transformLosslessToolResults(context);
+		const result = transformLosslessToolResults(context, allowlisted());
 
 		expect(result).toBe(context);
 		expect(result.messages[1]).toBe(candidate);
@@ -150,15 +193,15 @@ describe("lossless request-time transform", () => {
 		// makes byte and token margins non-equivalent. Production can additionally
 		// select the accurate native tokenizer via PI_TOKENIZER_ACCURATE=1.
 		const text = JSON.stringify(
-			Array.from({ length: 89 }, (_, id) => ({
+			Array.from({ length: 91 }, (_, id) => ({
 				id,
-				payload: "x".repeat(158),
+				payload: "x".repeat(153),
 			})),
 		);
 		const encoded = encodeLosslessJsonTable(text);
 		if (!encoded) throw new Error("Expected eligible rounding fixture");
 		const originalBytes = Buffer.byteLength(text, "utf8");
-		const replacement = `[lossless-reencode v1 schema+csv; original=${originalBytes}B]\n${encoded}`;
+		const replacement = `[lossless-reencode v1 schema+csv; values exact, formatting/key-order normalized; original=${originalBytes}B]\n${encoded}`;
 
 		expect(Buffer.byteLength(replacement, "utf8")).toBeLessThanOrEqual(
 			originalBytes * LOSSLESS_REENCODE_SAVINGS_MARGIN,
@@ -171,7 +214,7 @@ describe("lossless request-time transform", () => {
 		const context: Context = {
 			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
 		};
-		expect(transformLosslessToolResults(context)).toBe(context);
+		expect(transformLosslessToolResults(context, allowlisted())).toBe(context);
 	});
 
 	it("marks the format and exact original UTF-8 size", () => {
@@ -181,10 +224,12 @@ describe("lossless request-time transform", () => {
 			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
 		};
 
-		const result = transformLosslessToolResults(context);
+		const result = transformLosslessToolResults(context, allowlisted());
 		const marker = encodedText(result.messages[1]).split("\n", 1)[0];
 
-		expect(marker).toBe(`[lossless-reencode v1 schema+csv; original=${Buffer.byteLength(original, "utf8")}B]`);
+		expect(marker).toBe(
+			`[lossless-reencode v1 schema+csv; values exact, formatting/key-order normalized; original=${Buffer.byteLength(original, "utf8")}B]`,
+		);
 	});
 
 	it("preserves non-text blocks and existing artifact references untouched", () => {
@@ -199,7 +244,7 @@ describe("lossless request-time transform", () => {
 			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
 		};
 
-		const result = transformLosslessToolResults(context);
+		const result = transformLosslessToolResults(context, allowlisted());
 		const transformed = result.messages[1];
 		const transformedContent = toolResultContent(transformed);
 
@@ -218,7 +263,7 @@ describe("lossless request-time transform", () => {
 		const messages = context.messages;
 		const content = small.content;
 
-		const result = transformLosslessToolResults(context);
+		const result = transformLosslessToolResults(context, allowlisted());
 
 		expect(result).toBe(context);
 		expect(context.messages).toBe(messages);
@@ -231,8 +276,8 @@ describe("lossless request-time transform", () => {
 			messages: [userMessage(), toolResult("candidate", structuredJson()), toolResult("tail", "tail")],
 		};
 
-		const turnOne = JSON.stringify(transformLosslessToolResults(context));
-		const turnTwo = JSON.stringify(transformLosslessToolResults(context));
+		const turnOne = JSON.stringify(transformLosslessToolResults(context, allowlisted()));
+		const turnTwo = JSON.stringify(transformLosslessToolResults(context, allowlisted()));
 
 		expect(turnTwo).toBe(turnOne);
 	});
@@ -252,7 +297,7 @@ describe("lossless request-time transform", () => {
 		const snapcompactOnly = await snapcompact.transform(context, makeVisionModel());
 		expect(toolResultContent(snapcompactOnly.messages[1]).some(block => block.type === "image")).toBe(true);
 
-		const reencoded = transformLosslessToolResults(context);
+		const reencoded = transformLosslessToolResults(context, allowlisted());
 		const compactedText = encodedText(reencoded.messages[1]);
 		expect(agentCore.countTokens(compactedText)).toBeLessThan(3000);
 		const combined = await snapcompact.transform(reencoded, makeVisionModel());

--- a/packages/coding-agent/test/lossless-reencode-transform.test.ts
+++ b/packages/coding-agent/test/lossless-reencode-transform.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "bun:test";
+import { countTokens } from "@oh-my-pi/pi-agent-core";
+import type { Context, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	decodeLosslessJsonTable,
+	transformLosslessToolResults,
+} from "@oh-my-pi/pi-coding-agent/session/lossless-reencode";
+import { SnapcompactInlineTransformer } from "@oh-my-pi/pi-coding-agent/session/snapcompact-inline";
+
+function structuredJson(rows = 180): string {
+	return JSON.stringify(
+		Array.from({ length: rows }, (_, id) => ({
+			id,
+			endpoint: "/api/v1/orders",
+			status: id % 7 === 0 ? 201 : 200,
+			region: `region_${id % 4}`,
+			latency_ms: 40 + (id % 9),
+			ok: true,
+		})),
+	);
+}
+
+function highEntropyJson(rows = 80, width = 300): string {
+	return JSON.stringify(
+		Array.from({ length: rows }, (_, id) => ({
+			id,
+			payload: Array.from({ length: width }, (_, i) => ((id * 131 + i * 17) % 36).toString(36)).join(""),
+		})),
+	);
+}
+
+function toolResult(id: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	};
+}
+
+function userMessage(text = "go"): Message {
+	return { role: "user", content: text, timestamp: 0 };
+}
+
+function encodedText(message: Message): string {
+	if (message.role !== "toolResult" || message.content[0]?.type !== "text")
+		throw new Error("Expected text tool result");
+	return message.content[0].text;
+}
+
+function toolResultContent(message: Message): ToolResultMessage["content"] {
+	if (message.role !== "toolResult") throw new Error("Expected tool result");
+	return message.content;
+}
+
+function encodedBody(marked: string): string {
+	const newline = marked.indexOf("\n");
+	if (newline < 0) throw new Error("Expected marker line");
+	return marked.slice(newline + 1);
+}
+
+function makeVisionModel() {
+	return buildModel({
+		id: "test-model",
+		name: "Test Model",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	});
+}
+
+describe("lossless request-time transform", () => {
+	it("re-encodes eligible historical tool results oldest-first and skips the newest result", () => {
+		const first = toolResult("first", structuredJson());
+		const second = toolResult("second", structuredJson());
+		const newest = toolResult("newest", structuredJson());
+		const context: Context = { messages: [userMessage(), first, second, newest] };
+
+		const result = transformLosslessToolResults(context);
+
+		expect(result).not.toBe(context);
+		for (const [index, source] of [
+			[1, first],
+			[2, second],
+		] as const) {
+			const text = encodedText(result.messages[index]);
+			expect(text).toMatch(/^\[lossless-reencode v1 schema\+csv; original=\d+B]\n/);
+			expect(decodeLosslessJsonTable(encodedBody(text))).toEqual(JSON.parse(encodedText(source)));
+		}
+		expect(result.messages[3]).toBe(newest);
+		expect(encodedText(newest)).toBe(structuredJson());
+	});
+
+	it("uses the exact 3k-token lower gate and 50 KiB UTF-8 upper gate", () => {
+		const below = toolResult("below", '[{"id":1},{"id":2}]');
+		const overText = highEntropyJson(250, 220);
+		expect(Buffer.byteLength(overText, "utf8")).toBeGreaterThan(50 * 1024);
+		const over = toolResult("over", overText);
+		const tail = toolResult("tail", '[{"id":1},{"id":2}]');
+		const context: Context = { messages: [userMessage(), below, over, tail] };
+
+		const result = transformLosslessToolResults(context);
+
+		expect(result).toBe(context);
+		expect(result.messages[1]).toBe(below);
+		expect(result.messages[2]).toBe(over);
+	});
+
+	it("requires the marked replacement to be at least 10% smaller", () => {
+		const text = highEntropyJson();
+		expect(countTokens(text)).toBeGreaterThanOrEqual(3000);
+		expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(50 * 1024);
+		const candidate = toolResult("candidate", text);
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
+		};
+
+		const result = transformLosslessToolResults(context);
+
+		expect(result).toBe(context);
+		expect(result.messages[1]).toBe(candidate);
+	});
+
+	it("marks the format and exact original UTF-8 size", () => {
+		const original = structuredJson().replace("/api/v1/orders", "/api/v1/東京");
+		const candidate = toolResult("candidate", original);
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
+		};
+
+		const result = transformLosslessToolResults(context);
+		const marker = encodedText(result.messages[1]).split("\n", 1)[0];
+
+		expect(marker).toBe(`[lossless-reencode v1 schema+csv; original=${Buffer.byteLength(original, "utf8")}B]`);
+	});
+
+	it("preserves non-text blocks and existing artifact references untouched", () => {
+		const jsonBlock = { type: "text" as const, text: structuredJson() };
+		const artifactBlock = { type: "text" as const, text: "Original available at artifact://fixture-123" };
+		const imageBlock = { type: "image" as const, data: "aGk=", mimeType: "image/png" as const };
+		const candidate: ToolResultMessage = {
+			...toolResult("candidate", "unused"),
+			content: [jsonBlock, artifactBlock, imageBlock],
+		};
+		const context: Context = {
+			messages: [userMessage(), candidate, toolResult("tail", '[{"id":1},{"id":2}]')],
+		};
+
+		const result = transformLosslessToolResults(context);
+		const transformed = result.messages[1];
+		const transformedContent = toolResultContent(transformed);
+
+		expect(transformed).not.toBe(candidate);
+		expect(transformedContent[0]).not.toBe(jsonBlock);
+		expect(transformedContent[1]).toBe(artifactBlock);
+		expect(transformedContent[2]).toBe(imageBlock);
+		const retainedArtifact = transformedContent[1];
+		if (retainedArtifact.type !== "text") throw new Error("Expected artifact text block");
+		expect(retainedArtifact.text).toContain("artifact://fixture-123");
+	});
+
+	it("does not mutate persisted context and returns the same object when every result passes through", () => {
+		const small = toolResult("small", '[{"id":1},{"id":2}]');
+		const context: Context = { systemPrompt: ["system"], messages: [userMessage(), small] };
+		const messages = context.messages;
+		const content = small.content;
+
+		const result = transformLosslessToolResults(context);
+
+		expect(result).toBe(context);
+		expect(context.messages).toBe(messages);
+		expect(small.content).toBe(content);
+		expect(context.systemPrompt).toEqual(["system"]);
+	});
+
+	it("produces byte-identical output on every whole-context re-run", () => {
+		const context: Context = {
+			messages: [userMessage(), toolResult("candidate", structuredJson()), toolResult("tail", "tail")],
+		};
+
+		const turnOne = JSON.stringify(transformLosslessToolResults(context));
+		const turnTwo = JSON.stringify(transformLosslessToolResults(context));
+
+		expect(turnTwo).toBe(turnOne);
+	});
+
+	it("deterministically removes a compacted result from downstream snapcompact eligibility", async () => {
+		const original = structuredJson();
+		expect(countTokens(original)).toBeGreaterThanOrEqual(3000);
+		const context: Context = {
+			messages: [userMessage(), toolResult("candidate", original), toolResult("tail", "tail")],
+		};
+		const snapcompact = new SnapcompactInlineTransformer({
+			renderSystemPrompt: "none",
+			renderToolResults: true,
+			shape: "6x12-dim",
+		});
+
+		const snapcompactOnly = await snapcompact.transform(context, makeVisionModel());
+		expect(toolResultContent(snapcompactOnly.messages[1]).some(block => block.type === "image")).toBe(true);
+
+		const reencoded = transformLosslessToolResults(context);
+		const compactedText = encodedText(reencoded.messages[1]);
+		expect(countTokens(compactedText)).toBeLessThan(3000);
+		const combined = await snapcompact.transform(reencoded, makeVisionModel());
+
+		expect(combined).toBe(reencoded);
+		expect(toolResultContent(combined.messages[1])).toEqual([{ type: "text", text: compactedText }]);
+		expect(JSON.stringify(await snapcompact.transform(reencoded, makeVisionModel()))).toBe(JSON.stringify(combined));
+	});
+});

--- a/packages/coding-agent/test/lossless-reencode.test.ts
+++ b/packages/coding-agent/test/lossless-reencode.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import {
+	decodeLosslessJsonTable,
+	encodeLosslessJsonTable,
+	reencodeLosslessJsonArray,
+} from "@oh-my-pi/pi-coding-agent/session/lossless-reencode";
+
+function expectRoundTrip(input: string): string {
+	const encoded = encodeLosslessJsonTable(input);
+	expect(encoded).toBeDefined();
+	expect(decodeLosslessJsonTable(encoded!)).toEqual(JSON.parse(input));
+	return encoded!;
+}
+
+describe("lossless schema+CSV format", () => {
+	it("round-trips flat primitive objects with sorted columns", () => {
+		const input =
+			'[{"z":"plain","id":2,"note":"","nullable":null,"active":true},{"id":1,"z":"second","note":"null","active":false},{"z":"東京","id":3,"note":"last","nullable":"value","active":true}]';
+		const encoded = expectRoundTrip(input);
+
+		expect(encoded.split("\n", 1)[0]).toBe("[3]{active:boolean,id:number,note:string,nullable:string?,z:string}");
+	});
+
+	it("distinguishes null, absent fields, and empty strings reversibly", () => {
+		const input = '[{"id":1,"value":null},{"id":2},{"id":3,"value":""},{"id":4,"value":"null"}]';
+		const encoded = expectRoundTrip(input);
+		const decoded = decodeLosslessJsonTable(encoded)!;
+
+		expect(encoded).toContain('\n1,null\n2,\n3,""\n4,"null"');
+		expect(Object.hasOwn(decoded[0], "value")).toBe(true);
+		expect(decoded[0].value).toBeNull();
+		expect(Object.hasOwn(decoded[1], "value")).toBe(false);
+		expect(decoded[2].value).toBe("");
+		expect(decoded[3].value).toBe("null");
+	});
+
+	it("marks a column optional only when it is absent from at least one row", () => {
+		const input = '[{"always":null,"id":1,"sometimes":true},{"always":"x","id":2}]';
+		const encoded = expectRoundTrip(input);
+
+		expect(encoded.split("\n", 1)[0]).toBe("[2]{always:string,id:number,sometimes:boolean?}");
+	});
+
+	it("quotes comma, quote, CR, LF, edge whitespace, empty, and reserved null strings while preserving Unicode", () => {
+		const input = JSON.stringify([
+			{ id: 1, value: "comma,value" },
+			{ id: 2, value: 'quote"value' },
+			{ id: 3, value: "carriage\rreturn" },
+			{ id: 4, value: "line\nfeed" },
+			{ id: 5, value: " padded " },
+			{ id: 6, value: "" },
+			{ id: 7, value: "null" },
+			{ id: 8, value: "東京 α" },
+		]);
+		const encoded = expectRoundTrip(input);
+
+		expect(encoded).toContain('1,"comma,value"');
+		expect(encoded).toContain('2,"quote""value"');
+		expect(encoded).toContain('3,"carriage\rreturn"');
+		expect(encoded).toContain('4,"line\nfeed"');
+		expect(encoded).toContain('5," padded "');
+		expect(encoded).toContain('6,""');
+		expect(encoded).toContain('7,"null"');
+		expect(encoded).toContain("8,東京 α");
+	});
+
+	it("accepts only canonical, exactly round-trippable JSON number literals", () => {
+		const input = '[{"n":0},{"n":42},{"n":-42},{"n":1.25},{"n":0.000001},{"n":1e-7}]';
+		expectRoundTrip(input);
+
+		for (const literal of ["1.0", "1e3", "1E-7", "-0", "9007199254740992", "-9007199254740992"]) {
+			const original = `[{"n":${literal}},{"n":1}]`;
+			expect(encodeLosslessJsonTable(original)).toBeUndefined();
+			expect(reencodeLosslessJsonArray(original)).toBe(original);
+		}
+	});
+
+	it("allows null alongside one concrete column type but rejects mixed concrete types", () => {
+		expectRoundTrip('[{"id":1,"value":null},{"id":2,"value":3}]');
+
+		const mixed = '[{"id":1,"value":3},{"id":2,"value":"3"}]';
+		expect(encodeLosslessJsonTable(mixed)).toBeUndefined();
+		expect(reencodeLosslessJsonArray(mixed)).toBe(mixed);
+	});
+
+	it("passes through nested values and unsupported root or row shapes unchanged", () => {
+		const unsupported = [
+			'[{"id":1,"nested":{"x":1}},{"id":2,"nested":{"x":2}}]',
+			'[{"id":1,"nested":[1,2]},{"id":2,"nested":[3,4]}]',
+			'{"id":1}',
+			"[1,2,3]",
+			'[{"id":1},2]',
+			'[{"id":1}]',
+			"not json",
+		];
+
+		for (const input of unsupported) {
+			expect(encodeLosslessJsonTable(input)).toBeUndefined();
+			expect(reencodeLosslessJsonArray(input)).toBe(input);
+		}
+	});
+
+	it("rejects duplicate keys and disjoint object shapes rather than guessing", () => {
+		const duplicate = '[{"id":1,"id":2},{"id":3}]';
+		const escapedDuplicate = '[{"id":1,"\\u0069d":2},{"id":3}]';
+		const disjoint = '[{"left":1},{"right":2}]';
+
+		for (const input of [duplicate, escapedDuplicate, disjoint]) {
+			expect(encodeLosslessJsonTable(input)).toBeUndefined();
+			expect(reencodeLosslessJsonArray(input)).toBe(input);
+		}
+	});
+
+	it("emits byte-stable golden output independent of object key insertion order", () => {
+		const first = '[{"b":"x","a":1},{"a":2,"b":" y "}]';
+		const reordered = '[{"a":1,"b":"x"},{"b":" y ","a":2}]';
+		const golden = '[2]{a:number,b:string}\n1,x\n2," y "';
+
+		expect(encodeLosslessJsonTable(first)).toBe(golden);
+		expect(encodeLosslessJsonTable(first)).toBe(golden);
+		expect(encodeLosslessJsonTable(reordered)).toBe(golden);
+		expect(decodeLosslessJsonTable(golden)).toEqual([
+			{ a: 1, b: "x" },
+			{ a: 2, b: " y " },
+		]);
+	});
+
+	it("rejects malformed encoded tables in the decoder", () => {
+		expect(decodeLosslessJsonTable("[2]{id:number}\n1")).toBeUndefined();
+		expect(decodeLosslessJsonTable("[1]{id:number}\n1\n2")).toBeUndefined();
+		expect(decodeLosslessJsonTable("[1]{id:number}\n1.0")).toBeUndefined();
+		expect(decodeLosslessJsonTable("not a table")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/lossless-reencode.test.ts
+++ b/packages/coding-agent/test/lossless-reencode.test.ts
@@ -64,6 +64,16 @@ describe("lossless schema+CSV format", () => {
 		expect(encoded).toContain("8,東京 α");
 	});
 
+	it("rejects escaped lone surrogates before emitting CSV", () => {
+		const input = '[{"id":1,"value":"\\ud800"},{"id":2,"value":"well-formed"}]';
+		expect(encodeLosslessJsonTable(input)).toBeUndefined();
+		expect(reencodeLosslessJsonArray(input)).toBe(input);
+	});
+
+	it("accepts escaped well-formed surrogate pairs", () => {
+		expectRoundTrip('[{"id":1,"value":"\\ud83d\\ude00"},{"id":2,"value":"well-formed"}]');
+	});
+
 	it("accepts only canonical, exactly round-trippable JSON number literals", () => {
 		const input = '[{"n":0},{"n":42},{"n":-42},{"n":1.25},{"n":0.000001},{"n":1e-7}]';
 		expectRoundTrip(input);

--- a/packages/coding-agent/test/sdk-lossless-reencode.test.ts
+++ b/packages/coding-agent/test/sdk-lossless-reencode.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+function structuredJson(): string {
+	return JSON.stringify(
+		Array.from({ length: 180 }, (_, id) => ({
+			id,
+			endpoint: "/api/v1/orders",
+			status: id % 7 === 0 ? 201 : 200,
+			region: `region_${id % 4}`,
+			latency_ms: 40 + (id % 9),
+			ok: true,
+		})),
+	);
+}
+
+function toolResult(id: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	};
+}
+
+function resultText(message: Message): string {
+	if (message.role !== "toolResult" || message.content[0]?.type !== "text") throw new Error("Expected text result");
+	return message.content[0].text;
+}
+
+describe("createAgentSession lossless re-encode wiring", () => {
+	const tempDir = path.join(os.tmpdir(), `pi-sdk-lossless-reencode-${Snowflake.next()}`);
+	const model = getBundledModel("openai", "gpt-4o-mini");
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		fs.mkdirSync(tempDir, { recursive: true });
+		authStorage = await discoverAuthStorage(tempDir);
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		removeSyncWithRetries(tempDir);
+	});
+
+	function options(settings: Settings): CreateAgentSessionOptions {
+		return {
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			model,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			rules: [],
+			workspaceTree: { rootPath: tempDir, rendered: "", truncated: false, totalLines: 0, agentsMdFiles: [] },
+		};
+	}
+
+	it("leaves structured history verbatim when the opt-in setting is disabled", async () => {
+		const original = structuredJson();
+		const { session } = await createAgentSession(options(Settings.isolated()));
+		try {
+			const context = await session.agent.buildSideRequestContext([
+				{ role: "user", content: "go", timestamp: 0 },
+				toolResult("candidate", original),
+				toolResult("tail", "tail"),
+			]);
+
+			expect(resultText(context.messages[1])).toBe(original);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("runs re-encoding before snapcompact so sub-3k output remains text", async () => {
+		const settings = Settings.isolated({
+			"reencode.losslessToolResults": true,
+			"snapcompact.toolResults": true,
+			"snapcompact.shape": "6x12-dim",
+		});
+		const { session } = await createAgentSession(options(settings));
+		try {
+			const context = await session.agent.buildSideRequestContext([
+				{ role: "user", content: "go", timestamp: 0 },
+				toolResult("candidate", structuredJson()),
+				toolResult("tail", "tail"),
+			]);
+			const candidate = context.messages[1];
+
+			expect(resultText(candidate)).toMatch(/^\[lossless-reencode v1 schema\+csv; original=\d+B]\n/);
+			if (candidate.role !== "toolResult") throw new Error("Expected tool result");
+			expect(candidate.content.some(block => block.type === "image")).toBe(false);
+		} finally {
+			await session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-lossless-reencode.test.ts
+++ b/packages/coding-agent/test/sdk-lossless-reencode.test.ts
@@ -93,9 +93,47 @@ describe("createAgentSession lossless re-encode wiring", () => {
 		}
 	});
 
+	it("remains inert when the boolean is enabled but the allowlist is empty", async () => {
+		const original = structuredJson();
+		const settings = Settings.isolated({ "reencode.losslessToolResults": true });
+		const { session } = await createAgentSession(options(settings));
+		try {
+			const context = await session.agent.buildSideRequestContext([
+				{ role: "user", content: "go", timestamp: 0 },
+				toolResult("candidate", original),
+				toolResult("tail", "tail"),
+			]);
+
+			expect(resultText(context.messages[1])).toBe(original);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("fails closed when the allowlist setting is not an array", async () => {
+		const original = structuredJson();
+		const settings = Settings.isolated({
+			"reencode.losslessToolResults": true,
+			"reencode.toolResultAllowlist": "read",
+		});
+		const { session } = await createAgentSession(options(settings));
+		try {
+			const context = await session.agent.buildSideRequestContext([
+				{ role: "user", content: "go", timestamp: 0 },
+				toolResult("candidate", original),
+				toolResult("tail", "tail"),
+			]);
+
+			expect(resultText(context.messages[1])).toBe(original);
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("runs re-encoding before snapcompact so sub-3k output remains text", async () => {
 		const settings = Settings.isolated({
 			"reencode.losslessToolResults": true,
+			"reencode.toolResultAllowlist": ["read"],
 			"snapcompact.toolResults": true,
 			"snapcompact.shape": "6x12-dim",
 		});
@@ -108,7 +146,9 @@ describe("createAgentSession lossless re-encode wiring", () => {
 			]);
 			const candidate = context.messages[1];
 
-			expect(resultText(candidate)).toMatch(/^\[lossless-reencode v1 schema\+csv; original=\d+B]\n/);
+			expect(resultText(candidate)).toMatch(
+				/^\[lossless-reencode v1 schema\+csv; values exact, formatting\/key-order normalized; original=\d+B]\n/,
+			);
 			if (candidate.role !== "toolResult") throw new Error("Expected tool result");
 			expect(candidate.content.some(block => block.type === "image")).toBe(false);
 		} finally {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -143,6 +143,13 @@ describe("Settings", () => {
 			expect(getDefault("providers.maxInFlightRequests")).toEqual({});
 		});
 
+		it("keeps lossless tool-result re-encoding opt-in like snapcompact tool-result imaging", () => {
+			const settings = Settings.isolated();
+			expect(settings.get("snapcompact.toolResults")).toBe(false);
+			expect(settings.get("reencode.losslessToolResults")).toBe(false);
+			expect(getDefault("reencode.losslessToolResults")).toBe(false);
+		});
+
 		it("exposes all tool calling mode options", () => {
 			const values = getEnumValues("tools.format");
 			expect(values).toEqual([

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -147,7 +147,9 @@ describe("Settings", () => {
 			const settings = Settings.isolated();
 			expect(settings.get("snapcompact.toolResults")).toBe(false);
 			expect(settings.get("reencode.losslessToolResults")).toBe(false);
+			expect(settings.get("reencode.toolResultAllowlist")).toEqual([]);
 			expect(getDefault("reencode.losslessToolResults")).toBe(false);
+			expect(getDefault("reencode.toolResultAllowlist")).toEqual([]);
 		});
 
 		it("exposes all tool calling mode options", () => {


### PR DESCRIPTION
Stage 1 of #5338.

## What

- Add a deterministic, lossless schema+CSV codec for conservative v1 inputs: JSON arrays of flat primitive-valued objects. Nested values, duplicate keys, mixed concrete column types, non-canonical numbers, malformed roots, and ambiguous shapes pass through unchanged rather than being guessed.
- Derive columns deterministically, preserve null/absent/empty-string distinctions, apply RFC-style CSV escaping, and emit only after an encode → decode → deep-equality self-check proves the result for that specific block.
- Add a pure provider-context planner that walks historical tool results oldest-first, leaves the newest result as a stable frontier, never mutates persisted messages, and preserves adjacent artifact/image blocks. Repeated transforms produce byte-identical prefix content for prompt-cache stability.
- Gate replacement on actual `countTokens` savings (`replacement <= original × 0.9`) and independently require byte non-growth. The latter is a safety guard, not a proxy for token savings.
- Add the default-off `reencode.losslessToolResults` switch plus the empty-by-default `reencode.toolResultAllowlist`. Re-encoding runs only when the switch is enabled and the result's tool name is explicitly listed, so enabling the boolean alone is inert. Emitted blocks begin with `[lossless-reencode v1 schema+csv; values exact, formatting/key-order normalized; original=<N>B]`.
- Run re-encoding after secret obfuscation and before snapcompact-inline. When the table falls below snapcompact's 3K-token rasterization floor, the downstream result deterministically stays crisp text instead of becoming PNG frames.

## Why

1. I built this as the bounded first stage proposed in #5338: reduce repeated structural syntax on intact in-band results without changing the cap site or introducing statistical row selection. In place of claiming workload frequency from a live prototype, I replayed the mechanism retrospectively over my recorded corpus and keep the result scoped to that workload.
2. The mechanism itself is strong on eligible data. The original large pretty-JSON R&D fixtures—which exceed Stage 1's request-time band—reduced exact `o200k` tokens by 53.8% and 52.2%. The compact 300-row variants used for the in-band paired eval fired and reduced exact data-block tokens by **33.0% and 30.1%**, while reducing bytes by **49.5% and 51.1%**. I also observed **no retrieval degradation in this paired fixture harness**: 72 paired questions across two models, N=3, temperature 0; ORIGINAL scored 66/72 and ENCODED 69/72, with discordants 0 ORIGINAL-only / 3 ENCODED-only. This is a fixture-harness result, not a general comprehension claim.
3. The workload result is deliberately bounded and less flattering: on my own seven-week, 2,055-session agentic-development corpus, shipped v1 fired **0 times**. The 33 broader R6b-variant fires measured during design ablation are all non-emissions under v1, so real-workload comprehension remains untested. Treatment stratification was not identifiable, this is one machine, and shape frequency is workload-dependent; that is why this stays default-off and requires each eligible producer to be named explicitly in the empty-by-default `reencode.toolResultAllowlist`.
4. The follow-ups remain the maintainer decisions described in the issue. Markdown-table and CSV-ish near misses dominated my measured in-band corpus (630 and 141 candidates), while nested/NDJSON expansion was much smaller; any shape-scope change should follow those measurements rather than broaden the parser speculatively. Cap-site placement and its budget/recovery policy are still a separate Stage-2 decision. I am happy to iterate on roboomp's Q1–Q4 before either expansion.

## Testing

- New encoder/decoder, transform, settings, and SDK-joint suites cover round-trip proof, duplicate-key/nested/mixed rejection, CSV/null/absence semantics, deterministic golden bytes, stable frontier, marker/artifact preservation, snapcompact interaction, and the byte-vs-token rounding counterexample.
- Full `packages/coding-agent` suite: 9,925 passed / 5 failed. The same five failures reproduce on clean upstream/main@`639bac59`, whose run had eight total failures; the branch introduced zero unique failures.
- `bun check` passes at the repository root; package type checks and Biome are clean, and `git diff --check` passes.
- In-band fixtures pass runtime planning and per-result round-trip checks; the paired two-model fixture eval above had 0 ORIGINAL-only versus 3 ENCODED-only discordances.
- Provider-wire smoke observed the marker plus CSV body, a byte-identical repeated block (`a5e80b9d53e62a4987e5dd6adc3b1ef68b35fc713beb2893311bc9ab51ec3b90`), and untouched raw JSON with the setting off.
- CPU benchmark over a 200-message / 20-eligible-block (~520 KiB) history: 23.3 ms median and 28.6 ms p95 per transform; real-corpus rejection paths were in the low-microsecond range.
- Detailed measurement methodology and privacy-preserving aggregates are prepared for the #5338 issue thread; I can post the highlights there after this PR body is reviewed. No session content or identifiers are included here.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
