### PR TITLE
feat(omp): format tool call source with installed tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,7 +16,6 @@
 ### Fixed
 
 - Fixed coding-agent startup failing while compiling tool execution rendering.
-- Fixed source formatting collapsing completed write previews that previously fit without expansion.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with top-bar install hints when a formatter is missing and unchanged raw-source fallback when formatting fails.
+
+### Fixed
+
+- Fixed coding-agent startup failing while compiling tool execution rendering.
+
 ## [17.1.1] - 2026-07-24
 
 ### Added
@@ -11,11 +19,6 @@
 - Added the `/computer` slash command (`on`/`off`/`status`/toggle) to enable or disable the computer tool for the current session without persisting settings.
 - Exposed `computer` to models without native OpenAI computer-use support as a regular function tool with a typed GA action schema; the same native desktop backend and approval policy apply on both paths.
 - Hardened computer action ingress: action-specific fields, modifier/key arrays, coordinates, drag points, and scroll deltas fail closed before native input; numeric fields must be signed 32-bit integers and coordinates must be non-negative.
-- Added opt-in display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with top-bar install hints when a formatter is missing and unchanged raw-source fallback when formatting fails.
-
-### Fixed
-
-- Fixed coding-agent startup failing while compiling tool execution rendering.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,11 @@
 - Added the `/computer` slash command (`on`/`off`/`status`/toggle) to enable or disable the computer tool for the current session without persisting settings.
 - Exposed `computer` to models without native OpenAI computer-use support as a regular function tool with a typed GA action schema; the same native desktop backend and approval policy apply on both paths.
 - Hardened computer action ingress: action-specific fields, modifier/key arrays, coordinates, drag points, and scroll deltas fail closed before native input; numeric fields must be signed 32-bit integers and coordinates must be non-negative.
-- Added display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with top-bar install hints when a formatter is missing and unchanged raw-source fallback when formatting fails.
+- Added opt-in display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with top-bar install hints when a formatter is missing and unchanged raw-source fallback when formatting fails.
+
+### Fixed
+
+- Fixed coding-agent startup failing while compiling tool execution rendering.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fixed coding-agent startup failing while compiling tool execution rendering.
+- Fixed source formatting collapsing completed write previews that previously fit without expansion.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added the `/computer` slash command (`on`/`off`/`status`/toggle) to enable or disable the computer tool for the current session without persisting settings.
 - Exposed `computer` to models without native OpenAI computer-use support as a regular function tool with a typed GA action schema; the same native desktop backend and approval policy apply on both paths.
 - Hardened computer action ingress: action-specific fields, modifier/key arrays, coordinates, drag points, and scroll deltas fail closed before native input; numeric fields must be signed 32-bit integers and coordinates must be non-negative.
-- Added display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with unchanged raw-source fallback when formatting is unavailable or fails.
+- Added display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with top-bar install hints when a formatter is missing and unchanged raw-source fallback when formatting fails.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the `/computer` slash command (`on`/`off`/`status`/toggle) to enable or disable the computer tool for the current session without persisting settings.
 - Exposed `computer` to models without native OpenAI computer-use support as a regular function tool with a typed GA action schema; the same native desktop backend and approval policy apply on both paths.
 - Hardened computer action ingress: action-specific fields, modifier/key arrays, coordinates, drag points, and scroll deltas fail closed before native input; numeric fields must be signed 32-bit integers and coordinates must be non-negative.
+- Added display-only source formatting for completed eval, shell, and code-file write tool calls using compatible formatters already installed on `PATH`, with unchanged raw-source fallback when formatting is unavailable or fails.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli/gallery-cli.ts
+++ b/packages/coding-agent/src/cli/gallery-cli.ts
@@ -133,6 +133,7 @@ export async function renderGalleryState(
 	state: GalleryState,
 	width: number,
 	expanded = false,
+	formatCallSource = false,
 ): Promise<readonly string[]> {
 	if (fixture.renderState) {
 		return await fixture.renderState(state, width, expanded);
@@ -153,7 +154,7 @@ export async function renderGalleryState(
 	const component = new ToolExecutionComponent(
 		componentName,
 		streamingArgs,
-		{ showImages: false },
+		{ showImages: false, formatCallSource },
 		tool,
 		ui,
 		getProjectDir(),
@@ -173,6 +174,7 @@ export async function renderGalleryState(
 	// for it to settle so the snapshot is deterministic instead of racing a tick.
 	await component.whenPreviewSettled();
 
+	await component.whenSourceFormattingSettled();
 	const lines = component.render(width);
 	component.stopAnimation();
 	return lines;
@@ -200,6 +202,7 @@ async function renderGallerySections(
 	states: GalleryState[],
 	width: number,
 	expanded: boolean,
+	formatCallSource: boolean,
 ): Promise<GallerySection[]> {
 	const sections: GallerySection[] = [];
 	for (const name of names) {
@@ -209,7 +212,8 @@ async function renderGallerySections(
 		for (const state of states) {
 			lines.push("", theme.fg("dim", `  · ${GALLERY_STATE_LABELS[state]}`));
 			try {
-				for (const line of await renderGalleryState(name, fixture, state, width, expanded)) lines.push(line);
+				for (const line of await renderGalleryState(name, fixture, state, width, expanded, formatCallSource))
+					lines.push(line);
 			} catch (err) {
 				lines.push(theme.fg("error", `  render failed: ${String(err)}`));
 			}
@@ -252,7 +256,13 @@ export async function runGalleryCommand(args: GalleryCommandArgs): Promise<void>
 		return;
 	}
 
-	const sections = await renderGallerySections(names, states, width, expanded);
+	const sections = await renderGallerySections(
+		names,
+		states,
+		width,
+		expanded,
+		settingsInstance.get("tools.formatCallSource"),
+	);
 
 	if (args.screenshot) {
 		const paths = await captureGalleryScreenshots(sections, {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -143,6 +143,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Grep & Browser",
 		"Computer",
 		"GitHub",
+		"Display",
 		"Output Limits",
 		"Execution",
 		"Discovery & MCP",
@@ -773,6 +774,17 @@ export const SETTINGS_SCHEMA = {
 				{ value: "2048", label: "2048" },
 				{ value: "4096", label: "4096", description: "Loose" },
 			],
+		},
+	},
+	"tools.formatCallSource": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Display",
+			label: "Format Tool Call Source",
+			description:
+				"Format completed eval/shell/code-file tool call source with compatible installed formatters. Does not modify the source executed or written by the tool.",
 		},
 	},
 	"tools.artifactTailLines": {

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -372,6 +372,7 @@ export class ChatTranscriptBuilder {
 					// Stable ids and Kitty placeholder cells keep images anchored
 					// while the transcript viewport scrolls and reflows.
 					showImages: settings.get("terminal.showImages"),
+					formatCallSource: settings.get("tools.formatCallSource"),
 					editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 					editAllowFuzzy: settings.get("edit.fuzzyMatch"),
 					liveRegion: this.container,

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -24,7 +24,11 @@ import { EVAL_DEFAULT_PREVIEW_LINES } from "../../tools/eval";
 import { isWaitingPollDetails } from "../../tools/hub";
 import { formatStatusIcon, replaceTabs, resolveImageOptions } from "../../tools/render-utils";
 import { type FirstResultViewportRepaint, toolRenderers } from "../../tools/renderers";
-import { formatToolCallSourceArgs, type SourceFormatter } from "../../tools/source-formatter";
+import {
+	formatToolCallSourceArgs,
+	type SourceFormatter,
+	type SourceFormatterOutcome,
+} from "../../tools/source-formatter";
 import { TODO_STRIKE_TOTAL_FRAMES, type TodoToolDetails } from "../../tools/todo";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
@@ -70,6 +74,22 @@ function isTodoToolDetails(details: unknown): details is TodoToolDetails {
 		"phases" in details &&
 		Array.isArray((details as { phases?: unknown }).phases)
 	);
+}
+function isSourceFormatterOutcome(value: unknown): value is SourceFormatterOutcome {
+	if (typeof value !== "object" || value === null) return false;
+	const record = value as { status?: unknown };
+	if (record.status !== "formatted" && record.status !== "missing" && record.status !== "unchanged") return false;
+	if (record.status === "formatted") {
+		return (
+			typeof (record as { args?: unknown }).args === "object" &&
+			(record as { args?: unknown }).args !== null &&
+			!Array.isArray((record as { args?: unknown }).args)
+		);
+	}
+	if (record.status === "missing") {
+		return typeof (record as { formatter?: unknown }).formatter === "string";
+	}
+	return true;
 }
 
 function displaceableToolName(
@@ -280,6 +300,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#sourceFormatPass = 0;
 	#sourceFormattingAbort?: AbortController;
 	#formattedSourceArgs?: Record<string, unknown>;
+	#sourceFormatterHint?: string;
 	#expanded = false;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
@@ -440,6 +461,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#args = args;
 		this.#sourceFormatArgsVersion += 1;
 		this.#formattedSourceArgs = undefined;
+		this.#sourceFormatterHint = undefined;
 		this.#displayInputVersion++;
 		this.#abortSourceFormatting();
 		this.#updateSpinnerAnimation();
@@ -479,13 +501,16 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			try {
 				const formatted = await this.#sourceFormatter(this.#toolName, args, controller.signal);
 				if (controller.signal.aborted || this.#sealed || generation !== this.#sourceFormatArgsVersion) return;
-				this.#formattedSourceArgs = formatted;
+				this.#setSourceFormatterOutcome(isSourceFormatterOutcome(formatted) ? formatted : { status: "unchanged" });
 				this.#displayInputVersion++;
 				this.#updateDisplay();
 				this.#ui.requestComponentRender(this);
 			} catch (err) {
 				if (controller.signal.aborted) return;
-				this.#formattedSourceArgs = undefined;
+				this.#setSourceFormatterOutcome({ status: "unchanged" });
+				this.#displayInputVersion++;
+				this.#updateDisplay();
+				this.#ui.requestComponentRender(this);
 				logger.warn("Source formatter failed", { tool: this.#toolName, error: String(err) });
 			} finally {
 				if (this.#sourceFormattingAbort === controller) {
@@ -494,6 +519,26 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				this.#releaseSourceFormatFinalizationHold(formatPass);
 			}
 		})();
+	}
+
+	#setSourceFormatterOutcome(outcome: SourceFormatterOutcome): void {
+		switch (outcome.status) {
+			case "formatted": {
+				this.#formattedSourceArgs = outcome.args;
+				this.#sourceFormatterHint = undefined;
+				break;
+			}
+			case "missing": {
+				this.#formattedSourceArgs = undefined;
+				this.#sourceFormatterHint = `Install ${outcome.formatter} for pretty formatting`;
+				break;
+			}
+			case "unchanged": {
+				this.#formattedSourceArgs = undefined;
+				this.#sourceFormatterHint = undefined;
+				break;
+			}
+		}
 	}
 
 	/**
@@ -1296,7 +1341,6 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 					if (TERMINAL.imageProtocol === ImageProtocol.Kitty && imageMimeType !== "image/png") {
 						continue;
 					}
-
 					const spacer = new Spacer(1);
 					this.addChild(spacer);
 					this.#imageSpacers.push(spacer);
@@ -1338,12 +1382,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 * Build render context for tools that need extra state (bash, python, edit)
 	 */
 	#buildRenderContext(): Record<string, unknown> {
-		const context: Record<string, unknown> = {};
+		const context: Record<string, unknown> = { sourceFormatterHint: this.#sourceFormatterHint };
 		const normalizeTimeoutSeconds = (value: unknown, maxSeconds: number): number | undefined => {
 			if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
 			return Math.max(1, Math.min(maxSeconds, value));
 		};
-
 		if (this.#toolName === "bash") {
 			// Bash needs render context even before a result exists. The renderer uses the pending-call args
 			// plus this context to keep the inline command preview visible while tool-call JSON is still streaming.

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1160,7 +1160,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 						},
 						this.#renderState,
 						theme,
-						this.#args,
+						this.#getCallArgsForRender(),
 					);
 					if (resultComponent) {
 						this.#contentBox.addChild(
@@ -1466,6 +1466,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			}
 			context.renderDiff = renderDiff;
 		} else if (this.#toolName === "write") {
+			const rawContent =
+				typeof this.#args === "object" && this.#args !== null && "content" in this.#args
+					? this.#args.content
+					: undefined;
+			if (typeof rawContent === "string") context.sourceOriginalContent = rawContent;
 			// Device-dispatch previews delegate to the mounted tool's own renderer;
 			// expose the session's xd:// registry so custom/MCP renderers survive dispatch.
 			const writeTool = this.#tool as

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -304,6 +304,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#activeSourceFormatPass = 0;
 	#sourceFormatPass = 0;
 	#sourceFormattingAbort?: AbortController;
+	#sourceFormattingInFlight?: Promise<void>;
 	#formattedSourceArgs?: Record<string, unknown>;
 	#sourceFormatterHint?: string;
 	#expanded = false;
@@ -505,7 +506,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		const args = this.#args;
 		const formatter = this.#sourceFormatter;
 
-		void (async () => {
+		const sourceFormattingPass = (async () => {
 			try {
 				const formatted = await formatter?.(this.#toolName, args, controller.signal);
 				if (controller.signal.aborted || this.#sealed || generation !== this.#sourceFormatArgsVersion) return;
@@ -524,9 +525,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				if (this.#sourceFormattingAbort === controller) {
 					this.#sourceFormattingAbort = undefined;
 				}
+				if (this.#activeSourceFormatPass === formatPass) {
+					this.#sourceFormattingInFlight = undefined;
+				}
 				this.#releaseSourceFormatFinalizationHold(formatPass);
 			}
 		})();
+		this.#sourceFormattingInFlight = sourceFormattingPass;
 	}
 
 	#setSourceFormatterOutcome(outcome: SourceFormatterOutcome): void {
@@ -562,6 +567,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	/**
+	 * Await source formatting kicked off by the most recent args update.
+	 */
+	async whenSourceFormattingSettled(): Promise<void> {
+		await this.#sourceFormattingInFlight;
+	}
+
+	/**
 	 * Await the streaming diff recompute kicked off by the most recent
 	 * `updateArgs`/`setArgsComplete`. The recompute reads the file and re-runs the
 	 * whole-file Myers diff off the render path, signalling completion only via a
@@ -571,7 +583,6 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	async whenPreviewSettled(): Promise<void> {
 		await this.#editDiffInFlight;
 	}
-
 	/**
 	 * Schedule a streaming diff preview recompute, coalescing bursts of
 	 * `updateArgs` into one compute at a time: run the current compute to

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -238,6 +238,11 @@ export interface ToolExecutionOptions {
 	editFuzzyThreshold?: number;
 	editAllowFuzzy?: boolean;
 	sourceFormatter?: SourceFormatter;
+	/**
+	 * Format compatible tool call source previews for completed eval/shell/write/code-file results
+	 * without mutating the underlying executed/written source.
+	 */
+	formatCallSource?: boolean;
 	/** Live-region probe used to settle detached task progress once the block
 	 * leaves the repaintable transcript region. */
 	liveRegion?: TranscriptLiveRegionProbe;
@@ -291,9 +296,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#imageSpacers: Spacer[] = [];
 	readonly #instanceId = ++toolExecutionInstanceSeq;
 	#toolName: string;
+	#args: unknown;
 	#toolLabel: string;
-	#args: any;
-	#sourceFormatter: SourceFormatter;
+	#sourceFormatter?: SourceFormatter;
 	#sourceFormatArgsVersion = 0;
 	#sourceFormatRequestVersion = 0;
 	#activeSourceFormatPass = 0;
@@ -408,7 +413,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#ui = ui;
 		this.#cwd = cwd;
 		this.#args = args;
-		this.#sourceFormatter = options.sourceFormatter ?? formatToolCallSourceArgs;
+		this.#sourceFormatter =
+			options.sourceFormatter ?? (options.formatCallSource === true ? formatToolCallSourceArgs : undefined);
 		this.#sourceFormatArgsVersion = 1;
 		this.#editMode = resolveEditModeForTool(toolName, tool);
 
@@ -485,6 +491,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	#scheduleSourceFormattingPass(): void {
+		if (!this.#sourceFormatter) return;
 		if (this.#sealed) return;
 		// Don't request repeatedly for the same arg payload.
 		if (this.#sourceFormatRequestVersion >= this.#sourceFormatArgsVersion) return;
@@ -496,10 +503,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		const controller = new AbortController();
 		this.#sourceFormattingAbort = controller;
 		const args = this.#args;
+		const formatter = this.#sourceFormatter;
 
 		void (async () => {
 			try {
-				const formatted = await this.#sourceFormatter(this.#toolName, args, controller.signal);
+				const formatted = await formatter?.(this.#toolName, args, controller.signal);
 				if (controller.signal.aborted || this.#sealed || generation !== this.#sourceFormatArgsVersion) return;
 				this.#setSourceFormatterOutcome(isSourceFormatterOutcome(formatted) ? formatted : { status: "unchanged" });
 				this.#displayInputVersion++;
@@ -1221,8 +1229,18 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				}
 
 				// Show pending indicator for remaining files
-				const totalFiles = this.#args?.edits
-					? new Set((this.#args.edits as any[]).map((e: any) => e?.path).filter(Boolean)).size
+				const edits =
+					typeof this.#args === "object" && this.#args !== null && "edits" in this.#args
+						? this.#args.edits
+						: undefined;
+				const totalFiles = Array.isArray(edits)
+					? new Set(
+							edits
+								.map(edit =>
+									typeof edit === "object" && edit !== null && "path" in edit ? edit.path : undefined,
+								)
+								.filter(Boolean),
+						).size
 					: 0;
 				const remaining = Math.max(0, totalFiles - perFileResults.length);
 				if (remaining > 0 && this.#isPartial) {
@@ -1397,7 +1415,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			}
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;
-			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 3600);
+			const timeout =
+				typeof this.#args === "object" && this.#args !== null && "timeout" in this.#args
+					? this.#args.timeout
+					: undefined;
+			context.timeout = normalizeTimeoutSeconds(timeout, 3600);
 		} else if (this.#toolName === "eval" && this.#result) {
 			const output = this.#getTextOutput().trimEnd();
 			context.output = output;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -24,6 +24,7 @@ import { EVAL_DEFAULT_PREVIEW_LINES } from "../../tools/eval";
 import { isWaitingPollDetails } from "../../tools/hub";
 import { formatStatusIcon, replaceTabs, resolveImageOptions } from "../../tools/render-utils";
 import { type FirstResultViewportRepaint, toolRenderers } from "../../tools/renderers";
+import { formatToolCallSourceArgs, type SourceFormatter } from "../../tools/source-formatter";
 import { TODO_STRIKE_TOTAL_FRAMES, type TodoToolDetails } from "../../tools/todo";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
@@ -211,12 +212,12 @@ export interface ToolExecutionUi {
 	resetDisplay(): void;
 	imageBudget?: TUI["imageBudget"];
 }
-
 export interface ToolExecutionOptions {
 	snapshots?: SnapshotStore;
 	showImages?: boolean; // default: true (only used if terminal supports images)
 	editFuzzyThreshold?: number;
 	editAllowFuzzy?: boolean;
+	sourceFormatter?: SourceFormatter;
 	/** Live-region probe used to settle detached task progress once the block
 	 * leaves the repaintable transcript region. */
 	liveRegion?: TranscriptLiveRegionProbe;
@@ -272,6 +273,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#toolName: string;
 	#toolLabel: string;
 	#args: any;
+	#sourceFormatter: SourceFormatter;
+	#sourceFormatArgsVersion = 0;
+	#sourceFormatRequestVersion = 0;
+	#activeSourceFormatPass = 0;
+	#sourceFormatPass = 0;
+	#sourceFormattingAbort?: AbortController;
+	#formattedSourceArgs?: Record<string, unknown>;
 	#expanded = false;
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
@@ -379,6 +387,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#ui = ui;
 		this.#cwd = cwd;
 		this.#args = args;
+		this.#sourceFormatter = options.sourceFormatter ?? formatToolCallSourceArgs;
+		this.#sourceFormatArgsVersion = 1;
 		this.#editMode = resolveEditModeForTool(toolName, tool);
 
 		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins.
@@ -421,16 +431,69 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	updateArgs(args: any, _toolCallId?: string): void {
+		if (this.#sealed) return;
 		// Reference-equality short-circuit before any further work. Callers
 		// always allocate a new arg object on each streamed delta (see
 		// event-controller.ts and ui-helpers.ts), so a same-reference assignment
 		// signals "nothing meaningful changed" and the renderer can skip.
 		if (args === this.#args) return;
 		this.#args = args;
+		this.#sourceFormatArgsVersion += 1;
+		this.#formattedSourceArgs = undefined;
 		this.#displayInputVersion++;
+		this.#abortSourceFormatting();
 		this.#updateSpinnerAnimation();
 		this.#schedulePreviewDiff();
 		this.#updateDisplay();
+	}
+
+	#abortSourceFormatting(): void {
+		const activePass = this.#activeSourceFormatPass;
+		this.#sourceFormattingAbort?.abort();
+		this.#sourceFormattingAbort = undefined;
+		this.#releaseSourceFormatFinalizationHold(activePass);
+	}
+
+	#releaseSourceFormatFinalizationHold(pass: number): void {
+		if (this.#activeSourceFormatPass !== pass || pass === 0) return;
+		this.#activeSourceFormatPass = 0;
+		if (this.#result !== undefined && !this.#isPartial) {
+			this.#ui.requestRender();
+		}
+	}
+
+	#scheduleSourceFormattingPass(): void {
+		if (this.#sealed) return;
+		// Don't request repeatedly for the same arg payload.
+		if (this.#sourceFormatRequestVersion >= this.#sourceFormatArgsVersion) return;
+
+		const generation = this.#sourceFormatArgsVersion;
+		this.#sourceFormatRequestVersion = generation;
+		const formatPass = ++this.#sourceFormatPass;
+		this.#activeSourceFormatPass = formatPass;
+		const controller = new AbortController();
+		this.#sourceFormattingAbort = controller;
+		const args = this.#args;
+
+		void (async () => {
+			try {
+				const formatted = await this.#sourceFormatter(this.#toolName, args, controller.signal);
+				if (controller.signal.aborted || this.#sealed || generation !== this.#sourceFormatArgsVersion) return;
+				this.#formattedSourceArgs = formatted;
+				this.#displayInputVersion++;
+				this.#updateDisplay();
+				this.#ui.requestComponentRender(this);
+			} catch (err) {
+				if (controller.signal.aborted) return;
+				this.#formattedSourceArgs = undefined;
+				logger.warn("Source formatter failed", { tool: this.#toolName, error: String(err) });
+			} finally {
+				if (this.#sourceFormattingAbort === controller) {
+					this.#sourceFormattingAbort = undefined;
+				}
+				this.#releaseSourceFormatFinalizationHold(formatPass);
+			}
+		})();
 	}
 
 	/**
@@ -438,9 +501,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 * This triggers an immediate final diff computation for edit-like tools.
 	 */
 	setArgsComplete(_toolCallId?: string): void {
+		if (this.#sealed) return;
 		this.#argsComplete = true;
 		this.#updateSpinnerAnimation();
 		this.#schedulePreviewDiff();
+		this.#scheduleSourceFormattingPass();
 	}
 
 	/**
@@ -557,6 +622,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		isPartial = false,
 		_toolCallId?: string,
 	): void {
+		if (this.#sealed) return;
 		// A detached task spawn keeps streaming progress snapshots after the
 		// block froze (left the transcript live region). Drop them: the rows are
 		// static gray history now, and repainting would rewrite rows the engine
@@ -579,6 +645,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// When tool is complete, ensure args are marked complete so spinner stops
 		if (!isPartial) {
 			this.#argsComplete = true;
+			this.#scheduleSourceFormattingPass();
 		}
 		this.#updateSpinnerAnimation();
 		this.#updateTodoStrikeAnimation();
@@ -806,6 +873,10 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	isTranscriptBlockFinalized(): boolean {
 		if (this.#sealed) return true;
 		if (this.#result === undefined) return false;
+		// Keep async source-format updates alive until their pass settles so a late
+		// formatter completion can still repaint the tool-call args without
+		// stranding the live block in native scrollback.
+		if (this.#activeSourceFormatPass) return false;
 		// A displaceable snapshot stays live: its rows are kept out of native
 		// scrollback so a follow-up tool call can remove the block.
 		if (this.#displaceableByToolName) return false;
@@ -862,6 +933,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#stopTodoStrikeAnimation();
 		this.#editDiffAbort?.abort();
 		this.#editDiffAbort = undefined;
+		this.#abortSourceFormatting();
 		// Drop any queued rerun so the drain loop exits instead of recomputing a
 		// preview for a torn-down block after its in-flight compute is aborted.
 		this.#editDiffDirty = false;
@@ -1243,7 +1315,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	#getCallArgsForRender(): any {
-		const renderArgs = getArgsWithStreamedTextInput(this.#args);
+		const renderArgs = this.#formattedSourceArgs ?? getArgsWithStreamedTextInput(this.#args);
 		if (!isEditLikeToolName(this.#toolName)) {
 			return renderArgs;
 		}
@@ -1257,7 +1329,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		if (!first?.diff) {
 			return renderArgs;
 		}
-		return { ...(renderArgs as Record<string, unknown>), previewDiff: first.diff };
+		const previewArgSource =
+			typeof renderArgs === "object" && renderArgs !== null ? renderArgs : ({} as Record<string, unknown>);
+		return { ...previewArgSource, previewDiff: first.diff };
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1160,7 +1160,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 						},
 						this.#renderState,
 						theme,
-						this.#getCallArgsForRender(),
+						this.#args,
 					);
 					if (resultComponent) {
 						this.#contentBox.addChild(
@@ -1466,11 +1466,6 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			}
 			context.renderDiff = renderDiff;
 		} else if (this.#toolName === "write") {
-			const rawContent =
-				typeof this.#args === "object" && this.#args !== null && "content" in this.#args
-					? this.#args.content
-					: undefined;
-			if (typeof rawContent === "string") context.sourceOriginalContent = rawContent;
 			// Device-dispatch previews delegate to the mounted tool's own renderer;
 			// expose the session's xd:// registry so custom/MCP renderers survive dispatch.
 			const writeTool = this.#tool as

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -786,6 +786,7 @@ export class EventController {
 						{
 							snapshots: getFileSnapshotStore(this.ctx.viewSession),
 							showImages: settings.get("terminal.showImages"),
+							formatCallSource: settings.get("tools.formatCallSource"),
 							editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 							editAllowFuzzy: settings.get("edit.fuzzyMatch"),
 						},
@@ -985,6 +986,7 @@ export class EventController {
 				{
 					snapshots: getFileSnapshotStore(this.ctx.viewSession),
 					showImages: settings.get("terminal.showImages"),
+					formatCallSource: settings.get("tools.formatCallSource"),
 					editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 					editAllowFuzzy: settings.get("edit.fuzzyMatch"),
 					liveRegion: this.ctx.chatContainer,

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -487,6 +487,7 @@ export class UiHelpers {
 						{
 							snapshots: getFileSnapshotStore(this.ctx.viewSession),
 							showImages: settings.get("terminal.showImages"),
+							formatCallSource: settings.get("tools.formatCallSource"),
 							editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 							editAllowFuzzy: settings.get("edit.fuzzyMatch"),
 							liveRegion: this.ctx.chatContainer,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -8,7 +8,7 @@ import type {
 } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { ImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
-import { getProjectDir, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
+import { getProjectDir, isEnoent, logger, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import { applyDirenvPreflight, type BashResult, executeBash } from "../exec/bash-executor";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
@@ -1393,6 +1393,12 @@ export interface BashRenderArgs {
 	[key: string]: unknown;
 }
 
+function sanitizeSourceFormatterHint(sourceFormatterHint: string | undefined): string | undefined {
+	if (!sourceFormatterHint) return undefined;
+	const sanitized = sanitizeText(sourceFormatterHint).replace(/\s+/gu, " ").trim();
+	return sanitized.length > 0 ? sanitized : undefined;
+}
+
 export interface BashRenderContext {
 	/** Raw output text */
 	output?: string;
@@ -1404,6 +1410,8 @@ export interface BashRenderContext {
 	previewLines?: number;
 	/** Timeout in seconds */
 	timeout?: number;
+	/** Optional note to render in tool header when source formatting is unavailable */
+	sourceFormatterHint?: string;
 }
 
 export interface ShellRendererConfig<TArgs> {
@@ -1461,20 +1469,26 @@ function toBashRenderArgs<TArgs>(args: TArgs | undefined, config: ShellRendererC
 
 export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 	return {
-		renderCall(args: TArgs, options: RenderResultOptions, uiTheme: Theme): Component {
+		renderCall(
+			args: TArgs,
+			options: RenderResultOptions & { renderContext?: BashRenderContext },
+			uiTheme: Theme,
+		): Component {
 			const renderArgs = toBashRenderArgs(args, config);
 			const cmdLines = formatBashCommandLines(renderArgs, uiTheme);
+			const sourceFormatterHint = sanitizeSourceFormatterHint(options.renderContext?.sourceFormatterHint);
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({
 				render: (width: number): readonly string[] => {
 					const header =
-						config.showHeader === false
+						config.showHeader === false && !sourceFormatterHint
 							? undefined
 							: renderStatusLine(
 									{
 										icon: options.spinnerFrame !== undefined ? "running" : "pending",
 										spinnerFrame: options.spinnerFrame,
 										title: config.resolveTitle(args, options),
+										meta: sourceFormatterHint ? [sourceFormatterHint] : undefined,
 									},
 									uiTheme,
 								);
@@ -1505,6 +1519,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 			args?: TArgs,
 		): Component {
 			const renderArgs = toBashRenderArgs(args, config);
+			const sourceFormatterHint = sanitizeSourceFormatterHint(options.renderContext?.sourceFormatterHint);
 			const cmdLines = args ? formatBashCommandLines(renderArgs, uiTheme) : undefined;
 			const isError = result.isError === true;
 			const isPartial = options.isPartial === true;
@@ -1512,17 +1527,19 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 			const details = result.details;
 			const isTimeout = details?.timedOut === true;
 			const header =
-				config.showHeader === false
+				config.showHeader === false && !sourceFormatterHint
 					? undefined
 					: renderStatusLine(
 							success
 								? {
 										iconOverride: uiTheme.styledSymbol("tool.bash", "accent"),
 										title: config.resolveTitle(args, options),
+										meta: sourceFormatterHint ? [sourceFormatterHint] : undefined,
 									}
 								: {
 										icon: isPartial ? "pending" : isTimeout ? "warning" : "error",
 										title: config.resolveTitle(args, options),
+										meta: sourceFormatterHint ? [sourceFormatterHint] : undefined,
 									},
 							uiTheme,
 						);

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -552,9 +552,10 @@ export const evalToolRenderer = {
 		result: { content: Array<{ type: string; text?: string }>; details?: EvalToolDetails },
 		options: RenderResultOptions & { renderContext?: EvalRenderContext },
 		uiTheme: Theme,
-		_args?: EvalRenderArgs,
+		args?: EvalRenderArgs,
 	): Component {
 		const details = result.details;
+		const displayCells = getRenderCells(args);
 
 		const rawOutput =
 			options.renderContext?.output ?? (result.content?.find(c => c.type === "text")?.text ?? "").trimEnd();
@@ -604,6 +605,7 @@ export const evalToolRenderer = {
 					const lines: string[] = [];
 					for (let i = 0; i < cellResults.length; i++) {
 						const cell = cellResults[i];
+						const displayCell = displayCells[i];
 						const allEvents = cell.statusEvents ?? [];
 						const agentEvents = allEvents.filter(e => e.op === "agent");
 						const otherEvents = agentEvents.length > 0 ? allEvents.filter(e => e.op !== "agent") : allEvents;
@@ -623,7 +625,7 @@ export const evalToolRenderer = {
 						}
 						const cellLines = renderCodeCell(
 							{
-								code: cell.code,
+								code: displayCell?.code ?? cell.code,
 								language: languageForHighlighter(cell.language ?? details?.language),
 								showLanguage: true,
 								index: i,

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -68,6 +68,14 @@ interface EvalRenderContext {
 	expanded?: boolean;
 	previewLines?: number;
 	timeout?: number;
+	sourceFormatterHint?: string;
+}
+
+function getSourceFormatterHint(
+	options: RenderResultOptions & { renderContext?: EvalRenderContext },
+): string | undefined {
+	const raw = options.renderContext?.sourceFormatterHint;
+	return typeof raw === "string" ? raw : undefined;
 }
 
 interface EvalRenderCell {
@@ -493,7 +501,11 @@ function formatCellOutputLines(
 export const evalToolRenderer = {
 	animatedPendingPreview: true,
 	animatedPartialResult: true,
-	renderCall(args: EvalRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
+	renderCall(
+		args: EvalRenderArgs,
+		options: RenderResultOptions & { renderContext?: EvalRenderContext },
+		uiTheme: Theme,
+	): Component {
 		const cells = getRenderCells(args);
 
 		if (cells.length === 0) {
@@ -511,6 +523,7 @@ export const evalToolRenderer = {
 					return cached.result;
 				}
 
+				const headerNote = getSourceFormatterHint(options);
 				const lines: string[] = [];
 				for (let i = 0; i < cells.length; i++) {
 					const cell = cells[i];
@@ -524,6 +537,7 @@ export const evalToolRenderer = {
 							title: cell.title,
 							status: options.spinnerFrame !== undefined ? "running" : "pending",
 							spinnerFrame: options.spinnerFrame,
+							headerNote,
 							width,
 							// Viewport-sized tail window following the newest streamed code
 							// line; renderResult keeps the same cap so the cell never snaps
@@ -593,6 +607,7 @@ export const evalToolRenderer = {
 			return markFramedBlockComponent({
 				render: (width: number): readonly string[] => {
 					const expanded = options.renderContext?.expanded ?? options.expanded;
+					const headerNote = getSourceFormatterHint(options);
 					const previewLines = Math.min(
 						options.renderContext?.previewLines ?? EVAL_DEFAULT_PREVIEW_LINES,
 						previewWindowRows(),
@@ -633,6 +648,7 @@ export const evalToolRenderer = {
 								title: cell.title,
 								status: cell.status,
 								spinnerFrame: options.spinnerFrame,
+								headerNote,
 								duration: cell.durationMs,
 								output: outputLines.length > 0 ? outputLines.join("\n") : undefined,
 								outputMaxLines: outputLines.length,

--- a/packages/coding-agent/src/tools/source-formatter.ts
+++ b/packages/coding-agent/src/tools/source-formatter.ts
@@ -1,26 +1,29 @@
+import * as os from "node:os";
 import * as path from "node:path";
 import { $which } from "@oh-my-pi/pi-utils";
 import { LRUCache } from "lru-cache/raw";
 
-type SpawnOptions = {
+type FormatterProcessKillSignal = number | NodeJS.Signals;
+
+type SpawnOptions = Readonly<{
 	stdin: "pipe";
 	stdout: "pipe";
 	stderr: "pipe";
-};
+	cwd: string;
+}>;
+type FormatterSubprocess = Bun.PipedSubprocess;
 
 type FormatterProcessStdin = {
 	write(chunk: string | Uint8Array): number | Promise<number>;
-	end(chunk?: string | Uint8Array): void | Promise<void>;
-	flush?: () => void;
+	end(): number | undefined | Promise<number | undefined>;
 };
-
 type FormatterProcess = {
 	readonly stdin: FormatterProcessStdin | null;
 	readonly stdout: ReadableStream<Uint8Array> | null;
 	readonly stderr: ReadableStream<Uint8Array> | null;
 	readonly exited: Promise<number | null>;
 	exitCode: number | null;
-	kill: (signal?: Parameters<Bun.Subprocess["kill"]>[0]) => void;
+	kill: (signal?: FormatterProcessKillSignal) => void;
 };
 
 type CachedExecutable = { readonly kind: "found"; readonly path: string } | { readonly kind: "missing" };
@@ -90,10 +93,32 @@ const DEFAULT_OPTIONS: NormalizedSourceFormatterOptions = {
 const FALLBACK_PY_FILE = "tool-call.py";
 const FALLBACK_JS_FILE = "tool-call.js";
 const MISSING_EXECUTABLE: CachedExecutable = { kind: "missing" };
+const NEUTRAL_FORMATTER_CWD = os.tmpdir();
+
+function toFormatterProcess(child: FormatterSubprocess): FormatterProcess {
+	const stdin = child.stdin
+		? {
+				write: (chunk: string | Uint8Array) => child.stdin.write(chunk),
+				end: () => child.stdin.end() ?? undefined,
+			}
+		: null;
+	return {
+		stdin,
+		stdout: child.stdout ?? null,
+		stderr: child.stderr ?? null,
+		exited: child.exited,
+		get exitCode(): number | null {
+			return child.exitCode ?? null;
+		},
+		kill: (signal?: FormatterProcessKillSignal) => {
+			child.kill(signal);
+		},
+	};
+}
 
 const defaultRuntime: SourceFormatterRuntime = {
 	which: name => $which(name) ?? undefined,
-	spawn: (command, options) => Bun.spawn([...command], options) as unknown as FormatterProcess,
+	spawn: (command, options) => toFormatterProcess(Bun.spawn([...command], options)),
 };
 
 const textEncoder = new TextEncoder();
@@ -190,7 +215,7 @@ function inferEvalFormatter(argsRecord: Record<string, unknown>): FormatterComma
 			return {
 				field: "code",
 				binary: "ruff",
-				args: ["format", "--stdin-filename", FALLBACK_PY_FILE, "-"],
+				args: ["format", "--isolated", "--stdin-filename", FALLBACK_PY_FILE, "-"],
 				source,
 			};
 		case "js":
@@ -246,7 +271,7 @@ function inferWriteFormatter(argsRecord: Record<string, unknown>): FormatterComm
 		return {
 			field: "content",
 			binary: "ruff",
-			args: ["format", "--stdin-filename", writePath, "-"],
+			args: ["format", "--isolated", "--stdin-filename", writePath, "-"],
 			source,
 		};
 	}
@@ -298,20 +323,25 @@ type ProcessCompletion = { kind: "exit"; exitCode: number | null } | { kind: "ab
 
 async function waitForProcessExitOrAbort(child: FormatterProcess, signal: AbortSignal): Promise<ProcessCompletion> {
 	const { promise, resolve } = Promise.withResolvers<ProcessCompletion>();
-	const settleAborted = (): void => resolve({ kind: "aborted" });
+	const settleAborted = (): void => {
+		signal.removeEventListener("abort", settleAborted);
+		resolve({ kind: "aborted" });
+	};
+	const settleExited = (code?: number | null): void => {
+		signal.removeEventListener("abort", settleAborted);
+		resolve({ kind: "exit", exitCode: code ?? null });
+	};
 
 	if (signal.aborted) {
 		settleAborted();
 		return promise;
 	}
 
-	const settleExited = (code?: number | null): void => {
-		signal.removeEventListener("abort", settleAborted);
-		resolve({ kind: "exit", exitCode: code ?? null });
-	};
-
 	signal.addEventListener("abort", settleAborted, { once: true });
-	void child.exited.then(settleExited, () => settleExited());
+	void child.exited.then(
+		exitCode => settleExited(exitCode),
+		() => settleExited(),
+	);
 
 	return promise;
 }
@@ -346,7 +376,7 @@ async function terminateSubprocess(child: FormatterProcess, graceMs: number): Pr
 		return;
 	}
 
-	await child.exited.catch(() => {});
+	await waitForProcessExit(child, graceMs);
 }
 
 async function runFormatter(
@@ -358,14 +388,18 @@ async function runFormatter(
 ): Promise<string | undefined> {
 	const outputController = new AbortController();
 	let child: FormatterProcess | undefined;
+	const timeoutSignal = AbortSignal.timeout(options.timeoutMs);
+	const formatterSignal = signal.aborted ? signal : AbortSignal.any([signal, timeoutSignal]);
+
 	try {
-		child = runtime.spawn([executable, ...formatter.args], {
+		const spawned = runtime.spawn([executable, ...formatter.args], {
 			stdin: "pipe",
 			stdout: "pipe",
 			stderr: "pipe",
+			cwd: NEUTRAL_FORMATTER_CWD,
 		});
+		child = spawned;
 		const stdoutStream = child.stdout;
-
 		const stderrStream = child.stderr;
 		if (!child.stdin || !stdoutStream || !stderrStream) {
 			await terminateSubprocess(child, options.terminateGraceMs);
@@ -374,33 +408,39 @@ async function runFormatter(
 
 		const stdoutPromise = readBounded(stdoutStream, options.maxOutputBytes, outputController.signal);
 		const stderrPromise = readBounded(stderrStream, options.maxOutputBytes, outputController.signal);
+		const processCompletion = waitForProcessExitOrAbort(child, formatterSignal);
+		const cleanupDrains: Promise<unknown>[] = [stdoutPromise, stderrPromise];
+		const cleanup = async (formatterProcess: FormatterProcess): Promise<undefined> => {
+			outputController.abort();
+			await terminateSubprocess(formatterProcess, options.terminateGraceMs);
+			await Promise.allSettled(cleanupDrains);
+			return undefined;
+		};
 
 		const sourceBytes = textEncoder.encode(formatter.source);
-		const written = child.stdin.write(sourceBytes);
-		if (written instanceof Promise) {
-			await written;
-		}
-		const ended = child.stdin.end();
-		if (ended instanceof Promise) {
-			await ended;
-		}
-
-		const completion = await Promise.race<ProcessCompletion>([
-			waitForProcessExitOrAbort(child, signal),
-			Bun.sleep(options.timeoutMs).then(() => ({ kind: "aborted" }) as const),
+		const written = await Promise.race<ProcessCompletion | number>([
+			Promise.resolve(child.stdin.write(sourceBytes)),
+			processCompletion,
 		]);
+		if (typeof written !== "number") {
+			return cleanup(child);
+		}
 
+		const ended = await Promise.race<ProcessCompletion | undefined>([
+			Promise.resolve(child.stdin.end()).then(() => undefined),
+			processCompletion,
+		]);
+		if (ended !== undefined && typeof ended === "object") {
+			return cleanup(child);
+		}
+
+		const completion = await processCompletion;
 		if (completion.kind !== "exit") {
-			outputController.abort();
-			await terminateSubprocess(child, options.terminateGraceMs);
-			await Promise.allSettled([stdoutPromise, stderrPromise]);
-			return undefined;
+			return cleanup(child);
 		}
 
 		if (completion.exitCode !== 0) {
-			await terminateSubprocess(child, options.terminateGraceMs);
-			await Promise.allSettled([stdoutPromise, stderrPromise]);
-			return undefined;
+			return cleanup(child);
 		}
 
 		const [stdout, stderr] = await Promise.allSettled([stdoutPromise, stderrPromise]);

--- a/packages/coding-agent/src/tools/source-formatter.ts
+++ b/packages/coding-agent/src/tools/source-formatter.ts
@@ -1,0 +1,476 @@
+import * as path from "node:path";
+import { $which } from "@oh-my-pi/pi-utils";
+import { LRUCache } from "lru-cache/raw";
+
+type SpawnOptions = {
+	stdin: "pipe";
+	stdout: "pipe";
+	stderr: "pipe";
+};
+
+type FormatterProcessStdin = {
+	write(chunk: string | Uint8Array): number | Promise<number>;
+	end(chunk?: string | Uint8Array): void | Promise<void>;
+	flush?: () => void;
+};
+
+type FormatterProcess = {
+	readonly stdin: FormatterProcessStdin | null;
+	readonly stdout: ReadableStream<Uint8Array> | null;
+	readonly stderr: ReadableStream<Uint8Array> | null;
+	readonly exited: Promise<number | null>;
+	exitCode: number | null;
+	kill: (signal?: Parameters<Bun.Subprocess["kill"]>[0]) => void;
+};
+
+type CachedExecutable = { readonly kind: "found"; readonly path: string } | { readonly kind: "missing" };
+
+export type SourceFormatter = (
+	toolName: string,
+	args: unknown,
+	signal: AbortSignal,
+) => Promise<Record<string, unknown> | undefined>;
+
+export interface SourceFormatterRuntime {
+	which: (name: string) => string | undefined;
+	spawn: (command: readonly string[], options: SpawnOptions) => FormatterProcess;
+}
+
+export interface SourceFormatterOptions {
+	maxInputBytes?: number;
+	timeoutMs?: number;
+	maxOutputBytes?: number;
+	executableCacheSize?: number;
+	formattedCacheSize?: number;
+	terminateGraceMs?: number;
+}
+
+export interface SourceFormatterFactoryConfig {
+	runtime?: Partial<SourceFormatterRuntime>;
+	options?: SourceFormatterOptions;
+}
+
+interface NormalizedSourceFormatterOptions {
+	readonly maxInputBytes: number;
+	readonly timeoutMs: number;
+	readonly maxOutputBytes: number;
+	readonly executableCacheSize: number;
+	readonly formattedCacheSize: number;
+	readonly terminateGraceMs: number;
+}
+
+interface StreamCapture {
+	readonly text: string;
+	readonly overflowed: boolean;
+}
+
+interface FormatterCommand {
+	readonly field: "code" | "command" | "content";
+	readonly binary: "prettier" | "ruff" | "rustfmt" | "gofmt" | "shfmt";
+	readonly args: readonly string[];
+	readonly source: string;
+}
+
+const PRETTIER_EXTS = new Set([".js", ".jsx", ".ts", ".tsx", ".json"]);
+const PY_EXTS = new Set([".py"]);
+const RUST_EXTS = new Set([".rs"]);
+const GO_EXTS = new Set([".go"]);
+const SHELL_EXTS = new Set([".sh", ".bash", ".zsh", ".ksh", ".csh", ".tcsh", ".fish"]);
+const RAW_EXTS = new Set([".md", ".markdown", ".yml", ".yaml", ".css", ".html", ".htm"]);
+
+const DEFAULT_OPTIONS: NormalizedSourceFormatterOptions = {
+	maxInputBytes: 256 * 1024,
+	timeoutMs: 500,
+	maxOutputBytes: 1 * 1024 * 1024,
+	executableCacheSize: 64,
+	formattedCacheSize: 256,
+	terminateGraceMs: 40,
+};
+
+const FALLBACK_PY_FILE = "tool-call.py";
+const FALLBACK_JS_FILE = "tool-call.js";
+const MISSING_EXECUTABLE: CachedExecutable = { kind: "missing" };
+
+const defaultRuntime: SourceFormatterRuntime = {
+	which: name => $which(name) ?? undefined,
+	spawn: (command, options) => Bun.spawn([...command], options) as unknown as FormatterProcess,
+};
+
+const textEncoder = new TextEncoder();
+
+function normalizeOptions(options: SourceFormatterOptions | undefined): NormalizedSourceFormatterOptions {
+	return {
+		maxInputBytes: options?.maxInputBytes ?? DEFAULT_OPTIONS.maxInputBytes,
+		timeoutMs: options?.timeoutMs ?? DEFAULT_OPTIONS.timeoutMs,
+		maxOutputBytes: options?.maxOutputBytes ?? DEFAULT_OPTIONS.maxOutputBytes,
+		executableCacheSize: options?.executableCacheSize ?? DEFAULT_OPTIONS.executableCacheSize,
+		formattedCacheSize: options?.formattedCacheSize ?? DEFAULT_OPTIONS.formattedCacheSize,
+		terminateGraceMs: options?.terminateGraceMs ?? DEFAULT_OPTIONS.terminateGraceMs,
+	};
+}
+
+function toRecord(args: unknown): Record<string, unknown> | undefined {
+	if (typeof args !== "object" || args === null || Array.isArray(args)) return undefined;
+	return args as Record<string, unknown>;
+}
+
+function buildCacheKey(executable: string, argv: readonly string[], source: string): string {
+	return JSON.stringify([executable, argv, Bun.hash(source).toString(16)]);
+}
+
+function readBounded(
+	stream: ReadableStream<Uint8Array> | null,
+	maxBytes: number,
+	signal: AbortSignal,
+): Promise<StreamCapture> {
+	if (!stream || maxBytes <= 0) {
+		return Promise.resolve({ text: "", overflowed: false });
+	}
+
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let remaining = maxBytes;
+	let overflowed = false;
+	const chunks: string[] = [];
+
+	const onAbort = (): void => {
+		void reader.cancel();
+	};
+
+	if (signal.aborted) {
+		onAbort();
+	} else {
+		signal.addEventListener("abort", onAbort, { once: true });
+	}
+
+	return (async () => {
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				if (remaining <= 0) {
+					overflowed = true;
+					await reader.cancel();
+					break;
+				}
+
+				if (value.length <= remaining) {
+					chunks.push(decoder.decode(value, { stream: true }));
+					remaining -= value.length;
+					continue;
+				}
+
+				chunks.push(decoder.decode(value.subarray(0, remaining), { stream: true }));
+				overflowed = true;
+				await reader.cancel();
+				break;
+			}
+
+			chunks.push(decoder.decode());
+			return { text: chunks.join(""), overflowed };
+		} catch {
+			return { text: chunks.join(""), overflowed: true };
+		} finally {
+			signal.removeEventListener("abort", onAbort);
+			reader.releaseLock();
+		}
+	})();
+}
+
+function inferEvalFormatter(argsRecord: Record<string, unknown>): FormatterCommand | undefined {
+	const source = typeof argsRecord.code === "string" ? argsRecord.code : undefined;
+	if (!source) return undefined;
+
+	const languageValue = typeof argsRecord.language === "string" ? argsRecord.language.trim().toLowerCase() : "";
+
+	switch (languageValue) {
+		case "py":
+		case "python":
+			return {
+				field: "code",
+				binary: "ruff",
+				args: ["format", "--stdin-filename", FALLBACK_PY_FILE, "-"],
+				source,
+			};
+		case "js":
+		case "javascript":
+			return {
+				field: "code",
+				binary: "prettier",
+				args: ["--no-config", "--stdin-filepath", FALLBACK_JS_FILE],
+				source,
+			};
+		default:
+			return undefined;
+	}
+}
+
+function inferBashFormatter(argsRecord: Record<string, unknown>): FormatterCommand | undefined {
+	const source = typeof argsRecord.command === "string" ? argsRecord.command : undefined;
+	if (!source) return undefined;
+
+	return {
+		field: "command",
+		binary: "shfmt",
+		args: [],
+		source,
+	};
+}
+
+function inferWriteFormatter(argsRecord: Record<string, unknown>): FormatterCommand | undefined {
+	const source = typeof argsRecord.content === "string" ? argsRecord.content : undefined;
+	if (!source) return undefined;
+
+	const writePath =
+		typeof argsRecord.path === "string"
+			? argsRecord.path
+			: typeof argsRecord.file_path === "string"
+				? argsRecord.file_path
+				: "";
+	if (!writePath) return undefined;
+
+	const extension = path.extname(writePath).toLowerCase();
+	if (RAW_EXTS.has(extension)) return undefined;
+
+	if (PRETTIER_EXTS.has(extension)) {
+		return {
+			field: "content",
+			binary: "prettier",
+			args: ["--no-config", "--stdin-filepath", writePath],
+			source,
+		};
+	}
+
+	if (PY_EXTS.has(extension)) {
+		return {
+			field: "content",
+			binary: "ruff",
+			args: ["format", "--stdin-filename", writePath, "-"],
+			source,
+		};
+	}
+
+	if (RUST_EXTS.has(extension)) {
+		return {
+			field: "content",
+			binary: "rustfmt",
+			args: ["--emit", "stdout"],
+			source,
+		};
+	}
+
+	if (GO_EXTS.has(extension)) {
+		return {
+			field: "content",
+			binary: "gofmt",
+			args: [],
+			source,
+		};
+	}
+
+	if (SHELL_EXTS.has(extension)) {
+		return {
+			field: "content",
+			binary: "shfmt",
+			args: [],
+			source,
+		};
+	}
+
+	return undefined;
+}
+
+function createFormatterCommand(toolName: string, argsRecord: Record<string, unknown>): FormatterCommand | undefined {
+	switch (toolName.toLowerCase()) {
+		case "eval":
+			return inferEvalFormatter(argsRecord);
+		case "bash":
+			return inferBashFormatter(argsRecord);
+		case "write":
+			return inferWriteFormatter(argsRecord);
+		default:
+			return undefined;
+	}
+}
+
+type ProcessCompletion = { kind: "exit"; exitCode: number | null } | { kind: "aborted" };
+
+async function waitForProcessExitOrAbort(child: FormatterProcess, signal: AbortSignal): Promise<ProcessCompletion> {
+	const { promise, resolve } = Promise.withResolvers<ProcessCompletion>();
+	const settleAborted = (): void => resolve({ kind: "aborted" });
+
+	if (signal.aborted) {
+		settleAborted();
+		return promise;
+	}
+
+	const settleExited = (code?: number | null): void => {
+		signal.removeEventListener("abort", settleAborted);
+		resolve({ kind: "exit", exitCode: code ?? null });
+	};
+
+	signal.addEventListener("abort", settleAborted, { once: true });
+	void child.exited.then(settleExited, () => settleExited());
+
+	return promise;
+}
+
+async function waitForProcessExit(child: FormatterProcess, graceMs: number): Promise<boolean> {
+	if (child.exitCode !== null) return true;
+	if (graceMs <= 0) return false;
+
+	return await Promise.race<boolean>([
+		child.exited.then(
+			() => true,
+			() => true,
+		),
+		Bun.sleep(graceMs).then(() => false),
+	]);
+}
+
+async function terminateSubprocess(child: FormatterProcess, graceMs: number): Promise<void> {
+	if (child.exitCode !== null) return;
+
+	try {
+		child.kill("SIGTERM");
+	} catch {
+		return;
+	}
+
+	if (await waitForProcessExit(child, graceMs)) return;
+
+	try {
+		child.kill("SIGKILL");
+	} catch {
+		return;
+	}
+
+	await child.exited.catch(() => {});
+}
+
+async function runFormatter(
+	runtime: SourceFormatterRuntime,
+	executable: string,
+	formatter: FormatterCommand,
+	signal: AbortSignal,
+	options: NormalizedSourceFormatterOptions,
+): Promise<string | undefined> {
+	const child = runtime.spawn([executable, ...formatter.args], {
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const outputController = new AbortController();
+
+	try {
+		const stdoutStream = child.stdout;
+		const stderrStream = child.stderr;
+		if (!child.stdin || !stdoutStream || !stderrStream) {
+			await terminateSubprocess(child, options.terminateGraceMs);
+			return undefined;
+		}
+
+		const stdoutPromise = readBounded(stdoutStream, options.maxOutputBytes, outputController.signal);
+		const stderrPromise = readBounded(stderrStream, options.maxOutputBytes, outputController.signal);
+
+		const sourceBytes = textEncoder.encode(formatter.source);
+		const written = child.stdin.write(sourceBytes);
+		if (written instanceof Promise) {
+			await written;
+		}
+		const ended = child.stdin.end();
+		if (ended instanceof Promise) {
+			await ended;
+		}
+
+		const completion = await Promise.race<ProcessCompletion>([
+			waitForProcessExitOrAbort(child, signal),
+			Bun.sleep(options.timeoutMs).then(() => ({ kind: "aborted" }) as const),
+		]);
+
+		if (completion.kind !== "exit") {
+			outputController.abort();
+			await terminateSubprocess(child, options.terminateGraceMs);
+			await Promise.allSettled([stdoutPromise, stderrPromise]);
+			return undefined;
+		}
+
+		if (completion.exitCode !== 0) {
+			await terminateSubprocess(child, options.terminateGraceMs);
+			await Promise.allSettled([stdoutPromise, stderrPromise]);
+			return undefined;
+		}
+
+		const [stdout, stderr] = await Promise.allSettled([stdoutPromise, stderrPromise]);
+		if (stdout.status !== "fulfilled" || stderr.status !== "fulfilled") return undefined;
+		if (stdout.value.overflowed || stderr.value.overflowed) return undefined;
+		if (stdout.value.text.length === 0) return undefined;
+
+		return stdout.value.text;
+	} catch {
+		await terminateSubprocess(child, options.terminateGraceMs);
+		return undefined;
+	} finally {
+		outputController.abort();
+	}
+}
+
+export function createSourceFormatter({ runtime, options }: SourceFormatterFactoryConfig = {}): SourceFormatter {
+	const mergedRuntime: SourceFormatterRuntime = {
+		which: runtime?.which ?? defaultRuntime.which,
+		spawn: runtime?.spawn ?? defaultRuntime.spawn,
+	};
+	const normalized = normalizeOptions(options);
+	const executableCache = new LRUCache<string, CachedExecutable>({ max: normalized.executableCacheSize });
+	const formattedCache = new LRUCache<string, string>({ max: normalized.formattedCacheSize });
+
+	const resolveExecutable = (name: string): string | undefined => {
+		const cached = executableCache.get(name);
+		if (cached !== undefined) {
+			if (cached.kind === "missing") return undefined;
+			return cached.path;
+		}
+
+		let resolved: string | undefined;
+		try {
+			resolved = mergedRuntime.which(name);
+		} catch {
+			resolved = undefined;
+		}
+
+		executableCache.set(name, resolved ? { kind: "found", path: resolved } : MISSING_EXECUTABLE);
+		return resolved;
+	};
+
+	return async (toolName, args, signal): Promise<Record<string, unknown> | undefined> => {
+		if (signal.aborted) return undefined;
+
+		const argsRecord = toRecord(args);
+		if (!argsRecord) return undefined;
+
+		const formatter = createFormatterCommand(toolName, argsRecord);
+		if (!formatter) return undefined;
+		const sourceBytes = textEncoder.encode(formatter.source);
+		if (sourceBytes.length > normalized.maxInputBytes) return undefined;
+		if (normalized.timeoutMs <= 0) return undefined;
+		if (normalized.maxOutputBytes <= 0) return undefined;
+
+		const executable = resolveExecutable(formatter.binary);
+		if (!executable) return undefined;
+
+		const cacheKey = buildCacheKey(executable, formatter.args, formatter.source);
+		const cached = formattedCache.get(cacheKey);
+		if (cached !== undefined) {
+			return { ...argsRecord, [formatter.field]: cached };
+		}
+
+		const formatted = await runFormatter(mergedRuntime, executable, formatter, signal, normalized);
+		if (!formatted) return undefined;
+
+		formattedCache.set(cacheKey, formatted);
+		return { ...argsRecord, [formatter.field]: formatted };
+	};
+}
+
+export const formatToolCallSourceArgs = createSourceFormatter();

--- a/packages/coding-agent/src/tools/source-formatter.ts
+++ b/packages/coding-agent/src/tools/source-formatter.ts
@@ -25,11 +25,11 @@ type FormatterProcess = {
 
 type CachedExecutable = { readonly kind: "found"; readonly path: string } | { readonly kind: "missing" };
 
-export type SourceFormatter = (
-	toolName: string,
-	args: unknown,
-	signal: AbortSignal,
-) => Promise<Record<string, unknown> | undefined>;
+export type SourceFormatterOutcome =
+	| { status: "formatted"; args: Record<string, unknown> }
+	| { status: "missing"; formatter: string }
+	| { status: "unchanged" };
+export type SourceFormatter = (toolName: string, args: unknown, signal: AbortSignal) => Promise<SourceFormatterOutcome>;
 
 export interface SourceFormatterRuntime {
 	which: (name: string) => string | undefined;
@@ -356,15 +356,16 @@ async function runFormatter(
 	signal: AbortSignal,
 	options: NormalizedSourceFormatterOptions,
 ): Promise<string | undefined> {
-	const child = runtime.spawn([executable, ...formatter.args], {
-		stdin: "pipe",
-		stdout: "pipe",
-		stderr: "pipe",
-	});
 	const outputController = new AbortController();
-
+	let child: FormatterProcess | undefined;
 	try {
+		child = runtime.spawn([executable, ...formatter.args], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
 		const stdoutStream = child.stdout;
+
 		const stderrStream = child.stderr;
 		if (!child.stdin || !stdoutStream || !stderrStream) {
 			await terminateSubprocess(child, options.terminateGraceMs);
@@ -409,7 +410,9 @@ async function runFormatter(
 
 		return stdout.value.text;
 	} catch {
-		await terminateSubprocess(child, options.terminateGraceMs);
+		if (child !== undefined) {
+			await terminateSubprocess(child, options.terminateGraceMs);
+		}
 		return undefined;
 	} finally {
 		outputController.abort();
@@ -443,33 +446,33 @@ export function createSourceFormatter({ runtime, options }: SourceFormatterFacto
 		return resolved;
 	};
 
-	return async (toolName, args, signal): Promise<Record<string, unknown> | undefined> => {
-		if (signal.aborted) return undefined;
+	return async (toolName, args, signal): Promise<SourceFormatterOutcome> => {
+		if (signal.aborted) return { status: "unchanged" };
 
 		const argsRecord = toRecord(args);
-		if (!argsRecord) return undefined;
+		if (!argsRecord) return { status: "unchanged" };
 
 		const formatter = createFormatterCommand(toolName, argsRecord);
-		if (!formatter) return undefined;
+		if (!formatter) return { status: "unchanged" };
 		const sourceBytes = textEncoder.encode(formatter.source);
-		if (sourceBytes.length > normalized.maxInputBytes) return undefined;
-		if (normalized.timeoutMs <= 0) return undefined;
-		if (normalized.maxOutputBytes <= 0) return undefined;
+		if (sourceBytes.length > normalized.maxInputBytes) return { status: "unchanged" };
+		if (normalized.timeoutMs <= 0) return { status: "unchanged" };
+		if (normalized.maxOutputBytes <= 0) return { status: "unchanged" };
 
 		const executable = resolveExecutable(formatter.binary);
-		if (!executable) return undefined;
+		if (!executable) return { status: "missing", formatter: formatter.binary };
 
 		const cacheKey = buildCacheKey(executable, formatter.args, formatter.source);
 		const cached = formattedCache.get(cacheKey);
 		if (cached !== undefined) {
-			return { ...argsRecord, [formatter.field]: cached };
+			return { status: "formatted", args: { ...argsRecord, [formatter.field]: cached } };
 		}
 
 		const formatted = await runFormatter(mergedRuntime, executable, formatter, signal, normalized);
-		if (!formatted) return undefined;
+		if (!formatted) return { status: "unchanged" };
 
 		formattedCache.set(cacheKey, formatted);
-		return { ...argsRecord, [formatter.field]: formatted };
+		return { status: "formatted", args: { ...argsRecord, [formatter.field]: formatted } };
 	};
 }
 

--- a/packages/coding-agent/src/tools/source-formatter.ts
+++ b/packages/coding-agent/src/tools/source-formatter.ts
@@ -74,12 +74,27 @@ interface FormatterCommand {
 	readonly source: string;
 }
 
-const PRETTIER_EXTS = new Set([".js", ".jsx", ".ts", ".tsx", ".json"]);
-const PY_EXTS = new Set([".py"]);
-const RUST_EXTS = new Set([".rs"]);
-const GO_EXTS = new Set([".go"]);
-const SHELL_EXTS = new Set([".sh", ".bash", ".zsh", ".ksh", ".csh", ".tcsh", ".fish"]);
-const RAW_EXTS = new Set([".md", ".markdown", ".yml", ".yaml", ".css", ".html", ".htm"]);
+const PRETTIER_EXTS: Record<string, true> = { ".js": true, ".jsx": true, ".ts": true, ".tsx": true, ".json": true };
+const PY_EXTS: Record<string, true> = { ".py": true };
+const RUST_EXTS: Record<string, true> = { ".rs": true };
+const GO_EXTS: Record<string, true> = { ".go": true };
+const SHFMT_DIALECT_BY_EXT: Record<string, false | "bash" | "zsh" | "mksh" | "bats"> = {
+	".sh": false,
+	".bash": "bash",
+	".zsh": "zsh",
+	".ksh": "mksh",
+	".mksh": "mksh",
+	".bats": "bats",
+};
+const RAW_EXTS: Record<string, true> = {
+	".md": true,
+	".markdown": true,
+	".yml": true,
+	".yaml": true,
+	".css": true,
+	".html": true,
+	".htm": true,
+};
 
 const DEFAULT_OPTIONS: NormalizedSourceFormatterOptions = {
 	maxInputBytes: 256 * 1024,
@@ -256,9 +271,9 @@ function inferWriteFormatter(argsRecord: Record<string, unknown>): FormatterComm
 	if (!writePath) return undefined;
 
 	const extension = path.extname(writePath).toLowerCase();
-	if (RAW_EXTS.has(extension)) return undefined;
+	if (Object.hasOwn(RAW_EXTS, extension)) return undefined;
 
-	if (PRETTIER_EXTS.has(extension)) {
+	if (Object.hasOwn(PRETTIER_EXTS, extension)) {
 		return {
 			field: "content",
 			binary: "prettier",
@@ -267,7 +282,7 @@ function inferWriteFormatter(argsRecord: Record<string, unknown>): FormatterComm
 		};
 	}
 
-	if (PY_EXTS.has(extension)) {
+	if (Object.hasOwn(PY_EXTS, extension)) {
 		return {
 			field: "content",
 			binary: "ruff",
@@ -276,16 +291,16 @@ function inferWriteFormatter(argsRecord: Record<string, unknown>): FormatterComm
 		};
 	}
 
-	if (RUST_EXTS.has(extension)) {
+	if (Object.hasOwn(RUST_EXTS, extension)) {
 		return {
 			field: "content",
 			binary: "rustfmt",
-			args: ["--emit", "stdout"],
+			args: ["--emit", "stdout", "--edition", "2021"],
 			source,
 		};
 	}
 
-	if (GO_EXTS.has(extension)) {
+	if (Object.hasOwn(GO_EXTS, extension)) {
 		return {
 			field: "content",
 			binary: "gofmt",
@@ -294,11 +309,12 @@ function inferWriteFormatter(argsRecord: Record<string, unknown>): FormatterComm
 		};
 	}
 
-	if (SHELL_EXTS.has(extension)) {
+	const shellDialect = SHFMT_DIALECT_BY_EXT[extension];
+	if (shellDialect !== undefined) {
 		return {
 			field: "content",
 			binary: "shfmt",
-			args: [],
+			args: shellDialect ? ["--filename", writePath, "--language-dialect", shellDialect] : ["--filename", writePath],
 			source,
 		};
 	}

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1395,12 +1395,15 @@ function renderContentPreview(
 	language: string | undefined,
 	uiTheme: Theme,
 	cache?: RenderedStringCache,
+	originalContent?: string,
 ): string {
 	if (!content) return "";
 	return cachedRenderedString(cache, uiTheme, expanded, language ?? "", content, () => {
 		const rawLines = normalizeDisplayText(content).split("\n");
 		const totalLines = rawLines.length;
-		const maxLines = expanded ? totalLines : Math.min(totalLines, WRITE_PREVIEW_LINES);
+		const originalLineCount = originalContent === undefined ? totalLines : countLines(originalContent);
+		const showAllLines = expanded || originalLineCount <= WRITE_PREVIEW_LINES;
+		const maxLines = showAllLines ? totalLines : Math.min(totalLines, WRITE_PREVIEW_LINES);
 		const visibleLines = rawLines.slice(0, maxLines);
 		const highlighted = highlightCode(visibleLines.join("\n"), language);
 		const lineNumberWidth = Math.max(WRITE_GUTTER_MIN_WIDTH, String(totalLines).length);
@@ -1413,7 +1416,7 @@ function renderContentPreview(
 			const body = replaceTabs(highlighted[i] ?? "");
 			text += `${gutter}${body}\n`;
 		}
-		if (!expanded && hidden > 0) {
+		if (!showAllLines && hidden > 0) {
 			const hint = formatExpandHint(uiTheme, expanded, hidden > 0);
 			const moreLine = `${formatMoreItems(hidden, "line")}${hint ? ` ${hint}` : ""}`;
 			text += uiTheme.fg("dim", moreLine);
@@ -1435,6 +1438,7 @@ function renderSourceFormatterHint(
 export interface WriteRenderContext {
 	resolveXdevMounted?: (name: string) => AgentTool | undefined;
 	sourceFormatterHint?: string;
+	sourceOriginalContent?: string;
 }
 
 export const writeToolRenderer = {
@@ -1566,7 +1570,14 @@ export const writeToolRenderer = {
 		const previewCache = createRenderedStringCache();
 		return framedBlock(uiTheme, width => {
 			const { expanded } = options;
-			let body = renderContentPreview(fileContent, expanded, lang, uiTheme, previewCache);
+			let body = renderContentPreview(
+				fileContent,
+				expanded,
+				lang,
+				uiTheme,
+				previewCache,
+				options.renderContext?.sourceOriginalContent,
+			);
 			if (isPartial && progressText) {
 				const safeProgressText = truncateToWidth(
 					replaceTabs(progressText),

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1395,15 +1395,12 @@ function renderContentPreview(
 	language: string | undefined,
 	uiTheme: Theme,
 	cache?: RenderedStringCache,
-	originalContent?: string,
 ): string {
 	if (!content) return "";
 	return cachedRenderedString(cache, uiTheme, expanded, language ?? "", content, () => {
 		const rawLines = normalizeDisplayText(content).split("\n");
 		const totalLines = rawLines.length;
-		const originalLineCount = originalContent === undefined ? totalLines : countLines(originalContent);
-		const showAllLines = expanded || originalLineCount <= WRITE_PREVIEW_LINES;
-		const maxLines = showAllLines ? totalLines : Math.min(totalLines, WRITE_PREVIEW_LINES);
+		const maxLines = expanded ? totalLines : Math.min(totalLines, WRITE_PREVIEW_LINES);
 		const visibleLines = rawLines.slice(0, maxLines);
 		const highlighted = highlightCode(visibleLines.join("\n"), language);
 		const lineNumberWidth = Math.max(WRITE_GUTTER_MIN_WIDTH, String(totalLines).length);
@@ -1416,7 +1413,7 @@ function renderContentPreview(
 			const body = replaceTabs(highlighted[i] ?? "");
 			text += `${gutter}${body}\n`;
 		}
-		if (!showAllLines && hidden > 0) {
+		if (!expanded && hidden > 0) {
 			const hint = formatExpandHint(uiTheme, expanded, hidden > 0);
 			const moreLine = `${formatMoreItems(hidden, "line")}${hint ? ` ${hint}` : ""}`;
 			text += uiTheme.fg("dim", moreLine);
@@ -1438,7 +1435,6 @@ function renderSourceFormatterHint(
 export interface WriteRenderContext {
 	resolveXdevMounted?: (name: string) => AgentTool | undefined;
 	sourceFormatterHint?: string;
-	sourceOriginalContent?: string;
 }
 
 export const writeToolRenderer = {
@@ -1570,14 +1566,7 @@ export const writeToolRenderer = {
 		const previewCache = createRenderedStringCache();
 		return framedBlock(uiTheme, width => {
 			const { expanded } = options;
-			let body = renderContentPreview(
-				fileContent,
-				expanded,
-				lang,
-				uiTheme,
-				previewCache,
-				options.renderContext?.sourceOriginalContent,
-			);
+			let body = renderContentPreview(fileContent, expanded, lang, uiTheme, previewCache);
 			if (isPartial && progressText) {
 				const safeProgressText = truncateToWidth(
 					replaceTabs(progressText),

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1422,9 +1422,19 @@ function renderContentPreview(
 	});
 }
 
-/** Render context for the write tool: resolves an `xd://`-mounted tool so its live renderer drives device dispatch previews. */
+function renderSourceFormatterHint(
+	options: RenderResultOptions & { renderContext?: WriteRenderContext },
+	uiTheme: Theme,
+): string {
+	const sourceFormatterHint = options.renderContext?.sourceFormatterHint;
+	return typeof sourceFormatterHint === "string" && sourceFormatterHint.length > 0
+		? `${uiTheme.fg("dim", " · ")}${uiTheme.fg("dim", sourceFormatterHint)}`
+		: "";
+}
+
 export interface WriteRenderContext {
 	resolveXdevMounted?: (name: string) => AgentTool | undefined;
+	sourceFormatterHint?: string;
 }
 
 export const writeToolRenderer = {
@@ -1453,6 +1463,7 @@ export const writeToolRenderer = {
 		const lang = rawPath ? (getLanguageFromPath(rawPath) ?? "text") : "text";
 		const langIcon = uiTheme.fg("muted", uiTheme.getLangIcon(lang));
 		const pathDisplay = filePath ? uiTheme.fg("accent", filePath) : uiTheme.fg("toolOutput", "…");
+		const formatterHint = renderSourceFormatterHint(options, uiTheme);
 		// No status icon on the head row: it's the head of the framed block, and
 		// native-scrollback commits are prefix-only — an animated glyph would pin
 		// the commit boundary at the top, and the pending hourglass just adds
@@ -1460,7 +1471,7 @@ export const writeToolRenderer = {
 		const header = renderStatusLine(
 			{
 				title: "Write",
-				description: `${langIcon} ${pathDisplay}`,
+				description: `${langIcon} ${pathDisplay}${formatterHint}`,
 			},
 			uiTheme,
 		);
@@ -1515,11 +1526,12 @@ export const writeToolRenderer = {
 		const linkTarget = result.details?.resolvedPath;
 		const styledPath = filePath ? uiTheme.fg("accent", filePath) : uiTheme.fg("toolOutput", "…");
 		const pathDisplay = filePath && linkTarget ? fileHyperlink(linkTarget, styledPath) : styledPath;
+		const formatterHint = renderSourceFormatterHint(options, uiTheme);
 
 		if (result.isError) {
 			const errorText = result.content?.find(c => c.type === "text")?.text ?? "";
 			const header = renderStatusLine(
-				{ icon: "error", title: "Write", description: `${langIcon} ${pathDisplay}` },
+				{ icon: "error", title: "Write", description: `${langIcon} ${pathDisplay}${formatterHint}` },
 				uiTheme,
 			);
 			return framedBlock(uiTheme, width => ({
@@ -1545,7 +1557,7 @@ export const writeToolRenderer = {
 				iconOverride: isPartial ? undefined : uiTheme.styledSymbol("tool.write", "accent"),
 				spinnerFrame: options.spinnerFrame,
 				title: "Write",
-				description: `${langIcon} ${pathDisplay}${lineSuffix}${execSuffix}`,
+				description: `${langIcon} ${pathDisplay}${formatterHint}${lineSuffix}${execSuffix}`,
 			},
 			uiTheme,
 		);

--- a/packages/coding-agent/src/tui/code-cell.ts
+++ b/packages/coding-agent/src/tui/code-cell.ts
@@ -1,7 +1,9 @@
 /**
  * Render a code or markdown cell with optional output section.
  */
+
 import { Markdown } from "@oh-my-pi/pi-tui";
+import { sanitizeText } from "@oh-my-pi/pi-utils";
 import { getMarkdownTheme, highlightCode, type Theme } from "../modes/theme/theme";
 import {
 	formatDuration,
@@ -22,6 +24,10 @@ export interface CodeCellOptions {
 	status?: "pending" | "running" | "warning" | "complete" | "error";
 	spinnerFrame?: number;
 	duration?: number;
+	/**
+	 * Optional hint to render in the header metadata row, e.g. formatter guidance.
+	 */
+	headerNote?: string;
 	output?: string;
 	outputMaxLines?: number;
 	codeMaxLines?: number;
@@ -44,6 +50,12 @@ export interface CodeCellOptions {
 	codeLineNumbers?: Array<number | null>;
 }
 
+function sanitizeHeaderNote(headerNote: string | undefined): string | undefined {
+	if (!headerNote) return undefined;
+	const sanitized = sanitizeText(headerNote).replace(/\s+/gu, " ").trim();
+	return sanitized.length > 0 ? sanitized : undefined;
+}
+
 function getState(status?: CodeCellOptions["status"]): State | undefined {
 	if (!status) return undefined;
 	if (status === "complete") return "success";
@@ -54,7 +66,7 @@ function getState(status?: CodeCellOptions["status"]): State | undefined {
 }
 
 function formatHeader(options: CodeCellOptions, theme: Theme): { title: string; meta?: string } {
-	const { index, total, title, status, spinnerFrame, duration, language, showLanguage } = options;
+	const { index, total, title, status, spinnerFrame, duration, headerNote, language, showLanguage } = options;
 	const parts: string[] = [];
 	if (showLanguage && language) {
 		const langIcon = theme.getLangIconStyled(language);
@@ -89,6 +101,10 @@ function formatHeader(options: CodeCellOptions, theme: Theme): { title: string; 
 	const headerTitle = parts.length > 0 ? parts.join(" ") : theme.fg("toolTitle", "Code");
 
 	const metaParts: string[] = [];
+	const note = sanitizeHeaderNote(headerNote);
+	if (note) {
+		metaParts.push(theme.fg("dim", note));
+	}
 	if (duration !== undefined) {
 		metaParts.push(theme.fg("dim", `(${formatDuration(duration)})`));
 	}

--- a/packages/coding-agent/test/gallery-cli.test.ts
+++ b/packages/coding-agent/test/gallery-cli.test.ts
@@ -45,6 +45,11 @@ describe("gallery harness", () => {
 		}
 	});
 
+	it("renders with call-source formatting enabled", async () => {
+		const lines = await renderGalleryState("bash", resolveFixture("bash"), "success", 100, false, true);
+		expect(lines.length).toBeGreaterThan(0);
+	});
+
 	it("routes each state to the matching args/result (streaming args vs result, success vs error)", async () => {
 		const fixture: GalleryFixture = {
 			label: "Bash",

--- a/packages/coding-agent/test/source-formatter-hints.test.ts
+++ b/packages/coding-agent/test/source-formatter-hints.test.ts
@@ -1,0 +1,204 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { RenderResultOptions } from "@oh-my-pi/pi-agent-core";
+import { getThemeByName, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { bashToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/bash";
+import { evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval";
+import { writeToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/write";
+import { sanitizeText } from "@oh-my-pi/pi-utils";
+
+const HINT = "Install prettier for pretty formatting";
+
+let theme: Theme;
+
+function render(component: { render(width: number): readonly string[] }, width = 120): string {
+	return sanitizeText(component.render(width).join("\n"));
+}
+
+function withThemeOptions(
+	opts: RenderResultOptions & { sourceFormatterHint?: string },
+): RenderResultOptions & { renderContext?: { sourceFormatterHint?: string } } {
+	const { sourceFormatterHint, ...base } = opts;
+	return {
+		...base,
+		renderContext: sourceFormatterHint === undefined ? undefined : { sourceFormatterHint },
+	};
+}
+
+describe("formatter note in code-cell/eval top bars", () => {
+	beforeAll(async () => {
+		theme = (await getThemeByName("dark"))!;
+		expect(theme).toBeDefined();
+	});
+
+	it("shows formatter hint in the pending code-cell call header", () => {
+		const component = evalToolRenderer.renderCall(
+			{
+				cells: [{ language: "py", code: "print(42)", title: "Cell 0" }],
+			},
+			withThemeOptions({ expanded: false, isPartial: true, sourceFormatterHint: HINT }),
+			theme,
+		);
+		expect(render(component)).toContain(HINT);
+		expect(render(component)).toContain("Cell 0");
+		expect(render(component)).toContain("print(42)");
+	});
+
+	it("omits formatter hint in pending code-cell call when context is missing", () => {
+		const component = evalToolRenderer.renderCall(
+			{
+				cells: [{ language: "py", code: "print(42)", title: "Cell 0" }],
+			},
+			withThemeOptions({ expanded: false, isPartial: true }),
+			theme,
+		);
+		expect(render(component)).not.toContain(HINT);
+		expect(render(component)).toContain("Cell 0");
+	});
+
+	it("shows formatter hint in completed eval cell result headers", () => {
+		const component = evalToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "" }],
+				details: {
+					cells: [
+						{ index: 0, title: "Cell 0", code: "print(42)", language: "python", output: "", status: "complete" },
+					],
+				},
+			},
+			withThemeOptions({ expanded: false, isPartial: false, sourceFormatterHint: HINT }),
+			theme,
+			{ language: "py", code: "print(42)", title: "Cell 0" },
+		);
+		expect(render(component)).toContain(HINT);
+		expect(render(component)).toContain("Cell 0");
+	});
+
+	it("omits formatter hint in completed eval cell result headers", () => {
+		const component = evalToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "" }],
+				details: {
+					cells: [
+						{ index: 0, title: "Cell 0", code: "print(42)", language: "python", output: "", status: "complete" },
+					],
+				},
+			},
+			withThemeOptions({ expanded: false, isPartial: false }),
+			theme,
+			{ language: "py", code: "print(42)", title: "Cell 0" },
+		);
+		expect(render(component)).not.toContain(HINT);
+		expect(render(component)).toContain("Cell 0");
+	});
+});
+
+describe("formatter note in bash call and result top bars", () => {
+	beforeAll(async () => {
+		theme = (await getThemeByName("dark"))!;
+		expect(theme).toBeDefined();
+	});
+
+	it("shows formatter hint in the pending bash header and keeps the command text", () => {
+		const component = bashToolRenderer.renderCall(
+			{ command: "echo hello-world" },
+			withThemeOptions({ expanded: false, isPartial: true, sourceFormatterHint: HINT }),
+			theme,
+		);
+		expect(render(component)).toContain(HINT);
+		expect(render(component)).toContain("Bash");
+		expect(render(component)).toContain("echo hello-world");
+	});
+
+	it("omits formatter note in pending bash when context is missing", () => {
+		const component = bashToolRenderer.renderCall(
+			{ command: "echo hello-world" },
+			withThemeOptions({ expanded: false, isPartial: true }),
+			theme,
+		);
+		expect(render(component)).not.toContain(HINT);
+		expect(render(component)).toContain("echo hello-world");
+	});
+
+	it("shows formatter hint in completed bash result header and keeps title", () => {
+		const component = bashToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "ok" }], details: { timeoutSeconds: 1 }, isError: false },
+			withThemeOptions({ expanded: false, isPartial: false, sourceFormatterHint: HINT }),
+			theme,
+			{ command: "echo hello-world" },
+		);
+		expect(render(component)).toContain(HINT);
+		expect(render(component)).toContain("Bash");
+		expect(render(component)).toContain("echo hello-world");
+	});
+
+	it("omits formatter note in completed bash result header when context is missing", () => {
+		const component = bashToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "ok" }], details: { timeoutSeconds: 1 }, isError: false },
+			withThemeOptions({ expanded: false, isPartial: false }),
+			theme,
+			{ command: "echo hello-world" },
+		);
+		expect(render(component)).not.toContain(HINT);
+		expect(render(component)).toContain("echo hello-world");
+	});
+});
+
+describe("formatter note in write top bars", () => {
+	beforeAll(async () => {
+		theme = (await getThemeByName("dark"))!;
+		expect(theme).toBeDefined();
+	});
+
+	it("shows formatter hint in the pending write header and retains path text", () => {
+		const component = writeToolRenderer.renderCall(
+			{ file_path: "README.md", content: "hello" },
+			withThemeOptions({ expanded: false, isPartial: true, sourceFormatterHint: HINT }),
+			theme,
+		);
+		expect(component).toBeDefined();
+		expect(render(component!)).toContain(HINT);
+		expect(render(component!)).toContain("README.md");
+		expect(render(component!)).toContain("hello");
+	});
+
+	it("omits formatter hint in the pending write header without context", () => {
+		const component = writeToolRenderer.renderCall(
+			{ file_path: "README.md", content: "hello" },
+			withThemeOptions({ expanded: false, isPartial: true }),
+			theme,
+		);
+		expect(component).toBeDefined();
+		expect(render(component!)).not.toContain(HINT);
+		expect(render(component!)).toContain("README.md");
+	});
+
+	it("shows formatter hint in completed write header and retains path text", () => {
+		const component = writeToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "" }],
+				details: { resolvedPath: "/tmp/project/README.md" },
+				isError: false,
+			},
+			withThemeOptions({ expanded: false, isPartial: false, sourceFormatterHint: HINT }),
+			theme,
+			{ file_path: "README.md", content: "hello" },
+		);
+		expect(render(component)).toContain(HINT);
+		expect(render(component)).toContain("README.md");
+	});
+
+	it("omits formatter hint in completed write header without context", () => {
+		const component = writeToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "" }],
+				details: { resolvedPath: "/tmp/project/README.md" },
+				isError: false,
+			},
+			withThemeOptions({ expanded: false, isPartial: false }),
+			theme,
+			{ file_path: "README.md", content: "hello" },
+		);
+		expect(render(component)).not.toContain(HINT);
+		expect(render(component)).toContain("README.md");
+	});
+});

--- a/packages/coding-agent/test/source-formatter-setting.test.ts
+++ b/packages/coding-agent/test/source-formatter-setting.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { getDefault, getUi } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+
+describe("settings: tools.formatCallSource", () => {
+	it("defaults to false and uses tools Display metadata", () => {
+		expect(getDefault("tools.formatCallSource")).toBe(false);
+		expect(getUi("tools.formatCallSource")).toMatchObject({
+			tab: "tools",
+			group: "Display",
+			label: "Format Tool Call Source",
+			description:
+				"Format completed eval/shell/code-file tool call source with compatible installed formatters. Does not modify the source executed or written by the tool.",
+		});
+	});
+});

--- a/packages/coding-agent/test/source-formatter.test.ts
+++ b/packages/coding-agent/test/source-formatter.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "bun:test";
+import { createSourceFormatter } from "@oh-my-pi/pi-coding-agent/tools/source-formatter";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+	const body = new Response(text).body;
+	if (!body) throw new Error("Failed to create response stream.");
+	return body;
+}
+
+type SpawnOptions = {
+	readonly stdin: "pipe";
+	readonly stdout: "pipe";
+	readonly stderr: "pipe";
+};
+
+type MockSubprocessStdin = {
+	write(chunk: string | Uint8Array): number | Promise<number>;
+	end(chunk?: string | Uint8Array): void | Promise<void>;
+	flush?: () => void;
+};
+
+type MockSubprocessResult = {
+	readonly stdin: MockSubprocessStdin | null;
+	readonly stdout: ReadableStream<Uint8Array> | null;
+	readonly stderr: ReadableStream<Uint8Array> | null;
+	readonly exited: Promise<number | null>;
+	exitCode: number | null;
+	kill: (signal?: Parameters<Bun.Subprocess["kill"]>[0]) => void;
+};
+
+type SpawnCommand = (command: readonly string[], options: SpawnOptions) => MockSubprocessResult;
+
+interface MockSubprocess {
+	process: MockSubprocessResult;
+	getWritten: () => string;
+}
+
+function createSubprocess(
+	source: string,
+	options: {
+		exitCode?: number;
+		stderr?: string;
+	} = {},
+): MockSubprocess {
+	let written = "";
+	const proc: MockSubprocessResult = {
+		stdin: {
+			write: vi.fn((chunk: string | Uint8Array) => {
+				const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+				written += text;
+				return text.length;
+			}),
+			end: vi.fn(),
+			flush: vi.fn(),
+		},
+		stdout: streamFromText(source),
+		stderr: streamFromText(options.stderr ?? ""),
+		exited: Promise.resolve(options.exitCode ?? 0),
+		exitCode: null,
+		kill: vi.fn(),
+	};
+
+	return { process: proc, getWritten: () => written };
+}
+
+describe("createSourceFormatter", () => {
+	it("formats eval JS code via prettier and replaces only code", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const subprocess = createSubprocess("formatted-js\n");
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({
+			runtime: { which, spawn },
+		});
+
+		const args = { language: "js", code: "const  x =1", keep: true, nested: { level: 1 } };
+		const formatted = await formatter("eval", args, new AbortController().signal);
+
+		expect(formatted).toBeDefined();
+		expect(formatted).not.toBe(args);
+		expect(formatted).toEqual({
+			language: "js",
+			code: "formatted-js\n",
+			keep: true,
+			nested: args.nested,
+		});
+		expect(formatted!.nested).toBe(args.nested);
+		expect(formatted!.code).not.toBe(args.code);
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(spawn).toHaveBeenCalledWith(["/tmp/prettier", "--no-config", "--stdin-filepath", "tool-call.js"], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		expect(subprocess.getWritten()).toBe(args.code);
+		expect(which).toHaveBeenCalledTimes(1);
+	});
+
+	it("formats eval Python code via ruff", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/ruff");
+		const subprocess = createSubprocess("formatted-py\n");
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+		const args = { language: "py", code: "print('raw')" };
+		const formatted = await formatter("eval", args, new AbortController().signal);
+
+		expect(formatted).toEqual({
+			language: "py",
+			code: "formatted-py\n",
+		});
+		expect(spawn).toHaveBeenCalledWith(
+			["/tmp/ruff", "format", "--stdin-filename", "tool-call.py", "-"],
+			expect.anything(),
+		);
+	});
+
+	it("formats bash commands via shfmt", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/shfmt");
+		const subprocess = createSubprocess("formatted-bash\n");
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+		const args = { command: "echo  hi" };
+		const formatted = await formatter("bash", args, new AbortController().signal);
+
+		expect(formatted).toEqual({
+			command: "formatted-bash\n",
+		});
+		expect(spawn).toHaveBeenCalledWith(["/tmp/shfmt"], expect.anything());
+	});
+
+	type WriteCase = {
+		name: string;
+		path: string;
+		binary: string;
+		args: string[];
+	};
+
+	const writeCases: WriteCase[] = [
+		{
+			name: "javascript",
+			path: "/tmp/source.ts",
+			binary: "prettier",
+			args: ["--no-config", "--stdin-filepath", "/tmp/source.ts"],
+		},
+		{
+			name: "python",
+			path: "/tmp/source.py",
+			binary: "ruff",
+			args: ["format", "--stdin-filename", "/tmp/source.py", "-"],
+		},
+		{ name: "rust", path: "/tmp/source.rs", binary: "rustfmt", args: ["--emit", "stdout"] },
+		{ name: "go", path: "/tmp/source.go", binary: "gofmt", args: [] },
+		{ name: "shell", path: "/tmp/source.sh", binary: "shfmt", args: [] },
+	];
+
+	for (const writeCase of writeCases) {
+		it(`formats write.${writeCase.name} content with ${writeCase.binary}` as const, async () => {
+			const which = vi.fn().mockReturnValue(`/tmp/${writeCase.binary}`);
+			const subprocess = createSubprocess(`formatted-write-${writeCase.name}`);
+			const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+			const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+			const args = { path: writeCase.path, content: `raw-${writeCase.name}` };
+			const formatted = await formatter("write", args, new AbortController().signal);
+
+			expect(formatted).toEqual({
+				path: writeCase.path,
+				content: `formatted-write-${writeCase.name}`,
+			});
+			expect(spawn).toHaveBeenCalledWith([`/tmp/${writeCase.binary}`, ...writeCase.args], {
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+		});
+	}
+
+	it("does not format markdown write content (raw fallback)", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const spawn = vi.fn<SpawnCommand>();
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+		const args = { path: "README.md", content: "# heading" };
+		const formatted = await formatter("write", args, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).not.toHaveBeenCalled();
+		expect(which).not.toHaveBeenCalled();
+	});
+
+	it("falls back when formatter returns non-zero exit code", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const subprocess = createSubprocess("formatted-js\n", { exitCode: 1 });
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+		const args = { language: "js", code: "const x = 1" };
+		const formatted = await formatter("eval", args, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("reuses executable cache for missing formatter binaries", async () => {
+		const which = vi.fn().mockReturnValue(undefined);
+		const spawn = vi.fn<SpawnCommand>(() => {
+			throw new Error("spawn should not be called");
+		});
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+		const args = { language: "js", code: "const x = 1" };
+
+		await formatter("eval", args, new AbortController().signal);
+		await formatter("eval", args, new AbortController().signal);
+
+		expect(which).toHaveBeenCalledTimes(1);
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("reuses successful formatted content cache", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const subprocess = createSubprocess("cached\n");
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+		const args = { language: "js", code: "const x = 1" };
+
+		const first = await formatter("eval", args, new AbortController().signal);
+		const second = await formatter("eval", args, new AbortController().signal);
+
+		expect(first).toEqual(second);
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to raw on oversized input", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const spawn = vi.fn<SpawnCommand>(() => {
+			throw new Error("spawn should not be called");
+		});
+		const formatter = createSourceFormatter({
+			runtime: { which, spawn },
+			options: { maxInputBytes: 4 },
+		});
+
+		const args = { language: "js", code: "longer than four bytes" };
+		const formatted = await formatter("eval", args, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("falls back when formatter output exceeds configured bound", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const subprocess = createSubprocess("this output is far too long");
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({
+			runtime: { which, spawn },
+			options: { maxOutputBytes: 4 },
+		});
+
+		const args = { language: "js", code: "x = 1" };
+		const formatted = await formatter("eval", args, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back on non-positive timeout without invoking long-running process work", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/shfmt");
+		const subprocess = createSubprocess("formatted", { exitCode: 0 });
+		const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+		const formatter = createSourceFormatter({
+			runtime: { which, spawn },
+			options: { timeoutMs: 0 },
+		});
+
+		const args = { command: "printf 'hello'" };
+		const formatted = await formatter("bash", args, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).not.toHaveBeenCalled();
+		expect(which).not.toHaveBeenCalled();
+	});
+
+	it("falls back when args are non-object", async () => {
+		const which = vi.fn();
+		const spawn = vi.fn<SpawnCommand>(() => {
+			throw new Error("spawn should not be called");
+		});
+		const formatter = createSourceFormatter({
+			runtime: { which, spawn },
+		});
+
+		const formatted = await formatter("eval", "not-an-object" as unknown, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).not.toHaveBeenCalled();
+		expect(which).not.toHaveBeenCalled();
+	});
+
+	it("falls back when no formatter is defined for the tool invocation", async () => {
+		const which = vi.fn();
+		const spawn = vi.fn<SpawnCommand>(() => {
+			throw new Error("spawn should not be called");
+		});
+		const formatter = createSourceFormatter({
+			runtime: { which, spawn },
+		});
+
+		const formatted = await formatter("unknown", { code: "console.log(1)" }, new AbortController().signal);
+
+		expect(formatted).toBeUndefined();
+		expect(spawn).not.toHaveBeenCalled();
+		expect(which).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/source-formatter.test.ts
+++ b/packages/coding-agent/test/source-formatter.test.ts
@@ -63,6 +63,31 @@ function createSubprocess(
 	return { process: proc, getWritten: () => written };
 }
 
+type SourceFormatterOutcome = Awaited<ReturnType<ReturnType<typeof createSourceFormatter>>>;
+
+function expectFormatted(outcome: SourceFormatterOutcome): Record<string, unknown> & object {
+	expect(outcome.status).toBe("formatted");
+	if (outcome.status !== "formatted") {
+		throw new Error(`Expected formatted outcome, got ${outcome.status}`);
+	}
+	return outcome.args;
+}
+
+function expectUnchanged(outcome: SourceFormatterOutcome): void {
+	expect(outcome.status).toBe("unchanged");
+	if (outcome.status !== "unchanged") {
+		throw new Error(`Expected unchanged outcome, got ${outcome.status}`);
+	}
+}
+
+function expectMissingExecutable(outcome: SourceFormatterOutcome, formatter: string): void {
+	expect(outcome.status).toBe("missing");
+	if (outcome.status !== "missing") {
+		throw new Error(`Expected missing executable outcome, got ${outcome.status}`);
+	}
+	expect(outcome.formatter).toBe(formatter);
+}
+
 describe("createSourceFormatter", () => {
 	it("formats eval JS code via prettier and replaces only code", async () => {
 		const which = vi.fn().mockReturnValue("/tmp/prettier");
@@ -73,9 +98,9 @@ describe("createSourceFormatter", () => {
 		});
 
 		const args = { language: "js", code: "const  x =1", keep: true, nested: { level: 1 } };
-		const formatted = await formatter("eval", args, new AbortController().signal);
+		const result = await formatter("eval", args, new AbortController().signal);
+		const formatted = expectFormatted(result);
 
-		expect(formatted).toBeDefined();
 		expect(formatted).not.toBe(args);
 		expect(formatted).toEqual({
 			language: "js",
@@ -83,8 +108,8 @@ describe("createSourceFormatter", () => {
 			keep: true,
 			nested: args.nested,
 		});
-		expect(formatted!.nested).toBe(args.nested);
-		expect(formatted!.code).not.toBe(args.code);
+		expect(formatted.nested).toBe(args.nested);
+		expect(formatted.code).not.toBe(args.code);
 		expect(spawn).toHaveBeenCalledTimes(1);
 		expect(spawn).toHaveBeenCalledWith(["/tmp/prettier", "--no-config", "--stdin-filepath", "tool-call.js"], {
 			stdin: "pipe",
@@ -102,7 +127,7 @@ describe("createSourceFormatter", () => {
 		const formatter = createSourceFormatter({ runtime: { which, spawn } });
 
 		const args = { language: "py", code: "print('raw')" };
-		const formatted = await formatter("eval", args, new AbortController().signal);
+		const formatted = expectFormatted(await formatter("eval", args, new AbortController().signal));
 
 		expect(formatted).toEqual({
 			language: "py",
@@ -121,7 +146,7 @@ describe("createSourceFormatter", () => {
 		const formatter = createSourceFormatter({ runtime: { which, spawn } });
 
 		const args = { command: "echo  hi" };
-		const formatted = await formatter("bash", args, new AbortController().signal);
+		const formatted = expectFormatted(await formatter("bash", args, new AbortController().signal));
 
 		expect(formatted).toEqual({
 			command: "formatted-bash\n",
@@ -162,7 +187,7 @@ describe("createSourceFormatter", () => {
 			const formatter = createSourceFormatter({ runtime: { which, spawn } });
 
 			const args = { path: writeCase.path, content: `raw-${writeCase.name}` };
-			const formatted = await formatter("write", args, new AbortController().signal);
+			const formatted = expectFormatted(await formatter("write", args, new AbortController().signal));
 
 			expect(formatted).toEqual({
 				path: writeCase.path,
@@ -182,9 +207,9 @@ describe("createSourceFormatter", () => {
 		const formatter = createSourceFormatter({ runtime: { which, spawn } });
 
 		const args = { path: "README.md", content: "# heading" };
-		const formatted = await formatter("write", args, new AbortController().signal);
+		const result = await formatter("write", args, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
 		expect(spawn).not.toHaveBeenCalled();
 		expect(which).not.toHaveBeenCalled();
 	});
@@ -196,9 +221,24 @@ describe("createSourceFormatter", () => {
 		const formatter = createSourceFormatter({ runtime: { which, spawn } });
 
 		const args = { language: "js", code: "const x = 1" };
-		const formatted = await formatter("eval", args, new AbortController().signal);
+		const result = await formatter("eval", args, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back when formatter spawn throws", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/prettier");
+		const spawn = vi.fn<SpawnCommand>(() => {
+			throw new Error("spawn should fail");
+		});
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+		const args = { language: "js", code: "const x = 1" };
+		const result = await formatter("eval", args, new AbortController().signal);
+
+		expectUnchanged(result);
+		expect(which).toHaveBeenCalledTimes(1);
 		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 
@@ -210,9 +250,11 @@ describe("createSourceFormatter", () => {
 		const formatter = createSourceFormatter({ runtime: { which, spawn } });
 		const args = { language: "js", code: "const x = 1" };
 
-		await formatter("eval", args, new AbortController().signal);
-		await formatter("eval", args, new AbortController().signal);
+		const first = await formatter("eval", args, new AbortController().signal);
+		const second = await formatter("eval", args, new AbortController().signal);
 
+		expectMissingExecutable(first, "prettier");
+		expectMissingExecutable(second, "prettier");
 		expect(which).toHaveBeenCalledTimes(1);
 		expect(spawn).not.toHaveBeenCalled();
 	});
@@ -227,6 +269,8 @@ describe("createSourceFormatter", () => {
 		const first = await formatter("eval", args, new AbortController().signal);
 		const second = await formatter("eval", args, new AbortController().signal);
 
+		expectFormatted(first);
+		expectFormatted(second);
 		expect(first).toEqual(second);
 		expect(spawn).toHaveBeenCalledTimes(1);
 	});
@@ -242,9 +286,9 @@ describe("createSourceFormatter", () => {
 		});
 
 		const args = { language: "js", code: "longer than four bytes" };
-		const formatted = await formatter("eval", args, new AbortController().signal);
+		const result = await formatter("eval", args, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
 		expect(spawn).not.toHaveBeenCalled();
 	});
 
@@ -258,9 +302,9 @@ describe("createSourceFormatter", () => {
 		});
 
 		const args = { language: "js", code: "x = 1" };
-		const formatted = await formatter("eval", args, new AbortController().signal);
+		const result = await formatter("eval", args, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
 		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 
@@ -274,9 +318,9 @@ describe("createSourceFormatter", () => {
 		});
 
 		const args = { command: "printf 'hello'" };
-		const formatted = await formatter("bash", args, new AbortController().signal);
+		const result = await formatter("bash", args, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
 		expect(spawn).not.toHaveBeenCalled();
 		expect(which).not.toHaveBeenCalled();
 	});
@@ -290,9 +334,9 @@ describe("createSourceFormatter", () => {
 			runtime: { which, spawn },
 		});
 
-		const formatted = await formatter("eval", "not-an-object" as unknown, new AbortController().signal);
+		const result = await formatter("eval", "not-an-object" as unknown, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
 		expect(spawn).not.toHaveBeenCalled();
 		expect(which).not.toHaveBeenCalled();
 	});
@@ -306,9 +350,9 @@ describe("createSourceFormatter", () => {
 			runtime: { which, spawn },
 		});
 
-		const formatted = await formatter("unknown", { code: "console.log(1)" }, new AbortController().signal);
+		const result = await formatter("unknown", { code: "console.log(1)" }, new AbortController().signal);
 
-		expect(formatted).toBeUndefined();
+		expectUnchanged(result);
 		expect(spawn).not.toHaveBeenCalled();
 		expect(which).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/source-formatter.test.ts
+++ b/packages/coding-agent/test/source-formatter.test.ts
@@ -193,9 +193,20 @@ describe("createSourceFormatter", () => {
 			binary: "ruff",
 			args: ["format", "--isolated", "--stdin-filename", "/tmp/source.py", "-"],
 		},
-		{ name: "rust", path: "/tmp/source.rs", binary: "rustfmt", args: ["--emit", "stdout"] },
+		{
+			name: "rust",
+			path: "/tmp/source.rs",
+			binary: "rustfmt",
+			args: ["--emit", "stdout", "--edition", "2021"],
+		},
 		{ name: "go", path: "/tmp/source.go", binary: "gofmt", args: [] },
-		{ name: "shell", path: "/tmp/source.sh", binary: "shfmt", args: [] },
+		{ name: "shell", path: "/tmp/source.sh", binary: "shfmt", args: ["--filename", "/tmp/source.sh"] },
+		{
+			name: "zsh",
+			path: "/tmp/source.zsh",
+			binary: "shfmt",
+			args: ["--filename", "/tmp/source.zsh", "--language-dialect", "zsh"],
+		},
 	];
 
 	for (const writeCase of writeCases) {
@@ -228,6 +239,19 @@ describe("createSourceFormatter", () => {
 		const result = await formatter("write", args, new AbortController().signal);
 
 		expectUnchanged(result);
+		expect(spawn).not.toHaveBeenCalled();
+		expect(which).not.toHaveBeenCalled();
+	});
+
+	it("does not route unsupported shell dialects through shfmt", async () => {
+		const which = vi.fn().mockReturnValue("/tmp/shfmt");
+		const spawn = vi.fn<SpawnCommand>();
+		const formatter = createSourceFormatter({ runtime: { which, spawn } });
+
+		for (const path of ["script.csh", "script.tcsh", "script.fish"]) {
+			const result = await formatter("write", { path, content: "echo raw" }, new AbortController().signal);
+			expectUnchanged(result);
+		}
 		expect(spawn).not.toHaveBeenCalled();
 		expect(which).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/source-formatter.test.ts
+++ b/packages/coding-agent/test/source-formatter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
+import * as os from "node:os";
 import { createSourceFormatter } from "@oh-my-pi/pi-coding-agent/tools/source-formatter";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
@@ -11,12 +12,12 @@ type SpawnOptions = {
 	readonly stdin: "pipe";
 	readonly stdout: "pipe";
 	readonly stderr: "pipe";
+	readonly cwd: string;
 };
 
 type MockSubprocessStdin = {
 	write(chunk: string | Uint8Array): number | Promise<number>;
-	end(chunk?: string | Uint8Array): void | Promise<void>;
-	flush?: () => void;
+	end(): number | undefined | Promise<number | undefined>;
 };
 
 type MockSubprocessResult = {
@@ -25,7 +26,7 @@ type MockSubprocessResult = {
 	readonly stderr: ReadableStream<Uint8Array> | null;
 	readonly exited: Promise<number | null>;
 	exitCode: number | null;
-	kill: (signal?: Parameters<Bun.Subprocess["kill"]>[0]) => void;
+	kill: (signal?: number | NodeJS.Signals) => void;
 };
 
 type SpawnCommand = (command: readonly string[], options: SpawnOptions) => MockSubprocessResult;
@@ -40,27 +41,48 @@ function createSubprocess(
 	options: {
 		exitCode?: number;
 		stderr?: string;
+		write?: MockSubprocessStdin["write"];
+		end?: MockSubprocessStdin["end"];
+		exited?: Promise<number | null>;
 	} = {},
 ): MockSubprocess {
+	const exit = Promise.withResolvers<number | null>();
 	let written = "";
 	const proc: MockSubprocessResult = {
 		stdin: {
-			write: vi.fn((chunk: string | Uint8Array) => {
-				const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
-				written += text;
-				return text.length;
-			}),
-			end: vi.fn(),
-			flush: vi.fn(),
+			write:
+				options.write ??
+				vi.fn((chunk: string | Uint8Array) => {
+					const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+					written += text;
+					return text.length;
+				}),
+			end:
+				options.end ??
+				vi.fn(() => {
+					exit.resolve(options.exitCode ?? 0);
+					return undefined;
+				}),
 		},
 		stdout: streamFromText(source),
 		stderr: streamFromText(options.stderr ?? ""),
-		exited: Promise.resolve(options.exitCode ?? 0),
+		exited: options.exited ?? exit.promise,
 		exitCode: null,
 		kill: vi.fn(),
 	};
 
 	return { process: proc, getWritten: () => written };
+}
+
+const EXPECTED_FORMATTER_SPAWN_OPTIONS: SpawnOptions = {
+	stdin: "pipe",
+	stdout: "pipe",
+	stderr: "pipe",
+	cwd: os.tmpdir(),
+};
+
+function neverSettlingPromise<T>(): Promise<T> {
+	return Promise.withResolvers<T>().promise;
 }
 
 type SourceFormatterOutcome = Awaited<ReturnType<ReturnType<typeof createSourceFormatter>>>;
@@ -111,11 +133,10 @@ describe("createSourceFormatter", () => {
 		expect(formatted.nested).toBe(args.nested);
 		expect(formatted.code).not.toBe(args.code);
 		expect(spawn).toHaveBeenCalledTimes(1);
-		expect(spawn).toHaveBeenCalledWith(["/tmp/prettier", "--no-config", "--stdin-filepath", "tool-call.js"], {
-			stdin: "pipe",
-			stdout: "pipe",
-			stderr: "pipe",
-		});
+		expect(spawn).toHaveBeenCalledWith(
+			["/tmp/prettier", "--no-config", "--stdin-filepath", "tool-call.js"],
+			EXPECTED_FORMATTER_SPAWN_OPTIONS,
+		);
 		expect(subprocess.getWritten()).toBe(args.code);
 		expect(which).toHaveBeenCalledTimes(1);
 	});
@@ -134,8 +155,8 @@ describe("createSourceFormatter", () => {
 			code: "formatted-py\n",
 		});
 		expect(spawn).toHaveBeenCalledWith(
-			["/tmp/ruff", "format", "--stdin-filename", "tool-call.py", "-"],
-			expect.anything(),
+			["/tmp/ruff", "format", "--isolated", "--stdin-filename", "tool-call.py", "-"],
+			EXPECTED_FORMATTER_SPAWN_OPTIONS,
 		);
 	});
 
@@ -151,7 +172,7 @@ describe("createSourceFormatter", () => {
 		expect(formatted).toEqual({
 			command: "formatted-bash\n",
 		});
-		expect(spawn).toHaveBeenCalledWith(["/tmp/shfmt"], expect.anything());
+		expect(spawn).toHaveBeenCalledWith(["/tmp/shfmt"], EXPECTED_FORMATTER_SPAWN_OPTIONS);
 	});
 
 	type WriteCase = {
@@ -172,7 +193,7 @@ describe("createSourceFormatter", () => {
 			name: "python",
 			path: "/tmp/source.py",
 			binary: "ruff",
-			args: ["format", "--stdin-filename", "/tmp/source.py", "-"],
+			args: ["format", "--isolated", "--stdin-filename", "/tmp/source.py", "-"],
 		},
 		{ name: "rust", path: "/tmp/source.rs", binary: "rustfmt", args: ["--emit", "stdout"] },
 		{ name: "go", path: "/tmp/source.go", binary: "gofmt", args: [] },
@@ -193,11 +214,10 @@ describe("createSourceFormatter", () => {
 				path: writeCase.path,
 				content: `formatted-write-${writeCase.name}`,
 			});
-			expect(spawn).toHaveBeenCalledWith([`/tmp/${writeCase.binary}`, ...writeCase.args], {
-				stdin: "pipe",
-				stdout: "pipe",
-				stderr: "pipe",
-			});
+			expect(spawn).toHaveBeenCalledWith(
+				[`/tmp/${writeCase.binary}`, ...writeCase.args],
+				EXPECTED_FORMATTER_SPAWN_OPTIONS,
+			);
 		});
 	}
 
@@ -325,6 +345,32 @@ describe("createSourceFormatter", () => {
 		expect(which).not.toHaveBeenCalled();
 	});
 
+	for (const stalledInput of ["write", "end"] as const) {
+		it(`falls back when stdin.${stalledInput} and process exit never settle`, async () => {
+			const which = vi.fn().mockReturnValue("/tmp/prettier");
+			const subprocess = createSubprocess("formatted-js\n", {
+				write: stalledInput === "write" ? () => neverSettlingPromise<number>() : undefined,
+				end: stalledInput === "end" ? () => neverSettlingPromise<undefined>() : undefined,
+				exited: neverSettlingPromise<number | null>(),
+			});
+			const spawn = vi.fn<SpawnCommand>(() => subprocess.process);
+			const formatter = createSourceFormatter({
+				runtime: { which, spawn },
+				options: { timeoutMs: 20, terminateGraceMs: 5 },
+			});
+
+			const result = await formatter(
+				"eval",
+				{ language: "js", code: "const value = 1;" },
+				new AbortController().signal,
+			);
+
+			expectUnchanged(result);
+			expect(subprocess.process.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+			expect(subprocess.process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+		});
+	}
+
 	it("falls back when args are non-object", async () => {
 		const which = vi.fn();
 		const spawn = vi.fn<SpawnCommand>(() => {
@@ -334,7 +380,7 @@ describe("createSourceFormatter", () => {
 			runtime: { which, spawn },
 		});
 
-		const result = await formatter("eval", "not-an-object" as unknown, new AbortController().signal);
+		const result = await formatter("eval", "not-an-object", new AbortController().signal);
 
 		expectUnchanged(result);
 		expect(spawn).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/source-formatter.test.ts
+++ b/packages/coding-agent/test/source-formatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "bun:test";
 import * as os from "node:os";
-import { createSourceFormatter } from "@oh-my-pi/pi-coding-agent/tools/source-formatter";
+import { createSourceFormatter, type SourceFormatterOutcome } from "@oh-my-pi/pi-coding-agent/tools/source-formatter";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
 	const body = new Response(text).body;
@@ -84,8 +84,6 @@ const EXPECTED_FORMATTER_SPAWN_OPTIONS: SpawnOptions = {
 function neverSettlingPromise<T>(): Promise<T> {
 	return Promise.withResolvers<T>().promise;
 }
-
-type SourceFormatterOutcome = Awaited<ReturnType<ReturnType<typeof createSourceFormatter>>>;
 
 function expectFormatted(outcome: SourceFormatterOutcome): Record<string, unknown> & object {
 	expect(outcome.status).toBe("formatted");

--- a/packages/coding-agent/test/tool-execution-source-formatting.test.ts
+++ b/packages/coding-agent/test/tool-execution-source-formatting.test.ts
@@ -492,36 +492,6 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("raw()");
 	});
 
-	it("shows every formatted write line when the raw call fit the collapsed preview", async () => {
-		const formattedContent = Array.from({ length: 8 }, (_, index) => `const value${index + 1} = ${index + 1};`).join(
-			"\n",
-		);
-		const sourceFormatter = vi.fn(
-			async (_toolName: string, callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
-				const argsRecord = callArgs as Record<string, unknown>;
-				return sourceFormatterOutcomeFormatted({ ...argsRecord, content: formattedContent });
-			},
-		);
-		const tool = { name: "write", label: "Write" } as unknown as AgentTool;
-		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
-		const component = new ToolExecutionComponent(
-			"write",
-			{ path: "/tmp/example.ts", content: "const values={one:1,two:2,three:3};" },
-			sourceFormatterOptions(sourceFormatter),
-			tool,
-			ui,
-		);
-		components.push(component);
-
-		component.setArgsComplete();
-		component.updateResult({ content: [{ type: "text", text: "Wrote file" }] }, false);
-		await component.whenSourceFormattingSettled();
-
-		const rendered = Bun.stripANSI(component.render(100).join("\n"));
-		expect(rendered).toContain("const value8 = 8;");
-		expect(rendered).not.toContain("Ctrl+O");
-	});
-
 	it("finalizes immediately when source formatting throws", async () => {
 		const { tool } = makeTextRenderer();
 		const sourceFormatter = vi.fn(

--- a/packages/coding-agent/test/tool-execution-source-formatting.test.ts
+++ b/packages/coding-agent/test/tool-execution-source-formatting.test.ts
@@ -5,6 +5,7 @@ import {
 	type ToolExecutionOptions,
 } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SourceFormatter, SourceFormatterOutcome } from "@oh-my-pi/pi-coding-agent/tools/source-formatter";
 import type { TUI } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
 
@@ -29,11 +30,17 @@ function makeTextRenderer(): {
 	return { tool, getRenderedText: () => rendered };
 }
 
-type SourceFormatter = (
-	_toolName: string,
-	callArgs: unknown,
-	_signal: AbortSignal,
-) => Promise<Record<string, unknown> | undefined>;
+function sourceFormatterOutcomeMissing(formatter: string): SourceFormatterOutcome {
+	return { status: "missing", formatter };
+}
+
+function sourceFormatterOutcomeFormatted(args: Record<string, unknown>): SourceFormatterOutcome {
+	return { status: "formatted", args };
+}
+
+function sourceFormatterOutcomeUnchanged(): SourceFormatterOutcome {
+	return { status: "unchanged" };
+}
 
 function sourceFormatterOptions(formatter: SourceFormatter): ToolExecutionOptions {
 	return { sourceFormatter: formatter };
@@ -57,20 +64,16 @@ describe("ToolExecutionComponent source formatting", () => {
 	it("renders raw args before args are complete", async () => {
 		const { tool, getRenderedText } = makeTextRenderer();
 		const sourceFormatter = vi.fn(
-			async (
-				_toolName: string,
-				callArgs: unknown,
-				_signal: AbortSignal,
-			): Promise<Record<string, unknown> | undefined> => {
+			async (_toolName: string, callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
 				if (typeof callArgs !== "object" || callArgs === null) {
-					return undefined;
+					return sourceFormatterOutcomeUnchanged();
 				}
 				const argsRecord = callArgs as Record<string, unknown>;
 				const { code } = argsRecord;
-				return {
+				return sourceFormatterOutcomeFormatted({
 					...argsRecord,
 					code: `formatted(${typeof code === "string" ? code : ""})`,
-				};
+				});
 			},
 		);
 		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
@@ -85,23 +88,19 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(sourceFormatter).not.toHaveBeenCalled();
 	});
 
-	it("formats source args once after args complete", async () => {
+	it("formats source args once after args are complete", async () => {
 		const { tool, getRenderedText } = makeTextRenderer();
 		const sourceFormatter = vi.fn(
-			async (
-				_toolName: string,
-				callArgs: unknown,
-				_signal: AbortSignal,
-			): Promise<Record<string, unknown> | undefined> => {
+			async (_toolName: string, callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
 				if (typeof callArgs !== "object" || callArgs === null) {
-					return undefined;
+					return sourceFormatterOutcomeUnchanged();
 				}
 				const argsRecord = callArgs as Record<string, unknown>;
 				const { code } = argsRecord;
-				return {
+				return sourceFormatterOutcomeFormatted({
 					...argsRecord,
 					code: `formatted(${typeof code === "string" ? code : ""})`,
-				};
+				});
 			},
 		);
 		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
@@ -123,8 +122,8 @@ describe("ToolExecutionComponent source formatting", () => {
 
 	it("uses the latest formatter result when args update before completion", async () => {
 		const { tool, getRenderedText } = makeTextRenderer();
-		const firstPass = createDeferred<Record<string, unknown>>();
-		const secondPass = createDeferred<Record<string, unknown>>();
+		const firstPass = createDeferred<SourceFormatterOutcome>();
+		const secondPass = createDeferred<SourceFormatterOutcome>();
 		const responses = [firstPass, secondPass];
 		let responseIndex = 0;
 		const sourceFormatter = vi.fn(async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => {
@@ -147,8 +146,8 @@ describe("ToolExecutionComponent source formatting", () => {
 		component.updateArgs({ language: "js", code: "fresh()" });
 		component.setArgsComplete();
 
-		secondPass.resolve({ language: "js", code: "formatted(fresh())" });
-		firstPass.resolve({ language: "js", code: "formatted(stale())" });
+		secondPass.resolve(sourceFormatterOutcomeFormatted({ language: "js", code: "formatted(fresh())" }));
+		firstPass.resolve(sourceFormatterOutcomeFormatted({ language: "js", code: "formatted(stale())" }));
 
 		await Bun.sleep(0);
 		await Bun.sleep(0);
@@ -162,7 +161,7 @@ describe("ToolExecutionComponent source formatting", () => {
 
 	it("does not apply formatting after the block is sealed", async () => {
 		const { tool, getRenderedText } = makeTextRenderer();
-		const result = createDeferred<Record<string, unknown>>();
+		const result = createDeferred<SourceFormatterOutcome>();
 		const sourceFormatter = vi.fn(
 			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => result.promise,
 		);
@@ -178,7 +177,7 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(component.isTranscriptBlockFinalized()).toBe(false);
 		component.seal();
 		expect(component.isTranscriptBlockFinalized()).toBe(true);
-		result.resolve({ language: "js", code: "formatted(raw())" });
+		result.resolve(sourceFormatterOutcomeFormatted({ language: "js", code: "formatted(raw())" }));
 
 		await Bun.sleep(0);
 		await Bun.sleep(0);
@@ -191,15 +190,11 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(sourceFormatter).toHaveBeenCalledTimes(1);
 	});
 
-	it("falls back to raw args when formatter returns undefined", async () => {
+	it("falls back to raw args when formatter returns unchanged", async () => {
 		const { tool, getRenderedText } = makeTextRenderer();
 		const sourceFormatter = vi.fn(
-			async (
-				_toolName: string,
-				_callArgs: unknown,
-				_signal: AbortSignal,
-			): Promise<Record<string, unknown> | undefined> => {
-				return undefined;
+			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
+				return sourceFormatterOutcomeUnchanged();
 			},
 		);
 		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
@@ -217,9 +212,115 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(getRenderedText()).toContain("leave-me-raw");
 		expect(sourceFormatter).toHaveBeenCalledWith("eval", args, expect.any(AbortSignal));
 	});
+	it("shows the missing formatter install note after args complete and finalization settles", async () => {
+		const result = createDeferred<SourceFormatterOutcome>();
+		const sourceFormatter = vi.fn(
+			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => result.promise,
+		);
+		const requestRender = vi.fn();
+		const requestComponentRender = vi.fn();
+		const ui = { requestRender, requestComponentRender } as unknown as TUI;
 
+		const args = { language: "python", code: 'import json\nprint(json.dumps({"a": 1}))' };
+		const component = new ToolExecutionComponent(
+			"eval",
+			args,
+			sourceFormatterOptions(sourceFormatter),
+			undefined,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		const pending = Bun.stripANSI(component.render(120).join("\n"));
+		expect(pending).toContain("import json");
+		expect(pending).not.toContain("Install prettier for pretty formatting");
+
+		result.resolve(sourceFormatterOutcomeMissing("prettier"));
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("Install prettier for pretty formatting");
+		expect(rendered).toContain("import json");
+		expect(requestComponentRender).toHaveBeenCalled();
+	});
+
+	it("shows no install note when formatter outcome is unchanged", async () => {
+		const sourceFormatter = vi.fn(async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => {
+			return sourceFormatterOutcomeUnchanged();
+		});
+		const requestRender = vi.fn();
+		const requestComponentRender = vi.fn();
+		const ui = { requestRender, requestComponentRender } as unknown as TUI;
+
+		const args = { language: "python", code: "leave-me-raw" };
+		const component = new ToolExecutionComponent(
+			"eval",
+			args,
+			sourceFormatterOptions(sourceFormatter),
+			undefined,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("leave-me-raw");
+		expect(rendered).not.toContain("Install prettier for pretty formatting");
+		expect(requestComponentRender).toHaveBeenCalled();
+		expect(sourceFormatter).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears a stale missing formatter note when a later arg generation settles unchanged", async () => {
+		const firstPass = createDeferred<SourceFormatterOutcome>();
+		const secondPass = createDeferred<SourceFormatterOutcome>();
+		const responses = [firstPass, secondPass];
+		let responseIndex = 0;
+		const sourceFormatter = vi.fn(async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => {
+			const response = responses[responseIndex++];
+			if (!response) throw new Error("Unexpected formatter call");
+			return response.promise;
+		});
+		const requestRender = vi.fn();
+		const requestComponentRender = vi.fn();
+		const ui = { requestRender, requestComponentRender } as unknown as TUI;
+
+		const component = new ToolExecutionComponent(
+			"eval",
+			{ language: "js", code: "stale()" },
+			sourceFormatterOptions(sourceFormatter),
+			undefined,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		firstPass.resolve(sourceFormatterOutcomeMissing("prettier"));
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const staleHint = Bun.stripANSI(component.render(120).join("\n"));
+		expect(staleHint).toContain("Install prettier for pretty formatting");
+		expect(staleHint).toContain("stale()");
+
+		component.updateArgs({ language: "js", code: "fresh()" });
+		component.setArgsComplete();
+		secondPass.resolve(sourceFormatterOutcomeUnchanged());
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const settled = Bun.stripANSI(component.render(120).join("\n"));
+		expect(settled).not.toContain("Install prettier for pretty formatting");
+		expect(settled).toContain("fresh()");
+		expect(requestComponentRender).toHaveBeenCalled();
+		expect(sourceFormatter).toHaveBeenCalledTimes(2);
+	});
 	it("uses formatted eval args for completed cell code once formatter resolves", async () => {
-		const formatResult = createDeferred<Record<string, unknown>>();
+		const formatResult = createDeferred<SourceFormatterOutcome>();
 		const sourceFormatter = vi.fn(async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => {
 			return formatResult.promise;
 		});
@@ -264,10 +365,12 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(pendingRender).not.toContain("formatted(");
 		expect(pendingRender).not.toMatch(/\n│\s{2,}raw\(\)/);
 
-		formatResult.resolve({
-			language: "python",
-			code: "formatted(\n  raw()\n)",
-		});
+		formatResult.resolve(
+			sourceFormatterOutcomeFormatted({
+				language: "python",
+				code: "formatted(\n  raw()\n)",
+			}),
+		);
 		await Bun.sleep(0);
 
 		const completedRender = Bun.stripANSI(component.render(120).join("\n"));
@@ -279,7 +382,7 @@ describe("ToolExecutionComponent source formatting", () => {
 
 	it("stays in live region while final result waits for source-format settlement", async () => {
 		const { tool } = makeTextRenderer();
-		const result = createDeferred<Record<string, unknown>>();
+		const result = createDeferred<SourceFormatterOutcome>();
 		const sourceFormatter = vi.fn(
 			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => result.promise,
 		);
@@ -295,22 +398,18 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(component.isTranscriptBlockFinalized()).toBe(false);
 		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("raw()");
 
-		result.resolve({ language: "js", code: "formatted(raw())" });
+		result.resolve(sourceFormatterOutcomeFormatted({ language: "js", code: "formatted(raw())" }));
 		await Bun.sleep(0);
 
 		expect(component.isTranscriptBlockFinalized()).toBe(true);
 		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("formatted(raw())");
 	});
 
-	it("becomes finalizable when source formatting falls back on undefined result", async () => {
+	it("becomes finalizable when source formatting falls back on unchanged result", async () => {
 		const { tool } = makeTextRenderer();
 		const sourceFormatter = vi.fn(
-			async (
-				_toolName: string,
-				_callArgs: unknown,
-				_signal: AbortSignal,
-			): Promise<Record<string, unknown> | undefined> => {
-				return undefined;
+			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
+				return sourceFormatterOutcomeUnchanged();
 			},
 		);
 		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
@@ -332,11 +431,7 @@ describe("ToolExecutionComponent source formatting", () => {
 	it("finalizes immediately when source formatting throws", async () => {
 		const { tool } = makeTextRenderer();
 		const sourceFormatter = vi.fn(
-			async (
-				_toolName: string,
-				_callArgs: unknown,
-				_signal: AbortSignal,
-			): Promise<Record<string, unknown> | undefined> => {
+			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
 				throw new Error("format failed");
 			},
 		);

--- a/packages/coding-agent/test/tool-execution-source-formatting.test.ts
+++ b/packages/coding-agent/test/tool-execution-source-formatting.test.ts
@@ -1,0 +1,358 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import {
+	ToolExecutionComponent,
+	type ToolExecutionOptions,
+} from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { TUI } from "@oh-my-pi/pi-tui";
+import { Text } from "@oh-my-pi/pi-tui";
+
+function createDeferred<T>() {
+	const { promise, resolve } = Promise.withResolvers<T>();
+	return { promise, resolve };
+}
+
+function makeTextRenderer(): {
+	tool: AgentTool;
+	getRenderedText: () => string | undefined;
+} {
+	let rendered = "" as string | undefined;
+	const tool = {
+		name: "eval",
+		label: "MockEval",
+		renderCall: (args: unknown) => {
+			rendered = JSON.stringify(args);
+			return new Text(rendered, 0, 0);
+		},
+	} as unknown as AgentTool;
+	return { tool, getRenderedText: () => rendered };
+}
+
+type SourceFormatter = (
+	_toolName: string,
+	callArgs: unknown,
+	_signal: AbortSignal,
+) => Promise<Record<string, unknown> | undefined>;
+
+function sourceFormatterOptions(formatter: SourceFormatter): ToolExecutionOptions {
+	return { sourceFormatter: formatter };
+}
+
+describe("ToolExecutionComponent source formatting", () => {
+	const components: ToolExecutionComponent[] = [];
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	afterEach(() => {
+		for (const component of components) {
+			component.stopAnimation();
+		}
+		components.length = 0;
+		vi.restoreAllMocks();
+	});
+
+	it("renders raw args before args are complete", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const sourceFormatter = vi.fn(
+			async (
+				_toolName: string,
+				callArgs: unknown,
+				_signal: AbortSignal,
+			): Promise<Record<string, unknown> | undefined> => {
+				if (typeof callArgs !== "object" || callArgs === null) {
+					return undefined;
+				}
+				const argsRecord = callArgs as Record<string, unknown>;
+				const { code } = argsRecord;
+				return {
+					...argsRecord,
+					code: `formatted(${typeof code === "string" ? code : ""})`,
+				};
+			},
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		const before = Bun.stripANSI(component.render(100).join("\n"));
+		expect(before).toContain("raw()");
+		expect(getRenderedText()).toContain("raw()");
+		expect(sourceFormatter).not.toHaveBeenCalled();
+	});
+
+	it("formats source args once after args complete", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const sourceFormatter = vi.fn(
+			async (
+				_toolName: string,
+				callArgs: unknown,
+				_signal: AbortSignal,
+			): Promise<Record<string, unknown> | undefined> => {
+				if (typeof callArgs !== "object" || callArgs === null) {
+					return undefined;
+				}
+				const argsRecord = callArgs as Record<string, unknown>;
+				const { code } = argsRecord;
+				return {
+					...argsRecord,
+					code: `formatted(${typeof code === "string" ? code : ""})`,
+				};
+			},
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.setArgsComplete();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const after = Bun.stripANSI(component.render(100).join("\n"));
+		expect(sourceFormatter).toHaveBeenCalledTimes(1);
+		expect(after).toContain("formatted(raw())");
+		expect(getRenderedText()).toContain("formatted(raw())");
+	});
+
+	it("uses the latest formatter result when args update before completion", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const firstPass = createDeferred<Record<string, unknown>>();
+		const secondPass = createDeferred<Record<string, unknown>>();
+		const responses = [firstPass, secondPass];
+		let responseIndex = 0;
+		const sourceFormatter = vi.fn(async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => {
+			const response = responses[responseIndex++];
+			if (!response) throw new Error("Unexpected formatter call");
+			return response.promise;
+		});
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const component = new ToolExecutionComponent(
+			"eval",
+			{ language: "js", code: "stale()" },
+			sourceFormatterOptions(sourceFormatter),
+			tool,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateArgs({ language: "js", code: "fresh()" });
+		component.setArgsComplete();
+
+		secondPass.resolve({ language: "js", code: "formatted(fresh())" });
+		firstPass.resolve({ language: "js", code: "formatted(stale())" });
+
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const rendered = Bun.stripANSI(component.render(100).join("\n"));
+		expect(rendered).toContain("formatted(fresh())");
+		expect(rendered).not.toContain("formatted(stale())");
+		expect(sourceFormatter).toHaveBeenCalledTimes(2);
+		expect(getRenderedText()).toContain("formatted(fresh())");
+	});
+
+	it("does not apply formatting after the block is sealed", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const result = createDeferred<Record<string, unknown>>();
+		const sourceFormatter = vi.fn(
+			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => result.promise,
+		);
+		const requestRender = vi.fn();
+		const requestComponentRender = vi.fn();
+		const ui = { requestRender, requestComponentRender } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		component.seal();
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		result.resolve({ language: "js", code: "formatted(raw())" });
+
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const rendered = Bun.stripANSI(component.render(100).join("\n"));
+		expect(requestRender).toHaveBeenCalled();
+		expect(requestComponentRender).not.toHaveBeenCalled();
+		expect(rendered).toContain("raw()");
+		expect(getRenderedText()).toContain("raw()");
+		expect(sourceFormatter).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to raw args when formatter returns undefined", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const sourceFormatter = vi.fn(
+			async (
+				_toolName: string,
+				_callArgs: unknown,
+				_signal: AbortSignal,
+			): Promise<Record<string, unknown> | undefined> => {
+				return undefined;
+			},
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "leave-me-raw" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const rendered = Bun.stripANSI(component.render(100).join("\n"));
+		expect(rendered).toContain("leave-me-raw");
+		expect(getRenderedText()).toContain("leave-me-raw");
+		expect(sourceFormatter).toHaveBeenCalledWith("eval", args, expect.any(AbortSignal));
+	});
+
+	it("uses formatted eval args for completed cell code once formatter resolves", async () => {
+		const formatResult = createDeferred<Record<string, unknown>>();
+		const sourceFormatter = vi.fn(async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => {
+			return formatResult.promise;
+		});
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "python", code: "raw()" };
+		const component = new ToolExecutionComponent(
+			"eval",
+			args,
+			sourceFormatterOptions(sourceFormatter),
+			undefined,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateResult(
+			{
+				content: [{ type: "text", text: "final result text" }],
+				details: {
+					cells: [
+						{
+							index: 0,
+							title: "Cell 0",
+							code: "raw()",
+							language: "python",
+							output: "cell output text",
+							status: "complete",
+						},
+					],
+				},
+			},
+			false,
+		);
+
+		await Bun.sleep(0);
+
+		const pendingRender = Bun.stripANSI(component.render(120).join("\n"));
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(pendingRender).toContain("raw()");
+		expect(pendingRender).toContain("cell output text");
+		expect(pendingRender).not.toContain("formatted(");
+		expect(pendingRender).not.toMatch(/\n│\s{2,}raw\(\)/);
+
+		formatResult.resolve({
+			language: "python",
+			code: "formatted(\n  raw()\n)",
+		});
+		await Bun.sleep(0);
+
+		const completedRender = Bun.stripANSI(component.render(120).join("\n"));
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		expect(completedRender).toContain("formatted(");
+		expect(completedRender).toMatch(/\n│\s{2,}raw\(\)/);
+		expect(completedRender).toContain("cell output text");
+	});
+
+	it("stays in live region while final result waits for source-format settlement", async () => {
+		const { tool } = makeTextRenderer();
+		const result = createDeferred<Record<string, unknown>>();
+		const sourceFormatter = vi.fn(
+			async (_toolName: string, _callArgs: unknown, _signal: AbortSignal) => result.promise,
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateResult({ content: [{ type: "text", text: "finalized" }] }, false);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("raw()");
+
+		result.resolve({ language: "js", code: "formatted(raw())" });
+		await Bun.sleep(0);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("formatted(raw())");
+	});
+
+	it("becomes finalizable when source formatting falls back on undefined result", async () => {
+		const { tool } = makeTextRenderer();
+		const sourceFormatter = vi.fn(
+			async (
+				_toolName: string,
+				_callArgs: unknown,
+				_signal: AbortSignal,
+			): Promise<Record<string, unknown> | undefined> => {
+				return undefined;
+			},
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateResult({ content: [{ type: "text", text: "finalized" }] }, false);
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+
+		await Bun.sleep(0);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("raw()");
+	});
+
+	it("finalizes immediately when source formatting throws", async () => {
+		const { tool } = makeTextRenderer();
+		const sourceFormatter = vi.fn(
+			async (
+				_toolName: string,
+				_callArgs: unknown,
+				_signal: AbortSignal,
+			): Promise<Record<string, unknown> | undefined> => {
+				throw new Error("format failed");
+			},
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, sourceFormatterOptions(sourceFormatter), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateResult({ content: [{ type: "text", text: "finalized" }] }, false);
+		expect(component.isTranscriptBlockFinalized()).toBe(false);
+
+		await Bun.sleep(0);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("raw()");
+	});
+});

--- a/packages/coding-agent/test/tool-execution-source-formatting.test.ts
+++ b/packages/coding-agent/test/tool-execution-source-formatting.test.ts
@@ -42,8 +42,17 @@ function sourceFormatterOutcomeUnchanged(): SourceFormatterOutcome {
 	return { status: "unchanged" };
 }
 
-function sourceFormatterOptions(formatter: SourceFormatter): ToolExecutionOptions {
-	return { sourceFormatter: formatter };
+type ToolExecutionOptionsWithFormatCallSource = ToolExecutionOptions & { formatCallSource?: boolean };
+
+function sourceFormatterOptions(
+	formatter: SourceFormatter,
+	formatCallSource?: boolean,
+): ToolExecutionOptionsWithFormatCallSource {
+	return { sourceFormatter: formatter, formatCallSource };
+}
+
+function disabledSourceFormatterOptions(): ToolExecutionOptionsWithFormatCallSource {
+	return { formatCallSource: false };
 }
 
 describe("ToolExecutionComponent source formatting", () => {
@@ -86,6 +95,61 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(before).toContain("raw()");
 		expect(getRenderedText()).toContain("raw()");
 		expect(sourceFormatter).not.toHaveBeenCalled();
+	});
+
+	it("renders raw args and finalizes immediately when source formatting is disabled", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent("eval", args, disabledSourceFormatterOptions(), tool, ui);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateResult({ content: [{ type: "text", text: "finalized" }] }, false);
+
+		expect(component.isTranscriptBlockFinalized()).toBe(true);
+		const rendered = Bun.stripANSI(component.render(100).join("\n"));
+		expect(rendered).toContain("raw()");
+		expect(rendered).not.toContain("Install prettier for pretty formatting");
+		expect(getRenderedText()).toContain("raw()");
+	});
+
+	it("formats source args when an explicit formatter is injected even when formatCallSource is false", async () => {
+		const { tool, getRenderedText } = makeTextRenderer();
+		const sourceFormatter = vi.fn(
+			async (_toolName: string, callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
+				if (typeof callArgs !== "object" || callArgs === null) {
+					return sourceFormatterOutcomeUnchanged();
+				}
+				const argsRecord = callArgs as Record<string, unknown>;
+				const { code } = argsRecord;
+				return sourceFormatterOutcomeFormatted({
+					...argsRecord,
+					code: `formatted(${typeof code === "string" ? code : ""})`,
+				});
+			},
+		);
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+		const args = { language: "js", code: "raw()" };
+		const component = new ToolExecutionComponent(
+			"eval",
+			args,
+			sourceFormatterOptions(sourceFormatter, false),
+			tool,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const after = Bun.stripANSI(component.render(100).join("\n"));
+		expect(sourceFormatter).toHaveBeenCalledTimes(1);
+		expect(after).toContain("formatted(raw())");
+		expect(getRenderedText()).toContain("formatted(raw())");
 	});
 
 	it("formats source args once after args are complete", async () => {

--- a/packages/coding-agent/test/tool-execution-source-formatting.test.ts
+++ b/packages/coding-agent/test/tool-execution-source-formatting.test.ts
@@ -492,6 +492,36 @@ describe("ToolExecutionComponent source formatting", () => {
 		expect(Bun.stripANSI(component.render(100).join("\n"))).toContain("raw()");
 	});
 
+	it("shows every formatted write line when the raw call fit the collapsed preview", async () => {
+		const formattedContent = Array.from({ length: 8 }, (_, index) => `const value${index + 1} = ${index + 1};`).join(
+			"\n",
+		);
+		const sourceFormatter = vi.fn(
+			async (_toolName: string, callArgs: unknown, _signal: AbortSignal): Promise<SourceFormatterOutcome> => {
+				const argsRecord = callArgs as Record<string, unknown>;
+				return sourceFormatterOutcomeFormatted({ ...argsRecord, content: formattedContent });
+			},
+		);
+		const tool = { name: "write", label: "Write" } as unknown as AgentTool;
+		const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+		const component = new ToolExecutionComponent(
+			"write",
+			{ path: "/tmp/example.ts", content: "const values={one:1,two:2,three:3};" },
+			sourceFormatterOptions(sourceFormatter),
+			tool,
+			ui,
+		);
+		components.push(component);
+
+		component.setArgsComplete();
+		component.updateResult({ content: [{ type: "text", text: "Wrote file" }] }, false);
+		await component.whenSourceFormattingSettled();
+
+		const rendered = Bun.stripANSI(component.render(100).join("\n"));
+		expect(rendered).toContain("const value8 = 8;");
+		expect(rendered).not.toContain("Ctrl+O");
+	});
+
 	it("finalizes immediately when source formatting throws", async () => {
 		const { tool } = makeTextRenderer();
 		const sourceFormatter = vi.fn(


### PR DESCRIPTION
## Summary
- add opt-in `tools.formatCallSource` display formatting, disabled by default
- format completed eval, shell, and supported code-file write previews with compatible formatter executables already installed on `PATH`
- preserve raw execution and file-write arguments, with bounded timeout/output and unchanged fallback when formatting fails
- show `Install <formatter> for pretty formatting` in enabled eval, shell, and write top bars when the applicable formatter is missing
- keep tool blocks live until asynchronous formatting settles, including gallery rendering

## Screenshots
Not included. Verified interactively in the TUI with JavaScript, Python, shell, Go, and Rust tool calls.

## Testing
- `bun test packages/coding-agent/test/source-formatter.test.ts packages/coding-agent/test/tool-execution-source-formatting.test.ts packages/coding-agent/test/source-formatter-hints.test.ts packages/coding-agent/test/source-formatter-setting.test.ts packages/coding-agent/test/gallery-cli.test.ts` — 58 passed
- `bun run check` in `packages/coding-agent`
- manual TUI verification with Prettier, Ruff, shfmt, gofmt, rustfmt, and missing-formatter fallback

## Risk
- behavior is gated by `tools.formatCallSource`; existing installations remain unchanged until users opt in
- external formatter execution is bounded by a shared 500 ms deadline across stdin writes and process exit, followed by bounded termination grace
- formatter availability is cached for the process lifetime, so tools installed after OMP starts require a restart
- missing-formatter headers are additive and only appear when formatting is enabled

## Notes
- no formatter is bundled or installed automatically
- Markdown, YAML, CSS, and HTML write previews remain unformatted
- rustfmt uses edition 2021 when formatting standalone stdin; shfmt receives the write filename and an explicit supported dialect where applicable

## AI Review Report
Independent review found no remaining correctness defects. Review feedback led to opt-in settings propagation through interactive transcripts and gallery rendering, bounded formatter stdin/exit handling, explicit formatter result types, modern Rust edition handling, and shell-dialect preservation.

## Security Audit
Prettier runs with `--no-config`, Ruff uses `--isolated`, and formatter subprocesses use a neutral temporary cwd to avoid repository-controlled style configuration. Commands use direct argv spawning without a shell; stdin/stdout and termination waits are bounded, missing executable names are sanitized before rendering, and raw tool arguments remain canonical.