### PR TITLE
fix(omp): fit native compaction after large tool output

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced oversized OpenAI native compaction requests by replacing only trailing tool-output bodies that exceed the model context window, while preserving calls, assistant history, and reasoning.
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -28,7 +28,7 @@ import { convertTools } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import { buildResponsesInput, resolveOpenAICompatPolicy } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
-import { logger, prompt, stringifyJson } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, prompt, stringifyJson } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
 import { ThinkingLevel } from "../thinking";
@@ -1301,9 +1301,14 @@ function buildOpenAiResponsesCompactionInput(
 		includeThinkingSignatures: true,
 		repairOrphanOutputs: true,
 	});
-	return (previousReplacementHistory ? [...previousReplacementHistory, ...input] : input) as Array<
-		Record<string, unknown>
-	>;
+	const nativeInput: Array<Record<string, unknown>> = [];
+	for (const item of input) {
+		if (!isRecord(item)) {
+			throw new Error("OpenAI Responses compaction input contains a non-object item");
+		}
+		nativeInput.push(item);
+	}
+	return previousReplacementHistory ? [...previousReplacementHistory, ...nativeInput] : nativeInput;
 }
 
 /**

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -51,6 +51,7 @@ import {
 	requestOpenAiRemoteCompaction,
 	requestRemoteCompaction,
 	shouldUseOpenAiRemoteCompaction,
+	trimRemoteCompactionInputToContextWindow,
 	withOpenAiRemoteCompactionPreserveData,
 } from "./openai";
 import autoHandoffThresholdFocusPrompt from "./prompts/auto-handoff-threshold-focus.md" with { type: "text" };
@@ -1290,7 +1291,7 @@ function buildOpenAiResponsesCompactionInput(
 	messages: Message[],
 	model: Model<"openai-responses" | "azure-openai-responses" | "openai-codex-responses">,
 	previousReplacementHistory: Array<Record<string, unknown>> | undefined,
-): unknown[] {
+): Array<Record<string, unknown>> {
 	const input = buildResponsesInput({
 		model,
 		context: { messages },
@@ -1300,7 +1301,9 @@ function buildOpenAiResponsesCompactionInput(
 		includeThinkingSignatures: true,
 		repairOrphanOutputs: true,
 	});
-	return previousReplacementHistory ? [...previousReplacementHistory, ...input] : input;
+	return (previousReplacementHistory ? [...previousReplacementHistory, ...input] : input) as Array<
+		Record<string, unknown>
+	>;
 }
 
 /**
@@ -1415,20 +1418,33 @@ export async function compact(
 		);
 		if (remoteHistory.length > 0) {
 			try {
-				const request = buildCompactionV2Request(
-					model,
+				const instructions = summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT;
+				const tools = summaryOptions.tools
+					? convertTools(summaryOptions.tools, model.compat.supportsStrictMode, model)
+					: undefined;
+				const trimmed = trimRemoteCompactionInputToContextWindow(
 					remoteHistory,
-					summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT,
-					{
-						tools: summaryOptions.tools
-							? convertTools(summaryOptions.tools, model.compat.supportsStrictMode, model)
-							: undefined,
-						reasoning: buildCompactionV2Reasoning(model, summaryOptions.thinkingLevel),
-						sessionId: summaryOptions.sessionId,
-						promptCacheKey: summaryOptions.promptCacheKey,
-						retainedMessageBudget: settings.v2RetainedMessageBudget,
-					},
+					model.contextWindow,
+					instructions,
+					tools,
 				);
+				if (trimmed.rewrittenOutputs > 0) {
+					logger.info("Rewrote trailing tool outputs before OpenAI V2 remote compaction", {
+						model: model.id,
+						provider: model.provider,
+						rewrittenOutputs: trimmed.rewrittenOutputs,
+						estimatedTokensBefore: trimmed.estimatedTokensBefore,
+						estimatedTokensAfter: trimmed.estimatedTokensAfter,
+						contextWindow: model.contextWindow,
+					});
+				}
+				const request = buildCompactionV2Request(model, trimmed.input, instructions, {
+					tools,
+					reasoning: buildCompactionV2Reasoning(model, summaryOptions.thinkingLevel),
+					sessionId: summaryOptions.sessionId,
+					promptCacheKey: summaryOptions.promptCacheKey,
+					retainedMessageBudget: settings.v2RetainedMessageBudget,
+				});
 				const remote = await withAuth(
 					apiKey,
 					key =>

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -44,8 +44,9 @@ import {
 	OPENAI_HEADER_VALUES,
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
-import { $env, isRecord, logger, stringifyJson, structuredCloneJSON } from "@oh-my-pi/pi-utils";
+import { $env, isRecord, logger, prompt, stringifyJson, structuredCloneJSON } from "@oh-my-pi/pi-utils";
 import { countTokensConservatively } from "../tokenizer";
+import contextWindowTruncatedOutputPrompt from "./prompts/context-window-truncated-output.md" with { type: "text" };
 
 export * from "./compaction-v2-streaming";
 
@@ -67,7 +68,7 @@ export const REMOTE_COMPACTION_TIMEOUT_MS = 180_000;
 
 const DEFAULT_AZURE_API_VERSION = "v1";
 
-export const CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE = "Output exceeded the available model context and was truncated";
+export const CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE = prompt.render(contextWindowTruncatedOutputPrompt);
 
 const REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS = 256;
 const REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE = 12_000;

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -44,8 +44,8 @@ import {
 	OPENAI_HEADER_VALUES,
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
-import { $env, logger, stringifyJson, structuredCloneJSON } from "@oh-my-pi/pi-utils";
-import { countTokens } from "../tokenizer";
+import { $env, isRecord, logger, stringifyJson, structuredCloneJSON } from "@oh-my-pi/pi-utils";
+import { countTokensConservatively } from "../tokenizer";
 
 export * from "./compaction-v2-streaming";
 
@@ -72,6 +72,7 @@ export const CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE = "Output exceeded the avai
 const REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS = 256;
 const REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE = 765;
 const REMOTE_COMPACTION_ORIGINAL_IMAGE_TOKEN_ESTIMATE = 10_000;
+const TOOL_RESULT_IMAGE_ATTACHMENT_TEXT = "Attached image(s) from tool result:";
 
 interface NormalizedEstimateValue {
 	value: unknown;
@@ -126,7 +127,7 @@ function estimateRemoteCompactionInputTokens(
 ): number {
 	const normalized = normalizeRemoteCompactionEstimateValue({ instructions, input, ...(tools ? { tools } : {}) });
 	const serialized = stringifyJson(normalized.value) ?? "";
-	return countTokens(serialized) + normalized.imageTokens + REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS;
+	return countTokensConservatively(serialized) + normalized.imageTokens + REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS;
 }
 
 function rewriteToolOutputForContextWindow(item: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -137,6 +138,19 @@ function rewriteToolOutputForContextWindow(item: Record<string, unknown>): Recor
 		return { ...item, tools: [] };
 	}
 	return undefined;
+}
+
+function isToolResultImageAttachment(item: Record<string, unknown>): boolean {
+	if (item.type !== "message" || item.role !== "user" || !Array.isArray(item.content)) return false;
+
+	let hasLabel = false;
+	let hasImage = false;
+	for (const block of item.content) {
+		if (!isRecord(block)) continue;
+		if (block.type === "input_text" && block.text === TOOL_RESULT_IMAGE_ATTACHMENT_TEXT) hasLabel = true;
+		if (block.type === "input_image") hasImage = true;
+	}
+	return hasLabel && hasImage;
 }
 
 /**
@@ -165,7 +179,9 @@ export function trimRemoteCompactionInputToContextWindow(
 	let estimatedTokensAfter = estimatedTokensBefore;
 	let rewrittenOutputs = 0;
 	for (let index = input.length - 1; index >= 0 && estimatedTokensAfter > contextWindow; index--) {
-		const rewritten = rewriteToolOutputForContextWindow(input[index]);
+		const item = input[index];
+		if (isToolResultImageAttachment(item)) continue;
+		const rewritten = rewriteToolOutputForContextWindow(item);
 		if (!rewritten) break;
 		rewrittenInput ??= input.slice();
 		rewrittenInput[index] = rewritten;
@@ -707,7 +723,7 @@ export function buildOpenAiNativeHistory(
 
 			if (hasImages && model.input.includes("image")) {
 				const contentBlocks: Array<Record<string, unknown>> = [
-					{ type: "input_text", text: "Attached image(s) from tool result:" },
+					{ type: "input_text", text: TOOL_RESULT_IMAGE_ATTACHMENT_TEXT },
 				];
 				for (const block of message.content) {
 					if (block.type !== "image") continue;

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -70,8 +70,7 @@ const DEFAULT_AZURE_API_VERSION = "v1";
 export const CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE = "Output exceeded the available model context and was truncated";
 
 const REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS = 256;
-const REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE = 765;
-const REMOTE_COMPACTION_ORIGINAL_IMAGE_TOKEN_ESTIMATE = 10_000;
+const REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE = 12_000;
 const TOOL_RESULT_IMAGE_ATTACHMENT_TEXT = "Attached image(s) from tool result:";
 
 interface NormalizedEstimateValue {
@@ -96,10 +95,7 @@ function normalizeRemoteCompactionEstimateValue(value: unknown): NormalizedEstim
 	if (record.type === "input_image") {
 		return {
 			value: { ...record, image_url: "<image>" },
-			imageTokens:
-				record.detail === "original"
-					? REMOTE_COMPACTION_ORIGINAL_IMAGE_TOKEN_ESTIMATE
-					: REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE,
+			imageTokens: REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE,
 		};
 	}
 

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -45,6 +45,7 @@ import {
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, logger, stringifyJson, structuredCloneJSON } from "@oh-my-pi/pi-utils";
+import { countTokens } from "../tokenizer";
 
 export * from "./compaction-v2-streaming";
 
@@ -65,6 +66,120 @@ export const OPENAI_REMOTE_COMPACTION_PRESERVE_KEY = "openaiRemoteCompaction";
 export const REMOTE_COMPACTION_TIMEOUT_MS = 180_000;
 
 const DEFAULT_AZURE_API_VERSION = "v1";
+
+export const CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE = "Output exceeded the available model context and was truncated";
+
+const REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS = 256;
+const REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE = 765;
+const REMOTE_COMPACTION_ORIGINAL_IMAGE_TOKEN_ESTIMATE = 10_000;
+
+interface NormalizedEstimateValue {
+	value: unknown;
+	imageTokens: number;
+}
+
+function normalizeRemoteCompactionEstimateValue(value: unknown): NormalizedEstimateValue {
+	if (Array.isArray(value)) {
+		const normalized: unknown[] = [];
+		let imageTokens = 0;
+		for (const item of value) {
+			const result = normalizeRemoteCompactionEstimateValue(item);
+			normalized.push(result.value);
+			imageTokens += result.imageTokens;
+		}
+		return { value: normalized, imageTokens };
+	}
+	if (!value || typeof value !== "object") return { value, imageTokens: 0 };
+
+	const record = value as Record<string, unknown>;
+	if (record.type === "input_image") {
+		return {
+			value: { ...record, image_url: "<image>" },
+			imageTokens:
+				record.detail === "original"
+					? REMOTE_COMPACTION_ORIGINAL_IMAGE_TOKEN_ESTIMATE
+					: REMOTE_COMPACTION_IMAGE_TOKEN_ESTIMATE,
+		};
+	}
+
+	const normalized: Record<string, unknown> = {};
+	let imageTokens = 0;
+	for (const [key, item] of Object.entries(record)) {
+		const result = normalizeRemoteCompactionEstimateValue(item);
+		normalized[key] = result.value;
+		imageTokens += result.imageTokens;
+	}
+	return { value: normalized, imageTokens };
+}
+
+export interface TrimRemoteCompactionInputResult {
+	input: Array<Record<string, unknown>>;
+	rewrittenOutputs: number;
+	estimatedTokensBefore: number;
+	estimatedTokensAfter: number;
+}
+
+function estimateRemoteCompactionInputTokens(
+	input: Array<Record<string, unknown>>,
+	instructions: string,
+	tools?: unknown[],
+): number {
+	const normalized = normalizeRemoteCompactionEstimateValue({ instructions, input, ...(tools ? { tools } : {}) });
+	const serialized = stringifyJson(normalized.value) ?? "";
+	return countTokens(serialized) + normalized.imageTokens + REMOTE_COMPACTION_REQUEST_OVERHEAD_TOKENS;
+}
+
+function rewriteToolOutputForContextWindow(item: Record<string, unknown>): Record<string, unknown> | undefined {
+	if (item.type === "function_call_output" || item.type === "custom_tool_call_output") {
+		return { ...item, output: CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE };
+	}
+	if (item.type === "tool_search_output") {
+		return { ...item, tools: [] };
+	}
+	return undefined;
+}
+
+/**
+ * Preserve the full native transcript unless trailing tool outputs alone push a
+ * remote compaction request beyond the model window. Replacing only those
+ * outputs keeps call/result pairing and all earlier assistant/reasoning history,
+ * matching Codex's recovery path for oversized tool turns.
+ */
+export function trimRemoteCompactionInputToContextWindow(
+	input: Array<Record<string, unknown>>,
+	contextWindow: number | null | undefined,
+	instructions: string,
+	tools?: unknown[],
+): TrimRemoteCompactionInputResult {
+	const estimatedTokensBefore = estimateRemoteCompactionInputTokens(input, instructions, tools);
+	if (!contextWindow || contextWindow <= 0 || estimatedTokensBefore <= contextWindow) {
+		return {
+			input,
+			rewrittenOutputs: 0,
+			estimatedTokensBefore,
+			estimatedTokensAfter: estimatedTokensBefore,
+		};
+	}
+
+	let rewrittenInput: Array<Record<string, unknown>> | undefined;
+	let estimatedTokensAfter = estimatedTokensBefore;
+	let rewrittenOutputs = 0;
+	for (let index = input.length - 1; index >= 0 && estimatedTokensAfter > contextWindow; index--) {
+		const rewritten = rewriteToolOutputForContextWindow(input[index]);
+		if (!rewritten) break;
+		rewrittenInput ??= input.slice();
+		rewrittenInput[index] = rewritten;
+		rewrittenOutputs++;
+		estimatedTokensAfter = estimateRemoteCompactionInputTokens(rewrittenInput, instructions, tools);
+	}
+
+	return {
+		input: rewrittenInput ?? input,
+		rewrittenOutputs,
+		estimatedTokensBefore,
+		estimatedTokensAfter,
+	};
+}
 
 /** Race the caller's signal against the request timeout; `timeoutMs <= 0` disables the watchdog. */
 function withRequestTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal | undefined {
@@ -622,12 +737,23 @@ export async function requestOpenAiRemoteCompaction(
 ): Promise<OpenAiRemoteCompactionResponse> {
 	const endpoint = resolveOpenAiCompactEndpoint(model);
 	const requestModel = resolveOpenAiCompactModel(model);
+	const trimmed = trimRemoteCompactionInputToContextWindow(compactInput, model.contextWindow, instructions);
+	if (trimmed.rewrittenOutputs > 0) {
+		logger.info("Rewrote trailing tool outputs before OpenAI remote compaction", {
+			model: model.id,
+			provider: model.provider,
+			rewrittenOutputs: trimmed.rewrittenOutputs,
+			estimatedTokensBefore: trimmed.estimatedTokensBefore,
+			estimatedTokensAfter: trimmed.estimatedTokensAfter,
+			contextWindow: model.contextWindow,
+		});
+	}
 	const request: OpenAiRemoteCompactionRequest = {
 		model: requestModel,
-		// Send full history to the endpoint - don't trim locally.
-		// The provider handles compression via the compaction endpoint.
-		// Trimming before sending loses assistant messages and thinking blocks.
-		input: compactInput,
+		// Preserve the native transcript. Only oversized trailing tool outputs are
+		// rewritten above, reducing the request without losing assistant turns,
+		// reasoning, or call/result pairing.
+		input: trimmed.input,
 		instructions,
 	};
 	const isAzureOpenAiResponses = (model.remoteCompaction?.api ?? model.api) === "azure-openai-responses";

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -173,8 +173,17 @@ export function trimRemoteCompactionInputToContextWindow(
 		estimatedTokensAfter = estimateRemoteCompactionInputTokens(rewrittenInput, instructions, tools);
 	}
 
+	if (!rewrittenInput || estimatedTokensAfter > contextWindow) {
+		return {
+			input,
+			rewrittenOutputs: 0,
+			estimatedTokensBefore,
+			estimatedTokensAfter: estimatedTokensBefore,
+		};
+	}
+
 	return {
-		input: rewrittenInput ?? input,
+		input: rewrittenInput,
 		rewrittenOutputs,
 		estimatedTokensBefore,
 		estimatedTokensAfter,

--- a/packages/agent/src/compaction/prompts/context-window-truncated-output.md
+++ b/packages/agent/src/compaction/prompts/context-window-truncated-output.md
@@ -1,0 +1,1 @@
+Output exceeded the available model context and was truncated

--- a/packages/agent/src/tokenizer.ts
+++ b/packages/agent/src/tokenizer.ts
@@ -15,3 +15,13 @@ export function countTokens(text: string | string[]): number {
 		return estimateTokens(text);
 	}
 }
+
+export function countTokensConservatively(text: string | string[]): number {
+	if (accurate) {
+		return countTokensNat(text);
+	} else if (Array.isArray(text)) {
+		return text.reduce((sum, value) => sum + Buffer.byteLength(value, "utf-8"), 0);
+	} else {
+		return Buffer.byteLength(text, "utf-8");
+	}
+}

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -10,12 +10,14 @@ import {
 import {
 	buildCompactionV2Request,
 	buildOpenAiNativeHistory,
+	CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE,
 	getCompactionV2PreserveData,
 	requestCompactionV2Streaming,
 	requestOpenAiRemoteCompaction,
 	requestRemoteCompaction,
 	shouldUseCompactionV2Streaming,
 	shouldUseOpenAiRemoteCompaction,
+	trimRemoteCompactionInputToContextWindow,
 } from "@oh-my-pi/pi-agent-core/compaction/openai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { getOpenAICodexTransportDetails } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
@@ -460,13 +462,19 @@ describe("buildOpenAiNativeHistory computer calls", () => {
 });
 
 describe("remote compaction input forwarding", () => {
-	test("sends the full native history without local trimming", async () => {
-		// Contract: the compact endpoint owns compression. Trimming locally dropped
-		// assistant turns + encrypted reasoning before the provider ever saw them,
-		// so the client now forwards the full input untouched even on a tiny window.
+	test("rewrites an oversized trailing tool output without dropping native history", async () => {
+		// The compact endpoint still receives every call/result item. Only the
+		// trailing output body is replaced when the request cannot fit.
+		const nativeInput = [
+			{ type: "custom_tool_call", call_id: "call_apply_1", name: "apply_patch", input: "{}" },
+			{ type: "custom_tool_call_output", call_id: "call_apply_1", output: "patch applied".repeat(1_000) },
+		];
 		let requestInput: Array<Record<string, unknown>> | undefined;
 		const fetchMock: FetchImpl = async (_input, init) => {
-			const body = JSON.parse(String(init?.body)) as { input: Array<Record<string, unknown>> };
+			const body: unknown = JSON.parse(String(init?.body));
+			if (!isRecord(body) || !Array.isArray(body.input) || !body.input.every(isRecord)) {
+				throw new Error("expected remote compaction input");
+			}
 			requestInput = body.input;
 			return Response.json({
 				output: [{ type: "compaction_summary", summary: "compact" }],
@@ -474,19 +482,87 @@ describe("remote compaction input forwarding", () => {
 		};
 
 		await requestOpenAiRemoteCompaction(
-			makeOpenAiModel({ contextWindow: 1 }),
+			makeOpenAiModel({ contextWindow: 1_000 }),
 			"test-key",
-			[
-				{ type: "custom_tool_call", call_id: "call_apply_1", name: "apply_patch", input: "x".repeat(10_000) },
-				{ type: "custom_tool_call_output", call_id: "call_apply_1", output: "patch applied".repeat(1_000) },
-			],
+			nativeInput,
 			"compact",
 			undefined,
 			{ fetch: fetchMock },
 		);
 
+		const trimmed = trimRemoteCompactionInputToContextWindow(nativeInput, 1_000, "compact");
+		expect(trimmed.estimatedTokensAfter).toBeLessThanOrEqual(1_000);
 		expect(requestInput?.some(item => item.type === "custom_tool_call")).toBe(true);
-		expect(requestInput?.some(item => item.type === "custom_tool_call_output")).toBe(true);
+		expect(requestInput?.find(item => item.type === "custom_tool_call_output")?.output).toBe(
+			CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE,
+		);
+	});
+
+	test("rewrites contiguous trailing outputs until the request fits", () => {
+		const input = [
+			{ type: "function_call", call_id: "call_1", name: "read", arguments: "{}" },
+			{ type: "function_call", call_id: "call_2", name: "read", arguments: "{}" },
+			{ type: "function_call_output", call_id: "call_1", output: "a".repeat(8_000) },
+			{ type: "function_call_output", call_id: "call_2", output: "b".repeat(8_000) },
+		];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 1_000, "compact");
+
+		expect(result.rewrittenOutputs).toBe(2);
+		expect(result.input.slice(0, 2)).toEqual(input.slice(0, 2));
+		expect(result.input.slice(2).map(item => item.output)).toEqual([
+			CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE,
+			CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE,
+		]);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(1_000);
+		expect(input[2].output).toHaveLength(8_000);
+	});
+
+	test("charges inline images by vision tokens instead of serialized base64 size", () => {
+		const input = [
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_image", detail: "auto", image_url: `data:image/png;base64,${"a".repeat(80_000)}` },
+				],
+			},
+			{ type: "function_call_output", call_id: "call_1", output: "useful result" },
+		];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 2_000, "compact");
+
+		expect(result.rewrittenOutputs).toBe(0);
+		expect(result.input).toBe(input);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(2_000);
+	});
+
+	test("reserves the high-resolution patch budget for original-detail images", () => {
+		const input = [
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_image", detail: "original", image_url: `data:image/png;base64,${"a".repeat(80_000)}` },
+				],
+			},
+			{ type: "function_call_output", call_id: "call_1", output: "useful result".repeat(2_000) },
+		];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 12_000, "compact");
+
+		expect(result.estimatedTokensBefore).toBeGreaterThan(12_000);
+		expect(result.rewrittenOutputs).toBe(1);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(12_000);
+	});
+
+	test("returns the original input without allocation when it already fits", () => {
+		const input = [{ type: "function_call_output", call_id: "call_1", output: "small" }];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 1_000, "compact");
+
+		expect(result.rewrittenOutputs).toBe(0);
+		expect(result.input).toBe(input);
 	});
 });
 
@@ -1345,6 +1421,70 @@ describe("compact() remote compaction failure handling", () => {
 		expect(remote?.replacementHistory.at(-1)).toEqual(compactionItem);
 		expect(result.summary).toContain("Remote compaction preserved provider-native history");
 		expect(completeSpy).not.toHaveBeenCalled();
+	});
+
+	test("rewrites an oversized trailing tool output before V2 streaming compaction", async () => {
+		const preparation = makePreparation();
+		preparation.settings = { ...preparation.settings, remoteStreamingV2Enabled: true };
+		preparation.messagesToSummarize = [
+			{ role: "user", content: "inspect the large file", timestamp: 1 },
+			{
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: "call_read_large|fc_read_large", name: "read", arguments: { path: "/tmp/x" } },
+				],
+				timestamp: 2,
+				provider: "openai",
+				model: "gpt-5",
+				api: "openai-responses",
+				usage: ZERO_USAGE,
+				stopReason: "toolUse",
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_read_large|fc_read_large",
+				toolName: "read",
+				content: [{ type: "text", text: "large output".repeat(10_000) }],
+				isError: false,
+				timestamp: 3,
+			},
+		];
+		preparation.recentMessages = [];
+		const model = makeOpenAiModel({
+			contextWindow: 500,
+			remoteCompaction: {
+				enabled: true,
+				v2StreamingEnabled: true,
+				v2Endpoint: "https://compact.example/v1/responses",
+			},
+		});
+		let requestInput: Array<Record<string, unknown>> = [];
+		const fetchMock: FetchImpl = async (_input, init) => {
+			const body: unknown = JSON.parse(String(init?.body));
+			if (!isRecord(body) || !Array.isArray(body.input) || !body.input.every(isRecord)) {
+				throw new Error("expected V2 compaction input");
+			}
+			requestInput = body.input;
+			return sseResponse([
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "compaction", encrypted_content: "enc_trimmed" },
+				},
+				{
+					type: "response.completed",
+					response: { usage: { input_tokens: 100, output_tokens: 2, total_tokens: 102 } },
+				},
+			]);
+		};
+
+		await compact(preparation, model, "test-key", undefined, undefined, { fetch: fetchMock });
+
+		expect(requestInput.some(item => item.type === "function_call" && item.call_id === "call_read_large")).toBe(true);
+		expect(requestInput.find(item => item.type === "function_call_output")?.output).toBe(
+			CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE,
+		);
+		expect(requestInput.at(-1)).toEqual({ type: "compaction_trigger" });
 	});
 
 	test("re-expands a prior V2 compaction's originals when no candidate can reuse the replay", async () => {

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -518,6 +518,22 @@ describe("remote compaction input forwarding", () => {
 		expect(input[2].output).toHaveLength(8_000);
 	});
 
+	test("keeps the original input when trailing rewrites cannot make the request fit", () => {
+		const input = [
+			{ type: "function_call", call_id: "call_1", name: "read", arguments: "{}" },
+			{ type: "function_call_output", call_id: "call_1", output: "a".repeat(20_000) },
+			{ type: "function_call", call_id: "call_2", name: "read", arguments: "{}" },
+			{ type: "function_call_output", call_id: "call_2", output: "useful latest result" },
+		];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 1_000, "compact");
+
+		expect(result.rewrittenOutputs).toBe(0);
+		expect(result.input).toBe(input);
+		expect(result.input[3].output).toBe("useful latest result");
+		expect(result.estimatedTokensAfter).toBe(result.estimatedTokensBefore);
+	});
+
 	test("charges inline images by vision tokens instead of serialized base64 size", () => {
 		const input = [
 			{

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -553,6 +553,40 @@ describe("remote compaction input forwarding", () => {
 		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(2_000);
 	});
 
+	test("uses conservative token accounting for token-dense trailing output", () => {
+		const output = Array.from({ length: 1_000 }, (_, index) => index.toString(16).padStart(8, "0")).join("");
+		const input = [{ type: "function_call_output", call_id: "call_1", output }];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 3_000, "compact");
+
+		expect(result.estimatedTokensBefore).toBeGreaterThan(3_000);
+		expect(result.rewrittenOutputs).toBe(1);
+		expect(result.input[0].output).toBe(CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(3_000);
+	});
+
+	test("scans past a synthetic tool-image attachment to rewrite its output", () => {
+		const attachment = {
+			type: "message",
+			role: "user",
+			content: [
+				{ type: "input_text", text: "Attached image(s) from tool result:" },
+				{ type: "input_image", detail: "auto", image_url: "data:image/png;base64,AAAA" },
+			],
+		};
+		const input = [
+			{ type: "function_call_output", call_id: "call_1", output: "large tool output".repeat(1_000) },
+			attachment,
+		];
+
+		const result = trimRemoteCompactionInputToContextWindow(input, 2_000, "compact");
+
+		expect(result.rewrittenOutputs).toBe(1);
+		expect(result.input[0].output).toBe(CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE);
+		expect(result.input[1]).toBe(attachment);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(2_000);
+	});
+
 	test("reserves the high-resolution patch budget for original-detail images", () => {
 		const input = [
 			{
@@ -1467,7 +1501,7 @@ describe("compact() remote compaction failure handling", () => {
 		];
 		preparation.recentMessages = [];
 		const model = makeOpenAiModel({
-			contextWindow: 500,
+			contextWindow: 20_000,
 			remoteCompaction: {
 				enabled: true,
 				v2StreamingEnabled: true,

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -529,12 +529,12 @@ describe("remote compaction input forwarding", () => {
 		const result = trimRemoteCompactionInputToContextWindow(input, 1_000, "compact");
 
 		expect(result.rewrittenOutputs).toBe(0);
-		expect(result.input).toBe(input);
+		expect(result.input).toEqual(input);
 		expect(result.input[3].output).toBe("useful latest result");
 		expect(result.estimatedTokensAfter).toBe(result.estimatedTokensBefore);
 	});
 
-	test("charges inline images by vision tokens instead of serialized base64 size", () => {
+	test("charges inline images by the maximum vision budget instead of serialized base64 size", () => {
 		const input = [
 			{
 				type: "message",
@@ -546,11 +546,12 @@ describe("remote compaction input forwarding", () => {
 			{ type: "function_call_output", call_id: "call_1", output: "useful result" },
 		];
 
-		const result = trimRemoteCompactionInputToContextWindow(input, 2_000, "compact");
+		const result = trimRemoteCompactionInputToContextWindow(input, 15_000, "compact");
 
 		expect(result.rewrittenOutputs).toBe(0);
-		expect(result.input).toBe(input);
-		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(2_000);
+		expect(result.input).toEqual(input);
+		expect(result.estimatedTokensAfter).toBeGreaterThan(12_000);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(15_000);
 	});
 
 	test("uses conservative token accounting for token-dense trailing output", () => {
@@ -579,15 +580,15 @@ describe("remote compaction input forwarding", () => {
 			attachment,
 		];
 
-		const result = trimRemoteCompactionInputToContextWindow(input, 2_000, "compact");
+		const result = trimRemoteCompactionInputToContextWindow(input, 15_000, "compact");
 
 		expect(result.rewrittenOutputs).toBe(1);
 		expect(result.input[0].output).toBe(CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE);
-		expect(result.input[1]).toBe(attachment);
-		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(2_000);
+		expect(result.input[1]).toEqual(attachment);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(15_000);
 	});
 
-	test("reserves the high-resolution patch budget for original-detail images", () => {
+	test("reserves the maximum patch budget for original-detail images", () => {
 		const input = [
 			{
 				type: "message",
@@ -599,20 +600,20 @@ describe("remote compaction input forwarding", () => {
 			{ type: "function_call_output", call_id: "call_1", output: "useful result".repeat(2_000) },
 		];
 
-		const result = trimRemoteCompactionInputToContextWindow(input, 12_000, "compact");
+		const result = trimRemoteCompactionInputToContextWindow(input, 15_000, "compact");
 
-		expect(result.estimatedTokensBefore).toBeGreaterThan(12_000);
+		expect(result.estimatedTokensBefore).toBeGreaterThan(15_000);
 		expect(result.rewrittenOutputs).toBe(1);
-		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(12_000);
+		expect(result.estimatedTokensAfter).toBeLessThanOrEqual(15_000);
 	});
 
-	test("returns the original input without allocation when it already fits", () => {
+	test("returns semantically unchanged input when it already fits", () => {
 		const input = [{ type: "function_call_output", call_id: "call_1", output: "small" }];
 
 		const result = trimRemoteCompactionInputToContextWindow(input, 1_000, "compact");
 
 		expect(result.rewrittenOutputs).toBe(0);
-		expect(result.input).toBe(input);
+		expect(result.input).toEqual(input);
 	});
 });
 


### PR DESCRIPTION
## What

- Estimate OpenAI V1/V2 native compaction payloads against the model context window, including conservative default token accounting, wire overhead, and the maximum verified OpenAI image-token budget.
- Replace only contiguous trailing tool-output bodies when they prevent native compaction from fitting, scanning past the synthetic image attachment emitted for a tool result while preserving it.
- Load the model-facing truncation message from a static Markdown prompt.
- Use rewritten input only when it fits; otherwise preserve the original native input and existing fallback behavior.

## Why

A single large tool result can jump past the context boundary. The provider must first read the native compaction request before it can compact it, so an oversized trailing output can make both `/responses/compact` and V2 `compaction_trigger` fail. This ports Codex's targeted recovery behavior without broadly trimming conversation history.

## Testing

- `bun test packages/agent/test/remote-compaction.test.ts` — 37 passed, 180 assertions
- `bun --cwd=packages/agent run check:types`
- `CMAKE_POLICY_VERSION_MINIMUM=3.5 bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## AI Review Report

An independent reviewer audited the branch against Codex's implementation. Review findings covered image-token accounting, generated wire overhead, fit assertions, failed-to-fit preservation, an unsafe type assertion, default estimator undercounting, synthetic image attachments blocking the trailing scan, implementation-level identity assertions, and static model-prompt placement. All findings were remediated through `11672ae84`, with focused semantic regression coverage.

## Security Audit

No authentication, authorization, persistence format, or network destination changes. Rewrites operate on copied request-history entries and do not log tool-output contents.

## Risk

Without the native tokenizer enabled, UTF-8 byte length is used as a conservative token upper bound and may rewrite a trailing output before the provider's exact boundary. Each image reserves the verified maximum 12,000-token OpenAI patch budget. Client-side rewriting is limited to over-window estimates and accepted only when the rewritten request fits; otherwise the original input and existing V2 → V1 → local-summary fallback chain are preserved.
