### PR TITLE
fix(cursor): embed data URI for images in root-prompt history

### DIFF
--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2474,7 +2474,7 @@ function buildCursorRootPromptContent(content: string | (TextContent | ImageCont
 				parts.push({ type: "text", text });
 			}
 		} else {
-			parts.push({ type: "image", image: item.data, mediaType: item.mimeType });
+			parts.push({ type: "image", image: `data:${item.mimeType};base64,${item.data}`, mediaType: item.mimeType });
 		}
 	}
 	return parts;

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -269,7 +269,7 @@ describe("Cursor history encoding", () => {
 		expect(history.rootPromptMessagesJson).toEqual([
 			{
 				role: "user",
-				content: [{ type: "image", image: imageData, mediaType: "image/png" }],
+				content: [{ type: "image", image: `data:image/png;base64,${imageData}`, mediaType: "image/png" }],
 			},
 			{
 				role: "assistant",


### PR DESCRIPTION
One sentence explanation: After switching to Cursor models, images in the transcript stop working and cause the session to error out - even after compaction

## What broke

Switching mid-conversation to a `cursor/*` model (e.g. `claude-fable-5-high`) fails on the very next turn whenever the session already has an image anywhere earlier in its history, even when that next turn doesn't mention an image at all:

```
Connect error internal: Unable to parse image: iVBORw0KGgo...
```

This is not "cursor models can't see images." A brand new session with an image attached directly to a `cursor/*` model from turn one works fine.

## Root cause

`buildCursorRootPromptContent()` in `packages/ai/src/providers/cursor.ts` builds the Vercel-AI-SDK-shaped history Cursor's server uses to reconstruct prior turns (`rootPromptMessagesJson`). For image parts it emitted the raw base64 payload with no URI wrapper:

```ts
parts.push({ type: "image", image: item.data, mediaType: item.mimeType });
```

`item.data` (`ImageContent.data`) is bare base64 with no `data:<mime>;base64,` prefix, so Cursor's server can't parse it as an image reference and rejects the whole request.

The *other* Cursor image path (`buildConversationTurns` / `createCursorUserMessage`, used when an image is attached to the live turn) never hit this: it base64-decodes into a typed protobuf `bytes` field instead of a JSON string, so it doesn't need a URI wrapper.

## Fix

Wrap the payload as a data URI, matching the convention `openai-completions.ts` already uses for the same `ImageContent` type in this codebase:

```ts
parts.push({ type: "image", image: `data:${item.mimeType};base64,${item.data}`, mediaType: item.mimeType });
```

Also corrected the one existing test (`cursor-exec-handlers.test.ts`) that had encoded the broken (bare-base64) shape as its expected output.

## Verification

- Reproduced exactly: started a session, first turn on `anthropic/claude-sonnet-5` with an image attached, then `omp -p --continue --model cursor/claude-fable-5-high "..."` on the next turn (no image on that turn). Got the identical `Connect error internal: Unable to parse image:` failure before the fix.
- Confirmed the non-broken path stays non-broken: fresh session, image attached directly to `cursor/claude-fable-5-high` on turn one, works and answers correctly.
- `bun test packages/ai/test/cursor-exec-handlers.test.ts` and the other six `cursor*.test.ts` files: 62 pass, 0 fail.
- `tsgo -p tsconfig.json --noEmit` and `biome check` on both changed files: clean.

Diff is two lines: one in `cursor.ts`, one in the test assertion it invalidated.
