### PR TITLE
feat(coding-agent): add /undolast slash command for one-turn conversation rewind

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/undolast` (alias `/undo`) slash command that rewinds the conversation to the entry before the last user message, using the existing `navigateTree` branching infrastructure. Skips synthetic auto-continue messages and refuses to rewind past the first turn ([#5289](https://github.com/can1357/oh-my-pi/issues/5289)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1414,6 +1414,65 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			runtime.ctx.editor.setText("");
 		},
 	},
+
+	{
+		name: "undolast",
+		description: "Undo the last turn — rewind conversation to before the last user message",
+		aliases: ["undo"],
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			const sessionManager = runtime.ctx.sessionManager;
+			const branch = sessionManager.getBranch();
+
+			// Find the last non-synthetic user message entry on the active branch
+			let lastUserMsgIndex = -1;
+			let userMessageCount = 0;
+			for (let i = branch.length - 1; i >= 0; i--) {
+				const entry = branch[i];
+				if (entry.type === "message" && entry.message.role === "user" && !entry.message.synthetic) {
+					if (lastUserMsgIndex === -1) lastUserMsgIndex = i;
+					userMessageCount++;
+				}
+			}
+
+			if (lastUserMsgIndex === -1) {
+				runtime.ctx.showStatus("Nothing to undo");
+				return;
+			}
+
+			if (userMessageCount <= 1) {
+				runtime.ctx.showStatus("Cannot undo the first message — use /clear instead");
+				return;
+			}
+
+			// Target the entry before the last user message (end of previous turn)
+			const targetEntry = branch[lastUserMsgIndex - 1];
+			const currentLeafId = sessionManager.getLeafId();
+
+			if (targetEntry.id === currentLeafId) {
+				runtime.ctx.showStatus("Already at the earliest undo point");
+				return;
+			}
+
+			try {
+				const result = await runtime.ctx.session.navigateTree(targetEntry.id, {
+					summarize: false,
+				});
+
+				if (result.cancelled) {
+					runtime.ctx.showStatus("Undo cancelled");
+					return;
+				}
+
+				// Update UI — rebuild the display transcript for the new leaf
+				runtime.ctx.renderInitialMessages({ clearTerminalHistory: true });
+				await runtime.ctx.reloadTodos();
+				runtime.ctx.showStatus("Undid last turn");
+			} catch (error) {
+				runtime.ctx.showError(error instanceof Error ? error.message : String(error));
+			}
+		},
+	},
 	{
 		name: "login",
 		description: "Login with OAuth provider",

--- a/packages/coding-agent/test/slash-commands/undolast.test.ts
+++ b/packages/coding-agent/test/slash-commands/undolast.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, type Mock, vi } from "bun:test";
+import type { InteractiveModeContext } from "../../src/modes/types";
+import type { AgentSession } from "../../src/session/agent-session";
+import type { ModelChangeEntry, SessionEntry, SessionMessageEntry } from "../../src/session/session-entries";
+import type { SessionManager } from "../../src/session/session-manager";
+import { executeBuiltinSlashCommand } from "../../src/slash-commands/builtin-registry";
+import type { TuiSlashCommandRuntime } from "../../src/slash-commands/types";
+
+/**
+ * Tests for the /undolast slash command — rewinds the conversation to the
+ * entry before the last non-synthetic user message on the active branch.
+ *
+ * Uses typed mocks (no `any`) against the real InteractiveModeContext and
+ * SessionManager contracts.
+ */
+
+function makeMessageEntry(
+	id: string,
+	parentId: string | null,
+	role: "user" | "assistant",
+	synthetic = false,
+): SessionMessageEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		message: {
+			role,
+			content: role === "user" ? "test prompt" : "test response",
+			...(synthetic ? { synthetic: true } : {}),
+		} as SessionMessageEntry["message"],
+	};
+}
+
+interface UndolastTestHandle {
+	runtime: TuiSlashCommandRuntime;
+	navigateTree: Mock<(targetId: string, options: { summarize?: boolean }) => Promise<{ cancelled: boolean }>>;
+	renderInitialMessages: Mock<(options?: { clearTerminalHistory?: boolean }) => void>;
+	reloadTodos: Mock<() => Promise<void>>;
+	showStatus: Mock<(message: string) => void>;
+	showError: Mock<(message: string) => void>;
+	setText: Mock<(text: string) => void>;
+}
+
+function makeTuiRuntime(entries: SessionEntry[]): UndolastTestHandle {
+	const leafId = entries.length > 0 ? entries[entries.length - 1].id : null;
+
+	const navigateTree = vi.fn(async (_targetId: string, _options: { summarize?: boolean }) => ({
+		cancelled: false,
+	}));
+
+	const renderInitialMessages = vi.fn();
+	const reloadTodos = vi.fn(async () => {});
+	const showStatus = vi.fn();
+	const showError = vi.fn();
+	const setText = vi.fn();
+
+	const sessionManager = {
+		getBranch: () => entries,
+		getLeafId: () => leafId,
+	} as unknown as SessionManager;
+
+	const session = {
+		navigateTree,
+	} as unknown as AgentSession;
+
+	const ctx = {
+		sessionManager,
+		session,
+		editor: { setText } as unknown as InteractiveModeContext["editor"],
+		renderInitialMessages,
+		reloadTodos,
+		showStatus,
+		showError,
+	} as unknown as InteractiveModeContext;
+
+	const runtime = { ctx } as unknown as TuiSlashCommandRuntime;
+
+	return { runtime, navigateTree, renderInitialMessages, reloadTodos, showStatus, showError, setText };
+}
+
+describe("/undolast dispatch (TUI)", () => {
+	it("rewinds to the entry before the last user message", async () => {
+		const entries: SessionEntry[] = [
+			makeMessageEntry("1", null, "user"),
+			makeMessageEntry("2", "1", "assistant"),
+			makeMessageEntry("3", "2", "user"),
+			makeMessageEntry("4", "3", "assistant"),
+		];
+
+		const h = makeTuiRuntime(entries);
+		const handled = await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		expect(handled).toBe(true);
+		expect(h.setText).toHaveBeenCalledWith("");
+		// Target should be entry "2" (the assistant response before the last user message "3")
+		expect(h.navigateTree).toHaveBeenCalledWith("2", { summarize: false });
+		expect(h.renderInitialMessages).toHaveBeenCalledWith({ clearTerminalHistory: true });
+		expect(h.showStatus).toHaveBeenCalledWith("Undid last turn");
+	});
+
+	it("shows 'Nothing to undo' when there are no user messages", async () => {
+		const entries: SessionEntry[] = [makeMessageEntry("1", null, "assistant")];
+
+		const h = makeTuiRuntime(entries);
+		await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		expect(h.showStatus).toHaveBeenCalledWith("Nothing to undo");
+		expect(h.navigateTree).not.toHaveBeenCalled();
+	});
+
+	it("refuses to undo when the last user message is the first entry", async () => {
+		const entries: SessionEntry[] = [makeMessageEntry("1", null, "user"), makeMessageEntry("2", "1", "assistant")];
+
+		const h = makeTuiRuntime(entries);
+		await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		expect(h.showStatus).toHaveBeenCalledWith("Cannot undo the first message — use /clear instead");
+		expect(h.navigateTree).not.toHaveBeenCalled();
+	});
+
+	it("refuses to undo when metadata entries precede the only user message", async () => {
+		const modelChange: ModelChangeEntry = {
+			type: "model_change",
+			id: "0",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			model: "openai/gpt-5",
+		};
+		const entries: SessionEntry[] = [
+			modelChange,
+			makeMessageEntry("1", "0", "user"),
+			makeMessageEntry("2", "1", "assistant"),
+		];
+
+		const h = makeTuiRuntime(entries);
+		await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		// Only one real user message — cannot undo past the first turn
+		expect(h.showStatus).toHaveBeenCalledWith("Cannot undo the first message — use /clear instead");
+		expect(h.navigateTree).not.toHaveBeenCalled();
+	});
+
+	it("skips synthetic user messages when finding the last prompt", async () => {
+		const entries: SessionEntry[] = [
+			makeMessageEntry("1", null, "user"),
+			makeMessageEntry("2", "1", "assistant"),
+			// Synthetic auto-continue message — should be skipped
+			makeMessageEntry("3", "2", "user", true),
+			makeMessageEntry("4", "3", "assistant"),
+		];
+
+		const h = makeTuiRuntime(entries);
+		await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		// Should target entry "1" (before the last real user message at index 0)
+		// But entry "1" is the first entry, so it should say "Cannot undo"
+		expect(h.showStatus).toHaveBeenCalledWith("Cannot undo the first message — use /clear instead");
+	});
+
+	it("works when metadata entries precede the first turn with 2+ user turns", async () => {
+		const modelChange: ModelChangeEntry = {
+			type: "model_change",
+			id: "0",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			model: "openai/gpt-5",
+		};
+		const entries: SessionEntry[] = [
+			modelChange,
+			makeMessageEntry("1", "0", "user"),
+			makeMessageEntry("2", "1", "assistant"),
+			makeMessageEntry("3", "2", "user"),
+			makeMessageEntry("4", "3", "assistant"),
+		];
+
+		const h = makeTuiRuntime(entries);
+		await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		// Should target entry "2" (assistant response before the second user message "3")
+		expect(h.navigateTree).toHaveBeenCalledWith("2", { summarize: false });
+		expect(h.renderInitialMessages).toHaveBeenCalledWith({ clearTerminalHistory: true });
+		expect(h.showStatus).toHaveBeenCalledWith("Undid last turn");
+	});
+
+	it("handles navigateTree cancellation", async () => {
+		const entries: SessionEntry[] = [
+			makeMessageEntry("1", null, "user"),
+			makeMessageEntry("2", "1", "assistant"),
+			makeMessageEntry("3", "2", "user"),
+			makeMessageEntry("4", "3", "assistant"),
+		];
+
+		const h = makeTuiRuntime(entries);
+		h.navigateTree.mockResolvedValue({ cancelled: true });
+
+		await executeBuiltinSlashCommand("/undolast", h.runtime);
+
+		expect(h.showStatus).toHaveBeenCalledWith("Undo cancelled");
+		expect(h.renderInitialMessages).not.toHaveBeenCalled();
+	});
+
+	it("also responds to /undo alias", async () => {
+		const entries: SessionEntry[] = [
+			makeMessageEntry("1", null, "user"),
+			makeMessageEntry("2", "1", "assistant"),
+			makeMessageEntry("3", "2", "user"),
+			makeMessageEntry("4", "3", "assistant"),
+		];
+
+		const h = makeTuiRuntime(entries);
+		const handled = await executeBuiltinSlashCommand("/undo", h.runtime);
+
+		expect(handled).toBe(true);
+		expect(h.navigateTree).toHaveBeenCalledWith("2", { summarize: false });
+	});
+});


### PR DESCRIPTION
## What

Added a `/undolast` slash command (alias `/undo`) that rewinds the conversation to the entry before the last user message. It finds the last non-synthetic user message on the active branch, targets the entry before it, and branches via the existing `navigateTree` infrastructure — the same path the interactive `/tree` selector uses.

## Why

Users requested a quick way to undo the last turn without opening the full tree selector (issues #2427, #5289). The existing `/branch` and `/tree` commands require navigating a picker; `/undolast` is a one-shot shortcut for the most common case: "go back one turn."

This addresses #5289 partially — conversation rewind only. File snapshot rollback (restoring changed files to their pre-turn state) is not included here; it would build on `InMemorySnapshotStore` separately.

## Testing

- 6 new unit tests in `packages/coding-agent/test/slash-commands/undolast.test.ts` covering: normal rewind, no user messages, first-message guard, synthetic skip, cancellation, and `/undo` alias
- All 108 slash-command tests pass (108/108)
- All 98 session tests pass (98/98)
- `bun build --no-bundle` syntax-verified for both source and test files
- Native addon built locally to run the full test suite

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated