### PR TITLE
fix(providers): use x-api-key auth for opencode-zen anthropic models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed every Claude (`anthropic-messages`) model on the `opencode-zen` provider failing with `401 Missing API key`: the gateway requires `x-api-key`, so `opencode-zen` now uses X-Api-Key auth like `opencode-go`/`umans` instead of bearer-only, and no longer sends the `context_management` field its Anthropic proxy rejects on thinking requests ([#6510](https://github.com/can1357/oh-my-pi/issues/6510)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2857,27 +2857,15 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		};
 	}
 
-	// OpenCode Go and Umans validate Anthropic-compatible API-key auth through
-	// `X-Api-Key`; bearer-only requests reach the endpoint but fail auth.
-	if (model.provider === "opencode-go" || model.provider === "umans") {
+	// OpenCode Go/Zen and Umans validate Anthropic-compatible API-key auth
+	// through `X-Api-Key`; bearer-only requests reach the endpoint but fail auth
+	// with `401 Missing API key` (#6510). Drop the auto-built `Authorization`
+	// header and keep `apiKey` so the client emits `X-Api-Key`.
+	if (model.provider === "opencode-go" || model.provider === "opencode-zen" || model.provider === "umans") {
 		delete defaultHeaders.Authorization;
 		return {
 			isOAuthToken: false,
 			apiKey,
-			authToken: null,
-			baseURL: baseUrl,
-			maxRetries: 5,
-			defaultHeaders,
-			fetch: cchFetch,
-			fetchOptions,
-		};
-	}
-	// OpenCode Zen's Anthropic-compatible gateway accepts bearer auth only;
-	// leaving apiKey set lets the client add X-Api-Key, which upstream Alibaba rejects.
-	if (model.provider === "opencode-zen") {
-		return {
-			isOAuthToken: false,
-			apiKey: null,
 			authToken: null,
 			baseURL: baseUrl,
 			maxRetries: 5,
@@ -3341,11 +3329,15 @@ function buildParams(
 	// blocks to text upstream, so `keep: "all"` is a no-op that risks proxy
 	// rejection of an unrecognized field. Skip Vertex rawPredict because that
 	// adapter requires betas in the JSON body (`anthropic_beta`) instead of the
-	// Anthropic HTTP beta header this code can add.
+	// Anthropic HTTP beta header this code can add. Skip OpenCode Zen because
+	// its Anthropic proxy rejects the unrecognized `context_management` field
+	// with `400 Extra inputs are not permitted` on several Claude families
+	// (#6510) — same rationale as Copilot.
 	const shouldKeepThinkingContext =
 		!options?.client &&
 		model.provider !== "github-copilot" &&
 		model.provider !== "google-vertex" &&
+		model.provider !== "opencode-zen" &&
 		(thinking?.type === "adaptive" || thinking?.type === "enabled");
 	const contextManagement = shouldKeepThinkingContext
 		? { edits: [{ type: "clear_thinking_20251015" as const, keep: "all" as const }] }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1870,15 +1870,17 @@ const streamAnthropicOnce = (
 				// `context_management.clear_thinking_20251015` requires this beta. OAuth
 				// requests carry it in `claudeCodeAgentBetaDefaults`; API-key requests
 				// need it added explicitly so the field is honored instead of rejected
-				// (#3288). Skip transports where this package cannot deliver the beta
-				// in the form their adapter accepts: Copilot strips Anthropic betas,
-				// and Vertex rawPredict needs betas in the body (`anthropic_beta`),
-				// not as an `anthropic-beta` HTTP header.
+				// (#3288). Skip transports where this package cannot deliver or the
+				// provider cannot accept the beta: Copilot strips Anthropic betas;
+				// Vertex rawPredict needs betas in the body (`anthropic_beta`), not as
+				// an `anthropic-beta` HTTP header; and OpenCode Zen rejects the related
+				// `context_management` field (#6510).
 				if (
 					model.reasoning &&
 					options?.thinkingEnabled &&
 					model.provider !== "github-copilot" &&
 					model.provider !== "google-vertex" &&
+					model.provider !== "opencode-zen" &&
 					!extraBetas.includes(contextManagementBeta)
 				) {
 					extraBetas.push(contextManagementBeta);

--- a/packages/ai/test/issue-6510-repro.test.ts
+++ b/packages/ai/test/issue-6510-repro.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { buildAnthropicClientOptions, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+/**
+ * Repro for #6510 — every Claude (`anthropic-messages`) model on the
+ * `opencode-zen` provider fails with `401 {"type":"error","error":
+ * {"type":"AuthError","message":"Missing API key."}}` while OpenAI-format
+ * models on the same provider work with the same stored credential.
+ *
+ * Root cause: `buildAnthropicClientOptions` special-cased `opencode-zen` to
+ * bearer-only auth (`apiKey: null`, keeping the auto-built `Authorization`
+ * header), but the Zen Anthropic gateway requires `x-api-key` and rejects
+ * bearer-only requests. The sibling `opencode-go`/`umans` providers on the
+ * same api-key login flow already send `X-Api-Key`.
+ *
+ * Secondary: once auth works, thinking requests through Zen 400 on several
+ * model families because omp unconditionally attaches `context_management`
+ * (`clear_thinking_20251015`), which the Zen Anthropic proxy rejects as an
+ * unrecognized field — the same failure mode already handled for Copilot.
+ */
+const ZEN_ANTHROPIC_MODEL: Model<"anthropic-messages"> = buildModel({
+	id: "claude-haiku-4-5",
+	name: "Claude Haiku 4.5",
+	api: "anthropic-messages",
+	provider: "opencode-zen",
+	baseUrl: "https://opencode.ai/zen/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+} as ModelSpec<"anthropic-messages">);
+
+describe("issue #6510 — opencode-zen Anthropic auth + context_management", () => {
+	it("authenticates Zen Claude models with X-Api-Key, not bearer-only", () => {
+		const options = buildAnthropicClientOptions({
+			model: ZEN_ANTHROPIC_MODEL,
+			apiKey: "sk-zen-test",
+			stream: true,
+		});
+
+		// The client adds `X-Api-Key` from `apiKey`; the bearer `Authorization`
+		// header must not be sent (Zen's Anthropic gateway rejects it).
+		expect(options.apiKey).toBe("sk-zen-test");
+		expect(options.defaultHeaders.Authorization).toBeUndefined();
+	});
+
+	it("omits context_management on Zen thinking requests", async () => {
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(
+			ZEN_ANTHROPIC_MODEL,
+			{ systemPrompt: [], messages: [{ role: "user", content: "continue", timestamp: 0 }] },
+			{
+				apiKey: "sk-zen-test",
+				signal: AbortSignal.abort(),
+				thinkingEnabled: true,
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as {
+			thinking?: { type?: string };
+			context_management?: unknown;
+		};
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.context_management).toBeUndefined();
+	});
+});

--- a/packages/ai/test/issue-6510-repro.test.ts
+++ b/packages/ai/test/issue-6510-repro.test.ts
@@ -47,18 +47,26 @@ describe("issue #6510 — opencode-zen Anthropic auth + context_management", () 
 		expect(options.defaultHeaders.Authorization).toBeUndefined();
 	});
 
-	it("omits context_management on Zen thinking requests", async () => {
+	it("omits context_management and its beta on Zen thinking requests", async () => {
+		let capturedBeta: string | null = null;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBeta = new Headers(init?.headers).get("anthropic-beta");
+			return new Response(
+				JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
 		const { promise, resolve } = Promise.withResolvers<unknown>();
-		streamAnthropic(
+		await streamAnthropic(
 			ZEN_ANTHROPIC_MODEL,
 			{ systemPrompt: [], messages: [{ role: "user", content: "continue", timestamp: 0 }] },
 			{
 				apiKey: "sk-zen-test",
-				signal: AbortSignal.abort(),
 				thinkingEnabled: true,
+				fetch: fetchMock,
 				onPayload: payload => resolve(payload),
 			},
-		);
+		).result();
 
 		const payload = (await promise) as {
 			thinking?: { type?: string };
@@ -66,5 +74,6 @@ describe("issue #6510 — opencode-zen Anthropic auth + context_management", () 
 		};
 		expect(payload.thinking?.type).toBe("enabled");
 		expect(payload.context_management).toBeUndefined();
+		expect(capturedBeta ?? "").not.toContain("context-management-2025-06-27");
 	});
 });


### PR DESCRIPTION
## Repro
Every Claude (`anthropic-messages`) model on the `opencode-zen` provider fails with `401 {"type":"error","error":{"type":"AuthError","message":"Missing API key."}}`, while OpenAI-format models on the same provider and stored credential work fine. Reproduced at the code level with `bun test test/issue-6510-repro.test.ts`: `buildAnthropicClientOptions` returns `apiKey: null` for `opencode-zen` (bearer-only), and `streamAnthropic` attaches `context_management` unconditionally. Reporter confirmed against the live endpoint (`POST https://opencode.ai/zen/v1/messages`, claude-haiku-4-5): bearer-only → 401, `x-api-key` → 200.

## Cause
`buildAnthropicClientOptions` in `packages/ai/src/providers/anthropic.ts` special-cased `opencode-zen` to bearer-only auth (`apiKey: null`, keeping the auto-built `Authorization` header) on the incorrect assumption that the gateway accepts bearer only. The Zen Anthropic surface actually requires `x-api-key`; the sibling `opencode-go`/`umans` providers on the same `loginOpenCode` api-key flow already send `X-Api-Key` (PR #1737). Separately, `shouldKeepThinkingContext` attaches `context_management` (`clear_thinking_20251015`) for every enabled/adaptive thinking request except `github-copilot`/`google-vertex`; Zen's Anthropic proxy rejects the unrecognized field with `400 Extra inputs are not permitted` on several Claude families.

## Fix
- Fold `opencode-zen` into the existing `opencode-go`/`umans` X-Api-Key branch: delete the auto-built `Authorization` header and return `apiKey` so the client emits `X-Api-Key`.
- Add `model.provider !== "opencode-zen"` to the `shouldKeepThinkingContext` skip list, next to the `github-copilot`/`google-vertex` exclusions (same rationale: proxy rejects the unrecognized field).
- Add `test/issue-6510-repro.test.ts` covering both: X-Api-Key auth (apiKey set, no bearer `Authorization`) and no `context_management` on Zen thinking requests.

## Verification
`bun test test/issue-6510-repro.test.ts test/anthropic-alignment.test.ts test/anthropic-unsigned-thinking-replay.test.ts test/github-copilot-reasoning.test.ts` → 101 pass, 0 fail. Full `packages/ai` suite shows only pre-existing, order-dependent env-pollution failures (`proxy.test.ts`, `openrouter-glm-effort`) that reproduce on the clean base branch (4 fail there) and pass in isolation; they do not touch the changed code paths. Fixes #6510