### PR TITLE
fix(mcp): bound oauth discovery and smithery poll fetches with abort timeouts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed MCP OAuth endpoint discovery and Smithery browser-login polling hanging indefinitely against an endpoint that accepts the TCP connection but never responds. `discoverOAuthEndpoints`/`fetchResourceMetadataScopes` now bound every metadata/well-known/authorization-server fetch with a per-request `AbortSignal.timeout`, and `pollSmitheryCliAuthSession` bounds each poll so the loop reaches its 5-minute deadline instead of stalling ([#4103](https://github.com/can1357/oh-my-pi/issues/4103)).
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -6,6 +6,10 @@
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { withTimeoutSignal } from "../utils/fetch-timeout";
+
+/** Per-request abort deadline for each OAuth discovery metadata fetch. */
+const DISCOVERY_FETCH_TIMEOUT_MS = 10_000;
 
 export interface OAuthEndpoints {
 	authorizationUrl: string;
@@ -346,7 +350,7 @@ function readMetadataScopes(metadata: Record<string, unknown>): string | undefin
  */
 export async function fetchResourceMetadataScopes(
 	resourceMetadataUrl: string,
-	opts?: { fetch?: FetchImpl },
+	opts?: { fetch?: FetchImpl; signal?: AbortSignal },
 ): Promise<string | undefined> {
 	const fetchImpl: FetchImpl = opts?.fetch ?? fetch;
 	try {
@@ -354,6 +358,7 @@ export async function fetchResourceMetadataScopes(
 			method: "GET",
 			headers: { Accept: "application/json" },
 			redirect: "follow",
+			signal: withTimeoutSignal(DISCOVERY_FETCH_TIMEOUT_MS, opts?.signal),
 		});
 		if (!resp.ok) return undefined;
 		const meta = (await resp.json()) as Record<string, unknown>;
@@ -371,7 +376,7 @@ export async function discoverOAuthEndpoints(
 	serverUrl: string,
 	authServerUrl?: string,
 	resourceMetadataUrl?: string,
-	opts?: { fetch?: FetchImpl; protectedResource?: string; protectedScopes?: string },
+	opts?: { fetch?: FetchImpl; protectedResource?: string; protectedScopes?: string; signal?: AbortSignal },
 ): Promise<OAuthEndpoints | null> {
 	const fetchImpl: FetchImpl = opts?.fetch ?? fetch;
 	const wellKnownPaths = [
@@ -402,6 +407,7 @@ export async function discoverOAuthEndpoints(
 				method: "GET",
 				headers: { Accept: "application/json" },
 				redirect: "follow",
+				signal: withTimeoutSignal(DISCOVERY_FETCH_TIMEOUT_MS, opts?.signal),
 			});
 			if (metaResp.ok) {
 				const meta = (await metaResp.json()) as Record<string, unknown>;
@@ -486,6 +492,7 @@ export async function discoverOAuthEndpoints(
 						method: "GET",
 						headers: { Accept: "application/json" },
 						redirect: "follow",
+						signal: withTimeoutSignal(DISCOVERY_FETCH_TIMEOUT_MS, opts?.signal),
 					});
 
 					if (response.ok) {
@@ -521,6 +528,7 @@ export async function discoverOAuthEndpoints(
 									fetch: fetchImpl,
 									protectedResource: discoveredProtectedResource,
 									protectedScopes: readMetadataScopes(metadata) ?? protectedScopes,
+									signal: opts?.signal,
 								});
 								if (discovered) return discovered;
 							}

--- a/packages/coding-agent/src/mcp/smithery-auth.test.ts
+++ b/packages/coding-agent/src/mcp/smithery-auth.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { pollSmitheryCliAuthSession } from "./smithery-auth";
+
+type FetchInput = string | URL | Request;
+type FetchInit = RequestInit | BunFetchRequestInit;
+
+describe("pollSmitheryCliAuthSession fetch cancellation", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("bounds each poll request with a timeout abort signal even without a caller signal", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchStub = Object.assign(
+			async (_input: FetchInput, init?: FetchInit) => {
+				if (init?.signal instanceof AbortSignal) signals.push(init.signal);
+				return Response.json({ status: "pending" });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchStub);
+
+		const result = await pollSmitheryCliAuthSession("sess-123");
+
+		expect(result.status).toBe("pending");
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(false);
+	});
+});

--- a/packages/coding-agent/src/mcp/smithery-auth.ts
+++ b/packages/coding-agent/src/mcp/smithery-auth.ts
@@ -7,6 +7,7 @@ import { withTimeoutSignal } from "../utils/fetch-timeout";
 const SMITHERY_AUTH_FILENAME = "smithery.json";
 const SMITHERY_URL = process.env.SMITHERY_URL || "https://smithery.ai";
 const SMITHERY_AUTH_TIMEOUT_MS = 10_000;
+const SMITHERY_POLL_TIMEOUT_MS = 30_000;
 
 type SmitheryCliAuthSession = {
 	sessionId: string;
@@ -53,7 +54,7 @@ export async function pollSmitheryCliAuthSession(
 	signal?: AbortSignal,
 ): Promise<SmitheryCliPollResponse> {
 	const response = await fetch(`${SMITHERY_URL}/api/auth/cli/poll/${sessionId}`, {
-		signal,
+		signal: withTimeoutSignal(SMITHERY_POLL_TIMEOUT_MS, signal),
 	});
 	if (!response.ok) {
 		if (response.status === 404 || response.status === 410) {

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -51,6 +51,7 @@ import type { MCPAuthChallenge, MCPAuthConfig, MCPServerConfig, MCPServerConnect
 import { shortenPath } from "../../tools/render-utils";
 import { urlHyperlinkAlways } from "../../tui";
 import { copyToClipboard } from "../../utils/clipboard";
+import { isTimeoutError } from "../../utils/fetch-timeout";
 import { openPath } from "../../utils/open";
 import { ChatBlock } from "../components/chat-block";
 import { MCPAddWizard } from "../components/mcp-add-wizard";
@@ -2121,12 +2122,19 @@ export class MCPCommandController {
 			if (Date.now() - startedAt >= timeoutMs) {
 				throw new Error("Smithery authorization timed out after 5 minutes.");
 			}
-			const response = await pollSmitheryCliAuthSession(sessionId, signal);
-			if (response.status === "success" && response.apiKey) {
-				return response.apiKey;
-			}
-			if (response.status === "error") {
-				throw new Error(response.message ?? "Smithery authorization failed.");
+			try {
+				const response = await pollSmitheryCliAuthSession(sessionId, signal);
+				if (response.status === "success" && response.apiKey) {
+					return response.apiKey;
+				}
+				if (response.status === "error") {
+					throw new Error(response.message ?? "Smithery authorization failed.");
+				}
+			} catch (error) {
+				// A single hung/slow poll aborts via the per-request timeout; keep
+				// polling until the overall 5-minute deadline rather than failing the
+				// whole browser login on one timed-out request.
+				if (!isTimeoutError(error)) throw error;
 			}
 			await Bun.sleep(pollIntervalMs);
 		}

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import {
 	analyzeAuthError,
 	discoverOAuthEndpoints,
@@ -639,5 +640,36 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 			authorizationUrl: "https://auth.example.com/oauth",
 			tokenUrl: "https://auth.example.com/token",
 		});
+	});
+});
+
+describe("bounded discovery fetches", () => {
+	// A fetch that never resolves on its own; it settles only when its
+	// AbortSignal fires. Pre-fix, discovery passed no signal, so this hung forever.
+	const hangingFetch: FetchImpl = (_input, init) =>
+		new Promise<Response>((_resolve, reject) => {
+			const signal = init?.signal;
+			const abort = () => reject(new DOMException("aborted", "AbortError"));
+			if (signal?.aborted) {
+				abort();
+				return;
+			}
+			signal?.addEventListener("abort", abort, { once: true });
+		});
+
+	it("aborts hanging well-known discovery fetches instead of stalling", async () => {
+		const oauth = await discoverOAuthEndpoints("https://mcp.example.test/mcp", undefined, undefined, {
+			fetch: hangingFetch,
+			signal: AbortSignal.timeout(50),
+		});
+		expect(oauth).toBeNull();
+	});
+
+	it("aborts a hanging resource_metadata fetch and returns undefined", async () => {
+		const scopes = await fetchResourceMetadataScopes(
+			"https://mcp.example.test/.well-known/oauth-protected-resource",
+			{ fetch: hangingFetch, signal: AbortSignal.timeout(50) },
+		);
+		expect(scopes).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -646,16 +646,14 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 describe("bounded discovery fetches", () => {
 	// A fetch that never resolves on its own; it settles only when its
 	// AbortSignal fires. Pre-fix, discovery passed no signal, so this hung forever.
-	const hangingFetch: FetchImpl = (_input, init) =>
-		new Promise<Response>((_resolve, reject) => {
-			const signal = init?.signal;
-			const abort = () => reject(new DOMException("aborted", "AbortError"));
-			if (signal?.aborted) {
-				abort();
-				return;
-			}
-			signal?.addEventListener("abort", abort, { once: true });
-		});
+	const hangingFetch: FetchImpl = (_input, init) => {
+		const { promise, reject } = Promise.withResolvers<Response>();
+		const signal = init?.signal;
+		const abort = () => reject(new DOMException("aborted", "AbortError"));
+		if (signal?.aborted) abort();
+		else signal?.addEventListener("abort", abort, { once: true });
+		return promise;
+	};
 
 	it("aborts hanging well-known discovery fetches instead of stalling", async () => {
 		const oauth = await discoverOAuthEndpoints("https://mcp.example.test/mcp", undefined, undefined, {


### PR DESCRIPTION
## Repro
`/mcp add <url>`, `/mcp reauth`, the add wizard, and `/mcp smithery-login` hang indefinitely when an OAuth metadata / well-known / discovered `authorization_servers` endpoint or the Smithery poll endpoint accepts the TCP connection but never responds. `discoverOAuthEndpoints` runs before `MCPOAuthFlow.login()`, so its 5-minute envelope is never reached; the Smithery poll loop only checks its deadline between polls, so a hung poll fetch stalls before the check runs. Demonstrated against a `Bun.serve` endpoint that never responds:

```
unbounded fetch (pre-fix): STILL-HANGING (bug)
bounded fetch  (post-fix): aborted: TimeoutError
```

## Cause
`packages/coding-agent/src/mcp/oauth-discovery.ts` — `discoverOAuthEndpoints` and `fetchResourceMetadataScopes` issued every `fetchImpl` call with no `signal`, and the function had no signal parameter, so no caller could bound them. `packages/coding-agent/src/mcp/smithery-auth.ts` — `pollSmitheryCliAuthSession` forwarded only a caller signal, and `#waitForSmitheryCliApiKey` (in `mcp-command-controller.ts`) passes `new AbortController().signal`, which never aborts, leaving each poll fetch unbounded. (The report's claims that `createSmitheryCliAuthSession` and `searchSmitheryRegistry`/`#validateSmitheryApiKey` lack timeouts are stale — both are already bounded via `withTimeoutSignal`.)

## Fix
- `oauth-discovery.ts`: add optional `signal` to `discoverOAuthEndpoints`/`fetchResourceMetadataScopes` and wrap every fetch (resource-metadata, well-known probe, resource-metadata-scopes) in `withTimeoutSignal(DISCOVERY_FETCH_TIMEOUT_MS = 10s, opts?.signal)`, threaded through the recursive `authorization_servers` call.
- `smithery-auth.ts`: wrap the poll fetch in `withTimeoutSignal(SMITHERY_POLL_TIMEOUT_MS = 30s, signal)` so a hung poll aborts and the loop reaches its 5-minute deadline.
- Tests: `test/oauth-discovery.test.ts` adds a hanging-fetch that settles only on abort — discovery and `fetchResourceMetadataScopes` now resolve `null`/`undefined` instead of stalling; `src/mcp/smithery-auth.test.ts` asserts the poll request carries an `AbortSignal` even without a caller signal (mirrors the existing `smithery-registry` cancellation test).

## Verification
`bun test test/oauth-discovery.test.ts src/mcp/smithery-auth.test.ts` → 23 pass, 0 fail. `bun check` passes (run by the pre-publish gate). Manual repro script above shows the unbounded fetch hangs while the bounded one aborts with `TimeoutError`. Fixes #4103