### PR TITLE
fix(session): clear session-scoped tool state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Fixed
 
+- Fixed `/new` and cross-session switches retaining staged preview resolve callbacks and per-session ACP `allow_always`/`reject_always` decisions from the previous session ([#4093](https://github.com/can1357/oh-my-pi/issues/4093)).
+
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 ### Fixed
 
-- Fixed `/new` and cross-session switches retaining staged preview resolve callbacks and per-session ACP `allow_always`/`reject_always` decisions from the previous session ([#4093](https://github.com/can1357/oh-my-pi/issues/4093)).
+- Fixed `/new`, handoffs, and cross-session switches retaining staged preview resolve callbacks and per-session ACP `allow_always`/`reject_always` decisions from the previous session ([#4093](https://github.com/can1357/oh-my-pi/issues/4093)).
 
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3080,6 +3080,12 @@ export class AgentSession {
 		}
 	}
 
+	/** Drop mutable tool decisions and directives owned by the previous logical session. */
+	#clearSessionScopedToolState(): void {
+		this.#toolChoiceQueue.clear();
+		this.#acpPermissionDecisions.clear();
+	}
+
 	#resolveAdvisorRuntimeDescriptors(emitWarnings: boolean): AdvisorRuntimeDescriptor[] {
 		const legacy = !this.#advisorConfigs?.length;
 		const roster: AdvisorConfig[] = legacy ? [{ name: "default" }] : this.#advisorConfigs!;
@@ -10238,6 +10244,7 @@ export class AgentSession {
 			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
 		}
 
+		this.#clearSessionScopedToolState();
 		this.#clearCheckpointRuntimeState();
 		this.setTodoPhases([]);
 		this.#freshProviderSessionId = undefined;
@@ -17350,6 +17357,9 @@ export class AgentSession {
 
 			if (switchingToDifferentSession) {
 				await this.#resetMemoryContextForNewTranscript();
+			}
+			if (switchingToDifferentSession) {
+				this.#clearSessionScopedToolState();
 			}
 			this.#reconnectToAgent();
 			try {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -11739,6 +11739,8 @@ export class AgentSession {
 				this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
 			}
 
+			this.#clearSessionScopedToolState();
+
 			this.#clearCheckpointRuntimeState();
 			// agent.reset() clears the core steering/follow-up queues. Preserve any queued
 			// steers/follow-ups (RPC/SDK steer()/followUp() issued during the handoff, or a

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -32,6 +32,12 @@ import { type } from "arktype";
 let tempDir: TempDir;
 let session: AgentSession | undefined;
 
+const boundaryCases: Array<[decision: "allow_always" | "reject_always", transition: "new" | "switch"]> = [
+	["allow_always", "new"],
+	["allow_always", "switch"],
+	["reject_always", "new"],
+	["reject_always", "switch"],
+];
 /** Fake tool that records execute calls. */
 function makeFakeTool(name: string): AgentTool & { executeCalls: number } {
 	const tool = {
@@ -77,13 +83,20 @@ async function createSession(
 	tools: AgentTool[],
 	bridge?: ClientBridge,
 	settingsOverrides: Partial<Record<SettingPath, unknown>> = {},
-	options?: { xdevRegistry?: XdevRegistry; builtInToolNames?: string[]; initialMountedXdevToolNames?: string[] },
+	options?: {
+		xdevRegistry?: XdevRegistry;
+		builtInToolNames?: string[];
+		initialMountedXdevToolNames?: string[];
+		persist?: boolean;
+	},
 ): Promise<AgentSession> {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
 
 	const settings = Settings.isolated({ "compaction.enabled": false, ...settingsOverrides });
-	const sessionManager = SessionManager.inMemory(tempDir.path());
+	const sessionManager = options?.persist
+		? SessionManager.create(tempDir.path(), `${tempDir.path()}/sessions`)
+		: SessionManager.inMemory(tempDir.path());
 
 	const agent = new Agent({
 		getApiKey: () => "test-key",
@@ -837,6 +850,58 @@ it("allow_always: caches decision and calls bridge only once for subsequent exec
 	expect(permissionSpy).toHaveBeenCalledTimes(1);
 	expect(bashTool.executeCalls).toBe(2);
 });
+
+it.each(boundaryCases)(
+	"%s permission decisions prompt again after a successful %s session boundary",
+	async (decision, transition) => {
+		const bashTool = makeFakeTool("bash");
+		const bridge = makeBridge({ outcome: "selected", optionId: decision, kind: decision });
+		const permissionSpy = spyOn(bridge, "requestPermission");
+		session = await createSession([bashTool], bridge, {}, { persist: true });
+
+		await session.setActiveToolsByName(["bash"]);
+		const wrappedBash = session.agent.state.tools.find(tool => tool.name === "bash");
+		if (!wrappedBash) throw new Error("Expected wrapped bash tool");
+
+		for (let callIndex = 0; callIndex < 2; callIndex++) {
+			if (callIndex === 1) {
+				if (transition === "new") {
+					expect(await session.newSession()).toBe(true);
+				} else {
+					const targetId = `permission-target-${Bun.nanoseconds()}`;
+					const targetPath = `${tempDir.path()}/${targetId}.jsonl`;
+					await Bun.write(
+						targetPath,
+						`${JSON.stringify({
+							type: "session",
+							version: 3,
+							id: targetId,
+							timestamp: new Date().toISOString(),
+							cwd: tempDir.path(),
+						})}\n`,
+					);
+					expect(await session.switchSession(targetPath)).toBe(true);
+				}
+			}
+
+			const execution = wrappedBash.execute(
+				`call-${callIndex}`,
+				{ command: "echo boundary" },
+				undefined,
+				undefined as never,
+				undefined as never,
+			);
+			if (decision === "reject_always") {
+				await expect(execution).rejects.toThrow(/rejected by user/);
+			} else {
+				await execution;
+			}
+		}
+
+		expect(permissionSpy).toHaveBeenCalledTimes(2);
+		expect(bashTool.executeCalls).toBe(decision === "allow_always" ? 2 : 0);
+	},
+);
 
 // ---------------------------------------------------------------------------
 // 4. Read tool not gated: bridge never called even when bridge is set

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -163,6 +163,20 @@ describe("AgentSession handoff", () => {
 		expect(sessionManager.getEntries().filter(entry => entry.type === "compaction")).toHaveLength(0);
 	});
 
+	it("clears staged preview state when handoff creates the replacement session", async () => {
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockResolvedValue("## Goal\nContinue from here");
+		session.toolChoiceQueue.registerPendingInvoker("old-session-preview", "ast_edit", async () => ({
+			content: [{ type: "text", text: "applied old preview" }],
+		}));
+		expect(session.peekPendingInvoker()).toBeDefined();
+		expect(session.nextToolChoiceDirective()).toBeDefined();
+
+		await session.handoff();
+
+		expect(session.peekPendingInvoker()).toBeUndefined();
+		expect(session.nextToolChoiceDirective()).toBeUndefined();
+	});
+
 	it("emits handoff lifecycle hooks on the outgoing and replacement sessions", async () => {
 		const extensionsResult = await loadExtensions([], tempDir.path());
 		const extensionRunner = new ExtensionRunner(

--- a/packages/coding-agent/test/agent-session-resolve-reminder.test.ts
+++ b/packages/coding-agent/test/agent-session-resolve-reminder.test.ts
@@ -22,6 +22,7 @@ describe("AgentSession resolve reminder", () => {
 	let mock: MockModel;
 	let authStorage: AuthStorage | undefined;
 
+	const transitions: Array<"new" | "switch"> = ["new", "switch"];
 	beforeEach(async () => {
 		tempDir = path.join(os.tmpdir(), `pi-resolve-reminder-test-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
@@ -54,7 +55,7 @@ describe("AgentSession resolve reminder", () => {
 
 		session = new AgentSession({
 			agent,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.create(tempDir, path.join(tempDir, "sessions")),
 			settings: Settings.isolated(),
 			modelRegistry,
 		});
@@ -68,6 +69,26 @@ describe("AgentSession resolve reminder", () => {
 			removeSyncWithRetries(tempDir);
 		}
 	});
+
+	async function changeLogicalSession(transition: "new" | "switch"): Promise<void> {
+		if (transition === "new") {
+			expect(await session.newSession()).toBe(true);
+			return;
+		}
+		const targetId = `target-${Snowflake.next()}`;
+		const targetPath = path.join(tempDir, `${targetId}.jsonl`);
+		await Bun.write(
+			targetPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: targetId,
+				timestamp: new Date().toISOString(),
+				cwd: tempDir,
+			})}\n`,
+		);
+		expect(await session.switchSession(targetPath)).toBe(true);
+	}
 
 	it("delivers the resolve reminder via a non-forcing soft requirement, not a steer or a forced tool_choice", () => {
 		queueResolveHandler(toolSession, {
@@ -91,6 +112,21 @@ describe("AgentSession resolve reminder", () => {
 			expect(reminder.customType).toBe("resolve-reminder");
 		}
 		expect(session.agent.peekSteeringQueue()).toHaveLength(0);
+	});
+
+	it.each(transitions)("clears a staged preview after a successful %s session boundary", async transition => {
+		queueResolveHandler(toolSession, {
+			label: "AST Edit: 1 replacement in 1 file",
+			sourceToolName: "ast_edit",
+			apply: async () => ({ content: [{ type: "text", text: "Applied" }] }),
+		});
+		expect(session.peekPendingInvoker()).toBeDefined();
+		expect(isSoftToolRequirement(session.nextToolChoiceDirective())).toBe(true);
+
+		await changeLogicalSession(transition);
+
+		expect(session.peekPendingInvoker()).toBeUndefined();
+		expect(session.nextToolChoiceDirective()).toBeUndefined();
 	});
 
 	it("dispatches a staged preview through the production toolSession wiring and drains the gate", async () => {


### PR DESCRIPTION
## Repro
On current `main`, stage a preview with `queueResolveHandler`, cache an ACP `allow_always` decision through a gated `bash` execution, then call `AgentSession.newSession()` on the same instance: `peekPendingInvoker()` and `nextToolChoiceDirective()` remain defined, and a second `bash` execution does not call `requestPermission` again. The same state survives a cross-file `switchSession()`. The added regression paths can be exercised with `bun build test/agent-session-resolve-reminder.test.ts --target=bun --external=omp-legacy-pi-modules --outfile=/tmp/agent-session-resolve-reminder.test.bundle.js && bun test /tmp/agent-session-resolve-reminder.test.bundle.js` and the equivalent command for `test/agent-session-acp-permission.test.ts`.

## Cause
`AgentSession.newSession()` and `AgentSession.switchSession()` reset agent queues, transcript state, and advisor state, but never cleared the session-owned `#toolChoiceQueue` or `#acpPermissionDecisions`. `abort()` only rejects an in-flight hard directive, so pending preview invokers and ACP always decisions remained reachable after the logical session changed.

## Fix
- Add `#clearSessionScopedToolState()` to clear both registries at one boundary.
- Invoke it after a successful new-session transition and after a successful switch to a different session, while leaving ordinary aborts and same-session reloads unchanged.
- Cover new and switched sessions for staged preview invokers plus ACP `allow_always` and `reject_always` decisions.
- Document the fix in the coding-agent changelog.

## Verification
`bun check` passed. Bundled focused suites passed: `agent-session-resolve-reminder.test.ts` (5 tests, 25 assertions) and `agent-session-acp-permission.test.ts` (29 tests, 100 assertions). The original one-test reproducer changed from retaining a pending invoker and one permission prompt to returning no resolve directive and issuing a second permission prompt.

Fixes #4093