### PR TITLE
feat(task): add external executor hook without replacing Task

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -20,6 +20,7 @@ import { execCommand } from "../../exec/exec";
 import * as PiCodingAgent from "../../index";
 import type { CustomMessagePayload } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
+import type { ExternalTaskExecutor } from "../../task/types";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/legacy-pi-compat";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import * as TypeBox from "../typebox";
@@ -152,6 +153,21 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 			definition: tool,
 			extensionPath: this.extension.path,
 		});
+	}
+
+	registerTaskExecutor(executor: ExternalTaskExecutor): void {
+		if (!executor || executor.discriminator !== "recipe" || typeof executor.start !== "function") {
+			throw new Error('registerTaskExecutor() requires a valid executor for discriminator "recipe".');
+		}
+		if (this.extension.externalTaskExecutor) {
+			throw new Error(
+				`Extension "${this.extension.path}" registered more than one external Task executor for discriminator "recipe".`,
+			);
+		}
+		this.extension.externalTaskExecutor = {
+			executor,
+			extensionPath: this.extension.path,
+		};
 	}
 
 	registerCommand(

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -41,6 +41,7 @@ import type {
 	InputEventResult,
 	MessageRenderer,
 	RegisteredCommand,
+	RegisteredExternalTaskExecutor,
 	RegisteredTool,
 	ResourcesDiscoverEvent,
 	ResourcesDiscoverResult,
@@ -391,6 +392,25 @@ export class ExtensionRunner {
 			}
 		}
 		return tools;
+	}
+
+	/**
+	 * Resolve the one external Task executor allowed for this session.
+	 * Duplicate registrations fail instead of depending on extension load order.
+	 */
+	getExternalTaskExecutor(): RegisteredExternalTaskExecutor | undefined {
+		let registered: RegisteredExternalTaskExecutor | undefined;
+		for (const extension of this.extensions) {
+			const candidate = extension.externalTaskExecutor;
+			if (!candidate) continue;
+			if (registered) {
+				throw new Error(
+					`Multiple external Task executors registered for discriminator "recipe": "${registered.extensionPath}" and "${candidate.extensionPath}".`,
+				);
+			}
+			registered = candidate;
+		}
+		return registered;
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -49,6 +49,7 @@ import type { Theme } from "../../modes/theme/theme";
 import type { CompactMode } from "../../session/compact-modes";
 import type { CustomMessage, CustomMessagePayload } from "../../session/messages";
 import type { ReadonlySessionManager, SessionManager } from "../../session/session-manager";
+import type { ExternalTaskExecutor } from "../../task/types";
 import type {
 	BashToolDetails,
 	BashToolInput,
@@ -1132,6 +1133,14 @@ export interface ExtensionAPI {
 	/** Register a tool that the LLM can call. */
 	registerTool<TParams extends TSchema = TSchema, TDetails = unknown>(tool: ToolDefinition<TParams, TDetails>): void;
 
+	/**
+	 * Register the session's external Task item executor.
+	 *
+	 * Only one `recipe` executor may be registered across all loaded extensions.
+	 * This augments the native `task` tool; it does not register or replace a tool.
+	 */
+	registerTaskExecutor(executor: ExternalTaskExecutor): void;
+
 	// =========================================================================
 	// Command, Shortcut, Flag Registration
 	// =========================================================================
@@ -1361,6 +1370,11 @@ export interface RegisteredTool<TParams extends TSchema = TSchema, TDetails = un
 	extensionPath: string;
 }
 
+export interface RegisteredExternalTaskExecutor {
+	executor: ExternalTaskExecutor;
+	extensionPath: string;
+}
+
 export interface ExtensionFlag {
 	name: string;
 	description?: string;
@@ -1470,6 +1484,7 @@ export interface Extension {
 	label?: string;
 	handlers: Map<string, HandlerFn[]>;
 	tools: Map<string, RegisteredTool<any, any>>;
+	externalTaskExecutor?: RegisteredExternalTaskExecutor;
 	assistantThinkingRenderers: AssistantThinkingRenderer[];
 	messageRenderers: Map<string, MessageRenderer>;
 	commands: Map<string, RegisteredCommand>;

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -52,8 +52,14 @@ export interface RpcClientOptions {
 	cliPath?: string;
 	/** Working directory for the agent */
 	cwd?: string;
-	/** Environment variables */
+	/** Environment variables overlaid on the ambient environment by default */
 	env?: Record<string, string>;
+	/**
+	 * How to construct the child environment. `"merge"` preserves the default behavior by overlaying
+	 * {@link env} on `Bun.env`. `"replace"` passes only {@link env}, preventing ambient variables
+	 * (including credentials) from reaching the child; callers must supply every required variable.
+	 */
+	envMode?: "merge" | "replace";
 	/** Provider to use */
 	provider?: string;
 	/** Model ID to use */
@@ -298,9 +304,9 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		const child = ptree.spawn(["bun", cliPath, ...args], {
+		const child = ptree.spawn([process.execPath, cliPath, ...args], {
 			cwd: this.options.cwd,
-			env: { ...Bun.env, ...this.options.env },
+			env: this.options.envMode === "replace" ? (this.options.env ?? {}) : { ...Bun.env, ...this.options.env },
 			stdin: "pipe",
 		});
 		this.#process = child;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -151,7 +151,7 @@ import {
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
 import { wrapStreamFnWithProviderConcurrency } from "./task/provider-concurrency";
-import type { StructuredSubagentSchemaMode } from "./task/types";
+import type { ExternalTaskExecutor, StructuredSubagentSchemaMode } from "./task/types";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -1599,6 +1599,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				activeToolNames.add(name);
 			}
 		};
+		let externalTaskExecutor: ExternalTaskExecutor | undefined;
 		const toolSession: ToolSession = {
 			get cwd() {
 				return sessionManager.getCwd();
@@ -1626,6 +1627,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			},
 			refreshSkills: () => session.refreshSkills(),
 			rules: allRules,
+			get externalTaskExecutor() {
+				return externalTaskExecutor;
+			},
 			eventBus,
 			outputSchema: options.outputSchema,
 			outputSchemaMode: options.outputSchemaMode,
@@ -2400,6 +2404,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings,
 			localProtocolOptions,
 		);
+		externalTaskExecutor = extensionRunner.getExternalTaskExecutor()?.executor;
 
 		credentialDisabledTarget = extensionRunner;
 		for (const event of startupCredentialDisabledEvents.splice(0)) {
@@ -2422,7 +2427,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		});
 		const toolContextStore = new ToolContextStore(getSessionContext);
 
-		const registeredTools = restrictToolNames ? [] : extensionRunner.getAllRegisteredTools();
+		const registeredTools = restrictToolNames
+			? []
+			: extensionRunner.getAllRegisteredTools().filter(registeredTool => {
+					if (registeredTool.definition.name !== "task") return true;
+					logger.warn(
+						`Ignoring extension tool "task" from ${registeredTool.extensionPath}; extensions must use registerTaskExecutor() to augment the native Task tool.`,
+					);
+					return false;
+				});
 		const sdkCustomTools = restrictToolNames
 			? []
 			: (options.customTools?.filter(tool => !isLegacyBuiltinToolDefinition(tool)) ?? []);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2438,7 +2438,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				});
 		const sdkCustomTools = restrictToolNames
 			? []
-			: (options.customTools?.filter(tool => !isLegacyBuiltinToolDefinition(tool)) ?? []);
+			: (options.customTools ?? [])
+					.filter(tool => !isLegacyBuiltinToolDefinition(tool))
+					.filter(tool => {
+						if (tool.name !== "task") return true;
+						logger.warn(
+							'Ignoring customTools entry "task"; the native Task tool cannot be replaced via customTools. Use an extension\'s registerTaskExecutor() to augment it instead.',
+						);
+						return false;
+					});
 		const allCustomTools = [
 			...registeredTools,
 			...sdkCustomTools.map(tool => {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -30,6 +30,8 @@ import { resolveSpawnPolicy } from "./spawn-policy";
 import {
 	type AgentDefinition,
 	type AgentProgress,
+	type ExternalTaskExecution,
+	type ExternalTaskResult,
 	canSpawnAtDepth,
 	getTaskSchema,
 	type SingleResult,
@@ -104,10 +106,16 @@ export { AgentOutputManager } from "./output-manager";
 export type {
 	AgentDefinition,
 	AgentProgress,
+	ExternalTaskExecution,
+	ExternalTaskExecutor,
+	ExternalTaskExecutorRequest,
+	ExternalTaskProgress,
+	ExternalTaskResult,
 	SingleResult,
 	SubagentEventPayload,
 	SubagentLifecyclePayload,
 	SubagentProgressPayload,
+	TaskItem,
 	TaskParams,
 	TaskToolDetails,
 } from "./types";
@@ -115,6 +123,7 @@ export {
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
+	taskItemSchema,
 	taskSchema,
 } from "./types";
 
@@ -244,7 +253,34 @@ function hasInvalidModelSelector(model: unknown): boolean {
 	);
 }
 
-function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string | undefined {
+function validateRecipeItem(item: TaskItem, label: string, executorAvailable: boolean): string | undefined {
+	if (!Object.hasOwn(item, "recipe")) return undefined;
+	if (typeof item.recipe !== "string" || item.recipe.trim() === "") {
+		return `${label} has an invalid \`recipe\`. Provide a non-empty recipe identifier.`;
+	}
+	if (Object.hasOwn(item, "agent")) {
+		return `${label} cannot set both \`agent\` and \`recipe\`; choose native or external execution.`;
+	}
+	if (Object.hasOwn(item, "model")) {
+		return `${label} cannot set \`model\` for a recipe item; external model overrides are not supported.`;
+	}
+	if (Object.hasOwn(item, "outputSchema") || Object.hasOwn(item, "schemaMode")) {
+		return `${label} cannot set \`outputSchema\` or \`schemaMode\` for a recipe item; typed output schemas are not supported.`;
+	}
+	if (Object.hasOwn(item, "isolated")) {
+		return `${label} cannot set \`isolated\` for a recipe item; external worktree isolation is not supported.`;
+	}
+	if (!executorAvailable) {
+		return `${label} requested recipe execution, but no external Task executor is registered for discriminator \`recipe\`.`;
+	}
+	return undefined;
+}
+
+function validateSpawnParams(
+	params: TaskParams,
+	batchEnabled: boolean,
+	externalTaskExecutorAvailable: boolean,
+): string | undefined {
 	const hasTask = typeof params.task === "string" && params.task.trim() !== "";
 	const tasks = params.tasks;
 	if (batchEnabled && tasks !== undefined) {
@@ -259,7 +295,13 @@ function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string 
 			if (!item || typeof item.task !== "string" || item.task.trim() === "") {
 				return `Task ${i + 1}${item?.name ? ` (\`${item.name}\`)` : ""} is missing \`task\`. Every task needs complete, self-contained instructions.`;
 			}
-			if (hasInvalidModelSelector(item.model)) {
+			const recipeError = validateRecipeItem(
+				item,
+				`Task ${i + 1}${item?.name ? ` (\`${item.name}\`)` : ""}`,
+				externalTaskExecutorAvailable,
+			);
+			if (recipeError) return recipeError;
+			if (!Object.hasOwn(item, "recipe") && hasInvalidModelSelector(item.model)) {
 				return `Task ${i + 1}${item.name ? ` (\`${item.name}\`)` : ""} has an invalid \`model\`. Provide a non-empty selector or a non-empty array of non-empty selectors.`;
 			}
 		}
@@ -284,7 +326,9 @@ function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string 
 			? "Missing `tasks`. Provide a `tasks` array (one subagent per item) with a shared `context`."
 			: "Missing `task`. Provide complete, self-contained instructions for the agent.";
 	}
-	if (hasInvalidModelSelector(params.model)) {
+	const recipeError = validateRecipeItem(params, "Task", externalTaskExecutorAvailable);
+	if (recipeError) return recipeError;
+	if (!Object.hasOwn(params, "recipe") && hasInvalidModelSelector(params.model)) {
 		return "Invalid `model`. Provide a non-empty selector or a non-empty array of non-empty selectors.";
 	}
 	return undefined;
@@ -300,7 +344,13 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
 		return params.tasks;
 	}
-	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task, model: params.model };
+	const item: TaskItem = {
+		name: params.name,
+		agent: params.agent,
+		task: params.task,
+		model: params.model,
+	};
+	if ("recipe" in params) item.recipe = params.recipe;
 	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
 	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
 	if ("isolated" in params) item.isolated = params.isolated;
@@ -317,7 +367,9 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
  * `isolated` (batch form) wins over the top-level flag (flat form).
  */
 function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string): TaskParams {
-	const spawn: TaskParams = { agent: item.agent?.trim() || defaultAgent };
+	const spawn: TaskParams = Object.hasOwn(item, "recipe")
+		? { recipe: item.recipe }
+		: { agent: item.agent?.trim() || defaultAgent };
 	if (item.name !== undefined) spawn.name = item.name;
 	if (item.task !== undefined) spawn.task = item.task;
 	if (item.model !== undefined) spawn.model = item.model;
@@ -585,7 +637,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const planMode = this.session.getPlanModeState?.()?.enabled === true;
 		const isolationEnabled = !planMode && this.session.settings.get("task.isolation.mode") !== "none";
 		const defaultAgent = resolveSpawnPolicy(this.session.getSessionSpawns()).defaultAgent;
-		return getTaskSchema({ isolationEnabled, batchEnabled: this.#isBatchEnabled(), defaultAgent });
+		return getTaskSchema({
+			isolationEnabled,
+			batchEnabled: this.#isBatchEnabled(),
+			defaultAgent,
+			externalTaskExecutor: this.session.externalTaskExecutor !== undefined,
+		});
 	}
 
 	renderCall(args: unknown, options: Parameters<typeof renderTaskCall>[1], theme: Theme) {
@@ -597,7 +654,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const disabledAgents = this.session.settings.get("task.disabledAgents") as string[];
 		const planMode = this.session.getPlanModeState?.()?.enabled === true;
 		const isolationMode = this.session.settings.get("task.isolation.mode");
-		return renderDescription(
+		const nativeDescription = renderDescription(
 			this.#discoveredAgents,
 			!planMode && isolationMode !== "none",
 			this.session.settings.get("task.isolation.apply"),
@@ -607,6 +664,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			isIrcEnabled(this.session.settings, this.session.taskDepth ?? 0),
 			this.session.getSessionSpawns() ?? "*",
 		);
+		if (!this.session.externalTaskExecutor) return nativeDescription;
+		return `${nativeDescription}
+
+Recipe items run through one external fresh-process executor. External runs do not support model overrides, typed output schemas, worktree isolation, or Hub send/park/revive. Task still owns batching, concurrency, cancellation, and result rendering.`;
 	}
 	private constructor(
 		private readonly session: ToolSession,
@@ -678,20 +739,26 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// item's agent type against the session's actual default agent.
 		const defaultAgent = resolveSpawnPolicy(this.session.getSessionSpawns()).defaultAgent;
 		const batchEnabled = this.#isBatchEnabled();
-		const validationError = validateShapeParams(batchEnabled, params) ?? validateSpawnParams(params, batchEnabled);
+		const validationError =
+			validateShapeParams(batchEnabled, params) ??
+			validateSpawnParams(params, batchEnabled, this.session.externalTaskExecutor !== undefined);
 		if (validationError) {
 			return createTaskModeError(validationError);
 		}
 
 		const spawnItems = resolveSpawnItems(params);
 		const normalizedSpawnParams = spawnItems.map(item => spawnParamsFor(params, item, defaultAgent));
-		const resolvedAgents = normalizedSpawnParams.map(spawn => spawn.agent ?? defaultAgent);
+		const resolvedAgents = normalizedSpawnParams.map(spawn =>
+			Object.hasOwn(spawn, "recipe") ? "recipe" : (spawn.agent ?? defaultAgent),
+		);
 		// Execution mode is per item: an item whose agent type declares
 		// `blocking: true` runs inline on this turn (the parent waits on its
 		// result); every other item becomes a background job when async
 		// execution is available.
-		const provisionalBlocking = resolvedAgents.map(
-			name => this.#discoveredAgents.find(agent => agent.name === name)?.blocking === true,
+		const provisionalBlocking = normalizedSpawnParams.map((spawn, index) =>
+			Object.hasOwn(spawn, "recipe")
+				? false
+				: this.#discoveredAgents.find(agent => agent.name === resolvedAgents[index])?.blocking === true,
 		);
 		const asyncEnabled = this.session.settings.get("async.enabled");
 		const manager = asyncEnabled ? this.session.asyncJobManager : undefined;
@@ -745,15 +812,28 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// failures remain synchronous and cannot leave a queued invalid job.
 		const preflights = await Promise.all(
 			normalizedSpawnParams.map(async spawn => {
+				if (Object.hasOwn(spawn, "recipe")) {
+					return { external: true as const, policy: undefined, error: undefined };
+				}
 				try {
-					return { policy: await this.#resolveSpawnPreflight(spawn) };
+					return {
+						external: false as const,
+						policy: await this.#resolveSpawnPreflight(spawn),
+						error: undefined,
+					};
 				} catch (error) {
-					return { error: error instanceof StructuredSubagentError ? error.message : String(error) };
+					return {
+						external: false as const,
+						policy: undefined,
+						error: error instanceof StructuredSubagentError ? error.message : String(error),
+					};
 				}
 			}),
 		);
 		const preflightFailures = preflights
-			.map((preflight, index) => ("error" in preflight ? { index, error: preflight.error } : undefined))
+			.map((preflight, index) =>
+				preflight.error !== undefined ? { index, error: preflight.error } : undefined,
+			)
 			.filter((failure): failure is { index: number; error: string } => failure !== undefined);
 		const renderPreflightFailures = () =>
 			preflightFailures
@@ -766,7 +846,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			return createTaskModeError(renderPreflightFailures());
 		}
 
-		const validIndices = preflights.flatMap((preflight, index) => (preflight.policy ? [index] : []));
+		const validIndices = preflights.flatMap((preflight, index) =>
+			preflight.external || preflight.policy ? [index] : [],
+		);
 		const validSpawns = validIndices.map(index => ({ item: spawnItems[index]!, index }));
 		const itemBlocking = preflights.map(preflight => preflight.policy?.effectiveAgent.blocking === true);
 		const asyncItems = validIndices.filter(index => !itemBlocking[index]).map(index => spawnItems[index]!);
@@ -777,7 +859,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			? undefined
 			: composeSpawnAdvisory({
 					agents: validIndices.map(index => resolvedAgents[index]!),
-					items: asyncItems,
+					items: asyncItems.filter(item => !Object.hasOwn(item, "recipe")),
 					depthCapacity,
 					ircEnabled,
 					willRunAsync: asyncItems.length > 0,
@@ -840,8 +922,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const agentType = resolvedAgents[index]!;
 			const preflight = preflights[index]!;
 			const policy = preflight.policy;
-			if (!policy) continue;
-			const agentSource = policy.agent.source;
+			if (!policy && !preflight.external) continue;
+			const agentSource = policy?.agent.source ?? "bundled";
 			const agentId = await outputManager.allocate(item.name?.trim() || generateTaskName());
 			const assignment = (item.task ?? "").trim();
 			spawns.push({
@@ -897,7 +979,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			},
 		});
 
-		const started: Array<{ agentId: string; jobId: string }> = [];
+		const started: Array<{ agentId: string; jobId: string; external: boolean }> = [];
 		const failedSchedules: string[] = [];
 		for (const spawn of asyncSpawns) {
 			try {
@@ -916,7 +998,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					},
 				});
 				if (started.length === 0) primaryJobId = jobId;
-				started.push({ agentId: spawn.agentId, jobId });
+				started.push({ agentId: spawn.agentId, jobId, external: Object.hasOwn(spawn.item, "recipe") });
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				failedSchedules.push(`${spawn.agentId}: ${message}`);
@@ -942,16 +1024,20 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			failedSchedules.length > 0
 				? ` Failed to schedule ${failedSchedules.length} spawn${failedSchedules.length === 1 ? "" : "s"}: ${failedSchedules.join("; ")}.`
 				: "";
-		const coordinationHint = [
-			started.length === 1
-				? ircEnabled
-					? `DM \`${started[0].agentId}\` via \`hub\` send to coordinate while it runs; use \`hub\` only to inspect (\`jobs\`), wait, or cancel a stuck task.`
-					: `Use \`hub\` to inspect (\`jobs\`), wait, or cancel a stuck task.`
-				: ircEnabled
-					? `DM these ids via \`hub\` send to coordinate while they run; use \`hub\` only to inspect (\`jobs\`), wait, or cancel a stuck task.`
-					: `Use \`hub\` to inspect (\`jobs\`), wait, or cancel a stuck task by id.`,
-			taskAsyncContractTemplate.trim(),
-		].join("\n");
+		const externalStarted = started.filter(spawn => spawn.external);
+		const coordinationText =
+			externalStarted.length === started.length
+				? "External recipe jobs do not support Hub send, park, or revive. Use `hub` only to inspect (`jobs`), wait, or cancel the Task-owned job."
+				: externalStarted.length > 0
+					? "Hub send/park/revive applies only to the native agent jobs in this mixed call, not external recipe jobs. Use `hub` to inspect (`jobs`), wait, or cancel any Task-owned job."
+					: started.length === 1
+						? ircEnabled
+							? `DM \`${started[0].agentId}\` via \`hub\` send to coordinate while it runs; use \`hub\` only to inspect (\`jobs\`), wait, or cancel a stuck task.`
+							: `Use \`hub\` to inspect (\`jobs\`), wait, or cancel a stuck task.`
+						: ircEnabled
+							? `DM these ids via \`hub\` send to coordinate while they run; use \`hub\` only to inspect (\`jobs\`), wait, or cancel a stuck task.`
+							: `Use \`hub\` to inspect (\`jobs\`), wait, or cancel a stuck task by id.`;
+		const coordinationHint = [coordinationText, taskAsyncContractTemplate.trim()].join("\n");
 
 		if (syncSpawns.length === 0) {
 			if (spawns.length === 1) {
@@ -1080,6 +1166,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const { manager, toolCallId, spawnParams, agentId, progress, ircEnabled, buildDetails, onUpdate, onSettled } =
 			options;
 		const buildFollowUpHint = async (aborted: boolean): Promise<string> => {
+			if (Object.hasOwn(spawnParams, "recipe")) return "";
 			if (aborted) {
 				const ref = AgentRegistry.global().get(agentId);
 				const transcript = (await hasResolvableTranscript(agentId))
@@ -1414,6 +1501,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		detached = false,
 		launchTiming?: { invokedAt: number; acquiredAt: number },
 	): Promise<AgentToolResult<TaskToolDetails>> {
+		if (Object.hasOwn(params, "recipe")) {
+			return this.#runExternalTask(params, signal, onUpdate, preAllocatedId, spawnIndex);
+		}
 		const startTime = Date.now();
 		const assignment = (params.task ?? "").trim();
 		const context = this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined;
@@ -1473,12 +1563,198 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 	}
 
+	/**
+	 * Run one external recipe item while retaining Task ownership of identity,
+	 * progress, cancellation, error policy, and the final result surface.
+	 */
+	async #runExternalTask(
+		params: TaskParams,
+		signal: AbortSignal | undefined,
+		onUpdate: AgentToolUpdateCallback<TaskToolDetails> | undefined,
+		preAllocatedId: string | undefined,
+		spawnIndex: number,
+	): Promise<AgentToolResult<TaskToolDetails>> {
+		const startTime = Date.now();
+		const assignment = (params.task ?? "").trim();
+		const context = this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined;
+		const executor = this.session.externalTaskExecutor;
+		if (!executor || typeof params.recipe !== "string") {
+			return createTaskModeError(
+				"Recipe execution requested, but no external Task executor is registered for discriminator `recipe`.",
+			);
+		}
+
+		let outputManager = this.session.agentOutputManager;
+		if (!outputManager) {
+			outputManager = new AgentOutputManager(this.session.getArtifactsDir ?? (() => null));
+			this.session.agentOutputManager = outputManager;
+		}
+		const id = preAllocatedId ?? (await outputManager.allocate(params.name?.trim() || generateTaskName()));
+		const runSignal = signal ?? new AbortController().signal;
+		const progress: AgentProgress = {
+			index: spawnIndex,
+			id,
+			agent: "recipe",
+			agentSource: "bundled",
+			status: "running",
+			task: renderSubagentUserPrompt(assignment),
+			assignment,
+			description: params.recipe,
+			recentTools: [],
+			recentOutput: [],
+			toolCount: 0,
+			requests: 0,
+			tokens: 0,
+			cost: 0,
+			durationMs: 0,
+		};
+		const emitProgress = async (message: string): Promise<void> => {
+			const text = message.trim();
+			if (text) progress.recentOutput = [...progress.recentOutput, text].slice(-5);
+			progress.durationMs = Date.now() - startTime;
+			await onUpdate?.({
+				content: [{ type: "text", text: text || `Running external recipe task ${id}...` }],
+				details: {
+					projectAgentsDir: null,
+					results: [],
+					totalDurationMs: progress.durationMs,
+					progress: [{ ...progress, recentOutput: progress.recentOutput.slice() }],
+				},
+			});
+		};
+		const buildSingleResult = (
+			result: ExternalTaskResult,
+			options: { aborted?: boolean; abortReason?: string } = {},
+		): SingleResult => ({
+			index: spawnIndex,
+			id,
+			agent: "recipe",
+			agentSource: "bundled",
+			task: renderSubagentUserPrompt(assignment),
+			assignment,
+			description: params.recipe,
+			exitCode: result.error && result.exitCode === 0 ? 1 : result.exitCode,
+			output: result.output,
+			stderr: result.stderr ?? "",
+			truncated: false,
+			durationMs: Date.now() - startTime,
+			tokens: 0,
+			requests: 0,
+			...(result.error ? { error: result.error } : {}),
+			...(options.aborted ? { aborted: true } : {}),
+			...(options.abortReason ? { abortReason: options.abortReason } : {}),
+		});
+		const buildPayload = (result: SingleResult): AgentToolResult<TaskToolDetails> => {
+			progress.status = result.aborted ? "aborted" : result.exitCode === 0 ? "completed" : "failed";
+			progress.durationMs = result.durationMs;
+			return this.#buildResultPayload(result, null, result.durationMs, "", false);
+		};
+
+		let execution: ExternalTaskExecution | undefined;
+		let abortCleanup: Promise<{ error?: unknown }> | undefined;
+		try {
+			await emitProgress(`Starting external recipe task ${id}...`);
+			execution = await executor.start({
+				recipe: params.recipe.trim(),
+				assignment,
+				context,
+				cwd: this.session.cwd,
+				signal: runSignal,
+				onProgress: update => emitProgress(update.message),
+			});
+			if (
+				!execution ||
+				typeof execution.abort !== "function" ||
+				!execution.result ||
+				typeof execution.result.then !== "function"
+			) {
+				throw new Error("External Task executor returned an invalid execution handle.");
+			}
+
+			const abortSettled = Promise.withResolvers<{ error?: unknown }>();
+			const requestAbort = () => {
+				if (abortCleanup) return;
+				abortCleanup = Promise.resolve()
+					.then(() => execution!.abort())
+					.then(
+						() => ({}),
+						error => ({ error }),
+					);
+				void abortCleanup.then(abortSettled.resolve);
+			};
+			runSignal.addEventListener("abort", requestAbort, { once: true });
+			if (runSignal.aborted) requestAbort();
+			try {
+				const resultOutcome = Promise.resolve(execution.result).then(
+					result => ({ type: "result" as const, result }),
+					error => ({ type: "error" as const, error }),
+				);
+				const outcome = await Promise.race([
+					resultOutcome,
+					abortSettled.promise.then(cleanup => ({ type: "aborted" as const, cleanup })),
+				]);
+				const cleanup = abortCleanup ? await abortCleanup : undefined;
+				if (runSignal.aborted || outcome.type === "aborted") {
+					const reason =
+						runSignal.reason instanceof Error
+							? runSignal.reason.message
+							: typeof runSignal.reason === "string"
+								? runSignal.reason
+								: "Parent task cancelled";
+					const cleanupError = cleanup?.error;
+					const error = cleanupError
+						? `External Task abort cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+						: undefined;
+					return buildPayload(
+						buildSingleResult(
+							{ output: "", stderr: error, exitCode: 1, error },
+							{ aborted: true, abortReason: reason },
+						),
+					);
+				}
+				if (outcome.type === "error") throw outcome.error;
+				const result = outcome.result;
+				if (
+					!result ||
+					typeof result.output !== "string" ||
+					!Number.isInteger(result.exitCode) ||
+					(result.stderr !== undefined && typeof result.stderr !== "string") ||
+					(result.error !== undefined && typeof result.error !== "string")
+				) {
+					throw new Error("External Task executor returned an invalid result.");
+				}
+				return buildPayload(buildSingleResult(result));
+			} finally {
+				runSignal.removeEventListener("abort", requestAbort);
+			}
+		} catch (error) {
+			if (abortCleanup) await abortCleanup;
+			const message = error instanceof Error ? error.message : String(error);
+			const aborted = runSignal.aborted;
+			const reason =
+				aborted && runSignal.reason instanceof Error
+					? runSignal.reason.message
+					: aborted && typeof runSignal.reason === "string"
+						? runSignal.reason
+						: aborted
+							? "Parent task cancelled"
+							: undefined;
+			return buildPayload(
+				buildSingleResult(
+					{ output: "", stderr: message, exitCode: 1, error: message },
+					{ aborted, abortReason: reason },
+				),
+			);
+		}
+	}
+
 	/** Build the tool result (summary text + details) for a settled run. */
 	#buildResultPayload(
 		result: SingleResult,
 		projectAgentsDir: string | null,
 		totalDurationMs: number,
 		mergeSummary: string,
+		agentOutputResolvable = true,
 	): AgentToolResult<TaskToolDetails> {
 		const status = result.aborted
 			? "cancelled"
@@ -1492,7 +1768,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const fullOutputThreshold = 5000;
 		let preview = output;
 		let truncated = false;
-		if (outputCharCount > fullOutputThreshold) {
+		if (agentOutputResolvable && outputCharCount > fullOutputThreshold) {
 			const slice = output.slice(0, fullOutputThreshold);
 			const lastNewline = slice.lastIndexOf("\n");
 			preview = lastNewline >= 0 ? slice.slice(0, lastNewline) : slice;

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -16,7 +16,7 @@
 import path from "node:path";
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
-import { $env, logger, prompt } from "@oh-my-pi/pi-utils";
+import { $env, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "..";
 import type { Theme } from "../modes/theme/theme";
 import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.md" with { type: "text" };
@@ -51,7 +51,20 @@ import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { repairTaskParams } from "./repair-args";
-import { resolveEffectiveSubagentPolicy, runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
+import {
+	assertDepthAndSpawnAllowed,
+	resolveEffectiveSubagentPolicy,
+	runStructuredSubagent,
+	StructuredSubagentError,
+} from "./structured-subagent";
+
+/**
+ * Bound for external recipe abort cleanup: how long `#runExternalTask` waits
+ * for a late `executor.start()` handle or a hung `execution.abort()` before
+ * giving up and settling the call anyway. Mirrors the 5s cleanup bound used
+ * elsewhere for adopted-session teardown (see `task/executor.ts`).
+ */
+const EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS = 5000;
 
 function renderSubagentUserPrompt(assignment: string): string {
 	return prompt.render(subagentUserPromptTemplate, {
@@ -813,7 +826,16 @@ Recipe items run through one external fresh-process executor. External runs do n
 		const preflights = await Promise.all(
 			normalizedSpawnParams.map(async spawn => {
 				if (Object.hasOwn(spawn, "recipe")) {
-					return { external: true as const, policy: undefined, error: undefined };
+					try {
+						assertDepthAndSpawnAllowed({ session: this.session, blockedAgent: this.#blockedAgent }, "recipe");
+						return { external: true as const, policy: undefined, error: undefined };
+					} catch (error) {
+						return {
+							external: true as const,
+							policy: undefined,
+							error: error instanceof StructuredSubagentError ? error.message : String(error),
+						};
+					}
 				}
 				try {
 					return {
@@ -847,7 +869,7 @@ Recipe items run through one external fresh-process executor. External runs do n
 		}
 
 		const validIndices = preflights.flatMap((preflight, index) =>
-			preflight.external || preflight.policy ? [index] : [],
+			preflight.error === undefined && (preflight.external || preflight.policy) ? [index] : [],
 		);
 		const validSpawns = validIndices.map(index => ({ item: spawnItems[index]!, index }));
 		const itemBlocking = preflights.map(preflight => preflight.policy?.effectiveAgent.blocking === true);
@@ -1577,6 +1599,12 @@ Recipe items run through one external fresh-process executor. External runs do n
 		const startTime = Date.now();
 		const assignment = (params.task ?? "").trim();
 		const context = this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined;
+		try {
+			assertDepthAndSpawnAllowed({ session: this.session, blockedAgent: this.#blockedAgent }, "recipe");
+		} catch (error) {
+			const message = error instanceof StructuredSubagentError ? error.message : String(error);
+			return createTaskModeError(message);
+		}
 		const executor = this.session.externalTaskExecutor;
 		if (!executor || typeof params.recipe !== "string") {
 			return createTaskModeError(
@@ -1590,7 +1618,22 @@ Recipe items run through one external fresh-process executor. External runs do n
 			this.session.agentOutputManager = outputManager;
 		}
 		const id = preAllocatedId ?? (await outputManager.allocate(params.name?.trim() || generateTaskName()));
-		const runSignal = signal ?? new AbortController().signal;
+
+		// Apply the same wall-clock cap native subagents get (`task.maxRuntimeMs`;
+		// 0 disables). The timer aborts a dedicated controller folded into the
+		// caller's signal via `AbortSignal.any`, so a stuck external executor
+		// cannot outlive the bound even when no `signal` was supplied.
+		const maxRuntimeMs = Math.max(0, Math.trunc(Number(this.session.settings.get("task.maxRuntimeMs") ?? 0) || 0));
+		const runtimeController = new AbortController();
+		let runtimeTimeoutId: NodeJS.Timeout | undefined;
+		if (maxRuntimeMs > 0) {
+			runtimeTimeoutId = setTimeout(() => {
+				runtimeController.abort(
+					new Error(`External Task runtime limit exceeded (task.maxRuntimeMs=${maxRuntimeMs})`),
+				);
+			}, maxRuntimeMs);
+		}
+		const runSignal = signal ? AbortSignal.any([signal, runtimeController.signal]) : runtimeController.signal;
 		const progress: AgentProgress = {
 			index: spawnIndex,
 			id,
@@ -1651,17 +1694,69 @@ Recipe items run through one external fresh-process executor. External runs do n
 		};
 
 		let execution: ExternalTaskExecution | undefined;
+		// Populated the instant `start()` is invoked, before it can settle —
+		// `requestAbort` awaits this (bounded) when abort fires while `start()`
+		// is still in flight, so a late-arriving handle still gets cleaned up.
+		let startPromise: Promise<ExternalTaskExecution> | undefined;
+		// Resolves once `startPromise` above is assigned. Closes the gap between
+		// registering the abort listener and actually invoking `start()` (e.g.
+		// while `emitProgress`'s "Starting..." update is still in flight) so an
+		// abort landing in that gap still waits for, then cleans up, the handle.
+		const startInvoked = Promise.withResolvers<void>();
 		let abortCleanup: Promise<{ error?: unknown }> | undefined;
+		const abortSettled = Promise.withResolvers<{ error?: unknown }>();
+		const requestAbort = () => {
+			if (abortCleanup) return;
+			abortCleanup = (async (): Promise<{ error?: unknown }> => {
+				if (!execution) {
+					try {
+						await untilAborted(AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS), startInvoked.promise);
+					} catch {
+						// `start()` was never even invoked within the bound — nothing to abort.
+						return {};
+					}
+					try {
+						execution = await untilAborted(AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS), startPromise!);
+					} catch {
+						// `start()` never produced a usable handle within the bound, or
+						// it rejected — nothing to abort.
+						return {};
+					}
+				}
+				if (!execution) return {};
+				try {
+					await untilAborted(
+						AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS),
+						Promise.resolve(execution.abort()),
+					);
+					return {};
+				} catch (error) {
+					return { error };
+				}
+			})();
+			void abortCleanup.then(abortSettled.resolve);
+		};
+		// Registered before `start()` is ever called: a signal that fires while
+		// the executor is still starting (or before it's even invoked) must not
+		// wait for `start()` to settle before cleanup begins.
+		runSignal.addEventListener("abort", requestAbort, { once: true });
+		if (runSignal.aborted) requestAbort();
 		try {
 			await emitProgress(`Starting external recipe task ${id}...`);
-			execution = await executor.start({
-				recipe: params.recipe.trim(),
-				assignment,
-				context,
-				cwd: this.session.cwd,
-				signal: runSignal,
-				onProgress: update => emitProgress(update.message),
-			});
+			startPromise = Promise.resolve(
+				executor.start({
+					recipe: params.recipe.trim(),
+					assignment,
+					context,
+					cwd: this.session.cwd,
+					signal: runSignal,
+					onProgress: update => emitProgress(update.message),
+				}),
+			);
+			startInvoked.resolve();
+			// Races `start()` itself against the signal: a hung `start()` cannot
+			// block cancellation just because no execution handle exists yet.
+			execution = await untilAborted(runSignal, startPromise);
 			if (
 				!execution ||
 				typeof execution.abort !== "function" ||
@@ -1671,19 +1766,6 @@ Recipe items run through one external fresh-process executor. External runs do n
 				throw new Error("External Task executor returned an invalid execution handle.");
 			}
 
-			const abortSettled = Promise.withResolvers<{ error?: unknown }>();
-			const requestAbort = () => {
-				if (abortCleanup) return;
-				abortCleanup = Promise.resolve()
-					.then(() => execution!.abort())
-					.then(
-						() => ({}),
-						error => ({ error }),
-					);
-				void abortCleanup.then(abortSettled.resolve);
-			};
-			runSignal.addEventListener("abort", requestAbort, { once: true });
-			if (runSignal.aborted) requestAbort();
 			try {
 				const resultOutcome = Promise.resolve(execution.result).then(
 					result => ({ type: "result" as const, result }),
@@ -1745,6 +1827,8 @@ Recipe items run through one external fresh-process executor. External runs do n
 					{ aborted, abortReason: reason },
 				),
 			);
+		} finally {
+			clearTimeout(runtimeTimeoutId);
 		}
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1705,34 +1705,45 @@ Recipe items run through one external fresh-process executor. External runs do n
 		const startInvoked = Promise.withResolvers<void>();
 		let abortCleanup: Promise<{ error?: unknown }> | undefined;
 		const abortSettled = Promise.withResolvers<{ error?: unknown }>();
+		// Guards against calling `.abort()` twice — the bounded wait below and
+		// the unbounded late continuation it can spawn both funnel through this.
+		let handleAbortAttempted = false;
+		const abortHandleOnce = async (exec: ExternalTaskExecution): Promise<{ error?: unknown }> => {
+			if (handleAbortAttempted) return {};
+			handleAbortAttempted = true;
+			execution = exec;
+			try {
+				await untilAborted(AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS), Promise.resolve(exec.abort()));
+				return {};
+			} catch (error) {
+				return { error };
+			}
+		};
 		const requestAbort = () => {
 			if (abortCleanup) return;
 			abortCleanup = (async (): Promise<{ error?: unknown }> => {
-				if (!execution) {
-					try {
-						await untilAborted(AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS), startInvoked.promise);
-					} catch {
-						// `start()` was never even invoked within the bound — nothing to abort.
-						return {};
-					}
-					try {
-						execution = await untilAborted(AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS), startPromise!);
-					} catch {
-						// `start()` never produced a usable handle within the bound, or
-						// it rejected — nothing to abort.
-						return {};
-					}
-				}
-				if (!execution) return {};
+				if (execution) return abortHandleOnce(execution);
+				let lateHandle: ExternalTaskExecution;
 				try {
-					await untilAborted(
+					lateHandle = await untilAborted(
 						AbortSignal.timeout(EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS),
-						Promise.resolve(execution.abort()),
+						startInvoked.promise.then(() => startPromise!),
+					);
+				} catch {
+					// `start()` was not invoked, or did not produce a handle, within
+					// the bound — it may still run later (e.g. a slow pre-start
+					// progress callback delayed it, or the executor itself is slow).
+					// Attach an unbounded continuation so a late handle still gets
+					// aborted exactly once instead of orphaning an executor that
+					// ignores the already-aborted signal it was given. This settles
+					// this call's own (already-bounded) wait now regardless.
+					void startInvoked.promise.then(
+						() => startPromise!.then(abortHandleOnce, () => {}),
+						() => {},
 					);
 					return {};
-				} catch (error) {
-					return { error };
 				}
+				return abortHandleOnce(lateHandle);
 			})();
 			void abortCleanup.then(abortSettled.resolve);
 		};

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -206,7 +206,18 @@ function assertPlanControlsAllowed(request: StructuredSubagentRequest, planMode:
 	}
 }
 
-function assertDepthAndSpawnAllowed(request: StructuredSubagentRequest, agentName: string): void {
+/**
+ * Depth and spawn-policy containment gate shared by every child dispatch
+ * path — native agents via {@link resolveEffectiveSubagentPolicy} and the
+ * external `recipe` executor via its own explicit call in `task/index.ts`.
+ * `agentName` is compared against the parent's `spawns` allowlist exactly
+ * like a native agent type; `"recipe"` must appear in an explicit allowlist
+ * to be spawned from a caller restricted to specific agents.
+ */
+export function assertDepthAndSpawnAllowed(
+	request: Pick<StructuredSubagentRequest, "session" | "blockedAgent">,
+	agentName: string,
+): void {
 	const taskDepth = request.session.taskDepth ?? 0;
 	const maxDepth = request.session.settings.get("task.maxRecursionDepth") ?? 2;
 	if (!canSpawnAtDepth(maxDepth, taskDepth)) {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -109,18 +109,45 @@ export const LABEL_MAX = 80;
 // Keep this explicit: ArkType serializes `unknown` as a boolean subschema, which llama.cpp grammars reject.
 const outputSchemaInputSchema = type("object | boolean | string | null");
 
-export const taskItemSchema = type({
+const nativeTaskItemSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
+	"recipe?": "never",
 	task: "string",
 	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
 });
-const taskItemSchemaIsolated = type({
+const externalEnabledNativeTaskItemSchema = type({
+	"name?": "string",
+	"agent?": "string",
+	"recipe?": "never",
+	task: "string",
+	"model?": "string | string[]",
+	"outputSchema?": outputSchemaInputSchema,
+	"schemaMode?": '"permissive" | "strict"',
+	"+": "delete",
+});
+function createRecipeTaskItemSchema(): BaseType {
+	return type({
+		"name?": "string",
+		"agent?": "never",
+		recipe: "string",
+		task: "string",
+		"model?": "never",
+		"outputSchema?": "never",
+		"schemaMode?": "never",
+		"isolated?": "never",
+		"+": "delete",
+	});
+}
+/** Task batch item schema when an external executor is available. */
+export const taskItemSchema = externalEnabledNativeTaskItemSchema.or(createRecipeTaskItemSchema());
+const nativeTaskItemSchemaIsolated = type({
 	"name?": "string",
 	agent: "string = 'task'",
+	"recipe?": "never",
 	task: "string",
 	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
@@ -128,6 +155,18 @@ const taskItemSchemaIsolated = type({
 	"isolated?": "boolean",
 	"+": "delete",
 });
+const externalEnabledNativeTaskItemSchemaIsolated = type({
+	"name?": "string",
+	"agent?": "string",
+	"recipe?": "never",
+	task: "string",
+	"model?": "string | string[]",
+	"outputSchema?": outputSchemaInputSchema,
+	"schemaMode?": '"permissive" | "strict"',
+	"isolated?": "boolean",
+	"+": "delete",
+});
+const taskItemSchemaIsolated = externalEnabledNativeTaskItemSchemaIsolated.or(createRecipeTaskItemSchema());
 
 /** Single task item. Fields are optional defensively: args stream in token by token. */
 export interface TaskItem {
@@ -135,6 +174,8 @@ export interface TaskItem {
 	name?: string;
 	/** Agent type to run this item (e.g. "scout"). Defaults to the spawn policy's default agent. */
 	agent?: string;
+	/** External execution recipe. Mutually exclusive with `agent`. */
+	recipe?: string;
 	/** The work; required by the schema. */
 	task?: string;
 	/** Explicit model selector or fallback chain for this spawn, including optional reasoning suffixes. */
@@ -150,6 +191,7 @@ export interface TaskItem {
 export const taskSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
+	"recipe?": "never",
 	task: "string",
 	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
@@ -160,23 +202,64 @@ export const taskSchema = type({
 const taskSchemaNoIsolation = type({
 	"name?": "string",
 	agent: "string = 'task'",
+	"recipe?": "never",
 	task: "string",
 	"model?": "string | string[]",
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
 });
+const taskSchemaWithExternalExecutor = type({
+	"name?": "string",
+	"agent?": "string",
+	"recipe?": "never",
+	task: "string",
+	"model?": "string | string[]",
+	"outputSchema?": outputSchemaInputSchema,
+	"schemaMode?": '"permissive" | "strict"',
+	"isolated?": "boolean",
+	"+": "delete",
+}).or(createRecipeTaskItemSchema());
+const taskSchemaNoIsolationWithExternalExecutor = type({
+	"name?": "string",
+	"agent?": "string",
+	"recipe?": "never",
+	task: "string",
+	"model?": "string | string[]",
+	"outputSchema?": outputSchemaInputSchema,
+	"schemaMode?": '"permissive" | "strict"',
+	"+": "delete",
+}).or(createRecipeTaskItemSchema());
 const taskSchemaBatch = type({
 	context: "string",
-	tasks: taskItemSchemaIsolated.array(),
+	tasks: nativeTaskItemSchemaIsolated.array(),
 	"+": "delete",
 });
 const taskSchemaBatchNoIsolation = type({
 	context: "string",
+	tasks: nativeTaskItemSchema.array(),
+	"+": "delete",
+});
+const taskSchemaBatchWithExternalExecutor = type({
+	context: "string",
+	tasks: taskItemSchemaIsolated.array(),
+	"+": "delete",
+});
+const taskSchemaBatchNoIsolationWithExternalExecutor = type({
+	context: "string",
 	tasks: taskItemSchema.array(),
 	"+": "delete",
 });
-const ALL_TASK_SCHEMAS = [taskSchema, taskSchemaNoIsolation, taskSchemaBatch, taskSchemaBatchNoIsolation] as const;
+const ALL_TASK_SCHEMAS = [
+	taskSchema,
+	taskSchemaNoIsolation,
+	taskSchemaWithExternalExecutor,
+	taskSchemaNoIsolationWithExternalExecutor,
+	taskSchemaBatch,
+	taskSchemaBatchNoIsolation,
+	taskSchemaBatchWithExternalExecutor,
+	taskSchemaBatchNoIsolationWithExternalExecutor,
+] as const;
 
 type DynamicTaskSchema = (typeof ALL_TASK_SCHEMAS)[number];
 export type TaskSchema = typeof taskSchema;
@@ -198,84 +281,109 @@ function createTaskSchema(options: {
 	isolationEnabled: boolean;
 	batchEnabled: boolean;
 	defaultAgent: string;
+	externalTaskExecutor: boolean;
 }): BaseType {
 	const agent = taskAgentSchemaRule(options.defaultAgent);
 	if (options.batchEnabled) {
-		if (options.isolationEnabled) {
-			const item = type.raw({
-				"name?": "string",
-				agent,
-				task: "string",
-				"model?": "string | string[]",
-				"outputSchema?": outputSchemaInputSchema,
-				"schemaMode?": '"permissive" | "strict"',
-				"isolated?": "boolean",
-				"+": "delete",
-			});
-			return type.raw({
-				context: "string",
-				tasks: item.array(),
-				"+": "delete",
-			});
-		}
-		const item = type.raw({
-			"name?": "string",
-			agent,
-			task: "string",
-			"model?": "string | string[]",
-			"outputSchema?": outputSchemaInputSchema,
-			"schemaMode?": '"permissive" | "strict"',
-			"+": "delete",
-		});
+		const nativeItem = options.isolationEnabled
+			? type.raw({
+					"name?": "string",
+					...(options.externalTaskExecutor
+						? { "agent?": "string" as const, "recipe?": "never" as const }
+						: { agent, "recipe?": "never" as const }),
+					task: "string",
+					"model?": "string | string[]",
+					"outputSchema?": outputSchemaInputSchema,
+					"schemaMode?": '"permissive" | "strict"',
+					"isolated?": "boolean",
+					"+": "delete",
+				})
+			: type.raw({
+					"name?": "string",
+					...(options.externalTaskExecutor
+						? { "agent?": "string" as const, "recipe?": "never" as const }
+						: { agent, "recipe?": "never" as const }),
+					task: "string",
+					"model?": "string | string[]",
+					"outputSchema?": outputSchemaInputSchema,
+					"schemaMode?": '"permissive" | "strict"',
+					"+": "delete",
+				});
+		const item = options.externalTaskExecutor
+			? nativeItem.or(createRecipeTaskItemSchema())
+			: nativeItem;
 		return type.raw({
 			context: "string",
 			tasks: item.array(),
 			"+": "delete",
 		});
 	}
-	if (options.isolationEnabled) {
-		return type.raw({
-			"name?": "string",
-			agent,
-			task: "string",
-			"model?": "string | string[]",
-			"outputSchema?": outputSchemaInputSchema,
-			"schemaMode?": '"permissive" | "strict"',
-			"isolated?": "boolean",
-			"+": "delete",
-		});
-	}
-	return type.raw({
-		"name?": "string",
-		agent,
-		task: "string",
-		"model?": "string | string[]",
-		"outputSchema?": outputSchemaInputSchema,
-		"schemaMode?": '"permissive" | "strict"',
-		"+": "delete",
-	});
+	const nativeItem = options.isolationEnabled
+		? type.raw({
+				"name?": "string",
+				...(options.externalTaskExecutor
+					? { "agent?": "string" as const, "recipe?": "never" as const }
+					: { agent, "recipe?": "never" as const }),
+				task: "string",
+				"model?": "string | string[]",
+				"outputSchema?": outputSchemaInputSchema,
+				"schemaMode?": '"permissive" | "strict"',
+				"isolated?": "boolean",
+				"+": "delete",
+			})
+		: type.raw({
+				"name?": "string",
+				...(options.externalTaskExecutor
+					? { "agent?": "string" as const, "recipe?": "never" as const }
+					: { agent, "recipe?": "never" as const }),
+				task: "string",
+				"model?": "string | string[]",
+				"outputSchema?": outputSchemaInputSchema,
+				"schemaMode?": '"permissive" | "strict"',
+				"+": "delete",
+			});
+	return options.externalTaskExecutor
+		? nativeItem.or(createRecipeTaskItemSchema())
+		: nativeItem;
 }
 
-export function getTaskSchema(options: { isolationEnabled: boolean; batchEnabled: boolean }): DynamicTaskSchema;
+export function getTaskSchema(options: {
+	isolationEnabled: boolean;
+	batchEnabled: boolean;
+	externalTaskExecutor?: boolean;
+}): DynamicTaskSchema;
 export function getTaskSchema(options: {
 	isolationEnabled: boolean;
 	batchEnabled: boolean;
 	defaultAgent: string;
+	externalTaskExecutor?: boolean;
 }): TaskToolSchemaInstance;
 export function getTaskSchema(options: {
 	isolationEnabled: boolean;
 	batchEnabled: boolean;
 	defaultAgent?: string;
+	externalTaskExecutor?: boolean;
 }): TaskToolSchemaInstance {
 	const defaultAgent = options.defaultAgent ?? "task";
+	const externalTaskExecutor = options.externalTaskExecutor === true;
 	if (defaultAgent === "task") {
-		if (options.batchEnabled) return options.isolationEnabled ? taskSchemaBatch : taskSchemaBatchNoIsolation;
+		if (options.batchEnabled) {
+			if (externalTaskExecutor) {
+				return options.isolationEnabled
+					? taskSchemaBatchWithExternalExecutor
+					: taskSchemaBatchNoIsolationWithExternalExecutor;
+			}
+			return options.isolationEnabled ? taskSchemaBatch : taskSchemaBatchNoIsolation;
+		}
+		if (externalTaskExecutor) {
+			return options.isolationEnabled ? taskSchemaWithExternalExecutor : taskSchemaNoIsolationWithExternalExecutor;
+		}
 		return options.isolationEnabled ? taskSchema : taskSchemaNoIsolation;
 	}
-	const key = `${options.isolationEnabled ? "iso" : "flat"}:${options.batchEnabled ? "batch" : "single"}:${defaultAgent}`;
+	const key = `${options.isolationEnabled ? "iso" : "flat"}:${options.batchEnabled ? "batch" : "single"}:${externalTaskExecutor ? "external" : "native"}:${defaultAgent}`;
 	const cached = taskSchemaCache.get(key);
 	if (cached) return cached;
-	const schema = createTaskSchema({ ...options, defaultAgent });
+	const schema = createTaskSchema({ ...options, defaultAgent, externalTaskExecutor });
 	taskSchemaCache.set(key, schema);
 	return schema;
 }
@@ -291,6 +399,8 @@ export interface TaskParams {
 	name?: string;
 	/** Agent type to spawn (flat form); omitted values resolve from the session spawn policy. */
 	agent?: string;
+	/** External execution recipe (flat form). Mutually exclusive with `agent`. */
+	recipe?: string;
 	/** The work (flat form). */
 	task?: string;
 	/** Explicit model selector or fallback chain for the spawn, including optional reasoning suffixes. */
@@ -305,6 +415,52 @@ export interface TaskParams {
 	context?: string;
 	/** Run in an isolated worktree (flat form; per-item in batch form). */
 	isolated?: boolean;
+}
+
+/** A progress message emitted by one external Task execution. */
+export interface ExternalTaskProgress {
+	message: string;
+}
+
+/** Settled output from one external Task execution. */
+export interface ExternalTaskResult {
+	output: string;
+	exitCode: number;
+	stderr?: string;
+	error?: string;
+}
+
+/**
+ * Handle for one external fresh-process execution.
+ *
+ * `abort()` must resolve only after process shutdown and owned-resource cleanup
+ * complete. Task invokes and awaits it when the parent signal aborts.
+ */
+export interface ExternalTaskExecution {
+	result: Promise<ExternalTaskResult>;
+	abort(): void | Promise<void>;
+}
+
+/** Inputs owned by Task and supplied to the external executor. */
+export interface ExternalTaskExecutorRequest {
+	recipe: string;
+	assignment: string;
+	context?: string;
+	cwd: string;
+	signal: AbortSignal;
+	onProgress(progress: ExternalTaskProgress): void | Promise<void>;
+}
+
+/**
+ * Single external Task executor hook.
+ *
+ * This first contract supports only the `recipe` discriminator. Typed output
+ * schemas, model overrides, isolation, and Hub send/park/revive parity are not
+ * available for external executions and must not be silently emulated.
+ */
+export interface ExternalTaskExecutor {
+	readonly discriminator: "recipe";
+	start(request: ExternalTaskExecutorRequest): ExternalTaskExecution | Promise<ExternalTaskExecution>;
 }
 
 /**

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -30,7 +30,11 @@ import type { SessionManager } from "../session/session-manager";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
-import { canSpawnAtDepth, type StructuredSubagentSchemaMode } from "../task/types";
+import {
+	canSpawnAtDepth,
+	type ExternalTaskExecutor,
+	type StructuredSubagentSchemaMode,
+} from "../task/types";
 import type { EventBus } from "../utils/event-bus";
 import { WebSearchTool } from "../web/search";
 import type { WorkspaceTree } from "../workspace-tree";
@@ -179,6 +183,8 @@ export interface ToolSession {
 	 * (`<inline-N>`) are NOT included — those are session-local.
 	 */
 	extensionPaths?: string[];
+	/** Session-scoped executor for the Task tool's external `recipe` branch. */
+	externalTaskExecutor?: ExternalTaskExecutor;
 	/**
 	 * Pre-discovered custom-tool source paths from `.omp/tools/`, `.claude/tools/`,
 	 * plugins, etc. Forwarded to subagents so they skip the FS scan but still

--- a/packages/coding-agent/test/rpc-client.restart.test.ts
+++ b/packages/coding-agent/test/rpc-client.restart.test.ts
@@ -161,6 +161,71 @@ describe("RpcClient lifecycle (issue #4079 B)", () => {
 		}
 	}, 10_000);
 
+	test("envMode replace starts without PATH and excludes ambient variables while omitted mode merges them", async () => {
+		using tempDir = TempDir.createSync("@rpc-env-");
+		const parentOnlyKey = `OMP_RPC_PARENT_${crypto.randomUUID().replaceAll("-", "_")}`;
+		const parentOnlyValue = crypto.randomUUID();
+		const hadParentOnlyKey = Object.hasOwn(Bun.env, parentOnlyKey);
+		const previousParentOnlyValue = Bun.env[parentOnlyKey];
+		const probeAgent = tempDir.join("env-probe-agent.ts");
+		const replaceResultFile = tempDir.join("replace.json");
+		const mergeResultFile = tempDir.join("merge.json");
+
+		await Bun.write(
+			probeAgent,
+			`
+const resultPath = Bun.env.OMP_RPC_ENV_RESULT;
+if (!resultPath) throw new Error("OMP_RPC_ENV_RESULT is required");
+await Bun.write(resultPath, JSON.stringify({
+	parentPresent: Object.hasOwn(Bun.env, ${JSON.stringify(parentOnlyKey)}),
+	parentValue: Bun.env[${JSON.stringify(parentOnlyKey)}],
+	childValue: Bun.env.OMP_RPC_CHILD_ONLY,
+	pathPresent: Object.hasOwn(Bun.env, "PATH"),
+}));
+process.stdout.write(JSON.stringify({ type: "ready" }) + "\\n");
+for await (const _line of console) {}
+`,
+		);
+
+		Bun.env[parentOnlyKey] = parentOnlyValue;
+		try {
+			using replaceClient = new RpcClient({
+				cliPath: probeAgent,
+				env: {
+					OMP_RPC_CHILD_ONLY: "1",
+					OMP_RPC_ENV_RESULT: replaceResultFile,
+				},
+				envMode: "replace",
+			});
+			await replaceClient.start();
+			await replaceClient.stop();
+
+			using mergeClient = new RpcClient({
+				cliPath: probeAgent,
+				env: {
+					OMP_RPC_CHILD_ONLY: "2",
+					OMP_RPC_ENV_RESULT: mergeResultFile,
+				},
+			});
+			await mergeClient.start();
+			await mergeClient.stop();
+
+			const replaced = (await Bun.file(replaceResultFile).json()) as Record<string, unknown>;
+			const merged = (await Bun.file(mergeResultFile).json()) as Record<string, unknown>;
+			expect(replaced).toEqual({
+				parentPresent: false,
+				childValue: "1",
+				pathPresent: false,
+			});
+			expect(merged.parentPresent).toBe(true);
+			expect(merged.parentValue).toBe(parentOnlyValue);
+			expect(merged.childValue).toBe("2");
+		} finally {
+			if (hadParentOnlyKey) Bun.env[parentOnlyKey] = previousParentOnlyValue!;
+			else delete Bun.env[parentOnlyKey];
+		}
+	}, 10_000);
+
 	test("rejects pending requests and reaps a worker that closes stdout without exiting", async () => {
 		let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
 		let resolveExit: ((exitCode: number) => void) | undefined;

--- a/packages/coding-agent/test/task/task-external-executor.test.ts
+++ b/packages/coding-agent/test/task/task-external-executor.test.ts
@@ -13,7 +13,7 @@ import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { type CustomTool, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
@@ -43,10 +43,16 @@ function createManager(): AsyncJobManager {
 	return manager;
 }
 
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 10; i += 1) await Promise.resolve();
+}
+
 function createSession(options: {
 	executor?: ExternalTaskExecutor;
 	manager?: AsyncJobManager;
 	settings?: Record<string, unknown>;
+	taskDepth?: number;
+	spawns?: string | boolean | null;
 } = {}): ToolSession {
 	return {
 		cwd: "/tmp/external-task-cwd",
@@ -58,8 +64,9 @@ function createSession(options: {
 			...options.settings,
 		}),
 		getSessionFile: () => null,
-		getSessionSpawns: () => "*",
+		getSessionSpawns: () => options.spawns ?? "*",
 		getAgentId: () => "Parent",
+		taskDepth: options.taskDepth,
 		externalTaskExecutor: options.executor,
 		asyncJobManager: options.manager,
 	} as unknown as ToolSession;
@@ -352,6 +359,181 @@ describe("Task external recipe executor", () => {
 		}
 		expect(starts).toBe(0);
 	});
+
+	it("blocks recipe execution at the parent's max task depth like native spawns", async () => {
+		let starts = 0;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start() {
+				starts += 1;
+				return { result: Promise.resolve({ output: "unexpected", exitCode: 0 }), abort() {} };
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor, taskDepth: 2 }));
+		const result = await tool.execute("depth-blocked", { recipe: "r", task: "Work." });
+		expect(firstText(result)).toContain("Cannot spawn another agent at task depth 2");
+		expect(starts).toBe(0);
+	});
+
+	it("blocks recipe execution when the parent's spawns are disabled", async () => {
+		let starts = 0;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start() {
+				starts += 1;
+				return { result: Promise.resolve({ output: "unexpected", exitCode: 0 }), abort() {} };
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor, spawns: false }));
+		const result = await tool.execute("spawns-disabled", { recipe: "r", task: "Work." });
+		expect(firstText(result)).toContain("Cannot spawn 'recipe'. Allowed: none (spawns disabled for this agent)");
+		expect(starts).toBe(0);
+	});
+
+	it("blocks recipe execution when the parent's spawn allowlist excludes recipe", async () => {
+		let starts = 0;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start() {
+				starts += 1;
+				return { result: Promise.resolve({ output: "unexpected", exitCode: 0 }), abort() {} };
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor, spawns: "scout,task" }));
+		const result = await tool.execute("allowlist-blocked", { recipe: "r", task: "Work." });
+		expect(firstText(result)).toContain("Cannot spawn 'recipe'. Allowed: scout,task");
+		expect(starts).toBe(0);
+	});
+
+	it("blocks a batch recipe item at async preflight under the same containment gate", async () => {
+		let starts = 0;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start() {
+				starts += 1;
+				return { result: Promise.resolve({ output: "unexpected", exitCode: 0 }), abort() {} };
+			},
+		};
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({
+				executor,
+				manager,
+				spawns: false,
+				settings: { "async.enabled": true, "task.batch": true },
+			}),
+		);
+		const result = await tool.execute("batch-depth-blocked", {
+			context: "shared",
+			tasks: [{ recipe: "r", task: "Work." }],
+		} as TaskParams);
+		expect(firstText(result)).toContain("Cannot spawn 'recipe'. Allowed: none (spawns disabled for this agent)");
+		expect(starts).toBe(0);
+	});
+
+	it("settles within the bounded cleanup window when executor.start() never settles", async () => {
+		vi.useFakeTimers();
+		try {
+			const startCalled = Promise.withResolvers<void>();
+			const executor: ExternalTaskExecutor = {
+				discriminator: "recipe",
+				async start() {
+					startCalled.resolve();
+					return await new Promise<never>(() => {});
+				},
+			};
+			const tool = await TaskTool.create(createSession({ executor }));
+			const controller = new AbortController();
+			const pending = tool.execute(
+				"stuck-start",
+				{ recipe: "hung-start", task: "Wait." },
+				controller.signal,
+			);
+			await startCalled.promise;
+			controller.abort(new Error("cancelled during hung start"));
+			// Lets `requestAbort`'s wait for the already-resolved `startInvoked`
+			// gate settle so its bounded wait on the (never-settling) `start()`
+			// promise is actually constructed before the clock advances past it.
+			await flushMicrotasks();
+			vi.advanceTimersByTime(5000); // EXTERNAL_TASK_ABORT_CLEANUP_TIMEOUT_MS
+			const result = await pending;
+			expect(result.details?.results[0]).toMatchObject({
+				aborted: true,
+				abortReason: "cancelled during hung start",
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("aborts a still-starting executor once start() eventually produces a handle", async () => {
+		const startCalled = Promise.withResolvers<void>();
+		const releaseStart = Promise.withResolvers<void>();
+		let abortCalled = false;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			async start() {
+				startCalled.resolve();
+				await releaseStart.promise;
+				return {
+					result: new Promise<never>(() => {}),
+					async abort() {
+						abortCalled = true;
+					},
+				};
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor }));
+		const controller = new AbortController();
+		const pending = tool.execute(
+			"slow-start",
+			{ recipe: "slow-start", task: "Wait." },
+			controller.signal,
+		);
+		await startCalled.promise;
+		controller.abort(new Error("cancelled during start"));
+		// `start()` is still awaiting `releaseStart` — nothing to abort yet, and
+		// this check runs before any microtask could have produced a handle.
+		expect(abortCalled).toBe(false);
+		releaseStart.resolve();
+		const result = await pending;
+		expect(abortCalled).toBe(true);
+		expect(result.details?.results[0]).toMatchObject({
+			aborted: true,
+			abortReason: "cancelled during start",
+		});
+	});
+
+	it("applies task.maxRuntimeMs as a wall-clock bound for external recipe execution", async () => {
+		vi.useFakeTimers();
+		try {
+			let abortCalled = false;
+			const executor: ExternalTaskExecutor = {
+				discriminator: "recipe",
+				start() {
+					return {
+						result: new Promise<never>(() => {}),
+						async abort() {
+							abortCalled = true;
+						},
+					};
+				},
+			};
+			const tool = await TaskTool.create(createSession({ executor, settings: { "task.maxRuntimeMs": 50 } }));
+			const pending = tool.execute("runtime-capped", { recipe: "slow-work", task: "Run forever." });
+			// Lets execution reach the synchronous `setTimeout(..., 50)` call
+			// (past the async `outputManager.allocate()` step) before the clock
+			// advances past it.
+			await flushMicrotasks();
+			vi.advanceTimersByTime(50);
+			const result = await pending;
+			expect(abortCalled).toBe(true);
+			expect(result.details?.results[0]?.aborted).toBe(true);
+			expect(result.details?.results[0]?.abortReason).toContain("runtime limit exceeded");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });
 
 describe("extension registration plumbing", () => {
@@ -461,6 +643,62 @@ describe("extension registration plumbing", () => {
 			expect(task?.name).toBe("task");
 			expect(task?.label).toBe("Task");
 			const result = await task!.execute("sdk-recipe", {
+				recipe: "registered",
+				task: "Use the registered executor.",
+			} as never);
+			expect(firstText(result)).toContain("registered output");
+			expect(firstText(result)).not.toContain("replacement tool ran");
+			expect(replacementCalls).toBe(0);
+		} finally {
+			await session?.dispose();
+			authStorage.close();
+		}
+	}, 20_000);
+
+	it("keeps the native task tool when an SDK customTools entry is also named task", async () => {
+		using tempDir = TempDir.createSync("@omp-external-task-sdk-customtools-");
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		let replacementCalls = 0;
+		let session: AgentSession | undefined;
+		const replacementTool = {
+			name: "task",
+			label: "Replacement task",
+			description: "must not replace native Task",
+			parameters: type({ task: "string" }),
+			async execute() {
+				replacementCalls += 1;
+				return { content: [{ type: "text", text: "replacement tool ran" }] };
+			},
+		} satisfies CustomTool;
+		try {
+			const created = await createAgentSession({
+				cwd: tempDir.path(),
+				agentDir: tempDir.path(),
+				sessionManager: SessionManager.inMemory(),
+				modelRegistry,
+				settings: Settings.isolated({
+					"async.enabled": false,
+					"task.batch": false,
+					"task.isolation.mode": "none",
+					"tools.approvalMode": "yolo",
+				}),
+				extensions: [api => api.registerTaskExecutor(executor)],
+				customTools: [replacementTool],
+				enableLsp: false,
+				enableMCP: false,
+				skipPythonPreflight: true,
+				skills: [],
+				rules: [],
+				preloadedCustomToolPaths: [],
+				contextFiles: [],
+				promptTemplates: [],
+			});
+			session = created.session;
+			const task = session.getToolByName("task");
+			expect(task?.name).toBe("task");
+			expect(task?.label).toBe("Task");
+			const result = await task!.execute("sdk-recipe-customtools", {
 				recipe: "registered",
 				task: "Use the registered executor.",
 			} as never);

--- a/packages/coding-agent/test/task/task-external-executor.test.ts
+++ b/packages/coding-agent/test/task/task-external-executor.test.ts
@@ -534,6 +534,64 @@ describe("Task external recipe executor", () => {
 			vi.useRealTimers();
 		}
 	});
+
+	it("aborts a late-arriving handle after cleanup's bounded wait times out during a slow pre-start delay", async () => {
+		vi.useFakeTimers();
+		try {
+			const startCalled = Promise.withResolvers<void>();
+			const releaseProgress = Promise.withResolvers<void>();
+			let abortCalled = false;
+			const executor: ExternalTaskExecutor = {
+				discriminator: "recipe",
+				async start() {
+					startCalled.resolve();
+					// Simulates an executor that ignores the already-aborted signal
+					// it was handed and still produces a live handle.
+					return {
+						result: new Promise<never>(() => {}),
+						async abort() {
+							abortCalled = true;
+						},
+					};
+				},
+			};
+			const tool = await TaskTool.create(createSession({ executor }));
+			// A slow pre-start progress callback delays the "Starting..." emit,
+			// which in turn delays the `executor.start()` call well past the
+			// abort-cleanup bound.
+			const onUpdate = async () => {
+				await releaseProgress.promise;
+			};
+			const controller = new AbortController();
+			const pending = tool.execute(
+				"slow-pre-start",
+				{ recipe: "slow-pre-start", task: "Wait." },
+				controller.signal,
+				onUpdate,
+			);
+			await flushMicrotasks();
+			controller.abort(new Error("cancelled during slow pre-start"));
+			await flushMicrotasks();
+			// Elapse the whole abort-cleanup bound before `start()` is even
+			// invoked — cleanup gives up on its own bounded wait here.
+			vi.advanceTimersByTime(5000);
+			await flushMicrotasks();
+			expect(abortCalled).toBe(false);
+			// Now the delayed progress callback finally resolves; `start()` runs
+			// and produces a handle despite the already-aborted signal.
+			releaseProgress.resolve();
+			await startCalled.promise;
+			await flushMicrotasks();
+			expect(abortCalled).toBe(true);
+			const result = await pending;
+			expect(result.details?.results[0]).toMatchObject({
+				aborted: true,
+				abortReason: "cancelled during slow pre-start",
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });
 
 describe("extension registration plumbing", () => {

--- a/packages/coding-agent/test/task/task-external-executor.test.ts
+++ b/packages/coding-agent/test/task/task-external-executor.test.ts
@@ -1,0 +1,475 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	ExtensionRunner,
+	loadExtensionFromFactory,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
+import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
+import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
+import type {
+	AgentDefinition,
+	ExternalTaskExecutor,
+	SingleResult,
+	TaskParams,
+} from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { type } from "arktype";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const taskAgent: AgentDefinition = {
+	name: "task",
+	description: "General-purpose task agent",
+	systemPrompt: "You are a task agent.",
+	source: "bundled",
+};
+
+const managers: AsyncJobManager[] = [];
+
+function createManager(): AsyncJobManager {
+	const manager = new AsyncJobManager({ onJobComplete: () => {} });
+	managers.push(manager);
+	return manager;
+}
+
+function createSession(options: {
+	executor?: ExternalTaskExecutor;
+	manager?: AsyncJobManager;
+	settings?: Record<string, unknown>;
+} = {}): ToolSession {
+	return {
+		cwd: "/tmp/external-task-cwd",
+		hasUI: false,
+		settings: Settings.isolated({
+			"async.enabled": false,
+			"task.batch": false,
+			"task.isolation.mode": "none",
+			...options.settings,
+		}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getAgentId: () => "Parent",
+		externalTaskExecutor: options.executor,
+		asyncJobManager: options.manager,
+	} as unknown as ToolSession;
+}
+
+function mockDiscovery(): void {
+	vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+		agents: [taskAgent],
+		projectAgentsDir: null,
+	});
+}
+
+function makeNativeResult(id: string, output = "native output"): SingleResult {
+	return {
+		index: 0,
+		id,
+		agent: "task",
+		agentSource: "bundled",
+		task: "native task",
+		assignment: "native assignment",
+		exitCode: 0,
+		output,
+		stderr: "",
+		truncated: false,
+		durationMs: 5,
+		tokens: 0,
+		requests: 1,
+	};
+}
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find(part => part.type === "text")?.text ?? "";
+}
+
+beforeEach(() => {
+	AgentRegistry.resetGlobalForTests();
+	AgentLifecycleManager.resetGlobalForTests();
+	mockDiscovery();
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	for (const manager of managers.splice(0)) await manager.dispose({ timeoutMs: 1_000 });
+	AgentLifecycleManager.resetGlobalForTests();
+	AgentRegistry.resetGlobalForTests();
+});
+
+describe("Task external recipe executor", () => {
+	it("keeps native Task identity, schema, and execution unchanged without an executor", async () => {
+		let nativeCalls = 0;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			nativeCalls += 1;
+			return makeNativeResult(options.id ?? "native");
+		});
+		const tool = await TaskTool.create(createSession());
+		const wire = toolWireSchema(tool) as { properties?: Record<string, unknown>; anyOf?: unknown };
+
+		expect(tool.name).toBe("task");
+		expect(tool.label).toBe("Task");
+		expect(wire.properties?.task).toBeDefined();
+		expect(wire.anyOf).toBeUndefined();
+
+		const result = await tool.execute("native-call", { task: "Do native work." });
+		expect(nativeCalls).toBe(1);
+		expect(result.details?.results[0]?.agent).toBe("task");
+		expect(firstText(result)).toContain("native output");
+	});
+
+	it("exposes a discriminated recipe schema and routes one item through the registered executor", async () => {
+		let request: Parameters<ExternalTaskExecutor["start"]>[0] | undefined;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			async start(input) {
+				request = input;
+				await input.onProgress({ message: "external progress" });
+				return {
+					result: Promise.resolve({ output: "external output", exitCode: 0 }),
+					abort() {},
+				};
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor }));
+		const wire = toolWireSchema(tool) as {
+			anyOf?: Array<{ properties?: Record<string, unknown>; required?: string[] }>;
+		};
+		expect(wire.anyOf?.some(branch => branch.properties?.recipe !== undefined)).toBe(true);
+		expect(wire.anyOf?.some(branch => branch.properties?.agent !== undefined)).toBe(true);
+		expect(tool.description).toContain("Hub send/park/revive");
+
+		const updates: string[] = [];
+		const result = await tool.execute(
+			"recipe-call",
+			{ recipe: "release-check", task: "Run the release checks." },
+			undefined,
+			update => {
+				updates.push(firstText(update));
+			},
+		);
+
+		expect(request?.recipe).toBe("release-check");
+		expect(request?.assignment).toBe("Run the release checks.");
+		expect(request?.context).toBeUndefined();
+		expect(request?.cwd).toBe("/tmp/external-task-cwd");
+		expect(request?.signal).toBeInstanceOf(AbortSignal);
+		expect(updates).toContain("external progress");
+		expect(result.details?.results[0]).toMatchObject({ agent: "recipe", output: "external output", exitCode: 0 });
+		expect(firstText(result)).toContain("external output");
+	});
+
+	it("fans out a mixed native/recipe batch concurrently and preserves input ordering", async () => {
+		const started: string[] = [];
+		let active = 0;
+		let maxActive = 0;
+		const release = Promise.withResolvers<void>();
+		const enter = async (kind: string) => {
+			started.push(kind);
+			active += 1;
+			maxActive = Math.max(maxActive, active);
+			if (started.length === 2) release.resolve();
+			await release.promise;
+			active -= 1;
+		};
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			await enter("native");
+			return makeNativeResult(options.id ?? "native", "native mixed output");
+		});
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start(input) {
+				return {
+					result: (async () => {
+						await enter("recipe");
+						expect(input.context).toBe("shared context");
+						return { output: "recipe mixed output", exitCode: 0 };
+					})(),
+					abort() {},
+				};
+			},
+		};
+		const tool = await TaskTool.create(
+			createSession({ executor, settings: { "task.batch": true, "task.maxConcurrency": 2 } }),
+		);
+		const result = await tool.execute("mixed-call", {
+			context: "shared context",
+			tasks: [
+				{ name: "Native", agent: "task", task: "Do native work." },
+				{ name: "Recipe", recipe: "external-work", task: "Do external work." },
+			],
+		} as TaskParams);
+
+		expect(started.sort()).toEqual(["native", "recipe"]);
+		expect(maxActive).toBe(2);
+		expect(result.details?.results.map(item => item.id)).toEqual(["Native", "Recipe"]);
+		expect(result.details?.results.map(item => item.output)).toEqual([
+			"native mixed output",
+			"recipe mixed output",
+		]);
+	});
+
+	it("propagates cancellation to abort() and does not settle before cleanup completes", async () => {
+		const started = Promise.withResolvers<void>();
+		const cleanupStarted = Promise.withResolvers<void>();
+		const releaseCleanup = Promise.withResolvers<void>();
+		const neverSettles = Promise.withResolvers<never>();
+		let abortCalled = false;
+		let cleanupComplete = false;
+		let capturedSignal: AbortSignal | undefined;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start(input) {
+				capturedSignal = input.signal;
+				started.resolve();
+				return {
+					result: neverSettles.promise,
+					async abort() {
+						abortCalled = true;
+						cleanupStarted.resolve();
+						await releaseCleanup.promise;
+						cleanupComplete = true;
+					},
+				};
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor }));
+		const controller = new AbortController();
+		const pending = tool.execute(
+			"cancel-call",
+			{ recipe: "long-running", task: "Wait until cancelled." },
+			controller.signal,
+		);
+		await started.promise;
+		let settled = false;
+		void pending.then(() => {
+			settled = true;
+		});
+		controller.abort(new Error("cancelled by test"));
+		await cleanupStarted.promise;
+		expect(settled).toBe(false);
+		expect(cleanupComplete).toBe(false);
+		releaseCleanup.resolve();
+		const result = await pending;
+
+		expect(capturedSignal?.aborted).toBe(true);
+		expect(abortCalled).toBe(true);
+		expect(cleanupComplete).toBe(true);
+		expect(result.details?.results[0]).toMatchObject({ aborted: true, abortReason: "cancelled by test" });
+	});
+
+	it("keeps external jobs in Task async lifecycle without claiming Hub agent parity", async () => {
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start() {
+				return {
+					result: Promise.resolve({ output: "async external output", exitCode: 0 }),
+					abort() {},
+				};
+			},
+		};
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({ executor, manager, settings: { "async.enabled": true } }),
+		);
+		const result = await tool.execute("async-recipe", {
+			name: "ExternalJob",
+			recipe: "async-work",
+			task: "Run externally.",
+		});
+		const text = firstText(result);
+		expect(text).toContain("do not support Hub send, park, or revive");
+		expect(text).not.toContain("DM `ExternalJob`");
+		const job = manager.getJob("ExternalJob");
+		expect(job).toBeDefined();
+		await job!.promise;
+		expect(job!.status).toBe("completed");
+	});
+
+	it("fails clearly for absent executors, mutual exclusivity, model overrides, and typed schemas", async () => {
+		const absent = await TaskTool.create(createSession());
+		expect(firstText(await absent.execute("absent", { recipe: "missing", task: "Work." }))).toContain(
+			"no external Task executor is registered",
+		);
+		expect(absent.parameters({ recipe: "missing", task: "Work." }) instanceof type.errors).toBe(true);
+		const absentBatch = await TaskTool.create(createSession({ settings: { "task.batch": true } }));
+		const absentBatchParams = {
+			context: "shared",
+			tasks: [{ recipe: "missing", task: "Work." }],
+		};
+		expect(absentBatch.parameters(absentBatchParams) instanceof type.errors).toBe(true);
+		expect(firstText(await absentBatch.execute("absent-batch", absentBatchParams))).toContain(
+			"no external Task executor is registered",
+		);
+
+		let starts = 0;
+		const executor: ExternalTaskExecutor = {
+			discriminator: "recipe",
+			start() {
+				starts += 1;
+				return { result: Promise.resolve({ output: "unexpected", exitCode: 0 }), abort() {} };
+			},
+		};
+		const tool = await TaskTool.create(createSession({ executor }));
+		const cases: Array<{ params: TaskParams; message: string }> = [
+			{ params: { agent: "task", recipe: "r", task: "Work." }, message: "cannot set both `agent` and `recipe`" },
+			{ params: { recipe: "r", task: "Work.", model: "p/m" }, message: "model overrides are not supported" },
+			{
+				params: { recipe: "r", task: "Work.", outputSchema: { type: "object" } },
+				message: "typed output schemas are not supported",
+			},
+			{
+				params: { recipe: "r", task: "Work.", schemaMode: "strict" },
+				message: "typed output schemas are not supported",
+			},
+		];
+		const batchTool = await TaskTool.create(createSession({ executor, settings: { "task.batch": true } }));
+		for (const unsupported of [
+			{ model: "p/m" },
+			{ outputSchema: { type: "object" } },
+			{ schemaMode: "strict" as const },
+			{ isolated: true },
+		]) {
+			expect(
+				batchTool.parameters({
+					context: "shared",
+					tasks: [{ recipe: "r", task: "Work.", ...unsupported }],
+				}) instanceof type.errors,
+			).toBe(true);
+		}
+		for (const [index, testCase] of cases.entries()) {
+			expect(firstText(await tool.execute(`unsupported-${index}`, testCase.params))).toContain(testCase.message);
+		}
+		expect(starts).toBe(0);
+	});
+});
+
+describe("extension registration plumbing", () => {
+	const executor: ExternalTaskExecutor = {
+		discriminator: "recipe",
+		start() {
+			return { result: Promise.resolve({ output: "registered output", exitCode: 0 }), abort() {} };
+		},
+	};
+
+	it("registers one executor without registering a task tool and rejects duplicate registrations", async () => {
+		const runtime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			api => api.registerTaskExecutor(executor),
+			"/tmp",
+			new EventBus(),
+			runtime,
+			"one-executor",
+		);
+		expect(extension.externalTaskExecutor?.executor).toBe(executor);
+		expect(extension.tools.has("task")).toBe(false);
+
+		await expect(
+			loadExtensionFromFactory(
+				api => {
+					api.registerTaskExecutor(executor);
+					api.registerTaskExecutor(executor);
+				},
+				"/tmp",
+				new EventBus(),
+				runtime,
+				"duplicate-in-one-extension",
+			),
+		).rejects.toThrow("registered more than one external Task executor");
+	});
+
+	it("rejects duplicate executors across extensions without load-order precedence", async () => {
+		const runtime = new ExtensionRuntime();
+		const first = await loadExtensionFromFactory(
+			api => api.registerTaskExecutor(executor),
+			"/tmp",
+			new EventBus(),
+			runtime,
+			"first-extension",
+		);
+		const second = await loadExtensionFromFactory(
+			api => api.registerTaskExecutor(executor),
+			"/tmp",
+			new EventBus(),
+			runtime,
+			"second-extension",
+		);
+		const runner = new ExtensionRunner(
+			[first, second],
+			runtime,
+			"/tmp",
+			{} as never,
+			{} as never,
+		);
+		expect(() => runner.getExternalTaskExecutor()).toThrow(
+			'Multiple external Task executors registered for discriminator "recipe"',
+		);
+	});
+
+	it("keeps the native task tool when an extension also registers a tool named task", async () => {
+		using tempDir = TempDir.createSync("@omp-external-task-sdk-");
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		let replacementCalls = 0;
+		let session: AgentSession | undefined;
+		try {
+			const created = await createAgentSession({
+				cwd: tempDir.path(),
+				agentDir: tempDir.path(),
+				sessionManager: SessionManager.inMemory(),
+				modelRegistry,
+				settings: Settings.isolated({
+					"async.enabled": false,
+					"task.batch": false,
+					"task.isolation.mode": "none",
+					"tools.approvalMode": "yolo",
+				}),
+				extensions: [api => {
+					api.registerTaskExecutor(executor);
+					api.registerTool({
+						name: "task",
+						description: "must not replace native Task",
+						label: "Replacement task",
+						parameters: api.zod.object({ task: api.zod.string() }),
+						async execute() {
+							replacementCalls += 1;
+							return { content: [{ type: "text", text: "replacement tool ran" }] };
+						},
+					});
+				}],
+				enableLsp: false,
+				enableMCP: false,
+				skipPythonPreflight: true,
+				skills: [],
+				rules: [],
+				preloadedCustomToolPaths: [],
+				contextFiles: [],
+				promptTemplates: [],
+			});
+			session = created.session;
+			const task = session.getToolByName("task");
+			expect(task?.name).toBe("task");
+			expect(task?.label).toBe("Task");
+			const result = await task!.execute("sdk-recipe", {
+				recipe: "registered",
+				task: "Use the registered executor.",
+			} as never);
+			expect(firstText(result)).toContain("registered output");
+			expect(firstText(result)).not.toContain("replacement tool ran");
+			expect(replacementCalls).toBe(0);
+		} finally {
+			await session?.dispose();
+			authStorage.close();
+		}
+	}, 20_000);
+});


### PR DESCRIPTION
## What changed

- add `RpcClientOptions.envMode: "replace"` for clean child environments while preserving merge behavior by default
- let one extension register an external Task item executor for the `recipe` discriminator
- keep the native `task` tool authoritative; extension tools and SDK custom tools named `task` are ignored
- route `task({ recipe, task })` and mixed native/recipe batches through existing Task fan-out, async, progress, result, depth, spawn-policy, cancellation, and runtime-limit machinery
- reject recipe items that request model overrides, isolation, or typed output schemas until those contracts exist

## Containment and lifecycle

- recipe items obey `task.maxRecursionDepth`, `spawns: false`, and spawn allowlists before executor start
- abort is registered before `executor.start()`
- stuck start and runtime are bounded
- abort cleanup is bounded, with an idempotent late-handle continuation so an executor that resolves after the bound is still aborted exactly once

## Evidence

- focused Task/extension suite: 100 passed, 0 failed
- focused RpcClient suite: 11 passed, 0 failed
- package typecheck: clean
- source smoke: native Task unchanged, recipe execution routed, same-name replacements never invoked
- independent Cerberus review: PASS after fixing depth/spawn-policy bypass, custom-tool override, and late-start cleanup
- independent live verifier: PASS for mixed concurrency/order, cancellation cleanup, absent/duplicate executor errors, unsupported fields, spawn containment, stuck start/runtime bounds, late handle abort, and no-PATH clean RpcClient environment

## Deliberate gaps

This PR does not add recipe parsing or Hatchet knowledge. Typed output schemas and Hub send/park/revive for external executions remain deferred and fail clearly rather than silently degrading.