### PR TITLE
fix(cursor): forward write transport so xd:// previews resolve

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor sessions exposing `ast_edit` (and other staged-preview `xd://` devices) without a reachable resolver: the built-in `write` tool — which carries the `xd://resolve` / `xd://reject` transport that finalizes a staged preview — was filtered out of Cursor's forwarded catalog, so previews could never be resolved and the session aborted after three forced `write` turns. `write` is now re-included in the forwarded catalog whenever pi-agent devices are advertised ([#6536](https://github.com/can1357/oh-my-pi/issues/6536)).
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2401,7 +2401,7 @@ function readCursorBlob(blobStore: Map<string, Uint8Array>, blobId: Uint8Array):
 
 const CURSOR_NATIVE_TOOL_NAMES = new Set(["bash", "read", "write", "delete", "ls", "grep", "lsp", "todo"]);
 
-function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
+export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
 	if (!tools || tools.length === 0) {
 		return [];
 	}
@@ -2411,7 +2411,16 @@ function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[]
 		return [];
 	}
 
-	return advertisedTools.map(tool => {
+	// The `write` tool doubles as the xd:// transport: forwarded devices such as
+	// `ast_edit` stage previews finalized only by writing a reason to xd://resolve
+	// or xd://reject. Cursor's native catalog may expose no write path, so
+	// re-include the built-in `write` (dropped as native above) whenever pi-agent
+	// devices are advertised — otherwise a staged preview can never be resolved
+	// and the SoftToolRequirement('write') escalation aborts the turn.
+	const writeTool = tools.find(tool => tool.name === "write");
+	const forwarded = writeTool ? [...advertisedTools, writeTool] : advertisedTools;
+
+	return forwarded.map(tool => {
 		const jsonSchema = toolWireSchema(tool);
 		const schemaValue: JsonValue =
 			jsonSchema && typeof jsonSchema === "object"

--- a/packages/ai/test/cursor-mcp-tool-catalog.test.ts
+++ b/packages/ai/test/cursor-mcp-tool-catalog.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { buildMcpToolDefinitions } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
+
+const tool = (name: string): Tool => ({
+	name,
+	description: `${name} tool`,
+	parameters: { type: "object", properties: {} },
+});
+
+describe("cursor buildMcpToolDefinitions", () => {
+	it("forwards the write transport alongside preview-staging devices so xd:// resolution stays reachable", () => {
+		// A Cursor session with xdev on: ast_edit is a mounted device, write is the
+		// xd:// transport carried top-level. ast_edit always stages a preview whose
+		// resolution rides `write xd://resolve` / `write xd://reject`.
+		const defs = buildMcpToolDefinitions([
+			tool("read"),
+			tool("write"),
+			tool("bash"),
+			tool("todo"),
+			tool("ast_edit"),
+			tool("task"),
+		]);
+		const names = defs.map(def => def.name);
+
+		expect(names).toContain("ast_edit");
+		expect(names).toContain("task");
+		// `write` is the sole native-filtered tool re-included: without it the
+		// staged preview can never be resolved and the SoftToolRequirement('write')
+		// escalation aborts the turn.
+		expect(names).toContain("write");
+		expect(names).not.toContain("read");
+		expect(names).not.toContain("bash");
+		expect(names).not.toContain("todo");
+
+		// The forwarded write must be a routable pi-agent MCP tool, so Cursor
+		// dispatches it back through the coding-agent write tool's xd:// handler.
+		const writeDef = defs.find(def => def.name === "write");
+		expect(writeDef?.providerIdentifier).toBe("pi-agent");
+		expect(writeDef?.toolName).toBe("write");
+	});
+
+	it("keeps write out when only native tools are advertised (no pi-agent device needs resolution)", () => {
+		const names = buildMcpToolDefinitions([tool("read"), tool("write"), tool("bash")]).map(def => def.name);
+		expect(names).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Repro
With `tools.xdev=true` (the default), a Cursor session is exposed `ast_edit` but no callable `write`/`xd://resolve` path. `ast_edit` always stages a dry-run preview whose resolution is a plain-text write to `xd://resolve`/`xd://reject`; with no model-visible way to issue that write, OMP forces `write` for three turns then aborts with `Soft tool requirement 'write' was not satisfied after 3 forced turns`. Simulating the pre-fix filter over a Cursor xdev session's `context.tools` `[read, write, bash, todo, ast_edit, task]` yields the forwarded catalog `["ast_edit", "task"]` — `ast_edit` present, `write` absent (a live repro needs paid Cursor auth, so the gap is demonstrated deterministically against the forwarding logic).

## Cause
`buildMcpToolDefinitions` in `packages/ai/src/providers/cursor.ts` forwards mounted `xd://` devices (e.g. `ast_edit`) into Cursor's request-context catalog (PR #5651) but filters the built-in `write` tool out via `CURSOR_NATIVE_TOOL_NAMES`. `write` is the `xd://` resolution transport: staged previews from `ast_edit` (`tools/ast-edit.ts:299` runs `dryRun:true`, `:433` calls `queueResolveHandler`) are finalized only by a `write` to `xd://resolve`/`xd://reject`, and the session installs `SoftToolRequirement(toolName:"write", satisfies:isPreviewResolutionToolCall)` (`session/agent-session.ts:1486`). Cursor's native catalog for this model exposes no `write`, so the requirement is unsatisfiable and the agent-loop escalation (`MAX_SOFT_TOOL_ESCALATIONS=3`) aborts.

## Fix
- `packages/ai/src/providers/cursor.ts`: in `buildMcpToolDefinitions`, once any pi-agent (non-native) tool is advertised, re-include the built-in `write` tool in the forwarded catalog so the `xd://resolve`/`xd://reject` transport is reachable. It is forwarded as a routable pi-agent MCP tool, so Cursor dispatches it back through `CursorExecHandlers.mcp` → the coding-agent `write` tool's `xd://` handler. Other native tools (`read`, `bash`, `todo`, …) stay filtered; pure-native sessions (no advertised devices) still forward nothing.
- `packages/ai/test/cursor-mcp-tool-catalog.test.ts`: new regression test asserting `write` is forwarded (as a `pi-agent`/`toolName:write` def) alongside `ast_edit` while other natives are excluded, and that a purely-native tool set forwards nothing.
- `packages/ai/CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Verification
`bun test test/cursor-exec-handlers.test.ts test/cursor-streaming-args.test.ts test/cursor-mcp-tool-catalog.test.ts` in `packages/ai` → 38 pass, 0 fail. Pre-publish gate (`bun run fix` + `bun check`) passed on push. Fixes #6536