### PR TITLE
fix(tui): keep full-width overlays above inline images

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevented inline Kitty graphics from covering full-width overlays such as `/switch`.
+
 ## [17.1.0] - 2026-07-24
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1376,7 +1376,6 @@ export class TUI extends Container {
 			this.terminal.write(encodeKittyDeleteImage(id));
 		}
 	}
-
 	/**
 	 * Get whether scrollback divergence rebuild is enabled.
 	 */
@@ -2630,7 +2629,14 @@ export class TUI extends Container {
 		overlayWidth: number,
 		totalWidth: number,
 	): string {
-		if (TERMINAL.isImageLine(baseLine)) return baseLine;
+		if (TERMINAL.isImageLine(baseLine)) {
+			// Full-width overlays such as /switch are opaque: replace the
+			// Unicode placeholder cells so the image cannot cover the modal.
+			// Partial overlays cannot safely splice placement control sequences.
+			if (startCol !== 0 || overlayWidth < totalWidth) return baseLine;
+			const overlay = sliceWithWidth(overlayLine, 0, totalWidth, true);
+			return SEGMENT_RESET + overlay.text + " ".repeat(Math.max(0, totalWidth - overlay.width));
+		}
 
 		// Single pass through baseLine extracts both before and after segments
 		const afterStart = startCol + overlayWidth;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1376,6 +1376,7 @@ export class TUI extends Container {
 			this.terminal.write(encodeKittyDeleteImage(id));
 		}
 	}
+
 	/**
 	 * Get whether scrollback divergence rebuild is enabled.
 	 */

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -707,6 +707,45 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("lets a full-width non-fullscreen overlay replace Unicode image placeholder rows", async () => {
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		const tui = new TUI(term);
+		tui.addChild(makeImage(tui.imageBudget, "behind-modal"));
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+
+			const overlay = tui.showOverlay(new Text("MODEL SELECTOR\nMODEL ROW 2\nMODEL ROW 3\nMODEL ROW 4", 0, 0), {
+				anchor: "top-left",
+				width: "100%",
+				maxHeight: "100%",
+			});
+			await settle(term);
+
+			const modalOutput = writes.join("");
+			expect(modalOutput).not.toContain("\x1b[?1049h");
+			const modalViewport = term.getViewport().join("\n");
+			expect(modalViewport).toContain("MODEL SELECTOR");
+			expect(modalViewport).not.toContain(KITTY_PLACEHOLDER);
+
+			writes.length = 0;
+			overlay.hide();
+			await settle(term);
+
+			expect(term.getViewport().join("\n")).toContain(KITTY_PLACEHOLDER);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("transmits image data only once; a later full redraw re-emits just the placement", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -708,6 +708,7 @@ describe("TUI inline-image budget", () => {
 	});
 
 	it("lets a full-width non-fullscreen overlay replace Unicode image placeholder rows", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];
 		const realWrite = term.write.bind(term);
@@ -716,6 +717,7 @@ describe("TUI inline-image budget", () => {
 			realWrite(data);
 		});
 
+		setKittyGraphics({ unicodePlaceholders: true });
 		const tui = new TUI(term);
 		tui.addChild(makeImage(tui.imageBudget, "behind-modal"));
 		try {
@@ -743,6 +745,7 @@ describe("TUI inline-image budget", () => {
 			expect(term.getViewport().join("\n")).toContain(KITTY_PLACEHOLDER);
 		} finally {
 			tui.stop();
+			setKittyGraphics(originalGraphics);
 		}
 	});
 


### PR DESCRIPTION
## Summary
- let opaque full-width overlays replace terminal image placeholder rows
- preserve existing image rows beneath partial-width overlays
- cover the non-fullscreen `/switch` overlay regression

## Screenshots
No visual artifact attached; the regression was reproduced from an inline image followed by `/switch`.

## Testing
- `bun test packages/tui/test/image-budget.test.ts -t "non-fullscreen overlay"`
- `bun --cwd packages/tui check`

## Risk
- Limited to compositing full-width overlays over rows classified as terminal image lines.
- Partial overlays retain the previous conservative behavior.

## Notes
- Extracted into an isolated clone so the original working tree remains available to concurrent work.

## AI Review Report
- Traced `/switch` to its actual `temporaryOnly` non-fullscreen model picker path.
- Confirmed the failure originated in `#compositeLineAt`, which previously returned the image row unchanged.

## Security Audit
- No network, credential, persistence, or input-trust changes.
- Overlay text still passes through existing width-aware slicing and padding.