### PR TITLE
fix(edit): align relative path resolution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed direct edit calls failing with `File not found` for relative paths that `read` resolved to a unique nested workspace file. ([#6359](https://github.com/can1357/oh-my-pi/issues/6359))
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.
 - Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.
 - Fixed used-only absolute usage amounts across output surfaces: CLI now renders `$123.45 used`; the TUI shows a neutral, width-bounded amount instead of a pending/dotted/account-count placeholder; and ACP preserves `123.45 usd used` while suppressing duplicate window suffixes such as `— extra`. ([#5575](https://github.com/can1357/oh-my-pi/issues/5575))

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -3,7 +3,7 @@ import hashlineGrammar from "@oh-my-pi/hashline/grammar.lark" with { type: "text
 import hashlineDescription from "@oh-my-pi/hashline/prompt.md" with { type: "text" };
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample } from "@oh-my-pi/pi-ai";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { isEnoent, isEnotdir, prompt } from "@oh-my-pi/pi-utils";
 import { createLspWritethrough, flushLspWritethroughBatch, type WritethroughCallback, writethroughNoop } from "../lsp";
 import { DeferredDiagnostics } from "../lsp/deferred-diagnostics";
 import { getDiagnosticsLedger } from "../lsp/diagnostics-ledger";
@@ -12,7 +12,8 @@ import patchDescription from "../prompts/tools/patch.md" with { type: "text" };
 import replaceDescription from "../prompts/tools/replace.md" with { type: "text" };
 import type { ToolSession } from "../tools";
 import { truncateForPrompt } from "../tools/approval";
-import { isInternalUrlPath } from "../tools/path-utils";
+import { findUniqueWorkspaceSuffix, isInternalUrlPath } from "../tools/path-utils";
+import { resolvePlanPath } from "../tools/plan-mode-guard";
 import { type EditMode, normalizeEditMode, resolveEditMode } from "../utils/edit-mode";
 import { executeHashlineSingle, hashlineEditParamsSchema } from "./hashline";
 import { type ApplyPatchParams, applyPatchSchema, expandApplyPatchToEntries } from "./modes/apply-patch";
@@ -71,6 +72,24 @@ function resolveConfiguredEditMode(rawEditMode: string): EditMode | undefined {
 	}
 
 	return editMode;
+}
+
+async function resolveEditPath(
+	session: ToolSession,
+	authoredPath: string,
+	options: { mustExist: boolean; signal?: AbortSignal },
+): Promise<string> {
+	if (!options.mustExist || isInternalUrlPath(authoredPath)) return authoredPath;
+
+	try {
+		await Bun.file(resolvePlanPath(session, authoredPath)).stat();
+		return authoredPath;
+	} catch (error) {
+		if (!isEnoent(error) && !isEnotdir(error)) throw error;
+	}
+
+	const match = await findUniqueWorkspaceSuffix(authoredPath, session.cwd, options.signal);
+	return match?.displayPath ?? authoredPath;
 }
 
 function resolveAllowFuzzy(session: ToolSession, rawValue: string): boolean {
@@ -517,7 +536,7 @@ export class EditTool implements AgentTool<TInput> {
 						note: "All entries in one call apply to the top-level `path`; use separate calls for different files.",
 					},
 				] satisfies readonly ToolExample<PatchParams>[],
-				execute: (
+				execute: async (
 					tool: EditTool,
 					params: EditParams,
 					signal: AbortSignal | undefined,
@@ -525,11 +544,15 @@ export class EditTool implements AgentTool<TInput> {
 					onUpdate?: (partialResult: AgentToolResult<EditToolDetails, TInput>) => void,
 				) => {
 					const { edits, path } = params as PatchParams;
+					const targetPath = await resolveEditPath(tool.session, path, {
+						mustExist: (edits[0]?.op ?? "update") !== "create",
+						signal,
+					});
 					const runs = (edits as PatchEditEntry[]).map(
 						entry => (br: LspBatchRequest | undefined) =>
 							executePatchSingle({
 								session: tool.session,
-								path,
+								path: targetPath,
 								params: entry,
 								signal,
 								batchRequest: br,
@@ -542,7 +565,7 @@ export class EditTool implements AgentTool<TInput> {
 								beginDeferredDiagnosticsForPath: p => tool.#deferredDiagnostics.begin(p),
 							}),
 					);
-					return executeSinglePathEntries(path, runs, batchRequest, onUpdate, tool.session.cwd, signal);
+					return executeSinglePathEntries(targetPath, runs, batchRequest, onUpdate, tool.session.cwd, signal);
 				},
 			},
 			apply_patch: {
@@ -568,10 +591,14 @@ export class EditTool implements AgentTool<TInput> {
 						const { path, ...patchParams } = entry;
 						return {
 							path,
-							run: (br: LspBatchRequest | undefined) =>
-								executePatchSingle({
+							run: async (br: LspBatchRequest | undefined) => {
+								const targetPath = await resolveEditPath(tool.session, path, {
+									mustExist: patchParams.op !== "create",
+									signal,
+								});
+								return executePatchSingle({
 									session: tool.session,
-									path,
+									path: targetPath,
 									params: patchParams,
 									signal,
 									batchRequest: br,
@@ -579,7 +606,8 @@ export class EditTool implements AgentTool<TInput> {
 									fuzzyThreshold: tool.#fuzzyThreshold,
 									writethrough: tool.#writethrough,
 									beginDeferredDiagnosticsForPath: p => tool.#deferredDiagnostics.begin(p),
-								}),
+								});
+							},
 						};
 					});
 					return executeApplyPatchPerFile(perFile, batchRequest, tool.session.cwd, signal, onUpdate);
@@ -609,7 +637,7 @@ export class EditTool implements AgentTool<TInput> {
 			replace: {
 				description: () => prompt.render(replaceDescription),
 				parameters: replaceEditSchema,
-				execute: (
+				execute: async (
 					tool: EditTool,
 					params: EditParams,
 					signal: AbortSignal | undefined,
@@ -617,11 +645,12 @@ export class EditTool implements AgentTool<TInput> {
 					onUpdate?: (partialResult: AgentToolResult<EditToolDetails, TInput>) => void,
 				) => {
 					const { edits, path } = params as ReplaceParams;
+					const targetPath = await resolveEditPath(tool.session, path, { mustExist: true, signal });
 					const runs = (edits as ReplaceEditEntry[]).map(
 						entry => (br: LspBatchRequest | undefined) =>
 							executeReplaceSingle({
 								session: tool.session,
-								path,
+								path: targetPath,
 								params: entry,
 								signal,
 								batchRequest: br,
@@ -631,7 +660,7 @@ export class EditTool implements AgentTool<TInput> {
 								beginDeferredDiagnosticsForPath: p => tool.#deferredDiagnostics.begin(p),
 							}),
 					);
-					return executeSinglePathEntries(path, runs, batchRequest, onUpdate, tool.session.cwd, signal);
+					return executeSinglePathEntries(targetPath, runs, batchRequest, onUpdate, tool.session.cwd, signal);
 				},
 			},
 		}[this.mode];

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -2,10 +2,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
-import { isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
+import { glob } from "@oh-my-pi/pi-natives";
+import { isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
-import { ToolError } from "./tool-errors";
+import { ToolAbortError, ToolError } from "./tool-errors";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 // A single line-range chunk: `N`, `N-M`, `N+K`, or open-ended `N-`. `..` is
@@ -1130,6 +1131,52 @@ export function resolveReadPath(filePath: string, cwd: string): string {
 	}
 
 	return resolved;
+}
+
+const WORKSPACE_SUFFIX_TIMEOUT_MS = 5000;
+
+function escapeGlobMetachars(value: string): string {
+	return value.replace(/[*?[{]/g, "[$&]");
+}
+
+/**
+ * Find a unique workspace entry whose trailing path matches a missing authored path.
+ * Returns `null` for no match, ambiguity, timeout, or scan failure.
+ */
+export async function findUniqueWorkspaceSuffix(
+	rawPath: string,
+	cwd: string,
+	signal?: AbortSignal,
+): Promise<{ absolutePath: string; displayPath: string } | null> {
+	const normalized = rawPath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
+	if (!normalized) return null;
+
+	const timeoutSignal = AbortSignal.timeout(WORKSPACE_SUFFIX_TIMEOUT_MS);
+	const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+
+	let matches: string[];
+	try {
+		const result = await untilAborted(combinedSignal, () =>
+			glob({
+				pattern: `**/${escapeGlobMetachars(normalized)}`,
+				path: cwd,
+				hidden: true,
+			}),
+		);
+		matches = result.matches.map(match => match.path);
+	} catch (error) {
+		if (error instanceof Error && error.name === "AbortError") {
+			if (!signal?.aborted) return null;
+			throw new ToolAbortError();
+		}
+		return null;
+	}
+
+	if (matches.length !== 1) return null;
+	return {
+		absolutePath: path.resolve(cwd, matches[0]),
+		displayPath: matches[0],
+	};
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -11,7 +11,7 @@ import type {
 	ToolTier,
 } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
-import { glob, type SummaryResult, summarizeCode } from "@oh-my-pi/pi-natives";
+import { type SummaryResult, summarizeCode } from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
 import {
@@ -21,7 +21,6 @@ import {
 	logger,
 	prompt,
 	readImageMetadata,
-	untilAborted,
 } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import { LRUCache } from "lru-cache/raw";
@@ -94,6 +93,7 @@ import {
 } from "./output-meta";
 import {
 	expandPath,
+	findUniqueWorkspaceSuffix,
 	formatPathRelativeToCwd,
 	isReadableUrlPath,
 	type LineRange,
@@ -639,67 +639,11 @@ async function streamLinesFromFile(
 
 // Maximum image file size (20MB) - larger images will be rejected to prevent OOM during serialization
 const MAX_IMAGE_SIZE = MAX_IMAGE_INPUT_BYTES;
-const GLOB_TIMEOUT_MS = 5000;
 
 function isNotFoundError(error: unknown): boolean {
 	if (!error || typeof error !== "object") return false;
 	const code = (error as { code?: string }).code;
 	return code === "ENOENT" || code === "ENOTDIR";
-}
-
-/**
- * Escape glob metacharacters so a literal path (e.g. `foo[1].ts`) interpolated
- * into a suffix-glob pattern matches itself. Each metachar is wrapped in a
- * character class (the native glob engine rewrites `\` to `/`, so backslash
- * escaping is unavailable). `]`/`}` need no escaping once their openers are
- * neutralized — unmatched closers are literal.
- */
-function escapeGlobMetachars(value: string): string {
-	return value.replace(/[*?[{]/g, "[$&]");
-}
-
-/**
- * Attempt to resolve a non-existent path by finding a unique suffix match within the workspace.
- * Uses a glob suffix pattern so the native engine handles matching directly.
- * Returns null when 0 or >1 candidates match (ambiguous = no auto-resolution).
- */
-async function findUniqueSuffixMatch(
-	rawPath: string,
-	cwd: string,
-	signal?: AbortSignal,
-): Promise<{ absolutePath: string; displayPath: string } | null> {
-	const normalized = rawPath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
-	if (!normalized) return null;
-	const pattern = `**/${escapeGlobMetachars(normalized)}`;
-
-	const timeoutSignal = AbortSignal.timeout(GLOB_TIMEOUT_MS);
-	const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
-
-	let matches: string[];
-	try {
-		const result = await untilAborted(combinedSignal, () =>
-			glob({
-				pattern,
-				path: cwd,
-				// No fileType filter: matches both files and directories
-				hidden: true,
-			}),
-		);
-		matches = result.matches.map(m => m.path);
-	} catch (error) {
-		if (error instanceof Error && error.name === "AbortError") {
-			if (!signal?.aborted) return null; // timeout — give up silently
-			throw new ToolAbortError();
-		}
-		return null;
-	}
-
-	if (matches.length !== 1) return null;
-
-	return {
-		absolutePath: path.resolve(cwd, matches[0]),
-		displayPath: matches[0],
-	};
 }
 
 function decodeUtf8Text(bytes: Uint8Array): string | null {
@@ -991,7 +935,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	}
 
 	/**
-	 * Memoized {@link findUniqueSuffixMatch} for a single read call. A missing
+	 * Memoized {@link findUniqueWorkspaceSuffix} for a single read call. A missing
 	 * path with archive/sqlite extensions probes the workspace once per stage
 	 * (archive candidates, sqlite candidates, plain path) — each glob carries a
 	 * 5s timeout, so repeated lookups of the same string stack into a long
@@ -1004,7 +948,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	): Promise<{ absolutePath: string; displayPath: string } | null> {
 		const hit = cache.get(rawPath);
 		if (hit !== undefined) return hit;
-		const result = await findUniqueSuffixMatch(rawPath, this.session.cwd, signal);
+		const result = await findUniqueWorkspaceSuffix(rawPath, this.session.cwd, signal);
 		cache.set(rawPath, result);
 		return result;
 	}

--- a/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
+++ b/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { type ExecuteHashlineSingleOptions, executeHashlineSingle } from "@oh-my-pi/pi-coding-agent/edit";
+import { EditTool, type ExecuteHashlineSingleOptions, executeHashlineSingle } from "@oh-my-pi/pi-coding-agent/edit";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import type { ReadToolDetails } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
@@ -139,6 +139,63 @@ describe("read → edit round-trip for out-of-cwd files", () => {
 
 		expect(textOutput(result)).toContain("Workspace content.");
 		expect(textOutput(result)).not.toContain("Artifact content.");
+	});
+
+	it("uses the read-resolved workspace suffix across direct edit modes", async () => {
+		const cases: Array<{
+			mode: "replace" | "patch" | "apply_patch";
+			run: (tool: EditTool, fileName: string) => Promise<void>;
+		}> = [
+			{
+				mode: "replace",
+				run: async (tool, fileName) => {
+					await tool.execute("edit-workspace-suffix-replace", {
+						path: fileName,
+						edits: [{ old_text: "alpha", new_text: "ALPHA" }],
+					});
+				},
+			},
+			{
+				mode: "patch",
+				run: async (tool, fileName) => {
+					await tool.execute("edit-workspace-suffix-patch", {
+						path: fileName,
+						edits: [{ op: "update", diff: "@@\n-alpha\n+ALPHA" }],
+					});
+				},
+			},
+			{
+				mode: "apply_patch",
+				run: async (tool, fileName) => {
+					const input = [
+						"*** Begin Patch",
+						`*** Update File: ${fileName}`,
+						"@@",
+						"-alpha",
+						"+ALPHA",
+						"*** End Patch",
+						"",
+					].join("\n");
+					await tool.execute("edit-workspace-suffix-apply-patch", { input });
+				},
+			},
+		];
+
+		for (const testCase of cases) {
+			const fileName = `${testCase.mode}.txt`;
+			const workspaceFile = path.join(cwdDir, "src", fileName);
+			await Bun.write(workspaceFile, "alpha\nbeta\n");
+
+			const session = createSession(cwdDir);
+			session.settings.set("edit.mode", testCase.mode);
+			const readResult = await new ReadTool(session).execute(`read-workspace-suffix-${testCase.mode}`, {
+				path: fileName,
+			});
+			expect(textOutput(readResult)).toContain("alpha");
+
+			await testCase.run(new EditTool(session), fileName);
+			expect(await Bun.file(workspaceFile).text()).toBe("ALPHA\nbeta\n");
+		}
 	});
 
 	it("prefers a unique workspace suffix match over the approved local plan alias", async () => {


### PR DESCRIPTION
## Repro

Create `src/notes.txt`, then call `read` with `path: "notes.txt"` followed by replace-mode `edit` with the same relative path. Before this change, `bun test packages/coding-agent/test/read-edit-out-of-cwd.test.ts` fails because read finds the unique nested workspace suffix while edit throws `File not found: notes.txt`.

## Cause

`ReadTool` owned a private `findUniqueSuffixMatch` fallback, while the direct replace, patch, and apply-patch paths in `packages/coding-agent/src/edit/index.ts` passed authored paths directly to `resolvePlanPath`; missing cwd-relative paths therefore never received the workspace suffix resolution already used by read.

## Fix

- Move unique workspace suffix lookup into shared `tools/path-utils.ts` resolution code.
- Resolve existing direct edit targets through that shared lookup while preserving authored destinations for create operations and refusing ambiguous matches.
- Cover replace, patch, and apply-patch read-to-edit round trips and document the fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/read-edit-out-of-cwd.test.ts packages/coding-agent/test/core/apply-patch.test.ts packages/coding-agent/test/core/apply-patch-multi-file.test.ts packages/coding-agent/test/edit-per-file-diff-content.test.ts packages/coding-agent/test/edit-patch-unchanged-error.test.ts packages/coding-agent/test/tools/path-literal-colon-selector.test.ts` — 124 passed, 0 failed. `bun check` passed across all packages.

Fixes #6359