### PR TITLE
fix(tts): play buffered audio when streaming backend exits nonzero

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed `omp say` playing no audio for a short single-segment clip on hosts where the first streaming backend (the bundled ffmpeg built without pulse/alsa output) spawns then exits nonzero: the pipe write succeeds before that death and `player.end()` has already closed the input, so neither the broken-pipe replay nor the early-exit handler advanced to `paplay`/`aplay`. `StreamingAudioPlayer` now retains the utterance PCM and, when the streaming backend exits nonzero, replays it through per-file playback so short clips still reach the speakers ([#5875](https://github.com/can1357/oh-my-pi/issues/5875)).
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.

--- a/packages/coding-agent/src/tts/streaming-player.ts
+++ b/packages/coding-agent/src/tts/streaming-player.ts
@@ -90,6 +90,18 @@ export function streamingPlayerCommandsFor(
 }
 
 /**
+ * Test seams for {@link StreamingAudioPlayer}: override backend discovery and
+ * the per-file fallback so playback logic can be exercised without a real audio
+ * device. Both default to the platform lookup and {@link playAudioFile}.
+ */
+export interface StreamingPlayerOptions {
+	/** Ordered backend commands for a sample rate; defaults to {@link streamingPlayerCommandsFor}. */
+	commandsFor?: (sampleRate: number) => PlayerCommand[];
+	/** Per-file fallback playback; defaults to {@link playAudioFile}. */
+	playAudio?: (wavPath: string, signal: AbortSignal) => Promise<void>;
+}
+
+/**
  * Single-session gapless player. Lifecycle: {@link start} once, {@link write}
  * chunks in order, then {@link end} to drain or {@link stop} to abort. Not
  * reusable after stop/end — create a new instance per utterance.
@@ -111,6 +123,15 @@ export class StreamingAudioPlayer {
 	#abortController = new AbortController();
 	#wake: (() => void) | null = null;
 	#drain: Promise<void> = Promise.resolve();
+	readonly #commandsFor: (sampleRate: number) => PlayerCommand[];
+	readonly #playAudio: (wavPath: string, signal: AbortSignal) => Promise<void>;
+	/** Streamed PCM retained for this utterance so a failed backend can be replayed via file playback. */
+	#played: Float32Array[] = [];
+
+	constructor(options: StreamingPlayerOptions = {}) {
+		this.#commandsFor = options.commandsFor ?? (rate => streamingPlayerCommandsFor(process.platform, rate));
+		this.#playAudio = options.playAudio ?? ((wavPath, signal) => playAudioFile(wavPath, { signal }));
+	}
 
 	/** Pick a backend and begin draining. Idempotent; the first call's rate wins. */
 	start(sampleRate: number): void {
@@ -146,6 +167,7 @@ export class StreamingAudioPlayer {
 		if (this.#stopped) return;
 		this.#stopped = true;
 		this.#queue.length = 0;
+		this.#played.length = 0;
 		this.#abortController.abort();
 		this.#signal();
 		try {
@@ -168,7 +190,7 @@ export class StreamingAudioPlayer {
 	 * in-flight chunk.
 	 */
 	#spawnStream(): boolean {
-		this.#candidates ??= streamingPlayerCommandsFor(process.platform, this.#sampleRate);
+		this.#candidates ??= this.#commandsFor(this.#sampleRate);
 		for (let command = this.#candidates.shift(); command; command = this.#candidates.shift()) {
 			const { cmd, args } = command;
 			try {
@@ -213,6 +235,7 @@ export class StreamingAudioPlayer {
 					continue;
 				}
 				if (this.#mode === "stream") {
+					this.#played.push(chunk);
 					// Pace writes so the player buffers ~LEAD_SECONDS, no more, keeping
 					// ducking and stop responsive instead of locked behind buffered audio.
 					const ahead = this.#writtenSec - (performance.now() - this.#startedAt) / 1000;
@@ -242,10 +265,26 @@ export class StreamingAudioPlayer {
 				try {
 					await this.#sink?.end();
 				} catch {}
-				if (this.#proc) {
+				const proc = this.#proc;
+				let exitCode: number | null = null;
+				if (proc) {
 					try {
-						await this.#proc.exited;
+						exitCode = await proc.exited;
 					} catch {}
+				}
+				// A streaming backend that exits nonzero never opened its audio
+				// device (e.g. the bundled ffmpeg built without pulse/alsa output).
+				// For a short single-segment clip the pipe write succeeds before
+				// that death and #inputClosed is already set, so neither the
+				// broken-pipe replay nor the early-exit handler advances backends.
+				// Replay the buffered utterance through per-file playback so it
+				// still reaches the speakers.
+				if (!this.#stopped && proc && exitCode !== 0) {
+					this.#mode = "file";
+					for (const chunk of this.#played) {
+						if (this.#stopped) break;
+						await this.#playFile(chunk);
+					}
 				}
 			}
 		} catch (error) {
@@ -291,7 +330,7 @@ export class StreamingAudioPlayer {
 		const wavPath = path.join(os.tmpdir(), `omp-speech-${Snowflake.next()}.wav`);
 		try {
 			await fs.writeFile(wavPath, encodeWav(this.#scaled(pcm), this.#sampleRate));
-			if (!this.#stopped) await playAudioFile(wavPath, { signal: this.#abortController.signal });
+			if (!this.#stopped) await this.#playAudio(wavPath, this.#abortController.signal);
 		} catch (error) {
 			logger.debug("tts: file playback failed", {
 				error: error instanceof Error ? error.message : String(error),

--- a/packages/coding-agent/test/tts/streaming-player.test.ts
+++ b/packages/coding-agent/test/tts/streaming-player.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import type { PlayerCommand } from "@oh-my-pi/pi-coding-agent/tts/player";
+import { StreamingAudioPlayer } from "@oh-my-pi/pi-coding-agent/tts/streaming-player";
+
+/** A one-segment ~0.5s clip at 24 kHz, the shape `omp say "hi"` produces. */
+const clip = (): Float32Array => new Float32Array(24_000 / 2).fill(0.1);
+
+describe("StreamingAudioPlayer nonzero-exit fallback", () => {
+	it("replays the buffered clip via file playback when the streaming backend exits nonzero", async () => {
+		// `cat` drains stdin so the pipe write succeeds, then the shell exits 1 —
+		// exactly the bundled-ffmpeg-without-outdev failure that used to silently
+		// drop `omp say`'s single short clip.
+		const played: string[] = [];
+		const player = new StreamingAudioPlayer({
+			commandsFor: (): PlayerCommand[] => [{ cmd: "sh", args: ["-c", "cat >/dev/null; exit 1"] }],
+			playAudio: async wavPath => {
+				played.push(wavPath);
+			},
+		});
+		player.start(24_000);
+		player.write(clip());
+		await player.end();
+		expect(played.length).toBe(1);
+	});
+
+	it("does not replay when the streaming backend exits cleanly", async () => {
+		const played: string[] = [];
+		const player = new StreamingAudioPlayer({
+			commandsFor: (): PlayerCommand[] => [{ cmd: "sh", args: ["-c", "cat >/dev/null"] }],
+			playAudio: async wavPath => {
+				played.push(wavPath);
+			},
+		});
+		player.start(24_000);
+		player.write(clip());
+		await player.end();
+		expect(played.length).toBe(0);
+	});
+
+	it("plays every chunk via the file fallback when no streaming backend exists", async () => {
+		const played: string[] = [];
+		const player = new StreamingAudioPlayer({
+			commandsFor: (): PlayerCommand[] => [],
+			playAudio: async wavPath => {
+				played.push(wavPath);
+			},
+		});
+		player.start(24_000);
+		player.write(clip());
+		player.write(clip());
+		await player.end();
+		expect(played.length).toBe(2);
+	});
+});


### PR DESCRIPTION
## Repro
`omp say --voice af_heart 'Hi there! how are you?'` prints `spoke (af_heart, kokoro, 1.9s, 1 segments)` but plays no audio on Linux hosts whose first streaming backend is the bundled static ffmpeg (built without pulse/alsa output devices). Agent-reply TTS on the same machine works, which localizes the defect to the shared `StreamingAudioPlayer` for short single-segment clips. A deterministic repro of the drain sequence (backend that accepts the pipe write then exits nonzero):

```
writeStream returned: true (true => drain replay path NOT taken)
streaming backend exit code: 1
file fallback triggered by current code: false
BUG REPRODUCED: backend exited 1 but audio was dropped (no fallback)
```

## Cause
In `packages/coding-agent/src/tts/streaming-player.ts`, `omp say` writes its one chunk and immediately calls `player.end()`. `StreamingAudioPlayer.#writeStream` pushes the chunk into the OS pipe buffer and `flush()` resolves *before* ffmpeg dies, so it returns `true` and the drain's broken-pipe replay (`#drainLoop`) never fires. `end()` then sets `#inputClosed = true`; when ffmpeg finally exits nonzero, the early-exit handler in `#spawnStream` short-circuits on `if (... || this.#inputClosed) return;` and never advances to `paplay`/`aplay`. The end-of-stream cleanup awaited `proc.exited` but ignored the exit code, so the dropped audio surfaced as a silent success. The agent path escapes this because a multi-segment reply streams over time, so the death is caught while more deltas are pending.

## Fix
- `StreamingAudioPlayer` retains the utterance PCM (`#played`) for streamed chunks.
- The end-of-stream cleanup in `#drainLoop` now captures the backend exit code; on a nonzero exit it switches to file mode and replays the buffered chunks through `#playFile`, so short clips still reach the speakers via the per-file fallback (`playAudioFile` → `paplay`/`aplay`/etc.).
- Added a constructor options bag (`StreamingPlayerOptions`) with injectable `commandsFor` / `playAudio` seams so playback logic is testable without a real audio device; defaults are unchanged (`streamingPlayerCommandsFor` + `playAudioFile`).
- Added `test/tts/streaming-player.test.ts` covering nonzero-exit replay, clean-exit no-replay, and no-streaming-backend file playback.

## Verification
`bun test packages/coding-agent/test/tts/` → 38 pass, 0 fail. `bun check` → clean (ts + rs). Manual: the deterministic drain repro above now routes the buffered chunk to the file fallback instead of dropping it.

Fixes #5875