### PR TITLE
fix(ai): repair Alibaba Token Plan usage reporting

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed QwenCloud Token Plan quota reporting to call the current console usage RPC and document how to capture its optional Cookie during login.
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/ai/src/registry/alibaba-token-plan.ts
+++ b/packages/ai/src/registry/alibaba-token-plan.ts
@@ -9,7 +9,8 @@ const TOKEN_PLAN_BASE_URL = "https://token-plan.ap-southeast-1.maas.aliyuncs.com
 const loginApiKey = createApiKeyLogin({
 	providerLabel: "QwenCloud Token Plan",
 	authUrl: "https://home.qwencloud.com/billing/subscription/token-plan-individual",
-	instructions: "Subscribe to Token Plan Individual and copy its dedicated API key",
+	instructions:
+		"Subscribe to Token Plan Individual and copy its dedicated API key. Keep this page open; the next prompt explains how to enable optional quota reporting.",
 	promptMessage: "Paste your QwenCloud Token Plan API key",
 	placeholder: "sk-sp-...",
 	validation: {
@@ -24,14 +25,29 @@ export async function loginAlibabaTokenPlan(options: OAuthController): Promise<s
 		throw new AIError.OnPromptRequiredError("QwenCloud Token Plan");
 	}
 	const apiKey = await loginApiKey(options);
-	const cookie = await options.onPrompt({
+	const rawCookie = await options.onPrompt({
 		message:
-			"Paste the Cookie request header from home.qwencloud.com for optional quota reporting, or press Enter to skip",
-		placeholder: "login_aliyunid_csrf=...; ...",
+			"Optional quota reporting: open browser DevTools → Network, reload the Token Plan page, filter for api.json, and select the cs-data.qwencloud.com/data/api.json request whose api query ends in /tokenplan/personal/api/v2/usage. Copy Request Headers → Cookie, then paste the complete name=value; ... value here, or press Enter to skip.",
+		placeholder: "name=value; name=value; ...",
 		allowEmpty: true,
 	});
+	const cookie = rawCookie
+		.trim()
+		.replace(/^Cookie:\s*/i, "")
+		.trim();
 	if (options.signal?.aborted) {
 		throw new AIError.LoginCancelledError();
+	}
+	if (
+		cookie &&
+		!cookie.split(";").some(segment => {
+			const separator = segment.indexOf("=");
+			return separator > 0 && Boolean(segment.slice(0, separator).trim() && segment.slice(separator + 1).trim());
+		})
+	) {
+		throw new AIError.ConfigurationError(
+			"Invalid QwenCloud Cookie header. Copy the complete Cookie request header from the cs-data.qwencloud.com usage request, not a single cookie value.",
+		);
 	}
 	return serializeAlibabaTokenPlanCredential(apiKey, cookie);
 }

--- a/packages/ai/src/usage/alibaba-token-plan.ts
+++ b/packages/ai/src/usage/alibaba-token-plan.ts
@@ -14,13 +14,21 @@ const PROVIDER = "alibaba-token-plan";
 const CONSOLE_ORIGIN = "https://home.qwencloud.com";
 const DASHBOARD_URL = `${CONSOLE_ORIGIN}/billing/subscription/token-plan-individual`;
 const USER_INFO_URL = `${CONSOLE_ORIGIN}/tool/user/info.json`;
-const USAGE_URL = `${CONSOLE_ORIGIN}/data/api.json?product=sfm_bailian&action=IntlBroadScopeAspnGateway`;
 const GATEWAY_ACTION = "IntlBroadScopeAspnGateway";
 const USAGE_API = "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage";
+const USAGE_URL = `https://cs-data.qwencloud.com/data/api.json?product=sfm_bailian&action=${GATEWAY_ACTION}&api=${encodeURIComponent(USAGE_API)}`;
 const BROWSER_USER_AGENT =
 	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
 const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const CONSOLE_CORNERSTONE_PARAM = {
+	domain: "home.qwencloud.com",
+	consoleSite: "QWENCLOUD",
+	console: "ONE_CONSOLE",
+	xsp_lang: "en-US",
+	protocol: "V2",
+	productCode: "p_efm",
+} as const;
 
 function extractCookieValue(header: string, name: string): string | undefined {
 	for (const segment of header.split(";")) {
@@ -30,6 +38,21 @@ function extractCookieValue(header: string, name: string): string | undefined {
 		return value || undefined;
 	}
 	return undefined;
+}
+
+function unwrapGatewayData(value: Record<string, unknown>): Record<string, unknown> {
+	let current = value;
+	if (typeof current.Data === "string") {
+		try {
+			const parsed: unknown = JSON.parse(current.Data);
+			if (isRecord(parsed)) current = parsed;
+		} catch {
+			return current;
+		}
+	}
+	if (isRecord(current.DataV2) && isRecord(current.DataV2.data)) current = current.DataV2.data;
+	if (isRecord(current.data)) current = current.data;
+	return current;
 }
 
 function parseResetTime(value: unknown): number | undefined {
@@ -127,7 +150,11 @@ async function fetchAlibabaTokenPlanUsage(
 			action: GATEWAY_ACTION,
 			region: "ap-southeast-1",
 			sec_token: secToken,
-			params: JSON.stringify({ Api: USAGE_API, Data: {} }),
+			params: JSON.stringify({
+				Api: USAGE_API,
+				Data: { cornerstoneParam: CONSOLE_CORNERSTONE_PARAM },
+				V: "1.0",
+			}),
 		});
 		const usageResponse = await ctx.fetch(USAGE_URL, {
 			method: "POST",
@@ -145,22 +172,23 @@ async function fetchAlibabaTokenPlanUsage(
 			ctx.logger?.warn("QwenCloud usage response invalid", { provider: PROVIDER });
 			return null;
 		}
+		const responseData = unwrapGatewayData(payload.data);
 		const accountId = accountIdFromUserData(userPayload.data);
 		const limits = [
 			buildLimit(
 				"5h",
 				"5 Hour Credits",
 				FIVE_HOURS_MS,
-				parseUsedFraction(payload.data.per5HourPercentage),
-				parseResetTime(payload.data.per5HourResetTime),
+				parseUsedFraction(responseData.per5HourPercentage),
+				parseResetTime(responseData.per5HourResetTime),
 				accountId,
 			),
 			buildLimit(
 				"7d",
 				"7 Day Credits",
 				SEVEN_DAYS_MS,
-				parseUsedFraction(payload.data.per1WeekPercentage),
-				parseResetTime(payload.data.per1WeekResetTime),
+				parseUsedFraction(responseData.per1WeekPercentage),
+				parseResetTime(responseData.per1WeekResetTime),
 				accountId,
 			),
 		].filter((limit): limit is UsageLimit => limit !== undefined);

--- a/packages/ai/test/alibaba-token-plan-usage.test.ts
+++ b/packages/ai/test/alibaba-token-plan-usage.test.ts
@@ -27,13 +27,17 @@ describe("QwenCloud Token Plan opt-in usage", () => {
 			}
 			return Promise.resolve(
 				Response.json({
-					code: "200",
-					successResponse: true,
 					data: {
-						per5HourPercentage: 0.25,
-						per5HourResetTime: 1_800_000_000_000,
-						per1WeekPercentage: 0.5,
-						per1WeekResetTime: 1_800_100_000_000,
+						DataV2: {
+							data: {
+								data: {
+									per5HourPercentage: 0.25,
+									per5HourResetTime: 1_800_000_000_000,
+									per1WeekPercentage: 0.5,
+									per1WeekResetTime: 1_800_100_000_000,
+								},
+							},
+						},
 					},
 				}),
 			);
@@ -48,7 +52,7 @@ describe("QwenCloud Token Plan opt-in usage", () => {
 		expect(new Headers(requests[0]?.init?.headers).get("Cookie")).toBe(cookie);
 		expect(requests[0]?.init?.redirect).toBe("manual");
 		expect(requests[1]?.url).toBe(
-			"https://home.qwencloud.com/data/api.json?product=sfm_bailian&action=IntlBroadScopeAspnGateway",
+			"https://cs-data.qwencloud.com/data/api.json?product=sfm_bailian&action=IntlBroadScopeAspnGateway&api=zeldaHttp.apikeyMgr.%2Ftokenplan%2Fpersonal%2Fapi%2Fv2%2Fusage",
 		);
 		const usageHeaders = new Headers(requests[1]?.init?.headers);
 		expect(usageHeaders.get("Cookie")).toBe(cookie);
@@ -59,8 +63,22 @@ describe("QwenCloud Token Plan opt-in usage", () => {
 		expect(usageHeaders.get("x-csrf-token")).toBe("csrf-token");
 		expect(requests[1]?.init?.redirect).toBe("manual");
 		const body = new URLSearchParams(String(requests[1]?.init?.body));
+		expect(body.get("sec_token")).toBe("sec-token");
 		expect(body.get("params")).toBe(
-			JSON.stringify({ Api: "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage", Data: {} }),
+			JSON.stringify({
+				Api: "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage",
+				Data: {
+					cornerstoneParam: {
+						domain: "home.qwencloud.com",
+						consoleSite: "QWENCLOUD",
+						console: "ONE_CONSOLE",
+						xsp_lang: "en-US",
+						protocol: "V2",
+						productCode: "p_efm",
+					},
+				},
+				V: "1.0",
+			}),
 		);
 		expect(report).toMatchObject({
 			provider: "alibaba-token-plan",

--- a/packages/ai/test/alibaba-token-plan.test.ts
+++ b/packages/ai/test/alibaba-token-plan.test.ts
@@ -23,7 +23,8 @@ describe("QwenCloud Token Plan login", () => {
 		expect(authRequests).toEqual([
 			{
 				url: "https://home.qwencloud.com/billing/subscription/token-plan-individual",
-				instructions: "Subscribe to Token Plan Individual and copy its dedicated API key",
+				instructions:
+					"Subscribe to Token Plan Individual and copy its dedicated API key. Keep this page open; the next prompt explains how to enable optional quota reporting.",
 			},
 		]);
 		expect(requestedUrl).toBe("https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models");
@@ -31,12 +32,19 @@ describe("QwenCloud Token Plan login", () => {
 	});
 
 	test("stores an optional console Cookie while sending only the API key to inference", async () => {
-		const prompts = ["sk-sp-test", "session_id=test; login_aliyunid_csrf=csrf-token"];
+		let cookiePrompt = "";
 		const credential = await loginAlibabaTokenPlan({
 			onAuth: () => {},
-			onPrompt: async () => prompts.shift() ?? "",
+			onPrompt: async prompt => {
+				if (!prompt.allowEmpty) return "sk-sp-test";
+				cookiePrompt = prompt.message;
+				return "Cookie: session_id=test; login_aliyunid_csrf=csrf-token";
+			},
 			fetch: () => Promise.resolve(Response.json({ data: [{ id: "qwen3.7-plus" }] })),
 		});
+		expect(cookiePrompt).toContain("DevTools → Network");
+		expect(cookiePrompt).toContain("cs-data.qwencloud.com/data/api.json");
+		expect(cookiePrompt).toContain("Request Headers → Cookie");
 		expect(JSON.parse(credential)).toEqual({
 			token: "sk-sp-test",
 			cookie: "session_id=test; login_aliyunid_csrf=csrf-token",
@@ -50,6 +58,17 @@ describe("QwenCloud Token Plan login", () => {
 		});
 		expect(setup.headers.Authorization).toBe("Bearer sk-sp-test");
 		expect(JSON.stringify(setup)).not.toContain("session_id=test");
+	});
+
+	test("rejects a single cookie value with actionable guidance", async () => {
+		const prompts = ["sk-sp-test", "5123456789012345"];
+		await expect(
+			loginAlibabaTokenPlan({
+				onAuth: () => {},
+				onPrompt: async () => prompts.shift() ?? "",
+				fetch: () => Promise.resolve(Response.json({ data: [{ id: "qwen3.7-plus" }] })),
+			}),
+		).rejects.toThrow("cs-data.qwencloud.com usage request");
 	});
 
 	test("rejects malformed compound credentials before inference setup", () => {

--- a/packages/ai/test/auth-storage-usage-cache.test.ts
+++ b/packages/ai/test/auth-storage-usage-cache.test.ts
@@ -350,13 +350,17 @@ describe("AuthStorage usage cache: provider failure policy", () => {
 				return Promise.resolve(
 					usageCalls === 1
 						? Response.json({
-								code: "200",
-								successResponse: true,
 								data: {
-									per5HourPercentage: 0.25,
-									per5HourResetTime: 1_800_000_000_000,
-									per1WeekPercentage: 0.5,
-									per1WeekResetTime: 1_800_100_000_000,
+									DataV2: {
+										data: {
+											data: {
+												per5HourPercentage: 0.25,
+												per5HourResetTime: 1_800_000_000_000,
+												per1WeekPercentage: 0.5,
+												per1WeekResetTime: 1_800_100_000_000,
+											},
+										},
+									},
 								},
 							})
 						: Response.json({


### PR DESCRIPTION
## Problem

The native Alibaba Token Plan provider authenticated successfully, but `/usage` stayed empty. The quota client posted to the legacy `home.qwencloud.com` gateway without the console request metadata required by the current Token Plan UI, and parsed the obsolete flat response shape. The optional Cookie prompt also pointed users at the wrong request and did not explain how to capture a complete header.

## Changes

- Call the current `cs-data.qwencloud.com` Token Plan usage RPC with its `api` query, `sec_token`, `V: 1.0`, and required `cornerstoneParam`.
- Unwrap the live `DataV2.data.data` response envelope before building the 5-hour and 7-day usage windows.
- Expand `/login alibaba-token-plan` guidance with exact DevTools/Network steps for locating the quota request and copying Request Headers → Cookie.
- Normalize an optional `Cookie:` prefix and reject a lone cookie value with actionable, secret-free guidance.
- Update the usage, login, and stale-session cache regressions to cover the live wire contract.

## Live proof

Ran the patched source against an authenticated QwenCloud Token Plan account:

```console
$ bun packages/coding-agent/src/cli.ts usage --provider alibaba-token-plan --json
```

Sanitized result:

```json
{
  "reports": [
    {
      "provider": "alibaba-token-plan",
      "limits": [
        {
          "id": "credits:5h",
          "amount": { "usedFraction": 0, "unit": "percent" },
          "status": "ok"
        },
        {
          "id": "credits:7d",
          "amount": { "usedFraction": 0.000500281320855, "unit": "percent" },
          "status": "ok"
        }
      ],
      "metadata": { "source": "qwencloud-console" }
    }
  ],
  "accountsWithoutUsage": [],
  "capacity": {
    "alibaba-token-plan": [
      { "window": "5h", "accounts": 1 },
      { "window": "7d", "accounts": 1 }
    ]
  }
}
```

Cookie values, `sec_token`, account identifiers, request headers, and timestamps are intentionally omitted. The observable success criteria are present: one Alibaba report, both quota windows, and no unreported authenticated account.

## Verification

- `bun test packages/ai/test/alibaba-token-plan.test.ts packages/ai/test/alibaba-token-plan-usage.test.ts packages/ai/test/auth-storage-usage-cache.test.ts` — 27 passed, 163 assertions.
- `bun check` in `packages/ai` — passed.
- Live source smoke returned both quota windows with `accountsWithoutUsage: []`.
- OMP-native reviewer lane — clean, confidence 0.96.

## Risk

Quota reporting still depends on an undocumented QwenCloud console RPC. It remains optional and fails closed when the Cookie expires or the response contract changes.