### PR TITLE
fix(tui): correct Warp compatibility Jamo width

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed WarpTerminal wrapping streamed Compatibility Jamo at the platform-default width instead of its rendered one-cell width ([#6461](https://github.com/can1357/oh-my-pi/issues/6461)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -12,6 +12,7 @@ import {
 import { setKittyProtocolActive } from "./keys";
 import { StdinBuffer } from "./stdin-buffer";
 import {
+	detectTerminalId,
 	isInsideTerminalMultiplexer,
 	NotifyProtocol,
 	setCellDimensions,
@@ -25,23 +26,23 @@ const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 const WINDOWS_TERMINAL_OSC11_POLL_MS = 30_000;
-// Hangul Compatibility Jamo (U+3131..=U+318E) render width is terminal-dependent:
-// Ghostty follows UAX#11 (2 cells); Terminal.app and iTerm2 render narrow (1),
-// matching the macOS platform default. Override only for terminals known to
-// disagree — the rest keep the platform default (macOS narrow, otherwise UAX#11),
-// so this is a no-op everywhere except Ghostty. A runtime DSR/CPR probe that
-// auto-detects the width on unknown terminals is tracked separately.
+/**
+ * Resolves terminal-specific Compatibility Jamo widths while preserving the platform default for unknown terminals.
+ *
+ * Ghostty follows UAX#11 (2 cells), while Warp paints each code point at 1 cell.
+ * Terminal.app and iTerm2 also render narrow, matching the macOS platform default.
+ */
 export function resolveHangulCompatibilityJamoWidthFromTerminalIdentity(
 	env: NodeJS.ProcessEnv = Bun.env,
 ): HangulCompatibilityJamoWidth {
-	if (
-		env.GHOSTTY_RESOURCES_DIR ||
-		env.TERM_PROGRAM?.toLowerCase() === "ghostty" ||
-		env.TERM?.toLowerCase().includes("ghostty")
-	) {
-		return 2;
+	switch (detectTerminalId(env)) {
+		case "ghostty":
+			return 2;
+		case "warp":
+			return 1;
+		default:
+			return "platform";
 	}
-	return "platform";
 }
 
 function shouldEnableModifyOtherKeysFallback(env: NodeJS.ProcessEnv = Bun.env): boolean {

--- a/packages/tui/test/terminal-jamo-width-probe.test.ts
+++ b/packages/tui/test/terminal-jamo-width-probe.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "bun:test";
 import { resolveHangulCompatibilityJamoWidthFromTerminalIdentity } from "@oh-my-pi/pi-tui/terminal";
 
 describe("Hangul Compatibility Jamo width terminal-identity resolution", () => {
-	it("forces wide (2) for Ghostty, platform default otherwise", () => {
+	it("forces wide for Ghostty, narrow for Warp, and the platform default otherwise", () => {
 		// Ghostty follows UAX#11 and renders Hangul Compatibility Jamo at 2 cells;
-		// every other terminal keeps the platform default (macOS narrow, otherwise
-		// UAX#11), so the override is a no-op outside Ghostty.
+		// Warp renders them at 1 cell. Every other terminal keeps the platform
+		// default (macOS narrow, otherwise UAX#11).
 		expect(
 			resolveHangulCompatibilityJamoWidthFromTerminalIdentity({
 				GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app",
@@ -16,6 +16,7 @@ describe("Hangul Compatibility Jamo width terminal-identity resolution", () => {
 		// GHOSTTY_RESOURCES_DIR / TERM_PROGRAM) must still resolve wide — mirrors
 		// the Ghostty detection in terminal-capabilities.ts.
 		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM: "xterm-ghostty" })).toBe(2);
+		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "WarpTerminal" })).toBe(1);
 		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "iTerm.app" })).toBe("platform");
 		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "Apple_Terminal" })).toBe(
 			"platform",


### PR DESCRIPTION
## Repro
On Linux, Warp’s terminal identity remained on the platform profile, so the shared width engine counted each character in `ㅎㅏㄴ` as two cells although Warp paints one. Reproduce with:

```sh
bun -e 'import { resolveHangulCompatibilityJamoWidthFromTerminalIdentity } from "./packages/tui/src/terminal.ts"; import { setHangulCompatibilityJamoWidth, visibleWidth } from "./packages/tui/src/utils.ts"; const profile = resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "WarpTerminal" }); setHangulCompatibilityJamoWidth(profile); console.log({ profile, width: visibleWidth("ㅎㅏㄴ") }); if (profile !== 1 || visibleWidth("ㅎㅏㄴ") !== 3) process.exit(1);'
```

Before the fix this reports `{ profile: "platform", width: 6 }` and exits 1.

## Cause
`resolveHangulCompatibilityJamoWidthFromTerminalIdentity()` in `packages/tui/src/terminal.ts` only recognized Ghostty’s explicit wide profile. Warp was already recognized by `detectTerminalId()`, but the Jamo resolver ignored that identity and retained Linux’s two-cell platform default.

## Fix
- Reuse `detectTerminalId()` as the single terminal identity source for Compatibility Jamo width selection.
- Select Warp’s one-cell profile while retaining Ghostty’s two-cell profile and the platform default for all other terminals.
- Cover Warp identity resolution and document the fix in `packages/tui/CHANGELOG.md`.

## Verification
`bun run gen:tool-views` followed by `bun test packages/tui/test/terminal-jamo-width-probe.test.ts packages/tui/test/visible-width.test.ts packages/tui/test/line-width-sidecar.test.ts packages/tui/test/markdown.test.ts packages/coding-agent/test/streaming-reveal.test.ts packages/coding-agent/test/interactive-mode-status.test.ts packages/coding-agent/test/task/task-progress-render.test.ts packages/coding-agent/test/tools/eval-agent-progress.test.ts` passes: 220 tests, 0 failures. The reproduction now reports `{ profile: 1, compatibility: 3, conjoining: 4 }`. The pre-publish `bun check` gate also passed.

Fixes #6461