### PR TITLE
fix(agent): deliver queued steer on empty transcript instead of looping

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Queued steering no longer hard-aborts non-interruptible tools (e.g. `bash`): it aborts interruptible waits only and raises a cooperative steering signal (`ToolCallContext.steeringSignal`) that long-running tools may observe to finish early or background themselves. The mid-batch steering/IRC watch now runs for every tool batch instead of only batches containing an interruptible tool.
 
+### Fixed
+
+- Fixed an unbounded allocation loop when a steer (or follow-up) was queued on a session with an empty transcript: `Agent.continue()` now delivers the queued message as the opening turn instead of throwing, so idle-drain callers no longer respin `continue()` on every microtask until OOM ([#6344](https://github.com/can1357/oh-my-pi/issues/6344)).
+
 ## [17.0.8] - 2026-07-22
 
 ### Fixed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1047,6 +1047,22 @@ export class Agent {
 
 		const messages = this.#state.messages;
 		if (messages.length === 0) {
+			// An empty transcript has nothing to resume, but a queued steer/follow-up
+			// must still be delivered as the opening turn — mirroring the assistant-tail
+			// branch below. Throwing here leaves the message undeliverable, and idle-drain
+			// callers (AgentSession#scheduleQueuedMessageDrain) re-arm continue() on every
+			// microtask because hasQueuedMessages() never clears, spinning an unbounded
+			// allocation loop until OOM (issue #6344).
+			const queuedSteering = this.#dequeueSteeringMessages();
+			if (queuedSteering.length > 0) {
+				await this.#runLoop(queuedSteering, { skipInitialSteeringPoll: true });
+				return;
+			}
+			const queuedFollowUp = this.#dequeueFollowUpMessages();
+			if (queuedFollowUp.length > 0) {
+				await this.#runLoop(queuedFollowUp);
+				return;
+			}
 			throw new Error("No messages to continue from");
 		}
 		if (messages[messages.length - 1].role === "assistant") {

--- a/packages/agent/test/continue-empty-transcript.test.ts
+++ b/packages/agent/test/continue-empty-transcript.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+
+/**
+ * Regression: a `steer` (or follow-up) queued on an empty transcript must be
+ * delivered as the opening turn instead of leaving `continue()` to throw
+ * `No messages to continue from`. Before the fix the steer stayed queued, so the
+ * RPC idle-drain re-armed `continue()` on every microtask (gated only on
+ * `hasQueuedMessages()`), an unbounded allocation loop that OOM-killed the
+ * process (issue #6344).
+ */
+describe("Agent.continue() on an empty transcript", () => {
+	it("runs a queued steer as the opening turn and drains the queue", async () => {
+		const mock = createMockModel({ responses: [{ content: ["Answer"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.steer({
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			timestamp: Date.now(),
+		});
+
+		await expect(agent.continue()).resolves.toBeUndefined();
+
+		expect(mock.calls.length).toBe(1);
+		expect(agent.hasQueuedMessages()).toBe(false);
+		expect(agent.state.messages.map(m => m.role)).toEqual(["user", "assistant"]);
+		const steerDelivered = agent.state.messages.some(
+			m =>
+				m.role === "user" &&
+				Array.isArray(m.content) &&
+				m.content.some(part => part.type === "text" && part.text === "hello"),
+		);
+		expect(steerDelivered).toBe(true);
+	});
+
+	it("runs a queued follow-up as the opening turn and drains the queue", async () => {
+		const mock = createMockModel({ responses: [{ content: ["Answer"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "later" }],
+			timestamp: Date.now(),
+		});
+
+		await expect(agent.continue()).resolves.toBeUndefined();
+
+		expect(mock.calls.length).toBe(1);
+		expect(agent.hasQueuedMessages()).toBe(false);
+		expect(agent.state.messages.map(m => m.role)).toEqual(["user", "assistant"]);
+	});
+
+	it("still throws when the transcript is empty and nothing is queued", async () => {
+		const agent = new Agent();
+		await expect(agent.continue()).rejects.toThrow("No messages to continue from");
+	});
+});


### PR DESCRIPTION
## Repro
In `--mode rpc`, sending a single `steer` frame to an idle session that never ran a turn drives the process into an unbounded, microtask-rate allocation loop until it is OOM-killed (RSS ~100 MB/s on 17.0.8; a production incident reached 62.7 GB anon-rss before the kernel killed it). Isolated at the agent core with a mock model (no network):

```
bun test ./test/continue-empty-transcript.test.ts   # cwd packages/agent
# pre-fix:
#   threw: No messages to continue from
#   hasQueuedMessages after continue(): true
#   provider calls: 0
```

## Cause
A `steer` queues a user message and schedules the idle drain. `AgentSession.#scheduleQueuedMessageDrain` calls `#scheduleAgentContinue` (delayMs 0 = a microtask), which calls `Agent.continue()`. Core `continue()` (`packages/agent/src/agent.ts:1049-1051`) threw `No messages to continue from` on an empty transcript **before** dequeuing any steering message, so the steer was never consumed and `hasQueuedMessages()` stayed `true`. The re-arm path `#endInFlight -> #drainStrandedQueuedMessages -> #scheduleQueuedMessageDrain` is gated only on `hasQueuedMessages()` / `#canAutoContinueForFollowUp()` (true whenever a steer is queued) with no backoff or exit condition, so it respun forever — each iteration allocating a fresh `Error` + stack + `logger.warn` serialization and starving the transport, so subsequent frames (e.g. `follow_up`) never get a reply.

## Fix
- `packages/agent/src/agent.ts`: in `continue()`, when the transcript is empty, dequeue and run a queued steering message (then a queued follow-up) as the opening turn — mirroring the existing assistant-tail branch — before falling back to the `No messages to continue from` throw. Delivering the message drains the queue, so the re-arm's `hasQueuedMessages()` gate goes false and the loop terminates.
- `packages/agent/test/continue-empty-transcript.test.ts`: regression coverage — a queued steer/follow-up on an empty transcript runs exactly one turn, drains the queue, and lands as `[user, assistant]`; an empty transcript with nothing queued still throws.
- `packages/agent/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification
`bun test` in `packages/agent`: 394 pass / 0 fail (29 files), including the new regression file and the existing `agent.test.ts` / `agent-loop.test.ts` steering suites (96 pass). The regression test asserts `hasQueuedMessages() === false` after `continue()`, which is precisely the exit condition the re-arm loop was missing. Fixes #6344