### PR TITLE
feat(mcp): add mcp.reconnectNotices for visible reconnect status events

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
+- Added `mcp.reconnectNotices` (default `false`): opt-in status notices when an MCP server loses its connection, reconnects, fails to reconnect, or has automatic reconnects suspended after repeated crashes. Notices bypass `startup.quiet` (a runtime instability signal, not startup noise) and are live-togglable from `/settings`; manual `/mcp reconnect` flows stay quiet.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added `mcp.reconnectNotices` (default `false`): opt-in status notices when an MCP server loses its connection, reconnects, fails to reconnect, or has automatic reconnects suspended after repeated crashes. Notices bypass `startup.quiet` (a runtime instability signal, not startup noise) and are live-togglable from `/settings`; manual `/mcp reconnect` flows stay quiet.
 
 ### Fixed
 
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
-- Added `mcp.reconnectNotices` (default `false`): opt-in status notices when an MCP server loses its connection, reconnects, fails to reconnect, or has automatic reconnects suspended after repeated crashes. Notices bypass `startup.quiet` (a runtime instability signal, not startup noise) and are live-togglable from `/settings`; manual `/mcp reconnect` flows stay quiet.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4236,6 +4236,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"mcp.reconnectNotices": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "MCP Reconnect Notices",
+			description:
+				"Show a status notice when an MCP server loses its connection, reconnects, fails to reconnect, or has automatic reconnects suspended after repeated crashes",
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Tasks
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -198,8 +198,8 @@ export class MCPManager {
 	#onToolsChanged?: (tools: CustomTool<TSchema, MCPToolDetails>[]) => void;
 	#onResourcesChanged?: (serverName: string, uri: string) => void;
 	#onPromptsChanged?: (serverName: string) => void;
-	/** Channel for user-visible reconnect notices (`mcp.reconnectNotices`). */
-	#onConnectionStatus?: (event: McpConnectionStatusEvent) => void;
+	/** Channels for user-visible reconnect notices (`mcp.reconnectNotices`). */
+	#connectionStatusListeners = new Set<(event: McpConnectionStatusEvent) => void>();
 	#reconnectNoticesEnabled = false;
 	#notificationsEnabled = false;
 	#notificationsEpoch = 0;
@@ -240,19 +240,32 @@ export class MCPManager {
 		this.#reconnectNoticesEnabled = enabled;
 	}
 
-	/** Register the channel reconnect notices are emitted on (interactive sessions). */
+	/** Replace the reconnect-status channel (primarily for direct manager consumers). */
 	setOnConnectionStatus(handler: ((event: McpConnectionStatusEvent) => void) | undefined): void {
-		this.#onConnectionStatus = handler;
+		this.#connectionStatusListeners.clear();
+		if (handler) this.#connectionStatusListeners.add(handler);
+	}
+
+	/** Subscribe without replacing another session's reconnect-status channel. */
+	addConnectionStatusListener(handler: (event: McpConnectionStatusEvent) => void): () => void {
+		this.#connectionStatusListeners.add(handler);
+		return () => this.#connectionStatusListeners.delete(handler);
 	}
 
 	/** Fire a reconnect notice when enabled; a throwing consumer must never break reconnects. */
 	#emitReconnectNotice(event: McpConnectionStatusEvent): void {
 		if (!this.#reconnectNoticesEnabled) return;
-		try {
-			this.#onConnectionStatus?.(event);
-		} catch {
-			// notice delivery is best-effort by design
+		for (const listener of this.#connectionStatusListeners) {
+			try {
+				listener(event);
+			} catch {
+				// notice delivery is best-effort by design
+			}
 		}
+	}
+
+	#emitReconnectFailure(name: string, error: string, manual = false): void {
+		if (!manual) this.#emitReconnectNotice({ type: "reconnect-failed", serverName: name, error });
 	}
 
 	/**
@@ -920,22 +933,31 @@ export class MCPManager {
 		const oldConnection = this.#connections.get(name);
 		let config = oldConnection?.config ?? this.#serverConfigs.get(name);
 		const source = this.#sources.get(name) ?? oldConnection?._source;
-		if (!config) return null;
+		if (!config) {
+			this.#emitReconnectFailure(name, "No saved server configuration is available.", manual);
+			return null;
+		}
 
 		if (authChallenge) {
 			if (!this.#authHandler) {
+				const error = "No authentication handler is configured.";
 				logger.error("MCP auth challenge cannot be handled; no auth handler is configured", {
 					path: `mcp:${name}`,
 				});
+				this.#emitReconnectFailure(name, error, manual);
 				return null;
 			}
 			try {
 				const refreshedConfig = await this.#authHandler(name, authChallenge);
-				if (!refreshedConfig) return null;
+				if (!refreshedConfig) {
+					this.#emitReconnectFailure(name, "Authentication did not produce a server configuration.", manual);
+					return null;
+				}
 				config = refreshedConfig;
 				this.#serverConfigs.set(name, config);
 			} catch (error) {
 				logger.error("MCP auth challenge handling failed", { path: `mcp:${name}`, error });
+				this.#emitReconnectFailure(name, error instanceof Error ? error.message : String(error), manual);
 				return null;
 			}
 		}
@@ -993,7 +1015,7 @@ export class MCPManager {
 					await Bun.sleep(delays[attempt]);
 				} else {
 					logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
-					if (!manual) this.#emitReconnectNotice({ type: "reconnect-failed", serverName: name, error: msg });
+					this.#emitReconnectFailure(name, msg, manual);
 					// Don't remove stale tools — keep them in the registry so they
 					// remain selected. Calls will fail with MCP errors, which
 					// triggers the tool-level reconnect, or the user can run

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -199,7 +199,7 @@ export class MCPManager {
 	#onResourcesChanged?: (serverName: string, uri: string) => void;
 	#onPromptsChanged?: (serverName: string) => void;
 	/** Channels for user-visible reconnect notices (`mcp.reconnectNotices`). */
-	#connectionStatusListeners = new Set<(event: McpConnectionStatusEvent) => void>();
+	#connectionStatusListeners = new Map<(event: McpConnectionStatusEvent) => void, () => boolean>();
 	#reconnectNoticesEnabled = false;
 	#notificationsEnabled = false;
 	#notificationsEpoch = 0;
@@ -243,21 +243,23 @@ export class MCPManager {
 	/** Replace the reconnect-status channel (primarily for direct manager consumers). */
 	setOnConnectionStatus(handler: ((event: McpConnectionStatusEvent) => void) | undefined): void {
 		this.#connectionStatusListeners.clear();
-		if (handler) this.#connectionStatusListeners.add(handler);
+		if (handler) this.addConnectionStatusListener(handler);
 	}
 
 	/** Subscribe without replacing another session's reconnect-status channel. */
-	addConnectionStatusListener(handler: (event: McpConnectionStatusEvent) => void): () => void {
-		this.#connectionStatusListeners.add(handler);
+	addConnectionStatusListener(
+		handler: (event: McpConnectionStatusEvent) => void,
+		enabled: () => boolean = () => this.#reconnectNoticesEnabled,
+	): () => void {
+		this.#connectionStatusListeners.set(handler, enabled);
 		return () => this.#connectionStatusListeners.delete(handler);
 	}
 
-	/** Fire a reconnect notice when enabled; a throwing consumer must never break reconnects. */
+	/** Fire a reconnect notice for each enabled subscriber; consumers cannot break reconnects. */
 	#emitReconnectNotice(event: McpConnectionStatusEvent): void {
-		if (!this.#reconnectNoticesEnabled) return;
-		for (const listener of this.#connectionStatusListeners) {
+		for (const [listener, enabled] of this.#connectionStatusListeners) {
 			try {
-				listener(event);
+				if (enabled()) listener(event);
 			} catch {
 				// notice delivery is best-effort by design
 			}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -213,6 +213,8 @@ export class MCPManager {
 	 * crash-storm circuit breaker (see {@link RECONNECT_BURST_LIMIT}).
 	 */
 	#reconnectHistory = new Map<string, number[]>();
+	/** Auth-refresh retries use a separate silent breaker from transport crashes. */
+	#authReconnectHistory = new Map<string, number[]>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
 	#epoch = 0;
 
@@ -800,6 +802,7 @@ export class MCPManager {
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
 		this.#reconnectHistory.delete(name);
+		this.#authReconnectHistory.delete(name);
 
 		const connection = this.#connections.get(name);
 
@@ -849,6 +852,7 @@ export class MCPManager {
 		this.#tools = [];
 		this.#subscribedResources.clear();
 		this.#reconnectHistory.clear();
+		this.#authReconnectHistory.clear();
 	}
 
 	/**
@@ -870,15 +874,15 @@ export class MCPManager {
 	): Promise<MCPServerConnection | null> {
 		if (options?.manual) {
 			this.#reconnectHistory.delete(name);
+			this.#authReconnectHistory.delete(name);
 		}
 
 		const pending = this.#pendingReconnections.get(name);
 		if (pending) return pending;
 
 		const authDriven = options?.authChallenge !== undefined;
-		if (!authDriven && this.#tripReconnectBreaker(name)) {
-			return null;
-		}
+		const breakerTripped = authDriven ? this.#tripAuthReconnectBreaker(name) : this.#tripReconnectBreaker(name);
+		if (breakerTripped) return null;
 
 		const suppressNotices = options?.manual === true || authDriven;
 		if (!suppressNotices) this.#emitReconnectNotice({ type: "reconnecting", serverName: name });
@@ -889,23 +893,36 @@ export class MCPManager {
 	}
 
 	/**
-	 * Record a reconnect attempt against the per-server crash window and report
-	 * whether the circuit breaker is now open. Sliding window: entries older
-	 * than {@link RECONNECT_BURST_WINDOW_MS} are pruned before the new
-	 * timestamp is appended, so a single transient failure ages out cheaply
-	 * but repeated rapid crashes accumulate until the limit is hit.
+	 * Record one attempt in a sliding per-server window and return the number
+	 * still inside {@link RECONNECT_BURST_WINDOW_MS}.
 	 */
-	#tripReconnectBreaker(name: string): boolean {
+	#recordReconnectAttempt(history: Map<string, number[]>, name: string): number {
 		const now = Date.now();
-		const previous = this.#reconnectHistory.get(name) ?? [];
-		const recent = previous.filter(ts => now - ts < RECONNECT_BURST_WINDOW_MS);
+		const recent = (history.get(name) ?? []).filter(ts => now - ts < RECONNECT_BURST_WINDOW_MS);
 		recent.push(now);
-		this.#reconnectHistory.set(name, recent);
+		history.set(name, recent);
+		return recent.length;
+	}
 
-		if (recent.length > RECONNECT_BURST_LIMIT) {
+	#tripAuthReconnectBreaker(name: string): boolean {
+		const attempts = this.#recordReconnectAttempt(this.#authReconnectHistory, name);
+		if (attempts <= RECONNECT_BURST_LIMIT) return false;
+		logger.error("MCP authentication retried too many times; suspending automatic reauthorization", {
+			path: `mcp:${name}`,
+			attempts,
+			windowMs: RECONNECT_BURST_WINDOW_MS,
+		});
+		return true;
+	}
+
+	/** Trip the user-visible transport crash breaker and tear down stale state. */
+	#tripReconnectBreaker(name: string): boolean {
+		const crashes = this.#recordReconnectAttempt(this.#reconnectHistory, name);
+
+		if (crashes > RECONNECT_BURST_LIMIT) {
 			logger.error("MCP server crashed too many times; suspending automatic reconnects", {
 				path: `mcp:${name}`,
-				crashes: recent.length,
+				crashes,
 				windowMs: RECONNECT_BURST_WINDOW_MS,
 			});
 			// Tear down the stale connection so `getConnectionStatus()` no
@@ -923,7 +940,7 @@ export class MCPManager {
 			}
 			this.#pendingConnections.delete(name);
 			this.#pendingToolLoads.delete(name);
-			this.#emitReconnectNotice({ type: "reconnect-suspended", serverName: name, crashes: recent.length });
+			this.#emitReconnectNotice({ type: "reconnect-suspended", serverName: name, crashes });
 			return true;
 		}
 		return false;

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -266,8 +266,8 @@ export class MCPManager {
 		}
 	}
 
-	#emitReconnectFailure(name: string, error: string, manual = false): void {
-		if (!manual) this.#emitReconnectNotice({ type: "reconnect-failed", serverName: name, error });
+	#emitReconnectFailure(name: string, error: string, suppressNotice = false): void {
+		if (!suppressNotice) this.#emitReconnectNotice({ type: "reconnect-failed", serverName: name, error });
 	}
 
 	/**
@@ -861,8 +861,8 @@ export class MCPManager {
 	 * burst limit (see {@link RECONNECT_BURST_LIMIT}) is exceeded.
 	 * @param options.manual - When `true`, resets the crash-burst window so a
 	 *   user-driven retry (e.g. `/mcp reconnect`) is never blocked by an
-	 *   earlier storm. Defaults to `false`; the transport `onClose` callback
-	 *   and the per-tool-call retry path in `tool-bridge` MUST NOT set it.
+	 *   earlier storm. Auth-challenge reconnects are also excluded from crash
+	 *   accounting and notices because they are expected reauthorization.
 	 */
 	async reconnectServer(
 		name: string,
@@ -875,13 +875,15 @@ export class MCPManager {
 		const pending = this.#pendingReconnections.get(name);
 		if (pending) return pending;
 
-		if (this.#tripReconnectBreaker(name)) {
+		const authDriven = options?.authChallenge !== undefined;
+		if (!authDriven && this.#tripReconnectBreaker(name)) {
 			return null;
 		}
 
-		if (!options?.manual) this.#emitReconnectNotice({ type: "reconnecting", serverName: name });
+		const suppressNotices = options?.manual === true || authDriven;
+		if (!suppressNotices) this.#emitReconnectNotice({ type: "reconnecting", serverName: name });
 
-		const attempt = this.#doReconnect(name, options?.authChallenge, options?.manual);
+		const attempt = this.#doReconnect(name, options?.authChallenge, suppressNotices);
 		this.#pendingReconnections.set(name, attempt);
 		return attempt.finally(() => this.#pendingReconnections.delete(name));
 	}
@@ -930,13 +932,13 @@ export class MCPManager {
 	async #doReconnect(
 		name: string,
 		authChallenge?: MCPAuthChallenge,
-		manual = false,
+		suppressNotices = false,
 	): Promise<MCPServerConnection | null> {
 		const oldConnection = this.#connections.get(name);
 		let config = oldConnection?.config ?? this.#serverConfigs.get(name);
 		const source = this.#sources.get(name) ?? oldConnection?._source;
 		if (!config) {
-			this.#emitReconnectFailure(name, "No saved server configuration is available.", manual);
+			this.#emitReconnectFailure(name, "No saved server configuration is available.", suppressNotices);
 			return null;
 		}
 
@@ -946,20 +948,24 @@ export class MCPManager {
 				logger.error("MCP auth challenge cannot be handled; no auth handler is configured", {
 					path: `mcp:${name}`,
 				});
-				this.#emitReconnectFailure(name, error, manual);
+				this.#emitReconnectFailure(name, error, suppressNotices);
 				return null;
 			}
 			try {
 				const refreshedConfig = await this.#authHandler(name, authChallenge);
 				if (!refreshedConfig) {
-					this.#emitReconnectFailure(name, "Authentication did not produce a server configuration.", manual);
+					this.#emitReconnectFailure(
+						name,
+						"Authentication did not produce a server configuration.",
+						suppressNotices,
+					);
 					return null;
 				}
 				config = refreshedConfig;
 				this.#serverConfigs.set(name, config);
 			} catch (error) {
 				logger.error("MCP auth challenge handling failed", { path: `mcp:${name}`, error });
-				this.#emitReconnectFailure(name, error instanceof Error ? error.message : String(error), manual);
+				this.#emitReconnectFailure(name, error instanceof Error ? error.message : String(error), suppressNotices);
 				return null;
 			}
 		}
@@ -995,7 +1001,7 @@ export class MCPManager {
 			try {
 				const connection = await this.#connectAndWireServer(name, config, source, reconnectEpoch);
 				logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
-				if (!manual) this.#emitReconnectNotice({ type: "reconnected", serverName: name });
+				if (!suppressNotices) this.#emitReconnectNotice({ type: "reconnected", serverName: name });
 				return connection;
 			} catch (error) {
 				if (this.#epoch !== reconnectEpoch) {
@@ -1017,7 +1023,7 @@ export class MCPManager {
 					await Bun.sleep(delays[attempt]);
 				} else {
 					logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
-					this.#emitReconnectFailure(name, msg, manual);
+					this.#emitReconnectFailure(name, msg, suppressNotices);
 					// Don't remove stale tools — keep them in the registry so they
 					// remain selected. Calls will fail with MCP errors, which
 					// triggers the tool-level reconnect, or the user can run

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -198,6 +198,9 @@ export class MCPManager {
 	#onToolsChanged?: (tools: CustomTool<TSchema, MCPToolDetails>[]) => void;
 	#onResourcesChanged?: (serverName: string, uri: string) => void;
 	#onPromptsChanged?: (serverName: string) => void;
+	/** Channel for user-visible reconnect notices (`mcp.reconnectNotices`). */
+	#onConnectionStatus?: (event: McpConnectionStatusEvent) => void;
+	#reconnectNoticesEnabled = false;
 	#notificationsEnabled = false;
 	#notificationsEpoch = 0;
 	#subscribedResources = new Map<string, Set<string>>();
@@ -230,6 +233,26 @@ export class MCPManager {
 	 */
 	setOnToolsChanged(handler: (tools: CustomTool<TSchema, MCPToolDetails>[]) => void): void {
 		this.#onToolsChanged = handler;
+	}
+
+	/** Enable/disable user-visible reconnect notices (`mcp.reconnectNotices`). */
+	setReconnectNoticesEnabled(enabled: boolean): void {
+		this.#reconnectNoticesEnabled = enabled;
+	}
+
+	/** Register the channel reconnect notices are emitted on (interactive sessions). */
+	setOnConnectionStatus(handler: ((event: McpConnectionStatusEvent) => void) | undefined): void {
+		this.#onConnectionStatus = handler;
+	}
+
+	/** Fire a reconnect notice when enabled; a throwing consumer must never break reconnects. */
+	#emitReconnectNotice(event: McpConnectionStatusEvent): void {
+		if (!this.#reconnectNoticesEnabled) return;
+		try {
+			this.#onConnectionStatus?.(event);
+		} catch {
+			// notice delivery is best-effort by design
+		}
 	}
 
 	/**
@@ -841,7 +864,9 @@ export class MCPManager {
 			return null;
 		}
 
-		const attempt = this.#doReconnect(name, options?.authChallenge);
+		if (!options?.manual) this.#emitReconnectNotice({ type: "reconnecting", serverName: name });
+
+		const attempt = this.#doReconnect(name, options?.authChallenge, options?.manual);
 		this.#pendingReconnections.set(name, attempt);
 		return attempt.finally(() => this.#pendingReconnections.delete(name));
 	}
@@ -881,12 +906,17 @@ export class MCPManager {
 			}
 			this.#pendingConnections.delete(name);
 			this.#pendingToolLoads.delete(name);
+			this.#emitReconnectNotice({ type: "reconnect-suspended", serverName: name, crashes: recent.length });
 			return true;
 		}
 		return false;
 	}
 
-	async #doReconnect(name: string, authChallenge?: MCPAuthChallenge): Promise<MCPServerConnection | null> {
+	async #doReconnect(
+		name: string,
+		authChallenge?: MCPAuthChallenge,
+		manual = false,
+	): Promise<MCPServerConnection | null> {
 		const oldConnection = this.#connections.get(name);
 		let config = oldConnection?.config ?? this.#serverConfigs.get(name);
 		const source = this.#sources.get(name) ?? oldConnection?._source;
@@ -941,6 +971,7 @@ export class MCPManager {
 			try {
 				const connection = await this.#connectAndWireServer(name, config, source, reconnectEpoch);
 				logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
+				if (!manual) this.#emitReconnectNotice({ type: "reconnected", serverName: name });
 				return connection;
 			} catch (error) {
 				if (this.#epoch !== reconnectEpoch) {
@@ -962,6 +993,7 @@ export class MCPManager {
 					await Bun.sleep(delays[attempt]);
 				} else {
 					logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
+					if (!manual) this.#emitReconnectNotice({ type: "reconnect-failed", serverName: name, error: msg });
 					// Don't remove stale tools — keep them in the registry so they
 					// remain selected. Calls will fail with MCP errors, which
 					// triggers the tool-level reconnect, or the user can run

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -97,19 +97,22 @@ export function formatMCPConnectionStatusMessage(snapshot: McpConnectionStatusSn
 
 export function formatMCPReconnectNotice(event: McpReconnectStatusEvent): string {
 	const name = sanitizeMcpServerName(event.serverName);
-	// Recovery commands embed the FULL server name (sanitized for control
-	// chars only): sanitizeMcpServerName truncates to 40 cells, which would
-	// point the command at a nonexistent truncated server.
-	const fullName = sanitizeText(event.serverName);
+	// Keep exact, ordinary names actionable. Control characters cannot be
+	// represented safely in a one-line slash command, so those notices direct
+	// the user to the interactive MCP menu instead.
+	const hasUnsafeCommandChars = /[\r\n\t]/.test(event.serverName);
+	const recovery = hasUnsafeCommandChars
+		? "Use /mcp to retry manually."
+		: `Run /mcp reconnect ${sanitizeText(event.serverName)} to retry.`;
 	switch (event.type) {
 		case "reconnecting":
 			return `MCP server "${name}" lost its connection — reconnecting…`;
 		case "reconnected":
 			return `MCP server "${name}" reconnected.`;
 		case "reconnect-failed":
-			return `MCP server "${name}" could not reconnect: ${sanitizeMcpStatusError(event.error)} Run /mcp reconnect ${fullName} to retry.`;
+			return `MCP server "${name}" could not reconnect: ${sanitizeMcpStatusError(event.error)} ${recovery}`;
 		case "reconnect-suspended":
-			return `MCP server "${name}" crashed ${event.crashes} times in quick succession — automatic reconnects suspended. Fix the server, then run /mcp reconnect ${fullName}.`;
+			return `MCP server "${name}" crashed ${event.crashes} times in quick succession — automatic reconnects suspended. Fix the server, then ${recovery.charAt(0).toLowerCase()}${recovery.slice(1)}`;
 	}
 }
 

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -99,14 +99,17 @@ export function formatMCPConnectionStatusMessage(snapshot: McpConnectionStatusSn
 export function formatMCPReconnectNotice(event: McpReconnectStatusEvent): string {
 	const name = sanitizeMcpServerName(event.serverName);
 	const commandName = sanitizeText(event.serverName);
-	// Preserve an exact command only when its argument is parser-safe and its
-	// full value is already safe to display. Paths and names that require
-	// shortening/truncation use the generic interactive recovery flow instead.
+	// Preserve an exact command only when the advertised argument is the real
+	// server key: parser-safe, display-safe, and unchanged by sanitization.
+	// Control/ANSI stripping that would make `commandName === name` while
+	// both differ from the original key must fall back to generic `/mcp`
+	// (exact reconnect lookup would miss `server\x01` if we advertised `server`).
 	const commandNameIsSafe =
 		!/\s/.test(event.serverName) &&
 		!path.isAbsolute(event.serverName) &&
 		!path.win32.isAbsolute(event.serverName) &&
-		commandName === name;
+		commandName === event.serverName &&
+		name === event.serverName;
 	const recovery = commandNameIsSafe ? `Run /mcp reconnect ${commandName} to retry.` : "Use /mcp to retry manually.";
 	switch (event.type) {
 		case "reconnecting":

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -97,10 +97,10 @@ export function formatMCPConnectionStatusMessage(snapshot: McpConnectionStatusSn
 
 export function formatMCPReconnectNotice(event: McpReconnectStatusEvent): string {
 	const name = sanitizeMcpServerName(event.serverName);
-	// Keep exact, ordinary names actionable. Control characters cannot be
-	// represented safely in a one-line slash command, so those notices direct
-	// the user to the interactive MCP menu instead.
-	const hasUnsafeCommandChars = /[\r\n\t]/.test(event.serverName);
+	// Keep exact, ordinary names actionable. Whitespace cannot be represented
+	// by the current slash-command parser as one server-name argument, while
+	// control characters are also unsafe in a one-line status message.
+	const hasUnsafeCommandChars = /\s/.test(event.serverName);
 	const recovery = hasUnsafeCommandChars
 		? "Use /mcp to retry manually."
 		: `Run /mcp reconnect ${sanitizeText(event.serverName)} to retry.`;

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -6,7 +6,14 @@ export const MCP_CONNECTION_STATUS_EVENT_CHANNEL = "mcp:connection-status";
 export type McpConnectionStatusEvent =
 	| { type: "connecting"; serverNames: string[] }
 	| { type: "connected"; serverName: string }
-	| { type: "failed"; serverName: string; error: string };
+	| { type: "failed"; serverName: string; error: string }
+	| { type: "reconnecting"; serverName: string }
+	| { type: "reconnected"; serverName: string }
+	| { type: "reconnect-failed"; serverName: string; error: string }
+	| { type: "reconnect-suspended"; serverName: string; crashes: number };
+
+/** Reconnect-phase subset of {@link McpConnectionStatusEvent}. */
+export type McpReconnectStatusEvent = Extract<McpConnectionStatusEvent, { type: `reconnect${string}` }>;
 
 export type McpConnectionStatusSnapshot = {
 	pendingServers: readonly string[];
@@ -88,6 +95,24 @@ export function formatMCPConnectionStatusMessage(snapshot: McpConnectionStatusSn
 	return "";
 }
 
+export function formatMCPReconnectNotice(event: McpReconnectStatusEvent): string {
+	const name = sanitizeMcpServerName(event.serverName);
+	// Recovery commands embed the FULL server name (sanitized for control
+	// chars only): sanitizeMcpServerName truncates to 40 cells, which would
+	// point the command at a nonexistent truncated server.
+	const fullName = sanitizeText(event.serverName);
+	switch (event.type) {
+		case "reconnecting":
+			return `MCP server "${name}" lost its connection — reconnecting…`;
+		case "reconnected":
+			return `MCP server "${name}" reconnected.`;
+		case "reconnect-failed":
+			return `MCP server "${name}" could not reconnect: ${sanitizeMcpStatusError(event.error)} Run /mcp reconnect ${fullName} to retry.`;
+		case "reconnect-suspended":
+			return `MCP server "${name}" crashed ${event.crashes} times in quick succession — automatic reconnects suspended. Fix the server, then run /mcp reconnect ${fullName}.`;
+	}
+}
+
 function isRecord(data: unknown): data is Record<string, unknown> {
 	return typeof data === "object" && data !== null;
 }
@@ -110,6 +135,13 @@ export function isMcpConnectionStatusEvent(data: unknown): data is McpConnection
 			return typeof data.serverName === "string";
 		case "failed":
 			return typeof data.serverName === "string" && typeof data.error === "string";
+		case "reconnecting":
+		case "reconnected":
+			return typeof data.serverName === "string";
+		case "reconnect-failed":
+			return typeof data.serverName === "string" && typeof data.error === "string";
+		case "reconnect-suspended":
+			return typeof data.serverName === "string" && typeof data.crashes === "number";
 		default:
 			return false;
 	}

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import { replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
 
@@ -97,13 +98,16 @@ export function formatMCPConnectionStatusMessage(snapshot: McpConnectionStatusSn
 
 export function formatMCPReconnectNotice(event: McpReconnectStatusEvent): string {
 	const name = sanitizeMcpServerName(event.serverName);
-	// Keep exact, ordinary names actionable. Whitespace cannot be represented
-	// by the current slash-command parser as one server-name argument, while
-	// control characters are also unsafe in a one-line status message.
-	const hasUnsafeCommandChars = /\s/.test(event.serverName);
-	const recovery = hasUnsafeCommandChars
-		? "Use /mcp to retry manually."
-		: `Run /mcp reconnect ${sanitizeText(event.serverName)} to retry.`;
+	const commandName = sanitizeText(event.serverName);
+	// Preserve an exact command only when its argument is parser-safe and its
+	// full value is already safe to display. Paths and names that require
+	// shortening/truncation use the generic interactive recovery flow instead.
+	const commandNameIsSafe =
+		!/\s/.test(event.serverName) &&
+		!path.isAbsolute(event.serverName) &&
+		!path.win32.isAbsolute(event.serverName) &&
+		commandName === name;
+	const recovery = commandNameIsSafe ? `Run /mcp reconnect ${commandName} to retry.` : "Use /mcp to retry manually.";
 	switch (event.type) {
 		case "reconnecting":
 			return `MCP server "${name}" lost its connection — reconnecting…`;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -640,9 +640,6 @@ export class SelectorController {
 			case "mcp.notifications":
 				this.ctx.mcpManager?.setNotificationsEnabled(value as boolean);
 				break;
-			case "mcp.reconnectNotices":
-				this.ctx.mcpManager?.setReconnectNoticesEnabled(value as boolean);
-				break;
 
 			// All other settings are handled by the definitions (get/set on SettingsManager)
 			// No additional side effects needed

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -640,6 +640,9 @@ export class SelectorController {
 			case "mcp.notifications":
 				this.ctx.mcpManager?.setNotificationsEnabled(value as boolean);
 				break;
+			case "mcp.reconnectNotices":
+				this.ctx.mcpManager?.setReconnectNoticesEnabled(value as boolean);
+				break;
 
 			// All other settings are handled by the definitions (get/set on SettingsManager)
 			// No additional side effects needed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -85,6 +85,7 @@ import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-
 import type { MCPManager } from "../mcp";
 import {
 	formatMCPConnectionStatusMessage,
+	formatMCPReconnectNotice,
 	isMcpConnectionStatusEvent,
 	MCP_CONNECTION_STATUS_EVENT_CHANNEL,
 	type McpConnectionStatusEvent,
@@ -803,6 +804,12 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	#handleMcpConnectionStatusEvent(event: McpConnectionStatusEvent): void {
+		// Reconnect notices (mcp.reconnectNotices) are one-shot runtime messages,
+		// not startup connect noise — deliver them even under startup.quiet.
+		if (event.type !== "connecting" && event.type !== "connected" && event.type !== "failed") {
+			this.showStatus(formatMCPReconnectNotice(event));
+			return;
+		}
 		if (this.settings.get("startup.quiet")) return;
 		if (event.type === "connecting") {
 			this.#mcpStatusOrder = [];

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1204,6 +1204,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			startupCredentialDisabledEvents.push(event);
 		}
 	});
+	let unsubscribeReconnectStatus: (() => void) | undefined;
 	const settings = await (options.settings ??
 		options.settingsManager ??
 		logger.time("settings", Settings.init, { cwd, agentDir }));
@@ -1853,9 +1854,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		}
 		if (options.hasUI && mcpManager) {
-			mcpManager.setReconnectNoticesEnabled(settings.get("mcp.reconnectNotices"));
-			const unsubscribeReconnectStatus = mcpManager.addConnectionStatusListener(onMCPStatus);
-			postmortem.register("mcp-reconnect-status-cleanup", unsubscribeReconnectStatus);
+			unsubscribeReconnectStatus = mcpManager.addConnectionStatusListener(onMCPStatus, () =>
+				settings.get("mcp.reconnectNotices"),
+			);
 		}
 		// Only top-level sessions own the global MCPManager. Subagents already
 		// receive the parent's manager via `options.mcpManager`, and reassigning
@@ -3242,6 +3243,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				} finally {
 					unregisterUnlessParked();
 					unsubscribeCredentialDisabled?.();
+					unsubscribeReconnectStatus?.();
 				}
 			};
 		}
@@ -3475,6 +3477,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// dispose-wrap took ownership. Idempotent with dispose() — Set.delete is a no-op
 		// for already-removed listeners.
 		unsubscribeCredentialDisabled?.();
+		unsubscribeReconnectStatus?.();
 		try {
 			if (hasSession) {
 				await session.dispose();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1774,7 +1774,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		let startDeferredMCPDiscovery: ((liveSession: AgentSession) => void) | undefined;
 		const startupQuiet = settings.get("startup.quiet");
 		const onMCPStatus = (event: McpConnectionStatusEvent) => {
-			if (!options.hasUI || startupQuiet) return;
+			if (!options.hasUI) return;
+			// Reconnect notices are a runtime instability signal the user explicitly
+			// opted into via mcp.reconnectNotices — startup.quiet only suppresses
+			// startup connect noise, so it must not gate them.
+			if (startupQuiet && !event.type.startsWith("reconnect")) return;
 			if (event.type === "connecting" && event.serverNames.length === 0) return;
 			eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event);
 		};
@@ -1796,6 +1800,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				if (settings.get("mcp.notifications")) {
 					mcpManager.setNotificationsEnabled(true);
 				}
+				mcpManager.setReconnectNoticesEnabled(settings.get("mcp.reconnectNotices"));
+				mcpManager.setOnConnectionStatus(onMCPStatus);
 
 				const deferredMCPManager = mcpManager;
 				startDeferredMCPDiscovery = liveSession => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1800,8 +1800,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				if (settings.get("mcp.notifications")) {
 					mcpManager.setNotificationsEnabled(true);
 				}
-				mcpManager.setReconnectNoticesEnabled(settings.get("mcp.reconnectNotices"));
-				mcpManager.setOnConnectionStatus(onMCPStatus);
 
 				const deferredMCPManager = mcpManager;
 				startDeferredMCPDiscovery = liveSession => {
@@ -1853,6 +1851,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					customTools.push(...mcpResult.tools.map(loaded => loaded.tool));
 				}
 			}
+		}
+		if (options.hasUI && mcpManager) {
+			mcpManager.setReconnectNoticesEnabled(settings.get("mcp.reconnectNotices"));
+			const unsubscribeReconnectStatus = mcpManager.addConnectionStatusListener(onMCPStatus);
+			postmortem.register("mcp-reconnect-status-cleanup", unsubscribeReconnectStatus);
 		}
 		// Only top-level sessions own the global MCPManager. Subagents already
 		// receive the parent's manager via `options.mcpManager`, and reassigning

--- a/packages/coding-agent/test/fixtures/crash-once-mcp.ts
+++ b/packages/coding-agent/test/fixtures/crash-once-mcp.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: a stdio MCP server that answers `initialize` + `tools/list`
+ * exactly once, then exits — simulating a server that crashes right after a
+ * successful connect. On the NEXT spawn (marker file exists from the first
+ * run) it behaves normally forever.
+ *
+ * Used by `mcp-reconnect-notices.test.ts` to drive the manager's automatic
+ * reconnect path: first spawn connects and dies → transport onClose →
+ * reconnect (which spawns a fresh, now-healthy process) → reconnect succeeds.
+ *
+ * Protocol identical to ./instructions-mcp.ts (newline-delimited JSON-RPC).
+ * argv[2] is the marker file path; argv[2] missing means "always healthy".
+ */
+import * as fs from "node:fs";
+import * as readline from "node:readline";
+
+export const CRASH_TOOL_NAME = "crash_probe";
+
+type JsonRpcRequest = {
+	jsonrpc: "2.0";
+	id?: string | number;
+	method: string;
+	params?: Record<string, unknown>;
+};
+
+const markerPath = process.argv[2];
+const alreadyCrashed = markerPath === undefined || fs.existsSync(markerPath);
+
+function buildResult(method: string): Record<string, unknown> {
+	switch (method) {
+		case "initialize":
+			return {
+				protocolVersion: "2025-03-26",
+				serverInfo: { name: "crash-once-fixture", version: "1.0.0" },
+				capabilities: { tools: {} },
+			};
+		case "tools/list":
+			return {
+				tools: [
+					{
+						name: CRASH_TOOL_NAME,
+						description: "Probe tool for the reconnect fixture.",
+						inputSchema: { type: "object", properties: {}, additionalProperties: false },
+					},
+				],
+			};
+		default:
+			return {};
+	}
+}
+
+function startServer(): void {
+	const rl = readline.createInterface({ input: process.stdin });
+	rl.on("line", line => {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) return;
+		let msg: JsonRpcRequest;
+		try {
+			msg = JSON.parse(trimmed) as JsonRpcRequest;
+		} catch {
+			return;
+		}
+		if (msg.id === undefined || msg.id === null) return;
+		process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: buildResult(msg.method) })}\n`);
+		if (!alreadyCrashed && msg.method === "tools/list") {
+			// Let the response flush, then "crash": mark and exit so the
+			// transport sees a dead child and the manager starts a reconnect.
+			fs.writeFileSync(markerPath as string, "crashed");
+			setTimeout(() => process.exit(1), 100);
+		}
+	});
+	rl.on("close", () => process.exit(0));
+}
+
+if (import.meta.main) {
+	startServer();
+}

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -133,17 +133,22 @@ describe("MCPManager reconnect notices", () => {
 		});
 	});
 
-	it("adds and removes a listener without replacing the owner", async () => {
+	it("scopes enablement to each additive listener without replacing the owner", async () => {
 		const owner: McpConnectionStatusEvent[] = [];
 		const shared: McpConnectionStatusEvent[] = [];
+		let sharedEnabled = true;
 		manager = new MCPManager(tempDir, null);
 		manager.setOnConnectionStatus(event => owner.push(event));
-		const unsubscribe = manager.addConnectionStatusListener(event => shared.push(event));
 		manager.setReconnectNoticesEnabled(true);
+		const unsubscribe = manager.addConnectionStatusListener(
+			event => shared.push(event),
+			() => sharedEnabled,
+		);
 
 		await manager.reconnectServer("first");
-		unsubscribe();
+		sharedEnabled = false;
 		await manager.reconnectServer("second");
+		unsubscribe();
 		expect(owner).toHaveLength(4);
 		expect(shared).toHaveLength(2);
 	});
@@ -158,25 +163,35 @@ describe("MCPManager reconnect notices", () => {
 		expect(notice).not.toContain("\n");
 		expect(notice).toContain("Use /mcp to retry manually.");
 		expect(notice).not.toContain("/mcp reconnect");
+		const spacedNotice = formatMCPReconnectNotice({
+			type: "reconnect-failed",
+			serverName: "server with spaces",
+			error: "offline",
+		});
+		expect(spacedNotice).toContain("Use /mcp to retry manually.");
+		expect(spacedNotice).not.toContain("/mcp reconnect");
 	});
 
-	it("wires a supplied UI manager without replacing its owner", async () => {
+	it("scopes a supplied manager listener to the session settings and lifetime", async () => {
 		const owner: McpConnectionStatusEvent[] = [];
 		const uiEvents: McpConnectionStatusEvent[] = [];
 		manager = new MCPManager(tempDir, null);
 		manager.setOnConnectionStatus(event => owner.push(event));
+		manager.setReconnectNoticesEnabled(true);
 		const eventBus = new EventBus();
 		const unsubscribe = eventBus.on(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event => {
 			if (isMcpConnectionStatusEvent(event)) uiEvents.push(event);
 		});
 		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
 		const modelRegistry = new ModelRegistry(authStorage);
+		const settings = Settings.isolated();
+		settings.set("mcp.reconnectNotices", true);
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
 			modelRegistry,
 			sessionManager: SessionManager.inMemory(),
-			settings: Settings.isolated({ "mcp.reconnectNotices": true }),
+			settings,
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			eventBus,
 			mcpManager: manager,
@@ -194,14 +209,21 @@ describe("MCPManager reconnect notices", () => {
 			await manager.reconnectServer("during-session");
 			expect(owner).toHaveLength(2);
 			expect(uiEvents).toHaveLength(2);
+
+			settings.set("mcp.reconnectNotices", false);
+			await manager.reconnectServer("disabled-during-session");
+			expect(owner).toHaveLength(4);
+			expect(uiEvents).toHaveLength(2);
+
+			settings.set("mcp.reconnectNotices", true);
+			await session.dispose();
+			await manager.reconnectServer("after-dispose");
+			expect(owner).toHaveLength(6);
+			expect(uiEvents).toHaveLength(2);
 		} finally {
 			await session.dispose();
 			unsubscribe();
 			authStorage.close();
 		}
-
-		await manager.reconnectServer("after-dispose");
-		expect(owner).toHaveLength(4);
-		expect(uiEvents).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -185,6 +185,24 @@ describe("MCPManager reconnect notices", () => {
 		});
 		expect(spacedNotice).toContain("Use /mcp to retry manually.");
 		expect(spacedNotice).not.toContain("/mcp reconnect");
+		const absoluteName = path.join(os.homedir(), "private-mcp-server");
+		const absoluteNotice = formatMCPReconnectNotice({
+			type: "reconnect-failed",
+			serverName: absoluteName,
+			error: "offline",
+		});
+		expect(absoluteNotice).toContain("Use /mcp to retry manually.");
+		expect(absoluteNotice).not.toContain(absoluteName);
+		expect(absoluteNotice).not.toContain("/mcp reconnect");
+		const longName = `mcp-${"x".repeat(100)}`;
+		const longNotice = formatMCPReconnectNotice({
+			type: "reconnect-failed",
+			serverName: longName,
+			error: "offline",
+		});
+		expect(longNotice).toContain("Use /mcp to retry manually.");
+		expect(longNotice).not.toContain(longName);
+		expect(longNotice).not.toContain("/mcp reconnect");
 	});
 
 	it("scopes a supplied manager listener to the session settings and lifetime", async () => {

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -133,6 +133,21 @@ describe("MCPManager reconnect notices", () => {
 		});
 	});
 
+	it("keeps auth-driven reconnects out of crash notices and accounting", async () => {
+		const events: McpConnectionStatusEvent[] = [];
+		manager = new MCPManager(tempDir, null);
+		manager.setOnConnectionStatus(event => events.push(event));
+		manager.setReconnectNoticesEnabled(true);
+		const authChallenge = { wwwAuthenticate: ['Bearer realm="test"'] };
+
+		for (let attempt = 0; attempt < 7; attempt++) {
+			expect(await manager.reconnectServer("missing", { authChallenge })).toBeNull();
+		}
+		expect(events).toEqual([]);
+
+		expect(await manager.reconnectServer("missing")).toBeNull();
+		expect(events.map(event => event.type)).toEqual(["reconnecting", "reconnect-failed"]);
+	});
 	it("scopes enablement to each additive listener without replacing the owner", async () => {
 		const owner: McpConnectionStatusEvent[] = [];
 		const shared: McpConnectionStatusEvent[] = [];

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -133,16 +133,31 @@ describe("MCPManager reconnect notices", () => {
 		});
 	});
 
-	it("keeps auth-driven reconnects out of crash notices and accounting", async () => {
+	it("silently bounds auth-driven reconnects without consuming the transport breaker", async () => {
 		const events: McpConnectionStatusEvent[] = [];
 		manager = new MCPManager(tempDir, null);
 		manager.setOnConnectionStatus(event => events.push(event));
 		manager.setReconnectNoticesEnabled(true);
+		await manager.connectServers(
+			{
+				auth: {
+					type: "stdio",
+					command: path.join(tempDir, "missing-auth-mcp"),
+				},
+			},
+			{},
+		);
+		let authAttempts = 0;
+		manager.setAuthHandler(async () => {
+			authAttempts++;
+			throw new Error("simulated authentication failure");
+		});
 		const authChallenge = { wwwAuthenticate: ['Bearer realm="test"'] };
 
 		for (let attempt = 0; attempt < 7; attempt++) {
-			expect(await manager.reconnectServer("missing", { authChallenge })).toBeNull();
+			expect(await manager.reconnectServer("auth", { authChallenge })).toBeNull();
 		}
+		expect(authAttempts).toBe(5);
 		expect(events).toEqual([]);
 
 		expect(await manager.reconnectServer("missing")).toBeNull();

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import type { McpConnectionStatusEvent } from "@oh-my-pi/pi-coding-agent/mcp/startup-events";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+// Contract: with `mcp.reconnectNotices` enabled, the automatic reconnect path
+// (transport close → backoff reconnect) emits user-visible status events:
+// "reconnecting" when the connection drops and "reconnected" when it
+// recovers. With the default (disabled), no reconnect events are emitted.
+// Manual reconnects are excluded — they already have interactive UI feedback.
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "crash-once-mcp.ts");
+
+async function waitForEvent(
+	events: McpConnectionStatusEvent[],
+	type: McpConnectionStatusEvent["type"],
+	deadlineMs = 15_000,
+): Promise<McpConnectionStatusEvent | undefined> {
+	const deadline = Date.now() + deadlineMs;
+	while (Date.now() < deadline) {
+		const found = events.find(event => event.type === type);
+		if (found) return found;
+		await Bun.sleep(50);
+	}
+	return undefined;
+}
+
+describe("MCPManager reconnect notices", () => {
+	let tempDir: string;
+	let manager: MCPManager | undefined;
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-mcp-reconnect-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		if (manager) {
+			await manager.disconnectAll();
+			manager = undefined;
+		}
+		if (tempDir && fs.existsSync(tempDir)) {
+			removeSyncWithRetries(tempDir);
+		}
+	});
+
+	it("emits reconnecting then reconnected when a server crashes and recovers", async () => {
+		const events: McpConnectionStatusEvent[] = [];
+		manager = new MCPManager(tempDir, null);
+		manager.setOnConnectionStatus(event => events.push(event));
+		manager.setReconnectNoticesEnabled(true);
+
+		const marker = path.join(tempDir, "crashed.once");
+		await manager.connectServers(
+			{ crashy: { type: "stdio", command: process.execPath, args: [FIXTURE_PATH, marker] } },
+			{},
+		);
+		expect(manager.getConnectionStatus("crashy")).toBe("connected");
+
+		// The fixture exits 100ms after answering tools/list; the manager's
+		// onClose handler then drives the automatic reconnect (backoff 500ms+).
+		const reconnecting = await waitForEvent(events, "reconnecting");
+		expect(reconnecting).toBeDefined();
+		expect(reconnecting).toMatchObject({ serverName: "crashy" });
+
+		const reconnected = await waitForEvent(events, "reconnected");
+		expect(reconnected).toBeDefined();
+		expect(reconnected).toMatchObject({ serverName: "crashy" });
+
+		// Order matters: the drop must be announced before the recovery.
+		const firstIdx = events.findIndex(event => event.type === "reconnecting");
+		const secondIdx = events.findIndex(event => event.type === "reconnected");
+		expect(firstIdx).toBeGreaterThanOrEqual(0);
+		expect(secondIdx).toBeGreaterThan(firstIdx);
+
+		expect(manager.getConnectionStatus("crashy")).toBe("connected");
+	}, 25_000);
+
+	it("emits nothing with notices disabled (default)", async () => {
+		const events: McpConnectionStatusEvent[] = [];
+		manager = new MCPManager(tempDir, null);
+		manager.setOnConnectionStatus(event => events.push(event));
+		// setReconnectNoticesEnabled never called — default is off.
+
+		const marker = path.join(tempDir, "crashed.once");
+		await manager.connectServers(
+			{ crashy: { type: "stdio", command: process.execPath, args: [FIXTURE_PATH, marker] } },
+			{},
+		);
+		expect(manager.getConnectionStatus("crashy")).toBe("connected");
+
+		// Drive the crash + reconnect cycle by watching real connection state,
+		// not wall-clock guesses: the 500ms reconnect backoff keeps the
+		// "connecting" phase observable long enough for 50ms polls to catch.
+		// (Fake timers are not an option — the backoff and the fixture
+		// subprocess run against the platform clock by design.)
+		const deadline = Date.now() + 15_000;
+		while (manager.getConnectionStatus("crashy") !== "connecting" && Date.now() < deadline) {
+			await Bun.sleep(50);
+		}
+		while (manager.getConnectionStatus("crashy") !== "connected" && Date.now() < deadline) {
+			await Bun.sleep(50);
+		}
+		expect(manager.getConnectionStatus("crashy")).toBe("connected");
+		expect(events.filter(event => event.type.startsWith("reconnect"))).toEqual([]);
+	}, 25_000);
+});

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -2,8 +2,20 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
-import type { McpConnectionStatusEvent } from "@oh-my-pi/pi-coding-agent/mcp/startup-events";
+import {
+	formatMCPReconnectNotice,
+	isMcpConnectionStatusEvent,
+	MCP_CONNECTION_STATUS_EVENT_CHANNEL,
+	type McpConnectionStatusEvent,
+} from "@oh-my-pi/pi-coding-agent/mcp/startup-events";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 // Contract: with `mcp.reconnectNotices` enabled, the automatic reconnect path
@@ -106,4 +118,90 @@ describe("MCPManager reconnect notices", () => {
 		expect(manager.getConnectionStatus("crashy")).toBe("connected");
 		expect(events.filter(event => event.type.startsWith("reconnect"))).toEqual([]);
 	}, 25_000);
+
+	it("emits a terminal failure when reconnect cannot start", async () => {
+		const events: McpConnectionStatusEvent[] = [];
+		manager = new MCPManager(tempDir, null);
+		manager.setOnConnectionStatus(event => events.push(event));
+		manager.setReconnectNoticesEnabled(true);
+
+		expect(await manager.reconnectServer("missing")).toBeNull();
+		expect(events.map(event => event.type)).toEqual(["reconnecting", "reconnect-failed"]);
+		expect(events[1]).toMatchObject({
+			serverName: "missing",
+			error: "No saved server configuration is available.",
+		});
+	});
+
+	it("adds and removes a listener without replacing the owner", async () => {
+		const owner: McpConnectionStatusEvent[] = [];
+		const shared: McpConnectionStatusEvent[] = [];
+		manager = new MCPManager(tempDir, null);
+		manager.setOnConnectionStatus(event => owner.push(event));
+		const unsubscribe = manager.addConnectionStatusListener(event => shared.push(event));
+		manager.setReconnectNoticesEnabled(true);
+
+		await manager.reconnectServer("first");
+		unsubscribe();
+		await manager.reconnectServer("second");
+		expect(owner).toHaveLength(4);
+		expect(shared).toHaveLength(2);
+	});
+
+	it("keeps recovery notices on one line for unsafe server names", () => {
+		const notice = formatMCPReconnectNotice({
+			type: "reconnect-failed",
+			serverName: "bad\tserver\nname",
+			error: "offline",
+		});
+		expect(notice).not.toContain("\t");
+		expect(notice).not.toContain("\n");
+		expect(notice).toContain("Use /mcp to retry manually.");
+		expect(notice).not.toContain("/mcp reconnect");
+	});
+
+	it("wires a supplied UI manager without replacing its owner", async () => {
+		const owner: McpConnectionStatusEvent[] = [];
+		const uiEvents: McpConnectionStatusEvent[] = [];
+		manager = new MCPManager(tempDir, null);
+		manager.setOnConnectionStatus(event => owner.push(event));
+		const eventBus = new EventBus();
+		const unsubscribe = eventBus.on(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event => {
+			if (isMcpConnectionStatusEvent(event)) uiEvents.push(event);
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.reconnectNotices": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			eventBus,
+			mcpManager: manager,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+		});
+		try {
+			await manager.reconnectServer("during-session");
+			expect(owner).toHaveLength(2);
+			expect(uiEvents).toHaveLength(2);
+		} finally {
+			await session.dispose();
+			unsubscribe();
+			authStorage.close();
+		}
+
+		await manager.reconnectServer("after-dispose");
+		expect(owner).toHaveLength(4);
+		expect(uiEvents).toHaveLength(2);
+	});
 });

--- a/packages/coding-agent/test/mcp-reconnect-notices.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-notices.test.ts
@@ -218,6 +218,16 @@ describe("MCPManager reconnect notices", () => {
 		expect(longNotice).toContain("Use /mcp to retry manually.");
 		expect(longNotice).not.toContain(longName);
 		expect(longNotice).not.toContain("/mcp reconnect");
+		// Control chars strip equally from display + command text; equality of
+		// the two sanitized forms must not advertise a reconnect key that no
+		// longer matches the manager's real server name.
+		const controlNotice = formatMCPReconnectNotice({
+			type: "reconnect-failed",
+			serverName: "server\u0001",
+			error: "offline",
+		});
+		expect(controlNotice).toContain("Use /mcp to retry manually.");
+		expect(controlNotice).not.toContain("/mcp reconnect");
 	});
 
 	it("scopes a supplied manager listener to the session settings and lifetime", async () => {


### PR DESCRIPTION
## What

New opt-in setting `mcp.reconnectNotices` (default `false` = unchanged behavior). When enabled, automatic MCP reconnects emit user-visible status events: `reconnecting`, `reconnected`, `reconnect-failed`, and `reconnect-suspended` (crash-storm circuit breaker).

## Why

Automatic reconnects were silent: a dropped transport reconnected with backoff, failed after retries, or tripped the >5-crashes-in-30s breaker with log-only output. A flapping or misconfigured server was invisible to the user unless they went looking — while its tools silently degraded. This makes instability observable the moment it happens.

## How

- `mcp/startup-events.ts`: the `McpConnectionStatusEvent` union gains the four reconnect event types (plus runtime validator cases and a sanitized formatter), reusing the existing `mcp:connection-status` channel and UI handler.
- `mcp/manager.ts`: `setReconnectNoticesEnabled()` + `setOnConnectionStatus()`; notices fire from the reconnect path (non-manual only — manual `/mcp reconnect` already has interactive feedback) and from the breaker trip. Notice delivery is best-effort and can never break a reconnect.
- `sdk.ts` wires the setting and channel for interactive sessions; `selector-controller.ts` makes it live-togglable from /settings; the TUI renders reconnect events as one-shot status messages.

## Verification

- New `test/mcp-reconnect-notices.test.ts` with a crash-once stdio MCP fixture: with notices on, a real crash→recover cycle emits `reconnecting` then `reconnected` in order; with notices off (default), zero events while the reconnect still completes. All pass, plus 14 adjacent MCP tests.
- `bun run check` (biome + tsgo) clean.

I reviewed the full diff; this change surfaces automatic MCP reconnects as opt-in status notices without altering any reconnect behavior.