### PR TITLE
perf(coding-agent): prewarmed title worker after first paint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the first submitted prompt stalling while the local title worker starts ([#6462](https://github.com/can1357/oh-my-pi/issues/6462)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -113,6 +113,8 @@ import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { formatTaskId } from "../task/render";
 import type { ConfiguredThinkingLevel } from "../thinking";
+import { isTinyTitleLocalModelKey } from "../tiny/models";
+import { tinyTitleClient } from "../tiny/title-client";
 import type { LspStartupServerInfo } from "../tools";
 import { normalizeLocalScheme } from "../tools/path-utils";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
@@ -464,6 +466,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#loopAutoSubmitTimer: NodeJS.Timeout | undefined;
 	#todoAutoClearTimer: NodeJS.Timeout | undefined;
 	#modelCycleClearTimer: NodeJS.Timeout | undefined;
+	#titlePrewarmImmediate: ReturnType<typeof setImmediate> | undefined;
 	todoPhases: TodoPhase[] = [];
 	hideThinkingBlock = false;
 	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
@@ -995,6 +998,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Start the UI. Cold `omp` launch opts into clearing on the first paint so
 		// the initial welcome frame does not append over the previous run's scrollback.
 		this.ui.start({ clearScrollback: options.clearInitialTerminalHistory === true });
+		// After start()'s forced paint is queued: FIFO setImmediate paints first,
+		// then this idle title-worker prewarm runs without delaying first frame.
+		this.#scheduleTitleWorkerPrewarm();
 		pushTerminalTitle();
 		setTerminalTitleStateEnabled(this.settings.get("tui.titleState"));
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
@@ -1853,6 +1859,29 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!this.#todoAutoClearTimer) return;
 		clearTimeout(this.#todoAutoClearTimer);
 		this.#todoAutoClearTimer = undefined;
+	}
+
+	#cancelTitleWorkerPrewarm(): void {
+		if (!this.#titlePrewarmImmediate) return;
+		clearImmediate(this.#titlePrewarmImmediate);
+		this.#titlePrewarmImmediate = undefined;
+	}
+
+	/**
+	 * Schedule an idle tiny-title worker spawn after the initial forced paint.
+	 * Only local models need the worker; online/disabled/invalid keys skip it.
+	 * The callback re-checks shutdown so a queued immediate cannot respawn after
+	 * teardown (and {@link #cancelTitleWorkerPrewarm} clears it from stop()).
+	 */
+	#scheduleTitleWorkerPrewarm(): void {
+		this.#cancelTitleWorkerPrewarm();
+		const tinyModel = settings.get("providers.tinyModel");
+		if (!isTinyTitleLocalModelKey(tinyModel)) return;
+		this.#titlePrewarmImmediate = setImmediate(() => {
+			this.#titlePrewarmImmediate = undefined;
+			if (this.#isShuttingDown) return;
+			tinyTitleClient.prewarm();
+		});
 	}
 
 	#isClosedTodo(task: TodoItem): boolean {
@@ -3847,6 +3876,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#cleanupMicAnimation();
 		this.#liveCommandController.dispose();
 		this.#cancelTodoAutoClearTimer();
+		this.#cancelTitleWorkerPrewarm();
 		this.#cancelObserverUiSyncTimer();
 		this.#cancelGoalContinuation();
 		if (this.#sttController) {

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -196,6 +196,15 @@ export class TinyTitleClient {
 		return () => this.#progressListeners.delete(listener);
 	}
 
+	/**
+	 * Eagerly spawn the idle worker subprocess so the first {@link generate}
+	 * call reuses it. Idempotent: a warm worker is left untouched. Sends no
+	 * request and does not download, load weights, or run inference.
+	 */
+	prewarm(): void {
+		this.#ensureWorker();
+	}
+
 	async generate(modelKey: string, message: string, signal?: AbortSignal): Promise<string | null>;
 	async generate(modelKey: string, message: string, options?: TinyTitleGenerateOptions): Promise<string | null>;
 	async generate(

--- a/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
+++ b/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { tinyTitleClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import { type RenderScheduler, TUI } from "@oh-my-pi/pi-tui";
+import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+describe("InteractiveMode title worker prewarm", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode | undefined;
+	let session: AgentSession | undefined;
+	let tempDir: TempDir;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-interactive-mode-title-prewarm-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		Settings.instance.set("startup.quiet", true);
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		mode = undefined;
+		session = undefined;
+		resetSettingsForTest();
+		await tinyTitleClient.terminate();
+	});
+
+	function createMode(): InteractiveMode {
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.instance,
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		return mode;
+	}
+
+	function orderingScheduler(order: string[]): RenderScheduler {
+		return {
+			now: () => performance.now(),
+			scheduleImmediate: callback => {
+				setImmediate(() => {
+					order.push("frame");
+					callback();
+				});
+			},
+			scheduleRender: (callback, delayMs) => {
+				const timer = setTimeout(callback, delayMs);
+				return {
+					cancel: () => {
+						clearTimeout(timer);
+					},
+				};
+			},
+		};
+	}
+
+	async function flushImmediates(times = 4): Promise<void> {
+		for (let i = 0; i < times; i++) {
+			await new Promise<void>(resolve => {
+				setImmediate(resolve);
+			});
+		}
+	}
+
+	it("paints the initial forced frame before the title worker factory runs", async () => {
+		Settings.instance.set("providers.tinyModel", "lfm2-350m");
+		const created = createMode();
+		const order: string[] = [];
+		const term = new VirtualTerminal(80, 24);
+		created.ui = new TUI(term, undefined, { renderScheduler: orderingScheduler(order) });
+
+		const prewarm = vi.spyOn(tinyTitleClient, "prewarm").mockImplementation(() => {
+			order.push("prewarm");
+		});
+
+		await created.init({ suppressWelcomeIntro: true });
+		await flushImmediates();
+
+		expect(prewarm).toHaveBeenCalled();
+		const frameAt = order.indexOf("frame");
+		const prewarmAt = order.indexOf("prewarm");
+		expect(frameAt).toBeGreaterThanOrEqual(0);
+		expect(prewarmAt).toBeGreaterThan(frameAt);
+	});
+
+	it("skips prewarm when Tiny Model is Online", async () => {
+		Settings.instance.set("providers.tinyModel", "online");
+		const created = createMode();
+		const term = new VirtualTerminal(80, 24);
+		created.ui = new TUI(term);
+		const prewarm = vi.spyOn(tinyTitleClient, "prewarm");
+
+		await created.init({ suppressWelcomeIntro: true });
+		await flushImmediates();
+
+		expect(prewarm).not.toHaveBeenCalled();
+	});
+
+	it("queued prewarm after shutdown does not spawn a worker", async () => {
+		Settings.instance.set("providers.tinyModel", "lfm2-350m");
+		const created = createMode();
+		const term = new VirtualTerminal(80, 24);
+		created.ui = new TUI(term);
+
+		const queued: Array<() => void> = [];
+		vi.spyOn(globalThis, "setImmediate").mockImplementation(((
+			callback: (...args: unknown[]) => void,
+			...args: unknown[]
+		) => {
+			const run = () => {
+				callback(...args);
+			};
+			queued.push(run);
+			return run as unknown as ReturnType<typeof setImmediate>;
+		}) as typeof setImmediate);
+		// Leave clearImmediate as a no-op so a queued prewarm survives stop()
+		// and the #isShuttingDown guard is what must suppress respawn.
+		vi.spyOn(globalThis, "clearImmediate").mockImplementation(() => {});
+		vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+
+		const prewarm = vi.spyOn(tinyTitleClient, "prewarm");
+
+		await created.init({ suppressWelcomeIntro: true });
+		expect(queued.length).toBeGreaterThan(0);
+
+		await created.shutdown();
+		expect(created.isShuttingDown).toBe(true);
+
+		for (const run of [...queued]) run();
+
+		expect(prewarm).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/tiny-title-generator.test.ts
+++ b/packages/coding-agent/test/tiny-title-generator.test.ts
@@ -6,6 +6,7 @@ import { isSubcommand } from "@oh-my-pi/pi-coding-agent/cli-commands";
 import { getDefault, getEnumValues, getUi } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
 import { TinyTitleDownloadProgressComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tiny-title-download-progress";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { RefCountedWorkerHandle } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
 import {
 	TINY_MODEL_DEVICE_DEFAULT,
 	TINY_MODEL_DEVICE_SETTING_OPTIONS,
@@ -21,7 +22,12 @@ import {
 	TINY_TITLE_MODEL_OPTIONS,
 	TINY_TITLE_MODEL_VALUES,
 } from "@oh-my-pi/pi-coding-agent/tiny/models";
-import { createTinyTitleSubprocess, tinyTitleClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import {
+	createTinyTitleSubprocess,
+	TinyTitleClient,
+	tinyTitleClient,
+} from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import type { TinyTitleWorkerInbound, TinyTitleWorkerOutbound } from "@oh-my-pi/pi-coding-agent/tiny/title-protocol";
 import { generateSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
 import type { Subprocess } from "bun";
 
@@ -258,5 +264,67 @@ describe("tiny title download progress UI", () => {
 describe("tiny-models CLI", () => {
 	it("registers tiny-models as a top-level subcommand", () => {
 		expect(isSubcommand("tiny-models")).toBe(true);
+	});
+});
+
+describe("tiny title prewarm", () => {
+	it("spawns one unrefed idle worker and reuses it on first generate", async () => {
+		let spawnCount = 0;
+		const sent: TinyTitleWorkerInbound[] = [];
+		let refCount = 0;
+		const messageHandlers = new Set<(message: TinyTitleWorkerOutbound) => void>();
+
+		const client = new TinyTitleClient(() => {
+			spawnCount += 1;
+			const handle: RefCountedWorkerHandle<TinyTitleWorkerInbound, TinyTitleWorkerOutbound> = {
+				send(message) {
+					sent.push(message);
+					if (message.type !== "generate") return;
+					queueMicrotask(() => {
+						for (const handler of messageHandlers) {
+							handler({ type: "title", id: message.id, title: "Warm Title" });
+						}
+					});
+				},
+				onMessage(handler) {
+					messageHandlers.add(handler);
+					return () => {
+						messageHandlers.delete(handler);
+					};
+				},
+				onError() {
+					return () => {};
+				},
+				async terminate() {},
+				ref() {
+					refCount += 1;
+				},
+				unref() {
+					refCount -= 1;
+				},
+			};
+			return handle;
+		});
+
+		client.prewarm();
+		expect(spawnCount).toBe(1);
+		expect(sent).toEqual([]);
+		expect(refCount).toBe(0);
+
+		client.prewarm();
+		expect(spawnCount).toBe(1);
+
+		const title = await client.generate("lfm2-350m", "Investigate routing");
+		expect(title).toBe("Warm Title");
+		expect(spawnCount).toBe(1);
+		expect(sent).toHaveLength(1);
+		const first = sent[0];
+		if (first?.type !== "generate") {
+			throw new Error("expected one generate request");
+		}
+		expect(first.modelKey).toBe("lfm2-350m");
+		expect(refCount).toBe(0);
+
+		await client.terminate();
 	});
 });


### PR DESCRIPTION
Closes #6462

## What changed

- Edit `packages/coding-agent/src/tiny/title-client.ts`, `packages/coding-agent/src/modes/interactive-mode.ts`, `packages/coding-agent/test/tiny-title-generator.test.ts`, and a focused virtual-terminal startup test.
- Add `Fixed the first submitted prompt stalling while the local title worker starts ([#6462](https://github.com/can1357/oh-my-pi/issues/6462)).` to `packages/coding-agent/CHANGELOG.md` `[Unreleased] / Fixed`.

## Verification

- `bun install --frozen-lockfile`
- `bun run build:native`
- `bun test packages/coding-agent/test/tiny-title-generator.test.ts packages/coding-agent/test/interactive-mode-title-prewarm.test.ts`
- `bun run check:ts`
