### PR TITLE
feat(agent): classify Cloudflare response cache status

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 
 - Queued steering no longer hard-aborts non-interruptible tools (e.g. `bash`): it aborts interruptible waits only and raises a cooperative steering signal (`ToolCallContext.steeringSignal`) that long-running tools may observe to finish early or background themselves. The mid-batch steering/IRC watch now runs for every tool batch instead of only batches containing an interruptible tool.
+### Added
+
+- Classified Cloudflare AI Gateway `cf-aig-cache-status` into bounded `pi.gen_ai.gateway.response_cache.status` values (`hit` | `miss` | `bypass` | `unknown`) on chat spans, without mapping response replay to prompt-cache token attributes or recording arbitrary Cloudflare headers
 
 ## [17.0.8] - 2026-07-22
 

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -157,6 +157,8 @@ export const enum PiGenAIAttr {
 	GatewayEndpoint = "pi.gen_ai.gateway.endpoint",
 	GatewayCallId = "pi.gen_ai.gateway.call_id",
 	GatewayRoutedTo = "pi.gen_ai.gateway.routed_to",
+	/** Cloudflare AI Gateway response-cache status (`cf-aig-cache-status`), never prompt-cache. */
+	GatewayResponseCacheStatus = "pi.gen_ai.gateway.response_cache.status",
 }
 
 /** GenAI operation names — values for {@link GenAIAttr.OperationName}. */
@@ -1278,17 +1280,56 @@ export function detectGatewayFromHeaders(
 	return undefined;
 }
 
+/**
+ * Bounded Cloudflare AI Gateway response-cache statuses emitted on
+ * {@link PiGenAIAttr.GatewayResponseCacheStatus}. Distinct from provider
+ * prompt-cache token counters (`gen_ai.usage.cache_*`).
+ *
+ * Cloudflare documents `HIT` / `MISS` on `cf-aig-cache-status`; `bypass` covers
+ * skip-cache / CDN-aligned BYPASS values. Any other present value is `unknown`.
+ */
+export type GatewayResponseCacheStatus = "hit" | "miss" | "bypass" | "unknown";
+
+/**
+ * Classify Cloudflare AI Gateway `cf-aig-cache-status` into a bounded
+ * response-cache status. Returns `undefined` when the allow-listed header is
+ * absent so non-Cloudflare traffic stays unaffected. Does not read TTL,
+ * skip-cache, custom-key, or other Cloudflare headers.
+ */
+export function classifyGatewayResponseCacheStatus(
+	headers: Readonly<Record<string, string>> | undefined,
+): GatewayResponseCacheStatus | undefined {
+	if (!headers) return undefined;
+	const raw = headers["cf-aig-cache-status"];
+	if (raw == null) return undefined;
+	switch (raw.trim().toLowerCase()) {
+		case "hit":
+			return "hit";
+		case "miss":
+			return "miss";
+		case "bypass":
+			return "bypass";
+		default:
+			return "unknown";
+	}
+}
+
 function applyGatewayAttributes(
 	span: Span,
 	headers: Readonly<Record<string, string>> | undefined,
 	baseUrl: string | undefined,
 ): void {
 	const gateway = detectGatewayFromHeaders(headers);
-	if (!gateway) return;
-	span.setAttribute(PiGenAIAttr.GatewayName, gateway.name);
-	if (baseUrl) span.setAttribute(PiGenAIAttr.GatewayEndpoint, baseUrl);
-	if (gateway.callId) span.setAttribute(PiGenAIAttr.GatewayCallId, gateway.callId);
-	if (gateway.routedTo) span.setAttribute(PiGenAIAttr.GatewayRoutedTo, gateway.routedTo);
+	if (gateway) {
+		span.setAttribute(PiGenAIAttr.GatewayName, gateway.name);
+		if (baseUrl) span.setAttribute(PiGenAIAttr.GatewayEndpoint, baseUrl);
+		if (gateway.callId) span.setAttribute(PiGenAIAttr.GatewayCallId, gateway.callId);
+		if (gateway.routedTo) span.setAttribute(PiGenAIAttr.GatewayRoutedTo, gateway.routedTo);
+	}
+	const responseCacheStatus = classifyGatewayResponseCacheStatus(headers);
+	if (responseCacheStatus) {
+		span.setAttribute(PiGenAIAttr.GatewayResponseCacheStatus, responseCacheStatus);
+	}
 }
 
 interface AppliedCostEstimate {

--- a/packages/agent/test/otel.test.ts
+++ b/packages/agent/test/otel.test.ts
@@ -10,6 +10,7 @@ import { agentLoop } from "@oh-my-pi/pi-agent-core/agent-loop";
 import {
 	type AgentTelemetryConfig,
 	type ChatUsageEvent,
+	classifyGatewayResponseCacheStatus,
 	detectGatewayFromHeaders,
 	GenAIAttr,
 	GenAIOperation,
@@ -886,6 +887,59 @@ describe("detectGatewayFromHeaders", () => {
 		});
 		expect(detection?.name).toBe("litellm");
 	});
+
+	it("still identifies known gateways when Cloudflare response-cache headers are also present", () => {
+		expect(
+			detectGatewayFromHeaders({
+				"x-litellm-call-id": "ll-cf",
+				"cf-aig-cache-status": "HIT",
+			})?.name,
+		).toBe("litellm");
+		expect(
+			detectGatewayFromHeaders({
+				"helicone-id": "he-cf",
+				"cf-aig-cache-status": "MISS",
+			})?.name,
+		).toBe("helicone");
+		expect(
+			detectGatewayFromHeaders({
+				"x-portkey-trace-id": "pk-cf",
+				"cf-aig-cache-status": "BYPASS",
+			})?.name,
+		).toBe("portkey");
+		expect(
+			detectGatewayFromHeaders({
+				"x-generation-id": "gen-cf-1",
+				"cf-aig-cache-status": "HIT",
+			})?.name,
+		).toBe("openrouter");
+	});
+});
+
+describe("classifyGatewayResponseCacheStatus", () => {
+	it("case-normalizes HIT/MISS/BYPASS to bounded response-cache statuses", () => {
+		expect(classifyGatewayResponseCacheStatus({ "cf-aig-cache-status": "HIT" })).toBe("hit");
+		expect(classifyGatewayResponseCacheStatus({ "cf-aig-cache-status": " miss " })).toBe("miss");
+		expect(classifyGatewayResponseCacheStatus({ "cf-aig-cache-status": "ByPaSs" })).toBe("bypass");
+	});
+
+	it("maps unrecognized present values to unknown", () => {
+		expect(classifyGatewayResponseCacheStatus({ "cf-aig-cache-status": "EXPIRED" })).toBe("unknown");
+		expect(classifyGatewayResponseCacheStatus({ "cf-aig-cache-status": "" })).toBe("unknown");
+	});
+
+	it("ignores non-allow-listed Cloudflare headers and absent maps", () => {
+		expect(
+			classifyGatewayResponseCacheStatus({
+				"cf-aig-cache-ttl": "3600",
+				"cf-aig-skip-cache": "true",
+				"cf-aig-cache-key": "k1",
+				"cf-ray": "abc",
+			}),
+		).toBeUndefined();
+		expect(classifyGatewayResponseCacheStatus({})).toBeUndefined();
+		expect(classifyGatewayResponseCacheStatus(undefined)).toBeUndefined();
+	});
 });
 
 describe("ChatUsageEvent.headers and pi.gen_ai.gateway.* span attributes", () => {
@@ -1020,5 +1074,79 @@ describe("ChatUsageEvent.headers and pi.gen_ai.gateway.* span attributes", () =>
 		expect(seen[0]?.["x-litellm-call-id"]).toBe("ll-2");
 		const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
 		expect(chat?.attributes[PiGenAIAttr.GatewayName]).toBe("litellm");
+	});
+
+	it("stamps pi.gen_ai.gateway.response_cache.status from cf-aig-cache-status without prompt-cache attrs", async () => {
+		const mock = createMockModel({
+			...MOCK_IDENT,
+			responses: [
+				{
+					content: ["ok"],
+					usage: { input: 4, output: 2, totalTokens: 6 },
+					responseHeaders: {
+						"cf-aig-cache-status": "HIT",
+						"cf-aig-cache-ttl": "3600",
+						"cf-aig-cache-key": "secret-key",
+						"cf-ray": "ray-should-not-leak",
+						"x-custom-secret": "nope",
+					},
+				},
+			],
+		});
+		const events: ChatUsageEvent[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			telemetry: { onChatUsage: event => void events.push(event) },
+		};
+		const ctx: AgentContext = { systemPrompt: [], messages: [], tools: [] };
+		await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+
+		const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+		expect(chat?.attributes[PiGenAIAttr.GatewayResponseCacheStatus]).toBe("hit");
+		// Response replay must not inflate or invent provider prompt-cache token counters.
+		// Mock usage defaults cacheRead/cacheWrite to 0; HIT must leave them at zero, not promote a hit.
+		expect(chat?.attributes[GenAIAttr.UsageCacheReadInputTokens]).toBe(0);
+		expect(chat?.attributes[GenAIAttr.UsageCacheCreationInputTokens]).toBe(0);
+		// Only allow-listed classification — raw Cloudflare/custom headers stay off the span.
+		expect(chat?.attributes["cf-aig-cache-status"]).toBeUndefined();
+		expect(chat?.attributes["cf-aig-cache-ttl"]).toBeUndefined();
+		expect(chat?.attributes["cf-aig-cache-key"]).toBeUndefined();
+		expect(chat?.attributes["cf-ray"]).toBeUndefined();
+		expect(chat?.attributes["x-custom-secret"]).toBeUndefined();
+		// ChatUsageEvent.headers still forwards the full captured map unchanged.
+		expect(events[0]?.headers?.["cf-aig-cache-status"]).toBe("HIT");
+		expect(events[0]?.headers?.["cf-aig-cache-key"]).toBe("secret-key");
+		expect(events[0]?.headers?.["x-custom-secret"]).toBe("nope");
+	});
+
+	it("classifies miss/bypass/unknown response-cache statuses on the chat span", async () => {
+		const cases = [
+			{ header: "MISS", expected: "miss" },
+			{ header: "bypass", expected: "bypass" },
+			{ header: "DYNAMIC", expected: "unknown" },
+		] as const;
+		for (const { header, expected } of cases) {
+			exporter.reset();
+			const mock = createMockModel({
+				...MOCK_IDENT,
+				responses: [
+					{
+						content: ["ok"],
+						usage: { input: 1, output: 1, totalTokens: 2 },
+						responseHeaders: { "cf-aig-cache-status": header },
+					},
+				],
+			});
+			const config: AgentLoopConfig = {
+				model: mock.model,
+				convertToLlm: identityConverter,
+				telemetry: {},
+			};
+			const ctx: AgentContext = { systemPrompt: [], messages: [], tools: [] };
+			await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+			const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+			expect(chat?.attributes[PiGenAIAttr.GatewayResponseCacheStatus]).toBe(expected);
+		}
 	});
 });


### PR DESCRIPTION
## What

- Classifies the allow-listed `cf-aig-cache-status` response header as bounded `hit`, `miss`, `bypass`, or `unknown` telemetry.
- Emits `pi.gen_ai.gateway.response_cache.status` on chat spans.
- Keeps Cloudflare full-response replay separate from provider prompt-cache token accounting.
- Adds no request headers and does not enable gateway caching.

## Why

I reviewed the full diff; this makes a fast Cloudflare response explainable without falsely calling it a prompt-cache hit.

A Cloudflare cache hit replays a complete prior response, while provider prompt caching only reuses prefix computation. Operators need those mechanisms labeled separately for correctness, cost analysis, and personalized-response safety.

## Testing

- `bun test packages/agent/test/otel.test.ts` — 43 passed
- `bun run check:ts` — passed
- Classifier and streamed-chat integration tests cover normalized HIT/MISS/BYPASS, unknown values, prompt-cache separation, existing gateway detection, and arbitrary-header non-export.
- No live Cloudflare gateway request was run because no intentionally configured response-cache route was available.

---

- [x] `bun run check:ts` passes
- [x] Tested locally through OTel chat-span integration
- [x] CHANGELOG updated

## AI Review Report

Independent review inspected all changed files and found no correctness, security, public-contract, or test blocker. The branch remained one telemetry-only logical change.

## Security Audit

- Only one documented header is classified; arbitrary response headers are not copied to span attributes.
- Status values are normalized to a bounded allow-list.
- No request caching, TTL, custom key, prompt, credential, or response body is added to telemetry.
- Existing `ChatUsageEvent.headers` behavior remains unchanged.
