### PR TITLE
fix(coding-agent): closed output sinks on all exits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed failed bash and eval executions leaking artifact descriptors until later reads failed with EMFILE ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -364,7 +364,7 @@ export async function executeWithKernelBase<
 	} = params;
 
 	const settings = await Settings.init();
-	const sink = new OutputSink({
+	await using sink = new OutputSink({
 		onChunk: options?.onChunk,
 		artifactPath: options?.artifactPath,
 		artifactId: options?.artifactId,

--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -74,7 +74,7 @@ function formatJsTimeoutAnnotation(timeoutMs: number | undefined): string {
 
 export async function executeJs(code: string, options: JsExecutorOptions): Promise<JsResult> {
 	const displayOutputs: JsDisplayOutput[] = [];
-	const outputSink = new OutputSink({
+	await using outputSink = new OutputSink({
 		artifactPath: options.artifactPath,
 		artifactId: options.artifactId,
 		spillThreshold: DEFAULT_MAX_BYTES,
@@ -96,6 +96,12 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 	// and never derive a competing fixed timer from it.
 	const acquireBudgetMs = legacyTimeoutMs ?? options.idleTimeoutMs;
 
+	// Classify the VM outcome first and append any translated timeout/error text
+	// while the sink is still accepting. The single dump() runs outside this catch
+	// so a dump/end failure surfaces instead of being reclassified, appended to,
+	// or retried.
+	let exitCode: number | undefined;
+	let cancelled: boolean;
 	try {
 		await executeInVmContext({
 			sessionKey: options.sessionId,
@@ -121,53 +127,35 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 				},
 			},
 		});
-		const summary = await outputSink.dump();
-		return {
-			output: summary.output,
-			exitCode: 0,
-			cancelled: false,
-			truncated: summary.truncated,
-			artifactId: summary.artifactId,
-			totalLines: summary.totalLines,
-			totalBytes: summary.totalBytes,
-			outputLines: summary.outputLines,
-			outputBytes: summary.outputBytes,
-			displayOutputs,
-		};
+		exitCode = 0;
+		cancelled = false;
 	} catch (error) {
 		if (signal?.aborted || isAbortError(error)) {
 			const timedOut = Boolean(timeoutSignal?.aborted) || isTimeoutReason(options.signal?.reason);
 			if (timedOut) {
 				outputSink.push(formatJsTimeoutAnnotation(legacyTimeoutMs ?? options.idleTimeoutMs));
 			}
-			const summary = await outputSink.dump();
-			return {
-				output: summary.output,
-				exitCode: undefined,
-				cancelled: true,
-				truncated: summary.truncated,
-				artifactId: summary.artifactId,
-				totalLines: summary.totalLines,
-				totalBytes: summary.totalBytes,
-				outputLines: summary.outputLines,
-				outputBytes: summary.outputBytes,
-				displayOutputs,
-			};
+			exitCode = undefined;
+			cancelled = true;
+		} else {
+			const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+			outputSink.push(message);
+			exitCode = 1;
+			cancelled = false;
 		}
-		const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
-		outputSink.push(message);
-		const summary = await outputSink.dump();
-		return {
-			output: summary.output,
-			exitCode: 1,
-			cancelled: false,
-			truncated: summary.truncated,
-			artifactId: summary.artifactId,
-			totalLines: summary.totalLines,
-			totalBytes: summary.totalBytes,
-			outputLines: summary.outputLines,
-			outputBytes: summary.outputBytes,
-			displayOutputs,
-		};
 	}
+
+	const summary = await outputSink.dump();
+	return {
+		output: summary.output,
+		exitCode,
+		cancelled,
+		truncated: summary.truncated,
+		artifactId: summary.artifactId,
+		totalLines: summary.totalLines,
+		totalBytes: summary.totalBytes,
+		outputLines: summary.outputLines,
+		outputBytes: summary.outputBytes,
+		displayOutputs,
+	};
 }

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -373,7 +373,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			: preflight.command;
 
 	// Create output sink for truncation and artifact handling
-	const sink = new OutputSink({
+	await using sink = new OutputSink({
 		onChunk: options?.onChunk,
 		artifactPath: options?.artifactPath,
 		artifactId: options?.artifactId,

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -757,6 +757,25 @@ export class OutputSink {
 	#pendingFileWrites?: string[];
 	#fileReady = false;
 
+	// Retained lazy file-creation/drain promise; `close()` joins it before end so
+	// an admitted chunk that triggered creation cannot outlive descriptor release.
+	#fileCreation?: Promise<void>;
+	// Materialized artifact id, set only after the writer is created and its
+	// initial drain succeeds, and retained after the writer is detached/ended so
+	// `dump()` still reports it.
+	#materializedArtifactId?: string;
+
+	// Monotonic lifecycle: accepting -> closing -> closed. `#activeAdmissions`
+	// counts mutations admitted before the accepting->closing transition, so a
+	// reentrant `onChunk` close still lets the triggering chunk finish accounting
+	// and persistence before finalization begins.
+	#phase: "accepting" | "closing" | "closed" = "accepting";
+	#activeAdmissions = 0;
+	#closeCompletion?: Promise<void>;
+	#finishResolve?: () => void;
+	#finishReject?: (error: unknown) => void;
+	#finalizeStarted = false;
+
 	readonly #artifactPath?: string;
 	readonly #artifactId?: string;
 	readonly #spillThreshold: number;
@@ -838,27 +857,59 @@ export class OutputSink {
 	}
 
 	/**
-	 * Push a chunk of output. The buffer management and onChunk callback run
-	 * synchronously. File sink writes are deferred and serialized internally.
+	 * Push a chunk of output. Buffer management and the onChunk callback run
+	 * synchronously. Admission is the linearization point: a chunk admitted while
+	 * accepting always finishes its accounting and artifact persistence even if
+	 * `onChunk` reentrantly calls `close()`; a nested push after that transition
+	 * is ignored.
 	 */
 	push(chunk: string): void {
-		chunk = sanitizeWithOptionalSixelPassthrough(chunk, text => sanitizeText(this.#normalizeCarriageReturns(text)));
-
-		// Throttled onChunk: coalesce chunks arriving inside the throttle window.
-		// A timer flushes quiet tails at the throttle boundary; dump() catches a
-		// final pending chunk when the process exits before that timer fires.
-		// Live preview gets the raw (pre-cap) chunk so the TUI never lags behind
-		// what reached the sink — the column cap is for the persisted LLM view.
-		if (this.#onChunk) {
-			const now = Date.now();
-			if (now - this.#lastChunkTime >= this.#chunkThrottleMs) {
-				this.#emitPendingChunkWith(chunk, now);
-			} else {
-				this.#pendingChunk += chunk;
-				this.#schedulePendingChunkFlush();
+		if (this.#phase !== "accepting") return;
+		this.#activeAdmissions++;
+		let callbackError: { value: unknown } | undefined;
+		try {
+			const sanitized = sanitizeWithOptionalSixelPassthrough(chunk, text =>
+				sanitizeText(this.#normalizeCarriageReturns(text)),
+			);
+			// Callback-first: preserve the observable onChunk ordering. Capture a
+			// callback failure so the admitted chunk still completes its byte/line
+			// accounting, column cap, and artifact admission before we rethrow.
+			if (this.#onChunk) {
+				try {
+					this.#emitPreview(sanitized);
+				} catch (error) {
+					callbackError = { value: error };
+				}
 			}
+			this.#account(sanitized);
+		} finally {
+			this.#activeAdmissions--;
+			this.#maybeFinishAfterAdmission();
 		}
+		if (callbackError) throw callbackError.value;
+	}
 
+	/**
+	 * Emit the throttled live-preview for a sanitized chunk. Coalesces chunks
+	 * arriving inside the throttle window; a timer flushes quiet tails at the
+	 * boundary and finalization flushes any final pending chunk.
+	 */
+	#emitPreview(chunk: string): void {
+		const now = Date.now();
+		if (now - this.#lastChunkTime >= this.#chunkThrottleMs) {
+			this.#emitPendingChunkWith(chunk, now);
+		} else {
+			this.#pendingChunk += chunk;
+			this.#schedulePendingChunkFlush();
+		}
+	}
+
+	/**
+	 * Byte/line accounting, per-line column cap, artifact mirroring, and
+	 * head/tail retention for a sanitized chunk. Shared by `push()` (public,
+	 * admission-gated) and `#ingest()` (internal finalization).
+	 */
+	#account(chunk: string): void {
 		const rawBytes = Buffer.byteLength(chunk, "utf-8");
 		this.#totalBytes += rawBytes;
 
@@ -907,6 +958,26 @@ export class OutputSink {
 		}
 
 		this.#pushTail(tailChunk, tailBytes);
+	}
+
+	/**
+	 * Internal ingestion used only during finalization (turning a held terminal
+	 * carriage return into one newline). Runs the same accounting and persistence
+	 * as an admitted push without reopening public admission; a preview failure
+	 * here cannot abort descriptor release.
+	 */
+	#ingest(chunk: string): void {
+		const sanitized = sanitizeWithOptionalSixelPassthrough(chunk, text =>
+			sanitizeText(this.#normalizeCarriageReturns(text)),
+		);
+		if (this.#onChunk) {
+			try {
+				this.#emitPreview(sanitized);
+			} catch {
+				/* finalization preview failure is non-fatal */
+			}
+		}
+		this.#account(sanitized);
 	}
 
 	/**
@@ -1013,12 +1084,11 @@ export class OutputSink {
 			this.#emitToSink(chunk);
 			return;
 		}
-		// File sink not yet created — queue this chunk and kick off creation.
-		// The queue is bounded only by how many chunks arrive before the open
-		// resolves (typically <2). The cap is enforced on drain.
+		// File sink not yet created — queue this chunk and kick off creation. The
+		// creation/drain promise is retained so `close()` can join it before ending.
 		if (!this.#pendingFileWrites) {
 			this.#pendingFileWrites = [chunk];
-			void this.#createFileSink();
+			this.#fileCreation = this.#createFileSink();
 		} else {
 			this.#pendingFileWrites.push(chunk);
 		}
@@ -1117,14 +1187,30 @@ export class OutputSink {
 				}
 				this.#pendingFileWrites = undefined;
 			}
+
+			// Identity is materialized only once the writer exists and its initial
+			// drain has succeeded, so a creation failure never leaves a phantom id.
+			this.#materializedArtifactId = this.#artifactId;
 		} catch {
-			try {
-				await this.#file?.sink?.end();
-			} catch {
-				/* ignore */
-			}
-			this.#file = undefined;
 			this.#pendingFileWrites = undefined;
+			this.#materializedArtifactId = undefined;
+			// Best-effort: a single cleanup end attempt for any acquired writer.
+			await this.#endOwnedFile();
+		}
+	}
+
+	/**
+	 * The sole primitive that ends the owned file sink. Detaches the writer
+	 * before awaiting `end()` and clears writer/readiness fields in `finally`, so
+	 * exactly one end attempt is made for every acquired writer.
+	 */
+	async #endOwnedFile(): Promise<void> {
+		const file = this.#file;
+		if (!file) return;
+		try {
+			await file.sink.end();
+		} finally {
+			this.#file = undefined;
 			this.#fileReady = false;
 		}
 	}
@@ -1156,6 +1242,7 @@ export class OutputSink {
 	 * branch in `dump()` against stale totals.
 	 */
 	replace(text: string): void {
+		if (this.#phase !== "accepting") return;
 		this.#clearPendingChunkTimer();
 		this.#buffer = text;
 		this.#bufferBytes = Buffer.byteLength(text, "utf-8");
@@ -1203,8 +1290,28 @@ export class OutputSink {
 		const delay = Math.max(0, this.#chunkThrottleMs - elapsed);
 		this.#pendingChunkTimer = setTimeout(() => {
 			this.#pendingChunkTimer = undefined;
-			this.#flushPendingChunk();
+			if (this.#phase !== "accepting") return;
+			// Admit the timer-driven preview so a reentrant close it triggers still
+			// defers finalization until this flush completes.
+			this.#activeAdmissions++;
+			try {
+				this.#flushPendingChunk();
+			} finally {
+				this.#activeAdmissions--;
+				this.#maybeFinishAfterAdmission();
+			}
 		}, delay);
+	}
+
+	/**
+	 * Start deferred finalization once the last in-flight admission exits after a
+	 * close transition. Read in its own control-flow context so `#phase` is the
+	 * live value rather than a caller-narrowed literal.
+	 */
+	#maybeFinishAfterAdmission(): void {
+		if (this.#phase === "closing" && this.#activeAdmissions === 0) {
+			void this.#finishClose();
+		}
 	}
 
 	/**
@@ -1243,22 +1350,118 @@ export class OutputSink {
 		}
 	}
 
+	/**
+	 * Idempotent close. The first call transitions accepting -> closing
+	 * synchronously (so later public mutations are ignored) and finalizes once
+	 * every in-flight admission drains; concurrent close/dump/dispose calls share
+	 * the one completion and the single descriptor end attempt.
+	 */
+	close(): Promise<void> {
+		if (!this.#closeCompletion) {
+			this.#phase = "closing";
+			const { promise, resolve, reject } = Promise.withResolvers<void>();
+			this.#closeCompletion = promise;
+			this.#finishResolve = resolve;
+			this.#finishReject = reject;
+			if (this.#activeAdmissions === 0) {
+				void this.#finishClose();
+			}
+		}
+		return this.#closeCompletion;
+	}
+
+	/**
+	 * Run each finalization stage exactly once in order — trailing-CR
+	 * normalization, pending-preview drain, lazy creation join, capped-tail
+	 * flush, and writer end — collecting the first stage error without letting it
+	 * skip descriptor release, then transition to closed and settle the shared
+	 * completion. Never retried.
+	 */
+	async #finishClose(): Promise<void> {
+		if (this.#finalizeStarted) return;
+		this.#finalizeStarted = true;
+
+		let stageError: unknown;
+		const capture = (stage: () => void): void => {
+			try {
+				stage();
+			} catch (error) {
+				if (stageError === undefined) stageError = error;
+			}
+		};
+
+		// Turn a held terminal carriage return into one newline via the internal
+		// path (public admission stays closed).
+		capture(() => {
+			if (this.#pendingCarriageReturn) {
+				this.#pendingCarriageReturn = false;
+				this.#ingest(NL);
+			}
+		});
+		// Flush any chunk still held back by the throttle, then cancel its timer.
+		capture(() => this.#flushPendingChunk());
+		this.#clearPendingChunkTimer();
+
+		// Join the retained lazy file-creation/drain before ending.
+		if (this.#fileCreation) {
+			try {
+				await this.#fileCreation;
+			} catch (error) {
+				if (stageError === undefined) stageError = error;
+			}
+		}
+
+		// Flush the capped artifact tail/notice once, then end unconditionally.
+		capture(() => {
+			if (this.#file) this.#flushArtifactTailIfCapped();
+		});
+		try {
+			await this.#endOwnedFile();
+		} catch (error) {
+			if (stageError === undefined) stageError = error;
+		}
+
+		this.#pendingFileWrites = undefined;
+		this.#phase = "closed";
+		if (stageError !== undefined) {
+			this.#finishReject?.(stageError);
+		} else {
+			this.#finishResolve?.();
+		}
+	}
+
+	/**
+	 * Close the sink, then compose the summary from frozen fields. Repeated dumps
+	 * observe the retained completion and recompute the same summary; a per-call
+	 * `notice` prefix is applied without mutating counters, buffers, artifact
+	 * bytes, or ownership.
+	 */
 	async dump(notice?: string): Promise<OutputSummary> {
-		if (this.#pendingCarriageReturn) {
-			this.#pendingCarriageReturn = false;
-			this.push(NL);
+		await this.close();
+		return this.#buildSummary(notice);
+	}
+
+	/**
+	 * Non-throwing async disposal for lexical `await using` owners. Explicit
+	 * `dump()` still surfaces close failure; disposal consumes a cleanup
+	 * rejection so it cannot mask an already-active work error.
+	 */
+	async [Symbol.asyncDispose](): Promise<void> {
+		try {
+			await this.close();
+		} catch {
+			/* preserve the primary error; close failure is surfaced by dump() */
 		}
+	}
+
+	/**
+	 * Compose the {@link OutputSummary} from frozen post-close state. Truncation
+	 * is derived locally rather than mutating `#truncated`, so repeated dumps are
+	 * state-stable.
+	 */
+	#buildSummary(notice?: string): OutputSummary {
 		const noticeLine = notice ? `[${notice}]\n` : "";
-
-		// Flush any chunk still held back by the throttle so the live preview
-		// ends with the complete stream.
-		this.#flushPendingChunk();
 		const totalLines = this.#sawData ? this.#totalLines + 1 : 0;
-
-		if (this.#file) {
-			this.#flushArtifactTailIfCapped();
-			await this.#file.sink.end();
-		}
 
 		// Compose the visible output. With head retention, splice head + marker
 		// + tail when content was elided. Otherwise return the rolling buffer.
@@ -1277,6 +1480,7 @@ export class OutputSink {
 		let outputLines: number;
 		let elidedBytes: number | undefined;
 		let elidedLines: number | undefined;
+		let truncated = this.#truncated;
 
 		if (headBytes > 0 && effectiveTotalBytes > headBytes + tailBytes) {
 			// Middle was elided. Emit head + marker + tail.
@@ -1294,7 +1498,7 @@ export class OutputSink {
 				Buffer.byteLength(headSep, "utf-8") +
 				Buffer.byteLength(tailSep, "utf-8");
 			outputLines = headLines + 1 + tailLines;
-			this.#truncated = true;
+			truncated = true;
 		} else if (headBytes > 0) {
 			// Head + tail combine into the full buffered output (no overlap or elision).
 			body = `${this.#head}${tailBuf}`;
@@ -1308,7 +1512,7 @@ export class OutputSink {
 
 		return {
 			output: `${noticeLine}${body}`,
-			truncated: this.#truncated,
+			truncated,
 			totalLines,
 			totalBytes: this.#totalBytes,
 			outputLines,
@@ -1318,7 +1522,7 @@ export class OutputSink {
 			columnDroppedBytes: this.#columnDroppedBytes > 0 ? this.#columnDroppedBytes : undefined,
 			columnTruncatedLines: this.#columnTruncatedLines > 0 ? this.#columnTruncatedLines : undefined,
 			columnMax: this.#columnTruncatedLines > 0 ? this.#maxColumns : undefined,
-			artifactId: this.#file?.artifactId,
+			artifactId: this.#materializedArtifactId,
 		};
 	}
 }

--- a/packages/coding-agent/src/tools/bash-interactive.ts
+++ b/packages/coding-agent/src/tools/bash-interactive.ts
@@ -27,6 +27,11 @@ export interface BashInteractiveResult extends OutputSummary {
 	timedOut: boolean;
 }
 
+// Observed completion for the overlay: the detached PTY finalizer settles this
+// through ui.custom so a flush/dump failure surfaces to the caller instead of
+// stranding the overlay's `done` callback.
+type BashInteractiveCompletion = { ok: true; result: BashInteractiveResult } | { ok: false; error: unknown };
+
 function normalizeCaptureChunk(chunk: string): string {
 	const normalized = chunk.replace(/\r\n?/gu, "\n");
 	return sanitizeWithOptionalSixelPassthrough(normalized, sanitizeText);
@@ -334,13 +339,13 @@ export async function runInteractiveBashPty(
 	// Load the xterm Terminal ctor here (async boundary) — the ui.custom factory below is sync.
 	const XtermTerminal = await loadXtermTerminal();
 	const { shell: resolvedShell } = settings.getShellConfig();
-	const sink = new OutputSink({
+	await using sink = new OutputSink({
 		artifactPath: options.artifactPath,
 		artifactId: options.artifactId,
 		headBytes: resolveOutputSinkHeadBytes(settings),
 		maxColumns: resolveOutputMaxColumns(settings),
 	});
-	const result = await ui.custom<BashInteractiveResult>(
+	const outcome = await ui.custom<BashInteractiveCompletion>(
 		(tui, uiTheme, _keybindings, done) => {
 			const session = new PtySession();
 			const component = new BashInteractiveOverlayComponent(
@@ -357,14 +362,21 @@ export async function runInteractiveBashPty(
 				component.setComplete({ exitCode: run.exitCode, cancelled: run.cancelled, timedOut: run.timedOut });
 				tui.requestRender();
 				void (async () => {
-					await component.flushOutput();
-					const summary = await sink.dump();
-					done({
-						exitCode: run.exitCode,
-						cancelled: run.cancelled,
-						timedOut: run.timedOut,
-						...summary,
-					});
+					try {
+						await component.flushOutput();
+						const summary = await sink.dump();
+						done({
+							ok: true,
+							result: {
+								exitCode: run.exitCode,
+								cancelled: run.cancelled,
+								timedOut: run.timedOut,
+								...summary,
+							},
+						});
+					} catch (error) {
+						done({ ok: false, error });
+					}
 				})();
 			};
 			const cols = Math.max(20, tui.terminal.columns - 2);
@@ -427,5 +439,8 @@ export async function runInteractiveBashPty(
 		},
 		{ overlay: true },
 	);
-	return result;
+	if (!outcome.ok) {
+		throw outcome.error;
+	}
+	return outcome.result;
 }

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -428,333 +428,306 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		const languages = uniqueEvalLanguages(cells);
 		const notice = detailsNotice(cells);
 		const sessionAbortController = new AbortController();
-		let outputSink: OutputSink | undefined;
-		let outputSummary: OutputSummary | undefined;
-		let outputDumped = false;
-		const finalizeOutput = async (): Promise<OutputSummary | undefined> => {
-			if (outputDumped || !outputSink) return outputSummary;
-			outputSummary = await outputSink.dump();
-			outputDumped = true;
-			return outputSummary;
-		};
 
 		const execution = (async (): Promise<AgentToolResult<EvalToolDetails | undefined>> => {
-			try {
-				if (signal?.aborted) {
-					throw new ToolAbortError();
-				}
-				session.assertEvalExecutionAllowed?.();
+			if (signal?.aborted) {
+				throw new ToolAbortError();
+			}
+			session.assertEvalExecutionAllowed?.();
 
-				const tailBuffer = new TailBuffer(DEFAULT_MAX_BYTES * 2);
-				const jsonOutputs: unknown[] = [];
-				const images: ImageContent[] = [];
-				const statusEvents: EvalStatusEvent[] = [];
+			const tailBuffer = new TailBuffer(DEFAULT_MAX_BYTES * 2);
+			const jsonOutputs: unknown[] = [];
+			const images: ImageContent[] = [];
+			const statusEvents: EvalStatusEvent[] = [];
 
-				const cellResults: EvalCellResult[] = cells.map(cell => ({
-					index: cell.index,
-					title: cell.title,
-					code: cell.code,
-					language: cell.resolved.backend.id,
-					output: "",
-					status: "pending",
-				}));
-				const cellOutputs: string[] = [];
-				// The cell currently inside backend.execute(). Streamed stdout is
-				// appended to its rendered `output` live so a long-running cell (e.g. a
-				// sleep loop) shows progress instead of nothing until it returns. A
-				// dedicated per-cell tail buffer keeps attribution correct and avoids
-				// double-counting against the aggregate `tailBuffer`; on completion the
-				// authoritative `cellResult.output` (below) overwrites this live tail.
-				let activeLiveCell: { result: EvalCellResult; buf: TailBuffer } | undefined;
+			const cellResults: EvalCellResult[] = cells.map(cell => ({
+				index: cell.index,
+				title: cell.title,
+				code: cell.code,
+				language: cell.resolved.backend.id,
+				output: "",
+				status: "pending",
+			}));
+			const cellOutputs: string[] = [];
+			// The cell currently inside backend.execute(). Streamed stdout is
+			// appended to its rendered `output` live so a long-running cell (e.g. a
+			// sleep loop) shows progress instead of nothing until it returns. A
+			// dedicated per-cell tail buffer keeps attribution correct and avoids
+			// double-counting against the aggregate `tailBuffer`; on completion the
+			// authoritative `cellResult.output` (below) overwrites this live tail.
+			let activeLiveCell: { result: EvalCellResult; buf: TailBuffer } | undefined;
 
-				const appendTail = (text: string) => {
-					tailBuffer.append(text);
-				};
+			const appendTail = (text: string) => {
+				tailBuffer.append(text);
+			};
 
-				const buildUpdateDetails = (): EvalToolDetails => {
-					const details: EvalToolDetails = {
-						language: languages[0],
-						languages,
-						cells: cellResults.map(cell => ({
-							...cell,
-							statusEvents: cell.statusEvents ? [...cell.statusEvents] : undefined,
-						})),
-					};
-					if (jsonOutputs.length > 0) {
-						details.jsonOutputs = jsonOutputs;
-					}
-					if (images.length > 0) {
-						details.images = images;
-					}
-					if (statusEvents.length > 0) {
-						details.statusEvents = statusEvents;
-					}
-					if (notice) {
-						details.notice = notice;
-					}
-					return details;
-				};
-
-				const pushUpdate = () => {
-					if (!onUpdate) return;
-					const tailText = tailBuffer.text();
-					onUpdate({
-						content: [{ type: "text", text: tailText }],
-						details: buildUpdateDetails(),
-					});
-				};
-
-				const sessionFile = session.getSessionFile?.() ?? undefined;
-				const kernelOwnerId = session.getEvalKernelOwnerId?.() ?? undefined;
-				const { path: artifactPath, id: artifactId } = (await session.allocateOutputArtifact?.("eval")) ?? {};
-				session.assertEvalExecutionAllowed?.();
-				outputSink = new OutputSink({
-					artifactPath,
-					artifactId,
-					headBytes: resolveOutputSinkHeadBytes(session.settings),
-					maxColumns: resolveOutputMaxColumns(session.settings),
-					onChunk: chunk => {
-						appendTail(chunk);
-						if (activeLiveCell) {
-							activeLiveCell.buf.append(chunk);
-							activeLiveCell.result.output = activeLiveCell.buf.text();
-						}
-						pushUpdate();
-					},
-				});
-				const sessionId = session.getEvalSessionId?.() ?? defaultEvalSessionId(session);
-
-				for (let i = 0; i < cells.length; i++) {
-					const cell = cells[i];
-					const backend = cell.resolved.backend;
-					// The per-cell `timeout` is a budget on the cell runtime's *own*
-					// work. Host-side `agent()`/`parallel()`/`completion()` bridge calls suspend
-					// that budget entirely and restart a fresh timeout window when control
-					// returns to the active backend runtime. Compute, stdout, `log()`/`phase()`, and
-					// ordinary tool calls all count against the budget. The watchdog drives
-					// `combinedSignal`; we pass no wall-clock deadline downstream so the
-					// backends never arm a competing fixed timer.
-					const idleTimeoutMs =
-						cell.timeoutMs === 0
-							? undefined
-							: clampTimeout("eval", cell.timeoutMs / 1000, session.settings.get("tools.maxTimeout")) * 1000;
-					const idle = idleTimeoutMs === undefined ? undefined : new IdleTimeout(idleTimeoutMs);
-					const combinedSignal =
-						signal && idle
-							? AbortSignal.any([signal, idle.signal, sessionAbortController.signal])
-							: signal
-								? AbortSignal.any([signal, sessionAbortController.signal])
-								: idle
-									? AbortSignal.any([idle.signal, sessionAbortController.signal])
-									: sessionAbortController.signal;
-
-					const cellResult = cellResults[i];
-					cellResult.status = "running";
-					cellResult.output = "";
-					cellResult.statusEvents = undefined;
-					cellResult.exitCode = undefined;
-					cellResult.durationMs = undefined;
-					activeLiveCell = { result: cellResult, buf: new TailBuffer(DEFAULT_MAX_BYTES * 2) };
-					pushUpdate();
-
-					const startTime = Date.now();
-					let result: ExecutorBackendResult;
-					try {
-						result = await backend.execute(cell.code, {
-							cwd: session.cwd,
-							sessionId,
-							sessionFile: sessionFile ?? undefined,
-							kernelOwnerId,
-							signal: combinedSignal,
-							session,
-							idleTimeoutMs,
-							reset: cell.reset,
-							onChunk: chunk => {
-								outputSink!.push(chunk);
-							},
-							onStatus: event => {
-								if (event.op === EVAL_TIMEOUT_PAUSE_OP) {
-									idle?.pause();
-									return;
-								}
-								if (event.op === EVAL_TIMEOUT_RESUME_OP) {
-									idle?.resume();
-									return;
-								}
-								cellResult.statusEvents ??= [];
-								upsertStatusEvent(cellResult.statusEvents, event);
-								pushUpdate();
-							},
-						});
-					} finally {
-						idle?.dispose();
-						activeLiveCell = undefined;
-					}
-					const durationMs = Date.now() - startTime;
-
-					const cellStatusEvents: EvalStatusEvent[] = [];
-					const cellDisplayOutputs: EvalDisplayOutput[] = [];
-					const cellImageNotes: string[] = [];
-					let cellHasMarkdown = false;
-					for (const output of result.displayOutputs) {
-						if (output.type === "json") {
-							jsonOutputs.push(output.data);
-							cellDisplayOutputs.push(output);
-						}
-						if (output.type === "image") {
-							const resized = await resizeImage(
-								{
-									type: "image",
-									data: output.data,
-									mimeType: output.mimeType,
-								},
-								{ excludeWebP },
-							);
-							const image: ImageContent = {
-								type: "image",
-								data: resized.data,
-								mimeType: resized.mimeType,
-							};
-							images.push(image);
-							cellDisplayOutputs.push({
-								type: "image",
-								data: image.data,
-								mimeType: image.mimeType,
-							});
-							const dimensionNote = formatDimensionNote(resized);
-							if (dimensionNote) {
-								cellImageNotes.push(`display image ${cellImageNotes.length + 1}: ${dimensionNote}`);
-							}
-						}
-						if (output.type === "status") {
-							upsertStatusEvent(statusEvents, output.event);
-							upsertStatusEvent(cellStatusEvents, output.event);
-						}
-						if (output.type === "markdown") {
-							cellHasMarkdown = true;
-						}
-					}
-
-					const stdoutTrimmed = result.output.trim();
-					const imageText = cellImageNotes.join("\n");
-					const displayText = formatDisplayOutputsForText(cellDisplayOutputs);
-					const visibleDisplayText =
-						displayText && imageText ? `${displayText}\n\n${imageText}` : displayText || imageText;
-					const cellOutput =
-						stdoutTrimmed && visibleDisplayText
-							? `${stdoutTrimmed}\n\n${visibleDisplayText}`
-							: stdoutTrimmed || visibleDisplayText;
-					cellResult.output = cellOutput;
-					cellResult.exitCode = result.exitCode;
-					cellResult.durationMs = durationMs;
-					cellResult.statusEvents = cellStatusEvents.length > 0 ? cellStatusEvents : undefined;
-					cellResult.hasMarkdown = cellHasMarkdown || undefined;
-
-					if (cellOutput) {
-						cellOutputs.push(cellOutput);
-						appendTail(cellOutput);
-					}
-
-					if (result.cancelled) {
-						cellResult.status = "error";
-						pushUpdate();
-						const errorMsg = result.output || "Command aborted";
-						const combinedOutput = cellOutputs.join("\n\n");
-						const outputText = combinedOutput || errorMsg;
-
-						const summaryForMeta = await summarizeFinal(combinedOutput, finalizeOutput);
-						const details: EvalToolDetails = {
-							language: languages[0],
-							languages,
-							cells: cellResults,
-							jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
-							statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
-							isError: true,
-						};
-						if (notice) details.notice = notice;
-
-						return toolResult(details)
-							.content([{ type: "text", text: outputText }, ...images])
-							.truncationFromSummary(summaryForMeta, { direction: "tail" })
-							.done();
-					}
-
-					if (result.exitCode !== 0 && result.exitCode !== undefined) {
-						cellResult.status = "error";
-						pushUpdate();
-						const combinedOutput = cellOutputs.join("\n\n");
-						const outputText = combinedOutput
-							? `${combinedOutput}\n\nCommand exited with code ${result.exitCode}`
-							: `Command exited with code ${result.exitCode}`;
-
-						const summaryForMeta = await summarizeFinal(combinedOutput, finalizeOutput);
-						const details: EvalToolDetails = {
-							language: languages[0],
-							languages,
-							cells: cellResults,
-							jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
-							statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
-							isError: true,
-						};
-						if (notice) details.notice = notice;
-
-						return toolResult(details)
-							.content([{ type: "text", text: outputText }, ...images])
-							.truncationFromSummary(summaryForMeta, { direction: "tail" })
-							.done();
-					}
-
-					cellResult.status = "complete";
-					pushUpdate();
-				}
-
-				const combinedOutput = cellOutputs.join("\n\n");
-				const hasImages = images.length > 0;
-				const outputText =
-					combinedOutput ||
-					(hasImages
-						? `(displayed ${images.length} image${images.length === 1 ? "" : "s"}; no text output)`
-						: "(no output)");
-				const summaryForMeta = await summarizeFinal(combinedOutput, finalizeOutput);
-
+			const buildUpdateDetails = (): EvalToolDetails => {
 				const details: EvalToolDetails = {
 					language: languages[0],
 					languages,
-					cells: cellResults,
-					jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
-					statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
+					cells: cellResults.map(cell => ({
+						...cell,
+						statusEvents: cell.statusEvents ? [...cell.statusEvents] : undefined,
+					})),
 				};
-				if (notice) details.notice = notice;
-
-				return toolResult(details)
-					.content([{ type: "text", text: outputText }, ...images])
-					.truncationFromSummary(summaryForMeta, { direction: "tail" })
-					.done();
-			} finally {
-				if (!outputDumped) {
-					try {
-						await finalizeOutput();
-					} catch {}
+				if (jsonOutputs.length > 0) {
+					details.jsonOutputs = jsonOutputs;
 				}
+				if (images.length > 0) {
+					details.images = images;
+				}
+				if (statusEvents.length > 0) {
+					details.statusEvents = statusEvents;
+				}
+				if (notice) {
+					details.notice = notice;
+				}
+				return details;
+			};
+
+			const pushUpdate = () => {
+				if (!onUpdate) return;
+				const tailText = tailBuffer.text();
+				onUpdate({
+					content: [{ type: "text", text: tailText }],
+					details: buildUpdateDetails(),
+				});
+			};
+
+			const sessionFile = session.getSessionFile?.() ?? undefined;
+			const kernelOwnerId = session.getEvalKernelOwnerId?.() ?? undefined;
+			const { path: artifactPath, id: artifactId } = (await session.allocateOutputArtifact?.("eval")) ?? {};
+			session.assertEvalExecutionAllowed?.();
+			await using outputSink = new OutputSink({
+				artifactPath,
+				artifactId,
+				headBytes: resolveOutputSinkHeadBytes(session.settings),
+				maxColumns: resolveOutputMaxColumns(session.settings),
+				onChunk: chunk => {
+					appendTail(chunk);
+					if (activeLiveCell) {
+						activeLiveCell.buf.append(chunk);
+						activeLiveCell.result.output = activeLiveCell.buf.text();
+					}
+					pushUpdate();
+				},
+			});
+			const sessionId = session.getEvalSessionId?.() ?? defaultEvalSessionId(session);
+
+			for (let i = 0; i < cells.length; i++) {
+				const cell = cells[i];
+				const backend = cell.resolved.backend;
+				// The per-cell `timeout` is a budget on the cell runtime's *own*
+				// work. Host-side `agent()`/`parallel()`/`completion()` bridge calls suspend
+				// that budget entirely and restart a fresh timeout window when control
+				// returns to the active backend runtime. Compute, stdout, `log()`/`phase()`, and
+				// ordinary tool calls all count against the budget. The watchdog drives
+				// `combinedSignal`; we pass no wall-clock deadline downstream so the
+				// backends never arm a competing fixed timer.
+				const idleTimeoutMs =
+					cell.timeoutMs === 0
+						? undefined
+						: clampTimeout("eval", cell.timeoutMs / 1000, session.settings.get("tools.maxTimeout")) * 1000;
+				const idle = idleTimeoutMs === undefined ? undefined : new IdleTimeout(idleTimeoutMs);
+				const combinedSignal =
+					signal && idle
+						? AbortSignal.any([signal, idle.signal, sessionAbortController.signal])
+						: signal
+							? AbortSignal.any([signal, sessionAbortController.signal])
+							: idle
+								? AbortSignal.any([idle.signal, sessionAbortController.signal])
+								: sessionAbortController.signal;
+
+				const cellResult = cellResults[i];
+				cellResult.status = "running";
+				cellResult.output = "";
+				cellResult.statusEvents = undefined;
+				cellResult.exitCode = undefined;
+				cellResult.durationMs = undefined;
+				activeLiveCell = { result: cellResult, buf: new TailBuffer(DEFAULT_MAX_BYTES * 2) };
+				pushUpdate();
+
+				const startTime = Date.now();
+				let result: ExecutorBackendResult;
+				try {
+					result = await backend.execute(cell.code, {
+						cwd: session.cwd,
+						sessionId,
+						sessionFile: sessionFile ?? undefined,
+						kernelOwnerId,
+						signal: combinedSignal,
+						session,
+						idleTimeoutMs,
+						reset: cell.reset,
+						onChunk: chunk => {
+							outputSink.push(chunk);
+						},
+						onStatus: event => {
+							if (event.op === EVAL_TIMEOUT_PAUSE_OP) {
+								idle?.pause();
+								return;
+							}
+							if (event.op === EVAL_TIMEOUT_RESUME_OP) {
+								idle?.resume();
+								return;
+							}
+							cellResult.statusEvents ??= [];
+							upsertStatusEvent(cellResult.statusEvents, event);
+							pushUpdate();
+						},
+					});
+				} finally {
+					idle?.dispose();
+					activeLiveCell = undefined;
+				}
+				const durationMs = Date.now() - startTime;
+
+				const cellStatusEvents: EvalStatusEvent[] = [];
+				const cellDisplayOutputs: EvalDisplayOutput[] = [];
+				const cellImageNotes: string[] = [];
+				let cellHasMarkdown = false;
+				for (const output of result.displayOutputs) {
+					if (output.type === "json") {
+						jsonOutputs.push(output.data);
+						cellDisplayOutputs.push(output);
+					}
+					if (output.type === "image") {
+						const resized = await resizeImage(
+							{
+								type: "image",
+								data: output.data,
+								mimeType: output.mimeType,
+							},
+							{ excludeWebP },
+						);
+						const image: ImageContent = {
+							type: "image",
+							data: resized.data,
+							mimeType: resized.mimeType,
+						};
+						images.push(image);
+						cellDisplayOutputs.push({
+							type: "image",
+							data: image.data,
+							mimeType: image.mimeType,
+						});
+						const dimensionNote = formatDimensionNote(resized);
+						if (dimensionNote) {
+							cellImageNotes.push(`display image ${cellImageNotes.length + 1}: ${dimensionNote}`);
+						}
+					}
+					if (output.type === "status") {
+						upsertStatusEvent(statusEvents, output.event);
+						upsertStatusEvent(cellStatusEvents, output.event);
+					}
+					if (output.type === "markdown") {
+						cellHasMarkdown = true;
+					}
+				}
+
+				const stdoutTrimmed = result.output.trim();
+				const imageText = cellImageNotes.join("\n");
+				const displayText = formatDisplayOutputsForText(cellDisplayOutputs);
+				const visibleDisplayText =
+					displayText && imageText ? `${displayText}\n\n${imageText}` : displayText || imageText;
+				const cellOutput =
+					stdoutTrimmed && visibleDisplayText
+						? `${stdoutTrimmed}\n\n${visibleDisplayText}`
+						: stdoutTrimmed || visibleDisplayText;
+				cellResult.output = cellOutput;
+				cellResult.exitCode = result.exitCode;
+				cellResult.durationMs = durationMs;
+				cellResult.statusEvents = cellStatusEvents.length > 0 ? cellStatusEvents : undefined;
+				cellResult.hasMarkdown = cellHasMarkdown || undefined;
+
+				if (cellOutput) {
+					cellOutputs.push(cellOutput);
+					appendTail(cellOutput);
+				}
+
+				if (result.cancelled) {
+					cellResult.status = "error";
+					pushUpdate();
+					const errorMsg = result.output || "Command aborted";
+					const combinedOutput = cellOutputs.join("\n\n");
+					const outputText = combinedOutput || errorMsg;
+
+					const summaryForMeta = await summarizeFinal(combinedOutput, outputSink);
+					const details: EvalToolDetails = {
+						language: languages[0],
+						languages,
+						cells: cellResults,
+						jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
+						statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
+						isError: true,
+					};
+					if (notice) details.notice = notice;
+
+					return toolResult(details)
+						.content([{ type: "text", text: outputText }, ...images])
+						.truncationFromSummary(summaryForMeta, { direction: "tail" })
+						.done();
+				}
+
+				if (result.exitCode !== 0 && result.exitCode !== undefined) {
+					cellResult.status = "error";
+					pushUpdate();
+					const combinedOutput = cellOutputs.join("\n\n");
+					const outputText = combinedOutput
+						? `${combinedOutput}\n\nCommand exited with code ${result.exitCode}`
+						: `Command exited with code ${result.exitCode}`;
+
+					const summaryForMeta = await summarizeFinal(combinedOutput, outputSink);
+					const details: EvalToolDetails = {
+						language: languages[0],
+						languages,
+						cells: cellResults,
+						jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
+						statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
+						isError: true,
+					};
+					if (notice) details.notice = notice;
+
+					return toolResult(details)
+						.content([{ type: "text", text: outputText }, ...images])
+						.truncationFromSummary(summaryForMeta, { direction: "tail" })
+						.done();
+				}
+
+				cellResult.status = "complete";
+				pushUpdate();
 			}
+
+			const combinedOutput = cellOutputs.join("\n\n");
+			const hasImages = images.length > 0;
+			const outputText =
+				combinedOutput ||
+				(hasImages
+					? `(displayed ${images.length} image${images.length === 1 ? "" : "s"}; no text output)`
+					: "(no output)");
+			const summaryForMeta = await summarizeFinal(combinedOutput, outputSink);
+
+			const details: EvalToolDetails = {
+				language: languages[0],
+				languages,
+				cells: cellResults,
+				jsonOutputs: jsonOutputs.length > 0 ? jsonOutputs : undefined,
+				statusEvents: statusEvents.length > 0 ? statusEvents : undefined,
+			};
+			if (notice) details.notice = notice;
+
+			return toolResult(details)
+				.content([{ type: "text", text: outputText }, ...images])
+				.truncationFromSummary(summaryForMeta, { direction: "tail" })
+				.done();
 		})();
 
 		return await (session.trackEvalExecution?.(execution, sessionAbortController) ?? execution);
 	}
 }
 
-async function summarizeFinal(
-	combinedOutput: string,
-	finalizeOutput: () => Promise<OutputSummary | undefined>,
-): Promise<OutputSummary> {
-	const rawSummary = (await finalizeOutput()) ?? {
-		output: "",
-		truncated: false,
-		totalLines: 0,
-		totalBytes: 0,
-		outputLines: 0,
-		outputBytes: 0,
-	};
+async function summarizeFinal(combinedOutput: string, outputSink: OutputSink): Promise<OutputSummary> {
+	const rawSummary = await outputSink.dump();
 	const outputLines = combinedOutput.length > 0 ? combinedOutput.split("\n").length : 0;
 	const outputBytes = Buffer.byteLength(combinedOutput, "utf-8");
 	const missingLines = Math.max(0, rawSummary.totalLines - rawSummary.outputLines);

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -99,6 +99,37 @@ describe("executeBash", () => {
 		}
 	});
 
+	it("owner precedence: a rejected artifact end surfaces to the caller and is attempted once", async () => {
+		const state = { endCount: 0 };
+		const fakeSink = {
+			write: (chunk: string): number => chunk.length,
+			end: async (): Promise<void> => {
+				state.endCount++;
+				throw new Error("end-E");
+			},
+		};
+		const artifactPath = "omp-bash-owner://artifact";
+		const realFile = Bun.file.bind(Bun);
+		vi.spyOn(Bun, "file").mockImplementation(((p: unknown, ...rest: unknown[]) => {
+			if (p === artifactPath) {
+				return { writer: () => fakeSink } as unknown as ReturnType<typeof realFile>;
+			}
+			return realFile(p as never, ...(rest as []));
+		}) as typeof Bun.file);
+
+		// ~100 KB of output spills past the in-memory threshold, acquiring the
+		// artifact writer whose end() then rejects.
+		await expect(
+			executeBash('head -c 100000 /dev/zero | tr "\\0" Z', {
+				cwd: tempDir,
+				timeout: 5000,
+				artifactPath,
+				artifactId: "b",
+			}),
+		).rejects.toThrow("end-E");
+		expect(state.endCount).toBe(1);
+	});
+
 	it("omits minimizer options when the feature is disabled", () => {
 		const group: ShellMinimizerSettings = {
 			enabled: false,

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -4,6 +4,7 @@ import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { disposeAllVmContexts } from "@oh-my-pi/pi-coding-agent/eval/js/context-manager";
 import { executeJs, type JsResult } from "@oh-my-pi/pi-coding-agent/eval/js/executor";
+import { OutputSink } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -529,5 +530,13 @@ describe("executeJs", () => {
 		expect(result.cancelled).toBe(true);
 		expect(result.exitCode).toBeUndefined();
 		expect(result.output).toContain("Command timed out");
+	});
+
+	it("owner precedence: a dump failure surfaces and is not caught, appended, or retried", async () => {
+		const dumpSpy = vi.spyOn(OutputSink.prototype, "dump").mockRejectedValue(new Error("dump-E"));
+		await expect(executeJs("const dumpFail = 1; dumpFail;", { sessionId, session, sessionFile })).rejects.toThrow(
+			"dump-E",
+		);
+		expect(dumpSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/core/python-executor-lifecycle.test.ts
+++ b/packages/coding-agent/test/core/python-executor-lifecycle.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { disposeAllKernelSessions, executePython } from "@oh-my-pi/pi-coding-agent/eval/py/executor";
+import {
+	disposeAllKernelSessions,
+	executePython,
+	executePythonWithKernel,
+	type PythonKernelExecutor,
+} from "@oh-my-pi/pi-coding-agent/eval/py/executor";
 import type { KernelExecuteResult } from "@oh-my-pi/pi-coding-agent/eval/py/kernel";
 import * as pythonKernel from "@oh-my-pi/pi-coding-agent/eval/py/kernel";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
@@ -161,5 +166,43 @@ describe("executePython lifecycle", () => {
 		]);
 		expect(r1.exitCode).toBe(0);
 		expect(r2.exitCode).toBe(0);
+	});
+
+	it("owner precedence: a backend error survives while a rejected end is attempted once", async () => {
+		const backendError = new Error("backend-W");
+		const state = { endCount: 0 };
+		const fakeSink = {
+			write: (chunk: string): number => chunk.length,
+			end: async (): Promise<void> => {
+				state.endCount++;
+				throw new Error("end-E");
+			},
+		};
+		const artifactPath = "omp-kernel-owner://artifact";
+		const realFile = Bun.file.bind(Bun);
+		vi.spyOn(Bun, "file").mockImplementation(((p: unknown, ...rest: unknown[]) => {
+			if (p === artifactPath) {
+				return { writer: () => fakeSink } as unknown as ReturnType<typeof realFile>;
+			}
+			return realFile(p as never, ...(rest as []));
+		}) as typeof Bun.file);
+
+		const kernel: PythonKernelExecutor = {
+			execute: async (_code, options) => {
+				// Spill past the in-memory threshold so the artifact writer is acquired,
+				// then fail the backend work with a sentinel.
+				options?.onChunk?.("Z".repeat(100_000));
+				throw backendError;
+			},
+		};
+
+		await expect(
+			executePythonWithKernel(kernel, "boom()", {
+				artifactPath,
+				artifactId: "k",
+				cwd: getProjectDir(),
+			}),
+		).rejects.toThrow("backend-W");
+		expect(state.endCount).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
+++ b/packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { OutputSink } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
+
+// This regression proves the descriptor-ownership barrier: every `await using`
+// OutputSink scope that spills to an artifact file releases its `Bun.FileSink`
+// descriptor on ordinary and abort-like error exits. Without the barrier those
+// descriptors leaked until an unrelated cached `SKILL.md` read exhausted the
+// process fd table (EMFILE). Linux-gated because it inspects `/proc/self/fd`.
+//
+// Intended to run under a low descriptor limit:
+//   prlimit --nofile=64:64 bun test packages/coding-agent/test/output-sink-fd-lifecycle.test.ts
+
+const isLinux = process.platform === "linux";
+
+function openFdCount(): number {
+	return fs.readdirSync("/proc/self/fd").length;
+}
+
+async function spillingScope(artifactPath: string, exit: "ordinary" | "abort"): Promise<void> {
+	await using sink = new OutputSink({ artifactPath, artifactId: "fd", spillThreshold: 16 });
+	// Force artifact-file creation and a spill so a real descriptor is acquired.
+	sink.push("Z".repeat(4096));
+	if (exit === "ordinary") {
+		throw new Error("ordinary failure");
+	}
+	const abort = new Error("aborted");
+	abort.name = "AbortError";
+	throw abort;
+}
+
+describe.skipIf(!isLinux)("OutputSink descriptor lifecycle under a low fd limit", () => {
+	let dir: string;
+
+	beforeAll(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-fd-lifecycle-"));
+	});
+
+	afterAll(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("spilling scopes release every descriptor on ordinary and abort exits", async () => {
+		const artifactPath = path.join(dir, "spill.log");
+
+		// Warm the runtime + file-I/O paths so lazy fd allocations settle before
+		// we snapshot the baseline (exact baselines require warm-up).
+		for (let i = 0; i < 8; i++) {
+			await spillingScope(artifactPath, i % 2 === 0 ? "ordinary" : "abort").catch(() => {});
+		}
+
+		const baseline = openFdCount();
+
+		for (let i = 0; i < 64; i++) {
+			await spillingScope(artifactPath, i % 2 === 0 ? "ordinary" : "abort").catch(() => {});
+		}
+
+		// A leaked writer per error scope would push the count far above baseline
+		// (and, under nofile=64, would exhaust the table). The barrier keeps it flat.
+		const after = openFdCount();
+		expect(after).toBeLessThanOrEqual(baseline);
+	});
+
+	test("valid cached SKILL.md survives 16 concurrent reads under a 64-descriptor limit", async () => {
+		const skillPath = path.join(dir, "SKILL.md");
+		await Bun.write(
+			skillPath,
+			"---\nname: fd-lifecycle-skill\ndescription: descriptor regression fixture\n---\n# Skill\n\ncached body\n",
+		);
+
+		// Drain the leak first so the reads run against a warm, non-exhausted table.
+		const leakPath = path.join(dir, "pre-read-spill.log");
+		for (let i = 0; i < 32; i++) {
+			await spillingScope(leakPath, i % 2 === 0 ? "ordinary" : "abort").catch(() => {});
+		}
+
+		const reads = await Promise.all(Array.from({ length: 16 }, () => Bun.file(skillPath).text()));
+
+		expect(reads).toHaveLength(16);
+		for (const body of reads) {
+			expect(body).toContain("fd-lifecycle-skill");
+			expect(body).toContain("cached body");
+		}
+	});
+});

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -776,3 +776,175 @@ describe("OutputSink maxColumns (per-line cap)", () => {
 		expect(elided + dropped).toBeLessThan(dumped.totalBytes);
 	});
 });
+
+describe("OutputSink lifecycle ownership", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function makeFakeSink() {
+		const state = {
+			writes: [] as string[],
+			endCount: 0,
+			failEndWith: undefined as unknown,
+			failWritesWith: undefined as unknown,
+		};
+		const sink = {
+			write(chunk: string): number {
+				if (state.failWritesWith !== undefined) throw state.failWritesWith;
+				state.writes.push(chunk);
+				return chunk.length;
+			},
+			async end(): Promise<void> {
+				state.endCount++;
+				if (state.failEndWith !== undefined) throw state.failEndWith;
+			},
+		};
+		return { state, sink };
+	}
+
+	function spyBunFile(targetPath: string, fakeSink: unknown): void {
+		const realFile = Bun.file.bind(Bun);
+		vi.spyOn(Bun, "file").mockImplementation(((p: unknown, ...rest: unknown[]) => {
+			if (p === targetPath) {
+				return { writer: () => fakeSink } as unknown as ReturnType<typeof realFile>;
+			}
+			return realFile(p as never, ...(rest as []));
+		}) as typeof Bun.file);
+	}
+
+	test("reentrant onChunk close admits the triggering chunk once and ignores nested pushes", async () => {
+		const { state, sink: fakeSink } = makeFakeSink();
+		const artifactPath = "omp-lifecycle://reentrant";
+		spyBunFile(artifactPath, fakeSink);
+		let closed = false;
+		let nestedIgnored = false;
+		const preview: string[] = [];
+		const sink = new OutputSink({
+			artifactPath,
+			artifactId: "reentrant",
+			spillThreshold: 4,
+			onChunk: chunk => {
+				preview.push(chunk);
+				if (!closed) {
+					closed = true;
+					void sink.close();
+					sink.push("NESTED");
+					nestedIgnored = true;
+				}
+			},
+		});
+		sink.push("TRIGGERDATA");
+		const summary = await sink.dump();
+
+		expect(nestedIgnored).toBe(true);
+		expect(preview).toEqual(["TRIGGERDATA"]);
+		expect(summary.totalBytes).toBe(byteLength("TRIGGERDATA"));
+		expect(state.writes.join("")).toBe("TRIGGERDATA");
+		expect(state.writes.join("")).not.toContain("NESTED");
+		expect(state.endCount).toBe(1);
+		expect(summary.artifactId).toBe("reentrant");
+	});
+
+	test("reentrant onChunk close that throws keeps the chunk admitted and rethrows the sentinel", async () => {
+		const { state, sink: fakeSink } = makeFakeSink();
+		const artifactPath = "omp-lifecycle://reentrant-throw";
+		spyBunFile(artifactPath, fakeSink);
+		const sink = new OutputSink({
+			artifactPath,
+			artifactId: "rt",
+			spillThreshold: 4,
+			onChunk: () => {
+				void sink.close();
+				throw new Error("cb-sentinel");
+			},
+		});
+		expect(() => sink.push("TRIGGERDATA")).toThrow("cb-sentinel");
+		const summary = await sink.dump();
+
+		expect(summary.totalBytes).toBe(byteLength("TRIGGERDATA"));
+		expect(state.writes.join("")).toBe("TRIGGERDATA");
+		expect(state.endCount).toBe(1);
+	});
+
+	test("concurrent close/dump/dispose share one completion and end once", async () => {
+		const { state, sink: fakeSink } = makeFakeSink();
+		const artifactPath = "omp-lifecycle://coalesce";
+		spyBunFile(artifactPath, fakeSink);
+		const sink = new OutputSink({ artifactPath, artifactId: "c", spillThreshold: 4 });
+		sink.push("abcdef");
+		const p1 = sink.close();
+		const p2 = sink.dump();
+		const p3 = sink[Symbol.asyncDispose]();
+		const [, summary] = await Promise.all([p1, p2, p3]);
+
+		expect(state.endCount).toBe(1);
+		expect(summary.artifactId).toBe("c");
+	});
+
+	test("end rejection clears ownership, surfaces to explicit dump, and is not retried", async () => {
+		const { state, sink: fakeSink } = makeFakeSink();
+		state.failEndWith = new Error("end-fail");
+		const artifactPath = "omp-lifecycle://end-fail";
+		spyBunFile(artifactPath, fakeSink);
+		const sink = new OutputSink({ artifactPath, artifactId: "e", spillThreshold: 4 });
+		sink.push("abcdef");
+
+		await expect(sink.dump()).rejects.toThrow("end-fail");
+		await expect(sink.dump()).rejects.toThrow("end-fail");
+		expect(state.endCount).toBe(1);
+		await expect(Promise.resolve(sink[Symbol.asyncDispose]())).resolves.toBeUndefined();
+	});
+
+	test("push/replace after close cannot change frozen output and repeated dump is stable", async () => {
+		const sink = new OutputSink();
+		sink.push("kept");
+		await sink.close();
+		sink.push("ignored");
+		sink.replace("wiped");
+		const d1 = await sink.dump();
+		const d2 = await sink.dump();
+
+		expect(d1.output).toBe("kept");
+		expect(d2).toEqual(d1);
+	});
+
+	test("a throttled timer scheduled before close flushes once and does not fire after close", async () => {
+		vi.useFakeTimers();
+		const preview: string[] = [];
+		const sink = new OutputSink({ onChunk: chunk => preview.push(chunk), chunkThrottleMs: 50 });
+		sink.push("first");
+		sink.push("second");
+		expect(preview).toEqual(["first"]);
+
+		await sink.close();
+		vi.advanceTimersByTime(200);
+
+		expect(preview).toEqual(["first", "second"]);
+	});
+
+	test("close normalizes a held terminal carriage return into one newline", async () => {
+		const sink = new OutputSink();
+		sink.push("progress\r");
+		const summary = await sink.dump();
+		expect(summary.output).toBe("progress\n");
+	});
+
+	test("a capped-tail flush failure still ends the descriptor exactly once", async () => {
+		const { state, sink: fakeSink } = makeFakeSink();
+		const artifactPath = "omp-lifecycle://tail-fail";
+		spyBunFile(artifactPath, fakeSink);
+		const sink = new OutputSink({
+			artifactPath,
+			artifactId: "t",
+			spillThreshold: 16,
+			artifactMaxBytes: 32,
+			artifactHeadBytes: 16,
+		});
+		sink.push("0123456789ABCDEF".repeat(4));
+		state.failWritesWith = new Error("tail-flush-fail");
+
+		await expect(sink.dump()).rejects.toThrow("tail-flush-fail");
+		expect(state.endCount).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/tools/bash-interactive-lifecycle.test.ts
+++ b/packages/coding-agent/test/tools/bash-interactive-lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import type { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import type {
+	ExtensionUIContext,
+	ExtensionUiComponent,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { OutputSink } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
+import { runInteractiveBashPty } from "@oh-my-pi/pi-coding-agent/tools/bash-interactive";
+import { type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+// The interactive PTY overlay finalizes on a detached task: it flushes the
+// terminal, dumps the sink, and settles `ui.custom` via `done`. If the flush or
+// dump throws, the old code left `done` uncalled, so the overlay hung forever.
+// The completion-union contract routes success/error through `done` and rethrows
+// the error after the overlay resolves. These tests pin that contract.
+
+interface CustomCapture {
+	completion?: unknown;
+}
+
+function makeFakeUi(capture: CustomCapture): ExtensionUIContext {
+	const ui = {
+		custom: <T>(
+			factory: (
+				tui: TUI,
+				uiTheme: Theme,
+				keybindings: KeybindingsManager,
+				done: (result: T) => void,
+			) => ExtensionUiComponent | Promise<ExtensionUiComponent>,
+			_options?: { overlay?: boolean },
+		): Promise<T> =>
+			new Promise<T>(resolve => {
+				const fakeTui = {
+					terminal: { rows: 24, columns: 80 },
+					requestRender: () => {},
+				} as TUI;
+				const done = (result: T): void => {
+					capture.completion = result;
+					resolve(result);
+				};
+				// The factory is synchronous here; it wires the PtySession whose
+				// (mocked) start resolves and drives finalize.
+				void factory(fakeTui, theme, {} as KeybindingsManager, done);
+			}),
+	} as ExtensionUIContext;
+	return ui;
+}
+
+function completionOk(value: unknown): boolean | undefined {
+	if (value && typeof value === "object" && "ok" in value) {
+		const ok = value.ok;
+		return typeof ok === "boolean" ? ok : undefined;
+	}
+	return undefined;
+}
+
+describe("runInteractiveBashPty overlay settlement", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("a final dump failure settles ui.custom with an error outcome and rejects the caller", async () => {
+		vi.spyOn(PtySession.prototype, "start").mockImplementation(
+			async (): Promise<PtyRunResult> => ({ exitCode: 0, cancelled: false, timedOut: false }),
+		);
+		const dumpError = new Error("dump-fail");
+		vi.spyOn(OutputSink.prototype, "dump").mockRejectedValue(dumpError);
+
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const capture: CustomCapture = {};
+			const ui = makeFakeUi(capture);
+
+			await expect(runInteractiveBashPty(ui, { command: "echo hi", cwd: process.cwd() })).rejects.toThrow(
+				"dump-fail",
+			);
+
+			// The overlay settled with an error outcome instead of hanging.
+			expect(completionOk(capture.completion)).toBe(false);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+
+		// Let any stray microtasks flush, then assert the finalizer left no
+		// unhandled rejection behind.
+		await Promise.resolve();
+		expect(unhandled).toEqual([]);
+	});
+
+	test("a successful run settles ui.custom with a result outcome and resolves the caller", async () => {
+		vi.spyOn(PtySession.prototype, "start").mockImplementation(
+			async (): Promise<PtyRunResult> => ({ exitCode: 0, cancelled: false, timedOut: false }),
+		);
+
+		const capture: CustomCapture = {};
+		const ui = makeFakeUi(capture);
+
+		const result = await runInteractiveBashPty(ui, { command: "echo hi", cwd: process.cwd() });
+
+		expect(completionOk(capture.completion)).toBe(true);
+		expect(result.exitCode).toBe(0);
+		expect(result.cancelled).toBe(false);
+		expect(result.timedOut).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/eval-streaming-output.test.ts
+++ b/packages/coding-agent/test/tools/eval-streaming-output.test.ts
@@ -108,4 +108,40 @@ describe("EvalTool live stdout streaming", () => {
 		expect(result.details?.meta?.truncation).toBeUndefined();
 		expect(formatOutputNotice(result.details?.meta)).toContain("Some lines truncated to 8 chars");
 	});
+
+	it("owner precedence: a backend throw survives while the artifact end rejects once", async () => {
+		const state = { endCount: 0 };
+		const fakeSink = {
+			write: (chunk: string): number => chunk.length,
+			end: async (): Promise<void> => {
+				state.endCount++;
+				throw new Error("end-E");
+			},
+		};
+		const artifactPath = "omp-eval-owner://artifact";
+		const realFile = Bun.file.bind(Bun);
+		vi.spyOn(Bun, "file").mockImplementation(((p: unknown, ...rest: unknown[]) => {
+			if (p === artifactPath) {
+				return { writer: () => fakeSink } as unknown as ReturnType<typeof realFile>;
+			}
+			return realFile(p as never, ...(rest as []));
+		}) as typeof Bun.file);
+		vi.spyOn(evalIndex.jsBackend, "execute").mockImplementation((async (
+			_code: string,
+			options: { onChunk?: (chunk: string) => void },
+		) => {
+			// Spill past the in-memory threshold to acquire the artifact writer, then
+			// fail the backend work.
+			options.onChunk?.("Z".repeat(100_000));
+			throw new Error("backend-W");
+		}) as never);
+
+		const session = makeSession();
+		session.allocateOutputArtifact = async () => ({ path: artifactPath, id: "eval-art" });
+
+		await expect(
+			new EvalTool(session).execute("call-owner", { language: "js", code: "x" }, undefined, undefined),
+		).rejects.toThrow("backend-W");
+		expect(state.endCount).toBe(1);
+	});
 });


### PR DESCRIPTION
Closes #6463

## What changed

- Edit the six files named in Approach 4 plus `packages/coding-agent/test/streaming-output.test.ts`, executor lifecycle tests, and a low-file-limit regression.
- Add `Fixed failed bash and eval executions leaking artifact descriptors until later reads failed with EMFILE ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).` to `packages/coding-agent/CHANGELOG.md` `[Unreleased] / Fixed`.

## Verification

- `bun install --frozen-lockfile`
- `bun run build:native`
- `bun test packages/coding-agent/test/streaming-output.test.ts packages/coding-agent/test/bash-executor.test.ts packages/coding-agent/test/core/js-executor.test.ts packages/coding-agent/test/core/python-executor-lifecycle.test.ts packages/coding-agent/test/tools/eval-streaming-output.test.ts packages/coding-agent/test/tools/bash-interactive-lifecycle.test.ts`
- `prlimit --nofile=64:64 bun test ./packages/coding-agent/test/output-sink-fd-lifecycle.test.ts`
- `bun run check:ts`
