### PR TITLE
fix(compaction): judge remote-preserve reuse against the active model

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider-switched sessions being stranded without their remotely-compacted history: compaction now judges whether a prior OpenAI remote-compaction replay payload can be reused against the active model rather than the whole candidate set, so switching to a model that cannot replay the payload re-expands the originals into a portable local summary instead of leaving the model with only a placeholder ([#6343](https://github.com/can1357/oh-my-pi/issues/6343)).
+
 ## [17.0.8] - 2026-07-22
 
 ### Fixed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -1130,33 +1130,37 @@ export interface CompactionPreparation {
 }
 
 /**
- * Whether a prior compaction's preserve data can be carried forward by the
- * upcoming compaction. A local compaction (no remote preserve) always can — it
- * holds a real textual summary. A remote compaction (V2 or V1) only can when
- * some candidate model shares its provider AND remote replay is still enabled;
- * otherwise its provider-native replay is dead weight and only the opaque
- * placeholder summary survives, so the caller must re-expand the originals.
+ * Whether a prior remote compaction's provider-native replay can still be read
+ * by the active model — the model that assembles the request context on every
+ * turn. A local compaction (no remote preserve) always can: it holds a real
+ * textual summary. A remote compaction (V2 or V1) only can when the active model
+ * shares the blob's provider AND remote replay is still enabled; otherwise the
+ * active model's encoder drops the payload (see `getOpenAIResponsesHistoryPayload`)
+ * and only the opaque placeholder summary survives, so the caller must re-expand
+ * the originals into a portable local summary rather than strand that history.
+ *
+ * Judged against the ACTIVE model, not the compaction candidate set: a role
+ * model (e.g. `modelRoles.smol`) that still maps to the blob's provider does not
+ * let the active model replay it, so keying reuse on "any candidate shares the
+ * provider" left a provider-switched session permanently context-less (#6343).
  */
-function remotePreserveReusableByAny(
+function remotePreserveReusable(
 	preserveData: Record<string, unknown> | undefined,
-	models: readonly Model[],
+	activeModel: Model,
 	settings: CompactionSettings,
 ): boolean {
 	const remote = getCompactionV2PreserveData(preserveData) ?? getPreservedOpenAiRemoteCompactionData(preserveData);
 	if (!remote) return true;
 	if (settings.remoteEnabled === false) return false;
-	for (const model of models) {
-		if (remote.provider !== model.provider) continue;
-		const v2Ok = settings.remoteStreamingV2Enabled !== false && shouldUseCompactionV2Streaming(model);
-		if (v2Ok || shouldUseOpenAiRemoteCompaction(model)) return true;
-	}
-	return false;
+	if (remote.provider !== activeModel.provider) return false;
+	const v2Ok = settings.remoteStreamingV2Enabled !== false && shouldUseCompactionV2Streaming(activeModel);
+	return v2Ok || shouldUseOpenAiRemoteCompaction(activeModel);
 }
 
 export function prepareCompaction(
 	pathEntries: SessionEntry[],
 	settings: CompactionSettings,
-	compactionModels: readonly Model[] = [],
+	activeModel?: Model,
 ): CompactionPreparation | undefined {
 	if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
 		return undefined;
@@ -1165,13 +1169,13 @@ export function prepareCompaction(
 	let prevCompactionIndex = -1;
 	for (let i = pathEntries.length - 1; i >= 0; i--) {
 		if (pathEntries[i].type !== "compaction") continue;
-		// Skip a prior remote compaction (V2 or V1) whose provider-native replay
-		// none of the upcoming compaction candidates can reuse: its summary is only
-		// an opaque placeholder, so re-expand its original messages and summarize
-		// them locally rather than stranding that history. compact() still reuses it
-		// when a candidate can (same provider, remote enabled).
+		// Skip a prior remote compaction (V2 or V1) whose provider-native replay the
+		// active model cannot read: its summary is only an opaque placeholder, so
+		// re-expand its original messages and summarize them locally rather than
+		// stranding that history. compact() still reuses the payload when the active
+		// model can replay it (same provider, remote enabled).
 		const entry = pathEntries[i] as CompactionEntry;
-		if (compactionModels.length > 0 && !remotePreserveReusableByAny(entry.preserveData, compactionModels, settings)) {
+		if (activeModel && !remotePreserveReusable(entry.preserveData, activeModel, settings)) {
 			continue;
 		}
 		prevCompactionIndex = i;
@@ -1502,7 +1506,7 @@ export async function compact(
 		// summarization so a successful remote compaction never pays for a second,
 		// redundant LLM round. If a LATER compaction cannot reuse this payload,
 		// prepareCompaction re-expands the original messages and summarizes them
-		// locally then (see remotePreserveReusableByAny).
+		// locally then (see remotePreserveReusable).
 		const usedTokens = getCompactionV2PreserveData(preserveData)?.usedTokens ?? 0;
 		summary =
 			"Remote compaction preserved provider-native history for this session." +

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -1256,16 +1256,87 @@ describe("compact() remote compaction failure handling", () => {
 		const baseSettings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 1 };
 
 		// Remote disabled → the V2 replay is unusable → re-expand the pre-V2 original.
-		const reexpanded = prepareCompaction(entries, { ...baseSettings, remoteEnabled: false }, [v2Model]);
+		const reexpanded = prepareCompaction(entries, { ...baseSettings, remoteEnabled: false }, v2Model);
 		expect(reexpanded).toBeDefined();
 		const reexpandedText = JSON.stringify(reexpanded?.messagesToSummarize ?? []);
 		expect(reexpandedText).toContain("ORIGINAL ALPHA port 4242");
 
 		// Remote + V2 still enabled, same provider → reuse the replay, don't re-summarize originals.
-		const reused = prepareCompaction(entries, { ...baseSettings, remoteStreamingV2Enabled: true }, [v2Model]);
+		const reused = prepareCompaction(entries, { ...baseSettings, remoteStreamingV2Enabled: true }, v2Model);
 		expect(reused).toBeDefined();
 		const reusedText = JSON.stringify(reused?.messagesToSummarize ?? []);
 		expect(reusedText).not.toContain("ORIGINAL ALPHA port 4242");
+	});
+
+	test("re-expands a stranded remote compaction when the active model cannot replay it (#6343)", () => {
+		const ts = (n: number) => new Date(n).toISOString();
+		const anthropicActive = buildModel({
+			id: "claude-sonnet-4-5",
+			name: "Claude Sonnet 4.5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+		});
+		const openaiSmol = makeOpenAiModel({ id: "gpt-5-mini", name: "GPT-5 mini" });
+		// Prior OpenAI remote compaction: opaque placeholder summary, provider-native
+		// replay stored under preserveData tagged "openai".
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "m1",
+				parentId: null,
+				timestamp: ts(1),
+				message: { role: "user", content: "ORIGINAL ALPHA port 4242", timestamp: 1 },
+			},
+			{
+				type: "compaction",
+				id: "c1",
+				parentId: "m1",
+				timestamp: ts(2),
+				summary: "Remote compaction preserved provider-native history for this session.",
+				firstKeptEntryId: "m1",
+				tokensBefore: 100_000,
+				preserveData: {
+					openaiRemoteCompaction: {
+						provider: "openai",
+						replacementHistory: [{ type: "message", role: "user", content: "opaque native replay" }],
+						compactionItem: { type: "compaction", encrypted_content: "enc_v1" },
+					},
+				},
+			},
+			{
+				type: "message",
+				id: "m2",
+				parentId: "c1",
+				timestamp: ts(3),
+				message: { role: "user", content: "second turn", timestamp: 3 },
+			},
+			{
+				type: "message",
+				id: "m3",
+				parentId: "m2",
+				timestamp: ts(4),
+				message: { role: "user", content: "third turn", timestamp: 4 },
+			},
+		];
+		const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 1 };
+		// Reuse is judged by the ACTIVE model, not the candidate set. The active
+		// anthropic model's encoder drops the OpenAI replay payload, so the stranded
+		// originals are re-expanded into a portable local summary — even though the
+		// OpenAI smol role could still replay the blob.
+		const foreignActive = prepareCompaction(entries, settings, anthropicActive);
+		expect(foreignActive).toBeDefined();
+		expect(JSON.stringify(foreignActive?.messagesToSummarize ?? [])).toContain("ORIGINAL ALPHA port 4242");
+		// The same-provider OpenAI model can replay the payload, so the boundary is
+		// kept and the originals are not re-summarized.
+		const sameProviderActive = prepareCompaction(entries, settings, openaiSmol);
+		expect(sameProviderActive).toBeDefined();
+		expect(JSON.stringify(sameProviderActive?.messagesToSummarize ?? [])).not.toContain("ORIGINAL ALPHA port 4242");
 	});
 
 	test("user abort during the remote compact request rejects without falling back to local summarization", async () => {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3811,11 +3811,7 @@ export class AgentSession {
 			this.sessionId,
 			advisor.slug,
 		);
-		const preparation = prepareCompaction(
-			pathEntries,
-			compactionSettings,
-			await this.#runnableCompactionCandidates(candidates, advisorProviderSessionId),
-		);
+		const preparation = prepareCompaction(pathEntries, compactionSettings, advisorModel);
 		if (!preparation) {
 			// Cannot prepare compaction, fallback to re-prime
 			return true;
@@ -11031,11 +11027,7 @@ export class AgentSession {
 				compactionCandidates = this.#getCompactionModelCandidates(availableModels);
 			}
 			const pathEntries = this.sessionManager.getBranch();
-			const preparation = prepareCompaction(
-				pathEntries,
-				effectiveSettings,
-				await this.#runnableCompactionCandidates(compactionCandidates, this.sessionId),
-			);
+			const preparation = prepareCompaction(pathEntries, effectiveSettings, this.model);
 			if (!preparation) {
 				// Check why we can't compact
 				const lastEntry = pathEntries[pathEntries.length - 1];
@@ -13386,17 +13378,6 @@ export class AgentSession {
 		return this.#resolveCompactionModelCandidates(this.model, availableModels, filter);
 	}
 
-	/**
-	 * Compaction candidates that can actually run — those with a resolvable API
-	 * key, matching the per-candidate getApiKey gate the execution loop applies.
-	 * Re-expansion reusability (prepareCompaction) must judge remote-preserve
-	 * reuse against these, not against candidates the loop would skip at runtime.
-	 */
-	async #runnableCompactionCandidates(candidates: readonly Model[], sessionId: string | undefined): Promise<Model[]> {
-		const keys = await Promise.all(candidates.map(model => this.#modelRegistry.getApiKey(model, sessionId)));
-		return candidates.filter((_, index) => keys[index] !== undefined);
-	}
-
 	#resolveCompactionModelCandidates(
 		preferredModel: Model | null | undefined,
 		availableModels: Model[],
@@ -14025,12 +14006,8 @@ export class AgentSession {
 
 			const pathEntries = this.sessionManager.getBranch();
 
-			const autoCompactionCandidates = await this.#runnableCompactionCandidates(
-				this.#getCompactionModelCandidates(availableModels),
-				this.sessionId,
-			);
 			let pathEntriesForCompaction = pathEntries;
-			let preparation = prepareCompaction(pathEntriesForCompaction, compactionSettings, autoCompactionCandidates);
+			let preparation = prepareCompaction(pathEntriesForCompaction, compactionSettings, this.model);
 			if (!preparation) {
 				// prepareCompaction found nothing to summarize because the kept region
 				// is a single oversized recent turn — findCutPoint never cuts inside a
@@ -14057,11 +14034,7 @@ export class AgentSession {
 							// branch has been rewritten either way.
 							rescueRewroteHistory = true;
 							pathEntriesForCompaction = this.sessionManager.getBranch();
-							preparation = prepareCompaction(
-								pathEntriesForCompaction,
-								compactionSettings,
-								autoCompactionCandidates,
-							);
+							preparation = prepareCompaction(pathEntriesForCompaction, compactionSettings, this.model);
 							return preparation !== undefined;
 						},
 					});


### PR DESCRIPTION
## Repro
After a successful OpenAI remote compaction (V2 streaming or V1 `/responses/compact`), the `CompactionEntry` carries only a placeholder summary; the real history lives in `preserveData.openaiRemoteCompaction`, tagged with the producing provider. If the session then switches to a different provider (manual `/model` or a `retry.fallbackChains` failover), the new provider's encoder drops that payload and the model is left with only the placeholder. The re-expansion safeguard in `prepareCompaction` is supposed to self-heal by re-summarizing the originals locally, but never fires in multi-role configs. A unit test on `prepareCompaction` reproduces it: a prior OpenAI remote compaction, active model switched to `anthropic`, with `modelRoles.smol` still on an OpenAI model:

```
bun test packages/agent/test/remote-compaction.test.ts -t "stranded remote compaction when the active model cannot replay"

Expected to contain: "ORIGINAL ALPHA port 4242"
Received: "[{\"role\":\"user\",\"content\":\"second turn\",\"timestamp\":3}]"
```

The compacted span is stranded: `messagesToSummarize` holds only the post-compaction turn.

## Cause
`remotePreserveReusableByAny` (`packages/agent/src/compaction/compaction.ts`) returned true when *any* compaction candidate shared the blob's provider. Candidates come from `#resolveCompactionModelCandidates` (`packages/coding-agent/src/session/agent-session.ts`): the active model, every `MODEL_ROLE_IDS` role model, and the largest-context available model. As long as one role stays on OpenAI, the check passes, `prepareCompaction` keeps the stale boundary, and the originals are never re-expanded — while the active non-OpenAI model's encoder (`getOpenAIResponsesHistoryPayload`, `packages/ai/src/utils.ts`) drops the payload on every turn. The safeguard's own docstring says it exists "rather than stranding that history", so this is a hole in an existing guard, not intended behavior.

## Fix
- Renamed `remotePreserveReusableByAny` to `remotePreserveReusable` and changed it to judge a single **active** model (the model that assembles the request context each turn) instead of iterating the candidate set: reuse requires `remote.provider === activeModel.provider` plus the existing remote-enabled/capability check.
- Changed `prepareCompaction`'s third parameter from `compactionModels: readonly Model[]` to `activeModel?: Model`; the skip/re-expand gate now runs when the active model cannot replay the payload.
- Updated the four call sites in `agent-session.ts` to pass the reader model (`this.model` for auto-compaction and `/compact`, `advisorModel` for advisor maintenance). Removed the now-unused `#runnableCompactionCandidates` helper (its only purpose was feeding the old candidate-set gate).
- Added a regression test asserting the active model governs the decision: a foreign-provider active model re-expands the stranded originals, while a same-provider active model still reuses the payload. Updated the existing V2 re-expansion test to the new single-model signature.

## Verification
`bun test packages/agent/test/remote-compaction.test.ts` — 25 pass. `bun test packages/coding-agent/test/compaction.test.ts` plus the auto-compaction/snapcompact suites — 89 pass, 1 skip. `bun check` — exit 0 (TypeScript + Rust clean). The reproduction test now passes; the compacted span is re-expanded for the active model that cannot replay the payload. Fixes #6343