### PR TITLE
fix(coding-agent): count only rendered skills in /context accounting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/context` counting hidden, explicit-only skills (`hide: true` / `disable-model-invocation`) in the Skills category and subtracting that inflated estimate from the first system-prompt block, which reported `System prompt: 0 tokens` and inflated Skills usage. Accounting now counts only the skills actually rendered into the system prompt — mirroring `buildSystemPrompt`'s filter, so hidden skills and all skills when the `read` tool is unavailable contribute zero ([#6498](https://github.com/can1357/oh-my-pi/issues/6498)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -56,6 +56,22 @@ const EMPTY_STRING_PARTS: string[] = [];
 const EMPTY_TOOLS: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">> = [];
 const EMPTY_SKILLS: readonly Skill[] = [];
 
+/**
+ * Skills actually rendered into the system prompt, mirroring the filter in
+ * `buildSystemPrompt` (`system-prompt.ts`): the `read` tool must be present so
+ * the model can fetch skill content, and skills with frontmatter `hide: true`
+ * (or `disable-model-invocation`, normalized onto `hide`) are excluded.
+ * Accounting must count only these so the Skills category and the System-prompt
+ * subtraction stay aligned with the provider-facing prompt.
+ */
+function renderedSkills(
+	skills: readonly Skill[],
+	tools: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">>,
+): readonly Skill[] {
+	if (!tools.some(tool => tool.name === "read")) return EMPTY_SKILLS;
+	return skills.filter(skill => skill.hide !== true);
+}
+
 export function estimateSkillsTokens(skills: readonly Skill[]): number {
 	const fragments: string[] = [];
 	for (const skill of skills) {
@@ -171,8 +187,9 @@ export function computeNonMessageBreakdown(session: NonMessageTokenSource): {
 } {
 	const entry = nonMessageTokenCacheEntry(session);
 	if (entry.breakdown) return entry.breakdown;
-	const skillsTokens = estimateSkillsTokens(session.skills ?? EMPTY_SKILLS);
-	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? EMPTY_TOOLS);
+	const tools = session.agent?.state?.tools ?? EMPTY_TOOLS;
+	const skillsTokens = estimateSkillsTokens(renderedSkills(session.skills ?? EMPTY_SKILLS, tools));
+	const toolsTokens = estimateToolSchemaTokens(tools);
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const systemContextTokens = countTokens(systemPromptParts.slice(1));
 	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens);

--- a/packages/coding-agent/test/modes/context-usage.test.ts
+++ b/packages/coding-agent/test/modes/context-usage.test.ts
@@ -137,3 +137,36 @@ describe("computeNonMessageTokens / computeNonMessageBreakdown memoization", () 
 		expect(computeNonMessageBreakdown(session as never).systemPromptTokens).not.toBe(breakdown.systemPromptTokens);
 	});
 });
+
+/**
+ * Contract: the Skills category counts only skills actually rendered into the
+ * system prompt (mirroring `buildSystemPrompt`'s filter) — hidden/explicit-only
+ * skills, and every skill when the `read` tool is absent, contribute zero. The
+ * System-prompt subtraction must not be inflated by unrendered skill metadata
+ * and clamped to 0 (issue #6498).
+ */
+describe("computeNonMessageBreakdown skills filtering", () => {
+	const readTool = { name: "read", description: "read files", parameters: {} };
+	const hidden = { name: "hidden-skill", description: "X".repeat(4000), filePath: "/s/h.md", hide: true };
+	const visible = { name: "vis", description: "small visible skill", filePath: "/s/v.md" };
+	// First prompt block as rendered: only the visible skill appears.
+	const renderedPrompt = "You are an agent.\nSkills:\n- vis: small visible skill\n";
+
+	function session(tools: unknown[], skills: unknown[]) {
+		return { systemPrompt: [renderedPrompt], agent: { state: { tools } }, skills } as never;
+	}
+
+	it("excludes hidden skills and does not clamp System prompt to 0", () => {
+		const b = computeNonMessageBreakdown(session([readTool], [hidden, visible]));
+		// Only the visible skill is counted, not the large hidden one.
+		expect(b.skillsTokens).toBe(computeNonMessageBreakdown(session([readTool], [visible])).skillsTokens);
+		expect(b.skillsTokens).toBeLessThan(100);
+		expect(b.systemPromptTokens).toBeGreaterThan(0);
+	});
+
+	it("counts zero Skills tokens when the read tool is unavailable", () => {
+		const b = computeNonMessageBreakdown(session([], [hidden, visible]));
+		expect(b.skillsTokens).toBe(0);
+		expect(b.systemPromptTokens).toBe(computeNonMessageBreakdown(session([], [])).systemPromptTokens);
+	});
+});


### PR DESCRIPTION
## Repro
With multiple global skills marked `hide: true` (or `disable-model-invocation: true`), `/context` reports `System prompt: 0 tokens` and inflates Skills to ~16K, even though those skills are excluded from the provider-facing prompt. Driving the real accounting function `computeNonMessageBreakdown` with a hidden skill plus a rendered first system-prompt block containing only the visible skill reproduces it:

```json
{ "visibleSkillTokens": 6, "allSkillTokens": 15010, "reportedSkillsTokens": 15010, "reportedSystemPromptTokens": 0 }
```

## Cause
`computeNonMessageBreakdown` in `packages/coding-agent/src/modes/utils/context-usage.ts` estimated Skills from the unfiltered `session.skills` registry (`estimateSkillsTokens(session.skills ?? EMPTY_SKILLS)`) and subtracted that from `countTokens(systemPromptParts[0])`. But `buildSystemPrompt` (`system-prompt.ts`) only renders `filteredSkills = hasRead ? skills.filter(s => s.hide !== true) : []`. The first prompt block therefore only ever contained the rendered skills, so subtracting the full registry over-counted Skills and clamped System prompt to 0.

## Fix
- Add a `renderedSkills(skills, tools)` helper in `context-usage.ts` mirroring `buildSystemPrompt`'s filter: requires the `read` tool, drops `skill.hide === true`.
- Use it for the Skills estimate in `computeNonMessageBreakdown`, reusing the same resolved `tools` array for the tool-schema estimate.
- Regression tests in `context-usage.test.ts`: hidden skills excluded and System prompt not clamped to 0; zero Skills tokens when `read` is absent.

## Verification
`bun test test/modes/context-usage.test.ts` — 9 pass, 0 fail. Re-running the repro after the fix reports `reportedSkillsTokens: 6`, `reportedSystemPromptTokens: 8`. Fixes #6498