### PR TITLE
feat(tools): make xd:// external description cap configurable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added `tools.xdevExternalDescriptionCap` (default `200`): makes the previously hardcoded 200-character truncation of external (MCP/custom/extension) `xd://` device descriptions in the system prompt and catalog listings configurable. Schemas are never truncated and `read xd://<tool>` still returns the full description.
 
 ### Fixed
 
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
-- Added `tools.xdevExternalDescriptionCap` (default `200`): makes the previously hardcoded 200-character truncation of external (MCP/custom/extension) `xd://` device descriptions in the system prompt and catalog listings configurable. Schemas are never truncated and `read xd://<tool>` still returns the full description.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
+- Added `tools.xdevExternalDescriptionCap` (default `200`): makes the previously hardcoded 200-character truncation of external (MCP/custom/extension) `xd://` device descriptions in the system prompt and catalog listings configurable. Schemas are never truncated and `read xd://<tool>` still returns the full description.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4190,6 +4190,26 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tools.xdevExternalDescriptionCap": {
+		type: "number",
+		default: 200,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "xd:// Description Cap",
+			description:
+				"Maximum description characters embedded per external (MCP/custom/extension) xd:// device in the system prompt and catalog listings. Schemas are never truncated; the full description stays one `read xd://<tool>` away. Applies to new sessions.",
+			options: [
+				{ value: "100", label: "100 chars (tight)" },
+				{ value: "200", label: "200 chars (default)" },
+				{ value: "500", label: "500 chars" },
+				{ value: "1000", label: "1000 chars" },
+				{ value: "2000", label: "2000 chars" },
+				{ value: "4000", label: "4000 chars (full lede)" },
+			],
+		},
+	},
+
 	// MCP
 	"mcp.enableProjectConfig": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4198,7 +4198,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Discovery & MCP",
 			label: "xd:// Description Cap",
 			description:
-				"Maximum description characters embedded per external (MCP/custom/extension) xd:// device in the system prompt and catalog listings. Schemas are never truncated; the full description stays one `read xd://<tool>` away. Applies to new sessions.",
+				"Maximum description characters embedded per external (MCP/custom/extension) xd:// device in the system prompt and catalog listings. Schemas are never truncated; the full description stays one `read xd://<tool>` away.",
 			options: [
 				{ value: "100", label: "100 chars (tight)" },
 				{ value: "200", label: "200 chars (default)" },

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -445,6 +445,11 @@ export class SelectorController {
 					this.ctx.showError(`Failed to apply xd:// prompt docs setting: ${err}`);
 				});
 				break;
+			case "tools.xdevExternalDescriptionCap":
+				void this.ctx.session.applyXdevExternalDescriptionCap(Number(value)).catch(err => {
+					this.ctx.showError(`Failed to apply xd:// description cap: ${err}`);
+				});
+				break;
 			case "memory.backend":
 				void this.ctx.session.applyMemoryBackend().catch(err => {
 					this.ctx.showError(`Failed to apply memory backend: ${err}`);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -446,6 +446,8 @@ export class SelectorController {
 				});
 				break;
 			case "tools.xdevExternalDescriptionCap":
+				// Fire-and-forget is intentional for settings UI snappiness; the
+				// session serializes concurrent applies so the latest value wins.
 				void this.ctx.session.applyXdevExternalDescriptionCap(Number(value)).catch(err => {
 					this.ctx.showError(`Failed to apply xd:// description cap: ${err}`);
 				});

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1264,6 +1264,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			// project's configuration. Without this, the previous project's
 			// exclusions leak and newly-excluded providers are still used.
 			applyProviderGlobalsFromSettings(settings);
+			// Project configs may set a different xd:// external description cap;
+			// reapply so the live registry matches destination settings (selector
+			// handleSettingChange does not run on /move).
+			await this.session.applyXdevExternalDescriptionCap(settings.get("tools.xdevExternalDescriptionCap") ?? 200);
 		}
 		// Re-warm plugin roots, capabilities, slash commands, and the ssh tool so
 		// the next prompt sees everything scoped to the new project directory.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1264,13 +1264,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			// project's configuration. Without this, the previous project's
 			// exclusions leak and newly-excluded providers are still used.
 			applyProviderGlobalsFromSettings(settings);
-			// Project configs may set a different xd:// external description cap;
-			// reapply so the live registry matches destination settings (selector
-			// handleSettingChange does not run on /move).
-			await this.session.applyXdevExternalDescriptionCap(settings.get("tools.xdevExternalDescriptionCap") ?? 200);
 		}
 		// Re-warm plugin roots, capabilities, slash commands, and the ssh tool so
 		// the next prompt sees everything scoped to the new project directory.
+		// The skill refresh rebuilds the base prompt, which also re-syncs the
+		// xd:// description cap from the destination project's settings.
 		clearClaudePluginRootsCache();
 		await this.refreshTitleSystemPrompt(newCwd);
 		resetCapabilities();

--- a/packages/coding-agent/src/prompts/system/xdev-mount-notice.md
+++ b/packages/coding-agent/src/prompts/system/xdev-mount-notice.md
@@ -5,6 +5,9 @@ These tools became available:
 {{#each added}}
 - xd://{{this.name}} — {{this.summary}}
 {{/each}}
+{{#if omitted_line}}
+{{omitted_line}}
+{{/if}}
 Read `xd://<tool>` for docs + JSON schema before first use; write the JSON args object to `xd://<tool>` to execute.
 {{/if}}
 {{#if removed.length}}

--- a/packages/coding-agent/src/prompts/system/xdev-mount-notice.md
+++ b/packages/coding-agent/src/prompts/system/xdev-mount-notice.md
@@ -3,7 +3,7 @@ The xd:// device inventory changed.
 {{#if added.length}}
 These tools became available:
 {{#each added}}
-- xd://{{this.name}} — {{this.summary}}
+- xd://{{this.name}}{{#if this.summary}} — {{this.summary}}{{/if}}
 {{/each}}
 {{#if omitted_line}}
 {{omitted_line}}

--- a/packages/coding-agent/src/prompts/tools/xdev-omitted-catalog.md
+++ b/packages/coding-agent/src/prompts/tools/xdev-omitted-catalog.md
@@ -1,0 +1,1 @@
+- {{count}} more devices omitted — read {{inventory_url}} for the complete inventory.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4002,6 +4002,12 @@ export class AgentSession {
 		return this.#memory.applyMemoryBackend();
 	}
 
+	/** Applies a new external xd:// description cap and rebuilds the active prompt. */
+	async applyXdevExternalDescriptionCap(cap: number): Promise<void> {
+		this.#tools.setXdevExternalDescriptionCap(cap);
+		await this.#tools.refreshBaseSystemPrompt();
+	}
+
 	/** Rebuilds the stable base prompt for the current tools and model. */
 	refreshBaseSystemPrompt(): Promise<void> {
 		return this.#tools.refreshBaseSystemPrompt();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4004,8 +4004,7 @@ export class AgentSession {
 
 	/** Applies a new external xd:// description cap and rebuilds the active prompt. */
 	async applyXdevExternalDescriptionCap(cap: number): Promise<void> {
-		this.#tools.setXdevExternalDescriptionCap(cap);
-		await this.#tools.refreshBaseSystemPrompt();
+		return this.#tools.applyXdevExternalDescriptionCap(cap);
 	}
 
 	/** Rebuilds the stable base prompt for the current tools and model. */

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -576,8 +576,11 @@ export class SessionTools {
 		const pending = this.#pendingXdevMountDelta;
 		if (!pending) return undefined;
 		this.#pendingXdevMountDelta = undefined;
-		const summaries = new Map(this.#xdevRegistry?.entries().map(entry => [entry.name, entry.summary]) ?? []);
-		const added = [...pending.added].map(name => ({ name, summary: summaries.get(name) ?? "" }));
+		// Aggregate-budget the inventory rows: a high external description cap
+		// must not turn a large deferred mount batch into a multi-100k notice.
+		const added = this.#xdevRegistry
+			? this.#xdevRegistry.mountNoticeEntries(pending.added)
+			: [...pending.added].map(name => ({ name, summary: "" }));
 		const removed = [...pending.removed].map(name => ({ name }));
 		const docs = this.#xdevRegistry?.docsFor(
 			pending.added,

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -95,6 +95,15 @@ export class SessionTools {
 	/** Serializes {@link applyXdevExternalDescriptionCap}; generation discards stale rebuilds. */
 	#xdevCapApplyChain: Promise<void> = Promise.resolve();
 	#xdevCapApplyGen = 0;
+	/**
+	 * Serializes base-prompt rebuild→apply across every refresh path
+	 * ({@link refreshBaseSystemPrompt}, {@link applyActiveToolsByName}). A rebuild
+	 * that started before a concurrent change (cap apply, MCP/tool refresh) can
+	 * snapshot pre-change state; without mutual exclusion it could finish last and
+	 * overwrite the prompt with stale content. Rebuilding inside the chain makes
+	 * the last scheduled rebuild read the latest registry state and apply last.
+	 */
+	#promptApplyChain: Promise<void> = Promise.resolve();
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
@@ -173,6 +182,33 @@ export class SessionTools {
 			() => undefined,
 		);
 		await run;
+	}
+
+	/**
+	 * Converges the live xd:// registry cap to the effective setting. The setting
+	 * is the source of truth; project-settings reloads (`/move` →
+	 * `Settings.reloadForCwd`) bypass the selector's setting-change handler, so
+	 * every prompt rebuild re-syncs instead of trusting the registry's
+	 * construction-time snapshot.
+	 */
+	#syncXdevExternalDescriptionCap(): void {
+		this.#xdevRegistry?.setExternalDescriptionCap(
+			this.#host.settings.get("tools.xdevExternalDescriptionCap") ?? XdevRegistry.EXTERNAL_DESCRIPTION_CAP,
+		);
+	}
+
+	/**
+	 * Runs `run` after every previously scheduled prompt application settles, so
+	 * rebuild→apply sections across all refresh paths are mutually exclusive.
+	 */
+	#serializePromptApply<T>(run: () => Promise<T>): Promise<T> {
+		const result = this.#promptApplyChain.then(run);
+		// Keep the chain unbroken if a rebuild throws.
+		this.#promptApplyChain = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
 	}
 
 	/** Skills currently rendered into the system prompt. */
@@ -529,34 +565,40 @@ export class SessionTools {
 		this.#xdevRegistry?.reconcile(mountedTools);
 		this.#setActiveToolNames?.(validToolNames);
 
-		let rebuiltSystemPrompt: string[] | undefined;
-		let rebuiltSignature: string | undefined;
-		try {
-			if (this.#rebuildSystemPrompt) {
-				const signature = this.#computeAppliedToolSignature(validToolNames, tools);
-				if (signature !== this.#lastAppliedToolSignature) {
-					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
-					rebuiltSystemPrompt = built.systemPrompt;
-					rebuiltSignature = signature;
+		// Serialize rebuild→apply with every other prompt refresh (cap applies,
+		// skill reloads): a rebuild that snapshotted pre-change state must not
+		// finish after a concurrent refresh and overwrite its newer prompt.
+		await this.#serializePromptApply(async () => {
+			this.#syncXdevExternalDescriptionCap();
+			let rebuiltSystemPrompt: string[] | undefined;
+			let rebuiltSignature: string | undefined;
+			try {
+				if (this.#rebuildSystemPrompt) {
+					const signature = this.#computeAppliedToolSignature(validToolNames, tools);
+					if (signature !== this.#lastAppliedToolSignature) {
+						const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
+						rebuiltSystemPrompt = built.systemPrompt;
+						rebuiltSignature = signature;
+					}
 				}
+			} catch (error) {
+				this.#mountedXdevToolNames = previousMounted;
+				this.#xdevRegistry?.reconcile(previousMountedTools);
+				this.#setActiveToolNames?.(previousActiveToolNames);
+				throw error;
 			}
-		} catch (error) {
-			this.#mountedXdevToolNames = previousMounted;
-			this.#xdevRegistry?.reconcile(previousMountedTools);
-			this.#setActiveToolNames?.(previousActiveToolNames);
-			throw error;
-		}
 
-		this.#notifyXdevMountDelta(previousMounted);
-		this.#host.agent.setTools(tools);
-		if (rebuiltSystemPrompt && rebuiltSignature) {
-			if (this.#lastAppliedToolSignature !== undefined) this.#host.clearInheritedProviderPromptCacheKey();
-			this.#baseSystemPrompt = rebuiltSystemPrompt;
-			this.#host.clearMemoryPromotionSnapshot();
-			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
-			this.#lastAppliedToolSignature = rebuiltSignature;
-			this.#promptModelKey = this.#currentPromptModelKey();
-		}
+			this.#notifyXdevMountDelta(previousMounted);
+			this.#host.agent.setTools(tools);
+			if (rebuiltSystemPrompt && rebuiltSignature) {
+				if (this.#lastAppliedToolSignature !== undefined) this.#host.clearInheritedProviderPromptCacheKey();
+				this.#baseSystemPrompt = rebuiltSystemPrompt;
+				this.#host.clearMemoryPromotionSnapshot();
+				this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
+				this.#lastAppliedToolSignature = rebuiltSignature;
+				this.#promptModelKey = this.#currentPromptModelKey();
+			}
+		});
 	}
 
 	/**
@@ -781,28 +823,32 @@ export class SessionTools {
 	/** Rebuilds the stable base prompt for the current tools and model. */
 	async refreshBaseSystemPrompt(): Promise<void> {
 		if (this.#host.isDisposed() || !this.#rebuildSystemPrompt) return;
-		const activeToolNames = this.getActiveToolNames();
-		this.#setActiveToolNames?.(activeToolNames);
-		const previousBaseSystemPrompt = this.#baseSystemPrompt;
-		const built = await this.#rebuildSystemPrompt(activeToolNames, this.#toolRegistry);
-		if (this.#host.isDisposed()) return;
-		this.#baseSystemPrompt = built.systemPrompt;
-		this.#host.clearMemoryPromotionSnapshot();
-		if (
-			previousBaseSystemPrompt.length !== this.#baseSystemPrompt.length ||
-			previousBaseSystemPrompt.some((part, index) => part !== this.#baseSystemPrompt[index])
-		) {
-			this.#host.clearInheritedProviderPromptCacheKey();
-		}
-		this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
-		this.#promptModelKey = this.#currentPromptModelKey();
-		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
-		// the same tool set does not re-rebuild on top of the explicit refresh we
-		// just performed (and conversely, a different set forces a fresh rebuild).
-		const activeTools = activeToolNames
-			.map(name => this.#toolRegistry.get(name))
-			.filter((tool): tool is AgentTool => tool != null);
-		this.#lastAppliedToolSignature = this.#computeAppliedToolSignature(activeToolNames, activeTools);
+		await this.#serializePromptApply(async () => {
+			if (this.#host.isDisposed()) return;
+			this.#syncXdevExternalDescriptionCap();
+			const activeToolNames = this.getActiveToolNames();
+			this.#setActiveToolNames?.(activeToolNames);
+			const previousBaseSystemPrompt = this.#baseSystemPrompt;
+			const built = await this.#rebuildSystemPrompt!(activeToolNames, this.#toolRegistry);
+			if (this.#host.isDisposed()) return;
+			this.#baseSystemPrompt = built.systemPrompt;
+			this.#host.clearMemoryPromotionSnapshot();
+			if (
+				previousBaseSystemPrompt.length !== this.#baseSystemPrompt.length ||
+				previousBaseSystemPrompt.some((part, index) => part !== this.#baseSystemPrompt[index])
+			) {
+				this.#host.clearInheritedProviderPromptCacheKey();
+			}
+			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
+			this.#promptModelKey = this.#currentPromptModelKey();
+			// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
+			// the same tool set does not re-rebuild on top of the explicit refresh we
+			// just performed (and conversely, a different set forces a fresh rebuild).
+			const activeTools = activeToolNames
+				.map(name => this.#toolRegistry.get(name))
+				.filter((tool): tool is AgentTool => tool != null);
+			this.#lastAppliedToolSignature = this.#computeAppliedToolSignature(activeToolNames, activeTools);
+		});
 	}
 
 	/** Applies one-turn memory prompt injection before an agent run. */

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -92,6 +92,9 @@ export class SessionTools {
 	#xdevRegistry: XdevRegistry | undefined;
 	#mountedXdevToolNames: Set<string>;
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
+	/** Serializes {@link applyXdevExternalDescriptionCap}; generation discards stale rebuilds. */
+	#xdevCapApplyChain: Promise<void> = Promise.resolve();
+	#xdevCapApplyGen = 0;
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
@@ -149,6 +152,27 @@ export class SessionTools {
 	/** Updates the description cap used by the session-owned xd:// registry. */
 	setXdevExternalDescriptionCap(cap: number): void {
 		this.#xdevRegistry?.setExternalDescriptionCap(cap);
+	}
+
+	/**
+	 * Apply a new external description cap and rebuild the base prompt.
+	 * Concurrent calls are serialized and superseded so a slow rebuild from an
+	 * earlier selection cannot overwrite a later one (settings UI can fire
+	 * multiple changes before the first rebuild finishes).
+	 */
+	async applyXdevExternalDescriptionCap(cap: number): Promise<void> {
+		this.setXdevExternalDescriptionCap(cap);
+		const gen = ++this.#xdevCapApplyGen;
+		const run = this.#xdevCapApplyChain.then(async () => {
+			if (gen !== this.#xdevCapApplyGen) return;
+			await this.refreshBaseSystemPrompt();
+		});
+		// Keep the chain unbroken if a rebuild throws.
+		this.#xdevCapApplyChain = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		await run;
 	}
 
 	/** Skills currently rendered into the system prompt. */

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -146,6 +146,11 @@ export class SessionTools {
 		this.#baseSystemPrompt = prompt;
 	}
 
+	/** Updates the description cap used by the session-owned xd:// registry. */
+	setXdevExternalDescriptionCap(cap: number): void {
+		this.#xdevRegistry?.setExternalDescriptionCap(cap);
+	}
+
 	/** Skills currently rendered into the system prompt. */
 	get skills(): Skill[] {
 		return this.#skills;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -19,7 +19,7 @@ import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
-import { isMountableUnderXdev, type XdevRegistry } from "../tools/xdev";
+import { isMountableUnderXdev, XdevRegistry } from "../tools/xdev";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { formatLocalCalendarDate } from "../utils/local-date";
 import {
@@ -576,21 +576,34 @@ export class SessionTools {
 		const pending = this.#pendingXdevMountDelta;
 		if (!pending) return undefined;
 		this.#pendingXdevMountDelta = undefined;
-		// Aggregate-budget the inventory rows: a high external description cap
-		// must not turn a large deferred mount batch into a multi-100k notice.
-		const added = this.#xdevRegistry
-			? this.#xdevRegistry.mountNoticeEntries(pending.added)
-			: [...pending.added].map(name => ({ name, summary: "" }));
+		// One shared budget for inventory + inline docs so a high external
+		// description cap cannot produce ~2× DOCS_TOTAL_BUDGET notices.
+		const totalBudget = XdevRegistry.DOCS_TOTAL_BUDGET;
+		const inventory = this.#xdevRegistry
+			? this.#xdevRegistry.mountNoticeEntries(pending.added, totalBudget)
+			: {
+					entries: [...pending.added].map(name => ({ name, summary: "" })),
+					omitted: 0,
+					usedChars: 0,
+					omittedLine: "",
+				};
+		const docsBudget = Math.max(0, totalBudget - inventory.usedChars);
 		const removed = [...pending.removed].map(name => ({ name }));
 		const docs = this.#xdevRegistry?.docsFor(
 			pending.added,
 			this.#host.settings.get("tools.xdevDocs"),
 			this.#host.settings.get("tools.xdevInlineDevices"),
+			docsBudget,
 		);
 		return {
 			role: "custom",
 			customType: XDEV_MOUNT_NOTICE_MESSAGE_TYPE,
-			content: prompt.render(xdevMountNoticePrompt, { added, removed, docs }),
+			content: prompt.render(xdevMountNoticePrompt, {
+				added: inventory.entries,
+				removed,
+				docs,
+				omitted_line: inventory.omittedLine || undefined,
+			}),
 			attribution: "agent",
 			display: false,
 			timestamp: Date.now(),

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1880,6 +1880,11 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			setProjectDir(resolvedPath);
 			await runtime.settings.reloadForCwd(resolvedPath);
 			applyProviderGlobalsFromSettings(runtime.settings);
+			// Project configs may set a different xd:// external description cap;
+			// reapply so the live registry matches destination settings.
+			await runtime.session.applyXdevExternalDescriptionCap(
+				runtime.settings.get("tools.xdevExternalDescriptionCap") ?? 200,
+			);
 			// Reload plugin/capability caches so the next prompt sees commands and
 			// capabilities scoped to the new cwd.
 			await runtime.reloadPlugins();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1880,13 +1880,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			setProjectDir(resolvedPath);
 			await runtime.settings.reloadForCwd(resolvedPath);
 			applyProviderGlobalsFromSettings(runtime.settings);
-			// Project configs may set a different xd:// external description cap;
-			// reapply so the live registry matches destination settings.
-			await runtime.session.applyXdevExternalDescriptionCap(
-				runtime.settings.get("tools.xdevExternalDescriptionCap") ?? 200,
-			);
 			// Reload plugin/capability caches so the next prompt sees commands and
-			// capabilities scoped to the new cwd.
+			// capabilities scoped to the new cwd. The skill refresh also rebuilds the
+			// base prompt, which re-syncs the xd:// description cap from the
+			// destination project's settings.
 			await runtime.reloadPlugins();
 			await runtime.notifyConfigChanged?.();
 			await runtime.notifyTitleChanged?.();

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -627,7 +627,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			const mountable = mountBuiltinTools && isMountableUnderXdev(tool) && tool.name in BUILTIN_TOOLS;
 			(mountable ? mounted : kept).push(tool);
 		}
-		session.xdevRegistry = new XdevRegistry(mounted);
+		session.xdevRegistry = new XdevRegistry(mounted, session.settings.get("tools.xdevExternalDescriptionCap"));
 		tools = kept;
 		const finalActiveNames = new Set(tools.map(tool => tool.name));
 		if (session.setActiveToolNames) {

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -276,35 +276,46 @@ export class XdevRegistry {
 
 	/**
 	 * Mount-notice inventory rows for the given device names, keeping the
-	 * rendered bullet list within {@link DOCS_TOTAL_BUDGET}. Prefers listing
-	 * every name and shortening per-tool summaries when a high external
-	 * description cap would otherwise explode a deferred mount notice that
-	 * rides subsequent turns (docs stay one `read xd://` away).
+	 * rendered bullet list within {@link DOCS_TOTAL_BUDGET}.
+	 *
+	 * Two-pass: reserve name-only line cost for every device first so a high
+	 * external description cap cannot drop later tools from the notice
+	 * (with `tools.xdevDocs = "builtins"`, those names are the only signal
+	 * the model gets that they mounted). Remaining budget is spent on
+	 * summaries in catalog order; docs stay one `read xd://` away.
 	 */
 	mountNoticeEntries(names: Iterable<string>): Array<{ name: string; summary: string }> {
 		const budget = XdevRegistry.DOCS_TOTAL_BUDGET;
-		const rows: Array<{ name: string; summary: string }> = [];
-		let used = 0;
-		for (const name of names) {
+		const nameList = [...names];
+		// Pass 1 — name slots only (rendered: `- xd://{{name}}`).
+		const listed: string[] = [];
+		let reserved = 0;
+		for (const name of nameList) {
+			const prefix = `- ${XD_URL_PREFIX}${name}`;
+			const newline = listed.length > 0 ? 1 : 0;
+			const cost = newline + prefix.length;
+			if (reserved + cost > budget && listed.length > 0) break;
+			listed.push(name);
+			reserved += cost;
+		}
+		// Pass 2 — spend leftover budget on summaries in order.
+		let summaryBudget = Math.max(0, budget - reserved);
+		return listed.map(name => {
 			const tool = this.get(name);
 			const fullSummary = tool
 				? promptCatalogSummary(tool, this.#dynamic.has(name) ? this.#externalDescriptionCap : undefined)
 				: "";
-			// Rendered shape in xdev-mount-notice.md: `- xd://{{name}} — {{summary}}`
-			const prefix = `- ${XD_URL_PREFIX}${name}`;
-			const newline = rows.length > 0 ? 1 : 0;
-			const minCost = newline + prefix.length;
-			if (used + minCost > budget && rows.length > 0) break;
-			const sep = fullSummary.length > 0 ? " — " : "";
-			const room = Math.max(0, budget - used - minCost - sep.length);
+			if (fullSummary.length === 0 || summaryBudget <= 3) return { name, summary: "" };
+			// " — " separator between name and summary in the template.
+			const sep = 3;
+			const room = summaryBudget - sep;
 			let summary = fullSummary;
 			if (summary.length > room) {
 				summary = room > 1 ? `${summary.slice(0, room - 1).trimEnd()}…` : "";
 			}
-			used += minCost + (summary.length > 0 ? sep.length + summary.length : 0);
-			rows.push({ name, summary });
-		}
-		return rows;
+			if (summary.length > 0) summaryBudget -= sep + summary.length;
+			return { name, summary };
+		});
 	}
 
 	/** `read xd://` listing with one device per line. */

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -275,32 +275,49 @@ export class XdevRegistry {
 	}
 
 	/**
-	 * Mount-notice inventory rows for the given device names, keeping the
-	 * rendered bullet list within {@link DOCS_TOTAL_BUDGET}.
+	 * Mount-notice inventory for the given device names within `budget`
+	 * (default {@link DOCS_TOTAL_BUDGET}).
 	 *
-	 * Two-pass: reserve name-only line cost for every device first so a high
-	 * external description cap cannot drop later tools from the notice
-	 * (with `tools.xdevDocs = "builtins"`, those names are the only signal
-	 * the model gets that they mounted). Remaining budget is spent on
-	 * summaries in catalog order; docs stay one `read xd://` away.
+	 * Two-pass: reserve name-only line cost first so a high external
+	 * description cap cannot drop later tools mid-list; remaining budget
+	 * funds summaries. Devices that still do not fit contribute to
+	 * `omitted` with a `read xd://` pointer so the model knows they exist
+	 * when `tools.xdevDocs` is builtins-only.
 	 */
-	mountNoticeEntries(names: Iterable<string>): Array<{ name: string; summary: string }> {
-		const budget = XdevRegistry.DOCS_TOTAL_BUDGET;
+	mountNoticeEntries(
+		names: Iterable<string>,
+		budget: number = XdevRegistry.DOCS_TOTAL_BUDGET,
+	): {
+		entries: Array<{ name: string; summary: string }>;
+		omitted: number;
+		/** Rendered size of the inventory bullets (+ omission line if any). */
+		usedChars: number;
+		omittedLine: string;
+	} {
 		const nameList = [...names];
-		// Pass 1 — name slots only (rendered: `- xd://{{name}}`).
+		const omissionLine = (count: number): string =>
+			count > 0 ? prompt.render(omittedCatalogTemplate, { count, inventory_url: XD_URL_PREFIX }).trim() : "";
+		// Pass 1 — name slots, always reserving room for an omission line for
+		// any devices that would remain if we stop after this name.
 		const listed: string[] = [];
 		let reserved = 0;
-		for (const name of nameList) {
+		for (let i = 0; i < nameList.length; i++) {
+			const name = nameList[i]!;
 			const prefix = `- ${XD_URL_PREFIX}${name}`;
 			const newline = listed.length > 0 ? 1 : 0;
 			const cost = newline + prefix.length;
-			if (reserved + cost > budget && listed.length > 0) break;
+			const restAfterThis = nameList.length - i - 1;
+			const omitCost = restAfterThis > 0 ? 1 + omissionLine(restAfterThis).length : 0;
+			if (reserved + cost + omitCost > budget && listed.length > 0) break;
 			listed.push(name);
 			reserved += cost;
 		}
+		const omitted = nameList.length - listed.length;
+		const omittedText = omissionLine(omitted);
+		const omitChars = omittedText.length > 0 ? 1 + omittedText.length : 0;
 		// Pass 2 — spend leftover budget on summaries in order.
-		let summaryBudget = Math.max(0, budget - reserved);
-		return listed.map(name => {
+		let summaryBudget = Math.max(0, budget - reserved - omitChars);
+		const entries = listed.map(name => {
 			const tool = this.get(name);
 			const fullSummary = tool
 				? promptCatalogSummary(tool, this.#dynamic.has(name) ? this.#externalDescriptionCap : undefined)
@@ -316,6 +333,13 @@ export class XdevRegistry {
 			if (summary.length > 0) summaryBudget -= sep + summary.length;
 			return { name, summary };
 		});
+		const summaryUsed = entries.reduce((n, { summary }) => n + (summary.length > 0 ? 3 + summary.length : 0), 0);
+		return {
+			entries,
+			omitted,
+			usedChars: reserved + summaryUsed + omitChars,
+			omittedLine: omittedText,
+		};
 	}
 
 	/** `read xd://` listing with one device per line. */
@@ -416,8 +440,17 @@ export class XdevRegistry {
 		return sections.join("\n\n");
 	}
 
-	/** Docs for selected mounted devices under the configured prompt-doc policy. */
-	docsFor(names: Iterable<string>, mode: XdevDocsMode, inlinePatterns: readonly string[] = []): string {
+	/**
+	 * Docs for selected mounted devices under the configured prompt-doc policy.
+	 * `budget` defaults to {@link DOCS_TOTAL_BUDGET}; callers that share a budget
+	 * with mount-notice inventory (e.g. session tools) pass the remainder.
+	 */
+	docsFor(
+		names: Iterable<string>,
+		mode: XdevDocsMode,
+		inlinePatterns: readonly string[] = [],
+		budget: number = XdevRegistry.DOCS_TOTAL_BUDGET,
+	): string {
 		const sections: string[] = [];
 		const inlineGlobs = compileInlineGlobs(inlinePatterns);
 		let used = 0;
@@ -427,10 +460,7 @@ export class XdevRegistry {
 			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
 			const sep = sections.length > 0 ? 2 : 0;
-			if (
-				docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP ||
-				used + sep + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET
-			) {
+			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + sep + docs.length > budget) {
 				continue;
 			}
 			used += sep + docs.length;

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -318,6 +318,12 @@ export class XdevRegistry {
 		const overflow: Tool[] = [];
 		const inlineGlobs = compileInlineGlobs(inlinePatterns);
 		let used = 0;
+		const fits = (section: string): boolean =>
+			used + (sections.length > 0 ? 2 : 0) + section.length <= XdevRegistry.DOCS_TOTAL_BUDGET;
+		const append = (section: string): void => {
+			used += (sections.length > 0 ? 2 : 0) + section.length;
+			sections.push(section);
+		};
 		for (const tool of this.list()) {
 			if (!this.#shouldInline(tool, mode, inlineGlobs)) {
 				overflow.push(tool);
@@ -325,25 +331,24 @@ export class XdevRegistry {
 			}
 			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
-			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET) {
+			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || !fits(docs)) {
 				overflow.push(tool);
 				continue;
 			}
-			used += docs.length;
-			sections.push(docs);
+			append(docs);
 		}
 		if (overflow.length > 0) {
-			sections.push(
-				[
-					"## Additional devices (docs on demand)",
-					...overflow.map(tool => {
-						const maxLength = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
-						return `- ${XD_URL_PREFIX}${tool.name} — ${promptCatalogSummary(tool, maxLength)}`;
-					}),
-					"",
-					`Read ${XD_URL_PREFIX}<tool> for full docs + JSON schema before first use.`,
-				].join("\n"),
-			);
+			const heading = "## Additional devices (docs on demand)";
+			const footer = `Read ${XD_URL_PREFIX}<tool> for full docs + JSON schema before first use.`;
+			const lines: string[] = [];
+			for (const tool of overflow) {
+				const maxLength = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
+				const line = `- ${XD_URL_PREFIX}${tool.name} — ${promptCatalogSummary(tool, maxLength)}`;
+				const catalog = [heading, ...lines, line, "", footer].join("\n");
+				if (!fits(catalog)) break;
+				lines.push(line);
+			}
+			if (lines.length > 0) append([heading, ...lines, "", footer].join("\n"));
 		}
 		return sections.join("\n\n");
 	}

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -26,10 +26,11 @@
 import type { AgentToolContext, AgentToolResult, AgentToolUpdateCallback, ToolLoadMode } from "@oh-my-pi/pi-agent-core";
 import { type Tool as AiTool, toolWireSchema, validateToolArguments } from "@oh-my-pi/pi-ai";
 import { type Component, Container, Text } from "@oh-my-pi/pi-tui";
-import { parseStreamingJson } from "@oh-my-pi/pi-utils";
+import { parseStreamingJson, prompt } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { XD_URL_PREFIX } from "../internal-urls/xd-protocol";
 import type { Theme } from "../modes/theme/theme";
+import omittedCatalogTemplate from "../prompts/tools/xdev-omitted-catalog.md" with { type: "text" };
 import { renderDefaultToolExecution } from "./default-renderer";
 import type { Tool } from "./index";
 import { replaceTabs } from "./render-utils";
@@ -321,7 +322,7 @@ export class XdevRegistry {
 		const heading = "## Additional devices (docs on demand)";
 		const footer = `Read ${XD_URL_PREFIX}<tool> for full docs + JSON schema before first use.`;
 		const omittedLine = (count: number): string =>
-			`- ${count} more devices omitted — read ${XD_URL_PREFIX} for the complete inventory.`;
+			prompt.render(omittedCatalogTemplate, { count, inventory_url: XD_URL_PREFIX }).trim();
 		const catalogLength = (lineChars: number, lineCount: number, omitted: number): number =>
 			heading.length +
 			lineChars +

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -274,6 +274,39 @@ export class XdevRegistry {
 		}));
 	}
 
+	/**
+	 * Mount-notice inventory rows for the given device names, keeping the
+	 * rendered bullet list within {@link DOCS_TOTAL_BUDGET}. Prefers listing
+	 * every name and shortening per-tool summaries when a high external
+	 * description cap would otherwise explode a deferred mount notice that
+	 * rides subsequent turns (docs stay one `read xd://` away).
+	 */
+	mountNoticeEntries(names: Iterable<string>): Array<{ name: string; summary: string }> {
+		const budget = XdevRegistry.DOCS_TOTAL_BUDGET;
+		const rows: Array<{ name: string; summary: string }> = [];
+		let used = 0;
+		for (const name of names) {
+			const tool = this.get(name);
+			const fullSummary = tool
+				? promptCatalogSummary(tool, this.#dynamic.has(name) ? this.#externalDescriptionCap : undefined)
+				: "";
+			// Rendered shape in xdev-mount-notice.md: `- xd://{{name}} — {{summary}}`
+			const prefix = `- ${XD_URL_PREFIX}${name}`;
+			const newline = rows.length > 0 ? 1 : 0;
+			const minCost = newline + prefix.length;
+			if (used + minCost > budget && rows.length > 0) break;
+			const sep = fullSummary.length > 0 ? " — " : "";
+			const room = Math.max(0, budget - used - minCost - sep.length);
+			let summary = fullSummary;
+			if (summary.length > room) {
+				summary = room > 1 ? `${summary.slice(0, room - 1).trimEnd()}…` : "";
+			}
+			used += minCost + (summary.length > 0 ? sep.length + summary.length : 0);
+			rows.push({ name, summary });
+		}
+		return rows;
+	}
+
 	/** `read xd://` listing with one device per line. */
 	listing(): string {
 		const rows = this.entries().map(({ name, summary }) => `${XD_URL_PREFIX}${name.padEnd(14)} ${summary}`);
@@ -382,9 +415,14 @@ export class XdevRegistry {
 			if (!tool || !this.#shouldInline(tool, mode, inlineGlobs)) continue;
 			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
-			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET)
+			const sep = sections.length > 0 ? 2 : 0;
+			if (
+				docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP ||
+				used + sep + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET
+			) {
 				continue;
-			used += docs.length;
+			}
+			used += sep + docs.length;
 			sections.push(docs);
 		}
 		return sections.join("\n\n");

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -223,8 +223,19 @@ export class XdevRegistry {
 	 */
 	#dynamic = new Map<string, Tool>();
 
-	constructor(builtins: Iterable<Tool>) {
+	/** Active cap for external (dynamic-mount) description embedding; see
+	 *  {@link EXTERNAL_DESCRIPTION_CAP} for the default and rationale. Settable
+	 *  per session via `tools.xdevExternalDescriptionCap`. */
+	#externalDescriptionCap: number;
+
+	constructor(builtins: Iterable<Tool>, externalDescriptionCap: number = XdevRegistry.EXTERNAL_DESCRIPTION_CAP) {
 		for (const tool of builtins) this.#builtins.set(tool.name, tool);
+		this.#externalDescriptionCap = Math.max(0, externalDescriptionCap);
+	}
+
+	/** Update the external description cap (e.g. after a settings change). */
+	setExternalDescriptionCap(cap: number): void {
+		this.#externalDescriptionCap = Math.max(0, cap);
 	}
 
 	/**
@@ -258,10 +269,7 @@ export class XdevRegistry {
 	entries(): Array<{ name: string; summary: string }> {
 		return this.list().map(tool => ({
 			name: tool.name,
-			summary: promptCatalogSummary(
-				tool,
-				this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined,
-			),
+			summary: promptCatalogSummary(tool, this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined),
 		}));
 	}
 
@@ -315,7 +323,7 @@ export class XdevRegistry {
 				overflow.push(tool);
 				continue;
 			}
-			const descriptionCap = this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined;
+			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
 			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET) {
 				overflow.push(tool);
@@ -329,7 +337,7 @@ export class XdevRegistry {
 				[
 					"## Additional devices (docs on demand)",
 					...overflow.map(tool => {
-						const maxLength = this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined;
+						const maxLength = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 						return `- ${XD_URL_PREFIX}${tool.name} — ${promptCatalogSummary(tool, maxLength)}`;
 					}),
 					"",
@@ -348,7 +356,7 @@ export class XdevRegistry {
 		for (const name of names) {
 			const tool = this.get(name);
 			if (!tool || !this.#shouldInline(tool, mode, inlineGlobs)) continue;
-			const descriptionCap = this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined;
+			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
 			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET)
 				continue;

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -317,38 +317,56 @@ export class XdevRegistry {
 		const sections: string[] = [];
 		const overflow: Tool[] = [];
 		const inlineGlobs = compileInlineGlobs(inlinePatterns);
+		const tools = this.list();
+		const heading = "## Additional devices (docs on demand)";
+		const footer = `Read ${XD_URL_PREFIX}<tool> for full docs + JSON schema before first use.`;
+		const omittedLine = (count: number): string =>
+			`- ${count} more devices omitted — read ${XD_URL_PREFIX} for the complete inventory.`;
+		const catalogLength = (lineChars: number, lineCount: number, omitted: number): number =>
+			heading.length +
+			lineChars +
+			(omitted > 0 ? omittedLine(omitted).length : 0) +
+			footer.length +
+			2 +
+			lineCount +
+			(omitted > 0 ? 1 : 0);
+		// Always reserve enough room to point at the complete inventory if the
+		// detailed sections or catalog rows exhaust the remaining budget.
+		const catalogReserve = catalogLength(0, 0, tools.length) + 2;
+		const inlineBudget = XdevRegistry.DOCS_TOTAL_BUDGET - catalogReserve;
 		let used = 0;
-		const fits = (section: string): boolean =>
-			used + (sections.length > 0 ? 2 : 0) + section.length <= XdevRegistry.DOCS_TOTAL_BUDGET;
+		const fits = (length: number, budget = XdevRegistry.DOCS_TOTAL_BUDGET): boolean =>
+			used + (sections.length > 0 ? 2 : 0) + length <= budget;
 		const append = (section: string): void => {
 			used += (sections.length > 0 ? 2 : 0) + section.length;
 			sections.push(section);
 		};
-		for (const tool of this.list()) {
+		for (const tool of tools) {
 			if (!this.#shouldInline(tool, mode, inlineGlobs)) {
 				overflow.push(tool);
 				continue;
 			}
 			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
-			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || !fits(docs)) {
+			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || !fits(docs.length, inlineBudget)) {
 				overflow.push(tool);
 				continue;
 			}
 			append(docs);
 		}
 		if (overflow.length > 0) {
-			const heading = "## Additional devices (docs on demand)";
-			const footer = `Read ${XD_URL_PREFIX}<tool> for full docs + JSON schema before first use.`;
 			const lines: string[] = [];
+			let lineChars = 0;
 			for (const tool of overflow) {
 				const maxLength = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 				const line = `- ${XD_URL_PREFIX}${tool.name} — ${promptCatalogSummary(tool, maxLength)}`;
-				const catalog = [heading, ...lines, line, "", footer].join("\n");
-				if (!fits(catalog)) break;
+				const omitted = overflow.length - lines.length - 1;
+				if (!fits(catalogLength(lineChars + line.length, lines.length + 1, omitted))) break;
 				lines.push(line);
+				lineChars += line.length;
 			}
-			if (lines.length > 0) append([heading, ...lines, "", footer].join("\n"));
+			const omitted = overflow.length - lines.length;
+			append([heading, ...lines, ...(omitted > 0 ? [omittedLine(omitted)] : []), "", footer].join("\n"));
 		}
 		return sections.join("\n\n");
 	}

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -5,6 +5,8 @@ import { createMockModel, type MockResponseSource } from "@oh-my-pi/pi-ai/provid
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -616,6 +618,39 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(notices).toHaveLength(1);
 		expect(notices[0]).toContain("xd://mcp__nucleus_search");
 		expect(notices[0]).not.toContain("TAIL");
+	});
+
+	it("applies a settings description-cap change to the active xd prompt", async () => {
+		const registry = new XdevRegistry([], 50);
+		const description = `Search ${"x".repeat(400)} TAIL`;
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", description);
+		const rebuiltWithFullDescription = Promise.withResolvers<void>();
+		let expectFullDescription = false;
+		const { session } = newSession(
+			async () => {
+				const prompt = registry.docsAll("inline");
+				if (expectFullDescription && prompt.includes(description)) rebuiltWithFullDescription.resolve();
+				return prompt;
+			},
+			{ xdevRegistry: registry },
+		);
+		const errors: string[] = [];
+		const controller = new SelectorController({
+			session,
+			showError: (message: string) => errors.push(message),
+		} as unknown as InteractiveModeContext);
+
+		await session.refreshMCPTools([search]);
+		expect(session.agent.state.systemPrompt.join("\n")).not.toContain(description);
+
+		expectFullDescription = true;
+		session.settings.set("tools.xdevExternalDescriptionCap", 1000);
+		controller.handleSettingChange("tools.xdevExternalDescriptionCap", 1000);
+		await rebuiltWithFullDescription.promise;
+		await Promise.resolve();
+
+		expect(session.agent.state.systemPrompt.join("\n")).toContain(description);
+		expect(errors).toEqual([]);
 	});
 
 	it("inlines configured late xd:// device docs in mount notices", async () => {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -624,16 +624,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		const registry = new XdevRegistry([], 50);
 		const description = `Search ${"x".repeat(400)} TAIL`;
 		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", description);
-		const rebuiltWithFullDescription = Promise.withResolvers<void>();
-		let expectFullDescription = false;
-		const { session } = newSession(
-			async () => {
-				const prompt = registry.docsAll("inline");
-				if (expectFullDescription && prompt.includes(description)) rebuiltWithFullDescription.resolve();
-				return prompt;
-			},
-			{ xdevRegistry: registry },
-		);
+		const { session } = newSession(async () => registry.docsAll("inline"), { xdevRegistry: registry });
 		const errors: string[] = [];
 		const controller = new SelectorController({
 			session,
@@ -643,14 +634,39 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		expect(session.agent.state.systemPrompt.join("\n")).not.toContain(description);
 
-		expectFullDescription = true;
 		session.settings.set("tools.xdevExternalDescriptionCap", 1000);
+		// Settings UI fire-and-forgets; await the session path for the contract.
 		controller.handleSettingChange("tools.xdevExternalDescriptionCap", 1000);
-		await rebuiltWithFullDescription.promise;
-		await Promise.resolve();
+		await session.applyXdevExternalDescriptionCap(1000);
 
 		expect(session.agent.state.systemPrompt.join("\n")).toContain(description);
 		expect(errors).toEqual([]);
+	});
+
+	it("keeps the latest description-cap when settings change races a rebuild", async () => {
+		const registry = new XdevRegistry([], 50);
+		const description = `Search ${"x".repeat(400)} TAIL`;
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", description);
+		let rebuilds = 0;
+		const { session } = newSession(
+			async () => {
+				rebuilds++;
+				// Yield so a second apply can interleave before we snapshot docs.
+				await Bun.sleep(20);
+				return registry.docsAll("inline");
+			},
+			{ xdevRegistry: registry },
+		);
+
+		await session.refreshMCPTools([search]);
+		// First apply starts a slow rebuild; second supersedes before it finishes.
+		const first = session.applyXdevExternalDescriptionCap(100);
+		const second = session.applyXdevExternalDescriptionCap(1000);
+		await Promise.all([first, second]);
+
+		expect(session.agent.state.systemPrompt.join("\n")).toContain(description);
+		// At least one rebuild for the final value; supersession may skip an intermediate.
+		expect(rebuilds).toBeGreaterThanOrEqual(1);
 	});
 
 	it("inlines configured late xd:// device docs in mount notices", async () => {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -11,7 +11,9 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
+import xdevMountNoticePrompt from "../src/prompts/system/xdev-mount-notice.md" with { type: "text" };
 
 // Cache-stability invariant: when MCP servers reconnect with byte-identical tool
 // definitions, `refreshMCPTools` must not rebuild the system prompt. A rebuild
@@ -620,6 +622,71 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(notices[0]).not.toContain("TAIL");
 	});
 
+	it("keeps the rendered mount notice within one shared budget across inventory and inline docs", async () => {
+		// With `tools.xdevDocs = "inline"` and a 4000-char cap, 150 long
+		// descriptions would produce a ~96,000-char notice if the inventory and
+		// the inline docs each spent their own 48,000-char allowance. The notice
+		// must share a single budget across both sections.
+		const registry = new XdevRegistry([], 4000);
+		const tools = Array.from({ length: 150 }, (_, index) =>
+			createMcpCustomTool(
+				`mcp__large_tool_${index}`,
+				"large",
+				`tool_${index}`,
+				`Tool ${index}. ${"x".repeat(5000)}`,
+			),
+		);
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdevRegistry: registry,
+			responses: [{ content: ["ok"] }],
+		});
+		session.settings.set("tools.xdevDocs", "inline");
+
+		await session.refreshMCPTools(tools);
+		await session.prompt("hello");
+
+		const notices = mountNoticesIn(contexts[0]);
+		expect(notices).toHaveLength(1);
+		const notice = notices[0]!;
+		// Only the variable content is budgeted; measure the fixed template
+		// boilerplate by rendering the same branches with 1-char markers.
+		const marker = prompt.render(xdevMountNoticePrompt, {
+			added: [{ name: "n", summary: "s" }],
+			removed: [],
+			docs: "d",
+			omitted_line: undefined,
+		});
+		const overhead = marker.length - "- xd://n — s".length - "d".length;
+		expect(notice.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET + overhead);
+		// Name-slot reservation: every device is still announced by name.
+		expect(notice).toContain("- xd://mcp__large_tool_149");
+		// No device leaks its full 5000-char description into the notice.
+		expect(notice).not.toContain("x".repeat(4500));
+		// Rows whose summary was budgeted away must not emit a dangling separator.
+		expect(notice).not.toMatch(/—\s*\n/);
+	});
+
+	it("announces omitted devices in the mount notice when name rows exhaust the budget", async () => {
+		// With `tools.xdevDocs = "builtins"`, external devices contribute no docs,
+		// so devices dropped from an oversized inventory would be invisible to the
+		// model without an omission line pointing at `read xd://`.
+		const registry = new XdevRegistry([]);
+		const tools = Array.from({ length: 300 }, (_, index) =>
+			createMcpCustomTool(`mcp__${"n".repeat(180)}_${index}`, "longnames", `tool_${index}`, `Tool ${index}`),
+		);
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdevRegistry: registry,
+			responses: [{ content: ["ok"] }],
+		});
+
+		await session.refreshMCPTools(tools);
+		await session.prompt("hello");
+
+		const notices = mountNoticesIn(contexts[0]);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toMatch(/\d+ more devices omitted — read xd:\/\/ for the complete inventory\./);
+	});
+
 	it("applies a settings description-cap change to the active xd prompt", async () => {
 		const registry = new XdevRegistry([], 50);
 		const description = `Search ${"x".repeat(400)} TAIL`;
@@ -660,13 +727,110 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 		await session.refreshMCPTools([search]);
 		// First apply starts a slow rebuild; second supersedes before it finishes.
+		// The settings UI persists before notifying, so mirror that ordering.
+		session.settings.set("tools.xdevExternalDescriptionCap", 100);
 		const first = session.applyXdevExternalDescriptionCap(100);
+		session.settings.set("tools.xdevExternalDescriptionCap", 1000);
 		const second = session.applyXdevExternalDescriptionCap(1000);
 		await Promise.all([first, second]);
 
 		expect(session.agent.state.systemPrompt.join("\n")).toContain(description);
 		// At least one rebuild for the final value; supersession may skip an intermediate.
 		expect(rebuilds).toBeGreaterThanOrEqual(1);
+	});
+
+	it("converges the registry cap to the effective setting on prompt refresh (project settings reload)", async () => {
+		// `/move` reloads project settings without running the selector's
+		// setting-change handler; the next prompt refresh (which the /move flow
+		// triggers via refreshSkillState) must re-sync the registry from the
+		// effective setting instead of keeping the construction-time cap.
+		const registry = new XdevRegistry([], 50);
+		const description = `Search ${"x".repeat(400)} TAIL`;
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", description);
+		const { session } = newSession(async () => registry.docsAll("inline"), { xdevRegistry: registry });
+
+		session.settings.set("tools.xdevExternalDescriptionCap", 50);
+		await session.refreshMCPTools([search]);
+		expect(session.agent.state.systemPrompt.join("\n")).not.toContain(description);
+
+		// Simulates Settings.reloadForCwd landing a different project value.
+		session.settings.set("tools.xdevExternalDescriptionCap", 1000);
+		await session.refreshBaseSystemPrompt();
+
+		expect(session.agent.state.systemPrompt.join("\n")).toContain(description);
+	});
+
+	it("never lets a stale in-flight rebuild overwrite a newer description cap", async () => {
+		// Race from the review: a tool-refresh rebuild snapshots the prompt with
+		// the old cap and finishes after the cap-apply rebuild, clobbering the
+		// new cap's prompt while the registry keeps the new value. All prompt
+		// applications must serialize so the last scheduled rebuild wins.
+		const registry = new XdevRegistry([], 50);
+		const description = `Search ${"x".repeat(400)} TAIL`;
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", description);
+		const readTool = createBasicTool("read", "Read");
+		const writeTool = createBasicTool("write", "Write");
+		// A top-level tool with a mutable description: flipping it changes the
+		// tool signature, forcing a rebuild on the next MCP refresh while the
+		// mounted xd:// device (whose inventory is deliberately not signed) stays.
+		const bashState = { version: "v1" };
+		const bashTool = createBasicTool("bash", "Bash");
+		Object.defineProperty(bashTool, "description", {
+			get: () => `bash ${bashState.version}`,
+			enumerable: true,
+			configurable: true,
+		});
+		const staleRebuildGate = Promise.withResolvers<void>();
+		let rebuilds = 0;
+		const agent = new Agent({
+			initialState: {
+				model: createModel(),
+				systemPrompt: ["initial"],
+				tools: [readTool, writeTool, bashTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: { getApiKey: async () => "test-key" } as never,
+			toolRegistry: new Map<string, AgentTool>([
+				[readTool.name, readTool],
+				[writeTool.name, writeTool],
+				[bashTool.name, bashTool],
+			]),
+			builtInToolNames: ["read", "write", "bash"],
+			xdevRegistry: registry,
+			rebuildSystemPrompt: async () => {
+				rebuilds++;
+				// Snapshot first (with the cap active at build start), then park the
+				// second rebuild so the cap change lands mid-flight.
+				const snapshot = registry.docsAll("inline");
+				if (rebuilds === 2) await staleRebuildGate.promise;
+				return { systemPrompt: [snapshot] };
+			},
+		});
+		sessions.push(session);
+
+		session.settings.set("tools.xdevExternalDescriptionCap", 50);
+		await session.refreshMCPTools([search]);
+		expect(session.agent.state.systemPrompt.join("\n")).not.toContain("TAIL");
+
+		// Force rebuild 2, which snapshots with the old cap and stalls mid-flight.
+		bashState.version = "v2";
+		const slowRefresh = session.refreshMCPTools([search]);
+		await Bun.sleep(10);
+		expect(rebuilds).toBe(2);
+
+		// The cap changes while rebuild 2 is in flight; its own rebuild must apply last.
+		session.settings.set("tools.xdevExternalDescriptionCap", 1000);
+		const capApply = session.applyXdevExternalDescriptionCap(1000);
+		staleRebuildGate.resolve();
+		await Promise.all([slowRefresh, capApply]);
+
+		expect(session.agent.state.systemPrompt.join("\n")).toContain("TAIL");
+		expect(rebuilds).toBe(3);
 	});
 
 	it("inlines configured late xd:// device docs in mount notices", async () => {

--- a/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
@@ -17,4 +17,19 @@ describe("SelectorController prompt-affecting settings", () => {
 		expect(refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
+
+	it("applies xdev description cap changes to the active session", async () => {
+		const applyXdevExternalDescriptionCap = vi.fn(async () => {});
+		const ctx = {
+			session: { applyXdevExternalDescriptionCap },
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.handleSettingChange("tools.xdevExternalDescriptionCap", "1000");
+		await Promise.resolve();
+
+		expect(applyXdevExternalDescriptionCap).toHaveBeenCalledWith(1000);
+		expect(ctx.showError).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-settings.test.ts
@@ -17,19 +17,4 @@ describe("SelectorController prompt-affecting settings", () => {
 		expect(refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
-
-	it("applies xdev description cap changes to the active session", async () => {
-		const applyXdevExternalDescriptionCap = vi.fn(async () => {});
-		const ctx = {
-			session: { applyXdevExternalDescriptionCap },
-			showError: vi.fn(),
-		} as unknown as InteractiveModeContext;
-		const controller = new SelectorController(ctx);
-
-		controller.handleSettingChange("tools.xdevExternalDescriptionCap", "1000");
-		await Promise.resolve();
-
-		expect(applyXdevExternalDescriptionCap).toHaveBeenCalledWith(1000);
-		expect(ctx.showError).not.toHaveBeenCalled();
-	});
 });

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -79,4 +79,19 @@ describe("XdevRegistry external description cap", () => {
 		expect(docs).not.toContain(LONG_DESCRIPTION);
 		expect(docs).toContain("… (full docs: read xd://");
 	});
+
+	it("keeps the complete catalog within the aggregate docs budget", () => {
+		const registry = new XdevRegistry([], 4000);
+		registry.reconcile(
+			Array.from({ length: 150 }, (_, index) =>
+				fakeTool(`mcp__large_catalog_tool_${index}`, `Tool ${index}. ${"x".repeat(5000)}`),
+			),
+		);
+
+		const docs = registry.docsAll("catalog");
+		expect(docs.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		expect(docs).toContain("## Additional devices (docs on demand)");
+		expect(docs).toContain("- xd://mcp__large_catalog_tool_0 —");
+		expect(docs).not.toContain("- xd://mcp__large_catalog_tool_149 —");
+	});
 });

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -93,5 +93,6 @@ describe("XdevRegistry external description cap", () => {
 		expect(docs).toContain("## Additional devices (docs on demand)");
 		expect(docs).toContain("- xd://mcp__large_catalog_tool_0 —");
 		expect(docs).not.toContain("- xd://mcp__large_catalog_tool_149 —");
+		expect(docs).toMatch(/- \d+ more devices omitted — read xd:\/\/ for the complete inventory\./);
 	});
 });

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-coding-agent/tools";
+import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { type } from "arktype";
+
+// Contract: `tools.xdevExternalDescriptionCap` controls how much of an
+// EXTERNAL (dynamic-mount: MCP/custom/extension) device's description is
+// embedded into the system prompt and catalog lines. Built-in devices are
+// never capped, schemas are never capped, and `read xd://<tool>` (docs())
+// always returns the full text regardless of the cap.
+
+const LONG_DESCRIPTION = `gitnexus-style tool. ${"x".repeat(400)}`;
+
+function fakeTool(name: string, description: string): Tool {
+	return {
+		name,
+		label: name,
+		description,
+		parameters: type({}),
+		execute: async () => ({ content: [] }),
+	} as unknown as Tool;
+}
+
+const builtin = fakeTool("ast_grep", "Structural code search via ast-grep.");
+const dynamic = fakeTool("mcp__gateway_gitnexus_search_code_flows", LONG_DESCRIPTION);
+
+function makeRegistry(cap?: number): XdevRegistry {
+	const registry = cap === undefined ? new XdevRegistry([builtin]) : new XdevRegistry([builtin], cap);
+	registry.reconcile([dynamic]);
+	return registry;
+}
+
+describe("XdevRegistry external description cap", () => {
+	it("truncates dynamic descriptions to the custom cap in entries and docsAll", () => {
+		const registry = makeRegistry(50);
+
+		const entries = registry.entries();
+		const dynamicEntry = entries.find(entry => entry.name === dynamic.name);
+		const builtinEntry = entries.find(entry => entry.name === builtin.name);
+		expect(dynamicEntry).toBeDefined();
+		expect(dynamicEntry!.summary.length).toBeLessThanOrEqual(51); // 50 + ellipsis
+		// Built-ins are never capped.
+		expect(builtinEntry!.summary).toBe(builtin.description);
+
+		const docs = registry.docsAll("inline");
+		expect(docs).toContain("… (full docs: read xd://");
+		expect(docs).not.toContain(LONG_DESCRIPTION);
+		// The schema survives truncation intact.
+		expect(docs).toContain('"type": "object"');
+	});
+
+	it("keeps the 200-char default when no cap is given", () => {
+		const registry = makeRegistry();
+		const docs = registry.docsAll("inline");
+		expect(docs).not.toContain(LONG_DESCRIPTION);
+		expect(docs).toContain("… (full docs: read xd://");
+	});
+
+	it("embeds the full description when the cap exceeds its length", () => {
+		const registry = makeRegistry(10_000);
+		expect(registry.docsAll("inline")).toContain(LONG_DESCRIPTION);
+	});
+
+	it("applies setExternalDescriptionCap live", () => {
+		const registry = makeRegistry(50);
+		expect(registry.docsAll("inline")).not.toContain(LONG_DESCRIPTION);
+		registry.setExternalDescriptionCap(10_000);
+		expect(registry.docsAll("inline")).toContain(LONG_DESCRIPTION);
+	});
+
+	it("never truncates single-device docs (read xd://<tool>)", () => {
+		const registry = makeRegistry(50);
+		expect(registry.docs(dynamic.name)).toContain(LONG_DESCRIPTION);
+	});
+
+	it("caps docsFor the same way as docsAll", () => {
+		const registry = makeRegistry(50);
+		const docs = registry.docsFor([dynamic.name], "inline");
+		expect(docs).not.toContain(LONG_DESCRIPTION);
+		expect(docs).toContain("… (full docs: read xd://");
+	});
+});

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -109,6 +109,11 @@ describe("XdevRegistry external description cap", () => {
 			.map(({ name, summary }) => (summary.length > 0 ? `- xd://${name} — ${summary}` : `- xd://${name}`))
 			.join("\n");
 		expect(rendered.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		// Name slots are reserved first: every mounted tool is announced even
+		// when the high per-device cap would otherwise exhaust the budget early.
+		expect(rows.length).toBe(150);
+		expect(rows[0]?.name).toBe("mcp__large_catalog_tool_0");
+		expect(rows[149]?.name).toBe("mcp__large_catalog_tool_149");
 		// First tools keep some summary lede; later rows shrink rather than
 		// emitting uncapped 4000-char descriptions for every device.
 		expect(rows[0]?.summary.length ?? 0).toBeGreaterThan(0);

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -104,7 +104,8 @@ describe("XdevRegistry external description cap", () => {
 		registry.reconcile(tools);
 
 		const inventory = registry.mountNoticeEntries(tools.map(tool => tool.name));
-		// Render the same bullet shape the mount-notice template uses.
+		// Render the same bullet shape the mount-notice template uses
+		// (` — ` only when summary is non-empty).
 		const rendered = [
 			...inventory.entries.map(({ name, summary }) =>
 				summary.length > 0 ? `- xd://${name} — ${summary}` : `- xd://${name}`,
@@ -112,6 +113,7 @@ describe("XdevRegistry external description cap", () => {
 			...(inventory.omittedLine ? [inventory.omittedLine] : []),
 		].join("\n");
 		expect(rendered.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		expect(inventory.usedChars).toBe(rendered.length);
 		expect(inventory.usedChars).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
 		// Name slots are reserved first: every mounted tool is announced even
 		// when the high per-device cap would otherwise exhaust the budget early.

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -103,26 +103,53 @@ describe("XdevRegistry external description cap", () => {
 		);
 		registry.reconcile(tools);
 
-		const rows = registry.mountNoticeEntries(tools.map(tool => tool.name));
+		const inventory = registry.mountNoticeEntries(tools.map(tool => tool.name));
 		// Render the same bullet shape the mount-notice template uses.
-		const rendered = rows
-			.map(({ name, summary }) => (summary.length > 0 ? `- xd://${name} — ${summary}` : `- xd://${name}`))
-			.join("\n");
+		const rendered = [
+			...inventory.entries.map(({ name, summary }) =>
+				summary.length > 0 ? `- xd://${name} — ${summary}` : `- xd://${name}`,
+			),
+			...(inventory.omittedLine ? [inventory.omittedLine] : []),
+		].join("\n");
 		expect(rendered.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		expect(inventory.usedChars).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
 		// Name slots are reserved first: every mounted tool is announced even
 		// when the high per-device cap would otherwise exhaust the budget early.
-		expect(rows.length).toBe(150);
-		expect(rows[0]?.name).toBe("mcp__large_catalog_tool_0");
-		expect(rows[149]?.name).toBe("mcp__large_catalog_tool_149");
+		expect(inventory.entries.length).toBe(150);
+		expect(inventory.omitted).toBe(0);
+		expect(inventory.entries[0]?.name).toBe("mcp__large_catalog_tool_0");
+		expect(inventory.entries[149]?.name).toBe("mcp__large_catalog_tool_149");
 		// First tools keep some summary lede; later rows shrink rather than
 		// emitting uncapped 4000-char descriptions for every device.
-		expect(rows[0]?.summary.length ?? 0).toBeGreaterThan(0);
-		expect(rows.some(row => row.summary.length < 4000)).toBe(true);
-		// docsFor stays under the same budget for the same batch.
+		expect(inventory.entries[0]?.summary.length ?? 0).toBeGreaterThan(0);
+		expect(inventory.entries.some(row => row.summary.length < 4000)).toBe(true);
+		// Shared budget: inventory + docsFor remainder stay within one total.
+		const docsBudget = Math.max(0, XdevRegistry.DOCS_TOTAL_BUDGET - inventory.usedChars);
 		const docs = registry.docsFor(
 			tools.map(tool => tool.name),
 			"inline",
+			[],
+			docsBudget,
 		);
-		expect(docs.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		expect(inventory.usedChars + docs.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+	});
+
+	it("announces devices omitted when name-only rows exhaust the budget", () => {
+		const registry = new XdevRegistry([], 0);
+		// Pathologically long names so name-only bullets exceed a tiny budget.
+		const tools = Array.from({ length: 20 }, (_, index) =>
+			fakeTool(`mcp__${"x".repeat(200)}_${index}`, `Tool ${index}`),
+		);
+		registry.reconcile(tools);
+		const tinyBudget = 800;
+		const inventory = registry.mountNoticeEntries(
+			tools.map(tool => tool.name),
+			tinyBudget,
+		);
+		expect(inventory.entries.length).toBeGreaterThan(0);
+		expect(inventory.omitted).toBeGreaterThan(0);
+		expect(inventory.omittedLine).toMatch(/more devices omitted — read xd:\/\//);
+		expect(inventory.usedChars).toBeLessThanOrEqual(tinyBudget);
+		expect(inventory.entries.length + inventory.omitted).toBe(20);
 	});
 });

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { Tool } from "@oh-my-pi/pi-coding-agent/tools";
 import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
+import xdevMountNoticePrompt from "../src/prompts/system/xdev-mount-notice.md" with { type: "text" };
 
 // Contract: `tools.xdevExternalDescriptionCap` controls how much of an
 // EXTERNAL (dynamic-mount: MCP/custom/extension) device's description is
@@ -96,44 +98,52 @@ describe("XdevRegistry external description cap", () => {
 		expect(docs).toMatch(/- \d+ more devices omitted — read xd:\/\/ for the complete inventory\./);
 	});
 
-	it("bounds mount-notice inventory rows under the aggregate docs budget", () => {
+	it("bounds the rendered mount notice under the aggregate docs budget", () => {
 		const registry = new XdevRegistry([], 4000);
 		const tools = Array.from({ length: 150 }, (_, index) =>
 			fakeTool(`mcp__large_catalog_tool_${index}`, `Tool ${index}. ${"x".repeat(5000)}`),
 		);
 		registry.reconcile(tools);
+		const names = tools.map(tool => tool.name);
 
-		const inventory = registry.mountNoticeEntries(tools.map(tool => tool.name));
-		// Render the same bullet shape the mount-notice template uses
-		// (` — ` only when summary is non-empty).
-		const rendered = [
-			...inventory.entries.map(({ name, summary }) =>
-				summary.length > 0 ? `- xd://${name} — ${summary}` : `- xd://${name}`,
-			),
-			...(inventory.omittedLine ? [inventory.omittedLine] : []),
-		].join("\n");
-		expect(rendered.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
-		expect(inventory.usedChars).toBe(rendered.length);
-		expect(inventory.usedChars).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		const inventory = registry.mountNoticeEntries(names);
+		// Shared budget: inline docs get only what the inventory did not spend.
+		const docsBudget = Math.max(0, XdevRegistry.DOCS_TOTAL_BUDGET - inventory.usedChars);
+		const docs = registry.docsFor(names, "inline", [], docsBudget);
+		// Render the actual mount-notice template exactly as
+		// `SessionTools.takePendingXdevMountNotice()` does — the budget contract
+		// covers the provider-visible message, not a hand-built approximation.
+		const content = prompt.render(xdevMountNoticePrompt, {
+			added: inventory.entries,
+			removed: [],
+			docs,
+			omitted_line: inventory.omittedLine || undefined,
+		});
+
+		// The fixed template boilerplate is not budgeted; measure it by rendering
+		// the same branches with 1-char markers and subtracting the marker bytes.
+		const marker = prompt.render(xdevMountNoticePrompt, {
+			added: [{ name: "n", summary: "s" }],
+			removed: [],
+			docs: "d",
+			omitted_line: undefined,
+		});
+		const overhead = marker.length - "- xd://n — s".length - "d".length;
+		expect(content.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET + overhead);
+		// Rows whose summary was budgeted away must not emit an unbudgeted ` — `.
+		expect(content).not.toMatch(/—\s*\n/);
+
 		// Name slots are reserved first: every mounted tool is announced even
 		// when the high per-device cap would otherwise exhaust the budget early.
 		expect(inventory.entries.length).toBe(150);
 		expect(inventory.omitted).toBe(0);
 		expect(inventory.entries[0]?.name).toBe("mcp__large_catalog_tool_0");
 		expect(inventory.entries[149]?.name).toBe("mcp__large_catalog_tool_149");
+		expect(content).toContain("- xd://mcp__large_catalog_tool_149");
 		// First tools keep some summary lede; later rows shrink rather than
 		// emitting uncapped 4000-char descriptions for every device.
 		expect(inventory.entries[0]?.summary.length ?? 0).toBeGreaterThan(0);
 		expect(inventory.entries.some(row => row.summary.length < 4000)).toBe(true);
-		// Shared budget: inventory + docsFor remainder stay within one total.
-		const docsBudget = Math.max(0, XdevRegistry.DOCS_TOTAL_BUDGET - inventory.usedChars);
-		const docs = registry.docsFor(
-			tools.map(tool => tool.name),
-			"inline",
-			[],
-			docsBudget,
-		);
-		expect(inventory.usedChars + docs.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
 	});
 
 	it("announces devices omitted when name-only rows exhaust the budget", () => {
@@ -153,5 +163,14 @@ describe("XdevRegistry external description cap", () => {
 		expect(inventory.omittedLine).toMatch(/more devices omitted — read xd:\/\//);
 		expect(inventory.usedChars).toBeLessThanOrEqual(tinyBudget);
 		expect(inventory.entries.length + inventory.omitted).toBe(20);
+		// The rendered notice carries the omitted count and the `read xd://`
+		// inventory pointer so unlisted devices stay discoverable.
+		const content = prompt.render(xdevMountNoticePrompt, {
+			added: inventory.entries,
+			removed: [],
+			docs: "",
+			omitted_line: inventory.omittedLine || undefined,
+		});
+		expect(content).toContain(`${inventory.omitted} more devices omitted — read xd:// for the complete inventory.`);
 	});
 });

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -95,4 +95,29 @@ describe("XdevRegistry external description cap", () => {
 		expect(docs).not.toContain("- xd://mcp__large_catalog_tool_149 —");
 		expect(docs).toMatch(/- \d+ more devices omitted — read xd:\/\/ for the complete inventory\./);
 	});
+
+	it("bounds mount-notice inventory rows under the aggregate docs budget", () => {
+		const registry = new XdevRegistry([], 4000);
+		const tools = Array.from({ length: 150 }, (_, index) =>
+			fakeTool(`mcp__large_catalog_tool_${index}`, `Tool ${index}. ${"x".repeat(5000)}`),
+		);
+		registry.reconcile(tools);
+
+		const rows = registry.mountNoticeEntries(tools.map(tool => tool.name));
+		// Render the same bullet shape the mount-notice template uses.
+		const rendered = rows
+			.map(({ name, summary }) => (summary.length > 0 ? `- xd://${name} — ${summary}` : `- xd://${name}`))
+			.join("\n");
+		expect(rendered.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+		// First tools keep some summary lede; later rows shrink rather than
+		// emitting uncapped 4000-char descriptions for every device.
+		expect(rows[0]?.summary.length ?? 0).toBeGreaterThan(0);
+		expect(rows.some(row => row.summary.length < 4000)).toBe(true);
+		// docsFor stays under the same budget for the same batch.
+		const docs = registry.docsFor(
+			tools.map(tool => tool.name),
+			"inline",
+		);
+		expect(docs.length).toBeLessThanOrEqual(XdevRegistry.DOCS_TOTAL_BUDGET);
+	});
 });


### PR DESCRIPTION
## What

New setting `tools.xdevExternalDescriptionCap` (default `200` = unchanged behavior) controlling how many description characters are embedded per external (MCP/custom/extension) `xd://` device in the system prompt and catalog listings.

## Why

External device descriptions were hard-truncated at a fixed 200 chars (`XdevRegistry.EXTERNAL_DESCRIPTION_CAP`). For MCP servers whose tools carry longer, meaningful descriptions, the model only ever sees a 200-char lede in the prompt — everything past it requires an extra `read xd://<tool>` round trip. Reasonable default, but it should be the user's choice, not a constant.

Unchanged guarantees: schemas are never truncated; built-in devices are never capped; `read xd://<tool>` always returns the full description regardless of the cap.

## How

- `XdevRegistry` holds the cap as an instance field (constructor arg, default 200) with `setExternalDescriptionCap()` for live updates; `entries()`, `docsAll()`, and `docsFor()` use it instead of the static constant.
- `createTools` passes `tools.xdevExternalDescriptionCap` from settings at registry construction (applies to new sessions).
- `settings-schema.ts`: new number setting in the /settings UI.

## Verification

- New `test/xdev-description-cap.test.ts` (6 tests): custom cap truncates entries + docsAll + docsFor; default 200 preserved without a cap; schema intact after truncation; built-ins never capped; single-device `docs()` never truncated; live setter. All pass.
- `bun run check` (biome + tsgo) clean.
- Live before/after with `xdevInlineDevices: ["mcp__gateway_*"]`: cap 200 → System prompt 8.4K; cap 2000 → 9.8K (exactly the additional embedded description text).

I reviewed the full diff; this change turns the hardcoded 200-char external description cap into a user setting while keeping every existing default.