### PR TITLE
fix(update): verify GitHub release asset and digest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,9 @@ To change an entry, fix the source:
 
 Regenerate with `bun run gen:models` and commit `models.json` alongside the source change. Add a regression test against the **resolver/descriptor**, not the bundled JSON, so it survives upstream metadata shifts.
 
-## Logging
+## Logging and CLI Output
 
-**NEVER use `console.log`/`error`/`warn`** in the coding-agent package — it corrupts TUI rendering. Use the centralized logger:
+Code that may run while the TUI, RPC, SDK, workers, or background runtimes are active MUST NOT use `console.log`/`error`/`warn`; it corrupts rendering or protocols. Use the centralized logger:
 
 ```typescript
 import { logger } from "@oh-my-pi/pi-utils";
@@ -186,7 +186,7 @@ logger.warn("Theme file invalid, using fallback", { path });
 logger.debug("LSP fallback triggered", { reason });
 ```
 
-Logs go to `~/.omp/logs/omp.YYYY-MM-DD.log` with automatic rotation.
+Logs go to `~/.omp/logs/omp.YYYY-MM-DD.log` with automatic rotation. Standalone CLI commands that exit without entering the TUI MAY use `console.*` or process streams for intentional user-facing output. Keep structured stdout clean. This exception is semantic, not filename-based; shared code must use `logger` or an explicit output sink.
 
 ## TUI Sanitization
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct binary updates trusting an executable that only reported the expected version. The updater now selects one exact asset from the tagged GitHub release, requires its published SHA-256 digest and size, and verifies both while streaming the download before installation.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed direct binary updates trusting an executable that only reported the expected version. The updater now selects one exact asset from the tagged GitHub release, requires its published SHA-256 digest and size, and verifies both while streaming the download before installation.
+- Fixed direct binary updates trusting an executable that only reported the expected version. The updater now selects one exact asset from the tagged GitHub release, requires its published SHA-256 digest and size, and verifies both while streaming the download before installation. GitHub release metadata requests use `GITHUB_TOKEN` or `GH_TOKEN` when available, allowing users behind an exhausted anonymous rate limit to authenticate.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -4,9 +4,11 @@
  * Handles `omp update` to check for and install updates.
  * Uses the installer that owns the active omp executable when it can be detected.
  */
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { $which, APP_NAME, isEnoent, VERSION } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
@@ -30,6 +32,7 @@ const MISE_TOOL = "github:can1357/oh-my-pi";
  * See #1686.
  */
 const NPM_REGISTRY = "https://registry.npmjs.org/";
+const GITHUB_API = "https://api.github.com";
 const RELEASE_METADATA_TIMEOUT_MS = 30_000;
 const BINARY_DOWNLOAD_TIMEOUT_MS = 15 * 60_000;
 
@@ -63,6 +66,164 @@ function currentNativeTag(): string {
 interface ReleaseInfo {
 	tag: string;
 	version: string;
+}
+
+export interface ReleaseBinaryAsset {
+	url: string;
+	size: number;
+	digest: string;
+}
+
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * Select and validate the binary asset from GitHub release metadata.
+ */
+export function resolveReleaseBinaryAsset(
+	release: unknown,
+	expectedTag: string,
+	binaryName: string,
+): ReleaseBinaryAsset {
+	if (!isRecord(release)) {
+		throw new Error("Invalid GitHub release metadata");
+	}
+	if (release.tag_name !== expectedTag) {
+		throw new Error(`GitHub release tag mismatch: expected ${expectedTag}`);
+	}
+	if (release.draft !== false || release.prerelease !== false) {
+		throw new Error(`GitHub release ${expectedTag} is not a published stable release`);
+	}
+	if (!Array.isArray(release.assets)) {
+		throw new Error(`GitHub release ${expectedTag} has no asset list`);
+	}
+
+	const matches = release.assets.filter(asset => isRecord(asset) && asset.name === binaryName);
+	if (matches.length !== 1) {
+		throw new Error(`GitHub release ${expectedTag} has ${matches.length} assets named ${binaryName}`);
+	}
+
+	const asset = matches[0];
+	if (!isRecord(asset) || asset.state !== "uploaded") {
+		throw new Error(`GitHub release asset ${binaryName} is not fully uploaded`);
+	}
+	if (typeof asset.size !== "number" || !Number.isSafeInteger(asset.size) || asset.size <= 0) {
+		throw new Error(`GitHub release asset ${binaryName} has an invalid size`);
+	}
+	if (typeof asset.digest !== "string") {
+		throw new Error(`GitHub release asset ${binaryName} has no digest`);
+	}
+	const digest = /^sha256:([0-9a-f]{64})$/i.exec(asset.digest)?.[1];
+	if (!digest) {
+		throw new Error(`GitHub release asset ${binaryName} has an unsupported digest`);
+	}
+
+	const expectedUrl = `https://github.com/${REPO}/releases/download/${expectedTag}/${binaryName}`;
+	if (asset.browser_download_url !== expectedUrl) {
+		throw new Error(`GitHub release asset ${binaryName} has an unexpected download URL`);
+	}
+
+	return {
+		url: expectedUrl,
+		size: asset.size,
+		digest: `sha256:${digest.toLowerCase()}`,
+	};
+}
+
+async function getReleaseBinaryAsset(
+	expectedVersion: string,
+	binaryName: string,
+	fetchImpl: Fetch = fetch,
+): Promise<ReleaseBinaryAsset> {
+	const tag = `v${expectedVersion}`;
+	let response: Response;
+	try {
+		response = await fetchImpl(`${GITHUB_API}/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
+			headers: {
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+			signal: withTimeoutSignal(RELEASE_METADATA_TIMEOUT_MS),
+		});
+	} catch (err) {
+		if (isTimeoutError(err)) {
+			throw new Error("Timed out fetching GitHub release metadata after 30s", { cause: err });
+		}
+		throw err;
+	}
+	if (!response.ok) {
+		throw new Error(`Failed to fetch GitHub release metadata: ${response.statusText}`);
+	}
+
+	return resolveReleaseBinaryAsset(await response.json(), tag, binaryName);
+}
+
+export interface VerifiedBinaryDownloadOptions {
+	url: string;
+	targetPath: string;
+	expectedSize: number;
+	expectedDigest: string;
+	fetchImpl?: Fetch;
+}
+
+/**
+ * Download a binary and verify its GitHub-reported size and SHA-256 digest.
+ */
+export async function downloadVerifiedBinary(options: VerifiedBinaryDownloadOptions): Promise<void> {
+	const fetchImpl = options.fetchImpl ?? fetch;
+	await unlinkIfExists(options.targetPath);
+
+	let response: Response;
+	try {
+		response = await fetchImpl(options.url, {
+			redirect: "follow",
+			signal: withTimeoutSignal(BINARY_DOWNLOAD_TIMEOUT_MS),
+		});
+	} catch (err) {
+		if (isTimeoutError(err)) {
+			throw new Error("Timed out downloading release binary after 15 minutes", { cause: err });
+		}
+		throw err;
+	}
+	if (!response.ok || !response.body) {
+		throw new Error(`Download failed: ${response.statusText}`);
+	}
+
+	const hash = createHash("sha256");
+	let size = 0;
+	const verifier = new Transform({
+		transform(chunk, _encoding, callback) {
+			size += chunk.byteLength;
+			if (size > options.expectedSize) {
+				callback(
+					new Error(
+						`Downloaded binary size mismatch: expected ${options.expectedSize} bytes, received at least ${size}`,
+					),
+				);
+				return;
+			}
+			hash.update(chunk);
+			callback(null, chunk);
+		},
+	});
+
+	try {
+		await pipeline(response.body, verifier, fs.createWriteStream(options.targetPath, { mode: 0o600 }));
+		const digest = `sha256:${hash.digest("hex")}`;
+		if (size !== options.expectedSize) {
+			throw new Error(`Downloaded binary size mismatch: expected ${options.expectedSize} bytes, received ${size}`);
+		}
+		if (digest !== options.expectedDigest) {
+			throw new Error(`Downloaded binary digest mismatch: expected ${options.expectedDigest}, received ${digest}`);
+		}
+		await fs.promises.chmod(options.targetPath, 0o755);
+	} catch (err) {
+		await unlinkIfExists(options.targetPath);
+		throw err;
+	}
 }
 
 /** Result from running the installed binary and parsing its reported version. */
@@ -895,36 +1056,32 @@ async function updateViaMise(expectedVersion: string, force: boolean): Promise<v
 /**
  * Download a release binary to a target path, replacing an existing file.
  */
-async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
-	const binaryName = getBinaryName();
-	const tag = `v${expectedVersion}`;
-	const url = `https://github.com/${REPO}/releases/download/${tag}/${binaryName}`;
-
+export async function updateViaBinaryAt(
+	targetPath: string,
+	expectedVersion: string,
+	options: {
+		binaryName?: string;
+		fetchImpl?: Fetch;
+		verifyInstalledVersion?: typeof verifyInstalledVersion;
+	} = {},
+): Promise<void> {
+	const binaryName = options.binaryName ?? getBinaryName();
 	const tempPath = `${targetPath}.new`;
 	// Unique per attempt: a stale backup from an earlier update may still be
 	// locked (it is the previous process image on Windows), and a fixed name
 	// would force the move-aside rename to overwrite it. pid + timestamp keeps
 	// two forced updates in the same millisecond from colliding.
 	const backupPath = `${targetPath}.${Date.now()}.${process.pid}.bak`;
+	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl);
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
-
-	let response: Response;
-	try {
-		response = await fetch(url, {
-			redirect: "follow",
-			signal: withTimeoutSignal(BINARY_DOWNLOAD_TIMEOUT_MS),
-		});
-	} catch (err) {
-		if (isTimeoutError(err)) {
-			throw new Error("Timed out downloading release binary after 15 minutes", { cause: err });
-		}
-		throw err;
-	}
-	if (!response.ok || !response.body) {
-		throw new Error(`Download failed: ${response.statusText}`);
-	}
-	const fileStream = fs.createWriteStream(tempPath, { mode: 0o755 });
-	await pipeline(response.body, fileStream);
+	await downloadVerifiedBinary({
+		url: asset.url,
+		targetPath: tempPath,
+		expectedSize: asset.size,
+		expectedDigest: asset.digest,
+		fetchImpl: options.fetchImpl,
+	});
+	console.log(chalk.dim(`Verified ${asset.digest}`));
 
 	console.log(chalk.dim("Installing update..."));
 	await replaceBinaryForUpdate({
@@ -932,7 +1089,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 		tempPath,
 		backupPath,
 		expectedVersion,
-		verifyInstalledVersion,
+		verifyInstalledVersion: options.verifyInstalledVersion ?? verifyInstalledVersion,
 	});
 	// Reclaim backups from earlier updates whose owning process has since exited.
 	await sweepStaleBackups(targetPath);

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -10,7 +10,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { $which, APP_NAME, isEnoent, VERSION } from "@oh-my-pi/pi-utils";
+import { $env, $which, APP_NAME, isEnoent, VERSION } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import chalk from "chalk";
 import { theme } from "../modes/theme/theme";
@@ -137,15 +137,19 @@ async function getReleaseBinaryAsset(
 	expectedVersion: string,
 	binaryName: string,
 	fetchImpl: Fetch = fetch,
+	githubToken: string | undefined = $env.GITHUB_TOKEN || $env.GH_TOKEN,
 ): Promise<ReleaseBinaryAsset> {
 	const tag = `v${expectedVersion}`;
+	const headers: Record<string, string> = {
+		Accept: "application/vnd.github+json",
+		"X-GitHub-Api-Version": "2022-11-28",
+	};
+	if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
+
 	let response: Response;
 	try {
 		response = await fetchImpl(`${GITHUB_API}/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
-			headers: {
-				Accept: "application/vnd.github+json",
-				"X-GitHub-Api-Version": "2022-11-28",
-			},
+			headers,
 			signal: withTimeoutSignal(RELEASE_METADATA_TIMEOUT_MS),
 		});
 	} catch (err) {
@@ -153,6 +157,11 @@ async function getReleaseBinaryAsset(
 			throw new Error("Timed out fetching GitHub release metadata after 30s", { cause: err });
 		}
 		throw err;
+	}
+	if ((response.status === 403 && !githubToken) || response.status === 429) {
+		throw new Error(
+			"GitHub API rate limit exceeded while fetching release metadata; retry later or set GITHUB_TOKEN or GH_TOKEN",
+		);
 	}
 	if (!response.ok) {
 		throw new Error(`Failed to fetch GitHub release metadata: ${response.statusText}`);
@@ -1062,6 +1071,7 @@ export async function updateViaBinaryAt(
 	options: {
 		binaryName?: string;
 		fetchImpl?: Fetch;
+		githubToken?: string;
 		verifyInstalledVersion?: typeof verifyInstalledVersion;
 	} = {},
 ): Promise<void> {
@@ -1072,7 +1082,7 @@ export async function updateViaBinaryAt(
 	// would force the move-aside rename to overwrite it. pid + timestamp keeps
 	// two forced updates in the same millisecond from colliding.
 	const backupPath = `${targetPath}.${Date.now()}.${process.pid}.bak`;
-	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl);
+	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl, options.githubToken);
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
 	await downloadVerifiedBinary({
 		url: asset.url,

--- a/packages/coding-agent/src/commands/update.ts
+++ b/packages/coding-agent/src/commands/update.ts
@@ -15,6 +15,12 @@ export default class Update extends Command {
 		plugins: Flags.boolean({ char: "l", description: "Update installed plugins", default: false }),
 	};
 
+	static examples = [
+		"omp update",
+		"omp update --check",
+		"# If GitHub rate-limits release metadata, set GITHUB_TOKEN or GH_TOKEN\n  GITHUB_TOKEN=... omp update",
+	];
+
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Update);
 		await initTheme();

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { createHash } from "node:crypto";
 import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -11,12 +12,15 @@ import {
 	buildMiseForceInstallArgs,
 	buildMiseUpgradeArgs,
 	buildNpmInstallArgs,
+	downloadVerifiedBinary,
 	parseUpdateArgs,
 	pruneBunInstallCache,
 	replaceBinaryForUpdate,
 	resolveBunGlobalNodeModulesDirFromLocations,
+	resolveReleaseBinaryAsset,
 	resolveUpdateMethodForTest,
 	sweepStaleBackups,
+	updateViaBinaryAt,
 } from "@oh-my-pi/pi-coding-agent/cli/update-cli";
 import Update from "@oh-my-pi/pi-coding-agent/commands/update";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -32,6 +36,7 @@ async function makeTempDir(): Promise<string> {
 
 afterEach(async () => {
 	vi.restoreAllMocks();
+
 	await Promise.all(tempDirs.splice(0).map(dir => removeWithRetries(dir)));
 });
 const TEST_CONFIG: CliConfig = {
@@ -300,6 +305,177 @@ describe("update-cli bun cache pruning", () => {
 		expect(await Bun.file(path.join(dir, "pkg@1.0.0-beta.1@@@1", "package.json")).exists()).toBe(false);
 		expect(await Bun.file(path.join(dir, "pkg", "1.0.0@@@1")).exists()).toBe(true);
 		expect(await Bun.file(path.join(dir, "pkg@1.0.0@@@1", "package.json")).exists()).toBe(true);
+	});
+});
+
+describe("update-cli release binary integrity", () => {
+	const tag = "v17.1.2";
+	const binaryName = "omp-linux-x64";
+	const url = `https://github.com/can1357/oh-my-pi/releases/download/${tag}/${binaryName}`;
+	const content = "verified binary";
+	const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+
+	function releaseAsset(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+		return {
+			tag_name: tag,
+			draft: false,
+			prerelease: false,
+			assets: [
+				{
+					name: binaryName,
+					state: "uploaded",
+					size: Buffer.byteLength(content),
+					digest,
+					browser_download_url: url,
+					...overrides,
+				},
+			],
+		};
+	}
+
+	it("selects an uploaded asset with a valid SHA-256 digest", () => {
+		expect(resolveReleaseBinaryAsset(releaseAsset(), tag, binaryName)).toEqual({
+			url,
+			size: Buffer.byteLength(content),
+			digest,
+		});
+	});
+
+	it("rejects missing and unsupported release asset digests", () => {
+		expect(() => resolveReleaseBinaryAsset(releaseAsset({ digest: null }), tag, binaryName)).toThrow("has no digest");
+		expect(() => resolveReleaseBinaryAsset(releaseAsset({ digest: "sha512:abc" }), tag, binaryName)).toThrow(
+			"has an unsupported digest",
+		);
+	});
+
+	it("rejects release metadata that does not identify one exact stable asset", () => {
+		expect(() => resolveReleaseBinaryAsset({ ...releaseAsset(), prerelease: true }, tag, binaryName)).toThrow(
+			"is not a published stable release",
+		);
+		expect(() => resolveReleaseBinaryAsset({ ...releaseAsset(), assets: [] }, tag, binaryName)).toThrow(
+			`has 0 assets named ${binaryName}`,
+		);
+		expect(() =>
+			resolveReleaseBinaryAsset(
+				{ ...releaseAsset(), assets: [releaseAsset().assets, releaseAsset().assets].flat() },
+				tag,
+				binaryName,
+			),
+		).toThrow(`has 2 assets named ${binaryName}`);
+		expect(() =>
+			resolveReleaseBinaryAsset(
+				releaseAsset({ browser_download_url: "https://example.com/omp-linux-x64" }),
+				tag,
+				binaryName,
+			),
+		).toThrow("has an unexpected download URL");
+	});
+
+	it("writes a download only after its size and digest match", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+
+		await downloadVerifiedBinary({
+			url,
+			targetPath,
+			expectedSize: Buffer.byteLength(content),
+			expectedDigest: digest,
+			fetchImpl: async () => new Response(content),
+		});
+
+		expect(await Bun.file(targetPath).text()).toBe(content);
+		expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o755);
+	});
+
+	it("aborts the response stream as soon as it exceeds the expected size", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+		let pulls = 0;
+		const body = new ReadableStream<Uint8Array>(
+			{
+				pull(controller) {
+					pulls++;
+					controller.enqueue(new Uint8Array(pulls === 1 ? 2 : 1));
+					if (pulls === 2) controller.close();
+				},
+			},
+			{ highWaterMark: 0 },
+		);
+
+		await expect(
+			downloadVerifiedBinary({
+				url,
+				targetPath,
+				expectedSize: 1,
+				expectedDigest: digest,
+				fetchImpl: async () => new Response(body),
+			}),
+		).rejects.toThrow("received at least 2");
+		expect(pulls).toBe(1);
+		expect(await Bun.file(targetPath).exists()).toBe(false);
+	});
+
+	it("removes downloads whose size or digest does not match", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+		const fetchImpl = async () => new Response(content);
+
+		await expect(
+			downloadVerifiedBinary({
+				url,
+				targetPath,
+				expectedSize: Buffer.byteLength(content) + 1,
+				expectedDigest: digest,
+				fetchImpl,
+			}),
+		).rejects.toThrow("size mismatch");
+		expect(await Bun.file(targetPath).exists()).toBe(false);
+
+		await expect(
+			downloadVerifiedBinary({
+				url,
+				targetPath,
+				expectedSize: Buffer.byteLength(content),
+				expectedDigest: `sha256:${createHash("sha256").update("different binary").digest("hex")}`,
+				fetchImpl,
+			}),
+		).rejects.toThrow("digest mismatch");
+		expect(await Bun.file(targetPath).exists()).toBe(false);
+	});
+
+	it("rejects an altered version-reporting executable before replacing the installed binary", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+		const installed = "#!/bin/sh\necho omp/17.0.8\n";
+		const altered = "#!/bin/sh\necho omp/17.1.2\n";
+		const expectedDigest = `sha256:${createHash("sha256")
+			.update("x".repeat(Buffer.byteLength(altered)))
+			.digest("hex")}`;
+		await Bun.write(targetPath, installed);
+		await fs.chmod(targetPath, 0o755);
+
+		const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
+			const requestUrl = String(input);
+			if (requestUrl.startsWith("https://api.github.com/")) {
+				return new Response(
+					JSON.stringify(
+						releaseAsset({
+							size: Buffer.byteLength(altered),
+							digest: expectedDigest,
+						}),
+					),
+				);
+			}
+			if (requestUrl === url) return new Response(altered);
+			throw new Error(`Unexpected request: ${requestUrl}`);
+		};
+
+		await expect(updateViaBinaryAt(targetPath, "17.1.2", { binaryName, fetchImpl })).rejects.toThrow(
+			"digest mismatch",
+		);
+		expect(await Bun.file(targetPath).text()).toBe(installed);
+		expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o755);
+		expect(await Bun.file(`${targetPath}.new`).exists()).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -454,9 +454,11 @@ describe("update-cli release binary integrity", () => {
 		await Bun.write(targetPath, installed);
 		await fs.chmod(targetPath, 0o755);
 
-		const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
+		const metadataAuthorizations: Array<string | null> = [];
+		const fetchImpl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
 			const requestUrl = String(input);
 			if (requestUrl.startsWith("https://api.github.com/")) {
+				metadataAuthorizations.push(new Headers(init?.headers).get("Authorization"));
 				return new Response(
 					JSON.stringify(
 						releaseAsset({
@@ -470,12 +472,38 @@ describe("update-cli release binary integrity", () => {
 			throw new Error(`Unexpected request: ${requestUrl}`);
 		};
 
-		await expect(updateViaBinaryAt(targetPath, "17.1.2", { binaryName, fetchImpl })).rejects.toThrow(
-			"digest mismatch",
-		);
-		expect(await Bun.file(targetPath).text()).toBe(installed);
-		expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o755);
-		expect(await Bun.file(`${targetPath}.new`).exists()).toBe(false);
+		const previousGitHubToken = Bun.env.GITHUB_TOKEN;
+		Bun.env.GITHUB_TOKEN = "test-token";
+		try {
+			await expect(
+				updateViaBinaryAt(targetPath, "17.1.2", {
+					binaryName,
+					fetchImpl,
+				}),
+			).rejects.toThrow("digest mismatch");
+			expect(metadataAuthorizations).toEqual(["Bearer test-token"]);
+			expect(await Bun.file(targetPath).text()).toBe(installed);
+			expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o755);
+			expect(await Bun.file(`${targetPath}.new`).exists()).toBe(false);
+		} finally {
+			if (previousGitHubToken === undefined) delete Bun.env.GITHUB_TOKEN;
+			else Bun.env.GITHUB_TOKEN = previousGitHubToken;
+		}
+	});
+
+	it("explains how to authenticate after an anonymous GitHub API rate limit", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+		const fetchImpl = async () => new Response(null, { status: 403, statusText: "rate limit exceeded" });
+
+		await expect(
+			updateViaBinaryAt(targetPath, "17.1.2", {
+				binaryName,
+				fetchImpl,
+				githubToken: "",
+			}),
+		).rejects.toThrow("retry later or set GITHUB_TOKEN or GH_TOKEN");
+		expect(await Bun.file(targetPath).exists()).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

Verify binary from GH release rather than relying just on version check. Makes the most of the GH release asset metadata to verify that we got what we are supposed to get and that everything is in order inasmuch as we can know that.

Also added a second commit with a special-case carve-outs for `console.log` in the coding-agent package, since `update` isn't TUI or covered by any of the relevant concerns and there's already `console.log` in there.

## Why

Minor security improvement to the updater, doesn't fix an existing problem but adds an additional layer of assurance.

I'd like to contribute more to the updater if you're open to it, including the ability to update to a specific version rather than the latest. As much as I love the activity here I'm a little uncomfortable with bleeding-edge when there's so much churn so would like the ability to slow down and be more considered with my update process and the updater could help with that.

I'm thinking a `--to <version>` flag and also a more extensive `--check` flag, perhaps `--json`, that inspects the delta between current and what's released and could be used to have an agent figure out what to care about, what to prepare for, what settings might need changing and adapting to.

## Testing

Unit tests and ran a forced update locally to v17.1.3, `Verified sha256:17a7e2e1c49cbc09129e29fbf48cdebd1a545d053f5cad7295c1898b6eaa422e.`, got `omp/17.1.3.` and `--smoke-test` exited `0`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
