### PR TITLE
feat(agent): add a pre-model-call gate that can stop the turn

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -15,6 +15,13 @@
 - Fixed Cursor tool results being dropped for hosts that pass neither `cursorExecHandlers` nor `cursorOnToolResult`. Both are optional, but the Cursor provider resolves native todo calls server-side and synthesizes exec blocks regardless, marking both as resolved so no placeholder result is emitted for them. The result buffer callback was only installed when one of the options was present, so a bare SDK host discarded the provider's paired result and every rebuilt transcript stripped the interaction. It is now installed unconditionally.
 - Fixed an async `cursorOnToolResult` rewrite being lost when the provider errored mid-transform. The normal drain waits for a pending transformer, but the error path snapshotted the buffer without that await, so a transform still in flight patched an entry the catch path had already detached and the pre-transform payload was persisted. A provider error is exactly when a transform is most likely to be mid-flight.
 - Reduced oversized OpenAI native compaction requests by replacing only trailing tool-output bodies that exceed the model context window, while preserving calls, assistant history, and reasoning.
+### Added
+
+- Added a pre-model-call gate: `AgentLoopConfig.beforeModelCall` receives the finalized provider context and run abort signal, and may return `{ stop: true, reason? }` to end the run before the provider is called, so a host can refuse a request it has decided not to pay for (prompt no longer fits, budget boundary crossed, session should hand off). `Agent.setBeforeModelCall` installs the host callback; `Agent.addBeforeModelCall` registers an additional one without displacing it and returns a disposer
+
+### Fixed
+
+- Preserved pending soft tool reminders and escalations when the pre-model-call gate stops a run, rejected deferred hard choices that become unavailable before the next call, and cleared deferred choices with queued session state.
 
 ## [17.1.2] - 2026-07-24
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -10,6 +10,7 @@ import {
 	type Context,
 	EventStream,
 	isApiKeyResolver,
+	type Model,
 	resolveApiKeyOnce,
 	seedApiKeyResolver,
 	streamSimple,
@@ -42,7 +43,7 @@ import {
 	signalListLabel,
 } from "@oh-my-pi/pi-ai/utils/harmony-leak";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
-import { sanitizeText, structuredCloneJSON } from "@oh-my-pi/pi-utils";
+import { logger, sanitizeText, structuredCloneJSON } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import { agentPauseGate } from "./pause";
 import { type AgentRunCoverage, type AgentRunSummary, ToolCallBlockedError } from "./run-collector";
@@ -67,6 +68,7 @@ import type {
 	AgentEvent,
 	AgentLoopConfig,
 	AgentMessage,
+	AgentPreModelCallResult,
 	AgentTool,
 	AgentToolResult,
 	AgentTurnEndContext,
@@ -526,14 +528,9 @@ export function agentLoop(
 		};
 
 		stream.push({ type: "agent_start" });
-		stream.push({ type: "turn_start" });
-		for (const prompt of prompts) {
-			stream.push({ type: "message_start", message: prompt });
-			stream.push({ type: "message_end", message: prompt });
-		}
 
 		try {
-			await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
+			await runLoop(currentContext, newMessages, config, signal, stream, streamFn, prompts);
 		} catch (err) {
 			stream.fail(err);
 		}
@@ -571,7 +568,6 @@ export function agentLoopContinue(
 		const currentContext: AgentContext = { ...context, messages: [...context.messages] };
 
 		stream.push({ type: "agent_start" });
-		stream.push({ type: "turn_start" });
 
 		try {
 			await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
@@ -621,12 +617,34 @@ async function emitTurnEnd(
 	config: AgentLoopConfig,
 	signal?: AbortSignal,
 	context?: Omit<AgentTurnEndContext, "message" | "toolResults">,
+	runHookOnAbortedMessage = false,
 ): Promise<void> {
 	stream.push({ type: "turn_end", message, toolResults });
 	const isAbortedOrError =
 		message.role === "assistant" && (message.stopReason === "aborted" || message.stopReason === "error");
-	if (signal?.aborted || isAbortedOrError) return;
+	if (signal?.aborted || (isAbortedOrError && !runHookOnAbortedMessage)) return;
 	await config.onTurnEnd?.(currentContext.messages, signal, { message, toolResults, willContinue: false, ...context });
+}
+
+function createGateStopMessage(model: Model, reason: string | undefined): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "" }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "aborted",
+		errorMessage: reason ?? "Stopped before model call",
+		timestamp: Date.now(),
+	};
 }
 
 /**
@@ -866,6 +884,7 @@ async function runLoop(
 	signal: AbortSignal | undefined,
 	stream: EventStream<AgentEvent, AgentMessage[]>,
 	streamFn?: StreamFn,
+	initialMessages: AgentMessage[] = [],
 ): Promise<void> {
 	const telemetry = resolveTelemetry(config.telemetry, config.sessionId);
 	const invokeAgentSpan = startInvokeAgentSpan(telemetry, config.model);
@@ -882,6 +901,7 @@ async function runLoop(
 				telemetry,
 				invokeAgentSpan,
 				stepCounter,
+				initialMessages,
 				streamFn,
 			),
 		);
@@ -913,6 +933,12 @@ function endAgentStream(
 	stream.push(buildAgentEndEvent(newMessages, telemetry, stepCount));
 	stream.end(newMessages);
 }
+function emitInputMessages(stream: EventStream<AgentEvent, AgentMessage[]>, messages: readonly AgentMessage[]): void {
+	for (const message of messages) {
+		stream.push({ type: "message_start", message });
+		stream.push({ type: "message_end", message });
+	}
+}
 
 /**
  * Resolve aside entries at the moment the loop is about to inject them. Each entry
@@ -940,6 +966,7 @@ async function runLoopBody(
 	telemetry: AgentTelemetry | undefined,
 	invokeAgentSpan: Span | undefined,
 	stepCounter: StepCounter,
+	initialMessages: AgentMessage[],
 	streamFn?: StreamFn,
 ): Promise<void> {
 	let deadlineTimer: Timer | undefined;
@@ -957,26 +984,33 @@ async function runLoopBody(
 		signal = signal ? AbortSignal.any([signal, deadlineAbortController.signal]) : deadlineAbortController.signal;
 	}
 
+	const softRequirementState = config.softToolRequirementState ?? { escalations: 0 };
+	let preserveSoftRequirementState = false;
+
 	try {
-		let firstTurn = true;
+		let messagesToEmit = [...initialMessages];
 		if (isDeadlineExceeded(config.deadline)) {
+			emitInputMessages(stream, messagesToEmit);
 			endAgentStream(stream, newMessages, telemetry, stepCounter.count);
 			return;
 		}
 		// Check for steering messages at start (user may have typed while waiting).
 		// Skip when the run is already externally aborted — dequeuing would strand
 		// the messages in a run that is about to die.
-		let pendingMessages: AgentMessage[] = signal?.aborted ? [] : (await config.getSteeringMessages?.()) || [];
+		let pendingMessages: AgentMessage[];
+		try {
+			pendingMessages = signal?.aborted ? [] : (await config.getSteeringMessages?.()) || [];
+		} catch (error) {
+			stream.push({ type: "turn_start" });
+			emitInputMessages(stream, messagesToEmit);
+			throw error;
+		}
 		let harmonyRetryAttempt = 0;
 		let harmonyTruncateResumeCount = 0;
 		let pausedTurnContinuations = 0;
 
-		// Soft tool requirement lifecycle (reminder → escalate; see SoftToolRequirement).
-		// `forcedToolChoice` carries a one-turn escalation into the next model call. It
-		// overrides the static toolChoice but NEVER the host's hard getToolChoice().
-		let softRequirementId: string | undefined;
-		let forcedToolChoice: ToolChoice | undefined;
-		let softEscalations = 0;
+		// Soft tool requirement lifecycle (reminder then escalation; see SoftToolRequirement).
+		// The host-owned state survives only a gate stop between Agent.prompt calls.
 		// Resolved once per logical turn at the fetch site below and reused across
 		// Harmony-leak re-samples (which re-enter the same turn) so the consuming
 		// getToolChoice is never advanced twice; the flag resets at the message boundary.
@@ -984,6 +1018,7 @@ async function runLoopBody(
 		let softRequiredTool: string | undefined;
 		let softSatisfies: SoftToolRequirement["satisfies"];
 		let directiveResolvedForTurn = false;
+		let turnOpen = false;
 
 		// Outer loop: continues when queued follow-up messages arrive after agent would stop
 		while (true) {
@@ -992,6 +1027,7 @@ async function runLoopBody(
 			// Inner loop: process tool calls and steering messages
 			while (hasMoreToolCalls || pendingMessages.length > 0) {
 				if (isDeadlineExceeded(config.deadline)) {
+					emitInputMessages(stream, messagesToEmit);
 					endAgentStream(stream, newMessages, telemetry, stepCounter.count);
 					return;
 				}
@@ -1002,62 +1038,111 @@ async function runLoopBody(
 				// engaged (host /pause). An external abort releases the park so a
 				// cancelled run still unwinds while everything else stays frozen.
 				if (agentPauseGate.paused) await agentPauseGate.waitUntilResumed(signal);
-				if (!firstTurn) {
-					stream.push({ type: "turn_start" });
-				} else {
-					firstTurn = false;
-				}
 
-				// Process pending messages (inject before next assistant response)
+				// Build the provider-bound context before opening the turn. Queue
+				// messages are added now but their events remain deferred until
+				// provider preparation either succeeds or opens an error turn.
+				const turnMessages = messagesToEmit;
+				messagesToEmit = [];
 				if (pendingMessages.length > 0) {
 					for (const message of pendingMessages) {
-						stream.push({ type: "message_start", message });
-						stream.push({ type: "message_end", message });
 						currentContext.messages.push(message);
 						newMessages.push(message);
+						turnMessages.push(message);
 					}
 					pendingMessages = [];
 				}
 
-				// Refresh prompt/tool context from live state before each model call
-				if (config.syncContextBeforeModelCall) {
-					await config.syncContextBeforeModelCall(currentContext);
+				let preparedProviderCall: PreparedProviderCall;
+				let gateResult: AgentPreModelCallResult;
+				try {
+					if (config.syncContextBeforeModelCall) {
+						await config.syncContextBeforeModelCall(currentContext);
+					}
+
+					if (!directiveResolvedForTurn) {
+						const directive = signal?.aborted ? undefined : config.getToolChoice?.();
+						const softReq = isSoftToolRequirement(directive) ? directive : undefined;
+						hostToolChoice = directive === undefined || isSoftToolRequirement(directive) ? undefined : directive;
+						softRequiredTool = softReq?.toolName;
+						softSatisfies = softReq?.satisfies;
+						const softRequirementId = softRequirementState.id;
+						if (softReq !== undefined) {
+							if (softReq.id !== softRequirementId) {
+								softRequirementState.id = softReq.id;
+								softRequirementState.forcedToolChoice = undefined;
+								softRequirementState.escalations = 0;
+								for (const reminder of softReq.reminder) {
+									currentContext.messages.push(reminder);
+									newMessages.push(reminder);
+									turnMessages.push(reminder);
+								}
+							}
+						} else {
+							softRequirementState.id = undefined;
+							softRequirementState.forcedToolChoice = undefined;
+							softRequirementState.escalations = 0;
+						}
+						directiveResolvedForTurn = true;
+					}
+
+					preparedProviderCall = await prepareProviderCall(currentContext, config, signal);
+					gateResult = await config.beforeModelCall?.(preparedProviderCall.context, signal);
+				} catch (error) {
+					if (!turnOpen) {
+						stream.push({ type: "turn_start" });
+						emitInputMessages(stream, turnMessages);
+						turnOpen = true;
+					}
+					throw error;
+				}
+				if (config.beforeModelCall && signal?.aborted) {
+					emitInputMessages(stream, turnMessages);
+					endAgentStream(stream, newMessages, telemetry, stepCounter.count);
+					return;
+				}
+				if (gateResult?.stop) {
+					if (gateResult.reason) {
+						logger.debug("Agent loop stopped before the model call", { reason: gateResult.reason });
+					}
+					if (!turnOpen && !signal?.aborted) {
+						try {
+							config.onToolChoiceRejected?.();
+						} catch (error) {
+							stream.push({ type: "turn_start" });
+							emitInputMessages(stream, turnMessages);
+							turnOpen = true;
+							throw error;
+						}
+					}
+					emitInputMessages(stream, turnMessages);
+					if (turnOpen) {
+						const stopMessage = createGateStopMessage(preparedProviderCall.model, gateResult.reason);
+						currentContext.messages.push(stopMessage);
+						newMessages.push(stopMessage);
+						stream.push({ type: "message_start", message: stopMessage });
+						stream.push({ type: "message_end", message: stopMessage });
+						await emitTurnEnd(
+							stream,
+							currentContext,
+							stopMessage,
+							[],
+							config,
+							signal,
+							{ willContinue: false },
+							true,
+						);
+						turnOpen = false;
+					}
+					preserveSoftRequirementState = !signal?.aborted;
+					endAgentStream(stream, newMessages, telemetry, stepCounter.count);
+					return;
 				}
 
-				// Resolve the per-turn tool-choice directive ONCE per logical turn. The
-				// host hard-choice path (getToolChoice → nextToolChoice) is CONSUMING — it
-				// advances a generator on every call — so Harmony-leak retries, which
-				// re-sample the same turn via `continue` without a turn_end, must reuse the
-				// values fetched on the first attempt rather than double-advancing it.
-				// Fetched here (after pending-message flush + context sync, immediately
-				// before the call) so a throw in between cannot wedge an in-flight
-				// directive. A hard ToolChoice is applied verbatim; a SoftToolRequirement
-				// triggers the remind-then-escalate lifecycle: inject its reminder inline
-				// once per new id (toolChoice stays auto), and the gate below escalates to
-				// a forced choice only if the model declines. The host wrapper already
-				// dropped a soft requirement whose tool is inactive.
-				if (!directiveResolvedForTurn) {
-					const directive = signal?.aborted ? undefined : config.getToolChoice?.();
-					const softReq = isSoftToolRequirement(directive) ? directive : undefined;
-					hostToolChoice = directive === undefined || isSoftToolRequirement(directive) ? undefined : directive;
-					softRequiredTool = softReq?.toolName;
-					softSatisfies = softReq?.satisfies;
-					if (softReq !== undefined) {
-						if (softReq.id !== softRequirementId) {
-							softRequirementId = softReq.id;
-							softEscalations = 0;
-							for (const reminder of softReq.reminder) {
-								stream.push({ type: "message_start", message: reminder });
-								stream.push({ type: "message_end", message: reminder });
-								currentContext.messages.push(reminder);
-								newMessages.push(reminder);
-							}
-						}
-					} else {
-						softRequirementId = undefined;
-						softEscalations = 0;
-					}
-					directiveResolvedForTurn = true;
+				if (!turnOpen) {
+					stream.push({ type: "turn_start" });
+					emitInputMessages(stream, turnMessages);
+					turnOpen = true;
 				}
 
 				// Stream assistant response
@@ -1075,7 +1160,8 @@ async function runLoopBody(
 						streamFn,
 						harmonyRetryAttempt,
 						hostToolChoice,
-						forcedToolChoice,
+						softRequirementState.forcedToolChoice,
+						preparedProviderCall,
 					);
 					harmonyRetryAttempt = 0;
 					harmonyTruncateResumeCount = 0;
@@ -1118,7 +1204,7 @@ async function runLoopBody(
 
 				// The escalation choice (if any) applied to the call above; clear it so
 				// only the single escalation turn carries the forced choice.
-				forcedToolChoice = undefined;
+				softRequirementState.forcedToolChoice = undefined;
 
 				// A fresh logical turn re-resolves the directive next iteration; a Harmony
 				// retry `continue`s before this line and keeps the cached value.
@@ -1161,6 +1247,7 @@ async function runLoopBody(
 						});
 					}
 					await emitTurnEnd(stream, currentContext, message, toolResults, config, signal, { willContinue: false });
+					turnOpen = false;
 
 					stream.push(buildAgentEndEvent(newMessages, telemetry, stepCounter.count));
 					stream.end(newMessages);
@@ -1212,7 +1299,7 @@ async function runLoopBody(
 
 				const toolResults: ToolResultMessage[] = [];
 				if (softNonCompliant && softRequiredTool !== undefined) {
-					if (softEscalations >= MAX_SOFT_TOOL_ESCALATIONS) {
+					if (softRequirementState.escalations >= MAX_SOFT_TOOL_ESCALATIONS) {
 						throw new Error(
 							`Soft tool requirement '${softRequiredTool}' was not satisfied after ${MAX_SOFT_TOOL_ESCALATIONS} forced turns; aborting to avoid an unbounded force loop.`,
 						);
@@ -1239,8 +1326,8 @@ async function runLoopBody(
 							status: "skipped",
 						});
 					}
-					forcedToolChoice = { type: "tool", name: softRequiredTool };
-					softEscalations++;
+					softRequirementState.forcedToolChoice = { type: "tool", name: softRequiredTool };
+					softRequirementState.escalations++;
 					hasMoreToolCalls = true;
 				} else if (hasMoreToolCalls) {
 					const executionResult = await executeToolCalls(
@@ -1306,6 +1393,7 @@ async function runLoopBody(
 				await emitTurnEnd(stream, currentContext, message, toolResults, config, signal, {
 					willContinue: hasMoreToolCalls && !isDeadlineExceeded(config.deadline),
 				});
+				turnOpen = false;
 
 				if (isDeadlineExceeded(config.deadline)) {
 					endAgentStream(stream, newMessages, telemetry, stepCounter.count);
@@ -1361,6 +1449,11 @@ async function runLoopBody(
 
 		endAgentStream(stream, newMessages, telemetry, stepCounter.count);
 	} finally {
+		if (!preserveSoftRequirementState) {
+			softRequirementState.id = undefined;
+			softRequirementState.forcedToolChoice = undefined;
+			softRequirementState.escalations = 0;
+		}
 		if (deadlineTimer) {
 			clearTimeout(deadlineTimer);
 		}
@@ -1384,45 +1477,29 @@ async function emitHarmonyAudit(
 	);
 }
 
-/**
- * Stream an assistant response from the LLM.
- * This is where AgentMessage[] gets transformed to Message[] for the LLM.
- */
-async function streamAssistantResponse(
+interface PreparedProviderCall {
+	model: Model;
+	context: Context;
+	promptToolWireTools: Context["tools"];
+	ownedDialect: Dialect | undefined;
+}
+
+async function prepareProviderCall(
 	context: AgentContext,
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
-	stream: EventStream<AgentEvent, AgentMessage[]>,
-	telemetry: AgentTelemetry | undefined,
-	invokeAgentSpan: Span | undefined,
-	stepCounter: StepCounter,
-	streamFn?: StreamFn,
-	harmonyRetryAttempt = 0,
-	hostToolChoice?: ToolChoice,
-	forcedToolChoice?: ToolChoice,
-): Promise<AssistantMessage> {
-	// Re-resolve the model per provider call (like `getReasoning`): mid-run
-	// model switches — context promotion, retry fallback — must apply on the
-	// next call instead of the run silently finishing on the stale model
-	// captured at run start.
+): Promise<PreparedProviderCall> {
 	const model = config.getModel?.() ?? config.model;
-	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
 		messages = await config.transformContext(messages, signal);
 	}
 
-	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
 	const normalizedMessages = normalizeMessagesForProvider(llmMessages, model);
-
 	const ownedDialect: Dialect | undefined = config.dialect ?? resolveOwnedDialectFromEnv(Bun.env.PI_DIALECT);
 	const exampleDialect = ownedDialect ?? preferredDialect(model.id);
-	// Owned/in-band dialects carry the catalog in the prompt as text and send no
-	// native `tools`, so description pruning only applies to native tool calling.
 	const pruneToolDescriptions = !!config.pruneToolDescriptions && !ownedDialect;
-	// Build LLM context — append-only mode caches system prompt + tools
-	// AND keeps an append-only message log so prior-turn bytes are stable.
 	let llmContext: Context;
 	if (config.appendOnlyContext) {
 		config.appendOnlyContext.syncMessages(normalizedMessages);
@@ -1442,9 +1519,6 @@ async function streamAssistantResponse(
 		llmContext = await config.transformProviderContext(llmContext, model);
 	}
 
-	// Owned tool calling: take tool calls away from the provider and run them
-	// through the selected in-band prompt dialect. `PI_DIALECT=1` still
-	// force-enables GLM; `PI_DIALECT=<dialect>` force-enables that dialect.
 	let promptToolWireTools: Context["tools"];
 	if (ownedDialect && llmContext.tools && llmContext.tools.length > 0) {
 		promptToolWireTools = llmContext.tools;
@@ -1455,6 +1529,29 @@ async function streamAssistantResponse(
 			tools: undefined,
 		};
 	}
+	return { model, context: llmContext, promptToolWireTools, ownedDialect };
+}
+
+/**
+ * Stream an assistant response from the LLM.
+ * This is where AgentMessage[] gets transformed to Message[] for the LLM.
+ */
+async function streamAssistantResponse(
+	context: AgentContext,
+	config: AgentLoopConfig,
+	signal: AbortSignal | undefined,
+	stream: EventStream<AgentEvent, AgentMessage[]>,
+	telemetry: AgentTelemetry | undefined,
+	invokeAgentSpan: Span | undefined,
+	stepCounter: StepCounter,
+	streamFn?: StreamFn,
+	harmonyRetryAttempt = 0,
+	hostToolChoice?: ToolChoice,
+	forcedToolChoice?: ToolChoice,
+	prepared?: PreparedProviderCall,
+): Promise<AssistantMessage> {
+	const providerCall = prepared ?? (await prepareProviderCall(context, config, signal));
+	const { model, context: llmContext, promptToolWireTools, ownedDialect } = providerCall;
 
 	const streamFunction = streamFn || streamSimple;
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1097,9 +1097,7 @@ async function runLoopBody(
 					throw error;
 				}
 				if (config.beforeModelCall && signal?.aborted) {
-					emitInputMessages(stream, turnMessages);
-					endAgentStream(stream, newMessages, telemetry, stepCounter.count);
-					return;
+					gateResult = { stop: true };
 				}
 				if (gateResult?.stop) {
 					if (gateResult.reason) {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -975,11 +975,15 @@ export class Agent {
 		this.#followUpQueue = [];
 	}
 
+	clearDeferredToolChoice() {
+		this.#deferredToolChoice = undefined;
+	}
+
 	clearAllQueues() {
 		this.#steeringQueue = [];
 		this.#followUpQueue = [];
 		this.#notifySteeringWaiters();
-		this.#deferredToolChoice = undefined;
+		this.clearDeferredToolChoice();
 	}
 
 	hasQueuedMessages(): boolean {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -43,6 +43,7 @@ import type {
 	AgentEvent,
 	AgentLoopConfig,
 	AgentMessage,
+	AgentPreModelCallResult,
 	AgentState,
 	AgentTool,
 	AgentToolContext,
@@ -267,6 +268,8 @@ export interface AgentOptions {
 	abortOnFabricatedToolResult?: boolean;
 	/** Dynamic tool-choice directive (hard {@link ToolChoice} or {@link SoftToolRequirement}), resolved once per turn. */
 	getToolChoice?: () => ToolChoiceDirective | undefined;
+	/** Reject a deferred hard choice when its named tool is no longer active. */
+	onToolChoiceUnavailable?: () => void;
 
 	/**
 	 * Cursor exec handlers for local tool execution.
@@ -409,6 +412,9 @@ export class Agent {
 	#dialect?: Dialect;
 	#abortOnFabricatedToolResult?: boolean;
 	#getToolChoice?: () => ToolChoiceDirective | undefined;
+	#onToolChoiceUnavailable?: () => void;
+	#softToolRequirementState: NonNullable<AgentLoopConfig["softToolRequirementState"]> = { escalations: 0 };
+	#deferredToolChoice?: ToolChoice;
 	#onPayload?: SimpleStreamOptions["onPayload"];
 	#onResponse?: SimpleStreamOptions["onResponse"];
 	#onSseEvent?: SimpleStreamOptions["onSseEvent"];
@@ -416,6 +422,14 @@ export class Agent {
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
 	#onTurnEnd?: (messages: AgentMessage[], signal?: AbortSignal, context?: AgentTurnEndContext) => Promise<void> | void;
+	#beforeModelCall?: (
+		context: Context,
+		signal?: AbortSignal,
+	) => AgentPreModelCallResult | Promise<AgentPreModelCallResult>;
+	#additionalBeforeModelCalls = new Set<
+		(context: Context, signal?: AbortSignal) => AgentPreModelCallResult | Promise<AgentPreModelCallResult>
+	>();
+	#beforeModelContextBuild = new Set<(context: AgentContext) => Promise<void> | void>();
 	#asideMessageProvider?: () => AsideMessage[] | Promise<AsideMessage[]>;
 	#telemetry?: AgentLoopConfig["telemetry"];
 	#appendOnlyContext?: AppendOnlyContextManager;
@@ -490,6 +504,7 @@ export class Agent {
 		this.#dialect = opts.dialect;
 		this.#abortOnFabricatedToolResult = opts.abortOnFabricatedToolResult;
 		this.#getToolChoice = opts.getToolChoice;
+		this.#onToolChoiceUnavailable = opts.onToolChoiceUnavailable;
 		this.#onAssistantMessageEvent = opts.onAssistantMessageEvent;
 		this.#onHarmonyLeak = opts.onHarmonyLeak;
 		this.beforeToolCall = opts.beforeToolCall;
@@ -804,6 +819,38 @@ export class Agent {
 	}
 
 	/**
+	 * Add work that must update the mutable agent context before the provider
+	 * context is converted, normalized, and passed to pre-model gates.
+	 */
+	addBeforeModelContextBuild(fn: (context: AgentContext) => Promise<void> | void): () => void {
+		this.#beforeModelContextBuild.add(fn);
+		return () => {
+			this.#beforeModelContextBuild.delete(fn);
+		};
+	}
+
+	setBeforeModelCall(
+		fn:
+			| ((context: Context, signal?: AbortSignal) => AgentPreModelCallResult | Promise<AgentPreModelCallResult>)
+			| undefined,
+	): void {
+		this.#beforeModelCall = fn;
+	}
+
+	/**
+	 * Add a pre-model callback without replacing callbacks owned by the host.
+	 * Returns a disposer that removes only this callback.
+	 */
+	addBeforeModelCall(
+		fn: (context: Context, signal?: AbortSignal) => AgentPreModelCallResult | Promise<AgentPreModelCallResult>,
+	): () => void {
+		this.#additionalBeforeModelCalls.add(fn);
+		return () => {
+			this.#additionalBeforeModelCalls.delete(fn);
+		};
+	}
+
+	/**
 	 * Provide a source of non-interrupting "aside" messages (e.g. background-job
 	 * completions, late LSP diagnostics) drained at each step boundary. Never
 	 * aborts in-flight tools. See `AgentLoopConfig.getAsideMessages`.
@@ -932,6 +979,7 @@ export class Agent {
 		this.#steeringQueue = [];
 		this.#followUpQueue = [];
 		this.#notifySteeringWaiters();
+		this.#deferredToolChoice = undefined;
 	}
 
 	hasQueuedMessages(): boolean {
@@ -1044,6 +1092,8 @@ export class Agent {
 		this.#steeringQueue = [];
 		this.#followUpQueue = [];
 		this.#notifySteeringWaiters();
+		this.#deferredToolChoice = undefined;
+		this.#softToolRequirementState = { escalations: 0 };
 	}
 
 	/** Send a prompt with an AgentMessage */
@@ -1219,13 +1269,28 @@ export class Agent {
 			return entry.toolResult;
 		};
 
+		let claimedToolChoice: ToolChoice | undefined;
 		const getToolChoice = (): ToolChoiceDirective | undefined => {
+			claimedToolChoice = undefined;
+			const deferred = this.#deferredToolChoice;
+			if (deferred !== undefined) {
+				this.#deferredToolChoice = undefined;
+				const active = refreshToolChoiceForActiveTools(deferred, this.#state.tools);
+				if (active !== undefined) {
+					claimedToolChoice = deferred;
+					return active;
+				}
+				this.#onToolChoiceUnavailable?.();
+			}
+
 			const queued = this.#getToolChoice?.();
 			if (queued !== undefined) {
 				if (isSoftToolRequirement(queued)) {
 					return (this.#state.tools ?? []).some(tool => tool.name === queued.toolName) ? queued : undefined;
 				}
-				return refreshToolChoiceForActiveTools(queued, this.#state.tools);
+				const active = refreshToolChoiceForActiveTools(queued, this.#state.tools);
+				if (active !== undefined) claimedToolChoice = queued;
+				return active;
 			}
 			return refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
 		};
@@ -1267,7 +1332,22 @@ export class Agent {
 				}
 				context.systemPrompt = this.#state.systemPrompt;
 				context.tools = this.#toolsForModel(this.#state.model ?? model);
+				for (const callback of this.#beforeModelContextBuild) {
+					await callback(context);
+				}
 			},
+			beforeModelCall:
+				this.#beforeModelCall || this.#additionalBeforeModelCalls.size > 0
+					? async (context, signal) => {
+							const result = await this.#beforeModelCall?.(context, signal);
+							if (result?.stop) return result;
+							for (const callback of this.#additionalBeforeModelCalls) {
+								const callbackResult = await callback(context, signal);
+								if (callbackResult?.stop) return callbackResult;
+							}
+							return undefined;
+						}
+					: undefined,
 			cursorExecHandlers: this.#cursorExecHandlers,
 			cursorOnToolResult,
 			cwd: this.#cwd,
@@ -1288,6 +1368,10 @@ export class Agent {
 			onHarmonyLeak: this.#onHarmonyLeak,
 			onTurnEnd: (messages, signal, context) => this.#onTurnEnd?.(messages, signal, context),
 			getToolChoice,
+			softToolRequirementState: this.#softToolRequirementState,
+			onToolChoiceRejected: () => {
+				if (claimedToolChoice !== undefined) this.#deferredToolChoice = claimedToolChoice;
+			},
 			getModel: () => this.#state.model ?? model,
 			getReasoning: () => this.#state.thinkingLevel,
 			getDisableReasoning: () => this.#state.disableReasoning,
@@ -1322,6 +1406,7 @@ export class Agent {
 
 		let partial: AgentMessage | null = null;
 		const completedToolCallIds = new Set<string>();
+		let turnOpen = false;
 
 		try {
 			const stream = messages
@@ -1329,6 +1414,8 @@ export class Agent {
 				: agentLoopContinue(context, config, this.#abortController.signal, this.streamFn);
 
 			for await (const event of stream) {
+				if (event.type === "turn_start") turnOpen = true;
+				if (event.type === "turn_end") turnOpen = false;
 				// Update internal state based on events
 				switch (event.type) {
 					case "message_start":
@@ -1448,6 +1535,10 @@ export class Agent {
 						};
 
 			if (shouldEmitVisibleError) {
+				if (!turnOpen) {
+					this.#emit({ type: "turn_start" });
+					turnOpen = true;
+				}
 				if (!hadAssistantStart) {
 					this.#state.streamMessage = errorMsg;
 					this.#emit({ type: "message_start", message: errorMsg });
@@ -1489,6 +1580,7 @@ export class Agent {
 					toolResults.push(toolResult);
 				}
 				this.#emit({ type: "turn_end", message: errorMsg, toolResults });
+				turnOpen = false;
 				this.#emit({ type: "agent_end", messages: [errorMsg, ...toolResults] });
 			} else {
 				this.appendMessage(errorMsg);

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -48,6 +48,15 @@ export interface AgentTurnEndContext {
 	willContinue: boolean;
 }
 
+export interface AgentPreModelCallStop {
+	/** Stop the agent loop before sending the next provider request. */
+	stop: true;
+	/** Optional owner-facing reason, logged by the loop when it stops. */
+	reason?: string;
+}
+
+export type AgentPreModelCallResult = AgentPreModelCallStop | undefined;
+
 /**
  * A soft tool requirement: the host wants `toolName` called before the loop
  * runs other tools or yields, but WITHOUT paying the forced-`toolChoice` cost
@@ -86,6 +95,13 @@ export interface SoftToolRequirement {
  * (applied verbatim) or a {@link SoftToolRequirement} (remind-then-escalate).
  */
 export type ToolChoiceDirective = ToolChoice | SoftToolRequirement;
+
+/** Mutable soft-requirement lifecycle retained across stopped agent runs. */
+export interface SoftToolRequirementState {
+	id?: string;
+	forcedToolChoice?: ToolChoice;
+	escalations: number;
+}
 
 /** True when a {@link ToolChoiceDirective} is a soft requirement, not a hard choice. */
 export function isSoftToolRequirement(directive: ToolChoiceDirective | undefined): directive is SoftToolRequirement {
@@ -276,8 +292,25 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	/**
 	 * Refreshes prompt/tool context from live session state before each model call.
 	 * Use this when tool availability or the system prompt can change mid-turn.
+	 *
+	 * Runs after pending messages are folded in and before provider conversion.
+	 * Mutate the agent context here; use `beforeModelCall` to inspect the
+	 * provider-bound context.
 	 */
 	syncContextBeforeModelCall?: (context: AgentContext) => void | Promise<void>;
+
+	/**
+	 * Asked after the complete provider context has been built, including
+	 * message conversion, provider transforms, normalized tools, and owned
+	 * dialect prompt injection. Returning {@link AgentPreModelCallStop} ends
+	 * the stream without emitting `turn_start`, so no turn is left open and no
+	 * request is billed. Return `undefined` to proceed. The signal aborts when
+	 * the run is canceled or its deadline expires.
+	 */
+	beforeModelCall?: (
+		context: Context,
+		signal?: AbortSignal,
+	) => AgentPreModelCallResult | Promise<AgentPreModelCallResult>;
 
 	/**
 	 * Optional transform applied to tool call arguments before execution.
@@ -355,6 +388,18 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * to the static `toolChoice`.
 	 */
 	getToolChoice?: () => ToolChoiceDirective | undefined;
+
+	/**
+	 * Soft-requirement lifecycle retained by the host when a pre-model-call
+	 * gate stops a run before its pending reminder or escalation is served.
+	 */
+	softToolRequirementState?: SoftToolRequirementState;
+
+	/**
+	 * Returns a hard tool-choice directive obtained by {@link getToolChoice}
+	 * when the pre-model-call gate stops before serving it.
+	 */
+	onToolChoiceRejected?: () => void;
 
 	/**
 	 * Dynamic reasoning effort override, resolved per LLM call.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
 import {
 	agentLoop,
 	agentLoopContinue,
@@ -14,7 +15,7 @@ import type {
 	AgentToolContext,
 	ToolCallContext,
 } from "@oh-my-pi/pi-agent-core/types";
-import type { AssistantMessage, AssistantMessageEvent, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, AssistantMessageEvent, Context, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -97,6 +98,9 @@ describe("agentLoop with AgentMessage", () => {
 		expect(await stream.result()).toEqual([prompt]);
 		expect(mock.calls).toHaveLength(0);
 		expect(events.map(event => event.type)).toContain("agent_end");
+		expect(events.filter(event => event.type === "message_end")).toEqual([
+			expect.objectContaining({ message: prompt }),
+		]);
 	});
 
 	it("returns detailed telemetry when awaiting detailed() directly", async () => {
@@ -2514,6 +2518,12 @@ describe("agentLoop event-driven steering watch", () => {
 
 		const toolSchema = type({ value: "string" });
 		const tool: AgentTool<typeof toolSchema> = {
+describe("agentLoop pre-model-call gate", () => {
+	const echoToolSchema = type({ value: "string" });
+
+	function echoTool(executed: string[]): AgentTool<typeof echoToolSchema> {
+		const toolSchema = echoToolSchema;
+		return {
 			name: "echo",
 			label: "Echo",
 			description: "Echo tool",
@@ -2870,6 +2880,237 @@ describe("agentLoop event-driven steering watch", () => {
 		};
 
 		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+	}
+
+	it("gates the provider-bound context before opening the initial turn", async () => {
+		const context: AgentContext = { systemPrompt: ["stale"], messages: [], tools: [] };
+		const queued = createUserMessage("queued");
+		const providerMessage = createUserMessage("provider") as Message;
+		const mock = createMockModel({ responses: [{ content: ["should not be reached"] }] });
+		let pending = true;
+		let gatedContext: Context | undefined;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getSteeringMessages: async () => {
+				if (!pending) return [];
+				pending = false;
+				return [queued];
+			},
+			syncContextBeforeModelCall: current => {
+				current.systemPrompt = ["fresh"];
+			},
+			transformProviderContext: providerContext => ({
+				...providerContext,
+				systemPrompt: [...(providerContext.systemPrompt ?? []), "provider"],
+				messages: [...providerContext.messages, providerMessage],
+			}),
+			beforeModelCall: current => {
+				gatedContext = current;
+				return { stop: true, reason: "over budget" };
+			},
+		};
+
+		const prompts = [createUserMessage("start")];
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(prompts, context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(gatedContext?.systemPrompt).toEqual(["fresh", "provider"]);
+		expect(gatedContext?.messages.at(-1)).toEqual(providerMessage);
+		expect(prompts).toHaveLength(1);
+		expect(events.filter(event => event.type === "message_end")).toHaveLength(2);
+		expect(events.filter(event => event.type === "turn_start")).toHaveLength(0);
+		expect(events.filter(event => event.type === "turn_end")).toHaveLength(0);
+	});
+
+	it("balances the synthetic error turn when the gate throws", async () => {
+		const mock = createMockModel({ responses: [{ content: ["should not be reached"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+		agent.setBeforeModelCall(() => {
+			throw new Error("gate failed");
+		});
+		const events: AgentEvent[] = [];
+		const unsubscribe = agent.subscribe(event => events.push(event));
+
+		await agent.prompt("start");
+		unsubscribe();
+
+		expect(agent.state.messages.some(message => message.role === "user")).toBe(true);
+		expect(events.filter(event => event.type === "turn_start")).toHaveLength(1);
+		expect(events.filter(event => event.type === "turn_end")).toHaveLength(1);
+		const turnStartIndex = events.findIndex(event => event.type === "turn_start");
+		const userStartIndex = events.findIndex(event => event.type === "message_start" && event.message.role === "user");
+		expect(turnStartIndex).toBeLessThan(userStartIndex);
+	});
+
+	it("stops before the provider call and closes the open turn", async () => {
+		const executed: string[] = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [echoTool(executed)] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } }] },
+				// A second provider call would consume this; the gate must prevent it.
+				{ content: ["should not be reached"] },
+			],
+		});
+
+		let calls = 0;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			// Allow the first request, refuse the one that would follow the tool call.
+			beforeModelCall: () => (++calls > 1 ? ({ stop: true, reason: "over budget" } as const) : undefined),
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		// The tool ran, then the gate stopped the follow-up request.
+		expect(executed).toEqual(["first"]);
+		expect(calls).toBe(2);
+		expect(events.some(e => e.type === "agent_end")).toBe(true);
+
+		// Every started turn is closed, so consumers pairing the events are not
+		// left mid-turn by the stop.
+		const starts = events.filter(e => e.type === "turn_start").length;
+		const ends = events.filter(e => e.type === "turn_end").length;
+		expect(ends).toBe(starts);
+	});
+
+	it("returns a hard tool choice when the gate stops before serving it", async () => {
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		let toolChoiceCalls = 0;
+		let gateCalls = 0;
+		const agent = new Agent({
+			streamFn: mock.stream,
+			getToolChoice: () => {
+				toolChoiceCalls++;
+				return "none";
+			},
+		});
+		agent.setBeforeModelCall(() => (++gateCalls === 1 ? { stop: true, reason: "over budget" } : undefined));
+
+		await agent.prompt("stop");
+		await agent.prompt("continue");
+
+		expect(toolChoiceCalls).toBe(1);
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.options?.toolChoice).toBe("none");
+	});
+
+	it("discards a deferred tool choice when its tool is no longer active", async () => {
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		let toolChoiceCalls = 0;
+		let gateCalls = 0;
+		let unavailableToolChoices = 0;
+		const agent = new Agent({
+			streamFn: mock.stream,
+			getToolChoice: () => {
+				toolChoiceCalls++;
+				return toolChoiceCalls === 1 ? { type: "tool", name: "echo" } : "none";
+			},
+			onToolChoiceUnavailable: () => {
+				unavailableToolChoices++;
+			},
+		});
+		agent.setTools([echoTool([])]);
+		agent.setBeforeModelCall(() => (++gateCalls === 1 ? { stop: true, reason: "over budget" } : undefined));
+
+		await agent.prompt("stop");
+		agent.setTools([]);
+		await agent.prompt("continue");
+
+		expect(toolChoiceCalls).toBe(2);
+		expect(unavailableToolChoices).toBe(1);
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.options?.toolChoice).toBe("none");
+	});
+
+	it("clears a deferred tool choice when the agent resets", async () => {
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		let toolChoiceCalls = 0;
+		let gateCalls = 0;
+		const agent = new Agent({
+			streamFn: mock.stream,
+			getToolChoice: () => {
+				toolChoiceCalls++;
+				return toolChoiceCalls === 1 ? "none" : "auto";
+			},
+		});
+		agent.setBeforeModelCall(() => (++gateCalls === 1 ? { stop: true, reason: "over budget" } : undefined));
+
+		await agent.prompt("stop");
+		agent.reset();
+		await agent.prompt("continue");
+
+		expect(toolChoiceCalls).toBe(2);
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.options?.toolChoice).toBe("auto");
+	});
+
+	it("clears a deferred tool choice with all queued session state", async () => {
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		let toolChoiceCalls = 0;
+		let gateCalls = 0;
+		const agent = new Agent({
+			streamFn: mock.stream,
+			getToolChoice: () => {
+				toolChoiceCalls++;
+				return toolChoiceCalls === 1 ? "none" : "auto";
+			},
+		});
+		agent.setBeforeModelCall(() => (++gateCalls === 1 ? { stop: true, reason: "over budget" } : undefined));
+
+		await agent.prompt("stop");
+		agent.clearAllQueues();
+		await agent.prompt("new session");
+
+		expect(toolChoiceCalls).toBe(2);
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.options?.toolChoice).toBe("auto");
+	});
+
+	it("leaves tool-choice rejection to a concurrent abort", async () => {
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const mock = createMockModel({ responses: [{ content: ["should not be reached"] }] });
+		const gateEntered = Promise.withResolvers<void>();
+		const gateAborted = Promise.withResolvers<void>();
+		const controller = new AbortController();
+		let rejectedToolChoices = 0;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolChoice: () => "none",
+			onToolChoiceRejected: () => {
+				rejectedToolChoices++;
+			},
+			beforeModelCall: async (_context, signal) => {
+				if (!signal) throw new Error("missing gate abort signal");
+				gateEntered.resolve();
+				const waiter = Promise.withResolvers<void>();
+				signal.addEventListener(
+					"abort",
+					() => {
+						gateAborted.resolve();
+						waiter.resolve();
+					},
+					{ once: true },
+				);
+				await waiter.promise;
+				return { stop: true, reason: "over budget" };
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, controller.signal, mock.stream);
 		const drain = (async () => {
 			for await (const _event of stream) {
 				// drain
@@ -2900,6 +3141,235 @@ describe("agentLoop event-driven steering watch", () => {
 			},
 		};
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		await gateEntered.promise;
+		controller.abort();
+		await drain;
+
+		await gateAborted.promise;
+		expect(rejectedToolChoices).toBe(0);
+		expect(mock.calls).toHaveLength(0);
+	});
+
+	it("passes the run abort signal to agent pre-model hooks", async () => {
+		const mock = createMockModel({ responses: [{ content: ["should not be reached"] }] });
+		const gateEntered = Promise.withResolvers<void>();
+		const gateAborted = Promise.withResolvers<void>();
+		const agent = new Agent({ streamFn: mock.stream });
+		agent.setBeforeModelCall(async (_context, signal) => {
+			gateEntered.resolve();
+			if (!signal) throw new Error("missing gate abort signal");
+			const waiter = Promise.withResolvers<void>();
+			signal.addEventListener(
+				"abort",
+				() => {
+					gateAborted.resolve();
+					waiter.resolve();
+				},
+				{ once: true },
+			);
+			await waiter.promise;
+			return undefined;
+		});
+
+		const prompt = agent.prompt("start");
+		await gateEntered.promise;
+		agent.abort();
+		await prompt;
+		await gateAborted.promise;
+
+		expect(mock.calls).toHaveLength(0);
+	});
+
+	it("opens an error turn before accepted inputs when a tool-choice rejection hook throws", async () => {
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const mock = createMockModel({ responses: [{ content: ["should not be reached"] }] });
+		const softState: NonNullable<AgentLoopConfig["softToolRequirementState"]> = { escalations: 0 };
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolChoice: () => ({
+				soft: true,
+				id: "preview-1",
+				toolName: "resolve",
+				reminder: [createUserMessage("resolve")],
+			}),
+			softToolRequirementState: softState,
+			onToolChoiceRejected: () => {
+				throw new Error("rejection failed");
+			},
+			beforeModelCall: () => ({ stop: true, reason: "over budget" }),
+		};
+		const events: AgentEvent[] = [];
+		let failure: unknown;
+
+		try {
+			const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+			for await (const event of stream) events.push(event);
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		expect((failure as Error).message).toBe("rejection failed");
+		expect(events.some(event => event.type === "message_end" && event.message.role === "user")).toBe(true);
+		const turnStartIndex = events.findIndex(event => event.type === "turn_start");
+		const userStartIndex = events.findIndex(event => event.type === "message_start" && event.message.role === "user");
+		expect(turnStartIndex).toBeLessThan(userStartIndex);
+		expect(softState.id).toBeUndefined();
+		expect(softState.forcedToolChoice).toBeUndefined();
+		expect(softState.escalations).toBe(0);
+		expect(mock.calls).toHaveLength(0);
+	});
+
+	it("does not return a hard tool choice already served before a later gate stop", async () => {
+		const executed: string[] = [];
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } }] },
+				{ content: ["done"] },
+			],
+		});
+		let toolChoiceCalls = 0;
+		let gateCalls = 0;
+		const agent = new Agent({
+			streamFn: mock.stream,
+			getToolChoice: () => {
+				toolChoiceCalls++;
+				return toolChoiceCalls === 1 ? { type: "tool", name: "echo" } : undefined;
+			},
+		});
+		agent.setTools([echoTool(executed)]);
+		agent.setBeforeModelCall(() => (++gateCalls === 2 ? { stop: true, reason: "over budget" } : undefined));
+
+		await agent.prompt("run");
+		await agent.prompt("continue");
+
+		expect(executed).toEqual(["first"]);
+		expect(toolChoiceCalls).toBe(3);
+		expect(mock.calls).toHaveLength(2);
+		expect(mock.calls[0]?.options?.toolChoice).toEqual({ type: "tool", name: "echo" });
+		expect(mock.calls[1]?.options?.toolChoice).toBeUndefined();
+	});
+	it("gates a soft reminder once in the final provider context", async () => {
+		const reminder = createUserMessage("resolve the pending preview");
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const mock = createMockModel({ responses: [{ content: ["done"], stopReason: "aborted" }] });
+		let gatedContext: Context | undefined;
+		let gateCalls = 0;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolChoice: () => ({
+				soft: true,
+				id: "preview-1",
+				toolName: "resolve",
+				reminder: [reminder],
+			}),
+			beforeModelCall: providerContext => {
+				gateCalls++;
+				gatedContext = providerContext;
+				return undefined;
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(gateCalls).toBe(1);
+		expect(gatedContext?.messages).toContain(reminder);
+		expect(mock.calls).toHaveLength(1);
+	});
+
+	it("retains a soft reminder escalation when a gate stops the forced call", async () => {
+		const reminder = createUserMessage("resolve the pending preview");
+		const executed: string[] = [];
+		let pending = true;
+		const tool = echoTool(executed);
+		const execute = tool.execute.bind(tool);
+		tool.execute = async (...args) => {
+			pending = false;
+			return execute(...args);
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: ["not yet"] },
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "resolved" } }] },
+				{ content: ["done"] },
+			],
+		});
+		let gateCalls = 0;
+		const agent = new Agent({
+			streamFn: mock.stream,
+			getToolChoice: () =>
+				pending
+					? {
+							soft: true,
+							id: "preview-1",
+							toolName: "echo",
+							reminder: [reminder],
+						}
+					: undefined,
+		});
+		agent.setTools([tool]);
+		agent.setBeforeModelCall(() => (++gateCalls === 2 ? { stop: true, reason: "over budget" } : undefined));
+
+		await agent.prompt("start");
+		await agent.prompt("continue");
+
+		expect(mock.calls).toHaveLength(3);
+		expect(mock.calls[1]?.options?.toolChoice).toEqual({ type: "tool", name: "echo" });
+		expect(executed).toEqual(["resolved"]);
+		expect(agent.state.messages.filter(message => message === reminder)).toHaveLength(1);
+	});
+
+	it("closes an open Harmony retry turn when the gate stops the retry", async () => {
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const mock = createMockModel({
+			provider: "openai-codex",
+			responses: [{ content: ["Some prose. analysis to=functions.edit code"] }],
+		});
+		const retryModel = { ...mock.model, id: "retry-model" };
+		let gateCalls = 0;
+		let turnEndCalls = 0;
+		let rejectedToolChoices = 0;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			getModel: () => (gateCalls === 0 ? mock.model : retryModel),
+			convertToLlm: identityConverter,
+			beforeModelCall: () => (++gateCalls > 1 ? { stop: true, reason: "over budget" } : undefined),
+			onTurnEnd: () => {
+				turnEndCalls++;
+			},
+			onToolChoiceRejected: () => {
+				rejectedToolChoices++;
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		expect(mock.calls).toHaveLength(1);
+		expect(events.filter(event => event.type === "turn_start")).toHaveLength(1);
+		expect(events.filter(event => event.type === "turn_end")).toHaveLength(1);
+		expect(turnEndCalls).toBe(1);
+		expect(rejectedToolChoices).toBe(0);
+		const final = messages.at(-1);
+		expect(final?.role).toBe("assistant");
+		if (final?.role !== "assistant") throw new Error("expected stopped assistant message");
+		expect(final.stopReason).toBe("aborted");
+		expect(final.errorMessage).toBe("over budget");
+		expect(final.model).toBe(retryModel.id);
+	});
+
+	it("proceeds when the gate returns undefined", async () => {
+		const executed: string[] = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [echoTool(executed)] };
 		const mock = createMockModel({
 			responses: [
 				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
@@ -2916,6 +3386,7 @@ describe("agentLoop event-driven steering watch", () => {
 				return Promise.reject(new Error("subscription unavailable"));
 			},
 			getSteeringMessages: async () => [],
+			beforeModelCall: () => undefined,
 		};
 
 		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
@@ -2924,6 +3395,7 @@ describe("agentLoop event-driven steering watch", () => {
 		}
 
 		expect(waitCalls).toBe(1);
+		expect(executed).toEqual(["only"]);
 	});
 });
 

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -3367,6 +3367,43 @@ describe("agentLoop pre-model-call gate", () => {
 		expect(final.model).toBe(retryModel.id);
 	});
 
+	it("closes an open Harmony retry turn when abort lands inside the retry gate", async () => {
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const mock = createMockModel({
+			provider: "openai-codex",
+			responses: [{ content: ["Some prose. analysis to=functions.edit code"] }],
+		});
+		const gateEntered = Promise.withResolvers<void>();
+		const controller = new AbortController();
+		let gateCalls = 0;
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			beforeModelCall: async (_context, signal) => {
+				if (++gateCalls === 1) return undefined;
+				if (!signal) throw new Error("missing gate abort signal");
+				gateEntered.resolve();
+				const waiter = Promise.withResolvers<void>();
+				signal.addEventListener("abort", () => waiter.resolve(), { once: true });
+				await waiter.promise;
+				return undefined;
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("start")], context, config, controller.signal, mock.stream);
+		const drain = (async () => {
+			for await (const event of stream) events.push(event);
+		})();
+		await gateEntered.promise;
+		controller.abort();
+		await drain;
+
+		expect(mock.calls).toHaveLength(1);
+		expect(events.filter(event => event.type === "turn_start")).toHaveLength(1);
+		expect(events.filter(event => event.type === "turn_end")).toHaveLength(1);
+	});
+
 	it("proceeds when the gate returns undefined", async () => {
 		const executed: string[] = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [echoTool(executed)] };

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -98,9 +98,6 @@ describe("agentLoop with AgentMessage", () => {
 		expect(await stream.result()).toEqual([prompt]);
 		expect(mock.calls).toHaveLength(0);
 		expect(events.map(event => event.type)).toContain("agent_end");
-		expect(events.filter(event => event.type === "message_end")).toEqual([
-			expect.objectContaining({ message: prompt }),
-		]);
 	});
 
 	it("returns detailed telemetry when awaiting detailed() directly", async () => {
@@ -2518,12 +2515,6 @@ describe("agentLoop event-driven steering watch", () => {
 
 		const toolSchema = type({ value: "string" });
 		const tool: AgentTool<typeof toolSchema> = {
-describe("agentLoop pre-model-call gate", () => {
-	const echoToolSchema = type({ value: "string" });
-
-	function echoTool(executed: string[]): AgentTool<typeof echoToolSchema> {
-		const toolSchema = echoToolSchema;
-		return {
 			name: "echo",
 			label: "Echo",
 			description: "Echo tool",
@@ -2880,6 +2871,76 @@ describe("agentLoop pre-model-call gate", () => {
 		};
 
 		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		const drain = (async () => {
+			for await (const _event of stream) {
+				// drain
+			}
+		})();
+		const completed = await Promise.race([drain.then(() => true), Bun.sleep(1000).then(() => false)]);
+		try {
+			expect(completed).toBe(true);
+			expect(executed).toEqual(["only"]);
+		} finally {
+			check.resolve(false);
+			await drain;
+		}
+	});
+
+	it("stops watching after a steering subscription rejects", async () => {
+		let waitCalls = 0;
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				await Bun.sleep(0);
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => ({ queued: false }),
+			waitForSteeringMessages: () => {
+				waitCalls++;
+				return Promise.reject(new Error("subscription unavailable"));
+			},
+			getSteeringMessages: async () => [],
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(waitCalls).toBe(1);
+	});
+});
+
+describe("agentLoop pre-model-call gate", () => {
+	const echoToolSchema = type({ value: "string" });
+
+	function echoTool(executed: string[]): AgentTool<typeof echoToolSchema> {
+		const toolSchema = echoToolSchema;
+		return {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
 				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
 			},
 		};
@@ -3116,31 +3177,6 @@ describe("agentLoop pre-model-call gate", () => {
 				// drain
 			}
 		})();
-		const completed = await Promise.race([drain.then(() => true), Bun.sleep(1000).then(() => false)]);
-		try {
-			expect(completed).toBe(true);
-			expect(executed).toEqual(["only"]);
-		} finally {
-			check.resolve(false);
-			await drain;
-		}
-	});
-
-	it("stops watching after a steering subscription rejects", async () => {
-		let waitCalls = 0;
-		const toolSchema = type({ value: "string" });
-		const tool: AgentTool<typeof toolSchema> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			concurrency: "exclusive",
-			async execute(_toolCallId, params) {
-				await Bun.sleep(0);
-				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
-			},
-		};
-		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
 		await gateEntered.promise;
 		controller.abort();
 		await drain;
@@ -3416,13 +3452,6 @@ describe("agentLoop pre-model-call gate", () => {
 		const config: AgentLoopConfig = {
 			model: mock.model,
 			convertToLlm: identityConverter,
-			interruptMode: "immediate",
-			hasSteeringMessages: () => ({ queued: false }),
-			waitForSteeringMessages: () => {
-				waitCalls++;
-				return Promise.reject(new Error("subscription unavailable"));
-			},
-			getSteeringMessages: async () => [],
 			beforeModelCall: () => undefined,
 		};
 
@@ -3431,7 +3460,6 @@ describe("agentLoop pre-model-call gate", () => {
 			// drain
 		}
 
-		expect(waitCalls).toBe(1);
 		expect(executed).toEqual(["only"]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -55,6 +55,9 @@
 - Fixed Escape waiting for an in-flight `session_stop` extension handler to exhaust its timeout; abort now cancels the active stop pass without reporting a false timeout or applying stale continuation context ([#6489](https://github.com/can1357/oh-my-pi/issues/6489)).
 - Fixed the agent not resuming after re-answering a past `ask` from the session tree. Committing a new answer via `/tree` branched a fresh sibling `toolResult` and rebuilt context, but nothing ever continued the agent — unlike a live `ask`, whose continuation is intrinsic to the streaming run loop — so the model never consumed the new answer and the session sat idle until a manual prompt. `navigateTree` now reports the commit (`askReanswerCommitted`) and the interactive `/tree` handler resumes the agent via `resumeAfterAskReanswer()` *after* its transcript rebuild, so the resumed turn never renders against the stale pre-rebuild UI. Plain leaf moves and the read-only `reopenAsk` probe stay idle ([#6483](https://github.com/can1357/oh-my-pi/issues/6483)).
 - Fixed Ctrl+C and fatal shutdown entering an `ExtensionExitError` rejection loop while an extension or hook was still loading ([#6488](https://github.com/can1357/oh-my-pi/issues/6488)).
+### Fixed
+
+- Dropped unavailable forced tool choices through the queue rejection lifecycle and discarded their remaining sequence yields so a skipped force cannot disable tools on the next request.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3024,6 +3024,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			dialect: resolveDialect(settings.get("tools.format"), model),
 			abortOnFabricatedToolResult: settings.get("tools.abortOnFabricatedResult"),
 			getToolChoice: () => session?.nextToolChoiceDirective(),
+			onToolChoiceUnavailable: () => session?.toolChoiceQueue.reject("unavailable"),
 			telemetry: options.telemetry,
 			appendOnlyContext: model
 				? shouldEnableAppendOnlyContext(settings.get("provider.appendOnlyContext"), model)

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1471,7 +1471,7 @@ export class AgentSession {
 
 		this.#toolChoiceQueue.pushSequence([forced, "none"], {
 			label: "user-force",
-			onRejected: () => "requeue",
+			onRejected: info => (info.reason === "unavailable" ? "drop_sequence" : "requeue"),
 		});
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4222,6 +4222,7 @@ export class AgentSession {
 
 	/** Drop mutable tool decisions and directives owned by the previous logical session. */
 	#clearSessionScopedToolState(): void {
+		this.agent.clearDeferredToolChoice();
 		this.#toolChoiceQueue.clear();
 		this.#tools.clearAcpPermissionDecisions();
 	}

--- a/packages/coding-agent/src/session/tool-choice-queue.ts
+++ b/packages/coding-agent/src/session/tool-choice-queue.ts
@@ -13,15 +13,15 @@ export interface RejectInfo {
 	reason: "aborted" | "error" | "cleared" | "removed" | "unavailable" | "not_invoked";
 }
 
-/** "requeue" replays the lost yield next turn; "drop" (or void/undefined) discards it. */
-export type RejectOutcome = "requeue" | "drop";
+/** Controls whether rejection replays a yield, drops it, or drops its remaining sequence. */
+export type RejectOutcome = "requeue" | "drop" | "drop_sequence";
 
 export interface DirectiveCallbacks {
 	/** Fires when the yield completed; onInvoked directives require the requested tool to run first. */
 	onResolved?: (info: ResolveInfo) => void;
 	/**
-	 * Fires when the yield is being discarded. Return "requeue" to replay the
-	 * same value at the head of the queue for the next turn. Default: "drop".
+	 * Return "requeue" to replay the same value, or "drop_sequence" to discard
+	 * its directive including later yields. Default: drop the rejected yield.
 	 */
 	onRejected?: (info: RejectInfo) => RejectOutcome | undefined;
 	/**
@@ -39,6 +39,8 @@ export interface ToolChoiceDirective {
 	/** Stable label for targeted removal and debugging (e.g. "user-force"). */
 	label: string;
 	callbacks: DirectiveCallbacks;
+	/** Original multi-yield directive retained across one-yield replays. */
+	sequenceRoot?: ToolChoiceDirective;
 }
 
 export interface PushOptions {
@@ -178,6 +180,12 @@ export class ToolChoiceQueue {
 			reason,
 		});
 
+		if (outcome === "drop_sequence") {
+			const root = inFlight.directive.sequenceRoot ?? inFlight.directive;
+			this.#queue = this.#queue.filter(directive => directive !== root && directive.sequenceRoot !== root);
+			return;
+		}
+
 		if (outcome === "requeue") {
 			// Re-queue only the lost yield, not the rest of the sequence. Carry forward
 			// callbacks so the replayed yield still executes and finalizes correctly,
@@ -185,6 +193,7 @@ export class ToolChoiceQueue {
 			this.#queue.unshift({
 				generator: onceGen(inFlight.yielded),
 				label: `${inFlight.directive.label}-requeued`,
+				sequenceRoot: inFlight.directive.sequenceRoot ?? inFlight.directive,
 				callbacks: {
 					onResolved: inFlight.directive.callbacks.onResolved,
 					onInvoked: inFlight.directive.callbacks.onInvoked,

--- a/packages/coding-agent/test/agent-session-force-tool-choice.test.ts
+++ b/packages/coding-agent/test/agent-session-force-tool-choice.test.ts
@@ -89,16 +89,16 @@ it("forces specific tool, then transitions to none, then clears", () => {
 	expect(third).toBeUndefined();
 });
 
-it("requeues a forced choice whose tool is filtered out before dequeue", async () => {
+it("drops an unavailable forced choice with the rest of its sequence", async () => {
 	session.setForcedToolChoice("write");
 
 	await session.setActiveToolsByName(["bash"]);
 	expect(session.nextToolChoiceDirective()).toBeUndefined();
 	expect(session.toolChoiceQueue.hasInFlight).toBe(false);
+	expect(session.nextToolChoiceDirective()).toBeUndefined();
 
 	await session.setActiveToolsByName(["bash", "write"]);
-	expect(session.nextToolChoiceDirective()).toEqual({ type: "tool", name: "write" });
-	session.toolChoiceQueue.clear();
+	expect(session.nextToolChoiceDirective()).toBeUndefined();
 });
 
 it("throws when forcing a non-active tool", () => {

--- a/packages/coding-agent/test/agent-session-force-tool-choice.test.ts
+++ b/packages/coding-agent/test/agent-session-force-tool-choice.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, expect, it } from "bun:test";
+import { afterEach, beforeEach, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
-import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { createMockModel, type MockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -15,6 +15,8 @@ import { type } from "arktype";
 let tempDir: TempDir;
 let authStorage: AuthStorage | undefined;
 let session: AgentSession;
+let sessionManager: SessionManager;
+let mock: MockModel;
 
 beforeEach(async () => {
 	tempDir = TempDir.createSync("@pi-agent-session-force-tool-");
@@ -25,7 +27,7 @@ beforeEach(async () => {
 	authStorage.setRuntimeApiKey("anthropic", "test-key");
 	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
 	const settings = Settings.isolated({ "compaction.enabled": false });
-	const sessionManager = SessionManager.inMemory(tempDir.path());
+	sessionManager = SessionManager.inMemory(tempDir.path());
 
 	const emptyObjectSchema = type("object");
 
@@ -44,7 +46,10 @@ beforeEach(async () => {
 		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
 	};
 
+	mock = createMockModel({ handler: () => ({ content: ["done"] }) });
+
 	const agent = new Agent({
+		getToolChoice: () => session.nextToolChoiceDirective(),
 		getApiKey: () => "test-key",
 		initialState: {
 			model,
@@ -53,7 +58,7 @@ beforeEach(async () => {
 			messages: [],
 		},
 		convertToLlm,
-		streamFn: () => new AssistantMessageEventStream(),
+		streamFn: mock.stream,
 	});
 
 	session = new AgentSession({
@@ -74,6 +79,14 @@ afterEach(async () => {
 	authStorage = undefined;
 	tempDir.removeSync();
 });
+
+async function deferForcedWrite(): Promise<void> {
+	session.setForcedToolChoice("write");
+	session.agent.setBeforeModelCall(() => ({ stop: true, reason: "session transition" }));
+	await session.agent.prompt("defer");
+	session.agent.setBeforeModelCall(undefined);
+	expect(mock.calls).toHaveLength(0);
+}
 
 it("forces specific tool, then transitions to none, then clears", () => {
 	session.setForcedToolChoice("write");
@@ -103,4 +116,31 @@ it("drops an unavailable forced choice with the rest of its sequence", async () 
 
 it("throws when forcing a non-active tool", () => {
 	expect(() => session.setForcedToolChoice("read")).toThrow('Tool "read" is not currently active.');
+});
+
+it("drops a deferred forced choice when branching", async () => {
+	const entryId = sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "branch target" }],
+		timestamp: Date.now(),
+	});
+	await deferForcedWrite();
+
+	await session.branch(entryId);
+	await session.agent.prompt("new branch");
+
+	expect(mock.calls).toHaveLength(1);
+	expect(mock.calls[0]?.options?.toolChoice).toBeUndefined();
+});
+
+it("retains a deferred forced choice when session switching rolls back", async () => {
+	await deferForcedWrite();
+	const failure = new Error("switch failed");
+	vi.spyOn(sessionManager, "setSessionFile").mockRejectedValueOnce(failure);
+
+	await expect(session.switchSession(path.join(tempDir.path(), "target.jsonl"))).rejects.toBe(failure);
+	await session.agent.prompt("retry current session");
+
+	expect(mock.calls).toHaveLength(1);
+	expect(mock.calls[0]?.options?.toolChoice).toEqual({ type: "tool", name: "write" });
 });

--- a/packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts
@@ -189,7 +189,7 @@ describe("AgentSession queued steer delivery", () => {
 		const firstDelivered = nextUserMessage(session, "first queued");
 		await session.steer("first queued");
 		await firstDelivered;
-		expect(mock.calls.length).toBe(1);
+		expect(mock.calls.length).toBe(2);
 
 		await session.steer("second queued");
 		expect(session.getQueuedMessages().steering).toContain("second queued");

--- a/packages/coding-agent/test/tool-choice-queue.test.ts
+++ b/packages/coding-agent/test/tool-choice-queue.test.ts
@@ -54,6 +54,34 @@ describe("ToolChoiceQueue", () => {
 			expect(q.nextToolChoice()).toBeUndefined();
 		});
 
+		it("onRejected returning 'drop_sequence' discards its later yields", () => {
+			const q = new ToolChoiceQueue();
+			q.pushSequence([forced, "none"], {
+				label: "user-force",
+				onRejected: () => "drop_sequence",
+			});
+			q.pushOnce(forcedRead, { label: "later" });
+
+			expect(q.nextToolChoice()).toEqual(forced);
+			q.reject("unavailable");
+			expect(q.nextToolChoice()).toEqual(forcedRead);
+		});
+
+		it("drop_sequence removes the origin after an unavailable replay", () => {
+			const q = new ToolChoiceQueue();
+			q.pushSequence([forced, "none"], {
+				label: "user-force",
+				onRejected: info => (info.reason === "unavailable" ? "drop_sequence" : "requeue"),
+			});
+			q.pushOnce(forcedRead, { label: "later" });
+
+			expect(q.nextToolChoice()).toEqual(forced);
+			q.reject("aborted");
+			expect(q.nextToolChoice()).toEqual(forced);
+			q.reject("unavailable");
+			expect(q.nextToolChoice()).toEqual(forcedRead);
+		});
+
 		it("requeued directive preserves onRejected so it can re-requeue across aborts", () => {
 			const q = new ToolChoiceQueue();
 			let rejectCount = 0;


### PR DESCRIPTION
The agent loop had no place to refuse a provider request. A host that needs to check the assembled context, budget boundary, or handoff state could only react after tokens were committed.

`AgentLoopConfig.beforeModelCall` now receives the final provider context and run abort signal, and may stop before dispatch. Pending messages and soft tool reminders are included before the callback runs. A hard tool choice stopped before service is retained for the next admitted request. If its tool disappears, the choice is rejected through its queue lifecycle and the rest of its forced sequence is discarded. Queue clearing on a session transition also clears the deferred choice. Soft reminder and escalation state survives a gate stop without duplicating the reminder or losing an earned forced call. Other exits and agent reset clear retained state. `Agent.setBeforeModelCall` installs the host callback, while `addBeforeModelCall` registers an independent callback and returns a disposer.

The agent package check passes, and all 425 package tests pass. Focused regressions cover initial stops, finalized context, one gate call per provider request, hard tool-choice retention and invalidation, forced-sequence rejection, session-transition clearing, soft escalation resumption, reset and abort ownership, gate cancellation before provider entry, thrown gates, and balanced Harmony retry closure with the turn-end hook.
