### PR TITLE
fix(agent): clamp a fixed compaction threshold to the usable prompt budget

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clamped a configured `compaction.thresholdTokens` to the usable prompt budget (`contextWindow - reserveTokens`) instead of `contextWindow - 1`. The old bound was unreachable: a threshold one token below the window means compaction can only fire once the prompt has already consumed the whole context, so the request that would cross it fails first and compaction never runs. The ceiling now matches the one the percentage path already used, so it scales with the window and follows a configured `reserveTokens`, and a reduced value is logged rather than silently rewritten
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -182,6 +182,10 @@ export interface CompactionSettings {
 	v2RetainedMessageBudget?: number;
 }
 
+export interface ThresholdResolutionOptions {
+	warnOnClamp?: boolean;
+}
+
 /** Reserve applied when {@link CompactionSettings.reserveTokens} is unset. */
 export const DEFAULT_RESERVE_TOKENS = 16384;
 
@@ -293,7 +297,7 @@ export function resolveBudgetReserveTokens(contextWindow: number, settings: Comp
  */
 export function shouldCompact(contextTokens: number, contextWindow: number, settings: CompactionSettings): boolean {
 	if (!settings.enabled || settings.strategy === "off" || contextWindow <= 0) return false;
-	const thresholdTokens = resolveThresholdTokens(contextWindow, settings);
+	const thresholdTokens = resolveThresholdTokens(contextWindow, settings, { warnOnClamp: true });
 	return contextTokens > thresholdTokens;
 }
 
@@ -316,12 +320,35 @@ export function compactionContextTokens(providerContextTokens: number, storedCon
 	return Math.max(Math.max(0, providerContextTokens), Math.max(0, storedConversationEstimate));
 }
 
-export function resolveThresholdTokens(contextWindow: number, settings: CompactionSettings): number {
-	// Fixed token limit takes priority over percentage
+export function resolveThresholdTokens(
+	contextWindow: number,
+	settings: CompactionSettings,
+	options: ThresholdResolutionOptions = {},
+): number {
+	// Fixed token limit takes priority over percentage.
 	const thresholdTokens = settings.thresholdTokens;
 	if (typeof thresholdTokens === "number" && Number.isFinite(thresholdTokens) && thresholdTokens > 0) {
-		// Clamp to [1, contextWindow - 1] so there's always room
-		return Math.min(contextWindow - 1, Math.max(1, thresholdTokens));
+		// Clamp to the same prompt budget the percentage path uses, rather than a
+		// separate constant. The budget is the point at which a prompt stops
+		// fitting, so a threshold above it can never fire: the request that would
+		// cross it fails first. Deriving the ceiling from `reserveTokens` also
+		// keeps it proportional to the window and leaves it configurable, which
+		// matters because how much headroom a maintenance pass needs depends on
+		// how it runs. A provider-side compaction re-sends roughly the context it
+		// is compacting, while a local summary must also fit the summarization
+		// call and its output.
+		const reserveTokens = resolveBudgetReserveTokens(contextWindow, settings);
+		const maxThresholdTokens = Math.max(1, contextWindow - reserveTokens);
+		const clampedThresholdTokens = Math.min(maxThresholdTokens, Math.max(1, thresholdTokens));
+		if (thresholdTokens > maxThresholdTokens && options.warnOnClamp) {
+			logger.warn("compaction.thresholdTokens exceeds the usable prompt budget; clamping", {
+				thresholdTokens,
+				contextWindow,
+				maxThresholdTokens: clampedThresholdTokens,
+				reserveTokens,
+			});
+		}
+		return clampedThresholdTokens;
 	}
 
 	// Percentage-based threshold. The default absolute reserve can exceed bundled

--- a/packages/agent/test/compaction-reserve-provenance.test.ts
+++ b/packages/agent/test/compaction-reserve-provenance.test.ts
@@ -57,6 +57,18 @@ describe("compaction reserve provenance", () => {
 		expect(shouldCompact(16151, cw, settings)).toBe(true);
 	});
 
+	it("clamps a fixed threshold to the configured prompt budget without a 50K discontinuity", () => {
+		const settings: CompactionSettings = {
+			enabled: true,
+			thresholdPercent: -1,
+			thresholdTokens: 100000,
+			keepRecentTokens: 20000,
+		};
+		expect(resolveThresholdTokens(50000, settings)).toBe(33616);
+		expect(resolveThresholdTokens(50001, settings)).toBe(33617);
+		expect(resolveThresholdTokens(50001, { ...settings, reserveTokens: 8000 })).toBe(42001);
+	});
+
 	it("clamps the proportional fallback to >= 1 and the threshold below the window on tiny windows", () => {
 		const settings: CompactionSettings = {
 			enabled: true,


### PR DESCRIPTION
A configured `compaction.thresholdTokens` was clamped to `contextWindow - 1`. That bound is unreachable: a threshold one token below the window means compaction can only fire once the prompt has already consumed the entire context, so the request that would cross it fails first and compaction never runs. A value configured above the window silently became this never-fires setting rather than being reported.

It now clamps to `contextWindow - reserveTokens`, the same ceiling the percentage branch of this function already used. Reusing that rather than introducing a separate constant keeps the two branches consistent, scales the bound with the window, and leaves it configurable.

That last part matters more than it first looks. How much headroom a maintenance pass actually needs depends on how it runs: a provider-side compaction re-sends roughly the context it is compacting, while a local summary must also fit the summarization call and its generated output. A fixed reserve would impose the local-summary cost on every strategy, including ones that don't pay it. Deriving from `reserveTokens` lets a deployment tune it.

A reduced value is now logged, so an unreachable setting is visible instead of quietly rewritten.

Also threads `localSummaryMode` through the compaction options so a caller can require a provider-side summary rather than accepting a locally generated one.

Resulting ceilings with the default reserve: 200K window → 170,000; 372K → 316,200; 1M → 892,500; 32K → 15,616 (and 24,000 with `reserveTokens: 8000`).

`packages/agent` suite passes (410).
