### PR TITLE
fix(session): validate blob refs before path join

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed blob reference resolution passing unvalidated `blob:sha256:` suffixes into `path.join`, allowing a crafted ref (e.g. `blob:sha256:../../../etc/passwd`) in a persisted/shared session to escape the blob directory and read arbitrary files into resolved image history; `parseBlobRef` now rejects any suffix that is not a canonical 64-char lowercase hex hash, gating every resolution path ([#4088](https://github.com/can1357/oh-my-pi/issues/4088)).
 - Fixed discarded `Settings` instances keeping debounced save timers and chained background saves armed; discarding an instance now cancels its pending writes so they cannot race a successor's file locks.
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -5,10 +5,10 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import { getAgentDir, getBlobsDir, getHistoryDbPath, getModelDbPath, getSessionsDir } from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
+import { BLOB_HASH_RE } from "../session/blob-store";
 import { listSessionsReadOnly, type SessionInfo, type SessionStatus } from "../session/session-listing";
 import { FileSessionStorage } from "../session/session-storage";
 
-const HASH_RE = /^[a-f0-9]{64}$/;
 const BLOB_FILE_RE = /^([a-f0-9]{64})(?:\.[A-Za-z0-9][A-Za-z0-9._-]{0,31})?$/;
 const BLOB_REF_RE = /\bblob:sha256:([a-f0-9]{64})\b/gi;
 const JSONL_GLOB = new Bun.Glob("**/*.jsonl");
@@ -268,7 +268,7 @@ async function collectReferencedBlobHashes(sessionRoots: string[]): Promise<Set<
 			const text = await readTextIfPresent(file);
 			for (const match of text.matchAll(BLOB_REF_RE)) {
 				const hash = match[1]?.toLowerCase();
-				if (hash && HASH_RE.test(hash)) hashes.add(hash);
+				if (hash && BLOB_HASH_RE.test(hash)) hashes.add(hash);
 			}
 		}
 	}

--- a/packages/coding-agent/src/session/blob-store.test.ts
+++ b/packages/coding-agent/src/session/blob-store.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BlobStore, parseBlobRef, resolveImageData, resolveImageDataSync, resolveImageDataUrl } from "./blob-store";
+
+const base = fs.mkdtempSync(path.join(os.tmpdir(), "blob-store-test-"));
+const blobDir = path.join(base, "agent", "blobs", "data");
+fs.mkdirSync(blobDir, { recursive: true });
+fs.writeFileSync(path.join(base, "secret.txt"), "TOP-SECRET-CONTENTS");
+const store = new BlobStore(blobDir);
+
+afterAll(() => {
+	fs.rmSync(base, { recursive: true, force: true });
+});
+
+describe("parseBlobRef validation", () => {
+	it("accepts a canonical 64-char lowercase hex suffix", () => {
+		const hash = "a".repeat(64);
+		expect(parseBlobRef(`blob:sha256:${hash}`)).toBe(hash);
+	});
+
+	it("returns null for non-blob strings", () => {
+		expect(parseBlobRef("data:image/png;base64,AAAA")).toBeNull();
+	});
+
+	it.each([
+		"../../../secret.txt",
+		`${"../".repeat(6)}etc/passwd`,
+		"A".repeat(64), // uppercase hex is not the canonical shape
+		"a".repeat(63), // too short
+		"a".repeat(65), // too long
+		"", // empty
+	])("rejects malformed suffix %p", suffix => {
+		expect(parseBlobRef(`blob:sha256:${suffix}`)).toBeNull();
+	});
+});
+
+describe("blob resolution path confinement", () => {
+	const traversalRef = "blob:sha256:../../../secret.txt";
+
+	it("leaves a traversal ref unresolved instead of reading outside the blob dir (base64 path)", async () => {
+		expect(await resolveImageData(store, traversalRef)).toBe(traversalRef);
+		expect(resolveImageDataSync(store, traversalRef)).toBe(traversalRef);
+	});
+
+	it("leaves a traversal ref unresolved instead of reading outside the blob dir (data-url path)", async () => {
+		expect(await resolveImageDataUrl(store, traversalRef)).toBe(traversalRef);
+	});
+
+	it("still resolves a valid stored blob", async () => {
+		const put = store.putSync(Buffer.from("hello"));
+		expect(Buffer.from(resolveImageDataSync(store, put.ref), "base64").toString("utf8")).toBe("hello");
+		expect(Buffer.from(await resolveImageData(store, put.ref), "base64").toString("utf8")).toBe("hello");
+	});
+});

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -5,6 +5,9 @@ import { isEnoent, logger } from "@oh-my-pi/pi-utils";
 
 const BLOB_PREFIX = "blob:sha256:";
 
+/** Canonical blob hash shape: exactly 64 lowercase hex chars (a SHA-256 digest). */
+export const BLOB_HASH_RE = /^[a-f0-9]{64}$/;
+
 export interface BlobPutOptions {
 	/** Optional file extension for a sidecar hardlink/copy that OS openers can type-detect. */
 	extension?: string;
@@ -179,10 +182,23 @@ export function isBlobRef(data: string): boolean {
 	return data.startsWith(BLOB_PREFIX);
 }
 
-/** Extract the SHA-256 hash from a blob reference string. */
+/**
+ * Extract the SHA-256 hash from a blob reference string.
+ *
+ * Returns null when the string is not a blob ref, or when the suffix is not a
+ * canonical 64-char lowercase hex hash. Rejecting non-hash suffixes here is the
+ * single choke point that keeps every resolution path confined to the blob dir:
+ * `get`/`getSync` feed this value into `path.join(this.dir, hash)`, so an
+ * unvalidated `../` suffix would otherwise escape the store and read arbitrary files.
+ */
 export function parseBlobRef(data: string): string | null {
 	if (!data.startsWith(BLOB_PREFIX)) return null;
-	return data.slice(BLOB_PREFIX.length);
+	const hash = data.slice(BLOB_PREFIX.length);
+	if (!BLOB_HASH_RE.test(hash)) {
+		logger.warn("Rejected malformed blob reference", { suffix: hash });
+		return null;
+	}
+	return hash;
 }
 
 /** Identify provider transport image data URLs so persistence can externalize and restore them losslessly. */


### PR DESCRIPTION
## Repro
A `blob:sha256:` reference whose suffix contains `../` segments escapes the blob directory. Rooting a `BlobStore` at `<tmp>/agent/blobs/data`, planting `<tmp>/secret.txt`, then resolving `blob:sha256:../../../secret.txt` through `resolveImageDataSync`, `resolveImageData`, and `resolveImageDataUrl` returned the contents of `secret.txt` (base64 / base64 / raw UTF-8) — `TRAVERSAL_LEAK: true`. A crafted or shared/tampered session JSONL carrying such a ref in an image `data`/`image_url` field is resolved on resume (`session-manager.ts:850` -> `resolveBlobRefsInEntries`), injecting the target file into model history.

## Cause
`parseBlobRef` (`packages/coding-agent/src/session/blob-store.ts`) did `data.slice(BLOB_PREFIX.length)` with no shape check. `BlobStore.get`/`getSync` then fed that suffix into `path.join(this.dir, hash)`, which collapses `..`, so the read escaped the store. The project already defined the invariant (`HASH_RE = /^[a-f0-9]{64}$/`, `gc-cli.ts:11`) but never applied it on the runtime resolution path.

## Fix
- `parseBlobRef` now rejects any suffix that is not a canonical 64-char lowercase hex hash (`BLOB_HASH_RE`), logging a warning and returning `null`. This is the single choke point for all four resolution entry points (`resolveImageData`, `resolveImageDataSync`, `resolveImageDataUrl`, and the ACP sync path which calls `resolveImageDataSync`); each already returns the ref unchanged when parse yields `null`.
- Exported `BLOB_HASH_RE` from `blob-store.ts` and replaced the duplicate `HASH_RE` in `gc-cli.ts` with it.
- Added `blob-store.test.ts` covering suffix validation, traversal-ref confinement across all three resolvers, and that valid stored blobs still resolve.

## Verification
`bun test packages/coding-agent/src/session/blob-store.test.ts` -> 11 pass, 0 fail. Re-ran the standalone traversal repro post-fix: `LEAK: false REF_UNCHANGED: true`, and a valid `putSync` ref still resolves to its content. Fixes #4088