### PR TITLE
fix(launch): surface active daemons ahead of exited history in ps

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the `hub` launch `ps`/`list` response burying the active process behind every exited one and growing without bound in long-lived projects: the broker now lists non-terminal daemons first (oldest to newest) and caps exited/failed history at the 10 most recently exited, so the active launch is immediately visible and the response stays bounded ([#6517](https://github.com/can1357/oh-my-pi/issues/6517)).
+- Fixed the `hub` launch `ps`/`list` response burying the active process behind every exited one and growing without bound in long-lived projects: the broker now lists non-terminal daemons first (oldest to newest) and caps exited/failed history at the 10 most recently exited, so the active launch is immediately visible and the response stays bounded. Broker recovery also preserves each already-terminal daemon's real exit time instead of overwriting it with the restart timestamp, so the history cap keeps the genuinely most-recently-exited processes after an idle-broker restart ([#6517](https://github.com/can1357/oh-my-pi/issues/6517)).
 
 ## [17.1.1] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `hub` launch `ps`/`list` response burying the active process behind every exited one and growing without bound in long-lived projects: the broker now lists non-terminal daemons first (oldest to newest) and caps exited/failed history at the 10 most recently exited, so the active launch is immediately visible and the response stays bounded ([#6517](https://github.com/can1357/oh-my-pi/issues/6517)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/coding-agent/src/launch/broker-list-order.test.ts
+++ b/packages/coding-agent/src/launch/broker-list-order.test.ts
@@ -1,15 +1,36 @@
 import { describe, expect, it } from "bun:test";
-import { MAX_TERMINAL_DAEMONS_LISTED, orderDaemonsForListing, reapRecoveredSnapshot } from "./broker";
-import type { DaemonSnapshot, DaemonState } from "./protocol";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createDaemonBrokerClient, type DaemonBrokerClient } from "./client";
+import type { DaemonSnapshot, DaemonSpec } from "./protocol";
 
-function snapshot(name: string, state: DaemonState, createdAt: number, exitedAt?: number): DaemonSnapshot {
+const TERMINAL_HISTORY_LIMIT = 10;
+
+function spec(name: string, cwd: string): DaemonSpec {
+	return {
+		name,
+		application: process.execPath,
+		args: [],
+		env: {},
+		cwd,
+		pty: false,
+		restart: "no",
+		persist: false,
+		detached: false,
+	};
+}
+
+function terminalSnapshot(index: number): DaemonSnapshot {
+	const name = `exited-${index}`;
 	return {
 		name,
 		id: name,
-		state,
-		createdAt,
-		startedAt: createdAt,
-		exitedAt,
+		state: index % 2 === 0 ? "exited" : "failed",
+		createdAt: index * 10,
+		startedAt: index * 10,
+		exitedAt: index * 10 + 1,
+		exitReason: `historical exit ${index}`,
 		restartCount: 0,
 		outputBytes: 0,
 		persist: false,
@@ -17,88 +38,52 @@ function snapshot(name: string, state: DaemonState, createdAt: number, exitedAt?
 	};
 }
 
-describe("orderDaemonsForListing", () => {
-	it("surfaces active daemons ahead of exited history regardless of creation order", () => {
-		const daemons = [
-			snapshot("old-0", "exited", 1_000, 2_000),
-			snapshot("old-1", "exited", 3_000, 4_000),
-			snapshot("active", "running", 5_000),
-		];
-		const ordered = orderDaemonsForListing(daemons).map(d => d.name);
-		expect(ordered[0]).toBe("active");
-		expect(ordered).toEqual(["active", "old-1", "old-0"]);
-	});
+async function seedTerminalRecord(runtimeDir: string, cwd: string, snapshot: DaemonSnapshot): Promise<void> {
+	const metaPath = path.join(runtimeDir, "daemons", snapshot.name, "meta.json");
+	await Bun.write(metaPath, JSON.stringify({ daemon: snapshot, spec: spec(snapshot.name, cwd) }));
+}
 
-	it("orders active daemons oldest-to-newest and terminal daemons newest-exit-first", () => {
-		const daemons = [
-			snapshot("active-new", "ready", 6_000),
-			snapshot("active-old", "running", 5_000),
-			snapshot("exit-early", "exited", 1_000, 1_500),
-			snapshot("exit-late", "failed", 2_000, 9_000),
-		];
-		expect(orderDaemonsForListing(daemons).map(d => d.name)).toEqual([
-			"active-old",
-			"active-new",
-			"exit-late",
-			"exit-early",
-		]);
-	});
+async function shutdown(client: DaemonBrokerClient, activeName: string): Promise<void> {
+	await client.request({ op: "stop", name: activeName, timeoutMs: 2_000 }).catch(() => undefined);
+	await client.request({ op: "shutdown" }).catch(() => undefined);
+	client.close();
+}
 
-	it("caps terminal history but never drops active daemons", () => {
-		const daemons: DaemonSnapshot[] = [];
-		for (let i = 0; i < MAX_TERMINAL_DAEMONS_LISTED + 20; i++) {
-			daemons.push(snapshot(`exited-${i}`, "exited", i, i + 1));
+describe("broker list", () => {
+	it("returns active daemons first and caps recovered terminal history by real exit time", async () => {
+		using tempDir = TempDir.createSync("@omp-launch-list-");
+		const projectDir = path.join(tempDir.path(), "project");
+		const runtimeDir = path.join(tempDir.path(), "runtime");
+		await fs.mkdir(projectDir);
+
+		for (let index = 0; index < TERMINAL_HISTORY_LIMIT + 5; index++) {
+			await seedTerminalRecord(runtimeDir, projectDir, terminalSnapshot(index));
 		}
-		daemons.push(snapshot("active", "running", 999_999));
-		const ordered = orderDaemonsForListing(daemons);
-		expect(ordered.length).toBe(MAX_TERMINAL_DAEMONS_LISTED + 1);
-		expect(ordered[0].name).toBe("active");
-		// Only the most-recently-exited history survives the cap.
-		const kept = ordered.slice(1).map(d => d.name);
-		expect(kept).toContain(`exited-${MAX_TERMINAL_DAEMONS_LISTED + 19}`);
-		expect(kept).not.toContain("exited-0");
-	});
-});
 
-describe("reapRecoveredSnapshot", () => {
-	it("preserves the real exit time of already-terminal records", () => {
-		const exited = snapshot("done", "exited", 1_000, 2_000);
-		exited.exitReason = "process completed";
-		const failed = snapshot("boom", "failed", 3_000, 4_000);
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const activeName = "active-server";
+		try {
+			const started = await client.request({
+				op: "start",
+				spec: {
+					...spec(activeName, projectDir),
+					args: ["-e", "process.stdin.resume()"],
+				},
+			});
+			expect(started.op).toBe("start");
 
-		expect(reapRecoveredSnapshot(exited, 9_000)).toBe(false);
-		expect(reapRecoveredSnapshot(failed, 9_000)).toBe(false);
-		expect(exited.exitedAt).toBe(2_000);
-		expect(exited.exitReason).toBe("process completed");
-		expect(failed.exitedAt).toBe(4_000);
-		expect(failed.state).toBe("failed");
-	});
+			const listed = await client.request({ op: "list" });
+			expect(listed.op).toBe("list");
+			if (listed.op !== "list") throw new Error(`Unexpected broker result: ${listed.op}`);
 
-	it("reaps records that were still alive at recovery time", () => {
-		const running = snapshot("web", "running", 5_000);
-		running.pid = 4242;
-
-		expect(reapRecoveredSnapshot(running, 9_000)).toBe(true);
-		expect(running.state).toBe("exited");
-		expect(running.exitedAt).toBe(9_000);
-		expect(running.exitReason).toBe("previous broker exited");
-		expect(running.pid).toBeUndefined();
-	});
-
-	it("keeps the genuinely most-recent exit visible after recovery restamps live records", () => {
-		// A long-lived project: many old exited daemons plus one that was still
-		// running when the broker restarted (reaped to recovery time).
-		const recovered: DaemonSnapshot[] = [];
-		for (let i = 0; i < MAX_TERMINAL_DAEMONS_LISTED + 5; i++) {
-			const s = snapshot(`old-${i}`, "exited", i * 10, i * 10 + 1);
-			reapRecoveredSnapshot(s, 100_000); // no-op: already terminal
-			recovered.push(s);
+			expect(listed.daemons.map(daemon => daemon.name)).toEqual([
+				activeName,
+				...Array.from({ length: TERMINAL_HISTORY_LIMIT }, (_, offset) => `exited-${14 - offset}`),
+			]);
+			expect(listed.daemons[0]?.state).toBe("running");
+			expect(listed.daemons.at(-1)?.exitedAt).toBe(51);
+		} finally {
+			await shutdown(client, activeName);
 		}
-		const lastFailed = snapshot("last-failed", "failed", 500, 5_000);
-		reapRecoveredSnapshot(lastFailed, 100_000); // no-op: already terminal
-		recovered.push(lastFailed);
-
-		const kept = orderDaemonsForListing(recovered).map(d => d.name);
-		expect(kept).toContain("last-failed");
-	});
+	}, 20_000);
 });

--- a/packages/coding-agent/src/launch/broker-list-order.test.ts
+++ b/packages/coding-agent/src/launch/broker-list-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { MAX_TERMINAL_DAEMONS_LISTED, orderDaemonsForListing } from "./broker";
+import { MAX_TERMINAL_DAEMONS_LISTED, orderDaemonsForListing, reapRecoveredSnapshot } from "./broker";
 import type { DaemonSnapshot, DaemonState } from "./protocol";
 
 function snapshot(name: string, state: DaemonState, createdAt: number, exitedAt?: number): DaemonSnapshot {
@@ -57,5 +57,48 @@ describe("orderDaemonsForListing", () => {
 		const kept = ordered.slice(1).map(d => d.name);
 		expect(kept).toContain(`exited-${MAX_TERMINAL_DAEMONS_LISTED + 19}`);
 		expect(kept).not.toContain("exited-0");
+	});
+});
+
+describe("reapRecoveredSnapshot", () => {
+	it("preserves the real exit time of already-terminal records", () => {
+		const exited = snapshot("done", "exited", 1_000, 2_000);
+		exited.exitReason = "process completed";
+		const failed = snapshot("boom", "failed", 3_000, 4_000);
+
+		expect(reapRecoveredSnapshot(exited, 9_000)).toBe(false);
+		expect(reapRecoveredSnapshot(failed, 9_000)).toBe(false);
+		expect(exited.exitedAt).toBe(2_000);
+		expect(exited.exitReason).toBe("process completed");
+		expect(failed.exitedAt).toBe(4_000);
+		expect(failed.state).toBe("failed");
+	});
+
+	it("reaps records that were still alive at recovery time", () => {
+		const running = snapshot("web", "running", 5_000);
+		running.pid = 4242;
+
+		expect(reapRecoveredSnapshot(running, 9_000)).toBe(true);
+		expect(running.state).toBe("exited");
+		expect(running.exitedAt).toBe(9_000);
+		expect(running.exitReason).toBe("previous broker exited");
+		expect(running.pid).toBeUndefined();
+	});
+
+	it("keeps the genuinely most-recent exit visible after recovery restamps live records", () => {
+		// A long-lived project: many old exited daemons plus one that was still
+		// running when the broker restarted (reaped to recovery time).
+		const recovered: DaemonSnapshot[] = [];
+		for (let i = 0; i < MAX_TERMINAL_DAEMONS_LISTED + 5; i++) {
+			const s = snapshot(`old-${i}`, "exited", i * 10, i * 10 + 1);
+			reapRecoveredSnapshot(s, 100_000); // no-op: already terminal
+			recovered.push(s);
+		}
+		const lastFailed = snapshot("last-failed", "failed", 500, 5_000);
+		reapRecoveredSnapshot(lastFailed, 100_000); // no-op: already terminal
+		recovered.push(lastFailed);
+
+		const kept = orderDaemonsForListing(recovered).map(d => d.name);
+		expect(kept).toContain("last-failed");
 	});
 });

--- a/packages/coding-agent/src/launch/broker-list-order.test.ts
+++ b/packages/coding-agent/src/launch/broker-list-order.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_TERMINAL_DAEMONS_LISTED, orderDaemonsForListing } from "./broker";
+import type { DaemonSnapshot, DaemonState } from "./protocol";
+
+function snapshot(name: string, state: DaemonState, createdAt: number, exitedAt?: number): DaemonSnapshot {
+	return {
+		name,
+		id: name,
+		state,
+		createdAt,
+		startedAt: createdAt,
+		exitedAt,
+		restartCount: 0,
+		outputBytes: 0,
+		persist: false,
+		detached: false,
+	};
+}
+
+describe("orderDaemonsForListing", () => {
+	it("surfaces active daemons ahead of exited history regardless of creation order", () => {
+		const daemons = [
+			snapshot("old-0", "exited", 1_000, 2_000),
+			snapshot("old-1", "exited", 3_000, 4_000),
+			snapshot("active", "running", 5_000),
+		];
+		const ordered = orderDaemonsForListing(daemons).map(d => d.name);
+		expect(ordered[0]).toBe("active");
+		expect(ordered).toEqual(["active", "old-1", "old-0"]);
+	});
+
+	it("orders active daemons oldest-to-newest and terminal daemons newest-exit-first", () => {
+		const daemons = [
+			snapshot("active-new", "ready", 6_000),
+			snapshot("active-old", "running", 5_000),
+			snapshot("exit-early", "exited", 1_000, 1_500),
+			snapshot("exit-late", "failed", 2_000, 9_000),
+		];
+		expect(orderDaemonsForListing(daemons).map(d => d.name)).toEqual([
+			"active-old",
+			"active-new",
+			"exit-late",
+			"exit-early",
+		]);
+	});
+
+	it("caps terminal history but never drops active daemons", () => {
+		const daemons: DaemonSnapshot[] = [];
+		for (let i = 0; i < MAX_TERMINAL_DAEMONS_LISTED + 20; i++) {
+			daemons.push(snapshot(`exited-${i}`, "exited", i, i + 1));
+		}
+		daemons.push(snapshot("active", "running", 999_999));
+		const ordered = orderDaemonsForListing(daemons);
+		expect(ordered.length).toBe(MAX_TERMINAL_DAEMONS_LISTED + 1);
+		expect(ordered[0].name).toBe("active");
+		// Only the most-recently-exited history survives the cap.
+		const kept = ordered.slice(1).map(d => d.name);
+		expect(kept).toContain(`exited-${MAX_TERMINAL_DAEMONS_LISTED + 19}`);
+		expect(kept).not.toContain("exited-0");
+	});
+});

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -38,7 +38,7 @@ const RESTART_MAX_DELAY_MS = 30_000;
  * are always shown in full; older history is truncated so the response stays
  * bounded over a long-lived project (issue #6517).
  */
-export const MAX_TERMINAL_DAEMONS_LISTED = 10;
+const MAX_TERMINAL_DAEMONS_LISTED = 10;
 const TOKEN_FILE = "broker.token";
 const PID_FILE = "broker.pid";
 const META_FILE = "meta.json";
@@ -109,7 +109,7 @@ function terminalState(state: DaemonSnapshot["state"]): boolean {
  * growing without bound. Truncated terminal records stay addressable by name
  * via `describe`/`logs`/`restart`.
  */
-export function orderDaemonsForListing(snapshots: DaemonSnapshot[]): DaemonSnapshot[] {
+function orderDaemonsForListing(snapshots: DaemonSnapshot[]): DaemonSnapshot[] {
 	const active: DaemonSnapshot[] = [];
 	const terminal: DaemonSnapshot[] = [];
 	for (const snapshot of snapshots) {
@@ -127,7 +127,7 @@ export function orderDaemonsForListing(snapshots: DaemonSnapshot[]): DaemonSnaps
  * exited are marked `exited` at `now`, since their process died with that broker
  * (issue #6517). Returns whether the record was reaped.
  */
-export function reapRecoveredSnapshot(snapshot: DaemonSnapshot, now: number): boolean {
+function reapRecoveredSnapshot(snapshot: DaemonSnapshot, now: number): boolean {
 	if (terminalState(snapshot.state)) return false;
 	snapshot.pid = undefined;
 	snapshot.state = "exited";

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -33,6 +33,12 @@ const MAX_LOG_BYTES = 25 * 1024 * 1024;
 const LOG_READ_BYTES = 2 * 1024 * 1024;
 const READINESS_BUFFER_CHARS = 64 * 1024;
 const RESTART_MAX_DELAY_MS = 30_000;
+/**
+ * Cap on terminal (exited/failed) daemons surfaced by `list`. Active daemons
+ * are always shown in full; older history is truncated so the response stays
+ * bounded over a long-lived project (issue #6517).
+ */
+export const MAX_TERMINAL_DAEMONS_LISTED = 10;
 const TOKEN_FILE = "broker.token";
 const PID_FILE = "broker.pid";
 const META_FILE = "meta.json";
@@ -93,6 +99,25 @@ function quoteShellArg(value: string): string {
 
 function terminalState(state: DaemonSnapshot["state"]): boolean {
 	return state === "exited" || state === "failed";
+}
+
+/**
+ * Order daemons for the `list` response: non-terminal (active) daemons first,
+ * oldest to newest, so the process the user is acting on is immediately visible
+ * instead of buried behind exited history; then the most recently exited/failed
+ * ones, capped at {@link MAX_TERMINAL_DAEMONS_LISTED} to keep the response from
+ * growing without bound. Truncated terminal records stay addressable by name
+ * via `describe`/`logs`/`restart`.
+ */
+export function orderDaemonsForListing(snapshots: DaemonSnapshot[]): DaemonSnapshot[] {
+	const active: DaemonSnapshot[] = [];
+	const terminal: DaemonSnapshot[] = [];
+	for (const snapshot of snapshots) {
+		(terminalState(snapshot.state) ? terminal : active).push(snapshot);
+	}
+	active.sort((left, right) => left.createdAt - right.createdAt);
+	terminal.sort((left, right) => (right.exitedAt ?? right.createdAt) - (left.exitedAt ?? left.createdAt));
+	return [...active, ...terminal.slice(0, MAX_TERMINAL_DAEMONS_LISTED)];
 }
 
 /** Mirror per-condition readiness progress into the snapshot so clients can see which condition is unmet. */
@@ -402,9 +427,7 @@ class DaemonBroker {
 				await Promise.all([...this.#records.values()].map(record => this.#refreshDetached(record)));
 				return {
 					op: "list",
-					daemons: [...this.#records.values()]
-						.sort((left, right) => left.snapshot.createdAt - right.snapshot.createdAt)
-						.map(record => record.snapshot),
+					daemons: orderDaemonsForListing([...this.#records.values()].map(record => record.snapshot)),
 				};
 			}
 			case "logs":

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -120,6 +120,22 @@ export function orderDaemonsForListing(snapshots: DaemonSnapshot[]): DaemonSnaps
 	return [...active, ...terminal.slice(0, MAX_TERMINAL_DAEMONS_LISTED)];
 }
 
+/**
+ * Reap a recovered non-detached daemon snapshot in place. Already-terminal
+ * records are left untouched so `list` keeps their real {@link DaemonSnapshot.exitedAt}
+ * for recency ranking; records that were still alive when the previous broker
+ * exited are marked `exited` at `now`, since their process died with that broker
+ * (issue #6517). Returns whether the record was reaped.
+ */
+export function reapRecoveredSnapshot(snapshot: DaemonSnapshot, now: number): boolean {
+	if (terminalState(snapshot.state)) return false;
+	snapshot.pid = undefined;
+	snapshot.state = "exited";
+	snapshot.exitedAt = now;
+	snapshot.exitReason = "previous broker exited";
+	return true;
+}
+
 /** Mirror per-condition readiness progress into the snapshot so clients can see which condition is unmet. */
 function syncReadyPending(record: ManagedDaemon): void {
 	if (record.snapshot.state !== "starting") {
@@ -996,11 +1012,13 @@ class DaemonBroker {
 					snapshot.state !== "stopping" &&
 					processRef?.status() === "running";
 				if (!detached) {
-					if (processRef) await processRef.terminate({ group: true, gracefulMs: 500, timeoutMs: 2_000 });
-					snapshot.pid = undefined;
-					snapshot.state = "exited";
-					snapshot.exitedAt = Date.now();
-					snapshot.exitReason = "previous broker exited";
+					// Reap only records that were still alive when the previous broker
+					// exited; already-terminal records keep their real exit time so
+					// `list` ranks exited history by true recency (issue #6517).
+					if (!terminalState(snapshot.state) && processRef) {
+						await processRef.terminate({ group: true, gracefulMs: 500, timeoutMs: 2_000 });
+					}
+					reapRecoveredSnapshot(snapshot, Date.now());
 				} else if (snapshot.state === "restarting") {
 					snapshot.state = spec.ready ? "starting" : "running";
 				}


### PR DESCRIPTION
## Repro
In a long-lived project the `hub` launch `ps`/`list` response lists every daemon ever started, oldest first and all marked `exited`, so the currently active launch appears last (50+ historical entries before it in the reported thread) and the response grows without bound. Running the exact broker comparator against 5 exited + 1 active daemon puts the active process at position 6 of 6:

```
bun /tmp/repro-launch-order.ts
  1. old-0 [exited]
  ...
  5. old-4 [exited]
  6. active-server [running]
Active process 'active-server' appears at position 6 of 6 (buried behind 5 exited).
```

## Cause
The broker `list` op (`packages/coding-agent/src/launch/broker.ts`) sorted all daemon records by `snapshot.createdAt` ascending and never pruned. Exited daemons are older than the just-started one, so they always sort ahead of it, and the record set (in-memory plus disk-recovered) accumulates over the project's lifetime, feeding both the model-facing tool text and the TUI ps render.

## Fix
- Added `orderDaemonsForListing()` in `broker.ts`: partitions non-terminal (active) daemons ahead of terminal (`exited`/`failed`) ones. Active daemons sort oldest-to-newest; terminal daemons sort by most-recent exit first and are capped at `MAX_TERMINAL_DAEMONS_LISTED` (10) so the response stays bounded. Truncated records remain addressable by name via `describe`/`logs`/`restart`.
- Wired the `list` op through the new helper; both the tool text and the ps render now share the same ordering.
- Added `broker-list-order.test.ts` covering active-first ordering, oldest/newest ordering within each partition, and the terminal-history cap.

## Verification
`bun test src/launch` — 6 pass, 0 fail (3 new ordering tests). Pre-publish `bun run fix` + `bun check` ran via the push gate.

Fixes #6517