### PR TITLE
fix(mcp): serialize mcp.json config writes and use unique temp path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Fixed
 
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
+- Fixed concurrent MCP config mutations losing updates and racing on a shared temp path: every `mcp.json` read-modify-write (add/update/remove server, disabled/force-enabled lists) is now serialized under a per-file lock, and each atomic write uses a unique temp file so overlapping writers no longer rename each other's `.tmp` out from under them (ENOENT or clobbered config) — reachable in-process via the fire-and-forget extensions-dashboard toggle and across processes on a shared `~/.omp/mcp.json` ([#4104](https://github.com/can1357/oh-my-pi/issues/4104)).
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.
 - Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.

--- a/packages/coding-agent/src/mcp/config-writer.test.ts
+++ b/packages/coding-agent/src/mcp/config-writer.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { addMCPServer, readDisabledServers, readMCPConfigFile, setServerDisabled } from "./config-writer";
+
+describe("config-writer concurrent mutations", () => {
+	let dir: string;
+	let filePath: string;
+
+	beforeEach(async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-config-"));
+		filePath = path.join(dir, "mcp.json");
+	});
+
+	afterEach(async () => {
+		await fs.rm(dir, { recursive: true, force: true });
+	});
+
+	it("preserves both servers when two adds race the same file", async () => {
+		await Promise.all([
+			addMCPServer(filePath, "alpha", { type: "stdio", command: "a" }),
+			addMCPServer(filePath, "bravo", { type: "stdio", command: "b" }),
+		]);
+
+		const config = await readMCPConfigFile(filePath);
+		expect(Object.keys(config.mcpServers ?? {}).sort()).toEqual(["alpha", "bravo"]);
+	});
+
+	it("preserves both denylist edits when disable calls race", async () => {
+		await Promise.all([setServerDisabled(filePath, "alpha", true), setServerDisabled(filePath, "bravo", true)]);
+
+		expect((await readDisabledServers(filePath)).sort()).toEqual(["alpha", "bravo"]);
+	});
+
+	it("writes into a directory that does not exist yet", async () => {
+		const nestedPath = path.join(dir, "nested", "deep", "mcp.json");
+		await addMCPServer(nestedPath, "alpha", { type: "stdio", command: "a" });
+
+		const config = await readMCPConfigFile(nestedPath);
+		expect(Object.keys(config.mcpServers ?? {})).toEqual(["alpha"]);
+	});
+});

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -3,10 +3,12 @@
  *
  * Utilities for reading/writing .omp/mcp.json files at user or project level.
  */
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import { invalidate as invalidateFsCache } from "../capability/fs";
+import { withFileLock } from "../config/file-lock";
 
 import { validateServerConfig } from "./config";
 import { MCP_CONFIG_SCHEMA_URL, type MCPConfigFile, type MCPServerConfig } from "./types";
@@ -16,6 +18,20 @@ function withSchema(config: MCPConfigFile): MCPConfigFile {
 		$schema: config.$schema ?? MCP_CONFIG_SCHEMA_URL,
 		...config,
 	};
+}
+
+/**
+ * Serialize a read-modify-write against one config file.
+ *
+ * Wraps {@link withFileLock} but first ensures the config's parent directory
+ * exists, because the lock directory (`${filePath}.lock`) is created with a
+ * non-recursive `mkdir` — without this the very first write (before the config
+ * file or its parent exists) would fail to acquire the lock with ENOENT.
+ */
+function withConfigLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+	return fs.promises
+		.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 })
+		.then(() => withFileLock(filePath, fn));
 }
 
 /**
@@ -45,13 +61,20 @@ export async function writeMCPConfigFile(filePath: string, config: MCPConfigFile
 	const dir = path.dirname(filePath);
 	await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
 
-	// Write to temp file first (atomic write)
-	const tmpPath = `${filePath}.tmp`;
+	// Write to a per-writer temp file, then atomically rename into place. The
+	// temp name is unique (pid + random) so two concurrent writers to the same
+	// config never share one `.tmp` path and rename each other's file out from
+	// under them (which surfaced as ENOENT or a clobbered final file).
+	const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
 	const content = JSON.stringify(withSchema(config), null, 2);
-	await fs.promises.writeFile(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
-
-	// Rename to final path (atomic on most systems)
-	await fs.promises.rename(tmpPath, filePath);
+	try {
+		await fs.promises.writeFile(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
+		// Rename to final path (atomic on most systems)
+		await fs.promises.rename(tmpPath, filePath);
+	} catch (error) {
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+		throw error;
+	}
 	// Invalidate the capability fs cache so subsequent reads see the new content
 	invalidateFsCache(filePath);
 }
@@ -97,25 +120,26 @@ export async function addMCPServer(filePath: string, name: string, config: MCPSe
 		throw new Error(`Invalid server config: ${errors.join("; ")}`);
 	}
 
-	// Read existing config
-	const existing = await readMCPConfigFile(filePath);
+	// Serialize the read-modify-write under a per-file lock so a concurrent
+	// mutation cannot overwrite this one (lost update). The lock also guards
+	// against cross-process writers sharing the same config file.
+	await withConfigLock(filePath, async () => {
+		const existing = await readMCPConfigFile(filePath);
 
-	// Check for duplicate name
-	if (existing.mcpServers?.[name]) {
-		throw new Error(`Server "${name}" already exists in ${filePath}`);
-	}
+		// Check for duplicate name
+		if (existing.mcpServers?.[name]) {
+			throw new Error(`Server "${name}" already exists in ${filePath}`);
+		}
 
-	// Add server
-	const updated: MCPConfigFile = {
-		...existing,
-		mcpServers: {
-			...existing.mcpServers,
-			[name]: config,
-		},
-	};
-
-	// Write back
-	await writeMCPConfigFile(filePath, updated);
+		const updated: MCPConfigFile = {
+			...existing,
+			mcpServers: {
+				...existing.mcpServers,
+				[name]: config,
+			},
+		};
+		await writeMCPConfigFile(filePath, updated);
+	});
 }
 
 /**
@@ -137,20 +161,19 @@ export async function updateMCPServer(filePath: string, name: string, config: MC
 		throw new Error(`Invalid server config: ${errors.join("; ")}`);
 	}
 
-	// Read existing config
-	const existing = await readMCPConfigFile(filePath);
+	// Serialize the read-modify-write (see addMCPServer).
+	await withConfigLock(filePath, async () => {
+		const existing = await readMCPConfigFile(filePath);
 
-	// Update server
-	const updated: MCPConfigFile = {
-		...existing,
-		mcpServers: {
-			...existing.mcpServers,
-			[name]: config,
-		},
-	};
-
-	// Write back
-	await writeMCPConfigFile(filePath, updated);
+		const updated: MCPConfigFile = {
+			...existing,
+			mcpServers: {
+				...existing.mcpServers,
+				[name]: config,
+			},
+		};
+		await writeMCPConfigFile(filePath, updated);
+	});
 }
 
 /**
@@ -159,23 +182,21 @@ export async function updateMCPServer(filePath: string, name: string, config: MC
  * @throws Error if server doesn't exist
  */
 export async function removeMCPServer(filePath: string, name: string): Promise<void> {
-	// Read existing config
-	const existing = await readMCPConfigFile(filePath);
+	// Serialize the read-modify-write (see addMCPServer).
+	await withConfigLock(filePath, async () => {
+		const existing = await readMCPConfigFile(filePath);
 
-	// Check if server exists
-	if (!existing.mcpServers?.[name]) {
-		throw new Error(`Server "${name}" not found in ${filePath}`);
-	}
+		if (!existing.mcpServers?.[name]) {
+			throw new Error(`Server "${name}" not found in ${filePath}`);
+		}
 
-	// Remove server
-	const { [name]: _removed, ...remaining } = existing.mcpServers;
-	const updated: MCPConfigFile = {
-		...existing,
-		mcpServers: remaining,
-	};
-
-	// Write back
-	await writeMCPConfigFile(filePath, updated);
+		const { [name]: _removed, ...remaining } = existing.mcpServers;
+		const updated: MCPConfigFile = {
+			...existing,
+			mcpServers: remaining,
+		};
+		await writeMCPConfigFile(filePath, updated);
+	});
 }
 
 /**
@@ -207,25 +228,28 @@ export async function readDisabledServers(filePath: string): Promise<string[]> {
  * Add or remove a server name from the disabled servers list.
  */
 export async function setServerDisabled(filePath: string, name: string, disabled: boolean): Promise<void> {
-	const config = await readMCPConfigFile(filePath);
-	const current = new Set(config.disabledServers ?? []);
+	// Serialize the read-modify-write (see addMCPServer).
+	await withConfigLock(filePath, async () => {
+		const config = await readMCPConfigFile(filePath);
+		const current = new Set(config.disabledServers ?? []);
 
-	if (disabled) {
-		current.add(name);
-	} else {
-		current.delete(name);
-	}
+		if (disabled) {
+			current.add(name);
+		} else {
+			current.delete(name);
+		}
 
-	const updated: MCPConfigFile = {
-		...config,
-		disabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
-	};
+		const updated: MCPConfigFile = {
+			...config,
+			disabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
+		};
 
-	if (!updated.disabledServers) {
-		delete updated.disabledServers;
-	}
+		if (!updated.disabledServers) {
+			delete updated.disabledServers;
+		}
 
-	await writeMCPConfigFile(filePath, updated);
+		await writeMCPConfigFile(filePath, updated);
+	});
 }
 
 /**
@@ -243,25 +267,28 @@ export async function readEnabledServers(filePath: string): Promise<string[]> {
  * NOT override the `disabledServers` denylist.
  */
 export async function setServerForceEnabled(filePath: string, name: string, force: boolean): Promise<void> {
-	const config = await readMCPConfigFile(filePath);
-	const current = new Set(config.enabledServers ?? []);
+	// Serialize the read-modify-write (see addMCPServer).
+	await withConfigLock(filePath, async () => {
+		const config = await readMCPConfigFile(filePath);
+		const current = new Set(config.enabledServers ?? []);
 
-	if (force) {
-		current.add(name);
-	} else {
-		current.delete(name);
-	}
+		if (force) {
+			current.add(name);
+		} else {
+			current.delete(name);
+		}
 
-	const updated: MCPConfigFile = {
-		...config,
-		enabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
-	};
+		const updated: MCPConfigFile = {
+			...config,
+			enabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
+		};
 
-	if (!updated.enabledServers) {
-		delete updated.enabledServers;
-	}
+		if (!updated.enabledServers) {
+			delete updated.enabledServers;
+		}
 
-	await writeMCPConfigFile(filePath, updated);
+		await writeMCPConfigFile(filePath, updated);
+	});
 }
 
 /** Paths and target state for toggling one MCP server across known config files. */


### PR DESCRIPTION
## Repro
Two MCP config mutations on the same `mcp.json` interleave with no serialization. Each of the five exported read-modify-write helpers in `config-writer.ts` (`addMCPServer`, `updateMCPServer`, `removeMCPServer`, `setServerDisabled`, `setServerForceEnabled`) spans `read → mutate → write` across awaits, and `writeMCPConfigFile` used a fixed `${filePath}.tmp` shared by every writer. A two-way concurrent add crashes; other interleavings silently drop one writer's update.

```
bun test src/mcp/config-writer.test.ts
```
Before the fix, a concurrent `addMCPServer("alpha")` + `addMCPServer("bravo")` failed with:
```
ENOENT: no such file or directory, rename '.../mcp.json.tmp' -> '.../mcp.json'
    at async writeMCPConfigFile (config-writer.ts:54:20)
    at async addMCPServer (config-writer.ts:118:8)
```
Reachable in-process via `extension-dashboard.ts:272` (`void this.#toggleMcpExtension(...)`, fire-and-forget) and across processes on a shared `~/.omp/mcp.json`.

## Cause
`packages/coding-agent/src/mcp/config-writer.ts`. The RMW mutators had no lock, so the JS event loop yields at each await and lets a second mutation read the pre-mutation state and overwrite the first (lost update). `writeMCPConfigFile` derived one temp path per file (`${filePath}.tmp`), so two concurrent writes to the same file collide: one writer's `rename` moves the shared temp out from under the other, surfacing ENOENT or a clobbered final file.

## Fix
- `writeMCPConfigFile`: temp path is now `${filePath}.${process.pid}.${randomUUID()}.tmp` (unique per write) with try/catch cleanup of the temp on failure, so concurrent writers never share a `.tmp`.
- New local `withConfigLock(filePath, fn)` wraps the existing central `withFileLock` (from `config/file-lock.ts`, the same helper `settings.ts` uses) but first `mkdir -p`s the config's parent so the non-recursive lock-dir `mkdir` can succeed on the first-ever write.
- Each of the five RMW mutators now runs its `read → mutate → write` inside `withConfigLock`, serializing overlapping in-process and cross-process mutations. Validation stays outside the lock (fails fast, no I/O).
- Added `config-writer.test.ts` covering concurrent adds, concurrent denylist edits, and a first-write into a non-existent directory.

## Verification
`bun test src/mcp/config-writer.test.ts` → 3 pass / 0 fail (the concurrent-add case reproduced the ENOENT crash before the fix). LSP diagnostics on `config-writer.ts` clean.

Fixes #4104