### PR TITLE
fix(tool): expand internal urls inside backtick substitutions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed bash internal-URL expansion skipping unquoted `skill://` (and other supported schemes) inside a legacy backtick command substitution nested directly in double quotes (e.g. ``echo "`cat skill://valid-skill/SKILL.md`"``); `isInsideShellQuote` now treats `` ` `` as an expansion-context boundary like `$()`, including `$()`/backtick nesting in either order, while single-quoted and escaped-backtick text stay literal ([#5645](https://github.com/can1357/oh-my-pi/issues/5645)).
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -144,6 +144,8 @@ function unquoteToken(token: string): string {
 function isInsideShellQuote(command: string, index: number): boolean {
 	type ShellQuote = "'" | '"' | undefined;
 	interface CommandSubstitution {
+		/** `$(` … `)` tracks paren depth; `` ` `` … `` ` `` is a plain toggle. */
+		kind: "dollar" | "backtick";
 		outerQuote: ShellQuote;
 		depth: number;
 	}
@@ -165,15 +167,26 @@ function isInsideShellQuote(command: string, index: number): boolean {
 			continue;
 		}
 		if (char === "$" && command[i + 1] === "(" && quote !== "'") {
-			substitutions.push({ outerQuote: quote, depth: 1 });
+			substitutions.push({ kind: "dollar", outerQuote: quote, depth: 1 });
 			quote = undefined;
 			i++;
+			continue;
+		}
+		if (char === "`" && quote !== "'") {
+			const top = substitutions.at(-1);
+			if (top?.kind === "backtick") {
+				substitutions.pop();
+				quote = top.outerQuote;
+			} else {
+				substitutions.push({ kind: "backtick", outerQuote: quote, depth: 0 });
+				quote = undefined;
+			}
 			continue;
 		}
 		if (quote !== undefined) continue;
 
 		const substitution = substitutions.at(-1);
-		if (!substitution) continue;
+		if (substitution?.kind !== "dollar") continue;
 		if (char === "(") {
 			substitution.depth++;
 		} else if (char === ")") {

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -216,6 +216,58 @@ describe("expandInternalUrls", () => {
 		);
 	});
 
+	it("expands an unquoted URL inside a backtick substitution nested in double quotes", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = 'echo "`cat skill://valid-skill/SKILL.md`"';
+		const expectedPath = path.join(skills[0].baseDir, "SKILL.md");
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(
+			`echo "\`cat ${shellEscape(expectedPath)}\`"`,
+		);
+	});
+
+	it("expands a top-level unquoted URL inside a backtick substitution", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = "echo `cat skill://valid-skill/SKILL.md`";
+		const expectedPath = path.join(skills[0].baseDir, "SKILL.md");
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(`echo \`cat ${shellEscape(expectedPath)}\``);
+	});
+
+	it("expands nested $() inside a double-quoted backtick substitution", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = 'echo "`echo $(cat skill://valid-skill/SKILL.md)`"';
+		const expectedPath = path.join(skills[0].baseDir, "SKILL.md");
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(
+			`echo "\`echo $(cat ${shellEscape(expectedPath)})\`"`,
+		);
+	});
+
+	it("expands nested backticks inside a double-quoted $() substitution", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = 'echo "$(echo `cat skill://valid-skill/SKILL.md`)"';
+		const expectedPath = path.join(skills[0].baseDir, "SKILL.md");
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(
+			`echo "$(echo \`cat ${shellEscape(expectedPath)}\`)"`,
+		);
+	});
+
+	it("leaves a URL inside a single-quoted backtick string literal", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = "echo '`cat skill://valid-skill/SKILL.md`'";
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(command);
+	});
+
+	it("leaves a URL behind an escaped backtick in double quotes literal", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = 'echo "\\`skill://valid-skill/SKILL.md\\`"';
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(command);
+	});
+
 	it("leaves literal internal URLs embedded in quoted text unchanged", async () => {
 		const router = createInternalRouter({
 			"memory://root/summary.md": { sourcePath: "/tmp/memories/summary.md" },


### PR DESCRIPTION
## Repro
On current `main`, expanding a bash command through `expandInternalUrls` (`packages/coding-agent/src/tools/bash-skill-urls.ts`) leaves an unquoted internal URL literal when it sits inside a legacy backtick command substitution that is itself nested directly in double quotes:

```text
echo "`cat skill://valid-skill/SKILL.md`"   # skill:// left unchanged
```

The equivalent `$()` form, top-level backticks, and `$()`/backtick combinations already expand. (The report also listed the top-level and `$()`-wrapped backtick forms as broken; those already work on `main` — the sole genuine defect is a backtick pair directly inside double quotes.)

## Cause
`isInsideShellQuote` opens/closes an expansion context for `$(` … `)` (pushing the outer quote, resetting to unquoted inside, restoring on the closing paren) but never treats a `` ` `` as a substitution boundary. A backtick pair nested in double quotes therefore keeps the surrounding `"` active, so `isEmbeddedInQuotedText` classifies the token as quoted-literal text and skips it.

## Fix
- `isInsideShellQuote`: track substitutions with a `kind` (`"dollar"` | `"backtick"`) on the existing stack.
- An unescaped `` ` `` outside single quotes toggles a backtick context — open (push outer quote, reset to unquoted) or, when the stack top is already a backtick, close (restore the outer quote) — mirroring `$()`, including `$()`/backtick nesting in either order.
- Paren depth tracking now applies only to `dollar` substitutions; single-quoted and escaped-backtick text stay literal.

## Verification
`bun test test/tools/bash-skill-urls.test.ts` → 39 pass / 0 fail. Added six regression cases: double-quoted backtick substitution, top-level backtick, `$()` nested inside a double-quoted backtick, backticks nested inside a double-quoted `$()`, single-quoted backtick (literal), and escaped backtick (literal). Manually confirmed all seven scenarios from the issue behave as expected after the fix.

Fixes #5645