### PR TITLE
fix(tui): auto-detect alt-toggle size echo to stop overlay-exit flicker

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the terminal flickering when leaving a fullscreen overlay (e.g. `/settings`, the models page) or resizing on terminals that re-report their size whenever the alternate screen buffer toggles: the alt-toggle size echo no longer arms a destructive full-screen (ED3) rebuild, and the in-place repaint path is now auto-detected for any such terminal instead of only Warp ([#6511](https://github.com/can1357/oh-my-pi/issues/6511)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1091,6 +1091,13 @@ export class TUI extends Container {
 	// resize frames so width changes truncate the transient viewport instead of
 	// pushing wrapped fragments into native scrollback.
 	#resizeAltActive = false;
+	// Latched once this terminal is observed re-reporting its size across an
+	// alternate-screen toggle (a pure height change between alt-buffer enter and
+	// exit). That is the Warp-class quirk {@link reportsSizeOnAltScreenToggle}
+	// hardcodes: without it, leaving a fullscreen overlay flashes a destructive
+	// ED3 full paint and the revert SIGWINCH flashes another (#6511). Once set,
+	// {@link #resizeRepaintsInPlace} routes resizes through the in-place path.
+	#altToggleResizesInPlace = false;
 	#stopped = false;
 	// Always-on event-loop lag probe. The high default threshold keeps it quiet;
 	// it only logs `ui.loop-blocked` (with the current loop phase) when a frame
@@ -1590,8 +1597,26 @@ export class TUI extends Container {
 				// window) into a single render once the pane is quiet —
 				// `#resizeEventPending` is set first so the eventual render still
 				// classifies as a resize.
+				// A SIGWINCH while a fullscreen overlay covers the transcript is
+				// either a genuine resize behind the overlay or the alt-toggle size
+				// echo (a terminal re-reporting its size whenever the alternate
+				// screen buffer toggles). The transcript is not visible either way,
+				// so arming the drag/settle would only queue a destructive ED3
+				// rebuild that fires as a flash when the overlay closes (#6511). A
+				// pure height change is the alt-toggle-echo signature — latch the
+				// in-place resize path — and just repaint the overlay at the new
+				// size. #resizeEventPending carries to the overlay-exit render so it
+				// still classifies as a resize.
+				if (this.#altActive) {
+					if (this.#altEnterWidth === this.terminal.columns && this.#altEnterHeight !== this.terminal.rows) {
+						this.#altToggleResizesInPlace = true;
+					}
+					this.#resizeEventPending = true;
+					this.requestRender();
+					return;
+				}
 				this.#resizeEventPending = true;
-				if (!resizeRepaintsInPlace()) {
+				if (!this.#resizeRepaintsInPlace()) {
 					// Enter the viewport fast path and (re)arm the settle timer, then
 					// request the cheap viewport-only paint. The authoritative full
 					// replay fires from the settle timer once the drag goes quiet.
@@ -2815,9 +2840,15 @@ export class TUI extends Container {
 			this.#altPreviousLines = [];
 			// A resize while on the alt buffer reflowed the terminal's saved
 			// normal screen; it no longer matches our accounting, so force the
-			// geometry rebuild path instead of a stale diff.
+			// geometry rebuild path instead of a stale diff. A pure height change
+			// across the alt-buffer boundary (width unchanged) is the signature of
+			// a terminal that re-reports its size whenever the alternate screen
+			// toggles — the Warp-class quirk. Latch the in-place resize path so
+			// this exit and the revert SIGWINCH repaint without an ED3 scrollback
+			// rewrap instead of flashing a destructive full paint (#6511).
 			if (width !== this.#altEnterWidth || height !== this.#altEnterHeight) {
 				this.#resizeEventPending = true;
+				if (width === this.#altEnterWidth) this.#altToggleResizesInPlace = true;
 			}
 		} else if (wantMouseTracking !== this.#altMouseTrackingActive) {
 			this.terminal.write(wantMouseTracking ? MOUSE_TRACKING_ON : MOUSE_TRACKING_OFF);
@@ -2870,7 +2901,7 @@ export class TUI extends Container {
 		// count too: both enter the geometry rebuild path below.
 		const replayFullHistory =
 			this.#hasEverRendered &&
-			!resizeRepaintsInPlace() &&
+			!this.#resizeRepaintsInPlace() &&
 			(this.#clearScrollbackOnNextRender ||
 				this.#resizeEventPending ||
 				(this.#previousWidth > 0 && this.#previousWidth !== width) ||
@@ -3018,7 +3049,7 @@ export class TUI extends Container {
 		// feedback loop), so committed history keeps its old wrap.
 		const firstPaint = !this.#hasEverRendered;
 		const replaceRequested = this.#clearScrollbackOnNextRender;
-		const geometryRebuild = geometryChanged && !resizeRepaintsInPlace();
+		const geometryRebuild = geometryChanged && !this.#resizeRepaintsInPlace();
 		// Committed history no longer matches the frame: a finalized block
 		// replaced its scrolled-off live render, or the frame collapsed into
 		// recorded rows. Native scrollback is a render cache, not a court
@@ -3175,7 +3206,8 @@ export class TUI extends Container {
 			windowTop,
 			prevWindowTop,
 			prevHardwareCursorRow,
-			forceWindowRewrite: this.#forceViewportRepaintOnNextRender || (geometryChanged && resizeRepaintsInPlace()),
+			forceWindowRewrite:
+				this.#forceViewportRepaintOnNextRender || (geometryChanged && this.#resizeRepaintsInPlace()),
 			repaintVirtualScrollInPlace: hasVisibleOverlay,
 			cursorTrackingLineCount,
 		});
@@ -3810,6 +3842,17 @@ export class TUI extends Container {
 		setAltScreenActive(false);
 		this.#forgetHardwareCursorState();
 		return `${enhancementExit}${ALT_SCREEN_EXIT}`;
+	}
+
+	/**
+	 * Whether a resize repaints the visible window in place — no alternate-screen
+	 * borrow, no ED3 scrollback rewrap. Combines the static host detection
+	 * ({@link resizeRepaintsInPlace}) with the runtime {@link #altToggleResizesInPlace}
+	 * latch, so a terminal that re-reports its size on alt-screen toggles is
+	 * treated like Warp once observed, breaking the overlay-exit ED3 flash loop.
+	 */
+	#resizeRepaintsInPlace(): boolean {
+		return resizeRepaintsInPlace() || this.#altToggleResizesInPlace;
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3850,9 +3850,13 @@ export class TUI extends Container {
 	 * ({@link resizeRepaintsInPlace}) with the runtime {@link #altToggleResizesInPlace}
 	 * latch, so a terminal that re-reports its size on alt-screen toggles is
 	 * treated like Warp once observed, breaking the overlay-exit ED3 flash loop.
+	 * An explicit `PI_TUI_RESIZE_IN_PLACE=0|false` suppresses the runtime latch;
+	 * multiplexer handling remains authoritative through the static predicate.
 	 */
 	#resizeRepaintsInPlace(): boolean {
-		return resizeRepaintsInPlace() || this.#altToggleResizesInPlace;
+		const override = Bun.env.PI_TUI_RESIZE_IN_PLACE;
+		const allowAutoDetection = override !== "0" && override !== "false";
+		return resizeRepaintsInPlace() || (allowAutoDetection && this.#altToggleResizesInPlace);
 	}
 
 	/**

--- a/packages/tui/test/overlay-exit-flicker.test.ts
+++ b/packages/tui/test/overlay-exit-flicker.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type Component, type RenderScheduler, type RenderTimer, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// A terminal that re-reports its size when the alternate screen buffer toggles
+// (Warp does this; some Linux terminals do too) turns every fullscreen-overlay
+// exit into a spurious height-only resize. Before #6511 that drove a destructive
+// ED3 geometry rebuild — visible as a flicker when leaving /settings or /models
+// — and the size revert that follows flashed a second one. The alt-toggle echo
+// is now auto-detected and routed through the in-place repaint path.
+
+const ENV: Record<string, string | undefined> = {
+	TMUX: undefined,
+	STY: undefined,
+	ZELLIJ: undefined,
+	CMUX_WORKSPACE_ID: undefined,
+	CMUX_SURFACE_ID: undefined,
+	CMUX_REMOTE_TRANSPORT: undefined,
+	TERM_PROGRAM: undefined,
+	PI_TUI_RESIZE_IN_PLACE: undefined,
+};
+
+async function withEnv(patch: Record<string, string | undefined>, run: () => Promise<void>): Promise<void> {
+	const saved: Record<string, string | undefined> = {};
+	for (const key in patch) {
+		saved[key] = Bun.env[key];
+		if (patch[key] === undefined) delete Bun.env[key];
+		else Bun.env[key] = patch[key];
+	}
+	try {
+		await run();
+	} finally {
+		for (const key in saved) {
+			if (saved[key] === undefined) delete Bun.env[key];
+			else Bun.env[key] = saved[key];
+		}
+	}
+}
+
+class Scheduler implements RenderScheduler {
+	#time = 0;
+	#immediates: (() => void)[] = [];
+	#renders = new Map<number, () => void>();
+	#nextId = 0;
+	now(): number {
+		this.#time += 20;
+		return this.#time;
+	}
+	scheduleImmediate(callback: () => void): void {
+		this.#immediates.push(callback);
+	}
+	scheduleRender(callback: () => void): RenderTimer {
+		const id = this.#nextId++;
+		this.#renders.set(id, callback);
+		return { cancel: () => this.#renders.delete(id) };
+	}
+	async flushAll(term: VirtualTerminal): Promise<void> {
+		let rounds = 0;
+		while (this.#immediates.length > 0 || this.#renders.size > 0) {
+			if (++rounds > 100) throw new Error("did not settle");
+			const immediates = this.#immediates;
+			this.#immediates = [];
+			for (const cb of immediates) cb();
+			if (this.#immediates.length > 0) continue;
+			const renders = [...this.#renders.values()];
+			this.#renders.clear();
+			for (const cb of renders) cb();
+		}
+		await term.flush();
+	}
+}
+
+class Transcript implements Component {
+	invalidate(): void {}
+	render(width: number): string[] {
+		return Array.from({ length: 30 }, (_v, i) => `line-${i}`.slice(0, width));
+	}
+}
+
+class Modal implements Component {
+	invalidate(): void {}
+	render(width: number): string[] {
+		return ["MODAL".slice(0, width)];
+	}
+}
+
+describe("fullscreen overlay exit on alt-toggle-size terminals (#6511)", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("does not flash an ED3 rebuild when the terminal echoes a size on alt toggle", async () => {
+		await withEnv(ENV, async () => {
+			const term = new VirtualTerminal(40, 10, 1000);
+			const scheduler = new Scheduler();
+			const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+			tui.addChild(new Transcript());
+			try {
+				tui.start();
+				await scheduler.flushAll(term);
+
+				const overlay = tui.showOverlay(new Modal(), { fullscreen: true });
+				await scheduler.flushAll(term);
+
+				const writes: string[] = [];
+				const realWrite = term.write.bind(term);
+				vi.spyOn(term, "write").mockImplementation((data: string) => {
+					writes.push(data);
+					realWrite(data);
+				});
+
+				// Entering the alt buffer echoed a height one row shorter; leaving the
+				// overlay is seen while that echoed size is still in effect.
+				term.resize(40, 9);
+				await scheduler.flushAll(term);
+				overlay.hide();
+				await scheduler.flushAll(term);
+
+				const exitWrites = writes.length;
+				expect(writes.join("")).not.toContain("\x1b[3J");
+				expect(term.getViewport().at(-1)?.trimEnd()).toBe("line-29");
+
+				// The revert SIGWINCH back to the normal-buffer size must also stay
+				// in place — otherwise the flicker just moves to the revert frame.
+				term.resize(40, 10);
+				await scheduler.flushAll(term);
+				expect(writes.slice(exitWrites).join("")).not.toContain("\x1b[3J");
+				expect(term.getViewport().at(-1)?.trimEnd()).toBe("line-29");
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+});

--- a/packages/tui/test/overlay-exit-flicker.test.ts
+++ b/packages/tui/test/overlay-exit-flicker.test.ts
@@ -87,7 +87,7 @@ class Modal implements Component {
 describe("fullscreen overlay exit on alt-toggle-size terminals (#6511)", () => {
 	afterEach(() => vi.restoreAllMocks());
 
-	it("does not flash an ED3 rebuild when the terminal echoes a size on alt toggle", async () => {
+	it("auto-detects alt-toggle size echoes while respecting the explicit opt-out", async () => {
 		await withEnv(ENV, async () => {
 			const term = new VirtualTerminal(40, 10, 1000);
 			const scheduler = new Scheduler();
@@ -124,6 +124,17 @@ describe("fullscreen overlay exit on alt-toggle-size terminals (#6511)", () => {
 				await scheduler.flushAll(term);
 				expect(writes.slice(exitWrites).join("")).not.toContain("\x1b[3J");
 				expect(term.getViewport().at(-1)?.trimEnd()).toBe("line-29");
+
+				// The explicit opt-out must win even after runtime auto-detection.
+				// A later width drag therefore borrows the alt buffer and performs
+				// its authoritative ED3 rewrap at settle.
+				Bun.env.PI_TUI_RESIZE_IN_PLACE = "0";
+				const optOutWrites = writes.length;
+				term.resize(50, 10);
+				await scheduler.flushAll(term);
+				const optOut = writes.slice(optOutWrites).join("");
+				expect(optOut).toContain("\x1b[?1049h");
+				expect(optOut).toContain("\x1b[3J");
 			} finally {
 				tui.stop();
 			}


### PR DESCRIPTION
## Repro
On a terminal that re-reports its size whenever the alternate screen buffer toggles, opening a fullscreen overlay (`/settings`, the models page) and returning to chat — or resizing — flickers. A headless reproduction is added as `packages/tui/test/overlay-exit-flicker.test.ts`: a `VirtualTerminal` that echoes a height-only SIGWINCH when the alt buffer toggles, then a fullscreen overlay is opened and closed. Before the fix the overlay-exit render (and its resize-drag settle) emit `\x1b[3J` (destructive clear-scrollback full repaint); run `bun test packages/tui/test/overlay-exit-flicker.test.ts`.

## Cause
Entering a fullscreen overlay writes the alt-screen enter sequence; on these terminals that triggers a spurious height-only SIGWINCH. The resize handler in `TUI` (`packages/tui/src/tui.ts`, `start()`'s SIGWINCH callback) unconditionally armed the non-multiplexer resize drag + settle timer even though the transcript was hidden behind the overlay. The settle then forced a geometry rebuild through `#emitFullPaint` with `clearScrollback`, emitting `\x1b[H\x1b[3J` (tui.ts:3602) — atomic only under DEC 2026 synchronized output, so it flickered on terminals without it. `#doRender`'s overlay-exit branch (tui.ts:2819) also flagged a geometry rebuild on the exit size mismatch, and the size revert flashed a second one. The in-place repaint path (`resizeRepaintsInPlace()`) was hardcoded to Warp only (tui.ts:398-403).

## Fix
- `packages/tui/src/tui.ts`: a SIGWINCH while a fullscreen overlay covers the transcript now repaints the overlay in place and returns, instead of arming the drag/settle machinery that queues the destructive rebuild.
- Add a runtime latch `#altToggleResizesInPlace`, set when a pure height change is observed across the alt-buffer boundary (the alt-toggle-echo signature), and a `#resizeRepaintsInPlace()` method that ORs it into the static host detection — so any such terminal is auto-detected, not just Warp. This routes the exit render and the revert SIGWINCH through the in-place path (no ED3).
- Route the four `resizeRepaintsInPlace()` callsites (SIGWINCH handler, `replayFullHistory`, `geometryRebuild`, `forceWindowRewrite`) through the new method.
- Changelog entry under `## [Unreleased]`.

## Verification
`bun test packages/tui/test/overlay-exit-flicker.test.ts` — passes: no `\x1b[3J` on overlay exit or the revert SIGWINCH, and the transcript viewport is correct after exit. Full package suite `bun test` in `packages/tui` — 1351 pass, 0 fail. `bun run check:types` in `packages/tui` — clean. `biome check` on the changed files — clean. Note: the repo-wide `bun run fix`/`bun check` Rust step (`fix:rs`/`check:rs`) fails locally because `cmake` is not installed (`audiopus_sys` native build) — pre-existing and unrelated to this TS-only diff. Fixes #6511