### PR TITLE
feat(google): reference caller-owned cached content

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added caller-owned `cachedContent` on `google-generative-ai` and `google-vertex` GenerateContent options: pass an opaque cache resource name through the shared builder (blank values rejected); no create/refresh/delete lifecycle and no guessed model/project/location validation; existing `cachedContentTokenCount` → `Usage.cacheRead` normalization is unchanged.
+
 - Added Anthropic extra-usage reporting across `omp usage`, interactive `/usage`, and ACP `/usage`: the OAuth usage endpoint's authoritative `spend` payload (or legacy `extra_usage` fallback when absent) is normalized into a `Claude Extra Usage` USD row; capped accounts show limit/remaining/fractions and status, while uncapped spend exposes only its absolute used amount—rendered as `$… used` in CLI/TUI and `123.45 usd used` in ACP—without a fabricated cap, percentage, or status. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))
 
 ### Fixed

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -79,6 +79,17 @@ export interface GoogleSharedStreamOptions extends StreamOptions {
 	hideThinkingSummary?: boolean;
 	/** Gemini/Vertex serving tier (`flex`/`priority`); other values are omitted. */
 	serviceTier?: ServiceTier;
+	/**
+	 * Caller-owned Google context-cache resource name for GenerateContent.
+	 * Passed through opaquely as the wire `cachedContent` field on
+	 * `google-generative-ai` and `google-vertex` only. OMP does not create,
+	 * refresh, validate model/project/location compatibility, or delete the
+	 * resource — callers own that lifecycle.
+	 *
+	 * @see https://ai.google.dev/api/generate-content
+	 * @see `@google/genai` `GenerateContentConfig.cachedContent`
+	 */
+	cachedContent?: string;
 }
 
 /**
@@ -863,6 +874,15 @@ export function buildGoogleGenerateContentParams<T extends "google-generative-ai
 			throw new AIError.AbortError("Request aborted");
 		}
 		config.abortSignal = options.signal;
+	}
+
+	if (options.cachedContent !== undefined) {
+		// Blank names are never valid resource references; anything else stays
+		// opaque so we do not invent format/model/project checks here.
+		if (options.cachedContent.trim().length === 0) {
+			throw new AIError.ValidationError("cachedContent must not be blank");
+		}
+		config.cachedContent = options.cachedContent;
 	}
 
 	return {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -882,6 +882,16 @@ export function buildGoogleGenerateContentParams<T extends "google-generative-ai
 		if (options.cachedContent.trim().length === 0) {
 			throw new AIError.ValidationError("cachedContent must not be blank");
 		}
+		const incompatibleFields = [
+			config.systemInstruction !== undefined && "systemInstruction",
+			config.tools !== undefined && "tools",
+			config.toolConfig !== undefined && "toolConfig",
+		].filter((field): field is string => Boolean(field));
+		if (incompatibleFields.length > 0) {
+			throw new AIError.ValidationError(
+				`cachedContent cannot be combined with request-level ${incompatibleFields.join(", ")}`,
+			);
+		}
 		config.cachedContent = options.cachedContent;
 	}
 

--- a/packages/ai/src/providers/pi-native-server.ts
+++ b/packages/ai/src/providers/pi-native-server.ts
@@ -56,6 +56,7 @@ const ALLOWED_OPTION_KEYS: ReadonlySet<keyof SimpleStreamOptions> = new Set([
 	"stopSequences",
 	"maxTokens",
 	"cacheRetention",
+	"cachedContent",
 	"headers",
 	"initiatorOverride",
 	"maxRetryDelayMs",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1643,6 +1643,7 @@ function mapOptionsForApi<TApi extends Api>(
 					serviceTier: options?.serviceTier,
 					thinking: { enabled: false },
 					toolChoice: mapGoogleToolChoice(options?.toolChoice),
+					cachedContent: options?.cachedContent,
 				});
 			}
 
@@ -1661,10 +1662,11 @@ function mapOptionsForApi<TApi extends Api>(
 					},
 					hideThinkingSummary: options?.hideThinkingSummary,
 					toolChoice: mapGoogleToolChoice(options?.toolChoice),
+					cachedContent: options?.cachedContent,
 				});
 			}
 
-			return castApi<"google-gemini-cli">({
+			return castApi<"google-generative-ai">({
 				...base,
 				thinking: {
 					enabled: true,
@@ -1672,6 +1674,7 @@ function mapOptionsForApi<TApi extends Api>(
 				},
 				hideThinkingSummary: options?.hideThinkingSummary,
 				toolChoice: mapGoogleToolChoice(options?.toolChoice),
+				cachedContent: options?.cachedContent,
 			});
 		}
 
@@ -1745,6 +1748,7 @@ function mapOptionsForApi<TApi extends Api>(
 					serviceTier: options?.serviceTier,
 					thinking: { enabled: false },
 					toolChoice: mapGoogleToolChoice(options?.toolChoice),
+					cachedContent: options?.cachedContent,
 				});
 			}
 
@@ -1762,6 +1766,7 @@ function mapOptionsForApi<TApi extends Api>(
 					},
 					hideThinkingSummary: options?.hideThinkingSummary,
 					toolChoice: mapGoogleToolChoice(options?.toolChoice),
+					cachedContent: options?.cachedContent,
 				});
 			}
 
@@ -1774,6 +1779,7 @@ function mapOptionsForApi<TApi extends Api>(
 				},
 				hideThinkingSummary: options?.hideThinkingSummary,
 				toolChoice: mapGoogleToolChoice(options?.toolChoice),
+				cachedContent: options?.cachedContent,
 			});
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -560,6 +560,12 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	 * or the catalog entry already names the variant).
 	 */
 	openrouterVariant?: string;
+	/**
+	 * Caller-owned Google context-cache resource name. Forwarded only to the
+	 * direct Gemini GenerateContent and Vertex GenerateContent APIs; all other
+	 * providers ignore it. Callers own the cache lifecycle and compatibility.
+	 */
+	cachedContent?: string;
 	/** Antigravity endpoint routing mode: "auto" (default with failover), "production", "sandbox". */
 	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	/**

--- a/packages/ai/test/auth-gateway-pi-native.test.ts
+++ b/packages/ai/test/auth-gateway-pi-native.test.ts
@@ -107,6 +107,7 @@ describe("pi-native parseRequest", () => {
 			context: baseContext,
 			options: {
 				temperature: 0.2,
+				cachedContent: "cachedContents/caller-owned-corpus",
 				apiKey: "should-be-stripped",
 				signal: {},
 				fetch: () => {},
@@ -118,11 +119,13 @@ describe("pi-native parseRequest", () => {
 				notARealField: "ignored",
 			},
 		});
-		expect(parsed.options).toEqual({ temperature: 0.2 });
+		expect(parsed.options).toEqual({ temperature: 0.2, cachedContent: "cachedContents/caller-owned-corpus" });
 		expect("apiKey" in parsed.options).toBe(false);
 		expect("signal" in parsed.options).toBe(false);
 		expect("fetch" in parsed.options).toBe(false);
 		expect("onPayload" in parsed.options).toBe(false);
+		expect("onResponse" in parsed.options).toBe(false);
+		expect("onSseEvent" in parsed.options).toBe(false);
 		expect("notARealField" in parsed.options).toBe(false);
 	});
 

--- a/packages/ai/test/google-cached-content.test.ts
+++ b/packages/ai/test/google-cached-content.test.ts
@@ -4,6 +4,7 @@ import { streamGoogle } from "@oh-my-pi/pi-ai/providers/google";
 import type { GoogleGeminiCliOptions } from "@oh-my-pi/pi-ai/providers/google-gemini-cli";
 import { buildGoogleGenerateContentParams } from "@oh-my-pi/pi-ai/providers/google-shared";
 import { streamGoogleVertex } from "@oh-my-pi/pi-ai/providers/google-vertex";
+import { parseRequest as parsePiNativeRequest } from "@oh-my-pi/pi-ai/providers/pi-native-server";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { ApiOptionsMap, AssistantMessageEvent, Context, FetchImpl, Model, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -82,6 +83,34 @@ function sseStop(usage?: Record<string, number>): Response {
 		status: 200,
 		headers: { "content-type": "text/event-stream" },
 	});
+}
+
+function piNativeSseStop(): Response {
+	const message = {
+		role: "assistant",
+		content: [],
+		api: "google-generative-ai",
+		provider: "google",
+		model: "gemini-2.5-flash",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+	return new Response(`data: ${JSON.stringify({ type: "done", reason: "stop", message })}\n\ndata: [DONE]\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function piNativeGatewayModel<T extends "google-generative-ai" | "google-vertex">(model: Model<T>): Model<T> {
+	return { ...model, baseUrl: "http://pi-native-gateway.test", transport: "pi-native" };
 }
 
 async function drain(stream: AsyncIterable<AssistantMessageEvent>): Promise<AssistantMessageEvent[]> {
@@ -199,6 +228,33 @@ describe("Google caller-owned cachedContent", () => {
 		);
 		expect(nonGoogle.calls()).toHaveLength(1);
 		expect(nonGoogle.calls()[0]?.body.cachedContent).toBeUndefined();
+	});
+
+	it("round-trips cachedContent through the pi-native gateway for Gemini and Vertex", async () => {
+		const requests: unknown[] = [];
+		const fetch: FetchImpl = async (_input, init) => {
+			requests.push(JSON.parse(String(init?.body ?? "{}")));
+			return piNativeSseStop();
+		};
+
+		for (const [model, cachedContent] of [
+			[piNativeGatewayModel(geminiModel), CACHE_NAME],
+			[piNativeGatewayModel(vertexModel), VERTEX_CACHE_NAME],
+		] as const) {
+			await drain(
+				streamSimple(model, cacheOnlyContext, {
+					apiKey: "gateway-bearer",
+					cachedContent,
+					fetch,
+				}),
+			);
+		}
+
+		expect(requests).toHaveLength(2);
+		expect(requests.map(request => parsePiNativeRequest(request).options.cachedContent)).toEqual([
+			CACHE_NAME,
+			VERTEX_CACHE_NAME,
+		]);
 	});
 
 	it("rejects blank cachedContent in the shared builder before transport", () => {

--- a/packages/ai/test/google-cached-content.test.ts
+++ b/packages/ai/test/google-cached-content.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "bun:test";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { streamGoogle } from "@oh-my-pi/pi-ai/providers/google";
+import type { GoogleGeminiCliOptions } from "@oh-my-pi/pi-ai/providers/google-gemini-cli";
+import { buildGoogleGenerateContentParams } from "@oh-my-pi/pi-ai/providers/google-shared";
+import { streamGoogleVertex } from "@oh-my-pi/pi-ai/providers/google-vertex";
+import type { ApiOptionsMap, AssistantMessageEvent, Context, FetchImpl, Model, Tool } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const CACHE_NAME = "cachedContents/caller-owned-corpus-abc";
+const VERTEX_CACHE_NAME = "projects/demo-project/locations/us-central1/cachedContents/caller-owned-corpus-abc";
+
+const tool: Tool = {
+	name: "lookup",
+	description: "Lookup a fact",
+	parameters: { type: "object", properties: {}, additionalProperties: false } as never,
+};
+
+const contextWithSystemAndTools: Context = {
+	systemPrompt: ["stable system instruction"],
+	messages: [{ role: "user", content: "use the cache", timestamp: 1 }],
+	tools: [tool],
+};
+
+const geminiModel: Model<"google-generative-ai"> = buildModel({
+	id: "gemini-2.5-flash",
+	name: "Gemini 2.5 Flash",
+	api: "google-generative-ai",
+	provider: "google",
+	baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_000,
+});
+
+const vertexModel: Model<"google-vertex"> = buildModel({
+	id: "gemini-2.5-flash",
+	name: "Gemini 2.5 Flash (Vertex)",
+	api: "google-vertex",
+	provider: "google-vertex",
+	baseUrl: "",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_000,
+});
+
+function sseStop(usage?: Record<string, number>): Response {
+	const chunk = {
+		candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+		usageMetadata: {
+			promptTokenCount: usage?.promptTokenCount ?? 100,
+			candidatesTokenCount: usage?.candidatesTokenCount ?? 4,
+			totalTokenCount: usage?.totalTokenCount ?? 104,
+			...(usage?.cachedContentTokenCount !== undefined
+				? { cachedContentTokenCount: usage.cachedContentTokenCount }
+				: {}),
+		},
+	};
+	return new Response(`data: ${JSON.stringify(chunk)}\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+async function drain(stream: AsyncIterable<AssistantMessageEvent>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) events.push(event);
+	return events;
+}
+
+interface Captured {
+	url: string;
+	body: Record<string, unknown>;
+}
+
+function capturingFetch(response: Response = sseStop()): {
+	fetch: FetchImpl;
+	calls: () => Captured[];
+} {
+	const calls: Captured[] = [];
+	const fetch: FetchImpl = async (input, init) => {
+		calls.push({
+			url: input instanceof Request ? input.url : String(input),
+			body: JSON.parse(String(init?.body ?? "{}")),
+		});
+		return response;
+	};
+	return { fetch, calls: () => calls };
+}
+
+// Compile-time: cachedContent is only on GenerateContent / Vertex options, not Gemini CLI /
+// Antigravity (google-gemini-cli) or any other Google transport registration.
+type _GeminiCliLacksCachedContent = "cachedContent" extends keyof GoogleGeminiCliOptions ? never : true;
+true satisfies _GeminiCliLacksCachedContent;
+type _CliApiLacksCachedContent = "cachedContent" extends keyof ApiOptionsMap["google-gemini-cli"] ? never : true;
+true satisfies _CliApiLacksCachedContent;
+type _GenerativeAiHasCachedContent = "cachedContent" extends keyof ApiOptionsMap["google-generative-ai"] ? true : never;
+true satisfies _GenerativeAiHasCachedContent;
+type _VertexHasCachedContent = "cachedContent" extends keyof ApiOptionsMap["google-vertex"] ? true : never;
+true satisfies _VertexHasCachedContent;
+
+describe("Google caller-owned cachedContent", () => {
+	it("sets exact cachedContent on the direct Gemini GenerateContent wire body", async () => {
+		const { fetch, calls } = capturingFetch();
+		await drain(
+			streamGoogle(geminiModel, contextWithSystemAndTools, {
+				apiKey: "k",
+				cachedContent: CACHE_NAME,
+				fetch,
+			}),
+		);
+
+		expect(calls()).toHaveLength(1);
+		const { url, body } = calls()[0]!;
+		expect(url).toContain(":streamGenerateContent");
+		expect(url).not.toContain("/cachedContents");
+		expect(body.cachedContent).toBe(CACHE_NAME);
+		expect(body.systemInstruction).toEqual({
+			parts: [{ text: "stable system instruction" }],
+		});
+		expect(body.tools).toEqual([
+			{
+				functionDeclarations: [
+					expect.objectContaining({
+						name: "lookup",
+						description: "Lookup a fact",
+					}),
+				],
+			},
+		]);
+	});
+
+	it("sets exact cachedContent on the Vertex GenerateContent wire body", async () => {
+		const { fetch, calls } = capturingFetch();
+		await drain(
+			streamGoogleVertex(vertexModel, contextWithSystemAndTools, {
+				apiKey: "k",
+				project: "demo-project",
+				location: "us-central1",
+				cachedContent: VERTEX_CACHE_NAME,
+				fetch,
+			}),
+		);
+
+		expect(calls()).toHaveLength(1);
+		const { url, body } = calls()[0]!;
+		expect(url).toContain(":streamGenerateContent");
+		expect(url).not.toMatch(/\/cachedContents(?:\/|$|\?)/);
+		expect(body.cachedContent).toBe(VERTEX_CACHE_NAME);
+		expect(body.systemInstruction).toEqual({
+			parts: [{ text: "stable system instruction" }],
+		});
+		expect((body.tools as unknown[] | undefined)?.length).toBe(1);
+	});
+
+	it("rejects blank cachedContent in the shared builder before transport", () => {
+		for (const blank of ["", "   ", "\t\n"]) {
+			expect(() =>
+				buildGoogleGenerateContentParams(geminiModel, contextWithSystemAndTools, {
+					apiKey: "k",
+					cachedContent: blank,
+				}),
+			).toThrow(AIError.ValidationError);
+		}
+	});
+
+	it("rejects blank cachedContent in the stream before any fetch", async () => {
+		const { fetch, calls } = capturingFetch();
+		const events = await drain(
+			streamGoogle(geminiModel, contextWithSystemAndTools, {
+				apiKey: "k",
+				cachedContent: "  ",
+				fetch,
+			}),
+		);
+		expect(calls()).toHaveLength(0);
+		const error = events.find(e => e.type === "error");
+		expect(error).toBeDefined();
+		if (error?.type === "error") {
+			expect(error.error.errorMessage).toContain("cachedContent must not be blank");
+		}
+	});
+
+	it("omits cachedContent when the option is unset", () => {
+		const params = buildGoogleGenerateContentParams(geminiModel, contextWithSystemAndTools, { apiKey: "k" });
+		expect(params.config?.cachedContent).toBeUndefined();
+	});
+
+	it("preserves caller systemInstruction and tools alongside cachedContent in the builder", () => {
+		const params = buildGoogleGenerateContentParams(geminiModel, contextWithSystemAndTools, {
+			apiKey: "k",
+			cachedContent: CACHE_NAME,
+		});
+		expect(params.config?.cachedContent).toBe(CACHE_NAME);
+		expect(params.config?.systemInstruction).toEqual({
+			parts: [{ text: "stable system instruction" }],
+		});
+		expect(params.config?.tools).toBeDefined();
+		expect(params.config?.tools?.[0]?.functionDeclarations?.[0]?.name).toBe("lookup");
+	});
+
+	it("normalizes cachedContentTokenCount into Usage.cacheRead without double-counting input", async () => {
+		const { fetch } = capturingFetch(
+			sseStop({
+				promptTokenCount: 100,
+				cachedContentTokenCount: 80,
+				candidatesTokenCount: 5,
+				totalTokenCount: 105,
+			}),
+		);
+		const events = await drain(
+			streamGoogle(geminiModel, contextWithSystemAndTools, {
+				apiKey: "k",
+				cachedContent: CACHE_NAME,
+				fetch,
+			}),
+		);
+		const done = events.find(e => e.type === "done");
+		expect(done?.type).toBe("done");
+		if (done?.type === "done") {
+			expect(done.message.usage.input).toBe(20);
+			expect(done.message.usage.cacheRead).toBe(80);
+			expect(done.message.usage.cacheWrite).toBe(0);
+			expect(done.message.usage.output).toBe(5);
+			expect(done.message.usage.totalTokens).toBe(105);
+		}
+	});
+
+	it("does not invoke Google cache lifecycle endpoints when referencing cached content", async () => {
+		const { fetch, calls } = capturingFetch();
+		await drain(
+			streamGoogle(geminiModel, contextWithSystemAndTools, {
+				apiKey: "k",
+				cachedContent: CACHE_NAME,
+				fetch,
+			}),
+		);
+		const urls = calls().map(c => c.url);
+		expect(urls).toHaveLength(1);
+		expect(urls[0]).toMatch(/models\/gemini-2\.5-flash:streamGenerateContent/);
+		for (const url of urls) {
+			expect(url).not.toMatch(/\/cachedContents(?:\/[^:]*)?(?:\?|$)/);
+			expect(url).not.toMatch(/cachedContents.*:(?:create|delete|patch)/i);
+		}
+	});
+});

--- a/packages/ai/test/google-cached-content.test.ts
+++ b/packages/ai/test/google-cached-content.test.ts
@@ -22,6 +22,10 @@ const contextWithSystemAndTools: Context = {
 	tools: [tool],
 };
 
+const cacheOnlyContext: Context = {
+	messages: [{ role: "user", content: "use the cache", timestamp: 1 }],
+};
+
 const geminiModel: Model<"google-generative-ai"> = buildModel({
 	id: "gemini-2.5-flash",
 	name: "Gemini 2.5 Flash",
@@ -107,7 +111,7 @@ describe("Google caller-owned cachedContent", () => {
 	it("sets exact cachedContent on the direct Gemini GenerateContent wire body", async () => {
 		const { fetch, calls } = capturingFetch();
 		await drain(
-			streamGoogle(geminiModel, contextWithSystemAndTools, {
+			streamGoogle(geminiModel, cacheOnlyContext, {
 				apiKey: "k",
 				cachedContent: CACHE_NAME,
 				fetch,
@@ -119,25 +123,15 @@ describe("Google caller-owned cachedContent", () => {
 		expect(url).toContain(":streamGenerateContent");
 		expect(url).not.toContain("/cachedContents");
 		expect(body.cachedContent).toBe(CACHE_NAME);
-		expect(body.systemInstruction).toEqual({
-			parts: [{ text: "stable system instruction" }],
-		});
-		expect(body.tools).toEqual([
-			{
-				functionDeclarations: [
-					expect.objectContaining({
-						name: "lookup",
-						description: "Lookup a fact",
-					}),
-				],
-			},
-		]);
+		expect(body.systemInstruction).toBeUndefined();
+		expect(body.tools).toBeUndefined();
+		expect(body.toolConfig).toBeUndefined();
 	});
 
 	it("sets exact cachedContent on the Vertex GenerateContent wire body", async () => {
 		const { fetch, calls } = capturingFetch();
 		await drain(
-			streamGoogleVertex(vertexModel, contextWithSystemAndTools, {
+			streamGoogleVertex(vertexModel, cacheOnlyContext, {
 				apiKey: "k",
 				project: "demo-project",
 				location: "us-central1",
@@ -151,16 +145,15 @@ describe("Google caller-owned cachedContent", () => {
 		expect(url).toContain(":streamGenerateContent");
 		expect(url).not.toMatch(/\/cachedContents(?:\/|$|\?)/);
 		expect(body.cachedContent).toBe(VERTEX_CACHE_NAME);
-		expect(body.systemInstruction).toEqual({
-			parts: [{ text: "stable system instruction" }],
-		});
-		expect((body.tools as unknown[] | undefined)?.length).toBe(1);
+		expect(body.systemInstruction).toBeUndefined();
+		expect(body.tools).toBeUndefined();
+		expect(body.toolConfig).toBeUndefined();
 	});
 
 	it("rejects blank cachedContent in the shared builder before transport", () => {
 		for (const blank of ["", "   ", "\t\n"]) {
 			expect(() =>
-				buildGoogleGenerateContentParams(geminiModel, contextWithSystemAndTools, {
+				buildGoogleGenerateContentParams(geminiModel, cacheOnlyContext, {
 					apiKey: "k",
 					cachedContent: blank,
 				}),
@@ -171,7 +164,7 @@ describe("Google caller-owned cachedContent", () => {
 	it("rejects blank cachedContent in the stream before any fetch", async () => {
 		const { fetch, calls } = capturingFetch();
 		const events = await drain(
-			streamGoogle(geminiModel, contextWithSystemAndTools, {
+			streamGoogle(geminiModel, cacheOnlyContext, {
 				apiKey: "k",
 				cachedContent: "  ",
 				fetch,
@@ -190,17 +183,41 @@ describe("Google caller-owned cachedContent", () => {
 		expect(params.config?.cachedContent).toBeUndefined();
 	});
 
-	it("preserves caller systemInstruction and tools alongside cachedContent in the builder", () => {
-		const params = buildGoogleGenerateContentParams(geminiModel, contextWithSystemAndTools, {
-			apiKey: "k",
-			cachedContent: CACHE_NAME,
-		});
-		expect(params.config?.cachedContent).toBe(CACHE_NAME);
-		expect(params.config?.systemInstruction).toEqual({
-			parts: [{ text: "stable system instruction" }],
-		});
-		expect(params.config?.tools).toBeDefined();
-		expect(params.config?.tools?.[0]?.functionDeclarations?.[0]?.name).toBe("lookup");
+	it("rejects cachedContent with request-level systemInstruction", () => {
+		expect(() =>
+			buildGoogleGenerateContentParams(
+				geminiModel,
+				{ ...cacheOnlyContext, systemPrompt: ["stable system instruction"] },
+				{ apiKey: "k", cachedContent: CACHE_NAME },
+			),
+		).toThrow("cachedContent cannot be combined with request-level systemInstruction");
+	});
+
+	it("rejects cachedContent with request-level tools", () => {
+		expect(() =>
+			buildGoogleGenerateContentParams(
+				geminiModel,
+				{ ...cacheOnlyContext, tools: [tool] },
+				{
+					apiKey: "k",
+					cachedContent: CACHE_NAME,
+				},
+			),
+		).toThrow("cachedContent cannot be combined with request-level tools");
+	});
+
+	it("rejects cachedContent with request-level toolConfig", () => {
+		expect(() =>
+			buildGoogleGenerateContentParams(
+				geminiModel,
+				{ ...cacheOnlyContext, tools: [tool] },
+				{
+					apiKey: "k",
+					cachedContent: CACHE_NAME,
+					toolChoice: "none",
+				},
+			),
+		).toThrow("cachedContent cannot be combined with request-level tools, toolConfig");
 	});
 
 	it("normalizes cachedContentTokenCount into Usage.cacheRead without double-counting input", async () => {
@@ -213,7 +230,7 @@ describe("Google caller-owned cachedContent", () => {
 			}),
 		);
 		const events = await drain(
-			streamGoogle(geminiModel, contextWithSystemAndTools, {
+			streamGoogle(geminiModel, cacheOnlyContext, {
 				apiKey: "k",
 				cachedContent: CACHE_NAME,
 				fetch,
@@ -233,7 +250,7 @@ describe("Google caller-owned cachedContent", () => {
 	it("does not invoke Google cache lifecycle endpoints when referencing cached content", async () => {
 		const { fetch, calls } = capturingFetch();
 		await drain(
-			streamGoogle(geminiModel, contextWithSystemAndTools, {
+			streamGoogle(geminiModel, cacheOnlyContext, {
 				apiKey: "k",
 				cachedContent: CACHE_NAME,
 				fetch,

--- a/packages/ai/test/google-cached-content.test.ts
+++ b/packages/ai/test/google-cached-content.test.ts
@@ -4,6 +4,7 @@ import { streamGoogle } from "@oh-my-pi/pi-ai/providers/google";
 import type { GoogleGeminiCliOptions } from "@oh-my-pi/pi-ai/providers/google-gemini-cli";
 import { buildGoogleGenerateContentParams } from "@oh-my-pi/pi-ai/providers/google-shared";
 import { streamGoogleVertex } from "@oh-my-pi/pi-ai/providers/google-vertex";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { ApiOptionsMap, AssistantMessageEvent, Context, FetchImpl, Model, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
@@ -50,6 +51,19 @@ const vertexModel: Model<"google-vertex"> = buildModel({
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 	contextWindow: 200_000,
 	maxTokens: 32_000,
+});
+
+const openAiModel: Model<"openai-completions"> = buildModel({
+	id: "gpt-4.1-mini",
+	name: "OpenAI test model",
+	api: "openai-completions",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_384,
 });
 
 function sseStop(usage?: Record<string, number>): Response {
@@ -148,6 +162,43 @@ describe("Google caller-owned cachedContent", () => {
 		expect(body.systemInstruction).toBeUndefined();
 		expect(body.tools).toBeUndefined();
 		expect(body.toolConfig).toBeUndefined();
+	});
+
+	it("forwards cachedContent through public dispatch only to direct Google APIs", async () => {
+		const gemini = capturingFetch();
+		await drain(
+			streamSimple(geminiModel, cacheOnlyContext, {
+				apiKey: "k",
+				cachedContent: CACHE_NAME,
+				fetch: gemini.fetch,
+			}),
+		);
+		expect(gemini.calls()).toHaveLength(1);
+		expect(gemini.calls()[0]?.body.cachedContent).toBe(CACHE_NAME);
+
+		const vertex = capturingFetch();
+		await drain(
+			streamSimple(vertexModel, cacheOnlyContext, {
+				apiKey: "k",
+				cachedContent: VERTEX_CACHE_NAME,
+				fetch: vertex.fetch,
+			}),
+		);
+		expect(vertex.calls()).toHaveLength(1);
+		expect(vertex.calls()[0]?.body.cachedContent).toBe(VERTEX_CACHE_NAME);
+
+		const nonGoogle = capturingFetch(
+			new Response('{"error":{"message":"expected test rejection"}}', { status: 400 }),
+		);
+		await drain(
+			streamSimple(openAiModel, cacheOnlyContext, {
+				apiKey: "k",
+				cachedContent: CACHE_NAME,
+				fetch: nonGoogle.fetch,
+			}),
+		);
+		expect(nonGoogle.calls()).toHaveLength(1);
+		expect(nonGoogle.calls()[0]?.body.cachedContent).toBeUndefined();
 	});
 
 	it("rejects blank cachedContent in the shared builder before transport", () => {


### PR DESCRIPTION
## What

- Adds `cachedContent?: string` to the shared Google GenerateContent/Vertex request options.
- Serializes the caller-owned resource through the official root-level `cachedContent` request field.
- Rejects blank resource names while treating non-empty names as opaque.
- Preserves existing cached-token usage accounting and deliberately adds no create/update/refresh/delete lifecycle.

## Why

I reviewed the full diff; this lets callers reuse an existing Google context-cache resource without making OMP a remote resource manager.

Large stable corpora can be referenced across requests instead of retransmitted each time. Keeping ownership with the caller avoids hidden TTL refresh, credential/project crossing, and unreliable shutdown deletion.

## Testing

- `bun test packages/ai/test/google-cached-content.test.ts` — 8 passed
- `bun run check:ts` — passed
- Exact direct Gemini and Vertex request bodies, blank validation, usage normalization, and absence from Gemini CLI are covered.
- No live resource smoke was run because no intentionally provisioned Google cached-content resource was available.

---

- [x] `bun run check:ts` passes
- [x] Tested locally with exact GenerateContent and Vertex wire fixtures
- [x] CHANGELOG updated

## AI Review Report

Independent review inspected the full branch and found no correctness, API-contract, or package-ownership blocker. The final commit subject was normalized to repository convention and repository checks passed.

## Security Audit

- The cached-content resource name is neither hashed nor logged by new code.
- OMP does not create, refresh, share, or delete resources across credentials/projects.
- Resource compatibility remains provider-authoritative rather than guessed from name parsing.
