### PR TITLE
fix(tui): rendered Warp Jamo at terminal width

### DIFF
--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, test, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -6,6 +6,7 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
 import { buildSessionContext, type SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import { type Component, Container } from "@oh-my-pi/pi-tui";
+import { resetHangulCompatibilityJamoWidthForTests, setHangulCompatibilityJamoWidth } from "@oh-my-pi/pi-tui/utils";
 
 function renderLastLine(container: Container, width = 120): string {
 	const last = container.children[container.children.length - 1];
@@ -71,6 +72,10 @@ describe("InteractiveMode.showStatus", () => {
 		resetSettingsForTest();
 		await Settings.init({ inMemory: true });
 		await initTheme();
+	});
+
+	afterEach(() => {
+		resetHangulCompatibilityJamoWidthForTests();
 	});
 
 	test("coalesces immediately-sequential status messages", () => {
@@ -156,5 +161,30 @@ describe("InteractiveMode.showStatus", () => {
 		// handler owns this lifecycle and uses it to guard against clearing the
 		// user's in-progress editor draft during an optimistic send (#783).
 		expect(ctx.optimisticUserMessageSignature).toBe("hello\u00001");
+	});
+
+	test("wraps Compatibility Jamo status lines by the active width profile", () => {
+		const compatRun = "\u314e\u314f\u3134".repeat(12); // ㅎㅏㄴ × 12
+		const conjoiningRun = "\u1112\u1161\u11ab".repeat(12); // 한 × 12 (decomposed)
+
+		const statusRows = (statusText: string, width: number): number => {
+			const { ctx, helpers } = createInitialRenderHarness();
+			helpers.showStatus(statusText);
+			return renderLastLine(ctx.chatContainer, width).split("\n").length;
+		};
+
+		setHangulCompatibilityJamoWidth(1);
+		const compatNarrowRows = statusRows(compatRun, 20);
+		setHangulCompatibilityJamoWidth(2);
+		const compatWideRows = statusRows(compatRun, 20);
+		// Narrow Compatibility Jamo wrap into fewer rows than wide.
+		expect(compatNarrowRows).toBeLessThan(compatWideRows);
+
+		setHangulCompatibilityJamoWidth(1);
+		const conjoiningNarrowRows = statusRows(conjoiningRun, 20);
+		setHangulCompatibilityJamoWidth(2);
+		const conjoiningWideRows = statusRows(conjoiningRun, 20);
+		// Control: canonical conjoining Jamo wrap identically under both profiles.
+		expect(conjoiningNarrowRows).toBe(conjoiningWideRows);
 	});
 });

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -112,6 +112,24 @@ describe("streaming reveal", () => {
 		expect(textAt(target, 0)).toBe(`${familyEmoji}B`);
 	});
 
+	it("reveals compatibility Jamo per cluster and canonical conjoining Jamo atomically", () => {
+		// Compatibility Jamo (U+3131..U+318E) are three separate grapheme clusters;
+		// the canonical conjoining form of the same syllable (U+1100..U+11FF) is a
+		// single grapheme, so it reveals all-or-nothing.
+		const compatJamo = "\u314e\u314f\u3134"; // ㅎㅏㄴ
+		const conjoiningJamo = "\u1112\u1161\u11ab"; // 한 (decomposed)
+
+		const compatTarget = makeMessage([{ type: "text", text: compatJamo }]);
+		expect(visibleUnits(compatTarget, false)).toBe(3);
+		expect(textAt(buildDisplayMessage(compatTarget, 1, false), 0)).toBe("\u314e");
+		expect(textAt(buildDisplayMessage(compatTarget, 2, false), 0)).toBe("\u314e\u314f");
+		expect(textAt(buildDisplayMessage(compatTarget, 3, false), 0)).toBe(compatJamo);
+
+		const conjoiningTarget = makeMessage([{ type: "text", text: conjoiningJamo }]);
+		expect(visibleUnits(conjoiningTarget, false)).toBe(1);
+		expect(textAt(buildDisplayMessage(conjoiningTarget, 1, false), 0)).toBe(conjoiningJamo);
+	});
+
 	it("excludes hidden thinking from the reveal budget and passes it through", () => {
 		const thinkingBlock = { type: "thinking" as const, thinking: "thought" };
 		const target = makeMessage([thinkingBlock, { type: "text", text: "answer" }]);
@@ -419,6 +437,20 @@ describe("BlockUnitCounter.slice", () => {
 			revealed = rand() < 0.05 ? Math.floor(rand() * 3) : Math.min(total, revealed + 1 + Math.floor(rand() * 6));
 			if (revealed < 0) revealed = 0;
 			expect(counter.slice(0, text, revealed)).toBe(refSlice(text, revealed));
+		}
+	});
+
+	it("slices Hangul jamo fixtures at cluster boundaries (compat per jamo, conjoining atomic)", () => {
+		const compatJamo = "\u314e\u314f\u3134"; // ㅎㅏㄴ — three clusters
+		const conjoiningJamo = "\u1112\u1161\u11ab"; // 한 — one canonical cluster
+		expect(refCount(compatJamo)).toBe(3);
+		expect(refCount(conjoiningJamo)).toBe(1);
+		const counter = new BlockUnitCounter();
+		for (let units = 0; units <= refCount(compatJamo); units++) {
+			expect(counter.slice(0, compatJamo, units)).toBe(refSlice(compatJamo, units));
+		}
+		for (let units = 0; units <= refCount(conjoiningJamo); units++) {
+			expect(counter.slice(1, conjoiningJamo, units)).toBe(refSlice(conjoiningJamo, units));
 		}
 	});
 });

--- a/packages/coding-agent/test/task/task-progress-render.test.ts
+++ b/packages/coding-agent/test/task/task-progress-render.test.ts
@@ -5,6 +5,7 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { taskToolRenderer } from "@oh-my-pi/pi-coding-agent/task/renderer";
 import type { AgentProgress, SingleResult, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
+import { resetHangulCompatibilityJamoWidthForTests, setHangulCompatibilityJamoWidth } from "@oh-my-pi/pi-tui/utils";
 
 function runningProgress(overrides: Partial<AgentProgress> = {}): AgentProgress {
 	return {
@@ -66,6 +67,7 @@ describe("task progress rendering", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		resetSettingsForTest();
+		resetHangulCompatibilityJamoWidthForTests();
 	});
 	it("renders running task rows static with the agent dot", async () => {
 		const theme = (await getThemeByName("dark"))!;
@@ -441,6 +443,46 @@ describe("task progress rendering", () => {
 		// The run summary footer still counts the full batch.
 		expect(collapsed).toContain("5 succeeded");
 		expect(collapsed).toContain("1 failed");
+	});
+
+	it("truncates Compatibility Jamo task previews by width profile; canonical Jamo is the control", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		if (!theme) return;
+		const options: RenderResultOptions = { expanded: false, isPartial: true, spinnerFrame: 0 };
+		const renderTask = (task: string): string =>
+			Bun.stripANSI(
+				taskToolRenderer
+					.renderResult(
+						{
+							content: [{ type: "text", text: "" }],
+							details: detailsFor(runningProgress({ id: "JamoPreview", task })),
+						},
+						options,
+						theme,
+					)
+					.render(120)
+					.join("\n"),
+			);
+		const kept = (text: string, marker: string): number => [...text].filter(ch => ch === marker).length;
+
+		const compatRun = "\u314e\u314f\u3134".repeat(40); // ㅎㅏㄴ × 40
+		setHangulCompatibilityJamoWidth(1);
+		const compatNarrowKept = kept(renderTask(compatRun), "\u314e");
+		setHangulCompatibilityJamoWidth(2);
+		const compatWideKept = kept(renderTask(compatRun), "\u314e");
+		// The preview truncates to a fixed cell budget, so narrow Compatibility
+		// Jamo keep more glyphs than wide ones.
+		expect(compatNarrowKept).toBeGreaterThan(compatWideKept);
+
+		const conjoiningRun = "\u1112\u1161\u11ab".repeat(40); // 한 × 40 (decomposed)
+		setHangulCompatibilityJamoWidth(1);
+		const conjoiningNarrowKept = kept(renderTask(conjoiningRun), "\u1112");
+		setHangulCompatibilityJamoWidth(2);
+		const conjoiningWideKept = kept(renderTask(conjoiningRun), "\u1112");
+		// Control: canonical conjoining Jamo are outside the corrected block, so the
+		// same count survives under both profiles.
+		expect(conjoiningNarrowKept).toBe(conjoiningWideKept);
 	});
 });
 

--- a/packages/coding-agent/test/tools/eval-agent-progress.test.ts
+++ b/packages/coding-agent/test/tools/eval-agent-progress.test.ts
@@ -3,6 +3,7 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import type { EvalStatusEvent, EvalToolDetails } from "@oh-my-pi/pi-coding-agent/eval/types";
 import { getThemeByName, setThemeInstance, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval";
+import { resetHangulCompatibilityJamoWidthForTests, setHangulCompatibilityJamoWidth } from "@oh-my-pi/pi-tui/utils";
 
 /**
  * Defends the contract that `agent()` calls inside an eval cell surface as a
@@ -23,6 +24,7 @@ describe("eval renderer: agent() progress below the cell box", () => {
 
 	afterAll(() => {
 		resetSettingsForTest();
+		resetHangulCompatibilityJamoWidthForTests();
 	});
 
 	function render(statusEvents: EvalStatusEvent[], status: "running" | "complete" = "running"): string[] {
@@ -144,5 +146,42 @@ describe("eval renderer: agent() progress below the cell box", () => {
 		expect(inside).toContain("file.ts");
 		expect(inside).not.toContain("0-Scout");
 		expect(below).toContain("0-Scout");
+	});
+
+	it("truncates Compatibility Jamo agent intents by width profile; canonical Jamo is the control", () => {
+		const renderIntent = (intent: string): string =>
+			render([
+				{
+					op: "agent",
+					id: "0-Scout",
+					agent: "task",
+					status: "running",
+					currentTool: "read",
+					currentToolArgs: "config.ts",
+					lastIntent: intent,
+					taskPreview: "investigate the bug",
+					toolCount: 4,
+					contextTokens: 5000,
+					contextWindow: 200000,
+					cost: 0.03,
+					durationMs: 800,
+					model: "p/model",
+				},
+			]).join("\n");
+		const kept = (text: string, marker: string): number => [...text].filter(ch => ch === marker).length;
+
+		const compatRun = "\u314e\u314f\u3134".repeat(40); // ㅎㅏㄴ × 40
+		setHangulCompatibilityJamoWidth(1);
+		const compatNarrowKept = kept(renderIntent(compatRun), "\u314e");
+		setHangulCompatibilityJamoWidth(2);
+		const compatWideKept = kept(renderIntent(compatRun), "\u314e");
+		expect(compatNarrowKept).toBeGreaterThan(compatWideKept);
+
+		const conjoiningRun = "\u1112\u1161\u11ab".repeat(40); // 한 × 40 (decomposed)
+		setHangulCompatibilityJamoWidth(1);
+		const conjoiningNarrowKept = kept(renderIntent(conjoiningRun), "\u1112");
+		setHangulCompatibilityJamoWidth(2);
+		const conjoiningWideKept = kept(renderIntent(conjoiningRun), "\u1112");
+		expect(conjoiningNarrowKept).toBe(conjoiningWideKept);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed separated Hangul Jamo corrupting streamed layouts in WarpTerminal ([#6461](https://github.com/can1357/oh-my-pi/issues/6461)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -26,10 +26,9 @@ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 const WINDOWS_TERMINAL_OSC11_POLL_MS = 30_000;
 // Hangul Compatibility Jamo (U+3131..=U+318E) render width is terminal-dependent:
-// Ghostty follows UAX#11 (2 cells); Terminal.app and iTerm2 render narrow (1),
-// matching the macOS platform default. Override only for terminals known to
-// disagree — the rest keep the platform default (macOS narrow, otherwise UAX#11),
-// so this is a no-op everywhere except Ghostty. A runtime DSR/CPR probe that
+// Ghostty follows UAX#11 (2 cells); Terminal.app, iTerm2, and Warp render narrow
+// (1). Override only for terminals known to disagree — the rest keep the platform
+// default (macOS narrow, otherwise UAX#11). A runtime DSR/CPR probe that
 // auto-detects the width on unknown terminals is tracked separately.
 export function resolveHangulCompatibilityJamoWidthFromTerminalIdentity(
 	env: NodeJS.ProcessEnv = Bun.env,
@@ -40,6 +39,13 @@ export function resolveHangulCompatibilityJamoWidthFromTerminalIdentity(
 		env.TERM?.toLowerCase().includes("ghostty")
 	) {
 		return 2;
+	}
+	// Warp reports TERM_PROGRAM=WarpTerminal and renders Hangul Compatibility
+	// Jamo narrow (1 cell) on every platform, disagreeing with UAX#11's 2 cells
+	// that the Linux platform default follows. Correct so wrap/truncation math and
+	// the hardware cursor column stay aligned during Korean IME composition.
+	if (env.TERM_PROGRAM?.toLowerCase() === "warpterminal") {
+		return 1;
 	}
 	return "platform";
 }

--- a/packages/tui/test/line-width-sidecar.test.ts
+++ b/packages/tui/test/line-width-sidecar.test.ts
@@ -83,4 +83,30 @@ describe("line-width sidecar", () => {
 		setHangulCompatibilityJamoWidth(1);
 		expect(getWidthConfigEpoch()).toBe(afterFirst);
 	});
+
+	it("re-measures Compatibility Jamo across the Warp/Ghostty switch; canonical Jamo is the control", () => {
+		const compatJamo = "\u314e\u314f\u3134"; // ㅎㅏㄴ
+		const canonicalConjoiningJamo = "\u1112\u1161\u11ab"; // 한 (decomposed)
+		const compatLine = [compatJamo];
+		const conjoiningLine = [canonicalConjoiningJamo];
+
+		// Warp width (1): each Compatibility Jamo is one cell.
+		setHangulCompatibilityJamoWidth(1);
+		publishLineWidths(compatLine, [visibleWidth(compatJamo)]);
+		publishLineWidths(conjoiningLine, [visibleWidth(canonicalConjoiningJamo)]);
+		expect(getPublishedLineWidths(compatLine)).toEqual([3]);
+		const conjoiningWidth = visibleWidth(canonicalConjoiningJamo);
+		expect(getPublishedLineWidths(conjoiningLine)).toEqual([conjoiningWidth]);
+
+		// Switching to Ghostty width (2) bumps the epoch, so every sidecar entry
+		// drops — the invalidation is global, not per-string.
+		setHangulCompatibilityJamoWidth(2);
+		expect(getPublishedLineWidths(compatLine)).toBeUndefined();
+		expect(getPublishedLineWidths(conjoiningLine)).toBeUndefined();
+
+		// Compatibility Jamo now measures wide; canonical conjoining Jamo is the
+		// control and re-measures to the same width as before.
+		expect(visibleWidth(compatJamo)).toBe(6);
+		expect(visibleWidth(canonicalConjoiningJamo)).toBe(conjoiningWidth);
+	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -3,7 +3,11 @@ import { stripVTControlCharacters } from "node:util";
 import { clearRenderCache, Markdown, renderInlineMarkdown } from "@oh-my-pi/pi-tui/components/markdown";
 import { setTerminalTextSizing, TERMINAL } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { type Component, TUI } from "@oh-my-pi/pi-tui/tui";
-import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
+import {
+	resetHangulCompatibilityJamoWidthForTests,
+	setHangulCompatibilityJamoWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui/utils";
 import { Chalk } from "chalk";
 import { defaultMarkdownTheme } from "./test-themes.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
@@ -2317,5 +2321,58 @@ describe("Math rendering", () => {
 		expect(lines.join("\n")).not.toContain("begin{cases}");
 		// The cases body follows immediately: folding the lhs in avoids a blank-line paragraph split.
 		expect(lines[fxIdx + 1]).toContain("x > 0");
+	});
+});
+
+describe("Hangul jamo width profile", () => {
+	afterEach(() => {
+		resetHangulCompatibilityJamoWidthForTests();
+		clearRenderCache();
+	});
+
+	// The Markdown component wraps to the viewport with the shared width engine,
+	// so the resolved Compatibility Jamo profile (narrow on Warp, wide on Ghostty)
+	// changes where Compatibility Jamo wrap — while canonical conjoining Jamo
+	// (U+1100..U+11FF), the control, wraps identically under both profiles. The
+	// module render cache is keyed by (text, width), so it is cleared between the
+	// two profiles (the profile is fixed once at startup in normal use).
+	it("wraps Compatibility Jamo by the active width profile, canonical Jamo unchanged", () => {
+		const compatRun = "\u314e\u314f\u3134".repeat(12); // ㅎㅏㄴ × 12
+		const conjoiningRun = "\u1112\u1161\u11ab".repeat(12); // 한 × 12 (decomposed)
+
+		setHangulCompatibilityJamoWidth(1);
+		clearRenderCache();
+		const compatNarrow = new Markdown(compatRun, 0, 0, defaultMarkdownTheme).render(20);
+		setHangulCompatibilityJamoWidth(2);
+		clearRenderCache();
+		const compatWide = new Markdown(compatRun, 0, 0, defaultMarkdownTheme).render(20);
+		// Narrow Compatibility Jamo pack into fewer wrapped rows than wide.
+		expect(compatNarrow.length).toBeLessThan(compatWide.length);
+
+		setHangulCompatibilityJamoWidth(1);
+		clearRenderCache();
+		const conjoiningNarrow = new Markdown(conjoiningRun, 0, 0, defaultMarkdownTheme).render(20);
+		setHangulCompatibilityJamoWidth(2);
+		clearRenderCache();
+		const conjoiningWide = new Markdown(conjoiningRun, 0, 0, defaultMarkdownTheme).render(20);
+		// Control: canonical conjoining Jamo wraps the same under either profile.
+		expect(conjoiningNarrow).toEqual(conjoiningWide);
+	});
+
+	it("renders both Hangul jamo forms without corruption", () => {
+		setHangulCompatibilityJamoWidth(1);
+		clearRenderCache();
+		const compat = "\u314e\u314f\u3134"; // ㅎㅏㄴ
+		const conjoining = "\u1112\u1161\u11ab"; // 한 (decomposed)
+		const compatOut = new Markdown(compat, 0, 0, defaultMarkdownTheme)
+			.render(80)
+			.map(line => stripVTControlCharacters(line))
+			.join("");
+		const conjoiningOut = new Markdown(conjoining, 0, 0, defaultMarkdownTheme)
+			.render(80)
+			.map(line => stripVTControlCharacters(line))
+			.join("");
+		expect(compatOut).toContain(compat);
+		expect(conjoiningOut).toContain(conjoining);
 	});
 });

--- a/packages/tui/test/terminal-jamo-width-probe.test.ts
+++ b/packages/tui/test/terminal-jamo-width-probe.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { resolveHangulCompatibilityJamoWidthFromTerminalIdentity } from "@oh-my-pi/pi-tui/terminal";
+import {
+	resetHangulCompatibilityJamoWidthForTests,
+	setHangulCompatibilityJamoWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui/utils";
 
 describe("Hangul Compatibility Jamo width terminal-identity resolution", () => {
 	it("forces wide (2) for Ghostty, platform default otherwise", () => {
@@ -21,5 +26,56 @@ describe("Hangul Compatibility Jamo width terminal-identity resolution", () => {
 			"platform",
 		);
 		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({})).toBe("platform");
+	});
+
+	it("resolves WarpTerminal to narrow (1), case-insensitively and only on the exact identity", () => {
+		// Warp reports TERM_PROGRAM=WarpTerminal and renders Hangul Compatibility
+		// Jamo at one cell, disagreeing with UAX#11's two on the Linux platform
+		// default; the resolver opts it into the narrow width profile.
+		for (const id of ["WarpTerminal", "warpterminal", "WARPTERMINAL"]) {
+			expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: id })).toBe(1);
+		}
+		// Ghostty still wins when both identities are present.
+		expect(
+			resolveHangulCompatibilityJamoWidthFromTerminalIdentity({
+				TERM_PROGRAM: "WarpTerminal",
+				GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app",
+			}),
+		).toBe(2);
+		// Only the exact program opts in — a prefix, suffix, or TERM substring is
+		// not Warp and keeps the platform default.
+		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "warp" })).toBe("platform");
+		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "warpterminal-x" })).toBe(
+			"platform",
+		);
+		expect(resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM: "xterm-warp" })).toBe("platform");
+	});
+});
+
+describe("resolved profile drives the measured jamo width", () => {
+	afterEach(() => {
+		resetHangulCompatibilityJamoWidthForTests();
+	});
+
+	// End-to-end: the resolved terminal profile, pushed into the shared width
+	// engine, changes the measured width of Compatibility Jamo (U+3131..U+318E)
+	// — narrow (1) for Warp, wide (2) for Ghostty. Canonical conjoining Jamo
+	// (U+1100..U+11FF), the same syllable decomposed, is the control: it is
+	// outside the corrected block and measures the same under either profile.
+	it("measures Compatibility Jamo per the resolved profile; canonical Jamo is the control", () => {
+		const compatJamo = "\u314e\u314f\u3134"; // ㅎㅏㄴ
+		const canonicalConjoiningJamo = "\u1112\u1161\u11ab"; // 한 (decomposed)
+
+		setHangulCompatibilityJamoWidth(
+			resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "WarpTerminal" }),
+		);
+		expect(visibleWidth(compatJamo)).toBe(3);
+		const conjoiningWarp = visibleWidth(canonicalConjoiningJamo);
+
+		setHangulCompatibilityJamoWidth(
+			resolveHangulCompatibilityJamoWidthFromTerminalIdentity({ TERM_PROGRAM: "ghostty" }),
+		);
+		expect(visibleWidth(compatJamo)).toBe(6);
+		expect(visibleWidth(canonicalConjoiningJamo)).toBe(conjoiningWarp);
 	});
 });

--- a/packages/tui/test/visible-width.test.ts
+++ b/packages/tui/test/visible-width.test.ts
@@ -139,6 +139,28 @@ describe("visibleWidth — runtime Hangul Compatibility Jamo profile", () => {
 			expect(visibleWidth(input)).toBe(nativeVisibleWidth(input, TAB));
 		}
 	});
+
+	it("applies the WarpTerminal narrow profile to Compatibility Jamo, not canonical Jamo", () => {
+		// Warp (width 1) vs Ghostty (width 2): the same Compatibility Jamo run
+		// measures 3 vs 6 cells, in parity with the native engine that
+		// truncate/slice/wrap use.
+		const compatJamo = "\u314e\u314f\u3134"; // ㅎㅏㄴ
+		const canonicalConjoiningJamo = "\u1112\u1161\u11ab"; // 한 (decomposed)
+
+		setHangulCompatibilityJamoWidth(1);
+		expect(visibleWidth(compatJamo)).toBe(3);
+		expect(visibleWidth(compatJamo)).toBe(nativeVisibleWidth(compatJamo, TAB));
+		const conjoiningNarrow = visibleWidth(canonicalConjoiningJamo);
+		const conjoiningNarrowNative = nativeVisibleWidth(canonicalConjoiningJamo, TAB);
+
+		setHangulCompatibilityJamoWidth(2);
+		expect(visibleWidth(compatJamo)).toBe(6);
+		expect(visibleWidth(compatJamo)).toBe(nativeVisibleWidth(compatJamo, TAB));
+		// Control: canonical conjoining Jamo is outside the Compatibility block, so
+		// its width is identical under both profiles (both JS and native engines).
+		expect(visibleWidth(canonicalConjoiningJamo)).toBe(conjoiningNarrow);
+		expect(nativeVisibleWidth(canonicalConjoiningJamo, TAB)).toBe(conjoiningNarrowNative);
+	});
 });
 
 describe("native text helpers — runtime Hangul Compatibility Jamo profile", () => {


### PR DESCRIPTION
Closes #6461

## What changed

- Edit `packages/tui/src/terminal.ts` and extend the existing terminal-width, Markdown, streaming-reveal, status/progress, task-progress, and eval-agent-progress tests with the same two Jamo fixtures; no provider decoder, reveal-controller implementation, Markdown implementation, or Rust text implementation changes belong in this unit because every surface already consumes the shared width profile.
- Add `Fixed separated Hangul Jamo corrupting streamed layouts in WarpTerminal ([#6461](https://github.com/can1357/oh-my-pi/issues/6461)).` under `packages/tui/CHANGELOG.md` `[Unreleased] / Fixed`.

## Verification

- `bun install --frozen-lockfile`
- `bun run build:native`
- `bun test packages/tui/test/terminal-jamo-width-probe.test.ts packages/tui/test/visible-width.test.ts packages/tui/test/line-width-sidecar.test.ts packages/tui/test/markdown.test.ts packages/coding-agent/test/streaming-reveal.test.ts packages/coding-agent/test/interactive-mode-status.test.ts packages/coding-agent/test/task/task-progress-render.test.ts packages/coding-agent/test/tools/eval-agent-progress.test.ts`
- `bun run check:ts`
- `bun run check:rs`
