### PR TITLE
fix(coding-agent): make PDF image cache content-aware

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed PDF image reads returning stale extractions after same-path content replacement and racing concurrent cold reads by binding each cache generation to immutable source bytes and coalescing extraction with independent caller cancellation. ([#6368](https://github.com/can1357/oh-my-pi/issues/6368))
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.
 - Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.
 - Fixed used-only absolute usage amounts across output surfaces: CLI now renders `$123.45 used`; the TUI shows a neutral, width-bounded amount instead of a pending/dotted/account-count placeholder; and ACP preserves `123.45 usd used` while suppressing duplicate window suffixes such as `— extra`. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -17,6 +17,8 @@ import { Text } from "@oh-my-pi/pi-tui";
 import {
 	getRemoteDir,
 	type ImageMetadata,
+	isEexist,
+	isEnotempty,
 	isProbablyBinary,
 	logger,
 	prompt,
@@ -721,6 +723,22 @@ function prependSuffixResolutionNotice(text: string, suffixResolution?: { from: 
 const PDF_IMAGE_PLACEHOLDER_RE = /<!--\s*image:\s*([^\s<>]+)(.*?)-->/g;
 const PDF_IMAGE_MEMBER_RE = /^(.*\.pdf):(.*)$/i;
 const PDF_IMAGE_MEMBER_EXTENSION_RE = /\.png$/i;
+const PDF_IMAGE_CACHE_BASENAME_MAX_LENGTH = 96;
+
+interface PdfImageSnapshot {
+	directory: string;
+	filePath: string;
+	digest: string;
+}
+
+interface PdfImageExtraction {
+	controller: AbortController;
+	promise: Promise<string>;
+	settled: boolean;
+	waiters: number;
+}
+
+const pdfImageExtractions = new Map<string, PdfImageExtraction>();
 
 function pdfImageMemberPath(pdfPath: string, imageId: string): string {
 	const member = PDF_IMAGE_MEMBER_EXTENSION_RE.test(imageId) ? imageId : `${imageId}.png`;
@@ -1106,7 +1124,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		return null;
 	}
 
-	#pdfImageCacheDir(absolutePdfPath: string): string {
+	#pdfImageCacheDir(absolutePdfPath: string, contentDigest: string): string {
 		const artifactsDir = this.session.getArtifactsDir?.();
 		let root = artifactsDir ?? undefined;
 		if (root === undefined) {
@@ -1115,8 +1133,28 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				? sessionFile.slice(0, -6)
 				: path.join(os.tmpdir(), "omp-read-pdf-images");
 		}
-		const basename = path.basename(absolutePdfPath).replace(/[^A-Za-z0-9._-]/g, "_");
-		return path.join(root, "read-pdf-images", `${basename}-${Bun.hash(absolutePdfPath).toString(36)}`);
+		const basename = path
+			.basename(absolutePdfPath)
+			.replace(/[^A-Za-z0-9._-]/g, "_")
+			.slice(0, PDF_IMAGE_CACHE_BASENAME_MAX_LENGTH);
+		const pathDigest = Bun.hash(absolutePdfPath).toString(36);
+		return path.join(root, "read-pdf-images", `${basename}-${pathDigest}-${contentDigest}`);
+	}
+
+	async #snapshotPdfSource(absolutePdfPath: string, signal?: AbortSignal): Promise<PdfImageSnapshot> {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "omp-read-pdf-"));
+		try {
+			const bytes = await untilAborted(signal, () => Bun.file(absolutePdfPath).bytes());
+			signal?.throwIfAborted();
+			const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+			const filePath = path.join(directory, "source.pdf");
+			await Bun.write(filePath, bytes);
+			signal?.throwIfAborted();
+			return { directory, filePath, digest };
+		} catch (error) {
+			await fs.rm(directory, { recursive: true, force: true });
+			throw error;
+		}
 	}
 
 	async #listPdfImageMembers(imageDir: string): Promise<string[]> {
@@ -1133,8 +1171,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 	}
 
-	async #ensurePdfImageCache(absolutePdfPath: string, signal?: AbortSignal): Promise<string> {
-		const imageDir = this.#pdfImageCacheDir(absolutePdfPath);
+	async #extractPdfImages(snapshot: PdfImageSnapshot, imageDir: string, signal: AbortSignal): Promise<string> {
 		const markerPath = path.join(imageDir, ".extracted");
 		try {
 			await fs.stat(markerPath);
@@ -1143,15 +1180,74 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			if (!isNotFoundError(error)) throw error;
 		}
 
-		await fs.rm(imageDir, { recursive: true, force: true });
-		await fs.mkdir(imageDir, { recursive: true });
-		const result = await convertFileWithMarkit(absolutePdfPath, signal, { imageDir });
-		if (!result.ok) {
-			await fs.rm(imageDir, { recursive: true, force: true });
-			throw new ToolError(`Cannot extract images from PDF: ${result.error ?? "conversion failed"}`);
+		await fs.mkdir(path.dirname(imageDir), { recursive: true });
+		const stagingDir = await fs.mkdtemp(`${imageDir}.tmp-`);
+		let published = false;
+		try {
+			const result = await convertFileWithMarkit(snapshot.filePath, signal, { imageDir: stagingDir });
+			if (!result.ok) {
+				throw new ToolError(`Cannot extract images from PDF: ${result.error ?? "conversion failed"}`);
+			}
+			await Bun.write(path.join(stagingDir, ".extracted"), "ok");
+			try {
+				await fs.rename(stagingDir, imageDir);
+				published = true;
+			} catch (error) {
+				if (!isEexist(error) && !isEnotempty(error)) throw error;
+				try {
+					await fs.stat(markerPath);
+				} catch (markerError) {
+					if (isNotFoundError(markerError)) throw error;
+					throw markerError;
+				}
+			}
+			return imageDir;
+		} finally {
+			if (!published) await fs.rm(stagingDir, { recursive: true, force: true });
 		}
-		await Bun.write(markerPath, "ok");
-		return imageDir;
+	}
+
+	#createPdfImageExtraction(snapshot: PdfImageSnapshot, imageDir: string): PdfImageExtraction {
+		const controller = new AbortController();
+		const promise = this.#extractPdfImages(snapshot, imageDir, controller.signal).finally(() =>
+			fs.rm(snapshot.directory, { recursive: true, force: true }),
+		);
+		const extraction: PdfImageExtraction = { controller, promise, settled: false, waiters: 0 };
+		const settle = () => {
+			extraction.settled = true;
+			if (pdfImageExtractions.get(imageDir) === extraction) pdfImageExtractions.delete(imageDir);
+		};
+		void promise.then(settle, settle);
+		return extraction;
+	}
+
+	async #waitForPdfImageExtraction(extraction: PdfImageExtraction, signal: AbortSignal | undefined): Promise<string> {
+		extraction.waiters++;
+		try {
+			return await untilAborted(signal, extraction.promise);
+		} finally {
+			extraction.waiters--;
+			if (extraction.waiters === 0 && !extraction.settled) {
+				extraction.controller.abort();
+				try {
+					await extraction.promise;
+				} catch {}
+			}
+		}
+	}
+
+	async #ensurePdfImageCache(absolutePdfPath: string, signal?: AbortSignal): Promise<string> {
+		const snapshot = await this.#snapshotPdfSource(absolutePdfPath, signal);
+		const imageDir = this.#pdfImageCacheDir(absolutePdfPath, snapshot.digest);
+		const existing = pdfImageExtractions.get(imageDir);
+		if (existing && !existing.settled && !existing.controller.signal.aborted) {
+			await fs.rm(snapshot.directory, { recursive: true, force: true });
+			return this.#waitForPdfImageExtraction(existing, signal);
+		}
+
+		const extraction = this.#createPdfImageExtraction(snapshot, imageDir);
+		pdfImageExtractions.set(imageDir, extraction);
+		return this.#waitForPdfImageExtraction(extraction, signal);
 	}
 
 	async #readPdfImageMember(

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -10,9 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { ReadTool, type ReadToolDetails } from "@oh-my-pi/pi-coding-agent/tools/read";
 import * as markit from "@oh-my-pi/pi-coding-agent/utils/markit";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -46,6 +47,28 @@ function mockExtraction(members: Record<string, Buffer> = { "p11-img0.png": TINY
 		}
 		return { ok: true, content: "" };
 	});
+}
+
+function imageBytes(result: AgentToolResult<ReadToolDetails>): Buffer {
+	const image = result.content.find(content => content.type === "image");
+	if (image?.type !== "image") throw new Error("Expected an image result");
+	return Buffer.from(image.data, "base64");
+}
+
+function mockBlockedExtraction() {
+	const entered = Promise.withResolvers<void>();
+	const release = Promise.withResolvers<void>();
+	const spy = vi.spyOn(markit, "convertFileWithMarkit").mockImplementation(async (_sourcePath, signal, options) => {
+		entered.resolve();
+		await release.promise;
+		signal?.throwIfAborted();
+		if (options?.imageDir) {
+			fs.mkdirSync(options.imageDir, { recursive: true });
+			fs.writeFileSync(path.join(options.imageDir, "p11-img0.png"), TINY_PNG);
+		}
+		return { ok: true, content: "" };
+	});
+	return { entered, release, spy };
 }
 
 describe("read PDF image extraction", () => {
@@ -131,6 +154,218 @@ describe("read PDF image extraction", () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
+	it("re-extracts image members after same-path PDF replacement", async () => {
+		const sourceA = Buffer.from("%PDF-source-a");
+		const sourceB = Buffer.from("%PDF-source-b");
+		fs.writeFileSync(pdfPath, sourceA);
+		const spy = vi.spyOn(markit, "convertFileWithMarkit").mockImplementation(async (sourcePath, _signal, options) => {
+			if (options?.imageDir) {
+				fs.mkdirSync(options.imageDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(options.imageDir, "p11-img0.png"),
+					Buffer.concat([TINY_PNG, fs.readFileSync(sourcePath)]),
+				);
+			}
+			return { ok: true, content: "" };
+		});
+		const tool = new ReadTool(makeSession(testDir));
+
+		const originalStat = fs.statSync(pdfPath);
+		const first = await tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		fs.writeFileSync(pdfPath, sourceB);
+		fs.utimesSync(pdfPath, originalStat.atime, originalStat.mtime);
+		const second = await tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+
+		expect(imageBytes(first).subarray(TINY_PNG.length)).toEqual(sourceA);
+		expect(imageBytes(second).subarray(TINY_PNG.length)).toEqual(sourceB);
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it("converts an immutable snapshot when the source changes during extraction", async () => {
+		const sourceA = Buffer.from("%PDF-source-a");
+		const sourceB = Buffer.from("%PDF-source-b");
+		fs.writeFileSync(pdfPath, sourceA);
+		const entered = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		vi.spyOn(markit, "convertFileWithMarkit").mockImplementation(async (sourcePath, _signal, options) => {
+			entered.resolve();
+			await release.promise;
+			if (options?.imageDir) {
+				fs.mkdirSync(options.imageDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(options.imageDir, "p11-img0.png"),
+					Buffer.concat([TINY_PNG, fs.readFileSync(sourcePath)]),
+				);
+			}
+			return { ok: true, content: "" };
+		});
+		const pending = new ReadTool(makeSession(testDir)).execute("call", { path: `${pdfPath}:p11-img0.png` });
+
+		await entered.promise;
+		fs.writeFileSync(pdfPath, sourceB);
+		release.resolve();
+		const result = await pending;
+
+		expect(imageBytes(result).subarray(TINY_PNG.length)).toEqual(sourceA);
+	});
+
+	it("coalesces concurrent cold image extraction", async () => {
+		const { entered, release, spy } = mockBlockedExtraction();
+		const tool = new ReadTool(makeSession(testDir));
+		const first = tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		const second = tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+
+		await entered.promise;
+		const conversionCount = spy.mock.calls.length;
+		release.resolve();
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+
+		expect(conversionCount).toBe(1);
+		expect(imageBytes(firstResult)).toEqual(imageBytes(secondResult));
+	});
+
+	it("keeps shared extraction running when its owner aborts", async () => {
+		const { entered, release, spy } = mockBlockedExtraction();
+		const tool = new ReadTool(makeSession(testDir));
+		const ownerController = new AbortController();
+		const owner = tool.execute("call", { path: `${pdfPath}:p11-img0.png` }, ownerController.signal);
+		const joiner = tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		await entered.promise;
+
+		ownerController.abort();
+		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
+		release.resolve();
+		const result = await joiner;
+
+		expect(result.content.some(content => content.type === "image")).toBe(true);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps shared extraction running when a joiner aborts", async () => {
+		const { entered, release, spy } = mockBlockedExtraction();
+		const tool = new ReadTool(makeSession(testDir));
+		const joinerController = new AbortController();
+		const owner = tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		const joiner = tool.execute("call", { path: `${pdfPath}:p11-img0.png` }, joinerController.signal);
+		await entered.promise;
+
+		joinerController.abort();
+		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
+		release.resolve();
+		const result = await owner;
+
+		expect(result.content.some(content => content.type === "image")).toBe(true);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("cleans temporary extraction state when the only caller aborts", async () => {
+		const entered = Promise.withResolvers<void>();
+		let snapshotPath: string | undefined;
+		let stagingDir: string | undefined;
+		vi.spyOn(markit, "convertFileWithMarkit").mockImplementation(async (sourcePath, signal, options) => {
+			snapshotPath = sourcePath;
+			stagingDir = options?.imageDir;
+			entered.resolve();
+			const aborted = Promise.withResolvers<void>();
+			const onAbort = () => aborted.resolve();
+			if (signal?.aborted) onAbort();
+			else signal?.addEventListener("abort", onAbort, { once: true });
+			await aborted.promise;
+			signal?.removeEventListener("abort", onAbort);
+			signal?.throwIfAborted();
+			return { ok: true, content: "" };
+		});
+		const controller = new AbortController();
+		const pending = new ReadTool(makeSession(testDir)).execute(
+			"call",
+			{ path: `${pdfPath}:p11-img0.png` },
+			controller.signal,
+		);
+
+		await entered.promise;
+		controller.abort();
+		await expect(pending).rejects.toThrow(/Aborted|Cancelled/);
+		if (!snapshotPath || !stagingDir) throw new Error("Expected extraction paths");
+
+		expect(fs.existsSync(path.dirname(snapshotPath))).toBe(false);
+		expect(fs.existsSync(stagingDir)).toBe(false);
+	});
+
+	it("does not let a failed generation delete a replacement generation", async () => {
+		const sourceA = Buffer.from("%PDF-source-a");
+		const sourceB = Buffer.from("%PDF-source-b");
+		fs.writeFileSync(pdfPath, sourceA);
+		const firstEntered = Promise.withResolvers<void>();
+		const failFirst = Promise.withResolvers<void>();
+		const spy = vi.spyOn(markit, "convertFileWithMarkit").mockImplementation(async (sourcePath, _signal, options) => {
+			const source = fs.readFileSync(sourcePath);
+			if (source.equals(sourceA)) {
+				firstEntered.resolve();
+				await failFirst.promise;
+				return { ok: false, content: "", error: "generation A failed" };
+			}
+			if (options?.imageDir) {
+				fs.mkdirSync(options.imageDir, { recursive: true });
+				fs.writeFileSync(path.join(options.imageDir, "p11-img0.png"), Buffer.concat([TINY_PNG, source]));
+			}
+			return { ok: true, content: "" };
+		});
+		const tool = new ReadTool(makeSession(testDir));
+		const first = tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		await firstEntered.promise;
+		fs.writeFileSync(pdfPath, sourceB);
+
+		const replacement = await tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		failFirst.resolve();
+		await expect(first).rejects.toThrow(/Cannot extract images/);
+		const cachedReplacement = await tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+
+		expect(imageBytes(replacement).subarray(TINY_PNG.length)).toEqual(sourceB);
+		expect(imageBytes(cachedReplacement)).toEqual(imageBytes(replacement));
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it("isolates equal-content PDFs with the same basename in different directories", async () => {
+		const otherDir = path.join(testDir, "other");
+		const otherPdfPath = path.join(otherDir, path.basename(pdfPath));
+		fs.mkdirSync(otherDir, { recursive: true });
+		fs.writeFileSync(otherPdfPath, fs.readFileSync(pdfPath));
+		let conversion = 0;
+		const spy = vi
+			.spyOn(markit, "convertFileWithMarkit")
+			.mockImplementation(async (_sourcePath, _signal, options) => {
+				conversion++;
+				if (options?.imageDir) {
+					fs.mkdirSync(options.imageDir, { recursive: true });
+					fs.writeFileSync(
+						path.join(options.imageDir, "p11-img0.png"),
+						Buffer.concat([TINY_PNG, Buffer.from(String(conversion))]),
+					);
+				}
+				return { ok: true, content: "" };
+			});
+		const tool = new ReadTool(makeSession(testDir));
+
+		const first = await tool.execute("call", { path: `${pdfPath}:p11-img0.png` });
+		const second = await tool.execute("call", { path: `${otherPdfPath}:p11-img0.png` });
+
+		expect(imageBytes(first).subarray(TINY_PNG.length).toString()).toBe("1");
+		expect(imageBytes(second).subarray(TINY_PNG.length).toString()).toBe("2");
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it("supports PDF basenames at the filesystem component limit", async () => {
+		const longPdfPath = path.join(testDir, `${"a".repeat(250)}.pdf`);
+		fs.writeFileSync(longPdfPath, "%PDF-stub");
+		mockExtraction();
+
+		const result = await new ReadTool(makeSession(testDir)).execute("call", {
+			path: `${longPdfPath}:p11-img0.png`,
+		});
+
+		expect(result.content.some(content => content.type === "image")).toBe(true);
+	});
+
 	it("errors with the available members for an unknown member", async () => {
 		mockExtraction();
 		const tool = new ReadTool(makeSession(testDir));
@@ -160,12 +395,20 @@ describe("read PDF image extraction", () => {
 	});
 
 	it("does not cache a failed conversion", async () => {
+		let failedSnapshotPath: string | undefined;
+		let failedImageDir: string | undefined;
 		const spy = vi.spyOn(markit, "convertFileWithMarkit");
-		// First attempt fails and writes nothing → throws, leaves no `.extracted` marker.
-		spy.mockResolvedValueOnce({ ok: false, content: "", error: "boom" });
+		spy.mockImplementationOnce(async (sourcePath, _signal, options) => {
+			failedSnapshotPath = sourcePath;
+			failedImageDir = options?.imageDir;
+			return { ok: false, content: "", error: "boom" };
+		});
 		const tool = new ReadTool(makeSession(testDir));
 		await expect(tool.execute("call", { path: `${pdfPath}:p11-img0.png` })).rejects.toThrow(/Cannot extract images/);
-		// A later attempt succeeds and must re-run conversion (cache not poisoned).
+		if (!failedSnapshotPath || !failedImageDir) throw new Error("Expected failed extraction paths");
+		expect(fs.existsSync(path.dirname(failedSnapshotPath))).toBe(false);
+		expect(fs.existsSync(path.join(failedImageDir, ".extracted"))).toBe(false);
+
 		spy.mockImplementationOnce(async (_filePath: string, _signal, options) => {
 			if (options?.imageDir) {
 				fs.mkdirSync(options.imageDir, { recursive: true });


### PR DESCRIPTION
## Repro
Writing `%PDF-source-a` to one path, reading `<path>:p11-img0.png`, replacing the file with equal-length `%PDF-source-b` while restoring its mtime, and reading the same member again returned the first image bytes. Reproduced with `bun test packages/coding-agent/test/tools/read-pdf-images.test.ts --test-name-pattern 'same-path PDF replacement'` (0 pass, 1 fail before the fix).

## Cause
`ReadTool.#pdfImageCacheDir` keyed generations only by the resolved source path, while `ReadTool.#ensurePdfImageCache` converted that mutable path directly and let every cold caller remove and populate the same directory. The `.extracted` marker therefore outlived same-path content changes, and concurrent or aborted conversions could race shared output.

## Fix
- Snapshot PDF bytes privately, derive a SHA-256 content digest from those exact bytes, and convert the immutable snapshot.
- Include bounded basename, resolved-path identity, and content digest in each cache generation.
- Coalesce same-generation extraction, track independent waiters, and cancel shared conversion only after every caller leaves.
- Stage extraction in a private directory and atomically publish only complete generations; clean staging and snapshots on every outcome.
- Add contract coverage for same-size/mtime replacement, live mutation, cold concurrency, owner/joiner aborts, cleanup, failed-generation isolation, path isolation, and filesystem component limits.

## Verification
`bun test packages/coding-agent/test/tools/read-pdf-images.test.ts` — 17 pass, 0 fail. `bun check` — passed across TypeScript and Rust checks.

Fixes #6368