### PR TITLE
fix(coding-agent): guard retain renderer streaming args

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `retain` tool's TUI renderer crashing when streaming arguments temporarily expose a non-array `items` value ([#6528](https://github.com/can1357/oh-my-pi/issues/6528)).
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/coding-agent/src/tools/memory-render.ts
+++ b/packages/coding-agent/src/tools/memory-render.ts
@@ -27,7 +27,7 @@ import {
 // from the active theme (`•` by default, a nerd-font dot under nerd themes).
 
 interface RetainRenderArgs {
-	items?: Array<{ content?: string; context?: string }>;
+	items?: unknown;
 }
 
 interface QueryRenderArgs {
@@ -35,7 +35,16 @@ interface QueryRenderArgs {
 }
 
 function retainContents(args: RetainRenderArgs | undefined): string[] {
-	return (args?.items ?? []).map(item => replaceTabs((item?.content ?? "").trim())).filter(line => line.length > 0);
+	const items = args?.items;
+	if (!Array.isArray(items)) return [];
+
+	const contents: string[] = [];
+	for (const item of items) {
+		if (!item || typeof item !== "object" || !("content" in item) || typeof item.content !== "string") continue;
+		const content = replaceTabs(item.content.trim());
+		if (content.length > 0) contents.push(content);
+	}
+	return contents;
 }
 
 function resultText(result: { content?: Array<{ type: string; text?: string }> }): string {

--- a/packages/coding-agent/test/tools/memory-renderer.test.ts
+++ b/packages/coding-agent/test/tools/memory-renderer.test.ts
@@ -66,6 +66,17 @@ describe("retainToolRenderer", () => {
 		const rendered = lines(retainToolRenderer.renderCall(args, { expanded: false, isPartial: true }, uiTheme));
 		expect(rendered.filter(line => line.includes(bullet))).toHaveLength(3);
 	});
+
+	it("ignores transient non-array items while the call streams", async () => {
+		const uiTheme = await theme();
+		const bullet = uiTheme.format.bullet;
+		const rendered = lines(
+			retainToolRenderer.renderCall({ items: "[" }, { expanded: false, isPartial: true }, uiTheme),
+		);
+
+		expect(rendered[0]).toContain("Retain");
+		expect(rendered.some(line => line.includes(bullet))).toBe(false);
+	});
 });
 
 describe("recallToolRenderer", () => {


### PR DESCRIPTION
## Repro
On current `main`, invoke `retainToolRenderer.renderCall({ items: "[" }, { expanded: false, isPartial: true }, darkTheme)` through `bun -e`; the process exits 1 at `packages/coding-agent/src/tools/memory-render.ts:38` with `TypeError: (args?.items ?? []).map is not a function`.

## Cause
`retainContents` in `packages/coding-agent/src/tools/memory-render.ts` typed `items` as the final validated retain schema and immediately called `.map()`, but the TUI renderer also receives unvalidated partial display arguments while an `xd://retain` call streams. A transient non-array value therefore escaped the schema boundary and crashed rendering.

## Fix
- Treat non-array `items` as absent and ignore malformed entries before formatting memory content.
- Add renderer regression coverage for a transient string-valued `items` field.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/memory-renderer.test.ts` passes: 7 tests, 0 failures. The original `bun -e` reproduction now exits 0. Skipped the pre-publish gate because `bun run fix` fails identically on clean `main` while building `audiopus_sys`/`maudio-sys`: this workstation lacks CMake and libclang; the TypeScript formatter completes without changes.

Fixes #6528