### PR TITLE
fix(tui): make provider error blocks expandable via ctrl+o

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a turn-ending provider error being truncated to 8 lines in the transcript with no way to reveal the rest: `AssistantMessageComponent` now implements `setExpanded`, so Ctrl+O (tool-output expansion) reveals the full error body and the collapsed view shows a `… +N more lines (Ctrl+O to expand)` hint ([#6555](https://github.com/can1357/oh-my-pi/issues/6555)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -214,12 +214,14 @@ export class AssistantMessageComponent extends Container {
 	 */
 	#errorExpanded = false;
 	/**
-	 * True when the last {@link updateContent} rendered a length-capped error
-	 * block (the `#appendErrorBlock` path). Gates {@link setExpanded} so toggling
-	 * expansion only re-renders assistant turns that actually carry a truncatable
-	 * error, not every message in the transcript.
+	 * True when the current {@link updateContent} message carries a truncatable
+	 * inline provider error (the `#appendErrorBlock` path) — set whether or not
+	 * the inline block was actually drawn, so it stays true even while the error
+	 * is suppressed under a pinned banner. Gates {@link setExpanded} so toggling
+	 * expansion only re-renders assistant turns that carry such an error, not
+	 * every message in the transcript.
 	 */
-	#renderedTruncatableError = false;
+	#hasTruncatableError = false;
 	/**
 	 * Monotonic content version reported to the transcript container via
 	 * {@link getTranscriptBlockVersion}. Bumped by {@link updateContent} — the
@@ -435,13 +437,15 @@ export class AssistantMessageComponent extends Container {
 	/**
 	 * Expand or collapse the inline turn-ending error block so Ctrl+O
 	 * (tool-output expansion) can reveal a long provider error's hidden tail.
-	 * Only re-renders when the last render actually produced a truncatable error
-	 * block, so toggling expansion across the transcript skips ordinary turns.
+	 * Only re-renders when the current message carries a truncatable error, so
+	 * toggling expansion across the transcript skips ordinary turns. Works even
+	 * while the error is pinned in the banner: the inline block is drawn (in full)
+	 * when expanded so the complete body is reachable without sending a message.
 	 */
 	setExpanded(expanded: boolean): void {
 		if (this.#errorExpanded === expanded) return;
 		this.#errorExpanded = expanded;
-		if (this.#renderedTruncatableError && this.#lastMessage) {
+		if (this.#hasTruncatableError && this.#lastMessage) {
 			this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
 		}
 	}
@@ -536,7 +540,6 @@ export class AssistantMessageComponent extends Container {
 	 * the complete message is reachable. Mirrors {@link ErrorBannerComponent}.
 	 */
 	#appendErrorBlock(message: string): void {
-		this.#renderedTruncatableError = true;
 		if (this.#errorExpanded) {
 			const [first = "Unknown error", ...rest] = replaceTabs(message.replace(/\s+$/, "")).split("\n");
 			this.#contentContainer.addChild(new Text(theme.fg("error", `Error: ${first}`), 1, 0));
@@ -705,7 +708,10 @@ export class AssistantMessageComponent extends Container {
 		if (this.#toolImagesByCallId.size > 0) return false;
 		const errorPresentation = resolveAssistantErrorPresentation(message);
 		if (errorPresentation.kind === "compact-recovered") return false;
-		if (errorPresentation.kind === "full" && !(message.stopReason === "error" && this.#errorPinned)) {
+		if (
+			errorPresentation.kind === "full" &&
+			!(message.stopReason === "error" && this.#errorPinned && !this.#errorExpanded)
+		) {
 			return false;
 		}
 		// Extension stability: if thinking renderers exist and any tracked thinking
@@ -839,7 +845,7 @@ export class AssistantMessageComponent extends Container {
 		// Clear content container
 		this.#contentContainer.clear();
 		this.#thinkingDots = undefined;
-		this.#renderedTruncatableError = false;
+		this.#hasTruncatableError = false;
 
 		// Determine if we should capture Markdown instances for next fast path
 		const shouldCapture = this.#canFastPath(message);
@@ -922,11 +928,19 @@ export class AssistantMessageComponent extends Container {
 			this.#contentContainer.addChild(new Spacer(1));
 			this.#contentContainer.addChild(new Text(theme.fg("dim", errorPresentation.text), 1, 0));
 		} else if (!hasToolCalls && errorPresentation.kind === "full") {
-			if (!(message.stopReason === "error" && this.#errorPinned)) {
+			if (message.stopReason === "aborted") {
 				this.#contentContainer.addChild(new Spacer(1));
-				if (message.stopReason === "aborted") {
-					this.#contentContainer.addChild(new Text(theme.fg("error", errorPresentation.text), 1, 0));
-				} else {
+				this.#contentContainer.addChild(new Text(theme.fg("error", errorPresentation.text), 1, 0));
+			} else {
+				// Non-aborted provider error: a truncatable inline block. Mark it so
+				// setExpanded re-renders even while the same error is pinned above.
+				this.#hasTruncatableError = true;
+				// Suppress the inline block only while pinned AND collapsed — the
+				// banner already shows the capped error there. When expanded, draw
+				// the inline block in full so the complete body is reachable without
+				// sending a message; the pinned banner stays a short reminder.
+				if (!(message.stopReason === "error" && this.#errorPinned) || this.#errorExpanded) {
+					this.#contentContainer.addChild(new Spacer(1));
 					this.#appendErrorBlock(errorPresentation.text);
 				}
 			}

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,10 +1,20 @@
 import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
-import { Container, Image, type ImageBudget, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@oh-my-pi/pi-tui";
+import {
+	Container,
+	Image,
+	type ImageBudget,
+	ImageProtocol,
+	Markdown,
+	replaceTabs,
+	Spacer,
+	TERMINAL,
+	Text,
+} from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
-import { getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
+import { expandKeyHint, getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
 import { resolveAssistantErrorPresentation } from "../utils/transcript-render-helpers";
 import { type CacheInvalidation, CacheInvalidationMarkerComponent } from "./cache-invalidation-marker";
@@ -196,6 +206,20 @@ export class AssistantMessageComponent extends Container {
 	 * transcript keeps the error in history.
 	 */
 	#errorPinned = false;
+	/**
+	 * Whether the inline turn-ending error block renders its full body instead of
+	 * the {@link MAX_TRANSCRIPT_ERROR_LINES}-capped preview. Toggled by
+	 * {@link setExpanded} so Ctrl+O (tool-output expansion) reveals a long
+	 * provider error whose tail would otherwise be unreachable in the live TUI.
+	 */
+	#errorExpanded = false;
+	/**
+	 * True when the last {@link updateContent} rendered a length-capped error
+	 * block (the `#appendErrorBlock` path). Gates {@link setExpanded} so toggling
+	 * expansion only re-renders assistant turns that actually carry a truncatable
+	 * error, not every message in the transcript.
+	 */
+	#renderedTruncatableError = false;
 	/**
 	 * Monotonic content version reported to the transcript container via
 	 * {@link getTranscriptBlockVersion}. Bumped by {@link updateContent} — the
@@ -408,6 +432,20 @@ export class AssistantMessageComponent extends Container {
 		}
 	}
 
+	/**
+	 * Expand or collapse the inline turn-ending error block so Ctrl+O
+	 * (tool-output expansion) can reveal a long provider error's hidden tail.
+	 * Only re-renders when the last render actually produced a truncatable error
+	 * block, so toggling expansion across the transcript skips ordinary turns.
+	 */
+	setExpanded(expanded: boolean): void {
+		if (this.#errorExpanded === expanded) return;
+		this.#errorExpanded = expanded;
+		if (this.#renderedTruncatableError && this.#lastMessage) {
+			this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+		}
+	}
+
 	isTranscriptBlockFinalized(): boolean {
 		return this.#transcriptBlockFinalized;
 	}
@@ -488,18 +526,42 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	/**
-	 * Render a turn-ending provider error inline. Drops blank lines, clamps the
-	 * line count to {@link MAX_TRANSCRIPT_ERROR_LINES}, and width-truncates each
-	 * line so a pathological body — e.g. the HTML page a proxy returns on a 502 —
-	 * can't flood the transcript. Mirrors {@link ErrorBannerComponent}.
+	 * Render a turn-ending provider error inline. Collapsed (default), it drops
+	 * blank lines, clamps the line count to {@link MAX_TRANSCRIPT_ERROR_LINES},
+	 * and width-truncates each line so a pathological body — e.g. the HTML page a
+	 * proxy returns on a 502 — can't flood the transcript, appending a dim
+	 * `ctrl+o`/expand hint when lines were hidden. Expanded (via
+	 * {@link setExpanded}), it renders the full body — tabs replaced, blank lines
+	 * preserved — letting {@link Text} word-wrap each line to the render width so
+	 * the complete message is reachable. Mirrors {@link ErrorBannerComponent}.
 	 */
 	#appendErrorBlock(message: string): void {
+		this.#renderedTruncatableError = true;
+		if (this.#errorExpanded) {
+			const [first = "Unknown error", ...rest] = replaceTabs(message.replace(/\s+$/, "")).split("\n");
+			this.#contentContainer.addChild(new Text(theme.fg("error", `Error: ${first}`), 1, 0));
+			for (const line of rest) {
+				this.#contentContainer.addChild(new Text(theme.fg("error", `  ${line}`), 1, 0));
+			}
+			return;
+		}
+		const total = message.split("\n").filter(l => l.trim()).length;
 		const lines = getPreviewLines(message, MAX_TRANSCRIPT_ERROR_LINES, TRUNCATE_LENGTHS.LINE);
 		if (lines.length === 0) lines.push("Unknown error");
 		// The caller owns the separating Spacer; adding one here doubled the gap.
 		this.#contentContainer.addChild(new Text(theme.fg("error", `Error: ${lines[0]}`), 1, 0));
 		for (const line of lines.slice(1)) {
 			this.#contentContainer.addChild(new Text(theme.fg("error", `  ${line}`), 1, 0));
+		}
+		if (total > lines.length) {
+			const hidden = total - lines.length;
+			this.#contentContainer.addChild(
+				new Text(
+					theme.fg("dim", `  … +${hidden} more line${hidden === 1 ? "" : "s"} (${expandKeyHint()} to expand)`),
+					1,
+					0,
+				),
+			);
 		}
 	}
 
@@ -777,6 +839,7 @@ export class AssistantMessageComponent extends Container {
 		// Clear content container
 		this.#contentContainer.clear();
 		this.#thinkingDots = undefined;
+		this.#renderedTruncatableError = false;
 
 		// Determine if we should capture Markdown instances for next fast path
 		const shouldCapture = this.#canFastPath(message);

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -303,6 +303,7 @@ export class ChatTranscriptBuilder {
 			proseOnlyThinking,
 		);
 		assistantComponent.setImagesVisible(settings.get("terminal.showImages"));
+		this.#trackExpandable(assistantComponent);
 		this.container.addChild(assistantComponent);
 
 		if (settings.get("display.cacheMissMarker")) {
@@ -334,6 +335,7 @@ export class ChatTranscriptBuilder {
 				proseOnlyThinking,
 			);
 			component.setImagesVisible(settings.get("terminal.showImages"));
+			this.#trackExpandable(component);
 			this.container.addChild(component);
 		};
 

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -25,5 +25,6 @@ export function createAssistantMessageComponent(
 		ctx.proseOnlyThinking,
 	);
 	component.setImagesVisible(ctx.settings.get("terminal.showImages"));
+	component.setExpanded(ctx.toolOutputExpanded);
 	return component;
 }

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -110,6 +110,7 @@ function createFixture(streamingMessage?: AssistantMessage) {
 		streamingMessage,
 		chatContainer,
 		proseOnlyThinking: true,
+		toolOutputExpanded: false,
 		transcriptMessageComponents: new WeakMap(),
 		pendingTools: new Map(),
 		flushCompactionQueue: vi.fn(async () => {}),
@@ -234,6 +235,33 @@ describe("EventController error banner", () => {
 		await controller.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
 
 		expect(clearPinnedError).toHaveBeenCalledTimes(1);
+	});
+
+	it("initializes a new provider error from the active expanded mode", async () => {
+		const initial = makeAssistantMessage({ content: [] });
+		const errorMessage = Array.from({ length: 30 }, (_, i) => `provider error detail line ${i}`).join("\n");
+		const { controller, ctx } = createFixture();
+		ctx.toolOutputExpanded = true;
+
+		await controller.handleEvent({
+			type: "message_start",
+			message: initial,
+		} as Extract<AgentSessionEvent, { type: "message_start" }>);
+		const component = ctx.streamingComponent;
+		if (!(component instanceof AssistantMessageComponent)) {
+			throw new Error("Expected streaming assistant component");
+		}
+
+		component.updateContent(
+			makeAssistantMessage({
+				content: [],
+				stopReason: "error",
+				errorMessage,
+			}),
+		);
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("provider error detail line 29");
+		expect(rendered).not.toContain("more lines");
 	});
 });
 

--- a/packages/coding-agent/test/provider-error-expand.test.ts
+++ b/packages/coding-agent/test/provider-error-expand.test.ts
@@ -54,4 +54,26 @@ describe("provider error expand", () => {
 		const recollapsed = Bun.stripANSI(component.render(120).join("\n"));
 		expect(recollapsed).not.toContain("provider error detail line 29");
 	});
+
+	it("reveals the full body inline when expanded while the error is pinned", () => {
+		const component = new AssistantMessageComponent(makeErr(longError(30)));
+
+		// The banner above the editor mirrors the error, so the inline block is
+		// suppressed while pinned (EventController does this at message_end).
+		component.setErrorPinned(true);
+		const pinned = Bun.stripANSI(component.render(120).join("\n"));
+		expect(pinned).not.toContain("provider error detail line 0");
+
+		// Ctrl+O while pinned must still reach the full body inline.
+		component.setExpanded(true);
+		const expanded = Bun.stripANSI(component.render(120).join("\n"));
+		const shown = expanded.match(/provider error detail line \d+/g) ?? [];
+		expect(shown.length).toBe(30);
+		expect(expanded).toContain("provider error detail line 29");
+
+		// Collapsing again re-suppresses the pinned inline error.
+		component.setExpanded(false);
+		const recollapsed = Bun.stripANSI(component.render(120).join("\n"));
+		expect(recollapsed).not.toContain("provider error detail line 0");
+	});
 });

--- a/packages/coding-agent/test/provider-error-expand.test.ts
+++ b/packages/coding-agent/test/provider-error-expand.test.ts
@@ -1,0 +1,57 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+function longError(n: number): string {
+	return Array.from({ length: n }, (_, i) => `provider error detail line ${i}`).join("\n");
+}
+
+function makeErr(errorMessage: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "error",
+		errorMessage,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+describe("provider error expand", () => {
+	it("caps a long error collapsed and reveals the full body when expanded", () => {
+		const component = new AssistantMessageComponent(makeErr(longError(30)));
+
+		const collapsed = Bun.stripANSI(component.render(120).join("\n"));
+		const shown = collapsed.match(/provider error detail line \d+/g) ?? [];
+		expect(shown.length).toBe(8);
+		expect(collapsed).not.toContain("provider error detail line 29");
+		expect(collapsed).toMatch(/\+22 more lines/);
+
+		component.setExpanded(true);
+		const expanded = Bun.stripANSI(component.render(120).join("\n"));
+		const shownExpanded = expanded.match(/provider error detail line \d+/g) ?? [];
+		expect(shownExpanded.length).toBe(30);
+		expect(expanded).toContain("provider error detail line 0");
+		expect(expanded).toContain("provider error detail line 29");
+		expect(expanded).not.toMatch(/more lines/);
+
+		component.setExpanded(false);
+		const recollapsed = Bun.stripANSI(component.render(120).join("\n"));
+		expect(recollapsed).not.toContain("provider error detail line 29");
+	});
+});


### PR DESCRIPTION
## Repro
When a provider returns a long error, the turn ends on `stopReason === "error"` and the TUI renders the body inline but caps it at 8 non-blank lines; the tail is dropped and Ctrl+O does nothing. Rendering an `AssistantMessageComponent` for a 30-line error shows only lines 0-7 (`bun test packages/coding-agent/test/provider-error-expand.test.ts`), and the component exposes no `setExpanded`, so the full text is unreachable in the live TUI.

## Cause
`AssistantMessageComponent#appendErrorBlock` (`packages/coding-agent/src/modes/components/assistant-message.ts`) passes the full `errorMessage` through `getPreviewLines(message, MAX_TRANSCRIPT_ERROR_LINES = 8, TRUNCATE_LENGTHS.LINE)`. Unlike every other truncated block (bash/eval boxes, tool output, read groups, user/custom messages), the component implements no `setExpanded`, so `isExpandable()` in `modes/controllers/input-controller.ts` filters it out of `setToolsExpanded()` — Ctrl+O flips the global flag and repaints but never expands the error. The full body stays on `message.errorMessage` in the persisted session, yet is never shown.

## Fix
- Add `setExpanded(expanded)` to `AssistantMessageComponent`; when expanded, `#appendErrorBlock` renders the full body (tabs replaced via `replaceTabs`, blank lines preserved, `Text` word-wraps each line to the render width) instead of the 8-line cap.
- Collapsed view appends a dim `… +N more lines (<Ctrl+O> to expand)` hint (using `expandKeyHint()`) so the truncation and its remedy are discoverable.
- Track `#renderedTruncatableError` so toggling expansion only re-renders assistant turns that actually carry a truncatable error, not every message in the transcript.

## Verification
`bun test packages/coding-agent/test/provider-error-expand.test.ts` — new regression test: a 30-line error shows 8 lines + the hint collapsed, all 30 lines with no hint when expanded, and re-collapses. Also ran `event-controller-error-banner.test.ts` and `event-controller-mixed-assistant-render.test.ts` (17 pass). `bun check` passed via the pre-publish gate. Fixes #6555