### PR TITLE
fix(tui): stop Ctrl+O expand truncating the session on ConPTY

### DIFF
--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Ctrl+O (expand tools) truncating the session on ConPTY hosts (native Windows and WSL): the full-view replay routed through the ConPTY frame-truncation intended only for the initial session resume (issue #2115), dropping every row above the retained tail behind an "older lines hidden" marker. The bound now applies to the first resume paint only; user-driven redraws (Ctrl+O expand, resize) replay the whole transcript ([#4863](https://github.com/can1357/oh-my-pi/issues/4863)).
+- Fixed Ctrl+O (expand tools) truncating the session on ConPTY hosts (native Windows and WSL): the full-view replay routed through the ConPTY frame-truncation intended only for bulk transcript-replacement paints (issue #2115), dropping every row above the retained tail behind an "older lines hidden" marker. The bound now keys on paint intent — bulk replacements (initial resume, `/resume`, handoff, resize geometry rebuilds) stay bounded, while a user-driven `resetDisplay()` (Ctrl+O expand, thinking/setting toggles, display reset) replays the whole transcript ([#4863](https://github.com/can1357/oh-my-pi/issues/4863)).
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+O (expand tools) truncating the session on ConPTY hosts (native Windows and WSL): the full-view replay routed through the ConPTY frame-truncation intended only for the initial session resume (issue #2115), dropping every row above the retained tail behind an "older lines hidden" marker. The bound now applies to the first resume paint only; user-driven redraws (Ctrl+O expand, resize) replay the whole transcript ([#4863](https://github.com/can1357/oh-my-pi/issues/4863)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1000,6 +1000,13 @@ export class TUI extends Container {
 	#ghosttyInitialImageDelayTimer: RenderTimer | undefined;
 	#ghosttyImageReadyAtMs = 0;
 	#clearScrollbackOnNextRender = false;
+	// Set by `resetDisplay()`: the next full paint is a user-driven redraw of the
+	// current transcript (Ctrl+O expand, thinking/setting toggles, display reset)
+	// that must show every row, so it opts out of the ConPTY resume-paint bound
+	// (#truncateLargeConptyFrame). Bulk transcript-replacement paints — first
+	// paint, /resume and handoff (requestRender(true, { clearScrollback })), and
+	// resize geometry rebuilds — leave it false and stay bounded (#2115, #4863).
+	#unboundedConptyPaintRequested = false;
 	#forceViewportRepaintOnNextRender = false;
 	#hasEverRendered = false;
 	// Set by the terminal resize callback; consumed by the next render. A resize
@@ -1752,6 +1759,10 @@ export class TUI extends Container {
 	 */
 	resetDisplay(): void {
 		if (this.#stopped) return;
+		// This is a user-driven redraw of the current transcript; it must replay
+		// every row, so opt the next full paint out of the ConPTY resume bound.
+		// Set before the multiplexer early-return so it survives a deferred paint.
+		this.#unboundedConptyPaintRequested = true;
 		this.invalidate();
 		// A reset that lands inside a tmux/screen/zellij resize burst would
 		// paint mid-reflow and re-introduce the flash race (issue #2088).
@@ -2797,11 +2808,12 @@ export class TUI extends Container {
 				chunkTo,
 				windowTop,
 				cursorTrackingLineCount,
-				boundConptyPaint: firstPaint,
+				boundConptyPaint: !this.#unboundedConptyPaintRequested,
 			});
 			this.#committedPrefix = rawFrame.slice(0, chunkTo);
 			this.#committedPrefixAuditRows = Math.min(chunkTo, finalBoundary);
 			this.#clearScrollbackOnNextRender = false;
+			this.#unboundedConptyPaintRequested = false;
 			this.#hasEverRendered = true;
 			if (!firstPaint && frameLength > height) this.#armPostFullPaintSettle();
 			return;
@@ -3158,11 +3170,12 @@ export class TUI extends Container {
 			cursorTrackingLineCount: number;
 			/**
 			 * Whether this paint may be bounded by {@link #truncateLargeConptyFrame}
-			 * on ConPTY hosts. Only the initial session-resume paint sets this: a
-			 * multi-megabyte synchronized frame stalls conhost at startup (issue
-			 * #2115). A user-driven redraw — Ctrl+O expand (`resetDisplay`) or a
-			 * resize geometry rebuild — must replay the whole transcript so nothing
-			 * is silently dropped from scrollback (issue #4863).
+			 * on ConPTY hosts. True for bulk transcript-replacement paints — first
+			 * paint, /resume, handoff, and resize geometry rebuilds — where a
+			 * multi-megabyte synchronized frame stalls conhost (issue #2115). False
+			 * for a user-driven `resetDisplay()` (Ctrl+O expand, thinking/setting
+			 * toggles, display reset), which must replay the whole transcript so
+			 * nothing is silently dropped from scrollback (issue #4863).
 			 */
 			boundConptyPaint: boolean;
 		},
@@ -3180,16 +3193,16 @@ export class TUI extends Container {
 				paintCursorPos = { row: chunkTo + cursorPos.row - windowTop, col: cursorPos.col };
 			}
 		}
-		// ConPTY hosts bound the initial resume replay: merge prefix + window
-		// into one array so #truncateLargeConptyFrame can measure the payload and
-		// retain only the tail. Gated on `boundConptyPaint` (the first paint) — a
-		// user-driven redraw (Ctrl+O expand / resize) must replay the whole
-		// transcript untruncated so nothing is dropped from scrollback (#4863).
-		// Gated on the host check too — everywhere else the merge would copy a
-		// pointer per committed row (a 50k-row session = 50k-entry array per
-		// resize step / theme change / session replace) just to be returned
-		// unchanged. `paintLines` stays null unless truncation actually rewrote
-		// the replay.
+		// ConPTY hosts bound bulk transcript-replacement replays (resume, handoff,
+		// first paint, resize): merge prefix + window into one array so
+		// #truncateLargeConptyFrame can measure the payload and retain only the
+		// tail (#2115). Gated on `boundConptyPaint` — a user-driven `resetDisplay()`
+		// (Ctrl+O expand, toggles) sets it false and replays the whole transcript
+		// untruncated so nothing is dropped from scrollback (#4863). Gated on the
+		// host check too — everywhere else the merge would copy a pointer per
+		// committed row (a 50k-row session = 50k-entry array per resize step /
+		// theme change / session replace) just to be returned unchanged.
+		// `paintLines` stays null unless truncation actually rewrote the replay.
 		let paintLines: string[] | null = null;
 		let paintLineCount = chunkTo + height;
 		if (options.boundConptyPaint && isConPTYHosted()) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1000,12 +1000,12 @@ export class TUI extends Container {
 	#ghosttyInitialImageDelayTimer: RenderTimer | undefined;
 	#ghosttyImageReadyAtMs = 0;
 	#clearScrollbackOnNextRender = false;
-	// Set by `resetDisplay()`: the next full paint is a user-driven redraw of the
+	// Set by `resetDisplay()` and consumed by the next authoritative normal-screen
+	// render. If that render is a full paint, it is a user-driven replay of the
 	// current transcript (Ctrl+O expand, thinking/setting toggles, display reset)
-	// that must show every row, so it opts out of the ConPTY resume-paint bound
-	// (#truncateLargeConptyFrame). Bulk transcript-replacement paints — first
-	// paint, /resume and handoff (requestRender(true, { clearScrollback })), and
-	// resize geometry rebuilds — leave it false and stay bounded (#2115, #4863).
+	// that must show every row, so it opts out of #truncateLargeConptyFrame.
+	// Multiplexer resets render as in-place updates; consuming the flag there
+	// prevents a later /resume or handoff bulk replacement from inheriting it.
 	#unboundedConptyPaintRequested = false;
 	#forceViewportRepaintOnNextRender = false;
 	#hasEverRendered = false;
@@ -2778,6 +2778,12 @@ export class TUI extends Container {
 		}
 		const cursorTrackingLineCount = hasVisibleOverlay ? Math.max(frame.length, windowTop + height) : frame.length;
 
+		// `resetDisplay()` requests an unbounded replay of the current
+		// transcript. Consume that one-shot intent on this authoritative
+		// normal-screen render even when a multiplexer makes it an in-place
+		// update; otherwise a later /resume or handoff full paint inherits it.
+		const unboundedConptyPaint = this.#unboundedConptyPaintRequested;
+		this.#unboundedConptyPaintRequested = false;
 		const intent: RenderIntent = fullPaint
 			? { kind: "fullPaint", clearScrollback: replaceRequested || geometryRebuild ? !isMultiplexerSession() : false }
 			: { kind: "update", chunkTo, windowTop };
@@ -2808,12 +2814,11 @@ export class TUI extends Container {
 				chunkTo,
 				windowTop,
 				cursorTrackingLineCount,
-				boundConptyPaint: !this.#unboundedConptyPaintRequested,
+				boundConptyPaint: !unboundedConptyPaint,
 			});
 			this.#committedPrefix = rawFrame.slice(0, chunkTo);
 			this.#committedPrefixAuditRows = Math.min(chunkTo, finalBoundary);
 			this.#clearScrollbackOnNextRender = false;
-			this.#unboundedConptyPaintRequested = false;
 			this.#hasEverRendered = true;
 			if (!firstPaint && frameLength > height) this.#armPostFullPaintSettle();
 			return;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2797,6 +2797,7 @@ export class TUI extends Container {
 				chunkTo,
 				windowTop,
 				cursorTrackingLineCount,
+				boundConptyPaint: firstPaint,
 			});
 			this.#committedPrefix = rawFrame.slice(0, chunkTo);
 			this.#committedPrefixAuditRows = Math.min(chunkTo, finalBoundary);
@@ -3155,6 +3156,15 @@ export class TUI extends Container {
 			chunkTo: number;
 			windowTop: number;
 			cursorTrackingLineCount: number;
+			/**
+			 * Whether this paint may be bounded by {@link #truncateLargeConptyFrame}
+			 * on ConPTY hosts. Only the initial session-resume paint sets this: a
+			 * multi-megabyte synchronized frame stalls conhost at startup (issue
+			 * #2115). A user-driven redraw — Ctrl+O expand (`resetDisplay`) or a
+			 * resize geometry rebuild — must replay the whole transcript so nothing
+			 * is silently dropped from scrollback (issue #4863).
+			 */
+			boundConptyPaint: boolean;
 		},
 	): void {
 		this.#fullRedrawCount += 1;
@@ -3170,16 +3180,19 @@ export class TUI extends Container {
 				paintCursorPos = { row: chunkTo + cursorPos.row - windowTop, col: cursorPos.col };
 			}
 		}
-		// ConPTY hosts bound the replay: merge prefix + window into one array
-		// so #truncateLargeConptyFrame can measure the payload and retain only
-		// the tail. Gated on the host check — everywhere else the merge would
-		// copy a pointer per committed row (a 50k-row session = 50k-entry
-		// array per resize step / theme change / session replace) just to be
-		// returned unchanged. `paintLines` stays null unless truncation
-		// actually rewrote the replay.
+		// ConPTY hosts bound the initial resume replay: merge prefix + window
+		// into one array so #truncateLargeConptyFrame can measure the payload and
+		// retain only the tail. Gated on `boundConptyPaint` (the first paint) — a
+		// user-driven redraw (Ctrl+O expand / resize) must replay the whole
+		// transcript untruncated so nothing is dropped from scrollback (#4863).
+		// Gated on the host check too — everywhere else the merge would copy a
+		// pointer per committed row (a 50k-row session = 50k-entry array per
+		// resize step / theme change / session replace) just to be returned
+		// unchanged. `paintLines` stays null unless truncation actually rewrote
+		// the replay.
 		let paintLines: string[] | null = null;
 		let paintLineCount = chunkTo + height;
-		if (isConPTYHosted()) {
+		if (options.boundConptyPaint && isConPTYHosted()) {
 			const merged = new Array<string>(chunkTo + height);
 			for (let i = 0; i < chunkTo; i++) merged[i] = frame[i] ?? "";
 			for (let screenRow = 0; screenRow < height; screenRow++) {

--- a/packages/tui/test/issue-4863-repro.test.ts
+++ b/packages/tui/test/issue-4863-repro.test.ts
@@ -13,6 +13,8 @@ import { VirtualTerminal } from "./virtual-terminal";
 // dropped everything above the retained tail. The reporter hit this under WSL.
 
 const PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, "platform");
+const WSL_DISTRO_NAME = process.env.WSL_DISTRO_NAME;
+const TMUX = process.env.TMUX;
 
 class LargeContent implements Component {
 	#lines: string[];
@@ -36,7 +38,10 @@ class LargeContent implements Component {
 describe("issue #4863: Ctrl+O full-view expand truncates the session on ConPTY", () => {
 	afterEach(() => {
 		if (PLATFORM_DESCRIPTOR) Object.defineProperty(process, "platform", PLATFORM_DESCRIPTOR);
-		delete process.env.WSL_DISTRO_NAME;
+		if (WSL_DISTRO_NAME === undefined) delete process.env.WSL_DISTRO_NAME;
+		else process.env.WSL_DISTRO_NAME = WSL_DISTRO_NAME;
+		if (TMUX === undefined) delete process.env.TMUX;
+		else process.env.TMUX = TMUX;
 		vi.restoreAllMocks();
 	});
 
@@ -102,12 +107,13 @@ describe("issue #4863: Ctrl+O full-view expand truncates the session on ConPTY",
 		}
 	});
 
-	it("still bounds a post-startup session-replace paint on ConPTY (issue #2115)", async () => {
-		// /resume, handoff, and other session switches replace the transcript via
-		// requestRender(true, { clearScrollback: true }) after the TUI is already
-		// running — firstPaint is false, but these must stay bounded so a
-		// multi-megabyte replay does not stall conhost.
-		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+	it("bounds a session replace after a resetDisplay update under WSL+tmux", async () => {
+		// Under a multiplexer, resetDisplay() is an in-place update rather than
+		// a full paint. Its one-shot unbounded intent must be consumed by that
+		// update, not leak into the next /resume or handoff replacement.
+		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+		process.env.WSL_DISTRO_NAME = "Ubuntu";
+		process.env.TMUX = "/tmp/tmux-1000/default,1,0";
 		const term = new VirtualTerminal(80, 24, 20_000);
 		const writes: string[] = [];
 		const realWrite = term.write.bind(term);
@@ -122,8 +128,13 @@ describe("issue #4863: Ctrl+O full-view expand truncates the session on ConPTY",
 			tui.start();
 			await term.waitForRender();
 
-			// Simulate a session replace: bulk transcript swap requesting a
-			// scrollback-clearing full paint, the path handleResumeSession() takes.
+			// Ctrl+O/toggle reset: resizeRepaintsInPlace() makes this an update.
+			writes.length = 0;
+			tui.resetDisplay();
+			await term.waitForRender();
+			expect(writes.some(write => write.includes("\x1b[2J"))).toBe(false);
+
+			// Then simulate /resume: the later bulk replace must still be bounded.
 			writes.length = 0;
 			tui.requestRender(true, { clearScrollback: true });
 			await term.waitForRender();

--- a/packages/tui/test/issue-4863-repro.test.ts
+++ b/packages/tui/test/issue-4863-repro.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression probe for https://github.com/can1357/oh-my-pi/issues/4863
+//
+// On ConPTY hosts (native Windows + WSL) a full paint over a large transcript
+// is bounded by #truncateLargeConptyFrame: it keeps only the tail and replaces
+// the older committed prefix with an "older lines hidden" marker. That bound is
+// wanted for the *initial* session resume (issue #2115) where a multi-megabyte
+// synchronized frame stalls conhost. But it also fired on the user-initiated
+// Ctrl+O expand (resetDisplay), so pressing Ctrl+O to review the whole session
+// dropped everything above the retained tail. The reporter hit this under WSL.
+
+const PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, "platform");
+
+class LargeContent implements Component {
+	#lines: string[];
+
+	constructor(lineCount: number) {
+		this.#lines = [];
+		for (let i = 0; i < lineCount; i++) {
+			this.#lines.push(`row ${i.toString().padStart(5, "0")}: ${"x".repeat(100)}`);
+		}
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const rendered = new Array<string>(this.#lines.length);
+		for (let i = 0; i < this.#lines.length; i++) rendered[i] = this.#lines[i]!.slice(0, width);
+		return rendered;
+	}
+}
+
+describe("issue #4863: Ctrl+O full-view expand truncates the session on ConPTY", () => {
+	afterEach(() => {
+		if (PLATFORM_DESCRIPTOR) Object.defineProperty(process, "platform", PLATFORM_DESCRIPTOR);
+		delete process.env.WSL_DISTRO_NAME;
+		vi.restoreAllMocks();
+	});
+
+	it("does not drop older transcript rows on a user-driven resetDisplay under WSL", async () => {
+		// Reporter's environment: WSL. isConPTYHosted() is true on linux when a
+		// WSL marker is present (stdout still crosses into ConPTY at wslhost).
+		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+		process.env.WSL_DISTRO_NAME = "Ubuntu";
+		const term = new VirtualTerminal(80, 24, 20_000);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		const tui = new TUI(term);
+		// ~8000 * ~110 bytes ≈ 880 KiB — over the 512 KiB ConPTY truncate threshold.
+		tui.addChild(new LargeContent(8000));
+
+		try {
+			tui.start();
+			await term.waitForRender();
+
+			// The user presses Ctrl+O; the app calls resetDisplay() to replay the
+			// whole transcript at its expanded heights.
+			writes.length = 0;
+			tui.resetDisplay();
+			await term.waitForRender();
+
+			const resetPaint = writes.find(write => write.includes("\x1b[2J"));
+			expect(resetPaint).toBeDefined();
+			// The Ctrl+O replay must NOT hide the top of the session.
+			expect(resetPaint).not.toContain("older lines hidden");
+			expect(term.getScrollBuffer().some(line => line.includes("row 00000"))).toBe(true);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("still bounds the initial session-resume paint on ConPTY (issue #2115)", async () => {
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		const term = new VirtualTerminal(80, 24, 20_000);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		const tui = new TUI(term);
+		tui.addChild(new LargeContent(8000));
+
+		try {
+			tui.start({ clearScrollback: true });
+			await term.waitForRender();
+
+			const resumePaint = writes.find(write => write.includes("\x1b[2J"));
+			expect(resumePaint).toBeDefined();
+			// The first paint is a resume replay — it stays bounded.
+			expect(resumePaint).toContain("older lines hidden");
+			expect(Buffer.byteLength(resumePaint ?? "", "utf8")).toBeLessThan(128 * 1024);
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/issue-4863-repro.test.ts
+++ b/packages/tui/test/issue-4863-repro.test.ts
@@ -101,4 +101,39 @@ describe("issue #4863: Ctrl+O full-view expand truncates the session on ConPTY",
 			tui.stop();
 		}
 	});
+
+	it("still bounds a post-startup session-replace paint on ConPTY (issue #2115)", async () => {
+		// /resume, handoff, and other session switches replace the transcript via
+		// requestRender(true, { clearScrollback: true }) after the TUI is already
+		// running — firstPaint is false, but these must stay bounded so a
+		// multi-megabyte replay does not stall conhost.
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		const term = new VirtualTerminal(80, 24, 20_000);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		const tui = new TUI(term);
+		tui.addChild(new LargeContent(8000));
+
+		try {
+			tui.start();
+			await term.waitForRender();
+
+			// Simulate a session replace: bulk transcript swap requesting a
+			// scrollback-clearing full paint, the path handleResumeSession() takes.
+			writes.length = 0;
+			tui.requestRender(true, { clearScrollback: true });
+			await term.waitForRender();
+
+			const replacePaint = writes.find(write => write.includes("\x1b[2J"));
+			expect(replacePaint).toBeDefined();
+			expect(replacePaint).toContain("older lines hidden");
+			expect(Buffer.byteLength(replacePaint ?? "", "utf8")).toBeLessThan(128 * 1024);
+		} finally {
+			tui.stop();
+		}
+	});
 });


### PR DESCRIPTION
## Repro
On a ConPTY host (native Windows or WSL), populate a session with lots of long command output, then press Ctrl+O to expand and view the whole session. The view is truncated to the last few hundred rows — everything above is replaced by an `older lines hidden` marker. Reproduced in `packages/tui/test/issue-4863-repro.test.ts`: a simulated WSL host with an ~880 KiB (8000-row) transcript that receives a user-driven `resetDisplay()` (the path Ctrl+O invokes) drops the first ~7255 rows.

## Cause
`TUI.#emitFullPaint` in `packages/tui/src/tui.ts` runs every full paint on ConPTY hosts through `#truncateLargeConptyFrame`, which keeps only the tail and replaces the older committed prefix with an `older lines hidden` marker. That bound was added for the *initial* session resume (issue #2115), where a multi-megabyte synchronized frame stalls legacy conhost. Because the truncation was keyed only on host + byte size, it also fired on the user-driven `resetDisplay()` that Ctrl+O (`app.tools.expand`) and resize geometry rebuilds trigger — hiding the top of the session on the exact gesture meant to reveal all of it.

## Fix
- Thread a `boundConptyPaint` flag into `#emitFullPaint`'s options, set to `firstPaint` at the call site in `#composeAndEmit`.
- Gate the ConPTY merge + `#truncateLargeConptyFrame` block on `options.boundConptyPaint`, so only the initial resume paint is bounded. User-driven redraws (Ctrl+O expand, resize) now replay the whole transcript untruncated, and the redundant prefix-merge allocation is skipped for those non-first ConPTY paints.

## Verification
`bun test packages/tui/test/issue-4863-repro.test.ts packages/tui/test/issue-2115-repro.test.ts` — 4 pass, 0 fail. The new test asserts the WSL `resetDisplay()` replay contains no `older lines hidden` marker and keeps `row 00000` in scrollback, while a companion case confirms the initial resume paint stays bounded (guarding #2115). A pre-existing, unrelated failure in `packages/tui/test/markdown.test.ts` (`should keep wrapped URLs inside a single OSC 8 hyperlink span`) reproduces on `main` with this diff stashed and is untouched here.

Fixes #4863