### PR TITLE
fix(dap): reject and bound the unix socket connect on Linux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed the Linux socket-mode DAP launch (e.g. `dlv`) hanging forever when the unix socket connect failed: `connectSocket` now rejects on a `Bun.connect` error (ECONNREFUSED/ENOENT/EACCES) or when the connect stalls past the launch deadline, instead of leaving the awaiter pending and leaking the detached adapter ([#4087](https://github.com/can1357/oh-my-pi/issues/4087)).
 - Fixed discarded `Settings` instances keeping debounced save timers and chained background saves armed; discarding an instance now cancels its pending writes so they cannot race a successor's file locks.
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.

--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -260,7 +260,7 @@ export class DapClient {
 		// socket connect fails, we must not leak the detached adapter process.
 		try {
 			await waitForCondition(() => isUnixSocketReady(socketPath), timeoutMs, proc);
-			const { readable, writeSink, socket } = await connectSocket({ unix: socketPath });
+			const { readable, writeSink, socket } = await connectSocket({ unix: socketPath }, timeoutMs);
 			const client = new DapClient(adapter, cwd, proc, { readable, writeSink, socket });
 			proc.exited.then(() => client.#handleProcessExit());
 			void client.#startMessageReader();
@@ -924,10 +924,20 @@ function socketToSink(socket: Bun.Socket<undefined>): DapWriteSink {
 	};
 }
 
-/** Connect to a unix domain socket and return DAP transport streams. */
-async function connectSocket(options: { unix: string }): Promise<SocketTransport> {
-	const { promise, resolve } = Promise.withResolvers<SocketTransport>();
+/**
+ * Connect to a unix domain socket and return DAP transport streams.
+ *
+ * Rejects (rather than hanging) when the connect fails — a stat-ready but dead
+ * socket returns ECONNREFUSED, a socket removed between the readiness stat and
+ * the connect returns ENOENT, a permission mismatch returns EACCES — and when
+ * neither `open` nor an error arrives within `timeoutMs` (e.g. a TOCTOU stall).
+ * `#spawnSocketUnix`'s catch then kills the detached adapter instead of leaking
+ * it. Exported so tests can drive the reject path deterministically.
+ */
+export async function connectSocket(options: { unix: string }, timeoutMs: number): Promise<SocketTransport> {
+	const { promise, resolve, reject } = Promise.withResolvers<SocketTransport>();
 	let streamController: ReadableStreamDefaultController<Uint8Array>;
+	let opened = false;
 
 	const readable = new ReadableStream<Uint8Array>({
 		start(controller) {
@@ -935,10 +945,21 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 		},
 	});
 
+	const timer = setTimeout(() => {
+		reject(new Error(`Timed out connecting to unix socket ${options.unix} after ${timeoutMs}ms`));
+	}, timeoutMs);
+	// A late socket callback after settle is a no-op; clearing the timer just
+	// stops it from keeping the event loop alive past the connect.
+	void promise.then(
+		() => clearTimeout(timer),
+		() => clearTimeout(timer),
+	);
+
 	Bun.connect({
 		unix: options.unix,
 		socket: {
 			open(socket) {
+				opened = true;
 				resolve({
 					readable,
 					writeSink: socketToSink(socket),
@@ -949,6 +970,9 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 				streamController.enqueue(new Uint8Array(data));
 			},
 			close() {
+				if (!opened) {
+					reject(new Error(`Unix socket ${options.unix} closed before opening`));
+				}
 				try {
 					streamController.close();
 				} catch {
@@ -956,6 +980,9 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 				}
 			},
 			error(_socket, err) {
+				if (!opened) {
+					reject(err);
+				}
 				try {
 					streamController.error(err);
 				} catch {
@@ -963,6 +990,12 @@ async function connectSocket(options: { unix: string }): Promise<SocketTransport
 				}
 			},
 		},
+	}).catch(err => {
+		// Bun.connect rejects the returned promise on synchronous connect
+		// failures (e.g. ENOENT) without always firing the `error` handler.
+		if (!opened) {
+			reject(err);
+		}
 	});
 
 	return promise;

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -493,7 +493,10 @@ describe("connectSocket unix transport", () => {
 		// yields ECONNREFUSED/ENOENT from Bun.connect. Before the fix the error
 		// handler only errored the stream and the returned promise never settled,
 		// so `await connectSocket(...)` hung the launch forever.
-		const deadSocket = path.join(os.tmpdir(), `omp-dap-dead-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+		const deadSocket = path.join(
+			os.tmpdir(),
+			`omp-dap-dead-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`,
+		);
 		const start = Date.now();
 		await expect(connectSocket({ unix: deadSocket }, 5_000)).rejects.toThrow();
 		// Must settle on the connect error, not linger until the timeout bound.

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as dapModule from "@oh-my-pi/pi-coding-agent/dap";
-import { DapClient, waitForTcpServerListening } from "@oh-my-pi/pi-coding-agent/dap/client";
+import { connectSocket, DapClient, waitForTcpServerListening } from "@oh-my-pi/pi-coding-agent/dap/client";
 import { DapSessionManager } from "@oh-my-pi/pi-coding-agent/dap/session";
 import type {
 	DapCapabilities,
@@ -484,6 +484,20 @@ describe("DAP launch failure handling", () => {
 		} finally {
 			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
 		}
+	});
+});
+
+describe("connectSocket unix transport", () => {
+	it("rejects instead of hanging when the unix socket cannot be connected", async () => {
+		// A path that stat would report as a socket but that no one listens on
+		// yields ECONNREFUSED/ENOENT from Bun.connect. Before the fix the error
+		// handler only errored the stream and the returned promise never settled,
+		// so `await connectSocket(...)` hung the launch forever.
+		const deadSocket = path.join(os.tmpdir(), `omp-dap-dead-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+		const start = Date.now();
+		await expect(connectSocket({ unix: deadSocket }, 5_000)).rejects.toThrow();
+		// Must settle on the connect error, not linger until the timeout bound.
+		expect(Date.now() - start).toBeLessThan(2_000);
 	});
 });
 


### PR DESCRIPTION
## Repro
On Linux, socket-mode DAP launch (`DapClient.spawn` → `#spawnSocketUnix`, used by the default `dlv` adapter) awaits `connectSocket({ unix })` at `client.ts:263` after the readiness poll. When `Bun.connect` fails on a stat-ready-but-dead socket (ECONNREFUSED on a stale socket, ENOENT if the socket is removed between the stat and the connect, EACCES on a permission mismatch), the launch tool call hangs forever with no escape short of killing the host. Running the current `connectSocket` logic against a nonexistent unix socket:

```
$ bun repro.mjs   # inlines client.ts:928-969, connects to a nonexistent unix socket
connecting to nonexistent unix socket: /tmp/does-not-exist-...sock
error: Failed to connect  (syscall: "connect", errno: -2, code: "ENOENT")
HANG: connectSocket never settled after 2000ms (bug reproduced)
```

## Cause
`connectSocket` (`packages/coding-agent/src/dap/client.ts:928-969`) captured only `resolve` from `Promise.withResolvers`; its `error` socket handler called `streamController.error(err)` but never rejected the returned promise, and the `Bun.connect(...)` promise rejection was neither awaited nor caught. The `await connectSocket(...)` at `client.ts:263` had no timeout/`Promise.race` bound (unlike the macOS `--client-addr` and TCP paths), so a connect failure left the awaiter pending indefinitely. Because the await never settled, the surrounding kill/reap guard at `client.ts:261-275` could not fire, orphaning the detached adapter.

## Fix
- `connectSocket` now captures `reject`, tracks an `opened` flag, and rejects on: a `Bun.connect` `error` before open, a `close` before open, and the `Bun.connect` promise rejection (e.g. synchronous ENOENT).
- Added a `timeoutMs` bound (cleared on settle) so a connect that neither opens nor errors (TOCTOU stall) rejects rather than hanging past the launch deadline.
- `#spawnSocketUnix` threads its launch `timeoutMs` into `connectSocket`; its existing catch kills and reaps the detached adapter on the new rejection.
- Exported `connectSocket` (mirroring `waitForTcpServerListening`) for a deterministic reject-path test.

## Verification
`bun test test/debug/dap-launch-failures.test.ts` → 28 pass / 0 fail. New test drives the real exported `connectSocket` against a dead unix socket and asserts it rejects within the timeout window (settling on the connect error in <2s, not hanging). Existing readiness-timeout kill/reap tests (`#spawnSocketUnix`/`#spawnSocketClientAddr`) still pass. `Fixes #4087`