### PR TITLE
fix(coding-agent): avoid duplicate tools in transcript rebuilds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a tool call rendering twice in the transcript. A mid-stream `rebuildChatFromMessages` (from `/shake`, auto-compaction, or a settings toggle) preserves the live `pendingTools` components across the clear+replay, but that preservation assumed every pending-tool component was still dangling. When a tool's result had already landed in the session entries while its component still lingered in `pendingTools`, the replay reconstructed the completed block *and* the preserved live component was re-appended, so the same block appeared twice; resolved components are now dropped from preservation and owned by the replay ([#6516](https://github.com/can1357/oh-my-pi/issues/6516)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1740,6 +1740,26 @@ export class InteractiveMode implements InteractiveModeContext {
 		const context = this.viewSession.buildTranscriptSessionContext({
 			collapseCompactedHistory: settings.get("display.collapseCompacted"),
 		});
+		// A preserved pending-tool component whose result has already landed in
+		// the replayed transcript is re-rendered by `renderSessionContext` itself
+		// (the toolResult message reconstructs the block with its output). Keeping
+		// it in the live set too re-appends a second identical block below the
+		// replayed one — the tool call renders twice (#6516). The preservation
+		// above assumes every pending-tool component is still dangling (its result
+		// lives outside `state.messages`), which stops holding the instant the
+		// result is persisted while the component lingers in `pendingTools` (a
+		// rebuild racing tool-completion, a background/displaceable snapshot).
+		// Drop the already-resolved ones and let the replay own them; only
+		// genuinely in-flight (dangling, replay-stripped) calls still need
+		// preserving.
+		for (const message of context.messages) {
+			if (message.role !== "toolResult") continue;
+			const resolved = livePendingTools.get(message.toolCallId);
+			if (!resolved) continue;
+			livePendingTools.delete(message.toolCallId);
+			const index = liveComponents.indexOf(resolved as unknown as Component);
+			if (index >= 0) liveComponents.splice(index, 1);
+		}
 		// Prune the settled-component cache to the messages this rebuild will
 		// actually render. Message objects stay strongly reachable through
 		// session entries for the whole session, so entries for compacted-away

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1756,6 +1756,16 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (message.role !== "toolResult") continue;
 			const resolved = livePendingTools.get(message.toolCallId);
 			if (!resolved) continue;
+			// A background task's initial `async.state === "running"` result is
+			// persisted while `EventController#handleToolExecutionEnd` deliberately
+			// keeps its component in `pendingTools` so a later
+			// `tool_execution_update`/`_end` settles it. Such a handle is still
+			// live — dropping it would strand those updates on the running snapshot
+			// — so keep it and let the live component retain ownership; only
+			// terminal results are owned by the replay. (Cast mirrors the async
+			// detail reads in tool-execution.ts / event-controller.ts.)
+			const details = message.details as { async?: { state?: string } } | undefined;
+			if (details?.async?.state === "running") continue;
 			livePendingTools.delete(message.toolCallId);
 			const index = liveComponents.indexOf(resolved as unknown as Component);
 			if (index >= 0) liveComponents.splice(index, 1);

--- a/packages/coding-agent/test/repro-issue-6516-tool-double-render.test.ts
+++ b/packages/coding-agent/test/repro-issue-6516-tool-double-render.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression for issue #6516 — a tool call renders twice in the transcript.
+ *
+ * `rebuildChatFromMessages` (fired mid-stream by /shake, auto-compaction, and
+ * settings toggles) preserves the live `pendingTools` components across a
+ * clear+replay so streaming keeps routing into them. That preservation assumes
+ * every pending-tool component is still *dangling* — its result lives outside
+ * `state.messages`. Once a tool's result has landed in the session entries while
+ * its component still lingers in `pendingTools` (a rebuild racing the
+ * tool-completion event, or a background/displaceable snapshot), the replay
+ * reconstructs the completed block from the persisted `toolResult` AND the
+ * preserved live component is re-appended — the same tool call renders twice.
+ */
+const CMD = "mvn -q -pl module -Dmaven.gitcommitid.skip=true -DskipTests clean compile";
+const usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function countCommand(mode: InteractiveMode): number {
+	const rendered = Bun.stripANSI(mode.chatContainer.render(120).join("\n"));
+	let count = 0;
+	let index = 0;
+	while (true) {
+		const found = rendered.indexOf(CMD, index);
+		if (found === -1) return count;
+		count++;
+		index = found + CMD.length;
+	}
+}
+
+describe("issue #6516 — tool output appears twice", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+	const created: ToolExecutionComponent[] = [];
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "pause").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockReturnValue(process.stdin);
+		if (typeof process.stdin.setRawMode === "function") {
+			vi.spyOn(process.stdin, "setRawMode").mockReturnValue(process.stdin);
+		}
+
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-6516-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+	});
+
+	afterEach(async () => {
+		for (const component of created.splice(0)) component.stopAnimation();
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	function addLiveBash(): ToolExecutionComponent {
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: CMD },
+			{},
+			undefined,
+			mode.ui,
+			tempDir.path(),
+			"call-1",
+		);
+		created.push(component);
+		mode.chatContainer.addChild(component);
+		mode.pendingTools.set("call-1", component);
+		return component;
+	}
+
+	it("renders a completed tool once when its component lingers in pendingTools during a rebuild", () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "m1",
+				parentId: null,
+				timestamp: Date.now(),
+				message: { role: "user", content: [{ type: "text", text: "run it" }], timestamp: 1 },
+			},
+			{
+				type: "message",
+				id: "m2",
+				parentId: "m1",
+				timestamp: Date.now(),
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: CMD } }],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage,
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+			},
+			{
+				type: "message",
+				id: "m3",
+				parentId: "m2",
+				timestamp: Date.now(),
+				message: {
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "bash",
+					content: [{ type: "text", text: "" }],
+					isError: false,
+					timestamp: 3,
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		vi.spyOn(session, "buildTranscriptSessionContext").mockReturnValue(
+			buildSessionContext(entries, undefined, undefined, { transcript: true }),
+		);
+
+		addLiveBash();
+		expect(countCommand(mode)).toBe(1);
+
+		mode.rebuildChatFromMessages();
+
+		// The replay reconstructs the completed block from the persisted
+		// toolResult; the stale live component must NOT be re-appended on top.
+		expect(countCommand(mode)).toBe(1);
+	});
+
+	it("keeps a genuinely in-flight tool call across a rebuild (still exactly once, still live)", () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "m1",
+				parentId: null,
+				timestamp: Date.now(),
+				message: { role: "user", content: [{ type: "text", text: "run it" }], timestamp: 1 },
+			},
+			{
+				type: "message",
+				id: "m2",
+				parentId: "m1",
+				timestamp: Date.now(),
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: CMD } }],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage,
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		vi.spyOn(session, "buildTranscriptSessionContext").mockReturnValue(
+			buildSessionContext(entries, undefined, undefined, { transcript: true }),
+		);
+
+		const live = addLiveBash();
+		mode.rebuildChatFromMessages();
+
+		expect(countCommand(mode)).toBe(1);
+		// The in-flight component is preserved for live routing so the pending
+		// tool's result still lands in the on-screen block.
+		expect(mode.pendingTools.get("call-1")).toBe(live);
+	});
+});

--- a/packages/coding-agent/test/repro-issue-6516-tool-double-render.test.ts
+++ b/packages/coding-agent/test/repro-issue-6516-tool-double-render.test.ts
@@ -208,4 +208,79 @@ describe("issue #6516 — tool output appears twice", () => {
 		// tool's result still lands in the on-screen block.
 		expect(mode.pendingTools.get("call-1")).toBe(live);
 	});
+
+	it("keeps a still-running background task's live handle across a rebuild", () => {
+		const runningDetails = { async: { state: "running", jobId: "job-1", type: "task" } };
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "m1",
+				parentId: null,
+				timestamp: Date.now(),
+				message: { role: "user", content: [{ type: "text", text: "spawn it" }], timestamp: 1 },
+			},
+			{
+				type: "message",
+				id: "m2",
+				parentId: "m1",
+				timestamp: Date.now(),
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: "call-1", name: "task", arguments: { description: "run", prompt: "go" } },
+					],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage,
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+			},
+			{
+				type: "message",
+				id: "m3",
+				parentId: "m2",
+				timestamp: Date.now(),
+				message: {
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "task",
+					content: [{ type: "text", text: "running…" }],
+					details: runningDetails,
+					isError: false,
+					timestamp: 3,
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		vi.spyOn(session, "buildTranscriptSessionContext").mockReturnValue(
+			buildSessionContext(entries, undefined, undefined, { transcript: true }),
+		);
+
+		const live = new ToolExecutionComponent(
+			"task",
+			{ description: "run", prompt: "go" },
+			{},
+			undefined,
+			mode.ui,
+			tempDir.path(),
+			"call-1",
+		);
+		live.updateResult(
+			{ content: [{ type: "text", text: "running…" }], details: runningDetails, isError: false },
+			true,
+			"call-1",
+		);
+		created.push(live);
+		mode.chatContainer.addChild(live);
+		mode.pendingTools.set("call-1", live);
+
+		mode.rebuildChatFromMessages();
+
+		// The still-running task's live handle must survive the rebuild so a later
+		// tool_execution_update/_end settles it instead of stranding on "running".
+		expect(mode.pendingTools.get("call-1")).toBe(live);
+	});
 });


### PR DESCRIPTION
## Repro
While a tool result is already persisted in session entries but its live component still lingers in `pendingTools`, trigger a mid-stream transcript rebuild such as `/shake`, auto-compaction, or a transcript-affecting setting change. The deterministic regression harness drives `InteractiveMode.rebuildChatFromMessages` with that state: before the fix, the same `bash` command renders in two tool boxes.

## Cause
`InteractiveMode.rebuildChatFromMessages` in `packages/coding-agent/src/modes/interactive-mode.ts` preserved every component in `pendingTools` across its clear+replay. `renderSessionContext` simultaneously reconstructed completed tools from persisted `toolResult` messages. If a resolved component still appeared in `pendingTools`, the replay rendered one block and then the preservation loop appended the old live block as a second copy.

## Fix
- Remove preserved pending-tool components whose `toolCallId` already has a `toolResult` in the replayed context, leaving the replay as their single owner.
- Preserve genuinely in-flight dangling tools so subsequent streamed updates still reach their original on-screen component.
- Add an `InteractiveMode.rebuildChatFromMessages` regression covering both resolved-lingering and genuinely in-flight tool calls.
- Document the fix in the coding-agent changelog.

## Verification
`bun test test/repro-issue-6516-tool-double-render.test.ts test/issue-2372-repro.test.ts test/repro-issue-1955-sendmessage-double-render.test.ts test/transcript-history-exactly-once.test.ts test/compaction-transcript-reuse.test.ts test/modes/utils/render-initial-messages.test.ts` — 21 passed, 0 failed.

`bun test test/interactive-mode-loop.test.ts test/modes/controllers/ test/event-controller-mixed-assistant-render.test.ts` — 169 passed, 0 failed.

The pre-publish gate also completed `bun run fix` and `bun check`. Fixes #6516