### PR TITLE
fix(agent): commit plan-reference flag on delivery, not construction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed the approved plan reference being permanently suppressed when the first post-approval prompt bailed during setup: `#planReferenceSent` was set at message-construction time (before delivery), so a generation-bail, an `@`-mention read error, or a `before_agent_start` hook throw between build and `agent.prompt` left the flag set with nothing delivered and the retry skipped re-injection. The flag is now committed only when the plan-reference message is handed to `agent.prompt` ([#4094](https://github.com/can1357/oh-my-pi/issues/4094)).
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8642,8 +8642,6 @@ export class AgentSession {
 			planFilePath,
 		});
 
-		this.#planReferenceSent = true;
-
 		return {
 			role: "custom",
 			customType: "plan-mode-reference",
@@ -9273,6 +9271,17 @@ export class AgentSession {
 				nonMessageTokens,
 				cutoffCount: this.messages.length + messages.length,
 			});
+			// Commit the plan-reference delivery flag only now that the message is
+			// actually handed to agent.prompt. Every pre-send setup step above can
+			// return (generation-bail) or throw (@-mention reads, before_agent_start
+			// hooks, pre-prompt compaction) before this point; setting the flag at
+			// construction time (#buildPlanReferenceMessage) stranded it `true` with
+			// nothing delivered, so the retry skipped re-injection and the executor
+			// lost the approved plan (issue #4094). The compaction-success resets
+			// (issue #1246) still clear it for re-injection on the next turn.
+			if (planReferenceMessage) {
+				this.#planReferenceSent = true;
+			}
 			try {
 				await this.#promptAgentWithIdleRetry(messages, agentPromptOptions);
 			} finally {

--- a/packages/coding-agent/test/agent-session-plan-reference-setup-bail.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-reference-setup-bail.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression test for issue #4094: "Plan reference is marked sent before prompt
+ * delivery, so setup aborts can permanently suppress approved-plan context".
+ *
+ * After a plan is approved (but before plan mode re-entry), the executor's first
+ * prompt injects the approved plan reference (`plan-mode-reference`) via
+ * `#buildPlanReferenceMessage`, gated by `#planReferenceSent`. The flag used to
+ * flip to `true` at message-construction time — before the prompt survived the
+ * async setup steps (generation-bail returns, @-mention reads,
+ * `before_agent_start` hooks, pre-prompt compaction) that precede
+ * `agent.prompt`. If any of those bailed or threw, the flag stayed `true` with
+ * nothing delivered, and the retry short-circuited to `null`, silently dropping
+ * the approved plan for the rest of the session.
+ *
+ * Contract: `#planReferenceSent` tracks *delivery*, not construction. A prompt
+ * that never reaches `agent.prompt` leaves the flag clear, so the next prompt
+ * re-injects the plan. A prompt that DOES reach `agent.prompt` sets it, so the
+ * plan is delivered exactly once.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { TextContent } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { resolveLocalUrlToPath } from "../src/internal-urls";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { convertToLlm, USER_INTERRUPT_LABEL } from "../src/session/messages";
+import { SessionManager } from "../src/session/session-manager";
+import * as fileMentions from "../src/utils/file-mentions";
+
+type ObservedPromptCall = { messageTexts: string[] };
+
+type Harness = {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	observedCalls: ObservedPromptCall[];
+};
+
+function isTextContentBlock(value: unknown): value is TextContent {
+	if (!value || typeof value !== "object") return false;
+	return (value as TextContent).type === "text" && typeof (value as TextContent).text === "string";
+}
+
+function getMessageText(message: AgentMessage): string {
+	if (!("content" in message)) return "";
+	if (typeof message.content === "string") return message.content;
+	if (!Array.isArray(message.content)) return "";
+	const text: string[] = [];
+	for (const content of message.content) {
+		if (isTextContentBlock(content)) text.push(content.text);
+	}
+	return text.join("\n");
+}
+
+function createAssistantResponse(text: string) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession plan-reference delivery tracking (issue #4094)", () => {
+	let tempDir: TempDir;
+	const cleanups: Array<() => Promise<void>> = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-agent-session-plan-ref-setup-bail-");
+		cleanups.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const cleanup of cleanups) await cleanup();
+		cleanups.length = 0;
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	async function createHarness(): Promise<Harness> {
+		const observedCalls: ObservedPromptCall[] = [];
+
+		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!bundled) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const model = { ...bundled, contextWindow: 200_000, maxTokens: 64_000 };
+
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${cleanups.length}.db`));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${cleanups.length}.yml`));
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"task.eager": "off",
+			"todo.enabled": false,
+			"todo.eager": "off",
+			"todo.reminders": false,
+		});
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+
+		let session: AgentSession;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			getToolChoice: () => session?.nextToolChoiceDirective(),
+			streamFn: (_model, context) => {
+				observedCalls.push({ messageTexts: context.messages.map(message => getMessageText(message)) });
+				const response = createAssistantResponse("done");
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					stream.push({ type: "done", reason: "stop", message: response });
+				});
+				return stream;
+			},
+		});
+
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+
+		cleanups.push(async () => {
+			await session.dispose();
+			authStorage.close();
+		});
+		return { session, sessionManager, observedCalls };
+	}
+
+	/** Write a plan file to the session-scoped local root the executor reads from. */
+	function writePlanFile(sessionManager: SessionManager, url: string, content: string): void {
+		const resolved = resolveLocalUrlToPath(url, {
+			getArtifactsDir: () => sessionManager.getArtifactsDir(),
+			getSessionId: () => sessionManager.getSessionId(),
+		});
+		fs.mkdirSync(path.dirname(resolved), { recursive: true });
+		fs.writeFileSync(resolved, content);
+	}
+
+	function hasPlanReference(call: ObservedPromptCall | undefined, planUrl: string): boolean {
+		if (!call) return false;
+		return call.messageTexts.some(text => text.includes("## Existing Plan") && text.includes(planUrl));
+	}
+
+	function countPlanReferences(call: ObservedPromptCall | undefined, planUrl: string): number {
+		if (!call) return 0;
+		return call.messageTexts.filter(text => text.includes("## Existing Plan") && text.includes(planUrl)).length;
+	}
+
+	it("re-injects the approved plan on retry when a @-mention read throws mid-setup", async () => {
+		const { session, sessionManager, observedCalls } = await createHarness();
+		const planUrl = "local://approved-plan.md";
+		writePlanFile(sessionManager, planUrl, "# Approved Plan\n\nPHASE-6-MARKER\n");
+		session.setPlanReferencePath(planUrl);
+
+		// First post-approval prompt @-mentions a file whose read throws (I/O error).
+		// The throw propagates out of the setup path before `agent.prompt`, so no
+		// model request ever received the plan reference.
+		const readSpy = vi
+			.spyOn(fileMentions, "generateFileMentionMessages")
+			.mockRejectedValue(new Error("EACCES: permission denied"));
+		await expect(session.prompt("review @notes.md and continue")).rejects.toThrow();
+		expect(observedCalls).toHaveLength(0);
+		readSpy.mockRestore();
+
+		// Retry (no @-mention): the plan reference MUST be re-injected.
+		await session.prompt("continue the approved plan");
+		expect(observedCalls).toHaveLength(1);
+		expect(hasPlanReference(observedCalls[0], planUrl)).toBe(true);
+	});
+
+	it("re-injects the approved plan on retry when the prompt is aborted mid-setup", async () => {
+		const { session, sessionManager, observedCalls } = await createHarness();
+		const planUrl = "local://approved-plan-abort.md";
+		writePlanFile(sessionManager, planUrl, "# Approved Plan\n\nABORT-MARKER\n");
+		session.setPlanReferencePath(planUrl);
+
+		// Fire a user interrupt (Esc) while the setup is still awaiting the
+		// @-mention read: abort() bumps #promptGeneration, so the post-setup
+		// generation-bail returns before `agent.prompt`. Nothing is delivered.
+		let abortDone: Promise<void> = Promise.resolve();
+		const readSpy = vi.spyOn(fileMentions, "generateFileMentionMessages").mockImplementation(async () => {
+			abortDone = session.abort({ reason: USER_INTERRUPT_LABEL });
+			return [];
+		});
+		await session.prompt("review @notes.md and continue");
+		await abortDone;
+		expect(observedCalls).toHaveLength(0);
+		readSpy.mockRestore();
+
+		// Retry: the plan reference MUST be re-injected.
+		await session.prompt("continue the approved plan");
+		expect(observedCalls).toHaveLength(1);
+		expect(hasPlanReference(observedCalls[0], planUrl)).toBe(true);
+	});
+
+	it("delivers the approved plan exactly once when setup succeeds", async () => {
+		const { session, sessionManager, observedCalls } = await createHarness();
+		const planUrl = "local://approved-plan-once.md";
+		writePlanFile(sessionManager, planUrl, "# Approved Plan\n\nONCE-MARKER\n");
+		session.setPlanReferencePath(planUrl);
+
+		// First prompt reaches agent.prompt: the plan reference is delivered once
+		// and the flag is committed to the delivered state.
+		await session.prompt("start executing the approved plan");
+		expect(observedCalls).toHaveLength(1);
+		expect(countPlanReferences(observedCalls[0], planUrl)).toBe(1);
+
+		// Second prompt: the flag stays committed, so no SECOND copy is injected.
+		// The turn-1 reference persists in history (that is correct context), so
+		// the guard is that the count does not grow — not that it is absent.
+		await session.prompt("keep going");
+		expect(observedCalls).toHaveLength(2);
+		expect(countPlanReferences(observedCalls[1], planUrl)).toBe(1);
+	});
+});


### PR DESCRIPTION
## Repro
After a plan is approved, the executor's first prompt injects the approved plan reference via `AgentSession.#buildPlanReferenceMessage`, gated by `#planReferenceSent`. If that first post-approval prompt bails during the async setup window — a `#promptGeneration` generation-bail (user interrupt), an `@`-mention read error, or a throwing `before_agent_start` hook — the plan reference is never delivered, yet the retry silently skips re-injection, so the agent runs without the approved plan for the rest of the session. Reproduced with a new test that drives the `@`-mention-throw and abort-during-setup paths on the first prompt, then a retry:

```
bun test --preload ./src/tools/renderers.ts test/agent-session-plan-reference-setup-bail.test.ts
```

Against the pre-fix (construction-time) flag, both retries fail to re-inject the plan (`1 pass, 2 fail`).

## Cause
`#buildPlanReferenceMessage` (`packages/coding-agent/src/session/agent-session.ts`) set `this.#planReferenceSent = true` at message-construction time, but the message is not handed to `agent.prompt` until much later in `#promptWithMessage` via `#promptAgentWithIdleRetry`. The four `if (this.#promptGeneration !== generation) return;` bail points and the `generateFileMentionMessages` / `before_agent_start` throws all sit between build and delivery, and the `#promptWithMessage` `finally` only calls `#endInFlight()` — it never clears the flag. So a bail/throw strands the flag `true` with nothing delivered, and the retry short-circuits at `if (this.#planReferenceSent) return null`. This is the pre-send gap in the same delivery-tracking invariant that issue #1246 fixed for the compaction path.

## Fix
- Removed the construction-time `this.#planReferenceSent = true` from `#buildPlanReferenceMessage`.
- In `#promptWithMessage`, commit the flag at the delivery hand-off point: set it only when a plan-reference message was built AND we are about to call `#promptAgentWithIdleRetry`. Every pre-send bail/throw now leaves the flag clear, so the next prompt re-injects the plan; a prompt that reaches `agent.prompt` sets it, so the plan is delivered exactly once.
- The compaction-success resets (issue #1246) still clear the flag for re-injection on the next turn — unchanged.
- Added `test/agent-session-plan-reference-setup-bail.test.ts`: retry re-injects after an `@`-mention read throw and after a mid-setup abort, plus a blast-radius guard that a successful delivery is not re-injected on the next turn.

## Verification
`bun test --preload ./src/tools/renderers.ts test/agent-session-plan-reference-setup-bail.test.ts test/agent-session-plan-reference-compaction.test.ts` → 6 pass / 0 fail (new tests plus the issue #1246 sibling, confirming the invariant is preserved). The `--preload` breaks an unrelated pre-existing module-init cycle that trips single-file isolated runs in this environment (the untouched #1246 test fails identically without it). Reverting the fix flips the two bail tests to fail, confirming the tests are non-vacuous.

Fixes #4094