### PR TITLE
feat(catalog): add claude-opus-5 to curated Anthropic fallback catalog

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `claude-opus-5` to the curated Anthropic fallback catalog ([#6534](https://github.com/can1357/oh-my-pi/pull/6534) by [@wolfiesch](https://github.com/wolfiesch)).
+
 ## [17.1.1] - 2026-07-24
 
 ### Added

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -11628,6 +11628,37 @@
 				"supportsDisplay": true
 			}
 		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Claude Opus 5",
+			"api": "anthropic-messages",
+			"provider": "anthropic",
+			"baseUrl": "https://api.anthropic.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
 		"claude-sonnet-4-0": {
 			"id": "claude-sonnet-4-0",
 			"name": "Claude Sonnet 4",
@@ -11778,10 +11809,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -13860,7 +13891,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -16681,7 +16712,8 @@
 				"effortMap": {
 					"minimal": "none"
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"glm-5.2": {
 			"id": "glm-5.2",
@@ -16859,7 +16891,8 @@
 				"effortMap": {
 					"minimal": "none"
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -16925,7 +16958,8 @@
 				"effortMap": {
 					"minimal": "none"
 				}
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"minimax-m2.5": {
 			"id": "minimax-m2.5",
@@ -18563,7 +18597,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-gpt-5-2": {
 			"id": "duo-chat-gpt-5-2",
@@ -18592,7 +18627,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-gpt-5-2-codex": {
 			"id": "duo-chat-gpt-5-2-codex",
@@ -18621,7 +18657,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-gpt-5-codex": {
 			"id": "duo-chat-gpt-5-codex",
@@ -18650,7 +18687,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-gpt-5-mini": {
 			"id": "duo-chat-gpt-5-mini",
@@ -18679,7 +18717,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-haiku-4-5": {
 			"id": "duo-chat-haiku-4-5",
@@ -18709,7 +18748,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-opus-4-5": {
 			"id": "duo-chat-opus-4-5",
@@ -18739,7 +18779,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-opus-4-6": {
 			"id": "duo-chat-opus-4-6",
@@ -18769,7 +18810,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-sonnet-4-5": {
 			"id": "duo-chat-sonnet-4-5",
@@ -18799,7 +18841,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"duo-chat-sonnet-4-6": {
 			"id": "duo-chat-sonnet-4-6",
@@ -18829,7 +18872,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5-codex": {
 			"id": "gpt-5-codex",
@@ -50423,8 +50467,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 983616,
+			"maxTokens": 131072
 		},
 		"qwq-32b": {
 			"id": "qwq-32b",
@@ -62536,8 +62580,6 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"requestModelId": "gpt-5.6-luna",
-			"reasoningMode": "pro",
 			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
@@ -62548,7 +62590,9 @@
 					"xhigh",
 					"max"
 				]
-			}
+			},
+			"requestModelId": "gpt-5.6-luna",
+			"reasoningMode": "pro"
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -62600,8 +62644,6 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"requestModelId": "gpt-5.6-sol",
-			"reasoningMode": "pro",
 			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
@@ -62612,7 +62654,9 @@
 					"xhigh",
 					"max"
 				]
-			}
+			},
+			"requestModelId": "gpt-5.6-sol",
+			"reasoningMode": "pro"
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -62664,8 +62708,6 @@
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"requestModelId": "gpt-5.6-terra",
-			"reasoningMode": "pro",
 			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
@@ -62676,7 +62718,9 @@
 					"xhigh",
 					"max"
 				]
-			}
+			},
+			"requestModelId": "gpt-5.6-terra",
+			"reasoningMode": "pro"
 		},
 		"gpt-realtime-2.1": {
 			"id": "gpt-realtime-2.1",
@@ -87928,6 +87972,16 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87940,16 +87994,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.3": {
@@ -87971,6 +88015,16 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87983,16 +88037,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.5": {
@@ -88014,6 +88058,16 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88026,16 +88080,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-build": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -167,8 +167,11 @@ function buildAnthropicReferenceMap(
 	for (const model of modelsDevModels) {
 		merged.set(model.id, model);
 	}
-	// Anthropic /v1/models does not carry token limits, so bundled metadata stays canonical
-	// for known models while models.dev only fills gaps for newly discovered ids.
+	for (const model of ANTHROPIC_CURATED_FALLBACK_MODELS) {
+		merged.set(model.id, model);
+	}
+	// Curated entries override models.dev gaps, while bundled metadata stays canonical
+	// for known models.
 	const bundledModels = getBundledModels("anthropic").filter(
 		(model): model is Model<"anthropic-messages"> => model.api === "anthropic-messages",
 	);
@@ -188,6 +191,18 @@ function buildAnthropicReferenceMap(
  * by the generator's policy pass (scripts/generated-policies.ts).
  */
 export const ANTHROPIC_CURATED_FALLBACK_MODELS: readonly ModelSpec<"anthropic-messages">[] = [
+	{
+		id: "claude-opus-5",
+		name: "Claude Opus 5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	},
 	{
 		id: "claude-sonnet-5",
 		name: "Claude Sonnet 5",

--- a/packages/catalog/test/anthropic-provider.test.ts
+++ b/packages/catalog/test/anthropic-provider.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+	ANTHROPIC_CURATED_FALLBACK_MODELS,
+	anthropicModelManagerOptions,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+describe("Anthropic provider", () => {
+	test("preserves curated Opus 5 metadata during first-party discovery", async () => {
+		const fetchMock: FetchImpl = input => {
+			const url = String(input);
+			if (url === "https://models.dev/api.json") {
+				return Promise.resolve(Response.json({ anthropic: { models: {} } }));
+			}
+			if (url === "https://api.anthropic.com/v1/models") {
+				return Promise.resolve(Response.json({ data: [{ id: "claude-opus-5", display_name: "Claude Opus 5" }] }));
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+
+		const options = anthropicModelManagerOptions({ apiKey: "sk-ant-test", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+		const opus = models?.find(model => model.id === "claude-opus-5");
+		const curated = ANTHROPIC_CURATED_FALLBACK_MODELS.find(model => model.id === "claude-opus-5");
+
+		expect(curated).toBeDefined();
+		expect(opus).toMatchObject({
+			reasoning: curated?.reasoning,
+			input: curated?.input,
+			cost: curated?.cost,
+			contextWindow: curated?.contextWindow,
+			maxTokens: curated?.maxTokens,
+		});
+	});
+});


### PR DESCRIPTION
## What

Adds an authoritative Claude Opus 5 fallback for the direct Anthropic provider. When live discovery returns the model ID without complete capabilities or pricing, catalog resolution preserves the curated reasoning, image-input, pricing, and token-limit metadata.

## Why

“Opus 5 just dropped today. Why don’t I see it in OMP?” The model is available through Anthropic OAuth, but OMP’s bundled catalog did not include `claude-opus-5`, so it was absent from model discovery and selection.

## Testing

- `bun test ./test/anthropic-provider.test.ts`
- `bun test` in `packages/catalog` (489 passed)
- `bun run check:types` in `packages/catalog`
- `bunx biome check src/provider-models/openai-compat.ts test/anthropic-provider.test.ts src/models.json`
- Bundled-model smoke check verified reasoning, image input, 1M context, 128K output, and the `low,medium,high,xhigh,max` effort ladder
- Two consecutive credential-isolated, network-disabled catalog generations produced identical SHA-256 output

Full `bun run check` remains blocked by three pre-existing formatting errors in unrelated catalog tests; the changed-file Biome check and package type check pass.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
