### PR TITLE
fix(coding-agent): honor modelRoles.default over cursor/default catalog id

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--model default` (and other bare role names) resolving to the bundled `cursor/default` catalog model instead of the configured `modelRoles.default` role. `resolveCliModel`'s exact-match phase ran its unauthenticated catalog fallback before role resolution, so a bundled id colliding with a reserved role name shadowed a configured, runnable role — failing with `No API key found for cursor` on machines without Cursor credentials. The catalog fallback is now deferred so an authenticated exact model still wins, a configured role beats an unauthenticated catalog-only id, and the catalog id is still recovered when no role matches ([#6508](https://github.com/can1357/oh-my-pi/issues/6508)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/coding-agent/src/cli/bench-cli.ts
+++ b/packages/coding-agent/src/cli/bench-cli.ts
@@ -76,6 +76,7 @@ export interface BenchCommandArgs {
 
 export interface BenchModelRegistry {
 	getAll(): Model<Api>[];
+	getAvailable(): Model<Api>[];
 	getApiKey(model: Model<Api>, sessionId?: string): Promise<string | undefined>;
 	resolver(model: ApiKeyResolverModel, sessionId?: string): ApiKeyResolver;
 	hasConfiguredAuth?(model: Model<Api>): boolean;

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1601,6 +1601,7 @@ function findExactCliModel(
 	selector: string,
 	allModels: Model<Api>[],
 	availableModels: Model<Api>[],
+	options?: { catalogFallback?: boolean },
 ): Model<Api> | undefined {
 	// Explicit provider/id references stay authoritative against the full catalog.
 	const referenced = findExactModelReferenceMatch(selector, allModels);
@@ -1615,6 +1616,13 @@ function findExactCliModel(
 		model.id.toLowerCase() === lower || formatModelString(model).toLowerCase() === lower;
 	const preferred = availableModels.find(isFlatMatch);
 	if (preferred) return preferred;
+	// The unauthenticated catalog fallback is a weak match: a bare id like
+	// `default` collides with the bundled `cursor/default` model, which must not
+	// shadow a configured `modelRoles.default` role the user can actually run.
+	// Callers resolving a possible role name pass `catalogFallback: false` so the
+	// role gets a chance first; the deferred fuzzy fallback below still recovers
+	// the catalog id when no role matches.
+	if (options?.catalogFallback === false) return undefined;
 	return availableModels === allModels ? undefined : allModels.find(isFlatMatch);
 }
 
@@ -1635,7 +1643,10 @@ export interface ResolveCliModelResult {
 /**
  * Resolve a single model from CLI flags.
  *
- * Exact model names take precedence over configured role names.
+ * Explicit `provider/id` references and authenticated bare ids take precedence
+ * over configured role names, which in turn take precedence over an
+ * unauthenticated catalog-only id (so a bundled `cursor/default` never shadows a
+ * configured `modelRoles.default`).
  */
 export function resolveCliModel(options: {
 	cliProvider?: string;
@@ -1680,7 +1691,7 @@ export function resolveCliModel(options: {
 
 	const trimmedModel = cliModel.trim();
 	if (!provider) {
-		const exact = findExactCliModel(trimmedModel, allModels, availableModels);
+		const exact = findExactCliModel(trimmedModel, allModels, availableModels, { catalogFallback: false });
 		if (exact) {
 			return {
 				model: exact,
@@ -1696,7 +1707,7 @@ export function resolveCliModel(options: {
 			MAX_THINKING_SUFFIX_OPTIONS,
 		);
 		if (exactThinkingLevel) {
-			const exactSuffixed = findExactCliModel(exactBase, allModels, availableModels);
+			const exactSuffixed = findExactCliModel(exactBase, allModels, availableModels, { catalogFallback: false });
 			if (exactSuffixed) {
 				return {
 					model: exactSuffixed,

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -466,7 +466,7 @@ export interface ModelMatchPreferences {
 }
 
 export type ModelLookupRegistry = Pick<ModelRegistry, "getAvailable">;
-type CliModelRegistry = Pick<ModelRegistry, "getAll">;
+type CliModelRegistry = Pick<ModelRegistry, "getAll" | "getAvailable">;
 type InitialModelRegistry = Pick<ModelRegistry, "getAvailable" | "find">;
 type RestorableModelRegistry = Pick<ModelRegistry, "getAvailable" | "find" | "getApiKey">;
 
@@ -1652,7 +1652,7 @@ export function resolveCliModel(options: {
 	cliProvider?: string;
 	cliModel?: string;
 	modelRegistry: CliModelRegistry;
-	/** Authenticated models to prefer for unqualified selectors; omit to preserve catalog-order behavior. */
+	/** Authenticated models to prefer for unqualified selectors; defaults to the registry's authenticated set. */
 	availableModels?: Model<Api>[];
 	settings?: Settings;
 	preferences?: ModelMatchPreferences;
@@ -1673,7 +1673,7 @@ export function resolveCliModel(options: {
 		};
 	}
 
-	const availableModels = preferredModels ?? allModels;
+	const availableModels = preferredModels ?? modelRegistry.getAvailable();
 	const providerMap = new Map<string, string>();
 	for (const model of allModels) {
 		providerMap.set(model.provider.toLowerCase(), model.provider);

--- a/packages/coding-agent/test/bench-auth-fallback.test.ts
+++ b/packages/coding-agent/test/bench-auth-fallback.test.ts
@@ -65,6 +65,7 @@ function fakeRegistry(opts: FakeRegistryOptions): BenchModelRegistry {
 	const authed = new Set(opts.authedProviders);
 	return {
 		getAll: () => opts.models,
+		getAvailable: () => opts.models.filter(model => authed.has(model.provider)),
 		hasConfiguredAuth: model => authed.has(model.provider),
 		getApiKey: async model => (authed.has(model.provider) ? "sk-test" : undefined),
 		resolver: () => (() => Promise.resolve("sk-test")) as unknown as ApiKeyResolver,

--- a/packages/coding-agent/test/bench-cache.test.ts
+++ b/packages/coding-agent/test/bench-cache.test.ts
@@ -38,6 +38,7 @@ const codexModel = {
 
 const registry: BenchModelRegistry = {
 	getAll: () => [model],
+	getAvailable: () => [model],
 	getApiKey: async () => "sk-test",
 	resolver: () => (() => Promise.resolve("sk-test")) as unknown as ApiKeyResolver,
 };

--- a/packages/coding-agent/test/issue-980-bedrock-priority.test.ts
+++ b/packages/coding-agent/test/issue-980-bedrock-priority.test.ts
@@ -52,6 +52,7 @@ describe("issue #980 provider-qualified model resolution", () => {
 			cliModel: "anthropic/claude-3-7-sonnet",
 			modelRegistry: {
 				getAll: () => availableModels,
+				getAvailable: () => availableModels,
 			},
 		});
 		expect(cliResolved.model).toBeUndefined();

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1189,6 +1189,71 @@ describe("resolveCliModel", () => {
 		expect(suffixed.thinkingLevel).toBe(Effort.High);
 	});
 
+	test("configured role beats an unauthenticated catalog id collision (#6508)", () => {
+		// A bundled `cursor/default` model has the bare id `default`, which collides
+		// with the reserved `default` role selector. When the user has no Cursor
+		// credentials the catalog entry is not authenticated, so it must not shadow
+		// a configured, runnable `modelRoles.default`.
+		const cursorDefault = buildModel({
+			id: "default",
+			name: "Cursor Default",
+			api: "anthropic-messages",
+			provider: "cursor",
+			baseUrl: "https://cursor.sh",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		});
+		const registry = { getAll: () => [...allModels, cursorDefault] };
+		const settings = Settings.isolated({
+			modelRoles: { default: "openai/gpt-4o" },
+		});
+
+		const result = resolveCliModel({
+			cliModel: "default",
+			modelRegistry: registry,
+			settings,
+			// Authenticated set omits the catalog-only Cursor model.
+			availableModels: allModels,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("openai");
+		expect(result.model?.id).toBe("gpt-4o");
+	});
+
+	test("unauthenticated catalog id still resolves when no role matches", () => {
+		// Without a configured role the same bare id must still reach the catalog
+		// model (so `--model default` surfaces the usual "no API key" error rather
+		// than a spurious not-found), confirming the fallback is only deferred.
+		const cursorDefault = buildModel({
+			id: "default",
+			name: "Cursor Default",
+			api: "anthropic-messages",
+			provider: "cursor",
+			baseUrl: "https://cursor.sh",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		});
+		const registry = { getAll: () => [...allModels, cursorDefault] };
+		const settings = Settings.isolated({ modelRoles: {} });
+
+		const result = resolveCliModel({
+			cliModel: "default",
+			modelRegistry: registry,
+			settings,
+			availableModels: allModels,
+		});
+
+		expect(result.model?.provider).toBe("cursor");
+		expect(result.model?.id).toBe("default");
+	});
+
 	test("resolves configured custom, legacy, and default role aliases from --model", () => {
 		const registry = { getAll: () => allModels };
 		const settings = Settings.isolated({

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -992,7 +992,9 @@ describe("resolveModelOverride", () => {
 });
 describe("resolveCliModel", () => {
 	test("resolves --model provider/id without --provider", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openai/gpt-4o",
@@ -1006,9 +1008,7 @@ describe("resolveCliModel", () => {
 
 	test("prefers an authenticated provider for an unqualified exact model id", () => {
 		const availableModels = openaiGpt55Models.filter(model => model.provider === "openai-codex");
-		const registry = {
-			getAll: () => openaiGpt55Models,
-		};
+		const registry = { getAll: () => openaiGpt55Models, getAvailable: () => openaiGpt55Models };
 
 		const result = resolveCliModel({
 			cliModel: "gpt-5.5",
@@ -1043,7 +1043,7 @@ describe("resolveCliModel", () => {
 
 		const result = resolveCliModel({
 			cliModel: "openai/gpt-oss-120b",
-			modelRegistry: { getAll: () => catalog },
+			modelRegistry: { getAll: () => catalog, getAvailable: () => [authenticated] },
 			availableModels: [authenticated],
 		});
 
@@ -1053,7 +1053,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves bare configured role names from --model", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { task: "openai/gpt-4o" },
 		});
@@ -1070,7 +1070,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves bare configured role names with thinking suffixes", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { task: "anthropic/claude-sonnet-4-5" },
 		});
@@ -1088,7 +1088,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("preserves configured role fallback selectors for deferred resolution", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: {
 				task: "openrouter/z-ai/glm-4.7@cerebras,anthropic/claude-sonnet-4-5",
@@ -1105,7 +1105,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("reports when a configured role matches after unresolved candidates", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: {
 				task: "runtime-provider/runtime-model,anthropic/claude-sonnet-4-5",
@@ -1124,7 +1124,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("does not fuzzy-match unresolved configured roles", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { sonnet: "runtime-provider/runtime-model" },
 		});
@@ -1141,7 +1141,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("keeps unknown --model names on the not-found path", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 
 		const result = resolveCliModel({
 			cliModel: "not-a-model",
@@ -1165,7 +1165,7 @@ describe("resolveCliModel", () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		});
-		const registry = { getAll: () => [...allModels, exactModel] };
+		const registry = { getAll: () => [...allModels, exactModel], getAvailable: () => [...allModels, exactModel] };
 		const settings = Settings.isolated({
 			modelRoles: { task: "anthropic/claude-sonnet-4-5" },
 		});
@@ -1206,7 +1206,7 @@ describe("resolveCliModel", () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		});
-		const registry = { getAll: () => [...allModels, cursorDefault] };
+		const registry = { getAll: () => [...allModels, cursorDefault], getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { default: "openai/gpt-4o" },
 		});
@@ -1215,8 +1215,6 @@ describe("resolveCliModel", () => {
 			cliModel: "default",
 			modelRegistry: registry,
 			settings,
-			// Authenticated set omits the catalog-only Cursor model.
-			availableModels: allModels,
 		});
 
 		expect(result.error).toBeUndefined();
@@ -1240,14 +1238,13 @@ describe("resolveCliModel", () => {
 			contextWindow: 128000,
 			maxTokens: 4096,
 		});
-		const registry = { getAll: () => [...allModels, cursorDefault] };
+		const registry = { getAll: () => [...allModels, cursorDefault], getAvailable: () => allModels };
 		const settings = Settings.isolated({ modelRoles: {} });
 
 		const result = resolveCliModel({
 			cliModel: "default",
 			modelRegistry: registry,
 			settings,
-			availableModels: allModels,
 		});
 
 		expect(result.model?.provider).toBe("cursor");
@@ -1255,7 +1252,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves configured custom, legacy, and default role aliases from --model", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: {
 				default: "openai/gpt-4o",
@@ -1289,7 +1286,7 @@ describe("resolveCliModel", () => {
 	});
 
 	test("splits thinking suffixes and abbreviations off the * default alias", () => {
-		const registry = { getAll: () => allModels };
+		const registry = { getAll: () => allModels, getAvailable: () => allModels };
 		const settings = Settings.isolated({
 			modelRoles: { default: "anthropic/claude-sonnet-4-5" },
 		});
@@ -1315,7 +1312,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves fuzzy patterns within an explicit provider", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openai",
@@ -1329,7 +1328,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("supports --model <pattern>:<thinking> (without explicit --thinking)", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "sonnet:high",
@@ -1342,7 +1343,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("prefers exact model id match over provider inference (OpenRouter-style ids)", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openai/gpt-4o:extended",
@@ -1355,7 +1358,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("does not strip invalid :suffix as thinking level in --model (fail fast)", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openai",
@@ -1368,7 +1373,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("supports provider-prefixed OpenRouter route suffixes even when the base model is cataloged without them", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openrouter/z-ai/glm-4.7-20251222:nitro",
@@ -1381,7 +1388,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("supports explicit OpenRouter provider with route suffixes that are not in the catalog", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openrouter",
@@ -1401,12 +1410,12 @@ describe("resolveCliModel", () => {
 		const baseResult = resolveCliModel({
 			cliProvider: "amazon-bedrock",
 			cliModel: profileArn,
-			modelRegistry: { getAll: () => [defaultBedrockModel] },
+			modelRegistry: { getAll: () => [defaultBedrockModel], getAvailable: () => [defaultBedrockModel] },
 		});
 		const offResult = resolveCliModel({
 			cliProvider: "amazon-bedrock",
 			cliModel: `${profileArn}:off`,
-			modelRegistry: { getAll: () => [defaultBedrockModel] },
+			modelRegistry: { getAll: () => [defaultBedrockModel], getAvailable: () => [defaultBedrockModel] },
 		});
 
 		expect(baseResult.error).toBeUndefined();
@@ -1425,7 +1434,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("returns a clear error when there are no models", () => {
-		const registry = { getAll: () => [] } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => [], getAvailable: () => [] } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliProvider: "openai",
@@ -1438,7 +1449,9 @@ describe("resolveCliModel", () => {
 	});
 
 	test("resolves provider-prefixed fuzzy patterns (openrouter/qwen -> openrouter model)", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 
 		const result = resolveCliModel({
 			cliModel: "openrouter/qwen",
@@ -1479,7 +1492,7 @@ describe("resolveCliModel", () => {
 				maxTokens: 4096,
 			}),
 		];
-		const registry = { getAll: () => ambiguousModels } as unknown as Parameters<
+		const registry = { getAll: () => ambiguousModels, getAvailable: () => ambiguousModels } as unknown as Parameters<
 			typeof resolveCliModel
 		>[0]["modelRegistry"];
 
@@ -1843,7 +1856,9 @@ describe("provider routing selector (@upstream)", () => {
 	});
 
 	test("resolveCliModel round-trips @upstream in the selector and carries compat", () => {
-		const registry = { getAll: () => allModels } as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+		const registry = { getAll: () => allModels, getAvailable: () => allModels } as unknown as Parameters<
+			typeof resolveCliModel
+		>[0]["modelRegistry"];
 		const result = resolveCliModel({ cliModel: "openrouter/z-ai/glm-4.7@cerebras", modelRegistry: registry });
 		expect(result.model?.id).toBe("z-ai/glm-4.7");
 		expect(result.selector).toBe("openrouter/z-ai/glm-4.7@cerebras");


### PR DESCRIPTION
## Repro
With `modelRoles.default: openai-codex/gpt-5.6-sol:high` configured and no Cursor credentials, a standalone `omp -p --no-session --no-tools --model default ...` exits 1 with `No API key found for cursor` instead of resolving the configured default role. The distinct exact-model invocation (`--model openai-codex/gpt-5.6-sol`) succeeds in the same install, so this is role-selector resolution, not Codex auth. Reproduced against the current worktree via a unit test on `resolveCliModel` with `cliModel: "default"`, a configured `modelRoles.default`, and a catalog containing a `cursor` model whose bare id is `default` but which is not in the authenticated set — it returned `cursor/default`.

## Cause
The catalog ships a `cursor/default` model whose bare id (`default`) collides with the reserved `default` role selector. `resolveCliModel` (`packages/coding-agent/src/config/model-resolver.ts`) calls `findExactCliModel` at the top of the no-provider branch, before configured-role resolution. `findExactCliModel`'s final tier falls back to `allModels.find(isFlatMatch)` — the full catalog including unauthenticated providers — so the bare id `default` matched `cursor/default` and returned before `modelRoles.default` was ever consulted. On a host without Cursor credentials that model is unusable, hence the `No API key found for cursor` failure.

## Fix
- Added a `{ catalogFallback?: boolean }` option to `findExactCliModel`; when `false` it stops after explicit `provider/id` references and authenticated flat-id matches, skipping the unauthenticated catalog fallback.
- `resolveCliModel` now passes `catalogFallback: false` to both pre-role exact-match calls, so a configured role gets a chance before an unauthenticated catalog-only id.
- Precedence is now: explicit `provider/id` reference / authenticated bare id > configured role > unauthenticated catalog-only id. The trailing fuzzy fallback still recovers the catalog id when no role matches, so `--model default` with no configured role behaves exactly as before (surfaces the usual not-authenticated error).
- Updated the `resolveCliModel` doc comment and added a changelog entry.

## Verification
`bun test test/model-resolver.test.ts` — 143 pass (includes two new regression tests: a configured role beats the unauthenticated `cursor/default` collision, and the catalog id still resolves when no role matches). The pre-existing `prefers an exact model name over a same-named configured role` test still passes, confirming authenticated exact models keep priority. An unrelated pre-existing failure (`Cannot find module './tool-views.generated.js'` in `src/export/html/index.ts`) is a missing codegen artifact in the worktree and does not touch the changed code. Fixes #6508