### PR TITLE
docs: document /vibe mode and /fresh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,13 @@ Three standalone, lowercase words opt a turn into specialized agent behavior:
 
 They trigger only in prose, not inside code spans, fenced code blocks, XML/HTML sections, identifiers, or paths. See [Magic keywords](docs/magic-keywords.md) for exact matching rules and configuration.
 
+### Session controls
+
+Slash commands shift how a whole session runs:
+
+- `/vibe` — enter [Vibe mode](docs/vibe-mode.md): act as a director driving persistent `fast`/`good` worker sessions with a `read`-only toolset.
+- `/fresh` — reset the provider stream state (stale prompt cache, wedged stream) without changing the local transcript. See [Session operations](docs/session-operations-export-share-fork-resume.md#fresh).
+
 ## Forty-plus providers, hundreds of models, _one /model away_.
 
 Roles route work by intent. `default` for normal turns. `smol` for cheap subagent fan-out. `slow` for deep reasoning. `plan` for plan mode. `commit` for changelogs. Override at launch with `--smol`, `--slow`, or `--plan`; cycle through the configured models for the active role with `Ctrl+P`. Swap the active model mid-session with the `/model` slash command.

--- a/docs/session-operations-export-share-fork-resume.md
+++ b/docs/session-operations-export-share-fork-resume.md
@@ -155,6 +155,31 @@ Cancellation/abort semantics in share:
 - The upload itself is not aborted mid-flight; cancellation is UI-level and
   checked after the upload returns.
 
+## Fresh
+
+Interactive `/fresh` resets the provider-facing stream state of the current
+session **without touching the local transcript, session file, or header**. Use
+it to recover from a wedged or corrupted provider stream (stale prompt cache,
+a mid-turn glitch, or a server-side conversation id that has drifted) while
+keeping the conversation you can see.
+
+`AgentSession.freshSession()`:
+
+- Is rejected while the agent is streaming — wait for the response to finish or
+  abort it first.
+- Closes every cached provider-session state entry (server-side conversation /
+  prompt-cache handles) and reports how many were pruned.
+- Mints a fresh provider session id and re-keys hindsight and mnemopi memory to
+  it, and invalidates the append-only context so the next turn re-sends the full
+  local transcript to the provider.
+- Leaves the local transcript, session file, and session identity unchanged, so
+  nothing you have said or received is lost.
+
+Because it keeps the current session file, `/fresh` differs from `/new` (start a
+brand-new empty session) and `/drop` (delete the current session and start a new
+one): only `/fresh` preserves the visible history while giving the provider a
+clean slate.
+
 ## Fork
 
 Interactive `/fork` creates a new session from the current one and switches the active session identity.

--- a/docs/vibe-mode.md
+++ b/docs/vibe-mode.md
@@ -1,0 +1,71 @@
+# Vibe mode
+
+Vibe mode turns the session into a **director** that drives persistent background
+worker sessions instead of editing code itself. In vibe mode your own toolset is
+stripped down to `read` plus five worker-control tools; the workers do the
+grepping, editing, running, and building, and you verify their work by reading
+the files they touch.
+
+## Enabling and disabling
+
+Toggle it with the `/vibe` slash command:
+
+```text
+/vibe                 # enter vibe mode
+/vibe fix the flaky test in packages/tui   # enter and submit a first directive
+/vibe                 # run again to exit
+```
+
+- Entering installs the vibe tools, reduces the active toolset to `read` + the
+  vibe tools, and injects the director instructions for the turn.
+- An inline prompt (`/vibe <prompt>`) enters the mode and submits that prompt as
+  the first directive.
+- Exiting restores the previous toolset and **kills every worker session** — a
+  worker never outlives the mode that directs it.
+- Vibe mode is mutually exclusive with plan mode and goal mode; exit those
+  first. The status line shows a `Vibe` indicator while it is on.
+
+## The two worker tiers
+
+Every worker is a full coding agent with the normal tool surface. You choose a
+tier when you spawn one:
+
+| Tier   | Backing agent | Model role | Use for |
+|--------|---------------|------------|---------|
+| `fast` | `sonic`       | `@smol` (low-latency role) | Mechanical execution, drafts, high-volume work |
+| `good` | `task`        | `@task` (the session's strong model) | Design, judgment calls, reviewing `fast` output |
+
+Model resolution follows the same path as a `task` spawn, so
+`task.agentModelOverrides` and your model-role settings apply.
+
+## Worker-control tools
+
+| Tool | Purpose |
+|------|---------|
+| `vibe_spawn` | Start a worker (`fast` or `good`) with a complete, self-contained brief. Workers start blank — they never see the director's conversation. |
+| `vibe_send`  | Send a follow-up turn to a worker: a correction, the next step, or a review request. |
+| `vibe_wait`  | Block until a worker settles its next turn. Sends and spawns return immediately; results arrive on their own, so call `vibe_wait` only when you cannot proceed without one. |
+| `vibe_kill`  | Tear down a worker that is stuck or whose workstream is done. |
+| `vibe_list`  | List the active worker roster when you lose track of it. |
+
+A spawn or send returns immediately; the worker's turn result is delivered back
+into the director's conversation on its own, exactly like an async `task`
+result. Running one `fast` and one `good` worker on different workstreams
+concurrently is the normal shape.
+
+## Workflow
+
+1. Split the request into independent workstreams — one worker session per
+   workstream so each builds useful local context.
+2. `vibe_spawn` with a self-contained brief: files, constraints, acceptance
+   criteria.
+3. Keep directing other workers while turns are in flight; `vibe_wait` only when
+   blocked.
+4. When a turn result arrives, `read` the touched files to verify claims before
+   building on them, then `vibe_send` the next step.
+5. Route by difficulty: draft with `fast`, escalate to `good` when `fast` stalls
+   or the problem needs judgment.
+6. `vibe_kill` finished or stuck workers; `vibe_list` to recover the roster.
+
+You stay responsible for the final outcome — verify with `read`, never take a
+worker's word for it.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Made the statusline `git` segment jj-aware: in a Jujutsu repo it shows the nearest bookmark (falling back to the short change-id) instead of git's `detached` label or nothing, and working-copy change counts come from jj where there is no `.git` to read ([#3582](https://github.com/can1357/oh-my-pi/issues/3582))
 - Added `block`/`unblock` todo operations and a `blocked` status for tasks waiting on external input; blocked tasks stay visible in the todo HUD and summary but are excluded from the incomplete-todo stop reminder, and an optional blocker note records what the task is waiting for.
 - Added a toggle-list editor in `/settings` for array-of-enum settings: `providers.webSearchOrder` and `providers.imageOrder` (ordered — Enter/Space toggles, ←/→ nudges, 1-9 splices the hovered provider into that position) and `providers.webSearchExclude` now appear under Providers → Services instead of being config-file only.
+- Documented Vibe mode (`/vibe`) in `docs/vibe-mode.md` and the `/fresh` provider-stream reset in the session-operations doc, and linked both from the README's new "Session controls" section ([#6440](https://github.com/can1357/oh-my-pi/issues/6440)).
 
 ### Changed
 


### PR DESCRIPTION
## Repro
Searching the README for `vibe` returns no hits, and `/fresh` is impossible to find (the word `fresh` appears throughout the tree). `/vibe` — a full director/worker orchestration mode — has no user-facing page in `docs/`, and `/fresh` appears only as a matrix row in `docs/session-operations-export-share-fork-resume.md`, a doc whose own title (`... share, fresh, fork ...`) promises a section that does not exist. A user can only learn what these commands do by reading the source. Reported in #6440.

## Cause
No documentation gap in code, but a genuine docs gap: `/vibe` (`packages/coding-agent/src/slash-commands/builtin-registry.ts` → `handleVibeModeCommand`, `packages/coding-agent/src/vibe/runtime.ts`) and `/fresh` (`AgentSession.freshSession()` in `packages/coding-agent/src/session/agent-session.ts`) are shipping user-facing slash commands with only in-app descriptions. This mirrors the accepted magic-keywords documentation issue (#5590/#5591).

## Fix
- Add `docs/vibe-mode.md`: enabling/disabling `/vibe`, the `fast` (`sonic`/`@smol`) and `good` (`task`/`@task`) worker tiers, the five `vibe_*` control tools, and the director workflow.
- Add a `## Fresh` section to `docs/session-operations-export-share-fork-resume.md` describing the provider stream/session-state reset (`freshSession()`), its streaming guard, and its contrast with `/new` and `/drop`.
- Add a `Session controls` subsection to the README linking both docs, so `vibe` and `fresh` are now findable there.
- Changelog entry under `[Unreleased] → Added`.

## Verification
Docs-only change. Re-read all four edited files for accuracy against the source (`VIBE_CLI_AGENT` tier mapping, `activateVibeTools(["read"])` toolset, `freshSession()` behavior); the README `#fresh` anchor resolves to the new `## Fresh` heading. Pre-publish gate (`bun run fix` + `bun check`) passed on push. Fixes #6440