### PR TITLE
feat(task): opt-in minimal-task system prompt preset for subagents

### DIFF
--- a/docs/task-agent-discovery.md
+++ b/docs/task-agent-discovery.md
@@ -27,7 +27,7 @@ It covers runtime behavior as implemented today, including precedence, invalid-d
 Task agents normalize into `AgentDefinition` (`src/task/types.ts`):
 
 - required `name`, `description`, and `systemPrompt`
-- optional `tools`, `spawns`, prioritized `model` list, `thinkingLevel`, `output`, `blocking`, `autoloadSkills`, `readSummarize`, `prewalk`, `advisor`
+- optional `systemPreset`, `tools`, `spawns`, prioritized `model` list, `thinkingLevel`, `output`, `blocking`, `autoloadSkills`, `readSummarize`, `prewalk`, `advisor`
 - `source`: `"bundled" | "user" | "project"` (extension agents are tagged with their extension root's project/user level)
 - optional `filePath`
 
@@ -45,6 +45,7 @@ Parsing comes from frontmatter via `parseAgentFields()` (`src/discovery/helpers.
 - `autoloadSkills` names skills from the parent session to inject before the first child prompt; unknown names are ignored
 - `prewalk: true` starts the subagent on its resolved model and hands off to the default prewalk target (the `smol` role) at its first edit/write, exactly like the session-level `--prewalk`; a string value (e.g. `prewalk: "@smol"` or `prewalk: "openai/gpt-5-mini"`) picks a custom target. The `task.agentPrewalk` settings record (agent name → `"on"` / `"off"` / pattern, configured per agent from the `/agents` hub via its prewalk strip) overrides the frontmatter. Resolution happens in `runSubprocess` (`src/task/executor.ts`). An unavailable target is skipped instead of failing the spawn. A resolved target is skipped only when both its model identity and its effective thinking mode/level match the starting selection after model clamping; a same-model effort downgrade is a real hand-off and still arms and switches at the first edit/write.
 - `advisor: true` pairs spawned sessions of the agent with an advisor running the model resolved for the `advisor` role; a string value (e.g. `advisor: "deepseek/deepseek-v4-flash"` or `advisor: "@smol:high"`) sets an explicit advisor model pattern (optional `:level` suffix), applied as the spawned session's `modelRoles.advisor`. The `task.agentAdvisor` settings record (agent name → `"on"` / `"off"` / pattern, configured per agent from the `/agents` hub via its advisor strip) overrides the frontmatter. Resolution happens in `runSubprocess` (`src/task/executor.ts`); subagents default to no advisor, and the effective opt-in is persisted in `session_init` so cold revival restores it.
+- `systemPreset: minimal-task` (the only accepted value; anything else is a parse error) keeps only the subagent role/context/plan/worktree/IRC/yield/output packet and suppresses inherited project prompt blocks, skills, rules, and skill autoload. Native tool schemas retain their descriptions, while owned XML/Hermes/MiniMax dialects still receive their full catalog and grammar. The preset is persisted so the same behavior survives cold revival; agents without it remain unchanged.
 
 ## Role-backed custom agents
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added the opt-in `systemPreset: minimal-task` agent frontmatter setting for focused subagents, including faithful native and in-band tool guidance and cold-revival behavior ([#6548](https://github.com/can1357/oh-my-pi/pull/6548) by [@dexhunter](https://github.com/dexhunter)).
 - Sloppy edits now support inline replacements with `⟪old│new⟫` syntax (`⟪old│⟫` for deletions and `⟪│new⟫` for insertions), alongside automatic recovery for common formatting mistakes without needing a retry.
 - Sloppy edits now recover operations that mix `⟪old│new⟫` inline replacements with a `»` REWRITE instead of failing the payload: a redundant REWRITE is dropped, a diverging one is applied as the final text, and a note explains the interpretation.
 - Expanded archive support in `read` and `write` tools: `read` can now inspect and extract members from `.rar`, `.7z`, `.iso`, `.cab`, `.deb`, `.rpm`, `.cpio`, `.ar`/`.a`, `.lzh`, `.arj`, compressed tar files (`.tar.bz2`, `.tar.xz`, `.tar.zst`), package formats (`.whl`, `.ipa`, `.xpi`, `.vsix`, `.nupkg`, `.cbz`, `.cbr`), `.asar` archives, and single-file compressed streams; `write` can create `.tar.zst` and update `.asar` archives.

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -18,6 +18,7 @@ import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 import { resolveClaudePaths } from "../config/claude-paths";
 import type { MCPRequestIdFormat } from "../mcp/types";
+import type { SystemPromptPreset } from "../task/types";
 import { type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../thinking";
 import { normalizeToolNames } from "../tools/builtin-names";
 
@@ -235,6 +236,7 @@ export function parseModelList(value: unknown): string[] | undefined {
 export interface ParsedAgentFields {
 	name: string;
 	description: string;
+	systemPreset?: SystemPromptPreset;
 	tools?: string[];
 	spawns?: string[] | "*";
 	model?: string[];
@@ -260,6 +262,12 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 	if (!name || !description) {
 		return null;
 	}
+
+	const rawSystemPreset = frontmatter.systemPreset;
+	if (rawSystemPreset !== undefined && rawSystemPreset !== "minimal-task") {
+		throw new Error(`Invalid systemPreset: ${String(rawSystemPreset)}. Expected "minimal-task".`);
+	}
+	const systemPreset = rawSystemPreset as SystemPromptPreset | undefined;
 
 	let tools = parseArrayOrCSV(frontmatter.tools);
 	if (tools) tools = normalizeToolNames(tools);
@@ -319,6 +327,7 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 	return {
 		name,
 		description,
+		systemPreset,
 		tools,
 		spawns,
 		model,

--- a/packages/coding-agent/src/prompts/agents/frontmatter.md
+++ b/packages/coding-agent/src/prompts/agents/frontmatter.md
@@ -5,6 +5,7 @@ description: {{jsonStringify description}}
 {{#if spawns}}spawns: {{jsonStringify spawns}}
 {{/if}}{{#if model}}model: {{jsonStringify model}}
 {{/if}}{{#if thinkingLevel}}thinking-level: {{jsonStringify thinkingLevel}}
+{{/if}}{{#if systemPreset}}systemPreset: {{jsonStringify systemPreset}}
 {{/if}}{{#if blocking}}blocking: true
 {{/if}}{{#if prewalk}}prewalk: {{jsonStringify prewalk}}
 {{/if}}{{#if advisor}}advisor: {{jsonStringify advisor}}

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, MessageAttribution, ServiceTierByFamily, TextContent } from "@oh-my-pi/pi-ai";
-import type { StructuredSubagentSchemaMode } from "../task/types";
+import type { StructuredSubagentSchemaMode, SystemPromptPreset } from "../task/types";
 import type { CompactionMethod } from "./compaction-methods";
 
 export const CURRENT_SESSION_VERSION = 3;
@@ -213,6 +213,8 @@ export interface SessionInitEntry extends SessionEntryBase {
 	task: string;
 	/** Tools available to the agent */
 	tools: string[];
+	/** Prompt/capability preset; absent preserves historical session behavior. */
+	systemPreset?: SystemPromptPreset;
 	/** Agent definition name (for example `scout` or `reviewer`). */
 	agent?: string;
 	/** Semantic model role declared by the agent, retained even after concrete model resolution. */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -18,7 +18,7 @@ import {
 	stringifyJson,
 	toError,
 } from "@oh-my-pi/pi-utils";
-import type { StructuredSubagentSchemaMode } from "../task/types";
+import type { StructuredSubagentSchemaMode, SystemPromptPreset } from "../task/types";
 import { ArtifactManager } from "./artifacts";
 import { type BlobPutOptions, type BlobPutResult, BlobStore } from "./blob-store";
 import type { CompactionMethod } from "./compaction-methods";
@@ -2220,6 +2220,7 @@ export class SessionManager {
 		systemPrompt: string;
 		task: string;
 		tools: string[];
+		systemPreset?: SystemPromptPreset;
 		agent?: string;
 		modelRole?: string;
 		resolvedModel?: string;
@@ -2754,6 +2755,7 @@ export class SessionManager {
 			systemPrompt: string;
 			task: string;
 			tools: string[];
+			systemPreset?: SystemPromptPreset;
 			agent?: string;
 			modelRole?: string;
 			resolvedModel?: string;
@@ -2770,6 +2772,7 @@ export class SessionManager {
 			systemPrompt: string;
 			task: string;
 			tools: string[];
+			systemPreset?: SystemPromptPreset;
 			agent?: string;
 			modelRole?: string;
 			resolvedModel?: string;
@@ -2790,6 +2793,7 @@ export class SessionManager {
 					systemPrompt: entry.systemPrompt,
 					task: entry.task,
 					tools: entry.tools,
+					systemPreset: entry.systemPreset,
 					agent: entry.agent,
 					modelRole: entry.modelRole,
 					resolvedModel: entry.resolvedModel,

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -16,7 +16,7 @@ import securityReviewerMd from "../prompts/agents/security-reviewer.md" with { t
 import taskMd from "../prompts/agents/task.md" with { type: "text" };
 import { AUTO_THINKING } from "../thinking";
 
-import type { AgentDefinition, AgentSource } from "./types";
+import type { AgentDefinition, AgentSource, SystemPromptPreset } from "./types";
 
 interface AgentFrontmatter {
 	name: string;
@@ -25,6 +25,7 @@ interface AgentFrontmatter {
 	spawns?: string;
 	model?: string | string[];
 	thinkingLevel?: string;
+	systemPreset?: SystemPromptPreset;
 	blocking?: boolean;
 	prewalk?: boolean | string;
 	advisor?: boolean | string;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -37,7 +37,6 @@ import type { MCPManager } from "../mcp/manager";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import { initializeExtensions } from "../modes/runtime-init";
 import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pending.md" with { type: "text" };
-import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
 import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-lifecycle";
 import { AgentRegistry } from "../registry/agent-registry";
@@ -64,6 +63,7 @@ import { generateTaskLabel } from "./label";
 import { resolveAgentPrewalkDefault } from "./prewalk";
 import { isReadOnlyAgent } from "./read-only-policy";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
+import { buildSubagentSystemPrompt } from "./system-prompt";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -2662,6 +2662,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		onProgress,
 	} = options;
 	const cleanupGraceMs = options.cleanupGraceMs ?? TASK_ABORT_CLEANUP_GRACE_MS;
+	const isMinimalTask = agent.systemPreset === "minimal-task";
 	const startTime = Date.now();
 	// Set by the session's onFirstChatDispatch hook the first time the agent
 	// loop dispatches a chat request to the provider — the launch-complete boundary.
@@ -2713,6 +2714,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		settings,
 		{
 			...(agent.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
+			// Minimal native sessions omit the in-prompt catalog, so provider schemas
+			// must retain descriptions. Owned dialects independently append their
+			// full catalog and grammar in agent-loop provider preparation.
+			...(isMinimalTask ? { inlineToolDescriptors: "off" } : undefined),
 			// Isolated runs must not expose roots outside the worktree.
 			...(worktree !== undefined ? { "workspace.additionalDirectories": [] } : undefined),
 			...(advisorSelection ? { "advisor.enabled": true } : undefined),
@@ -3082,14 +3087,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				restrictToolNames: options.restrictToolNames,
 				requireYieldTool: true,
 				contextFiles: options.contextFiles,
-				skills: options.skills,
+				skills: isMinimalTask ? [] : options.skills,
 				promptTemplates: options.promptTemplates,
 				workspaceTree: options.workspaceTree,
-				rules: options.rules,
+				rules: isMinimalTask ? [] : options.rules,
 				preloadedExtensionPaths: restrictToolNames ? [] : options.preloadedExtensionPaths,
 				preloadedCustomToolPaths: restrictToolNames ? [] : options.preloadedCustomToolPaths,
-				systemPrompt: defaultPrompt => {
-					const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
+				systemPrompt: defaultPrompt =>
+					buildSubagentSystemPrompt(defaultPrompt, agent.systemPreset, {
 						agent: agent.systemPrompt,
 						context: options.context?.trim() ?? "",
 						planReference: options.planReference?.content ?? "",
@@ -3099,11 +3104,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
 						ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
 						ircSelfId: ircEnabled ? id : "",
-					});
-					return defaultPrompt.length === 0
-						? [subagentPrompt]
-						: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
-				},
+					}),
 				sessionManager: sessionManagerForRun,
 				hasUI: false,
 				prewalk,
@@ -3213,6 +3214,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				systemPrompt: session.agent.state.systemPrompt.join("\n\n"),
 				task,
 				tools: session.getEnabledToolNames(),
+				systemPreset: agent.systemPreset,
 				agent: agent.name,
 				modelRole: modelRole ?? resolveExplicitModelRole(modelOverride ?? agent.model, subagentSettings),
 				resolvedModel: progress.resolvedModel,
@@ -3305,7 +3307,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			checkAbort();
 			// Autoload skills via sendCustomMessage (same mechanic as /skill:<name>)
-			if (options.autoloadSkills?.length) {
+			if (!isMinimalTask && options.autoloadSkills?.length) {
 				for (const skill of options.autoloadSkills) {
 					const { message } = await buildSkillPromptMessage(skill, "", "autoload");
 					await session.sendCustomMessage(

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -87,6 +87,7 @@ export function createPersistedSubagentReviverFactory(
 		// createSubagentSettings default).
 		const subagentSettings = createSubagentSettings(ctx.settings, {
 			...(init.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
+			...(init.systemPreset === "minimal-task" ? { inlineToolDescriptors: "off" } : undefined),
 			...(init.advisor
 				? {
 						"advisor.enabled": true,
@@ -100,6 +101,7 @@ export function createPersistedSubagentReviverFactory(
 			init.modelRole && init.modelRole !== "default"
 				? [formatModelRoleAlias(init.modelRole), ...(init.resolvedModel ? [init.resolvedModel] : [])]
 				: init.resolvedModel;
+		const minimalCapabilityOverrides = init.systemPreset === "minimal-task" ? { skills: [], rules: [] } : undefined;
 		return async expectedRef => {
 			// Re-open fresh on every revive: park closes the writer, so this takes
 			// the single-writer lock cleanly and restores the full message history.
@@ -132,6 +134,7 @@ export function createPersistedSubagentReviverFactory(
 				outputSchemaMode: init.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,
 				requireYieldTool: true,
+				...minimalCapabilityOverrides,
 				systemPrompt: () => [init.systemPrompt],
 				// Old files predate persisted spawns: deny re-spawning rather than let
 				// createAgentSession default to wildcard ("*").
@@ -177,6 +180,7 @@ export function createPersistedSubagentReviverFactory(
 				name: ref.displayName,
 				description: "",
 				systemPrompt: init.systemPrompt,
+				systemPreset: init.systemPreset,
 				source: "user",
 			};
 			attachIrcWakeTurnMonitor(session, {

--- a/packages/coding-agent/src/task/system-prompt.ts
+++ b/packages/coding-agent/src/task/system-prompt.ts
@@ -1,0 +1,26 @@
+import { prompt } from "@oh-my-pi/pi-utils";
+import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
+import type { SystemPromptPreset } from "./types";
+
+export interface SubagentSystemPromptData {
+	[key: string]: unknown;
+	agent: string;
+	context: string;
+	planReference: string;
+	planReferencePath: string;
+	worktree: string;
+	outputSchema: unknown;
+	outputSchemaOverridesAgent: boolean;
+	ircPeers: string;
+	ircSelfId: string;
+}
+
+export function buildSubagentSystemPrompt(
+	defaultPrompt: readonly string[],
+	systemPreset: SystemPromptPreset | undefined,
+	data: SubagentSystemPromptData,
+): string[] {
+	const subagentPrompt = prompt.render(subagentSystemPromptTemplate, data);
+	if (systemPreset === "minimal-task" || defaultPrompt.length === 0) return [subagentPrompt];
+	return [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
+}

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -7,6 +7,9 @@ import type { NestedRepoPatch } from "./worktree";
 
 /** Source of an agent definition */
 export type AgentSource = "bundled" | "user" | "project";
+
+/** Opt-in strategy for constructing a subagent's system prompt. */
+export type SystemPromptPreset = "minimal-task";
 /**
  * Enforcement policy for a structured subagent output schema.
  *
@@ -360,6 +363,7 @@ export interface AgentDefinition {
 	name: string;
 	description: string;
 	systemPrompt: string;
+	systemPreset?: SystemPromptPreset;
 	tools?: string[];
 	spawns?: string[] | "*";
 	model?: string[];

--- a/packages/coding-agent/test/session/peek-session-init.test.ts
+++ b/packages/coding-agent/test/session/peek-session-init.test.ts
@@ -61,6 +61,7 @@ describe("SessionManager.peekSessionInit", () => {
 			systemPrompt: "second",
 			task: "t2",
 			tools: ["read", "bash", "yield"],
+			systemPreset: "minimal-task",
 			spawns: "task",
 			readSummarize: false,
 			restrictToolNames: true,
@@ -73,6 +74,7 @@ describe("SessionManager.peekSessionInit", () => {
 		// Latest init wins — the reviver must rebuild from the most recent contract.
 		expect(peek?.init?.systemPrompt).toBe("second");
 		expect(peek?.init?.tools).toEqual(["read", "bash", "yield"]);
+		expect(peek?.init?.systemPreset).toBe("minimal-task");
 		expect(peek?.init?.spawns).toBe("task");
 		expect(peek?.init?.readSummarize).toBe(false);
 		expect(peek?.init?.restrictToolNames).toBe(true);

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -13,6 +13,7 @@ import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-regis
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolPathWithSource } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
@@ -135,6 +136,39 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.rules).toBe(rules);
 		expect(forwarded?.preloadedExtensionPaths).toBe(preloadedExtensionPaths);
 		expect(forwarded?.preloadedCustomToolPaths).toBe(preloadedCustomToolPaths);
+	});
+
+	it("keeps native descriptors while suppressing inherited capabilities for minimal-task", async () => {
+		const session = yieldEmittingSession();
+		const initSpy = vi.spyOn(session.sessionManager, "appendSessionInit");
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({ inlineToolDescriptors: "on" });
+		const inheritedSkill = { name: "sentinel-skill" } as unknown as Skill;
+		const inheritedRule = { name: "sentinel-rule" } as unknown as Rule;
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, systemPreset: "minimal-task" },
+			id: "minimal-task-child",
+			settings,
+			skills: [inheritedSkill],
+			rules: [inheritedRule],
+			autoloadSkills: [inheritedSkill],
+		});
+
+		expect(result.exitCode).toBe(0);
+		const forwarded = spy.mock.calls[0]?.[0];
+		expect(forwarded?.settings?.get("inlineToolDescriptors")).toBe("off");
+		expect(forwarded?.skills).toEqual([]);
+		expect(forwarded?.rules).toEqual([]);
+		if (typeof forwarded?.systemPrompt !== "function") throw new Error("Expected system-prompt builder");
+		const rendered = forwarded.systemPrompt(["PROJECT_SENTINEL", "SKILL_SENTINEL", "RULE_SENTINEL"]);
+		const renderedParts = typeof rendered === "string" ? [rendered] : rendered;
+		expect(renderedParts).toHaveLength(1);
+		expect(renderedParts.join("\n")).not.toContain("PROJECT_SENTINEL");
+		expect(renderedParts.join("\n")).not.toContain("SKILL_SENTINEL");
+		expect(renderedParts.join("\n")).not.toContain("RULE_SENTINEL");
+		expect(initSpy).toHaveBeenCalledWith(expect.objectContaining({ systemPreset: "minimal-task" }));
 	});
 
 	it("forwards an exact credential resolver without replacing it", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -69,6 +69,7 @@ async function createPersistedSession(
 	restrictToolNames?: boolean,
 	modelRole?: string,
 	advisor?: string,
+	systemPreset?: "minimal-task",
 ): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
@@ -81,6 +82,7 @@ async function createPersistedSession(
 		modelRole,
 		resolvedModel: modelRole ? "anthropic/claude-sonnet-4-5" : undefined,
 		advisor,
+		systemPreset,
 	});
 	manager.appendMessage({
 		role: "assistant",
@@ -103,7 +105,7 @@ async function createPersistedSession(
 	return sessionFile;
 }
 
-function createFactory(cwd: string, eventBus?: EventBus) {
+function createFactory(cwd: string, eventBus?: EventBus, settings = Settings.isolated()) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
@@ -117,7 +119,7 @@ function createFactory(cwd: string, eventBus?: EventBus) {
 		session: parentSession,
 		authStorage: {} as never,
 		modelRegistry: { authStorage: {} } as ModelRegistry,
-		settings: Settings.isolated(),
+		settings,
 		enableLsp: true,
 		eventBus,
 	});
@@ -190,6 +192,7 @@ describe("persisted subagent revival", () => {
 	it("preserves normal revival capability wiring for contracts without the marker", async () => {
 		const cwd = makeTempDir("@pi-normal-revive-");
 		const sessionFile = await createPersistedSession(cwd);
+		const parentSettings = Settings.isolated({ inlineToolDescriptors: "on" });
 		const hostileMcp = {
 			getTools: () => [{ name: "mcp__server_read", label: "server/read" }],
 		} as unknown as MCPManager;
@@ -201,15 +204,38 @@ describe("persisted subagent revival", () => {
 		});
 
 		const ref = createRef(sessionFile);
-		const reviver = await createFactory(cwd)(ref);
+		const reviver = await createFactory(cwd, undefined, parentSettings)(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
+		expect(capturedOptions?.settings?.get("inlineToolDescriptors")).toBe("on");
+		expect(capturedOptions?.skills).toBeUndefined();
+		expect(capturedOptions?.rules).toBeUndefined();
 		expect(capturedOptions?.restrictToolNames).toBeUndefined();
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
 	});
+	it("preserves minimal-task suppression and native descriptors on cold revival", async () => {
+		const cwd = makeTempDir("@pi-minimal-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, undefined, "minimal-task");
+		const parentSettings = Settings.isolated({ inlineToolDescriptors: "on" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, undefined, parentSettings)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("inlineToolDescriptors")).toBe("off");
+		expect(capturedOptions?.skills).toEqual([]);
+		expect(capturedOptions?.rules).toEqual([]);
+	});
+
 	it("restores the persisted per-agent advisor opt-in on cold revival", async () => {
 		const cwd = makeTempDir("@pi-advisor-revive-");
 		const advisedFile = await createPersistedSession(cwd, undefined, undefined, "moonshot/k3");

--- a/packages/coding-agent/test/task/system-prompt-preset.test.ts
+++ b/packages/coding-agent/test/task/system-prompt-preset.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
+import { agentLoop } from "@oh-my-pi/pi-agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core/types";
+import type { Context, Message } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import "../../src/config/prompt-templates";
+import { parseAgentFields } from "../../src/discovery/helpers";
+import { resolveDialect } from "../../src/sdk";
+import { buildSubagentSystemPrompt, type SubagentSystemPromptData } from "../../src/task/system-prompt";
+
+const data: SubagentSystemPromptData = {
+	agent: "Probe agent role prompt.",
+	context: "Supplied context block.",
+	planReference: "Plan packet body.",
+	planReferencePath: "/plans/probe.md",
+	worktree: "/tmp/probe-worktree",
+	outputSchema: undefined,
+	outputSchemaOverridesAgent: false,
+	ircPeers: "",
+	ircSelfId: "",
+};
+
+const inheritedPrompt = ["PROJECT_SENTINEL", "SKILL_SENTINEL", "RULE_SENTINEL"];
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		message => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	) as Message[];
+}
+
+async function captureProviderContext(dialect?: AgentLoopConfig["dialect"]): Promise<Context> {
+	const schema = type({ path: type("string").describe("path argument sentinel") });
+	const readTool: AgentTool<typeof schema, { path: string }> = {
+		name: "read_probe",
+		label: "Read probe",
+		description: "tool description sentinel",
+		parameters: schema,
+		async execute(_toolCallId, params) {
+			return { content: [{ type: "text", text: params.path }], details: params };
+		},
+	};
+	let captured: Context | undefined;
+	const mock = createMockModel({
+		responses: [
+			context => {
+				captured = context;
+				return { content: ["done"] };
+			},
+		],
+	});
+	const context: AgentContext = {
+		systemPrompt: buildSubagentSystemPrompt(inheritedPrompt, "minimal-task", data),
+		messages: [],
+		tools: [readTool],
+	};
+	const config: AgentLoopConfig = {
+		model: mock.model,
+		convertToLlm: identityConverter,
+		dialect,
+		pruneToolDescriptions: false,
+	};
+	const message: AgentMessage = { role: "user", content: "inspect", timestamp: Date.now() };
+	await agentLoop([message], context, config, undefined, mock.stream).result();
+	if (!captured) throw new Error("Expected a provider request");
+	return captured;
+}
+
+function expectNoInheritedBlocks(context: Context): void {
+	const text = (context.systemPrompt ?? []).join("\n");
+	expect(text).not.toContain("PROJECT_SENTINEL");
+	expect(text).not.toContain("SKILL_SENTINEL");
+	expect(text).not.toContain("RULE_SENTINEL");
+}
+
+describe("systemPreset: minimal-task", () => {
+	it("keeps only the subagent packet before provider tool adaptation", () => {
+		const out = buildSubagentSystemPrompt(inheritedPrompt, "minimal-task", data);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toContain("Probe agent role prompt.");
+		expect(out[0]).toContain("Supplied context block.");
+		expect(out[0]).toContain("Plan packet body.");
+		expect(out[0]).toContain("/tmp/probe-worktree");
+		expect(out.join("\n")).not.toContain("PROJECT_SENTINEL");
+		expect(out.join("\n")).not.toContain("SKILL_SENTINEL");
+		expect(out.join("\n")).not.toContain("RULE_SENTINEL");
+	});
+
+	it("preserves the existing sandwich composition without the preset", () => {
+		const out = buildSubagentSystemPrompt(inheritedPrompt, undefined, data);
+		expect(out).toHaveLength(4);
+		expect(out[0]).toBe("PROJECT_SENTINEL");
+		expect(out[1]).toBe("SKILL_SENTINEL");
+		expect(out[2]).toContain("Probe agent role prompt.");
+		expect(out[3]).toBe("RULE_SENTINEL");
+	});
+
+	it("still collapses to the subagent packet when no default prompt exists", () => {
+		const out = buildSubagentSystemPrompt([], undefined, data);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toContain("Probe agent role prompt.");
+	});
+
+	it("keeps native tool and parameter descriptions on the provider wire", async () => {
+		const context = await captureProviderContext();
+		expect(context.tools).toHaveLength(1);
+		expect(context.tools?.[0]?.description).toBe("tool description sentinel");
+		expect(JSON.stringify(context.tools?.[0]?.parameters)).toContain("path argument sentinel");
+		expectNoInheritedBlocks(context);
+	});
+
+	for (const [dialect, grammar] of [
+		["xml", "<invoke name="],
+		["hermes", "<tool_call>"],
+		["minimax", "<minimax:tool_call>"],
+	] as const) {
+		it(`keeps the full catalog and ${dialect} grammar for forced in-band tools`, async () => {
+			const context = await captureProviderContext(dialect);
+			expect(context.tools).toBeUndefined();
+			const systemPrompt = (context.systemPrompt ?? []).join("\n");
+			expect(systemPrompt).toContain("<tools>");
+			expect(systemPrompt).toContain('"name":"read_probe"');
+			expect(systemPrompt).toContain("tool description sentinel");
+			expect(systemPrompt).toContain("path argument sentinel");
+			expect(systemPrompt).toContain(grammar);
+			expectNoInheritedBlocks(context);
+		});
+	}
+
+	it("keeps the catalog and dialect guide when auto selects a non-native model", async () => {
+		const dialect = resolveDialect("auto", { id: "MiniMax-M3", supportsTools: false });
+		expect(dialect).toBe("minimax");
+		const context = await captureProviderContext(dialect);
+		const systemPrompt = (context.systemPrompt ?? []).join("\n");
+		expect(context.tools).toBeUndefined();
+		expect(systemPrompt).toContain('"name":"read_probe"');
+		expect(systemPrompt).toContain("<minimax:tool_call>");
+		expectNoInheritedBlocks(context);
+	});
+
+	it("parses and validates the preset in agent frontmatter", () => {
+		expect(
+			parseAgentFields({ name: "probe", description: "probe", systemPreset: "minimal-task" })?.systemPreset,
+		).toBe("minimal-task");
+		expect(parseAgentFields({ name: "probe", description: "probe" })?.systemPreset).toBeUndefined();
+		expect(() => parseAgentFields({ name: "probe", description: "probe", systemPreset: "everything" })).toThrow(
+			'Invalid systemPreset: everything. Expected "minimal-task".',
+		);
+	});
+});


### PR DESCRIPTION
## What

Adds an opt-in `systemPreset: minimal-task` agent frontmatter setting. Agents with the preset get a system prompt built from the subagent packet alone — agent role, supplied context, plan packet, worktree constraints, IRC protocol, yield protocol, and output schema — and skip the inherited project/harness prompt blocks, skills, rules, and skill autoload for the run. Agents without the preset keep the existing sandwich composition unchanged. `systemPreset` accepts only `minimal-task`; any other value is a parse error surfaced at agent load. The field is round-tripped through the agent frontmatter template and documented in `docs/task-agent-discovery.md`.

## Why

Fixes #4991. Focused subagents spawned for narrow structured work inherit the full project/harness prompt stack they don't use. On current `main` (`de5ffc4201c4941992402daea355adc1aad3a8db`), a representative task subagent's serialized system prompt is **6,573 o200k_base tokens**; the subagent packet it actually needs is **343 tokens**. The preset lets such agents opt into just that packet — a **94.78% reduction in those tokens** (26,459 → 1,696 characters, a 93.59% reduction), measured on the real `runSubprocess` → provider request path against a local OpenAI-compatible fixture, with only the frontmatter flag differing between the two runs.

Vouch request for this change: discussion #5226 (vouched by @can1357 on 2026-07-23).

Supplementary autoresearch record of this externally measured change, uploaded via Weco's external observe API: [public dashboard](https://dashboard.weco.ai/share/vzPO1m00rQO--bD_hy91hSP3yvH0yPb8).

## Testing

- Focused minimal-task/provider/cold-revival/session-init validation: **38 pass / 0 fail across 4 files**, covering native top-level and parameter descriptions, forced XML/Hermes/MiniMax catalogs and grammar, auto-selected non-native tools, capability suppression, persistence, and extension initialization.
- Full `packages/coding-agent/test/task/` suite: **370 pass / 0 fail across 36 files**.
- `bun run check` in `packages/coding-agent` (package-wide Biome + `tsgo -p tsconfig.json --noEmit`): clean.
- `bun scripts/format-prompts.ts`: all prompt files formatted.
- Token measurement as above: 6,573 → 343 tokens on the serialized provider request.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated — added the user-facing entry under `packages/coding-agent/CHANGELOG.md` → `[Unreleased]` → `Added`.
