### PR TITLE
fix(ai): preserve Anthropic server-tool history

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -348,6 +348,8 @@ function snapshotAssistantContentBlock(block: AssistantContentBlock): AssistantC
 			return { ...block };
 		case "redactedThinking":
 			return { ...block };
+		case "anthropicServerTool":
+			return { ...block, block: structuredCloneJSON(block.block) };
 		case "fallback":
 			return { ...block, from: { ...block.from }, to: { ...block.to } };
 		case "toolCall":

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -427,6 +427,14 @@ function computeMessageTokens(message: AgentMessage, options?: { excludeEncrypte
 					// Encrypted reasoning blob the provider still bills for on replay;
 					// excluded from the compaction floor for the same reason as above.
 					if (!options?.excludeEncryptedReasoning) fragments.push(block.data);
+				} else if (block.type === "anthropicServerTool") {
+					// Native Anthropic server-tool call/result replayed verbatim on the
+					// wire (server_tool_use input, web_search_tool_result
+					// encrypted_content). Opaque provider-replay state the provider still
+					// bills for on same-provider replay; excluded from the compaction
+					// floor like other encrypted reasoning because its local byte size
+					// diverges from provider billing.
+					if (!options?.excludeEncryptedReasoning) fragments.push(stringifyJson(block.block) ?? "null");
 				}
 			}
 			break;

--- a/packages/agent/test/message-cache.test.ts
+++ b/packages/agent/test/message-cache.test.ts
@@ -110,6 +110,34 @@ describe("estimate cache option split", () => {
 		expect(estimateTokens(msg as AgentMessage)).toBe(withBlob);
 		expect(estimateTokens(msg as AgentMessage, { excludeEncryptedReasoning: true })).toBe(floored);
 	});
+
+	test("counts native server-tool blocks by default and drops them from the compaction floor", () => {
+		const encrypted = "cipher".repeat(4000);
+		const msg: AssistantMessage = {
+			...settledAssistant("with search"),
+			content: [
+				{ type: "text", text: "answer" },
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvtoolu_1",
+						content: [{ type: "web_search_result", encrypted_content: encrypted }],
+					},
+				},
+			],
+		};
+		const textOnly = estimateTokens({
+			...settledAssistant("x"),
+			content: [{ type: "text", text: "answer" }],
+		} as AgentMessage);
+		const withServerTool = estimateTokens(msg as AgentMessage);
+		const floored = estimateTokens(msg as AgentMessage, { excludeEncryptedReasoning: true });
+		// Default estimate charges for the serialized server-tool payload…
+		expect(withServerTool).toBeGreaterThan(floored + 500);
+		// …while the compaction floor ignores the opaque encrypted blob entirely.
+		expect(floored).toBe(textOnly);
+	});
 });
 
 describe("estimate cache invalidation seams", () => {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic native server-tool blocks being dropped from persisted assistant turns, preserving signed web-search continuations in their original response order ([#6495](https://github.com/can1357/oh-my-pi/issues/6495))
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -27,6 +27,7 @@ import {
 	type AnthropicUserContentBlock,
 	anthropicMessagesRequestSchema,
 } from "./anthropic-messages-server-schema";
+import { isAnthropicWebSearchHistoryBlock } from "./anthropic-wire";
 
 /**
  * Anthropic Messages API (https://docs.anthropic.com/en/api/messages) ↔ pi-ai
@@ -215,12 +216,19 @@ function walkAssistantContent(
 				break;
 			case "server_tool_use":
 			case "web_search_tool_result":
-				// Native Anthropic server-tool call/result. Anthropic requires
-				// these replayed verbatim (encrypted_content/signatures included),
-				// so retain the block as-is instead of flattening to text — a
-				// gateway client sending the response back as history must be able
-				// to reconstruct the exact assistant turn.
-				out.push({ type: "anthropicServerTool", block: { ...block } });
+				if (isAnthropicWebSearchHistoryBlock(block)) {
+					// Native web-search call/result. Anthropic requires these
+					// replayed verbatim (encrypted_content included), so retain
+					// the block instead of flattening it to text.
+					out.push({ type: "anthropicServerTool", block: { ...block } });
+				} else {
+					// Other server tools use distinct result block types that omp
+					// cannot yet replay atomically. Flatten both sides rather than
+					// persisting a lone server_tool_use without its matching result.
+					const unknown = block as { type: string };
+					warnUnknownBlockType("assistant", unknown.type);
+					out.push({ type: "text", text: describeUnknownBlock(unknown) });
+				}
 				break;
 			default: {
 				// Unknown assistant variant (mcp_tool_use, code_execution_*, …).

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -578,6 +578,25 @@ export function encodeStream(
 				);
 			};
 
+			let nextContentIndexToInspect = 0;
+			const emitServerToolBlocksBefore = (message: AssistantMessage, beforeIndex: number) => {
+				const limit = Math.min(beforeIndex, message.content.length);
+				while (nextContentIndexToInspect < limit) {
+					const index = nextContentIndexToInspect++;
+					const content = message.content[index];
+					if (content?.type !== "anthropicServerTool") continue;
+					ensureStart(message);
+					controller.enqueue(
+						sseFrame("content_block_start", {
+							type: "content_block_start",
+							index,
+							content_block: content.block,
+						}),
+					);
+					controller.enqueue(sseFrame("content_block_stop", { type: "content_block_stop", index }));
+				}
+			};
+
 			const closeBlock = (index: number) => {
 				if (!open.has(index)) return;
 				controller.enqueue(sseFrame("content_block_stop", { type: "content_block_stop", index }));
@@ -609,6 +628,7 @@ export function encodeStream(
 							ensureStart(ev.partial);
 							break;
 						case "text_start": {
+							emitServerToolBlocksBefore(ev.partial, ev.contentIndex);
 							ensureStart(ev.partial);
 							open.set(ev.contentIndex, { index: ev.contentIndex, kind: "text" });
 							controller.enqueue(
@@ -633,6 +653,7 @@ export function encodeStream(
 							closeBlock(ev.contentIndex);
 							break;
 						case "thinking_start": {
+							emitServerToolBlocksBefore(ev.partial, ev.contentIndex);
 							ensureStart(ev.partial);
 							open.set(ev.contentIndex, { index: ev.contentIndex, kind: "thinking" });
 							controller.enqueue(
@@ -668,6 +689,7 @@ export function encodeStream(
 							break;
 						}
 						case "toolcall_start": {
+							emitServerToolBlocksBefore(ev.partial, ev.contentIndex);
 							ensureStart(ev.partial);
 							const tc = ev.partial.content[ev.contentIndex] as ToolCall | undefined;
 							open.set(ev.contentIndex, { index: ev.contentIndex, kind: "tool_use" });
@@ -699,6 +721,7 @@ export function encodeStream(
 							break;
 						case "done": {
 							for (const idx of [...open.keys()]) closeBlock(idx);
+							emitServerToolBlocksBefore(ev.message, ev.message.content.length);
 							controller.enqueue(
 								sseFrame("message_delta", {
 									type: "message_delta",

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -4,6 +4,7 @@ import { type } from "arktype";
 import { captureRequestHeaders, resolvePromptCacheKey } from "../auth-gateway/http";
 import * as AIError from "../error";
 import type {
+	AnthropicServerToolContent,
 	AssistantMessage,
 	AssistantMessageEventStream,
 	Message,
@@ -181,8 +182,8 @@ function walkUserContent(
 
 function walkAssistantContent(
 	blocks: string | AnthropicAssistantContentBlock[],
-): (TextContent | ThinkingContent | RedactedThinkingContent | ToolCall)[] {
-	const out: (TextContent | ThinkingContent | RedactedThinkingContent | ToolCall)[] = [];
+): (TextContent | ThinkingContent | RedactedThinkingContent | AnthropicServerToolContent | ToolCall)[] {
+	const out: (TextContent | ThinkingContent | RedactedThinkingContent | AnthropicServerToolContent | ToolCall)[] = [];
 	if (typeof blocks === "string") {
 		if (blocks.length > 0) out.push({ type: "text", text: blocks });
 		return out;
@@ -212,8 +213,17 @@ function walkAssistantContent(
 							: {},
 				});
 				break;
+			case "server_tool_use":
+			case "web_search_tool_result":
+				// Native Anthropic server-tool call/result. Anthropic requires
+				// these replayed verbatim (encrypted_content/signatures included),
+				// so retain the block as-is instead of flattening to text — a
+				// gateway client sending the response back as history must be able
+				// to reconstruct the exact assistant turn.
+				out.push({ type: "anthropicServerTool", block: { ...block } });
+				break;
 			default: {
-				// Unknown assistant variant (server_tool_use, mcp_tool_use, …).
+				// Unknown assistant variant (mcp_tool_use, code_execution_*, …).
 				// Flatten to a text placeholder; warn once per unknown type.
 				const unknown = block as { type: string };
 				warnUnknownBlockType("assistant", unknown.type);

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -457,6 +457,9 @@ function encodeContentBlocks(message: AssistantMessage): Record<string, unknown>
 			case "redactedThinking":
 				blocks.push({ type: "redacted_thinking", data: c.data });
 				break;
+			case "anthropicServerTool":
+				blocks.push(c.block);
+				break;
 			case "toolCall":
 				blocks.push({ type: "tool_use", id: c.id, name: c.name, input: c.arguments ?? {} });
 				break;

--- a/packages/ai/src/providers/anthropic-wire.ts
+++ b/packages/ai/src/providers/anthropic-wire.ts
@@ -89,8 +89,17 @@ export type WebSearchToolResultBlockParam = {
 export function isAnthropicWebSearchHistoryBlock(block: {
 	type: string;
 	name?: unknown;
+	id?: unknown;
+	tool_use_id?: unknown;
+	content?: unknown;
 }): block is WebSearchServerToolUseBlockParam | WebSearchToolResultBlockParam {
-	return block.type === "web_search_tool_result" || (block.type === "server_tool_use" && block.name === "web_search");
+	if (block.type === "server_tool_use") {
+		return block.name === "web_search" && typeof block.id === "string" && block.id.length > 0;
+	}
+	if (block.type === "web_search_tool_result") {
+		return typeof block.tool_use_id === "string" && block.tool_use_id.length > 0 && Object.hasOwn(block, "content");
+	}
+	return false;
 }
 
 export type ThinkingBlockParam = {

--- a/packages/ai/src/providers/anthropic-wire.ts
+++ b/packages/ai/src/providers/anthropic-wire.ts
@@ -74,6 +74,9 @@ export type ServerToolUseBlockParam = {
 	[key: string]: unknown;
 };
 
+/** Web-search server-tool call whose matching result is replayable by omp. */
+export type WebSearchServerToolUseBlockParam = ServerToolUseBlockParam & { name: "web_search" };
+
 /** Native web-search result replayed inside an assistant turn. */
 export type WebSearchToolResultBlockParam = {
 	type: "web_search_tool_result";
@@ -81,6 +84,14 @@ export type WebSearchToolResultBlockParam = {
 	content: unknown;
 	[key: string]: unknown;
 };
+
+/** True for the complete native web-search history variants omp can replay. */
+export function isAnthropicWebSearchHistoryBlock(block: {
+	type: string;
+	name?: unknown;
+}): block is WebSearchServerToolUseBlockParam | WebSearchToolResultBlockParam {
+	return block.type === "web_search_tool_result" || (block.type === "server_tool_use" && block.name === "web_search");
+}
 
 export type ThinkingBlockParam = {
 	type: "thinking";

--- a/packages/ai/src/providers/anthropic-wire.ts
+++ b/packages/ai/src/providers/anthropic-wire.ts
@@ -65,6 +65,23 @@ export type ToolResultBlockParam = {
 	cache_control?: CacheControlEphemeral | null;
 };
 
+/** Anthropic-executed server tool call replayed inside an assistant turn. */
+export type ServerToolUseBlockParam = {
+	type: "server_tool_use";
+	id: string;
+	name: string;
+	input?: Record<string, unknown> | null;
+	[key: string]: unknown;
+};
+
+/** Native web-search result replayed inside an assistant turn. */
+export type WebSearchToolResultBlockParam = {
+	type: "web_search_tool_result";
+	tool_use_id: string;
+	content: unknown;
+	[key: string]: unknown;
+};
+
 export type ThinkingBlockParam = {
 	type: "thinking";
 	thinking: string;
@@ -93,6 +110,8 @@ export type ContentBlockParam =
 	| ImageBlockParam
 	| ToolUseBlockParam
 	| ToolResultBlockParam
+	| ServerToolUseBlockParam
+	| WebSearchToolResultBlockParam
 	| ThinkingBlockParam
 	| RedactedThinkingBlockParam
 	| FallbackBlockParam;
@@ -278,6 +297,8 @@ export type ResponseContentBlock =
 	| { type: "thinking"; thinking: string; signature?: string }
 	| { type: "redacted_thinking"; data: string }
 	| { type: "tool_use"; id: string; name: string; input?: Record<string, unknown> | null }
+	| ServerToolUseBlockParam
+	| WebSearchToolResultBlockParam
 	| { type: "fallback"; from: { model: string }; to: { model: string } };
 
 export type ContentBlockDelta =

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -72,16 +72,17 @@ import {
 	calculateAnthropicRetryDelayMs,
 	retryDelayFromHeaders,
 } from "./anthropic-client";
-import type {
-	ToolInputSchema as AnthropicToolInputSchema,
-	Tool as AnthropicWireTool,
-	Usage as AnthropicWireUsage,
-	ContentBlockParam,
-	FallbackParam,
-	MessageCreateParamsStreaming,
-	MessageParam,
-	RawMessageStreamEvent,
-	TextBlockParam,
+import {
+	type ToolInputSchema as AnthropicToolInputSchema,
+	type Tool as AnthropicWireTool,
+	type Usage as AnthropicWireUsage,
+	type ContentBlockParam,
+	type FallbackParam,
+	isAnthropicWebSearchHistoryBlock,
+	type MessageCreateParamsStreaming,
+	type MessageParam,
+	type RawMessageStreamEvent,
+	type TextBlockParam,
 } from "./anthropic-wire";
 import {
 	buildCopilotDynamicHeaders,
@@ -2303,8 +2304,7 @@ const streamAnthropicOnce = (
 									kind: "redactedThinking",
 								});
 							} else if (
-								(event.content_block.type === "server_tool_use" ||
-									event.content_block.type === "web_search_tool_result") &&
+								isAnthropicWebSearchHistoryBlock(event.content_block) &&
 								umansGatewayWebSearchHeader === undefined
 							) {
 								streamedReplayUnsafeContent = true;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -21,6 +21,7 @@ import * as AIError from "../error";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
 	AnthropicFallbackContent,
+	AnthropicServerToolContent,
 	Api,
 	AssistantMessage,
 	CacheRetention,
@@ -1977,6 +1978,7 @@ const streamAnthropicOnce = (
 				| RedactedThinkingContent
 				| TextContent
 				| AnthropicFallbackContent
+				| (AnthropicServerToolContent & { [kStreamingPartialJson]?: string })
 				| (ToolCall & { [kStreamingPartialJson]: string; [kStreamingLastParseLen]?: number })
 			) & { [kStreamingBlockIndex]: number };
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
@@ -1994,6 +1996,23 @@ const streamAnthropicOnce = (
 						block.thinkingSignature = undefined;
 					}
 					stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial: output });
+				} else if (block.type === "anthropicServerTool" && block.block.type === "server_tool_use") {
+					const partialJson = block[kStreamingPartialJson];
+					if (partialJson) {
+						try {
+							const input = parseJsonWithRepair(partialJson);
+							if (isRecord(input)) {
+								block.block.input = input;
+							} else {
+								reportAnthropicEnvelopeAnomaly("server_tool_use input is not a JSON object");
+							}
+						} catch (parseError) {
+							reportAnthropicEnvelopeAnomaly(
+								`server_tool_use ${block.block.id} input is not valid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+							);
+						}
+					}
+					clearStreamingPartialJson(block);
 				} else if (block.type === "toolCall") {
 					const finalJson =
 						block[kStreamingPartialJson].length > 0
@@ -2094,7 +2113,14 @@ const streamAnthropicOnce = (
 						number,
 						{
 							contentIndex: number;
-							kind: "text" | "thinking" | "redactedThinking" | "fallback" | "toolCall" | "ignored";
+							kind:
+								| "text"
+								| "thinking"
+								| "redactedThinking"
+								| "fallback"
+								| "anthropicServerTool"
+								| "toolCall"
+								| "ignored";
 						}
 					>();
 
@@ -2276,6 +2302,23 @@ const streamAnthropicOnce = (
 									contentIndex: output.content.length - 1,
 									kind: "redactedThinking",
 								});
+							} else if (
+								(event.content_block.type === "server_tool_use" ||
+									event.content_block.type === "web_search_tool_result") &&
+								umansGatewayWebSearchHeader === undefined
+							) {
+								streamedReplayUnsafeContent = true;
+								const block: Block = {
+									type: "anthropicServerTool",
+									block: { ...event.content_block },
+									[kStreamingPartialJson]: "",
+									[kStreamingBlockIndex]: event.index,
+								};
+								output.content.push(block);
+								openBlocks.set(event.index, {
+									contentIndex: output.content.length - 1,
+									kind: "anthropicServerTool",
+								});
 							} else if (event.content_block.type === "tool_use") {
 								streamedReplayUnsafeContent = true;
 								const block: Block = {
@@ -2346,6 +2389,15 @@ const streamAnthropicOnce = (
 									partial: output,
 								});
 							} else if (event.delta.type === "input_json_delta") {
+								if (
+									openBlock.kind === "anthropicServerTool" &&
+									block?.type === "anthropicServerTool" &&
+									block.block.type === "server_tool_use"
+								) {
+									block[kStreamingPartialJson] =
+										(block[kStreamingPartialJson] ?? "") + event.delta.partial_json;
+									continue;
+								}
 								if (openBlock.kind !== "toolCall" || block?.type !== "toolCall") {
 									reportAnthropicEnvelopeAnomaly(`received input_json_delta for ${openBlock.kind} block`);
 									continue;
@@ -3637,6 +3689,8 @@ export function convertAnthropicMessages(
 						type: "redacted_thinking",
 						data: block.data,
 					});
+				} else if (block.type === "anthropicServerTool") {
+					blocks.push(block.block);
 				} else if (block.type === "fallback") {
 					// Replay ONLY when both sides are aligned: the current
 					// request opted into the beta chain, and the target is

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -742,6 +742,14 @@ export function transformMessages<TApi extends Api>(
 					return [];
 				}
 
+				if (block.type === "anthropicServerTool") {
+					// Anthropic requires native server-tool calls and results to be
+					// replayed unchanged. They are meaningful only to the provider
+					// that produced them; every cross-provider target drops them.
+					if (isAnthropicReplay && assistantMsg.provider === model.provider) return block;
+					return [];
+				}
+
 				if (block.type === "fallback") {
 					// Server-side-fallback boundary marker (Anthropic beta
 					// `server-side-fallback-2026-06-01`). Only the official

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -659,8 +659,8 @@ export interface AnthropicFallbackContent {
 }
 
 /**
- * Verbatim Anthropic server-tool block retained for same-provider history
- * replay. Other providers discard it in `transformMessages`.
+ * Verbatim Anthropic web-search call/result retained for same-provider
+ * history replay. Other providers discard it in `transformMessages`.
  */
 export interface AnthropicServerToolContent {
 	type: "anthropicServerTool";
@@ -668,7 +668,7 @@ export interface AnthropicServerToolContent {
 		| {
 				type: "server_tool_use";
 				id: string;
-				name: string;
+				name: "web_search";
 				input?: Record<string, unknown> | null;
 				[key: string]: unknown;
 		  }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -658,6 +658,28 @@ export interface AnthropicFallbackContent {
 	to: { model: string };
 }
 
+/**
+ * Verbatim Anthropic server-tool block retained for same-provider history
+ * replay. Other providers discard it in `transformMessages`.
+ */
+export interface AnthropicServerToolContent {
+	type: "anthropicServerTool";
+	block:
+		| {
+				type: "server_tool_use";
+				id: string;
+				name: string;
+				input?: Record<string, unknown> | null;
+				[key: string]: unknown;
+		  }
+		| {
+				type: "web_search_tool_result";
+				tool_use_id: string;
+				content: unknown;
+				[key: string]: unknown;
+		  };
+}
+
 export interface ImageContent {
 	type: "image";
 	data: string; // base64 encoded image data
@@ -804,6 +826,7 @@ export interface AssistantMessage {
 		| ThinkingContent
 		| RedactedThinkingContent
 		| AnthropicFallbackContent
+		| AnthropicServerToolContent
 		| ImageContent
 		| ToolCall
 	)[];

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -672,6 +672,79 @@ describe("anthropic stream envelope handling", () => {
 		]);
 	});
 
+	it("does not persist a code-execution call without its unsupported result block", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_code_execution",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: {
+							type: "server_tool_use",
+							id: "srvtoolu_code",
+							name: "bash_code_execution",
+						},
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "input_json_delta", partial_json: '{"command":"printf ok"}' },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "content_block_start",
+						index: 1,
+						content_block: {
+							type: "bash_code_execution_tool_result",
+							tool_use_id: "srvtoolu_code",
+							content: {
+								type: "bash_code_execution_result",
+								stdout: "ok",
+								stderr: "",
+								return_code: 0,
+								content: [],
+							},
+						},
+					},
+					{ type: "content_block_stop", index: 1 },
+					{ type: "content_block_start", index: 2, content_block: { type: "text", text: "" } },
+					{ type: "content_block_delta", index: 2, delta: { type: "text_delta", text: "done" } },
+					{ type: "content_block_stop", index: 2 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "end_turn" },
+						usage: {
+							input_tokens: 12,
+							output_tokens: 8,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		for await (const _ of stream) {
+			// drain stream
+		}
+		const result = await stream.result();
+
+		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "done" }]);
+	});
+
 	it("passes Umans gateway web search headers to custom clients", async () => {
 		type CapturedPayload = { tools?: Array<{ name?: string }> };
 		let capturedParams: CapturedPayload | undefined;

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -6,8 +6,10 @@ import {
 	type AnthropicMessagesClientLike,
 	type AnthropicRequestOptions,
 } from "@oh-my-pi/pi-ai/providers/anthropic-client";
+import type { WebSearchToolResultBlockParam } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { AssistantMessageEvent, Context, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { structuredCloneJSON } from "@oh-my-pi/pi-utils";
 import { withEnv } from "./helpers";
 
 const model: Model<"anthropic-messages"> = buildModel({
@@ -544,6 +546,132 @@ describe("anthropic stream envelope handling", () => {
 		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "59" }]);
 	});
 
+	it("replays native server-tool blocks in their original assistant order", async () => {
+		const searchResult: WebSearchToolResultBlockParam = {
+			type: "web_search_tool_result",
+			tool_use_id: "srvtoolu_1",
+			content: [
+				{
+					type: "web_search_result",
+					url: "https://example.com/result",
+					title: "Search result",
+					encrypted_content: "encrypted-result",
+					page_age: "July 24, 2026",
+				},
+			],
+		};
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() =>
+				createMockRequest([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_native_search",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+					{ type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } },
+					{ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "Search first." } },
+					{ type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "sig-1" } },
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "content_block_start",
+						index: 1,
+						content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search" },
+					},
+					{
+						type: "content_block_delta",
+						index: 1,
+						delta: { type: "input_json_delta", partial_json: '{"query":"current weather"}' },
+					},
+					{ type: "content_block_stop", index: 1 },
+					{ type: "content_block_start", index: 2, content_block: searchResult },
+					{ type: "content_block_stop", index: 2 },
+					{ type: "content_block_start", index: 3, content_block: { type: "thinking", thinking: "" } },
+					{ type: "content_block_delta", index: 3, delta: { type: "thinking_delta", thinking: "Read the file." } },
+					{ type: "content_block_delta", index: 3, delta: { type: "signature_delta", signature: "sig-2" } },
+					{ type: "content_block_stop", index: 3 },
+					{ type: "content_block_start", index: 4, content_block: { type: "text", text: "" } },
+					{ type: "content_block_delta", index: 4, delta: { type: "text_delta", text: "I found the forecast." } },
+					{ type: "content_block_stop", index: 4 },
+					{
+						type: "content_block_start",
+						index: 5,
+						content_block: { type: "tool_use", id: "tool_1", name: "read", input: {} },
+					},
+					{
+						type: "content_block_delta",
+						index: 5,
+						delta: { type: "input_json_delta", partial_json: '{"path":"forecast.txt"}' },
+					},
+					{ type: "content_block_stop", index: 5 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "tool_use" },
+						usage: {
+							input_tokens: 12,
+							output_tokens: 20,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+							server_tool_use: { web_search_requests: 1 },
+						},
+					},
+					{ type: "message_stop" },
+				]) as never,
+		);
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		for await (const _ of stream) {
+			// drain stream
+		}
+		const result = await stream.result();
+		const persistedResult = structuredCloneJSON(result);
+		const replay = convertAnthropicMessages(
+			[
+				context.messages[0],
+				persistedResult,
+				{
+					role: "toolResult",
+					toolCallId: "tool_1",
+					toolName: "read",
+					content: [{ type: "text", text: "forecast contents" }],
+					isError: false,
+					timestamp: 2,
+				},
+			],
+			model,
+			false,
+		);
+		const assistant = replay.find(message => message.role === "assistant");
+
+		expect(assistant?.content).toEqual([
+			{ type: "thinking", thinking: "Search first.", signature: "sig-1" },
+			{
+				type: "server_tool_use",
+				id: "srvtoolu_1",
+				name: "web_search",
+				input: { query: "current weather" },
+			},
+			searchResult,
+			{ type: "thinking", thinking: "Read the file.", signature: "sig-2" },
+			{ type: "text", text: "I found the forecast." },
+			{ type: "tool_use", id: "tool_1", name: "read", input: { path: "forecast.txt" } },
+		]);
+		expect(replay.at(-1)?.content).toEqual([
+			{
+				type: "tool_result",
+				tool_use_id: "tool_1",
+				content: "forecast contents",
+				is_error: false,
+			},
+		]);
+	});
+
 	it("passes Umans gateway web search headers to custom clients", async () => {
 		type CapturedPayload = { tools?: Array<{ name?: string }> };
 		let capturedParams: CapturedPayload | undefined;
@@ -906,7 +1034,7 @@ describe("anthropic stream envelope handling", () => {
 			{
 				type: "content_block_start",
 				index: 0,
-				content_block: { type: "server_tool_use", id: "srv_1", name: "web_search" },
+				content_block: { type: "future_server_block", id: "srv_1", name: "web_search" },
 			},
 			{
 				type: "content_block_delta",

--- a/packages/ai/test/auth-gateway-anthropic-messages.test.ts
+++ b/packages/ai/test/auth-gateway-anthropic-messages.test.ts
@@ -344,6 +344,28 @@ describe("anthropic-messages parseRequest", () => {
 		]);
 	});
 
+	it("flattens malformed web-search history blocks instead of preserving invalid replay state", () => {
+		const parsed = parseRequest({
+			model: "claude-opus-4-7",
+			max_tokens: 8,
+			messages: [
+				{ role: "user", content: "weather?" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "server_tool_use", name: "web_search" },
+						{ type: "web_search_tool_result", tool_use_id: "srvtoolu_1" },
+						{ type: "web_search_tool_result", content: [] },
+					],
+				},
+			],
+		});
+		const assistant = parsed.context.messages.find(message => message.role === "assistant");
+		expect(assistant?.content).toHaveLength(3);
+		expect(assistant?.content.every(block => block.type === "text")).toBe(true);
+		expect(assistant?.content.some(block => block.type === "anthropicServerTool")).toBe(false);
+	});
+
 	it("does not retain a partial code-execution server-tool history", () => {
 		const parsed = parseRequest({
 			model: "claude-opus-4-7",

--- a/packages/ai/test/auth-gateway-anthropic-messages.test.ts
+++ b/packages/ai/test/auth-gateway-anthropic-messages.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { encodeResponse, encodeStream, parseRequest } from "@oh-my-pi/pi-ai/providers/anthropic-messages-server";
-import type { ServerToolUseBlockParam, WebSearchToolResultBlockParam } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
+import type {
+	WebSearchServerToolUseBlockParam,
+	WebSearchToolResultBlockParam,
+} from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { AssistantMessage, AssistantMessageEvent, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
@@ -297,8 +300,8 @@ describe("anthropic-messages parseRequest", () => {
 		expect(unknown.context.messages).toHaveLength(1);
 	});
 
-	it("preserves inbound assistant server_tool_use/web_search_tool_result blocks verbatim", () => {
-		const serverToolUse: ServerToolUseBlockParam = {
+	it("preserves inbound assistant web-search call/result blocks verbatim", () => {
+		const serverToolUse: WebSearchServerToolUseBlockParam = {
 			type: "server_tool_use",
 			id: "srvtoolu_1",
 			name: "web_search",
@@ -339,6 +342,42 @@ describe("anthropic-messages parseRequest", () => {
 			{ type: "anthropicServerTool", block: searchResult },
 			{ type: "text", text: "forecast ready" },
 		]);
+	});
+
+	it("does not retain a partial code-execution server-tool history", () => {
+		const parsed = parseRequest({
+			model: "claude-opus-4-7",
+			max_tokens: 8,
+			messages: [
+				{ role: "user", content: "run code" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "server_tool_use",
+							id: "srvtoolu_code",
+							name: "bash_code_execution",
+							input: { command: "printf ok" },
+						},
+						{
+							type: "bash_code_execution_tool_result",
+							tool_use_id: "srvtoolu_code",
+							content: {
+								type: "bash_code_execution_result",
+								stdout: "ok",
+								stderr: "",
+								return_code: 0,
+								content: [],
+							},
+						},
+					],
+				},
+			],
+		});
+		const assistant = parsed.context.messages.find(message => message.role === "assistant");
+		expect(assistant?.content).toHaveLength(2);
+		expect(assistant?.content.every(block => block.type === "text")).toBe(true);
+		expect(assistant?.content.some(block => block.type === "anthropicServerTool")).toBe(false);
 	});
 });
 

--- a/packages/ai/test/auth-gateway-anthropic-messages.test.ts
+++ b/packages/ai/test/auth-gateway-anthropic-messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { encodeResponse, encodeStream, parseRequest } from "@oh-my-pi/pi-ai/providers/anthropic-messages-server";
+import type { ServerToolUseBlockParam, WebSearchToolResultBlockParam } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { AssistantMessage, AssistantMessageEvent, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
@@ -294,6 +295,50 @@ describe("anthropic-messages parseRequest", () => {
 			],
 		});
 		expect(unknown.context.messages).toHaveLength(1);
+	});
+
+	it("preserves inbound assistant server_tool_use/web_search_tool_result blocks verbatim", () => {
+		const serverToolUse: ServerToolUseBlockParam = {
+			type: "server_tool_use",
+			id: "srvtoolu_1",
+			name: "web_search",
+			input: { query: "weather" },
+		};
+		const searchResult: WebSearchToolResultBlockParam = {
+			type: "web_search_tool_result",
+			tool_use_id: "srvtoolu_1",
+			content: [
+				{
+					type: "web_search_result",
+					url: "https://example.com/weather",
+					title: "Weather",
+					encrypted_content: "encrypted-result",
+				},
+			],
+		};
+		const parsed = parseRequest({
+			model: "claude-opus-4-7",
+			max_tokens: 8,
+			messages: [
+				{ role: "user", content: "weather?" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "search", signature: "sig-1" },
+						serverToolUse,
+						searchResult,
+						{ type: "text", text: "forecast ready" },
+					],
+				},
+			],
+		});
+		const assistant = parsed.context.messages.find(message => message.role === "assistant");
+		expect(assistant?.content).toEqual([
+			{ type: "thinking", thinking: "search", thinkingSignature: "sig-1" },
+			{ type: "anthropicServerTool", block: serverToolUse },
+			{ type: "anthropicServerTool", block: searchResult },
+			{ type: "text", text: "forecast ready" },
+		]);
 	});
 });
 

--- a/packages/ai/test/auth-gateway-anthropic-messages.test.ts
+++ b/packages/ai/test/auth-gateway-anthropic-messages.test.ts
@@ -503,6 +503,99 @@ describe("anthropic-messages encodeStream", () => {
 		expect(sse[14]!.data).toEqual({ type: "message_stop" });
 	});
 
+	it("emits persisted server-tool blocks before the next streamed content block", async () => {
+		const finalMessage: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "search first", thinkingSignature: "SIG" },
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "server_tool_use",
+						id: "srvtoolu_1",
+						name: "web_search",
+						input: { query: "weather" },
+					},
+				},
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvtoolu_1",
+						content: [
+							{
+								type: "web_search_result",
+								url: "https://example.com/weather",
+								title: "Weather",
+								encrypted_content: "encrypted-result",
+							},
+						],
+					},
+				},
+				{ type: "text", text: "forecast ready" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-opus-4-7",
+			usage: emptyUsage(),
+			stopReason: "stop",
+			timestamp: 0,
+		};
+		const events: AssistantMessageEvent[] = [
+			{ type: "start", partial: finalMessage },
+			{ type: "thinking_start", contentIndex: 0, partial: finalMessage },
+			{ type: "thinking_delta", contentIndex: 0, delta: "search first", partial: finalMessage },
+			{ type: "thinking_end", contentIndex: 0, content: "search first", partial: finalMessage },
+			{ type: "text_start", contentIndex: 3, partial: finalMessage },
+			{ type: "text_delta", contentIndex: 3, delta: "forecast ready", partial: finalMessage },
+			{ type: "text_end", contentIndex: 3, content: "forecast ready", partial: finalMessage },
+			{ type: "done", reason: "stop", message: finalMessage },
+		];
+
+		const sse = await collectSse(encodeStream(makeStream(events), "claude-opus-4-7"));
+		expect(sse.filter(event => event.event === "content_block_start").map(event => event.data)).toEqual([
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "thinking", thinking: "" },
+			},
+			{
+				type: "content_block_start",
+				index: 1,
+				content_block: {
+					type: "server_tool_use",
+					id: "srvtoolu_1",
+					name: "web_search",
+					input: { query: "weather" },
+				},
+			},
+			{
+				type: "content_block_start",
+				index: 2,
+				content_block: {
+					type: "web_search_tool_result",
+					tool_use_id: "srvtoolu_1",
+					content: [
+						{
+							type: "web_search_result",
+							url: "https://example.com/weather",
+							title: "Weather",
+							encrypted_content: "encrypted-result",
+						},
+					],
+				},
+			},
+			{
+				type: "content_block_start",
+				index: 3,
+				content_block: { type: "text", text: "" },
+			},
+		]);
+		expect(sse.filter(event => event.event === "content_block_stop").map(event => event.data.index)).toEqual([
+			0, 1, 2, 3,
+		]);
+	});
+
 	it("emits an error event when the upstream stream errors", async () => {
 		const errMessage: AssistantMessage = {
 			role: "assistant",

--- a/packages/coding-agent/src/export/share.ts
+++ b/packages/coding-agent/src/export/share.ts
@@ -400,8 +400,9 @@ function redactShareMessage(
 			};
 		case "assistant":
 			// Drop opaque provider-replay state (encrypted reasoning / native history) the viewer
-			// never reads and we cannot redact field-by-field: `providerPayload` and any
-			// `redactedThinking` blocks.
+			// never reads and we cannot redact field-by-field: `providerPayload`, any
+			// `redactedThinking` blocks, and native Anthropic server-tool blocks
+			// (`server_tool_use` input / `web_search_tool_result` encrypted_content).
 			return {
 				...message,
 				providerPayload: undefined,
@@ -410,7 +411,7 @@ function redactShareMessage(
 						? undefined
 						: o.obfuscate(message.errorMessage, sharedRegexSecretValues),
 				content: message.content.flatMap((block): AssistantMessage["content"] => {
-					if (block.type === "redactedThinking") return [];
+					if (block.type === "redactedThinking" || block.type === "anthropicServerTool") return [];
 					if (block.type === "text") return [{ ...block, text: o.obfuscate(block.text, sharedRegexSecretValues) }];
 					if (block.type === "thinking") {
 						return [{ ...block, thinking: o.obfuscate(block.thinking, sharedRegexSecretValues) }];

--- a/packages/coding-agent/src/session/queued-messages.ts
+++ b/packages/coding-agent/src/session/queued-messages.ts
@@ -44,7 +44,13 @@ export function isTerminalTextAssistantAnswer(message: AgentMessage | undefined)
 			if (part.text.trim().length > 0) hasText = true;
 			continue;
 		}
-		if (part.type === "thinking" || part.type === "redactedThinking" || part.type === "fallback") continue;
+		if (
+			part.type === "thinking" ||
+			part.type === "redactedThinking" ||
+			part.type === "fallback" ||
+			part.type === "anthropicServerTool"
+		)
+			continue;
 		return false;
 	}
 	return hasText;

--- a/packages/coding-agent/test/share.test.ts
+++ b/packages/coding-agent/test/share.test.ts
@@ -174,6 +174,7 @@ describe("buildShareSnapshot", () => {
 	test("redacts assistant tool calls / error messages and bash meta, and drops provider replay payloads", () => {
 		const secret = "asst-secret-ABCDE";
 		const replaySentinel = "REPLAY_BLOB_SENTINEL_XYZ";
+		const serverToolSentinel = "SERVER_TOOL_ENCRYPTED_SENTINEL_QWE";
 		const ts = "2026-06-12T00:00:00.000Z";
 		const usage = {
 			input: 0,
@@ -200,6 +201,23 @@ describe("buildShareSnapshot", () => {
 							arguments: { path: `/x/${secret}` },
 							intent: `intent ${secret}`,
 							rawBlock: `raw ${secret}`,
+						},
+						{
+							type: "anthropicServerTool",
+							block: {
+								type: "server_tool_use",
+								id: "srvtoolu_1",
+								name: "web_search",
+								input: { query: `find ${secret}` },
+							},
+						},
+						{
+							type: "anthropicServerTool",
+							block: {
+								type: "web_search_tool_result",
+								tool_use_id: "srvtoolu_1",
+								content: [{ type: "web_search_result", encrypted_content: serverToolSentinel }],
+							},
 						},
 					],
 					api: "test",
@@ -246,6 +264,9 @@ describe("buildShareSnapshot", () => {
 		// Opaque provider-replay payload is dropped wholesale — the sentinel is NOT a configured secret,
 		// so its absence proves the subtree was removed rather than merely obfuscated.
 		expect(flat).not.toContain(replaySentinel);
+		// Native Anthropic server-tool blocks are opaque provider-replay state: dropped wholesale,
+		// so neither the obfuscated query secret nor the encrypted result sentinel can leak.
+		expect(flat).not.toContain(serverToolSentinel);
 		// Source entries keep the real values; redaction is share-only.
 		expect(JSON.stringify(entries)).toContain(secret);
 	});


### PR DESCRIPTION
## Repro
A focused Messages API stream emits `thinking → server_tool_use → web_search_tool_result → thinking → text → tool_use`; before this fix, `bun test packages/ai/test/anthropic-stream-envelope.test.ts --test-name-pattern "replays native server-tool"` failed because replay contained only `thinking → thinking → text → tool_use`.

## Cause
`streamAnthropic()` in `packages/ai/src/providers/anthropic.ts` classified `server_tool_use` and `web_search_tool_result` content blocks as ignored, while `AssistantMessage.content` and `convertAnthropicMessages()` had no serializable representation or replay encoder for them.

## Fix
- Persist Anthropic server-tool calls and web-search results as verbatim provider-specific assistant content blocks, including streamed server-tool input and encrypted result fields.
- Retain those blocks only for same-provider Anthropic replay, encode them in original assistant order, and keep the existing Umans gateway filtering behavior.
- Cover stream parsing, a persistence-equivalent JSON clone, assistant replay order, and the following client `tool_result` with a regression fixture.

## Verification
`bun test packages/ai/test/anthropic-stream-envelope.test.ts` passes: 31 tests, 171 assertions. `bun run check:ts` passes across all TypeScript workspaces. Skipped the pre-publish gate because `bun check` fails on a clean `origin/main` worktree in unrelated Rust Cargo workspace discovery; this PR changes no Rust paths.

Fixes #6495