### PR TITLE
fix(tools): close spilled output descriptors on error/abort paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spilled tool-output artifact descriptors leaking on error/abort paths. `OutputSink.dump()` was the only path that closed the spill `Bun.FileSink`, but the bash and Python executors re-throw on failure and their `finally` blocks never closed the sink, so a large-output command that errored leaked the artifact descriptor until an unrelated read (e.g. a `SKILL.md` load) hit `EMFILE`. `OutputSink` now exposes an idempotent `dispose()` that closes the sink exactly once, wired into every executor's `finally` ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -497,6 +497,7 @@ export async function executeWithKernelBase<
 		logger.error(`${errorLogLabel} execution failed`, { error: error.message });
 		throw error;
 	} finally {
+		await sink.dispose();
 		unregisterBridge?.();
 		abortShield.dispose?.();
 	}

--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -169,5 +169,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 			outputBytes: summary.outputBytes,
 			displayOutputs,
 		};
+	} finally {
+		await outputSink.dispose();
 	}
 }

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -581,6 +581,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		resetSession = true;
 		throw err;
 	} finally {
+		await sink.dispose();
 		if (timeoutTimer) {
 			clearTimeout(timeoutTimer);
 		}

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -1338,12 +1338,22 @@ export class OutputSink {
 		if (this.#fileCreation) {
 			await this.#fileCreation.catch(() => undefined);
 		}
-		if (!this.#file) return;
-		this.#flushArtifactTailIfCapped();
+		const file = this.#file;
+		if (!file) return;
+		// The tail/notice replay writes to the sink and can throw (e.g. a disk
+		// write error). Closing the descriptor MUST still happen — otherwise the
+		// fd leaks and the replay error masks the original tool error that put us
+		// on this path. Both failures are swallowed so dispose() never throws.
 		try {
-			await this.#file.sink.end();
+			this.#flushArtifactTailIfCapped();
 		} catch {
 			/* ignore */
+		} finally {
+			try {
+				await file.sink.end();
+			} catch {
+				/* ignore */
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -756,6 +756,10 @@ export class OutputSink {
 	// Queue of chunks waiting for the file sink to be created.
 	#pendingFileWrites?: string[];
 	#fileReady = false;
+	/** In-flight sink creation, awaited by finalize/dispose so a fd opened by a late chunk is still released. */
+	#fileCreation?: Promise<void>;
+	/** Set once the spill file has been closed; guards double-close and post-finalize resurrection. */
+	#finalized = false;
 
 	readonly #artifactPath?: string;
 	readonly #artifactId?: string;
@@ -842,6 +846,7 @@ export class OutputSink {
 	 * synchronously. File sink writes are deferred and serialized internally.
 	 */
 	push(chunk: string): void {
+		if (this.#finalized) return;
 		chunk = sanitizeWithOptionalSixelPassthrough(chunk, text => sanitizeText(this.#normalizeCarriageReturns(text)));
 
 		// Throttled onChunk: coalesce chunks arriving inside the throttle window.
@@ -1018,7 +1023,7 @@ export class OutputSink {
 		// resolves (typically <2). The cap is enforced on drain.
 		if (!this.#pendingFileWrites) {
 			this.#pendingFileWrites = [chunk];
-			void this.#createFileSink();
+			this.#fileCreation = this.#createFileSink();
 		} else {
 			this.#pendingFileWrites.push(chunk);
 		}
@@ -1255,10 +1260,7 @@ export class OutputSink {
 		this.#flushPendingChunk();
 		const totalLines = this.#sawData ? this.#totalLines + 1 : 0;
 
-		if (this.#file) {
-			this.#flushArtifactTailIfCapped();
-			await this.#file.sink.end();
-		}
+		await this.#finalizeFile();
 
 		// Compose the visible output. With head retention, splice head + marker
 		// + tail when content was elided. Otherwise return the rolling buffer.
@@ -1320,6 +1322,41 @@ export class OutputSink {
 			columnMax: this.#columnTruncatedLines > 0 ? this.#maxColumns : undefined,
 			artifactId: this.#file?.artifactId,
 		};
+	}
+
+	/**
+	 * Flush any capped artifact tail and close the spill file descriptor,
+	 * awaiting an in-flight sink creation so a descriptor opened by a late
+	 * chunk is still released. Idempotent via {@link #finalized}: the artifact
+	 * is finalized exactly once whether the caller reached {@link dump} or
+	 * bailed through {@link dispose}. `#file` is left set so {@link dump} can
+	 * still read `artifactId` for its summary.
+	 */
+	async #finalizeFile(): Promise<void> {
+		if (this.#finalized) return;
+		this.#finalized = true;
+		if (this.#fileCreation) {
+			await this.#fileCreation.catch(() => undefined);
+		}
+		if (!this.#file) return;
+		this.#flushArtifactTailIfCapped();
+		try {
+			await this.#file.sink.end();
+		} catch {
+			/* ignore */
+		}
+	}
+
+	/**
+	 * Release the artifact spill descriptor on an exit path that skips
+	 * {@link dump} — a thrown error or abort. Idempotent and safe in a
+	 * `finally`: if {@link dump} already ran this is a no-op, otherwise it
+	 * flushes the capped tail and closes the sink so the descriptor is not
+	 * leaked until a later unrelated read hits `EMFILE` (issue #6463).
+	 */
+	async dispose(): Promise<void> {
+		this.#clearPendingChunkTimer();
+		await this.#finalizeFile();
 	}
 }
 

--- a/packages/coding-agent/src/tools/bash-interactive.ts
+++ b/packages/coding-agent/src/tools/bash-interactive.ts
@@ -340,92 +340,96 @@ export async function runInteractiveBashPty(
 		headBytes: resolveOutputSinkHeadBytes(settings),
 		maxColumns: resolveOutputMaxColumns(settings),
 	});
-	const result = await ui.custom<BashInteractiveResult>(
-		(tui, uiTheme, _keybindings, done) => {
-			const session = new PtySession();
-			const component = new BashInteractiveOverlayComponent(
-				options.command,
-				uiTheme,
-				() => tui.terminal.rows,
-				XtermTerminal,
-			);
-			component.setSession(session);
-			let finished = false;
-			const finalize = (run: PtyRunResult) => {
-				if (finished) return;
-				finished = true;
-				component.setComplete({ exitCode: run.exitCode, cancelled: run.cancelled, timedOut: run.timedOut });
-				tui.requestRender();
-				void (async () => {
-					await component.flushOutput();
-					const summary = await sink.dump();
-					done({
-						exitCode: run.exitCode,
-						cancelled: run.cancelled,
-						timedOut: run.timedOut,
-						...summary,
-					});
-				})();
-			};
-			const cols = Math.max(20, tui.terminal.columns - 2);
-			const rows = Math.max(5, tui.terminal.rows - 4);
-			component.setHandlers(
-				data => {
-					try {
-						session.write(data);
-					} catch {
-						// ignore writes after command exits
-					}
-				},
-				() => {
-					try {
-						session.kill();
-					} catch {
-						// ignore
-					}
-				},
-				() => {
-					try {
-						session.kill();
-					} catch {
-						// ignore
-					}
-				},
-			);
-			void session
-				.start(
-					{
-						command: options.command,
-						cwd: options.cwd,
-						timeoutMs: options.timeoutMs,
-						// Interactive PTY: inherit the user's environment (the Rust side
-						// applies these as overrides), with a real TERM so editors,
-						// pagers, and TUIs behave like a normal terminal.
-						env: {
-							TERM: "xterm-256color",
-							...options.env,
+	try {
+		const result = await ui.custom<BashInteractiveResult>(
+			(tui, uiTheme, _keybindings, done) => {
+				const session = new PtySession();
+				const component = new BashInteractiveOverlayComponent(
+					options.command,
+					uiTheme,
+					() => tui.terminal.rows,
+					XtermTerminal,
+				);
+				component.setSession(session);
+				let finished = false;
+				const finalize = (run: PtyRunResult) => {
+					if (finished) return;
+					finished = true;
+					component.setComplete({ exitCode: run.exitCode, cancelled: run.cancelled, timedOut: run.timedOut });
+					tui.requestRender();
+					void (async () => {
+						await component.flushOutput();
+						const summary = await sink.dump();
+						done({
+							exitCode: run.exitCode,
+							cancelled: run.cancelled,
+							timedOut: run.timedOut,
+							...summary,
+						});
+					})();
+				};
+				const cols = Math.max(20, tui.terminal.columns - 2);
+				const rows = Math.max(5, tui.terminal.rows - 4);
+				component.setHandlers(
+					data => {
+						try {
+							session.write(data);
+						} catch {
+							// ignore writes after command exits
+						}
+					},
+					() => {
+						try {
+							session.kill();
+						} catch {
+							// ignore
+						}
+					},
+					() => {
+						try {
+							session.kill();
+						} catch {
+							// ignore
+						}
+					},
+				);
+				void session
+					.start(
+						{
+							command: options.command,
+							cwd: options.cwd,
+							timeoutMs: options.timeoutMs,
+							// Interactive PTY: inherit the user's environment (the Rust side
+							// applies these as overrides), with a real TERM so editors,
+							// pagers, and TUIs behave like a normal terminal.
+							env: {
+								TERM: "xterm-256color",
+								...options.env,
+							},
+							signal: options.signal,
+							cols,
+							rows,
+							shell: resolvedShell,
 						},
-						signal: options.signal,
-						cols,
-						rows,
-						shell: resolvedShell,
-					},
-					(err, chunk) => {
-						if (finished || err || !chunk) return;
-						component.appendOutput(chunk);
-						const normalizedChunk = normalizeCaptureChunk(chunk);
-						sink.push(normalizedChunk);
-						tui.requestRender();
-					},
-				)
-				.then(finalize)
-				.catch(error => {
-					sink.push(`PTY error: ${error instanceof Error ? error.message : String(error)}\n`);
-					finalize({ exitCode: undefined, cancelled: false, timedOut: false });
-				});
-			return component;
-		},
-		{ overlay: true },
-	);
-	return result;
+						(err, chunk) => {
+							if (finished || err || !chunk) return;
+							component.appendOutput(chunk);
+							const normalizedChunk = normalizeCaptureChunk(chunk);
+							sink.push(normalizedChunk);
+							tui.requestRender();
+						},
+					)
+					.then(finalize)
+					.catch(error => {
+						sink.push(`PTY error: ${error instanceof Error ? error.message : String(error)}\n`);
+						finalize({ exitCode: undefined, cancelled: false, timedOut: false });
+					});
+				return component;
+			},
+			{ overlay: true },
+		);
+		return result;
+	} finally {
+		await sink.dispose();
+	}
 }

--- a/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
+++ b/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -14,6 +14,7 @@ async function createTempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	for (const dir of createdTempDirs.splice(0)) {
 		await removeWithRetries(dir);
 	}
@@ -82,5 +83,52 @@ describe("OutputSink fd lifecycle", () => {
 
 		const content = await Bun.file(artifactPath).text();
 		expect(content).not.toContain("y".repeat(64));
+	});
+
+	test("dispose() closes the descriptor even when the capped tail replay write throws", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "capped.txt");
+
+		let ended = false;
+		// Mock FileSink: head bytes ("h") write fine; the tail replay (the
+		// `[ARTIFACT TRUNCATED …]` notice + "t" ring) throws, mirroring a disk
+		// write error while closing a capped artifact. Cast to the sink type — a
+		// full FileSink has methods OutputSink never calls.
+		const fakeSink = {
+			write(chunk: string): number {
+				if (chunk.includes("[ARTIFACT TRUNCATED") || chunk.includes("t")) {
+					throw new Error("simulated disk write failure");
+				}
+				return Buffer.byteLength(chunk, "utf-8");
+			},
+			end(): Promise<number> {
+				ended = true;
+				return Promise.resolve(0);
+			},
+		} as unknown as Bun.FileSink;
+		const fakeFile = { writer: () => fakeSink } as unknown as Bun.BunFile;
+
+		const realFile = Bun.file.bind(Bun);
+		vi.spyOn(Bun, "file").mockImplementation((source, options) => {
+			if (source === artifactPath) return fakeFile;
+			return realFile(source as string, options);
+		});
+
+		// Small on-disk cap so head fills, the rest overflows into the tail ring,
+		// and #flushArtifactTailIfCapped replays a truncation notice on close.
+		const sink = new OutputSink({
+			artifactPath,
+			artifactId: "capped",
+			spillThreshold: 16,
+			artifactMaxBytes: 40,
+			artifactHeadBytes: 20,
+		});
+		sink.push("h".repeat(30));
+		sink.push("t".repeat(60));
+
+		// The tail replay throws, but dispose() must still close the sink and must
+		// not surface the replay error (it would mask the original tool error).
+		await expect(sink.dispose()).resolves.toBeUndefined();
+		expect(ended).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
+++ b/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { OutputSink } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const createdTempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "output-sink-fd-"));
+	createdTempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	for (const dir of createdTempDirs.splice(0)) {
+		await removeWithRetries(dir);
+	}
+});
+
+// Force a spill on the first push: a tiny threshold plus a chunk larger than it
+// kicks off the async artifact `Bun.FileSink` creation. dump()/dispose() both
+// await that in-flight creation internally, so no wall-clock wait is needed to
+// observe the fd being opened and then closed.
+function spill(sink: OutputSink): void {
+	sink.push(`${"x".repeat(64)}\n`);
+}
+
+describe("OutputSink fd lifecycle", () => {
+	test("dispose() releases the spill descriptor on error/abort paths that skip dump()", async () => {
+		const dir = await createTempDir();
+		const skill = path.join(dir, "SKILL.md");
+		await Bun.write(skill, "# skill\n");
+
+		// Far more iterations than the 64-descriptor limit the repro runs under.
+		// A leaked spill fd would exhaust the table and make the skill read below
+		// throw EMFILE — exactly the reported failure.
+		for (let i = 0; i < 256; i++) {
+			const artifactPath = path.join(dir, `spill-${i}.txt`);
+			const sink = new OutputSink({ artifactPath, artifactId: `art-${i}`, spillThreshold: 16 });
+			spill(sink);
+			// Error/abort path: bail without dump().
+			await sink.dispose();
+			// Descriptor released → the artifact is closed, complete, and readable,
+			// and the unrelated skill read never hits EMFILE.
+			const content = await Bun.file(artifactPath).text();
+			expect(content).toContain("x".repeat(64));
+			await Bun.file(skill).text();
+		}
+	});
+
+	test("dump() then dispose() closes the sink exactly once", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "spill.txt");
+		const sink = new OutputSink({ artifactPath, artifactId: "once", spillThreshold: 16 });
+		spill(sink);
+
+		const summary = await sink.dump();
+		expect(summary.artifactId).toBe("once");
+		expect(summary.truncated).toBe(true);
+
+		// dispose() after dump() must be a harmless idempotent no-op — no throw
+		// from double-closing the underlying FileSink.
+		await sink.dispose();
+
+		const content = await Bun.file(artifactPath).text();
+		expect(content).toContain("x".repeat(64));
+	});
+
+	test("push() after finalize is dropped and never resurrects the descriptor", async () => {
+		const dir = await createTempDir();
+		const artifactPath = path.join(dir, "spill.txt");
+		const sink = new OutputSink({ artifactPath, artifactId: "drop", spillThreshold: 16 });
+		spill(sink);
+		await sink.dispose();
+
+		// A late chunk (e.g. a native callback firing after the error path tore
+		// down) must not reopen a fresh spill sink.
+		sink.push(`${"y".repeat(64)}\n`);
+		await sink.dispose();
+
+		const content = await Bun.file(artifactPath).text();
+		expect(content).not.toContain("y".repeat(64));
+	});
+});


### PR DESCRIPTION
## Repro
A bash/python/js command whose output spills to an `artifact://` file and then errors or aborts leaks the spill descriptor: `OutputSink.dump()` is the only path that closes the underlying `Bun.FileSink`, but the executors re-throw on failure without calling it. Enough leaks exhaust the descriptor table and a later unrelated read (e.g. a `SKILL.md` load) throws `EMFILE`. Reproduced with a loop of 300 sinks that spill then bail without `dump()`, interleaved with a skill read:

```
prlimit --nofile=64:64 bun repro.ts
FAIL: EMFILE: too many open files, open '.../SKILL.md'
```

## Cause
`OutputSink.dump()` (`packages/coding-agent/src/session/streaming-output.ts`) closes `#file.sink` and is the sole close path. `executeBash()` (`src/exec/bash-executor.ts` `catch` → `throw err`) and `executeWithKernelBase()` (`src/eval/executor-base.ts` non-cancellation `catch` → re-throw) skip `dump()` on failure, and their `finally` blocks never touch the sink, so the spilled descriptor is retained for the life of the process.

## Fix
- Added `OutputSink.dispose()` plus a shared `#finalizeFile()` in `streaming-output.ts`: flushes any capped artifact tail and closes the sink exactly once. It awaits an in-flight `#createFileSink()` so a descriptor opened by a late chunk is still released, and a `#finalized` flag guards double-close; `push()` after finalize is dropped so a stray callback cannot resurrect the sink.
- Wired `await sink.dispose()` into the `finally` of `executeBash()`, `executeWithKernelBase()` (python), `executeJs()`, and `runInteractiveBashPty()`. Since `dump()` finalizes first on success/abort paths, the `finally` `dispose()` is a no-op there and only does work on the throw/bail path.
- `eval.ts` already closed via its `finalizeOutput()` `finally`, so it was left unchanged.

## Verification
`bun test packages/coding-agent/test/streaming-output.test.ts packages/coding-agent/test/bash-executor.test.ts packages/coding-agent/test/core/js-executor.test.ts packages/coding-agent/test/core/python-executor-lifecycle.test.ts packages/coding-agent/test/tools/eval-streaming-output.test.ts` → 160 pass, 0 fail (the listed `bash-interactive-lifecycle.test.ts` does not exist in the tree; the fd contract is covered at the `OutputSink` level instead of through a PTY harness).

New regression test `packages/coding-agent/test/output-sink-fd-lifecycle.test.ts` run under the reporter's limit: `prlimit --nofile=64:64 bun test ./packages/coding-agent/test/output-sink-fd-lifecycle.test.ts` → 3 pass. It fails without the fix (`sink.dispose is not a function`) and asserts: dispose releases the fd across 256 spill-then-bail iterations without EMFILE, `dump()`+`dispose()` closes once idempotently, and post-finalize `push()` never resurrects the descriptor.

Fixes #6463