### PR TITLE
feat(gateway): map Vercel prompt cache controls

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added Anthropic extra-usage reporting across `omp usage`, interactive `/usage`, and ACP `/usage`: the OAuth usage endpoint's authoritative `spend` payload (or legacy `extra_usage` fallback when absent) is normalized into a `Claude Extra Usage` USD row; capped accounts show limit/remaining/fractions and status, while uncapped spend exposes only its absolute used amount—rendered as `$… used` in CLI/TUI and `123.45 usd used` in ACP—without a fabricated cap, percentage, or status. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))
 - Added opt-in Vercel AI Gateway automatic prompt caching for OpenAI Chat Completions while preserving `only` and `order` routing preferences.
+- Added Vercel AI Gateway Responses cache anchors and cache lifetimes, emitted only with automatic caching.
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Anthropic extra-usage reporting across `omp usage`, interactive `/usage`, and ACP `/usage`: the OAuth usage endpoint's authoritative `spend` payload (or legacy `extra_usage` fallback when absent) is normalized into a `Claude Extra Usage` USD row; capped accounts show limit/remaining/fractions and status, while uncapped spend exposes only its absolute used amount—rendered as `$… used` in CLI/TUI and `123.45 usd used` in ACP—without a fabricated cap, percentage, or status. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))
+- Added opt-in Vercel AI Gateway automatic prompt caching for OpenAI Chat Completions while preserving `only` and `order` routing preferences.
 
 ### Fixed
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -27,7 +27,7 @@ import type {
 	ToolChoice,
 	ToolResultMessage,
 } from "../types";
-import { normalizeSystemPrompts } from "../utils";
+import { normalizeSystemPrompts, resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { isDemotedThinking, kStreamingLastParseLen } from "../utils/block-symbols";
 import { hasVisibleAssistantContent, withEmptyCompletionRetry } from "../utils/empty-completion-retry";
@@ -1463,6 +1463,7 @@ function buildParams(
 } {
 	const initialPolicy = resolveOpenAICompatForRequest(model, options);
 	const initialCompat = initialPolicy.compat as ResolvedOpenAICompat;
+	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 
 	const requestModelId = resolveOpenAICompletionsModelId(model, options);
 	const params: OpenAICompletionsParams = {
@@ -1615,7 +1616,7 @@ function buildParams(
 	applyChatCompletionsCompatPolicy(params, finalPolicy);
 	dropOpenRouterKimiForcedToolReasoning(params, model, finalPolicy);
 
-	applyOpenAIGatewayRouting(params, compat);
+	applyOpenAIGatewayRouting(params, compat, cacheRetention !== "none");
 
 	applyOpenAIExtraBody(params, compat.extraBody, {
 		dropThinkingWhenReasoningEffort: compat.dropThinkingWhenReasoningEffort,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -71,6 +71,7 @@ import {
 	applyOpenAIExtraBody,
 	applyOpenAIGatewayRouting,
 	applyResponsesCompatPolicy,
+	applyVercelResponsesCacheControls,
 	applyWireModelIdTransform,
 	buildResponsesDeltaInput,
 	buildResponsesInput,
@@ -359,6 +360,9 @@ type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	provider?: OpenAICompat["openRouterRouting"];
 	reasoning?: { effort?: string } | { enabled: false };
 	cache_control?: OpenRouterAnthropicCacheControl;
+	caching?: "auto";
+	cache_anchor_items?: number;
+	cache_ttl?: "5m" | "1h";
 };
 
 function maybeAddOpenRouterAnthropicCacheControl(
@@ -1024,7 +1028,11 @@ export function buildParams(
 		params.reasoning = { ...params.reasoning, mode: model.reasoningMode };
 	}
 
-	applyOpenAIGatewayRouting(params, model.compat);
+	if (model.compat.isVercelGatewayHost) {
+		applyVercelResponsesCacheControls(params, model.compat, cacheRetention !== "none");
+	} else {
+		applyOpenAIGatewayRouting(params, model.compat);
+	}
 
 	applyOpenAIExtraBody(params, options?.extraBody);
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1029,7 +1029,7 @@ export function buildParams(
 	}
 
 	if (model.compat.isVercelGatewayHost) {
-		applyVercelResponsesCacheControls(params, model.compat, cacheRetention !== "none");
+		applyVercelResponsesCacheControls(params, model.compat, cacheRetention);
 	} else {
 		applyOpenAIGatewayRouting(params, model.compat);
 	}

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -669,6 +669,7 @@ export function applyVercelResponsesCacheControls(
 
 	params.caching = "auto";
 	if (routing.cacheAnchorItems !== undefined) params.cache_anchor_items = routing.cacheAnchorItems;
+	// A configured 1h TTL is capped by resolved retention; default and short intentionally omit it.
 	if (routing.cacheTtl !== undefined && (routing.cacheTtl !== "1h" || cacheRetention === "long")) {
 		params.cache_ttl = routing.cacheTtl;
 	}

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -616,20 +616,49 @@ export interface OpenAIGatewayRoutingCompat {
 export function applyOpenAIGatewayRouting(
 	params: OpenAIGatewayRoutingParams,
 	compat: OpenAIGatewayRoutingCompat,
+	cacheEnabled = true,
 ): void {
 	if (compat.isOpenRouterHost && compat.openRouterRouting) {
 		params.provider = compat.openRouterRouting;
 	}
 	if (compat.isVercelGatewayHost && compat.vercelGatewayRouting) {
 		const routing = compat.vercelGatewayRouting;
-		if (routing.only || routing.order || routing.caching) {
+		if (routing.only || routing.order || (cacheEnabled && routing.caching)) {
 			const gatewayOptions: Pick<VercelGatewayRouting, "only" | "order" | "caching"> = {};
 			if (routing.only) gatewayOptions.only = routing.only;
 			if (routing.order) gatewayOptions.order = routing.order;
-			if (routing.caching) gatewayOptions.caching = routing.caching;
+			if (cacheEnabled && routing.caching) gatewayOptions.caching = routing.caching;
 			params.providerOptions = { gateway: gatewayOptions };
 		}
 	}
+}
+
+export interface VercelResponsesCacheParams {
+	caching?: "auto";
+	cache_anchor_items?: number;
+	cache_ttl?: "5m" | "1h";
+}
+
+export interface VercelResponsesCacheCompat {
+	isVercelGatewayHost: boolean;
+	vercelGatewayRouting?: VercelGatewayRouting;
+}
+
+/**
+ * Apply Vercel AI Gateway's Responses-only automatic cache controls. Chat
+ * Completions uses the distinct `providerOptions.gateway` shape above.
+ */
+export function applyVercelResponsesCacheControls(
+	params: VercelResponsesCacheParams,
+	compat: VercelResponsesCacheCompat,
+	cacheEnabled = true,
+): void {
+	const routing = compat.vercelGatewayRouting;
+	if (!cacheEnabled || !compat.isVercelGatewayHost || routing?.caching !== "auto") return;
+
+	params.caching = "auto";
+	if (routing.cacheAnchorItems !== undefined) params.cache_anchor_items = routing.cacheAnchorItems;
+	if (routing.cacheTtl !== undefined) params.cache_ttl = routing.cacheTtl;
 }
 
 export interface OpenAIExtraBodyOptions {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -598,7 +598,7 @@ export function resolveOpenAIOutputTokenParam(
 
 export interface OpenAIGatewayRoutingParams {
 	provider?: OpenRouterRouting;
-	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
+	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order" | "caching"> };
 }
 
 export interface OpenAIGatewayRoutingCompat {
@@ -610,10 +610,8 @@ export interface OpenAIGatewayRoutingCompat {
 
 /**
  * Apply gateway routing preferences to the request body. OpenRouter routes via
- * the top-level `provider` field; the Vercel AI Gateway routes via
- * `providerOptions.gateway`. Both Chat Completions and Responses call this; the
- * Vercel branch is inert for Responses, whose resolved compat never sets
- * `isVercelGatewayHost`.
+ * the top-level `provider` field; the Vercel AI Gateway routes Chat
+ * Completions through `providerOptions.gateway`.
  */
 export function applyOpenAIGatewayRouting(
 	params: OpenAIGatewayRoutingParams,
@@ -624,10 +622,11 @@ export function applyOpenAIGatewayRouting(
 	}
 	if (compat.isVercelGatewayHost && compat.vercelGatewayRouting) {
 		const routing = compat.vercelGatewayRouting;
-		if (routing.only || routing.order) {
-			const gatewayOptions: { only?: string[]; order?: string[] } = {};
+		if (routing.only || routing.order || routing.caching) {
+			const gatewayOptions: Pick<VercelGatewayRouting, "only" | "order" | "caching"> = {};
 			if (routing.only) gatewayOptions.only = routing.only;
 			if (routing.order) gatewayOptions.order = routing.order;
+			if (routing.caching) gatewayOptions.caching = routing.caching;
 			params.providerOptions = { gateway: gatewayOptions };
 		}
 	}

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -637,6 +637,7 @@ export interface VercelResponsesCacheParams {
 	caching?: "auto";
 	cache_anchor_items?: number;
 	cache_ttl?: "5m" | "1h";
+	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order"> };
 }
 
 export interface VercelResponsesCacheCompat {
@@ -645,20 +646,32 @@ export interface VercelResponsesCacheCompat {
 }
 
 /**
- * Apply Vercel AI Gateway's Responses-only automatic cache controls. Chat
- * Completions uses the distinct `providerOptions.gateway` shape above.
+ * Apply Vercel AI Gateway's Responses-only automatic cache controls and
+ * provider routing. Cache settings are top-level Responses fields, while
+ * `only` and `order` remain under `providerOptions.gateway`.
  */
 export function applyVercelResponsesCacheControls(
 	params: VercelResponsesCacheParams,
 	compat: VercelResponsesCacheCompat,
-	cacheEnabled = true,
+	cacheRetention: CacheRetention = "short",
 ): void {
 	const routing = compat.vercelGatewayRouting;
-	if (!cacheEnabled || !compat.isVercelGatewayHost || routing?.caching !== "auto") return;
+	if (!compat.isVercelGatewayHost) return;
+
+	if (routing?.only || routing?.order) {
+		const gateway: Pick<VercelGatewayRouting, "only" | "order"> = {};
+		if (routing.only) gateway.only = routing.only;
+		if (routing.order) gateway.order = routing.order;
+		params.providerOptions = { gateway };
+	}
+
+	if (cacheRetention === "none" || routing?.caching !== "auto") return;
 
 	params.caching = "auto";
 	if (routing.cacheAnchorItems !== undefined) params.cache_anchor_items = routing.cacheAnchorItems;
-	if (routing.cacheTtl !== undefined) params.cache_ttl = routing.cacheTtl;
+	if (routing.cacheTtl !== undefined && (routing.cacheTtl !== "1h" || cacheRetention === "long")) {
+		params.cache_ttl = routing.cacheTtl;
+	}
 }
 
 export interface OpenAIExtraBodyOptions {

--- a/packages/ai/test/openai-output-token-policy.test.ts
+++ b/packages/ai/test/openai-output-token-policy.test.ts
@@ -147,6 +147,23 @@ describe("applyOpenAIGatewayRouting", () => {
 		expect(params.provider).toBeUndefined();
 	});
 
+	it("merges Vercel automatic caching with existing gateway routing", () => {
+		const params = routingParams();
+		applyOpenAIGatewayRouting(params, {
+			isOpenRouterHost: false,
+			isVercelGatewayHost: true,
+			vercelGatewayRouting: {
+				only: ["bedrock"],
+				order: ["bedrock", "anthropic"],
+				caching: "auto",
+			},
+		});
+		expect(params.providerOptions).toEqual({
+			gateway: { only: ["bedrock"], order: ["bedrock", "anthropic"], caching: "auto" },
+		});
+		expect(params.provider).toBeUndefined();
+	});
+
 	it("ignores Vercel gateway routing with neither only nor order", () => {
 		const params = routingParams();
 		applyOpenAIGatewayRouting(params, {

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { Context, Model, ModelSpec, VercelGatewayRouting } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { withEnv } from "./helpers";
+
+const context: Context = {
+	messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+};
+
+type Payload = Record<string, unknown>;
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function vercelChatModel(routing?: VercelGatewayRouting): Model<"openai-completions"> {
+	return buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "openai-completions",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://ai-gateway.vercel.sh/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		...(routing ? { compat: { vercelGatewayRouting: routing } } : {}),
+	} satisfies ModelSpec<"openai-completions">);
+}
+
+function responsesModel(provider: string, baseUrl: string, routing?: VercelGatewayRouting): Model<"openai-responses"> {
+	return buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "openai-responses",
+		provider,
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		...(routing ? { compat: { vercelGatewayRouting: routing } } : {}),
+	} satisfies ModelSpec<"openai-responses">);
+}
+
+function captureChatPayload(
+	model: Model<"openai-completions">,
+	options: { cacheRetention?: "none" } = {},
+): Promise<Payload> {
+	const { promise, resolve } = Promise.withResolvers<Payload>();
+	streamOpenAICompletions(model, context, {
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		...options,
+		onPayload: payload => resolve(payload as Payload),
+	});
+	return promise;
+}
+
+function captureResponsesPayload(
+	model: Model<"openai-responses">,
+	options: { cacheRetention?: "none" } = {},
+): Promise<Payload> {
+	const { promise, resolve } = Promise.withResolvers<Payload>();
+	streamOpenAIResponses(model, context, {
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		...options,
+		onPayload: payload => resolve(payload as Payload),
+	});
+	return promise;
+}
+
+describe("Vercel AI Gateway automatic cache controls", () => {
+	it("maps cache fields to their documented Chat and Responses request shapes", async () => {
+		const routing: VercelGatewayRouting = {
+			only: ["anthropic"],
+			order: ["anthropic", "bedrock"],
+			caching: "auto",
+			cacheAnchorItems: 1,
+			cacheTtl: "1h",
+		};
+		const [chat, responses] = await Promise.all([
+			captureChatPayload(vercelChatModel(routing)),
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing)),
+		]);
+
+		expect(chat.providerOptions).toEqual({
+			gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"], caching: "auto" },
+		});
+		expect(chat.caching).toBeUndefined();
+		expect(chat.cache_anchor_items).toBeUndefined();
+		expect(chat.cache_ttl).toBeUndefined();
+
+		expect(responses.caching).toBe("auto");
+		expect(responses.cache_anchor_items).toBe(1);
+		expect(responses.cache_ttl).toBe("1h");
+		expect(responses.providerOptions).toBeUndefined();
+	});
+
+	it("omits Chat and Responses automatic cache controls when cache retention is none", async () => {
+		const routing: VercelGatewayRouting = {
+			only: ["anthropic"],
+			order: ["anthropic", "bedrock"],
+			caching: "auto",
+			cacheAnchorItems: 1,
+			cacheTtl: "1h",
+		};
+		const [chat, responses] = await Promise.all([
+			captureChatPayload(vercelChatModel(routing), { cacheRetention: "none" }),
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing), {
+				cacheRetention: "none",
+			}),
+		]);
+
+		expect(chat.providerOptions).toEqual({ gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"] } });
+		expect(chat.caching).toBeUndefined();
+		expect(chat.cache_anchor_items).toBeUndefined();
+		expect(chat.cache_ttl).toBeUndefined();
+
+		expect(responses.caching).toBeUndefined();
+		expect(responses.cache_anchor_items).toBeUndefined();
+		expect(responses.cache_ttl).toBeUndefined();
+	});
+
+	it("omits Chat and Responses automatic cache controls when PI_CACHE_RETENTION is none", async () => {
+		const routing: VercelGatewayRouting = {
+			only: ["anthropic"],
+			order: ["anthropic", "bedrock"],
+			caching: "auto",
+			cacheAnchorItems: 1,
+			cacheTtl: "1h",
+		};
+		await withEnv({ PI_CACHE_RETENTION: "none" }, async () => {
+			const [chat, responses] = await Promise.all([
+				captureChatPayload(vercelChatModel(routing)),
+				captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing)),
+			]);
+
+			expect(chat.providerOptions).toEqual({ gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"] } });
+			expect(chat.caching).toBeUndefined();
+			expect(chat.cache_anchor_items).toBeUndefined();
+			expect(chat.cache_ttl).toBeUndefined();
+
+			expect(responses.caching).toBeUndefined();
+			expect(responses.cache_anchor_items).toBeUndefined();
+			expect(responses.cache_ttl).toBeUndefined();
+		});
+	});
+
+	it("leaves unconfigured and non-Vercel Responses requests unchanged", async () => {
+		const routing: VercelGatewayRouting = {
+			caching: "auto",
+			cacheAnchorItems: 1,
+			cacheTtl: "1h",
+		};
+		const [unconfiguredVercel, nonVercel] = await Promise.all([
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1")),
+			captureResponsesPayload(responsesModel("custom", "https://api.example.com/v1", routing)),
+		]);
+
+		for (const payload of [unconfiguredVercel, nonVercel]) {
+			expect(payload.caching).toBeUndefined();
+			expect(payload.cache_anchor_items).toBeUndefined();
+			expect(payload.cache_ttl).toBeUndefined();
+			expect(payload.providerOptions).toBeUndefined();
+		}
+	});
+});

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -51,7 +51,7 @@ function responsesModel(provider: string, baseUrl: string, routing?: VercelGatew
 
 function captureChatPayload(
 	model: Model<"openai-completions">,
-	options: { cacheRetention?: "none" } = {},
+	options: { cacheRetention?: "long" | "short" | "none" } = {},
 ): Promise<Payload> {
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	streamOpenAICompletions(model, context, {
@@ -65,7 +65,7 @@ function captureChatPayload(
 
 function captureResponsesPayload(
 	model: Model<"openai-responses">,
-	options: { cacheRetention?: "none" } = {},
+	options: { cacheRetention?: "long" | "short" | "none" } = {},
 ): Promise<Payload> {
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	streamOpenAIResponses(model, context, {
@@ -78,7 +78,7 @@ function captureResponsesPayload(
 }
 
 describe("Vercel AI Gateway automatic cache controls", () => {
-	it("maps cache fields to their documented Chat and Responses request shapes", async () => {
+	it("maps cache fields and routing to their documented Chat and Responses request shapes", async () => {
 		const routing: VercelGatewayRouting = {
 			only: ["anthropic"],
 			order: ["anthropic", "bedrock"],
@@ -88,7 +88,9 @@ describe("Vercel AI Gateway automatic cache controls", () => {
 		};
 		const [chat, responses] = await Promise.all([
 			captureChatPayload(vercelChatModel(routing)),
-			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing)),
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing), {
+				cacheRetention: "long",
+			}),
 		]);
 
 		expect(chat.providerOptions).toEqual({
@@ -98,10 +100,44 @@ describe("Vercel AI Gateway automatic cache controls", () => {
 		expect(chat.cache_anchor_items).toBeUndefined();
 		expect(chat.cache_ttl).toBeUndefined();
 
+		expect(responses.providerOptions).toEqual({
+			gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"] },
+		});
 		expect(responses.caching).toBe("auto");
 		expect(responses.cache_anchor_items).toBe(1);
 		expect(responses.cache_ttl).toBe("1h");
-		expect(responses.providerOptions).toBeUndefined();
+	});
+
+	it("uses the Vercel default TTL for default, explicit, and environment short retention", async () => {
+		const routing: VercelGatewayRouting = {
+			only: ["anthropic"],
+			order: ["anthropic", "bedrock"],
+			caching: "auto",
+			cacheAnchorItems: 1,
+			cacheTtl: "1h",
+		};
+		const defaultRetention = await captureResponsesPayload(
+			responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing),
+		);
+		const explicitShortRetention = await captureResponsesPayload(
+			responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing),
+			{ cacheRetention: "short" },
+		);
+		let environmentShortRetention!: Payload;
+		await withEnv({ PI_CACHE_RETENTION: "short" }, async () => {
+			environmentShortRetention = await captureResponsesPayload(
+				responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing),
+			);
+		});
+
+		for (const payload of [defaultRetention, explicitShortRetention, environmentShortRetention]) {
+			expect(payload.providerOptions).toEqual({
+				gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"] },
+			});
+			expect(payload.caching).toBe("auto");
+			expect(payload.cache_anchor_items).toBe(1);
+			expect(payload.cache_ttl).toBeUndefined();
+		}
 	});
 
 	it("omits Chat and Responses automatic cache controls when cache retention is none", async () => {
@@ -124,6 +160,9 @@ describe("Vercel AI Gateway automatic cache controls", () => {
 		expect(chat.cache_anchor_items).toBeUndefined();
 		expect(chat.cache_ttl).toBeUndefined();
 
+		expect(responses.providerOptions).toEqual({
+			gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"] },
+		});
 		expect(responses.caching).toBeUndefined();
 		expect(responses.cache_anchor_items).toBeUndefined();
 		expect(responses.cache_ttl).toBeUndefined();
@@ -148,6 +187,9 @@ describe("Vercel AI Gateway automatic cache controls", () => {
 			expect(chat.cache_anchor_items).toBeUndefined();
 			expect(chat.cache_ttl).toBeUndefined();
 
+			expect(responses.providerOptions).toEqual({
+				gateway: { only: ["anthropic"], order: ["anthropic", "bedrock"] },
+			});
 			expect(responses.caching).toBeUndefined();
 			expect(responses.cache_anchor_items).toBeUndefined();
 			expect(responses.cache_ttl).toBeUndefined();

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added the native Meta Model API provider and Muse Spark 1.1 with Responses API reasoning replay, image input, and the full supported reasoning-effort ladder ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 - Added an opt-in Vercel AI Gateway automatic prompt-cache compatibility option alongside provider routing preferences.
+- Added Vercel AI Gateway Responses cache-anchor and cache-lifetime compatibility controls.
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added the native Meta Model API provider and Muse Spark 1.1 with Responses API reasoning replay, image input, and the full supported reasoning-effort ladder ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
+- Added an opt-in Vercel AI Gateway automatic prompt-cache compatibility option alongside provider routing preferences.
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -623,6 +623,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 	const isAzure = modelMatchesHost({ provider: spec.provider, baseUrl }, "azureOpenAI");
 	const isOpenRouter = modelMatchesHost({ provider: spec.provider, baseUrl }, "openrouter");
 	const isOpenAIUrl = hostMatchesUrl(baseUrl, "openai");
+	const isVercelGateway = modelMatchesHost({ provider: spec.provider, baseUrl }, "vercelAIGateway");
 	const id = spec.id ?? "";
 	const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] = isOpenRouter ? "openrouter" : "openai";
 	const isKimiModel = id ? isKimiModelId(id) : false;
@@ -686,7 +687,9 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		requiresAssistantAfterToolResult: false,
 		requiresAssistantContentForToolCalls: isKimiModel,
 		openRouterRouting: undefined,
+		vercelGatewayRouting: undefined,
 		isOpenRouterHost: isOpenRouter,
+		isVercelGatewayHost: isVercelGateway,
 		wireModelIdMode: isOpenRouter ? "openrouter" : "raw",
 		// Mirrors buildOpenAICompat: Kimi behind a Responses-capable proxy still
 		// lands on Moonshot's MFJS validator.
@@ -724,6 +727,7 @@ function pickResponsesOnly(compat: ResolvedOpenAIResponsesCompat): ResponsesOnly
 		strictResponsesPairing: compat.strictResponsesPairing,
 		supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
 		supportsObfuscationOptOut: compat.supportsObfuscationOptOut,
+		isVercelGatewayHost: compat.isVercelGatewayHost,
 	} satisfies ResponsesOnlyCompat;
 }
 

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -483,6 +483,10 @@ export interface VercelGatewayRouting {
 	order?: string[];
 	/** Enables Vercel AI Gateway's provider-aware automatic prompt caching. */
 	caching?: "auto";
+	/** Stable Responses input-item prefix to anchor for automatic caching. */
+	cacheAnchorItems?: number;
+	/** Requested automatic-cache lifetime for the Responses API. */
+	cacheTtl?: "5m" | "1h";
 }
 
 type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mixed";
@@ -622,6 +626,9 @@ export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompa
 	supportsImageDetailOriginal: boolean;
 	supportsObfuscationOptOut: boolean;
 	streamIdleTimeoutMs?: number;
+	vercelGatewayRouting?: OpenAICompat["vercelGatewayRouting"];
+	/** The model sits behind Vercel AI Gateway's Responses endpoint. */
+	isVercelGatewayHost: boolean;
 }
 
 /**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -481,6 +481,8 @@ export interface VercelGatewayRouting {
 	only?: string[];
 	/** List of provider slugs to try in order (e.g., ["anthropic", "openai"]). */
 	order?: string[];
+	/** Enables Vercel AI Gateway's provider-aware automatic prompt caching. */
+	caching?: "auto";
 }
 
 type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mixed";

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { buildModel } from "../src/build";
 import { getBundledModelReferenceIndex } from "../src/identity/bundled";
 import { inheritReferenceThinking, resolveModelReference } from "../src/identity/reference";
-import { buildModel } from "../src/build";
 import type { ModelSpec } from "../src/types";
 
 describe("Portkey gateway model references", () => {
@@ -48,4 +48,38 @@ describe("Vercel AI Gateway cache compat", () => {
 			caching: "auto",
 		});
 	});
+});
+
+test("resolves Responses cache controls only for the Vercel endpoint", () => {
+	const routing = { caching: "auto" as const, cacheAnchorItems: 1, cacheTtl: "1h" as const };
+	const vercel = buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "openai-responses",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://ai-gateway.vercel.sh/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		compat: { vercelGatewayRouting: routing },
+	} satisfies ModelSpec<"openai-responses">);
+	const direct = buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "openai-responses",
+		provider: "custom",
+		baseUrl: "https://api.example.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		compat: { vercelGatewayRouting: routing },
+	} satisfies ModelSpec<"openai-responses">);
+
+	expect(vercel.compat.isVercelGatewayHost).toBe(true);
+	expect(vercel.compat.vercelGatewayRouting).toEqual(routing);
+	expect(direct.compat.isVercelGatewayHost).toBe(false);
 });

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { getBundledModelReferenceIndex } from "../src/identity/bundled";
 import { inheritReferenceThinking, resolveModelReference } from "../src/identity/reference";
+import { buildModel } from "../src/build";
+import type { ModelSpec } from "../src/types";
 
 describe("Portkey gateway model references", () => {
 	test("@modal ids do not fuzzy-match bundled catalog entries", () => {
@@ -14,5 +16,36 @@ describe("Portkey gateway model references", () => {
 		expect(kiloGigaPotato?.provider).toBe("kilo");
 		expect(kiloGigaPotato?.thinking?.effortRouting).toBeDefined();
 		expect(inheritReferenceThinking(undefined, kiloGigaPotato, "gateway")).toBeUndefined();
+	});
+});
+
+describe("Vercel AI Gateway cache compat", () => {
+	test("resolves Chat Completions caching controls only for the Vercel endpoint", () => {
+		const model = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-completions",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: {
+				vercelGatewayRouting: {
+					only: ["anthropic"],
+					order: ["anthropic", "bedrock"],
+					caching: "auto",
+				},
+			},
+		} satisfies ModelSpec<"openai-completions">);
+
+		expect(model.compat.isVercelGatewayHost).toBe(true);
+		expect(model.compat.vercelGatewayRouting).toEqual({
+			only: ["anthropic"],
+			order: ["anthropic", "bedrock"],
+			caching: "auto",
+		});
 	});
 });


### PR DESCRIPTION
## What

- Adds opt-in Vercel AI Gateway automatic prompt caching while preserving existing `only`/`order` routing.
- Adds Responses-only `cache_anchor_items` and `cache_ttl` controls behind resolved Vercel endpoint compatibility.
- Keeps Chat and Responses wire shapes separate.
- Honors `cacheRetention: "none"` and `PI_CACHE_RETENTION=none` by suppressing every new Vercel cache field.

## Why

I reviewed the full diff; this exposes Vercel-native cache controls without changing routing or enabling caching by default.

Users behind the gateway can request provider prompt reuse without bypassing Vercel or constructing untyped extra bodies. Exact endpoint gating prevents Vercel extensions from leaking to direct OpenAI, OpenRouter, or other compatible endpoints.

## Testing

- `bun test packages/ai/test/vercel-gateway-cache-controls.test.ts packages/ai/test/openai-output-token-policy.test.ts packages/catalog/test/gateway-reference.test.ts` — 26 passed
- `bun run check:ts` — passed
- Exact Chat and Responses payload tests cover enabled/unset/disabled retention, environment opt-out, routing merge, endpoint gating, and absence of cross-surface fields.
- No live Vercel cold/warm pair was run because no intentional `AI_GATEWAY_API_KEY` or Vercel OIDC credential was available.

---

- [x] `bun run check:ts` passes
- [x] Tested locally with exact gateway request fixtures
- [x] CHANGELOG updated

## AI Review Report

Independent review found and remediation covered the explicit no-cache opt-out and Responses compat materialization. Final review found no remaining correctness, security, or endpoint-contract blocker; final typecheck and formatter gates pass.

## Security Audit

- Caching remains opt-in and respects the existing global/per-request disable control.
- Existing route allow/order settings are preserved rather than overwritten.
- No cache key, prompt, credential, or arbitrary gateway header is exposed.
- Vercel-specific fields are emitted only for recognized Vercel endpoint/API combinations.
