### PR TITLE
fix(coding-agent): repainted mutable tool blocks on settle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed mutable tool progress duplicating or overlapping final output after settlement ([#6466](https://github.com/can1357/oh-my-pi/issues/6466)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -716,6 +716,10 @@ function wrapEditRendererLine(line: string, width: number): string[] {
 
 export const editToolRenderer = {
 	mergeCallAndResult: true,
+	// Shared by the `edit` and `apply_patch` registry aliases. Streaming diff
+	// previews settle to a different final diff topology; force one viewport
+	// repaint at settlement.
+	forceResultViewportRepaintOnSettle: true,
 
 	renderCall(
 		args: EditRenderArgs,

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -384,6 +384,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	// `history` at seal/detached-task retirement. Not rendered data — excluded
 	// from the display memo key.
 	#settlementState: ResultSettlementRepaintState = "live-unpainted";
+	// Observed geometry of the last composed partial-result frame. Settlement
+	// only pays for a full viewport reset when the final render differs in
+	// height from this painted shape; same-height settles keep the ordinary
+	// in-place repaint path (avoids ED3 scrollback wipe for stable stream tails).
+	#paintedPartialLineCount = 0;
+	#paintedPartialWidth = 0;
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -607,6 +613,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			!isPartial &&
 			this.#settlementState === "live-painted" &&
 			this.#rendererFlag("forceResultViewportRepaintOnSettle");
+		// Snapshot painted partial geometry before consuming settlement evidence.
+		const paintedPartialLineCount = this.#paintedPartialLineCount;
+		const paintedPartialWidth = this.#paintedPartialWidth;
 		// Clear only the pending-to-first-result latch; `render()` re-arms it.
 		this.#firstResultViewportRepaintShapePainted = false;
 		// Consume live paint evidence before any display mutation or the
@@ -614,6 +623,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// render cannot replay the reset. A partial keeps the evidence intact.
 		if (!isPartial && this.#settlementState === "live-painted") {
 			this.#settlementState = "live-unpainted";
+			this.#paintedPartialLineCount = 0;
+			this.#paintedPartialWidth = 0;
 		}
 		this.#result = result;
 		this.#resultVersion++;
@@ -626,9 +637,20 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#updateSpinnerAnimation();
 		this.#updateTodoStrikeAnimation();
 		this.#updateDisplay();
+		// Settlement reset only when the final compose differs in height from the
+		// last painted partial. Same-height settles keep the in-place path.
+		let settlementTopologyChanged = false;
+		if (provisionalResultSettled) {
+			if (paintedPartialWidth <= 0) {
+				settlementTopologyChanged = true;
+			} else {
+				const finalLineCount = super.render(paintedPartialWidth).length;
+				settlementTopologyChanged = finalLineCount !== paintedPartialLineCount;
+			}
+		}
 		this.#resetDisplayForResultTopologyChange(
 			hadNoResult && firstResultRepaintShapePainted,
-			provisionalResultSettled,
+			settlementTopologyChanged,
 		);
 		// Convert non-PNG images to PNG for Kitty protocol (async)
 		this.#maybeConvertImagesForKitty();
@@ -996,8 +1018,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	/**
 	 * Emit exactly one full-viewport reset when a result update changed the
 	 * block's terminal topology. Both effects are precomputed by the caller
-	 * (which owns the renderer-flag and lifecycle checks); this only ORs them so
-	 * the settlement state is already consumed before the synchronous reset.
+	 * (renderer-flag / lifecycle / observed painted-vs-final height); this only
+	 * ORs them so the settlement state is already consumed before the reset.
 	 */
 	#resetDisplayForResultTopologyChange(
 		paintedPendingShapeReplaced: boolean,
@@ -1020,6 +1042,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// it) and never revives an absorbed `history` block.
 		if (this.#settlementState === "live-unpainted" && this.#result !== undefined && this.#isPartial) {
 			this.#settlementState = "live-painted";
+		}
+		// Record the painted partial's observed height so settlement can gate the
+		// destructive reset on a real topology change rather than every settle.
+		if (this.#settlementState === "live-painted" && this.#result !== undefined && this.#isPartial) {
+			this.#paintedPartialLineCount = lines.length;
+			this.#paintedPartialWidth = width;
 		}
 		return lines;
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -299,6 +299,14 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#multiFileBoxes: (Box | Spacer)[] = []; // Extra boxes for multi-file edit results
 	#imageComponents: Image[] = [];
 	#imageSpacers: Spacer[] = [];
+	/**
+	 * Monotonic content version reported to the transcript container via
+	 * {@link getTranscriptBlockVersion}. Bumped by `#updateDisplay()` — the
+	 * choke point every mutator funnels through — so a mutation landing after
+	 * the block reports finalized (most notably a result arriving after
+	 * {@link seal}) cannot be masked by the committed-scrollback replay.
+	 */
+	#blockVersion = 0;
 	readonly #instanceId = ++toolExecutionInstanceSeq;
 	#toolName: string;
 	#toolLabel: string;
@@ -618,9 +626,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		const paintedPartialWidth = this.#paintedPartialWidth;
 		// Clear only the pending-to-first-result latch; `render()` re-arms it.
 		this.#firstResultViewportRepaintShapePainted = false;
-		// Consume live paint evidence before any display mutation or the
-		// synchronous resetDisplay() below, so a duplicate final or reentrant
-		// render cannot replay the reset. A partial keeps the evidence intact.
+		// Consume live paint evidence before any display mutation, so a duplicate
+		// final or reentrant render cannot replay the reset. A partial keeps the
+		// evidence intact.
 		if (!isPartial && this.#settlementState === "live-painted") {
 			this.#settlementState = "live-unpainted";
 			this.#paintedPartialLineCount = 0;
@@ -641,12 +649,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// last painted partial. Same-height settles keep the in-place path.
 		let settlementTopologyChanged = false;
 		if (provisionalResultSettled) {
-			if (paintedPartialWidth <= 0) {
-				settlementTopologyChanged = true;
-			} else {
-				const finalLineCount = super.render(paintedPartialWidth).length;
-				settlementTopologyChanged = finalLineCount !== paintedPartialLineCount;
-			}
+			settlementTopologyChanged =
+				paintedPartialWidth <= 0 ||
+				this.#measureSettledHeightOutsideCompose(paintedPartialWidth) !== paintedPartialLineCount;
 		}
 		this.#resetDisplayForResultTopologyChange(
 			hadNoResult && firstResultRepaintShapePainted,
@@ -913,6 +918,15 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	/**
+	 * Content version for the transcript's committed-scrollback render bypass.
+	 * A sealed block reports finalized, so without this the container would
+	 * replay its previous rows and a late terminal result would never appear.
+	 */
+	getTranscriptBlockVersion(): number {
+		return this.#blockVersion;
+	}
+
+	/**
 	 * Mark the tool terminal even though no result arrived (the turn aborted or
 	 * abandoned it) and stop animating, so it can freeze and stops pinning the
 	 * transcript live region.
@@ -990,6 +1004,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 		this.#rebuildDisplay();
 		this.#displayBuilt = true;
+		// Every mutator funnels through here, so this is the choke point that
+		// reports content change to the transcript (see
+		// {@link getTranscriptBlockVersion}). A result arriving after `seal()` —
+		// an abort/rewind that later receives its terminal payload — reshapes the
+		// block while it already reports finalized, and the container replays its
+		// committed rows unless the version moves.
+		this.#blockVersion++;
 	}
 
 	#rendererFlag(name: "forceResultViewportRepaintOnSettle"): boolean {
@@ -1013,6 +1034,27 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			toolValue !== undefined ? toolValue : toolRenderers[this.#toolName]?.forceFirstResultViewportRepaint;
 		if (typeof value === "function") return value(this.#args, this.#renderState);
 		return value === true;
+	}
+	/**
+	 * Height the settled block composes to at `width`, measured outside the
+	 * renderer's compose.
+	 *
+	 * `Image.render()` is stateful against the shared {@link ImageBudget}: it
+	 * records display order, queues transmissions, and raises the image's
+	 * reserved-row floor. Those effects are only coherent between the renderer's
+	 * `beginPass()`/`endPass()`, so an image-bearing block cannot be measured
+	 * here — composing it would let the budget hand out a live graphic the
+	 * authoritative pass then suppresses, padding the text fallback to a height
+	 * that never reached the terminal. Such a settle reports an incomparable
+	 * height and takes the unconditional reset, which is what an image-bearing
+	 * settle needs anyway: the block reshapes when the image resolves.
+	 *
+	 * An image-free block composes only text, so the measurement is a pure
+	 * function of the display tree and safe outside the pass.
+	 */
+	#measureSettledHeightOutsideCompose(width: number): number {
+		if (this.#imageComponents.length > 0) return -1;
+		return super.render(width).length;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -275,6 +275,22 @@ export function sharedSpinnerFrame(frameCount: number, now: number = performance
 let toolExecutionInstanceSeq = 0;
 
 /**
+ * Lifecycle of a mutable tool block's provisional-result paint evidence, used
+ * to decide whether settling a painted partial into its final render requires
+ * one full-viewport repaint. A zero-allocation string union tracked
+ * independently of {@link ToolExecutionComponent}'s other lifecycle flags:
+ * - `live-unpainted`: still in the repaintable live region; no partial-result
+ *   frame in the current result cycle has been composed.
+ * - `live-painted`: `render()` composed at least one partial-result frame while
+ *   live. Sticky across later partial updates that may settle before the next
+ *   render, so coalesced partials cannot erase the evidence.
+ * - `history`: the block was sealed or a detached async task left the live
+ *   region. Absorbing — a later partial/final render can never re-arm a
+ *   settlement reset from here.
+ */
+type ResultSettlementRepaintState = "live-unpainted" | "live-painted" | "history";
+
+/**
  * Component that renders a tool call with its result (updateable)
  */
 export class ToolExecutionComponent extends Container implements NativeScrollbackLiveRegion {
@@ -362,7 +378,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	// terminals wipes native scrollback and flashes the user's history —
 	// reviewer note on PR #4315).
 	#firstResultViewportRepaintShapePainted = false;
-	#partialResultShapePainted = false;
+	// Provisional-result paint lifecycle. Armed to `live-painted` by `render()`
+	// once a partial-result frame is composed, consumed back to `live-unpainted`
+	// when that partial settles into its final render, and absorbed into
+	// `history` at seal/detached-task retirement. Not rendered data — excluded
+	// from the display memo key.
+	#settlementState: ResultSettlementRepaintState = "live-unpainted";
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -558,21 +579,42 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		isPartial = false,
 		_toolCallId?: string,
 	): void {
-		// A detached task spawn keeps streaming progress snapshots after the
-		// block froze (left the transcript live region). Drop them: the rows are
-		// static gray history now, and repainting would rewrite rows the engine
-		// may already have committed to native scrollback. The terminal snapshot
-		// (async completed/failed → isPartial=false) still applies so a block
-		// that is still on screen settles on real results.
-		if (isPartial && this.#toolName === "task" && this.#maybeFreezeBackgroundTask()) {
-			return;
+		// Retire a detached task the instant it leaves the transcript live region,
+		// before any settlement eligibility is computed. This runs for BOTH an
+		// incoming partial and an incoming final: a running task can leave the
+		// live region and receive its terminal (completed/failed) snapshot as its
+		// very next update, and without retiring here first a painted running
+		// partial would look like a live settlement and destructively reset the
+		// rows the engine may already have committed to native scrollback.
+		if (this.#toolName === "task") {
+			if (isPartial) {
+				// Incoming progress snapshot after the seam: freeze the rows to
+				// static gray and drop the snapshot.
+				if (this.#maybeFreezeBackgroundTask()) return;
+			} else {
+				// Incoming terminal snapshot: retire without emitting a stale gray
+				// partial render, then fall through to apply the final content.
+				this.#retireDetachedTaskAtSeam();
+			}
 		}
 		const hadNoResult = this.#result === undefined;
 		const wasPartialResult = this.#result !== undefined && this.#isPartial;
 		const firstResultRepaintShapePainted = this.#firstResultViewportRepaintShapePainted;
-		const partialResultPainted = this.#partialResultShapePainted;
+		// Settlement eligibility is read from the post-retirement lifecycle: a
+		// block absorbed into `history` at the seam can never arm a reset here.
+		const provisionalResultSettled =
+			wasPartialResult &&
+			!isPartial &&
+			this.#settlementState === "live-painted" &&
+			this.#rendererFlag("forceResultViewportRepaintOnSettle");
+		// Clear only the pending-to-first-result latch; `render()` re-arms it.
 		this.#firstResultViewportRepaintShapePainted = false;
-		this.#partialResultShapePainted = false;
+		// Consume live paint evidence before any display mutation or the
+		// synchronous resetDisplay() below, so a duplicate final or reentrant
+		// render cannot replay the reset. A partial keeps the evidence intact.
+		if (!isPartial && this.#settlementState === "live-painted") {
+			this.#settlementState = "live-unpainted";
+		}
 		this.#result = result;
 		this.#resultVersion++;
 		this.#isPartial = isPartial;
@@ -586,8 +628,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#updateDisplay();
 		this.#resetDisplayForResultTopologyChange(
 			hadNoResult && firstResultRepaintShapePainted,
-			wasPartialResult && partialResultPainted,
-			isPartial,
+			provisionalResultSettled,
 		);
 		// Convert non-PNG images to PNG for Kitty protocol (async)
 		this.#maybeConvertImagesForKitty();
@@ -713,19 +754,51 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	/**
-	 * Freeze a detached (`async.state === "running"`) task block once it leaves
-	 * the transcript's live region. Past that seam its rows are commit-eligible
-	 * native-scrollback history: repaint the progress rows static gray and drop
-	 * further partial snapshots. One-way — blocks never re-enter the live
-	 * region. Returns whether the block is frozen.
+	 * Enter the absorbing `history` lifecycle: the block left the repaintable
+	 * live region (detached-task seam) or was sealed. The single owner of every
+	 * `#backgroundTaskFrozen` assignment paired with the settlement `history`
+	 * transition, so paint evidence can never re-arm a destructive reset past
+	 * this point. Pure state — no render side effect; callers own their render.
 	 */
-	#maybeFreezeBackgroundTask(): boolean {
-		if (this.#backgroundTaskFrozen) return true;
+	#enterSettlementHistory(): void {
+		this.#backgroundTaskFrozen = true;
+		this.#settlementState = "history";
+	}
+
+	/**
+	 * Whether a detached (`async.state === "running"`) task block has crossed the
+	 * seam where it leaves the transcript live region. Pure probe.
+	 */
+	#detachedTaskLeftLiveRegion(): boolean {
 		if (this.#toolName !== "task" || this.#liveRegion === undefined) return false;
 		const asyncState = (this.#result?.details as { async?: { state?: string } } | undefined)?.async?.state;
 		if (asyncState !== "running") return false;
-		if (this.#liveRegion.isBlockInLiveRegion(this)) return false;
-		this.#backgroundTaskFrozen = true;
+		return !this.#liveRegion.isBlockInLiveRegion(this);
+	}
+
+	/**
+	 * Retire a detached task block at the seam where it leaves the live region:
+	 * past that point its rows are commit-eligible native-scrollback history.
+	 * Idempotent; returns whether the block is (now or already) retired. Pure
+	 * lifecycle with no render effect, so the direct-final update path can retire
+	 * without emitting a stale gray partial frame before applying the result.
+	 */
+	#retireDetachedTaskAtSeam(): boolean {
+		if (this.#backgroundTaskFrozen) return true;
+		if (!this.#detachedTaskLeftLiveRegion()) return false;
+		this.#enterSettlementHistory();
+		return true;
+	}
+
+	/**
+	 * Freeze wrapper for spinner-tick and incoming-partial callers: retire the
+	 * block at the seam and, only on the newly-retired transition, repaint the
+	 * progress rows static gray and request a render so the animation settles.
+	 * Returns whether the block is frozen.
+	 */
+	#maybeFreezeBackgroundTask(): boolean {
+		if (this.#backgroundTaskFrozen) return true;
+		if (!this.#retireDetachedTaskAtSeam()) return false;
 		this.#updateSpinnerAnimation();
 		this.#updateDisplay();
 		this.#ui.requestRender();
@@ -826,9 +899,10 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		if (this.#sealed) return;
 		this.#sealed = true;
 		this.#displaceableByToolName = undefined;
-		// A sealed detached task is abandoned history: settle its progress rows
-		// on static gray.
-		this.#backgroundTaskFrozen = true;
+		// A sealed block is history: enter the absorbing lifecycle before stopping
+		// animation and rebuilding the static display, so a render after seal can
+		// never revive paint evidence into a late destructive reset.
+		this.#enterSettlementHistory();
 		this.stopAnimation();
 		this.#updateDisplay();
 		this.#ui.requestRender();
@@ -919,26 +993,34 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		return value === true;
 	}
 
+	/**
+	 * Emit exactly one full-viewport reset when a result update changed the
+	 * block's terminal topology. Both effects are precomputed by the caller
+	 * (which owns the renderer-flag and lifecycle checks); this only ORs them so
+	 * the settlement state is already consumed before the synchronous reset.
+	 */
 	#resetDisplayForResultTopologyChange(
-		firstResultAfterRepaintShapePaint: boolean,
-		partialResultPaintedBeforeSettle: boolean,
-		isPartial: boolean,
+		paintedPendingShapeReplaced: boolean,
+		eligiblePaintedPartialSettled: boolean,
 	): void {
-		const provisionalResultSettled =
-			partialResultPaintedBeforeSettle && !isPartial && this.#rendererFlag("forceResultViewportRepaintOnSettle");
-		if (firstResultAfterRepaintShapePaint || provisionalResultSettled) {
+		if (paintedPendingShapeReplaced || eligiblePaintedPartialSettled) {
 			this.#ui.resetDisplay();
 		}
 	}
 
 	override render(width: number): readonly string[] {
 		const lines = super.render(width);
-		// Update the paint-tracking flags after `super.render(width)` — the
-		// override runs on every compose the parent Container performs, so a
-		// frame that never gets composed leaves the flags false and prevents a
-		// spurious `resetDisplay()`.
+		// Paint evidence originates only after a real compose. The parent
+		// Container runs this override on every compose; a frame that never
+		// composes leaves the state untouched and cannot arm a spurious
+		// `resetDisplay()`.
 		this.#firstResultViewportRepaintShapePainted = this.#needsFirstResultViewportRepaintAtRender();
-		this.#partialResultShapePainted = this.#result !== undefined && this.#isPartial;
+		// A composed partial-result frame arms `live-painted`. It never clears the
+		// evidence (so coalesced partials that settle before the next render keep
+		// it) and never revives an absorbed `history` block.
+		if (this.#settlementState === "live-unpainted" && this.#result !== undefined && this.#isPartial) {
+			this.#settlementState = "live-painted";
+		}
 		return lines;
 	}
 

--- a/packages/coding-agent/src/task/renderer.ts
+++ b/packages/coding-agent/src/task/renderer.ts
@@ -11,4 +11,8 @@ export const taskToolRenderer = {
 	renderCall,
 	renderResult,
 	mergeCallAndResult: true,
+	// Foreground task progress settles to a different final topology; force one
+	// viewport repaint at settlement. Detached tasks are excluded by the
+	// component's history retirement, not by removing this opt-in.
+	forceResultViewportRepaintOnSettle: true,
 } as const;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1702,6 +1702,9 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 		},
 		mergeCallAndResult: true,
 		inline: true,
+		// Streaming shell output settles from a pending frame to a final framed
+		// block whose chrome differs; force one viewport repaint at settlement.
+		forceResultViewportRepaintOnSettle: true,
 	};
 }
 

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -493,6 +493,9 @@ function formatCellOutputLines(
 export const evalToolRenderer = {
 	animatedPendingPreview: true,
 	animatedPartialResult: true,
+	// Progress tree topology (subagent rows, current-tool lines) differs between
+	// the partial and final render; force one viewport repaint at settlement.
+	forceResultViewportRepaintOnSettle: true,
 	renderCall(args: EvalRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const cells = getRenderCells(args);
 

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -416,6 +416,11 @@ function renderWatchCall(args: GithubToolRenderArgs, options: RenderResultOption
 }
 
 export const githubToolRenderer = {
+	// Only `run_watch` emits partials; its live watch frame settles to a
+	// different final topology, so force one viewport repaint at settlement.
+	// Safe for the non-watch ops because settlement still requires an actual
+	// painted partial-result transition.
+	forceResultViewportRepaintOnSettle: true,
 	// No animatedPendingPreview: renderCall materializes plain Text components
 	// once per display rebuild (no render closure), so a live spinner interval
 	// would request 30fps repaints while the visible glyph stays frozen.

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -509,6 +509,9 @@ function globStatusIcon(uiTheme: Theme): string {
 
 export const globToolRenderer = {
 	inline: true,
+	// Execution emits growing partial file-list snapshots that settle to a
+	// different final list topology; force one viewport repaint at settlement.
+	forceResultViewportRepaintOnSettle: true,
 	renderCall(args: GlobRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const meta: string[] = [];
 		if (args.limit !== undefined) meta.push(`limit:${args.limit}`);

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -537,6 +537,10 @@ function toLaunchArgs(args: HubRenderArgs | undefined): LaunchRenderArgs {
 export const hubToolRenderer = {
 	inline: true,
 	mergeCallAndResult: true,
+	// Only `wait` emits partials; its live wait frame settles to a different
+	// final topology, so force one viewport repaint at settlement. Safe for the
+	// other ops because settlement still requires an actual painted partial.
+	forceResultViewportRepaintOnSettle: true,
 	// Only launch pending frames consume the spinner (broker RPC in flight);
 	// messaging/job pending frames are static, exactly as before the merge.
 	animatedPendingPreview: (args: unknown): boolean => isLaunchStyleArgs(args as HubRenderArgs | undefined),

--- a/packages/coding-agent/src/tools/vibe.ts
+++ b/packages/coding-agent/src/tools/vibe.ts
@@ -485,6 +485,10 @@ export function createVibeToolRenderer(op: VibeOp) {
 		mergeCallAndResult: true,
 		animatedPendingPreview: composerOp,
 		animatedPartialResult: op === "wait",
+		// Only `vibe_wait` emits partials (the live TV wall) that settle to a
+		// different final topology; force one viewport repaint at settlement for
+		// that op alone.
+		forceResultViewportRepaintOnSettle: op === "wait",
 
 		renderCall(args: VibeRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 			const title = uiTheme.fg("muted", `vibe ${describeCall(op, args)}`);

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1585,6 +1585,10 @@ export const writeToolRenderer = {
 		});
 	},
 	mergeCallAndResult: true,
+	// The streaming write preview (and delegated xd://xdev device output) settles
+	// from a pending frame to a final framed block whose chrome differs; force
+	// one viewport repaint at settlement.
+	forceResultViewportRepaintOnSettle: true,
 	// The collapsed pending preview follows the streaming edge with a tail
 	// window once the content outgrows it (`… (N earlier lines)` + last rows);
 	// the first partial result re-anchors the frame to the top of the file, so

--- a/packages/coding-agent/test/modes/components/tool-execution-background-task.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-background-task.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import {
+	ToolExecutionComponent,
+	type ToolExecutionUi,
+} from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentProgress, SingleResult, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
-import type { TUI } from "@oh-my-pi/pi-tui";
 
 function progressEntry(description: string): AgentProgress {
 	return {
@@ -71,6 +73,37 @@ function finalSnapshot(output: string): {
 	};
 }
 
+function failedSnapshot(output: string): {
+	content: Array<{ type: string; text: string }>;
+	details: TaskToolDetails;
+	isError: boolean;
+} {
+	const result: SingleResult = {
+		index: 0,
+		id: "Anna",
+		agent: "scout",
+		agentSource: "bundled",
+		task: "investigate the auth flow",
+		exitCode: 1,
+		output,
+		stderr: "",
+		truncated: false,
+		durationMs: 1234,
+		tokens: 10,
+		requests: 1,
+	};
+	return {
+		content: [{ type: "text", text: output }],
+		details: {
+			projectAgentsDir: null,
+			results: [result],
+			totalDurationMs: 1234,
+			async: { state: "failed", jobId: "job-1", type: "task" },
+		},
+		isError: true,
+	};
+}
+
 // Contract under test: a detached (`async.state === "running"`) task block keeps
 // progress rows static, avoids a redraw driver, freezes once a later partial
 // snapshot observes that it left the live region, drops further partial
@@ -89,7 +122,8 @@ describe("ToolExecutionComponent detached task freeze", () => {
 	function makeComponent(live: () => boolean) {
 		const requestRender = vi.fn();
 		const requestComponentRender = vi.fn();
-		const ui = { requestRender, requestComponentRender } as unknown as TUI;
+		const resetDisplay = vi.fn();
+		const ui: ToolExecutionUi = { requestRender, requestComponentRender, resetDisplay };
 		const component = new ToolExecutionComponent(
 			"task",
 			{ agent: "scout", id: "Anna", description: "scout auth", assignment: "investigate the auth flow" },
@@ -97,7 +131,7 @@ describe("ToolExecutionComponent detached task freeze", () => {
 			undefined,
 			ui,
 		);
-		return { component, requestRender, requestComponentRender };
+		return { component, requestRender, requestComponentRender, resetDisplay };
 	}
 
 	it("does not drive redraws while live and keeps progress bytes static", () => {
@@ -138,5 +172,64 @@ describe("ToolExecutionComponent detached task freeze", () => {
 		component.updateResult(finalSnapshot("found it in src/auth.ts"), false);
 		const final = stripVTControlCharacters(component.render(100).join("\n"));
 		expect(final).toContain("found it in src/auth.ts");
+	});
+
+	// Regression: a painted running task can leave the live region and receive its
+	// terminal snapshot as the very next update (no intermediate partial, timer,
+	// or frozen render). The seam retirement must run before settlement
+	// eligibility so the painted partial is absorbed into history and never
+	// destructively resets committed native scrollback.
+	for (const kind of ["completed", "failed"] as const) {
+		it(`applies a ${kind} final directly after the seam with zero settlement resets and no stale render`, () => {
+			let live = true;
+			const { component, resetDisplay, requestRender } = makeComponent(() => live);
+
+			component.updateResult(asyncSnapshot("scouting the auth flow"), true);
+			// The running partial reaches the terminal → live-painted.
+			component.render(100);
+			requestRender.mockClear();
+			resetDisplay.mockClear();
+
+			live = false;
+			const terminal =
+				kind === "completed"
+					? finalSnapshot("found it in src/auth.ts")
+					: failedSnapshot("scan failed in src/auth.ts");
+			component.updateResult(terminal, false);
+
+			// No settlement reset (the seam absorbed the block into history) and no
+			// stale gray partial render before the final content is applied.
+			expect(resetDisplay).not.toHaveBeenCalled();
+			expect(requestRender).not.toHaveBeenCalled();
+			const rendered = stripVTControlCharacters(component.render(100).join("\n"));
+			expect(rendered).toContain("src/auth.ts");
+		});
+	}
+
+	it("freezes and drops a post-seam partial, then applies the final with zero settlement resets", () => {
+		let live = true;
+		const { component, resetDisplay, requestRender } = makeComponent(() => live);
+
+		component.updateResult(asyncSnapshot("scouting the auth flow"), true);
+		// The running partial reaches the terminal → live-painted.
+		component.render(100);
+		resetDisplay.mockClear();
+
+		// Left the live region: the next partial freezes the block to static gray,
+		// is dropped, and requests exactly one render.
+		live = false;
+		requestRender.mockClear();
+		component.updateResult(asyncSnapshot("a much newer description"), true);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+		const frozen = stripVTControlCharacters(component.render(100).join("\n"));
+		expect(frozen).toContain("scouting the auth flow");
+		expect(frozen).not.toContain("a much newer description");
+
+		// The terminal snapshot settles the block; no settlement reset fires at any
+		// point after the painted partial.
+		component.updateResult(finalSnapshot("found it in src/auth.ts"), false);
+		const final = stripVTControlCharacters(component.render(100).join("\n"));
+		expect(final).toContain("found it in src/auth.ts");
+		expect(resetDisplay).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -9,6 +9,19 @@ import type { TUI } from "@oh-my-pi/pi-tui";
 // must keep the spinner glyph tied to the shared tool-frame ticker. This covers
 // both the shared ToolExecutionComponent interval and renderer-local caches that
 // would otherwise keep serving the first pending frame.
+
+function makeTuiStub() {
+	const requestRender = vi.fn();
+	const requestComponentRender = vi.fn();
+	const resetDisplay = vi.fn();
+	return {
+		requestRender,
+		requestComponentRender,
+		resetDisplay,
+		ui: { requestRender, requestComponentRender, resetDisplay } as unknown as TUI,
+	};
+}
+
 describe("ToolExecutionComponent live preview spinners", () => {
 	beforeAll(async () => {
 		await initTheme();
@@ -21,14 +34,13 @@ describe("ToolExecutionComponent live preview spinners", () => {
 
 	it("animates the eval pending cell while the call is live", () => {
 		vi.useFakeTimers();
-		const requestRender = vi.fn();
-		const requestComponentRender = vi.fn();
+		const { ui, requestRender, requestComponentRender } = makeTuiStub();
 		const component = new ToolExecutionComponent(
 			"eval",
 			{ language: "py", code: "import time\ntime.sleep(10)" },
 			{},
 			undefined,
-			{ requestRender, requestComponentRender } as unknown as TUI,
+			ui,
 			process.cwd(),
 		);
 
@@ -49,16 +61,8 @@ describe("ToolExecutionComponent live preview spinners", () => {
 
 	it("does not tick headerless bash pending previews", () => {
 		vi.useFakeTimers();
-		const requestRender = vi.fn();
-		const requestComponentRender = vi.fn();
-		const component = new ToolExecutionComponent(
-			"bash",
-			{ command: "sleep 600" },
-			{},
-			undefined,
-			{ requestRender, requestComponentRender } as unknown as TUI,
-			process.cwd(),
-		);
+		const { ui, requestRender, requestComponentRender } = makeTuiStub();
+		const component = new ToolExecutionComponent("bash", { command: "sleep 600" }, {}, undefined, ui, process.cwd());
 
 		try {
 			requestRender.mockClear();
@@ -73,14 +77,13 @@ describe("ToolExecutionComponent live preview spinners", () => {
 
 	it("does not tick detached async bash result snapshots", () => {
 		vi.useFakeTimers();
-		const requestRender = vi.fn();
-		const requestComponentRender = vi.fn();
+		const { ui, requestRender, requestComponentRender } = makeTuiStub();
 		const component = new ToolExecutionComponent(
 			"bash",
 			{ command: "sleep 600", async: true },
 			{},
 			undefined,
-			{ requestRender, requestComponentRender } as unknown as TUI,
+			ui,
 			process.cwd(),
 		);
 
@@ -107,14 +110,13 @@ describe("ToolExecutionComponent live preview spinners", () => {
 
 	it("does not tick github pending previews whose Text is materialized per rebuild", () => {
 		vi.useFakeTimers();
-		const requestRender = vi.fn();
-		const requestComponentRender = vi.fn();
+		const { ui, requestRender, requestComponentRender } = makeTuiStub();
 		const component = new ToolExecutionComponent(
 			"github",
 			{ op: "run_watch", run: "12345" },
 			{},
 			undefined,
-			{ requestRender, requestComponentRender } as unknown as TUI,
+			ui,
 			process.cwd(),
 		);
 
@@ -131,19 +133,11 @@ describe("ToolExecutionComponent live preview spinners", () => {
 
 	it("does not tick custom tools whose pending label is a static tool-name Text", () => {
 		vi.useFakeTimers();
-		const requestRender = vi.fn();
-		const requestComponentRender = vi.fn();
+		const { ui, requestRender, requestComponentRender } = makeTuiStub();
 		// A renderResult-only custom tool renders the static tool-name label
 		// while pending, so the spinner interval must not start.
 		const tool = { name: "ext_tool", renderResult: () => undefined };
-		const component = new ToolExecutionComponent(
-			"ext_tool",
-			{ input: 1 },
-			{},
-			tool as never,
-			{ requestRender, requestComponentRender } as unknown as TUI,
-			process.cwd(),
-		);
+		const component = new ToolExecutionComponent("ext_tool", { input: 1 }, {}, tool as never, ui, process.cwd());
 
 		try {
 			requestRender.mockClear();
@@ -157,14 +151,7 @@ describe("ToolExecutionComponent live preview spinners", () => {
 	});
 
 	it("pins the live vibe_wait wall and releases it after the final result", () => {
-		const component = new ToolExecutionComponent(
-			"vibe_wait",
-			{},
-			{},
-			undefined,
-			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
-			process.cwd(),
-		);
+		const component = new ToolExecutionComponent("vibe_wait", {}, {}, undefined, makeTuiStub().ui, process.cwd());
 		const transcript = new TranscriptContainer();
 		transcript.addChild(component);
 
@@ -192,7 +179,7 @@ describe("ToolExecutionComponent live preview spinners", () => {
 			{ op: "wait" },
 			{},
 			undefined,
-			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+			makeTuiStub().ui,
 			process.cwd(),
 		);
 		const transcript = new TranscriptContainer();

--- a/packages/coding-agent/test/tool-execution-custom-repaint.test.ts
+++ b/packages/coding-agent/test/tool-execution-custom-repaint.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import { toolRenderers } from "@oh-my-pi/pi-coding-agent/tools/renderers";
 import { type Component, Text, TUI } from "@oh-my-pi/pi-tui";
 import { StressRenderScheduler } from "../../tui/test/render-stress-scheduler";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
@@ -159,13 +159,18 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 		vi.restoreAllMocks();
 	});
 
-	function makeComponent(args: unknown, tool: AgentTool | undefined = makeFakeTool()) {
+	/** Builds a component on a stub TUI, exposing the reset spy the seams assert on. */
+	function makeComponentFor(toolName: string, args: unknown, tool: AgentTool | undefined) {
 		const resetDisplay = vi.fn();
 		const ui = { requestRender() {}, requestComponentRender() {}, resetDisplay } as unknown as TUI;
-		const component = new ToolExecutionComponent("fake_device", args, {}, tool, ui);
+		const component = new ToolExecutionComponent(toolName, args, {}, tool, ui);
 		components.push(component);
 		resetDisplay.mockClear();
 		return { component, resetDisplay };
+	}
+
+	function makeComponent(args: unknown, tool: AgentTool | undefined = makeFakeTool()) {
+		return makeComponentFor("fake_device", args, tool);
 	}
 
 	it("forces a viewport repaint when a painted streamed placeholder receives its first result", () => {
@@ -404,39 +409,50 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 		expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Output final output");
 	});
 
-	it("opts exactly the topology-changing built-in renderers into settlement repaint", () => {
-		const flagged = Object.keys(toolRenderers)
-			.filter(name => toolRenderers[name]?.forceResultViewportRepaintOnSettle === true)
-			.sort();
-		expect(flagged).toEqual([
-			"apply_patch",
-			"bash",
-			"edit",
-			"eval",
-			"github",
-			"glob",
-			"hub",
-			"task",
-			"vibe_wait",
-			"write",
-		]);
-		// edit and apply_patch share one renderer object.
-		expect(toolRenderers.edit).toBe(toolRenderers.apply_patch);
-		// Non-wait vibe ops and search/read-like tools stay opted out.
-		for (const name of [
-			"vibe_spawn",
-			"vibe_send",
-			"vibe_list",
-			"vibe_kill",
-			"read",
-			"grep",
-			"todo",
-			"browser",
-			"debug",
-		]) {
-			expect(toolRenderers[name]?.forceResultViewportRepaintOnSettle ?? false).toBe(false);
-		}
+	it("makes a result that arrives after seal visible in the committed transcript", () => {
+		const container = new TranscriptContainer();
+		const { component } = makeComponent({ host: "router", command: "uptime" });
+		container.addChild(component);
+
+		component.updateResult(toolResult("partial output"), true);
+		expect(Bun.stripANSI(container.render(80).join("\n"))).toContain("provisional partial output");
+
+		// An abort/rewind seals the block. Its finalized rows then reach native
+		// scrollback, so the transcript replays them instead of re-rendering the
+		// child — the state in which a late result used to stay invisible.
+		component.seal();
+		const sealedRows = container.render(80);
+		container.setNativeScrollbackCommittedRows(sealedRows.length);
+		expect(container.render(80)).toEqual(sealedRows);
+
+		// The tool's terminal result still lands afterwards.
+		component.updateResult(toolResult("final output"), false);
+
+		expect(Bun.stripANSI(container.render(80).join("\n"))).toContain("Output final output");
 	});
+
+	// Settlement repaint is a rendering contract, not a registry shape: a
+	// height-changing settle resets the viewport for a renderer that opted in
+	// and leaves the in-place path alone for one that did not.
+	for (const [toolName, args, settles] of [
+		["bash", { command: "uptime" }, true],
+		["grep", { pattern: "needle" }, false],
+	] as const) {
+		it(`${settles ? "settles" : "does not settle"} a height-changing final for the ${toolName} renderer`, () => {
+			const { component, resetDisplay } = makeComponentFor(toolName, args, undefined);
+			component.updateResult(multilineResult("prov", 20), true);
+			const paintedPartialHeight = component.render(80).length;
+			resetDisplay.mockClear();
+
+			component.updateResult(multilineResult("fin", 4), false);
+
+			// Both renderers really do change height here, so the opted-out case
+			// is a decision to stay in place rather than a settle that never had
+			// anything to compare.
+			expect(component.render(80).length).not.toBe(paintedPartialHeight);
+			expect(resetDisplay).toHaveBeenCalledTimes(settles ? 1 : 0);
+		});
+	}
 
 	it("emits exactly one ED3 and leaves one final block on a direct terminal when a long partial settles", async () => {
 		await withSettlementEnv({ TERM: "xterm-256color" }, async () => {

--- a/packages/coding-agent/test/tool-execution-custom-repaint.test.ts
+++ b/packages/coding-agent/test/tool-execution-custom-repaint.test.ts
@@ -197,15 +197,29 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 		expect(resetDisplay).not.toHaveBeenCalled();
 	});
 
-	it("forces a viewport repaint when a painted provisional partial result settles", () => {
+	it("forces a viewport repaint when a painted provisional partial result settles to a different height", () => {
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
+		component.updateResult(multilineResult("prov", 20), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		component.updateResult(multilineResult("fin", 4), false);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not resetDisplay when a painted partial settles at the same rendered height", () => {
 		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
 		component.updateResult(toolResult("partial output"), true);
 		component.render(80);
 		resetDisplay.mockClear();
 
+		// Same single-line result chrome height as the provisional frame — settle
+		// must keep the ordinary in-place repaint path (no ED3 scrollback wipe).
 		component.updateResult(toolResult("final output"), false);
 
-		expect(resetDisplay).toHaveBeenCalledTimes(1);
+		expect(resetDisplay).not.toHaveBeenCalled();
+		expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Output final output");
 	});
 
 	it("does not repaint when the provisional partial result never reaches the terminal", () => {
@@ -303,14 +317,14 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 
 	it("settles exactly once when a painted partial coalesces with a newer partial before the final", () => {
 		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
-		component.updateResult(toolResult("partial 1"), true);
+		component.updateResult(multilineResult("prov", 20), true);
 		// Partial 1 reaches the terminal → live-painted.
 		component.render(80);
 		resetDisplay.mockClear();
 		// A newer partial coalesces in without its own render; the paint evidence
 		// from partial 1 must survive so the final still settles once.
-		component.updateResult(toolResult("partial 2"), true);
-		component.updateResult(toolResult("final output"), false);
+		component.updateResult(multilineResult("prov", 20), true);
+		component.updateResult(multilineResult("fin", 4), false);
 
 		expect(resetDisplay).toHaveBeenCalledTimes(1);
 	});
@@ -327,19 +341,19 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 
 	it("keeps the settlement reset count at one across a duplicate success final", () => {
 		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
-		component.updateResult(toolResult("partial output"), true);
+		component.updateResult(multilineResult("prov", 20), true);
 		component.render(80);
 		resetDisplay.mockClear();
 
-		component.updateResult(toolResult("final output"), false);
-		component.updateResult(toolResult("final output"), false);
+		component.updateResult(multilineResult("fin", 4), false);
+		component.updateResult(multilineResult("fin", 4), false);
 
 		expect(resetDisplay).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps the settlement reset count at one across a duplicate error final", () => {
 		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
-		component.updateResult(toolResult("partial output"), true);
+		component.updateResult(multilineResult("prov", 20), true);
 		component.render(80);
 		resetDisplay.mockClear();
 

--- a/packages/coding-agent/test/tool-execution-custom-repaint.test.ts
+++ b/packages/coding-agent/test/tool-execution-custom-repaint.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { toolRenderers } from "@oh-my-pi/pi-coding-agent/tools/renderers";
 import { type Component, Text, TUI } from "@oh-my-pi/pi-tui";
 import { StressRenderScheduler } from "../../tui/test/render-stress-scheduler";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
@@ -43,6 +44,29 @@ function makeFakeTool(): AgentTool {
 	return tool as unknown as AgentTool;
 }
 
+/**
+ * Fake tool with an overridden settlement flag. Aliases the fake tool through a
+ * view whose only member is the optional ad-hoc flag the component reads by
+ * shape, so no cast is needed and the mutation lands on the shared object.
+ */
+function makeFakeToolWithSettleFlag(flag: boolean | undefined): AgentTool {
+	const tool = makeFakeTool();
+	Object.assign(tool, { forceResultViewportRepaintOnSettle: flag });
+	return tool;
+}
+
+/**
+ * A result whose text is `rowCount` distinctly-prefixed lines. The fake tool's
+ * renderResult renders it as one row per line (`provisional <prefix>-0` … and
+ * `Output <prefix>-0` …), so a partial can overflow the viewport while its
+ * final settles to a shorter, distinctly-marked block.
+ */
+function multilineResult(prefix: string, rowCount: number) {
+	return {
+		content: [{ type: "text", text: Array.from({ length: rowCount }, (_unused, i) => `${prefix}-${i}`).join("\n") }],
+	};
+}
+
 class Footer implements Component {
 	constructor(readonly rows: number) {}
 	invalidate(): void {}
@@ -62,6 +86,66 @@ async function drain(scheduler: StressRenderScheduler, term: VirtualTerminal): P
 	await scheduler.drain(term);
 }
 
+function plainViewport(term: VirtualTerminal): string[] {
+	return term
+		.getViewport()
+		.map(row => Bun.stripANSI(row).trimEnd())
+		.filter(Boolean);
+}
+
+function captureWrites(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	vi.spyOn(term, "write").mockImplementation((data: string) => {
+		writes.push(data);
+		realWrite(data);
+	});
+	return writes;
+}
+
+function ed3Count(writes: string[]): number {
+	return (writes.join("").match(/\x1b\[3J/g) ?? []).length;
+}
+
+// Every multiplexer marker `isInsideTerminalMultiplexer` honours, plus TERM
+// (which it inspects as a fallback). Snapshot/clear/restore all seven so a
+// direct-terminal case is host-independent even under an inherited mux/TERM,
+// and a mux case sets only its own marker.
+const MULTIPLEXER_ENV_KEYS = [
+	"TERM",
+	"TMUX",
+	"STY",
+	"ZELLIJ",
+	"CMUX_WORKSPACE_ID",
+	"CMUX_SURFACE_ID",
+	"CMUX_REMOTE_TRANSPORT",
+];
+
+async function withSettlementEnv(
+	overrides: Record<string, string | undefined>,
+	run: () => Promise<void>,
+): Promise<void> {
+	const saved: Record<string, string | undefined> = {};
+	for (const key of MULTIPLEXER_ENV_KEYS) {
+		saved[key] = Bun.env[key];
+		delete Bun.env[key];
+	}
+	for (const key in overrides) {
+		const value = overrides[key];
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
+	try {
+		await run();
+	} finally {
+		for (const key of MULTIPLEXER_ENV_KEYS) {
+			const value = saved[key];
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+	}
+}
+
 describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 	const components: ToolExecutionComponent[] = [];
 
@@ -75,10 +159,10 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 		vi.restoreAllMocks();
 	});
 
-	function makeComponent(args: unknown) {
+	function makeComponent(args: unknown, tool: AgentTool | undefined = makeFakeTool()) {
 		const resetDisplay = vi.fn();
 		const ui = { requestRender() {}, requestComponentRender() {}, resetDisplay } as unknown as TUI;
-		const component = new ToolExecutionComponent("fake_device", args, {}, makeFakeTool(), ui);
+		const component = new ToolExecutionComponent("fake_device", args, {}, tool, ui);
 		components.push(component);
 		resetDisplay.mockClear();
 		return { component, resetDisplay };
@@ -216,4 +300,228 @@ describe("ToolExecutionComponent custom-renderer repaint seams", () => {
 			await term.flush();
 		}
 	});
+
+	it("settles exactly once when a painted partial coalesces with a newer partial before the final", () => {
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
+		component.updateResult(toolResult("partial 1"), true);
+		// Partial 1 reaches the terminal → live-painted.
+		component.render(80);
+		resetDisplay.mockClear();
+		// A newer partial coalesces in without its own render; the paint evidence
+		// from partial 1 must survive so the final still settles once.
+		component.updateResult(toolResult("partial 2"), true);
+		component.updateResult(toolResult("final output"), false);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not settle when no partial ever reaches the terminal before the final", () => {
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
+		component.updateResult(toolResult("partial 1"), true);
+		component.updateResult(toolResult("partial 2"), true);
+		// No render between any partial and the final: no paint evidence armed.
+		component.updateResult(toolResult("final output"), false);
+
+		expect(resetDisplay).not.toHaveBeenCalled();
+	});
+
+	it("keeps the settlement reset count at one across a duplicate success final", () => {
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
+		component.updateResult(toolResult("partial output"), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		component.updateResult(toolResult("final output"), false);
+		component.updateResult(toolResult("final output"), false);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the settlement reset count at one across a duplicate error final", () => {
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
+		component.updateResult(toolResult("partial output"), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		const errorFinal = { content: [{ type: "text", text: "boom" }], isError: true };
+		component.updateResult(errorFinal, false);
+		component.updateResult(errorFinal, false);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not settle a painted partial for a stable (unflagged) renderer", () => {
+		const stable = makeFakeToolWithSettleFlag(undefined);
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" }, stable);
+		component.updateResult(toolResult("partial output"), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		component.updateResult(toolResult("final output"), false);
+
+		expect(resetDisplay).not.toHaveBeenCalled();
+	});
+
+	it("does not settle a painted partial when the tool sets forceResultViewportRepaintOnSettle false", () => {
+		const disabled = makeFakeToolWithSettleFlag(false);
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" }, disabled);
+		component.updateResult(toolResult("partial output"), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		component.updateResult(toolResult("final output"), false);
+
+		expect(resetDisplay).not.toHaveBeenCalled();
+	});
+
+	it("does not settle a painted partial after seal and keeps the late final renderable", () => {
+		const { component, resetDisplay } = makeComponent({ host: "router", command: "uptime" });
+		component.updateResult(toolResult("partial output"), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		// seal() enters the absorbing history state; a render after seal cannot
+		// revive paint evidence into a late destructive reset.
+		component.seal();
+		component.render(80);
+		component.updateResult(toolResult("final output"), false);
+
+		expect(resetDisplay).not.toHaveBeenCalled();
+		expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Output final output");
+	});
+
+	it("opts exactly the topology-changing built-in renderers into settlement repaint", () => {
+		const flagged = Object.keys(toolRenderers)
+			.filter(name => toolRenderers[name]?.forceResultViewportRepaintOnSettle === true)
+			.sort();
+		expect(flagged).toEqual([
+			"apply_patch",
+			"bash",
+			"edit",
+			"eval",
+			"github",
+			"glob",
+			"hub",
+			"task",
+			"vibe_wait",
+			"write",
+		]);
+		// edit and apply_patch share one renderer object.
+		expect(toolRenderers.edit).toBe(toolRenderers.apply_patch);
+		// Non-wait vibe ops and search/read-like tools stay opted out.
+		for (const name of [
+			"vibe_spawn",
+			"vibe_send",
+			"vibe_list",
+			"vibe_kill",
+			"read",
+			"grep",
+			"todo",
+			"browser",
+			"debug",
+		]) {
+			expect(toolRenderers[name]?.forceResultViewportRepaintOnSettle ?? false).toBe(false);
+		}
+	});
+
+	it("emits exactly one ED3 and leaves one final block on a direct terminal when a long partial settles", async () => {
+		await withSettlementEnv({ TERM: "xterm-256color" }, async () => {
+			const term = new VirtualTerminal(48, 10, 2_000);
+			const scheduler = new StressRenderScheduler();
+			const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+			const resetSpy = vi.spyOn(tui, "resetDisplay");
+			const writes = captureWrites(term);
+			const component = new ToolExecutionComponent(
+				"fake_device",
+				{ host: "router", command: "uptime" },
+				{},
+				makeFakeTool(),
+				tui,
+			);
+			components.push(component);
+			tui.addChild(component);
+			tui.addChild(new Footer(2));
+
+			try {
+				tui.start();
+				await drain(scheduler, term);
+
+				// A long partial overflows the 10-row viewport → rows commit to
+				// native scrollback.
+				component.updateResult(multilineResult("prov", 20), true);
+				tui.requestRender();
+				await drain(scheduler, term);
+				expect(plainBuffer(term).some(row => row.includes("prov-0"))).toBe(true);
+				resetSpy.mockClear();
+
+				// The coalesced newer partial and the shorter final drain together.
+				component.updateResult(multilineResult("prov", 20), true);
+				component.updateResult(multilineResult("fin", 4), false);
+				tui.requestRender();
+				await drain(scheduler, term);
+
+				expect(resetSpy).toHaveBeenCalledTimes(1);
+				expect(ed3Count(writes)).toBe(1);
+				const tape = plainBuffer(term);
+				expect(tape.some(row => row.includes("prov-"))).toBe(false);
+				expect(tape.filter(row => row.includes("fin-0"))).toHaveLength(1);
+				expect(tape.some(row => row.includes("fin-3"))).toBe(true);
+			} finally {
+				tui.stop();
+				await term.flush();
+			}
+		});
+	});
+
+	for (const [label, muxEnv] of [
+		["tmux", { TMUX: "1" }],
+		["screen", { STY: "1234.pts-0" }],
+		["zellij", { ZELLIJ: "0" }],
+	] as const) {
+		it(`settles once without ED3 and shows one final block under ${label}`, async () => {
+			await withSettlementEnv(muxEnv, async () => {
+				const term = new VirtualTerminal(48, 10, 2_000);
+				const scheduler = new StressRenderScheduler();
+				const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+				const resetSpy = vi.spyOn(tui, "resetDisplay");
+				const writes = captureWrites(term);
+				const component = new ToolExecutionComponent(
+					"fake_device",
+					{ host: "router", command: "uptime" },
+					{},
+					makeFakeTool(),
+					tui,
+				);
+				components.push(component);
+				tui.addChild(component);
+				tui.addChild(new Footer(2));
+
+				try {
+					tui.start();
+					await drain(scheduler, term);
+
+					component.updateResult(multilineResult("prov", 20), true);
+					tui.requestRender();
+					await drain(scheduler, term);
+					resetSpy.mockClear();
+
+					component.updateResult(multilineResult("prov", 20), true);
+					component.updateResult(multilineResult("fin", 4), false);
+					tui.requestRender();
+					await drain(scheduler, term);
+
+					// The component still requests exactly one reset, but the mux
+					// path never emits ED3 (native pane history is not destroyed).
+					expect(resetSpy).toHaveBeenCalledTimes(1);
+					expect(ed3Count(writes)).toBe(0);
+					const view = plainViewport(term);
+					expect(view.some(row => row.includes("prov-"))).toBe(false);
+					expect(view.some(row => row.includes("fin-0"))).toBe(true);
+				} finally {
+					tui.stop();
+					await term.flush();
+				}
+			});
+		});
+	}
 });

--- a/packages/coding-agent/test/tool-execution-write-repaint.test.ts
+++ b/packages/coding-agent/test/tool-execution-write-repaint.test.ts
@@ -137,4 +137,46 @@ describe("ToolExecutionComponent write repaint seam", () => {
 			await term.flush();
 		}
 	});
+
+	it("forces one viewport repaint when a painted write partial settles into its final", () => {
+		// 12 lines fit the streaming window, so the first result never re-anchors
+		// (no first-result repaint). This isolates the partial -> final settlement
+		// repaint driven by forceResultViewportRepaintOnSettle.
+		const { component, resetDisplay } = makeComponent(writeArgs(12));
+		component.updateResult(partialWriteResult(), true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		component.updateResult({ content: [{ type: "text", text: "Wrote notes.txt" }] }, false);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not repaint a painted write partial that fits the window and never settles a topology change", () => {
+		// Pending-tail coverage remains: a 12-line preview neither re-anchors on
+		// its first result nor, without a subsequent settle, resets again.
+		const { component, resetDisplay } = makeComponent(writeArgs(12));
+		component.render(80);
+
+		component.updateResult(partialWriteResult(), true);
+
+		expect(resetDisplay).not.toHaveBeenCalled();
+	});
+
+	it("settles a delegated xd://glob device result through the outer write renderer exactly once", () => {
+		const { component, resetDisplay } = makeComponent({ path: "xd://glob", content: "**/*.ts" });
+		const dispatch = { tool: "glob", mode: "execute", args: { paths: ["**/*.ts"] } };
+		component.updateResult({ content: [{ type: "text", text: "scanning…" }], details: { xdev: dispatch } }, true);
+		component.render(80);
+		resetDisplay.mockClear();
+
+		component.updateResult(
+			{ content: [{ type: "text", text: "src/a.ts\nsrc/b.ts" }], details: { xdev: dispatch } },
+			false,
+		);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+		// The delegated device output is rendered inside the outer write block.
+		expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("src/a.ts");
+	});
 });


### PR DESCRIPTION
Closes #6466

## What changed

- Edit renderer definitions for the partial producers named in Approach 5, `packages/coding-agent/src/modes/components/tool-execution.ts` only if its existing painted-shape gate needs correction, and the transcript/tool-execution regression tests. Do not edit the TUI committed-prefix/no-loss algorithm.
- Add `Fixed mutable tool progress duplicating or overlapping final output after settlement ([#6466](https://github.com/can1357/oh-my-pi/issues/6466)).` to `packages/coding-agent/CHANGELOG.md` `[Unreleased] / Fixed`.

## Verification

- `bun install --frozen-lockfile`
- `bun run build:native`
- `bun test packages/coding-agent/test/tool-execution-custom-repaint.test.ts packages/coding-agent/test/tool-execution-write-repaint.test.ts packages/coding-agent/test/modes/components/tool-execution-background-task.test.ts packages/coding-agent/test/transcript-streaming-commit-repro.test.ts packages/coding-agent/test/transcript-history-exactly-once.test.ts packages/coding-agent/test/tools/eval-agent-progress.test.ts packages/coding-agent/test/task/task-progress-render.test.ts packages/coding-agent/test/interactive-mode-status.test.ts packages/coding-agent/test/streaming-reveal.test.ts`
- `bun run check:ts`
