### PR TITLE
fix(bedrock): validate prompt cache checkpoints

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed Bedrock cache checkpoints to use resolved model compatibility: unsupported 1-hour retention now falls back to the provider-default 5-minute cache, bundled Nova Lite, Micro, and Pro requests emit AWS-recommended explicit checkpoints for cache savings, and forced opaque profiles remain conservative.
+
 - Fixed outbound credential-pattern redaction (`[github_token_redacted]` & co.) running unconditionally: it is now opt-in via `configureCredentialRedaction` and disabled by default, so credential-shaped strings the user deliberately pastes reach the provider unmodified unless the host enables redaction.
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 - Fixed SuperGrok (`xai-oauth`) `/usage` showing "no usage data" for unified-billing accounts: when `?format=credits` lacks `creditUsagePercent` (or marks `isUnifiedBillingUser`), fall back to / merge the default monthly `monthlyLimit`/`used` payload.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed Bedrock cache checkpoints to use resolved model compatibility: unsupported 1-hour retention now falls back to the provider-default 5-minute cache, bundled Nova Lite, Micro, and Pro requests emit AWS-recommended explicit checkpoints for cache savings, and forced opaque profiles remain conservative.
+- Fixed Bedrock cache checkpoints to use resolved model compatibility: unsupported 1-hour retention now falls back to the provider-default 5-minute cache, bundled Nova Lite, Micro, Pro, and Premier requests—and Nova Premier's documented in-region model ID—emit AWS-recommended explicit checkpoints for cache savings, and forced opaque profiles remain conservative.
 
 - Fixed outbound credential-pattern redaction (`[github_token_redacted]` & co.) running unconditionally: it is now opt-in via `configureCredentialRedaction` and disabled by default, so credential-shaped strings the user deliberately pastes reach the provider unmodified unless the host enables redaction.
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed Bedrock cache checkpoints to use resolved model compatibility: unsupported 1-hour retention now falls back to the provider-default 5-minute cache, bundled Nova Lite, Micro, Pro, and Premier requests—and Nova Premier's documented in-region model ID—emit AWS-recommended explicit checkpoints for cache savings, and forced opaque profiles remain conservative.
+- Fixed Bedrock cache checkpoints to use resolved model compatibility: unsupported 1-hour retention now falls back to the provider-default 5-minute cache, bundled Nova Lite, Micro, Pro, Premier, and Nova 2 Lite requests—and every documented Nova 2 Lite model or profile ID—emit AWS-recommended explicit checkpoints for cache savings, and forced opaque profiles remain conservative.
 
 - Fixed outbound credential-pattern redaction (`[github_token_redacted]` & co.) running unconditionally: it is now opt-in via `configureCredentialRedaction` and disabled by default, so credential-shaped strings the user deliberately pastes reach the provider unmodified unless the host enables redaction.
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -171,6 +171,11 @@ type Block = (TextContent | ThinkingContent | ToolCall) & {
 interface CachePoint {
 	cachePoint: { type: "default"; ttl?: "5m" | "1h" };
 }
+
+interface BedrockPromptCachePolicy {
+	emitCheckpoints: boolean;
+	ttl?: "1h";
+}
 interface TextBlockWire {
 	text: string;
 }
@@ -310,7 +315,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 		try {
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
-			const convertedMessages = convertMessages(context, model, cacheRetention);
+			const promptCachePolicy = resolvePromptCachePolicy(model, cacheRetention);
+			const convertedMessages = convertMessages(context, model, promptCachePolicy);
 			const toolPlan = planToolConfig(context.tools, options.toolChoice, convertedMessages);
 			const toolConfig = toolPlan.toolConfig;
 			const sentinelInjected = toolPlan.sentinelInjected;
@@ -325,7 +331,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 			const commandInput: ConverseStreamRequest = {
 				messages: convertedMessages,
-				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
+				system: buildSystemPrompt(context.systemPrompt, promptCachePolicy),
 				inferenceConfig: {
 					maxTokens: options.maxTokens,
 					temperature: options.temperature,
@@ -693,29 +699,32 @@ function handleContentBlockStop(
 }
 
 /**
- * Check if the model supports prompt caching.
- * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, Claude 4.x+ models, Haiku 4.5+
- *
- * For base models and system-defined inference profiles the model ID / ARN
- * contains the model name, so we can decide locally.
- *
- * For application inference profiles (whose ARNs don't contain the model name),
- * set AWS_BEDROCK_FORCE_CACHE=1 to enable cache points.  Amazon Nova models
- * have automatic caching and don't need explicit cache points.
+ * Resolve Bedrock's explicit-cache request policy from the catalog's
+ * materialized provider contract. `AWS_BEDROCK_FORCE_CACHE` remains an escape
+ * hatch for opaque application inference profiles, but it cannot invent 1h
+ * retention that the model compat did not explicitly grant.
  */
-function supportsPromptCaching(model: Model<"bedrock-converse-stream">): boolean {
-	if (model.cost.cacheRead || model.cost.cacheWrite) return true;
-	const id = model.id.toLowerCase();
-	// Claude 4.x models (opus-4, sonnet-4, haiku-4)
-	if (id.includes("claude") && (id.includes("-4-") || id.includes("-4."))) return true;
-	// Claude 3.5 Haiku, Claude 3.7 Sonnet (legacy naming)
-	if (id.includes("claude-3-7-sonnet") || id.includes("claude-3-5-haiku")) return true;
-	// Claude Haiku 4.5+ (new naming)
-	if (id.includes("claude-haiku")) return true;
-	// Application inference profiles don't contain the model name in the ARN.
-	// Allow users to force cache points via environment variable.
-	if (typeof process !== "undefined" && $flag("AWS_BEDROCK_FORCE_CACHE")) return true;
-	return false;
+function resolvePromptCachePolicy(
+	model: Model<"bedrock-converse-stream">,
+	cacheRetention: CacheRetention,
+): BedrockPromptCachePolicy {
+	if (cacheRetention === "none" || model.compat.promptCacheMode === "automatic") {
+		return { emitCheckpoints: false };
+	}
+
+	const forced = $flag("AWS_BEDROCK_FORCE_CACHE");
+	if (model.compat.promptCacheMode !== "explicit" && !forced) {
+		return { emitCheckpoints: false };
+	}
+
+	return {
+		emitCheckpoints: true,
+		...(cacheRetention === "long" && model.compat.supportsLongPromptCacheRetention ? { ttl: "1h" } : {}),
+	};
+}
+
+function createCachePoint(policy: BedrockPromptCachePolicy): CachePoint {
+	return { cachePoint: { type: "default", ...(policy.ttl ? { ttl: policy.ttl } : {}) } };
 }
 
 /**
@@ -731,19 +740,15 @@ function supportsThinkingSignature(model: Model<"bedrock-converse-stream">): boo
 
 function buildSystemPrompt(
 	systemPrompt: readonly string[] | undefined,
-	model: Model<"bedrock-converse-stream">,
-	cacheRetention: CacheRetention,
+	promptCachePolicy: BedrockPromptCachePolicy,
 ): SystemContent[] | undefined {
 	const prompts = systemPrompt?.map(prompt => prompt.toWellFormed()).filter(prompt => prompt.length > 0) ?? [];
 	if (prompts.length === 0) return undefined;
 
 	const blocks: SystemContent[] = prompts.map(prompt => ({ text: prompt }));
 
-	// Add cache point for supported Claude models
-	if (cacheRetention !== "none" && supportsPromptCaching(model)) {
-		blocks.push({
-			cachePoint: { type: "default", ...(cacheRetention === "long" ? { ttl: "1h" } : {}) },
-		});
+	if (promptCachePolicy.emitCheckpoints) {
+		blocks.push(createCachePoint(promptCachePolicy));
 	}
 
 	return blocks;
@@ -752,7 +757,7 @@ function buildSystemPrompt(
 function convertMessages(
 	context: Context,
 	model: Model<"bedrock-converse-stream">,
-	cacheRetention: CacheRetention,
+	promptCachePolicy: BedrockPromptCachePolicy,
 ): WireMessage[] {
 	const result: WireMessage[] = [];
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
@@ -883,13 +888,11 @@ function convertMessages(
 		}
 	}
 
-	// Add cache point to the last user message for supported Claude models
-	if (cacheRetention !== "none" && supportsPromptCaching(model) && result.length > 0) {
+	// Preserve the existing second checkpoint after the final user message.
+	if (promptCachePolicy.emitCheckpoints && result.length > 0) {
 		const lastMessage = result[result.length - 1];
 		if (lastMessage.role === "user" && lastMessage.content) {
-			(lastMessage.content as UserContent[]).push({
-				cachePoint: { type: "default", ...(cacheRetention === "long" ? { ttl: "1h" } : {}) },
-			});
+			(lastMessage.content as UserContent[]).push(createCachePoint(promptCachePolicy));
 		}
 	}
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -173,7 +173,7 @@ interface CachePoint {
 }
 
 interface BedrockPromptCachePolicy {
-	emitCheckpoints: boolean;
+	remainingCheckpoints: number;
 	ttl?: "1h";
 }
 interface TextBlockWire {
@@ -702,33 +702,41 @@ function handleContentBlockStop(
  * Resolve Bedrock's explicit-cache request policy from the catalog's
  * materialized provider contract. Bedrock enforces each model's minimum
  * prefix-token requirement, so this boundary intentionally does not locally
- * count tokens. The fixed emitter adds at most two checkpoints (system and
- * final user), within every known explicit model's documented maximum of four.
+ * count tokens. The emitter prioritizes the final user boundary, then the
+ * system boundary, without exceeding the configured checkpoint maximum.
  *
  * `AWS_BEDROCK_FORCE_CACHE` remains an escape hatch for opaque application
- * inference profiles, but it cannot invent 1h retention that the model compat
- * did not explicitly grant.
+ * inference profiles, defaulting those otherwise-unknown models to the
+ * existing two-checkpoint layout without inventing 1h retention.
  */
 function resolvePromptCachePolicy(
 	model: Model<"bedrock-converse-stream">,
 	cacheRetention: CacheRetention,
 ): BedrockPromptCachePolicy {
 	if (cacheRetention === "none" || model.compat.promptCacheMode === "automatic") {
-		return { emitCheckpoints: false };
+		return { remainingCheckpoints: 0 };
 	}
 
 	const forced = $flag("AWS_BEDROCK_FORCE_CACHE");
-	if (model.compat.promptCacheMode !== "explicit" && !forced) {
-		return { emitCheckpoints: false };
+	const explicit = model.compat.promptCacheMode === "explicit";
+	if (!explicit && !forced) {
+		return { remainingCheckpoints: 0 };
+	}
+
+	const configuredMaximum = explicit ? model.compat.promptCacheMaximumCheckpoints : 2;
+	if (configuredMaximum <= 0) {
+		return { remainingCheckpoints: 0 };
 	}
 
 	return {
-		emitCheckpoints: true,
+		remainingCheckpoints: Math.min(configuredMaximum, 2),
 		...(cacheRetention === "long" && model.compat.supportsLongPromptCacheRetention ? { ttl: "1h" } : {}),
 	};
 }
 
-function createCachePoint(policy: BedrockPromptCachePolicy): CachePoint {
+function takeCachePoint(policy: BedrockPromptCachePolicy): CachePoint | undefined {
+	if (policy.remainingCheckpoints <= 0) return undefined;
+	policy.remainingCheckpoints--;
 	return { cachePoint: { type: "default", ...(policy.ttl ? { ttl: policy.ttl } : {}) } };
 }
 
@@ -752,9 +760,8 @@ function buildSystemPrompt(
 
 	const blocks: SystemContent[] = prompts.map(prompt => ({ text: prompt }));
 
-	if (promptCachePolicy.emitCheckpoints) {
-		blocks.push(createCachePoint(promptCachePolicy));
-	}
+	const cachePoint = takeCachePoint(promptCachePolicy);
+	if (cachePoint) blocks.push(cachePoint);
 
 	return blocks;
 }
@@ -893,11 +900,13 @@ function convertMessages(
 		}
 	}
 
-	// Preserve the existing second checkpoint after the final user message.
-	if (promptCachePolicy.emitCheckpoints && result.length > 0) {
+	// Prioritize the final user checkpoint; buildSystemPrompt consumes any
+	// remaining configured capacity afterward.
+	if (result.length > 0) {
 		const lastMessage = result[result.length - 1];
 		if (lastMessage.role === "user" && lastMessage.content) {
-			(lastMessage.content as UserContent[]).push(createCachePoint(promptCachePolicy));
+			const cachePoint = takeCachePoint(promptCachePolicy);
+			if (cachePoint) (lastMessage.content as UserContent[]).push(cachePoint);
 		}
 	}
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -700,9 +700,14 @@ function handleContentBlockStop(
 
 /**
  * Resolve Bedrock's explicit-cache request policy from the catalog's
- * materialized provider contract. `AWS_BEDROCK_FORCE_CACHE` remains an escape
- * hatch for opaque application inference profiles, but it cannot invent 1h
- * retention that the model compat did not explicitly grant.
+ * materialized provider contract. Bedrock enforces each model's minimum
+ * prefix-token requirement, so this boundary intentionally does not locally
+ * count tokens. The fixed emitter adds at most two checkpoints (system and
+ * final user), within every known explicit model's documented maximum of four.
+ *
+ * `AWS_BEDROCK_FORCE_CACHE` remains an escape hatch for opaque application
+ * inference profiles, but it cannot invent 1h retention that the model compat
+ * did not explicitly grant.
  */
 function resolvePromptCachePolicy(
 	model: Model<"bedrock-converse-stream">,

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -94,44 +94,32 @@ describe("Bedrock prompt cache checkpoints", () => {
 		expect(checkpoints(payload)).toEqual([{ cachePoint: { type: "default" } }, { cachePoint: { type: "default" } }]);
 	});
 
-	test("emits default-5m checkpoints for every bundled Nova cache-capable payload", async () => {
-		for (const id of [
-			"us.amazon.nova-lite-v1:0",
-			"us.amazon.nova-micro-v1:0",
-			"us.amazon.nova-pro-v1:0",
-			"us.amazon.nova-premier-v1:0",
-		] as const) {
-			const nova = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id);
-			expect(nova).toBeDefined();
-			const payload = await capturePayload(nova!, "long");
-			expect(payload).toEqual({
-				system: [{ text: "Use concise answers." }, { cachePoint: { type: "default" } }],
-				messages: [
-					{
-						role: "user",
-						content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }],
-					},
-				],
-				inferenceConfig: { maxTokens: undefined, temperature: undefined, topP: undefined },
-				toolConfig: undefined,
-				additionalModelRequestFields: undefined,
-			});
-		}
-	});
+	test("emits default-5m checkpoints for every AWS-documented Nova 2 Lite ID", async () => {
+		const expected: Payload = {
+			system: [{ text: "Use concise answers." }, { cachePoint: { type: "default" } }],
+			messages: [
+				{
+					role: "user",
+					content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }],
+				},
+			],
+			inferenceConfig: { maxTokens: undefined, temperature: undefined, topP: undefined },
+			toolConfig: undefined,
+			additionalModelRequestFields: undefined,
+		};
 
-	test("emits default-5m system and message checkpoints for every exact Nova base ID", async () => {
+		const bundled = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", "global.amazon.nova-2-lite-v1:0");
+		expect(bundled).toBeDefined();
+		expect(await capturePayload(bundled!, "long")).toEqual(expected);
+
 		for (const id of [
-			"amazon.nova-lite-v1:0",
-			"amazon.nova-micro-v1:0",
-			"amazon.nova-pro-v1:0",
-			"amazon.nova-premier-v1:0",
+			"amazon.nova-2-lite-v1:0",
+			"us.amazon.nova-2-lite-v1:0",
+			"eu.amazon.nova-2-lite-v1:0",
+			"jp.amazon.nova-2-lite-v1:0",
+			"global.amazon.nova-2-lite-v1:0",
 		] as const) {
-			const payload = await capturePayload(model(id), "long");
-			expect(payload.system).toEqual([{ text: "Use concise answers." }, { cachePoint: { type: "default" } }]);
-			expect(payload.messages).toEqual([
-				{ role: "user", content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }] },
-			]);
-			expect(checkpoints(payload)).toHaveLength(2);
+			expect(await capturePayload(model(id), "long")).toEqual(expected);
 		}
 	});
 
@@ -141,6 +129,10 @@ describe("Bedrock prompt cache checkpoints", () => {
 			"amazon.nova-micro-v1:1",
 			"amazon.nova-pro-v1:1",
 			"amazon.nova-premier-v1:1",
+			"amazon.nova-2-lite-v1:1",
+			"global.amazon.nova-2-lite-v1:1",
+			"global.amazon.nova-2-lite-v2:0",
+			"us.amazon.nova-2-lite-v1:0-preview",
 			"us.amazon.nova-unknown-v1:0",
 		] as const) {
 			const payload = await capturePayload(model(id), "long");
@@ -148,14 +140,6 @@ describe("Bedrock prompt cache checkpoints", () => {
 			expect(payload.messages).toEqual([{ role: "user", content: [{ text: "What is the answer?" }] }]);
 			expect(checkpoints(payload)).toHaveLength(0);
 		}
-	});
-
-	test("emits default-5m system and message checkpoints for Nova Premier's in-region ID", async () => {
-		const payload = await capturePayload(model("amazon.nova-premier-v1:0"), "long");
-		expect(payload.system).toEqual([{ text: "Use concise answers." }, { cachePoint: { type: "default" } }]);
-		expect(payload.messages).toEqual([
-			{ role: "user", content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }] },
-		]);
 	});
 
 	test("forces opaque profiles to default checkpoints without granting 1h retention", async () => {

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -95,7 +95,12 @@ describe("Bedrock prompt cache checkpoints", () => {
 	});
 
 	test("emits default-5m checkpoints for every bundled Nova cache-capable payload", async () => {
-		for (const id of ["us.amazon.nova-lite-v1:0", "us.amazon.nova-micro-v1:0", "us.amazon.nova-pro-v1:0"] as const) {
+		for (const id of [
+			"us.amazon.nova-lite-v1:0",
+			"us.amazon.nova-micro-v1:0",
+			"us.amazon.nova-pro-v1:0",
+			"us.amazon.nova-premier-v1:0",
+		] as const) {
 			const nova = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id);
 			expect(nova).toBeDefined();
 			const payload = await capturePayload(nova!, "long");
@@ -112,6 +117,14 @@ describe("Bedrock prompt cache checkpoints", () => {
 				additionalModelRequestFields: undefined,
 			});
 		}
+	});
+
+	test("emits default-5m system and message checkpoints for Nova Premier's in-region ID", async () => {
+		const payload = await capturePayload(model("amazon.nova-premier-v1:0"), "long");
+		expect(payload.system).toEqual([{ text: "Use concise answers." }, { cachePoint: { type: "default" } }]);
+		expect(payload.messages).toEqual([
+			{ role: "user", content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }] },
+		]);
 	});
 
 	test("forces opaque profiles to default checkpoints without granting 1h retention", async () => {

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { withEnv } from "./helpers";
+
+interface CachePoint {
+	cachePoint: { type: "default"; ttl?: "1h" };
+}
+interface Payload {
+	system?: Array<{ text: string } | CachePoint>;
+	messages: Array<{ role: string; content: Array<{ text: string } | CachePoint> }>;
+	inferenceConfig: { maxTokens?: number; temperature?: number; topP?: number };
+	toolConfig?: unknown;
+	additionalModelRequestFields?: Record<string, unknown>;
+}
+
+const context: Context = {
+	systemPrompt: ["Use concise answers."],
+	messages: [{ role: "user", content: "What is the answer?", timestamp: 0 }],
+};
+
+function model(id: string): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id,
+		name: id,
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	});
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function capturePayload(
+	bedrockModel: Model<"bedrock-converse-stream">,
+	cacheRetention: "none" | "short" | "long",
+): Promise<Payload> {
+	const { promise, resolve } = Promise.withResolvers<Payload>();
+	void streamBedrock(bedrockModel, context, {
+		signal: abortedSignal(),
+		cacheRetention,
+		onPayload: payload => {
+			resolve(payload as Payload);
+		},
+	});
+	return promise;
+}
+
+function checkpoints(payload: Payload): CachePoint[] {
+	return [...(payload.system ?? []), ...payload.messages.flatMap(message => message.content)].filter(
+		(block): block is CachePoint => "cachePoint" in block,
+	);
+}
+
+describe("Bedrock prompt cache checkpoints", () => {
+	test("downgrades unsupported long retention to default 5m at the existing two checkpoint locations", async () => {
+		const payload = await capturePayload(model("anthropic.claude-opus-4-6-v1"), "long");
+		expect(payload.system).toEqual([{ text: "Use concise answers." }, { cachePoint: { type: "default" } }]);
+		expect(payload.messages).toEqual([
+			{ role: "user", content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }] },
+		]);
+		expect(checkpoints(payload)).toHaveLength(2);
+	});
+
+	test("uses 1h only for catalog-confirmed long-retention models", async () => {
+		const payload = await capturePayload(model("anthropic.claude-haiku-4-5-20251001-v1:0"), "long");
+		expect(checkpoints(payload)).toEqual([
+			{ cachePoint: { type: "default", ttl: "1h" } },
+			{ cachePoint: { type: "default", ttl: "1h" } },
+		]);
+	});
+
+	test("emits checkpoints for the default bundled Opus 4.8 inference profile", async () => {
+		const payload = await capturePayload(model("us.anthropic.claude-opus-4-8"), "long");
+		expect(checkpoints(payload)).toEqual([
+			{ cachePoint: { type: "default", ttl: "1h" } },
+			{ cachePoint: { type: "default", ttl: "1h" } },
+		]);
+	});
+
+	test("uses Bedrock's default 5m TTL for short retention", async () => {
+		const payload = await capturePayload(model("anthropic.claude-haiku-4-5-20251001-v1:0"), "short");
+		expect(checkpoints(payload)).toEqual([{ cachePoint: { type: "default" } }, { cachePoint: { type: "default" } }]);
+	});
+
+	test("emits default-5m checkpoints for every bundled Nova cache-capable payload", async () => {
+		for (const id of ["us.amazon.nova-lite-v1:0", "us.amazon.nova-micro-v1:0", "us.amazon.nova-pro-v1:0"] as const) {
+			const nova = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id);
+			expect(nova).toBeDefined();
+			const payload = await capturePayload(nova!, "long");
+			expect(payload).toEqual({
+				system: [{ text: "Use concise answers." }, { cachePoint: { type: "default" } }],
+				messages: [
+					{
+						role: "user",
+						content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }],
+					},
+				],
+				inferenceConfig: { maxTokens: undefined, temperature: undefined, topP: undefined },
+				toolConfig: undefined,
+				additionalModelRequestFields: undefined,
+			});
+		}
+	});
+
+	test("forces opaque profiles to default checkpoints without granting 1h retention", async () => {
+		await withEnv({ AWS_BEDROCK_FORCE_CACHE: "1" }, async () => {
+			const payload = await capturePayload(
+				model("arn:aws:bedrock:us-east-1:1234567890:application-inference-profile/opaque-profile"),
+				"long",
+			);
+			expect(checkpoints(payload)).toEqual([
+				{ cachePoint: { type: "default" } },
+				{ cachePoint: { type: "default" } },
+			]);
+		});
+	});
+});

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -142,6 +142,29 @@ describe("Bedrock prompt cache checkpoints", () => {
 		}
 	});
 
+	test("does not exceed a configured checkpoint maximum", async () => {
+		const base = model("anthropic.claude-haiku-4-5-20251001-v1:0");
+		const disabled: Model<"bedrock-converse-stream"> = {
+			...base,
+			compat: { ...base.compat, promptCacheMaximumCheckpoints: 0 },
+		};
+		const single: Model<"bedrock-converse-stream"> = {
+			...base,
+			compat: { ...base.compat, promptCacheMaximumCheckpoints: 1 },
+		};
+
+		const disabledPayload = await capturePayload(disabled, "long");
+		expect(checkpoints(disabledPayload)).toHaveLength(0);
+
+		const singlePayload = await capturePayload(single, "long");
+		expect(checkpoints(singlePayload)).toEqual([{ cachePoint: { type: "default", ttl: "1h" } }]);
+		expect(singlePayload.messages[0]?.content).toEqual([
+			{ text: "What is the answer?" },
+			{ cachePoint: { type: "default", ttl: "1h" } },
+		]);
+		expect(singlePayload.system).toEqual([{ text: "Use concise answers." }]);
+	});
+
 	test("forces opaque profiles to default checkpoints without granting 1h retention", async () => {
 		await withEnv({ AWS_BEDROCK_FORCE_CACHE: "1" }, async () => {
 			const payload = await capturePayload(

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -119,6 +119,37 @@ describe("Bedrock prompt cache checkpoints", () => {
 		}
 	});
 
+	test("emits default-5m system and message checkpoints for every exact Nova base ID", async () => {
+		for (const id of [
+			"amazon.nova-lite-v1:0",
+			"amazon.nova-micro-v1:0",
+			"amazon.nova-pro-v1:0",
+			"amazon.nova-premier-v1:0",
+		] as const) {
+			const payload = await capturePayload(model(id), "long");
+			expect(payload.system).toEqual([{ text: "Use concise answers." }, { cachePoint: { type: "default" } }]);
+			expect(payload.messages).toEqual([
+				{ role: "user", content: [{ text: "What is the answer?" }, { cachePoint: { type: "default" } }] },
+			]);
+			expect(checkpoints(payload)).toHaveLength(2);
+		}
+	});
+
+	test("does not emit checkpoints for unknown Nova IDs", async () => {
+		for (const id of [
+			"amazon.nova-lite-v1:1",
+			"amazon.nova-micro-v1:1",
+			"amazon.nova-pro-v1:1",
+			"amazon.nova-premier-v1:1",
+			"us.amazon.nova-unknown-v1:0",
+		] as const) {
+			const payload = await capturePayload(model(id), "long");
+			expect(payload.system).toEqual([{ text: "Use concise answers." }]);
+			expect(payload.messages).toEqual([{ role: "user", content: [{ text: "What is the answer?" }] }]);
+			expect(checkpoints(payload)).toHaveLength(0);
+		}
+	});
+
 	test("emits default-5m system and message checkpoints for Nova Premier's in-region ID", async () => {
 		const payload = await capturePayload(model("amazon.nova-premier-v1:0"), "long");
 		expect(payload.system).toEqual([{ text: "Use concise answers." }, { cachePoint: { type: "default" } }]);

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added resolved Bedrock Converse prompt-cache compatibility limits, including explicit 5-minute checkpoint support for bundled Nova Lite, Micro, and Pro models and model-specific 1-hour Claude retention.
+- Added resolved Bedrock Converse prompt-cache compatibility limits, including explicit 5-minute checkpoint support for bundled Nova Lite, Micro, Pro, and Premier models plus Nova Premier's documented in-region model ID, and model-specific 1-hour Claude retention.
 
 - Added the native Meta Model API provider and Muse Spark 1.1 with Responses API reasoning replay, image input, and the full supported reasoning-effort ladder ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added resolved Bedrock Converse prompt-cache compatibility limits, including explicit 5-minute checkpoint support for bundled Nova Lite, Micro, and Pro models and model-specific 1-hour Claude retention.
+
 - Added the native Meta Model API provider and Muse Spark 1.1 with Responses API reasoning replay, image input, and the full supported reasoning-effort ladder ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 
 ## [17.0.9] - 2026-07-23

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added resolved Bedrock Converse prompt-cache compatibility limits, including explicit 5-minute checkpoint support for bundled Nova Lite, Micro, Pro, and Premier models plus Nova Premier's documented in-region model ID, and model-specific 1-hour Claude retention.
+- Added resolved Bedrock Converse prompt-cache compatibility limits, including explicit 5-minute checkpoint support for bundled Nova Lite, Micro, Pro, Premier, and Nova 2 Lite plus its documented regional and global IDs, and model-specific 1-hour Claude retention.
 
 - Added the native Meta Model API provider and Muse Spark 1.1 with Responses API reasoning replay, image input, and the full supported reasoning-effort ladder ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -9,7 +9,9 @@
  * Request handlers read fields — they never detect, parse ids, or allocate
  * compat per request.
  */
+
 import { buildAnthropicCompat } from "./compat/anthropic";
+import { buildBedrockCompat } from "./compat/bedrock";
 import { buildDevinCompat } from "./compat/devin";
 import { buildOpenAICompat, buildOpenAIResponsesCompat, buildOpenRouterCompat } from "./compat/openai";
 import { resolveModelThinking } from "./model-thinking";
@@ -39,6 +41,8 @@ export function buildCompat(spec: ModelSpec<Api>): CompatOf<Api> {
 			return buildOpenAIResponsesCompat(spec as ModelSpec<"openai-responses">);
 		case "anthropic-messages":
 			return buildAnthropicCompat(spec as ModelSpec<"anthropic-messages">);
+		case "bedrock-converse-stream":
+			return buildBedrockCompat(spec as ModelSpec<"bedrock-converse-stream">);
 		case "devin-agent":
 			return buildDevinCompat(spec as ModelSpec<"devin-agent">);
 		default:

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -45,13 +45,19 @@ const EXPLICIT_CHECKPOINTS_4096_1H: ResolvedBedrockCompat = {
 /**
  * Explicit Nova cache points complement Bedrock's automatic prefix caching:
  * AWS recommends them for consistent cache hits and input-cost savings. Keep
- * this exact bundled set conservative rather than treating arbitrary Nova-like
- * application profiles as checkpoint-capable.
+ * these exact documented model and inference-profile IDs conservative rather
+ * than treating arbitrary Nova-like application profiles as checkpoint-capable.
  */
 function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
 	const id = modelId.toLowerCase();
 
-	if (id === "us.amazon.nova-lite-v1:0" || id === "us.amazon.nova-micro-v1:0" || id === "us.amazon.nova-pro-v1:0") {
+	if (
+		id === "us.amazon.nova-lite-v1:0" ||
+		id === "us.amazon.nova-micro-v1:0" ||
+		id === "us.amazon.nova-pro-v1:0" ||
+		id === "amazon.nova-premier-v1:0" ||
+		id === "us.amazon.nova-premier-v1:0"
+	) {
 		return EXPLICIT_CHECKPOINTS_1024_5M;
 	}
 

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -1,0 +1,100 @@
+import type { ModelSpec, ResolvedBedrockCompat } from "../types";
+import { applyCompatOverrides } from "./apply";
+
+const NO_EXPLICIT_CHECKPOINTS: ResolvedBedrockCompat = {
+	promptCacheMode: "none",
+	supportsLongPromptCacheRetention: false,
+	promptCacheMinimumTokens: 0,
+	promptCacheMaximumCheckpoints: 0,
+};
+const EXPLICIT_CHECKPOINTS_1024_5M: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: false,
+	promptCacheMinimumTokens: 1024,
+	promptCacheMaximumCheckpoints: 4,
+};
+
+const EXPLICIT_CHECKPOINTS_1024_1H: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: true,
+	promptCacheMinimumTokens: 1024,
+	promptCacheMaximumCheckpoints: 4,
+};
+
+const EXPLICIT_CHECKPOINTS_2048_5M: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: false,
+	promptCacheMinimumTokens: 2048,
+	promptCacheMaximumCheckpoints: 4,
+};
+
+const EXPLICIT_CHECKPOINTS_4096_5M: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: false,
+	promptCacheMinimumTokens: 4096,
+	promptCacheMaximumCheckpoints: 4,
+};
+
+const EXPLICIT_CHECKPOINTS_4096_1H: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: true,
+	promptCacheMinimumTokens: 4096,
+	promptCacheMaximumCheckpoints: 4,
+};
+
+/**
+ * Explicit Nova cache points complement Bedrock's automatic prefix caching:
+ * AWS recommends them for consistent cache hits and input-cost savings. Keep
+ * this exact bundled set conservative rather than treating arbitrary Nova-like
+ * application profiles as checkpoint-capable.
+ */
+function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
+	const id = modelId.toLowerCase();
+
+	if (id === "us.amazon.nova-lite-v1:0" || id === "us.amazon.nova-micro-v1:0" || id === "us.amazon.nova-pro-v1:0") {
+		return EXPLICIT_CHECKPOINTS_1024_5M;
+	}
+
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+	// This list is deliberately sourced from AWS model cards, not cache pricing:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
+	if (
+		id.includes("anthropic.claude-opus-4-5") ||
+		id.includes("anthropic.claude-sonnet-4-5") ||
+		id.includes("anthropic.claude-haiku-4-5") ||
+		id.includes("anthropic.claude-opus-4-7") ||
+		id.includes("anthropic.claude-opus-4-8") ||
+		id.includes("anthropic.claude-sonnet-5")
+	) {
+		return EXPLICIT_CHECKPOINTS_4096_1H;
+	}
+	if (id.includes("anthropic.claude-opus-4-6")) {
+		return EXPLICIT_CHECKPOINTS_4096_5M;
+	}
+	if (id.includes("anthropic.claude-3-5-haiku")) {
+		return EXPLICIT_CHECKPOINTS_2048_5M;
+	}
+	if (id.includes("anthropic.claude-fable-5")) {
+		return EXPLICIT_CHECKPOINTS_1024_1H;
+	}
+
+	if (
+		id.includes("anthropic.claude-opus-4-1") ||
+		id.includes("anthropic.claude-opus-4-20250514") ||
+		id.includes("anthropic.claude-sonnet-4-20250514") ||
+		id.includes("anthropic.claude-sonnet-4-6") ||
+		id.includes("anthropic.claude-3-7-sonnet") ||
+		id.includes("anthropic.claude-3-5-sonnet-20241022-v2")
+	) {
+		return EXPLICIT_CHECKPOINTS_1024_5M;
+	}
+
+	return NO_EXPLICIT_CHECKPOINTS;
+}
+
+/** Resolve Bedrock Converse prompt-cache capabilities once per model. */
+export function buildBedrockCompat(spec: ModelSpec<"bedrock-converse-stream">): ResolvedBedrockCompat {
+	const compat = { ...detectedBedrockCompat(spec.id) };
+	applyCompatOverrides(compat, spec.compat);
+	return compat;
+}

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -59,7 +59,12 @@ function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
 		id === "us.amazon.nova-micro-v1:0" ||
 		id === "us.amazon.nova-pro-v1:0" ||
 		id === "amazon.nova-premier-v1:0" ||
-		id === "us.amazon.nova-premier-v1:0"
+		id === "us.amazon.nova-premier-v1:0" ||
+		id === "amazon.nova-2-lite-v1:0" ||
+		id === "us.amazon.nova-2-lite-v1:0" ||
+		id === "eu.amazon.nova-2-lite-v1:0" ||
+		id === "jp.amazon.nova-2-lite-v1:0" ||
+		id === "global.amazon.nova-2-lite-v1:0"
 	) {
 		return EXPLICIT_CHECKPOINTS_1024_5M;
 	}

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -52,6 +52,9 @@ function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
 	const id = modelId.toLowerCase();
 
 	if (
+		id === "amazon.nova-lite-v1:0" ||
+		id === "amazon.nova-micro-v1:0" ||
+		id === "amazon.nova-pro-v1:0" ||
 		id === "us.amazon.nova-lite-v1:0" ||
 		id === "us.amazon.nova-micro-v1:0" ||
 		id === "us.amazon.nova-pro-v1:0" ||

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -460,6 +460,29 @@ export interface AnthropicCompat {
 }
 
 /**
+ * Compatibility settings for Bedrock Converse prompt caching. Cache pricing is
+ * deliberately not used to infer these request-shape capabilities.
+ */
+export interface BedrockCompat {
+	/** Whether this endpoint accepts no checkpoints, automatic caching, or explicit cachePoint blocks. */
+	promptCacheMode?: "none" | "automatic" | "explicit";
+	/** Whether explicit cachePoint blocks accept `ttl: "1h"`; omitted TTL means Bedrock's 5-minute default. */
+	supportsLongPromptCacheRetention?: boolean;
+	/** Minimum prompt-prefix tokens required for an effective checkpoint. Zero means no explicit checkpoints. */
+	promptCacheMinimumTokens?: number;
+	/** Maximum explicit cache checkpoints accepted in one request. Zero means no explicit checkpoints. */
+	promptCacheMaximumCheckpoints?: number;
+}
+
+/** Fully-resolved Bedrock Converse prompt-cache capabilities, materialized once by `buildModel`. */
+export interface ResolvedBedrockCompat {
+	promptCacheMode: NonNullable<BedrockCompat["promptCacheMode"]>;
+	supportsLongPromptCacheRetention: boolean;
+	promptCacheMinimumTokens: number;
+	promptCacheMaximumCheckpoints: number;
+}
+
+/**
  * OpenRouter provider routing preferences.
  * Controls which upstream providers OpenRouter routes requests to.
  * @see https://openrouter.ai/docs/provider-routing
@@ -681,9 +704,11 @@ export type CompatConfigOf<TApi extends Api> = TApi extends
 	? OpenAICompat
 	: TApi extends "anthropic-messages"
 		? AnthropicCompat
-		: TApi extends "devin-agent"
-			? DevinCompat
-			: undefined;
+		: TApi extends "bedrock-converse-stream"
+			? BedrockCompat
+			: TApi extends "devin-agent"
+				? DevinCompat
+				: undefined;
 
 /** Resolved compat for a given API: complete record, materialized once by `buildModel`. */
 export type CompatOf<TApi extends Api> = TApi extends "openrouter"
@@ -694,9 +719,11 @@ export type CompatOf<TApi extends Api> = TApi extends "openrouter"
 			? ResolvedOpenAIResponsesCompat
 			: TApi extends "anthropic-messages"
 				? ResolvedAnthropicCompat
-				: TApi extends "devin-agent"
-					? ResolvedDevinCompat
-					: undefined;
+				: TApi extends "bedrock-converse-stream"
+					? ResolvedBedrockCompat
+					: TApi extends "devin-agent"
+						? ResolvedDevinCompat
+						: undefined;
 
 /** Provider-native compaction endpoint configuration for one model. */
 export interface RemoteCompactionConfig<TApi extends Api = Api> {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -468,9 +468,16 @@ export interface BedrockCompat {
 	promptCacheMode?: "none" | "automatic" | "explicit";
 	/** Whether explicit cachePoint blocks accept `ttl: "1h"`; omitted TTL means Bedrock's 5-minute default. */
 	supportsLongPromptCacheRetention?: boolean;
-	/** Minimum prompt-prefix tokens required for an effective checkpoint. Zero means no explicit checkpoints. */
+	/**
+	 * Bedrock-enforced minimum prompt-prefix tokens for an effective checkpoint.
+	 * Capability metadata only: emitters must not estimate local token counts.
+	 * Zero means no explicit checkpoints.
+	 */
 	promptCacheMinimumTokens?: number;
-	/** Maximum explicit cache checkpoints accepted in one request. Zero means no explicit checkpoints. */
+	/**
+	 * Bedrock-enforced maximum explicit cache checkpoints per request.
+	 * Capability metadata only; zero means no explicit checkpoints.
+	 */
 	promptCacheMaximumCheckpoints?: number;
 }
 

--- a/packages/catalog/test/bedrock-prompt-cache.test.ts
+++ b/packages/catalog/test/bedrock-prompt-cache.test.ts
@@ -94,24 +94,37 @@ describe("Bedrock prompt-cache compat", () => {
 		}
 	});
 
-	test("models every bundled cache-capable Nova variant for explicit 5m checkpoints", () => {
-		for (const id of ["us.amazon.nova-lite-v1:0", "us.amazon.nova-micro-v1:0", "us.amazon.nova-pro-v1:0"] as const) {
-			const model = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id);
-			expect(model?.compat).toEqual({
-				promptCacheMode: "explicit",
-				supportsLongPromptCacheRetention: false,
-				promptCacheMinimumTokens: 1024,
-				promptCacheMaximumCheckpoints: 4,
-			});
+	test("models exact cache-capable Nova IDs for explicit 5m checkpoints", () => {
+		const expected = {
+			promptCacheMode: "explicit",
+			supportsLongPromptCacheRetention: false,
+			promptCacheMinimumTokens: 1024,
+			promptCacheMaximumCheckpoints: 4,
+		} as const;
+
+		for (const id of [
+			"us.amazon.nova-lite-v1:0",
+			"us.amazon.nova-micro-v1:0",
+			"us.amazon.nova-pro-v1:0",
+			"us.amazon.nova-premier-v1:0",
+		] as const) {
+			expect(getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id)?.compat).toEqual(expected);
+		}
+
+		// AWS documents these as Nova Premier's in-region model and US geo inference IDs.
+		for (const id of ["amazon.nova-premier-v1:0", "us.amazon.nova-premier-v1:0"] as const) {
+			expect(buildModel(bedrockSpec({ id })).compat).toEqual(expected);
 		}
 	});
 
 	test("keeps unknown routes conservative and honors sparse profile overrides", () => {
-		const unknown = buildModel(
-			bedrockSpec({ id: "arn:aws:bedrock:us-east-1:123:application-inference-profile/opaque" }),
-		);
+		const opaqueProfileId = "arn:aws:bedrock:us-east-1:123:application-inference-profile/opaque";
+		const unknown = buildModel(bedrockSpec({ id: opaqueProfileId }));
 		expect(unknown.compat.promptCacheMode).toBe("none");
 
+		for (const id of ["amazon.nova-premier-v1:1", "us.amazon.nova-unknown-v1:0"]) {
+			expect(buildModel(bedrockSpec({ id })).compat.promptCacheMode).toBe("none");
+		}
 		const sparse = {
 			promptCacheMode: "explicit" as const,
 			promptCacheMinimumTokens: 1024,

--- a/packages/catalog/test/bedrock-prompt-cache.test.ts
+++ b/packages/catalog/test/bedrock-prompt-cache.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+function bedrockSpec(
+	overrides: Partial<ModelSpec<"bedrock-converse-stream">> = {},
+): ModelSpec<"bedrock-converse-stream"> {
+	return {
+		id: "anthropic.claude-opus-4-6-v1",
+		name: "Claude Opus 4.6",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+		...overrides,
+	};
+}
+
+describe("Bedrock prompt-cache compat", () => {
+	test("resolves the AWS-documented capability for every cache-priced bundled Claude family", () => {
+		const cases = [
+			{
+				id: "anthropic.claude-3-5-haiku-20241022-v1:0",
+				minimumTokens: 2048,
+				supportsLongRetention: false,
+			},
+			// Current AWS docs do not advertise Converse cache checkpoints for this
+			// legacy v1 model, so catalog cache pricing alone must not enable them.
+			{
+				id: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+				minimumTokens: 0,
+				supportsLongRetention: false,
+			},
+			{
+				id: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+				minimumTokens: 1024,
+				supportsLongRetention: false,
+			},
+			{
+				id: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+				minimumTokens: 1024,
+				supportsLongRetention: false,
+			},
+			{ id: "anthropic.claude-fable-5", minimumTokens: 1024, supportsLongRetention: true },
+			{
+				id: "anthropic.claude-haiku-4-5-20251001-v1:0",
+				minimumTokens: 4096,
+				supportsLongRetention: true,
+			},
+			{
+				id: "anthropic.claude-opus-4-1-20250805-v1:0",
+				minimumTokens: 1024,
+				supportsLongRetention: false,
+			},
+			{
+				id: "anthropic.claude-opus-4-20250514-v1:0",
+				minimumTokens: 1024,
+				supportsLongRetention: false,
+			},
+			{
+				id: "anthropic.claude-opus-4-5-20251101-v1:0",
+				minimumTokens: 4096,
+				supportsLongRetention: true,
+			},
+			{ id: "anthropic.claude-opus-4-6-v1", minimumTokens: 4096, supportsLongRetention: false },
+			{ id: "global.anthropic.claude-opus-4-7", minimumTokens: 4096, supportsLongRetention: true },
+			{ id: "us.anthropic.claude-opus-4-8", minimumTokens: 4096, supportsLongRetention: true },
+			{
+				id: "anthropic.claude-sonnet-4-20250514-v1:0",
+				minimumTokens: 1024,
+				supportsLongRetention: false,
+			},
+			{
+				id: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+				minimumTokens: 4096,
+				supportsLongRetention: true,
+			},
+			{ id: "anthropic.claude-sonnet-4-6", minimumTokens: 1024, supportsLongRetention: false },
+			{ id: "us.anthropic.claude-sonnet-5", minimumTokens: 4096, supportsLongRetention: true },
+		] as const;
+
+		for (const { id, minimumTokens, supportsLongRetention } of cases) {
+			expect(buildModel(bedrockSpec({ id })).compat).toEqual({
+				promptCacheMode: minimumTokens === 0 ? "none" : "explicit",
+				supportsLongPromptCacheRetention: supportsLongRetention,
+				promptCacheMinimumTokens: minimumTokens,
+				promptCacheMaximumCheckpoints: minimumTokens === 0 ? 0 : 4,
+			});
+		}
+	});
+
+	test("models every bundled cache-capable Nova variant for explicit 5m checkpoints", () => {
+		for (const id of ["us.amazon.nova-lite-v1:0", "us.amazon.nova-micro-v1:0", "us.amazon.nova-pro-v1:0"] as const) {
+			const model = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id);
+			expect(model?.compat).toEqual({
+				promptCacheMode: "explicit",
+				supportsLongPromptCacheRetention: false,
+				promptCacheMinimumTokens: 1024,
+				promptCacheMaximumCheckpoints: 4,
+			});
+		}
+	});
+
+	test("keeps unknown routes conservative and honors sparse profile overrides", () => {
+		const unknown = buildModel(
+			bedrockSpec({ id: "arn:aws:bedrock:us-east-1:123:application-inference-profile/opaque" }),
+		);
+		expect(unknown.compat.promptCacheMode).toBe("none");
+
+		const sparse = {
+			promptCacheMode: "explicit" as const,
+			promptCacheMinimumTokens: 1024,
+			promptCacheMaximumCheckpoints: 4,
+		};
+		const configured = buildModel(
+			bedrockSpec({ id: "arn:aws:bedrock:us-east-1:123:application-inference-profile/opaque", compat: sparse }),
+		);
+		expect(configured.compat).toEqual({ ...unknown.compat, ...sparse });
+		expect(configured.compatConfig).toBe(sparse);
+	});
+
+	test("keeps bundled models memoized while materializing resolved compat", () => {
+		const first = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", "anthropic.claude-opus-4-6-v1");
+		const second = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", "anthropic.claude-opus-4-6-v1");
+		expect(first).toBe(second);
+		expect(first?.compat.promptCacheMode).toBe("explicit");
+	});
+});

--- a/packages/catalog/test/bedrock-prompt-cache.test.ts
+++ b/packages/catalog/test/bedrock-prompt-cache.test.ts
@@ -94,7 +94,7 @@ describe("Bedrock prompt-cache compat", () => {
 		}
 	});
 
-	test("models exact cache-capable Nova IDs for explicit 5m checkpoints", () => {
+	test("models exact cache-capable Nova base and geo IDs for explicit 5m checkpoints", () => {
 		const expected = {
 			promptCacheMode: "explicit",
 			supportsLongPromptCacheRetention: false,
@@ -111,8 +111,12 @@ describe("Bedrock prompt-cache compat", () => {
 			expect(getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id)?.compat).toEqual(expected);
 		}
 
-		// AWS documents these as Nova Premier's in-region model and US geo inference IDs.
-		for (const id of ["amazon.nova-premier-v1:0", "us.amazon.nova-premier-v1:0"] as const) {
+		for (const id of [
+			"amazon.nova-lite-v1:0",
+			"amazon.nova-micro-v1:0",
+			"amazon.nova-pro-v1:0",
+			"amazon.nova-premier-v1:0",
+		] as const) {
 			expect(buildModel(bedrockSpec({ id })).compat).toEqual(expected);
 		}
 	});
@@ -122,7 +126,13 @@ describe("Bedrock prompt-cache compat", () => {
 		const unknown = buildModel(bedrockSpec({ id: opaqueProfileId }));
 		expect(unknown.compat.promptCacheMode).toBe("none");
 
-		for (const id of ["amazon.nova-premier-v1:1", "us.amazon.nova-unknown-v1:0"]) {
+		for (const id of [
+			"amazon.nova-lite-v1:1",
+			"amazon.nova-micro-v1:1",
+			"amazon.nova-pro-v1:1",
+			"amazon.nova-premier-v1:1",
+			"us.amazon.nova-unknown-v1:0",
+		]) {
 			expect(buildModel(bedrockSpec({ id })).compat.promptCacheMode).toBe("none");
 		}
 		const sparse = {

--- a/packages/catalog/test/bedrock-prompt-cache.test.ts
+++ b/packages/catalog/test/bedrock-prompt-cache.test.ts
@@ -94,7 +94,7 @@ describe("Bedrock prompt-cache compat", () => {
 		}
 	});
 
-	test("models exact cache-capable Nova base and geo IDs for explicit 5m checkpoints", () => {
+	test("models every AWS-documented Nova 2 Lite ID for explicit 5m checkpoints", () => {
 		const expected = {
 			promptCacheMode: "explicit",
 			supportsLongPromptCacheRetention: false,
@@ -102,20 +102,15 @@ describe("Bedrock prompt-cache compat", () => {
 			promptCacheMaximumCheckpoints: 4,
 		} as const;
 
-		for (const id of [
-			"us.amazon.nova-lite-v1:0",
-			"us.amazon.nova-micro-v1:0",
-			"us.amazon.nova-pro-v1:0",
-			"us.amazon.nova-premier-v1:0",
-		] as const) {
-			expect(getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id)?.compat).toEqual(expected);
-		}
+		const bundled = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", "global.amazon.nova-2-lite-v1:0");
+		expect(bundled?.compat).toEqual(expected);
 
 		for (const id of [
-			"amazon.nova-lite-v1:0",
-			"amazon.nova-micro-v1:0",
-			"amazon.nova-pro-v1:0",
-			"amazon.nova-premier-v1:0",
+			"amazon.nova-2-lite-v1:0",
+			"us.amazon.nova-2-lite-v1:0",
+			"eu.amazon.nova-2-lite-v1:0",
+			"jp.amazon.nova-2-lite-v1:0",
+			"global.amazon.nova-2-lite-v1:0",
 		] as const) {
 			expect(buildModel(bedrockSpec({ id })).compat).toEqual(expected);
 		}
@@ -131,6 +126,10 @@ describe("Bedrock prompt-cache compat", () => {
 			"amazon.nova-micro-v1:1",
 			"amazon.nova-pro-v1:1",
 			"amazon.nova-premier-v1:1",
+			"amazon.nova-2-lite-v1:1",
+			"global.amazon.nova-2-lite-v1:1",
+			"global.amazon.nova-2-lite-v2:0",
+			"us.amazon.nova-2-lite-v1:0-preview",
 			"us.amazon.nova-unknown-v1:0",
 		]) {
 			expect(buildModel(bedrockSpec({ id })).compat.promptCacheMode).toBe("none");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Bound interactive bash live display write queue to prevent unbounded PTY chunk backlog ([#4240](https://github.com/can1357/oh-my-pi/issues/4240))
 - All Markdown flavors (`.markdown`, `.mdx`, `.mdc`, `.mkd`, `.mdown`) now follow the `read.summarize.prose` setting like `.md`, so they read verbatim instead of being code-block summarized when prose summaries are off.
 - xAI web search now uses `grok-4.5` (at low reasoning effort) instead of `grok-4.3`.
+### Added
+
+- Added `models.yml` Bedrock Converse prompt-cache capability overrides for bundled and opaque inference profiles.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -73,8 +73,19 @@ export const OpenAICompatSchema = type({
 	"whenThinking?": OpenAICompatFieldsSchema,
 });
 
+const BedrockCompatSchema = type({
+	"promptCacheMode?": '"none" | "automatic" | "explicit"',
+	"supportsLongPromptCacheRetention?": "boolean",
+	"promptCacheMinimumTokens?": "number >= 0",
+	"promptCacheMaximumCheckpoints?": "number >= 0",
+});
+
+// Provider-level overrides can target bundled models whose API is not repeated
+// in models.yml, so preserve the sparse compat shape for each supported API.
+const ApiCompatSchema = OpenAICompatSchema.or(BedrockCompatSchema);
+
 const ApiSchema = type(
-	'"openai-completions" | "openai-responses" | "openai-codex-responses" | "azure-openai-responses" | "anthropic-messages" | "google-generative-ai" | "google-gemini-cli" | "google-vertex"',
+	'"openai-completions" | "openai-responses" | "openai-codex-responses" | "azure-openai-responses" | "anthropic-messages" | "bedrock-converse-stream" | "google-generative-ai" | "google-gemini-cli" | "google-vertex"',
 );
 
 const EffortSchema = type('"minimal" | "low" | "medium" | "high" | "xhigh" | "max"');
@@ -173,7 +184,7 @@ const ModelDefinitionSchema = type({
 	"maxTokens?": "number",
 	"omitMaxOutputTokens?": "boolean",
 	"headers?": { "[string]": "string" },
-	"compat?": OpenAICompatSchema,
+	"compat?": ApiCompatSchema,
 	"contextPromotionTarget?": "string",
 	"compactionModel?": "string",
 	"remoteCompaction?": RemoteCompactionSchema,
@@ -222,7 +233,7 @@ export const ModelOverrideSchema = type({
 	"maxTokens?": "number",
 	"omitMaxOutputTokens?": "boolean",
 	"headers?": { "[string]": "string" },
-	"compat?": OpenAICompatSchema,
+	"compat?": ApiCompatSchema,
 	"contextPromotionTarget?": "string",
 	"compactionModel?": "string",
 	"remoteCompaction?": RemoteCompactionSchema,
@@ -263,7 +274,7 @@ const ProviderConfigSchema = type({
 	"apiKey?": "string",
 	"api?": ApiSchema,
 	"headers?": { "[string]": "string" },
-	"compat?": OpenAICompatSchema,
+	"compat?": ApiCompatSchema,
 	"remoteCompaction?": RemoteCompactionSchema,
 	"authHeader?": "boolean",
 	"auth?": ProviderAuthSchema,

--- a/packages/coding-agent/test/model-registry-default-config.test.ts
+++ b/packages/coding-agent/test/model-registry-default-config.test.ts
@@ -33,6 +33,22 @@ describe("ModelRegistry default custom models config", () => {
 		expect(model?.baseUrl).toBe("https://yaml-default.example.com/v1");
 	});
 
+	test("loads Bedrock cache capabilities from a model override", () => {
+		writeBedrockCacheOverride();
+
+		const model = loadDefaultRegistryModel({
+			provider: "amazon-bedrock",
+			modelId: "us.anthropic.claude-opus-4-8",
+		});
+
+		expect(model?.compat).toEqual({
+			promptCacheMode: "explicit",
+			supportsLongPromptCacheRetention: false,
+			promptCacheMinimumTokens: 1024,
+			promptCacheMaximumCheckpoints: 4,
+		});
+	});
+
 	test("prefers default models.yml over models.yaml when both exist", () => {
 		writeModelsYaml("models.yml", {
 			provider: "yaml-precedence",
@@ -105,6 +121,12 @@ interface ModelSnapshot {
 	id: string;
 	name: string;
 	baseUrl: string | undefined;
+	compat: {
+		promptCacheMode: string;
+		supportsLongPromptCacheRetention: boolean;
+		promptCacheMinimumTokens: number;
+		promptCacheMaximumCheckpoints: number;
+	};
 }
 
 function writeModelsYaml(file: "models.yml" | "models.yaml", fixture: ProviderFixture): void {
@@ -128,6 +150,24 @@ function writeModelsYaml(file: "models.yml" | "models.yaml", fixture: ProviderFi
 			"          cacheWrite: 0",
 			"        contextWindow: 100000",
 			"        maxTokens: 8000",
+			"",
+		].join("\n"),
+	);
+}
+
+function writeBedrockCacheOverride(): void {
+	fs.writeFileSync(
+		path.join(tempDir.path(), "models.yml"),
+		[
+			"providers:",
+			"  amazon-bedrock:",
+			"    modelOverrides:",
+			"      us.anthropic.claude-opus-4-8:",
+			"        compat:",
+			"          promptCacheMode: explicit",
+			"          supportsLongPromptCacheRetention: false",
+			"          promptCacheMinimumTokens: 1024",
+			"          promptCacheMaximumCheckpoints: 4",
 			"",
 		].join("\n"),
 	);
@@ -173,6 +213,7 @@ function loadDefaultRegistryModel(lookup: ModelLookup): ModelSnapshot | undefine
 				id: model.id,
 				name: model.name,
 				baseUrl: model.baseUrl,
+				compat: model.compat,
 			} : null));
 		} finally {
 			authStorage.close();


### PR DESCRIPTION
## What

- Adds resolved Bedrock prompt-cache compatibility for supported Claude and Nova model families, recording provider-enforced token minima, documented checkpoint limits, and 1-hour TTL support.
- Drives checkpoint fields and TTLs from that compatibility contract instead of cache-price and broad model-ID heuristics. Bedrock enforces minimum prefix tokens; OMP prioritizes the final-user and system boundaries without exceeding the configured checkpoint maximum.
- Downgrades unsupported long retention to Bedrock's default 5-minute checkpoint rather than sending an invalid `ttl: "1h"`.
- Preserves explicit 5-minute checkpoints for Nova while preventing unsupported 1-hour TTLs.

## Why

I reviewed the full diff; this keeps valid Bedrock requests working while preventing model/TTL combinations that Bedrock rejects.

The current provider can emit `ttl: "1h"` whenever generic retention is long, even for models that only support 5 minutes. A generation should fall back to a valid cache lifetime, not fail because the cache hint was too aggressive. Materialized compat also gives opaque inference profiles a supported configuration path without inferring capability from pricing.

## Testing

- `bun test packages/catalog/test/bedrock-prompt-cache.test.ts packages/ai/test/bedrock-prompt-cache.test.ts packages/coding-agent/test/model-registry-default-config.test.ts` — 16 passed
- `bun run check:ts` — passed
- Deterministic `onPayload` coverage verifies supported/unsupported long TTL, short/disabled caching, Nova, the default Opus 4.8 profile, and opaque configured/forced profiles.
- Live AWS smoke was not run because intentional Bedrock credentials were unavailable.

---

- [x] `bun run check:ts` passes
- [x] Tested locally with exact request-payload fixtures
- [x] CHANGELOG updated

## AI Review Report

Independent review remediation covered Sonnet 4.6's token minimum, bundled newer Claude families, models.yml compat loading, Nova explicit-cache behavior, Nova Premier, exact base Nova IDs, and all documented Nova 2 Lite inference IDs. Bedrock remains responsible for minimum-token enforcement; OMP now enforces configured checkpoint maxima, including zero and one.

## Security Audit

- No credential, prompt, or cache-key logging added.
- Unknown models remain conservative; the force escape hatch cannot grant 1-hour retention.
- Configuration accepts only bounded enum/numeric compatibility fields.
- No cross-session or cross-credential state sharing introduced.
