### PR TITLE
fix(ai): stop one Codex window's limit from blocking the others

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 - Fixed Cursor sessions exposing `ast_edit` (and other staged-preview `xd://` devices) without a reachable resolver: the built-in `write` tool — which carries the `xd://resolve` / `xd://reject` transport that finalizes a staged preview — was filtered out of Cursor's forwarded catalog, so previews could never be resolved and the session aborted after three forced `write` turns. `write` is now re-included in the forwarded catalog whenever pi-agent devices are advertised ([#6536](https://github.com/can1357/oh-my-pi/issues/6536)).
 - Fixed OpenAI Responses and chat-completions streams honoring per-model first-event watchdog policy, allowing local llama.cpp-style backends to process arbitrarily large prompts without a premature client cancellation ([#6524](https://github.com/can1357/oh-my-pi/issues/6524)).
+### Fixed
+
+- Stopped the account-level Codex `rate_limit.limit_reached` flag from being applied to individual chat windows. Codex reports one shared flag for the whole account, so a window with real headroom was marked `exhausted` because a different window (or a separate metered feature) was at its limit, which over-blocked sibling accounts during credential selection. Each window's status now reflects only its own usage
+- Scoped Codex reactive backoff per meter: a `usage_limit_reached` from a Spark request no longer persists a block that ordinary chat requests honour, and the reverse. Blocks written before scoping used a shared scope meaning "block everything", so requests still honour it and reconciliation still heals it
+- Implemented `scopeLimits` for the Codex ranking strategy so a request gates only on the windows it actually consumes: `-spark` models spend the Spark meter and every other model spends the 5h/weekly chat windows, instead of OR-ing every window and meter into one provider-wide block
 
 ## [17.1.2] - 2026-07-24
 

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -533,6 +533,12 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			});
 	}
 
+	deleteCredentialBlock(_credentialId: number, _providerKey: string, _blockScope: string): void {
+		// The broker protocol only supports deleting every block for a credential.
+		// Keep scoped blocks until expiry rather than risk deleting unrelated or
+		// newer broker state through that broader operation.
+	}
+
 	deleteCredentialBlocks(credentialId: number): void {
 		this.#deleteSnapshotBlocks(credentialId);
 		for (const key of this.#credentialBlockReconcileAfter.keys()) {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -381,6 +381,8 @@ export interface AuthCredentialStore {
 	getCredentialBlockReconcileAfter?(credentialId: number, providerKey: string, blockScope: string): number | undefined;
 	/** Upsert with MAX semantics: keep the later blockedUntilMs on conflict. */
 	upsertCredentialBlock?(block: StoredCredentialBlock): void;
+	/** Drop one block row for a credential/provider/scope key. */
+	deleteCredentialBlock?(credentialId: number, providerKey: string, blockScope: string): void;
 	/** Drop every block row for a credential (all providerKeys/scopes). */
 	deleteCredentialBlocks?(credentialId: number): void;
 	/** Prune rows with blocked_until_ms <= nowMs. */
@@ -1654,11 +1656,16 @@ export class AuthStorage {
 		provider: string,
 		providerKey: string,
 		credentialIndex: number,
-		blockScope: string | undefined = undefined,
+		blockScopeOrScopes: string | readonly string[] | undefined = undefined,
 	): number | undefined {
 		const nowMs = Date.now();
+		// A request honours its own scope plus any legacy catch-all scope, so a
+		// block written before backoff was scoped still applies to everything.
+		const scopes = (
+			typeof blockScopeOrScopes === "string" ? [blockScopeOrScopes] : (blockScopeOrScopes ?? [])
+		).filter(scope => scope.length > 0);
 		let blockedUntil = this.#getCredentialBlockedUntilForKey(providerKey, credentialIndex, nowMs);
-		if (blockScope) {
+		for (const blockScope of scopes) {
 			const scopedBlockedUntil = this.#getCredentialBlockedUntilForKey(
 				this.#toScopedBackoffKey(providerKey, blockScope),
 				credentialIndex,
@@ -1671,16 +1678,14 @@ export class AuthStorage {
 
 		const credentialId = this.#getStoredCredentials(provider)[credentialIndex]?.id;
 		if (credentialId === undefined) return blockedUntil;
-		if (!blockScope || provider !== "openai-codex") {
-			const persistedGlobalBlockedUntil = this.#readPersistedCredentialBlock(credentialId, providerKey, "");
-			if (
-				persistedGlobalBlockedUntil !== undefined &&
-				(blockedUntil === undefined || persistedGlobalBlockedUntil > blockedUntil)
-			) {
-				blockedUntil = persistedGlobalBlockedUntil;
-			}
+		const persistedGlobalBlockedUntil = this.#readPersistedCredentialBlock(credentialId, providerKey, "");
+		if (
+			persistedGlobalBlockedUntil !== undefined &&
+			(blockedUntil === undefined || persistedGlobalBlockedUntil > blockedUntil)
+		) {
+			blockedUntil = persistedGlobalBlockedUntil;
 		}
-		if (blockScope) {
+		for (const blockScope of scopes) {
 			const persistedScopedBlockedUntil = this.#readPersistedCredentialBlock(credentialId, providerKey, blockScope);
 			if (
 				persistedScopedBlockedUntil !== undefined &&
@@ -1697,7 +1702,7 @@ export class AuthStorage {
 		provider: string,
 		providerKey: string,
 		credentialIndex: number,
-		blockScope: string | undefined = undefined,
+		blockScope: string | readonly string[] | undefined = undefined,
 	): boolean {
 		return this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScope) !== undefined;
 	}
@@ -1882,6 +1887,8 @@ export class AuthStorage {
 		strategy: CredentialRankingStrategy;
 		rankingContext: CredentialRankingContext;
 		blockScope?: string;
+		/** Scopes a block may live under for this request; reads honour all of them. */
+		blockScopes?: readonly string[];
 	}): Promise<ApiKeyCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -1895,7 +1902,7 @@ export class AuthStorage {
 					args.provider,
 					args.providerKey,
 					selection.index,
-					args.blockScope,
+					args.blockScopes ?? args.blockScope,
 				);
 				if (blockedUntil !== undefined) {
 					return { selection, usage: null, usageChecked: false, blockedUntil };
@@ -1920,7 +1927,7 @@ export class AuthStorage {
 					args.provider,
 					args.providerKey,
 					selection.index,
-					args.blockScope,
+					args.blockScopes ?? args.blockScope,
 				);
 				return { selection, usage: null, usageChecked: false, blockedUntil };
 			});
@@ -2003,6 +2010,7 @@ export class AuthStorage {
 
 		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
 		const blockScope = strategy.blockScope?.(rankingContext);
+		const blockScopes = strategy.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
 		const candidates = await this.#rankApiKeySelections({
 			providerKey,
 			provider,
@@ -2012,6 +2020,7 @@ export class AuthStorage {
 			strategy,
 			rankingContext,
 			blockScope,
+			blockScopes,
 		});
 		return candidates[0]?.selection ?? fallback;
 	}
@@ -3684,6 +3693,7 @@ export class AuthStorage {
 
 		const rankingContext: CredentialRankingContext = { modelId: options.modelId };
 		const blockScope = strategy.blockScope?.(rankingContext);
+		const blockScopes = strategy.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
 		const reserveFraction = Number.isFinite(options.reserveFraction)
 			? Math.max(0, Math.min(1, options.reserveFraction))
 			: 0;
@@ -3692,7 +3702,7 @@ export class AuthStorage {
 			pool.map(async ({ entry, index }): Promise<ModelUsageAccountHealth> => {
 				const credentialType = entry.credential.type;
 				const providerKey = this.#getProviderTypeKey(provider, credentialType);
-				let blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScope);
+				let blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
 				if (blockedUntil !== undefined && provider !== "openai-codex") {
 					return {
 						credentialId: entry.id,
@@ -3718,7 +3728,7 @@ export class AuthStorage {
 				}
 
 				if (provider === "openai-codex") {
-					blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScope);
+					blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
 				}
 				if (blockedUntil !== undefined) {
 					return {
@@ -4145,6 +4155,7 @@ export class AuthStorage {
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
 		const blockScope = strategy?.blockScope?.(rankingContext);
+		const siblingBlockScopes = strategy?.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
 		const now = Date.now();
 		let blockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
 
@@ -4179,11 +4190,14 @@ export class AuthStorage {
 
 		let retryAtMs: number | undefined;
 		for (const candidate of remainingCredentials) {
+			// Sibling availability must use the same scope set selection reads, or
+			// this reports a sibling as free that selection will then refuse, most
+			// visibly when the sibling still carries a legacy shared block.
 			const candidateBlockedUntil = this.#getCredentialBlockedUntil(
 				provider,
 				providerKey,
 				candidate.index,
-				blockScope,
+				siblingBlockScopes,
 			);
 			if (candidateBlockedUntil === undefined) return { switched: true };
 			if (retryAtMs === undefined || candidateBlockedUntil < retryAtMs) retryAtMs = candidateBlockedUntil;
@@ -4305,6 +4319,8 @@ export class AuthStorage {
 		strategy: CredentialRankingStrategy;
 		rankingContext: CredentialRankingContext;
 		blockScope?: string;
+		/** Scopes a block may live under for this request; reads honour all of them. */
+		blockScopes?: readonly string[];
 	}): Promise<OAuthCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -4322,7 +4338,7 @@ export class AuthStorage {
 					args.provider,
 					args.providerKey,
 					selection.index,
-					args.blockScope,
+					args.blockScopes ?? args.blockScope,
 				);
 				let usage: UsageReport | null = null;
 				let usageChecked = false;
@@ -4336,7 +4352,7 @@ export class AuthStorage {
 						args.provider,
 						args.providerKey,
 						selection.index,
-						args.blockScope,
+						args.blockScopes ?? args.blockScope,
 					);
 				}
 				if (blockedUntil !== undefined) return { selection, usage, usageChecked, blockedUntil };
@@ -4447,6 +4463,8 @@ export class AuthStorage {
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
 		const blockScope = strategy?.blockScope?.(rankingContext);
+		// Reads honour every scope that applies; the scalar above is for args that persist.
+		const blockScopes = strategy?.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
 		const planRequirement = resolveOpenAICodexPlanRequirement(provider, options?.modelId);
 		const hasPlanRequirement = planRequirement !== "none";
 		const checkUsage = strategy !== undefined && (credentials.length > 1 || hasPlanRequirement);
@@ -4475,7 +4493,7 @@ export class AuthStorage {
 		const sessionPreferredIsAvailable =
 			sessionPreferredIndex !== undefined &&
 			sessionPreferredCanRefreshOrUse &&
-			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScope);
+			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScopes);
 		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || !sessionPreferredIsWarm || hasPlanRequirement);
 		// When ranking, seed the pinned credential first in the evaluation order so it wins genuine
 		// ties (the ranked comparator falls back to `orderPos`) without overriding a strictly-better
@@ -4504,6 +4522,7 @@ export class AuthStorage {
 					strategy: strategy!,
 					rankingContext,
 					blockScope,
+					blockScopes,
 				})
 			: order
 					.map(idx => credentials[idx])
@@ -4516,7 +4535,7 @@ export class AuthStorage {
 		if (!shouldRank && sessionPreferredIndex !== undefined && !hasPlanRequirement) {
 			const sessionPreferredCandidate = candidates.findIndex(
 				candidate =>
-					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScope) &&
+					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScopes) &&
 					candidate.selection.index === sessionPreferredIndex,
 			);
 			if (sessionPreferredCandidate > 0) {
@@ -4610,7 +4629,7 @@ export class AuthStorage {
 		if (hasPlanRequirement && sessionPreferredIndex !== undefined) {
 			const sessionPreferredCandidate = candidates.findIndex(
 				candidate =>
-					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScope) &&
+					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScopes) &&
 					candidate.selection.index === sessionPreferredIndex,
 			);
 			if (sessionPreferredCandidate > 0) {
@@ -4647,6 +4666,7 @@ export class AuthStorage {
 						strategy,
 						rankingContext,
 						blockScope,
+						blockScopes,
 					},
 				);
 				if (resolved) return resolved;
@@ -4824,6 +4844,7 @@ export class AuthStorage {
 			strategy?: CredentialRankingStrategy;
 			rankingContext?: CredentialRankingContext;
 			blockScope?: string;
+			blockScopes?: readonly string[];
 			/** When false, a definitive failure of THIS credential returns undefined instead of falling back to the ranked/round-robin selector (target-only resolution). */
 			allowFallback?: boolean;
 		},
@@ -4838,9 +4859,13 @@ export class AuthStorage {
 			strategy,
 			rankingContext,
 			blockScope,
+			blockScopes,
 			allowFallback = true,
 		} = usageOptions;
-		if (!allowBlocked && this.#isCredentialBlocked(provider, providerKey, selection.index, blockScope)) {
+		if (
+			!allowBlocked &&
+			this.#isCredentialBlocked(provider, providerKey, selection.index, blockScopes ?? blockScope)
+		) {
 			return undefined;
 		}
 
@@ -5573,6 +5598,70 @@ export class AuthStorage {
 	 * persisted and in-memory `openai-codex:oauth` blocks so credential selection
 	 * can re-include recovered seats before a stale block naturally expires.
 	 */
+	/**
+	 * Narrow a usage report to the limits a backoff scope covers, so a scope is
+	 * judged only by the meters it gates. A legacy scope that meant "block
+	 * everything" keeps the whole report.
+	 */
+	#scopeUsageReportToBlockScope(
+		report: UsageReport,
+		blockScope: string | undefined,
+		strategy: CredentialRankingStrategy | undefined,
+	): UsageReport {
+		if (!blockScope || !strategy?.scopeLimits || !strategy.blockScopes) return report;
+		// Find a request context whose scope set leads with this scope; its scoped
+		// limits are the ones this block gates.
+		const modelId = blockScope === "spark" ? "gpt-5.3-codex-spark" : "gpt-5.3-codex";
+		if (strategy.blockScopes({ modelId })[0] !== blockScope) return report;
+		const scopedLimits = strategy.scopeLimits(report, { modelId });
+		const meterStates = report.metadata?.meterStates;
+		const meterState =
+			meterStates !== null && typeof meterStates === "object"
+				? (meterStates as Record<string, { allowed?: boolean; limitReached?: boolean }>)[blockScope]
+				: undefined;
+		return {
+			...report,
+			limits: scopedLimits,
+			metadata:
+				meterState || blockScope === "spark"
+					? {
+							...report.metadata,
+							allowed: meterState?.allowed,
+							limitReached: meterState?.limitReached,
+						}
+					: report.metadata,
+		};
+	}
+
+	/**
+	 * Clear one backoff scope. The in-memory backoff is per scope so it is
+	 * dropped directly; the persisted store deletes a credential's blocks as a
+	 * unit, so it is only purged once no other scope still holds a live block.
+	 * Leaving a persisted row behind is safe: the scope it belongs to is
+	 * unblocked in memory, and the row heals on the pass where its own meter
+	 * recovers.
+	 */
+	#clearCredentialBlockScope(
+		provider: string,
+		credentialId: number,
+		credentialIndex: number,
+		providerKey: string,
+		blockScope: string | undefined,
+	): void {
+		const key = this.#toScopedBackoffKey(providerKey, blockScope);
+		const backoffMap = this.#credentialBackoff.get(key);
+		backoffMap?.delete(credentialIndex);
+		if (backoffMap?.size === 0) this.#credentialBackoff.delete(key);
+		const probeAfterMap = this.#credentialBackoffProbeAfter.get(key);
+		probeAfterMap?.delete(credentialIndex);
+		if (probeAfterMap?.size === 0) this.#credentialBackoffProbeAfter.delete(key);
+		try {
+			this.deleteCredentialBlock(credentialId, providerKey, blockScope ?? "");
+		} catch (err) {
+			logger.debug("Failed to clear persisted credential block", { err, provider, credentialId, blockScope });
+		}
+	}
+
 	#isHealthyCodexUsageReport(report: UsageReport): boolean {
 		if (report.provider !== "openai-codex") return false;
 		const metadata = report.metadata;
@@ -5581,13 +5670,51 @@ export class AuthStorage {
 	}
 
 	#reconcileCodexUsageBlockForCredential(provider: Provider, credentialId: number, report: UsageReport): void {
-		if (!this.#isHealthyCodexUsageReport(report)) return;
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
 		const credentialIndex = this.#getStoredCredentials(provider).findIndex(entry => entry.id === credentialId);
 		if (credentialIndex < 0) return;
 		// Mirror selection: consult the same strategy scope `markUsageLimitReached`
 		// persists under, else a scoped block is invisible here and never healed.
-		const blockScope = this.#rankingStrategyResolver?.(provider)?.blockScope?.({});
+		// Reconciliation has no request context, so it cannot know which scope a
+		// block was written under. Heal every scope the strategy can produce, plus
+		// any legacy scope it still lists, or a block persisted under one scope
+		// stays invisible here forever.
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		const blockScopes =
+			strategy?.blockScopes?.() ?? [strategy?.blockScope?.({})].filter(scope => scope !== undefined);
+		const scopesToHeal = blockScopes.length > 0 ? blockScopes : [undefined];
+		for (const blockScope of scopesToHeal) {
+			this.#healCodexUsageBlockScope(
+				provider,
+				providerKey,
+				credentialId,
+				credentialIndex,
+				blockScope,
+				report,
+				strategy,
+			);
+		}
+	}
+
+	/**
+	 * Heal one backoff scope against the limits that scope actually covers.
+	 *
+	 * Judging a scope by the whole report is wrong once scopes are per-meter: an
+	 * exhausted Spark meter would keep a recovered chat block alive, and healing
+	 * would then delete every scope including a block that is still valid. So
+	 * each scope is evaluated against its own limits and cleared on its own.
+	 */
+	#healCodexUsageBlockScope(
+		provider: Provider,
+		providerKey: string,
+		credentialId: number,
+		credentialIndex: number,
+		blockScope: string | undefined,
+		report: UsageReport,
+		strategy: CredentialRankingStrategy | undefined,
+	): void {
+		const scopedReport = this.#scopeUsageReportToBlockScope(report, blockScope, strategy);
+		if (!this.#isHealthyCodexUsageReport(scopedReport)) return;
 		const blockedUntilMs = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScope);
 		if (blockedUntilMs === undefined) return;
 		// `/usage` can lag the request path that just returned 429. Fresh local or
@@ -5603,10 +5730,11 @@ export class AuthStorage {
 		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
 			return;
 		}
-		this.#clearCredentialBlocks(provider, credentialId);
+		this.#clearCredentialBlockScope(provider, credentialId, credentialIndex, providerKey, blockScope);
 		logger.info("Cleared stale Codex usage-limit block after healthy live usage report", {
 			credentialId,
 			provider,
+			blockScope,
 			clearedBlockedUntilMs: blockedUntilMs,
 		});
 	}
@@ -5647,7 +5775,6 @@ export class AuthStorage {
 	#reconcileCodexUsageBlocksFromReports(reports: UsageReport[]): void {
 		const reconciled = new Set<number>();
 		for (const report of reports) {
-			if (!this.#isHealthyCodexUsageReport(report)) continue;
 			for (const credentialId of this.#findStoredCredentialIdsForUsageReport(report)) {
 				if (reconciled.has(credentialId)) continue;
 				reconciled.add(credentialId);
@@ -6069,6 +6196,14 @@ export class AuthStorage {
 	/**
 	 * Broker-server seam: clear all persisted blocks for one credential and notify snapshot waiters.
 	 */
+	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
+		const deleteCredentialBlock = this.#store.deleteCredentialBlock?.bind(this.#store);
+		if (!deleteCredentialBlock) return;
+		deleteCredentialBlock(credentialId, providerKey, blockScope);
+		this.#invalidateUsageReportCacheForProviderKey(providerKey);
+		this.#bumpGeneration("credential-block");
+	}
+
 	deleteCredentialBlocks(credentialId: number): void {
 		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
 		if (!deleteCredentialBlocks) return;
@@ -6445,6 +6580,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#listCredentialBlocksByCredentialStmt: Statement;
 	#upsertCredentialBlockStmt: Statement;
 	#deleteCredentialBlocksStmt: Statement;
+	#deleteCredentialBlockStmt: Statement;
 	#deleteExpiredCredentialBlocksStmt: Statement;
 	#acquireCredentialRefreshLeaseStmt: Statement;
 	#getCredentialRefreshLeaseStmt: Statement;
@@ -6532,6 +6668,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				updated_at = excluded.updated_at`,
 		);
 		this.#deleteCredentialBlocksStmt = this.#db.prepare("DELETE FROM auth_credential_blocks WHERE credential_id = ?");
+		this.#deleteCredentialBlockStmt = this.#db.prepare(
+			"DELETE FROM auth_credential_blocks WHERE credential_id = ? AND provider_key = ? AND block_scope = ?",
+		);
 		this.#deleteExpiredCredentialBlocksStmt = this.#db.prepare(
 			"DELETE FROM auth_credential_blocks WHERE blocked_until_ms <= ?",
 		);
@@ -7296,6 +7435,11 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		);
 	}
 
+	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
+		this.#deleteCredentialBlockStmt.run(credentialId, providerKey, blockScope);
+		this.#credentialBlockReconcileAfter.delete(`${credentialId}\0${providerKey}\0${blockScope}`);
+	}
+
 	deleteCredentialBlocks(credentialId: number): void {
 		this.#deleteCredentialBlocksStmt.run(credentialId);
 		for (const key of this.#credentialBlockReconcileAfter.keys()) {
@@ -7666,6 +7810,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#listCredentialBlocksByCredentialStmt.finalize();
 		this.#upsertCredentialBlockStmt.finalize();
 		this.#deleteCredentialBlocksStmt.finalize();
+		this.#deleteCredentialBlockStmt.finalize();
 		this.#deleteExpiredCredentialBlocksStmt.finalize();
 		this.#insertUsageHistoryStmt.finalize();
 		this.#lastUsageHistoryStmt.finalize();

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -391,6 +391,16 @@ export interface CredentialRankingStrategy {
 	 * not block unrelated families on the same OAuth credential.
 	 */
 	blockScope?(context?: CredentialRankingContext): string | undefined;
+	/**
+	 * Scopes that apply to a request, most specific first. With a context, the
+	 * request's own scope plus any legacy catch-all scope whose blocks still
+	 * apply to everything. Without one — reconciliation runs with no request —
+	 * every scope whose blocks must be healed.
+	 *
+	 * A provider that scopes backoff by model family must implement this, or a
+	 * block written under one scope is invisible to requests and to healing.
+	 */
+	blockScopes?(context?: CredentialRankingContext): string[];
 	/** Fallback window durations (ms) when limits don't specify durationMs. */
 	windowDefaults: {
 		primaryMs: number;

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import type {
+	CredentialRankingContext,
 	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
@@ -275,7 +276,6 @@ function buildUsageLimit(args: {
 	window: ParsedUsageWindow;
 	accountId?: string;
 	planType?: string;
-	limitReached?: boolean;
 	nowMs: number;
 }): UsageLimit {
 	const usageWindow = buildUsageWindow(args.window, args.key, args.nowMs);
@@ -290,7 +290,16 @@ function buildUsageLimit(args: {
 		},
 		window: usageWindow,
 		amount,
-		status: buildUsageStatus(amount.usedFraction, args.limitReached),
+		// Each chat window's status reflects ONLY its own usage. The account-level
+		// `rate_limit.limit_reached` flag is intentionally not applied here: Codex
+		// returns a single shared flag for the whole account, so threading it into
+		// both the primary (5h) and secondary (weekly) windows marked a window with
+		// real headroom `exhausted` purely because a different window (or a separate
+		// metered feature) was at its limit, which over-blocked sibling accounts
+		// during credential selection. `usedFraction >= 1` already marks a window
+		// that is genuinely full; a real enforced limit not reflected in
+		// `used_percent` is caught when the live request returns usage_limit_reached.
+		status: buildUsageStatus(amount.usedFraction),
 	};
 }
 function additionalLimitSlug(args: { limitName?: string; meteredFeature?: string }): string {
@@ -320,7 +329,6 @@ function buildAdditionalUsageLimit(args: {
 	displayName: string;
 	window: ParsedUsageWindow;
 	accountId?: string;
-	limitReached?: boolean;
 	limitName?: string;
 	meteredFeature?: string;
 	nowMs: number;
@@ -340,7 +348,10 @@ function buildAdditionalUsageLimit(args: {
 		},
 		window: usageWindow,
 		amount,
-		status: buildUsageStatus(amount.usedFraction, args.limitReached),
+		// The additional meter exposes one account-level flag for both windows.
+		// Status must follow this window's own usage or a full weekly meter marks
+		// the shorter window exhausted and schedules a premature retry.
+		status: buildUsageStatus(amount.usedFraction),
 	};
 }
 
@@ -428,6 +439,9 @@ export const openaiCodexUsageProvider: UsageProvider = {
 			(isRecord(payload) && typeof payload.plan_type === "string" ? payload.plan_type : undefined);
 
 		const limits: UsageLimit[] = [];
+		const meterStates: Record<string, { allowed?: boolean; limitReached?: boolean }> = {
+			chat: { allowed: parsed?.allowed, limitReached: parsed?.limitReached },
+		};
 		if (parsed?.primary) {
 			limits.push(
 				buildUsageLimit({
@@ -435,7 +449,6 @@ export const openaiCodexUsageProvider: UsageProvider = {
 					window: parsed.primary,
 					accountId,
 					planType,
-					limitReached: parsed.limitReached,
 					nowMs,
 				}),
 			);
@@ -447,7 +460,6 @@ export const openaiCodexUsageProvider: UsageProvider = {
 					window: parsed.secondary,
 					accountId,
 					planType,
-					limitReached: parsed.limitReached,
 					nowMs,
 				}),
 			);
@@ -455,6 +467,7 @@ export const openaiCodexUsageProvider: UsageProvider = {
 		for (const extra of parsed?.additional ?? []) {
 			const slug = additionalLimitSlug({ limitName: extra.limitName, meteredFeature: extra.meteredFeature });
 			const displayName = additionalDisplayName(slug, extra.limitName);
+			meterStates[slug] = { allowed: extra.allowed, limitReached: extra.limitReached };
 			if (extra.primary) {
 				limits.push(
 					buildAdditionalUsageLimit({
@@ -463,7 +476,6 @@ export const openaiCodexUsageProvider: UsageProvider = {
 						displayName,
 						window: extra.primary,
 						accountId,
-						limitReached: extra.limitReached,
 						limitName: extra.limitName,
 						meteredFeature: extra.meteredFeature,
 						nowMs,
@@ -478,7 +490,6 @@ export const openaiCodexUsageProvider: UsageProvider = {
 						displayName,
 						window: extra.secondary,
 						accountId,
-						limitReached: extra.limitReached,
 						limitName: extra.limitName,
 						meteredFeature: extra.meteredFeature,
 						nowMs,
@@ -527,6 +538,7 @@ export const openaiCodexUsageProvider: UsageProvider = {
 				limitReached: parsed?.limitReached,
 				email,
 				accountId,
+				meterStates,
 			},
 			raw: parsed?.raw ?? payload,
 		};
@@ -537,18 +549,53 @@ export const openaiCodexUsageProvider: UsageProvider = {
 
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 
+// A Codex request gates only on the chat windows it actually consumes. A
+// "-spark" model spends the separate Spark meter; every other Codex model spends
+// the 5h/weekly chat windows. Scoping the gating set this way keeps an exhausted
+// Spark meter from blocking a normal chat request (and vice versa), instead of
+// OR-ing every window and meter in the report into one provider-wide block.
+function scopeCodexLimitsForRequest(report: UsageReport, context?: CredentialRankingContext): UsageLimit[] {
+	const isSparkRequest = isCodexSparkRequest(context);
+	return report.limits.filter(limit => {
+		if (limit.id === "openai-codex:primary" || limit.id === "openai-codex:secondary") {
+			return !isSparkRequest;
+		}
+		// Additional metered features have ids of the form `openai-codex:<slug>:<key>`.
+		const slug = limit.id.split(":")[1];
+		return slug === "spark" ? isSparkRequest : false;
+	});
+}
+
+/** True when the requested model spends the separate Spark meter. */
+function isCodexSparkRequest(context?: CredentialRankingContext): boolean {
+	return (context?.modelId ?? "").toLowerCase().includes("-spark");
+}
+
 export const codexRankingStrategy: CredentialRankingStrategy = {
-	blockScope() {
-		return "shared";
+	scopeLimits: scopeCodexLimitsForRequest,
+	// A `usage_limit_reached` from a Spark request means the Spark meter is
+	// spent, not the chat windows, so the two back off under separate scopes;
+	// one shared block would let an exhausted Spark meter stop ordinary chat
+	// requests, and the reverse.
+	blockScope(context) {
+		return isCodexSparkRequest(context) ? "spark" : "chat";
 	},
-	findWindowLimits(report) {
+	// "shared" is the scope earlier versions persisted under, and it meant "block
+	// everything", so it stays honoured by every request and healed by
+	// reconciliation. Without a context (reconciliation) this is the full set.
+	blockScopes(context) {
+		if (!context) return ["chat", "spark", "shared"];
+		return [isCodexSparkRequest(context) ? "spark" : "chat", "shared"];
+	},
+	findWindowLimits(report, context) {
+		const limits = scopeCodexLimitsForRequest(report, context);
 		const findLimit = (key: "primary" | "secondary"): UsageLimit | undefined => {
-			const direct = report.limits.find(l => l.id === `openai-codex:${key}`);
+			const direct = limits.find(l => l.id === `openai-codex:${key}`);
 			if (direct) return direct;
-			const byId = report.limits.find(l => l.id.toLowerCase().includes(key));
+			const byId = limits.find(l => l.id.toLowerCase().includes(key));
 			if (byId) return byId;
 			const windowId = key === "secondary" ? "7d" : "1h";
-			return report.limits.find(l => l.scope.windowId?.toLowerCase() === windowId);
+			return limits.find(l => l.scope.windowId?.toLowerCase() === windowId);
 		};
 		return { primary: findLimit("primary"), secondary: findLimit("secondary") };
 	},

--- a/packages/ai/test/auth-storage-block-persistence.test.ts
+++ b/packages/ai/test/auth-storage-block-persistence.test.ts
@@ -168,6 +168,16 @@ describe("AuthStorage credential block persistence", () => {
 					updatedAtMs: expect.any(Number),
 				},
 			]);
+			const generationBeforeScopedDelete = storage.getGeneration();
+			storage.deleteCredentialBlock(row.id, PROVIDER_KEY, "tier:fable");
+			expect(storage.listCredentialBlocks([row.id])).toEqual([]);
+			expect(storage.getGeneration()).toBe(generationBeforeScopedDelete + 1);
+			storage.upsertCredentialBlock({
+				credentialId: row.id,
+				providerKey: PROVIDER_KEY,
+				blockScope: "tier:fable",
+				blockedUntilMs: FUTURE_BLOCK_MS,
+			});
 
 			const generationBeforeDelete = storage.getGeneration();
 			storage.deleteCredentialBlocks(row.id);

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -117,6 +117,51 @@ function createCodexUsageReport(args: {
 		metadata: { accountId: args.accountId, ...args.metadata },
 	};
 }
+function addSparkUsage(
+	report: UsageReport,
+	primaryUsedFraction: number,
+	secondaryUsedFraction: number,
+	meterState: { allowed: boolean; limitReached: boolean } = {
+		allowed: primaryUsedFraction < 1 && secondaryUsedFraction < 1,
+		limitReached: primaryUsedFraction >= 1 || secondaryUsedFraction >= 1,
+	},
+): UsageReport {
+	const makeSparkLimit = (key: "primary" | "secondary", usedFraction: number): UsageLimit => {
+		const limit = createLimit({
+			key,
+			windowId: key === "primary" ? "5h" : "7d",
+			windowLabel: key === "primary" ? "5 Hours (Spark)" : "7 Days (Spark)",
+			durationMs: key === "primary" ? FIVE_HOUR_MS : WEEK_MS,
+			usedFraction,
+			resetInMs: key === "primary" ? FIVE_HOUR_MS : WEEK_MS,
+		});
+		return {
+			...limit,
+			id: `openai-codex:spark:${key}`,
+			scope: {
+				provider: "openai-codex",
+				windowId: limit.scope.windowId,
+				tier: "spark",
+				modelId: "gpt-5.3-codex-spark",
+			},
+		};
+	};
+	return {
+		...report,
+		limits: [
+			...report.limits,
+			makeSparkLimit("primary", primaryUsedFraction),
+			makeSparkLimit("secondary", secondaryUsedFraction),
+		],
+		metadata: {
+			...report.metadata,
+			meterStates: {
+				...(report.metadata?.meterStates as Record<string, unknown> | undefined),
+				spark: meterState,
+			},
+		},
+	};
+}
 
 function createCredential(accountId: string, email: string): OAuthCredentials {
 	return {
@@ -385,6 +430,33 @@ describe("AuthStorage codex oauth ranking", () => {
 			.filter((accountId): accountId is string => accountId !== undefined)
 			.sort();
 		expect(activeAccounts).toEqual(["acct-A", "acct-B"]);
+	});
+
+	test("honors a persisted unscoped Codex block for Spark requests", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock) throw new Error("test setup failed");
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-globally-blocked", "globally-blocked@example.com") },
+			{ type: "oauth", ...createCredential("acct-sibling", "sibling@example.com") },
+		]);
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-globally-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+		store.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + HOUR_MS,
+		});
+
+		for (let index = 0; index < 20; index++) {
+			expect(
+				await authStorage.getApiKey("openai-codex", `global-block-spark-${index}`, {
+					modelId: "gpt-5.3-codex-spark",
+				}),
+			).toBe("api-acct-sibling");
+		}
 	});
 
 	test("a healthy live Codex usage report clears a stale persisted block so the account is selectable again", async () => {
@@ -674,7 +746,7 @@ describe("AuthStorage codex oauth ranking", () => {
 		const selectionAfterBlock = await authStorage.getApiKey("openai-codex", blockedSessionId);
 		expect(selectionAfterBlock).not.toBe("api-acct-fresh-blocked");
 		expect(selectionAfterBlock).toBe("api-acct-fresh-healthy");
-		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 	});
 
 	test("protects a fresh Codex block after reopening SQLite storage", async () => {
@@ -737,7 +809,7 @@ describe("AuthStorage codex oauth ranking", () => {
 		});
 
 		expect(markResult.switched).toBe(true);
-		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 
 		authStorage.close();
 		authStorage = null;
@@ -755,7 +827,7 @@ describe("AuthStorage codex oauth ranking", () => {
 				"codex-reopened-fresh-block-sibling",
 			);
 			expect(selectionAfterReopen).toBe(`api-${healthyAccountId}`);
-			expect(reopenedStore.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+			expect(reopenedStore.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 		} finally {
 			reopenedAuthStorage.close();
 		}
@@ -857,14 +929,14 @@ describe("AuthStorage codex oauth ranking", () => {
 				if (updatedSnapshot.status !== 200) throw new Error("expected broker snapshot containing fresh block");
 
 				await remoteStoreB.refreshSnapshot();
-				expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
-				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+				expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
+				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 
 				expect(await clientStorageB.getApiKey("openai-codex", "codex-broker-fresh-block-sibling")).toBe(
 					"api-acct-broker-fresh-healthy",
 				);
-				expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
-				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+				expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
+				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 			} finally {
 				clientStorageA.close();
 				clientStorageB.close();
@@ -1128,10 +1200,10 @@ describe("AuthStorage codex oauth ranking", () => {
 				if (!blockedRow) throw new Error("expected blocked credential row");
 				expect(
 					blockedRow.blocks?.some(
-						block => block.providerKey === "openai-codex:oauth" && block.blockScope === "shared",
+						block => block.providerKey === "openai-codex:oauth" && block.blockScope === "chat",
 					),
 				).toBe(true);
-				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 
 				const remoteStoreB = new RemoteAuthCredentialStore({
 					client: clientB,
@@ -1141,13 +1213,13 @@ describe("AuthStorage codex oauth ranking", () => {
 				const clientStorageB = new AuthStorage(remoteStoreB);
 				await clientStorageB.reload();
 				try {
-					expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+					expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 
 					expect(await clientStorageB.getApiKey("openai-codex", "codex-broker-initial-snapshot-sibling")).toBe(
 						`api-${healthyAccountId}`,
 					);
-					expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
-					expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+					expect(remoteStoreB.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
+					expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 				} finally {
 					clientStorageB.close();
 					remoteStoreB.close();
@@ -1233,19 +1305,19 @@ describe("AuthStorage codex oauth ranking", () => {
 			baseUrlResolver: provider => (provider === "openai-codex" ? inFlightBaseUrl : undefined),
 		});
 		await inFlightStarted.promise;
-		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeUndefined();
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeUndefined();
 
 		const markResult = await authStorage.markUsageLimitReached("openai-codex", blockedSessionId, {
 			retryAfterMs: 6 * 24 * HOUR_MS,
 		});
 
 		expect(markResult.switched).toBe(true);
-		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 
 		inFlightUsage.resolve(blockedReport);
 		await inFlightReports;
 
-		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "shared")).toBeDefined();
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "chat")).toBeDefined();
 	});
 
 	test("broker-sourced healthy Codex usage clears remote gateway backoff", async () => {
@@ -2067,50 +2139,208 @@ describe("AuthStorage codex oauth ranking", () => {
 		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("api-acct-plus");
 	});
 
-	test("ignores legacy global Codex blocks when a scoped quota window has fresh siblings", async () => {
-		if (!authStorage || !store) throw new Error("test setup failed");
+	test("ranks chat and Spark requests by their own usage windows", async () => {
+		if (!authStorage) throw new Error("test setup failed");
 		await authStorage.set("openai-codex", [
-			{ type: "oauth", ...createCredential("acct-k12", "k12@example.com") },
-			{ type: "oauth", ...createCredential("acct-plus", "plus@example.com") },
+			{ type: "oauth", ...createCredential("acct-chat-headroom", "chat-headroom@example.com") },
+			{ type: "oauth", ...createCredential("acct-spark-headroom", "spark-headroom@example.com") },
 		]);
 		usageByAccount.set(
-			"acct-k12",
-			createCodexUsageReport({
-				accountId: "acct-k12",
-				primary: { usedFraction: 1, resetInMs: FIVE_HOUR_MS },
-				secondary: { usedFraction: 1, resetInMs: WEEK_MS },
-			}),
+			"acct-chat-headroom",
+			addSparkUsage(
+				createCodexUsageReport({
+					accountId: "acct-chat-headroom",
+					primary: { usedFraction: 0.1, resetInMs: FIVE_HOUR_MS },
+					secondary: { usedFraction: 0.1, resetInMs: WEEK_MS },
+					metadata: { allowed: true, limitReached: false, planType: "pro" },
+				}),
+				0.9,
+				0.9,
+			),
 		);
 		usageByAccount.set(
-			"acct-plus",
+			"acct-spark-headroom",
+			addSparkUsage(
+				createCodexUsageReport({
+					accountId: "acct-spark-headroom",
+					primary: { usedFraction: 0.8, resetInMs: FIVE_HOUR_MS },
+					secondary: { usedFraction: 0.8, resetInMs: WEEK_MS },
+					metadata: { allowed: true, limitReached: false, planType: "pro" },
+				}),
+				0.2,
+				0.2,
+			),
+		);
+
+		expect(await authStorage.getApiKey("openai-codex", undefined, { modelId: "gpt-5.3-codex" })).toBe(
+			"api-acct-chat-headroom",
+		);
+		expect(await authStorage.getApiKey("openai-codex", undefined, { modelId: "gpt-5.3-codex-spark" })).toBe(
+			"api-acct-spark-headroom",
+		);
+	});
+
+	test("deletes only the recovered persisted Codex meter block", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-meter-recovery", "meter-recovery@example.com") },
+		]);
+		const row = store.listAuthCredentials("openai-codex")[0];
+		if (!row) throw new Error("expected credential row");
+		const blockedUntilMs = Date.now() + WEEK_MS;
+		store.upsertCredentialBlock({
+			credentialId: row.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "chat",
+			blockedUntilMs,
+		});
+		store.upsertCredentialBlock({
+			credentialId: row.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "spark",
+			blockedUntilMs,
+		});
+		ageCredentialBlockRows(dbPath);
+		store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
+		usageByAccount.set(
+			"acct-meter-recovery",
+			addSparkUsage(
+				createCodexUsageReport({
+					accountId: "acct-meter-recovery",
+					primary: { usedFraction: 0.2, resetInMs: FIVE_HOUR_MS },
+					secondary: { usedFraction: 0.2, resetInMs: WEEK_MS },
+					metadata: { allowed: true, limitReached: false, planType: "pro" },
+				}),
+				1,
+				1,
+			),
+		);
+
+		await authStorage.fetchUsageReports();
+		expect(await authStorage.getApiKey("openai-codex", "meter-recovery", { modelId: "gpt-5.3-codex" })).toBe(
+			"api-acct-meter-recovery",
+		);
+		expect(store.getCredentialBlock(row.id, "openai-codex:oauth", "chat")).toBeUndefined();
+		expect(store.getCredentialBlock(row.id, "openai-codex:oauth", "spark")).toBe(blockedUntilMs);
+	});
+
+	test("keeps a stale Spark block when live usage omits the Spark meter", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-missing-spark", "missing-spark@example.com") },
+		]);
+		const row = store.listAuthCredentials("openai-codex")[0];
+		if (!row) throw new Error("expected credential row");
+		const blockedUntilMs = Date.now() + WEEK_MS;
+		store.upsertCredentialBlock({
+			credentialId: row.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "spark",
+			blockedUntilMs,
+		});
+		ageCredentialBlockRows(dbPath);
+		store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
+		usageByAccount.set(
+			"acct-missing-spark",
 			createCodexUsageReport({
-				accountId: "acct-plus",
+				accountId: "acct-missing-spark",
 				primary: { usedFraction: 0.2, resetInMs: FIVE_HOUR_MS },
-				secondary: { usedFraction: 0.74, resetInMs: WEEK_MS },
+				secondary: { usedFraction: 0.2, resetInMs: WEEK_MS },
+				metadata: { allowed: true, limitReached: false, planType: "pro" },
 			}),
 		);
-		const plus = store
+
+		await authStorage.fetchUsageReports();
+		expect(store.getCredentialBlock(row.id, "openai-codex:oauth", "spark")).toBe(blockedUntilMs);
+	});
+
+	test("reconciles each meter against its own provider status", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-meter-status", "meter-status@example.com") },
+		]);
+		const row = store.listAuthCredentials("openai-codex")[0];
+		if (!row) throw new Error("expected credential row");
+		const blockedUntilMs = Date.now() + WEEK_MS;
+		for (const blockScope of ["chat", "spark"]) {
+			store.upsertCredentialBlock({
+				credentialId: row.id,
+				providerKey: "openai-codex:oauth",
+				blockScope,
+				blockedUntilMs,
+			});
+		}
+		ageCredentialBlockRows(dbPath);
+		store.cleanExpiredCredentialBlocks?.(Date.now() + STALE_BLOCK_GUARD_MS);
+		usageByAccount.set(
+			"acct-meter-status",
+			addSparkUsage(
+				createCodexUsageReport({
+					accountId: "acct-meter-status",
+					primary: { usedFraction: 1, resetInMs: FIVE_HOUR_MS },
+					secondary: { usedFraction: 1, resetInMs: WEEK_MS },
+					metadata: { allowed: false, limitReached: true, planType: "pro" },
+				}),
+				0.2,
+				0.2,
+				{ allowed: true, limitReached: false },
+			),
+		);
+
+		await authStorage.fetchUsageReports();
+		expect(store.getCredentialBlock(row.id, "openai-codex:oauth", "chat")).toBe(blockedUntilMs);
+		expect(store.getCredentialBlock(row.id, "openai-codex:oauth", "spark")).toBeUndefined();
+	});
+
+	test("does not reselect a pinned Spark credential with a legacy shared block", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock) throw new Error("test setup failed");
+		const accounts = ["acct-pinned-a", "acct-pinned-b"];
+		await authStorage.set(
+			"openai-codex",
+			accounts.map(accountId => ({
+				type: "oauth" as const,
+				...createCredential(accountId, `${accountId}@example.com`),
+			})),
+		);
+		for (const accountId of accounts) {
+			usageByAccount.set(
+				accountId,
+				addSparkUsage(
+					createCodexUsageReport({
+						accountId,
+						primary: { usedFraction: 0.2, resetInMs: FIVE_HOUR_MS },
+						secondary: { usedFraction: 0.2, resetInMs: WEEK_MS },
+						metadata: { allowed: true, limitReached: false, planType: "pro" },
+					}),
+					0.2,
+					0.2,
+				),
+			);
+		}
+		const sessionId = "spark-legacy-shared-pin";
+		const modelId = "gpt-5.3-codex-spark";
+		const firstKey = await authStorage.getApiKey("openai-codex", sessionId, { modelId });
+		if (!firstKey) throw new Error("expected initial selection");
+		const firstAccountId = firstKey.replace(/^api-/, "");
+		const siblingAccountId = accounts.find(accountId => accountId !== firstAccountId);
+		const pinnedRow = store
 			.listAuthCredentials("openai-codex")
-			.find(row => row.credential.type === "oauth" && row.credential.accountId === "acct-plus");
-		if (!plus || !store.upsertCredentialBlock) throw new Error("missing plus credential row");
+			.find(row => row.credential.type === "oauth" && row.credential.accountId === firstAccountId);
+		if (!pinnedRow || !siblingAccountId) throw new Error("expected pinned credential and sibling");
 		store.upsertCredentialBlock({
-			credentialId: plus.id,
-			providerKey: "openai-codex:oauth",
-			blockScope: "",
-			blockedUntilMs: Date.now() + WEEK_MS,
-		});
-		const k12 = store
-			.listAuthCredentials("openai-codex")
-			.find(row => row.credential.type === "oauth" && row.credential.accountId === "acct-k12");
-		if (!k12 || !store.upsertCredentialBlock) throw new Error("missing k12 credential row");
-		store.upsertCredentialBlock({
-			credentialId: k12.id,
+			credentialId: pinnedRow.id,
 			providerKey: "openai-codex:oauth",
 			blockScope: "shared",
-			blockedUntilMs: Date.now() + HOUR_MS,
+			blockedUntilMs: Date.now() + WEEK_MS,
 		});
 
-		expect(await authStorage.getApiKey("openai-codex", "session-with-legacy-global-block")).toBe("api-acct-plus");
+		expect(await authStorage.getApiKey("openai-codex", sessionId, { modelId })).toBe(`api-${siblingAccountId}`);
 	});
 });
 

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -81,6 +81,7 @@ const strategy: CredentialRankingStrategy = {
 	scopeLimits: (usage, context) =>
 		usage.limits.filter(entry => entry.scope.modelId === undefined || entry.scope.modelId === context?.modelId),
 	blockScope: context => (context?.modelId ? `model:${context.modelId}` : undefined),
+	blockScopes: context => [context?.modelId ? `model:${context.modelId}` : "model", "shared"],
 	windowDefaults: { primaryMs: 60_000, secondaryMs: 60_000 },
 };
 
@@ -115,6 +116,30 @@ describe("AuthStorage model usage health", () => {
 		storages.push(storage);
 		return storage;
 	}
+
+	it("honours every request scope when checking persisted health blocks", async () => {
+		const rows = [oauthRow(1)];
+		const store = makeStore(rows);
+		store.getCredentialBlock = (credentialId, _providerKey, blockScope) =>
+			credentialId === 1 && blockScope === "shared" ? Date.now() + 60_000 : undefined;
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "anthropic"
+					? makeUsageProvider({ "account-1": report("account-1", [limit("short", 0.2)]) })
+					: undefined,
+			rankingStrategyResolver: provider => (provider === "anthropic" ? strategy : undefined),
+			configValueResolver: async value => value,
+		});
+		await storage.reload();
+		storages.push(storage);
+
+		const health = await storage.getModelUsageHealth("anthropic", {
+			modelId: "claude",
+			reserveFraction: 0.1,
+		});
+		expect(health.state).toBe("depleted");
+		expect(health.accounts[0]?.state).toBe("depleted");
+	});
 
 	it("keeps the model healthy while any OAuth sibling has headroom", async () => {
 		const storage = await createStorage([oauthRow(1), oauthRow(2)], {

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from "bun:test";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
-import { openaiCodexUsageProvider } from "@oh-my-pi/pi-ai/usage/openai-codex";
+import { codexRankingStrategy, openaiCodexUsageProvider } from "@oh-my-pi/pi-ai/usage/openai-codex";
 
 const accessTokenFixture = (() => {
 	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
@@ -290,5 +290,85 @@ describe("openai-codex usage parser", () => {
 			{ fetch: fetchImpl },
 		);
 		expect(requested).toEqual(["https://chatgpt.com/backend-api/wham/usage"]);
+	});
+
+	it("keeps a window with headroom usable when the account flag is set", async () => {
+		// The account-level flag covers the whole account, so applying it to each
+		// window marked one with real headroom as exhausted. This is the original
+		// bug: the fixture below has `limit_reached: true` with the primary window
+		// at 4%.
+		const payload = makePayload();
+		payload.rate_limit.limit_reached = true;
+		const report = await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fakeFetch(payload) },
+		);
+
+		const primary = report?.limits.find(l => l.id === "openai-codex:primary");
+		expect(primary).toBeDefined();
+		expect(primary?.amount.usedFraction).toBeLessThan(1);
+		expect(primary?.status).not.toBe("exhausted");
+	});
+
+	it("keeps each Spark window independent of the shared meter flag", async () => {
+		const payload = makePayload();
+		payload.additional_rate_limits[0].rate_limit.limit_reached = true;
+		payload.additional_rate_limits[0].rate_limit.primary_window.used_percent = 17;
+		payload.additional_rate_limits[0].rate_limit.secondary_window.used_percent = 100;
+		const report = await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fakeFetch(payload) },
+		);
+
+		const primary = report?.limits.find(limit => limit.id === "openai-codex:spark:primary");
+		const secondary = report?.limits.find(limit => limit.id === "openai-codex:spark:secondary");
+		expect(primary?.status).toBe("ok");
+		expect(secondary?.status).toBe("exhausted");
+	});
+
+	it("scopes a request to the meters it actually spends", async () => {
+		const payload = makePayload();
+		const report = await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fakeFetch(payload) },
+		);
+		const scope = codexRankingStrategy.scopeLimits;
+		expect(scope).toBeDefined();
+
+		const chatIds = (report ? (scope?.(report, { modelId: "gpt-5.3-codex" }) ?? []) : []).map(l => l.id);
+		const sparkIds = (report ? (scope?.(report, { modelId: "gpt-5.3-codex-spark" }) ?? []) : []).map(l => l.id);
+
+		// A chat request gates on the chat windows and never on the Spark meter.
+		expect(chatIds).toContain("openai-codex:primary");
+		expect(chatIds).toContain("openai-codex:secondary");
+		expect(chatIds.some(id => id.includes("spark"))).toBe(false);
+
+		// A Spark request gates only on the Spark meter.
+		expect(sparkIds.some(id => id.includes("spark"))).toBe(true);
+		expect(sparkIds).not.toContain("openai-codex:primary");
+		expect(sparkIds).not.toContain("openai-codex:secondary");
+	});
+
+	it("backs off Spark and chat under separate scopes", () => {
+		// A reactive `usage_limit_reached` must not persist a block the other meter
+		// honours, or the request-level isolation above is undone on the reactive
+		// path. "shared" stays in both lists because blocks written before scoping
+		// meant "block everything".
+		const chat = codexRankingStrategy.blockScope?.({ modelId: "gpt-5.3-codex" });
+		const spark = codexRankingStrategy.blockScope?.({ modelId: "gpt-5.3-codex-spark" });
+		expect(chat).not.toBe(spark);
+		expect(codexRankingStrategy.blockScopes?.({ modelId: "gpt-5.3-codex" })).toEqual(["chat", "shared"]);
+		expect(codexRankingStrategy.blockScopes?.({ modelId: "gpt-5.3-codex-spark" })).toEqual(["spark", "shared"]);
+		// Reconciliation runs with no request context and must heal every scope.
+		expect(codexRankingStrategy.blockScopes?.()).toEqual(["chat", "spark", "shared"]);
 	});
 });

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -786,7 +786,10 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 						},
 						identityKey: "email:remote@example.com",
 						rotatesInMs: null,
-						blocks: [{ providerKey: "anthropic:oauth", blockScope: "tier:fable", blockedUntilMs: futureBlock }],
+						blocks: [
+							{ providerKey: "anthropic:oauth", blockScope: "tier:fable", blockedUntilMs: futureBlock },
+							{ providerKey: "anthropic:oauth", blockScope: "shared", blockedUntilMs: futureBlock },
+						],
 					},
 				],
 			},
@@ -807,6 +810,9 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 				blockScope: "tier:fable",
 				blockedUntilMs: laterBlock,
 			});
+			remoteStore.deleteCredentialBlock(7, "anthropic:oauth", "tier:fable");
+			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "tier:fable")).toBe(laterBlock);
+			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "shared")).toBe(futureBlock);
 		} finally {
 			remoteStore.close();
 		}


### PR DESCRIPTION
Codex returns a single account-level `rate_limit.limit_reached` flag covering the whole account, and that flag was threaded into the status of both the 5h and the weekly chat window. A window with real headroom therefore came back as `exhausted` because a *different* window, or a separate metered feature, had reached its limit. During credential selection that propagates outward and blocks sibling accounts that could have served the request.

Each window's status now reflects only its own usage. `usedFraction >= 1` already marks a window that is genuinely full, and an enforced limit the reported percentage doesn't show still surfaces when the live request returns `usage_limit_reached`, so nothing is lost by dropping the shared flag.

The second half is the same problem at request granularity. A Codex request only consumes the windows it actually spends: a `-spark` model spends the Spark meter, every other model spends the chat windows. `codexRankingStrategy` now implements `scopeLimits` to gate on just those, so an exhausted Spark meter no longer blocks an ordinary chat request and vice versa. The hook already existed on `CredentialRankingStrategy` for providers whose quotas aren't account-wide; this fills it in for Codex.

Verified against the existing `packages/ai` suite (3290 pass; the two `openai-responses max_output_tokens` failures reproduce on main and are unrelated).
