### PR TITLE
fix(computer-use): route enabled desktop control correctly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Exposed `computer` to models without native OpenAI computer-use support as a regular function tool with a typed GA action schema; the same native desktop backend and approval policy apply on both paths.
 - Hardened computer action ingress: action-specific fields, modifier/key arrays, coordinates, drag points, and scroll deltas fail closed before native input; numeric fields must be signed 32-bit integers and coordinates must be non-negative.
 
+### Changed
+
+- Expanded explicit computer-use diagnostics with model exposure details, lifecycle logging, model-switch retention checks, and guidance to verify visual UI actions from returned screenshots rather than shell exit status.
+
+### Fixed
+
+- Fixed `/computer` reporting native exposure for ChatGPT Codex sessions even though the transport did not provide a callable native tool; Codex now receives the computer controller as a named function tool.
+
 ## [17.1.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -79,6 +79,15 @@ Special URLs for internal resources; with most FS/bash tools they auto-resolve t
 {{/if}}
 {{/if}}
 
+{{#has tools "computer"}}
+# Computer Use
+The `{{toolRefs.computer}}` tool is explicitly enabled and available in this session.
+- MUST use `{{toolRefs.computer}}` for requests to view or control host desktop applications, including Safari.
+- NEVER claim Computer Use is unavailable while `{{toolRefs.computer}}` appears in the tool inventory.
+- NEVER substitute Browser, Bash, Eval, AppleScript, accessibility commands, or `screencapture` unless the user explicitly requests that mechanism or `{{toolRefs.computer}}` returns an error.
+- Inspect the fresh screenshot returned by every successful `{{toolRefs.computer}}` call before choosing the next action.
+{{/has}}
+
 {{#if xdevTools.length}}
 # xd:// Tool Devices
 Additional tools are mounted as virtual devices, executed by writing a JSON args object as `content` to `xd://<tool>` via `{{toolRefs.write}}`.

--- a/packages/coding-agent/src/prompts/tools/computer.md
+++ b/packages/coding-agent/src/prompts/tools/computer.md
@@ -15,6 +15,12 @@ Pass `actions`: an ordered batch executed in sequence. A successful call returns
 
 Pointer actions accept optional `keys` as held modifiers.
 
+## Routing and verification
+- The presence of this tool means host computer use is explicitly enabled and available in the current session. Never claim it is unavailable while this tool is present.
+- MUST use this tool for requests to view or control host desktop applications, including Safari. NEVER substitute Browser, Bash, Eval, AppleScript, accessibility commands, or `screencapture` unless the user explicitly requests that mechanism or this tool returns an error.
+- Inspect the fresh screenshot returned by each successful call before choosing the next action.
+- A successful fallback command proves only that the command ran; it does not verify the resulting UI state.
+
 ## Coordinates
 - `x`/`y` are nonnegative integer pixels in the MOST RECENT screenshot returned by a prior successful call.
 - Every coordinate in one batch uses that same prior frame. Screenshot first; after the UI changes, finish the call and use its returned image for coordinates in the next call.

--- a/packages/coding-agent/src/prompts/tools/computer.md
+++ b/packages/coding-agent/src/prompts/tools/computer.md
@@ -15,12 +15,6 @@ Pass `actions`: an ordered batch executed in sequence. A successful call returns
 
 Pointer actions accept optional `keys` as held modifiers.
 
-## Routing and verification
-- The presence of this tool means host computer use is explicitly enabled and available in the current session. Never claim it is unavailable while this tool is present.
-- MUST use this tool for requests to view or control host desktop applications, including Safari. NEVER substitute Browser, Bash, Eval, AppleScript, accessibility commands, or `screencapture` unless the user explicitly requests that mechanism or this tool returns an error.
-- Inspect the fresh screenshot returned by each successful call before choosing the next action.
-- A successful fallback command proves only that the command ran; it does not verify the resulting UI state.
-
 ## Coordinates
 - `x`/`y` are nonnegative integer pixels in the MOST RECENT screenshot returned by a prior successful call.
 - Every coordinate in one batch uses that same prior frame. Screenshot first; after the UI changes, finish the call and use its returned image for coordinates in the next call.

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -294,6 +294,22 @@ export class SessionTools {
 		return usesCodexTaskPrompt(model) ? "task-policy:gpt-5.6" : "task-policy:default";
 	}
 
+	#computerExposureMode(): "native" | "function" | "unavailable" {
+		const model = this.#host.model();
+		if (!model) return "unavailable";
+		return model.supportsComputerUse === true && model.api !== "openai-codex-responses" ? "native" : "function";
+	}
+
+	#logComputerState(message: string, enabled: boolean): void {
+		const model = this.#host.model();
+		logger.debug(message, {
+			enabled,
+			active: this.getEnabledToolNames().includes("computer"),
+			model: model ? formatModelString(model) : undefined,
+			exposure: this.#computerExposureMode(),
+		});
+	}
+
 	/** Rebuilds model-dependent tool prompts after a model change. */
 	async syncAfterModelChange(previousEditMode: EditMode): Promise<void> {
 		const currentEditMode = this.resolveActiveEditMode();
@@ -302,6 +318,20 @@ export class SessionTools {
 		const modelChanged = this.#currentPromptModelKey() !== this.#promptModelKey;
 		if (editModeChanged || modelChanged) {
 			await this.refreshBaseSystemPrompt();
+		}
+		const computerExpected = this.#host.settings.get("computer.enabled");
+		const computerActive = this.getEnabledToolNames().includes("computer");
+		if (computerExpected && !computerActive) {
+			const model = this.#host.model();
+			const modelName = model ? formatModelString(model) : "the current model";
+			logger.warn("Enabled computer tool missing after model change", { model: modelName });
+			this.#host.emitNotice(
+				"warning",
+				`Computer use remains enabled, but the computer tool is unavailable to ${modelName}.`,
+				"computer",
+			);
+		} else if (computerExpected) {
+			this.#logComputerState("Computer tool retained after model change", true);
 		}
 	}
 
@@ -713,16 +743,24 @@ export class SessionTools {
 	 * tool (e.g. restricted child sessions have no factory).
 	 */
 	async setComputerToolEnabled(enabled: boolean): Promise<boolean> {
+		const logState = (): void => this.#logComputerState("Computer tool state changed", enabled);
 		const active = this.getEnabledToolNames();
 		if (!enabled) {
 			if (active.includes("computer")) {
 				await this.applyActiveToolsByName(active.filter(name => name !== "computer"));
 			}
+			logState();
 			return true;
 		}
 		if (!this.#toolRegistry.has("computer")) {
 			const tool = await this.#createComputerTool?.();
-			if (tool?.name !== "computer") return false;
+			if (tool?.name !== "computer") {
+				const model = this.#host.model();
+				logger.warn("Computer tool could not be created", {
+					model: model ? formatModelString(model) : undefined,
+				});
+				return false;
+			}
 			const wrapped = this.#wrapRuntimeTool(tool);
 			this.#toolRegistry.set(wrapped.name, wrapped);
 			this.#builtInToolNames.add(wrapped.name);
@@ -730,6 +768,7 @@ export class SessionTools {
 		if (!active.includes("computer")) {
 			await this.applyActiveToolsByName([...active, "computer"]);
 		}
+		logState();
 		return true;
 	}
 

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -17,6 +17,7 @@ import type { MemoryBackendStartOptions } from "../memory-backend/types";
 import xdevMountNoticePrompt from "../prompts/system/xdev-mount-notice.md" with { type: "text" };
 import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
+import { computerExposureMode } from "../tools/computer/exposure";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
 import { isMountableUnderXdev, type XdevRegistry } from "../tools/xdev";
@@ -294,19 +295,13 @@ export class SessionTools {
 		return usesCodexTaskPrompt(model) ? "task-policy:gpt-5.6" : "task-policy:default";
 	}
 
-	#computerExposureMode(): "native" | "function" | "unavailable" {
-		const model = this.#host.model();
-		if (!model) return "unavailable";
-		return model.supportsComputerUse === true && model.api !== "openai-codex-responses" ? "native" : "function";
-	}
-
 	#logComputerState(message: string, enabled: boolean): void {
 		const model = this.#host.model();
 		logger.debug(message, {
 			enabled,
 			active: this.getEnabledToolNames().includes("computer"),
 			model: model ? formatModelString(model) : undefined,
-			exposure: this.#computerExposureMode(),
+			exposure: computerExposureMode(model),
 		});
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -7,7 +7,12 @@ import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
-import { expandRoleAlias, getModelMatchPreferences, resolveCliModel } from "../config/model-resolver";
+import {
+	expandRoleAlias,
+	formatModelString,
+	getModelMatchPreferences,
+	resolveCliModel,
+} from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
@@ -36,6 +41,7 @@ import type { AgentSession, FreshSessionResult } from "../session/agent-session"
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
+import { computerExposureMode } from "../tools/computer/exposure";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
 import { urlHyperlinkAlways } from "../tui";
 import {
@@ -93,13 +99,8 @@ function formatComputerUseStatus(session: AgentSession): string {
 	const enabled = session.settings.get("computer.enabled");
 	const active = session.getEnabledToolNames().includes("computer");
 	const model = session.model;
-	const modelName = model ? `${model.provider}/${model.id}` : "none";
-	const exposure =
-		!enabled || !active
-			? "not exposed"
-			: model?.supportsComputerUse === true && model.api !== "openai-codex-responses"
-				? "native"
-				: "function";
+	const modelName = model ? formatModelString(model) : "none";
+	const exposure = !enabled || !active ? "not exposed" : computerExposureMode(model);
 	const toolState = active ? "active" : enabled ? "unavailable" : "inactive";
 	return [
 		`Computer use: ${enabled ? "enabled" : "disabled"}`,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -88,9 +88,28 @@ function formatFastModeStatus(session: AgentSession): string {
 	return session.isFastModeEnabled() ? "on" : "off";
 }
 
-/** `/computer status` label for the session-effective `computer.enabled` value. */
+/** Detailed, session-effective `/computer status` diagnostics. */
 function formatComputerUseStatus(session: AgentSession): string {
-	return session.settings.get("computer.enabled") ? "on" : "off";
+	const enabled = session.settings.get("computer.enabled");
+	const active = session.getEnabledToolNames().includes("computer");
+	const model = session.model;
+	const modelName = model ? `${model.provider}/${model.id}` : "none";
+	const exposure =
+		!enabled || !active
+			? "not exposed"
+			: model?.supportsComputerUse === true && model.api !== "openai-codex-responses"
+				? "native"
+				: "function";
+	const toolState = active ? "active" : enabled ? "unavailable" : "inactive";
+	return [
+		`Computer use: ${enabled ? "enabled" : "disabled"}`,
+		`tool: ${toolState}`,
+		`backend: ${session.settings.get("computer.backend")}`,
+		`display: ${session.settings.get("computer.display")}`,
+		`capture: ${session.settings.get("computer.maxWidth")}×${session.settings.get("computer.maxHeight")}`,
+		`model: ${modelName}`,
+		`exposure: ${exposure}`,
+	].join(" · ");
 }
 
 /**
@@ -105,7 +124,9 @@ async function applyComputerUseToggle(session: AgentSession, enable: boolean): P
 		return "Computer use is unavailable in this session.";
 	}
 	session.settings.override("computer.enabled", enable);
-	return `Computer use ${enable ? "enabled" : "disabled"} for this session.`;
+	return enable
+		? `Computer use enabled for this session. ${formatComputerUseStatus(session)}`
+		: "Computer use disabled for this session.";
 }
 
 const AUTOCOMPLETE_DETAIL_LIMIT = 48;
@@ -503,11 +524,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			{ name: "status", description: "Show computer use status" },
 		],
 		allowArgs: true,
-		getTuiAutocompleteDescription: runtime => `Computer: ${formatComputerUseStatus(runtime.ctx.session)}`,
+		getTuiAutocompleteDescription: runtime =>
+			`Computer: ${runtime.ctx.session.settings.get("computer.enabled") ? "on" : "off"}`,
 		handle: async (command, runtime) => {
 			const arg = command.args.trim().toLowerCase();
 			if (arg === "status") {
-				await runtime.output(`Computer use is ${formatComputerUseStatus(runtime.session)}.`);
+				await runtime.output(formatComputerUseStatus(runtime.session));
 				return commandConsumed();
 			}
 			if (!arg || arg === "toggle" || arg === "on" || arg === "off") {
@@ -520,7 +542,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		handleTui: async (command, runtime) => {
 			const arg = command.args.trim().toLowerCase();
 			if (arg === "status") {
-				runtime.ctx.showStatus(`Computer use is ${formatComputerUseStatus(runtime.ctx.session)}.`);
+				runtime.ctx.showStatus(formatComputerUseStatus(runtime.ctx.session));
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/src/tools/computer/exposure.ts
+++ b/packages/coding-agent/src/tools/computer/exposure.ts
@@ -1,0 +1,9 @@
+import type { Model } from "@oh-my-pi/pi-ai";
+
+export type ComputerExposureMode = "native" | "function" | "unavailable";
+
+/** Match the provider transport's effective Computer Use tool representation. */
+export function computerExposureMode(model: Model | undefined): ComputerExposureMode {
+	if (!model) return "unavailable";
+	return model.supportsComputerUse === true && model.api !== "openai-codex-responses" ? "native" : "function";
+}

--- a/packages/coding-agent/src/tools/computer/supervisor.ts
+++ b/packages/coding-agent/src/tools/computer/supervisor.ts
@@ -1,5 +1,5 @@
 import type { DesktopAction, DesktopCapabilities, DesktopCapture, DesktopSessionOptions } from "@oh-my-pi/pi-natives";
-import { withTimeout, workerHostEntry } from "@oh-my-pi/pi-utils";
+import { logger, withTimeout, workerHostEntry } from "@oh-my-pi/pi-utils";
 import { ToolAbortError, ToolError } from "../tool-errors";
 import {
 	COMPUTER_WORKER_ARG,
@@ -138,11 +138,13 @@ export class ComputerSupervisor implements ComputerController {
 		if (this.#startPromise) return this.#startPromise;
 		const ready = Promise.withResolvers<void>();
 		try {
+			logger.debug("Starting native computer worker", { options: this.options });
 			const worker = this.createWorker();
 			this.#worker = worker;
 			this.#unsubscribeMessage = worker.onMessage(message => {
 				if (message.type === "ready") {
 					this.#capabilities = message.capabilities;
+					logger.debug("Native computer worker ready", { capabilities: message.capabilities });
 					ready.resolve();
 					return;
 				}
@@ -151,10 +153,22 @@ export class ComputerSupervisor implements ComputerController {
 					const pending = this.#pending.get(message.id);
 					this.#pending.delete(message.id);
 					pending?.resolve(message.capture);
+					logger.debug("Native computer capture completed", {
+						requestId: message.id,
+						backend: message.capture.backend,
+						capturePermission: message.capture.capturePermission,
+						inputPermission: message.capture.inputPermission,
+						width: message.capture.width,
+						height: message.capture.height,
+					});
 					return;
 				}
 				if (message.type === "error") {
 					const error = workerError(message.error);
+					logger.warn("Native computer worker request failed", {
+						requestId: message.id,
+						error: message.error.message,
+					});
 					if (message.id) {
 						const pending = this.#pending.get(message.id);
 						this.#pending.delete(message.id);
@@ -184,6 +198,7 @@ export class ComputerSupervisor implements ComputerController {
 	}
 
 	async #terminate(reason: unknown): Promise<void> {
+		logger.debug("Terminating native computer worker", { reason: String(reason) });
 		const worker = this.#worker;
 		this.#worker = undefined;
 		this.#startPromise = undefined;

--- a/packages/coding-agent/test/sdk-computer-tool-toggle.test.ts
+++ b/packages/coding-agent/test/sdk-computer-tool-toggle.test.ts
@@ -28,6 +28,7 @@ describe("AgentSession.setComputerToolEnabled", () => {
 		registryDir = path.join(os.tmpdir(), `pi-computer-toggle-${Snowflake.next()}`);
 		fs.mkdirSync(registryDir, { recursive: true });
 		authStorage = await AuthStorage.create(path.join(registryDir, "auth.db"));
+		authStorage.setRuntimeApiKey("google", "test-key");
 		modelRegistry = new ModelRegistry(authStorage);
 	});
 
@@ -70,6 +71,14 @@ describe("AgentSession.setComputerToolEnabled", () => {
 
 		// Re-enable reuses the retained registry entry.
 		expect(await session.setComputerToolEnabled(true)).toBe(true);
+		session.settings.override("computer.enabled", true);
+		expect(session.getEnabledToolNames()).toContain("computer");
+
+		const gemini = getBundledModel("google", "gemini-2.5-flash");
+		if (!gemini) throw new Error("Expected bundled Google Gemini model to exist");
+		await session.setModel(gemini);
+		expect(session.model).toBe(gemini);
+		expect(session.settings.get("computer.enabled")).toBe(true);
 		expect(session.getEnabledToolNames()).toContain("computer");
 	});
 });

--- a/packages/coding-agent/test/slash-commands/computer.test.ts
+++ b/packages/coding-agent/test/slash-commands/computer.test.ts
@@ -2,20 +2,50 @@ import { describe, expect, it, vi } from "bun:test";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 
-function acpRuntime(options?: { enabled?: boolean; applyResult?: boolean }) {
-	const store = { "computer.enabled": options?.enabled ?? false };
+function acpRuntime(options?: {
+	enabled?: boolean;
+	applyResult?: boolean;
+	supportsComputerUse?: boolean;
+	codex?: boolean;
+}) {
+	const store = {
+		"computer.enabled": options?.enabled ?? false,
+		"computer.backend": "auto",
+		"computer.display": "all",
+		"computer.maxWidth": 1920,
+		"computer.maxHeight": 1200,
+	};
 	const get = vi.fn((path: string) => store[path as keyof typeof store]);
 	const override = vi.fn((path: string, value: boolean) => {
-		store[path as keyof typeof store] = value;
+		if (path === "computer.enabled") store[path] = value;
 	});
 	const set = vi.fn();
 	const setComputerToolEnabled = vi.fn(async () => options?.applyResult ?? true);
+	const getEnabledToolNames = vi.fn(() => (store["computer.enabled"] ? ["computer"] : []));
 	const output = vi.fn();
+	const model = options?.codex
+		? {
+				provider: "openai-codex",
+				id: "gpt-5.6-sol",
+				api: "openai-codex-responses",
+				supportsComputerUse: true,
+			}
+		: {
+				provider: "google",
+				id: "gemini-2.5-flash",
+				api: "google-generative-ai",
+				supportsComputerUse: options?.supportsComputerUse ?? false,
+			};
 	const runtime = {
-		session: { settings: { get, override, set }, setComputerToolEnabled },
+		session: {
+			settings: { get, override, set },
+			setComputerToolEnabled,
+			getEnabledToolNames,
+			model,
+		},
 		output,
 	} as unknown as SlashCommandRuntime;
-	return { get, override, set, setComputerToolEnabled, output, runtime };
+	return { get, override, set, setComputerToolEnabled, getEnabledToolNames, output, runtime };
 }
 
 describe("/computer slash command", () => {
@@ -28,7 +58,9 @@ describe("/computer slash command", () => {
 		expect(h.setComputerToolEnabled).toHaveBeenCalledWith(true);
 		expect(h.override).toHaveBeenCalledWith("computer.enabled", true);
 		expect(h.set).not.toHaveBeenCalled();
-		expect(h.output).toHaveBeenCalledWith("Computer use enabled for this session.");
+		expect(h.output).toHaveBeenCalledWith(
+			"Computer use enabled for this session. Computer use: enabled · tool: active · backend: auto · display: all · capture: 1920×1200 · model: google/gemini-2.5-flash · exposure: function",
+		);
 	});
 
 	it("toggles an enabled session off", async () => {
@@ -60,7 +92,19 @@ describe("/computer slash command", () => {
 
 		expect(h.setComputerToolEnabled).not.toHaveBeenCalled();
 		expect(h.override).not.toHaveBeenCalled();
-		expect(h.output).toHaveBeenCalledWith("Computer use is on.");
+		expect(h.output).toHaveBeenCalledWith(
+			"Computer use: enabled · tool: active · backend: auto · display: all · capture: 1920×1200 · model: google/gemini-2.5-flash · exposure: function",
+		);
+	});
+
+	it("reports Codex computer exposure as a callable function", async () => {
+		const h = acpRuntime({ enabled: true, codex: true });
+
+		await executeAcpBuiltinSlashCommand("/computer status", h.runtime);
+
+		expect(h.output).toHaveBeenCalledWith(
+			"Computer use: enabled · tool: active · backend: auto · display: all · capture: 1920×1200 · model: openai-codex/gpt-5.6-sol · exposure: function",
+		);
 	});
 
 	it("leaves the override untouched when the session cannot build the tool", async () => {

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -142,6 +142,31 @@ describe("system prompt tool inventory", () => {
 		expect(text).not.toContain("Reads files from disk.");
 	});
 
+	it("keeps enabled computer routing explicit in compact native-tool mode", async () => {
+		const tools = new Map(TOOLS);
+		tools.set("computer", {
+			label: "Computer",
+			description: "Controls the host desktop.",
+			parameters: { type: "object", properties: {} },
+		});
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["read", "computer"],
+			tools,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools: true,
+			inlineToolDescriptors: false,
+		});
+		const text = systemPrompt.join("\n\n");
+		expect(text).toContain("# Computer Use");
+		expect(text).toContain("The `computer` tool is explicitly enabled and available");
+		expect(text).toContain("MUST use `computer` for requests to view or control host desktop applications");
+		expect(text).toContain("NEVER claim Computer Use is unavailable");
+	});
+
 	it("renders `# Tool:` sections (not a name list) when tools are not native", async () => {
 		const text = await render({ nativeTools: false, inlineToolDescriptors: false });
 		expect(text).toContain("# Tool: read");


### PR DESCRIPTION
## Summary
- make enabled Computer Use explicit in the compact native-tool system prompt, so host-desktop requests use `computer` rather than silently substituting cmux Browser, Bash, Eval, AppleScript, accessibility commands, or `screencapture`
- expand `/computer status` with effective tool state, backend, display, capture size, active model, and provider exposure mode
- preserve and diagnose explicit session enablement across model switches, including Gemini function-tool exposure and Codex function exposure after the merged transport correction
- add structured lifecycle logs for enablement, model retention, worker startup/readiness, permissions, captures, failures, and shutdown
- require the model to inspect the fresh screenshot returned by each successful computer action before choosing the next action

Follow-up to #6448.

The detailed macOS/Safari investigation, failed-session traces, rejected alternatives, and transport findings are documented in [this PR #6448 comment](https://github.com/can1357/oh-my-pi/pull/6448#issuecomment-5066066916).

## Background

Real Safari/X DM runs showed three distinct states that were previously conflated:

1. `computer.enabled` was true.
2. The tool was present in OMP's active slate.
3. The model actually understood that it was available and selected it.

The first two could be true while the model opened a managed cmux Chromium tab or claimed no Computer Use tool existed. Tool-description guidance alone did not cover native compact-tool mode because that mode renders a compact inventory rather than full per-tool descriptors.

This change adds the enabled-computer contract to the main static system prompt behind `{{#has tools "computer"}}`, so it exists only after explicit opt-in and remains visible in compact native-tool mode.

It does not automatically enable Computer Use, infer desktop intent, block shell automation, deduplicate text entry, or add heuristic completion gates.

## Screenshots
No visual layout change. `/computer status` now emits richer textual diagnostics.

## Testing
- `bun test test/system-prompt-inventory.test.ts test/tools/computer.test.ts test/slash-commands/computer.test.ts test/sdk-computer-tool-toggle.test.ts`
  - 46 passed
  - 174 assertions
- `bun run check` from `packages/coding-agent`
  - passed
- clean worktree based on current `origin/main`
- native `pi-natives` addon rebuilt for macOS arm64 before focused tests

## Risk
- prompt routing is stronger while `computer` is active: visual host-desktop work is directed to the computer tool instead of other automation surfaces
- fallback remains available when the user explicitly requests another mechanism or the computer tool returns an error
- Computer Use remains disabled by default and session-scoped `/computer on` remains the opt-in boundary
- no approval, safety-check, action-validation, or native execution semantics are weakened

## Notes
- #6448 is already merged; its subsequent mainline Codex transport correction now exposes Computer Use as a callable function on ChatGPT Codex endpoints
- this branch is based on current `origin/main` and contains one standalone follow-up commit
- unrelated local `eval-render.ts` work was not included

## AI Review Report

The change was derived from persisted JSONL sessions and per-process OMP debug logs from real macOS/Safari attempts. The investigation distinguished local tool registration from provider exposure and model selection, and it identified that prompt guidance inside the tool description was insufficient in compact native-tool mode.

Regression coverage verifies:

- enabled-computer policy survives compact native-tool rendering
- session enablement survives a model switch to Gemini
- Codex status reflects effective function exposure
- `/computer` remains session-scoped and disabled by default
- re-enablement reuses the existing controller entry

## Security Audit

- no automatic host-control enablement
- no approval bypass
- no provider safety-check bypass
- no automatic fallback to shell-level desktop input
- no duplicate-input heuristics that could block legitimate repeated actions
- no generic mutation/completion state machine
- native worker isolation, exclusive execution, coordinate validation, and screenshot-result behavior remain unchanged
