### PR TITLE
feat(agent): wake steering on an event instead of polling for it

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Steering is now woken by an event instead of polled on a fixed interval while a tool batch runs. `AgentLoopConfig.waitForSteeringMessages` resolves when a steer is enqueued, so an interruption is observed as soon as it arrives rather than at the next tick, and idle batches stop burning wakeups. The interval timer remains for the IRC interrupt queue, which has no wake callback, and checks only IRC while the event watcher owns steering. Waits are raced against local abort, so a callback that does not observe its signal cannot hang batch teardown.
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2004,7 +2004,7 @@ async function executeToolCalls(
 	// external + IRC aborts. Every other tool sees ONLY the external signal:
 	// neither queued steering nor a peer IRC ever hard-kills a partially
 	// side-effecting foreground tool (e.g. `bash`) — those get the cooperative
-	// steeringSignal above, and the message injects at the next boundary.
+	// `steeringSignal` above, and the message injects at the next boundary.
 	const nonInterruptibleSignal: AbortSignal = signal ?? new AbortController().signal;
 	const interruptibleSignal: AbortSignal = signal
 		? AbortSignal.any([signal, steeringAbortController.signal, ircAbortController.signal])
@@ -2050,6 +2050,21 @@ async function executeToolCalls(
 		};
 	});
 
+	const checkIrcInterrupts = async (): Promise<void> => {
+		// IRC only fires once: a peer interrupt already recorded on interruptState
+		// must not re-abort, and (unlike steering) never re-consumes a queue.
+		if (!shouldInterruptImmediately || signal?.aborted || interruptState.triggered) return;
+		if (hasIrcInterrupts && (await hasIrcInterrupts())) {
+			// Peer IRC hard-aborts interruptible waits only; foreground tools keep
+			// running (no partial side effects) but get the cooperative soft
+			// signal so backgroundable work can step aside for the peer message.
+			interruptState.triggered = true;
+			interruptState.source = "irc";
+			ircAbortController.abort();
+			steeringSoftController.abort();
+		}
+	};
+
 	const checkSteering = async (): Promise<void> => {
 		// `signal` (external/user abort) is checked separately from the internal
 		// abort controllers: once the run is externally aborted it is unwinding
@@ -2087,18 +2102,7 @@ async function executeToolCalls(
 			}
 			return;
 		}
-		// IRC only fires once: a peer interrupt already recorded on interruptState
-		// must not re-abort, and (unlike steering above) never re-consume a queue.
-		if (interruptState.triggered) return;
-		if (hasIrcInterrupts && (await hasIrcInterrupts())) {
-			// Peer IRC hard-aborts interruptible waits only; foreground tools keep
-			// running (no partial side effects) but get the cooperative soft
-			// signal so backgroundable work can step aside for the peer message.
-			interruptState.triggered = true;
-			interruptState.source = "irc";
-			ircAbortController.abort();
-			steeringSoftController.abort();
-		}
+		await checkIrcInterrupts();
 	};
 
 	const emitToolResult = (record: (typeof records)[number], result: AgentToolResult<any>, isError: boolean): void => {
@@ -2443,13 +2447,60 @@ async function executeToolCalls(
 	// mode; checkSteering is idempotent (no-op once triggered).
 	const watchSteeringWhileRunning =
 		shouldInterruptImmediately && (hasSteeringMessages !== undefined || hasIrcInterrupts !== undefined);
-	const steeringWatchTimer = watchSteeringWhileRunning
-		? setInterval(() => void checkSteering(), STEERING_INTERRUPT_POLL_MS)
+	const eventDrivenSteeringWatch =
+		watchSteeringWhileRunning && config.waitForSteeringMessages !== undefined && hasSteeringMessages !== undefined;
+	const steeringWatchAbortController = new AbortController();
+	const steeringWatchSignal = signal
+		? AbortSignal.any([signal, steeringWatchAbortController.signal])
+		: steeringWatchAbortController.signal;
+	// Race every wait against one local abort promise. The callback contract does
+	// not require an implementation to observe the signal, and one that resolves
+	// only on the next queue event would otherwise never settle once the batch
+	// finishes, so awaiting it during teardown would hang a batch with no steer.
+	const { promise: watchAborted, resolve: resolveWatchAbort } = Promise.withResolvers<void>();
+	if (steeringWatchSignal.aborted) {
+		resolveWatchAbort();
+	} else {
+		steeringWatchSignal.addEventListener("abort", () => resolveWatchAbort(), { once: true });
+	}
+	const watchAbortedFalse = watchAborted.then(() => false);
+	const steeringWatchPromise = eventDrivenSteeringWatch
+		? (async (): Promise<void> => {
+				while (!steeringWatchSignal.aborted) {
+					// Subscribe before checking queue state. This closes the edge
+					// race where a steer arrives after a check but before listener
+					// registration: the subsequent check observes queued state,
+					// while later arrivals resolve this already-installed wait.
+					const steeringQueued = config.waitForSteeringMessages?.(steeringWatchSignal).then(
+						() => true,
+						() => false,
+					);
+					const steeringChecked = checkSteering().then(
+						() => true,
+						() => false,
+					);
+					if (!(await Promise.race([steeringChecked, watchAbortedFalse]))) return;
+					if (steeringWatchSignal.aborted || interruptState.triggered) return;
+					if (!(await Promise.race([steeringQueued, watchAbortedFalse]))) return;
+				}
+			})()
 		: undefined;
+	// IRC interrupt records have a separate session-owned queue and no wake
+	// callback. Keep its established timer fallback when that queue is present;
+	// system steering uses the event-driven path above and does not poll.
+	const steeringWatchTimer =
+		watchSteeringWhileRunning && (!eventDrivenSteeringWatch || hasIrcInterrupts !== undefined)
+			? setInterval(
+					() => void (eventDrivenSteeringWatch ? checkIrcInterrupts() : checkSteering()),
+					STEERING_INTERRUPT_POLL_MS,
+				)
+			: undefined;
 	try {
 		await Promise.allSettled(tasks);
 	} finally {
-		if (steeringWatchTimer !== undefined) clearInterval(steeringWatchTimer);
+		steeringWatchAbortController.abort();
+		await steeringWatchPromise?.catch(() => undefined);
+		clearInterval(steeringWatchTimer);
 	}
 	// Yield after batch tool execution to let GC and I/O catch up,
 	// especially when tool results are large (e.g. bash output).

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -353,6 +353,8 @@ export class Agent {
 	#transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
 	#steeringQueue: AgentMessage[] = [];
 	#followUpQueue: AgentMessage[] = [];
+	#steeringWaiters = new Set<() => void>();
+
 	#steeringMode: "all" | "one-at-a-time";
 	#followUpMode: "all" | "one-at-a-time";
 	#interruptMode: "immediate" | "wait";
@@ -397,6 +399,7 @@ export class Agent {
 	#onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
+	#beforeSteeringPoll?: () => Promise<void> | void;
 	#onTurnEnd?: (messages: AgentMessage[], signal?: AbortSignal, context?: AgentTurnEndContext) => Promise<void> | void;
 	#asideMessageProvider?: () => AsideMessage[] | Promise<AsideMessage[]>;
 	#telemetry?: AgentLoopConfig["telemetry"];
@@ -777,6 +780,10 @@ export class Agent {
 	setOnBeforeYield(fn: (() => Promise<void> | void) | undefined): void {
 		this.#onBeforeYield = fn;
 	}
+
+	setBeforeSteeringPoll(fn: (() => Promise<void> | void) | undefined): void {
+		this.#beforeSteeringPoll = fn;
+	}
 	setOnTurnEnd(
 		fn:
 			| ((messages: AgentMessage[], signal?: AbortSignal, context?: AgentTurnEndContext) => Promise<void> | void)
@@ -869,6 +876,7 @@ export class Agent {
 	replaceQueues(steering: AgentMessage[], followUp: AgentMessage[]) {
 		this.#steeringQueue = steering.slice();
 		this.#followUpQueue = followUp.slice();
+		this.#notifySteeringWaiters();
 	}
 
 	appendMessage(m: AgentMessage) {
@@ -889,6 +897,7 @@ export class Agent {
 	 */
 	steer(m: AgentMessage) {
 		this.#steeringQueue.push(m);
+		this.#notifySteeringWaiters();
 	}
 
 	/**
@@ -901,6 +910,7 @@ export class Agent {
 
 	clearSteeringQueue() {
 		this.#steeringQueue = [];
+		this.#notifySteeringWaiters();
 	}
 
 	clearFollowUpQueue() {
@@ -910,6 +920,7 @@ export class Agent {
 	clearAllQueues() {
 		this.#steeringQueue = [];
 		this.#followUpQueue = [];
+		this.#notifySteeringWaiters();
 	}
 
 	hasQueuedMessages(): boolean {
@@ -990,6 +1001,29 @@ export class Agent {
 		return this.#runningPrompt ?? Promise.resolve();
 	}
 
+	/**
+	 * Wait for a steering message without consuming the steering queue.
+	 *
+	 * The signal releases the waiter when the prompt ends, so an in-flight
+	 * tool watcher never survives the tool batch that owns it.
+	 */
+	#waitForSteeringMessages(signal?: AbortSignal): Promise<void> {
+		if (this.#steeringQueue.length > 0 || signal?.aborted) return Promise.resolve();
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const onAbort = (): void => resolve();
+		this.#steeringWaiters.add(resolve);
+		signal?.addEventListener("abort", onAbort, { once: true });
+		return promise.finally(() => {
+			this.#steeringWaiters.delete(resolve);
+			signal?.removeEventListener("abort", onAbort);
+		});
+	}
+
+	#notifySteeringWaiters(): void {
+		const waiters = [...this.#steeringWaiters];
+		for (const resolve of waiters) resolve();
+	}
+
 	reset() {
 		this.#state.messages.length = 0;
 		this.#state.isStreaming = false;
@@ -998,6 +1032,7 @@ export class Agent {
 		this.#state.error = undefined;
 		this.#steeringQueue = [];
 		this.#followUpQueue = [];
+		this.#notifySteeringWaiters();
 	}
 
 	/** Send a prompt with an AgentMessage */
@@ -1226,9 +1261,11 @@ export class Agent {
 					skipInitialSteeringPoll = false;
 					return [];
 				}
+				await this.#beforeSteeringPoll?.();
 				return this.#dequeueSteeringMessages();
 			},
-			hasSteeringMessages: () => {
+			hasSteeringMessages: async () => {
+				await this.#beforeSteeringPoll?.();
 				if (this.#steeringQueue.length === 0) {
 					return { queued: false };
 				}
@@ -1241,6 +1278,7 @@ export class Agent {
 				}
 				return { queued: true, source: "system" };
 			},
+			waitForSteeringMessages: signal => this.#waitForSteeringMessages(signal),
 			hasIrcInterrupts: this.hasIrcInterrupts,
 			getFollowUpMessages: async () => this.#dequeueFollowUpMessages(),
 			getAsideMessages: async () => (await this.#asideMessageProvider?.()) ?? [],

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -224,6 +224,14 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	hasSteeringMessages?: () => boolean | SteeringQueueState | Promise<boolean | SteeringQueueState>;
 
 	/**
+	 * Wakes the in-flight tool interrupt watcher when a steering message is queued.
+	 * The callback must not consume the queue; the loop still calls
+	 * {@link hasSteeringMessages} before aborting and injects through
+	 * {@link getSteeringMessages}.
+	 */
+	waitForSteeringMessages?: (signal?: AbortSignal) => Promise<void>;
+
+	/**
 	 * Peeks whether IRC messages should interrupt an interruptible waiting tool.
 	 *
 	 * Uses the same delivery rules as steering: the poll is non-consuming, only

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -2504,6 +2504,429 @@ it("recovers from provider whitespace loop recovery without duplicating assistan
 	expect(updates.length).toBeGreaterThan(0);
 });
 
+describe("agentLoop event-driven steering watch", () => {
+	it("wakes on a steering event instead of polling for it", async () => {
+		const executed: string[] = [];
+		let steerReady = false;
+		let drained = false;
+		let waitCalls = 0;
+		let wake: (() => void) | undefined;
+
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				// Make a steer available and wake the watcher, the way a real queue
+				// does on enqueue. No timer is involved.
+				if (params.value === "first") {
+					steerReady = true;
+					wake?.();
+				}
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+						{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => (steerReady && !drained ? { queued: true, source: "user" } : { queued: false }),
+			waitForSteeringMessages: async signal => {
+				waitCalls++;
+				if (steerReady) return;
+				const waiter = Promise.withResolvers<void>();
+				wake = waiter.resolve;
+				signal?.addEventListener("abort", () => waiter.resolve(), { once: true });
+				await waiter.promise;
+			},
+			getSteeringMessages: async () => {
+				if (steerReady && !drained) {
+					drained = true;
+					return [createUserMessage("interrupt")];
+				}
+				return [];
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		// The watcher woke on the event and stopped the batch before the second call.
+		expect(executed).toEqual(["first"]);
+		expect(waitCalls).toBeGreaterThan(0);
+	});
+
+	it("does not miss steering queued between the state check and subscription", async () => {
+		const executed: string[] = [];
+		let steerReady = false;
+		let waitTimedOut = false;
+		const firstToolStarted = Promise.withResolvers<void>();
+		const checkStarted = Promise.withResolvers<void>();
+		const checkRelease = Promise.withResolvers<void>();
+		let checking = false;
+		let drained = false;
+		let wake: (() => void) | undefined;
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			interruptible: true,
+			async execute(_toolCallId, params, signal) {
+				executed.push(params.value);
+				if (params.value === "first") {
+					firstToolStarted.resolve();
+					const waiter = Promise.withResolvers<void>();
+					const timer = setTimeout(() => {
+						waitTimedOut = true;
+						waiter.resolve();
+					}, 500);
+					signal?.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(timer);
+							waiter.resolve();
+						},
+						{ once: true },
+					);
+					await waiter.promise;
+				}
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+						{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: async () => {
+				const queued = steerReady && !drained;
+				if (!checking) {
+					checking = true;
+					checkStarted.resolve();
+					await checkRelease.promise;
+				}
+				return queued ? { queued: true, source: "user" } : { queued: false };
+			},
+			waitForSteeringMessages: async signal => {
+				// This queue emits future transitions only. Queue state belongs to
+				// hasSteeringMessages, so subscribing late cannot recover this edge.
+				const waiter = Promise.withResolvers<void>();
+				wake = waiter.resolve;
+				signal?.addEventListener("abort", () => waiter.resolve(), { once: true });
+				await waiter.promise;
+			},
+			getSteeringMessages: async () => {
+				if (!steerReady || drained) return [];
+				drained = true;
+				return [createUserMessage("arrived on the edge")];
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		const completion = (async () => {
+			for await (const _event of stream) {
+				// drain
+			}
+		})();
+		await Promise.all([firstToolStarted.promise, checkStarted.promise]);
+		steerReady = true;
+		wake?.();
+		checkRelease.resolve();
+		await completion;
+
+		expect(waitTimedOut).toBe(false);
+		expect(drained).toBe(true);
+		expect(executed).not.toContain("second");
+	});
+
+	it("completes cleanly when canceling a rejecting wait after queued steering", async () => {
+		let drained = false;
+		let watchCanceled = false;
+		const unhandledRejections: unknown[] = [];
+		const captureUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+		process.on("unhandledRejection", captureUnhandledRejection);
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => (drained ? { queued: false } : { queued: true, source: "user" }),
+			waitForSteeringMessages: signal => {
+				const waiter = Promise.withResolvers<void>();
+				signal?.addEventListener(
+					"abort",
+					() => {
+						watchCanceled = true;
+						waiter.reject(new Error("watch canceled"));
+					},
+					{ once: true },
+				);
+				return waiter.promise;
+			},
+			getSteeringMessages: async () => {
+				if (drained) return [];
+				drained = true;
+				return [createUserMessage("already queued")];
+			},
+		};
+
+		try {
+			const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+			for await (const _event of stream) {
+				// drain
+			}
+			await Bun.sleep(0);
+
+			expect(drained).toBe(true);
+			expect(watchCanceled).toBe(true);
+			expect(unhandledRejections).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", captureUnhandledRejection);
+		}
+	});
+
+	it("does not hang teardown when the steering wait ignores its signal", async () => {
+		const executed: string[] = [];
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
+				{ content: ["done"] },
+			],
+		});
+
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => ({ queued: false }),
+			// Never settles and never observes the signal: a shape an integration can
+			// legitimately write, since the contract does not require honouring it.
+			waitForSteeringMessages: () => Promise.withResolvers<void>().promise,
+			getSteeringMessages: async () => [],
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		expect(executed).toEqual(["only"]);
+	});
+
+	it("uses the IRC timer without polling the steering queue", async () => {
+		const secondIrcCheck = Promise.withResolvers<void>();
+		let steeringChecks = 0;
+		let ircChecks = 0;
+		let steeringChecksAtIrcTimer: number | undefined;
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				await secondIrcCheck.promise;
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => {
+				steeringChecks++;
+				return false;
+			},
+			waitForSteeringMessages: () => Promise.withResolvers<void>().promise,
+			hasIrcInterrupts: () => {
+				ircChecks++;
+				if (ircChecks === 2) {
+					steeringChecksAtIrcTimer = steeringChecks;
+					secondIrcCheck.resolve();
+				}
+				return false;
+			},
+			getSteeringMessages: async () => [],
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(steeringChecksAtIrcTimer).toBe(1);
+		expect(ircChecks).toBeGreaterThanOrEqual(2);
+	});
+
+	it("does not hang teardown when the steering check ignores cancellation", async () => {
+		const executed: string[] = [];
+		const check = Promise.withResolvers<boolean>();
+		const checkStarted = Promise.withResolvers<void>();
+		let checkCalls = 0;
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				await checkStarted.promise;
+				executed.push(params.value);
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => {
+				checkCalls++;
+				if (checkCalls !== 1) return false;
+				checkStarted.resolve();
+				return check.promise;
+			},
+			waitForSteeringMessages: () => Promise.withResolvers<void>().promise,
+			getSteeringMessages: async () => [],
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		const drain = (async () => {
+			for await (const _event of stream) {
+				// drain
+			}
+		})();
+		const completed = await Promise.race([drain.then(() => true), Bun.sleep(1000).then(() => false)]);
+		try {
+			expect(completed).toBe(true);
+			expect(executed).toEqual(["only"]);
+		} finally {
+			check.resolve(false);
+			await drain;
+		}
+	});
+
+	it("stops watching after a steering subscription rejects", async () => {
+		let waitCalls = 0;
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				await Bun.sleep(0);
+				return { content: [{ type: "text", text: `ok:${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "only" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => ({ queued: false }),
+			waitForSteeringMessages: () => {
+				waitCalls++;
+				return Promise.reject(new Error("subscription unavailable"));
+			},
+			getSteeringMessages: async () => [],
+		};
+
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(waitCalls).toBe(1);
+	});
+});
+
 describe("agentLoop useless-flag propagation", () => {
 	async function runProbe(toolReturn: unknown): Promise<ToolResultMessage> {
 		const toolSchema = type({});


### PR DESCRIPTION
While a turn is running, the loop watched for out-of-band steering by re-checking the queue on a fixed interval. The interval sets a floor on how long a message waits and burns a wakeup on every tick that finds nothing. A cancellation or correction issued during a long tool loop can therefore sit until the next tick.

It now waits on the queue. `Agent` keeps a set of steering waiters and notifies them whenever a message is enqueued; the loop awaits `waitForSteeringMessages` and re-checks only when woken. Queue inspection and subscription waits are raced against batch cancellation. An unavailable subscription stops the watcher rather than creating a retry loop. The timer path stays for the IRC interrupt queue, which is session-owned and has no wake callback, and checks only IRC while the event watcher owns steering.

This changes interrupt timing only. Which controllers a steer raises is unchanged. The agent package check passes, and all 417 package tests pass. Focused regressions cover event wakeup, already-queued messages, missed-edge prevention, IRC-only timer fallback, cancellation-insensitive callbacks, rejecting subscriptions, and teardown while a queue check is still pending.
