### PR TITLE
fix(config): preserve symlinked settings files

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed settings saves replacing symlinked global and project `config.yml` files, preserving dotfiles/Nix links by writing through to their targets instead ([#4452](https://github.com/can1357/oh-my-pi/issues/4452)).
 - Fixed discarded `Settings` instances keeping debounced save timers and chained background saves armed; discarding an instance now cancels its pending writes so they cannot race a successor's file locks.
 - Fixed `error.notify` raising a "Stopped with error" toast for provider failures while an auto-retry or async-delivery continuation was pending; the toast now waits for the true terminal settle.
 - Fixed terminal `yield` results racing post-turn maintenance, which could trigger an unnecessary automatic handoff or compaction.

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -61,6 +61,16 @@ export interface RawSettings {
 	[key: string]: unknown;
 }
 
+async function writeConfigFile(configPath: string, settings: RawSettings): Promise<void> {
+	let writePath = configPath;
+	try {
+		writePath = await fs.promises.realpath(configPath);
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+	}
+	await Bun.write(writePath, YAML.stringify(settings, null, 2));
+}
+
 export interface SettingsOptions {
 	/** Current working directory for project settings discovery */
 	cwd?: string;
@@ -1176,7 +1186,7 @@ export class Settings {
 		// 3. Write merged settings
 		if (migrated && Object.keys(settings).length > 0) {
 			try {
-				await Bun.write(this.#configPath, YAML.stringify(settings, null, 2));
+				await writeConfigFile(this.#configPath, settings);
 				logger.debug("Settings: migrated to config.yml", { path: this.#configPath });
 			} catch {}
 		}
@@ -1765,7 +1775,7 @@ export class Settings {
 
 				// Update our global with any external changes we preserved
 				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				await writeConfigFile(configPath, this.#global);
 				// These pending roles were included in this write. Remove each
 				// only if no newer local change arrived while Bun.write was in
 				// flight; a newer value still needs the queued follow-up save.
@@ -1827,7 +1837,7 @@ export class Settings {
 					setByPath(projectSettings, ["modelRoles", role], value);
 				}
 
-				await Bun.write(projectConfigPath, YAML.stringify(projectSettings, null, 2));
+				await writeConfigFile(projectConfigPath, projectSettings);
 			});
 			invalidateCapabilityFsCache(projectConfigPath);
 		} catch (error) {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -91,6 +91,21 @@ describe("Settings", () => {
 			expect(await Bun.file(getConfigPath()).exists()).toBe(false);
 		});
 
+		it("writes through a symlinked config file without replacing the link", async () => {
+			const targetPath = tempDir.join("dotfiles", "config.yml");
+			fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+			await Bun.write(targetPath, YAML.stringify({ setupVersion: 1 }, null, 2));
+			fs.symlinkSync(targetPath, getConfigPath());
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 2);
+			await settings.flush();
+
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+			const savedSettings = YAML.parse(await Bun.file(targetPath).text()) as Record<string, unknown>;
+			expect(savedSettings.setupVersion).toBe(2);
+		});
+
 		it("clones the selected config.yaml path for persisted settings", async () => {
 			const yamlConfigPath = path.join(agentDir, "config.yaml");
 			await Bun.write(yamlConfigPath, YAML.stringify({ setupVersion: 1 }, null, 2));


### PR DESCRIPTION
## Repro
On macOS with omp 16.3.4 and Bun 1.3.13, point `~/.omp/agent/config.yml` at a tracked file with `ln -s /path/to/dotfiles/config.yml ~/.omp/agent/config.yml`, start `omp`, open `/settings`, and change a persisted setting. The save replaces `config.yml` with a regular file instead of updating the tracked target.

## Cause
`Settings.#saveNow`, the config migration path, and `Settings.#saveProjectNow` passed the lexical config path directly to `Bun.write`. On the affected runtime, writing that path replaces the directory entry when it is a symlink, leaving the referent stale.

## Fix
- Resolve an existing config path with `realpath` before serializing settings, so writes target the referent while missing first-run paths retain existing creation behavior.
- Route global saves, migrations, and project model-role saves through the same symlink-safe path.
- Add a settings-level regression covering link preservation and target updates, plus the Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/settings-manager.test.ts` passed 66 tests with 0 failures. `bun run check` in `packages/coding-agent` passed. A Settings init/set/flush smoke run returned `{"symlinkPreserved":true,"targetContent":"setupVersion: 2"}`.

Fixes #4452