### PR TITLE
fix(ai): retry statusless provider capacity errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed statusless provider capacity errors such as `no_capacity` and high-demand responses being treated as terminal instead of retryable. ([#6503](https://github.com/can1357/oh-my-pi/issues/6503))
+
 ## [17.1.1] - 2026-07-24
 
 ### Added
@@ -24,7 +28,6 @@
 
 - Fixed stateful OpenAI Responses explicit cache breakpoints being restored onto edited historical messages, ensuring full replays recompute the latest stable cache boundary.
 - Fixed ChatGPT Codex standard and Lite transports rejecting or hiding native computer-use payloads by unrolling the tool definition, forced choice, `computer_call`, and `computer_call_output` into ordinary function-tool forms.
-- Fixed statusless provider capacity errors such as `no_capacity` and high-demand responses being treated as terminal instead of retryable. ([#6503](https://github.com/can1357/oh-my-pi/issues/6503))
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fixed stateful OpenAI Responses explicit cache breakpoints being restored onto edited historical messages, ensuring full replays recompute the latest stable cache boundary.
 - Fixed ChatGPT Codex standard and Lite transports rejecting or hiding native computer-use payloads by unrolling the tool definition, forced choice, `computer_call`, and `computer_call_output` into ordinary function-tool forms.
+- Fixed statusless provider capacity errors such as `no_capacity` and high-demand responses being treated as terminal instead of retryable. ([#6503](https://github.com/can1357/oh-my-pi/issues/6503))
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -90,7 +90,7 @@ const TRANSIENT_ENVELOPE_PATTERN = /anthropic stream envelope error:/i;
 const TRANSIENT_ENVELOPE_BEFORE_START_PATTERN = /before message_start/i;
 export const STREAM_READ_ERROR_PATTERN = /stream[_ -]?read[_ -]?error/i;
 export const TRANSIENT_TRANSPORT_PATTERN =
-	/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|unable.?to.?connect\.\s*is the computer able to access the url\?|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|malformed.?function.?call/i;
+	/\b(?:no[_ -]?capacity|(?:high|peak)[ _-]?demand|(?:at|over|insufficient)[ _-]?capacity|capacity[ _-]?(?:exceeded|exhausted)|peak[ _-]?load)\b|overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|unable.?to.?connect\.\s*is the computer able to access the url\?|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|malformed.?function.?call/i;
 const AUTH_FAILURE_PATTERN =
 	/\b(?:401|403|unauthorized|forbidden|authentication|auth[_ ]?unavailable|no auth available|(?:invalid|no)[_ ]?api[_ ]?key)\b/i;
 const MALFORMED_FUNCTION_CALL_PATTERN = /\bmalformed.?function.?call\b/i;

--- a/packages/ai/test/error-aierr.test.ts
+++ b/packages/ai/test/error-aierr.test.ts
@@ -23,6 +23,25 @@ describe("AIError.classify — structural provider errors", () => {
 		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
 	});
 
+	it("classifies statusless provider capacity errors as transient and retryable", () => {
+		const messages = [
+			"Error Code no_capacity: The system is currently experiencing high demand",
+			"Provider is at capacity",
+			"Insufficient capacity during peak load",
+			"Capacity exhausted",
+		];
+		for (const message of messages) {
+			const id = AIError.classify(new Error(message));
+			expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
+			expect(AIError.retriable(id)).toBe(true);
+		}
+	});
+
+	it("does not treat benign capacity descriptions as transient", () => {
+		const id = AIError.classify(new Error("This model has a 128k token capacity"));
+		expect(AIError.is(id, AIError.Flag.Transient)).toBe(false);
+	});
+
 	it("maps 401/403 to authFailed via status", () => {
 		expect(
 			AIError.is(AIError.classify(new AIError.ProviderHttpError("Unauthorized", 401)), AIError.Flag.AuthFailed),


### PR DESCRIPTION
## Repro
On current `main`, classifying the reported bare proxy error produces no flags and is not retryable. Command: `bun -e 'import * as AIError from "@oh-my-pi/pi-ai/error"; const message = "Error: Error Code no_capacity: The system is currently experiencing high demand and cannot process your request."; const id = AIError.classify(new Error(message)); console.log(JSON.stringify({ transient: AIError.is(id, AIError.Flag.Transient), retryable: AIError.retriable(id), id })); process.exit(AIError.retriable(id) ? 0 : 1);'` exited 1 with `{"transient":false,"retryable":false,"id":0}` before the fix.

## Cause
`packages/ai/src/error/flags.ts` classifies statusless errors through `TRANSIENT_TRANSPORT_PATTERN`; that pattern covered overload, rate-limit, timeout, and 5xx wording but omitted explicit capacity and demand phrases, so `AIError.classify` emitted no transient flag and `TurnRecovery.isRetryableError` rejected the turn.

## Fix
- Recognize conservative capacity-exhaustion phrasings including `no_capacity`, high/peak demand, at/over/insufficient capacity, exhausted/exceeded capacity, and peak load.
- Cover retryability and the benign-capacity false-positive boundary in `packages/ai/test/error-aierr.test.ts`.
- Record the fix in the AI package changelog.

## Verification
`bun test packages/ai/test/error-aierr.test.ts` passed: 20 tests, 0 failures. Re-running the exact repro now exits 0 with `{"transient":true,"retryable":true,"id":135168}`. The pre-publish `bun run fix` and `bun check` gate passed through `gh_push_branch`.

Fixes #6503