### PR TITLE
feat(openai): add explicit prompt cache policy

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Anthropic extra-usage reporting across `omp usage`, interactive `/usage`, and ACP `/usage`: the OAuth usage endpoint's authoritative `spend` payload (or legacy `extra_usage` fallback when absent) is normalized into a `Claude Extra Usage` USD row; capped accounts show limit/remaining/fractions and status, while uncapped spend exposes only its absolute used amount—rendered as `$… used` in CLI/TUI and `123.45 usd used` in ACP—without a fabricated cap, percentage, or status. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))
+- Added opt-in OpenAI GPT-5.6 explicit prompt-cache controls for Responses and Chat Completions. Existing requests remain implicit; the policy marks at most one existing stable-history block and is rejected locally on unsupported explicit routes.
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Fixed OpenAI GPT-5.6+ explicit prompt-cache controls to select the latest stable boundary, preserve established stateful Responses markers (including no-system histories), and support later official GPT-5.x and GPT-6.x models.
+
 - Fixed outbound credential-pattern redaction (`[github_token_redacted]` & co.) running unconditionally: it is now opt-in via `configureCredentialRedaction` and disabled by default, so credential-shaped strings the user deliberately pastes reach the provider unmodified unless the host enables redaction.
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 - Fixed SuperGrok (`xai-oauth`) `/usage` showing "no usage data" for unified-billing accounts: when `?format=credits` lacks `creditUsagePercent` (or marks `isUnifiedBillingUser`), fall back to / merge the default monthly `monthlyLimit`/`used` payload.

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -11,6 +11,7 @@ import type {
 	StreamOptions,
 	ToolChoice,
 } from "../types";
+import { resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
@@ -82,6 +83,11 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 	context: Context,
 	options?: AzureOpenAIResponsesOptions,
 ): AssistantMessageEventStream => {
+	if (options?.promptCache?.mode === "explicit" && resolveCacheRetention(options.cacheRetention) !== "none") {
+		throw new AIError.ConfigurationError(
+			`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; Azure Responses does not emit explicit cache controls.`,
+		);
+	}
 	const stream = new AssistantMessageEventStream();
 
 	// Start async processing

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -49,6 +49,35 @@ function isServiceTier(value: unknown): value is ServiceTier {
 	return value === "auto" || value === "default" || value === "flex" || value === "scale" || value === "priority";
 }
 
+const UNSUPPORTED_EXPLICIT_PROMPT_CACHE_MESSAGE =
+	"openai-chat: prompt_cache_options and prompt_cache_breakpoint are unsupported by this auth-gateway route; use /v1/pi/stream with options.promptCache instead";
+
+function hasUnsupportedExplicitPromptCacheFields(body: unknown): boolean {
+	if (typeof body !== "object" || body === null || Array.isArray(body)) return false;
+	const request = body as Record<string, unknown>;
+	if ("prompt_cache_options" in request || "prompt_cache_breakpoint" in request) return true;
+	if (!Array.isArray(request.messages)) return false;
+
+	return request.messages.some(message => {
+		if (typeof message !== "object" || message === null || Array.isArray(message)) return false;
+		const wireMessage = message as Record<string, unknown>;
+		if ("prompt_cache_breakpoint" in wireMessage) return true;
+		return (
+			Array.isArray(wireMessage.content) &&
+			wireMessage.content.some(
+				part =>
+					typeof part === "object" && part !== null && !Array.isArray(part) && "prompt_cache_breakpoint" in part,
+			)
+		);
+	});
+}
+
+function rejectUnsupportedExplicitPromptCacheFields(body: unknown): void {
+	if (hasUnsupportedExplicitPromptCacheFields(body)) {
+		throw new AIError.ValidationError(UNSUPPORTED_EXPLICIT_PROMPT_CACHE_MESSAGE);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // parseRequest
 // ---------------------------------------------------------------------------
@@ -59,6 +88,7 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	// land on `options.headers` automatically). We consult `headers` here too
 	// for `resolvePromptCacheKey` to pull a cache identity out of inbound
 	// vendor-neutral headers when the body doesn't carry one.
+	rejectUnsupportedExplicitPromptCacheFields(body);
 	const parsed = openaiChatRequestSchema(body);
 	if (parsed instanceof type.errors) {
 		throw new AIError.ValidationError(`openai-chat: ${parsed.summary}`);

--- a/packages/ai/src/providers/openai-chat-wire.ts
+++ b/packages/ai/src/providers/openai-chat-wire.ts
@@ -196,6 +196,8 @@ export interface ChatCompletionContentPartText {
 	text: string;
 	/** Always `text`. */
 	type: "text";
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 
 /** Image content part. */
@@ -203,6 +205,8 @@ export interface ChatCompletionContentPartImage {
 	image_url: ChatCompletionContentPartImageImageURL;
 	/** Always `image_url`. */
 	type: "image_url";
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 
 /** SDK `ChatCompletionContentPartImage.ImageURL`. */
@@ -218,6 +222,8 @@ export interface ChatCompletionContentPartInputAudio {
 	input_audio: ChatCompletionContentPartInputAudioInputAudio;
 	/** Always `input_audio`. */
 	type: "input_audio";
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 
 /** SDK `ChatCompletionContentPartInputAudio.InputAudio`. */
@@ -233,6 +239,8 @@ export interface ChatCompletionContentPartFile {
 	file: ChatCompletionContentPartFileFile;
 	/** Always `file`. */
 	type: "file";
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 
 /** SDK `ChatCompletionContentPart.File.File`. */
@@ -251,6 +259,8 @@ export interface ChatCompletionContentPartRefusal {
 	refusal: string;
 	/** Always `refusal`. */
 	type: "refusal";
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 
 /** User-message content part union. */
@@ -798,6 +808,8 @@ export interface ChatCompletionCreateParamsBase {
 	prompt_cache_key?: string;
 	/** Retention policy for the prompt cache; `24h` enables extended caching. */
 	prompt_cache_retention?: "in_memory" | "24h" | null;
+	/** Explicit prompt-cache mode and minimum lifetime for GPT-5.6+ models. */
+	prompt_cache_options?: { mode: "implicit" | "explicit"; ttl?: "30m" };
 	/** Constrains effort on reasoning for reasoning models. */
 	reasoning_effort?: ReasoningEffort | null;
 	/** Output format: text, JSON mode, or Structured Outputs JSON schema. */

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -27,7 +27,7 @@ import type {
 	ToolChoice,
 	ToolResultMessage,
 } from "../types";
-import { normalizeSystemPrompts } from "../utils";
+import { normalizeSystemPrompts, resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { isDemotedThinking, kStreamingLastParseLen } from "../utils/block-symbols";
 import { hasVisibleAssistantContent, withEmptyCompletionRetry } from "../utils/empty-completion-retry";
@@ -96,6 +96,7 @@ import {
 	isStrictToolsDisabledForScope,
 	type OpenAICompatPolicy,
 	type OpenAICompletionsParams,
+	type OpenAIPromptCacheOptions,
 	type OpenAIRequestSetup,
 	type OpenAIStrictToolsState,
 	parseAzureDeploymentNameMap,
@@ -481,6 +482,8 @@ export interface OpenAICompletionsOptions extends StreamOptions {
 	 * with the variant baked in).
 	 */
 	openrouterVariant?: string;
+	/** Opt-in GPT-5.6+ prompt-cache policy. Unsupported explicit mode fails locally. */
+	promptCache?: OpenAIPromptCacheOptions;
 }
 
 type AppliedToolStrictMode = "mixed" | "all_strict" | "none";
@@ -1451,6 +1454,68 @@ function hasActiveNativeKimiK3Reasoning(
 	}
 }
 
+function isChatCompletionsPromptCacheableContentBlock(
+	block: unknown,
+): block is { type: "text" | "image_url" | "input_audio" | "file"; prompt_cache_breakpoint?: { mode: "explicit" } } {
+	if (typeof block !== "object" || block === null || !("type" in block)) return false;
+	return block.type === "text" || block.type === "image_url" || block.type === "input_audio" || block.type === "file";
+}
+
+function markLatestStableChatCompletionsCacheBreakpoint(messages: ChatCompletionMessageParam[]): boolean {
+	let latestInputMessage = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message.role === "user" || message.role === "developer") {
+			latestInputMessage = i;
+			break;
+		}
+	}
+	if (latestInputMessage <= 0) return false;
+
+	for (let i = latestInputMessage - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message.role !== "user" && message.role !== "developer" && message.role !== "system") continue;
+		if (typeof message.content === "string") {
+			messages[i] = {
+				...message,
+				content: [{ type: "text", text: message.content, prompt_cache_breakpoint: { mode: "explicit" } }],
+			};
+			return true;
+		}
+		for (let j = message.content.length - 1; j >= 0; j--) {
+			const block = message.content[j];
+			if (!isChatCompletionsPromptCacheableContentBlock(block)) continue;
+			Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
+			return true;
+		}
+	}
+	return false;
+}
+
+function applyOpenAIChatCompletionsPromptCachePolicy(
+	params: OpenAICompletionsParams,
+	model: Model<"openai-completions">,
+	options: OpenAICompletionsOptions | undefined,
+): void {
+	const promptCache = options?.promptCache;
+	if (!promptCache || resolveCacheRetention(options?.cacheRetention) === "none") return;
+	if (!model.compat.supportsPromptCacheBreakpoints) {
+		if (promptCache.mode === "explicit") {
+			throw new AIError.ConfigurationError(
+				`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; enable compat.supportsPromptCacheBreakpoints only for a compatible endpoint.`,
+			);
+		}
+		return;
+	}
+
+	params.prompt_cache_key = getOpenAIPromptCacheKey(options);
+	params.prompt_cache_options = {
+		mode: promptCache.mode,
+		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
+	};
+	if (promptCache.breakpoint !== "none") markLatestStableChatCompletionsCacheBreakpoint(params.messages);
+}
+
 function buildParams(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -1620,6 +1685,7 @@ function buildParams(
 	applyOpenAIExtraBody(params, compat.extraBody, {
 		dropThinkingWhenReasoningEffort: compat.dropThinkingWhenReasoningEffort,
 	});
+	applyOpenAIChatCompletionsPromptCachePolicy(params, model, options);
 
 	return { params, toolStrictMode, strictToolsApplied };
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1513,7 +1513,8 @@ function applyOpenAIChatCompletionsPromptCachePolicy(
 		mode: promptCache.mode,
 		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
 	};
-	if (promptCache.breakpoint !== "none") markLatestStableChatCompletionsCacheBreakpoint(params.messages);
+	if (promptCache.mode === "explicit" && promptCache.breakpoint !== "none")
+		markLatestStableChatCompletionsCacheBreakpoint(params.messages);
 }
 
 function buildParams(

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -58,6 +58,27 @@ function isObj(v: unknown): v is Record<string, unknown> {
 	return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+const UNSUPPORTED_EXPLICIT_PROMPT_CACHE_MESSAGE =
+	"openai-responses: prompt_cache_options and prompt_cache_breakpoint are unsupported by this auth-gateway route; use /v1/pi/stream with options.promptCache instead";
+
+function hasUnsupportedExplicitPromptCacheFields(body: unknown): boolean {
+	if (!isObj(body)) return false;
+	if ("prompt_cache_options" in body || "prompt_cache_breakpoint" in body) return true;
+	if (!Array.isArray(body.input)) return false;
+
+	return body.input.some(item => {
+		if (!isObj(item)) return false;
+		if ("prompt_cache_breakpoint" in item) return true;
+		return Array.isArray(item.content) && item.content.some(part => isObj(part) && "prompt_cache_breakpoint" in part);
+	});
+}
+
+function rejectUnsupportedExplicitPromptCacheFields(body: unknown): void {
+	if (hasUnsupportedExplicitPromptCacheFields(body)) {
+		throw new AIError.ValidationError(UNSUPPORTED_EXPLICIT_PROMPT_CACHE_MESSAGE);
+	}
+}
+
 function asString(v: unknown): string | undefined {
 	return typeof v === "string" ? v : undefined;
 }
@@ -294,6 +315,7 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	// client signals a cache identity outside the body — see the
 	// `resolvePromptCacheKey` call further down.
 
+	rejectUnsupportedExplicitPromptCacheFields(body);
 	const data = openaiResponsesRequestSchema(body);
 	if (data instanceof type.errors) {
 		throw new AIError.ValidationError(`openai-responses: ${data.summary}`);

--- a/packages/ai/src/providers/openai-responses-wire.ts
+++ b/packages/ai/src/providers/openai-responses-wire.ts
@@ -2884,6 +2884,8 @@ export interface ResponseInputFile {
 	 * The name of the file to be sent to the model.
 	 */
 	filename?: string;
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 /**
  * A file input to the model.
@@ -2939,6 +2941,8 @@ export interface ResponseInputImage {
 	 * encoded image in a data URL.
 	 */
 	image_url?: string | null;
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 /**
  * An image input to the model. Learn about
@@ -3642,6 +3646,8 @@ export interface ResponseInputText {
 	 * The type of the input item. Always `input_text`.
 	 */
 	type: "input_text";
+	/** Explicit OpenAI prompt-cache breakpoint. */
+	prompt_cache_breakpoint?: { mode: "explicit" };
 }
 /**
  * A text input to the model.
@@ -5922,6 +5928,8 @@ export interface ResponseCreateParamsBase {
 	 *   `prompt_cache_retention` is not specified.
 	 */
 	prompt_cache_retention?: "in_memory" | "24h" | null;
+	/** Explicit prompt-cache mode and minimum lifetime for GPT-5.6+ models. */
+	prompt_cache_options?: { mode: "implicit" | "explicit"; ttl?: "30m" } | null;
 	/**
 	 * **gpt-5 and o-series models only**
 	 *

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -906,7 +906,7 @@ function isStableStringResponsesInstruction(item: unknown): item is ResponsesStr
 	);
 }
 
-function markLatestStableResponsesCacheBreakpoint(input: ResponseInput | undefined): boolean {
+function markEarliestStableResponsesCacheBreakpoint(input: ResponseInput | undefined): boolean {
 	if (!input) return false;
 	let latestInputMessage = -1;
 	for (let i = input.length - 1; i >= 0; i--) {
@@ -919,7 +919,10 @@ function markLatestStableResponsesCacheBreakpoint(input: ResponseInput | undefin
 	}
 	if (latestInputMessage <= 0) return false;
 
-	for (let i = latestInputMessage - 1; i >= 0; i--) {
+	// Anchor at the first eligible history block. A stateful turn rebuilds its
+	// full transcript before deriving a delta, so moving this marker toward the
+	// growing tail would make the append baseline appear mutated.
+	for (let i = 0; i < latestInputMessage; i++) {
 		const message = input[i];
 		if (isResponsesPromptCacheableMessage(message)) {
 			const block = message.content[message.content.length - 1];
@@ -963,7 +966,7 @@ function applyOpenAIResponsesPromptCachePolicy(
 		mode: promptCache.mode,
 		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
 	};
-	if (promptCache.breakpoint !== "none") markLatestStableResponsesCacheBreakpoint(params.input);
+	if (promptCache.breakpoint !== "none") markEarliestStableResponsesCacheBreakpoint(params.input);
 }
 
 export function buildParams(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -64,6 +64,7 @@ import type {
 	Tool as OpenAITool,
 	ResponseCreateParamsStreaming,
 	ResponseInput,
+	ResponseInputContent,
 	ResponseStreamEvent,
 } from "./openai-responses-wire";
 import {
@@ -86,6 +87,7 @@ import {
 	isOpenAIResponsesProgressEvent,
 	isOpenRouterAnthropicModel,
 	isStrictToolsDisabledForScope,
+	type OpenAIPromptCacheOptions,
 	type OpenAIStrictToolsScope,
 	type OpenAIStrictToolsState,
 	processResponsesStream,
@@ -150,6 +152,8 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 	 * prompt_cache_key for prompt-cache routing).
 	 */
 	extraBody?: Record<string, unknown>;
+	/** Opt-in GPT-5.6+ prompt-cache policy. Unsupported explicit mode fails locally. */
+	promptCache?: OpenAIPromptCacheOptions;
 }
 
 const OPENAI_RESPONSES_PROVIDER_SESSION_STATE_PREFIX = "openai-responses:";
@@ -871,6 +875,97 @@ function isOfficialOpenAIResponsesEndpoint(model: Model<"openai-responses">): bo
 	}
 }
 
+function isResponsesPromptCacheableContentBlock(block: unknown): block is ResponseInputContent {
+	if (typeof block !== "object" || block === null || !("type" in block)) return false;
+	return block.type === "input_text" || block.type === "input_image" || block.type === "input_file";
+}
+
+type ResponsesPromptCacheableMessage = {
+	role: "assistant" | "developer" | "system" | "user";
+	content: ResponseInputContent[];
+};
+
+function isResponsesPromptCacheableMessage(item: unknown): item is ResponsesPromptCacheableMessage {
+	if (typeof item !== "object" || item === null || !("role" in item) || !("content" in item)) return false;
+	if (item.role !== "assistant" && item.role !== "developer" && item.role !== "system" && item.role !== "user")
+		return false;
+	return Array.isArray(item.content) && item.content.every(isResponsesPromptCacheableContentBlock);
+}
+
+type ResponsesStringInstruction = {
+	role: "developer" | "system";
+	content: string | ResponseInputContent[];
+};
+
+function isStableStringResponsesInstruction(item: unknown): item is ResponsesStringInstruction {
+	if (typeof item !== "object" || item === null || !("role" in item) || !("content" in item)) return false;
+	return (
+		(item.role === "developer" || item.role === "system") &&
+		typeof item.content === "string" &&
+		item.content.length > 0
+	);
+}
+
+function markLatestStableResponsesCacheBreakpoint(input: ResponseInput | undefined): boolean {
+	if (!input) return false;
+	let latestInputMessage = -1;
+	for (let i = input.length - 1; i >= 0; i--) {
+		const message = input[i];
+		if (!("role" in message)) continue;
+		if (message.role === "user" || message.role === "developer") {
+			latestInputMessage = i;
+			break;
+		}
+	}
+	if (latestInputMessage <= 0) return false;
+
+	for (let i = latestInputMessage - 1; i >= 0; i--) {
+		const message = input[i];
+		if (isResponsesPromptCacheableMessage(message)) {
+			const block = message.content[message.content.length - 1];
+			if (block) {
+				Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
+				return true;
+			}
+		}
+		if (isStableStringResponsesInstruction(message) && typeof message.content === "string") {
+			const text = message.content;
+			message.content = [
+				{
+					type: "input_text",
+					text,
+					prompt_cache_breakpoint: { mode: "explicit" },
+				},
+			];
+			return true;
+		}
+	}
+	return false;
+}
+
+function applyOpenAIResponsesPromptCachePolicy(
+	params: OpenAIResponsesSamplingParams,
+	model: Model<"openai-responses">,
+	options: OpenAIResponsesOptions | undefined,
+): void {
+	const promptCache = options?.promptCache;
+	if (!promptCache || resolveCacheRetention(options?.cacheRetention) === "none") return;
+	if (!model.compat.supportsPromptCacheBreakpoints) {
+		if (promptCache.mode === "explicit") {
+			throw new AIError.ConfigurationError(
+				`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; enable compat.supportsPromptCacheBreakpoints only for a compatible endpoint.`,
+			);
+		}
+		return;
+	}
+
+	params.prompt_cache_options = {
+		mode: promptCache.mode,
+		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
+	};
+	if (promptCache.breakpoint !== "none") markLatestStableResponsesCacheBreakpoint(params.input);
+}
+
 export function buildParams(
 	model: Model<"openai-responses">,
 	context: Context,
@@ -1027,6 +1122,7 @@ export function buildParams(
 	applyOpenAIGatewayRouting(params, model.compat);
 
 	applyOpenAIExtraBody(params, options?.extraBody);
+	applyOpenAIResponsesPromptCachePolicy(params, model, options);
 
 	return { params, strictToolsApplied };
 }

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -960,6 +960,16 @@ function restoreResponsesCacheBreakpointsFromBaseline(
 	return restored;
 }
 
+function hasResponsesCacheBreakpoint(input: ResponseInput | undefined): boolean {
+	return (
+		input?.some(
+			message =>
+				isResponsesPromptCacheableMessage(message) &&
+				message.content.some(block => block.prompt_cache_breakpoint !== undefined),
+		) ?? false
+	);
+}
+
 function markLatestStableResponsesCacheBreakpoint(
 	input: ResponseInput | undefined,
 	statefulBaseline?: ResponseInput,
@@ -967,7 +977,13 @@ function markLatestStableResponsesCacheBreakpoint(
 	if (!input) return false;
 	// Stateful appends use a strict wire-prefix comparison. Retain the exact
 	// marker from that prefix rather than recomputing a newer boundary.
-	if (statefulBaseline) return restoreResponsesCacheBreakpointsFromBaseline(input, statefulBaseline);
+	if (statefulBaseline) {
+		if (restoreResponsesCacheBreakpointsFromBaseline(input, statefulBaseline)) return true;
+		// A prior marker whose content no longer matches means chaining will
+		// reset to a full replay. Recompute a fresh boundary for that replay.
+		// Markerless baselines stay markerless so appends do not mutate them.
+		if (!hasResponsesCacheBreakpoint(statefulBaseline)) return false;
+	}
 
 	let latestInputMessage = -1;
 	for (let i = input.length - 1; i >= 0; i--) {
@@ -1044,6 +1060,7 @@ export function buildParams(
 		reasoning: options?.reasoning,
 		disableReasoning: options?.disableReasoning,
 		toolChoice: options?.toolChoice,
+		strictResponsesPairing: options?.strictResponsesPairing,
 		includeEncryptedReasoning: options?.includeEncryptedReasoning,
 		filterReasoningHistory: options?.filterReasoningHistory,
 		omitReasoningEffort: options?.omitReasoningEffort,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -447,7 +447,7 @@ const streamOpenAIResponsesOnce = (
 				providerSessionState,
 				strictToolsScope,
 				false,
-				chainState?.canAppend === true,
+				chainState?.canAppend ? chainState.lastParams?.input : undefined,
 			);
 			const params = builtParams.params;
 			let activeParams = params;
@@ -613,6 +613,7 @@ const streamOpenAIResponsesOnce = (
 								providerSessionState,
 								strictToolsScope,
 								true,
+								chainState?.canAppend ? chainState.lastParams?.input : undefined,
 							);
 							const fallbackParams = fallbackBuilt.params;
 							if (chainState && !chainState.disabled) fallbackParams.store = true;
@@ -902,7 +903,7 @@ function isResponsesPromptCacheableMessage(item: unknown): item is ResponsesProm
 
 type ResponsesStringInstruction = {
 	role: "developer" | "system";
-	content: string | ResponseInputContent[];
+	content: string;
 };
 
 function isStableStringResponsesInstruction(item: unknown): item is ResponsesStringInstruction {
@@ -914,11 +915,60 @@ function isStableStringResponsesInstruction(item: unknown): item is ResponsesStr
 	);
 }
 
-function markEarliestStableResponsesCacheBreakpoint(
+function restoreResponsesCacheBreakpointsFromBaseline(
 	input: ResponseInput | undefined,
-	preserveStatefulPrefix = false,
+	baseline: ResponseInput | undefined,
+): boolean {
+	if (!input || !baseline) return false;
+	let restored = false;
+	for (let i = 0; i < baseline.length && i < input.length; i++) {
+		const baselineMessage = baseline[i];
+		const message = input[i];
+		if (!isResponsesPromptCacheableMessage(baselineMessage)) continue;
+
+		if (isStableStringResponsesInstruction(message)) {
+			const [baselineBlock] = baselineMessage.content;
+			if (
+				baselineMessage.content.length === 1 &&
+				baselineBlock?.type === "input_text" &&
+				baselineBlock.text === message.content &&
+				baselineBlock.prompt_cache_breakpoint
+			) {
+				Object.assign(message, {
+					content: [
+						{
+							type: "input_text",
+							text: message.content,
+							prompt_cache_breakpoint: baselineBlock.prompt_cache_breakpoint,
+						},
+					],
+				});
+				restored = true;
+			}
+			continue;
+		}
+
+		if (!isResponsesPromptCacheableMessage(message)) continue;
+		for (let j = 0; j < baselineMessage.content.length && j < message.content.length; j++) {
+			const baselineBlock = baselineMessage.content[j];
+			const block = message.content[j];
+			if (!baselineBlock?.prompt_cache_breakpoint || !isResponsesPromptCacheableContentBlock(block)) continue;
+			Object.assign(block, { prompt_cache_breakpoint: baselineBlock.prompt_cache_breakpoint });
+			restored = true;
+		}
+	}
+	return restored;
+}
+
+function markLatestStableResponsesCacheBreakpoint(
+	input: ResponseInput | undefined,
+	statefulBaseline?: ResponseInput,
 ): boolean {
 	if (!input) return false;
+	// Stateful appends use a strict wire-prefix comparison. Retain the exact
+	// marker from that prefix rather than recomputing a newer boundary.
+	if (statefulBaseline) return restoreResponsesCacheBreakpointsFromBaseline(input, statefulBaseline);
+
 	let latestInputMessage = -1;
 	for (let i = input.length - 1; i >= 0; i--) {
 		const message = input[i];
@@ -930,32 +980,26 @@ function markEarliestStableResponsesCacheBreakpoint(
 	}
 	if (latestInputMessage <= 0) return false;
 
-	// Anchor at the first eligible history block. A stateful turn rebuilds its
-	// full transcript before deriving a delta, so moving this marker toward the
-	// growing tail would make the append baseline appear mutated. If its prior
-	// turn did not have a system/developer prefix, do not introduce a marker on
-	// historical user content now: that content has already been stored.
-	for (let i = 0; i < latestInputMessage; i++) {
+	for (let i = latestInputMessage - 1; i >= 0; i--) {
 		const message = input[i];
-		if (
-			isResponsesPromptCacheableMessage(message) &&
-			(!preserveStatefulPrefix || message.role === "developer" || message.role === "system")
-		) {
-			const block = message.content[message.content.length - 1];
-			if (block) {
-				Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
-				return true;
-			}
-		}
-		if (isStableStringResponsesInstruction(message) && typeof message.content === "string") {
+		if (isStableStringResponsesInstruction(message)) {
 			const text = message.content;
-			message.content = [
-				{
-					type: "input_text",
-					text,
-					prompt_cache_breakpoint: { mode: "explicit" },
-				},
-			];
+			Object.assign(message, {
+				content: [
+					{
+						type: "input_text",
+						text,
+						prompt_cache_breakpoint: { mode: "explicit" },
+					},
+				],
+			});
+			return true;
+		}
+		if (!isResponsesPromptCacheableMessage(message)) continue;
+		for (let j = message.content.length - 1; j >= 0; j--) {
+			const block = message.content[j];
+			if (!isResponsesPromptCacheableContentBlock(block)) continue;
+			Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
 			return true;
 		}
 	}
@@ -966,7 +1010,7 @@ function applyOpenAIResponsesPromptCachePolicy(
 	params: OpenAIResponsesSamplingParams,
 	model: Model<"openai-responses">,
 	options: OpenAIResponsesOptions | undefined,
-	preserveStatefulPrefix = false,
+	statefulCacheBaseline?: ResponseInput,
 ): void {
 	const promptCache = options?.promptCache;
 	if (!promptCache || resolveCacheRetention(options?.cacheRetention) === "none") return;
@@ -983,8 +1027,7 @@ function applyOpenAIResponsesPromptCachePolicy(
 		mode: promptCache.mode,
 		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
 	};
-	if (promptCache.breakpoint !== "none")
-		markEarliestStableResponsesCacheBreakpoint(params.input, preserveStatefulPrefix);
+	if (promptCache.breakpoint !== "none") markLatestStableResponsesCacheBreakpoint(params.input, statefulCacheBaseline);
 }
 
 export function buildParams(
@@ -994,14 +1037,13 @@ export function buildParams(
 	providerSessionState: OpenAIResponsesProviderSessionState | undefined,
 	strictToolsScope?: OpenAIStrictToolsScope,
 	disableStrictToolsOverride = false,
-	preserveStatefulPrefix = false,
+	statefulCacheBaseline?: ResponseInput,
 ): { params: OpenAIResponsesSamplingParams; strictToolsApplied: boolean } {
 	const policy = resolveOpenAICompatPolicy(model, {
 		endpoint: "responses",
 		reasoning: options?.reasoning,
 		disableReasoning: options?.disableReasoning,
 		toolChoice: options?.toolChoice,
-		strictResponsesPairing: options?.strictResponsesPairing,
 		includeEncryptedReasoning: options?.includeEncryptedReasoning,
 		filterReasoningHistory: options?.filterReasoningHistory,
 		omitReasoningEffort: options?.omitReasoningEffort,
@@ -1144,7 +1186,7 @@ export function buildParams(
 	applyOpenAIGatewayRouting(params, model.compat);
 
 	applyOpenAIExtraBody(params, options?.extraBody);
-	applyOpenAIResponsesPromptCachePolicy(params, model, options, preserveStatefulPrefix);
+	applyOpenAIResponsesPromptCachePolicy(params, model, options, statefulCacheBaseline);
 
 	return { params, strictToolsApplied };
 }

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1043,7 +1043,8 @@ function applyOpenAIResponsesPromptCachePolicy(
 		mode: promptCache.mode,
 		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
 	};
-	if (promptCache.breakpoint !== "none") markLatestStableResponsesCacheBreakpoint(params.input, statefulCacheBaseline);
+	if (promptCache.mode === "explicit" && promptCache.breakpoint !== "none")
+		markLatestStableResponsesCacheBreakpoint(params.input, statefulCacheBaseline);
 }
 
 export function buildParams(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -204,6 +204,7 @@ interface OpenAIResponsesChainState {
 	 * `previous_response_id`.
 	 */
 	lastParams?: OpenAIResponsesSamplingParams;
+	lastPromptCacheBreakpointPolicy?: "latest-stable-message" | "none";
 	lastResponseId?: string;
 	/** Output items of the last response, in replay-sanitized form (matches next-turn input). */
 	lastResponseItems?: ResponseInput;
@@ -277,6 +278,7 @@ function resetOpenAIResponsesChainState(state: OpenAIResponsesChainState): void 
 	state.lastParams = undefined;
 	state.lastResponseId = undefined;
 	state.lastResponseItems = undefined;
+	state.lastPromptCacheBreakpointPolicy = undefined;
 }
 
 interface OpenAIResponsesChainedParams {
@@ -437,8 +439,15 @@ const streamOpenAIResponsesOnce = (
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
 			const strictToolsScope = getOpenAIStrictToolsScope(model, baseUrl);
+			const promptCacheBreakpointPolicy =
+				resolveCacheRetention(options?.cacheRetention) !== "none" && options?.promptCache?.mode === "explicit"
+					? (options.promptCache.breakpoint ?? "latest-stable-message")
+					: undefined;
 			if (isOpenAIResponsesStatefulEnabled(options, baseUrl) && routingSessionId && providerSessionState) {
 				chainState = getOpenAIResponsesChainState(providerSessionState, model, baseUrl, routingSessionId);
+				if (chainState.canAppend && chainState.lastPromptCacheBreakpointPolicy !== promptCacheBreakpointPolicy) {
+					resetOpenAIResponsesChainState(chainState);
+				}
 			}
 			const builtParams = buildParams(
 				model,
@@ -812,6 +821,7 @@ const streamOpenAIResponsesOnce = (
 				if (providerSessionState) providerSessionState.nativeHistoryReplayWarmed = true;
 				if (chainState) {
 					chainState.lastParams = structuredCloneJSON(activeParams);
+					chainState.lastPromptCacheBreakpointPolicy = promptCacheBreakpointPolicy;
 					if (output.responseId) {
 						chainState.lastResponseId = output.responseId;
 						chainState.lastResponseItems = replayableResponseItems;
@@ -830,6 +840,7 @@ const streamOpenAIResponsesOnce = (
 				// without re-enabling `previous_response_id` chaining.
 				chainState.canAppend = false;
 				chainState.lastParams = structuredCloneJSON(activeParams);
+				chainState.lastPromptCacheBreakpointPolicy = promptCacheBreakpointPolicy;
 				chainState.lastResponseId = undefined;
 				chainState.lastResponseItems = undefined;
 			}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -437,7 +437,18 @@ const streamOpenAIResponsesOnce = (
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
 			const strictToolsScope = getOpenAIStrictToolsScope(model, baseUrl);
-			const builtParams = buildParams(model, context, options, providerSessionState, strictToolsScope);
+			if (isOpenAIResponsesStatefulEnabled(options, baseUrl) && routingSessionId && providerSessionState) {
+				chainState = getOpenAIResponsesChainState(providerSessionState, model, baseUrl, routingSessionId);
+			}
+			const builtParams = buildParams(
+				model,
+				context,
+				options,
+				providerSessionState,
+				strictToolsScope,
+				false,
+				chainState?.canAppend === true,
+			);
 			const params = builtParams.params;
 			let activeParams = params;
 			const resolvedBaseUrl = (baseUrl ?? "https://api.openai.com/v1").replace(/\/+$/, "");
@@ -460,12 +471,9 @@ const streamOpenAIResponsesOnce = (
 				}
 				return fallbackKey;
 			};
-			if (isOpenAIResponsesStatefulEnabled(options, baseUrl) && routingSessionId && providerSessionState) {
-				chainState = getOpenAIResponsesChainState(providerSessionState, model, baseUrl, routingSessionId);
-				if (!chainState.disabled) {
-					// Platform `previous_response_id` chaining only resolves stored responses.
-					params.store = true;
-				}
+			if (chainState && !chainState.disabled) {
+				// Platform `previous_response_id` chaining only resolves stored responses.
+				params.store = true;
 			}
 			applyReasoningEffortFallbackForRequest(params);
 			let chained: OpenAIResponsesChainedParams =
@@ -906,7 +914,10 @@ function isStableStringResponsesInstruction(item: unknown): item is ResponsesStr
 	);
 }
 
-function markEarliestStableResponsesCacheBreakpoint(input: ResponseInput | undefined): boolean {
+function markEarliestStableResponsesCacheBreakpoint(
+	input: ResponseInput | undefined,
+	preserveStatefulPrefix = false,
+): boolean {
 	if (!input) return false;
 	let latestInputMessage = -1;
 	for (let i = input.length - 1; i >= 0; i--) {
@@ -921,10 +932,15 @@ function markEarliestStableResponsesCacheBreakpoint(input: ResponseInput | undef
 
 	// Anchor at the first eligible history block. A stateful turn rebuilds its
 	// full transcript before deriving a delta, so moving this marker toward the
-	// growing tail would make the append baseline appear mutated.
+	// growing tail would make the append baseline appear mutated. If its prior
+	// turn did not have a system/developer prefix, do not introduce a marker on
+	// historical user content now: that content has already been stored.
 	for (let i = 0; i < latestInputMessage; i++) {
 		const message = input[i];
-		if (isResponsesPromptCacheableMessage(message)) {
+		if (
+			isResponsesPromptCacheableMessage(message) &&
+			(!preserveStatefulPrefix || message.role === "developer" || message.role === "system")
+		) {
 			const block = message.content[message.content.length - 1];
 			if (block) {
 				Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
@@ -950,6 +966,7 @@ function applyOpenAIResponsesPromptCachePolicy(
 	params: OpenAIResponsesSamplingParams,
 	model: Model<"openai-responses">,
 	options: OpenAIResponsesOptions | undefined,
+	preserveStatefulPrefix = false,
 ): void {
 	const promptCache = options?.promptCache;
 	if (!promptCache || resolveCacheRetention(options?.cacheRetention) === "none") return;
@@ -966,7 +983,8 @@ function applyOpenAIResponsesPromptCachePolicy(
 		mode: promptCache.mode,
 		ttl: promptCache.ttl ?? model.compat.promptCacheBreakpointTtl,
 	};
-	if (promptCache.breakpoint !== "none") markEarliestStableResponsesCacheBreakpoint(params.input);
+	if (promptCache.breakpoint !== "none")
+		markEarliestStableResponsesCacheBreakpoint(params.input, preserveStatefulPrefix);
 }
 
 export function buildParams(
@@ -976,6 +994,7 @@ export function buildParams(
 	providerSessionState: OpenAIResponsesProviderSessionState | undefined,
 	strictToolsScope?: OpenAIStrictToolsScope,
 	disableStrictToolsOverride = false,
+	preserveStatefulPrefix = false,
 ): { params: OpenAIResponsesSamplingParams; strictToolsApplied: boolean } {
 	const policy = resolveOpenAICompatPolicy(model, {
 		endpoint: "responses",
@@ -1125,7 +1144,7 @@ export function buildParams(
 	applyOpenAIGatewayRouting(params, model.compat);
 
 	applyOpenAIExtraBody(params, options?.extraBody);
-	applyOpenAIResponsesPromptCachePolicy(params, model, options);
+	applyOpenAIResponsesPromptCachePolicy(params, model, options, preserveStatefulPrefix);
 
 	return { params, strictToolsApplied };
 }

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -54,6 +54,9 @@ import {
 	type ToolResultMessage,
 	type Usage,
 } from "../types";
+
+export type { OpenAIPromptCacheOptions } from "../types";
+
 import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,

--- a/packages/ai/src/providers/pi-native-server.ts
+++ b/packages/ai/src/providers/pi-native-server.ts
@@ -62,6 +62,7 @@ const ALLOWED_OPTION_KEYS: ReadonlySet<keyof SimpleStreamOptions> = new Set([
 	"metadata",
 	"sessionId",
 	"promptCacheKey",
+	"promptCache",
 	"streamFirstEventTimeoutMs",
 	"streamIdleTimeoutMs",
 	"reasoning",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1425,6 +1425,7 @@ function assertExplicitOpenAIResponsesPromptCacheSupport<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): void {
 	if (
+		model.transport === "pi-native" ||
 		options?.cacheRetention === "none" ||
 		options?.promptCache?.mode !== "explicit" ||
 		!isOpenAIResponsesPromptCacheSurface(model) ||

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -776,6 +776,7 @@ function streamDispatch<TApi extends Api>(
 		...debugOptions,
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
 	} as OptionsForApi<TApi>;
+	assertExplicitOpenAIResponsesPromptCacheSupport(model, requestOptions);
 
 	// Check custom API registry first (extension-provided APIs like "vertex-claude-api")
 	const customApiProvider = getCustomApi(model.api);
@@ -1013,7 +1014,6 @@ export function streamSimple<TApi extends Api>(
 		...debugOptions,
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
 	} as SimpleStreamOptions;
-	assertExplicitOpenAIResponsesPromptCacheSupport(model, requestOptions);
 
 	const apiKeyResolver = isApiKeyResolver(requestOptions?.apiKey) ? requestOptions.apiKey : undefined;
 	if (apiKeyResolver) {
@@ -1423,7 +1423,7 @@ function isOpenAIResponsesPromptCacheSurface<TApi extends Api>(model: Model<TApi
 
 function assertExplicitOpenAIResponsesPromptCacheSupport<TApi extends Api>(
 	model: Model<TApi>,
-	options?: SimpleStreamOptions,
+	options?: StreamOptions,
 ): void {
 	if (
 		model.transport === "pi-native" ||

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -73,6 +73,7 @@ import type {
 	ThinkingBudgets,
 	ToolChoice,
 } from "./types";
+import { resolveCacheRetention } from "./utils";
 import { AssistantMessageEventStream } from "./utils/event-stream";
 import { isFoundryEnabled } from "./utils/foundry";
 import { wrapLeakedThinkingStream } from "./utils/leaked-thinking-stream";
@@ -1426,7 +1427,7 @@ function assertExplicitOpenAIResponsesPromptCacheSupport<TApi extends Api>(
 ): void {
 	if (
 		model.transport === "pi-native" ||
-		options?.cacheRetention === "none" ||
+		resolveCacheRetention(options?.cacheRetention) === "none" ||
 		options?.promptCache?.mode !== "explicit" ||
 		!isOpenAIResponsesPromptCacheSurface(model) ||
 		supportsExplicitOpenAIResponsesPromptCache(model.compat)

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1012,6 +1012,8 @@ export function streamSimple<TApi extends Api>(
 		...debugOptions,
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
 	} as SimpleStreamOptions;
+	assertExplicitOpenAIResponsesPromptCacheSupport(model, requestOptions);
+
 	const apiKeyResolver = isApiKeyResolver(requestOptions?.apiKey) ? requestOptions.apiKey : undefined;
 	if (apiKeyResolver) {
 		const outer = new AssistantMessageEventStream();
@@ -1401,6 +1403,40 @@ function normalizeMandatoryReasoningOptions<TApi extends Api>(
 	return { ...options, reasoning: floor, disableReasoning: undefined };
 }
 
+function supportsExplicitOpenAIResponsesPromptCache(compat: unknown): boolean {
+	return (
+		typeof compat === "object" &&
+		compat !== null &&
+		"supportsPromptCacheBreakpoints" in compat &&
+		compat.supportsPromptCacheBreakpoints === true
+	);
+}
+
+function isOpenAIResponsesPromptCacheSurface<TApi extends Api>(model: Model<TApi>): boolean {
+	return (
+		model.api === "openai-responses" ||
+		model.api === "azure-openai-responses" ||
+		(model.api === "openrouter" && $env.PI_OPENROUTER_RESPONSES !== "0")
+	);
+}
+
+function assertExplicitOpenAIResponsesPromptCacheSupport<TApi extends Api>(
+	model: Model<TApi>,
+	options?: SimpleStreamOptions,
+): void {
+	if (
+		options?.cacheRetention === "none" ||
+		options?.promptCache?.mode !== "explicit" ||
+		!isOpenAIResponsesPromptCacheSurface(model) ||
+		supportsExplicitOpenAIResponsesPromptCache(model.compat)
+	) {
+		return;
+	}
+	throw new AIError.ConfigurationError(
+		`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; enable compat.supportsPromptCacheBreakpoints only for a compatible endpoint.`,
+	);
+}
+
 function mapOptionsForApi<TApi extends Api>(
 	model: Model<TApi>,
 	rawOptions?: SimpleStreamOptions,
@@ -1575,6 +1611,7 @@ function mapOptionsForApi<TApi extends Api>(
 					maxTokensExplicit: rawOptions?.maxTokens !== undefined,
 					disableReasoning: options?.disableReasoning,
 					textVerbosity: options?.textVerbosity,
+					promptCache: options?.promptCache,
 				});
 			}
 			return castApi<"openai-completions">({
@@ -1585,6 +1622,7 @@ function mapOptionsForApi<TApi extends Api>(
 				serviceTier: options?.serviceTier,
 				openrouterVariant: options?.openrouterVariant,
 				maxTokensExplicit: rawOptions?.maxTokens !== undefined,
+				promptCache: options?.promptCache,
 			});
 		}
 
@@ -1597,6 +1635,7 @@ function mapOptionsForApi<TApi extends Api>(
 				serviceTier: options?.serviceTier,
 				openrouterVariant: options?.openrouterVariant,
 				maxTokensExplicit: rawOptions?.maxTokens !== undefined,
+				promptCache: options?.promptCache,
 			});
 
 		case "openai-responses":
@@ -1610,6 +1649,7 @@ function mapOptionsForApi<TApi extends Api>(
 				maxTokensExplicit: rawOptions?.maxTokens !== undefined,
 				disableReasoning: options?.disableReasoning,
 				textVerbosity: options?.textVerbosity,
+				promptCache: options?.promptCache,
 			});
 
 		case "azure-openai-responses":
@@ -1619,6 +1659,7 @@ function mapOptionsForApi<TApi extends Api>(
 				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
 				serviceTier: options?.serviceTier,
 				reasoningSummary: options?.hideThinkingSummary ? null : undefined,
+				promptCache: options?.promptCache,
 			});
 
 		case "openai-codex-responses":

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -352,6 +352,16 @@ export interface CodexCompactionRequestContext extends CodexCompactionMetadata {
 	operationId: string;
 }
 
+/** OpenAI's GPT-5.6+ explicit prompt-cache controls. */
+export interface OpenAIPromptCacheOptions {
+	/** `explicit` disables OpenAI's automatic latest-message breakpoint. */
+	mode: "implicit" | "explicit";
+	/** The only currently supported minimum breakpoint lifetime. */
+	ttl?: "30m";
+	/** By default, mark one existing block from stable history; `none` suppresses that marker. */
+	breakpoint?: "latest-stable-message" | "none";
+}
+
 export interface StreamOptions {
 	temperature?: number;
 	topP?: number;
@@ -422,6 +432,12 @@ export interface StreamOptions {
 	 * `x-grok-conv-id`; when omitted, they fall back to `sessionId`.
 	 */
 	promptCacheKey?: string;
+	/**
+	 * OpenAI GPT-5.6+ prompt-cache policy. Ignored by providers that do not
+	 * support explicit OpenAI cache breakpoints; explicit mode fails locally on
+	 * incompatible OpenAI-compatible endpoints.
+	 */
+	promptCache?: OpenAIPromptCacheOptions;
 	/**
 	 * Provider-scoped mutable state store for this agent session.
 	 * Providers can use this to persist transport/session state between turns.

--- a/packages/ai/test/auth-gateway-openai-chat.test.ts
+++ b/packages/ai/test/auth-gateway-openai-chat.test.ts
@@ -142,6 +142,27 @@ describe("auth-gateway openai-chat: parseRequest", () => {
 		expect(parsed.options.extra).toEqual({ includeStreamingUsage: true });
 	});
 
+	it("rejects raw explicit prompt-cache controls instead of silently dropping them", () => {
+		expect(() =>
+			parseRequest({
+				model: "gpt-5.6",
+				messages: [{ role: "user", content: "hi" }],
+				prompt_cache_options: { mode: "explicit", ttl: "30m" },
+			}),
+		).toThrow("prompt_cache_options and prompt_cache_breakpoint are unsupported");
+		expect(() =>
+			parseRequest({
+				model: "gpt-5.6",
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "hi", prompt_cache_breakpoint: { mode: "explicit" } }],
+					},
+				],
+			}),
+		).toThrow("prompt_cache_options and prompt_cache_breakpoint are unsupported");
+	});
+
 	it("rejects missing required fields", () => {
 		expect(() => parseRequest({ messages: [] })).toThrow(/model/);
 		expect(() => parseRequest({ model: "x" })).toThrow(/messages/);

--- a/packages/ai/test/auth-gateway-openai-prompt-cache.test.ts
+++ b/packages/ai/test/auth-gateway-openai-prompt-cache.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
+import { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+
+describe("auth-gateway explicit OpenAI prompt cache controls", () => {
+	it("rejects raw controls clearly and forwards the pi-native policy", async () => {
+		registerMockApi();
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gw-openai-prompt-cache-"));
+		const storage = await AuthStorage.create(path.join(dir, "auth.db"));
+		storage.setRuntimeApiKey("mock", "test-key");
+		const mock = createMockModel({
+			provider: "mock",
+			id: "gateway-prompt-cache",
+			handler: () => ({ content: ["ok"] }),
+		});
+		const handle = startAuthGateway({
+			bind: "127.0.0.1:0",
+			bearerTokens: ["t"],
+			storage,
+			resolveModel: () => mock.model,
+			version: "test",
+		});
+
+		try {
+			const chatResponse = await fetch(`${handle.url}/v1/chat/completions`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: "Bearer t" },
+				body: JSON.stringify({
+					model: "gateway-prompt-cache",
+					messages: [{ role: "user", content: "hi" }],
+					prompt_cache_options: { mode: "explicit", ttl: "30m" },
+				}),
+			});
+			const chatBody = (await chatResponse.json()) as { error?: { type?: string; message?: string } };
+			expect(chatResponse.status).toBe(400);
+			expect(chatBody.error).toEqual({
+				type: "invalid_request_error",
+				message:
+					"openai-chat: prompt_cache_options and prompt_cache_breakpoint are unsupported by this auth-gateway route; use /v1/pi/stream with options.promptCache instead",
+			});
+
+			const responsesResponse = await fetch(`${handle.url}/v1/responses`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: "Bearer t" },
+				body: JSON.stringify({
+					model: "gateway-prompt-cache",
+					input: [
+						{
+							role: "user",
+							content: [{ type: "input_text", text: "hi", prompt_cache_breakpoint: { mode: "explicit" } }],
+						},
+					],
+				}),
+			});
+			const responsesBody = (await responsesResponse.json()) as { error?: { type?: string; message?: string } };
+			expect(responsesResponse.status).toBe(400);
+			expect(responsesBody.error).toEqual({
+				type: "invalid_request_error",
+				message:
+					"openai-responses: prompt_cache_options and prompt_cache_breakpoint are unsupported by this auth-gateway route; use /v1/pi/stream with options.promptCache instead",
+			});
+
+			const piResponse = await fetch(`${handle.url}/v1/pi/stream`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: "Bearer t" },
+				body: JSON.stringify({
+					modelId: "gateway-prompt-cache",
+					context: { messages: [{ role: "user", content: "hi", timestamp: 0 }] },
+					options: { promptCache: { mode: "explicit", ttl: "30m", breakpoint: "none" } },
+					stream: false,
+				}),
+			});
+			expect(piResponse.status).toBe(200);
+			expect(mock.calls).toHaveLength(1);
+			expect(mock.calls[0]?.options?.promptCache).toEqual({ mode: "explicit", ttl: "30m", breakpoint: "none" });
+		} finally {
+			await handle.close();
+			storage.close();
+			clearCustomApis();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/ai/test/auth-gateway-openai-responses.test.ts
+++ b/packages/ai/test/auth-gateway-openai-responses.test.ts
@@ -168,6 +168,27 @@ describe("openai-responses parseRequest", () => {
 		expect(parsed.options.extra).toBeUndefined();
 	});
 
+	it("rejects raw explicit prompt-cache controls instead of silently dropping them", () => {
+		expect(() =>
+			parseRequest({
+				model: "gpt-5.6",
+				input: "hi",
+				prompt_cache_options: { mode: "explicit", ttl: "30m" },
+			}),
+		).toThrow("prompt_cache_options and prompt_cache_breakpoint are unsupported");
+		expect(() =>
+			parseRequest({
+				model: "gpt-5.6",
+				input: [
+					{
+						role: "user",
+						content: [{ type: "input_text", text: "hi", prompt_cache_breakpoint: { mode: "explicit" } }],
+					},
+				],
+			}),
+		).toThrow("prompt_cache_options and prompt_cache_breakpoint are unsupported");
+	});
+
 	it("accepts a bare string input and rejects a missing model", () => {
 		const parsed = parseRequest({ model: "m", input: "hi" });
 		expect(parsed.context.messages).toHaveLength(1);

--- a/packages/ai/test/auth-gateway-pi-native.test.ts
+++ b/packages/ai/test/auth-gateway-pi-native.test.ts
@@ -160,6 +160,16 @@ describe("pi-native parseRequest", () => {
 		expect(parsed.options.cacheRetention).toBe("long");
 	});
 
+	it("forwards the explicit prompt-cache policy through the canonical options bag", () => {
+		const parsed = parseRequest({
+			modelId: "gpt-5.6",
+			context: baseContext,
+			options: { promptCache: { mode: "explicit", ttl: "30m", breakpoint: "none" } },
+		});
+
+		expect(parsed.options.promptCache).toEqual({ mode: "explicit", ttl: "30m", breakpoint: "none" });
+	});
+
 	it("rejects missing required fields", () => {
 		expect(() => parseRequest({ context: baseContext })).toThrow(/modelId/);
 		expect(() => parseRequest({ modelId: "x" })).toThrow(/context/);

--- a/packages/ai/test/openai-completions-cache-affinity.test.ts
+++ b/packages/ai/test/openai-completions-cache-affinity.test.ts
@@ -1,12 +1,42 @@
 import { describe, expect, it } from "bun:test";
 import { type OpenAICompletionsOptions, streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
-import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+import type { AssistantMessage, Context, FetchImpl, Model, SimpleStreamOptions, Usage } from "@oh-my-pi/pi-ai/types";
+import { buildOpenAICompat } from "@oh-my-pi/pi-catalog/compat/openai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 const model = getBundledModel<"openai-completions">("xai", "grok-code-fast-1");
 if (!model) throw new Error("Expected bundled xAI Grok model");
 if (model.api !== "openai-completions") throw new Error(`Expected Chat Completions model, received ${model.api}`);
 const context: Context = { messages: [{ role: "user", content: "hello", timestamp: 0 }] };
+
+const openAI56ResponsesModel = getBundledModel<"openai-responses">("openai", "gpt-5.6");
+if (!openAI56ResponsesModel) throw new Error("Expected bundled OpenAI GPT-5.6 model");
+if (openAI56ResponsesModel.api !== "openai-responses") {
+	throw new Error(`Expected OpenAI Responses model, received ${openAI56ResponsesModel.api}`);
+}
+const {
+	compat: _responsesCompat,
+	remoteCompaction: _responsesRemoteCompaction,
+	...openAI56CompletionsSpec
+} = openAI56ResponsesModel;
+const openAI56CompletionsModel: Model<"openai-completions"> = {
+	...openAI56CompletionsSpec,
+	api: "openai-completions",
+	compat: buildOpenAICompat({
+		...openAI56CompletionsSpec,
+		api: "openai-completions",
+	}),
+};
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
 
 function chatCompletionsSse(): Response {
 	const chunk = (delta: unknown, finishReason: string | null) =>
@@ -24,25 +54,54 @@ function chatCompletionsSse(): Response {
 	);
 }
 
-async function captureRequestHeaders(options: OpenAICompletionsOptions): Promise<Headers> {
+async function captureRequest(
+	options: OpenAICompletionsOptions,
+	requestModel: Model<"openai-completions"> = model,
+	requestContext: Context = context,
+): Promise<{ headers: Headers; body: Record<string, unknown> }> {
 	let requestHeaders: Headers | undefined;
+	let body: Record<string, unknown> | undefined;
 	const fetchMock: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
 		const request =
 			input instanceof Request
 				? new Request(input, init)
 				: new Request(input instanceof URL ? input.href : input, init);
 		requestHeaders = request.headers;
+		body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
 		return chatCompletionsSse();
 	};
 
-	await streamOpenAICompletions(model, context, {
+	await streamOpenAICompletions(requestModel, requestContext, {
 		apiKey: "test-key",
 		...options,
 		fetch: fetchMock,
 	}).result();
 
-	if (!requestHeaders) throw new Error("Expected a serialized Chat Completions request");
-	return requestHeaders;
+	if (!requestHeaders || !body) throw new Error("Expected a serialized Chat Completions request");
+	return { headers: requestHeaders, body };
+}
+
+async function captureSimpleRequest(
+	options: SimpleStreamOptions,
+	requestModel: Model<"openai-completions"> = model,
+	requestContext: Context = context,
+): Promise<{ headers: Headers; body: Record<string, unknown> }> {
+	let requestHeaders: Headers | undefined;
+	let body: Record<string, unknown> | undefined;
+	const fetchMock: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+		const request =
+			input instanceof Request
+				? new Request(input, init)
+				: new Request(input instanceof URL ? input.href : input, init);
+		requestHeaders = request.headers;
+		body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+		return chatCompletionsSse();
+	};
+
+	await streamSimple(requestModel, requestContext, { apiKey: "test-key", ...options, fetch: fetchMock }).result();
+
+	if (!requestHeaders || !body) throw new Error("Expected a serialized Chat Completions request");
+	return { headers: requestHeaders, body };
 }
 
 describe("openai-completions xAI cache affinity", () => {
@@ -83,9 +142,81 @@ describe("openai-completions xAI cache affinity", () => {
 
 	for (const { name, options, expectedHeader } of cases) {
 		it(name, async () => {
-			const headers = await captureRequestHeaders(options);
+			const { headers } = await captureRequest(options);
 
 			expect(headers.get("x-grok-conv-id")).toBe(expectedHeader);
 		});
 	}
+});
+
+describe("OpenAI Chat Completions explicit prompt cache policy", () => {
+	const historicalContext: Context = {
+		messages: [
+			{ role: "user", content: [{ type: "text", text: "stable history" }], timestamp: 0 },
+			{ role: "user", content: [{ type: "text", text: "current prompt" }], timestamp: 1 },
+		],
+	};
+
+	it("leaves the wire shape unchanged when the policy is unset", async () => {
+		const { body } = await captureRequest({ sessionId: "cache-key" }, openAI56CompletionsModel, historicalContext);
+
+		expect(body).not.toHaveProperty("prompt_cache_options");
+		expect(body).not.toHaveProperty("prompt_cache_key");
+	});
+
+	it("routes explicit policy through streamSimple and marks existing text-only history", async () => {
+		const previousAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "openai-completions",
+			provider: "openai",
+			model: "gpt-5.6",
+			usage: emptyUsage,
+			stopReason: "stop",
+			timestamp: 1,
+		};
+		const textOnlyHistory: Context = {
+			messages: [
+				{ role: "user", content: "stable history", timestamp: 0 },
+				previousAssistant,
+				{ role: "user", content: "current prompt", timestamp: 2 },
+			],
+		};
+		const { body } = await captureSimpleRequest(
+			{ sessionId: "cache-key", promptCache: { mode: "explicit" } },
+			openAI56CompletionsModel,
+			textOnlyHistory,
+		);
+
+		expect(body.prompt_cache_key).toBe("cache-key");
+		expect(body.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" });
+		const messages = body.messages;
+		if (!Array.isArray(messages)) throw new Error("Expected Chat Completions messages");
+		expect(messages).toHaveLength(3);
+		expect(messages[0]).toMatchObject({
+			content: [{ type: "text", text: "stable history", prompt_cache_breakpoint: { mode: "explicit" } }],
+		});
+		expect(messages[1]).toMatchObject({ content: "previous answer" });
+		expect(messages[2]).toMatchObject({ content: "current prompt" });
+	});
+
+	it("does not synthesize first-turn content or a caller-disabled breakpoint", async () => {
+		const firstTurn: Context = {
+			messages: [{ role: "user", content: "only prompt", timestamp: 0 }],
+		};
+		const first = await captureRequest({ promptCache: { mode: "explicit" } }, openAI56CompletionsModel, firstTurn);
+		const none = await captureRequest(
+			{ promptCache: { mode: "explicit", breakpoint: "none" } },
+			openAI56CompletionsModel,
+			historicalContext,
+		);
+
+		for (const body of [first.body, none.body]) {
+			const messages = body.messages;
+			if (!Array.isArray(messages)) throw new Error("Expected Chat Completions messages");
+			for (const message of messages) {
+				expect(message).not.toMatchObject({ content: [{ prompt_cache_breakpoint: { mode: "explicit" } }] });
+			}
+		}
+	});
 });

--- a/packages/ai/test/openai-completions-cache-affinity.test.ts
+++ b/packages/ai/test/openai-completions-cache-affinity.test.ts
@@ -200,6 +200,17 @@ describe("OpenAI Chat Completions explicit prompt cache policy", () => {
 		expect(messages[2]).toMatchObject({ content: "current prompt" });
 	});
 
+	it("leaves boundary selection automatic in implicit mode", async () => {
+		const { body } = await captureRequest(
+			{ sessionId: "cache-key", promptCache: { mode: "implicit" } },
+			openAI56CompletionsModel,
+			historicalContext,
+		);
+
+		expect(body.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" });
+		expect(JSON.stringify(body.messages)).not.toContain("prompt_cache_breakpoint");
+	});
+
 	it("does not synthesize first-turn content or a caller-disabled breakpoint", async () => {
 		const firstTurn: Context = {
 			messages: [{ role: "user", content: "only prompt", timestamp: 0 }],

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import {
+	type AzureOpenAIResponsesOptions,
+	streamAzureOpenAIResponses,
+} from "@oh-my-pi/pi-ai/providers/azure-openai-responses";
+import {
 	buildParams,
 	type OpenAIResponsesOptions,
 	streamOpenAIResponses,
@@ -465,6 +469,28 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 			"OpenAI explicit prompt caching is unsupported",
 		);
 		expect(() => streamSimple(azureOpenAI56ResponsesModel, context, options)).toThrow(
+			"OpenAI explicit prompt caching is unsupported",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects explicit policy through typed and direct Azure Responses dispatch", () => {
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			throw new Error("Unsupported Azure Responses requests must not reach fetch");
+		});
+		const context: Context = {
+			messages: [{ role: "user", content: [{ type: "text", text: "prompt" }], timestamp: 0 }],
+		};
+		const options: AzureOpenAIResponsesOptions = {
+			apiKey: "test-key",
+			promptCache: { mode: "explicit" },
+			fetch: fetchMock,
+		};
+
+		expect(() => streamModel(azureOpenAI56ResponsesModel, context, options)).toThrow(
+			"OpenAI explicit prompt caching is unsupported",
+		);
+		expect(() => streamAzureOpenAIResponses(azureOpenAI56ResponsesModel, context, options)).toThrow(
 			"OpenAI explicit prompt caching is unsupported",
 		);
 		expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -10,6 +10,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { buildOpenAIResponsesCompat } from "@oh-my-pi/pi-catalog/compat/openai";
 
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { withEnv } from "./helpers";
 
 const model = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
 const openRouterResponsesModel: Model<"openai-responses"> = {
@@ -538,6 +539,38 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 		expect(contentBlocks.length).toBeGreaterThan(0);
 		for (const block of contentBlocks) {
 			expect(block).not.toHaveProperty("prompt_cache_breakpoint");
+		}
+	});
+
+	it("honors cache retention environment overrides before public explicit policy validation", async () => {
+		const unsupportedModel: Model<"openai-responses"> = {
+			...openAI56ResponsesModel,
+			id: "gpt-5.5",
+			compat: buildOpenAIResponsesCompat({
+				id: "gpt-5.5",
+				name: "GPT-5.5",
+				provider: "openai",
+				baseUrl: "https://api.openai.com/v1",
+			}),
+		};
+
+		await withEnv({ PI_CACHE_RETENTION: "none" }, async () => {
+			const body = await captureSimpleOpenAIResponseBody({ promptCache: { mode: "explicit" } }, unsupportedModel);
+
+			if (body === null) throw new Error("Expected disabled prompt-cache request to reach the provider");
+			expect(body).not.toHaveProperty("prompt_cache_options");
+		});
+
+		for (const retention of ["short", "long"] as const) {
+			await withEnv({ PI_CACHE_RETENTION: retention }, () => {
+				expect(() =>
+					streamSimple(
+						unsupportedModel,
+						{ messages: [{ role: "user", content: [{ type: "text", text: "prompt" }], timestamp: 0 }] },
+						{ apiKey: "test-key", promptCache: { mode: "explicit" } },
+					),
+				).toThrow("OpenAI explicit prompt caching is unsupported");
+			});
 		}
 	});
 });

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -427,6 +427,57 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it("defers explicit policy validation to the gateway-resolved model for pi-native transport", async () => {
+		const sidecarModel: Model<"openai-responses"> = {
+			...openAI56ResponsesModel,
+			id: "gateway-model",
+			baseUrl: "http://gateway.internal",
+			transport: "pi-native",
+			compat: buildOpenAIResponsesCompat({
+				id: "gpt-5.5",
+				name: "Gateway model",
+				provider: "openai",
+				baseUrl: "https://api.openai.com/v1",
+			}),
+		};
+		const fetchMock: FetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			const body = JSON.parse(String(init?.body)) as { options?: SimpleStreamOptions };
+			expect(body.options?.promptCache).toEqual({ mode: "explicit" });
+			return new Response(
+				`data: ${JSON.stringify({
+					type: "done",
+					reason: "stop",
+					message: {
+						role: "assistant",
+						content: [],
+						api: "openai-responses",
+						provider: "openai",
+						model: "gpt-5.6",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: 0,
+					},
+				})}\n\ndata: [DONE]\n\n`,
+				{ headers: { "content-type": "text/event-stream" } },
+			);
+		}) as FetchImpl;
+		const result = await streamSimple(
+			sidecarModel,
+			{ messages: [{ role: "user", content: "prompt", timestamp: 0 }] },
+			{ apiKey: "gateway-token", promptCache: { mode: "explicit" }, fetch: fetchMock },
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("treats cacheRetention none as a disabled no-op before public policy validation", async () => {
 		const unsupportedModel: Model<"openai-responses"> = {
 			...openAI56ResponsesModel,

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { type OpenAIResponsesOptions, streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import {
+	buildParams,
+	type OpenAIResponsesOptions,
+	streamOpenAIResponses,
+} from "@oh-my-pi/pi-ai/providers/openai-responses";
 import { stream as streamModel, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context, FetchImpl, Model, ProviderSessionState, SimpleStreamOptions } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { buildOpenAIResponsesCompat } from "@oh-my-pi/pi-catalog/compat/openai";
+
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 const model = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
@@ -46,6 +52,31 @@ const xaiOAuthResponsesModel: Model<"openai-responses"> = {
 		reasoning: true,
 	}),
 };
+
+const openAI56ResponsesModel: Model<"openai-responses"> = {
+	...model,
+	id: "gpt-5.6",
+	name: "GPT-5.6",
+	compat: buildOpenAIResponsesCompat({
+		id: "gpt-5.6",
+		name: "GPT-5.6",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+	}),
+};
+
+const azureOpenAI56ResponsesModel: Model<"azure-openai-responses"> = buildModel({
+	id: "gpt-5.6",
+	name: "GPT-5.6",
+	api: "azure-openai-responses",
+	provider: "azure",
+	baseUrl: "https://example.openai.azure.com/openai/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400_000,
+	maxTokens: 128_000,
+});
 
 function createSseResponse(events: unknown[]): Response {
 	const payload = `${events.map(event => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\n`;
@@ -192,6 +223,10 @@ async function captureDispatchedOpenAIResponseHeaders(
 async function captureSimpleOpenAIResponseBody(
 	options: SimpleStreamOptions,
 	requestModel: Model<"openai-responses"> = model,
+	requestContext: Context = {
+		systemPrompt: ["stable system", "stable durable context"],
+		messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+	},
 ): Promise<Record<string, unknown> | null> {
 	let body: Record<string, unknown> | null = null;
 	const fetchMock: FetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -228,12 +263,7 @@ async function captureSimpleOpenAIResponseBody(
 		]);
 	});
 
-	const context: Context = {
-		systemPrompt: ["stable system", "stable durable context"],
-		messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
-	};
-	const stream = streamSimple(requestModel, context, { apiKey: "test-key", ...options, fetch: fetchMock });
-
+	const stream = streamSimple(requestModel, requestContext, { apiKey: "test-key", ...options, fetch: fetchMock });
 	for await (const event of stream) {
 		if (event.type === "done" || event.type === "error") break;
 	}
@@ -243,6 +273,192 @@ async function captureSimpleOpenAIResponseBody(
 
 afterEach(() => {
 	vi.restoreAllMocks();
+});
+
+describe("OpenAI Responses explicit prompt cache policy", () => {
+	const historicalContext: Context = {
+		messages: [
+			{ role: "user", content: [{ type: "text", text: "stable history" }], timestamp: 0 },
+			{ role: "user", content: [{ type: "text", text: "current prompt" }], timestamp: 1 },
+		],
+	};
+
+	it("leaves the existing request shape unchanged when the policy is unset", () => {
+		const params = buildParams(
+			openAI56ResponsesModel,
+			historicalContext,
+			{ sessionId: "cache-key" },
+			undefined,
+		).params;
+
+		expect(params.prompt_cache_key).toBe("cache-key");
+		expect(params).not.toHaveProperty("prompt_cache_options");
+		const [firstMessage] = params.input ?? [];
+		if (!firstMessage || !("content" in firstMessage) || !Array.isArray(firstMessage.content)) {
+			throw new Error("Expected Responses input message content");
+		}
+		expect(firstMessage.content[0]).not.toHaveProperty("prompt_cache_breakpoint");
+	});
+
+	it("marks one existing stable history block and leaves the current prompt unmodified", () => {
+		const params = buildParams(
+			openAI56ResponsesModel,
+			historicalContext,
+			{ sessionId: "cache-key", promptCache: { mode: "explicit" } },
+			undefined,
+		).params;
+
+		expect(params.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" });
+		const [historical, current] = params.input ?? [];
+		if (
+			!historical ||
+			!current ||
+			!("content" in historical) ||
+			!Array.isArray(historical.content) ||
+			!("content" in current) ||
+			!Array.isArray(current.content)
+		) {
+			throw new Error("Expected Responses input message content");
+		}
+		expect(historical.content[0]).toMatchObject({ prompt_cache_breakpoint: { mode: "explicit" } });
+		expect(current.content[0]).not.toHaveProperty("prompt_cache_breakpoint");
+		expect(historicalContext.messages[0].content).toEqual([{ type: "text", text: "stable history" }]);
+	});
+
+	it("marks an existing first-turn developer string without adding a message or changing its text", () => {
+		const firstTurnWithSystem: Context = {
+			systemPrompt: ["stable developer instruction"],
+			messages: [{ role: "user", content: [{ type: "text", text: "only prompt" }], timestamp: 0 }],
+		};
+		const params = buildParams(
+			openAI56ResponsesModel,
+			firstTurnWithSystem,
+			{ promptCache: { mode: "explicit" } },
+			undefined,
+		).params;
+
+		expect(params.input).toEqual([
+			{
+				role: "developer",
+				content: [
+					{
+						type: "input_text",
+						text: "stable developer instruction",
+						prompt_cache_breakpoint: { mode: "explicit" },
+					},
+				],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "only prompt" }] },
+		]);
+	});
+
+	it("routes explicit policy through streamSimple", async () => {
+		const body = await captureSimpleOpenAIResponseBody(
+			{ sessionId: "cache-key", promptCache: { mode: "explicit" } },
+			openAI56ResponsesModel,
+			historicalContext,
+		);
+
+		expect(body?.prompt_cache_key).toBe("cache-key");
+		expect(body?.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" });
+		const input = body?.input;
+		if (!Array.isArray(input)) throw new Error("Expected Responses input");
+		expect(input[0]).toMatchObject({
+			content: [{ type: "input_text", text: "stable history", prompt_cache_breakpoint: { mode: "explicit" } }],
+		});
+	});
+
+	it("does not manufacture a breakpoint on a first-turn prompt or when the caller opts out", () => {
+		const firstTurn: Context = {
+			messages: [{ role: "user", content: [{ type: "text", text: "only prompt" }], timestamp: 0 }],
+		};
+		const firstTurnParams = buildParams(
+			openAI56ResponsesModel,
+			firstTurn,
+			{ promptCache: { mode: "explicit" } },
+			undefined,
+		).params;
+		const noBreakpointParams = buildParams(
+			openAI56ResponsesModel,
+			historicalContext,
+			{ promptCache: { mode: "explicit", breakpoint: "none" } },
+			undefined,
+		).params;
+
+		for (const params of [firstTurnParams, noBreakpointParams]) {
+			for (const item of params.input ?? []) {
+				if (!("content" in item) || !Array.isArray(item.content)) continue;
+				for (const block of item.content) {
+					expect(block).not.toHaveProperty("prompt_cache_breakpoint");
+				}
+			}
+		}
+	});
+
+	it("rejects explicit policy through streamSimple before sending unsupported Responses requests", () => {
+		const unsupportedModel: Model<"openai-responses"> = {
+			...openAI56ResponsesModel,
+			id: "gpt-5.5",
+			compat: buildOpenAIResponsesCompat({
+				id: "gpt-5.5",
+				name: "GPT-5.5",
+				provider: "openai",
+				baseUrl: "https://api.openai.com/v1",
+			}),
+		};
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			throw new Error("Unsupported Responses requests must not reach fetch");
+		});
+		const context: Context = {
+			messages: [{ role: "user", content: [{ type: "text", text: "prompt" }], timestamp: 0 }],
+		};
+		const options: SimpleStreamOptions = {
+			apiKey: "test-key",
+			promptCache: { mode: "explicit" },
+			fetch: fetchMock,
+		};
+
+		expect(() => streamSimple(unsupportedModel, context, options)).toThrow(
+			"OpenAI explicit prompt caching is unsupported",
+		);
+		expect(() => streamSimple(azureOpenAI56ResponsesModel, context, options)).toThrow(
+			"OpenAI explicit prompt caching is unsupported",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("treats cacheRetention none as a disabled no-op before public policy validation", async () => {
+		const unsupportedModel: Model<"openai-responses"> = {
+			...openAI56ResponsesModel,
+			id: "gpt-5.5",
+			compat: buildOpenAIResponsesCompat({
+				id: "gpt-5.5",
+				name: "GPT-5.5",
+				provider: "openai",
+				baseUrl: "https://api.openai.com/v1",
+			}),
+		};
+
+		const body = await captureSimpleOpenAIResponseBody(
+			{ cacheRetention: "none", promptCache: { mode: "explicit" } },
+			unsupportedModel,
+		);
+
+		if (body === null) throw new Error("Expected disabled prompt-cache request to reach the provider");
+		expect(body).not.toHaveProperty("prompt_cache_options");
+		const input = body.input;
+		if (!Array.isArray(input)) throw new Error("Expected Responses input");
+		const contentBlocks = input.flatMap(item => {
+			if (typeof item !== "object" || item === null || !("content" in item) || !Array.isArray(item.content)) {
+				return [];
+			}
+			return item.content;
+		});
+		expect(contentBlocks.length).toBeGreaterThan(0);
+		for (const block of contentBlocks) {
+			expect(block).not.toHaveProperty("prompt_cache_breakpoint");
+		}
+	});
 });
 
 describe("openai-responses cache affinity", () => {

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -326,6 +326,18 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 		expect(historicalContext.messages[0].content).toEqual([{ type: "text", text: "stable history" }]);
 	});
 
+	it("leaves boundary selection automatic in implicit mode", () => {
+		const params = buildParams(
+			openAI56ResponsesModel,
+			historicalContext,
+			{ sessionId: "cache-key", promptCache: { mode: "implicit" } },
+			undefined,
+		).params;
+
+		expect(params.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" });
+		expect(JSON.stringify(params.input)).not.toContain("prompt_cache_breakpoint");
+	});
+
 	it("marks the latest eligible stable history block", () => {
 		const params = buildParams(
 			openAI56ResponsesModel,

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -325,6 +325,36 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 		expect(historicalContext.messages[0].content).toEqual([{ type: "text", text: "stable history" }]);
 	});
 
+	it("marks the latest eligible stable history block", () => {
+		const params = buildParams(
+			openAI56ResponsesModel,
+			{
+				messages: [
+					{ role: "user", content: [{ type: "text", text: "oldest stable history" }], timestamp: 0 },
+					{ role: "user", content: [{ type: "text", text: "newer stable history" }], timestamp: 1 },
+					{ role: "user", content: [{ type: "text", text: "current prompt" }], timestamp: 2 },
+				],
+			},
+			{ sessionId: "cache-key", promptCache: { mode: "explicit" } },
+			undefined,
+		).params;
+
+		expect(params.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "oldest stable history" }] },
+			{
+				role: "user",
+				content: [
+					{
+						type: "input_text",
+						text: "newer stable history",
+						prompt_cache_breakpoint: { mode: "explicit" },
+					},
+				],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "current prompt" }] },
+		]);
+	});
+
 	it("marks an existing first-turn developer string without adding a message or changing its text", () => {
 		const firstTurnWithSystem: Context = {
 			systemPrompt: ["stable developer instruction"],

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1360,13 +1360,6 @@ describe("OpenAI responses history payload", () => {
 
 		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
 		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
-		const nonStrictDefaultModel: Model<"openai-responses"> = {
-			...model,
-			compat: { ...model.compat, strictResponsesPairing: false },
-		};
-		const overriddenPayload = (await captureResponsesPayload(nonStrictDefaultModel, context, undefined, {
-			strictResponsesPairing: true,
-		})) as { input?: unknown[] };
 
 		const orphanSurvivors = (payload.input ?? []).filter(item => {
 			if (!item || typeof item !== "object") return false;
@@ -1374,12 +1367,6 @@ describe("OpenAI responses history payload", () => {
 			return candidate.type === "function_call_output" && candidate.call_id === orphanCallId;
 		});
 		expect(orphanSurvivors).toEqual([]);
-		const overriddenOrphanSurvivors = (overriddenPayload.input ?? []).filter(item => {
-			if (!item || typeof item !== "object") return false;
-			const candidate = item as { type?: unknown; call_id?: unknown };
-			return candidate.type === "function_call_output" && candidate.call_id === orphanCallId;
-		});
-		expect(overriddenOrphanSurvivors).toEqual([]);
 
 		const pairedOutputs = (payload.input ?? []).filter(item => {
 			if (!item || typeof item !== "object") return false;
@@ -1399,5 +1386,64 @@ describe("OpenAI responses history payload", () => {
 			);
 		}) as { content?: string } | undefined;
 		expect(note?.content).toContain(orphanOutput);
+	});
+
+	it("honors strict pairing overrides against opposite catalog defaults", async () => {
+		const orphanCallId = "call_override_orphan";
+		const orphanOutput = "orphan result";
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: orphanCallId, name: "read", arguments: { path: "README.md" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt-5-mini",
+					usage: issue5002ZeroUsage,
+					stopReason: "toolUse",
+					providerPayload: createOpenAIResponsesHistoryPayload(
+						"openai",
+						[{ type: "message", role: "assistant", content: [{ type: "output_text", text: "snapshot" }] }],
+						false,
+					),
+					timestamp: Date.now(),
+				},
+				{
+					role: "toolResult",
+					toolCallId: orphanCallId,
+					toolName: "read",
+					content: [{ type: "text", text: orphanOutput }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "Continue", timestamp: Date.now() },
+			],
+		};
+		const catalogNonStrictModel = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const catalogStrictModel: Model<"openai-responses"> = {
+			...catalogNonStrictModel,
+			compat: { ...catalogNonStrictModel.compat, strictResponsesPairing: true },
+		};
+		const strictOverridePayload = (await captureResponsesPayload(catalogNonStrictModel, context, undefined, {
+			strictResponsesPairing: true,
+		})) as { input?: unknown[] };
+		const nonStrictOverridePayload = (await captureResponsesPayload(catalogStrictModel, context, undefined, {
+			strictResponsesPairing: false,
+		})) as { input?: unknown[] };
+		const orphanNote = (input: unknown[] | undefined): { content?: string } | undefined =>
+			input?.find(item => {
+				if (!item || typeof item !== "object") return false;
+				const candidate = item as { type?: unknown; role?: unknown; content?: unknown };
+				return (
+					candidate.type === "message" &&
+					candidate.role === "assistant" &&
+					typeof candidate.content === "string" &&
+					candidate.content.includes(orphanCallId) &&
+					candidate.content.includes(orphanOutput)
+				);
+			}) as { content?: string } | undefined;
+
+		expect(orphanNote(strictOverridePayload.input)?.content).toContain("[Orphan read result;");
+		expect(orphanNote(nonStrictOverridePayload.input)?.content).toContain("[Orphan tool result;");
 	});
 });

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1360,6 +1360,13 @@ describe("OpenAI responses history payload", () => {
 
 		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
 		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+		const nonStrictDefaultModel: Model<"openai-responses"> = {
+			...model,
+			compat: { ...model.compat, strictResponsesPairing: false },
+		};
+		const overriddenPayload = (await captureResponsesPayload(nonStrictDefaultModel, context, undefined, {
+			strictResponsesPairing: true,
+		})) as { input?: unknown[] };
 
 		const orphanSurvivors = (payload.input ?? []).filter(item => {
 			if (!item || typeof item !== "object") return false;
@@ -1367,6 +1374,12 @@ describe("OpenAI responses history payload", () => {
 			return candidate.type === "function_call_output" && candidate.call_id === orphanCallId;
 		});
 		expect(orphanSurvivors).toEqual([]);
+		const overriddenOrphanSurvivors = (overriddenPayload.input ?? []).filter(item => {
+			if (!item || typeof item !== "object") return false;
+			const candidate = item as { type?: unknown; call_id?: unknown };
+			return candidate.type === "function_call_output" && candidate.call_id === orphanCallId;
+		});
+		expect(overriddenOrphanSurvivors).toEqual([]);
 
 		const pairedOutputs = (payload.input ?? []).filter(item => {
 			if (!item || typeof item !== "object") return false;

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -199,20 +199,26 @@ describe("openai-responses stateful chaining", () => {
 			{ messages: [oldestUser, firstUser] },
 			options,
 		).result();
+		const secondUser = { role: "user" as const, content: "Second question", timestamp: 1002 };
 		const secondResponse = await streamOpenAIResponses(
 			explicitPromptCacheModel,
 			{
-				messages: [
-					oldestUser,
-					firstUser,
-					firstResponse,
-					{ role: "user", content: "Second question", timestamp: 1002 },
-				],
+				messages: [oldestUser, firstUser, firstResponse, secondUser],
+			},
+			options,
+		).result();
+		const thirdUser = { role: "user" as const, content: "Third question", timestamp: 1003 };
+		const thirdResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{
+				messages: [oldestUser, firstUser, firstResponse, secondUser, secondResponse, thirdUser],
 			},
 			options,
 		).result();
 
 		expect(secondResponse.stopReason).toBe("stop");
+		expect(thirdResponse.stopReason).toBe("stop");
+		expect(sentRequests).toHaveLength(3);
 		expect(sentRequests[0]?.input).toEqual([
 			{
 				role: "user",
@@ -229,6 +235,10 @@ describe("openai-responses stateful chaining", () => {
 		expect(sentRequests[1]?.previous_response_id).toBe("resp_1");
 		expect(sentRequests[1]?.input).toEqual([
 			{ role: "user", content: [{ type: "input_text", text: "Second question" }] },
+		]);
+		expect(sentRequests[2]?.previous_response_id).toBe("resp_2");
+		expect(sentRequests[2]?.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "Third question" }] },
 		]);
 	});
 

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -2,9 +2,22 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, FetchImpl, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { buildOpenAIResponsesCompat } from "@oh-my-pi/pi-catalog/compat/openai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 const model = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+
+const explicitPromptCacheModel: Model<"openai-responses"> = {
+	...model,
+	id: "gpt-5.6",
+	name: "GPT-5.6",
+	compat: buildOpenAIResponsesCompat({
+		id: "gpt-5.6",
+		name: "GPT-5.6",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+	}),
+};
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -95,6 +108,41 @@ describe("openai-responses stateful chaining", () => {
 		expect(deltaInput[0]?.role).toBe("user");
 		expect(JSON.stringify(deltaInput)).toContain("Second question");
 		expect(JSON.stringify(deltaInput)).not.toContain("Answer 1");
+	});
+
+	it("keeps the automatic explicit cache breakpoint stable across chained turns", async () => {
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = createCapturingFetch(sentRequests);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const options = {
+			apiKey: "test-key",
+			sessionId: "stateful-cache-session",
+			providerSessionState,
+			statefulResponses: true,
+			promptCache: { mode: "explicit" as const },
+			fetch: fetchMock,
+		};
+		const firstUser = { role: "user" as const, content: "First question", timestamp: 1000 };
+		const firstResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ systemPrompt, messages: [firstUser] },
+			options,
+		).result();
+		const secondResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{
+				systemPrompt,
+				messages: [firstUser, firstResponse, { role: "user", content: "Second question", timestamp: 1001 }],
+			},
+			options,
+		).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(sentRequests).toHaveLength(2);
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_1");
+		expect(sentRequests[1]?.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "Second question" }] },
+		]);
 	});
 
 	it("chains turns without appending an extra no-reasoning developer item", async () => {

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -242,6 +242,53 @@ describe("openai-responses stateful chaining", () => {
 		]);
 	});
 
+	it("recomputes a cache breakpoint when an edited prefix resets the chain", async () => {
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = createCapturingFetch(sentRequests);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const options = {
+			apiKey: "test-key",
+			sessionId: "stateful-edited-cache-prefix-session",
+			providerSessionState,
+			statefulResponses: true,
+			promptCache: { mode: "explicit" as const },
+			fetch: fetchMock,
+		};
+		const firstUser = { role: "user" as const, content: "First question", timestamp: 1000 };
+		const firstResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ systemPrompt: ["Original system prompt"], messages: [firstUser] },
+			options,
+		).result();
+		const secondUser = { role: "user" as const, content: "Second question", timestamp: 1001 };
+		const secondResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{
+				systemPrompt: ["Edited system prompt"],
+				messages: [firstUser, firstResponse, secondUser],
+			},
+			options,
+		).result();
+		const thirdUser = { role: "user" as const, content: "Third question", timestamp: 1002 };
+		await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{
+				systemPrompt: ["Edited system prompt"],
+				messages: [firstUser, firstResponse, secondUser, secondResponse, thirdUser],
+			},
+			options,
+		).result();
+
+		expect(sentRequests).toHaveLength(3);
+		expect(sentRequests[1]?.previous_response_id).toBeUndefined();
+		expect(JSON.stringify(sentRequests[1]?.input)).toContain("Edited system prompt");
+		expect(JSON.stringify(sentRequests[1]?.input)).toContain("prompt_cache_breakpoint");
+		expect(sentRequests[2]?.previous_response_id).toBe("resp_2");
+		expect(sentRequests[2]?.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "Third question" }] },
+		]);
+	});
+
 	it("chains turns without appending an extra no-reasoning developer item", async () => {
 		const sentRequests: Array<Record<string, unknown>> = [];
 		const fetchMock = createCapturingFetch(sentRequests);

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -180,6 +180,58 @@ describe("openai-responses stateful chaining", () => {
 		]);
 	});
 
+	it("preserves an established no-system cache breakpoint across chained turns", async () => {
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = createCapturingFetch(sentRequests);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const options = {
+			apiKey: "test-key",
+			sessionId: "stateful-no-system-marker-session",
+			providerSessionState,
+			statefulResponses: true,
+			promptCache: { mode: "explicit" as const },
+			fetch: fetchMock,
+		};
+		const oldestUser = { role: "user" as const, content: "Oldest stable question", timestamp: 1000 };
+		const firstUser = { role: "user" as const, content: "First question", timestamp: 1001 };
+		const firstResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ messages: [oldestUser, firstUser] },
+			options,
+		).result();
+		const secondResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{
+				messages: [
+					oldestUser,
+					firstUser,
+					firstResponse,
+					{ role: "user", content: "Second question", timestamp: 1002 },
+				],
+			},
+			options,
+		).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(sentRequests[0]?.input).toEqual([
+			{
+				role: "user",
+				content: [
+					{
+						type: "input_text",
+						text: "Oldest stable question",
+						prompt_cache_breakpoint: { mode: "explicit" },
+					},
+				],
+			},
+			{ role: "user", content: [{ type: "input_text", text: "First question" }] },
+		]);
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_1");
+		expect(sentRequests[1]?.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "Second question" }] },
+		]);
+	});
+
 	it("chains turns without appending an extra no-reasoning developer item", async () => {
 		const sentRequests: Array<Record<string, unknown>> = [];
 		const fetchMock = createCapturingFetch(sentRequests);

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -180,6 +180,46 @@ describe("openai-responses stateful chaining", () => {
 		]);
 	});
 
+	it("re-enables an explicit cache breakpoint after a markerless chained turn", async () => {
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = createCapturingFetch(sentRequests);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const baseOptions = {
+			apiKey: "test-key",
+			sessionId: "stateful-reenabled-cache-breakpoint-session",
+			providerSessionState,
+			statefulResponses: true,
+			fetch: fetchMock,
+		};
+		const firstUser = { role: "user" as const, content: "First question", timestamp: 1000 };
+		const firstResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ messages: [firstUser] },
+			{ ...baseOptions, promptCache: { mode: "explicit", breakpoint: "none" } },
+		).result();
+		const secondUser = { role: "user" as const, content: "Second question", timestamp: 1001 };
+		const secondResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ messages: [firstUser, firstResponse, secondUser] },
+			{ ...baseOptions, promptCache: { mode: "explicit" } },
+		).result();
+		const thirdUser = { role: "user" as const, content: "Third question", timestamp: 1002 };
+		await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ messages: [firstUser, firstResponse, secondUser, secondResponse, thirdUser] },
+			{ ...baseOptions, promptCache: { mode: "explicit" } },
+		).result();
+
+		expect(sentRequests).toHaveLength(3);
+		expect(JSON.stringify(sentRequests[0]?.input)).not.toContain("prompt_cache_breakpoint");
+		expect(sentRequests[1]?.previous_response_id).toBeUndefined();
+		expect(JSON.stringify(sentRequests[1]?.input)).toContain("prompt_cache_breakpoint");
+		expect(sentRequests[2]?.previous_response_id).toBe("resp_2");
+		expect(sentRequests[2]?.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "Third question" }] },
+		]);
+	});
+
 	it("preserves an established no-system cache breakpoint across chained turns", async () => {
 		const sentRequests: Array<Record<string, unknown>> = [];
 		const fetchMock = createCapturingFetch(sentRequests);

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -145,6 +145,41 @@ describe("openai-responses stateful chaining", () => {
 		]);
 	});
 
+	it("chains no-system explicit-cache turns without retroactively marking user history", async () => {
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = createCapturingFetch(sentRequests);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const options = {
+			apiKey: "test-key",
+			sessionId: "stateful-no-system-cache-session",
+			providerSessionState,
+			statefulResponses: true,
+			promptCache: { mode: "explicit" as const },
+			fetch: fetchMock,
+		};
+		const firstUser = { role: "user" as const, content: "First question", timestamp: 1000 };
+		const firstResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{ messages: [firstUser] },
+			options,
+		).result();
+		const secondResponse = await streamOpenAIResponses(
+			explicitPromptCacheModel,
+			{
+				messages: [firstUser, firstResponse, { role: "user", content: "Second question", timestamp: 1001 }],
+			},
+			options,
+		).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(sentRequests).toHaveLength(2);
+		expect(JSON.stringify(sentRequests[0]?.input)).not.toContain("prompt_cache_breakpoint");
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_1");
+		expect(sentRequests[1]?.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "Second question" }] },
+		]);
+	});
+
 	it("chains turns without appending an extra no-reasoning developer item", async () => {
 		const sentRequests: Array<Record<string, unknown>> = [];
 		const fetchMock = createCapturingFetch(sentRequests);

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added the native Meta Model API provider and Muse Spark 1.1 with Responses API reasoning replay, image input, and the full supported reasoning-effort ladder ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
+- Added resolved OpenAI GPT-5.6 prompt-cache breakpoint capability metadata, keeping older models and compatible endpoints opt-in only.
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -134,6 +134,15 @@ function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
 }
 
 /**
+ * Explicit prompt-cache breakpoints are a GPT-5.6+ first-party contract. Keep
+ * this intentionally narrow: compatible gateways and older OpenAI models
+ * reject the new request fields unless their catalog compat opts in.
+ */
+function supportsOfficialOpenAIPromptCacheBreakpoints(provider: string, modelId: string, baseUrl: string): boolean {
+	return isOfficialOpenAIEndpoint(provider, baseUrl) && /^gpt-5\.6(?:[-.]|$)/i.test(modelId);
+}
+
+/**
  * OpenCode's gateways (https://opencode.ai/zen|go) gate `reasoning_content`
  * on the request's thinking state for every model they front (Kimi K2.x,
  * DeepSeek V4, GLM-5.x, Qwen3.x, MiMo, MiniMax, …): they 400 with `Extra
@@ -341,6 +350,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		hostMatchesUrl(baseUrl, "fireworks") ||
 		isDirectDeepseekApi;
 
+	const supportsPromptCacheBreakpoints = supportsOfficialOpenAIPromptCacheBreakpoints(provider, spec.id, baseUrl);
 	// Hosts whose chat-completions endpoints are known to accept multiple
 	// leading `system`/`developer` messages (preferred for KV-cache reuse).
 	// Anything outside this allowlist defaults to coalescing because
@@ -546,6 +556,8 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 			(thinkingFormat === "qwen" || thinkingFormat === "qwen-chat-template") && isLocalOpenAICompatBackend,
 		requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
 		cacheControlFormat: isOpenRouter && spec.id.startsWith("anthropic/") ? "anthropic" : undefined,
+		supportsPromptCacheBreakpoints,
+		promptCacheBreakpointTtl: supportsPromptCacheBreakpoints ? "30m" : undefined,
 		openRouterRouting: undefined,
 		vercelGatewayRouting: undefined,
 		isOpenRouterHost: isOpenRouter,
@@ -624,6 +636,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 	const isOpenRouter = modelMatchesHost({ provider: spec.provider, baseUrl }, "openrouter");
 	const isOpenAIUrl = hostMatchesUrl(baseUrl, "openai");
 	const id = spec.id ?? "";
+	const supportsPromptCacheBreakpoints = supportsOfficialOpenAIPromptCacheBreakpoints(spec.provider, id, baseUrl);
 	const thinkingFormat: ResolvedOpenAISharedCompat["thinkingFormat"] = isOpenRouter ? "openrouter" : "openai";
 	const isKimiModel = id ? isKimiModelId(id) : false;
 	const isAnthropicModel = id ? isClaudeModelId(id) || isAnthropicNamespacedModelId(id) : false;
@@ -642,6 +655,8 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		supportsStrictMode: isAzure || detectStrictModeSupport(spec.provider, baseUrl),
 		supportsReasoningEffort: spec.provider !== "xai-oauth" || isGrokReasoningEffortCapable(id),
 		supportsLongPromptCacheRetention: isOpenAIUrl,
+		supportsPromptCacheBreakpoints,
+		promptCacheBreakpointTtl: supportsPromptCacheBreakpoints ? "30m" : undefined,
 		// Azure OpenAI and GitHub Copilot Responses paths require tool results
 		// to strictly match prior tool calls when building Responses inputs.
 		strictResponsesPairing: isAzure || spec.provider === "github-copilot",

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -9,6 +9,7 @@
  */
 import { isFireworksFastModelId } from "../fireworks-model-id";
 import { hostMatchesUrl, modelMatchesHost } from "../hosts";
+import { bareModelId, parseOpenAIModel, semverGte } from "../identity/classify";
 import {
 	isAnthropicNamespacedModelId,
 	isClaudeModelId,
@@ -139,7 +140,9 @@ function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
  * reject the new request fields unless their catalog compat opts in.
  */
 function supportsOfficialOpenAIPromptCacheBreakpoints(provider: string, modelId: string, baseUrl: string): boolean {
-	return isOfficialOpenAIEndpoint(provider, baseUrl) && /^gpt-5\.6(?:[-.]|$)/i.test(modelId);
+	if (!isOfficialOpenAIEndpoint(provider, baseUrl)) return false;
+	const model = parseOpenAIModel(bareModelId(modelId));
+	return model !== null && semverGte(model.version, "5.6");
 }
 
 /**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -306,6 +306,14 @@ export interface OpenAICompat {
 	promptCacheSessionHeader?: "x-grok-conv-id";
 	/** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
 	cacheControlFormat?: "anthropic" | undefined;
+	/**
+	 * Whether this endpoint/model accepts OpenAI's explicit
+	 * `prompt_cache_breakpoint` content markers and `prompt_cache_options`.
+	 * Defaults to the exact first-party model generation allowlist.
+	 */
+	supportsPromptCacheBreakpoints?: boolean;
+	/** The only currently supported minimum lifetime for explicit OpenAI cache breakpoints. */
+	promptCacheBreakpointTtl?: "30m";
 	/** Whether the provider supports the `strict` field in tool definitions. Default: auto-detected per provider/baseUrl (conservative for unknown providers). */
 	supportsStrictMode?: boolean;
 	/**
@@ -525,6 +533,14 @@ export interface ResolvedOpenAISharedCompat {
 	emptyLengthFinishIsContextError: boolean;
 	usesOpenAIToolCallIdLimit: boolean;
 	promptCacheSessionHeader?: OpenAICompat["promptCacheSessionHeader"];
+	/**
+	 * Whether this model accepts explicit OpenAI prompt-cache breakpoints.
+	 * Built catalog models always materialize this false-by-default value;
+	 * optionality preserves hand-authored resolved compat fixtures.
+	 */
+	supportsPromptCacheBreakpoints?: boolean;
+	/** Minimum cache lifetime supported by explicit OpenAI prompt-cache breakpoints. */
+	promptCacheBreakpointTtl?: "30m";
 	/** The model sits behind OpenRouter (routing prefs and max-token omission apply). */
 	isOpenRouterHost: boolean;
 	/** Whether this endpoint needs a max-token field even when caller did not set one. */
@@ -581,6 +597,8 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "emptyLengthFinishIsContextError"
 			| "usesOpenAIToolCallIdLimit"
 			| "promptCacheSessionHeader"
+			| "supportsPromptCacheBreakpoints"
+			| "promptCacheBreakpointTtl"
 			| "openRouterRouting"
 			| "isOpenRouterHost"
 			| "supportsStrictMode"

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -442,6 +442,14 @@ describe("OpenAI explicit prompt-cache breakpoint compat", () => {
 		).toBe(false);
 		expect(
 			buildOpenAIResponsesCompat({
+				id: "gpt-5.6",
+				provider: "openrouter",
+				name: "GPT 5.6 through OpenRouter",
+				baseUrl: "https://openrouter.ai/api/v1",
+			}).supportsPromptCacheBreakpoints,
+		).toBe(false);
+		expect(
+			buildOpenAIResponsesCompat({
 				id: "gpt-4.1",
 				provider: "openai",
 				name: "GPT 4.1",

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -401,6 +401,50 @@ describe("openai-completions wire-quirk compat detection", () => {
 	});
 });
 
+describe("OpenAI explicit prompt-cache breakpoint compat", () => {
+	it("enables the 30-minute breakpoint contract only for GPT-5.6 on the official API", () => {
+		const completions = buildOpenAICompat(
+			completionsSpec({ id: "gpt-5.6", provider: "openai", baseUrl: "https://api.openai.com/v1" }),
+		);
+		const responses = buildOpenAIResponsesCompat({
+			id: "gpt-5.6-mini",
+			provider: "openai",
+			name: "GPT 5.6 Mini",
+			baseUrl: "https://api.openai.com/v1",
+		});
+
+		expect(completions.supportsPromptCacheBreakpoints).toBe(true);
+		expect(completions.promptCacheBreakpointTtl).toBe("30m");
+		expect(responses.supportsPromptCacheBreakpoints).toBe(true);
+		expect(responses.promptCacheBreakpointTtl).toBe("30m");
+
+		expect(
+			buildOpenAICompat(completionsSpec({ id: "gpt-5.5", provider: "openai", baseUrl: "https://api.openai.com/v1" }))
+				.supportsPromptCacheBreakpoints,
+		).toBe(false);
+		expect(
+			buildOpenAIResponsesCompat({
+				id: "gpt-5.6",
+				provider: "openai",
+				name: "GPT 5.6",
+				baseUrl: "https://api.openai.com.evil/v1",
+			}).supportsPromptCacheBreakpoints,
+		).toBe(false);
+	});
+
+	it("keeps custom endpoint support opt-in", () => {
+		const compat = buildOpenAICompat(
+			completionsSpec({
+				id: "gpt-5.6",
+				compat: { supportsPromptCacheBreakpoints: true, promptCacheBreakpointTtl: "30m" },
+			}),
+		);
+
+		expect(compat.supportsPromptCacheBreakpoints).toBe(true);
+		expect(compat.promptCacheBreakpointTtl).toBe("30m");
+	});
+});
+
 describe("OpenRouter model discovery", () => {
 	it("keeps refreshed OpenRouter models on the OpenRouter pseudo API", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-openrouter-refresh-"));

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -402,7 +402,7 @@ describe("openai-completions wire-quirk compat detection", () => {
 });
 
 describe("OpenAI explicit prompt-cache breakpoint compat", () => {
-	it("enables the 30-minute breakpoint contract only for GPT-5.6 on the official API", () => {
+	it("enables the 30-minute breakpoint contract for GPT-5.6+ on the official API", () => {
 		const completions = buildOpenAICompat(
 			completionsSpec({ id: "gpt-5.6", provider: "openai", baseUrl: "https://api.openai.com/v1" }),
 		);
@@ -419,8 +419,34 @@ describe("OpenAI explicit prompt-cache breakpoint compat", () => {
 		expect(responses.promptCacheBreakpointTtl).toBe("30m");
 
 		expect(
+			buildOpenAICompat(
+				completionsSpec({ id: "gpt-5.6-preview", provider: "openai", baseUrl: "https://api.openai.com/v1" }),
+			).supportsPromptCacheBreakpoints,
+		).toBe(true);
+		expect(
+			buildOpenAICompat(completionsSpec({ id: "gpt-5.7", provider: "openai", baseUrl: "https://api.openai.com/v1" }))
+				.supportsPromptCacheBreakpoints,
+		).toBe(true);
+		expect(
+			buildOpenAIResponsesCompat({
+				id: "gpt-6.1-mini",
+				provider: "openai",
+				name: "GPT 6.1 Mini",
+				baseUrl: "https://api.openai.com/v1",
+			}).supportsPromptCacheBreakpoints,
+		).toBe(true);
+
+		expect(
 			buildOpenAICompat(completionsSpec({ id: "gpt-5.5", provider: "openai", baseUrl: "https://api.openai.com/v1" }))
 				.supportsPromptCacheBreakpoints,
+		).toBe(false);
+		expect(
+			buildOpenAIResponsesCompat({
+				id: "gpt-4.1",
+				provider: "openai",
+				name: "GPT 4.1",
+				baseUrl: "https://api.openai.com/v1",
+			}).supportsPromptCacheBreakpoints,
 		).toBe(false);
 		expect(
 			buildOpenAIResponsesCompat({


### PR DESCRIPTION
## What

- Adds resolved OpenAI compatibility gating for explicit prompt-cache breakpoints.
- Adds an opt-in `promptCache` policy for supported GPT-5.6 Chat Completions and Responses requests.
- Marks only an existing stable content block; string content is converted to the equivalent wire block without adding a message or changing text.
- Routes the option through `streamSimple` and Pi-native, preserves existing cache keys/legacy retention/stateful chains, and rejects unsupported explicit gateway input instead of silently dropping it.

## Why

I reviewed the full diff; this exposes OpenAI's explicit cache boundary without changing existing requests or manufacturing prompt content.

Explicit mode lets agentic callers place the cache breakpoint before changing input and avoid an automatic breakpoint consuming a write slot. It remains opt-in because cache writes have a cost and only help when the prefix is sufficiently stable and reused.

## Testing

- `bun test packages/ai/test/openai-responses-cache-affinity.test.ts packages/ai/test/openai-completions-cache-affinity.test.ts packages/ai/test/auth-gateway-openai-prompt-cache.test.ts packages/ai/test/auth-gateway-pi-native.test.ts packages/catalog/test/build.test.ts` — 87 passed
- `bun run check:ts` — passed
- Public `streamSimple`, direct provider, Pi-native, and auth-gateway fixtures cover unset, supported, unsupported, Azure, disabled retention, first-turn system prefix, text-only history, explicit-none, and stored-history isolation.
- No live OpenAI cold/warm pair was run because intentional credentials were unavailable.

---

- [x] `bun run check:ts` passes
- [x] Tested locally through public dispatch and exact wire fixtures
- [x] CHANGELOG updated

## AI Review Report

Independent review identified and remediation covered typed compat consumers, public dispatcher reachability, string-history markers, Azure rejection, first-turn system breakpoints, disabled-retention semantics, Pi-native forwarding, and raw auth-gateway handling. Final publish review inspected all changed files and found no remaining blocker.

## Security Audit

- No raw prompts, cache keys, or credentials are logged.
- Unknown and unsupported endpoints cannot receive the new fields by default.
- The implementation marks existing content only; it never injects a synthetic prompt message.
- Raw gateway requests using unsupported explicit fields receive a clear validation response instead of silent mutation or forwarding.
