### PR TITLE
fix(coding-agent): restore legacy keyText export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Fixed
 
+- Fixed legacy Pi extensions failing validation when importing the upstream `keyText` keybinding helper ([#6470](https://github.com/can1357/oh-my-pi/issues/6470)).
 - Fixed a path traversal vulnerability in blob reference resolution by rejecting non-canonical hashes in `parseBlobRef`.
 - Fixed multiple edge cases in the secret obfuscation and redaction engine, including handling of context-sensitive regexes, placeholder key requirements in unwritable directories, friendly-name forgery vulnerabilities, and regex match boundaries straddling existing placeholders.
 - Fixed a first-use race condition in `ArtifactManager` where concurrent callers could allocate duplicate artifact IDs.

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -17,7 +17,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import { type AuthCredential, SqliteAuthCredentialStore, type TSchema } from "@oh-my-pi/pi-ai";
-import { Text } from "@oh-my-pi/pi-tui";
+import { getKeybindings, type Keybinding, Text } from "@oh-my-pi/pi-tui";
 import {
 	getAgentDbPath,
 	getAgentDir,
@@ -26,6 +26,7 @@ import {
 	parseFrontmatter as parseOmpFrontmatter,
 } from "@oh-my-pi/pi-utils";
 import { getPackageDir as getOmpPackageDir } from "../config";
+import { formatKeyHints } from "../config/keybindings";
 import type { PromptTemplate } from "../config/prompt-templates";
 import { type SettingPath, Settings } from "../config/settings";
 import { EditTool } from "../edit";
@@ -371,6 +372,11 @@ async function executeLegacyBashOperations(
 		}
 		throw err;
 	}
+}
+
+/** Format the active shortcut for legacy extensions that render keybinding hints. */
+export function keyText(action: Keybinding): string {
+	return formatKeyHints(getKeybindings().getKeys(action));
 }
 
 /** Parse frontmatter using the historical Pi package-root helper. */

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { getDefaultPasteImageKeys, KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { keyText } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
 
 describe("KeybindingsManager.getDisplayString", () => {
 	it("formats a single binding as a human-readable key hint", () => {
@@ -30,6 +32,24 @@ describe("KeybindingsManager.getDisplayString", () => {
 		});
 
 		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("");
+	});
+});
+
+describe("legacy keyText", () => {
+	let previous: TuiKeybindingsManager;
+
+	beforeEach(() => {
+		previous = getKeybindings();
+	});
+
+	afterEach(() => {
+		setKeybindings(previous);
+	});
+
+	it("formats the active binding for legacy extensions", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+e" }));
+
+		expect(keyText("app.tools.expand")).toBe("Alt+E");
 	});
 });
 


### PR DESCRIPTION
## Repro

With isolated XDG directories, `bun packages/coding-agent/src/cli.ts install npm:pi-mcporter --json` exited 1 because extension validation could not find the named `keyText` export in `legacy-pi-coding-agent-shim.ts`.

## Cause

`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts` re-exported the package-root compatibility surface but omitted upstream’s `keyText` keybinding helper, so plugins importing that public symbol failed Bun’s static export validation before loading.

## Fix

- Export `keyText(action)` from the legacy coding-agent shim using the active global keybindings and the coding-agent’s existing key-hint formatter.
- Add regression coverage for a remapped `app.tools.expand` binding.
- Record the compatibility fix in the coding-agent changelog.

## Verification

`bun test test/keybindings-display.test.ts` passed 7 tests; `bun check` passed all workspace checks. The isolated `omp install npm:pi-mcporter` source invocation now installs version 1.0.1 successfully, and `plugin list --json` reports it enabled.

Fixes #6470