### PR TITLE
feat(mcp): add mcp.awaitStartupMs to mount MCP tools before first prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
+- Added `mcp.awaitStartupMs` (default `0`): interactive sessions can opt into waiting up to the given milliseconds for MCP servers before assembling the tool registry and system prompt, so connected/cached tools mount into the initial `xd://` inventory instead of arriving via the hidden mount-notice message that then rides every request until compaction. The budget threads through to the `connectServers` startup gate (previously a fixed 250ms constant); slow or uncached servers still register in the background.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added `mcp.awaitStartupMs` (default `0`): interactive sessions can opt into waiting up to the given milliseconds for MCP servers before assembling the tool registry and system prompt, so connected/cached tools mount into the initial `xd://` inventory instead of arriving via the hidden mount-notice message that then rides every request until compaction. The budget threads through to the `connectServers` startup gate (previously a fixed 250ms constant); slow or uncached servers still register in the background.
 
 ### Fixed
 
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
-- Added `mcp.awaitStartupMs` (default `0`): interactive sessions can opt into waiting up to the given milliseconds for MCP servers before assembling the tool registry and system prompt, so connected/cached tools mount into the initial `xd://` inventory instead of arriving via the hidden mount-notice message that then rides every request until compaction. The budget threads through to the `connectServers` startup gate (previously a fixed 250ms constant); slow or uncached servers still register in the background.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4236,6 +4236,26 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"mcp.awaitStartupMs": {
+		type: "number",
+		default: 0,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "MCP Await Startup",
+			description:
+				"Wait up to this many milliseconds for MCP servers to connect before first paint, so their tools mount directly into the system prompt instead of arriving via an xd:// mount notice; 0 connects in the background",
+			options: [
+				{ value: "0", label: "Disabled (background connect)" },
+				{ value: "250", label: "250 ms" },
+				{ value: "1000", label: "1 second" },
+				{ value: "2500", label: "2.5 seconds" },
+				{ value: "5000", label: "5 seconds" },
+				{ value: "10000", label: "10 seconds" },
+			],
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Tasks
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -139,6 +139,33 @@ export function resolveSubscriptionPostAction(
 	if (currentEpoch !== subscriptionEpoch) return "ignore";
 	return "apply";
 }
+
+/** Cap on buffered resource-updated events before a listener is installed. */
+export const PENDING_RESOURCE_UPDATE_CAP = 128;
+
+/**
+ * Queue a resource-updated event that arrived before {@link MCPManager.setOnResourcesChanged}
+ * had a listener. Dedupes by server+uri; drops new keys once the cap is hit.
+ */
+export function queuePendingResourceUpdate(
+	pending: Map<string, { serverName: string; uri: string }>,
+	serverName: string,
+	uri: string,
+	cap: number = PENDING_RESOURCE_UPDATE_CAP,
+): void {
+	const key = `${serverName}\0${uri}`;
+	if (!pending.has(key) && pending.size >= cap) return;
+	pending.set(key, { serverName, uri });
+}
+
+/** Drain buffered resource-updated events in insertion order. */
+export function takePendingResourceUpdates(
+	pending: Map<string, { serverName: string; uri: string }>,
+): Array<{ serverName: string; uri: string }> {
+	const items = [...pending.values()];
+	pending.clear();
+	return items;
+}
 /** Result of loading MCP tools */
 export interface MCPLoadResult {
 	/** Loaded tools as CustomTool instances */
@@ -213,6 +240,12 @@ export class MCPManager {
 	#notificationsEpoch = 0;
 	#subscribedResources = new Map<string, Set<string>>();
 	#pendingResourceRefresh = new Map<string, { connection: MCPServerConnection; promise: Promise<void> }>();
+	/**
+	 * Resource-updated notifications that arrived before a session listener was
+	 * installed (e.g. during `mcp.awaitStartupMs` discovery). Flushed by
+	 * {@link setOnResourcesChanged}.
+	 */
+	#pendingResourceUpdates = new Map<string, { serverName: string; uri: string }>();
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
@@ -245,9 +278,14 @@ export class MCPManager {
 
 	/**
 	 * Set a callback to fire when any server's resources change.
+	 * Replays any resource-updated events that arrived before the listener was
+	 * installed (awaited-startup discovery window).
 	 */
 	setOnResourcesChanged(handler: (serverName: string, uri: string) => void): void {
 		this.#onResourcesChanged = handler;
+		for (const { serverName, uri } of takePendingResourceUpdates(this.#pendingResourceUpdates)) {
+			handler(serverName, uri);
+		}
 	}
 
 	/**
@@ -653,7 +691,13 @@ export class MCPManager {
 				const uri = (params as { uri?: string })?.uri;
 				const subscribed = this.#subscribedResources.get(serverName);
 				if (uri && subscribed?.has(uri)) {
-					this.#onResourcesChanged?.(serverName, uri);
+					if (this.#onResourcesChanged) {
+						this.#onResourcesChanged(serverName, uri);
+					} else {
+						// Discovery can complete (and emit updates) before the
+						// session wires its listener under mcp.awaitStartupMs.
+						queuePendingResourceUpdate(this.#pendingResourceUpdates, serverName, uri);
+					}
 				}
 				break;
 			}
@@ -791,6 +835,9 @@ export class MCPManager {
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
 		this.#reconnectHistory.delete(name);
+		for (const key of this.#pendingResourceUpdates.keys()) {
+			if (key.startsWith(`${name}\0`)) this.#pendingResourceUpdates.delete(key);
+		}
 
 		const connection = this.#connections.get(name);
 
@@ -836,6 +883,7 @@ export class MCPManager {
 		this.#pendingReconnections.clear();
 		this.#pendingConnectionAborts.clear();
 		this.#pendingResourceRefresh.clear();
+		this.#pendingResourceUpdates.clear();
 		this.#sources.clear();
 		this.#serverConfigs.clear();
 		this.#connections.clear();

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -159,6 +159,14 @@ export interface MCPDiscoverOptions {
 	filterBrowser?: boolean;
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
+	/**
+	 * Override for the startup gate (default STARTUP_TIMEOUT_MS = 250): how long
+	 * `connectServers` waits for in-flight connects before returning whatever is
+	 * ready (live + cached-deferred tools) and leaving stragglers to register in
+	 * the background. Interactive sessions opt into a longer gate via
+	 * `mcp.awaitStartupMs` so tools mount before the first prompt build.
+	 */
+	startupTimeoutMs?: number;
 }
 
 /** Handles an MCP `WWW-Authenticate` challenge and returns refreshed config. */
@@ -340,7 +348,7 @@ export class MCPManager {
 			throw error;
 		}
 		const { configs, exaApiKeys, sources } = loadedConfigs;
-		const result = await this.connectServers(configs, sources, options?.onStatus);
+		const result = await this.connectServers(configs, sources, options?.onStatus, options?.startupTimeoutMs);
 		result.exaApiKeys = exaApiKeys;
 		return result;
 	}
@@ -353,6 +361,7 @@ export class MCPManager {
 		configs: Record<string, MCPServerConfig>,
 		sources: Record<string, SourceMeta>,
 		onStatus?: (event: McpConnectionStatusEvent) => void,
+		startupTimeoutMs: number = STARTUP_TIMEOUT_MS,
 	): Promise<MCPLoadResult> {
 		type ConnectionTask = {
 			name: string;
@@ -515,7 +524,7 @@ export class MCPManager {
 		if (connectionTasks.length > 0) {
 			await Promise.race([
 				Promise.allSettled(connectionTasks.map(task => task.tracked.promise)),
-				delay(STARTUP_TIMEOUT_MS),
+				delay(startupTimeoutMs),
 			]);
 
 			const cachedTools = new Map<string, MCPToolDefinition[]>();

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -109,8 +109,10 @@ function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 	return tracked;
 }
 
-function delay(ms: number): Promise<void> {
-	return Bun.sleep(ms);
+function cancelableDelay(ms: number): { promise: Promise<void>; cancel: () => void } {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	const timer = setTimeout(resolve, ms);
+	return { promise, cancel: () => clearTimeout(timer) };
 }
 
 /**
@@ -522,10 +524,15 @@ export class MCPManager {
 		}
 
 		if (connectionTasks.length > 0) {
-			await Promise.race([
-				Promise.allSettled(connectionTasks.map(task => task.tracked.promise)),
-				delay(startupTimeoutMs),
-			]);
+			const startupDelay = cancelableDelay(startupTimeoutMs);
+			try {
+				await Promise.race([
+					Promise.allSettled(connectionTasks.map(task => task.tracked.promise)),
+					startupDelay.promise,
+				]);
+			} finally {
+				startupDelay.cancel();
+			}
 
 			const cachedTools = new Map<string, MCPToolDefinition[]>();
 			const pendingTasks = connectionTasks.filter(task => task.tracked.status === "pending");

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -200,6 +200,7 @@ export class MCPManager {
 	#connections = new Map<string, MCPServerConnection>();
 	#tools: CustomTool<TSchema, MCPToolDetails>[] = [];
 	#pendingConnections = new Map<string, Promise<MCPServerConnection>>();
+	#pendingConnectionAborts = new Map<string, AbortController>();
 	#pendingToolLoads = new Map<string, Promise<ToolLoadResult>>();
 	#sources = new Map<string, SourceMeta>();
 	#authStorage: AuthStorage | null = null;
@@ -422,6 +423,9 @@ export class MCPManager {
 			// and falls back to cached/deferred tools.
 			this.#serverConfigs.set(name, config);
 
+			const abortController = new AbortController();
+			this.#pendingConnectionAborts.set(name, abortController);
+
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
 				const resolvedConfig = await this.#resolveAuthConfig(config);
@@ -432,6 +436,7 @@ export class MCPManager {
 					onRequest: (method, params) => {
 						return this.#handleServerRequest(method, params);
 					},
+					signal: abortController.signal,
 				});
 			})().then(
 				connection => {
@@ -483,7 +488,7 @@ export class MCPManager {
 			this.#pendingConnections.set(name, connectionPromise);
 
 			const toolsPromise = connectionPromise.then(async connection => {
-				const serverTools = await listTools(connection);
+				const serverTools = await listTools(connection, { signal: abortController.signal });
 				return { connection, serverTools };
 			});
 			this.#pendingToolLoads.set(name, toolsPromise);
@@ -504,8 +509,14 @@ export class MCPManager {
 
 					onStatus?.({ type: "connected", serverName: name });
 					await this.#loadServerResourcesAndPrompts(name, connection);
+					if (this.#pendingConnectionAborts.get(name) === abortController) {
+						this.#pendingConnectionAborts.delete(name);
+					}
 				})
 				.catch(error => {
+					if (this.#pendingConnectionAborts.get(name) === abortController) {
+						this.#pendingConnectionAborts.delete(name);
+					}
 					if (this.#pendingToolLoads.get(name) !== toolsPromise) return;
 					this.#pendingToolLoads.delete(name);
 					const message = error instanceof Error ? error.message : String(error);
@@ -771,6 +782,8 @@ export class MCPManager {
 	 * Disconnect from a specific server.
 	 */
 	async disconnectServer(name: string): Promise<void> {
+		this.#pendingConnectionAborts.get(name)?.abort();
+		this.#pendingConnectionAborts.delete(name);
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
 		this.#pendingReconnections.delete(name);
@@ -810,6 +823,7 @@ export class MCPManager {
 		// Invalidate any in-flight reconnection attempts that outlive this call.
 		// They captured the old epoch; after increment they'll detect staleness.
 		this.#epoch++;
+		for (const controller of this.#pendingConnectionAborts.values()) controller.abort();
 		// Detach onClose before closing to prevent spurious reconnect attempts
 		for (const conn of this.#connections.values()) {
 			conn.transport.onClose = undefined;
@@ -820,6 +834,7 @@ export class MCPManager {
 		this.#pendingConnections.clear();
 		this.#pendingToolLoads.clear();
 		this.#pendingReconnections.clear();
+		this.#pendingConnectionAborts.clear();
 		this.#pendingResourceRefresh.clear();
 		this.#sources.clear();
 		this.#serverConfigs.clear();

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -485,10 +485,22 @@ export class MCPManager {
 					if (sources[name]) {
 						connection._source = sources[name];
 					}
-					if (this.#pendingConnections.get(name) === connectionPromise) {
-						this.#pendingConnections.delete(name);
-						this.#connections.set(name, connection);
+					// disconnectAll() may clear #pendingConnections after connect
+					// resolved but before this continuation runs — abort is too late
+					// to cancel connectToServer, so close the untracked transport
+					// instead of wiring onClose/listTools on a leaked process.
+					if (this.#pendingConnections.get(name) !== connectionPromise) {
+						connection.transport.onClose = undefined;
+						void disconnectServer(connection).catch(error => {
+							logger.debug("Failed to close raced MCP connection", {
+								path: `mcp:${name}`,
+								error: error instanceof Error ? error.message : String(error),
+							});
+						});
+						throw new Error(`MCP connection cancelled: ${name}`);
 					}
+					this.#pendingConnections.delete(name);
+					this.#connections.set(name, connection);
 
 					// Wire auth refresh for HTTP-like transports so 401s trigger token refresh.
 					// Gate on a resolvable managed credential, not on the auth block:

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1593,6 +1593,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		agentRegistry.unregister(resolvedAgentId, ref);
 	};
 	const evalKernelOwnerId = `agent-session:${Snowflake.next()}`;
+	let ownedMCPManager: MCPManager | undefined;
+	const previousMCPManager = MCPManager.instance();
 
 	try {
 		const getActiveModelString = (): string | undefined => {
@@ -1790,6 +1792,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			if (deferMCPDiscoveryForUI) {
 				const cacheStorage = settings.getStorage();
 				mcpManager = new MCPManager(cwd, cacheStorage ? new MCPToolCache(cacheStorage) : null);
+				ownedMCPManager = mcpManager;
 				mcpManager.setAuthStorage(authStorage);
 				toolSession.mcpManager = mcpManager;
 
@@ -1862,6 +1865,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					authStorage,
 				});
 				mcpManager = mcpResult.manager;
+				ownedMCPManager = mcpManager;
 				toolSession.mcpManager = mcpManager;
 
 				if (settings.get("mcp.notifications")) {
@@ -3510,6 +3514,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				if (hasRegistered) unregisterUnlessParked();
 			} else {
 				if (hasRegistered) unregisterUnlessParked();
+				if (ownedMCPManager) {
+					await ownedMCPManager.disconnectAll();
+					if (MCPManager.instance() === ownedMCPManager) MCPManager.setInstance(previousMCPManager);
+				}
 				if (asyncJobManager) {
 					if (AsyncJobManager.instance() === asyncJobManager) {
 						AsyncJobManager.setInstance(undefined);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1798,31 +1798,63 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 
 				const deferredMCPManager = mcpManager;
-				startDeferredMCPDiscovery = liveSession => {
-					void (async () => {
-						try {
-							const mcpResult = await logger.time("discoverAndLoadMCPTools", () =>
-								deferredMCPManager.discoverAndConnect(mcpDiscoverOptions),
-							);
-							// The session can be torn down while servers are still connecting.
-							// Don't resurrect tools on a disposed session, and don't leak the
-							// transports/subprocesses the connect just spawned.
-							if (liveSession.isDisposed) {
-								await deferredMCPManager.disconnectAll();
-								return;
+				// Opt-in (`mcp.awaitStartupMs` > 0): give servers a bounded window to
+				// connect BEFORE the session and its system prompt are assembled, so
+				// their tools mount into the initial xd:// inventory instead of
+				// arriving via a hidden mount notice that then rides every request
+				// until compaction. Slow/uncached stragglers still register later
+				// through the manager's #onToolsChanged -> refreshMCPTools path.
+				const awaitStartupMs = Math.min(Math.max(0, settings.get("mcp.awaitStartupMs") ?? 0), 30_000);
+				if (awaitStartupMs > 0) {
+					let mcpResult: MCPLoadResult | undefined;
+					let discoveryError: unknown;
+					try {
+						mcpResult = await logger.time("discoverAndLoadMCPTools", () =>
+							deferredMCPManager.discoverAndConnect({ ...mcpDiscoverOptions, startupTimeoutMs: awaitStartupMs }),
+						);
+					} catch (error) {
+						discoveryError = error;
+					}
+					if (mcpResult) {
+						applyMCPEnvironment(mcpResult);
+						logMCPLoadErrors(mcpResult.errors);
+						customTools.push(...mcpResult.tools);
+					} else {
+						// Discovery hard-failed (config load); mirror the deferred
+						// path's behavior: log and continue with no MCP tools rather
+						// than failing session startup.
+						logger.error("MCP tool load failed", {
+							path: ".mcp.json",
+							error: discoveryError instanceof Error ? discoveryError.message : String(discoveryError),
+						});
+					}
+				} else {
+					startDeferredMCPDiscovery = liveSession => {
+						void (async () => {
+							try {
+								const mcpResult = await logger.time("discoverAndLoadMCPTools", () =>
+									deferredMCPManager.discoverAndConnect(mcpDiscoverOptions),
+								);
+								// The session can be torn down while servers are still connecting.
+								// Don't resurrect tools on a disposed session, and don't leak the
+								// transports/subprocesses the connect just spawned.
+								if (liveSession.isDisposed) {
+									await deferredMCPManager.disconnectAll();
+									return;
+								}
+								applyMCPEnvironment(mcpResult);
+								logMCPLoadErrors(mcpResult.errors);
+								// Connected MCP tools are enabled and mounted under xd:// devices.
+								await liveSession.refreshMCPTools(mcpResult.tools);
+							} catch (error) {
+								logger.error("MCP tool load failed", {
+									path: ".mcp.json",
+									error: error instanceof Error ? error.message : String(error),
+								});
 							}
-							applyMCPEnvironment(mcpResult);
-							logMCPLoadErrors(mcpResult.errors);
-							// Connected MCP tools are enabled and mounted under xd:// devices.
-							await liveSession.refreshMCPTools(mcpResult.tools);
-						} catch (error) {
-							logger.error("MCP tool load failed", {
-								path: ".mcp.json",
-								error: error instanceof Error ? error.message : String(error),
-							});
-						}
-					})();
-				};
+						})();
+					};
+				}
 			} else {
 				const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
 					...mcpDiscoverOptions,
@@ -3419,6 +3451,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					}
 				})();
 			});
+			// Awaited-startup path (mcp.awaitStartupMs > 0): discovery already
+			// returned and its tools were registered at build time, but a server
+			// that was still pending at the startup gate may have completed in
+			// the window before this callback was installed — its tools updated
+			// the manager with no listener attached. Replay the manager's current
+			// view once so no server's tools are stranded for the session.
+			if (deferMCPDiscoveryForUI && !startDeferredMCPDiscovery && mcpManager.getTools().length > 0) {
+				await session.refreshMCPTools(mcpManager.getTools());
+			}
 			// Wire prompt refresh → rebuild MCP prompt slash commands
 			mcpManager.setOnPromptsChanged(serverName => {
 				const promptCommands = buildMCPPromptCommands(mcpManager);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3466,6 +3466,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// empty tool list so instruction-only servers are observed.
 			if (deferMCPDiscoveryForUI && !startDeferredMCPDiscovery) {
 				await session.refreshMCPTools(mcpManager.getTools());
+				session.setMCPPromptCommands(buildMCPPromptCommands(mcpManager));
 			}
 			const notificationDebounceTimers = new Map<string, Timer>();
 			const clearDebounceTimers = () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3451,21 +3451,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					}
 				})();
 			});
-			// Awaited-startup path (mcp.awaitStartupMs > 0): discovery already
-			// returned and its tools were registered at build time, but a server
-			// that was still pending at the startup gate may have completed in
-			// the window before this callback was installed — its tools updated
-			// the manager with no listener attached. Replay the manager's current
-			// view once so no server's tools are stranded for the session.
-			if (deferMCPDiscoveryForUI && !startDeferredMCPDiscovery && mcpManager.getTools().length > 0) {
-				await session.refreshMCPTools(mcpManager.getTools());
-			}
 			// Wire prompt refresh → rebuild MCP prompt slash commands
 			mcpManager.setOnPromptsChanged(serverName => {
 				const promptCommands = buildMCPPromptCommands(mcpManager);
 				session.setMCPPromptCommands(promptCommands);
 				logger.debug("MCP prompt commands refreshed", { path: `mcp:${serverName}` });
 			});
+			// Awaited-startup path (mcp.awaitStartupMs > 0): discovery already
+			// returned before the tools callback was installed. Replay even an
+			// empty tool list so instruction-only servers are observed.
+			if (deferMCPDiscoveryForUI && !startDeferredMCPDiscovery) {
+				await session.refreshMCPTools(mcpManager.getTools());
+			}
 			const notificationDebounceTimers = new Map<string, Timer>();
 			const clearDebounceTimers = () => {
 				for (const timer of notificationDebounceTimers.values()) clearTimeout(timer);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3510,8 +3510,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		unsubscribeCredentialDisabled?.();
 		try {
 			if (hasSession) {
-				await session.dispose();
-				if (hasRegistered) unregisterUnlessParked();
+				try {
+					await session.dispose();
+				} finally {
+					if (hasRegistered) unregisterUnlessParked();
+					if (ownedMCPManager && MCPManager.instance() === ownedMCPManager) {
+						MCPManager.setInstance(previousMCPManager);
+					}
+				}
 			} else {
 				if (hasRegistered) unregisterUnlessParked();
 				if (ownedMCPManager) {

--- a/packages/coding-agent/test/fixtures/hang-during-init-mcp.ts
+++ b/packages/coding-agent/test/fixtures/hang-during-init-mcp.ts
@@ -11,6 +11,9 @@
  */
 import * as readline from "node:readline";
 
+const pidFile = process.argv[2];
+if (pidFile) await Bun.write(pidFile, String(process.pid));
+
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", () => {
 	// Intentionally drop every message — server never responds.

--- a/packages/coding-agent/test/fixtures/instructions-mcp.ts
+++ b/packages/coding-agent/test/fixtures/instructions-mcp.ts
@@ -26,8 +26,9 @@ import * as readline from "node:readline";
 export const SERVER_INSTRUCTIONS =
 	"INSTR_FIXTURE_SENTINEL_3f9a2c: when this server is connected, always greet in Latin.";
 
-/** Single tool advertised by the fixture so `tools/list` is non-empty. */
+/** Tool and prompt advertised by the fixture. */
 export const TOOL_NAME = "do_thing";
+export const PROMPT_NAME = "greet";
 export const TOOL_RESULT = "MCP_DEFERRED_SMOKE_OK_5c92";
 
 type JsonRpcRequest = {
@@ -43,9 +44,7 @@ function buildResult(method: string): Record<string, unknown> {
 			return {
 				protocolVersion: "2025-03-26",
 				serverInfo: { name: "instr-fixture", version: "1.0.0" },
-				// Declare only the tools capability so the client never probes
-				// resources/list or prompts/list — keeps the fixture minimal.
-				capabilities: { tools: {} },
+				capabilities: { tools: {}, prompts: {} },
 				instructions: SERVER_INSTRUCTIONS,
 			};
 		case "tools/list":
@@ -57,6 +56,15 @@ function buildResult(method: string): Record<string, unknown> {
 						inputSchema: { type: "object", properties: {}, additionalProperties: false },
 					},
 				],
+			};
+		case "prompts/list":
+			return {
+				prompts: [{ name: PROMPT_NAME, description: "Return the fixture greeting." }],
+			};
+		case "prompts/get":
+			return {
+				description: "Fixture greeting.",
+				messages: [{ role: "user", content: { type: "text", text: "Salve!" } }],
 			};
 		case "tools/call":
 			return { content: [{ type: "text", text: TOOL_RESULT }], isError: false };

--- a/packages/coding-agent/test/mcp-manager-subscription-action.test.ts
+++ b/packages/coding-agent/test/mcp-manager-subscription-action.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { resolveSubscriptionPostAction } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import {
+	PENDING_RESOURCE_UPDATE_CAP,
+	queuePendingResourceUpdate,
+	resolveSubscriptionPostAction,
+	takePendingResourceUpdates,
+} from "@oh-my-pi/pi-coding-agent/mcp/manager";
 
 describe("resolveSubscriptionPostAction", () => {
 	it("returns rollback when notifications are disabled", () => {
@@ -13,5 +18,33 @@ describe("resolveSubscriptionPostAction", () => {
 
 	it("returns apply when notifications are enabled and epoch matches", () => {
 		expect(resolveSubscriptionPostAction(true, 3, 3)).toBe("apply");
+	});
+});
+
+describe("pending resource-update buffer (awaited-startup gap)", () => {
+	it("dedupes by server+uri and drains in insertion order", () => {
+		const pending = new Map<string, { serverName: string; uri: string }>();
+		queuePendingResourceUpdate(pending, "a", "uri://1");
+		queuePendingResourceUpdate(pending, "b", "uri://2");
+		queuePendingResourceUpdate(pending, "a", "uri://1"); // dedupe
+		expect(takePendingResourceUpdates(pending)).toEqual([
+			{ serverName: "a", uri: "uri://1" },
+			{ serverName: "b", uri: "uri://2" },
+		]);
+		expect(pending.size).toBe(0);
+		expect(takePendingResourceUpdates(pending)).toEqual([]);
+	});
+
+	it("stops accepting new keys once the cap is reached", () => {
+		const pending = new Map<string, { serverName: string; uri: string }>();
+		const cap = 3;
+		for (let i = 0; i < cap + 5; i++) {
+			queuePendingResourceUpdate(pending, "s", `uri://${i}`, cap);
+		}
+		expect(pending.size).toBe(cap);
+		// Existing keys can still be refreshed under the cap.
+		queuePendingResourceUpdate(pending, "s", "uri://0", cap);
+		expect(pending.size).toBe(cap);
+		expect(PENDING_RESOURCE_UPDATE_CAP).toBeGreaterThan(0);
 	});
 });

--- a/packages/coding-agent/test/mcp-startup-no-block.test.ts
+++ b/packages/coding-agent/test/mcp-startup-no-block.test.ts
@@ -16,17 +16,25 @@
  * left in flight; its tools surface via the background `#onToolsChanged`
  * path if/when it eventually connects.
  */
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
-import * as mcpClient from "../src/mcp/client";
 import { MCPManager } from "../src/mcp/manager";
-import type { MCPServerConnection, MCPStdioServerConfig } from "../src/mcp/types";
+import type { MCPStdioServerConfig } from "../src/mcp/types";
 
 const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "hang-during-init-mcp.ts");
 const BUN_EXEC = process.execPath;
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
 
 describe("MCP startup (issue #2100)", () => {
 	let workDir: string;
@@ -76,36 +84,34 @@ describe("MCP startup (issue #2100)", () => {
 		}
 	}, 15_000);
 
-	it("aborts a pending connection when the manager disconnects", async () => {
+	it("terminates a pending server process when the manager disconnects", async () => {
 		const manager = new MCPManager(workDir);
-		const pending = Promise.withResolvers<MCPServerConnection>();
-		let signal: AbortSignal | undefined;
-		const connect = spyOn(mcpClient, "connectToServer").mockImplementation((_name, _config, options) => {
-			signal = options?.signal;
-			signal?.addEventListener(
-				"abort",
-				() => pending.reject(new DOMException("Connection cancelled", "AbortError")),
-				{ once: true },
-			);
-			return pending.promise;
-		});
+		const pidPath = path.join(workDir, "server.pid");
+		const pidFile = Bun.file(pidPath);
+		let serverPid: number | undefined;
 		const config: MCPStdioServerConfig = {
 			type: "stdio",
 			command: BUN_EXEC,
-			args: [FIXTURE_PATH],
+			args: [FIXTURE_PATH, pidPath],
 		};
 
 		try {
-			const result = await manager.connectServers({ pending: config }, {}, undefined, 0);
+			const result = await manager.connectServers({ pending: config }, {}, undefined, 50);
 			expect(result.tools).toEqual([]);
-			expect(signal?.aborted).toBe(false);
+
+			const startedDeadline = Date.now() + 5_000;
+			while (!(await pidFile.exists()) && Date.now() < startedDeadline) await Bun.sleep(10);
+			expect(await pidFile.exists()).toBe(true);
+			serverPid = Number(await pidFile.text());
+			expect(isProcessAlive(serverPid)).toBe(true);
 
 			await manager.disconnectAll();
-			expect(signal?.aborted).toBe(true);
+			const stoppedDeadline = Date.now() + 5_000;
+			while (isProcessAlive(serverPid) && Date.now() < stoppedDeadline) await Bun.sleep(10);
+			expect(isProcessAlive(serverPid)).toBe(false);
 		} finally {
-			pending.reject(new DOMException("Test cleanup", "AbortError"));
-			connect.mockRestore();
 			await manager.disconnectAll();
+			if (serverPid !== undefined && isProcessAlive(serverPid)) process.kill(serverPid, "SIGKILL");
 		}
-	});
+	}, 15_000);
 });

--- a/packages/coding-agent/test/mcp-startup-no-block.test.ts
+++ b/packages/coding-agent/test/mcp-startup-no-block.test.ts
@@ -16,13 +16,14 @@
  * left in flight; its tools surface via the background `#onToolsChanged`
  * path if/when it eventually connects.
  */
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import * as mcpClient from "../src/mcp/client";
 import { MCPManager } from "../src/mcp/manager";
-import type { MCPStdioServerConfig } from "../src/mcp/types";
+import type { MCPServerConnection, MCPStdioServerConfig } from "../src/mcp/types";
 
 const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "hang-during-init-mcp.ts");
 const BUN_EXEC = process.execPath;
@@ -74,4 +75,37 @@ describe("MCP startup (issue #2100)", () => {
 			await manager.disconnectAll();
 		}
 	}, 15_000);
+
+	it("aborts a pending connection when the manager disconnects", async () => {
+		const manager = new MCPManager(workDir);
+		const pending = Promise.withResolvers<MCPServerConnection>();
+		let signal: AbortSignal | undefined;
+		const connect = spyOn(mcpClient, "connectToServer").mockImplementation((_name, _config, options) => {
+			signal = options?.signal;
+			signal?.addEventListener(
+				"abort",
+				() => pending.reject(new DOMException("Connection cancelled", "AbortError")),
+				{ once: true },
+			);
+			return pending.promise;
+		});
+		const config: MCPStdioServerConfig = {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [FIXTURE_PATH],
+		};
+
+		try {
+			const result = await manager.connectServers({ pending: config }, {}, undefined, 0);
+			expect(result.tools).toEqual([]);
+			expect(signal?.aborted).toBe(false);
+
+			await manager.disconnectAll();
+			expect(signal?.aborted).toBe(true);
+		} finally {
+			pending.reject(new DOMException("Test cleanup", "AbortError"));
+			connect.mockRestore();
+			await manager.disconnectAll();
+		}
+	});
 });

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -95,6 +95,13 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 			settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			disableExtensionDiscovery: true,
+			extensions: [
+				async () => {
+					// Let prompts/list finish before session callbacks are installed,
+					// forcing the awaited replay to seed commands from manager state.
+					await Bun.sleep(100);
+				},
+			],
 			skills: [],
 			contextFiles: [],
 			promptTemplates: [],

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -9,7 +9,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
-import { SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
+import { PROMPT_NAME, SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
 
 // Contract: with `mcp.awaitStartupMs` > 0, an interactive (`hasUI`) session
 // waits (bounded) for MCP discovery BEFORE assembling its tool registry and
@@ -110,6 +110,7 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 			expect(prompt).toContain(SERVER_INSTRUCTIONS);
 			expect(prompt).toContain("MCP Server Instructions");
 			expect(session.getEnabledToolNames()).toContain(MCP_TOOL_NAME);
+			expect(session.mcpPromptCommands.map(command => command.command.name)).toContain(`instr:${PROMPT_NAME}`);
 			// Mounted under xd:// (xdev default) and catalogued in the prompt.
 			expect(prompt).toContain(`xd://${MCP_TOOL_NAME}`);
 			// Note: full ambient isolation is not achievable here — the native

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
+
+// Contract: with `mcp.awaitStartupMs` > 0, an interactive (`hasUI`) session
+// waits (bounded) for MCP discovery BEFORE assembling its tool registry and
+// system prompt. Connected/cached tools mount into the INITIAL xd://
+// inventory, so they appear in the prompt immediately and no xd:// mount
+// notice is ever queued for them (an initial mount produces no delta).
+// The default (0) keeps deferred background discovery; that path's
+// first-paint behavior is covered by sdk-mcp-instructions.test.ts.
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "instructions-mcp.ts");
+const MCP_TOOL_NAME = `mcp__instr_${TOOL_NAME}`;
+
+describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
+	let registryDir: string;
+	let tempDir: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	// Discovery resolves user-level MCP config from `os.homedir()`; redirect it
+	// to an empty dir so the test connects ONLY to the fixture server and never
+	// spawns the developer's real MCP servers.
+	let isolatedHome: string;
+	let savedHomeEnv: string | undefined;
+	let savedXdgEnv: string | undefined;
+
+	beforeAll(async () => {
+		registryDir = path.join(os.tmpdir(), `pi-sdk-mcp-await-registry-${Snowflake.next()}`);
+		fs.mkdirSync(registryDir, { recursive: true });
+		isolatedHome = path.join(os.tmpdir(), `pi-sdk-mcp-await-home-${Snowflake.next()}`);
+		fs.mkdirSync(isolatedHome, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(registryDir, "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		for (const dir of [registryDir, isolatedHome]) {
+			if (dir && fs.existsSync(dir)) {
+				removeSyncWithRetries(dir);
+			}
+		}
+	});
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-sdk-mcp-await-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		spyOn(os, "homedir").mockReturnValue(isolatedHome);
+		// The os.homedir() mock alone does not isolate discovery: parts of the
+		// config stack resolve the user dir through env vars, which let the
+		// developer's real MCP servers leak into these tests. Scoped per test
+		// (not beforeAll) so sibling test files never see the redirect.
+		savedHomeEnv = process.env.HOME;
+		savedXdgEnv = process.env.XDG_CONFIG_HOME;
+		process.env.HOME = isolatedHome;
+		process.env.XDG_CONFIG_HOME = isolatedHome;
+		fs.writeFileSync(
+			path.join(tempDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					instr: { type: "stdio", command: process.execPath, args: [FIXTURE_PATH] },
+				},
+			}),
+		);
+	});
+
+	afterEach(() => {
+		if (savedHomeEnv === undefined) delete process.env.HOME;
+		else process.env.HOME = savedHomeEnv;
+		if (savedXdgEnv === undefined) delete process.env.XDG_CONFIG_HOME;
+		else process.env.XDG_CONFIG_HOME = savedXdgEnv;
+		if (tempDir && fs.existsSync(tempDir)) {
+			removeSyncWithRetries(tempDir);
+		}
+		mock.restore();
+	});
+
+	it("mounts MCP tools into the initial prompt when startup await is enabled", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+		});
+		try {
+			// No polling: discovery must have completed before createAgentSession
+			// returned, so the server's instructions and tool menu line are
+			// already in the very first prompt build.
+			const prompt = session.systemPrompt.join("\n");
+			expect(prompt).toContain(SERVER_INSTRUCTIONS);
+			expect(prompt).toContain("MCP Server Instructions");
+			expect(session.getEnabledToolNames()).toContain(MCP_TOOL_NAME);
+			// Mounted under xd:// (xdev default) and catalogued in the prompt.
+			expect(prompt).toContain(`xd://${MCP_TOOL_NAME}`);
+			// Note: full ambient isolation is not achievable here — the native
+			// user-level MCP dir resolves via getAgentDir(), which is frozen at
+			// module import (PI_CODING_AGENT_DIR), before test mocks install.
+			// Assertions therefore target only the fixture server.
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
+
+	it("keeps MCP tools out of the first prompt when startup await is disabled", async () => {
+		// Negative control: identical setup with the default (0) must NOT have
+		// the server at first paint — otherwise the positive test above could be
+		// passing because the fixture merely beat the prompt build on its own.
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.awaitStartupMs": 0 }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+		});
+		try {
+			const prompt = session.systemPrompt.join("\n");
+			expect(prompt).not.toContain(SERVER_INSTRUCTIONS);
+			expect(session.getEnabledToolNames()).not.toContain(MCP_TOOL_NAME);
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
+
+	it("starts cleanly when a configured server fails to connect", async () => {
+		// The robustness contract of the awaited path: a dead server is a
+		// per-server error, never a session-startup failure. (The fixture config
+		// from beforeEach is replaced with one pointing at a missing binary.)
+		fs.writeFileSync(
+			path.join(tempDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					badserver: { type: "stdio", command: "/nonexistent/omp-test-mcp-server-xyz" },
+				},
+			}),
+		);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+		});
+		try {
+			const badTools = session.getEnabledToolNames().filter(name => name.startsWith("mcp__badserver_"));
+			expect(badTools).toEqual([]);
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
+});

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -8,6 +8,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { PROMPT_NAME, SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
@@ -221,6 +222,40 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 			expect(MCPManager.instance()).toBe(previousManager);
 		} finally {
 			MCPManager.setInstance(previousManager);
+		}
+	}, 20_000);
+
+	it("restores the prior MCP manager when awaited replay fails", async () => {
+		const originalManager = MCPManager.instance();
+		const previousManager = new MCPManager(tempDir);
+		MCPManager.setInstance(previousManager);
+		const refresh = spyOn(AgentSession.prototype, "refreshMCPTools").mockRejectedValue(
+			new Error("simulated awaited replay failure"),
+		);
+		try {
+			await expect(
+				createAgentSession({
+					cwd: tempDir,
+					agentDir: tempDir,
+					modelRegistry,
+					sessionManager: SessionManager.inMemory(),
+					settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
+					model: getBundledModel("openai", "gpt-4o-mini"),
+					disableExtensionDiscovery: true,
+					skills: [],
+					contextFiles: [],
+					promptTemplates: [],
+					slashCommands: [],
+					enableLsp: false,
+					skipPythonPreflight: true,
+					enableMCP: true,
+					hasUI: true,
+				}),
+			).rejects.toThrow("simulated awaited replay failure");
+			expect(MCPManager.instance()).toBe(previousManager);
+		} finally {
+			refresh.mockRestore();
+			MCPManager.setInstance(originalManager);
 		}
 	}, 20_000);
 });

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -34,6 +34,10 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 	let isolatedHome: string;
 	let savedHomeEnv: string | undefined;
 	let savedXdgEnv: string | undefined;
+	// createAgentSession installs an owned manager as the process-global
+	// singleton; dispose disconnects it but does not restore the prior
+	// instance. Capture/restore so later files in the suite stay clean.
+	let previousMCPManager: MCPManager | undefined;
 
 	beforeAll(async () => {
 		registryDir = path.join(os.tmpdir(), `pi-sdk-mcp-await-registry-${Snowflake.next()}`);
@@ -54,6 +58,7 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 	});
 
 	beforeEach(() => {
+		previousMCPManager = MCPManager.instance();
 		tempDir = path.join(os.tmpdir(), `pi-sdk-mcp-await-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		spyOn(os, "homedir").mockReturnValue(isolatedHome);
@@ -83,6 +88,7 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 		if (tempDir && fs.existsSync(tempDir)) {
 			removeSyncWithRetries(tempDir);
 		}
+		MCPManager.setInstance(previousMCPManager);
 		mock.restore();
 	});
 

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -6,7 +6,8 @@ import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { PROMPT_NAME, SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
@@ -186,6 +187,40 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 			expect(badTools).toEqual([]);
 		} finally {
 			await session.dispose();
+		}
+	}, 20_000);
+
+	it("disconnects awaited servers when later session setup fails", async () => {
+		const previousManager = MCPManager.instance();
+		const disconnect = spyOn(MCPManager.prototype, "disconnectAll");
+		const throwingExtension: ExtensionFactory = () => {
+			throw new Error("simulated post-MCP startup failure");
+		};
+		try {
+			await expect(
+				createAgentSession({
+					cwd: tempDir,
+					agentDir: tempDir,
+					modelRegistry,
+					sessionManager: SessionManager.inMemory(),
+					settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
+					model: getBundledModel("openai", "gpt-4o-mini"),
+					disableExtensionDiscovery: true,
+					extensions: [throwingExtension],
+					skills: [],
+					contextFiles: [],
+					promptTemplates: [],
+					slashCommands: [],
+					enableLsp: false,
+					skipPythonPreflight: true,
+					enableMCP: true,
+					hasUI: true,
+				}),
+			).rejects.toThrow("simulated post-MCP startup failure");
+			expect(disconnect).toHaveBeenCalled();
+			expect(MCPManager.instance()).toBe(previousManager);
+		} finally {
+			MCPManager.setInstance(previousManager);
 		}
 	}, 20_000);
 });

--- a/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-await-startup.test.ts
@@ -210,65 +210,53 @@ describe("createAgentSession with mcp.awaitStartupMs (interactive UI)", () => {
 		const throwingExtension: ExtensionFactory = () => {
 			throw new Error("simulated post-MCP startup failure");
 		};
-		try {
-			await expect(
-				createAgentSession({
-					cwd: tempDir,
-					agentDir: tempDir,
-					modelRegistry,
-					sessionManager: SessionManager.inMemory(),
-					settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
-					model: getBundledModel("openai", "gpt-4o-mini"),
-					disableExtensionDiscovery: true,
-					extensions: [throwingExtension],
-					skills: [],
-					contextFiles: [],
-					promptTemplates: [],
-					slashCommands: [],
-					enableLsp: false,
-					skipPythonPreflight: true,
-					enableMCP: true,
-					hasUI: true,
-				}),
-			).rejects.toThrow("simulated post-MCP startup failure");
-			expect(disconnect).toHaveBeenCalled();
-			expect(MCPManager.instance()).toBe(previousManager);
-		} finally {
-			MCPManager.setInstance(previousManager);
-		}
+		await expect(
+			createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				extensions: [throwingExtension],
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				skipPythonPreflight: true,
+				enableMCP: true,
+				hasUI: true,
+			}),
+		).rejects.toThrow("simulated post-MCP startup failure");
+		expect(disconnect).toHaveBeenCalled();
+		expect(MCPManager.instance()).toBe(previousManager);
 	}, 20_000);
 
 	it("restores the prior MCP manager when awaited replay fails", async () => {
-		const originalManager = MCPManager.instance();
 		const previousManager = new MCPManager(tempDir);
 		MCPManager.setInstance(previousManager);
-		const refresh = spyOn(AgentSession.prototype, "refreshMCPTools").mockRejectedValue(
-			new Error("simulated awaited replay failure"),
-		);
-		try {
-			await expect(
-				createAgentSession({
-					cwd: tempDir,
-					agentDir: tempDir,
-					modelRegistry,
-					sessionManager: SessionManager.inMemory(),
-					settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
-					model: getBundledModel("openai", "gpt-4o-mini"),
-					disableExtensionDiscovery: true,
-					skills: [],
-					contextFiles: [],
-					promptTemplates: [],
-					slashCommands: [],
-					enableLsp: false,
-					skipPythonPreflight: true,
-					enableMCP: true,
-					hasUI: true,
-				}),
-			).rejects.toThrow("simulated awaited replay failure");
-			expect(MCPManager.instance()).toBe(previousManager);
-		} finally {
-			refresh.mockRestore();
-			MCPManager.setInstance(originalManager);
-		}
+		spyOn(AgentSession.prototype, "refreshMCPTools").mockRejectedValue(new Error("simulated awaited replay failure"));
+		await expect(
+			createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.awaitStartupMs": 5000 }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				skipPythonPreflight: true,
+				enableMCP: true,
+				hasUI: true,
+			}),
+		).rejects.toThrow("simulated awaited replay failure");
+		expect(MCPManager.instance()).toBe(previousManager);
 	}, 20_000);
 });


### PR DESCRIPTION
## What

New opt-in setting `mcp.awaitStartupMs` (default `0` = unchanged behavior). When > 0, interactive (`hasUI`) sessions await MCP discovery with that bounded budget **before** assembling the tool registry and system prompt, so connected/cached servers mount into the initial `xd://` inventory instead of arriving via the hidden mount notice.

## Why

Today interactive sessions always discover MCP in the background after the session (and system prompt) is built. Late tools are announced through a hidden `xdev-mount-notice` conversation message (~45 tokens/tool) that rides every request until compaction — duplicating the catalog lines those tools get once the header is rebuilt. With several MCP servers this is a recurring multi-K-token tax on every turn of every session.

With this setting on, tools that connect within the budget land in the header menu from the start: one copy, no notice, no duplication. Slow/uncached stragglers still register later through the existing `#onToolsChanged` → `refreshMCPTools` path, exactly as before.

## How

- `sdk.ts`: in the deferred-UI branch, when `mcp.awaitStartupMs > 0`, await `discoverAndConnect` (clamped to ≤30s) and push resulting tools into `customTools` pre-session (mirroring the headless path); on hard discovery failure, log and continue without MCP (same contract as the deferred path).
- `mcp/manager.ts`: the startup gate inside `connectServers` was a fixed 250ms constant (`STARTUP_TIMEOUT_MS`); it's now a parameter (`startupTimeoutMs`) threaded from the setting, so budgets > 250ms are honored. `MCPDiscoverOptions` gains the optional field.
- `settings-schema.ts`: `mcp.awaitStartupMs` (number, default 0) in the /settings UI.

## Verification

- New `test/sdk-mcp-await-startup.test.ts` (3 tests): setting on → fixture server's tools + instructions present in the very first prompt with no waiting (negative control: setting off → absent at first paint); dead server → session starts fine, no tools. All pass, plus 52 adjacent MCP/xd tests.
- `bun run check` (biome + tsgo) clean.
- Live before/after in a real TUI against a production MCP gateway (21 tools): with the setting off, first prompt carries the mount notice (Messages 2.3K); with it on (5000ms), no notice exists (Messages 2.0K) and the tools' catalog lines are in the initial header (System prompt 8.4K → 8.7K).

I reviewed the full diff; this change lets interactive sessions opt into the headless startup ordering so MCP tools mount before the first prompt build.