### PR TITLE
fix(coding-agent): preserved Unicode in file tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed file-writing tools replacing malformed Unicode arguments with replacement characters ([#6464](https://github.com/can1357/oh-my-pi/issues/6464)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -26,6 +26,7 @@ import { outputMeta } from "../../tools/output-meta";
 import { ToolError } from "../../tools/tool-errors";
 import { generateDiffString } from "../diff";
 import { getFileSnapshotStore } from "../file-snapshot-store";
+import { formatEscapedCodeUnitsNotice } from "../read-file";
 import type { EditToolDetails, EditToolPerFileResult, LspBatchRequest } from "../renderer";
 import { pruneOversizedEditSnapshots } from "../snapshot-details";
 import { nativeBlockResolver } from "./block-resolver";
@@ -158,13 +159,16 @@ function renderSection(
 			? `\n${result.blockResolutions.map(formatBlockResolution).join("\n")}`
 			: "";
 	const moveBlock = result.moveDest ? `\nMoved to ${result.moveDest}` : "";
+	const noticePath = result.moveDest ?? result.path;
+	const escapeBlock =
+		result.escapedCodeUnits > 0 ? `\n${formatEscapedCodeUnitsNotice(result.escapedCodeUnits, noticePath)}` : "";
 	const firstChangedLine = result.firstChangedLine ?? diff.firstChangedLine;
 	return {
 		toolResult: {
 			content: [
 				{
 					type: "text",
-					text: `${result.header}${blockBlock}${moveBlock}${previewBlock}${warningsBlock}`,
+					text: `${result.header}${blockBlock}${moveBlock}${previewBlock}${warningsBlock}${escapeBlock}`,
 				},
 			],
 			details: pruneOversizedEditSnapshots({
@@ -177,6 +181,7 @@ function renderSection(
 				sourcePath: result.moveDest ? sourcePath : undefined,
 				oldText: result.before,
 				newText: result.after,
+				escapedCodeUnits: result.escapedCodeUnits,
 				meta,
 			}),
 		},
@@ -190,6 +195,7 @@ function renderSection(
 			sourcePath: result.moveDest ? sourcePath : undefined,
 			oldText: result.before,
 			newText: result.after,
+			escapedCodeUnits: result.escapedCodeUnits,
 		}),
 	};
 }
@@ -273,6 +279,7 @@ export async function executeHashlineSingle(
 		details: pruneOversizedEditSnapshots({
 			diff: rendered.map(r => r.toolResult.details?.diff ?? "").join("\n"),
 			perFileResults: rendered.map(r => r.perFileResult),
+			escapedCodeUnits: rendered.reduce((sum, r) => sum + (r.perFileResult.escapedCodeUnits ?? 0), 0),
 		}),
 	};
 }

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -159,11 +159,12 @@ export class HashlineFilesystem extends Filesystem {
 			throw error;
 		}
 		if (this.session.enableLsp ?? true) {
-			await notifyWorkspaceWatchedFiles(
-				this.session.cwd,
-				[{ filePath: absolutePath, type: FileChangeType.Deleted }],
-				this.#signal,
-			);
+			// Same ordering guarantee as `move`: the file is already gone and the
+			// caller invalidates its snapshot next, so no abortable step may sit
+			// between the physical removal and that bookkeeping.
+			await notifyWorkspaceWatchedFiles(this.session.cwd, [
+				{ filePath: absolutePath, type: FileChangeType.Deleted },
+			]);
 		}
 		invalidateFsScanAfterWrite(absolutePath);
 	}
@@ -187,14 +188,16 @@ export class HashlineFilesystem extends Filesystem {
 			await fs.rename(fromAbsolute, toAbsolute);
 		}
 		if (this.session.enableLsp ?? true) {
-			await notifyWorkspaceWatchedFiles(
-				this.session.cwd,
-				[
-					{ filePath: fromAbsolute, type: FileChangeType.Deleted },
-					{ filePath: toAbsolute, type: FileChangeType.Created },
-				],
-				this.#signal,
-			);
+			// The bytes have already moved and the caller relocates snapshot
+			// ownership the instant this resolves, so nothing after the physical
+			// move may abort: an AbortError here would strand the file at its new
+			// path with the snapshot still keyed to the old one, and the next read
+			// would tag against a stale snapshot. The notification is bounded by
+			// its own internal timeout, so dropping the signal cannot hang.
+			await notifyWorkspaceWatchedFiles(this.session.cwd, [
+				{ filePath: fromAbsolute, type: FileChangeType.Deleted },
+				{ filePath: toAbsolute, type: FileChangeType.Created },
+			]);
 		}
 		invalidateFsScanAfterWrite(fromAbsolute);
 		invalidateFsScanAfterWrite(toAbsolute);

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -168,13 +168,21 @@ export class HashlineFilesystem extends Filesystem {
 		invalidateFsScanAfterWrite(absolutePath);
 	}
 
-	async move(fromRelative: string, toRelative: string, content?: string): Promise<void> {
+	async move(fromRelative: string, toRelative: string, content: string): Promise<WriteResult>;
+	async move(fromRelative: string, toRelative: string, content?: undefined): Promise<undefined>;
+	async move(fromRelative: string, toRelative: string, content?: string): Promise<WriteResult | undefined> {
 		enforcePlanModeWrite(this.session, fromRelative, { op: "update", move: toRelative });
 		const fromAbsolute = this.resolveAbsolute(fromRelative);
 		const toAbsolute = this.resolveAbsolute(toRelative);
+		let result: WriteResult | undefined;
 		if (content !== undefined) {
-			await Bun.write(toAbsolute, content);
+			// Destination extension decides the physical format; the source is a
+			// metadata template only when both ends are notebooks. Write the
+			// destination first so a failure leaves the source intact.
+			const prepared = await serializeEditFileText(fromAbsolute, toAbsolute, toRelative, content);
+			await Bun.write(toAbsolute, prepared.content);
 			await fs.rm(fromAbsolute);
+			result = { text: prepared.editContent, escapedCodeUnits: prepared.escapedCodeUnits };
 		} else {
 			await fs.rename(fromAbsolute, toAbsolute);
 		}
@@ -190,22 +198,23 @@ export class HashlineFilesystem extends Filesystem {
 		}
 		invalidateFsScanAfterWrite(fromAbsolute);
 		invalidateFsScanAfterWrite(toAbsolute);
+		return result;
 	}
 
 	async writeText(relativePath: string, content: string): Promise<WriteResult> {
 		await this.preflightWrite(relativePath);
 		const absolutePath = this.resolveAbsolute(relativePath);
-		const finalContent = await serializeEditFileText(absolutePath, relativePath, content);
+		const prepared = await serializeEditFileText(absolutePath, absolutePath, relativePath, content);
 
 		// Route through ACP bridge when available; skips internal artifacts.
-		if (await routeWriteThroughBridge(this.session, relativePath, absolutePath, finalContent, this.#signal)) {
+		if (await routeWriteThroughBridge(this.session, relativePath, absolutePath, prepared.content, this.#signal)) {
 			this.#diagnosticsByPath.set(relativePath, undefined);
-			return { text: finalContent };
+			return { text: prepared.editContent, escapedCodeUnits: prepared.escapedCodeUnits };
 		}
 
 		const diagnostics = await this.#writethrough(
 			absolutePath,
-			finalContent,
+			prepared.content,
 			this.#signal,
 			Bun.file(absolutePath),
 			this.#batchRequest,
@@ -213,7 +222,7 @@ export class HashlineFilesystem extends Filesystem {
 		);
 		invalidateFsScanAfterWrite(absolutePath);
 		this.#diagnosticsByPath.set(relativePath, diagnostics);
-		return { text: finalContent };
+		return { text: prepared.editContent, escapedCodeUnits: prepared.escapedCodeUnits };
 	}
 
 	async exists(relativePath: string): Promise<boolean> {

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -182,6 +182,7 @@ async function executeApplyPatchPerFile(
 				oldText: details?.oldText,
 				newText: details?.newText,
 				snapshotsPruned: details?.snapshotsPruned,
+				escapedCodeUnits: details?.escapedCodeUnits,
 			});
 			const text = result.content?.find(c => c.type === "text")?.text ?? "";
 			if (text) contentTexts.push(text);
@@ -233,6 +234,7 @@ async function executeApplyPatchPerFile(
 						.join("\n"),
 					firstChangedLine: perFileResults.find(r => r.firstChangedLine)?.firstChangedLine,
 					perFileResults: [...perFileResults],
+					escapedCodeUnits: perFileResults.reduce((sum, r) => sum + (r.escapedCodeUnits ?? 0), 0),
 				},
 			});
 		}
@@ -247,6 +249,7 @@ async function executeApplyPatchPerFile(
 				.join("\n"),
 			firstChangedLine: perFileResults.find(r => r.firstChangedLine)?.firstChangedLine,
 			perFileResults,
+			escapedCodeUnits: perFileResults.reduce((sum, r) => sum + (r.escapedCodeUnits ?? 0), 0),
 		}),
 		// Any per-file failure marks the aggregate result as an error so the
 		// agent loop and renderer take the error branch instead of treating
@@ -281,6 +284,7 @@ async function executeSinglePathEntries(
 	// would describe a transition the file never made. Suppress aggregate
 	// snapshots and stamp the marker so ACP/downstream can degrade cleanly.
 	let snapshotsPruned = false;
+	let escapedCodeUnits = 0;
 
 	for (let i = 0; i < runs.length; i++) {
 		const isLast = i === runs.length - 1;
@@ -305,6 +309,7 @@ async function executeSinglePathEntries(
 				hasLastNewText = true;
 			}
 			if (details?.snapshotsPruned) snapshotsPruned = true;
+			escapedCodeUnits += details?.escapedCodeUnits ?? 0;
 			const text = result.content?.find(c => c.type === "text")?.text ?? "";
 			if (text) contentTexts.push(text);
 		} catch (err) {
@@ -337,6 +342,7 @@ async function executeSinglePathEntries(
 				details: {
 					diff: diffTexts.join("\n"),
 					firstChangedLine,
+					escapedCodeUnits,
 				},
 				...(hasError ? { isError: true } : {}),
 			});
@@ -355,6 +361,7 @@ async function executeSinglePathEntries(
 						...(hasFirstOldText ? { oldText: firstOldText } : {}),
 						...(hasLastNewText ? { newText: lastNewText } : {}),
 					}),
+			escapedCodeUnits,
 		}),
 		// Any per-entry failure marks the aggregate result as an error so the
 		// renderer takes the error branch instead of falling through to the

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -47,7 +47,12 @@ import {
 	restoreLineEndings,
 	stripBom,
 } from "../normalize";
-import { readEditFileText, serializeEditFileText } from "../read-file";
+import {
+	formatEscapedCodeUnitsNotice,
+	readEditFileText,
+	type SerializedEditFileText,
+	serializeEditFileText,
+} from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
 import { pruneOversizedEditSnapshots } from "../snapshot-details";
 import {
@@ -69,22 +74,52 @@ export interface PatchInput {
 	diff?: string;
 }
 
+export interface PrepareWriteArgs {
+	/** Present for moves so notebook metadata can be templated from the source. */
+	sourcePath?: string;
+	/** Destination path; its extension decides the physical format. */
+	targetPath: string;
+	/** Logical candidate text (BOM + line endings restored). */
+	candidate: string;
+}
+
 export interface FileSystem {
 	exists(path: string): Promise<boolean>;
 	read(path: string): Promise<string>;
 	readBinary?: (path: string) => Promise<Uint8Array>;
+	/** Prepare a finalized write: escape surrogates and (for notebooks) serialize to JSON. Never mutates. */
+	prepareWrite(args: PrepareWriteArgs): Promise<SerializedEditFileText>;
+	/** Effect-only persistence of already-prepared physical `content`. */
 	write(path: string, content: string): Promise<void>;
 	delete(path: string): Promise<void>;
 	mkdir(path: string): Promise<void>;
 }
 
-interface FileChange {
-	type: Operation;
-	path: string;
-	newPath?: string;
-	oldContent?: string;
-	newContent?: string;
-}
+type FileChange =
+	| {
+			type: "create";
+			path: string;
+			newContent: string;
+			prepared: SerializedEditFileText;
+			newPath?: never;
+			oldContent?: never;
+	  }
+	| {
+			type: "update";
+			path: string;
+			newPath?: string;
+			oldContent: string;
+			newContent: string;
+			prepared: SerializedEditFileText;
+	  }
+	| {
+			type: "delete";
+			path: string;
+			oldContent: string;
+			newPath?: never;
+			newContent?: never;
+			prepared?: never;
+	  };
 
 export interface ApplyPatchResult {
 	change: FileChange;
@@ -122,8 +157,11 @@ export const defaultFileSystem: FileSystem = {
 	async readBinary(path: string): Promise<Uint8Array> {
 		return fs.promises.readFile(path);
 	},
+	async prepareWrite({ sourcePath, targetPath, candidate }: PrepareWriteArgs): Promise<SerializedEditFileText> {
+		return serializeEditFileText(sourcePath ?? targetPath, targetPath, targetPath, candidate);
+	},
 	async write(path: string, content: string): Promise<void> {
-		await Bun.write(path, await serializeEditFileText(path, path, content));
+		await Bun.write(path, content);
 	},
 	async delete(path: string): Promise<void> {
 		await fs.promises.unlink(path);
@@ -1531,20 +1569,24 @@ async function applyNormalizedPatch(input: PatchInput, options: ApplyPatchOption
 		// Strip + prefixes if present (handles diffs formatted as additions)
 		const normalizedContent = normalizeCreateContent(input.diff);
 		const content = normalizedContent.endsWith("\n") ? normalizedContent : `${normalizedContent}\n`;
+		// Prepare for both dry-run and commit so preview and final diffs share the
+		// escaped/serialized representation; only the write is gated on !dryRun.
+		const prepared = await fs.prepareWrite({ targetPath: absolutePath, candidate: content });
 
 		if (!dryRun) {
 			const parentDir = path.dirname(absolutePath);
 			if (parentDir && parentDir !== ".") {
 				await fs.mkdir(parentDir);
 			}
-			await fs.write(absolutePath, content);
+			await fs.write(absolutePath, prepared.content);
 		}
 
 		return {
 			change: {
 				type: "create",
 				path: absolutePath,
-				newContent: content,
+				newContent: prepared.editContent,
+				prepared,
 			},
 		};
 	}
@@ -1597,6 +1639,9 @@ async function applyNormalizedPatch(input: PatchInput, options: ApplyPatchOption
 	const finalContent = bom + restoreLineEndings(newContent, lineEnding);
 	const destPath = input.rename ? resolvePath(input.rename) : absolutePath;
 	const isMove = Boolean(input.rename) && destPath !== absolutePath;
+	// The destination extension decides the physical format; source templates
+	// notebook metadata on a move. Prepared in dry-run too for preview parity.
+	const prepared = await fs.prepareWrite({ sourcePath: absolutePath, targetPath: destPath, candidate: finalContent });
 
 	if (!dryRun) {
 		if (isMove) {
@@ -1604,10 +1649,10 @@ async function applyNormalizedPatch(input: PatchInput, options: ApplyPatchOption
 			if (parentDir && parentDir !== ".") {
 				await fs.mkdir(parentDir);
 			}
-			await fs.write(destPath, finalContent);
+			await fs.write(destPath, prepared.content);
 			await fs.delete(absolutePath);
 		} else {
-			await fs.write(absolutePath, finalContent);
+			await fs.write(absolutePath, prepared.content);
 		}
 	}
 
@@ -1617,7 +1662,8 @@ async function applyNormalizedPatch(input: PatchInput, options: ApplyPatchOption
 			path: absolutePath,
 			newPath: isMove ? destPath : undefined,
 			oldContent: originalContent,
-			newContent: finalContent,
+			newContent: prepared.editContent,
+			prepared,
 		},
 		warnings: warnings.length > 0 ? warnings : undefined,
 	};
@@ -1729,11 +1775,14 @@ class LspFileSystem implements FileSystem {
 		return bytes;
 	}
 
-	async write(path: string, content: string): Promise<void> {
-		const finalContent = await serializeEditFileText(path, path, content);
+	async prepareWrite({ sourcePath, targetPath, candidate }: PrepareWriteArgs): Promise<SerializedEditFileText> {
+		return serializeEditFileText(sourcePath ?? targetPath, targetPath, targetPath, candidate);
+	}
 
+	async write(path: string, content: string): Promise<void> {
+		// `content` is already the prepared physical text (escaped, notebook JSON).
 		// Route through ACP bridge when available; skips internal artifacts and local:// paths.
-		if (await routeWriteThroughBridge(this.session, this.requestedPath, path, finalContent, this.signal)) {
+		if (await routeWriteThroughBridge(this.session, this.requestedPath, path, content, this.signal)) {
 			return;
 		}
 
@@ -1741,7 +1790,7 @@ class LspFileSystem implements FileSystem {
 		const deferredForPath = this.deferredForPath;
 		const result = await this.writethrough(
 			path,
-			finalContent,
+			content,
 			this.signal,
 			file,
 			this.batchRequest,
@@ -1935,6 +1984,11 @@ export async function executePatchSingle(
 
 	const oldText = result.change.type !== "create" ? result.change.oldContent : undefined;
 	const newText = result.change.type !== "delete" ? result.change.newContent : undefined;
+	const escapedCodeUnits = result.change.prepared?.escapedCodeUnits ?? 0;
+	if (escapedCodeUnits > 0) {
+		const noticePath = effectiveRename ?? path;
+		resultText += `\n${formatEscapedCodeUnitsNotice(escapedCodeUnits, noticePath)}`;
+	}
 
 	return {
 		content: [{ type: "text", text: resultText }],
@@ -1953,6 +2007,7 @@ export async function executePatchSingle(
 			meta,
 			oldText,
 			newText,
+			escapedCodeUnits,
 		}),
 	};
 }

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -22,7 +22,7 @@ import {
 	restoreLineEndings,
 	stripBom,
 } from "../normalize";
-import { readEditFileText, serializeEditFileText } from "../read-file";
+import { formatEscapedCodeUnitsNotice, readEditFileText, serializeEditFileText } from "../read-file";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
 import { pruneOversizedEditSnapshots } from "../snapshot-details";
 
@@ -1095,7 +1095,8 @@ export async function executeReplaceSingle(
 		throw new Error(`Edits to ${path} resulted in no changes being made.`);
 	}
 
-	const finalContent = await serializeEditFileText(
+	const prepared = await serializeEditFileText(
+		absolutePath,
 		absolutePath,
 		path,
 		bom + restoreLineEndings(result.content, originalEnding),
@@ -1103,20 +1104,31 @@ export async function executeReplaceSingle(
 
 	// Route through ACP bridge when available; skips internal artifacts.
 	let diagnostics: FileDiagnosticsResult | undefined;
-	if (await routeWriteThroughBridge(session, path, absolutePath, finalContent, signal)) {
+	if (await routeWriteThroughBridge(session, path, absolutePath, prepared.content, signal)) {
 		// bridge handled the write; diagnostics not available via writethrough
 	} else {
-		diagnostics = await writethrough(absolutePath, finalContent, signal, Bun.file(absolutePath), batchRequest, dst =>
-			dst === absolutePath ? beginDeferredDiagnosticsForPath(absolutePath) : undefined,
+		diagnostics = await writethrough(
+			absolutePath,
+			prepared.content,
+			signal,
+			Bun.file(absolutePath),
+			batchRequest,
+			dst => (dst === absolutePath ? beginDeferredDiagnosticsForPath(absolutePath) : undefined),
 		);
 		invalidateFsScanAfterWrite(absolutePath);
 	}
 
-	const diffResult = generateDiffString(normalizedContent, result.content, undefined, { path });
-	const resultText =
+	// Diff and reported text derive from the logical persisted text, so an
+	// escaped surrogate shows as `\uXXXX` and a notebook shows virtual cells.
+	const editedLogical = normalizeToLF(stripBom(prepared.editContent).text);
+	const diffResult = generateDiffString(normalizedContent, editedLogical, undefined, { path });
+	let resultText =
 		result.count > 1
 			? `Successfully replaced ${result.count} occurrences in ${path}.`
 			: `Successfully replaced text in ${path}.`;
+	if (prepared.escapedCodeUnits > 0) {
+		resultText += `\n${formatEscapedCodeUnitsNotice(prepared.escapedCodeUnits, path)}`;
+	}
 
 	const meta = outputMeta()
 		.diagnostics(diagnostics?.summary ?? "", diagnostics?.messages ?? [])
@@ -1131,7 +1143,8 @@ export async function executeReplaceSingle(
 			diagnostics,
 			meta,
 			oldText: rawContent,
-			newText: finalContent,
+			newText: prepared.editContent,
+			escapedCodeUnits: prepared.escapedCodeUnits,
 		}),
 	};
 }

--- a/packages/coding-agent/src/edit/read-file.ts
+++ b/packages/coding-agent/src/edit/read-file.ts
@@ -4,8 +4,14 @@
  * Reads a file via Bun and rethrows ENOENT as a user-facing "File not found"
  * error referencing the display path.
  */
-import { isEnoent } from "@oh-my-pi/pi-utils";
-import { isNotebookPath, readEditableNotebookText, serializeEditedNotebookText } from "./notebook";
+import { escapeUnpairedSurrogates, isEnoent } from "@oh-my-pi/pi-utils";
+import {
+	isNotebookPath,
+	type NotebookDocument,
+	notebookToEditableText,
+	readEditableNotebookText,
+	serializeEditedNotebookText,
+} from "./notebook";
 
 export async function readEditFileText(absolutePath: string, path: string): Promise<string> {
 	try {
@@ -19,7 +25,51 @@ export async function readEditFileText(absolutePath: string, path: string): Prom
 	}
 }
 
-export async function serializeEditFileText(absolutePath: string, path: string, content: string): Promise<string> {
-	if (isNotebookPath(absolutePath)) return serializeEditedNotebookText(absolutePath, path, content);
-	return content;
+/**
+ * The one post-boundary representation of a finalized edit. `content` is the
+ * exact text a physical UTF-8/structured sink receives; `editContent` is the
+ * logical text every diff, `newText`, hash, header, and snapshot derives from
+ * (they diverge only for notebooks, where `content` is JSON and `editContent`
+ * is virtual cell text). `escapedCodeUnits` counts lone UTF-16 surrogates that
+ * were spelled as literal `\\uXXXX` before persistence.
+ */
+export interface SerializedEditFileText {
+	content: string;
+	editContent: string;
+	escapedCodeUnits: number;
+}
+
+/**
+ * Prepare plain (non-notebook) file content: escape unpaired surrogates once
+ * and reuse that text for both the physical sink and every logical projection.
+ */
+export function toPersistedEdit(candidate: string): SerializedEditFileText {
+	const { text, escapedCodeUnits } = escapeUnpairedSurrogates(candidate);
+	return { content: text, editContent: text, escapedCodeUnits };
+}
+
+export function formatEscapedCodeUnitsNotice(escapedCodeUnits: number, displayPath: string): string {
+	return `Escaped ${escapedCodeUnits} invalid Unicode code unit(s) before writing ${displayPath}.`;
+}
+
+/**
+ * Destination-aware serialization. The destination extension decides the
+ * physical format: non-notebook targets persist the escaped candidate
+ * verbatim; notebook targets serialize the escaped virtual text into a JSON
+ * document, using the source notebook as a metadata template only when both
+ * ends are notebooks (an absent notebook destination falls back to an empty
+ * notebook, so plain-to-notebook moves still produce a valid container).
+ */
+export async function serializeEditFileText(
+	sourcePath: string,
+	targetPath: string,
+	displayPath: string,
+	candidate: string,
+): Promise<SerializedEditFileText> {
+	if (!isNotebookPath(targetPath)) return toPersistedEdit(candidate);
+	const { text: editContent, escapedCodeUnits } = escapeUnpairedSurrogates(candidate);
+	const templatePath = isNotebookPath(sourcePath) ? sourcePath : targetPath;
+	const content = await serializeEditedNotebookText(templatePath, displayPath, editContent);
+	const canonicalEditContent = notebookToEditableText(JSON.parse(content) as NotebookDocument);
+	return { content, editContent: canonicalEditContent, escapedCodeUnits };
 }

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -41,6 +41,7 @@ import type { EditMode } from "../utils/edit-mode";
 import type { DiffError, DiffResult } from "./diff";
 import { type ApplyPatchEntry, expandApplyPatchToEntries, expandApplyPatchToPreviewEntries } from "./modes/apply-patch";
 import type { Operation } from "./modes/patch";
+import { formatEscapedCodeUnitsNotice } from "./read-file";
 import type { PerFileDiffPreview } from "./streaming";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -857,11 +858,17 @@ function renderSingleFileResult(
 			(result.content?.find(c => c.type === "text")?.text ?? "")
 		: "";
 
+	// Lone surrogates rewritten to literal `\uXXXX` change what landed on disk,
+	// so the count is reported on every success path (single file, and each card
+	// of a multi-file result, which renders through here with its per-file
+	// details). Errors already surface their own text.
+	const escapedCodeUnits = isError ? 0 : (details?.escapedCodeUnits ?? 0);
+
 	// Delete and move-only results carry no diff to box. Per design these render
 	// as an inline status row (eraser / move glyph) rather than an empty framed
-	// container. Errors, no-ops, creates, move-with-edits, and anything with
-	// diagnostics keep the framed block below.
-	if (!isError && !details?.diff && !details?.diagnostics && (op === "delete" || rename)) {
+	// container. Errors, no-ops, creates, move-with-edits, an escape notice, and
+	// anything with diagnostics keep the framed block below.
+	if (!isError && !details?.diff && !details?.diagnostics && escapedCodeUnits === 0 && (op === "delete" || rename)) {
 		const linkPath = details && "path" in details ? details.path : undefined;
 		return renderInlineEditRow(uiTheme, { op, rename, rawPath, linkPath, pending: false });
 	}
@@ -926,6 +933,12 @@ function renderSingleFileResult(
 			body += formatDiagnostics(details.diagnostics, expanded, uiTheme, (fp: string) =>
 				uiTheme.getLangIcon(getLanguageFromPath(fp)),
 			);
+		}
+		if (escapedCodeUnits > 0) {
+			const noticeTarget = rename ?? linkPath ?? rawPath;
+			const notice = formatEscapedCodeUnitsNotice(escapedCodeUnits, noticeTarget ? shortenPath(noticeTarget) : "");
+			if (body.length > 0) body += "\n";
+			body += uiTheme.fg("warning", truncateToWidth(replaceTabs(notice), Math.max(1, width - 2)));
 		}
 
 		// Diff lines self-wrap with a continuation gutter; pre-wrap to the frame's

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -74,6 +74,8 @@ export interface EditToolPerFileResult {
 	snapshotsPruned?: boolean;
 	/** Pre-move source path; set only when the edit moved/renamed the file. The header renders `sourcePath → path`. */
 	sourcePath?: string;
+	/** Count of lone UTF-16 surrogates escaped before this file was written. */
+	escapedCodeUnits?: number;
 }
 
 export interface EditToolDetails {
@@ -101,6 +103,8 @@ export interface EditToolDetails {
 	snapshotsPruned?: boolean;
 	/** Pre-move source path; set only when the edit moved/renamed the file. The header renders `sourcePath → path`. */
 	sourcePath?: string;
+	/** Count of lone UTF-16 surrogates escaped before writing (summed across children for aggregates). */
+	escapedCodeUnits?: number;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -393,6 +393,22 @@ interface PreparedSqliteContent {
 	escapedCodeUnits: number;
 }
 
+/** Decode the four hex digits of a `\uXXXX` escape starting at `start`, or -1 when malformed. */
+function readHex4(source: string, start: number): number {
+	if (start + 4 > source.length) return -1;
+	let value = 0;
+	for (let index = start; index < start + 4; index++) {
+		const digit = source.charCodeAt(index);
+		let nibble: number;
+		if (digit >= 0x30 && digit <= 0x39) nibble = digit - 0x30;
+		else if (digit >= 0x41 && digit <= 0x46) nibble = digit - 0x37;
+		else if (digit >= 0x61 && digit <= 0x66) nibble = digit - 0x57;
+		else return -1;
+		value = value * 16 + nibble;
+	}
+	return value;
+}
+
 /**
  * Parse SQLite write content as JSON5 while preserving lone UTF-16 surrogates.
  *
@@ -440,7 +456,30 @@ function prepareSqliteContent(content: string): PreparedSqliteContent {
 					shielded += placeholder;
 					continue;
 				}
-				shielded += char;
+				const escapeUnit = char === "u" ? readHex4(content, i + 1) : -1;
+				if (escapeUnit < 0xd800 || escapeUnit > 0xdfff) {
+					shielded += char;
+					continue;
+				}
+				const pairedLow =
+					escapeUnit <= 0xdbff && content[i + 5] === "\\" && content[i + 6] === "u"
+						? readHex4(content, i + 7)
+						: -1;
+				if (pairedLow >= 0xdc00 && pairedLow <= 0xdfff) {
+					// Well-formed `\uD83D\uDE00`: JSON5 decodes it to a valid astral
+					// character, so both escapes pass through untouched.
+					shielded += content.slice(i, i + 11);
+					i += 10;
+					continue;
+				}
+				// A lone surrogate spelled with valid JSON5 syntax. The parser would
+				// materialize (or U+FFFD-replace) it before the binding, so shield the
+				// whole escape and restore the literal text it already spells.
+				shielded = shielded.slice(0, -1);
+				const escapePlaceholder = `${nonce}${shieldIndex++}Z`;
+				replacements.set(escapePlaceholder, escapeUnpairedSurrogates(String.fromCharCode(escapeUnit)).text);
+				shielded += escapePlaceholder;
+				i += 4;
 				continue;
 			}
 			if (char === "\\") {
@@ -468,7 +507,9 @@ function prepareSqliteContent(content: string): PreparedSqliteContent {
 			continue;
 		}
 		if (state === "line") {
-			if (char === "\n") state = "top";
+			// JSON5 ends a `//` comment on any line terminator, not just LF:
+			// LF, CR, LS (U+2028), PS (U+2029).
+			if (code === 0x0a || code === 0x0d || code === 0x2028 || code === 0x2029) state = "top";
 			shielded += char;
 			continue;
 		}
@@ -504,21 +545,25 @@ function prepareSqliteContent(content: string): PreparedSqliteContent {
 	}
 
 	let escapedCodeUnits = 0;
+	// One scan per string. Iterating the placeholder map instead rescanned and
+	// split the whole value once per shielded code unit — quadratic in `k`.
+	const placeholderRe = new RegExp(`${nonce}(\\d+)Z`, "g");
+	const restoreText = (text: string): string => {
+		if (!text.includes(nonce)) return text;
+		return text.replace(placeholderRe, (match, index: string) => {
+			const literal = replacements.get(`${nonce}${index}Z`);
+			if (literal === undefined) return match;
+			escapedCodeUnits++;
+			return literal;
+		});
+	};
 	const restore = (value: unknown): unknown => {
-		if (typeof value === "string") {
-			let text = value;
-			for (const [placeholder, literal] of replacements) {
-				if (!text.includes(placeholder)) continue;
-				escapedCodeUnits += text.split(placeholder).length - 1;
-				text = text.split(placeholder).join(literal);
-			}
-			return text;
-		}
+		if (typeof value === "string") return restoreText(value);
 		if (Array.isArray(value)) return value.map(restore);
 		if (isRecord(value)) {
 			const out: Record<string, unknown> = {};
 			for (const [key, item] of Object.entries(value)) {
-				out[restore(key) as string] = restore(item);
+				out[restoreText(key)] = restore(item);
 			}
 			return out;
 		}
@@ -1797,6 +1842,14 @@ export const writeToolRenderer = {
 					const firstNonEmpty = diagLines.findIndex(line => line.trim());
 					if (firstNonEmpty >= 0) body += `\n${diagLines.slice(firstNonEmpty).join("\n")}`;
 				}
+			}
+			if (!isPartial && result.details?.escapedCodeUnits) {
+				const notice = truncateToWidth(
+					replaceTabs(formatEscapedCodeUnitsNotice(result.details.escapedCodeUnits, filePath)),
+					TRUNCATE_LENGTHS.LINE,
+					Ellipsis.Unicode,
+				);
+				body += `${body ? "\n" : ""}${uiTheme.fg("dim", notice)}`;
 			}
 			const bodyLines = body.split("\n");
 			while (bodyLines.length > 0 && bodyLines[0].trim() === "") bodyLines.shift();

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -759,7 +759,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					exists: true,
 				};
 			} catch (error) {
-				if (!isEnoent(error)) throw error;
+				if (!isArchivePathNotFound(error)) throw error;
 			}
 		}
 
@@ -1279,7 +1279,24 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				if (handler?.write) {
 					if (scheme !== "xd") {
 						enforcePlanModeWrite(this.session, path, { op: "update" });
-						emitWriteProgress(onUpdate, toPersistedEdit(cleanContent).content, path);
+						const prepared = toPersistedEdit(cleanContent);
+						emitWriteProgress(onUpdate, prepared.content, path);
+						await internalRouter.write(path, prepared.content, {
+							cwd: this.session.cwd,
+							signal,
+						});
+						let resultText = `Successfully wrote ${prepared.content.length} bytes to ${path}`;
+						if (stripped) {
+							resultText += "\nNote: auto-stripped hashline display prefixes from content before writing.";
+						}
+						return finalizeEscapeReport(
+							{
+								content: [{ type: "text", text: resultText }],
+								details: {},
+							},
+							prepared.escapedCodeUnits,
+							path,
+						);
 					}
 					let xdResult: AgentToolResult<WriteToolDetails> | undefined;
 					await internalRouter.write(path, cleanContent, {

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -410,6 +410,22 @@ function readHex4(source: string, start: number): number {
 }
 
 /**
+ * Decode the next string-token unit at `start`: a raw code unit, a `\uXXXX`
+ * escape, or a permissive `\X` escape. Callers pair on the decoded `code`, so
+ * a surrogate is classified identically however it was spelled.
+ */
+function readStringUnit(source: string, start: number): { code: number; length: number } {
+	if (source[start] !== "\\") return { code: source.charCodeAt(start), length: 1 };
+	if (source[start + 1] === "u") {
+		const escapeUnit = readHex4(source, start + 2);
+		if (escapeUnit >= 0) return { code: escapeUnit, length: 6 };
+	}
+	// JSON5 permissive escape: `\X` yields X itself (or a mapped control
+	// character, never a surrogate), so the escaped character carries the unit.
+	return { code: source.charCodeAt(start + 1), length: 2 };
+}
+
+/**
  * Parse SQLite write content as JSON5 while preserving lone UTF-16 surrogates.
  *
  * `Bun.JSON5.parse` decodes lone surrogates in string tokens to U+FFFD, so the
@@ -430,80 +446,45 @@ function prepareSqliteContent(content: string): PreparedSqliteContent {
 	let shieldIndex = 0;
 	let state: "top" | "string" | "line" | "block" = "top";
 	let quote = "";
-	let escaped = false;
 	for (let i = 0; i < content.length; i++) {
 		const char = content[i] ?? "";
 		const code = content.charCodeAt(i);
-		const nextCode = content.charCodeAt(i + 1);
-		const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
-		const hasFollowingLow = nextCode >= 0xdc00 && nextCode <= 0xdfff;
-		const isLoneSurrogate = (isHighSurrogate && !hasFollowingLow) || (code >= 0xdc00 && code <= 0xdfff);
 		if (state === "string") {
-			if (escaped) {
-				escaped = false;
-				if (isHighSurrogate && hasFollowingLow) {
-					shielded += content.slice(i, i + 2);
-					i++;
-					continue;
-				}
-				if (isLoneSurrogate) {
-					// JSON5 consumes the preceding backslash as a permissive
-					// escape prefix. Remove it with the code unit and shield the
-					// semantic character the parser would otherwise replace.
-					shielded = shielded.slice(0, -1);
-					const placeholder = `${nonce}${shieldIndex++}Z`;
-					replacements.set(placeholder, escapeUnpairedSurrogates(char).text);
-					shielded += placeholder;
-					continue;
-				}
-				const escapeUnit = char === "u" ? readHex4(content, i + 1) : -1;
-				if (escapeUnit < 0xd800 || escapeUnit > 0xdfff) {
-					shielded += char;
-					continue;
-				}
-				const pairedLow =
-					escapeUnit <= 0xdbff && content[i + 5] === "\\" && content[i + 6] === "u"
-						? readHex4(content, i + 7)
-						: -1;
-				if (pairedLow >= 0xdc00 && pairedLow <= 0xdfff) {
-					// Well-formed `\uD83D\uDE00`: JSON5 decodes it to a valid astral
-					// character, so both escapes pass through untouched.
-					shielded += content.slice(i, i + 11);
-					i += 10;
-					continue;
-				}
-				// A lone surrogate spelled with valid JSON5 syntax. The parser would
-				// materialize (or U+FFFD-replace) it before the binding, so shield the
-				// whole escape and restore the literal text it already spells.
-				shielded = shielded.slice(0, -1);
-				const escapePlaceholder = `${nonce}${shieldIndex++}Z`;
-				replacements.set(escapePlaceholder, escapeUnpairedSurrogates(String.fromCharCode(escapeUnit)).text);
-				shielded += escapePlaceholder;
-				i += 4;
-				continue;
-			}
-			if (char === "\\") {
-				shielded += char;
-				escaped = true;
-				continue;
-			}
 			if (char === quote) {
 				shielded += char;
 				state = "top";
 				continue;
 			}
-			if (isHighSurrogate && hasFollowingLow) {
-				shielded += content.slice(i, i + 2);
-				i++;
+			// One unit at a time, escape prefix included, so pairing never depends
+			// on whether a side arrived raw or as `\uXXXX`.
+			const unit = readStringUnit(content, i);
+			const isHigh = unit.code >= 0xd800 && unit.code <= 0xdbff;
+			const isLow = unit.code >= 0xdc00 && unit.code <= 0xdfff;
+			if (!isHigh && !isLow) {
+				shielded += content.slice(i, i + unit.length);
+				i += unit.length - 1;
 				continue;
 			}
-			if (!isLoneSurrogate) {
-				shielded += char;
-				continue;
+			if (isHigh) {
+				const low = readStringUnit(content, i + unit.length);
+				if (low.code >= 0xdc00 && low.code <= 0xdfff) {
+					// A genuine pair, whatever mix of forms spelled it. JSON5 pairs
+					// only within one form (it U+FFFD-replaces each half of a
+					// raw/escaped mix), so emit the decoded pair as raw code units
+					// — the same astral character, spelled the way the parser
+					// already handles, and never counted as an escape.
+					shielded += String.fromCharCode(unit.code, low.code);
+					i += unit.length + low.length - 1;
+					continue;
+				}
 			}
+			// A lone surrogate, raw or escaped, counted exactly once. The parser
+			// would materialize (or U+FFFD-replace) it before the binding, so
+			// shield the whole unit and restore the literal text it spells.
 			const placeholder = `${nonce}${shieldIndex++}Z`;
-			replacements.set(placeholder, escapeUnpairedSurrogates(char).text);
+			replacements.set(placeholder, escapeUnpairedSurrogates(String.fromCharCode(unit.code)).text);
 			shielded += placeholder;
+			i += unit.length - 1;
 			continue;
 		}
 		if (state === "line") {
@@ -541,7 +522,9 @@ function prepareSqliteContent(content: string): PreparedSqliteContent {
 	}
 
 	if (replacements.size === 0) {
-		return { value: Bun.JSON5.parse(content), escapedCodeUnits: 0 };
+		// `shielded` is byte-identical to `content` unless the scan normalized a
+		// mixed-form surrogate pair, which the parser only handles as raw units.
+		return { value: Bun.JSON5.parse(shielded), escapedCodeUnits: 0 };
 	}
 
 	let escapedCodeUnits = 0;
@@ -1172,6 +1155,9 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			const resolvedEntries: ConflictEntry[] = [];
 			const staleEntries: ConflictEntry[] = [];
 			let failure: string | undefined;
+			// Per-file until the write commits: a file that fails to splice or
+			// persist must not inflate the trimmed-line note the user is shown.
+			let fileEchoTrimmed = 0;
 			try {
 				text = await Bun.file(absolutePath).text();
 			} catch (error) {
@@ -1187,7 +1173,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					const expanded = expandContentTokens(contentFor(entry), entry);
 					const splice = spliceConflict(text, entry, expanded);
 					text = splice.text;
-					totalEchoTrimmed += splice.trimmedLeading + splice.trimmedTrailing;
+					fileEchoTrimmed += splice.trimmedLeading + splice.trimmedTrailing;
 					resolvedEntries.push(entry);
 				} catch (error) {
 					// A locate-miss for a region an earlier entry already spliced
@@ -1226,6 +1212,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					escaped: prepared.escapedCodeUnits,
 				});
 				totalResolvedIds += resolvedEntries.length;
+				totalEchoTrimmed += fileEchoTrimmed;
 			} catch (error) {
 				failedFiles.push({
 					displayPath: sample.displayPath,

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -11,11 +11,12 @@ import type {
 	ToolTier,
 } from "@oh-my-pi/pi-agent-core";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
-import { isEnoent, isRecord, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { escapeUnpairedSurrogates, isEnoent, isRecord, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 
 import { canonicalSnapshotKey, getFileSnapshotStore } from "../edit/file-snapshot-store";
 import { normalizeToLF } from "../edit/normalize";
+import { formatEscapedCodeUnitsNotice, type SerializedEditFileText, toPersistedEdit } from "../edit/read-file";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { InternalUrlRouter } from "../internal-urls";
 import { parseInternalUrl } from "../internal-urls/parse";
@@ -271,6 +272,8 @@ export interface WriteToolDetails {
 	resolvedPath?: string;
 	/** Set when the write dispatched an `xd://` tool device; drives renderer delegation. */
 	xdev?: XdevDispatch;
+	/** Count of lone UTF-16 surrogates escaped to literal `\uXXXX` before persistence. */
+	escapedCodeUnits?: number;
 }
 
 /**
@@ -340,6 +343,189 @@ function appendNoteToResult(result: AgentToolResult<WriteToolDetails>, note: str
 	} else {
 		result.content.push({ type: "text", text: note });
 	}
+}
+
+/**
+ * Record the escaped-surrogate count on a successful write result and append
+ * the exact user-facing notice once when any code unit was escaped. Only the
+ * persisted (non-delegated) branches call this after their sink succeeds.
+ */
+function finalizeEscapeReport(
+	result: AgentToolResult<WriteToolDetails>,
+	escapedCodeUnits: number,
+	displayPath: string,
+): AgentToolResult<WriteToolDetails> {
+	result.details = { ...result.details, escapedCodeUnits };
+	if (escapedCodeUnits > 0) {
+		appendNoteToResult(result, formatEscapedCodeUnitsNotice(escapedCodeUnits, displayPath));
+	}
+	return result;
+}
+
+/** Collect every string value/key reachable in a parsed JSON5 value. */
+function collectSemanticStrings(value: unknown, acc: string[]): void {
+	if (typeof value === "string") {
+		acc.push(value);
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) collectSemanticStrings(item, acc);
+		return;
+	}
+	if (isRecord(value)) {
+		for (const [key, item] of Object.entries(value)) {
+			acc.push(key);
+			collectSemanticStrings(item, acc);
+		}
+	}
+}
+
+/** Pick a deterministic ASCII sentinel base that appears in neither the raw source nor any parsed string. */
+function chooseSqliteShieldNonce(source: string, semanticStrings: string[]): string {
+	for (let attempt = 0; ; attempt++) {
+		const nonce = `\u0001OMPU${attempt}_`;
+		if (!source.includes(nonce) && !semanticStrings.some(text => text.includes(nonce))) return nonce;
+	}
+}
+
+interface PreparedSqliteContent {
+	value: unknown;
+	escapedCodeUnits: number;
+}
+
+/**
+ * Parse SQLite write content as JSON5 while preserving lone UTF-16 surrogates.
+ *
+ * `Bun.JSON5.parse` decodes lone surrogates in string tokens to U+FFFD, so the
+ * raw code units are shielded with a collision-free ASCII sentinel before the
+ * parse and each sentinel is swapped for the literal `\uXXXX` output of
+ * {@link escapeUnpairedSurrogates} in the parsed keys/values afterward. Only
+ * surrogates that survive into a persisted string are counted; those in
+ * comments or discarded syntax never reach the parsed value.
+ */
+function prepareSqliteContent(content: string): PreparedSqliteContent {
+	// Inventory parse (surrogates already mangled here) only informs nonce choice.
+	const inventory: string[] = [];
+	collectSemanticStrings(Bun.JSON5.parse(content), inventory);
+	const nonce = chooseSqliteShieldNonce(content, inventory);
+
+	const replacements = new Map<string, string>();
+	let shielded = "";
+	let shieldIndex = 0;
+	let state: "top" | "string" | "line" | "block" = "top";
+	let quote = "";
+	let escaped = false;
+	for (let i = 0; i < content.length; i++) {
+		const char = content[i] ?? "";
+		const code = content.charCodeAt(i);
+		const nextCode = content.charCodeAt(i + 1);
+		const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+		const hasFollowingLow = nextCode >= 0xdc00 && nextCode <= 0xdfff;
+		const isLoneSurrogate = (isHighSurrogate && !hasFollowingLow) || (code >= 0xdc00 && code <= 0xdfff);
+		if (state === "string") {
+			if (escaped) {
+				escaped = false;
+				if (isHighSurrogate && hasFollowingLow) {
+					shielded += content.slice(i, i + 2);
+					i++;
+					continue;
+				}
+				if (isLoneSurrogate) {
+					// JSON5 consumes the preceding backslash as a permissive
+					// escape prefix. Remove it with the code unit and shield the
+					// semantic character the parser would otherwise replace.
+					shielded = shielded.slice(0, -1);
+					const placeholder = `${nonce}${shieldIndex++}Z`;
+					replacements.set(placeholder, escapeUnpairedSurrogates(char).text);
+					shielded += placeholder;
+					continue;
+				}
+				shielded += char;
+				continue;
+			}
+			if (char === "\\") {
+				shielded += char;
+				escaped = true;
+				continue;
+			}
+			if (char === quote) {
+				shielded += char;
+				state = "top";
+				continue;
+			}
+			if (isHighSurrogate && hasFollowingLow) {
+				shielded += content.slice(i, i + 2);
+				i++;
+				continue;
+			}
+			if (!isLoneSurrogate) {
+				shielded += char;
+				continue;
+			}
+			const placeholder = `${nonce}${shieldIndex++}Z`;
+			replacements.set(placeholder, escapeUnpairedSurrogates(char).text);
+			shielded += placeholder;
+			continue;
+		}
+		if (state === "line") {
+			if (char === "\n") state = "top";
+			shielded += char;
+			continue;
+		}
+		if (state === "block") {
+			if (char === "*" && content[i + 1] === "/") {
+				shielded += "*/";
+				i++;
+				state = "top";
+				continue;
+			}
+			shielded += char;
+			continue;
+		}
+		if (char === '"' || char === "'") {
+			quote = char;
+			state = "string";
+		} else if (char === "/" && content[i + 1] === "/") {
+			shielded += "//";
+			i++;
+			state = "line";
+			continue;
+		} else if (char === "/" && content[i + 1] === "*") {
+			shielded += "/*";
+			i++;
+			state = "block";
+			continue;
+		}
+		shielded += char;
+	}
+
+	if (replacements.size === 0) {
+		return { value: Bun.JSON5.parse(content), escapedCodeUnits: 0 };
+	}
+
+	let escapedCodeUnits = 0;
+	const restore = (value: unknown): unknown => {
+		if (typeof value === "string") {
+			let text = value;
+			for (const [placeholder, literal] of replacements) {
+				if (!text.includes(placeholder)) continue;
+				escapedCodeUnits += text.split(placeholder).length - 1;
+				text = text.split(placeholder).join(literal);
+			}
+			return text;
+		}
+		if (Array.isArray(value)) return value.map(restore);
+		if (isRecord(value)) {
+			const out: Record<string, unknown> = {};
+			for (const [key, item] of Object.entries(value)) {
+				out[restore(key) as string] = restore(item);
+			}
+			return out;
+		}
+		return value;
+	};
+	const value = restore(Bun.JSON5.parse(shielded));
+	return { value, escapedCodeUnits };
 }
 
 function emitWriteProgress(
@@ -550,11 +736,10 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 
 	async #resolveArchiveWritePath(writePath: string): Promise<ResolvedArchiveWritePath | null> {
 		const candidates = parseArchivePathCandidates(writePath).filter(candidate => candidate.archivePath !== writePath);
-		if (candidates.length === 0) {
-			return null;
-		}
+		if (candidates.length === 0) return null;
 
-		const fallbackCandidate = candidates[candidates.length - 1]!;
+		const fallbackCandidate = candidates.at(-1);
+		if (!fallbackCandidate) return null;
 		const fallback: ResolvedArchiveWritePath = {
 			absolutePath: resolvePlanPath(this.session, fallbackCandidate.archivePath),
 			archivePath: fallbackCandidate.archivePath,
@@ -566,10 +751,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			const absolutePath = resolvePlanPath(this.session, candidate.archivePath);
 			try {
 				const stat = await Bun.file(absolutePath).stat();
-				if (stat.isDirectory()) {
-					continue;
-				}
-
+				if (stat.isDirectory()) continue;
 				return {
 					absolutePath,
 					archivePath: candidate.archivePath,
@@ -577,9 +759,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					exists: true,
 				};
 			} catch (error) {
-				if (!isArchivePathNotFound(error)) {
-					throw error;
-				}
+				if (!isEnoent(error)) throw error;
 			}
 		}
 
@@ -587,21 +767,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 	}
 
 	async #writeArchiveEntry(
-		content: string,
+		prepared: SerializedEditFileText,
 		resolvedArchivePath: ResolvedArchiveWritePath,
 	): Promise<AgentToolResult<WriteToolDetails>> {
-		// Resolve symlinks before the tmp+rename swap: renaming over a symlink
-		// replaces the link itself with a regular file instead of writing
-		// through to its target.
 		const finalPath = resolvedArchivePath.exists
 			? await fs.realpath(resolvedArchivePath.absolutePath).catch(() => resolvedArchivePath.absolutePath)
 			: resolvedArchivePath.absolutePath;
-		// A realpath swap can land on a name without an archive extension; a
-		// whole-archive rewrite then defaults to an uncompressed tar, matching the
-		// previous `isZip`/`isGzip`/else fallthrough.
 		const format = archiveFormatFromPath(finalPath) ?? "tar";
-		// Rewrites are whole-archive: write to a temp file and rename so a
-		// crash/disk-full mid-write can't destroy the original archive.
 		const tmpPath = `${finalPath}.tmp-${process.pid}`;
 
 		const parentDir = path.dirname(resolvedArchivePath.absolutePath);
@@ -613,19 +785,17 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		if (resolvedArchivePath.exists) {
 			try {
 				const existing = await readArchiveEntries({ bytes: await Bun.file(finalPath).bytes(), format });
-				for (const [entryPath, data] of existing) {
-					entries.set(entryPath, data);
-				}
+				for (const [entryPath, data] of existing) entries.set(entryPath, data);
 			} catch (error) {
 				throw new ToolError(error instanceof Error ? error.message : String(error));
 			}
 		}
 		const writeTarget = `${resolvedArchivePath.archivePath}:${resolvedArchivePath.archiveSubPath}`;
-		const sel = readSelectorForEmptyWrite(writeTarget, content);
+		const sel = readSelectorForEmptyWrite(writeTarget, prepared.content);
 		if (sel !== undefined && !entries.has(resolvedArchivePath.archiveSubPath)) {
 			throwReadSelectorMisfire(writeTarget, sel);
 		}
-		entries.set(resolvedArchivePath.archiveSubPath, content);
+		entries.set(resolvedArchivePath.archiveSubPath, prepared.content);
 
 		try {
 			await writeArchive(tmpPath, format, entries);
@@ -639,10 +809,14 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		const outputPath = `${formatPathRelativeToCwd(resolvedArchivePath.absolutePath, this.session.cwd)}:${
 			resolvedArchivePath.archiveSubPath
 		}`;
-		return {
-			content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${outputPath}` }],
-			details: { resolvedPath: resolvedArchivePath.absolutePath },
-		};
+		return finalizeEscapeReport(
+			{
+				content: [{ type: "text", text: `Successfully wrote ${prepared.content.length} bytes to ${outputPath}` }],
+				details: { resolvedPath: resolvedArchivePath.absolutePath },
+			},
+			prepared.escapedCodeUnits,
+			outputPath,
+		);
 	}
 
 	async #resolveSqliteWritePath(writePath: string): Promise<ResolvedSqliteWritePath | null> {
@@ -712,6 +886,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 
 			const trimmedContent = content.trim();
 			let resultText: string;
+			let escapedCodeUnits = 0;
 			if (trimmedContent.length === 0) {
 				if (!resolvedSqlitePath.key) {
 					throw new ToolError("SQLite deletes require a row key in the path");
@@ -729,7 +904,9 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			} else {
 				let parsedContent: unknown;
 				try {
-					parsedContent = Bun.JSON5.parse(content);
+					const prepared = prepareSqliteContent(content);
+					parsedContent = prepared.value;
+					escapedCodeUnits = prepared.escapedCodeUnits;
 				} catch (error) {
 					throw new ToolError(
 						`SQLite write content must be valid JSON5: ${error instanceof Error ? error.message : String(error)}`,
@@ -757,10 +934,11 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			}
 
 			invalidateFsScanAfterWrite(resolvedSqlitePath.absolutePath);
-			return toolResult<WriteToolDetails>({ resolvedPath: resolvedSqlitePath.absolutePath })
+			const sqliteResult = toolResult<WriteToolDetails>({ resolvedPath: resolvedSqlitePath.absolutePath })
 				.text(resultText)
 				.sourcePath(resolvedSqlitePath.absolutePath)
 				.done();
+			return finalizeEscapeReport(sqliteResult, escapedCodeUnits, displayPath);
 		} catch (error) {
 			if (isEnoent(error)) {
 				throw new ToolError(`SQLite database '${displayPath}' not found`);
@@ -800,7 +978,8 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		const expanded = expandContentTokens(replacementContent, entry);
 		const originalText = await Bun.file(absolutePath).text();
 		const splice = spliceConflict(originalText, entry, expanded);
-		const newContent = splice.text;
+		const prepared = toPersistedEdit(splice.text);
+		const newContent = prepared.content;
 
 		await writethroughNoop(absolutePath, newContent, signal);
 		invalidateFsScanAfterWrite(absolutePath);
@@ -840,10 +1019,14 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			resultText += `\nNote: dropped ${echoTrimmed} content line(s) that duplicated the code adjacent to the conflict region — writes replace only the marker block; surrounding lines stay in place.`;
 		}
 
-		return {
-			content: [{ type: "text", text: resultText }],
-			details: { resolvedPath: absolutePath },
-		};
+		return finalizeEscapeReport(
+			{
+				content: [{ type: "text", text: resultText }],
+				details: { resolvedPath: absolutePath },
+			},
+			prepared.escapedCodeUnits,
+			entry.displayPath,
+		);
 	}
 
 	/**
@@ -921,13 +1104,14 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			byFile.set(entry.absolutePath, bucket);
 		}
 
-		const succeededFiles: { displayPath: string; count: number; header?: string }[] = [];
+		const succeededFiles: { displayPath: string; count: number; header?: string; escaped: number }[] = [];
 		const failedFiles: { displayPath: string; count: number; error: string }[] = [];
 		let totalResolvedIds = 0;
 		let totalEchoTrimmed = 0;
 
 		for (const [absolutePath, fileEntries] of byFile) {
-			const sample = fileEntries[0]!;
+			const sample = fileEntries[0];
+			if (!sample) continue;
 			if (!(await fs.exists(absolutePath))) {
 				failedFiles.push({
 					displayPath: sample.displayPath,
@@ -981,15 +1165,29 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				continue;
 			}
 
-			await writethroughNoop(absolutePath, text, signal);
-			invalidateFsScanAfterWrite(absolutePath);
-			this.session.bumpFileMutationVersion?.(absolutePath);
-			this.session.fileSnapshotStore?.invalidate(absolutePath);
-			for (const entry of resolvedEntries) history.invalidate(entry.id);
-			for (const entry of staleEntries) history.invalidate(entry.id);
-			const header = maybeWriteSnapshotHeader(this.session, absolutePath, text);
-			succeededFiles.push({ displayPath: sample.displayPath, count: resolvedEntries.length, header });
-			totalResolvedIds += resolvedEntries.length;
+			try {
+				const prepared = toPersistedEdit(text);
+				await writethroughNoop(absolutePath, prepared.content, signal);
+				invalidateFsScanAfterWrite(absolutePath);
+				this.session.bumpFileMutationVersion?.(absolutePath);
+				this.session.fileSnapshotStore?.invalidate(absolutePath);
+				for (const entry of resolvedEntries) history.invalidate(entry.id);
+				for (const entry of staleEntries) history.invalidate(entry.id);
+				const header = maybeWriteSnapshotHeader(this.session, absolutePath, prepared.content);
+				succeededFiles.push({
+					displayPath: sample.displayPath,
+					count: resolvedEntries.length,
+					header,
+					escaped: prepared.escapedCodeUnits,
+				});
+				totalResolvedIds += resolvedEntries.length;
+			} catch (error) {
+				failedFiles.push({
+					displayPath: sample.displayPath,
+					count: fileEntries.length,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
 		}
 
 		const summaryLines: string[] = [];
@@ -1032,6 +1230,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		if (stripped && !directives) {
 			summaryLines.push("Note: auto-stripped hashline display prefixes from content before writing.");
 		}
+		let totalEscaped = 0;
+		for (const file of succeededFiles) {
+			if (file.escaped > 0) {
+				totalEscaped += file.escaped;
+				summaryLines.push(formatEscapedCodeUnitsNotice(file.escaped, file.displayPath));
+			}
+		}
 		const resultText = summaryLines.join("\n");
 
 		if (failedFiles.length > 0 && succeededFiles.length === 0) {
@@ -1039,7 +1244,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		}
 		return {
 			content: [{ type: "text", text: resultText }],
-			details: {},
+			details: { escapedCodeUnits: totalEscaped },
 			isError: failedFiles.length > 0 ? true : undefined,
 		};
 	}
@@ -1072,11 +1277,9 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				const scheme = parsed.protocol.replace(/:$/, "").toLowerCase();
 				const handler = internalRouter.getHandler(scheme);
 				if (handler?.write) {
-					// Handler-owned writes mutate user data outside the local
-					// sandbox. xd:// dispatches retain each wrapped tool's tier.
 					if (scheme !== "xd") {
 						enforcePlanModeWrite(this.session, path, { op: "update" });
-						emitWriteProgress(onUpdate, cleanContent, path);
+						emitWriteProgress(onUpdate, toPersistedEdit(cleanContent).content, path);
 					}
 					let xdResult: AgentToolResult<WriteToolDetails> | undefined;
 					await internalRouter.write(path, cleanContent, {
@@ -1117,9 +1320,6 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 									_toolCallId,
 									signal,
 									onUpdate as AgentToolUpdateCallback,
-									// The write tool's own gate just resolved approval at this
-									// device's tier (see #approval above) — mark it so a wrapped
-									// inner tool does not prompt a second time.
 									context ? { ...context, xdevApproved: true } : undefined,
 								);
 								xdResult = {
@@ -1134,13 +1334,11 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					if (xdResult) return xdResult;
 					let resultText = `Successfully wrote ${cleanContent.length} bytes to ${path}`;
 					if (stripped) {
-						resultText += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
+						resultText += "\nNote: auto-stripped hashline display prefixes from content before writing.";
 					}
 					return { content: [{ type: "text", text: resultText }], details: {} };
 				}
 				if (scheme !== "local") await internalRouter.write(path, cleanContent);
-				// local:// is backed by the session-local artifact sandbox and is
-				// resolved by resolvePlanPath below so write/read share the same root.
 			}
 
 			const conflictUri = parseConflictUri(path);
@@ -1150,7 +1348,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 						`Conflict URI scope '/${conflictUri.scope}' is read-only — read \`conflict://${conflictUri.id}/${conflictUri.scope}\` to inspect that side. To write, drop the scope (\`conflict://${conflictUri.id}\`) and put the chosen content (or shorthand like \`@${conflictUri.scope}\`) in \`content\`.`,
 					);
 				}
-				emitWriteProgress(onUpdate, cleanContent, path);
+				emitWriteProgress(onUpdate, toPersistedEdit(cleanContent).content, path);
 				const result =
 					conflictUri.id === "*"
 						? await this.#resolveAllConflicts(cleanContent, stripped, signal, content)
@@ -1163,28 +1361,29 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				}
 				return result;
 			}
+
 			const resolvedArchivePath = await this.#resolveArchiveWritePath(path);
 			if (resolvedArchivePath) {
 				enforcePlanModeWrite(this.session, resolvedArchivePath.archivePath, {
 					op: resolvedArchivePath.exists ? "update" : "create",
 				});
-
+				const preparedArchive = toPersistedEdit(cleanContent);
 				emitWriteProgress(
 					onUpdate,
-					cleanContent,
+					preparedArchive.content,
 					`${formatPathRelativeToCwd(resolvedArchivePath.absolutePath, this.session.cwd)}:${
 						resolvedArchivePath.archiveSubPath
 					}`,
 					resolvedArchivePath.absolutePath,
 				);
-				const archiveResult = await this.#writeArchiveEntry(cleanContent, resolvedArchivePath);
+				const archiveResult = await this.#writeArchiveEntry(preparedArchive, resolvedArchivePath);
 				if (stripped) {
 					const firstText = archiveResult.content.find(
 						(block): block is { type: "text"; text: string } =>
 							block.type === "text" && typeof block.text === "string",
 					);
 					if (firstText) {
-						firstText.text += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
+						firstText.text += "\nNote: auto-stripped hashline display prefixes from content before writing.";
 					}
 				}
 				return archiveResult;
@@ -1193,8 +1392,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			const resolvedSqlitePath = await this.#resolveSqliteWritePath(path);
 			if (resolvedSqlitePath) {
 				enforcePlanModeWrite(this.session, resolvedSqlitePath.sqlitePath, { op: "update" });
-
-				emitWriteProgress(onUpdate, cleanContent, path, resolvedSqlitePath.absolutePath);
+				emitWriteProgress(onUpdate, toPersistedEdit(cleanContent).content, path, resolvedSqlitePath.absolutePath);
 				const sqliteResult = await this.#writeSqliteRow(path, cleanContent, resolvedSqlitePath);
 				if (stripped) {
 					const firstText = sqliteResult.content.find(
@@ -1202,7 +1400,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 							block.type === "text" && typeof block.text === "string",
 					);
 					if (firstText) {
-						firstText.text += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
+						firstText.text += "\nNote: auto-stripped hashline display prefixes from content before writing.";
 					}
 				}
 				return sqliteResult;
@@ -1212,21 +1410,19 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			enforcePlanModeWrite(this.session, path, { op: "create" });
 			const absolutePath = resolvePlanPath(this.session, path);
 			const batchRequest = getLspBatchRequest(context?.toolCall);
-
-			// Check if file exists and is auto-generated before overwriting
 			if (await fs.exists(absolutePath)) {
 				await assertEditableFile(absolutePath, path);
 			}
 
 			const displayPath = formatPathRelativeToCwd(absolutePath, this.session.cwd);
-			emitWriteProgress(onUpdate, cleanContent, displayPath, absolutePath);
-
+			const prepared = toPersistedEdit(cleanContent);
+			emitWriteProgress(onUpdate, prepared.content, displayPath, absolutePath);
 			// Try ACP bridge first for editor-visible filesystem paths. Internal
 			// artifacts such as local:// plans are owned by OMP, not the editor.
-			if (await routeWriteThroughBridge(this.session, path, absolutePath, cleanContent, signal)) {
-				const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, cleanContent);
-				const header = maybeWriteSnapshotHeader(this.session, absolutePath, cleanContent);
-				const writeLine = `Successfully wrote ${cleanContent.length} bytes to ${displayPath}`;
+			if (await routeWriteThroughBridge(this.session, path, absolutePath, prepared.content, signal)) {
+				const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, prepared.content);
+				const header = maybeWriteSnapshotHeader(this.session, absolutePath, prepared.content);
+				const writeLine = `Successfully wrote ${prepared.content.length} bytes to ${displayPath}`;
 				let resultText = header ? `${header}\n${writeLine}` : writeLine;
 				if (stripped) {
 					resultText += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
@@ -1234,15 +1430,19 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				if (madeExecutable) {
 					resultText += `\n${EXECUTABLE_NOTICE}`;
 				}
-				return {
-					content: [{ type: "text", text: resultText }],
-					details: { resolvedPath: absolutePath, madeExecutable: madeExecutable || undefined },
-				};
+				return finalizeEscapeReport(
+					{
+						content: [{ type: "text", text: resultText }],
+						details: { resolvedPath: absolutePath, madeExecutable: madeExecutable || undefined },
+					},
+					prepared.escapedCodeUnits,
+					displayPath,
+				);
 			}
 
 			const diagnostics = await this.#writethrough(
 				absolutePath,
-				cleanContent,
+				prepared.content,
 				signal,
 				undefined,
 				batchRequest,
@@ -1252,10 +1452,10 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			if (!this.#deferredDiagnostics || batchRequest?.flush === false) {
 				this.session.bumpFileMutationVersion?.(absolutePath);
 			}
-			const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, cleanContent);
+			const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, prepared.content);
 
-			const header = maybeWriteSnapshotHeader(this.session, absolutePath, cleanContent);
-			const writeLine = `Successfully wrote ${cleanContent.length} bytes to ${displayPath}`;
+			const header = maybeWriteSnapshotHeader(this.session, absolutePath, prepared.content);
+			const writeLine = `Successfully wrote ${prepared.content.length} bytes to ${displayPath}`;
 			let resultText = header ? `${header}\n${writeLine}` : writeLine;
 			if (stripped) {
 				resultText += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
@@ -1264,23 +1464,31 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				resultText += `\n${EXECUTABLE_NOTICE}`;
 			}
 			if (!diagnostics) {
-				return {
-					content: [{ type: "text", text: resultText }],
-					details: { resolvedPath: absolutePath, madeExecutable: madeExecutable || undefined },
-				};
+				return finalizeEscapeReport(
+					{
+						content: [{ type: "text", text: resultText }],
+						details: { resolvedPath: absolutePath, madeExecutable: madeExecutable || undefined },
+					},
+					prepared.escapedCodeUnits,
+					displayPath,
+				);
 			}
 
-			return {
-				content: [{ type: "text", text: resultText }],
-				details: {
-					resolvedPath: absolutePath,
-					diagnostics,
-					madeExecutable: madeExecutable || undefined,
-					meta: outputMeta()
-						.diagnostics(diagnostics.summary, diagnostics.messages ?? [])
-						.get(),
+			return finalizeEscapeReport(
+				{
+					content: [{ type: "text", text: resultText }],
+					details: {
+						resolvedPath: absolutePath,
+						diagnostics,
+						madeExecutable: madeExecutable || undefined,
+						meta: outputMeta()
+							.diagnostics(diagnostics.summary, diagnostics.messages ?? [])
+							.get(),
+					},
 				},
-			};
+				prepared.escapedCodeUnits,
+				displayPath,
+			);
 		});
 	}
 }

--- a/packages/coding-agent/test/core/apply-patch-multi-file.test.ts
+++ b/packages/coding-agent/test/core/apply-patch-multi-file.test.ts
@@ -96,6 +96,34 @@ describe("EditTool apply_patch multi-file aggregate (#4074-B)", () => {
 		expect(perFile.some(r => r.path.endsWith("c.txt"))).toBe(false);
 	});
 
+	test("sums committed Unicode escapes before a partial failure without duplicating child notices", async () => {
+		await Bun.write(path.join(tempDir, "a.txt"), "a\n");
+		const tool = new EditTool(makeApplyPatchSession(tempDir));
+		const patch = [
+			"*** Begin Patch",
+			"*** Update File: a.txt",
+			"@@",
+			"-a",
+			`+A \ud800`,
+			"*** Update File: missing.txt",
+			"@@",
+			"-x",
+			`+Y \udc00`,
+			"*** End Patch",
+			"",
+		].join("\n");
+
+		const result = await tool.execute("call-unicode-partial", { input: patch });
+		const details = result.details as EditToolDetails | undefined;
+		const text = result.content?.find(block => block.type === "text")?.text ?? "";
+
+		expect(result.isError).toBe(true);
+		expect(await Bun.file(path.join(tempDir, "a.txt")).text()).toBe(`A ${String.raw`\uD800`}\n`);
+		expect(details?.escapedCodeUnits).toBe(1);
+		expect(details?.perFileResults?.[0]?.escapedCodeUnits).toBe(1);
+		expect(text.match(/Escaped 1 invalid Unicode/g)).toHaveLength(1);
+		expect(text).not.toContain("Escaped 2 invalid Unicode");
+	});
 	test("all-success multi-file apply_patch does not set isError", async () => {
 		await Bun.write(path.join(tempDir, "a.txt"), "a\n");
 		await Bun.write(path.join(tempDir, "b.txt"), "b\n");

--- a/packages/coding-agent/test/tools/conflict-integration.test.ts
+++ b/packages/coding-agent/test/tools/conflict-integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -728,21 +728,33 @@ describe("write resolves conflicts via conflict://N", () => {
 		const write = await getTool(session, "write");
 		await read.execute("read-unicode-bulk-a", { path: "unicode-bulk-a.ts:conflicts" });
 		await read.execute("read-unicode-bulk-b", { path: "unicode-bulk-b.ts:conflicts" });
-		await fs.chmod(fileB, 0o444);
 
-		const result = await write.execute("write-unicode-bulk", {
-			path: "conflict://*",
-			content: `resolved \ud800\n`,
-		});
-		const details = result.details as { escapedCodeUnits?: number } | undefined;
-		const text = getText(result);
+		// Deterministic sink failure: chmod 0444 is a no-op for root / privileged CI.
+		const bunWrite = Bun.write.bind(Bun);
+		const writeSpy = spyOn(Bun, "write").mockImplementation(((destination, data) => {
+			if (typeof destination === "string" && destination === fileB) {
+				return Promise.reject(Object.assign(new Error("simulated write failure"), { code: "EACCES" }));
+			}
+			return bunWrite(destination as Parameters<typeof Bun.write>[0], data as Parameters<typeof Bun.write>[1]);
+		}) as typeof Bun.write);
 
-		expect(result.isError).toBe(true);
-		expect(await Bun.file(fileA).text()).toBe(`line 1\nresolved ${String.raw`\uD800`}\nline N\n`);
-		expect(await Bun.file(fileB).text()).toBe(TWO_WAY);
-		expect(details?.escapedCodeUnits).toBe(1);
-		expect(text.match(/Escaped 1 invalid Unicode/g)).toHaveLength(1);
-		expect(text).toContain("registered entries left intact for retry");
+		try {
+			const result = await write.execute("write-unicode-bulk", {
+				path: "conflict://*",
+				content: `resolved \ud800\n`,
+			});
+			const details = result.details as { escapedCodeUnits?: number } | undefined;
+			const text = getText(result);
+
+			expect(result.isError).toBe(true);
+			expect(await Bun.file(fileA).text()).toBe(`line 1\nresolved ${String.raw`\uD800`}\nline N\n`);
+			expect(await Bun.file(fileB).text()).toBe(TWO_WAY);
+			expect(details?.escapedCodeUnits).toBe(1);
+			expect(text.match(/Escaped 1 invalid Unicode/g)).toHaveLength(1);
+			expect(text).toContain("registered entries left intact for retry");
+		} finally {
+			writeSpy.mockRestore();
+		}
 	});
 	it("`write conflict://*` errors when no conflicts are registered", async () => {
 		const session = createTestSession(tempDir);

--- a/packages/coding-agent/test/tools/conflict-integration.test.ts
+++ b/packages/coding-agent/test/tools/conflict-integration.test.ts
@@ -756,6 +756,53 @@ describe("write resolves conflicts via conflict://N", () => {
 			writeSpy.mockRestore();
 		}
 	});
+
+	it("counts echo-trimmed lines only for files whose write committed", async () => {
+		const echoFile = [
+			"function f() {",
+			"<<<<<<< HEAD",
+			"\tours();",
+			"=======",
+			"\ttheirs();",
+			">>>>>>> feature/x",
+			"\tdone();",
+			"}",
+			"",
+		].join("\n");
+		const fileA = path.join(tempDir, "echo-bulk-a.ts");
+		const fileB = path.join(tempDir, "echo-bulk-b.ts");
+		await Bun.write(fileA, echoFile);
+		await Bun.write(fileB, echoFile);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+		await read.execute("read-echo-bulk-a", { path: "echo-bulk-a.ts:conflicts" });
+		await read.execute("read-echo-bulk-b", { path: "echo-bulk-b.ts:conflicts" });
+
+		const bunWrite = Bun.write.bind(Bun);
+		const writeSpy = spyOn(Bun, "write").mockImplementation(((destination, data) => {
+			if (typeof destination === "string" && destination === fileB) {
+				return Promise.reject(Object.assign(new Error("simulated write failure"), { code: "EACCES" }));
+			}
+			return bunWrite(destination as Parameters<typeof Bun.write>[0], data as Parameters<typeof Bun.write>[1]);
+		}) as typeof Bun.write);
+
+		try {
+			// Both files would trim the same 2 echoed trailing lines, but only one
+			// write survives, so the note must report 2 — not the pre-commit 4.
+			const result = await write.execute("write-echo-bulk", {
+				path: "conflict://*",
+				content: "\tours();\n\ttheirs();\n\tdone();\n}\n",
+			});
+			const text = getText(result);
+
+			expect(result.isError).toBe(true);
+			expect(text).toContain("dropped 2 content line(s)");
+			expect(await Bun.file(fileB).text()).toBe(echoFile);
+		} finally {
+			writeSpy.mockRestore();
+		}
+	});
 	it("`write conflict://*` errors when no conflicts are registered", async () => {
 		const session = createTestSession(tempDir);
 		const write = await getTool(session, "write");

--- a/packages/coding-agent/test/tools/conflict-integration.test.ts
+++ b/packages/coding-agent/test/tools/conflict-integration.test.ts
@@ -332,6 +332,25 @@ describe("write resolves conflicts via conflict://N", () => {
 		expect(session.conflictHistory?.get(1)).toBeUndefined();
 	});
 
+	it("escapes lone surrogates in conflict replacements before the file write", async () => {
+		const filePath = path.join(tempDir, "unicode.ts");
+		await Bun.write(filePath, TWO_WAY);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+
+		await read.execute("read-unicode", { path: "unicode.ts" });
+		const result = await write.execute("write-unicode", {
+			path: "conflict://1",
+			content: `한 \ud800 😀\n`,
+		});
+
+		expect(await Bun.file(filePath).text()).toBe(`line 1\n한 ${String.raw`\uD800`} 😀\nline N\n`);
+		const text = getText(result);
+		expect(text).toContain("Resolved conflict #1");
+		expect(text).toContain("Escaped 1 invalid Unicode code unit(s) before writing unicode.ts.");
+		expect(text.match(/Escaped 1 invalid Unicode/g)).toHaveLength(1);
+	});
 	it("drops trailing lines that echo the context below the region and notes the repair", async () => {
 		const filePath = path.join(tempDir, "echo.ts");
 		const content = [
@@ -699,6 +718,32 @@ describe("write resolves conflicts via conflict://N", () => {
 		expect(session.conflictHistory?.entries()).toHaveLength(0);
 	});
 
+	it("reports Unicode counts from committed files before a later bulk sink failure", async () => {
+		const fileA = path.join(tempDir, "unicode-bulk-a.ts");
+		const fileB = path.join(tempDir, "unicode-bulk-b.ts");
+		await Bun.write(fileA, TWO_WAY);
+		await Bun.write(fileB, TWO_WAY);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+		await read.execute("read-unicode-bulk-a", { path: "unicode-bulk-a.ts:conflicts" });
+		await read.execute("read-unicode-bulk-b", { path: "unicode-bulk-b.ts:conflicts" });
+		await fs.chmod(fileB, 0o444);
+
+		const result = await write.execute("write-unicode-bulk", {
+			path: "conflict://*",
+			content: `resolved \ud800\n`,
+		});
+		const details = result.details as { escapedCodeUnits?: number } | undefined;
+		const text = getText(result);
+
+		expect(result.isError).toBe(true);
+		expect(await Bun.file(fileA).text()).toBe(`line 1\nresolved ${String.raw`\uD800`}\nline N\n`);
+		expect(await Bun.file(fileB).text()).toBe(TWO_WAY);
+		expect(details?.escapedCodeUnits).toBe(1);
+		expect(text.match(/Escaped 1 invalid Unicode/g)).toHaveLength(1);
+		expect(text).toContain("registered entries left intact for retry");
+	});
 	it("`write conflict://*` errors when no conflicts are registered", async () => {
 		const session = createTestSession(tempDir);
 		const write = await getTool(session, "write");

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -467,6 +467,58 @@ describe("editToolRenderer", () => {
 		expect(rendered).not.toContain("No changes would be made");
 		for (const path of paths) expect(rendered).toContain(path);
 	});
+	it("reports escaped code units on a single-file success result", async () => {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Updated notes.txt" }],
+				details: { diff: "+1│broken", op: "update", path: "notes.txt", escapedCodeUnits: 2 },
+			},
+			{ expanded: false, isPartial: false, renderContext: { editMode: "hashline" } },
+			uiTheme,
+		);
+
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("Escaped 2 invalid Unicode code unit(s) before writing notes.txt.");
+	});
+
+	it("reports escaped code units per card in a multi-file success result", async () => {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Updated 2 files" }],
+				details: {
+					diff: "",
+					perFileResults: [
+						{ path: "a.txt", diff: "+1│a", op: "update" as const, escapedCodeUnits: 1 },
+						{ path: "b.txt", diff: "+1│b", op: "update" as const },
+					],
+				},
+			},
+			{ expanded: false, isPartial: false, renderContext: { editMode: "hashline" } },
+			uiTheme,
+		);
+
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("Escaped 1 invalid Unicode code unit(s) before writing a.txt.");
+		// The clean file's card stays silent — the count is per file, not shared.
+		expect(rendered.match(/Escaped \d+ invalid Unicode/g)).toHaveLength(1);
+	});
+
+	it("keeps a move result framed when it escaped code units instead of collapsing to an inline row", async () => {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Moved a.txt to b.txt" }],
+				details: { diff: "", op: "update", path: "b.txt", move: "b.txt", sourcePath: "a.txt", escapedCodeUnits: 3 },
+			},
+			{ expanded: false, isPartial: false, renderContext: { editMode: "hashline" } },
+			uiTheme,
+		);
+
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("Escaped 3 invalid Unicode code unit(s) before writing b.txt.");
+	});
 
 	it("renders a move-only result as source → destination with no diff body", async () => {
 		const uiTheme = await getUiTheme();

--- a/packages/coding-agent/test/unicode-edit-persistence.test.ts
+++ b/packages/coding-agent/test/unicode-edit-persistence.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	applyPatch,
+	EditTool,
+	executeReplaceSingle,
+	type FileSystem,
+	type PrepareWriteArgs,
+} from "@oh-my-pi/pi-coding-agent/edit";
+import {
+	readEditFileText,
+	type SerializedEditFileText,
+	toPersistedEdit,
+} from "@oh-my-pi/pi-coding-agent/edit/read-file";
+import { writethroughNoop } from "@oh-my-pi/pi-coding-agent/lsp";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const LONE_HIGH = "\ud800";
+const LONE_LOW = "\udc00";
+
+function createSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		enableLsp: false,
+		getSessionFile: () => path.join(cwd, "session.jsonl"),
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		allocateOutputArtifact: async () => ({ id: "artifact-1", path: path.join(cwd, "artifact-1.log") }),
+		settings: Settings.isolated(),
+	};
+}
+
+function notebook(source: string, metadata: Record<string, unknown> = {}): string {
+	return JSON.stringify(
+		{
+			cells: [
+				{
+					cell_type: "markdown",
+					metadata: { preserved: "cell" },
+					source: [source],
+				},
+			],
+			metadata,
+			nbformat: 4,
+			nbformat_minor: 5,
+		},
+		null,
+		1,
+	);
+}
+
+function textFromResult(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
+		.map(part => part.text)
+		.join("\n");
+}
+
+class RecordingFileSystem implements FileSystem {
+	readonly files = new Map<string, string>();
+	readonly preparedCalls: PrepareWriteArgs[] = [];
+	readonly writes: Array<{ path: string; content: string }> = [];
+
+	async exists(filePath: string): Promise<boolean> {
+		return this.files.has(filePath);
+	}
+
+	async read(filePath: string): Promise<string> {
+		const value = this.files.get(filePath);
+		if (value === undefined) throw Object.assign(new Error(`missing ${filePath}`), { code: "ENOENT" });
+		return value;
+	}
+
+	async prepareWrite(args: PrepareWriteArgs): Promise<SerializedEditFileText> {
+		this.preparedCalls.push(args);
+		return toPersistedEdit(args.candidate);
+	}
+
+	async write(filePath: string, content: string): Promise<void> {
+		this.writes.push({ path: filePath, content });
+		this.files.set(filePath, content);
+	}
+
+	async delete(filePath: string): Promise<void> {
+		this.files.delete(filePath);
+	}
+
+	async mkdir(): Promise<void> {}
+}
+
+describe("Unicode edit persistence boundary", () => {
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+	});
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "unicode-edit-test-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(tmpDir);
+	});
+
+	it("prepares injected patch adapters during dry-run and writes only prepared physical text on commit", async () => {
+		const adapter = new RecordingFileSystem();
+		const target = path.join(tmpDir, "memory.txt");
+		adapter.files.set(target, "old\n");
+		const input = {
+			path: "memory.txt",
+			op: "update" as const,
+			diff: `@@\n-old\n+new ${LONE_HIGH}`,
+		};
+
+		const preview = await applyPatch(input, { cwd: tmpDir, dryRun: true, fs: adapter });
+		expect(adapter.preparedCalls).toHaveLength(1);
+		expect(adapter.preparedCalls[0]?.sourcePath).toBe(target);
+		expect(adapter.preparedCalls[0]?.targetPath).toBe(target);
+		expect(adapter.writes).toHaveLength(0);
+		expect(preview.change.newContent).toBe(`${String.raw`new \uD800`}\n`);
+		expect(preview.change.prepared?.escapedCodeUnits).toBe(1);
+		expect(adapter.files.get(target)).toBe("old\n");
+
+		const committed = await applyPatch(input, { cwd: tmpDir, fs: adapter });
+		expect(adapter.preparedCalls).toHaveLength(2);
+		expect(adapter.writes).toEqual([{ path: target, content: `${String.raw`new \uD800`}\n` }]);
+		expect(committed.change.newContent).toBe(preview.change.newContent);
+		expect(adapter.files.get(target)).toBe(`${String.raw`new \uD800`}\n`);
+	});
+
+	it("replace mode preserves notebook metadata while diffing and reporting virtual text", async () => {
+		const filePath = path.join(tmpDir, "book.ipynb");
+		await Bun.write(filePath, notebook("hello", { owner: "unicode-test" }));
+		const session = createSession(tmpDir);
+		const result = await executeReplaceSingle({
+			session,
+			path: "book.ipynb",
+			params: { old_text: "hello", new_text: `한 ${LONE_HIGH} 😀` },
+			allowFuzzy: false,
+			fuzzyThreshold: 1,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: () => {
+				throw new Error("deferred diagnostics are unused with writethroughNoop");
+			},
+		});
+
+		const persisted = JSON.parse(await Bun.file(filePath).text()) as {
+			cells: Array<{ metadata: Record<string, unknown>; source: string[] }>;
+			metadata: Record<string, unknown>;
+		};
+		expect(persisted.metadata.owner).toBe("unicode-test");
+		expect(persisted.cells[0]?.metadata.preserved).toBe("cell");
+		expect(persisted.cells[0]?.source.join("")).toBe(`한 ${String.raw`\uD800`} 😀`);
+		expect(result.details?.escapedCodeUnits).toBe(1);
+		expect(result.details?.newText).toContain(`한 ${String.raw`\uD800`} 😀`);
+		expect(result.details?.newText).not.toContain("nbformat");
+		expect(result.details?.diff).not.toContain('"cells"');
+		expect(result.details?.diff).not.toContain("nbformat");
+		expect(textFromResult(result)).toContain("Escaped 1 invalid Unicode code unit(s) before writing book.ipynb.");
+	});
+
+	it("patch mode prepares notebook JSON physically but returns logical virtual text", async () => {
+		const filePath = path.join(tmpDir, "patch-book.ipynb");
+		await Bun.write(filePath, notebook("before", { preserved: true }));
+
+		const result = await applyPatch(
+			{
+				path: "patch-book.ipynb",
+				op: "update",
+				diff: `@@\n-before\n+after ${LONE_LOW}`,
+			},
+			{ cwd: tmpDir },
+		);
+
+		expect(result.change.type).toBe("update");
+		expect(result.change.newContent).toContain(String.raw`after \uDC00`);
+		expect(result.change.newContent).not.toContain("nbformat");
+		expect(result.change.prepared?.escapedCodeUnits).toBe(1);
+		expect(result.change.prepared?.content).toContain('"nbformat": 4');
+		const persisted = JSON.parse(await Bun.file(filePath).text()) as {
+			cells: Array<{ source: string[] }>;
+			metadata: Record<string, unknown>;
+		};
+		expect(persisted.metadata.preserved).toBe(true);
+		expect(persisted.cells[0]?.source.join("")).toBe(String.raw`after \uDC00`);
+		expect(await readEditFileText(filePath, "patch-book.ipynb")).toBe(result.change.newContent ?? "");
+	});
+
+	it("uses destination format for patch moves in every direction", async () => {
+		const notebookSource = path.join(tmpDir, "source.ipynb");
+		await Bun.write(notebookSource, notebook("notebook text", { identity: "keep-me" }));
+		const notebookMove = await applyPatch(
+			{
+				path: "source.ipynb",
+				rename: "moved.ipynb",
+				op: "update",
+				diff: "@@\n-notebook text\n+notebook moved",
+			},
+			{ cwd: tmpDir },
+		);
+		const movedNotebookPath = path.join(tmpDir, "moved.ipynb");
+		const movedNotebook = JSON.parse(await Bun.file(movedNotebookPath).text()) as {
+			metadata: Record<string, unknown>;
+		};
+		expect(movedNotebook.metadata.identity).toBe("keep-me");
+		expect(await readEditFileText(movedNotebookPath, "moved.ipynb")).toContain("notebook moved");
+		expect(notebookMove.change.newContent).not.toContain("nbformat");
+
+		const plainSource = path.join(tmpDir, "plain.txt");
+		await Bun.write(plainSource, "# %% [markdown]\nplain text\n");
+		await applyPatch(
+			{
+				path: "plain.txt",
+				rename: "plain-to-notebook.ipynb",
+				op: "update",
+				diff: "@@\n-plain text\n+plain moved",
+			},
+			{ cwd: tmpDir },
+		);
+		const plainToNotebook = path.join(tmpDir, "plain-to-notebook.ipynb");
+		const plainNotebookJson = JSON.parse(await Bun.file(plainToNotebook).text()) as {
+			nbformat: number;
+			cells: unknown[];
+		};
+		expect(plainNotebookJson.nbformat).toBe(4);
+		expect(plainNotebookJson.cells).toHaveLength(1);
+		expect(await readEditFileText(plainToNotebook, "plain-to-notebook.ipynb")).toContain("plain moved");
+
+		const toPlain = path.join(tmpDir, "notebook-to-plain.ipynb");
+		await Bun.write(toPlain, notebook("original virtual"));
+		const notebookToPlain = await applyPatch(
+			{
+				path: "notebook-to-plain.ipynb",
+				rename: "notebook.txt",
+				op: "update",
+				diff: "@@\n-original virtual\n+plain virtual",
+			},
+			{ cwd: tmpDir },
+		);
+		const plainDestination = path.join(tmpDir, "notebook.txt");
+		expect(await Bun.file(plainDestination).text()).toBe(notebookToPlain.change.newContent ?? "");
+		expect(await Bun.file(plainDestination).text()).toContain("plain virtual");
+		expect(await Bun.file(plainDestination).text()).not.toContain("nbformat");
+	});
+
+	it("sums same-path child escape counts while retaining exactly one notice per committed edit", async () => {
+		const filePath = path.join(tmpDir, "same-path.txt");
+		await Bun.write(filePath, "one\ntwo\n");
+		const session = createSession(tmpDir);
+		session.settings.set("edit.mode", "replace");
+		const tool = new EditTool(session);
+		const result = await tool.execute("same-path-unicode", {
+			path: "same-path.txt",
+			edits: [
+				{ old_text: "one", new_text: `one ${LONE_HIGH}` },
+				{ old_text: "two", new_text: `two ${LONE_LOW}` },
+			],
+		});
+		const text = textFromResult(result);
+
+		expect(await Bun.file(filePath).text()).toBe(`one ${String.raw`\uD800`}\ntwo ${String.raw`\uDC00`}\n`);
+		expect(result.details?.escapedCodeUnits).toBe(2);
+		expect(text.match(/Escaped 1 invalid Unicode/g)).toHaveLength(2);
+		expect(text).not.toContain("Escaped 2 invalid Unicode");
+	});
+});

--- a/packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts
+++ b/packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts
@@ -302,4 +302,75 @@ describe("unicode file-tool persistence", () => {
 		// The lone surrogate landed as its literal escape, never U+FFFD.
 		expect(await decode(members.get("docs/broken.txt"))).toBe(String.raw`x\uD800y`);
 	});
+
+	// JSON5 accepts CR, LS (U+2028) and PS (U+2029) as line terminators, so a `//`
+	// comment closed by any of them still leaves the following property live.
+	for (const [label, terminator] of [
+		["a carriage return", "\r"],
+		["a line separator", "\u2028"],
+		["a paragraph separator", "\u2029"],
+	] as const) {
+		it(`shields surrogates after a JSON5 comment closed by ${label}`, async () => {
+			const dbPath = path.join(tmpDir, `${label.replaceAll(" ", "-")}.db`);
+			const db = new Database(dbPath);
+			db.run("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+			db.close();
+
+			const tool = new WriteTool(createSession(tmpDir));
+			const result = await tool.execute("call-term", {
+				path: `${dbPath}:notes`,
+				content: `{ // note${terminator}body: "v ${LONE_HIGH}" }`,
+			});
+
+			const readDb = new Database(dbPath, { readonly: true });
+			const row = readDb.prepare<{ body: string }, []>("SELECT body FROM notes LIMIT 1").get();
+			readDb.close();
+
+			expect(row?.body).toBe(`v ${String.raw`\uD800`}`);
+			expect(result.details?.escapedCodeUnits).toBe(1);
+		});
+	}
+
+	it("shields a lone surrogate spelled as a JSON5 \\uXXXX escape", async () => {
+		const dbPath = path.join(tmpDir, "escaped-lone.db");
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+		db.close();
+
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-escaped-lone", {
+			path: `${dbPath}:notes`,
+			content: String.raw`{ body: "lone \uD800" }`,
+		});
+
+		const readDb = new Database(dbPath, { readonly: true });
+		const row = readDb.prepare<{ body: string }, []>("SELECT body FROM notes LIMIT 1").get();
+		readDb.close();
+
+		// Persisted as the literal escape it already spelled — never U+FFFD.
+		expect(row?.body).toBe(`lone ${String.raw`\uD800`}`);
+		expect(result.details?.escapedCodeUnits).toBe(1);
+		expect(resultText(result)).toContain("Escaped 1 invalid Unicode code unit(s) before writing");
+	});
+
+	it("leaves a well-formed \\uXXXX surrogate pair intact", async () => {
+		const dbPath = path.join(tmpDir, "escaped-pair.db");
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+		db.close();
+
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-escaped-pair", {
+			path: `${dbPath}:notes`,
+			content: String.raw`{ body: "emoji \uD83D\uDE00" }`,
+		});
+
+		const readDb = new Database(dbPath, { readonly: true });
+		const row = readDb.prepare<{ body: string }, []>("SELECT body FROM notes LIMIT 1").get();
+		readDb.close();
+
+		expect(row?.body).toBe("emoji 😀");
+		expect(result.details?.escapedCodeUnits).toBe(0);
+		expect(resultText(result)).not.toContain("invalid Unicode code unit");
+	});
 });

--- a/packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts
+++ b/packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts
@@ -373,4 +373,56 @@ describe("unicode file-tool persistence", () => {
 		expect(result.details?.escapedCodeUnits).toBe(0);
 		expect(resultText(result)).not.toContain("invalid Unicode code unit");
 	});
+
+	// A surrogate pair is a pair whatever each half was spelled as: shielding
+	// must decide on the decoded code unit, never on the source form.
+	const HIGH_EMOJI = "\ud83d";
+	const LOW_EMOJI = "\ude00";
+	for (const [label, body] of [
+		["raw high with escaped low", `${HIGH_EMOJI}${String.raw`\uDE00`}`],
+		["escaped high with raw low", `${String.raw`\uD83D`}${LOW_EMOJI}`],
+	] as const) {
+		it(`leaves a mixed-form surrogate pair intact — ${label}`, async () => {
+			const dbPath = path.join(tmpDir, `mixed-${label.replace(/\s+/g, "-")}.db`);
+			const db = new Database(dbPath);
+			db.run("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+			db.close();
+
+			const tool = new WriteTool(createSession(tmpDir));
+			const result = await tool.execute("call-mixed-pair", {
+				path: `${dbPath}:notes`,
+				content: `{ body: "mixed ${body}" }`,
+			});
+
+			const readDb = new Database(dbPath, { readonly: true });
+			const row = readDb.prepare<{ body: string }, []>("SELECT body FROM notes LIMIT 1").get();
+			readDb.close();
+
+			expect(row?.body).toBe("mixed 😀");
+			expect(result.details?.escapedCodeUnits).toBe(0);
+			expect(resultText(result)).not.toContain("invalid Unicode code unit");
+		});
+	}
+
+	it("counts an escaped high surrogate beside a raw high surrogate as two lone units", async () => {
+		const dbPath = path.join(tmpDir, "mixed-two-highs.db");
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+		db.close();
+
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-mixed-lone", {
+			path: `${dbPath}:notes`,
+			content: `{ body: "lone ${String.raw`\uD83D`}${HIGH_EMOJI}" }`,
+		});
+
+		const readDb = new Database(dbPath, { readonly: true });
+		const row = readDb.prepare<{ body: string }, []>("SELECT body FROM notes LIMIT 1").get();
+		readDb.close();
+
+		// Neither high surrogate pairs with anything, so both persist as literal escapes.
+		expect(row?.body).toBe(`lone ${String.raw`\uD83D\uD83D`}`);
+		expect(result.details?.escapedCodeUnits).toBe(2);
+		expect(resultText(result)).toContain("Escaped 2 invalid Unicode code unit(s) before writing");
+	});
 });

--- a/packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts
+++ b/packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts
@@ -1,0 +1,305 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type ToolCall, validateToolArguments } from "@oh-my-pi/pi-ai";
+import { finalizeToolCallArgumentsDone } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import { kStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
+import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { type ArchiveMemberContent, readArchiveEntries } from "@oh-my-pi/pi-coding-agent/utils/zip";
+import { parseStreamingJson, removeWithRetries } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+// Lone UTF-16 surrogate code units used across the suite.
+const LONE_HIGH = "\ud800";
+const LONE_LOW = "\udc00";
+const REPLACEMENT_BYTES = [0xef, 0xbf, 0xbd] as const;
+
+function createSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		enableLsp: false,
+		getSessionFile: () => path.join(cwd, "session.jsonl"),
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		allocateOutputArtifact: async () => ({ id: "artifact-1", path: path.join(cwd, "artifact-1.log") }),
+		settings: Settings.isolated(),
+		...overrides,
+	};
+}
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter(
+			(block): block is { type: "text"; text: string } => block.type === "text" && typeof block.text === "string",
+		)
+		.map(block => block.text)
+		.join("\n");
+}
+
+function containsReplacementBytes(bytes: Uint8Array): boolean {
+	for (let i = 0; i + 2 < bytes.length; i++) {
+		if (
+			bytes[i] === REPLACEMENT_BYTES[0] &&
+			bytes[i + 1] === REPLACEMENT_BYTES[1] &&
+			bytes[i + 2] === REPLACEMENT_BYTES[2]
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+describe("unicode file-tool persistence", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "unicode-write-test-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(tmpDir);
+	});
+
+	it("carries raw lone surrogates through streamed JSON finalization and escapes them at the sink", async () => {
+		const filePath = path.join(tmpDir, "note.txt");
+		// Wire JSON with two independent `\uXXXX` escapes plus valid Hangul/emoji.
+		const wire = `{"path":${JSON.stringify(filePath)},"content":"한 ${String.raw`\uD800`} 😀 ${String.raw`\uDC00`} 끝"}`;
+
+		const block: ToolCall & { [kStreamingPartialJson]: string } = {
+			type: "toolCall",
+			id: "call-1",
+			name: "write",
+			arguments: {},
+			[kStreamingPartialJson]: "",
+		};
+		for (let i = 0; i < wire.length; i += 3) {
+			block[kStreamingPartialJson] += wire.slice(i, i + 3);
+			parseStreamingJson(block[kStreamingPartialJson]);
+		}
+		finalizeToolCallArgumentsDone(block, block[kStreamingPartialJson]);
+		const tool = new WriteTool(createSession(tmpDir));
+		const validated = validateToolArguments(tool, block);
+		if (typeof validated.path !== "string" || typeof validated.content !== "string") {
+			throw new Error("write arguments were not finalized as strings");
+		}
+		const args = { path: validated.path, content: validated.content };
+
+		// At dispatch the lone surrogates are still raw code units, not escapes or U+FFFD.
+		expect(args.content.includes(LONE_HIGH)).toBe(true);
+		expect(args.content.includes(LONE_LOW)).toBe(true);
+		expect(args.content.includes("\ufffd")).toBe(false);
+		expect(args.content.includes("한")).toBe(true);
+		expect(args.content.includes("😀")).toBe(true);
+
+		const result = await tool.execute("call-1", args);
+
+		const bytes = await Bun.file(filePath).bytes();
+		expect(containsReplacementBytes(bytes)).toBe(false);
+		const onDisk = new TextDecoder().decode(bytes);
+		expect(onDisk.includes(String.raw`\uD800`)).toBe(true);
+		expect(onDisk.includes(String.raw`\uDC00`)).toBe(true);
+		expect(onDisk.includes("한")).toBe(true);
+		expect(onDisk.includes("😀")).toBe(true);
+		expect(result.details?.escapedCodeUnits).toBe(2);
+		expect(resultText(result)).toContain(`Escaped 2 invalid Unicode code unit(s) before writing`);
+	});
+
+	it("keeps valid Unicode byte-identical with a zero count and no notice", async () => {
+		const filePath = path.join(tmpDir, "valid.txt");
+		const content = ["한", "\u1112\u1161\u11ab", "\u314e\u314f\u3134", "😀", String.raw`literal \uD800`, "�"].join(
+			"\n",
+		);
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-1", { path: filePath, content });
+
+		expect(await Bun.file(filePath).text()).toBe(content);
+		expect(result.details?.escapedCodeUnits).toBe(0);
+		expect(resultText(result)).not.toContain("invalid Unicode code unit");
+	});
+
+	it("writes raw .ipynb content verbatim without invoking virtual-cell serialization", async () => {
+		const filePath = path.join(tmpDir, "book.ipynb");
+		const notebook = {
+			cells: [
+				{ cell_type: "markdown", metadata: {}, source: ["# 제목 한글\n", "본문 😀"] },
+				{ cell_type: "code", execution_count: null, metadata: {}, outputs: [], source: ["print('한')\n"] },
+			],
+			metadata: { kernelspec: { name: "python3" } },
+			nbformat: 4,
+			nbformat_minor: 5,
+		};
+		const raw = JSON.stringify(notebook, null, 1);
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-1", { path: filePath, content: raw });
+
+		// Byte-identical: WriteTool never rewraps a notebook payload as a virtual cell.
+		expect(await Bun.file(filePath).text()).toBe(raw);
+		const parsed = JSON.parse(await Bun.file(filePath).text());
+		expect(parsed.cells).toHaveLength(2);
+		expect(parsed.cells[0].cell_type).toBe("markdown");
+		expect(parsed.cells[1].cell_type).toBe("code");
+		expect(parsed.nbformat).toBe(4);
+		// No cell-marker header leaked in — proof virtual serialization was not run.
+		expect(await Bun.file(filePath).text()).not.toContain("# %% [");
+		expect(result.details?.escapedCodeUnits).toBe(0);
+	});
+
+	it("escapes raw surrogate code units inside notebook JSON without changing its container", async () => {
+		const filePath = path.join(tmpDir, "broken-book.ipynb");
+		const encoded = JSON.stringify({
+			cells: [{ cell_type: "markdown", metadata: {}, source: ["broken \ud800"] }],
+			metadata: { identity: "raw-write" },
+			nbformat: 4,
+			nbformat_minor: 5,
+		});
+		const rawSurrogateJson = encoded.replace(String.raw`\ud800`, LONE_HIGH);
+		expect(rawSurrogateJson.includes(LONE_HIGH)).toBe(true);
+
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-broken-book", { path: filePath, content: rawSurrogateJson });
+		const persistedText = await Bun.file(filePath).text();
+		const persisted = JSON.parse(persistedText) as {
+			cells: Array<{ source: string[] }>;
+			metadata: Record<string, unknown>;
+		};
+
+		expect(persisted.metadata.identity).toBe("raw-write");
+		expect(persisted.cells[0]?.source[0]?.charCodeAt(7)).toBe(0xd800);
+		expect(persistedText).toContain(String.raw`\uD800`);
+		expect(persistedText).not.toContain("# %% [");
+		expect(result.details?.escapedCodeUnits).toBe(1);
+		expect(resultText(result).match(/Escaped 1 invalid Unicode/g)).toHaveLength(1);
+	});
+	it("persists SQLite string values with shielded surrogate escapes, not U+FFFD", async () => {
+		const dbPath = path.join(tmpDir, "app.db");
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+		db.close();
+
+		const tool = new WriteTool(createSession(tmpDir));
+		// JSON5 with comments, a literal-backslash control, and raw lone surrogates.
+		const content = `{
+			// leading comment ${LONE_HIGH} (in a comment, must not count)
+			body: "start ${LONE_HIGH} mid \\\\ end ${LONE_LOW}",
+		}`;
+		const result = await tool.execute("call-1", { path: `${dbPath}:notes`, content });
+
+		const readDb = new Database(dbPath, { readonly: true });
+		const row = readDb.prepare<{ body: string }, []>("SELECT body FROM notes LIMIT 1").get();
+		readDb.close();
+
+		expect(row).not.toBeNull();
+		const body = row?.body ?? "";
+		expect(body.includes("\ufffd")).toBe(false);
+		expect(body.includes(String.raw`\uD800`)).toBe(true);
+		expect(body.includes(String.raw`\uDC00`)).toBe(true);
+		// The literal backslash pair survives without being double-decoded.
+		expect(body.includes("\\")).toBe(true);
+		// Only the two surrogates inside the persisted string value count; the one in the comment does not.
+		expect(result.details?.escapedCodeUnits).toBe(2);
+		expect(resultText(result)).toContain("Escaped 2 invalid Unicode code unit(s) before writing");
+	});
+
+	it("shields single-quoted and permissively escaped JSON5 surrogate values", async () => {
+		const dbPath = path.join(tmpDir, "quotes.db");
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE payloads (id INTEGER PRIMARY KEY, body TEXT NOT NULL, title TEXT NOT NULL)");
+		db.close();
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-quotes", {
+			path: `${dbPath}:payloads`,
+			content: `{ body: 'single ${LONE_LOW}', title: "escaped \\${LONE_HIGH}" }`,
+		});
+
+		const readDb = new Database(dbPath, { readonly: true });
+		const row = readDb.prepare<{ body: string; title: string }, []>("SELECT body, title FROM payloads LIMIT 1").get();
+		readDb.close();
+		expect(row?.body).toBe(`single ${String.raw`\uDC00`}`);
+		expect(row?.title).toBe(`escaped ${String.raw`\uD800`}`);
+		expect(result.details?.escapedCodeUnits).toBe(2);
+		expect(resultText(result).match(/Escaped 2 invalid Unicode/g)).toHaveLength(1);
+	});
+
+	it("preserves valid surrogate pairs after permissive JSON5 escapes", async () => {
+		const dbPath = path.join(tmpDir, "emoji.db");
+		const db = new Database(dbPath);
+		db.run("CREATE TABLE payloads (id INTEGER PRIMARY KEY, body TEXT NOT NULL)");
+		db.close();
+		const tool = new WriteTool(createSession(tmpDir));
+		const result = await tool.execute("call-emoji", {
+			path: `${dbPath}:payloads`,
+			content: `{ body: "escaped \\😀" }`,
+		});
+
+		const readDb = new Database(dbPath, { readonly: true });
+		const row = readDb.prepare<{ body: string }, []>("SELECT body FROM payloads LIMIT 1").get();
+		readDb.close();
+		expect(row?.body).toBe("escaped 😀");
+		expect(result.details?.escapedCodeUnits).toBe(0);
+		expect(resultText(result)).not.toContain("invalid Unicode code unit");
+	});
+
+	it("forwards xd:// device payloads verbatim with no escape count or notice", async () => {
+		const captureSchema = type({ value: "string" });
+		let received: string | undefined;
+		const captureTool: AgentTool<typeof captureSchema> = {
+			name: "capture",
+			label: "Capture",
+			description: "records the payload it receives",
+			parameters: captureSchema,
+			execute: async (_id, args) => {
+				received = args.value;
+				return { content: [{ type: "text", text: "captured" }] };
+			},
+		};
+		const session = createSession(tmpDir, { xdevRegistry: new XdevRegistry([captureTool]) });
+		const tool = new WriteTool(session);
+
+		const deviceContent = JSON.stringify({ value: `a${LONE_HIGH}b` });
+		const result = await tool.execute("call-1", { path: "xd://capture", content: deviceContent });
+
+		// The wrapped device sees the identical raw code unit (no escape, no U+FFFD).
+		expect(received).toBeDefined();
+		expect(received?.charCodeAt(1)).toBe(0xd800);
+		expect(received?.includes(String.raw`\uD800`)).toBe(false);
+		// Delegated route: no persistence claim.
+		expect(result.details?.escapedCodeUnits).toBeUndefined();
+		expect(resultText(result)).not.toContain("invalid Unicode code unit");
+	});
+
+	it("escapes archive member content before packing while leaving valid text intact", async () => {
+		const archivePath = path.join(tmpDir, "bundle.zip");
+		const tool = new WriteTool(createSession(tmpDir));
+
+		const good = await tool.execute("call-good", {
+			path: `${archivePath}:docs/한글.txt`,
+			content: "한글 본문 😀\n",
+		});
+		expect(good.details?.escapedCodeUnits).toBe(0);
+
+		const bad = await tool.execute("call-bad", {
+			path: `${archivePath}:docs/broken.txt`,
+			content: `x${LONE_HIGH}y`,
+		});
+		expect(bad.details?.escapedCodeUnits).toBe(1);
+		expect(resultText(bad)).toContain("Escaped 1 invalid Unicode code unit(s) before writing");
+
+		const members = await readArchiveEntries(archivePath);
+		const decode = async (member: ArchiveMemberContent | undefined): Promise<string> => {
+			if (member === undefined) return "";
+			if (typeof member === "string") return member;
+			if (member instanceof Blob) return member.text();
+			return new TextDecoder().decode(member);
+		};
+		expect(await decode(members.get("docs/한글.txt"))).toBe("한글 본문 😀\n");
+		// The lone surrogate landed as its literal escape, never U+FFFD.
+		expect(await decode(members.get("docs/broken.txt"))).toBe(String.raw`x\uD800y`);
+	});
+});

--- a/packages/coding-agent/test/write-acp-fs.test.ts
+++ b/packages/coding-agent/test/write-acp-fs.test.ts
@@ -83,6 +83,36 @@ describe("write tool ACP fs routing", () => {
 		}
 	});
 
+	it("sends prepared Unicode text through ACP and reports the persisted escape count", async () => {
+		const filePath = path.join(tmpDir, "unicode.txt");
+		const bridge: ClientBridge = {
+			capabilities: { writeTextFile: true },
+			writeTextFile: async () => undefined,
+		};
+		const bridgeSpy = spyOn(bridge, "writeTextFile");
+		const bunWriteSpy = spyOn(Bun, "write");
+		try {
+			const tool = new WriteTool(createSession(tmpDir, { bridge }));
+			const result = await tool.execute("call-unicode", {
+				path: filePath,
+				content: `한 \ud800 😀`,
+			});
+
+			expect(bridgeSpy).toHaveBeenCalledTimes(1);
+			expect(bridgeSpy).toHaveBeenCalledWith({
+				path: filePath,
+				content: `한 ${String.raw`\uD800`} 😀`,
+			});
+			expect(bunWriteSpy).not.toHaveBeenCalled();
+			expect(result.details?.escapedCodeUnits).toBe(1);
+			expect(resultText(result)).toContain(
+				`Escaped 1 invalid Unicode code unit(s) before writing ${path.basename(filePath)}.`,
+			);
+		} finally {
+			bunWriteSpy.mockRestore();
+		}
+	});
+
 	it("emits a progress snapshot before filesystem writes complete", async () => {
 		const filePath = path.join(tmpDir, "progress.txt");
 		const session = createSession(tmpDir);

--- a/packages/coding-agent/test/write-hashline-header.test.ts
+++ b/packages/coding-agent/test/write-hashline-header.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Patch, Patcher } from "@oh-my-pi/hashline";
+import { formatHashlineHeader, Patch, Patcher } from "@oh-my-pi/hashline";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { canonicalSnapshotKey, getFileSnapshotStore } from "@oh-my-pi/pi-coding-agent/edit/file-snapshot-store";
 import { HashlineFilesystem } from "@oh-my-pi/pi-coding-agent/edit/hashline/filesystem";
@@ -95,7 +95,9 @@ describe("write tool hashline header", () => {
 			},
 		});
 		const patcher = new Patcher({ fs: filesystem, snapshots: getFileSnapshotStore(session) });
-		const prepared = await patcher.prepare(patch.sections[0]!);
+		const section = patch.sections[0];
+		if (!section) throw new Error("expected one parsed hashline section");
+		const prepared = await patcher.prepare(section);
 		const sectionResult = await patcher.commit(prepared);
 		expect(sectionResult.op).toBe("update");
 
@@ -114,5 +116,112 @@ describe("write tool hashline header", () => {
 		const text = resultText(result);
 		expect(text.startsWith("[")).toBe(false);
 		expect(text).toBe(`Successfully wrote ${content.length} bytes to ${path.relative(tmpDir, filePath)}`);
+	});
+
+	it("hashes the escaped logical text and makes the returned header immediately reusable", async () => {
+		const filePath = path.join(tmpDir, "unicode.ts");
+		const session = createSession(tmpDir);
+		const tool = new WriteTool(session);
+		const writeResult = await tool.execute("call-1", { path: filePath, content: "export const value = 1;\n" });
+		const firstHeader = resultText(writeResult).split("\n")[0] ?? "";
+		const filesystem = new HashlineFilesystem({
+			session,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: () => {
+				throw new Error("deferred diagnostics unused with writethroughNoop");
+			},
+		});
+		const patcher = new Patcher({ fs: filesystem, snapshots: getFileSnapshotStore(session) });
+		const rawSurrogate = "\ud800";
+		const firstPatch = Patch.parse(`${firstHeader}\nSWAP 1.=1:\n+export const value = "${rawSurrogate}";\n`, {
+			cwd: tmpDir,
+		});
+		const firstSection = firstPatch.sections[0];
+		if (!firstSection) throw new Error("expected one Unicode hashline section");
+		const firstResult = await patcher.commit(await patcher.prepare(firstSection));
+
+		expect(firstResult.escapedCodeUnits).toBe(1);
+		expect(await Bun.file(filePath).text()).toBe(`${String.raw`export const value = "\uD800";`}\n`);
+		expect(firstResult.header).toMatch(HASHLINE_HEADER_LINE);
+
+		const secondPatch = Patch.parse(`${firstResult.header}\nSWAP 1.=1:\n+export const value = "reused";\n`, {
+			cwd: tmpDir,
+		});
+		const secondSection = secondPatch.sections[0];
+		if (!secondSection) throw new Error("expected one reusable hashline section");
+		const secondResult = await patcher.commit(await patcher.prepare(secondSection));
+
+		expect(secondResult.op).toBe("update");
+		expect(await Bun.file(filePath).text()).toBe('export const value = "reused";\n');
+	});
+
+	it("uses destination format for hashline moves and reuses every returned header", async () => {
+		const session = createSession(tmpDir);
+		const snapshots = getFileSnapshotStore(session);
+		const filesystem = new HashlineFilesystem({
+			session,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: () => {
+				throw new Error("deferred diagnostics unused with writethroughNoop");
+			},
+		});
+		const patcher = new Patcher({ fs: filesystem, snapshots });
+		const seedHeader = async (relativePath: string) => {
+			const logical = await filesystem.readText(relativePath);
+			const tag = snapshots.record(filesystem.canonicalPath(relativePath), logical);
+			return formatHashlineHeader(relativePath, tag);
+		};
+		const commit = async (patchText: string) => {
+			const parsed = Patch.parse(patchText, { cwd: tmpDir });
+			const section = parsed.sections[0];
+			if (!section) throw new Error("expected one cross-format move section");
+			return patcher.commit(await patcher.prepare(section));
+		};
+		const notebookJson = (source: string, identity: string) =>
+			JSON.stringify(
+				{
+					cells: [{ cell_type: "markdown", metadata: { cell: identity }, source: [source] }],
+					metadata: { identity },
+					nbformat: 4,
+					nbformat_minor: 5,
+				},
+				null,
+				1,
+			);
+
+		await Bun.write(path.join(tmpDir, "notebook-source.ipynb"), notebookJson("notebook old", "preserve"));
+		const notebookMove = await commit(
+			`${await seedHeader("notebook-source.ipynb")}\nSWAP 2.=2:\n+notebook moved\nMV notebook-moved.ipynb\n`,
+		);
+		const movedNotebook = JSON.parse(await Bun.file(path.join(tmpDir, "notebook-moved.ipynb")).text()) as {
+			metadata: Record<string, unknown>;
+		};
+		expect(movedNotebook.metadata.identity).toBe("preserve");
+		const notebookReuse = await commit(`${notebookMove.header}\nSWAP 2.=2:\n+notebook reused\n`);
+		expect(notebookReuse.op).toBe("update");
+
+		await Bun.write(path.join(tmpDir, "plain-source.txt"), "# %% [markdown]\nplain old");
+		const plainMove = await commit(
+			`${await seedHeader("plain-source.txt")}\nSWAP 2.=2:\n+plain moved\nMV plain-moved.ipynb\n`,
+		);
+		const plainNotebook = JSON.parse(await Bun.file(path.join(tmpDir, "plain-moved.ipynb")).text()) as {
+			cells: unknown[];
+			nbformat: number;
+		};
+		expect(plainNotebook.nbformat).toBe(4);
+		expect(plainNotebook.cells).toHaveLength(1);
+		const plainReuse = await commit(`${plainMove.header}\nSWAP 2.=2:\n+plain reused\n`);
+		expect(plainReuse.op).toBe("update");
+
+		await Bun.write(path.join(tmpDir, "to-plain.ipynb"), notebookJson("virtual old", "to-plain"));
+		const toPlainMove = await commit(
+			`${await seedHeader("to-plain.ipynb")}\nSWAP 2.=2:\n+virtual moved\nMV virtual.txt\n`,
+		);
+		const plainText = await Bun.file(path.join(tmpDir, "virtual.txt")).text();
+		expect(plainText).toBe("# %% [markdown] cell:0\nvirtual moved");
+		expect(plainText).not.toContain("nbformat");
+		const toPlainReuse = await commit(`${toPlainMove.header}\nSWAP 2.=2:\n+virtual reused\n`);
+		expect(toPlainReuse.op).toBe("update");
+		expect(await Bun.file(path.join(tmpDir, "virtual.txt")).text()).toContain("virtual reused");
 	});
 });

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Made `escapedCodeUnits` a required field on `WriteResult`.
+- Changed `Filesystem.move` from `Promise<void>` to an overloaded content-bearing `Promise<WriteResult>`.
+
 ## [17.0.8] - 2026-07-22
 
 ### Changed

--- a/packages/hashline/src/fs.ts
+++ b/packages/hashline/src/fs.ts
@@ -79,7 +79,13 @@ export abstract class Filesystem {
 	/** Persist `content` at `path`. Returns the actual final text that was written. */
 	abstract writeText(path: string, content: string): Promise<WriteResult>;
 
-	/** Delete the file at `path`. Default: not supported. */
+	/**
+	 * Delete the file at `path`. Default: not supported.
+	 *
+	 * Once the file is physically gone, the implementation MUST NOT perform
+	 * abortable follow-up work: the patcher invalidates the snapshot on return,
+	 * and a late rejection would strand a deleted file behind a live snapshot.
+	 */
 	async delete(path: string): Promise<void> {
 		throw new Error(`Filesystem does not support delete: ${path}`);
 	}
@@ -87,6 +93,11 @@ export abstract class Filesystem {
 	/**
 	 * Move/rename `from` to `to`. A content-bearing move must return the
 	 * logical text and escape count accepted by the destination adapter.
+	 *
+	 * Once the bytes have physically moved, the implementation MUST NOT perform
+	 * abortable follow-up work: the patcher relocates snapshot ownership on
+	 * return, so a late rejection would leave the file at its new path with the
+	 * snapshot still keyed to the old one.
 	 */
 	async move(from: string, to: string, content: string): Promise<WriteResult>;
 	async move(from: string, to: string, content?: undefined): Promise<undefined>;

--- a/packages/hashline/src/fs.ts
+++ b/packages/hashline/src/fs.ts
@@ -12,13 +12,18 @@ import * as fs from "node:fs/promises";
 import * as pathModule from "node:path";
 
 /**
- * Result returned by {@link Filesystem.writeText}. The patcher echoes back
- * `text` so adapters that transform on serialization (e.g. notebooks) can
- * report what actually landed on disk.
+ * Result returned by {@link Filesystem.writeText} (and content-bearing
+ * {@link Filesystem.move}). The patcher echoes back `text` — the LOGICAL text
+ * that maps to what a re-read yields (virtual cell text for notebooks) — so
+ * hashes, headers, snapshots, and diffs derive from it. `escapedCodeUnits`
+ * reports how many lone UTF-16 surrogates the adapter spelled as `\\uXXXX`
+ * before persisting; generic adapters that transform nothing report `0`.
  */
 export interface WriteResult {
-	/** Final text that was persisted. May differ from the input if the FS transformed it. */
+	/** Logical text that maps to what a re-read yields. May differ from the physical bytes (notebooks). */
 	text: string;
+	/** Count of lone UTF-16 surrogates escaped before persistence. */
+	escapedCodeUnits: number;
 }
 
 import type { FileOp } from "./types";
@@ -80,14 +85,15 @@ export abstract class Filesystem {
 	}
 
 	/**
-	 * Move/rename `from` to `to`. When `content` is provided the destination
-	 * receives that text; otherwise implementations may preserve the source bytes.
+	 * Move/rename `from` to `to`. A content-bearing move must return the
+	 * logical text and escape count accepted by the destination adapter.
 	 */
-	async move(from: string, to: string, content?: string): Promise<void> {
+	async move(from: string, to: string, content: string): Promise<WriteResult>;
+	async move(from: string, to: string, content?: undefined): Promise<undefined>;
+	async move(from: string, to: string, content?: string): Promise<WriteResult | undefined> {
 		void content;
 		throw new Error(`Filesystem does not support move: ${from} -> ${to}`);
 	}
-
 	/** Return true when the path exists and can be read. Default: probe via {@link readText}. */
 	async exists(path: string): Promise<boolean> {
 		try {
@@ -147,21 +153,23 @@ export class InMemoryFilesystem extends Filesystem {
 
 	async writeText(path: string, content: string): Promise<WriteResult> {
 		this.#files.set(path, content);
-		return { text: content };
+		return { text: content, escapedCodeUnits: 0 };
 	}
 
 	async delete(path: string): Promise<void> {
 		if (!this.#files.delete(path)) throw new NotFoundError(path);
 	}
 
-	async move(from: string, to: string, content?: string): Promise<void> {
+	async move(from: string, to: string, content: string): Promise<WriteResult>;
+	async move(from: string, to: string, content?: undefined): Promise<undefined>;
+	async move(from: string, to: string, content?: string): Promise<WriteResult | undefined> {
 		const existing = this.#files.get(from);
 		if (existing === undefined) throw new NotFoundError(from);
 		const finalContent = content ?? existing;
 		this.#files.set(to, finalContent);
 		this.#files.delete(from);
+		return content === undefined ? undefined : { text: finalContent, escapedCodeUnits: 0 };
 	}
-
 	async exists(path: string): Promise<boolean> {
 		return this.#files.has(path);
 	}
@@ -210,7 +218,7 @@ export class NodeFilesystem extends Filesystem {
 
 	async writeText(path: string, content: string): Promise<WriteResult> {
 		await Bun.write(path, content);
-		return { text: content };
+		return { text: content, escapedCodeUnits: 0 };
 	}
 
 	async delete(path: string): Promise<void> {
@@ -222,11 +230,13 @@ export class NodeFilesystem extends Filesystem {
 		}
 	}
 
-	async move(from: string, to: string, content?: string): Promise<void> {
+	async move(from: string, to: string, content: string): Promise<WriteResult>;
+	async move(from: string, to: string, content?: undefined): Promise<undefined>;
+	async move(from: string, to: string, content?: string): Promise<WriteResult | undefined> {
 		if (content !== undefined) {
 			await Bun.write(to, content);
 			await this.delete(from);
-			return;
+			return { text: content, escapedCodeUnits: 0 };
 		}
 		try {
 			await fs.rename(from, to);

--- a/packages/hashline/src/patcher.ts
+++ b/packages/hashline/src/patcher.ts
@@ -453,6 +453,8 @@ export class Patcher {
 			const destCanonical = this.fs.canonicalPath(moveDest);
 			// Write the destination first; only a successful move may relocate
 			// snapshot ownership and delete the source (owned by the adapter).
+			// `move` guarantees no abortable step runs after the bytes land, so
+			// the relocate below is reached whenever the file actually moved.
 			const write = await this.fs.move(section.path, moveDest, persisted);
 			this.snapshots.relocate(canonicalPath, destCanonical);
 			const canonicalAfter = normalizeToLF(stripBom(write.text).text);

--- a/packages/hashline/src/patcher.ts
+++ b/packages/hashline/src/patcher.ts
@@ -97,6 +97,8 @@ export interface PatchSectionResult {
 	persisted: string;
 	/** Final text that the {@link Filesystem} actually wrote (may differ if the FS transformed it). */
 	written: string;
+	/** Count of lone UTF-16 surrogates the filesystem escaped before persisting `after`. */
+	escapedCodeUnits: number;
 	/** 4-hex content-hash tag for `after`. Use to anchor follow-up edits. */
 	fileHash: string;
 	/** Hashline section header (`[path#tag]`) of the post-edit content. */
@@ -421,6 +423,7 @@ export class Patcher {
 				after: normalized,
 				persisted: prepared.rawContent,
 				written: prepared.rawContent,
+				escapedCodeUnits: 0,
 				fileHash: computeFileHash(normalized),
 				header: formatHashlineHeader(section.path, computeFileHash(normalized)),
 				warnings,
@@ -437,6 +440,7 @@ export class Patcher {
 				after: normalized,
 				persisted: prepared.rawContent,
 				written: prepared.rawContent,
+				escapedCodeUnits: 0,
 				fileHash: hash,
 				header: formatHashlineHeader(section.path, hash),
 				warnings,
@@ -447,17 +451,21 @@ export class Patcher {
 
 		if (moveDest !== undefined) {
 			const destCanonical = this.fs.canonicalPath(moveDest);
+			// Write the destination first; only a successful move may relocate
+			// snapshot ownership and delete the source (owned by the adapter).
+			const write = await this.fs.move(section.path, moveDest, persisted);
 			this.snapshots.relocate(canonicalPath, destCanonical);
-			await this.fs.move(section.path, moveDest, persisted);
-			const fileHash = this.#recordFullSnapshot(destCanonical, after);
+			const canonicalAfter = normalizeToLF(stripBom(write.text).text);
+			const fileHash = this.#recordFullSnapshot(destCanonical, canonicalAfter);
 			return {
 				path: resultPath,
 				canonicalPath: destCanonical,
 				op: "update",
 				before: normalized,
-				after,
-				persisted,
-				written: persisted,
+				after: canonicalAfter,
+				persisted: write.text,
+				written: write.text,
+				escapedCodeUnits: write.escapedCodeUnits,
 				fileHash,
 				header: formatHashlineHeader(moveDest, fileHash),
 				firstChangedLine: applyResult.firstChangedLine,
@@ -468,7 +476,10 @@ export class Patcher {
 		}
 
 		const write: WriteResult = await this.fs.writeText(section.path, persisted);
-		const fileHash = this.#recordFullSnapshot(canonicalPath, after);
+		// Hash/header/snapshot follow the logical text the adapter reports (with
+		// surrogates escaped), so an immediate re-read's tag matches on-disk bytes.
+		const canonicalAfter = normalizeToLF(stripBom(write.text).text);
+		const fileHash = this.#recordFullSnapshot(canonicalPath, canonicalAfter);
 		const op = exists ? "update" : "create";
 
 		return {
@@ -476,9 +487,10 @@ export class Patcher {
 			canonicalPath,
 			op,
 			before: normalized,
-			after,
-			persisted,
+			after: canonicalAfter,
+			persisted: write.text,
 			written: write.text,
+			escapedCodeUnits: write.escapedCodeUnits,
 			fileHash,
 			header: formatHashlineHeader(section.path, fileHash),
 			firstChangedLine: applyResult.firstChangedLine,

--- a/packages/hashline/test/file-ops.test.ts
+++ b/packages/hashline/test/file-ops.test.ts
@@ -6,6 +6,7 @@ import {
 	Patch,
 	Patcher,
 	parsePatch,
+	type WriteResult,
 } from "@oh-my-pi/hashline";
 
 const PATH = "src/old.ts";
@@ -66,5 +67,55 @@ describe("hashline file ops", () => {
 		expect(fs.get(DEST)).toBe("one\nTWO\nthree\n");
 		expect(result.sections[0]?.fileHash).toBe(computeFileHash("one\nTWO\nthree\n"));
 		expect(snapshots.head(DEST)?.hash).toBe(result.sections[0]?.fileHash);
+	});
+
+	it("derives hashes, snapshots, and reusable headers from filesystem-returned logical text", async () => {
+		class TransformingFilesystem extends InMemoryFilesystem {
+			override async writeText(path: string, content: string): Promise<WriteResult> {
+				const logical = content.replace("TWO", String.raw`TWO\uD800`);
+				await super.writeText(path, logical);
+				return { text: logical, escapedCodeUnits: 1 };
+			}
+		}
+
+		const fs = new TransformingFilesystem([[PATH, CONTENT]]);
+		const snapshots = new InMemorySnapshotStore();
+		const tag = snapshots.record(PATH, CONTENT);
+		const patcher = new Patcher({ fs, snapshots });
+		const first = await patcher.apply(Patch.parse(`[${PATH}#${tag}]\nSWAP 2.=2:\n+TWO`));
+		const firstResult = first.sections[0];
+		if (!firstResult) throw new Error("expected one transformed section");
+
+		const logical = `one\n${String.raw`TWO\uD800`}\nthree\n`;
+		expect(firstResult.after).toBe(logical);
+		expect(firstResult.escapedCodeUnits).toBe(1);
+		expect(firstResult.fileHash).toBe(computeFileHash(logical));
+		expect(snapshots.head(PATH)?.text).toBe(logical);
+
+		const second = await patcher.apply(Patch.parse(`${firstResult.header}\nSWAP 1.=1:\n+ONE`));
+		expect(second.sections[0]?.op).toBe("update");
+	});
+
+	it("leaves source and snapshot ownership intact when a destination move fails", async () => {
+		class FailingMoveFilesystem extends InMemoryFilesystem {
+			override async move(from: string, to: string, content: string): Promise<WriteResult>;
+			override async move(from: string, to: string, content?: undefined): Promise<undefined>;
+			override async move(_from: string, _to: string, _content?: string): Promise<WriteResult | undefined> {
+				throw new Error("destination write failed");
+			}
+		}
+
+		const fs = new FailingMoveFilesystem([[PATH, CONTENT]]);
+		const snapshots = new InMemorySnapshotStore();
+		const tag = snapshots.record(PATH, CONTENT, [1, 2]);
+		const patcher = new Patcher({ fs, snapshots });
+
+		await expect(patcher.apply(Patch.parse(`[${PATH}#${tag}]\nMV ${DEST}`))).rejects.toThrow(
+			"destination write failed",
+		);
+		expect(fs.get(PATH)).toBe(CONTENT);
+		expect(fs.get(DEST)).toBeUndefined();
+		expect(snapshots.byHash(PATH, tag)?.text).toBe(CONTENT);
+		expect(snapshots.byHash(DEST, tag)).toBeNull();
 	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added lossless escaping for lone UTF-16 surrogates before UTF-8 file writes.
+
 ## [17.0.9] - 2026-07-23
 
 ### Breaking Changes

--- a/packages/utils/src/sanitize-text.ts
+++ b/packages/utils/src/sanitize-text.ts
@@ -20,6 +20,59 @@ const CONTROL_RE = /[\x00-\x08\x0B-\x1F\x7F-\x9F]/g;
 
 const REPLACEMENT_CHAR = "\ufffd";
 
+export interface EscapedSurrogates {
+	text: string;
+	escapedCodeUnits: number;
+}
+
+/**
+ * Preserve well-formed UTF-16 while spelling each unmatched surrogate as an
+ * uppercase ASCII `\\uXXXX` escape before a UTF-8 persistence boundary.
+ */
+export function escapeUnpairedSurrogates(text: string): EscapedSurrogates {
+	let firstInvalid = -1;
+	for (let index = 0; index < text.length; index++) {
+		const codeUnit = text.charCodeAt(index);
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const next = text.charCodeAt(index + 1);
+			if (next >= 0xdc00 && next <= 0xdfff) {
+				index++;
+				continue;
+			}
+			firstInvalid = index;
+			break;
+		}
+		if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+			firstInvalid = index;
+			break;
+		}
+	}
+	if (firstInvalid === -1) return { text, escapedCodeUnits: 0 };
+
+	let escaped = text.slice(0, firstInvalid);
+	let segmentStart = firstInvalid;
+	let escapedCodeUnits = 0;
+	for (let index = firstInvalid; index < text.length; index++) {
+		const codeUnit = text.charCodeAt(index);
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const next = text.charCodeAt(index + 1);
+			if (next >= 0xdc00 && next <= 0xdfff) {
+				index++;
+				continue;
+			}
+		} else if (codeUnit < 0xdc00 || codeUnit > 0xdfff) {
+			continue;
+		}
+
+		escaped += text.slice(segmentStart, index);
+		escaped += `\\u${codeUnit.toString(16).toUpperCase().padStart(4, "0")}`;
+		escapedCodeUnits++;
+		segmentStart = index + 1;
+	}
+	escaped += text.slice(segmentStart);
+	return { text: escaped, escapedCodeUnits };
+}
+
 export function sanitizeText(text: string): string {
 	const wellFormed = text.toWellFormed();
 	if (wellFormed !== text) {

--- a/packages/utils/test/sanitize-text.test.ts
+++ b/packages/utils/test/sanitize-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
+import { escapeUnpairedSurrogates, sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
 
 describe("sanitizeText", () => {
 	it("strips ANSI CSI and removes C0/C1 control chars while keeping tab + LF", () => {
@@ -49,5 +49,43 @@ describe("sanitizeText", () => {
 
 	it("strips DEL and normalizes lone CR", () => {
 		expect(sanitizeText("a\x7fb\rc")).toBe("abc");
+	});
+});
+
+describe("escapeUnpairedSurrogates", () => {
+	it("preserves valid Unicode and returns the original string on the fast path", () => {
+		const values = [
+			"한",
+			"한",
+			"ㅎㅏㄴ",
+			"😀",
+			"A😀B",
+			String.fromCharCode(0xd83d, 0xde00),
+			String.raw`literal \uD800`,
+			"�",
+		];
+		for (const value of values) {
+			const escaped = escapeUnpairedSurrogates(value);
+			expect(escaped.text).toBe(value);
+			expect(escaped.escapedCodeUnits).toBe(0);
+		}
+	});
+
+	it("escapes each unmatched UTF-16 surrogate with uppercase hex", () => {
+		const cases: Array<[string, string, number]> = [
+			["a\ud800b", String.raw`a\uD800b`, 1],
+			["a\udc00b", String.raw`a\uDC00b`, 1],
+			["\ud800\ud800\udc00", `${String.raw`\uD800`}𐀀`, 1],
+			["\udc00\ud800\udc00", `${String.raw`\uDC00`}𐀀`, 1],
+			["\ud800x\udc00y\udfff", String.raw`\uD800x\uDC00y\uDFFF`, 3],
+		];
+		for (const [input, expected, count] of cases) {
+			expect(escapeUnpairedSurrogates(input)).toEqual({ text: expected, escapedCodeUnits: count });
+		}
+	});
+
+	it("is idempotent", () => {
+		const once = escapeUnpairedSurrogates("a\ud800b\udc00c");
+		expect(escapeUnpairedSurrogates(once.text)).toEqual({ text: once.text, escapedCodeUnits: 0 });
 	});
 });


### PR DESCRIPTION
Closes #6464

## What changed

- Edit `packages/utils/src/sanitize-text.ts`, `packages/coding-agent/src/edit/read-file.ts`, `packages/coding-agent/src/edit/renderer.ts`, `packages/coding-agent/src/tools/write.ts`, their focused tests, and only the edit-mode callers required by the `SerializedEditFileText { content: string; escapedCodeUnits: number }` return type.
- Add `Added lossless escaping for lone UTF-16 surrogates before UTF-8 file writes.` to `packages/utils/CHANGELOG.md` `[Unreleased] / Added` and `Fixed file-writing tools replacing malformed Unicode arguments with replacement characters ([#6464](https://github.com/can1357/oh-my-pi/issues/6464)).` to `packages/coding-agent/CHANGELOG.md` `[Unreleased] / Fixed`.

## Verification

- `bun install --frozen-lockfile`
- `bun run build:native`
- `bun test packages/utils/test/sanitize-text.test.ts packages/coding-agent/test/unicode-tool-write-roundtrip.test.ts packages/coding-agent/test/unicode-edit-persistence.test.ts packages/coding-agent/test/edit-mode.test.ts packages/coding-agent/test/write-hashline-header.test.ts packages/coding-agent/test/write-acp-fs.test.ts packages/coding-agent/test/tools/conflict-integration.test.ts packages/coding-agent/test/core/apply-patch-multi-file.test.ts packages/hashline/test/file-ops.test.ts packages/hashline/test/patcher.test.ts`
- `bun run check:ts`
