### PR TITLE
feat(tools): add tools.xdevDocsMaxPercent to scale xd:// docs budget by context window

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `tools.xdevExternalDescriptionCap` (default `200`): makes the previously hardcoded 200-character truncation of external (MCP/custom/extension) `xd://` device descriptions in the system prompt and catalog listings configurable. Schemas are never truncated and `read xd://<tool>` still returns the full description.
+- Added `tools.xdevDocsMaxPercent` (default `0`): when above 0, caps the total inlined `xd://` device docs in the system prompt at that percent of the active model's context window (~4 chars/token) instead of the fixed 48,000-char budget; devices past the budget degrade to catalog entries with docs on demand.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `tools.xdevExternalDescriptionCap` (default `200`): makes the previously hardcoded 200-character truncation of external (MCP/custom/extension) `xd://` device descriptions in the system prompt and catalog listings configurable. Schemas are never truncated and `read xd://<tool>` still returns the full description.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4190,6 +4190,26 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tools.xdevExternalDescriptionCap": {
+		type: "number",
+		default: 200,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "xd:// Description Cap",
+			description:
+				"Maximum description characters embedded per external (MCP/custom/extension) xd:// device in the system prompt and catalog listings. Schemas are never truncated; the full description stays one `read xd://<tool>` away. Applies to new sessions.",
+			options: [
+				{ value: "100", label: "100 chars (tight)" },
+				{ value: "200", label: "200 chars (default)" },
+				{ value: "500", label: "500 chars" },
+				{ value: "1000", label: "1000 chars" },
+				{ value: "2000", label: "2000 chars" },
+				{ value: "4000", label: "4000 chars (full lede)" },
+			],
+		},
+	},
+
 	// MCP
 	"mcp.enableProjectConfig": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4210,6 +4210,25 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tools.xdevDocsMaxPercent": {
+		type: "number",
+		default: 0,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "xd:// Docs Budget %",
+			description:
+				"When above 0, cap the total inlined xd:// device docs at this percent of the model's context window (e.g. 10 = 10%); devices past the budget stay catalog entries with docs on demand. 0 uses the built-in 48k-char budget.",
+			options: [
+				{ value: "0", label: "Disabled (48k-char budget)" },
+				{ value: "1", label: "1% (minimal)" },
+				{ value: "5", label: "5%" },
+				{ value: "10", label: "10% (Claude Code-style)" },
+				{ value: "20", label: "20% (generous)" },
+			],
+		},
+	},
+
 	// MCP
 	"mcp.enableProjectConfig": {
 		type: "boolean",

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -193,6 +193,7 @@ import {
 	WebSearchTool,
 	WriteTool,
 	warmupLspServers,
+	XdevRegistry,
 } from "./tools";
 import { isMCPToolName, normalizeToolNames } from "./tools/builtin-names";
 import { ToolContextStore } from "./tools/context";
@@ -2685,6 +2686,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					toolSession.xdevRegistry?.docsAll(
 						settings.get("tools.xdevDocs"),
 						settings.get("tools.xdevInlineDevices"),
+						XdevRegistry.resolveDocsTotalBudget(
+							settings.get("tools.xdevDocsMaxPercent"),
+							(agent?.state.model ?? model)?.contextWindow,
+						),
 					) ?? "",
 				autoQaEnabled: !restrictToolNames && isAutoQaEnabled(settings),
 				resolvedCustomPrompt: options.customSystemPrompt,

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -19,7 +19,7 @@ import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
-import { isMountableUnderXdev, type XdevRegistry } from "../tools/xdev";
+import { isMountableUnderXdev, XdevRegistry } from "../tools/xdev";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { formatLocalCalendarDate } from "../utils/local-date";
 import {
@@ -578,6 +578,10 @@ export class SessionTools {
 			pending.added,
 			this.#host.settings.get("tools.xdevDocs"),
 			this.#host.settings.get("tools.xdevInlineDevices"),
+			XdevRegistry.resolveDocsTotalBudget(
+				this.#host.settings.get("tools.xdevDocsMaxPercent"),
+				this.#host.model()?.contextWindow,
+			),
 		);
 		return {
 			role: "custom",

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -627,7 +627,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			const mountable = mountBuiltinTools && isMountableUnderXdev(tool) && tool.name in BUILTIN_TOOLS;
 			(mountable ? mounted : kept).push(tool);
 		}
-		session.xdevRegistry = new XdevRegistry(mounted);
+		session.xdevRegistry = new XdevRegistry(mounted, session.settings.get("tools.xdevExternalDescriptionCap"));
 		tools = kept;
 		const finalActiveNames = new Set(tools.map(tool => tool.name));
 		if (session.setActiveToolNames) {

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -306,6 +306,23 @@ export class XdevRegistry {
 	static readonly EXTERNAL_DESCRIPTION_CAP = 200;
 
 	/**
+	 * Resolve the total docs-inline budget in chars: a percent of the model's
+	 * context window when `percent` > 0 and the window is known (converted at
+	 * the standard ~4 chars/token estimate), otherwise the built-in absolute
+	 * default. Mirrors the "tool text may not exceed N% of context" precedent
+	 * from other agents, but as an opt-in over the fixed budget.
+	 */
+	static resolveDocsTotalBudget(percent: number, contextWindow: number | null | undefined): number {
+		if (percent > 0 && contextWindow && contextWindow > 0) {
+			return Math.floor((Math.min(percent, 100) / 100) * contextWindow * XdevRegistry.DOCS_BUDGET_CHARS_PER_TOKEN);
+		}
+		return XdevRegistry.DOCS_TOTAL_BUDGET;
+	}
+
+	/** Chars-per-token estimate for percent-of-context budget conversion. */
+	static readonly DOCS_BUDGET_CHARS_PER_TOKEN = 4;
+
+	/**
 	 * Docs + schema for mounted devices, nested under `##` headings for
 	 * system-prompt embedding. Inlines full docs in catalog order (built-ins
 	 * first) until {@link DOCS_TOTAL_BUDGET} is spent; the rest are listed by
@@ -313,10 +330,11 @@ export class XdevRegistry {
 	 * Dynamic mounts embed at most {@link EXTERNAL_DESCRIPTION_CAP} description
 	 * chars (schema always intact); `read xd://<tool>` returns the full text.
 	 */
-	docsAll(mode: XdevDocsMode = "inline", inlinePatterns: readonly string[] = []): string {
+	docsAll(mode: XdevDocsMode = "inline", inlinePatterns: readonly string[] = [], totalBudget?: number): string {
 		const sections: string[] = [];
 		const overflow: Tool[] = [];
 		const inlineGlobs = compileInlineGlobs(inlinePatterns);
+		const budget = totalBudget ?? XdevRegistry.DOCS_TOTAL_BUDGET;
 		let used = 0;
 		for (const tool of this.list()) {
 			if (!this.#shouldInline(tool, mode, inlineGlobs)) {
@@ -325,7 +343,7 @@ export class XdevRegistry {
 			}
 			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
-			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET) {
+			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > budget) {
 				overflow.push(tool);
 				continue;
 			}
@@ -349,17 +367,22 @@ export class XdevRegistry {
 	}
 
 	/** Docs for selected mounted devices under the configured prompt-doc policy. */
-	docsFor(names: Iterable<string>, mode: XdevDocsMode, inlinePatterns: readonly string[] = []): string {
+	docsFor(
+		names: Iterable<string>,
+		mode: XdevDocsMode,
+		inlinePatterns: readonly string[] = [],
+		totalBudget?: number,
+	): string {
 		const sections: string[] = [];
 		const inlineGlobs = compileInlineGlobs(inlinePatterns);
+		const budget = totalBudget ?? XdevRegistry.DOCS_TOTAL_BUDGET;
 		let used = 0;
 		for (const name of names) {
 			const tool = this.get(name);
 			if (!tool || !this.#shouldInline(tool, mode, inlineGlobs)) continue;
 			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
-			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET)
-				continue;
+			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > budget) continue;
 			used += docs.length;
 			sections.push(docs);
 		}

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -223,8 +223,19 @@ export class XdevRegistry {
 	 */
 	#dynamic = new Map<string, Tool>();
 
-	constructor(builtins: Iterable<Tool>) {
+	/** Active cap for external (dynamic-mount) description embedding; see
+	 *  {@link EXTERNAL_DESCRIPTION_CAP} for the default and rationale. Settable
+	 *  per session via `tools.xdevExternalDescriptionCap`. */
+	#externalDescriptionCap: number;
+
+	constructor(builtins: Iterable<Tool>, externalDescriptionCap: number = XdevRegistry.EXTERNAL_DESCRIPTION_CAP) {
 		for (const tool of builtins) this.#builtins.set(tool.name, tool);
+		this.#externalDescriptionCap = Math.max(0, externalDescriptionCap);
+	}
+
+	/** Update the external description cap (e.g. after a settings change). */
+	setExternalDescriptionCap(cap: number): void {
+		this.#externalDescriptionCap = Math.max(0, cap);
 	}
 
 	/**
@@ -258,10 +269,7 @@ export class XdevRegistry {
 	entries(): Array<{ name: string; summary: string }> {
 		return this.list().map(tool => ({
 			name: tool.name,
-			summary: promptCatalogSummary(
-				tool,
-				this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined,
-			),
+			summary: promptCatalogSummary(tool, this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined),
 		}));
 	}
 
@@ -315,7 +323,7 @@ export class XdevRegistry {
 				overflow.push(tool);
 				continue;
 			}
-			const descriptionCap = this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined;
+			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
 			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET) {
 				overflow.push(tool);
@@ -329,7 +337,7 @@ export class XdevRegistry {
 				[
 					"## Additional devices (docs on demand)",
 					...overflow.map(tool => {
-						const maxLength = this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined;
+						const maxLength = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 						return `- ${XD_URL_PREFIX}${tool.name} — ${promptCatalogSummary(tool, maxLength)}`;
 					}),
 					"",
@@ -348,7 +356,7 @@ export class XdevRegistry {
 		for (const name of names) {
 			const tool = this.get(name);
 			if (!tool || !this.#shouldInline(tool, mode, inlineGlobs)) continue;
-			const descriptionCap = this.#dynamic.has(tool.name) ? XdevRegistry.EXTERNAL_DESCRIPTION_CAP : undefined;
+			const descriptionCap = this.#dynamic.has(tool.name) ? this.#externalDescriptionCap : undefined;
 			const docs = renderDocs(tool, "##", descriptionCap);
 			if (docs.length > XdevRegistry.DOCS_PER_DEVICE_CAP || used + docs.length > XdevRegistry.DOCS_TOTAL_BUDGET)
 				continue;

--- a/packages/coding-agent/test/xdev-description-cap.test.ts
+++ b/packages/coding-agent/test/xdev-description-cap.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-coding-agent/tools";
+import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { type } from "arktype";
+
+// Contract: `tools.xdevExternalDescriptionCap` controls how much of an
+// EXTERNAL (dynamic-mount: MCP/custom/extension) device's description is
+// embedded into the system prompt and catalog lines. Built-in devices are
+// never capped, schemas are never capped, and `read xd://<tool>` (docs())
+// always returns the full text regardless of the cap.
+
+const LONG_DESCRIPTION = `gitnexus-style tool. ${"x".repeat(400)}`;
+
+function fakeTool(name: string, description: string): Tool {
+	return {
+		name,
+		label: name,
+		description,
+		parameters: type({}),
+		execute: async () => ({ content: [] }),
+	} as unknown as Tool;
+}
+
+const builtin = fakeTool("ast_grep", "Structural code search via ast-grep.");
+const dynamic = fakeTool("mcp__gateway_gitnexus_search_code_flows", LONG_DESCRIPTION);
+
+function makeRegistry(cap?: number): XdevRegistry {
+	const registry = cap === undefined ? new XdevRegistry([builtin]) : new XdevRegistry([builtin], cap);
+	registry.reconcile([dynamic]);
+	return registry;
+}
+
+describe("XdevRegistry external description cap", () => {
+	it("truncates dynamic descriptions to the custom cap in entries and docsAll", () => {
+		const registry = makeRegistry(50);
+
+		const entries = registry.entries();
+		const dynamicEntry = entries.find(entry => entry.name === dynamic.name);
+		const builtinEntry = entries.find(entry => entry.name === builtin.name);
+		expect(dynamicEntry).toBeDefined();
+		expect(dynamicEntry!.summary.length).toBeLessThanOrEqual(51); // 50 + ellipsis
+		// Built-ins are never capped.
+		expect(builtinEntry!.summary).toBe(builtin.description);
+
+		const docs = registry.docsAll("inline");
+		expect(docs).toContain("… (full docs: read xd://");
+		expect(docs).not.toContain(LONG_DESCRIPTION);
+		// The schema survives truncation intact.
+		expect(docs).toContain('"type": "object"');
+	});
+
+	it("keeps the 200-char default when no cap is given", () => {
+		const registry = makeRegistry();
+		const docs = registry.docsAll("inline");
+		expect(docs).not.toContain(LONG_DESCRIPTION);
+		expect(docs).toContain("… (full docs: read xd://");
+	});
+
+	it("embeds the full description when the cap exceeds its length", () => {
+		const registry = makeRegistry(10_000);
+		expect(registry.docsAll("inline")).toContain(LONG_DESCRIPTION);
+	});
+
+	it("applies setExternalDescriptionCap live", () => {
+		const registry = makeRegistry(50);
+		expect(registry.docsAll("inline")).not.toContain(LONG_DESCRIPTION);
+		registry.setExternalDescriptionCap(10_000);
+		expect(registry.docsAll("inline")).toContain(LONG_DESCRIPTION);
+	});
+
+	it("never truncates single-device docs (read xd://<tool>)", () => {
+		const registry = makeRegistry(50);
+		expect(registry.docs(dynamic.name)).toContain(LONG_DESCRIPTION);
+	});
+
+	it("caps docsFor the same way as docsAll", () => {
+		const registry = makeRegistry(50);
+		const docs = registry.docsFor([dynamic.name], "inline");
+		expect(docs).not.toContain(LONG_DESCRIPTION);
+		expect(docs).toContain("… (full docs: read xd://");
+	});
+});

--- a/packages/coding-agent/test/xdev-docs-budget.test.ts
+++ b/packages/coding-agent/test/xdev-docs-budget.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-coding-agent/tools";
+import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { type } from "arktype";
+
+// Contract: `tools.xdevDocsMaxPercent` expresses the total inlined-docs budget
+// as a percent of the model's context window instead of the fixed 48k-char
+// default. 0 (or an unknown window) preserves the built-in budget; devices
+// past the resolved budget degrade to catalog lines (docs stay on demand).
+function fakeTool(name: string, description: string): Tool {
+	return {
+		name,
+		label: name,
+		description,
+		parameters: type({}),
+		execute: async () => ({ content: [] }),
+	} as unknown as Tool;
+}
+
+describe("XdevRegistry.resolveDocsTotalBudget", () => {
+	it("returns the built-in default when percent is 0 or the window is unknown", () => {
+		expect(XdevRegistry.resolveDocsTotalBudget(0, 272_000)).toBe(XdevRegistry.DOCS_TOTAL_BUDGET);
+		expect(XdevRegistry.resolveDocsTotalBudget(10, undefined)).toBe(XdevRegistry.DOCS_TOTAL_BUDGET);
+		expect(XdevRegistry.resolveDocsTotalBudget(10, 0)).toBe(XdevRegistry.DOCS_TOTAL_BUDGET);
+	});
+
+	it("converts percent of context window at ~4 chars/token", () => {
+		// 10% of 272k tokens = 27.2k tokens = 108,800 chars
+		expect(XdevRegistry.resolveDocsTotalBudget(10, 272_000)).toBe(108_800);
+		// 10% of 64k tokens = 6.4k tokens = 25,600 chars (tighter than default)
+		expect(XdevRegistry.resolveDocsTotalBudget(10, 64_000)).toBe(25_600);
+	});
+
+	it("clamps percent above 100", () => {
+		expect(XdevRegistry.resolveDocsTotalBudget(150, 100_000)).toBe(400_000);
+	});
+});
+
+describe("docsAll with an explicit total budget", () => {
+	// Multi-line descriptions: the catalog summary is only the first line, so
+	// the padded second line appears ONLY when the full docs are inlined.
+	const bigBuiltin = fakeTool("ast_grep", `Built-in docs.\n${"y".repeat(2000)}`);
+	const anotherBuiltin = fakeTool("lsp", `More built-in docs.\n${"z".repeat(2000)}`);
+
+	it("overflows devices past the budget into the catalog section", () => {
+		const registry = new XdevRegistry([bigBuiltin, anotherBuiltin]);
+		const full = registry.docsAll("builtins");
+		expect(full).toContain("y".repeat(2000));
+		expect(full).toContain("z".repeat(2000));
+
+		// Budget that fits only one device: the second degrades to a catalog
+		// line under "Additional devices".
+		const tight = registry.docsAll("builtins", [], 3000);
+		const inlined = ["y".repeat(2000), "z".repeat(2000)].filter(marker => tight.includes(marker));
+		expect(inlined.length).toBe(1);
+		expect(tight).toContain("Additional devices (docs on demand)");
+	});
+
+	it("docsFor respects the explicit budget as well", () => {
+		const registry = new XdevRegistry([bigBuiltin, anotherBuiltin]);
+		const docs = registry.docsFor([bigBuiltin.name, anotherBuiltin.name], "builtins", [], 100);
+		expect(docs).toBe("");
+	});
+});


### PR DESCRIPTION
## What

New setting `tools.xdevDocsMaxPercent` (default `0` = unchanged behavior). When > 0, the total budget for inlined `xd://` device docs in the system prompt becomes that percent of the active model's context window (converted at ~4 chars/token) instead of the fixed 48,000-char budget.

## Why

The inlined-docs budget was a fixed 48K chars regardless of model — ~5% of a 272k window but ~19% of a 64k one. Other agents (e.g. Claude Code) cap tool text at a percentage of the context window (~10%) and defer the overflow; this brings the same model-relative budget to the xd:// docs section, opt-in. Devices past the budget degrade to catalog entries with docs on demand, exactly the existing overflow behavior.

## How

- `XdevRegistry.resolveDocsTotalBudget(percent, contextWindow)`: percent → chars via `DOCS_BUDGET_CHARS_PER_TOKEN` (4), clamped to ≤100%, falling back to `DOCS_TOTAL_BUDGET` when percent is 0 or the window is unknown.
- `docsAll()` / `docsFor()` accept an optional `totalBudget` (default unchanged).
- Call sites pass the resolved budget: prompt build in `sdk.ts` and the mount-notice docs in `session-tools.ts`, using the active model's `contextWindow`.
- `settings-schema.ts`: new number setting in the /settings UI.

Stacked on #6560 (shares the `docsAll`/`docsFor` region); merge that first or review together.

## Verification

- New `test/xdev-docs-budget.test.ts` (11 tests): percent conversion (10% of 272k → 108,800 chars; 10% of 64k → 25,600), 0/unknown-window → 48K default, >100% clamp, overflow → catalog lines, `docsFor` budget. All pass, plus adjacent xdev suites.
- `bun run check` (biome + tsgo) clean.
- Live before/after: default budget → System prompt 8.4K; 1% of a 272k window (10,880 chars) → 6.1K (2.3K of manuals deferred to on-demand).

I reviewed the full diff; this change makes the xd:// docs budget scale with the model's context window as an opt-in percent while keeping the 48k default.