### PR TITLE
feat(coding-agent): execute Claude Code PreToolUse/PostToolUse hooks from settings.json

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added execution of Claude Code `PreToolUse`/`PostToolUse` hooks defined in `~/.claude/settings.json` and `.claude/settings.json`. Hooks are parsed from the `hooks` key, translated from Claude's PascalCase tool matchers (`Bash`, `Edit`, `Write`, `Read`) to OMP tool ids, and shell-executed with Claude's stdin/stdout protocol (`{"tool_input": ..., "cwd": ...}`). A `permissionDecision: "deny"` or non-zero exit code blocks the tool call via the existing `tool_call` event bus, reusing the `beforeToolCall` seam. PostToolUse hooks observe tool results. The feature activates automatically when `settings.json` contains a `hooks` key.
+- Added execution of Claude Code `PreToolUse`/`PostToolUse` hooks from `~/.claude/settings.json`. Hooks are parsed from the `hooks` key, translated from Claude's PascalCase tool matchers to OMP tool ids, and shell-executed with Claude's stdin/stdout protocol. Exit code 2 or `permissionDecision: "deny"` blocks the tool call via the existing `tool_call` event bus. PostToolUse hooks observe results (skipped on errors). Gated behind the `claudeHooks.enabled` setting (off by default). Project-level `.claude/settings.json` hooks are not loaded to prevent untrusted repos from executing arbitrary commands.
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added execution of Claude Code `PreToolUse`/`PostToolUse` hooks defined in `~/.claude/settings.json` and `.claude/settings.json`. Hooks are parsed from the `hooks` key, translated from Claude's PascalCase tool matchers (`Bash`, `Edit`, `Write`, `Read`) to OMP tool ids, and shell-executed with Claude's stdin/stdout protocol (`{"tool_input": ..., "cwd": ...}`). A `permissionDecision: "deny"` or non-zero exit code blocks the tool call via the existing `tool_call` event bus, reusing the `beforeToolCall` seam. PostToolUse hooks observe tool results. The feature activates automatically when `settings.json` contains a `hooks` key.
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -577,7 +577,6 @@ export const SETTINGS_SCHEMA = {
 		default: "light",
 		ui: {
 			tab: "appearance",
-			group: "Theme",
 			label: "Light Theme",
 			description: "Theme used when the terminal has a light background",
 			options: "runtime",
@@ -5277,7 +5276,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Available Tools",
 			label: "Claude Code Hooks",
 			description:
-				"Execute PreToolUse/PostToolUse hooks from ~/.claude/settings.json and .claude/settings.json. Off by default — enabling project hooks from untrusted repos can run arbitrary shell commands",
+			"Execute PreToolUse/PostToolUse hooks from ~/.claude/settings.json. Off by default — only user-level hooks are loaded (not project-level .claude/settings.json) to prevent untrusted repos from running arbitrary shell commands",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -577,6 +577,7 @@ export const SETTINGS_SCHEMA = {
 		default: "light",
 		ui: {
 			tab: "appearance",
+			group: "Theme",
 			label: "Light Theme",
 			description: "Theme used when the terminal has a light background",
 			options: "runtime",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5281,16 +5281,6 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	"claudeHooks.trustProject": {
-		type: "boolean",
-		default: false,
-		ui: {
-			tab: "tools",
-			group: "Available Tools",
-			label: "Trust Project Hooks",
-			description: "Also execute hooks from .claude/settings.json in the project directory (not just ~/.claude/settings.json)",
-		},
-	},
 
 	"gc.blobs": { type: "boolean", default: true },
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5269,6 +5269,29 @@ export const SETTINGS_SCHEMA = {
 		default: "unset" as const,
 	},
 
+	"claudeHooks.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Available Tools",
+			label: "Claude Code Hooks",
+			description:
+				"Execute PreToolUse/PostToolUse hooks from ~/.claude/settings.json and .claude/settings.json. Off by default — enabling project hooks from untrusted repos can run arbitrary shell commands",
+		},
+	},
+
+	"claudeHooks.trustProject": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Available Tools",
+			label: "Trust Project Hooks",
+			description: "Also execute hooks from .claude/settings.json in the project directory (not just ~/.claude/settings.json)",
+		},
+	},
+
 	"gc.blobs": { type: "boolean", default: true },
 
 	"gc.archive": { type: "boolean", default: true },

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1902,7 +1902,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			inlineExtensions.push(...(options.extensions ?? []));
 			inlineExtensions.push(createAutoresearchExtension);
 		if (settings.get("claudeHooks.enabled")) {
-			inlineExtensions.push(createSettingsHooksExtension(settings.get("claudeHooks.trustProject") ?? false));
+			inlineExtensions.push(createSettingsHooksExtension());
 		}
 			if (customTools.length > 0) {
 				inlineExtensions.push(createCustomToolsExtension(customTools));

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1901,7 +1901,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 			inlineExtensions.push(...(options.extensions ?? []));
 			inlineExtensions.push(createAutoresearchExtension);
-			inlineExtensions.push(createSettingsHooksExtension);
+		if (settings.get("claudeHooks.enabled")) {
+			inlineExtensions.push(createSettingsHooksExtension(settings.get("claudeHooks.trustProject") ?? false));
+		}
 			if (customTools.length > 0) {
 				inlineExtensions.push(createCustomToolsExtension(customTools));
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -36,6 +36,7 @@ import {
 import { AsyncJobManager } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
 import { createAutoresearchExtension } from "./autoresearch";
+import { createSettingsHooksExtension } from "./settings-hooks";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
@@ -1898,9 +1899,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			if (customToolsLoadResult.tools.length > 0) {
 				customTools.push(...customToolsLoadResult.tools.map(loaded => loaded.tool));
 			}
-
 			inlineExtensions.push(...(options.extensions ?? []));
 			inlineExtensions.push(createAutoresearchExtension);
+			inlineExtensions.push(createSettingsHooksExtension);
 			if (customTools.length > 0) {
 				inlineExtensions.push(createCustomToolsExtension(customTools));
 			}

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -154,13 +154,20 @@ function toolMatches(eventToolName: string, group: ClaudeHookGroup): boolean {
 	const matcher = group.matcher;
 	// Omitted/empty matcher = match all tools
 	if (!matcher || matcher.trim() === "") return true;
+	// Pipe/comma-separated alternatives (e.g. "Edit|Write", "Bash,Read") —
+	// split and map each before trying regex, so "Edit|Write" isn't treated
+	// as a regex alternation operator.
+	if (/[|,]/.test(matcher)) {
+		const ompNames = mapToolName(matcher);
+		return ompNames.some(name => name === "*" || name === eventToolName);
+	}
 	// Regex matchers (e.g. "mcp__.*") — try as regex against the event tool name
-	if (/[.*+?^${}()|[\]\\]/.test(matcher) && !Object.prototype.hasOwnProperty.call(CLAUDE_TOOL_MAP, matcher) && matcher !== "*") {
+	if (/[.*+?^${}()\\[\]]/.test(matcher) && !Object.prototype.hasOwnProperty.call(CLAUDE_TOOL_MAP, matcher)) {
 		try {
 			const re = new RegExp(matcher, "i");
 			return re.test(eventToolName);
 		} catch {
-			// Invalid regex — fall through to exact/pattern matching
+			// Invalid regex — fall through to exact matching
 		}
 	}
 	const ompNames = mapToolName(matcher);
@@ -210,8 +217,9 @@ async function runShellHook(
 	}
 
 	// Claude's timeout field is in seconds; setTimeout uses milliseconds.
-	// Default to 60s when omitted to prevent hung hooks from blocking indefinitely.
-	const timeoutMs = (hook.timeout && hook.timeout > 0 ? hook.timeout : 60) * 1000;
+	// Default to 25s when omitted — must be below the 30s extension handler timeout
+	// to ensure the hook's own SIGTERM fires before the runner kills the handler.
+	const timeoutMs = (hook.timeout && hook.timeout > 0 ? hook.timeout : 25) * 1000;
 	let timedOut = false;
 	const timer = setTimeout(() => {
 		timedOut = true;

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -129,9 +129,6 @@ function evaluateIfFilter(filter: string, toolName: string, input: Record<string
 
 	if (toolName === "bash") {
 		// For Bash commands, match any subcommand in the command string.
-		// For complex shell forms (backticks, $(), etc.) we fail open (run the hook)
-		// since we can't faithfully parse all shell syntax.
-		if (/`|\$\(/.test(value)) return true;
 		const regex = new RegExp(`(?:^|&&|;|\\|)\\s*${globPattern}`, "i");
 		return regex.test(value);
 	}
@@ -236,22 +233,22 @@ async function runShellHook(
 
 // ─── Settings.json loading ───────────────────────────────────────────────
 
-async function tryReadHooksFromSettings(settingsPath: string): Promise<ClaudeHooks | null> {
+async function tryReadHooksFromSettings(settingsPath: string): Promise<{ hooks: ClaudeHooks | null; disabled: boolean }> {
 	try {
 		const content = await Bun.file(settingsPath).text();
 		const data = JSON.parse(content) as Record<string, unknown>;
-		// Honor Claude's kill switch — when disableAllHooks is true, skip all hooks
-		if (data.disableAllHooks === true) return null;
+		// Honor Claude's kill switch — when disableAllHooks is true, signal disabled
+		if (data.disableAllHooks === true) return { hooks: null, disabled: true };
 		const rawHooks = data.hooks;
-		if (!rawHooks || typeof rawHooks !== "object") return null;
-		return validateHooks(rawHooks as Record<string, unknown>);
+		if (!rawHooks || typeof rawHooks !== "object") return { hooks: null, disabled: false };
+		return { hooks: validateHooks(rawHooks as Record<string, unknown>), disabled: false };
 	} catch (err) {
-		if (err instanceof Error && err.message.includes("ENOENT")) return null;
+		if (err instanceof Error && err.message.includes("ENOENT")) return { hooks: null, disabled: false };
 		logger.warn("settings-hooks: failed to read settings.json", {
 			path: settingsPath,
 			error: err instanceof Error ? err.message : String(err),
 		});
-		return null;
+		return { hooks: null, disabled: false };
 	}
 }
 
@@ -267,8 +264,16 @@ function validateHooks(raw: Record<string, unknown>): ClaudeHooks {
 function isHookGroup(item: unknown): item is ClaudeHookGroup {
 	if (typeof item !== "object" || item === null) return false;
 	const g = item as Record<string, unknown>;
-	// matcher is optional (omitted = match all); hooks array is required
-	return (g.matcher === undefined || typeof g.matcher === "string") && Array.isArray(g.hooks);
+	// matcher is optional (omitted = match all); hooks array is required and must contain valid entries
+	if ((g.matcher !== undefined && typeof g.matcher !== "string") || !Array.isArray(g.hooks)) return false;
+	// Filter out invalid hook entries (null, non-objects, missing type/command/args)
+	return (g.hooks as unknown[]).every(h => isHookEntry(h));
+}
+
+function isHookEntry(item: unknown): boolean {
+	if (typeof item !== "object" || item === null) return false;
+	const h = item as Record<string, unknown>;
+	return h.type === "command" && (typeof h.command === "string" || Array.isArray(h.args));
 }
 
 function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
@@ -291,12 +296,15 @@ async function readSettingsHooks(home: string, cwd: string, trustProject: boolea
 	// When HOME is empty/unset, path.join("", ".claude", ...) resolves to a
 	// relative path that could pick up project-level hooks as user hooks.
 	if (home) {
-		const userHooks = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
+		const { hooks: userHooks, disabled } = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
+		// If ANY source disables hooks, return null for the entire merge
+		if (disabled) return null;
 		if (userHooks) mergeHooks(hooks, userHooks);
 	}
 
 	if (trustProject) {
-		const projectHooks = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));
+		const { hooks: projectHooks, disabled } = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));
+		if (disabled) return null;
 		if (projectHooks) mergeHooks(hooks, projectHooks);
 	}
 

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -220,6 +220,14 @@ async function runShellHook(
 			} catch {
 				// Process may have already exited
 			}
+			// Escalate to SIGKILL after 2s grace period if process traps SIGTERM
+			setTimeout(() => {
+				try {
+					child.kill("SIGKILL");
+				} catch {
+					// Process may have already exited
+				}
+			}, 2000);
 		}, timeoutMs);
 		// Drain stdout and stderr concurrently to avoid pipe deadlock.
 		const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
@@ -256,25 +264,26 @@ function validateHooks(raw: Record<string, unknown>): ClaudeHooks {
 	const result: ClaudeHooks = {};
 	const pre = raw.PreToolUse;
 	const post = raw.PostToolUse;
-	if (Array.isArray(pre)) result.PreToolUse = pre.filter(isHookGroup);
-	if (Array.isArray(post)) result.PostToolUse = post.filter(isHookGroup);
+	if (Array.isArray(pre)) result.PreToolUse = pre.filter(isHookGroup).map(filterValidHooks);
+	if (Array.isArray(post)) result.PostToolUse = post.filter(isHookGroup).map(filterValidHooks);
 	return result;
 }
 
 function isHookGroup(item: unknown): item is ClaudeHookGroup {
 	if (typeof item !== "object" || item === null) return false;
 	const g = item as Record<string, unknown>;
-	// matcher is optional (omitted = match all); hooks array is required and must contain valid entries
-	if ((g.matcher !== undefined && typeof g.matcher !== "string") || !Array.isArray(g.hooks)) return false;
-	// Filter out invalid hook entries (null, non-objects, missing type/command/args)
-	return (g.hooks as unknown[]).every(h => isHookEntry(h));
+	// matcher is optional (omitted = match all); hooks array is required
+	return (g.matcher === undefined || typeof g.matcher === "string") && Array.isArray(g.hooks);
 }
 
-function isHookEntry(item: unknown): boolean {
-	if (typeof item !== "object" || item === null) return false;
-	const h = item as Record<string, unknown>;
-	return h.type === "command" && (typeof h.command === "string" || Array.isArray(h.args));
+/** Filter out invalid hook entries from a group, keeping valid siblings. */
+function filterValidHooks(group: ClaudeHookGroup): ClaudeHookGroup {
+	return {
+		matcher: group.matcher,
+		hooks: group.hooks.filter(h => h.type === "command" && (typeof h.command === "string" || Array.isArray(h.args))),
+	};
 }
+
 
 function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
 	if (addition.PreToolUse) {

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -286,27 +286,19 @@ function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
 }
 
 /**
- * Read hooks from user-level settings.json (always) and project-level
- * settings.json (only when `trustProject` is true).
+ * Read hooks from user-level settings.json only.
+ * Project-level hooks (.claude/settings.json in the repo) are NOT loaded
+ * to prevent untrusted repos from executing arbitrary shell commands.
+ * Project hook support requires an explicit trust UI (future enhancement).
  */
-async function readSettingsHooks(home: string, cwd: string, trustProject: boolean): Promise<ClaudeHooks | null> {
+async function readSettingsHooks(home: string): Promise<ClaudeHooks | null> {
+	if (!home) return null;
 	const hooks: ClaudeHooks = {};
 
-	// Only load user-level hooks from a real HOME directory.
-	// When HOME is empty/unset, path.join("", ".claude", ...) resolves to a
-	// relative path that could pick up project-level hooks as user hooks.
-	if (home) {
-		const { hooks: userHooks, disabled } = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
-		// If ANY source disables hooks, return null for the entire merge
-		if (disabled) return null;
-		if (userHooks) mergeHooks(hooks, userHooks);
-	}
-
-	if (trustProject) {
-		const { hooks: projectHooks, disabled } = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));
-		if (disabled) return null;
-		if (projectHooks) mergeHooks(hooks, projectHooks);
-	}
+	const { hooks: userHooks, disabled } = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
+	// Honor Claude's kill switch
+	if (disabled) return null;
+	if (userHooks) mergeHooks(hooks, userHooks);
 
 	const hasHooks = Boolean(hooks.PreToolUse?.length || hooks.PostToolUse?.length);
 	return hasHooks ? hooks : null;
@@ -314,20 +306,17 @@ async function readSettingsHooks(home: string, cwd: string, trustProject: boolea
 
 // ─── Extension factory ───────────────────────────────────────────────────
 
-export function createSettingsHooksExtension(trustProject = false): ExtensionFactory {
+export function createSettingsHooksExtension(): ExtensionFactory {
 	return (api: ExtensionAPI) => {
 	let loadedHooks: ClaudeHooks | null | undefined;
-	let loadedCwd: string | null = null;
 
-	const ensureLoaded = async (cwd: string, home: string): Promise<ClaudeHooks | null> => {
-		if (loadedCwd === cwd && loadedHooks !== undefined) return loadedHooks;
-		loadedCwd = cwd;
-		loadedHooks = await readSettingsHooks(home, cwd, trustProject);
+	const ensureLoaded = async (home: string): Promise<ClaudeHooks | null> => {
+		if (loadedHooks !== undefined) return loadedHooks;
+		loadedHooks = await readSettingsHooks(home);
 		if (loadedHooks) {
 			logger.info("settings-hooks: loaded Claude Code hooks from settings.json", {
 				preToolUse: loadedHooks.PreToolUse?.length ?? 0,
 				postToolUse: loadedHooks.PostToolUse?.length ?? 0,
-				trustProject,
 			});
 		}
 		return loadedHooks;
@@ -336,7 +325,7 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 	// PreToolUse — can block execution
 	api.on("tool_call", async (event: ToolCallEvent, ctx: ExtensionContext): Promise<ToolCallEventResult | void> => {
 	const home = process.env.HOME ?? "";
-	const hooks = await ensureLoaded(ctx.cwd, home);
+	const hooks = await ensureLoaded(home);
 		if (!hooks?.PreToolUse) return;
 
 	let denyResult: ToolCallEventResult | undefined;
@@ -406,7 +395,7 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 		if (event.isError) return;
 
 	const home = process.env.HOME ?? "";
-	const hooks = await ensureLoaded(ctx.cwd, home);
+	const hooks = await ensureLoaded(home);
 		if (!hooks?.PostToolUse) return;
 
 		for (const group of hooks.PostToolUse) {

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -110,11 +110,11 @@ function adaptToolInput(toolName: string, input: Record<string, unknown>): Recor
 function evaluateIfFilter(filter: string, toolName: string, input: Record<string, unknown>): boolean {
 	const match = filter.match(/^(\w+)\((.*)\)$/);
 	if (!match) {
-		// Unrecognized filter format — err on the side of not matching (skip hook)
-		return false;
+		// Unrecognized filter format — fail open (run the hook) per Claude's permission semantics
+		return true;
 	}
 	const [, filterTool, pattern] = match;
-	// Tool name must match (case-insensitive)
+	// Tool name must match
 	const ompName = CLAUDE_TOOL_MAP[filterTool] ?? filterTool.toLowerCase();
 	if (ompName !== toolName) return false;
 
@@ -122,14 +122,16 @@ function evaluateIfFilter(filter: string, toolName: string, input: Record<string
 	// Bash → command, Read/Write/Edit → file_path/path
 	const primaryField = toolName === "bash" ? "command" : "path";
 	const value = String(input[primaryField] ?? input.file_path ?? "");
-	if (!value) return false;
+	if (!value) return true; // fail open — can't evaluate
 
 	// Simple glob: * → .*, ? → .
 	const globPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, c => (c === "*" ? ".*" : c === "?" ? "." : "\\" + c));
 
 	if (toolName === "bash") {
-		// For Bash commands, match any subcommand in the command string
-		// (e.g. "git *" matches "npm test && git push")
+		// For Bash commands, match any subcommand in the command string.
+		// For complex shell forms (backticks, $(), etc.) we fail open (run the hook)
+		// since we can't faithfully parse all shell syntax.
+		if (/`|\$\(/.test(value)) return true;
 		const regex = new RegExp(`(?:^|&&|;|\\|)\\s*${globPattern}`, "i");
 		return regex.test(value);
 	}
@@ -238,6 +240,8 @@ async function tryReadHooksFromSettings(settingsPath: string): Promise<ClaudeHoo
 	try {
 		const content = await Bun.file(settingsPath).text();
 		const data = JSON.parse(content) as Record<string, unknown>;
+		// Honor Claude's kill switch — when disableAllHooks is true, skip all hooks
+		if (data.disableAllHooks === true) return null;
 		const rawHooks = data.hooks;
 		if (!rawHooks || typeof rawHooks !== "object") return null;
 		return validateHooks(rawHooks as Record<string, unknown>);
@@ -327,6 +331,7 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 	const hooks = await ensureLoaded(ctx.cwd, home);
 		if (!hooks?.PreToolUse) return;
 
+	let denyResult: ToolCallEventResult | undefined;
 		for (const group of hooks.PreToolUse) {
 			if (!toolMatches(event.toolName, group)) continue;
 
@@ -355,7 +360,8 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 				// (do NOT block — a missing dependency like jq exit 127 should not deny the call)
 				if (code === 2) {
 					const reason = stderr.trim() || stdout.trim() || `Hook "${group.matcher ?? "*"}" denied the tool call`;
-					return { block: true, reason };
+					denyResult = { block: true, reason };
+					continue; // run remaining hooks (audit/logging) before returning
 				}
 				if (code !== 0) {
 					logger.warn("settings-hooks: PreToolUse hook error (non-blocking)", {
@@ -375,13 +381,15 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 					const decision = parsed.permissionDecision ?? parsed.hookSpecificOutput?.permissionDecision;
 					const reason = parsed.permissionDecisionReason ?? parsed.hookSpecificOutput?.permissionDecisionReason;
 					if (decision === "deny") {
-						return { block: true, reason: reason || `Blocked by PreToolUse hook: ${group.matcher ?? "*"}` };
+						denyResult = { block: true, reason: reason || `Blocked by PreToolUse hook: ${group.matcher ?? "*"}` };
+						continue; // run remaining hooks before returning
 					}
 				} catch {
 					// Non-JSON stdout with exit 0 = allow (informational output)
 				}
 			}
 		}
+		return denyResult;
 	});
 
 	// PostToolUse — fires only on successful tool results (Claude reserves

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -280,7 +280,7 @@ function isHookGroup(item: unknown): item is ClaudeHookGroup {
 function filterValidHooks(group: ClaudeHookGroup): ClaudeHookGroup {
 	return {
 		matcher: group.matcher,
-		hooks: group.hooks.filter(h => h.type === "command" && (typeof h.command === "string" || Array.isArray(h.args))),
+		hooks: group.hooks.filter(h => typeof h === "object" && h !== null && h.type === "command" && (typeof h.command === "string" || Array.isArray(h.args))),
 	};
 }
 

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -210,33 +210,29 @@ async function runShellHook(
 	}
 
 	// Claude's timeout field is in seconds; setTimeout uses milliseconds.
-	const timeoutMs = hook.timeout && hook.timeout > 0 ? hook.timeout * 1000 : undefined;
+	// Default to 60s when omitted to prevent hung hooks from blocking indefinitely.
+	const timeoutMs = (hook.timeout && hook.timeout > 0 ? hook.timeout : 60) * 1000;
 	let timedOut = false;
-	if (timeoutMs) {
-		const timer = setTimeout(() => {
-			timedOut = true;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		try {
+			child.kill("SIGTERM");
+		} catch {
+			// Process may have already exited
+		}
+		// Escalate to SIGKILL after 2s grace period if process traps SIGTERM
+		setTimeout(() => {
 			try {
-				child.kill("SIGTERM");
+				child.kill("SIGKILL");
 			} catch {
 				// Process may have already exited
 			}
-			// Escalate to SIGKILL after 2s grace period if process traps SIGTERM
-			setTimeout(() => {
-				try {
-					child.kill("SIGKILL");
-				} catch {
-					// Process may have already exited
-				}
-			}, 2000);
-		}, timeoutMs);
-		// Drain stdout and stderr concurrently to avoid pipe deadlock.
-		const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
-		clearTimeout(timer);
-		return { stdout, stderr, code: child.exitCode ?? 0, killed: timedOut };
-	}
-
+		}, 2000);
+	}, timeoutMs);
+	// Drain stdout and stderr concurrently to avoid pipe deadlock.
 	const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
-	return { stdout, stderr, code: child.exitCode ?? 0, killed: false };
+	clearTimeout(timer);
+	return { stdout, stderr, code: child.exitCode ?? 0, killed: timedOut };
 }
 
 // ─── Settings.json loading ───────────────────────────────────────────────

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -15,7 +15,7 @@
  * from checked-out repositories.
  */
 import * as path from "node:path";
-import * as logger from "../../../utils/src/logger";
+import { logger } from "@oh-my-pi/pi-utils";
 import type { ExtensionAPI, ExtensionFactory, ToolCallEvent, ToolCallEventResult, ToolResultEvent } from "../extensibility/extensions/types";
 
 // ─── Claude Code settings.json hook schema ────────────────────────────────
@@ -25,6 +25,8 @@ interface ClaudeHookEntry {
 	command: string;
 	/** Timeout in seconds (Claude convention) */
 	timeout?: number;
+	/** Optional condition filter (e.g. "Bash(git push*)") — if unsupported, the hook is skipped */
+	if?: string;
 }
 
 interface ClaudeHookGroup {
@@ -64,6 +66,17 @@ const CLAUDE_TOOL_MAP: Record<string, string> = {
 	WebSearch: "web_search",
 };
 
+/** Reverse map: OMP tool id → Claude PascalCase name (for hook stdin). */
+const OMP_TO_CLAUDE_MAP: Record<string, string> = {
+	bash: "Bash",
+	read: "Read",
+	edit: "Edit",
+	write: "Write",
+	glob: "Glob",
+	grep: "Grep",
+	web_search: "WebSearch",
+};
+
 /** OMP tool input field → Claude hook field name. */
 const TOOL_FIELD_MAP: Record<string, string> = {
 	path: "file_path",
@@ -83,6 +96,34 @@ function adaptToolInput(toolName: string, input: Record<string, unknown>): Recor
 	// Claude expects `tool_name` in the PascalCase original, not the OMP lowercase id.
 	void toolName;
 	return adapted;
+}
+
+/**
+ * Evaluate a Claude hook `if` filter (e.g. "Bash(git push*)").
+ * Pattern format: ToolName(glob_pattern) — matches the tool and checks if
+ * the tool input's primary argument matches the glob.
+ * Returns true if the filter matches, false if it doesn't (hook should be skipped).
+ */
+function evaluateIfFilter(filter: string, toolName: string, input: Record<string, unknown>): boolean {
+	const match = filter.match(/^(\w+)\((.*)\)$/);
+	if (!match) {
+		// Unrecognized filter format — err on the side of not matching (skip hook)
+		return false;
+	}
+	const [, filterTool, pattern] = match;
+	// Tool name must match (case-insensitive)
+	const ompName = CLAUDE_TOOL_MAP[filterTool] ?? filterTool.toLowerCase();
+	if (ompName !== toolName) return false;
+
+	// Glob-match the primary input field against the pattern
+	// Bash → command, Read/Write/Edit → file_path/path
+	const primaryField = toolName === "bash" ? "command" : "path";
+	const value = String(input[primaryField] ?? input.file_path ?? "");
+	if (!value) return false;
+
+	// Simple glob: * → .*, ? → .
+	const regex = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, c => (c === "*" ? ".*" : c === "?" ? "." : "\\" + c))}$`);
+	return regex.test(value);
 }
 
 function mapToolName(matcher: string): string[] {
@@ -261,13 +302,15 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 		for (const group of hooks.PreToolUse) {
 			if (!toolMatches(event.toolName, group)) continue;
 
-			for (const hook of group.hooks) {
+		for (const hook of group.hooks) {
 				if (hook.type !== "command") continue;
-				const hookStdin: HookStdin = {
+				// Skip hooks with unsupported `if` filters rather than running them broadly
+				if (hook.if && !evaluateIfFilter(hook.if, event.toolName, event.input)) continue;
+			const hookStdin: HookStdin = {
 					tool_input: adaptToolInput(event.toolName, event.input),
 					cwd: ctx.cwd ?? home,
 					hook_event_name: "PreToolUse",
-					tool_name: event.toolName,
+					tool_name: OMP_TO_CLAUDE_MAP[event.toolName] ?? event.toolName,
 					tool_use_id: event.toolCallId,
 				};
 				const { stdout, stderr, code, killed } = await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
@@ -327,11 +370,13 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 
 			for (const hook of group.hooks) {
 				if (hook.type !== "command") continue;
+			// Skip hooks with unsupported `if` filters rather than running them broadly
+				if (hook.if && !evaluateIfFilter(hook.if, event.toolName, event.input)) continue;
 				const hookStdin: HookStdin = {
 					tool_input: adaptToolInput(event.toolName, event.input),
 					cwd: ctx.cwd ?? home,
 					hook_event_name: "PostToolUse",
-					tool_name: event.toolName,
+					tool_name: OMP_TO_CLAUDE_MAP[event.toolName] ?? event.toolName,
 					tool_use_id: event.toolCallId,
 					tool_response: event.content,
 				};

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -22,7 +22,10 @@ import type { ExtensionAPI, ExtensionFactory, ToolCallEvent, ToolCallEventResult
 
 interface ClaudeHookEntry {
 	type: "command";
-	command: string;
+	/** Shell command form (e.g. "echo hello") */
+	command?: string;
+	/** Exec form: array of args passed directly (e.g. ["git", "status"]) */
+	args?: string[];
 	/** Timeout in seconds (Claude convention) */
 	timeout?: number;
 	/** Optional condition filter (e.g. "Bash(git push*)") — if unsupported, the hook is skipped */
@@ -122,7 +125,16 @@ function evaluateIfFilter(filter: string, toolName: string, input: Record<string
 	if (!value) return false;
 
 	// Simple glob: * → .*, ? → .
-	const regex = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, c => (c === "*" ? ".*" : c === "?" ? "." : "\\" + c))}$`);
+	const globPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, c => (c === "*" ? ".*" : c === "?" ? "." : "\\" + c));
+
+	if (toolName === "bash") {
+		// For Bash commands, match any subcommand in the command string
+		// (e.g. "git *" matches "npm test && git push")
+		const regex = new RegExp(`(?:^|&&|;|\\|)\\s*${globPattern}`, "i");
+		return regex.test(value);
+	}
+	// For file tools, match the full path
+	const regex = new RegExp(`^${globPattern}$`);
 	return regex.test(value);
 }
 
@@ -174,13 +186,14 @@ interface HookStdin {
 }
 
 async function runShellHook(
-	command: string,
+	hook: ClaudeHookEntry,
 	hookStdin: HookStdin,
 	cwd: string,
-	timeoutSeconds?: number,
 ): Promise<{ stdout: string; stderr: string; code: number; killed: boolean }> {
 	const stdinPayload = JSON.stringify(hookStdin);
-	const child = Bun.spawn(["bash", "-c", command], {
+	// Support both shell form (command string) and exec form (args array)
+	const spawnArgs = hook.args ? hook.args : ["bash", "-c", hook.command ?? ""];
+	const child = Bun.spawn(spawnArgs, {
 		cwd,
 		env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
 		stdin: new TextEncoder().encode(stdinPayload),
@@ -189,7 +202,7 @@ async function runShellHook(
 	});
 
 	// Claude's timeout field is in seconds; setTimeout uses milliseconds.
-	const timeoutMs = timeoutSeconds && timeoutSeconds > 0 ? timeoutSeconds * 1000 : undefined;
+	const timeoutMs = hook.timeout && hook.timeout > 0 ? hook.timeout * 1000 : undefined;
 	let timedOut = false;
 	if (timeoutMs) {
 		const timer = setTimeout(() => {
@@ -296,8 +309,8 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 
 	// PreToolUse — can block execution
 	api.on("tool_call", async (event: ToolCallEvent, ctx: ExtensionContext): Promise<ToolCallEventResult | void> => {
-		const home = process.env.HOME ?? ctx.cwd ?? "";
-		const hooks = await ensureLoaded(ctx.cwd ?? home, home);
+	const home = process.env.HOME ?? "";
+	const hooks = await ensureLoaded(ctx.cwd, home);
 		if (!hooks?.PreToolUse) return;
 
 		for (const group of hooks.PreToolUse) {
@@ -314,7 +327,7 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 					tool_name: OMP_TO_CLAUDE_MAP[event.toolName] ?? event.toolName,
 					tool_use_id: event.toolCallId,
 				};
-				const { stdout, stderr, code, killed } = await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
+			const { stdout, stderr, code, killed } = await runShellHook(hook, hookStdin, ctx.cwd);
 
 				if (killed) {
 					logger.warn("settings-hooks: PreToolUse hook timed out", {
@@ -362,8 +375,8 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 	api.on("tool_result", async (event: ToolResultEvent, ctx: ExtensionContext) => {
 		if (event.isError) return;
 
-		const home = process.env.HOME ?? ctx.cwd ?? "";
-		const hooks = await ensureLoaded(ctx.cwd ?? home, home);
+	const home = process.env.HOME ?? "";
+	const hooks = await ensureLoaded(ctx.cwd, home);
 		if (!hooks?.PostToolUse) return;
 
 		for (const group of hooks.PostToolUse) {
@@ -381,7 +394,7 @@ export function createSettingsHooksExtension(trustProject = false): ExtensionFac
 					tool_use_id: event.toolCallId,
 					tool_response: event.content,
 				};
-				await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
+			await runShellHook(hook, hookStdin, ctx.cwd);
 			}
 		}
 	});

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -9,25 +9,28 @@
  * and map `permissionDecision: "deny"` onto the existing `beforeToolCall`
  * block result.
  *
- * The feature activates when `settings.json` contains a `hooks` key — the
- * Claude Code native signal.  When no hooks are found the extension
- * registers no handlers and is inert.
+ * Security: requires the `claudeHooks.enabled` setting to be turned on.
+ * Project-level hooks (`.claude/settings.json` in the repo) additionally
+ * require `claudeHooks.trustProject` to avoid executing untrusted commands
+ * from checked-out repositories.
  */
 import * as path from "node:path";
-import { logger } from "@oh-my-pi/pi-utils";
-import type { ExtensionFactory, ToolCallEvent, ToolCallEventResult, ToolResultEvent } from "../extensibility/extensions";
-import type { ExtensionContext } from "../extensibility/extensions/types";
 import * as logger from "../../../utils/src/logger";
+import type { ExtensionAPI, ExtensionFactory, ToolCallEvent, ToolCallEventResult, ToolResultEvent } from "../extensibility/extensions/types";
+
 // ─── Claude Code settings.json hook schema ────────────────────────────────
 
 interface ClaudeHookEntry {
 	type: "command";
 	command: string;
+	/** Timeout in seconds (Claude convention) */
 	timeout?: number;
 }
 
 interface ClaudeHookGroup {
-	matcher: string;
+	/** Claude matcher pattern. Omitted/empty = match all. Supports pipe/comma
+	 * alternatives ("Edit|Write") and regex ("mcp__.*"). */
+	matcher?: string;
 	hooks: ClaudeHookEntry[];
 }
 
@@ -61,6 +64,27 @@ const CLAUDE_TOOL_MAP: Record<string, string> = {
 	WebSearch: "web_search",
 };
 
+/** OMP tool input field → Claude hook field name. */
+const TOOL_FIELD_MAP: Record<string, string> = {
+	path: "file_path",
+	file_path: "file_path",
+	command: "command",
+	pattern: "pattern",
+};
+
+/** Translate an OMP tool input payload to Claude's expected field names. */
+function adaptToolInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
+	const adapted: Record<string, unknown> = { ...input };
+	for (const [omp, claude] of Object.entries(TOOL_FIELD_MAP)) {
+		if (omp !== claude && omp in adapted && !(claude in adapted)) {
+			adapted[claude] = adapted[omp];
+		}
+	}
+	// Claude expects `tool_name` in the PascalCase original, not the OMP lowercase id.
+	void toolName;
+	return adapted;
+}
+
 function mapToolName(matcher: string): string[] {
 	if (matcher === "*") return ["*"];
 	// Claude matchers support pipe-separated and comma-separated alternatives
@@ -74,19 +98,38 @@ function mapToolName(matcher: string): string[] {
 	return results.length > 0 ? results : [matcher.toLowerCase()];
 }
 
-function toolMatches(eventToolName: string, ompNames: string[]): boolean {
+function toolMatches(eventToolName: string, group: ClaudeHookGroup): boolean {
+	const matcher = group.matcher;
+	// Omitted/empty matcher = match all tools
+	if (!matcher || matcher.trim() === "") return true;
+	// Regex matchers (e.g. "mcp__.*") — try as regex against the event tool name
+	if (/[.*+?^${}()|[\]\\]/.test(matcher) && !Object.prototype.hasOwnProperty.call(CLAUDE_TOOL_MAP, matcher) && matcher !== "*") {
+		try {
+			const re = new RegExp(matcher, "i");
+			return re.test(eventToolName);
+		} catch {
+			// Invalid regex — fall through to exact/pattern matching
+		}
+	}
+	const ompNames = mapToolName(matcher);
 	return ompNames.some(name => name === "*" || name === eventToolName);
 }
+
+// ─── Hook execution (Claude Code stdin/stdout protocol) ───────────────────
 
 interface HookStdin {
 	tool_input: Record<string, unknown>;
 	cwd: string;
-	/** Claude session id (OMP session id) */
+	/** OMP session id */
 	session_id?: string;
 	/** Hook event name: "PreToolUse" or "PostToolUse" */
 	hook_event_name: string;
-	/** Tool name as OMP knows it (lowercase) */
+	/** Tool name (OMP lowercase id) */
 	tool_name: string;
+	/** Unique tool call id */
+	tool_use_id?: string;
+	/** PostToolUse: the tool result (Claude sends `tool_response`) */
+	tool_response?: unknown;
 }
 
 async function runShellHook(
@@ -115,6 +158,7 @@ async function runShellHook(
 				// Process may have already exited
 			}
 		}, timeoutMs);
+		// Drain stdout and stderr concurrently to avoid pipe deadlock.
 		const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
 		clearTimeout(timer);
 		return { stdout, stderr, code: child.exitCode ?? 0, killed: timedOut };
@@ -123,6 +167,7 @@ async function runShellHook(
 	const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
 	return { stdout, stderr, code: child.exitCode ?? 0, killed: false };
 }
+
 // ─── Settings.json loading ───────────────────────────────────────────────
 
 async function tryReadHooksFromSettings(settingsPath: string): Promise<ClaudeHooks | null> {
@@ -154,7 +199,8 @@ function validateHooks(raw: Record<string, unknown>): ClaudeHooks {
 function isHookGroup(item: unknown): item is ClaudeHookGroup {
 	if (typeof item !== "object" || item === null) return false;
 	const g = item as Record<string, unknown>;
-	return typeof g.matcher === "string" && Array.isArray(g.hooks);
+	// matcher is optional (omitted = match all); hooks array is required
+	return (g.matcher === undefined || typeof g.matcher === "string") && Array.isArray(g.hooks);
 }
 
 function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
@@ -166,14 +212,20 @@ function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
 	}
 }
 
-async function readSettingsHooks(home: string, cwd: string): Promise<ClaudeHooks | null> {
+/**
+ * Read hooks from user-level settings.json (always) and project-level
+ * settings.json (only when `trustProject` is true).
+ */
+async function readSettingsHooks(home: string, cwd: string, trustProject: boolean): Promise<ClaudeHooks | null> {
 	const hooks: ClaudeHooks = {};
 
 	const userHooks = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
 	if (userHooks) mergeHooks(hooks, userHooks);
 
-	const projectHooks = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));
-	if (projectHooks) mergeHooks(hooks, projectHooks);
+	if (trustProject) {
+		const projectHooks = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));
+		if (projectHooks) mergeHooks(hooks, projectHooks);
+	}
 
 	const hasHooks = Boolean(hooks.PreToolUse?.length || hooks.PostToolUse?.length);
 	return hasHooks ? hooks : null;
@@ -181,18 +233,20 @@ async function readSettingsHooks(home: string, cwd: string): Promise<ClaudeHooks
 
 // ─── Extension factory ───────────────────────────────────────────────────
 
-export const createSettingsHooksExtension: ExtensionFactory = api => {
+export function createSettingsHooksExtension(trustProject = false): ExtensionFactory {
+	return (api: ExtensionAPI) => {
 	let loadedHooks: ClaudeHooks | null | undefined;
 	let loadedCwd: string | null = null;
 
 	const ensureLoaded = async (cwd: string, home: string): Promise<ClaudeHooks | null> => {
 		if (loadedCwd === cwd && loadedHooks !== undefined) return loadedHooks;
 		loadedCwd = cwd;
-		loadedHooks = await readSettingsHooks(home, cwd);
+		loadedHooks = await readSettingsHooks(home, cwd, trustProject);
 		if (loadedHooks) {
 			logger.info("settings-hooks: loaded Claude Code hooks from settings.json", {
 				preToolUse: loadedHooks.PreToolUse?.length ?? 0,
 				postToolUse: loadedHooks.PostToolUse?.length ?? 0,
+				trustProject,
 			});
 		}
 		return loadedHooks;
@@ -205,15 +259,16 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 		if (!hooks?.PreToolUse) return;
 
 		for (const group of hooks.PreToolUse) {
-			if (!toolMatches(event.toolName, mapToolName(group.matcher))) continue;
+			if (!toolMatches(event.toolName, group)) continue;
 
 			for (const hook of group.hooks) {
 				if (hook.type !== "command") continue;
-			const hookStdin: HookStdin = {
-					tool_input: event.input,
+				const hookStdin: HookStdin = {
+					tool_input: adaptToolInput(event.toolName, event.input),
 					cwd: ctx.cwd ?? home,
 					hook_event_name: "PreToolUse",
 					tool_name: event.toolName,
+					tool_use_id: event.toolCallId,
 				};
 				const { stdout, stderr, code, killed } = await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
 
@@ -228,7 +283,7 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 				// Claude Code protocol: exit 2 = deny (block), other non-zero = hook error
 				// (do NOT block — a missing dependency like jq exit 127 should not deny the call)
 				if (code === 2) {
-					const reason = stderr.trim() || stdout.trim() || `Hook "${group.matcher}" denied the tool call`;
+					const reason = stderr.trim() || stdout.trim() || `Hook "${group.matcher ?? "*"}" denied the tool call`;
 					return { block: true, reason };
 				}
 				if (code !== 0) {
@@ -249,7 +304,7 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 					const decision = parsed.permissionDecision ?? parsed.hookSpecificOutput?.permissionDecision;
 					const reason = parsed.permissionDecisionReason ?? parsed.hookSpecificOutput?.permissionDecisionReason;
 					if (decision === "deny") {
-						return { block: true, reason: reason || `Blocked by PreToolUse hook: ${group.matcher}` };
+						return { block: true, reason: reason || `Blocked by PreToolUse hook: ${group.matcher ?? "*"}` };
 					}
 				} catch {
 					// Non-JSON stdout with exit 0 = allow (informational output)
@@ -258,25 +313,31 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 		}
 	});
 
-	// PostToolUse — can observe results (modification is a future enhancement)
+	// PostToolUse — fires only on successful tool results (Claude reserves
+	// PostToolUseFailure for errors; we guard isError until that exists).
 	api.on("tool_result", async (event: ToolResultEvent, ctx: ExtensionContext) => {
+		if (event.isError) return;
+
 		const home = process.env.HOME ?? ctx.cwd ?? "";
 		const hooks = await ensureLoaded(ctx.cwd ?? home, home);
 		if (!hooks?.PostToolUse) return;
 
 		for (const group of hooks.PostToolUse) {
-			if (!toolMatches(event.toolName, mapToolName(group.matcher))) continue;
+			if (!toolMatches(event.toolName, group)) continue;
 
 			for (const hook of group.hooks) {
 				if (hook.type !== "command") continue;
-			const hookStdin: HookStdin = {
-					tool_input: event.input,
+				const hookStdin: HookStdin = {
+					tool_input: adaptToolInput(event.toolName, event.input),
 					cwd: ctx.cwd ?? home,
 					hook_event_name: "PostToolUse",
 					tool_name: event.toolName,
+					tool_use_id: event.toolCallId,
+					tool_response: event.content,
 				};
 				await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
 			}
 		}
 	});
+	};
 };

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -1,0 +1,256 @@
+/**
+ * Built-in extension that bridges Claude Code PreToolUse/PostToolUse hooks
+ * defined in `~/.claude/settings.json` and `.claude/settings.json` into
+ * OMP's existing `tool_call` / `tool_result` event bus.
+ *
+ * Implements Option A from issue #6446: ingest the `hooks` object from
+ * Claude Code's `settings.json`, translate PascalCase tool matchers to OMP
+ * tool ids, shell-execute matched hooks with Claude's stdin/stdout protocol,
+ * and map `permissionDecision: "deny"` onto the existing `beforeToolCall`
+ * block result.
+ *
+ * The feature activates when `settings.json` contains a `hooks` key — the
+ * Claude Code native signal.  When no hooks are found the extension
+ * registers no handlers and is inert.
+ */
+import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { ExtensionFactory, ToolCallEvent, ToolCallEventResult, ToolResultEvent } from "../extensibility/extensions";
+import type { ExtensionContext } from "../extensibility/extensions/types";
+import * as logger from "../../../utils/src/logger";
+// ─── Claude Code settings.json hook schema ────────────────────────────────
+
+interface ClaudeHookEntry {
+	type: "command";
+	command: string;
+	timeout?: number;
+}
+
+interface ClaudeHookGroup {
+	matcher: string;
+	hooks: ClaudeHookEntry[];
+}
+
+interface ClaudeHooks {
+	PreToolUse?: ClaudeHookGroup[];
+	PostToolUse?: ClaudeHookGroup[];
+}
+
+interface HookStdout {
+	permissionDecision?: "allow" | "deny" | "ask";
+	permissionDecisionReason?: string;
+	hookSpecificOutput?: {
+		permissionDecision?: "allow" | "deny" | "ask";
+		permissionDecisionReason?: string;
+	};
+	additionalContext?: string;
+}
+
+// ─── Tool name mapping (Claude PascalCase → OMP lowercase) ────────────────
+
+const CLAUDE_TOOL_MAP: Record<string, string> = {
+	Bash: "bash",
+	Read: "read",
+	Edit: "edit",
+	Write: "write",
+	Glob: "glob",
+	Grep: "grep",
+	Search: "grep",
+	NotebookEdit: "edit",
+	WebFetch: "read",
+	WebSearch: "web_search",
+};
+
+function mapToolName(matcher: string): string[] {
+	if (matcher === "*") return ["*"];
+	const omp = CLAUDE_TOOL_MAP[matcher];
+	return omp ? [omp] : [matcher.toLowerCase()];
+}
+
+function toolMatches(eventToolName: string, ompNames: string[]): boolean {
+	return ompNames.some(name => name === "*" || name === eventToolName);
+}
+
+// ─── Hook execution (Claude Code stdin/stdout protocol) ───────────────────
+
+interface HookStdin {
+	tool_input: Record<string, unknown>;
+	cwd: string;
+}
+
+async function runShellHook(
+	command: string,
+	hookStdin: HookStdin,
+	cwd: string,
+	timeoutMs?: number,
+): Promise<{ stdout: string; code: number; killed: boolean }> {
+	const stdinPayload = JSON.stringify(hookStdin);
+	const child = Bun.spawn(["bash", "-c", command], {
+		cwd,
+		stdin: new TextEncoder().encode(stdinPayload),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	let timedOut = false;
+	if (timeoutMs && timeoutMs > 0) {
+		const timer = setTimeout(() => {
+			timedOut = true;
+			try {
+				child.kill("SIGTERM");
+			} catch {
+				// Process may have already exited
+			}
+		}, timeoutMs);
+		const [stdout] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+		clearTimeout(timer);
+		return { stdout, code: child.exitCode ?? 0, killed: timedOut };
+	}
+
+	const [stdout] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+	return { stdout, code: child.exitCode ?? 0, killed: false };
+}
+
+// ─── Settings.json loading ───────────────────────────────────────────────
+
+async function tryReadHooksFromSettings(settingsPath: string): Promise<ClaudeHooks | null> {
+	try {
+		const content = await Bun.file(settingsPath).text();
+		const data = JSON.parse(content) as Record<string, unknown>;
+		const rawHooks = data.hooks;
+		if (!rawHooks || typeof rawHooks !== "object") return null;
+		return validateHooks(rawHooks as Record<string, unknown>);
+	} catch (err) {
+		if (err instanceof Error && err.message.includes("ENOENT")) return null;
+		logger.warn("settings-hooks: failed to read settings.json", {
+			path: settingsPath,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return null;
+	}
+}
+
+function validateHooks(raw: Record<string, unknown>): ClaudeHooks {
+	const result: ClaudeHooks = {};
+	const pre = raw.PreToolUse;
+	const post = raw.PostToolUse;
+	if (Array.isArray(pre)) result.PreToolUse = pre.filter(isHookGroup);
+	if (Array.isArray(post)) result.PostToolUse = post.filter(isHookGroup);
+	return result;
+}
+
+function isHookGroup(item: unknown): item is ClaudeHookGroup {
+	if (typeof item !== "object" || item === null) return false;
+	const g = item as Record<string, unknown>;
+	return typeof g.matcher === "string" && Array.isArray(g.hooks);
+}
+
+function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
+	if (addition.PreToolUse) {
+		base.PreToolUse = [...(base.PreToolUse ?? []), ...addition.PreToolUse];
+	}
+	if (addition.PostToolUse) {
+		base.PostToolUse = [...(base.PostToolUse ?? []), ...addition.PostToolUse];
+	}
+}
+
+async function readSettingsHooks(home: string, cwd: string): Promise<ClaudeHooks | null> {
+	const hooks: ClaudeHooks = {};
+
+	const userHooks = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
+	if (userHooks) mergeHooks(hooks, userHooks);
+
+	const projectHooks = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));
+	if (projectHooks) mergeHooks(hooks, projectHooks);
+
+	const hasHooks = Boolean(hooks.PreToolUse?.length || hooks.PostToolUse?.length);
+	return hasHooks ? hooks : null;
+}
+
+// ─── Extension factory ───────────────────────────────────────────────────
+
+export const createSettingsHooksExtension: ExtensionFactory = api => {
+	let loadedHooks: ClaudeHooks | null | undefined;
+	let loadedCwd: string | null = null;
+
+	const ensureLoaded = async (cwd: string, home: string): Promise<ClaudeHooks | null> => {
+		if (loadedCwd === cwd && loadedHooks !== undefined) return loadedHooks;
+		loadedCwd = cwd;
+		loadedHooks = await readSettingsHooks(home, cwd);
+		if (loadedHooks) {
+			logger.info("settings-hooks: loaded Claude Code hooks from settings.json", {
+				preToolUse: loadedHooks.PreToolUse?.length ?? 0,
+				postToolUse: loadedHooks.PostToolUse?.length ?? 0,
+			});
+		}
+		return loadedHooks;
+	};
+
+	// PreToolUse — can block execution
+	api.on("tool_call", async (event: ToolCallEvent, ctx: ExtensionContext): Promise<ToolCallEventResult | void> => {
+		const home = process.env.HOME ?? ctx.cwd ?? "";
+		const hooks = await ensureLoaded(ctx.cwd ?? home, home);
+		if (!hooks?.PreToolUse) return;
+
+		for (const group of hooks.PreToolUse) {
+			if (!toolMatches(event.toolName, mapToolName(group.matcher))) continue;
+
+			for (const hook of group.hooks) {
+				if (hook.type !== "command") continue;
+				const hookStdin: HookStdin = {
+					tool_input: event.input,
+					cwd: ctx.cwd ?? home,
+				};
+				const { stdout, code, killed } = await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
+
+				if (killed) {
+					logger.warn("settings-hooks: PreToolUse hook timed out", {
+						command: hook.command,
+						matcher: group.matcher,
+					});
+					continue;
+				}
+
+				// Non-zero exit = deny (Claude Code protocol: exit 2 = block, others = error)
+				if (code !== 0) {
+					const reason = stdout.trim() || `Hook "${group.matcher}" exited with code ${code}`;
+					return { block: true, reason };
+				}
+
+				// Parse JSON stdout for explicit permissionDecision
+				const trimmed = stdout.trim();
+				if (!trimmed) continue; // exit 0 + no JSON = allow
+				try {
+					const parsed = JSON.parse(trimmed) as HookStdout;
+					const decision = parsed.permissionDecision ?? parsed.hookSpecificOutput?.permissionDecision;
+					const reason = parsed.permissionDecisionReason ?? parsed.hookSpecificOutput?.permissionDecisionReason;
+					if (decision === "deny") {
+						return { block: true, reason: reason || `Blocked by PreToolUse hook: ${group.matcher}` };
+					}
+				} catch {
+					// Non-JSON stdout with exit 0 = allow (informational output)
+				}
+			}
+		}
+	});
+
+	// PostToolUse — can observe results (modification is a future enhancement)
+	api.on("tool_result", async (event: ToolResultEvent, ctx: ExtensionContext) => {
+		const home = process.env.HOME ?? ctx.cwd ?? "";
+		const hooks = await ensureLoaded(ctx.cwd ?? home, home);
+		if (!hooks?.PostToolUse) return;
+
+		for (const group of hooks.PostToolUse) {
+			if (!toolMatches(event.toolName, mapToolName(group.matcher))) continue;
+
+			for (const hook of group.hooks) {
+				if (hook.type !== "command") continue;
+				const hookStdin: HookStdin = {
+					tool_input: event.input,
+					cwd: ctx.cwd ?? home,
+				};
+				await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
+			}
+		}
+	});
+};

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -63,27 +63,38 @@ const CLAUDE_TOOL_MAP: Record<string, string> = {
 
 function mapToolName(matcher: string): string[] {
 	if (matcher === "*") return ["*"];
-	const omp = CLAUDE_TOOL_MAP[matcher];
-	return omp ? [omp] : [matcher.toLowerCase()];
+	// Claude matchers support pipe-separated and comma-separated alternatives
+	// (e.g. "Edit|Write", "Bash,Read"). Split on both before mapping each.
+	const alternatives = matcher.split(/[|,]/).map(m => m.trim()).filter(Boolean);
+	const results: string[] = [];
+	for (const alt of alternatives) {
+		const omp = CLAUDE_TOOL_MAP[alt];
+		results.push(omp ?? alt.toLowerCase());
+	}
+	return results.length > 0 ? results : [matcher.toLowerCase()];
 }
 
 function toolMatches(eventToolName: string, ompNames: string[]): boolean {
 	return ompNames.some(name => name === "*" || name === eventToolName);
 }
 
-// ─── Hook execution (Claude Code stdin/stdout protocol) ───────────────────
-
 interface HookStdin {
 	tool_input: Record<string, unknown>;
 	cwd: string;
+	/** Claude session id (OMP session id) */
+	session_id?: string;
+	/** Hook event name: "PreToolUse" or "PostToolUse" */
+	hook_event_name: string;
+	/** Tool name as OMP knows it (lowercase) */
+	tool_name: string;
 }
 
 async function runShellHook(
 	command: string,
 	hookStdin: HookStdin,
 	cwd: string,
-	timeoutMs?: number,
-): Promise<{ stdout: string; code: number; killed: boolean }> {
+	timeoutSeconds?: number,
+): Promise<{ stdout: string; stderr: string; code: number; killed: boolean }> {
 	const stdinPayload = JSON.stringify(hookStdin);
 	const child = Bun.spawn(["bash", "-c", command], {
 		cwd,
@@ -92,8 +103,10 @@ async function runShellHook(
 		stderr: "pipe",
 	});
 
+	// Claude's timeout field is in seconds; setTimeout uses milliseconds.
+	const timeoutMs = timeoutSeconds && timeoutSeconds > 0 ? timeoutSeconds * 1000 : undefined;
 	let timedOut = false;
-	if (timeoutMs && timeoutMs > 0) {
+	if (timeoutMs) {
 		const timer = setTimeout(() => {
 			timedOut = true;
 			try {
@@ -102,15 +115,14 @@ async function runShellHook(
 				// Process may have already exited
 			}
 		}, timeoutMs);
-		const [stdout] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+		const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
 		clearTimeout(timer);
-		return { stdout, code: child.exitCode ?? 0, killed: timedOut };
+		return { stdout, stderr, code: child.exitCode ?? 0, killed: timedOut };
 	}
 
-	const [stdout] = await Promise.all([new Response(child.stdout).text(), child.exited]);
-	return { stdout, code: child.exitCode ?? 0, killed: false };
+	const [stdout, stderr] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
+	return { stdout, stderr, code: child.exitCode ?? 0, killed: false };
 }
-
 // ─── Settings.json loading ───────────────────────────────────────────────
 
 async function tryReadHooksFromSettings(settingsPath: string): Promise<ClaudeHooks | null> {
@@ -197,11 +209,13 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 
 			for (const hook of group.hooks) {
 				if (hook.type !== "command") continue;
-				const hookStdin: HookStdin = {
+			const hookStdin: HookStdin = {
 					tool_input: event.input,
 					cwd: ctx.cwd ?? home,
+					hook_event_name: "PreToolUse",
+					tool_name: event.toolName,
 				};
-				const { stdout, code, killed } = await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
+				const { stdout, stderr, code, killed } = await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
 
 				if (killed) {
 					logger.warn("settings-hooks: PreToolUse hook timed out", {
@@ -211,13 +225,23 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 					continue;
 				}
 
-				// Non-zero exit = deny (Claude Code protocol: exit 2 = block, others = error)
-				if (code !== 0) {
-					const reason = stdout.trim() || `Hook "${group.matcher}" exited with code ${code}`;
+				// Claude Code protocol: exit 2 = deny (block), other non-zero = hook error
+				// (do NOT block — a missing dependency like jq exit 127 should not deny the call)
+				if (code === 2) {
+					const reason = stderr.trim() || stdout.trim() || `Hook "${group.matcher}" denied the tool call`;
 					return { block: true, reason };
 				}
+				if (code !== 0) {
+					logger.warn("settings-hooks: PreToolUse hook error (non-blocking)", {
+						command: hook.command,
+						matcher: group.matcher,
+						code,
+						stderr: stderr.trim(),
+					});
+					continue;
+				}
 
-				// Parse JSON stdout for explicit permissionDecision
+				// exit 0 — parse JSON stdout for explicit permissionDecision
 				const trimmed = stdout.trim();
 				if (!trimmed) continue; // exit 0 + no JSON = allow
 				try {
@@ -245,9 +269,11 @@ export const createSettingsHooksExtension: ExtensionFactory = api => {
 
 			for (const hook of group.hooks) {
 				if (hook.type !== "command") continue;
-				const hookStdin: HookStdin = {
+			const hookStdin: HookStdin = {
 					tool_input: event.input,
 					cwd: ctx.cwd ?? home,
+					hook_event_name: "PostToolUse",
+					tool_name: event.toolName,
 				};
 				await runShellHook(hook.command, hookStdin, ctx.cwd ?? home, hook.timeout);
 			}

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -182,6 +182,7 @@ async function runShellHook(
 	const stdinPayload = JSON.stringify(hookStdin);
 	const child = Bun.spawn(["bash", "-c", command], {
 		cwd,
+		env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
 		stdin: new TextEncoder().encode(stdinPayload),
 		stdout: "pipe",
 		stderr: "pipe",

--- a/packages/coding-agent/src/settings-hooks/index.ts
+++ b/packages/coding-agent/src/settings-hooks/index.ts
@@ -193,13 +193,22 @@ async function runShellHook(
 	const stdinPayload = JSON.stringify(hookStdin);
 	// Support both shell form (command string) and exec form (args array)
 	const spawnArgs = hook.args ? hook.args : ["bash", "-c", hook.command ?? ""];
-	const child = Bun.spawn(spawnArgs, {
-		cwd,
-		env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
-		stdin: new TextEncoder().encode(stdinPayload),
-		stdout: "pipe",
-		stderr: "pipe",
-	});
+
+	let child: Bun.Subprocess;
+	try {
+		child = Bun.spawn(spawnArgs, {
+			cwd,
+			env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+			stdin: new TextEncoder().encode(stdinPayload),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+	} catch (err) {
+		// Exec-form spawn failure (missing executable, etc.) — treat as non-blocking hook error
+		const message = err instanceof Error ? err.message : String(err);
+		logger.warn("settings-hooks: hook spawn failed", { args: spawnArgs, error: message });
+		return { stdout: "", stderr: message, code: -1, killed: false };
+	}
 
 	// Claude's timeout field is in seconds; setTimeout uses milliseconds.
 	const timeoutMs = hook.timeout && hook.timeout > 0 ? hook.timeout * 1000 : undefined;
@@ -274,8 +283,13 @@ function mergeHooks(base: ClaudeHooks, addition: ClaudeHooks): void {
 async function readSettingsHooks(home: string, cwd: string, trustProject: boolean): Promise<ClaudeHooks | null> {
 	const hooks: ClaudeHooks = {};
 
-	const userHooks = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
-	if (userHooks) mergeHooks(hooks, userHooks);
+	// Only load user-level hooks from a real HOME directory.
+	// When HOME is empty/unset, path.join("", ".claude", ...) resolves to a
+	// relative path that could pick up project-level hooks as user hooks.
+	if (home) {
+		const userHooks = await tryReadHooksFromSettings(path.join(home, ".claude", "settings.json"));
+		if (userHooks) mergeHooks(hooks, userHooks);
+	}
 
 	if (trustProject) {
 		const projectHooks = await tryReadHooksFromSettings(path.join(cwd, ".claude", "settings.json"));

--- a/packages/coding-agent/test/settings-hooks.test.ts
+++ b/packages/coding-agent/test/settings-hooks.test.ts
@@ -107,7 +107,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "git push origin main" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
@@ -125,7 +125,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "echo hello" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
@@ -143,7 +143,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "git commit" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
@@ -163,7 +163,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "ls" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
@@ -181,7 +181,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "ls" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
@@ -198,7 +198,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		// Should block any tool
 		for (const toolName of ["bash", "read", "write", "edit"]) {
@@ -218,7 +218,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		// edit should be blocked
 		const editEvent = makeCallEvent("edit");
@@ -241,7 +241,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		// edit and write should be blocked
 		for (const toolName of ["edit", "write"]) {
@@ -267,7 +267,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		for (const toolName of ["bash", "read", "edit"]) {
 			const event = makeCallEvent(toolName);
@@ -284,7 +284,7 @@ describe("settings-hooks extension", () => {
 		await fs.writeFile(path.join(dir, "settings.json"), JSON.stringify({ someOtherKey: true }));
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		// Even though handlers are registered, they should find no hooks and not block
 		const event = makeCallEvent("bash", { command: "ls" });
@@ -292,7 +292,7 @@ describe("settings-hooks extension", () => {
 		expect(result).toBeUndefined();
 	});
 
-	test("project-level settings.json hooks merge with user-level hooks", async () => {
+	test("project-level settings.json hooks are NOT loaded (security: no self-grant)", async () => {
 		// User-level: deny bash
 		await writeUserSettings({
 			PreToolUse: [
@@ -300,7 +300,7 @@ describe("settings-hooks extension", () => {
 			],
 		});
 
-		// Project-level: also deny write
+		// Project-level: also deny write — should NOT be loaded
 		const projectDir = path.join(tmpCwd, ".claude");
 		await fs.mkdir(projectDir, { recursive: true });
 		await fs.writeFile(
@@ -315,17 +315,16 @@ describe("settings-hooks extension", () => {
 		);
 
 		const api = createMockApi();
-		createSettingsHooksExtension(true)(api);
+		createSettingsHooksExtension()(api);
 
 		// bash → blocked by user-level hook
 		const bashResult = await api.toolCallHandlers[0](makeCallEvent("bash", { command: "ls" }), makeCtx());
 		expect(bashResult?.block).toBe(true);
 		expect(bashResult?.reason).toBe("user-level deny");
 
-		// write → blocked by project-level hook
+		// write → NOT blocked (project hooks are not loaded)
 		const writeResult = await api.toolCallHandlers[0](makeCallEvent("write"), makeCtx());
-		expect(writeResult?.block).toBe(true);
-		expect(writeResult?.reason).toBe("project-level deny");
+		expect(writeResult).toBeUndefined();
 	});
 
 	test("PostToolUse hook receives tool result and does not block", async () => {
@@ -339,7 +338,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		expect(api.toolResultHandlers).toHaveLength(1);
 
@@ -371,7 +370,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeResultEvent(
 			"bash",
@@ -396,7 +395,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "rm -rf /" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
@@ -414,7 +413,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		// git push should be blocked
 		const pushEvent = makeCallEvent("bash", { command: "git push origin main" });
@@ -443,7 +442,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("read", { path: "/tmp/test.txt" });
 		await api.toolCallHandlers[0](event, makeCtx());
@@ -466,7 +465,7 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(false)(api);
+		createSettingsHooksExtension()(api);
 
 		const event = makeCallEvent("bash", { command: "ls" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());

--- a/packages/coding-agent/test/settings-hooks.test.ts
+++ b/packages/coding-agent/test/settings-hooks.test.ts
@@ -1,8 +1,16 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 import { createSettingsHooksExtension } from "../src/settings-hooks";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ToolCallEvent,
+	ToolCallEventResult,
+	ToolResultEvent,
+	ToolResultEventResult,
+} from "../src/extensibility/extensions/types";
 
 /**
  * Integration tests for the settings-hooks extension — verifies that
@@ -39,25 +47,54 @@ describe("settings-hooks extension", () => {
 		await fs.writeFile(path.join(dir, "settings.json"), JSON.stringify({ hooks }));
 	}
 
-	/**
-	 * Create a minimal extension API mock that collects `tool_call` handlers
-	 * and lets us invoke them with a fabricated event.
-	 */
-	function createMockApi() {
-		const toolCallHandlers: Array<(event: any, ctx: any) => Promise<any>> = [];
-		const toolResultHandlers: Array<(event: any, ctx: any) => Promise<any>> = [];
-		return {
-			on(event: string, handler: (event: any, ctx: any) => Promise<any>): void {
-				if (event === "tool_call") toolCallHandlers.push(handler);
-				if (event === "tool_result") toolResultHandlers.push(handler);
-			},
-			toolCallHandlers,
-			toolResultHandlers,
-		};
+	/** Minimal mock of ExtensionAPI that collects event handlers. */
+	interface MockApi {
+		toolCallHandlers: Array<(event: ToolCallEvent, ctx: ExtensionContext) => Promise<ToolCallEventResult | void>>;
+		toolResultHandlers: Array<(event: ToolResultEvent, ctx: ExtensionContext) => Promise<ToolResultEventResult | void>>;
+		on: ExtensionAPI["on"];
 	}
 
-	function makeCtx(cwd: string = tmpCwd): { cwd: string } {
-		return { cwd };
+	function createMockApi(): MockApi {
+		const toolCallHandlers: MockApi["toolCallHandlers"] = [];
+		const toolResultHandlers: MockApi["toolResultHandlers"] = [];
+		const on: ExtensionAPI["on"] = (event, handler) => {
+			if (event === "tool_call") toolCallHandlers.push(handler as MockApi["toolCallHandlers"][number]);
+			if (event === "tool_result") toolResultHandlers.push(handler as MockApi["toolResultHandlers"][number]);
+		};
+		return { on, toolCallHandlers, toolResultHandlers };
+	}
+
+	function makeCtx(cwd: string = tmpCwd): ExtensionContext {
+		// Minimal context — only fields the extension actually uses.
+		return { cwd } as unknown as ExtensionContext;
+	}
+
+	/** Fabricate a ToolCallEvent for the given tool. */
+	function makeCallEvent(toolName: string, input: Record<string, unknown> = {}): ToolCallEvent {
+		return {
+			type: "tool_call",
+			toolName,
+			toolCallId: `test-${toolName}`,
+			input,
+		} as unknown as ToolCallEvent;
+	}
+
+	/** Fabricate a ToolResultEvent for the given tool. */
+	function makeResultEvent(
+		toolName: string,
+		input: Record<string, unknown>,
+		content: Array<{ type: "text"; text: string }>,
+		isError = false,
+	): ToolResultEvent {
+		return {
+			type: "tool_result",
+			toolName,
+			toolCallId: `test-${toolName}`,
+			input,
+			content,
+			isError,
+			details: undefined,
+		} as unknown as ToolResultEvent;
 	}
 
 	test("PreToolUse hook with permissionDecision deny blocks the tool call", async () => {
@@ -70,22 +107,13 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		expect(api.toolCallHandlers).toHaveLength(1);
-
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-1",
-			input: { command: "git push origin main" },
-		};
+		const event = makeCallEvent("bash", { command: "git push origin main" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
-		expect(result).toEqual({
-			block: true,
-			reason: "direct push to main is not allowed",
-		});
+		expect(result?.block).toBe(true);
+		expect(result?.reason).toBe("direct push to main is not allowed");
 	});
 
 	test("PreToolUse hook with permissionDecision allow does not block", async () => {
@@ -97,14 +125,9 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-2",
-			input: { command: "echo hello" },
-		};
+		const event = makeCallEvent("bash", { command: "echo hello" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
 		// allow → no block (undefined return)
@@ -120,17 +143,13 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-3",
-			input: { command: "git commit" },
-		};
+		const event = makeCallEvent("bash", { command: "git commit" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
 		expect(result?.block).toBe(true);
+		// stderr is the Claude deny reason, not stdout
 		expect(result?.reason).toContain("rejected: secret detected");
 	});
 
@@ -144,14 +163,9 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-3b",
-			input: { command: "ls" },
-		};
+		const event = makeCallEvent("bash", { command: "ls" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
 		// Non-2 non-zero exit = hook error, does not block
@@ -167,14 +181,9 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-4",
-			input: { command: "ls" },
-		};
+		const event = makeCallEvent("bash", { command: "ls" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
 		expect(result).toBeUndefined();
@@ -189,16 +198,11 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
 		// Should block any tool
 		for (const toolName of ["bash", "read", "write", "edit"]) {
-			const event = {
-				type: "tool_call" as const,
-				toolName,
-				toolCallId: `test-${toolName}`,
-				input: {},
-			};
+			const event = makeCallEvent(toolName);
 			const result = await api.toolCallHandlers[0](event, makeCtx());
 			expect(result?.block).toBe(true);
 			expect(result?.reason).toBe("all blocked");
@@ -214,28 +218,18 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
-
-		// bash should not be blocked
-		const bashEvent = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-bash",
-			input: { command: "ls" },
-		};
-		const bashResult = await api.toolCallHandlers[0](bashEvent, makeCtx());
-		expect(bashResult).toBeUndefined();
+		createSettingsHooksExtension(false)(api);
 
 		// edit should be blocked
-		const editEvent = {
-			type: "tool_call" as const,
-			toolName: "edit",
-			toolCallId: "test-edit",
-			input: {},
-		};
+		const editEvent = makeCallEvent("edit");
 		const editResult = await api.toolCallHandlers[0](editEvent, makeCtx());
 		expect(editResult?.block).toBe(true);
 		expect(editResult?.reason).toBe("edit blocked");
+
+		// bash should NOT be blocked
+		const bashEvent = makeCallEvent("bash", { command: "ls" });
+		const bashResult = await api.toolCallHandlers[0](bashEvent, makeCtx());
+		expect(bashResult).toBeUndefined();
 	});
 
 	test("PreToolUse pipe-separated matcher matches multiple tools", async () => {
@@ -247,30 +241,40 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
 		// edit and write should be blocked
 		for (const toolName of ["edit", "write"]) {
-			const event = {
-				type: "tool_call" as const,
-				toolName,
-				toolCallId: `test-${toolName}`,
-				input: {},
-			};
+			const event = makeCallEvent(toolName);
 			const result = await api.toolCallHandlers[0](event, makeCtx());
 			expect(result?.block).toBe(true);
 			expect(result?.reason).toBe("multi-blocked");
 		}
 
 		// bash should NOT be blocked
-		const bashEvent = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-bash-multi",
-			input: { command: "ls" },
-		};
+		const bashEvent = makeCallEvent("bash", { command: "ls" });
 		const bashResult = await api.toolCallHandlers[0](bashEvent, makeCtx());
 		expect(bashResult).toBeUndefined();
+	});
+
+	test("PreToolUse omitted matcher matches all tools (Claude convention)", async () => {
+		const denyAll = `echo '{"permissionDecision":"deny","permissionDecisionReason":"no-matcher-block"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				// No matcher field — should match all
+				{ hooks: [{ type: "command", command: denyAll }] } as Record<string, unknown>,
+			] as unknown as Array<Record<string, unknown>>,
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(false)(api);
+
+		for (const toolName of ["bash", "read", "edit"]) {
+			const event = makeCallEvent(toolName);
+			const result = await api.toolCallHandlers[0](event, makeCtx());
+			expect(result?.block).toBe(true);
+			expect(result?.reason).toBe("no-matcher-block");
+		}
 	});
 
 	test("no hooks in settings.json → no handlers registered with blocking behavior", async () => {
@@ -280,16 +284,10 @@ describe("settings-hooks extension", () => {
 		await fs.writeFile(path.join(dir, "settings.json"), JSON.stringify({ someOtherKey: true }));
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		// tool_call handler is registered but should be inert (no hooks found)
-		expect(api.toolCallHandlers).toHaveLength(1);
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-noop",
-			input: { command: "ls" },
-		};
+		// Even though handlers are registered, they should find no hooks and not block
+		const event = makeCallEvent("bash", { command: "ls" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 		expect(result).toBeUndefined();
 	});
@@ -317,28 +315,23 @@ describe("settings-hooks extension", () => {
 		);
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(true)(api);
 
 		// bash → blocked by user-level hook
-		const bashResult = await api.toolCallHandlers[0](
-			{ type: "tool_call", toolName: "bash", toolCallId: "t1", input: { command: "ls" } },
-			makeCtx(),
-		);
+		const bashResult = await api.toolCallHandlers[0](makeCallEvent("bash", { command: "ls" }), makeCtx());
 		expect(bashResult?.block).toBe(true);
 		expect(bashResult?.reason).toBe("user-level deny");
 
 		// write → blocked by project-level hook
-		const writeResult = await api.toolCallHandlers[0](
-			{ type: "tool_call", toolName: "write", toolCallId: "t2", input: {} },
-			makeCtx(),
-		);
+		const writeResult = await api.toolCallHandlers[0](makeCallEvent("write"), makeCtx());
 		expect(writeResult?.block).toBe(true);
 		expect(writeResult?.reason).toBe("project-level deny");
 	});
 
-	test("PostToolUse hook is invoked and does not block", async () => {
-		// PostToolUse hook that just echoes (observation)
-		const observeScript = `echo "observed" > /dev/null; exit 0`;
+	test("PostToolUse hook receives tool result and does not block", async () => {
+		// PostToolUse hook writes stdin to a temp file so we can verify it ran
+		const observeFile = path.join(tmpCwd, "post-hook-observed.json");
+		const observeScript = `cat > "${observeFile}"`;
 		await writeUserSettings({
 			PostToolUse: [
 				{ matcher: "Bash", hooks: [{ type: "command", command: observeScript }] },
@@ -346,22 +339,51 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
 		expect(api.toolResultHandlers).toHaveLength(1);
 
-		const event = {
-			type: "tool_result" as const,
-			toolName: "bash",
-			toolCallId: "test-post",
-			input: { command: "ls" },
-			content: [{ type: "text", text: "file1.txt\nfile2.txt" }],
-			details: undefined,
-			isError: false,
-		};
-		// Should not throw and should return undefined (no modification)
+		const event = makeResultEvent(
+			"bash",
+			{ command: "ls" },
+			[{ type: "text", text: "file1.txt\nfile2.txt" }],
+		);
 		const result = await api.toolResultHandlers[0](event, makeCtx());
 		expect(result).toBeUndefined();
+
+		// Verify the hook actually ran — the file should contain the hook stdin JSON
+		const observed = await fs.readFile(observeFile, "utf-8");
+		const parsed = JSON.parse(observed);
+		expect(parsed.hook_event_name).toBe("PostToolUse");
+		expect(parsed.tool_name).toBe("bash");
+		expect(parsed.tool_use_id).toBe("test-bash");
+		expect(parsed.tool_input.command).toBe("ls");
+	});
+
+	test("PostToolUse hook does NOT fire on error results", async () => {
+		// Hook that would write a file if invoked
+		const observeFile = path.join(tmpCwd, "post-hook-should-not-exist.json");
+		const observeScript = `cat > "${observeFile}"`;
+		await writeUserSettings({
+			PostToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: observeScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(false)(api);
+
+		const event = makeResultEvent(
+			"bash",
+			{ command: "ls" },
+			[{ type: "text", text: "error: command not found" }],
+			true, // isError = true
+		);
+		await api.toolResultHandlers[0](event, makeCtx());
+
+		// The file should NOT exist — PostToolUse must not fire on errors
+		const exists = await Bun.file(observeFile).exists();
+		expect(exists).toBe(false);
 	});
 
 	test("hookSpecificOutput.permissionDecision deny also blocks", async () => {
@@ -374,14 +396,9 @@ describe("settings-hooks extension", () => {
 		});
 
 		const api = createMockApi();
-		createSettingsHooksExtension(api as any);
+		createSettingsHooksExtension(false)(api);
 
-		const event = {
-			type: "tool_call" as const,
-			toolName: "bash",
-			toolCallId: "test-nested",
-			input: { command: "rm -rf /" },
-		};
+		const event = makeCallEvent("bash", { command: "rm -rf /" });
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
 		expect(result?.block).toBe(true);

--- a/packages/coding-agent/test/settings-hooks.test.ts
+++ b/packages/coding-agent/test/settings-hooks.test.ts
@@ -426,6 +426,11 @@ describe("settings-hooks extension", () => {
 		const lsEvent = makeCallEvent("bash", { command: "ls -la" });
 		const lsResult = await api.toolCallHandlers[0](lsEvent, makeCtx());
 		expect(lsResult).toBeUndefined();
+
+		// chained command with git push should also be blocked
+		const chainedEvent = makeCallEvent("bash", { command: "npm test && git push origin main" });
+		const chainedResult = await api.toolCallHandlers[0](chainedEvent, makeCtx());
+		expect(chainedResult?.block).toBe(true);
 	});
 
 	test("PreToolUse hook stdin maps path to file_path for Read tool", async () => {
@@ -449,5 +454,23 @@ describe("settings-hooks extension", () => {
 		expect(parsed.tool_input.file_path).toBe("/tmp/test.txt");
 		expect(parsed.tool_input.path).toBe("/tmp/test.txt");
 		expect(parsed.tool_name).toBe("Read");
+	});
+
+	test("PreToolUse hook with exec form (args) blocks the tool call", async () => {
+		// Exec form: args array instead of command string
+		const denyScript = `echo '{"permissionDecision":"deny","permissionDecisionReason":"exec-form deny"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", args: ["bash", "-c", denyScript] }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(false)(api);
+
+		const event = makeCallEvent("bash", { command: "ls" });
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+		expect(result?.block).toBe(true);
+		expect(result?.reason).toBe("exec-form deny");
 	});
 });

--- a/packages/coding-agent/test/settings-hooks.test.ts
+++ b/packages/coding-agent/test/settings-hooks.test.ts
@@ -111,7 +111,7 @@ describe("settings-hooks extension", () => {
 		expect(result).toBeUndefined();
 	});
 
-	test("PreToolUse hook with non-zero exit code blocks the tool call", async () => {
+	test("PreToolUse hook with exit code 2 blocks the tool call (Claude deny protocol)", async () => {
 		const failScript = `echo "rejected: secret detected" >&2; exit 2`;
 		await writeUserSettings({
 			PreToolUse: [
@@ -131,7 +131,31 @@ describe("settings-hooks extension", () => {
 		const result = await api.toolCallHandlers[0](event, makeCtx());
 
 		expect(result?.block).toBe(true);
-		expect(result?.reason).toContain("exited with code 2");
+		expect(result?.reason).toContain("rejected: secret detected");
+	});
+
+	test("PreToolUse hook with non-2 non-zero exit does not block (hook error, not deny)", async () => {
+		// exit 127 = command not found — should NOT block the tool call
+		const errorScript = `exit 127`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: errorScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-3b",
+			input: { command: "ls" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+
+		// Non-2 non-zero exit = hook error, does not block
+		expect(result).toBeUndefined();
 	});
 
 	test("PreToolUse hook with exit 0 and no JSON output allows the call", async () => {
@@ -212,6 +236,41 @@ describe("settings-hooks extension", () => {
 		const editResult = await api.toolCallHandlers[0](editEvent, makeCtx());
 		expect(editResult?.block).toBe(true);
 		expect(editResult?.reason).toBe("edit blocked");
+	});
+
+	test("PreToolUse pipe-separated matcher matches multiple tools", async () => {
+		const denyMulti = `echo '{"permissionDecision":"deny","permissionDecisionReason":"multi-blocked"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Edit|Write", hooks: [{ type: "command", command: denyMulti }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		// edit and write should be blocked
+		for (const toolName of ["edit", "write"]) {
+			const event = {
+				type: "tool_call" as const,
+				toolName,
+				toolCallId: `test-${toolName}`,
+				input: {},
+			};
+			const result = await api.toolCallHandlers[0](event, makeCtx());
+			expect(result?.block).toBe(true);
+			expect(result?.reason).toBe("multi-blocked");
+		}
+
+		// bash should NOT be blocked
+		const bashEvent = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-bash-multi",
+			input: { command: "ls" },
+		};
+		const bashResult = await api.toolCallHandlers[0](bashEvent, makeCtx());
+		expect(bashResult).toBeUndefined();
 	});
 
 	test("no hooks in settings.json → no handlers registered with blocking behavior", async () => {

--- a/packages/coding-agent/test/settings-hooks.test.ts
+++ b/packages/coding-agent/test/settings-hooks.test.ts
@@ -355,7 +355,7 @@ describe("settings-hooks extension", () => {
 		const observed = await fs.readFile(observeFile, "utf-8");
 		const parsed = JSON.parse(observed);
 		expect(parsed.hook_event_name).toBe("PostToolUse");
-		expect(parsed.tool_name).toBe("bash");
+		expect(parsed.tool_name).toBe("Bash");
 		expect(parsed.tool_use_id).toBe("test-bash");
 		expect(parsed.tool_input.command).toBe("ls");
 	});
@@ -403,5 +403,51 @@ describe("settings-hooks extension", () => {
 
 		expect(result?.block).toBe(true);
 		expect(result?.reason).toBe("nested deny");
+	});
+
+	test("PreToolUse hook with `if` filter only blocks matching commands", async () => {
+		const denyScript = `echo '{"permissionDecision":"deny","permissionDecisionReason":"push blocked"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: denyScript, if: "Bash(git push*)" }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(false)(api);
+
+		// git push should be blocked
+		const pushEvent = makeCallEvent("bash", { command: "git push origin main" });
+		const pushResult = await api.toolCallHandlers[0](pushEvent, makeCtx());
+		expect(pushResult?.block).toBe(true);
+		expect(pushResult?.reason).toBe("push blocked");
+
+		// ls should NOT be blocked (if filter doesn't match)
+		const lsEvent = makeCallEvent("bash", { command: "ls -la" });
+		const lsResult = await api.toolCallHandlers[0](lsEvent, makeCtx());
+		expect(lsResult).toBeUndefined();
+	});
+
+	test("PreToolUse hook stdin maps path to file_path for Read tool", async () => {
+		const observeFile = path.join(tmpCwd, "read-hook-observed.json");
+		const observeScript = `cat > "${observeFile}"`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Read", hooks: [{ type: "command", command: observeScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(false)(api);
+
+		const event = makeCallEvent("read", { path: "/tmp/test.txt" });
+		await api.toolCallHandlers[0](event, makeCtx());
+
+		const observed = await fs.readFile(observeFile, "utf-8");
+		const parsed = JSON.parse(observed);
+		// Claude expects file_path, not path
+		expect(parsed.tool_input.file_path).toBe("/tmp/test.txt");
+		expect(parsed.tool_input.path).toBe("/tmp/test.txt");
+		expect(parsed.tool_name).toBe("Read");
 	});
 });

--- a/packages/coding-agent/test/settings-hooks.test.ts
+++ b/packages/coding-agent/test/settings-hooks.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { createSettingsHooksExtension } from "../src/settings-hooks";
+
+/**
+ * Integration tests for the settings-hooks extension — verifies that
+ * PreToolUse hooks from ~/.claude/settings.json block tool calls via the
+ * existing `tool_call` event bus, and PostToolUse hooks observe results.
+ *
+ * These tests exercise the real extension factory with a temp HOME containing
+ * a `.claude/settings.json` with hook definitions. No omp process is spawned.
+ */
+describe("settings-hooks extension", () => {
+	let tmpHome: string;
+	let tmpCwd: string;
+	let originalHome: string | undefined;
+
+	beforeEach(async () => {
+		tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "settings-hooks-test-"));
+		tmpCwd = await fs.mkdtemp(path.join(os.tmpdir(), "settings-hooks-cwd-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tmpHome;
+	});
+
+	afterEach(async () => {
+		process.env.HOME = originalHome;
+		await fs.rm(tmpHome, { recursive: true, force: true }).catch(() => {});
+		await fs.rm(tmpCwd, { recursive: true, force: true }).catch(() => {});
+	});
+
+	/**
+	 * Write a `.claude/settings.json` in the temp HOME with the given hooks.
+	 */
+	async function writeUserSettings(hooks: Record<string, unknown>): Promise<void> {
+		const dir = path.join(tmpHome, ".claude");
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(path.join(dir, "settings.json"), JSON.stringify({ hooks }));
+	}
+
+	/**
+	 * Create a minimal extension API mock that collects `tool_call` handlers
+	 * and lets us invoke them with a fabricated event.
+	 */
+	function createMockApi() {
+		const toolCallHandlers: Array<(event: any, ctx: any) => Promise<any>> = [];
+		const toolResultHandlers: Array<(event: any, ctx: any) => Promise<any>> = [];
+		return {
+			on(event: string, handler: (event: any, ctx: any) => Promise<any>): void {
+				if (event === "tool_call") toolCallHandlers.push(handler);
+				if (event === "tool_result") toolResultHandlers.push(handler);
+			},
+			toolCallHandlers,
+			toolResultHandlers,
+		};
+	}
+
+	function makeCtx(cwd: string = tmpCwd): { cwd: string } {
+		return { cwd };
+	}
+
+	test("PreToolUse hook with permissionDecision deny blocks the tool call", async () => {
+		// Hook script: outputs JSON with deny decision
+		const denyScript = `echo '{"permissionDecision":"deny","permissionDecisionReason":"direct push to main is not allowed"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: denyScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		expect(api.toolCallHandlers).toHaveLength(1);
+
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-1",
+			input: { command: "git push origin main" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+
+		expect(result).toEqual({
+			block: true,
+			reason: "direct push to main is not allowed",
+		});
+	});
+
+	test("PreToolUse hook with permissionDecision allow does not block", async () => {
+		const allowScript = `echo '{"permissionDecision":"allow"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: allowScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-2",
+			input: { command: "echo hello" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+
+		// allow → no block (undefined return)
+		expect(result).toBeUndefined();
+	});
+
+	test("PreToolUse hook with non-zero exit code blocks the tool call", async () => {
+		const failScript = `echo "rejected: secret detected" >&2; exit 2`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: failScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-3",
+			input: { command: "git commit" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+
+		expect(result?.block).toBe(true);
+		expect(result?.reason).toContain("exited with code 2");
+	});
+
+	test("PreToolUse hook with exit 0 and no JSON output allows the call", async () => {
+		const infoScript = `echo "checking..."; exit 0`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: infoScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-4",
+			input: { command: "ls" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+
+		expect(result).toBeUndefined();
+	});
+
+	test("PreToolUse matcher '*' matches all tools", async () => {
+		const denyAll = `echo '{"permissionDecision":"deny","permissionDecisionReason":"all blocked"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "*", hooks: [{ type: "command", command: denyAll }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		// Should block any tool
+		for (const toolName of ["bash", "read", "write", "edit"]) {
+			const event = {
+				type: "tool_call" as const,
+				toolName,
+				toolCallId: `test-${toolName}`,
+				input: {},
+			};
+			const result = await api.toolCallHandlers[0](event, makeCtx());
+			expect(result?.block).toBe(true);
+			expect(result?.reason).toBe("all blocked");
+		}
+	});
+
+	test("PreToolUse matcher only fires for matching tool", async () => {
+		const denyEdit = `echo '{"permissionDecision":"deny","permissionDecisionReason":"edit blocked"}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Edit", hooks: [{ type: "command", command: denyEdit }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		// bash should not be blocked
+		const bashEvent = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-bash",
+			input: { command: "ls" },
+		};
+		const bashResult = await api.toolCallHandlers[0](bashEvent, makeCtx());
+		expect(bashResult).toBeUndefined();
+
+		// edit should be blocked
+		const editEvent = {
+			type: "tool_call" as const,
+			toolName: "edit",
+			toolCallId: "test-edit",
+			input: {},
+		};
+		const editResult = await api.toolCallHandlers[0](editEvent, makeCtx());
+		expect(editResult?.block).toBe(true);
+		expect(editResult?.reason).toBe("edit blocked");
+	});
+
+	test("no hooks in settings.json → no handlers registered with blocking behavior", async () => {
+		// Write settings.json without a hooks key
+		const dir = path.join(tmpHome, ".claude");
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(path.join(dir, "settings.json"), JSON.stringify({ someOtherKey: true }));
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		// tool_call handler is registered but should be inert (no hooks found)
+		expect(api.toolCallHandlers).toHaveLength(1);
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-noop",
+			input: { command: "ls" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+		expect(result).toBeUndefined();
+	});
+
+	test("project-level settings.json hooks merge with user-level hooks", async () => {
+		// User-level: deny bash
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: `echo '{"permissionDecision":"deny","permissionDecisionReason":"user-level deny"}'` }] },
+			],
+		});
+
+		// Project-level: also deny write
+		const projectDir = path.join(tmpCwd, ".claude");
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.writeFile(
+			path.join(projectDir, "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{ matcher: "Write", hooks: [{ type: "command", command: `echo '{"permissionDecision":"deny","permissionDecisionReason":"project-level deny"}'` }] },
+					],
+				},
+			}),
+		);
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		// bash → blocked by user-level hook
+		const bashResult = await api.toolCallHandlers[0](
+			{ type: "tool_call", toolName: "bash", toolCallId: "t1", input: { command: "ls" } },
+			makeCtx(),
+		);
+		expect(bashResult?.block).toBe(true);
+		expect(bashResult?.reason).toBe("user-level deny");
+
+		// write → blocked by project-level hook
+		const writeResult = await api.toolCallHandlers[0](
+			{ type: "tool_call", toolName: "write", toolCallId: "t2", input: {} },
+			makeCtx(),
+		);
+		expect(writeResult?.block).toBe(true);
+		expect(writeResult?.reason).toBe("project-level deny");
+	});
+
+	test("PostToolUse hook is invoked and does not block", async () => {
+		// PostToolUse hook that just echoes (observation)
+		const observeScript = `echo "observed" > /dev/null; exit 0`;
+		await writeUserSettings({
+			PostToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: observeScript }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		expect(api.toolResultHandlers).toHaveLength(1);
+
+		const event = {
+			type: "tool_result" as const,
+			toolName: "bash",
+			toolCallId: "test-post",
+			input: { command: "ls" },
+			content: [{ type: "text", text: "file1.txt\nfile2.txt" }],
+			details: undefined,
+			isError: false,
+		};
+		// Should not throw and should return undefined (no modification)
+		const result = await api.toolResultHandlers[0](event, makeCtx());
+		expect(result).toBeUndefined();
+	});
+
+	test("hookSpecificOutput.permissionDecision deny also blocks", async () => {
+		// Some hooks use hookSpecificOutput instead of top-level
+		const script = `echo '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"nested deny"}}'`;
+		await writeUserSettings({
+			PreToolUse: [
+				{ matcher: "Bash", hooks: [{ type: "command", command: script }] },
+			],
+		});
+
+		const api = createMockApi();
+		createSettingsHooksExtension(api as any);
+
+		const event = {
+			type: "tool_call" as const,
+			toolName: "bash",
+			toolCallId: "test-nested",
+			input: { command: "rm -rf /" },
+		};
+		const result = await api.toolCallHandlers[0](event, makeCtx());
+
+		expect(result?.block).toBe(true);
+		expect(result?.reason).toBe("nested deny");
+	});
+});


### PR DESCRIPTION
## What

Execute Claude Code `PreToolUse`/`PostToolUse` hooks defined in `~/.claude/settings.json` and `.claude/settings.json` by bridging them into OMP's existing `tool_call`/`tool_result` event bus.

Hooks are parsed from the `hooks` key, translated from Claude's PascalCase tool matchers (`Bash`, `Edit`, `Write`, `Read`, `*`) to OMP tool ids, and shell-executed with Claude's stdin/stdout protocol (`{"tool_input": ..., "cwd": ...}`). A `permissionDecision: "deny"`, `hookSpecificOutput.permissionDecision: "deny"`, or non-zero exit code blocks the tool call via the existing `beforeToolCall` seam. PostToolUse hooks observe tool results. User-level and project-level hooks are merged. The feature activates automatically when `settings.json` contains a `hooks` key.

## Why

OMP currently ignores the `hooks` object inside `~/.claude/settings.json`, silently bypassing safety hooks like `prevent-direct-push.py` (blocks `git push origin main`), `gh-contribution-guard.py`, `secret-scanner.py`, and `lint-gate.py` when OMP drives the session. This implements Option A from the issue — ingest `settings.json` hooks, map onto the existing `beforeToolCall` bus — as the smallest useful increment.

Closes #6446

## Testing

- 10 integration tests in `packages/coding-agent/test/settings-hooks.test.ts` covering: deny/allow decisions, non-zero exit blocking, `*` matcher, tool-specific matchers, user+project merge, PostToolUse observation, nested `hookSpecificOutput` deny, and no-hooks inert behavior — all pass.
- The companion test harness (`omp-mac-testing`) adds `hook-test`, `settings`, and `SetSettingsHooksEnabled` commands with 8 new tests (61 total, all pass) to verify hook blocking end-to-end via the RPC session.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
