### PR TITLE
fix(ai): prevent invalid callbacks from aborting oauth

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added interactive Meta Model API key login and `MODEL_API_KEY` / `META_API_KEY` environment authentication ([#4941](https://github.com/can1357/oh-my-pi/issues/4941)).
 - Fixed SuperGrok (`xai-oauth`) `/usage` showing "no usage data" for unified-billing accounts: when `?format=credits` lacks `creditUsagePercent` (or marks `isUnifiedBillingUser`), fall back to / merge the default monthly `monthlyLimit`/`used` payload.
 - Fixed sessions wedging onto their fallback model with `400 Invalid \`signature\` in \`thinking\` block` after switching to an Anthropic signing endpoint while the latest assistant turn came from a different Anthropic-compatible provider (e.g. Kimi k3). The cross-model thinking-signature strip skipped the latest surviving assistant turn entirely, replaying the foreign signature verbatim on every attempt; the latest turn now strips signatures whose issuing provider differs from the target (same-provider switches keep their byte-for-byte latest turn), and foreign `redacted_thinking` siblings are dropped alongside instead of riding the wire unverifiable.
+- Fixed OAuth callback servers aborting login when an invalid callback arrives before the legitimate browser redirect, and restricted `localhost` callback listeners to the IPv4 loopback interface ([#4106](https://github.com/can1357/oh-my-pi/issues/4106)).
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -64,7 +64,6 @@ export abstract class OAuthCallbackFlow {
 	allowPortFallback: boolean;
 	#manualInputOnly: boolean;
 	#callbackResolve?: (result: CallbackResult) => void;
-	#callbackReject?: (error: string) => void;
 	/**
 	 * Authorization URL the `/launch` route currently redirects to. Set by
 	 * {@link login} after {@link generateAuthUrl} and before {@link OAuthController.onAuth}
@@ -280,9 +279,9 @@ export abstract class OAuthCallbackFlow {
 	 * Create HTTP server for OAuth callback.
 	 */
 	#createServer(port: number, expectedState: string): Bun.Server<unknown> {
-		const hostname = this.callbackHostname === DEFAULT_HOSTNAME ? undefined : this.callbackHostname;
+		const hostname = this.callbackHostname === DEFAULT_HOSTNAME ? "127.0.0.1" : this.callbackHostname;
 		return Bun.serve({
-			...(hostname === undefined ? {} : { hostname }),
+			hostname,
 			port,
 			reusePort: false,
 			fetch: req => this.#handleCallback(req, expectedState),
@@ -334,16 +333,12 @@ export abstract class OAuthCallbackFlow {
 			resultState = { ok: true, code, state };
 		}
 
-		// Signal to waitForCallback - capture refs before they could be cleared
-		const resolve = this.#callbackResolve;
-		const reject = this.#callbackReject;
-		queueMicrotask(() => {
-			if (resultState.ok) {
+		if (resultState.ok) {
+			const resolve = this.#callbackResolve;
+			queueMicrotask(() => {
 				resolve?.({ code: resultState.code, state: resultState.state });
-			} else {
-				reject?.(resultState.error ?? "Unknown error");
-			}
-		});
+			});
+		}
 
 		return new Response(
 			(templateHtml as unknown as string).replaceAll("__OAUTH_STATE__", JSON.stringify(resultState)),
@@ -364,11 +359,9 @@ export abstract class OAuthCallbackFlow {
 
 		const callback = Promise.withResolvers<CallbackResult>();
 		this.#callbackResolve = callback.resolve;
-		this.#callbackReject = callback.reject;
 
 		signal.addEventListener("abort", () => {
 			this.#callbackResolve = undefined;
-			this.#callbackReject = undefined;
 			callback.reject(new AIError.LoginCancelledError(`OAuth callback cancelled: ${signal.reason}`));
 		});
 		const callbackPromise = callback.promise;

--- a/packages/ai/test/callback-server-security.test.ts
+++ b/packages/ai/test/callback-server-security.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { OAuthCallbackFlow } from "@oh-my-pi/pi-ai/registry/oauth/callback-server";
+import type { OAuthAuthInfo, OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+
+class CallbackProbeFlow extends OAuthCallbackFlow {
+	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string }> {
+		const url = new URL("https://provider.example.com/authorize");
+		url.searchParams.set("redirect_uri", redirectUri);
+		url.searchParams.set("state", state);
+		return { url: url.toString() };
+	}
+
+	async exchangeToken(code: string): Promise<OAuthCredentials> {
+		return { access: code, refresh: "refresh", expires: Date.now() + 60_000 };
+	}
+}
+
+async function startFlow(): Promise<{
+	info: OAuthAuthInfo;
+	abort: AbortController;
+	login: Promise<OAuthCredentials>;
+}> {
+	const abort = new AbortController();
+	const authFired = Promise.withResolvers<OAuthAuthInfo>();
+	const flow = new CallbackProbeFlow(
+		{
+			onAuth: info => authFired.resolve(info),
+			signal: abort.signal,
+		},
+		{ preferredPort: 0 },
+	);
+	const login = flow.login();
+	void login.catch(() => undefined);
+	const info = await authFired.promise;
+	return { info, abort, login };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("OAuthCallbackFlow callback security", () => {
+	it("keeps waiting after invalid callback requests and accepts the legitimate callback", async () => {
+		const { info, abort, login } = await startFlow();
+		const authUrl = new URL(info.url);
+		const redirectUri = authUrl.searchParams.get("redirect_uri");
+		const state = authUrl.searchParams.get("state");
+		if (!redirectUri || !state) throw new Error("OAuth test flow did not advertise its callback parameters");
+
+		try {
+			const invalidCallbacks = [
+				`${redirectUri}?error=access_denied&error_description=Denied`,
+				redirectUri,
+				`${redirectUri}?code=attacker-code&state=wrong-state`,
+			];
+			for (const callback of invalidCallbacks) {
+				const response = await fetch(callback);
+				expect(response.status).toBe(500);
+			}
+
+			const response = await fetch(`${redirectUri}?code=legitimate-code&state=${encodeURIComponent(state)}`);
+			expect(response.status).toBe(200);
+			expect((await login).access).toBe("legitimate-code");
+		} finally {
+			abort.abort("test cleanup");
+			await login.catch(() => undefined);
+		}
+	});
+
+	it("binds localhost callback URLs to the IPv4 loopback interface", async () => {
+		const serve = Bun.serve;
+		let hostname: string | undefined;
+		vi.spyOn(Bun, "serve").mockImplementation(options => {
+			hostname = options.hostname;
+			return serve(options);
+		});
+
+		const { abort, login } = await startFlow();
+		try {
+			expect(hostname).toBe("127.0.0.1");
+		} finally {
+			abort.abort("test cleanup");
+			await login.catch(() => undefined);
+		}
+	});
+});


### PR DESCRIPTION
## Repro
Start an `OAuthCallbackFlow`, send an `error`, missing-code, or wrong-state request to its callback URL, then send the legitimate callback. Before this fix the first invalid request permanently rejected login and stopped the server; `bun test packages/ai/test/callback-server-security.test.ts` reproduced that failure and also showed that the `localhost` listener passed no hostname to `Bun.serve`.

## Cause
`OAuthCallbackFlow.#handleCallback` in `packages/ai/src/registry/oauth/callback-server.ts` forwarded every per-request validation error to the flow-level callback rejection function, while `#createServer` converted the documented `localhost` callback hostname to `undefined`, selecting Bun's `0.0.0.0` default.

## Fix
- Leave the callback promise pending for denied, missing-code, and state-mismatched requests while preserving their HTTP error responses.
- Set the bind hostname to `127.0.0.1` when the advertised callback hostname is `localhost`.
- Cover all three invalid-request branches, subsequent legitimate completion, and explicit loopback binding with regression tests.
- Document the fix in the AI package changelog.

## Verification
`bun test packages/ai/test/callback-server-security.test.ts` — 2 passed, 0 failed. `bun test packages/ai/test/callback-server-*.test.ts` — 15 passed, 0 failed. `bun run check` in `packages/ai` passed. `bun test --parallel` in `packages/ai` — 3,155 passed, 337 skipped, 0 failed. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #4106