### PR TITLE
fix(session): resume resolved tool stalls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed discarded `Settings` instances keeping debounced save timers and chained background saves armed; discarding an instance now cancels its pending writes so they cannot race a successor's file locks.
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
+- Fixed transient provider stream stalls after tool calls failing to auto-retry even when every call already had a tool result, including synthetic `executed:false` results from OpenAI-completions stalls ([#6414](https://github.com/can1357/oh-my-pi/issues/6414)).
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.
 - Fixed credential-shaped tokens (GitHub/GitLab/OpenAI/Anthropic key patterns) being redacted from outbound provider requests even with `secrets.enabled` off; the pattern redaction now follows the `secrets.enabled` ("Hide Secrets") setting like the secret obfuscator.
 - Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5227,11 +5227,11 @@ export class AgentSession {
 					return;
 				}
 			}
-			const resumeCursorStreamStall = this.#canResumeCursorStreamStall(msg);
-			if (resumeCursorStreamStall || this.#isRetryableError(msg)) {
+			const resumeResolvedStreamStall = this.#canResumeResolvedStreamStall(msg);
+			if (resumeResolvedStreamStall || this.#isRetryableError(msg)) {
 				const didRetry = await this.#handleRetryableError(
 					msg,
-					resumeCursorStreamStall ? { preserveFailedTurn: true } : undefined,
+					resumeResolvedStreamStall ? { preserveFailedTurn: true } : undefined,
 				);
 				if (didRetry) {
 					await emitAgentEndNotification({ willContinue: true });
@@ -15266,17 +15266,13 @@ export class AgentSession {
 	}
 
 	/**
-	 * Resume a stalled Cursor turn after every server-executed tool has produced
-	 * a result. The failed assistant/tool-result pair must stay in context: it
-	 * records completed side effects and lets the next request continue from
-	 * them instead of replaying the original turn.
+	 * Resume a stalled turn after every emitted tool call has produced a result.
+	 * Cursor calls must also carry the server-execution marker. The failed
+	 * assistant/tool-result pair stays in context so completed side effects are
+	 * continued from rather than replayed.
 	 */
-	#canResumeCursorStreamStall(message: AssistantMessage): boolean {
-		if (
-			message.provider !== "cursor" ||
-			message.stopReason !== "error" ||
-			!message.errorMessage?.toLowerCase().includes("stream stall")
-		) {
+	#canResumeResolvedStreamStall(message: AssistantMessage): boolean {
+		if (message.stopReason !== "error" || !message.errorMessage?.toLowerCase().includes("stream stall")) {
 			return false;
 		}
 		const id = this.#classifyRetryMessage(message);
@@ -15285,7 +15281,12 @@ export class AgentSession {
 		const resolvedToolCallIds: string[] = [];
 		for (const block of message.content) {
 			if (block.type !== "toolCall") continue;
-			if (!(kCursorExecResolved in block) || block[kCursorExecResolved] !== true) return false;
+			if (
+				message.provider === "cursor" &&
+				(!(kCursorExecResolved in block) || block[kCursorExecResolved] !== true)
+			) {
+				return false;
+			}
 			resolvedToolCallIds.push(block.id);
 		}
 		if (resolvedToolCallIds.length === 0) return false;
@@ -16131,8 +16132,8 @@ export class AgentSession {
 			errorId: message.errorId,
 		});
 
-		// Cursor exec-channel tools have already run and emitted results. Keep that
-		// failed turn intact so continuation cannot repeat their side effects.
+		// Resolved stream-stall tools have already emitted results. Keep that failed
+		// turn intact so continuation cannot repeat their side effects.
 		if (!options?.preserveFailedTurn) {
 			this.#removeAssistantMessageFromActiveContext(message, "auto-retry");
 		}

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -744,9 +744,11 @@ describe("AgentSession retry delay cap", () => {
 
 		const retryStartEvents: AutoRetryStartEvent[] = [];
 		const retryEndEvents: AutoRetryEndEvent[] = [];
+		const agentEndEvents: Array<Extract<AgentSessionEvent, { type: "agent_end" }>> = [];
 		session.subscribe(event => {
 			if (event.type === "auto_retry_start") retryStartEvents.push(event);
 			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+			if (event.type === "agent_end") agentEndEvents.push(event);
 		});
 
 		await session.prompt("Write a large report");
@@ -756,11 +758,128 @@ describe("AgentSession retry delay cap", () => {
 		expect(retryStartEvents).toHaveLength(0);
 		expect(retryEndEvents).toHaveLength(0);
 		expect(session.agent.state.messages.at(-1)?.role).toBe("toolResult");
-		const lastError = [...session.agent.state.messages]
+		expect(agentEndEvents).toHaveLength(1);
+		expect(agentEndEvents[0].isTerminal).toBe(true);
+		const terminalError = [...agentEndEvents[0].messages]
 			.reverse()
 			.find((message): message is AssistantMessage => message.role === "assistant");
-		expect(lastError?.stopReason).toBe("error");
-		expect(lastError?.errorMessage).toBe("The operation timed out.");
+		expect(terminalError?.stopReason).toBe("error");
+		expect(terminalError?.errorMessage).toBe("The operation timed out.");
+	});
+
+	it("resumes an OpenAI-completions stall after a synthetic unexecuted tool result", async () => {
+		const stallMessage = "OpenAI completions stream stalled while waiting for the next event";
+		const model = createMockModel({
+			id: "grok-4",
+			provider: "openrouter",
+		});
+		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "grok-write-1",
+			name: "write",
+			arguments: { path: "review.md", content: "partial review" },
+		};
+		let streamCalls = 0;
+		let resumedWithSyntheticResult = false;
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (_requestedModel, context, options) => {
+				streamCalls += 1;
+				if (streamCalls > 1) {
+					const matchingResult = context.messages.find(
+						message => message.role === "toolResult" && message.toolCallId === toolCall.id,
+					);
+					resumedWithSyntheticResult =
+						matchingResult?.role === "toolResult" &&
+						typeof matchingResult.details === "object" &&
+						matchingResult.details !== null &&
+						"executed" in matchingResult.details &&
+						matchingResult.details.executed === false;
+					model.push({ content: ["Recovered after Grok stall"] });
+					return model.stream(model, context, options);
+				}
+
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial: AssistantMessage = {
+						role: "assistant",
+						content: [toolCall],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial });
+					stream.push({ type: "toolcall_start", contentIndex: 0, partial });
+					stream.push({
+						type: "toolcall_delta",
+						contentIndex: 0,
+						delta: JSON.stringify(toolCall.arguments),
+						partial,
+					});
+					stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: {
+							...partial,
+							stopReason: "error",
+							errorMessage: stallMessage,
+						},
+					});
+				});
+				return stream;
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Write a review");
+		await session.waitForIdle();
+
+		expect(streamCalls).toBe(2);
+		expect(resumedWithSyntheticResult).toBe(true);
+		expect(
+			session.agent.state.messages.filter(
+				message => message.role === "toolResult" && message.toolCallId === toolCall.id,
+			),
+		).toHaveLength(1);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toContainEqual(expect.objectContaining({ success: true, attempt: 1 }));
+		expect(lastAssistant(session).content).toContainEqual({ type: "text", text: "Recovered after Grok stall" });
 	});
 
 	it("resumes a stalled Cursor stream after its exec tool result", async () => {


### PR DESCRIPTION
## Repro
A deterministic OpenRouter/Grok-shaped stream emits a complete tool call and then `OpenAI completions stream stalled while waiting for the next event`; the agent synthesizes an `executed:false` tool result, but `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts -t "resumes an OpenAI-completions stall"` originally failed with `Expected: 2, Received: 1` provider calls.

## Cause
`AgentSession.#hasReplayUnsafeToolOutput` correctly blocked generic retries whenever a failed assistant message contained a tool call, but only `#canResumeCursorStreamStall` could prove a resolved tool turn safe and preserve it. OpenAI-completions stalls therefore never entered `#handleRetryableError`, even after `packages/agent` had appended a matching synthetic non-executed result.

## Fix
- Generalize the resolved stream-stall resume gate while retaining Cursor’s server-execution marker check.
- Require a matching post-assistant tool result for every emitted tool call, then preserve the failed assistant/result pair during continuation.
- Cover Grok-style synthetic results, unchanged non-stall replay safety, Cursor recovery, and terminal error-bearing `agent_end` delivery.
- Add the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-cap.test.ts` passes: 19 tests, 255510 assertions, 0 failures. The publish gate also completed formatting and `bun check`.

Fixes #6414