### PR TITLE
feat(ai): implement MiniMax Token Plan usage provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a MiniMax Token Plan usage provider, replacing the no-op `minimax-code` stub: `/usage` now queries `GET /v1/token_plan/remains` with the `sk-cp-…` API key from `/login minimax-code` and maps each `model_remains[]` product row to its own 5-hour + weekly `UsageLimit` pair (per-product, not aggregated), inverting counts to remaining, treating `*_status === 3` as the Coding Plan's unlimited state, and filtering non-`general` product rows (e.g. video).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -54,6 +54,7 @@ import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
+import { minimaxCodeUsageProvider } from "./usage/minimax-code";
 import { ollamaCloudUsageProvider, ollamaUsageProvider } from "./usage/ollama";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import {
@@ -617,6 +618,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	cursorUsageProvider,
 	syntheticUsageProvider,
 	xaiOauthUsageProvider,
+	minimaxCodeUsageProvider,
 ];
 
 const DEFAULT_USAGE_PROVIDER_MAP = new Map<Provider, UsageProvider>(

--- a/packages/ai/src/usage/minimax-code.ts
+++ b/packages/ai/src/usage/minimax-code.ts
@@ -1,30 +1,345 @@
-import type { UsageFetchContext, UsageFetchParams, UsageProvider, UsageReport } from "../usage";
-
 /**
- * MiniMax Token Plan usage provider.
+ * MiniMax "Token Plan" Coding Plan usage provider.
  *
- * MiniMax Token Plan is a subscription-based service with a rolling quota system.
+ * MiniMax exposes quota on the platform host (`www.minimax.io`) at
+ * `GET /v1/token_plan/remains`. The endpoint is authenticated with the
+ * same `sk-cp-…` api-key the user pasted at `/login minimax-code`.
  *
- * Currently, MiniMax does not expose a usage/quota API endpoint for the Token Plan.
- * Usage is tracked via the web dashboard at https://platform.minimax.io/user-center/payment/token-plan
+ * Response shape (2026-Q3):
+ *   {
+ *     "model_remains": [
+ *       {
+ *         "end_time":                        1783382400000,  // 5h window end (ms)
+ *         "current_interval_total_count":    N,
+ *         "current_interval_usage_count":    M,              // remaining (note: misleading name)
+ *         "model_name":                      "general" | "video" | ...,
+ *         "current_interval_status":         1 | 3,          // 1 = active, 3 = unlimited
+ *         "current_interval_remaining_percent": 83,
+ *         "current_weekly_total_count":      N,
+ *         "current_weekly_usage_count":      M,              // remaining
+ *         "weekly_end_time":                 1783900800000,
+ *         "current_weekly_status":           1 | 3,
+ *         "current_weekly_remaining_percent": 100
+ *       },
+ *       ...
+ *     ],
+ *     "base_resp": { "status_code": 0, "status_msg": "success" }
+ *   }
  *
- * This provider exists to register support for the minimax-code provider in the
- * usage system. When MiniMax adds a usage API, this can be implemented.
+ * Field semantics
+ * - The fields named `*_usage_count` are actually **remaining** quota, not
+ *   consumed. The corresponding `*_remaining_percent` is computed against
+ *   that denominator and matches.
+ * - `*_status === 3` is the Coding Plan's "unlimited" state per the web
+ *   UI, not "exhausted". `*_status === 1` is the active, capped state —
+ *   the percent + totals are trustworthy.
+ *
+ * Only the `general` row is surfaced; other products (e.g. `video`) are
+ * dropped since the renderer only handles a single product. Rows with a
+ * missing `model_name` default to `general` and are kept.
  */
-async function fetchMiniMaxCodeUsage(params: UsageFetchParams, _ctx: UsageFetchContext): Promise<UsageReport | null> {
-	if (params.provider !== "minimax-code" && params.provider !== "minimax-code-cn") {
+import type {
+	UsageAmount,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+	UsageStatus,
+	UsageWindow,
+} from "../usage";
+import { isRecord } from "../utils";
+import { toNumber } from "./shared";
+
+const MINIMAX_CODE_PROVIDER = "minimax-code";
+const INTL_TOKEN_PLAN_HOST = "https://www.minimax.io";
+const USAGE_PATH = "/v1/token_plan/remains";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** `*_status: 3` is the Coding Plan's "unlimited" state; `1` is active/capped. */
+const STATUS_UNLIMITED = 3;
+
+interface MiniMaxModelRemain {
+	model_name?: unknown;
+	start_time?: unknown;
+	end_time?: unknown;
+	remains_time?: unknown;
+	current_interval_total_count?: unknown;
+	current_interval_usage_count?: unknown;
+	current_interval_status?: unknown;
+	current_interval_remaining_percent?: unknown;
+	current_weekly_total_count?: unknown;
+	current_weekly_usage_count?: unknown;
+	weekly_start_time?: unknown;
+	weekly_end_time?: unknown;
+	weekly_remains_time?: unknown;
+	current_weekly_status?: unknown;
+	current_weekly_remaining_percent?: unknown;
+}
+
+interface MiniMaxTokenPlanPayload {
+	base_resp?: { status_code?: number; status_msg?: string };
+	model_remains?: unknown;
+}
+
+interface WindowState {
+	resetsAt?: number;
+	remainingPercent?: number;
+	totalCount?: number;
+	remainingCount?: number;
+	status?: number;
+}
+
+interface WindowSpec {
+	id: string;
+	label: string;
+	durationMs: number;
+	totalKey: keyof MiniMaxModelRemain;
+	remainingKey: keyof MiniMaxModelRemain;
+	percentKey: keyof MiniMaxModelRemain;
+	statusKey: keyof MiniMaxModelRemain;
+	endKey: keyof MiniMaxModelRemain;
+}
+
+const WINDOW_INTERVAL: WindowSpec = {
+	id: "5h",
+	label: "5 Hour",
+	durationMs: 5 * HOUR_MS,
+	totalKey: "current_interval_total_count",
+	remainingKey: "current_interval_usage_count",
+	percentKey: "current_interval_remaining_percent",
+	statusKey: "current_interval_status",
+	endKey: "end_time",
+};
+
+const WINDOW_WEEKLY: WindowSpec = {
+	id: "weekly",
+	label: "Weekly",
+	durationMs: 7 * DAY_MS,
+	totalKey: "current_weekly_total_count",
+	remainingKey: "current_weekly_usage_count",
+	percentKey: "current_weekly_remaining_percent",
+	statusKey: "current_weekly_status",
+	endKey: "weekly_end_time",
+};
+
+function readWindowState(row: MiniMaxModelRemain, spec: WindowSpec): WindowState {
+	return {
+		resetsAt: toNumber(row[spec.endKey]),
+		remainingPercent: toNumber(row[spec.percentKey]),
+		totalCount: toNumber(row[spec.totalKey]),
+		remainingCount: toNumber(row[spec.remainingKey]),
+		status: toNumber(row[spec.statusKey]),
+	};
+}
+
+function clampPercent(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	if (value < 0) return 0;
+	if (value > 100) return 100;
+	return value;
+}
+
+function buildAmount(state: WindowState): UsageAmount {
+	const pctRaw = state.remainingPercent;
+	const total = state.totalCount !== undefined ? Math.max(0, state.totalCount) : undefined;
+	const remaining = state.remainingCount !== undefined ? Math.max(0, state.remainingCount) : undefined;
+
+	const amount: UsageAmount = { unit: "requests" };
+
+	// Prefer numeric totals when present: they give exact used/remaining
+	// counts. Otherwise derive from `*_remaining_percent`.
+	if (total !== undefined && total > 0 && remaining !== undefined) {
+		const safeRemaining = Math.min(remaining, total);
+		const used = Math.max(0, total - safeRemaining);
+		amount.limit = total;
+		amount.remaining = safeRemaining;
+		amount.used = used;
+		amount.usedFraction = used / total;
+		amount.remainingFraction = safeRemaining / total;
+	} else if (pctRaw !== undefined) {
+		const pct = clampPercent(pctRaw);
+		amount.remainingFraction = pct / 100;
+		amount.usedFraction = (100 - pct) / 100;
+	} else {
+		amount.remainingFraction = 1;
+		amount.usedFraction = 0;
+	}
+
+	return amount;
+}
+
+function resolveLimitStatus(state: WindowState, usedFraction: number): UsageStatus {
+	// `*_status: 3` is "unlimited" on the Coding Plan, not "exhausted".
+	if (state.status === STATUS_UNLIMITED) return "ok";
+	if (!Number.isFinite(usedFraction)) return "unknown";
+	if (usedFraction >= 1) return "exhausted";
+	if (usedFraction >= 0.8) return "warning";
+	return "ok";
+}
+
+function buildUsageWindow(spec: WindowSpec, resetsAt: number | undefined): UsageWindow {
+	const out: UsageWindow = { id: spec.id, label: spec.label, durationMs: spec.durationMs };
+	if (resetsAt !== undefined) out.resetsAt = resetsAt;
+	return out;
+}
+
+function buildLimit(args: { providerId: string; tier: string; window: UsageWindow; state: WindowState }): UsageLimit {
+	const { providerId, tier, window, state } = args;
+	const amount = buildAmount(state);
+	const status = resolveLimitStatus(state, amount.usedFraction ?? 0);
+	const tierSlug = tier.replace(/[^a-zA-Z0-9_-]/g, "_").toLowerCase();
+	const limit: UsageLimit = {
+		id: `${providerId}:${window.id}:${tierSlug}`,
+		label: `MiniMax ${tier} ${window.label} quota`,
+		scope: {
+			provider: providerId,
+			windowId: window.id,
+			tier,
+			shared: true,
+		},
+		window,
+		amount,
+		status,
+	};
+	if (state.status === STATUS_UNLIMITED) {
+		limit.notes = ["Unlimited on this window — see Coding Plan."];
+	}
+	return limit;
+}
+
+function pickModelRows(payload: unknown): MiniMaxModelRemain[] {
+	if (!isRecord(payload)) return [];
+	const data = payload as MiniMaxTokenPlanPayload;
+	return Array.isArray(data.model_remains)
+		? data.model_remains.filter((row): row is MiniMaxModelRemain => isRecord(row))
+		: [];
+}
+
+function rowHasWindowSignal(row: MiniMaxModelRemain, spec: WindowSpec): boolean {
+	return (
+		toNumber(row[spec.percentKey]) !== undefined ||
+		toNumber(row[spec.totalKey]) !== undefined ||
+		toNumber(row[spec.statusKey]) !== undefined
+	);
+}
+
+async function fetchMiniMaxCodeUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
+	if (params.provider !== MINIMAX_CODE_PROVIDER) return null;
+	if (params.credential.type !== "api_key" || !params.credential.apiKey) return null;
+
+	const url = `${INTL_TOKEN_PLAN_HOST.replace(/\/+$/, "")}${USAGE_PATH}`;
+	let payload: unknown;
+	try {
+		const response = await ctx.fetch(url, {
+			headers: {
+				Authorization: `Bearer ${params.credential.apiKey}`,
+				"Content-Type": "application/json",
+			},
+			signal: params.signal,
+		});
+		if (!response.ok) {
+			ctx.logger?.warn("MiniMax token plan usage request failed", {
+				provider: params.provider,
+				status: response.status,
+				statusText: response.statusText,
+			});
+			return null;
+		}
+		payload = await response.json();
+	} catch (error) {
+		ctx.logger?.warn("MiniMax token plan usage request error", {
+			provider: params.provider,
+			error: String(error),
+		});
 		return null;
 	}
 
-	// MiniMax Token Plan does not currently expose a usage API
-	// Users can check their usage via the web dashboard
-	return null;
+	if (!isRecord(payload)) {
+		ctx.logger?.warn("MiniMax token plan usage response invalid", { provider: params.provider });
+		return null;
+	}
+
+	const data = payload as MiniMaxTokenPlanPayload;
+	const baseResp = isRecord(data.base_resp) ? data.base_resp : undefined;
+	const baseStatus = baseResp ? toNumber(baseResp.status_code) : 0;
+	if (baseStatus !== 0) {
+		ctx.logger?.warn("MiniMax token plan usage returned non-success status", {
+			provider: params.provider,
+			statusCode: baseStatus,
+			statusMsg: typeof baseResp?.status_msg === "string" ? baseResp.status_msg : undefined,
+		});
+		return null;
+	}
+
+	const rows = pickModelRows(payload);
+	if (rows.length === 0) {
+		ctx.logger?.warn("MiniMax token plan usage response had no model rows", {
+			provider: params.provider,
+			rawKeys: Object.keys(data),
+		});
+		return null;
+	}
+
+	const limits: UsageLimit[] = [];
+	const tiersSeen: string[] = [];
+	for (const row of rows) {
+		// Drop non-general products (e.g. "video") — the renderer only
+		// handles a single product. Rows whose model_name is missing
+		// default to "general" and are kept.
+		const rawName = typeof row.model_name === "string" ? row.model_name : "";
+		if (rawName && rawName !== "general") continue;
+		const tier = rawName || "general";
+		tiersSeen.push(tier);
+		const intervalState = readWindowState(row, WINDOW_INTERVAL);
+		const weeklyState = readWindowState(row, WINDOW_WEEKLY);
+		if (rowHasWindowSignal(row, WINDOW_INTERVAL)) {
+			limits.push(
+				buildLimit({
+					providerId: params.provider,
+					tier,
+					window: buildUsageWindow(WINDOW_INTERVAL, intervalState.resetsAt),
+					state: intervalState,
+				}),
+			);
+		}
+		if (rowHasWindowSignal(row, WINDOW_WEEKLY)) {
+			limits.push(
+				buildLimit({
+					providerId: params.provider,
+					tier,
+					window: buildUsageWindow(WINDOW_WEEKLY, weeklyState.resetsAt),
+					state: weeklyState,
+				}),
+			);
+		}
+	}
+
+	if (limits.length === 0) {
+		ctx.logger?.warn("MiniMax token plan usage response carried no usable quota", {
+			provider: params.provider,
+			rowCount: rows.length,
+			sample: rows[0] ?? null,
+		});
+		return null;
+	}
+
+	return {
+		provider: params.provider,
+		fetchedAt: Date.now(),
+		limits,
+		metadata: {
+			endpoint: url,
+			tiers: tiersSeen,
+		},
+		raw: data,
+	};
 }
 
 export const minimaxCodeUsageProvider: UsageProvider = {
-	id: "minimax-code",
+	id: MINIMAX_CODE_PROVIDER,
+	supports: params => params.provider === MINIMAX_CODE_PROVIDER && params.credential.type === "api_key",
 	fetchUsage: fetchMiniMaxCodeUsage,
-	supports: (params: UsageFetchParams) =>
-		(params.provider === "minimax-code" || params.provider === "minimax-code-cn") &&
-		params.credential.type === "api_key",
 };

--- a/packages/ai/test/minimax-code-usage.test.ts
+++ b/packages/ai/test/minimax-code-usage.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "bun:test";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import type { UsageFetchContext, UsageFetchParams, UsageLogger } from "@oh-my-pi/pi-ai/usage";
+import { minimaxCodeUsageProvider } from "@oh-my-pi/pi-ai/usage/minimax-code";
+
+function makeCredential(): UsageFetchParams["credential"] {
+	return {
+		type: "api_key",
+		apiKey: "sk-cp-test",
+	};
+}
+
+function silentLogger(): UsageLogger {
+	return {
+		debug: () => {},
+		warn: () => {},
+	};
+}
+
+interface CapturedRequest {
+	url: string;
+	init: RequestInit;
+}
+
+function makeCtx(payload: unknown, captures: CapturedRequest[] = []): UsageFetchContext {
+	const fetchImpl: FetchImpl = async (input, init) => {
+		captures.push({ url: String(input), init: init ?? {} });
+		return new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+	};
+	return { fetch: fetchImpl, logger: silentLogger() };
+}
+
+function makeErroringCtx(status: number, body: unknown = {}): UsageFetchContext {
+	const fetchImpl: FetchImpl = async () =>
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	return { fetch: fetchImpl };
+}
+
+function okBaseResp() {
+	return { base_resp: { status_code: 0, status_msg: "success" } };
+}
+
+function modelRemain(args: {
+	model_name: string;
+	fiveHour: { total: number; remaining: number; endTime: number };
+	weekly: { total: number; remaining: number; endTime: number; startTime: number };
+	fiveHourPercent?: number;
+	weeklyPercent?: number;
+	fiveHourStatus?: number;
+	weeklyStatus?: number;
+}) {
+	const out: Record<string, unknown> = {
+		start_time: args.fiveHour.endTime - 5 * 60 * 60 * 1000,
+		end_time: args.fiveHour.endTime,
+		remains_time: 60_000,
+		current_interval_total_count: args.fiveHour.total,
+		current_interval_usage_count: args.fiveHour.remaining,
+		model_name: args.model_name,
+		current_weekly_total_count: args.weekly.total,
+		current_weekly_usage_count: args.weekly.remaining,
+		weekly_start_time: args.weekly.startTime,
+		weekly_end_time: args.weekly.endTime,
+		weekly_remains_time: 60_000,
+		current_interval_status: args.fiveHourStatus ?? 1,
+		current_interval_remaining_percent: args.fiveHourPercent ?? 100,
+		current_weekly_status: args.weeklyStatus ?? 1,
+		current_weekly_remaining_percent: args.weeklyPercent ?? 100,
+	};
+	return out;
+}
+
+describe("minimax-code usage provider", () => {
+	it("ignores non-general products (e.g. video) and emits one UsageLimit pair per general row", async () => {
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				...okBaseResp(),
+				model_remains: [
+					modelRemain({
+						model_name: "general",
+						fiveHour: { total: 500, remaining: 480, endTime: 1783382400000 },
+						weekly: { total: 10000, remaining: 8000, startTime: 1783296000000, endTime: 1783900800000 },
+						fiveHourStatus: 1,
+						weeklyStatus: 1,
+					}),
+					modelRemain({
+						model_name: "video",
+						fiveHour: { total: 100, remaining: 10, endTime: 1783382400000 },
+						weekly: { total: 2000, remaining: 1500, startTime: 1783296000000, endTime: 1783900800000 },
+						fiveHourStatus: 1,
+						weeklyStatus: 1,
+					}),
+				],
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		// Only the general row is surfaced; video is filtered out.
+		const ids = report!.limits.map(limit => limit.id).sort();
+		expect(ids).toEqual(["minimax-code:5h:general", "minimax-code:weekly:general"]);
+		expect(ids.some(id => id.includes("video"))).toBe(false);
+
+		const general5h = report!.limits.find(limit => limit.id === "minimax-code:5h:general");
+		expect(general5h?.amount).toEqual({
+			unit: "requests",
+			limit: 500,
+			remaining: 480,
+			used: 20,
+			usedFraction: 20 / 500,
+			remainingFraction: 480 / 500,
+		});
+		expect(general5h?.window?.resetsAt).toBe(1783382400000);
+		expect(general5h?.status).toBe("ok");
+	});
+
+	it("treats *_status: 3 as unlimited (Coding Plan tier) — uses percent as a hint, surfaces note", async () => {
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				...okBaseResp(),
+				model_remains: [
+					modelRemain({
+						model_name: "general",
+						fiveHour: { total: 0, remaining: 0, endTime: 1783382400000 },
+						weekly: { total: 0, remaining: 0, startTime: 1783296000000, endTime: 1783900800000 },
+						fiveHourPercent: 83,
+						weeklyPercent: 100,
+						fiveHourStatus: 1, // capped 5h
+						weeklyStatus: 3, // unlimited weekly
+					}),
+				],
+			}),
+		);
+
+		expect(report).not.toBeNull();
+
+		// general / 5h: status=1, percent=83 → trust the percent
+		const general5h = report!.limits.find(limit => limit.id === "minimax-code:5h:general");
+		expect(general5h?.amount.usedFraction).toBeCloseTo(0.17, 5);
+		expect(general5h?.amount.remainingFraction).toBeCloseTo(0.83, 5);
+		expect(general5h?.status).toBe("ok");
+		expect(general5h?.notes).toBeUndefined();
+
+		// general / weekly: status=3 → unlimited
+		const generalWeekly = report!.limits.find(limit => limit.id === "minimax-code:weekly:general");
+		expect(generalWeekly?.status).toBe("ok");
+		expect(generalWeekly?.notes).toEqual(["Unlimited on this window — see Coding Plan."]);
+		expect(generalWeekly?.amount.usedFraction).toBe(0);
+		expect(generalWeekly?.amount.remainingFraction).toBe(1);
+	});
+
+	it("calls the international platform host with a Bearer api-key", async () => {
+		const captures: CapturedRequest[] = [];
+		await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code", credential: makeCredential(), signal: undefined },
+			makeCtx(
+				{
+					...okBaseResp(),
+					model_remains: [
+						modelRemain({
+							model_name: "general",
+							fiveHour: { total: 1, remaining: 1, endTime: 1783382400000 },
+							weekly: { total: 1, remaining: 1, startTime: 1783296000000, endTime: 1783900800000 },
+						}),
+					],
+				},
+				captures,
+			),
+		);
+
+		expect(captures).toHaveLength(1);
+		expect(captures[0]!.url).toBe("https://www.minimax.io/v1/token_plan/remains");
+		const headers = (captures[0]!.init.headers ?? {}) as Record<string, string>;
+		expect(headers.Authorization).toBe("Bearer sk-cp-test");
+		expect(headers["Content-Type"]).toBe("application/json");
+	});
+
+	it("ignores providers that don't match its id", async () => {
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code-cn", credential: makeCredential(), signal: undefined },
+			makeCtx({ ...okBaseResp(), model_remains: [] }),
+		);
+		expect(report).toBeNull();
+	});
+
+	it("returns null when base_resp.status_code is non-zero", async () => {
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				base_resp: { status_code: 1004, status_msg: "cookie is missing, log in again" },
+				model_remains: [],
+			}),
+		);
+		expect(report).toBeNull();
+	});
+
+	it("returns null and warns when the HTTP response is non-OK", async () => {
+		const warnings: unknown[][] = [];
+		const ctx: UsageFetchContext = {
+			fetch: makeErroringCtx(503).fetch,
+			logger: {
+				debug: () => {},
+				warn: (...args: unknown[]) => {
+					warnings.push(args);
+				},
+			},
+		};
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+		expect(report).toBeNull();
+		expect(warnings).toHaveLength(1);
+	});
+
+	it("warns and returns null when model_remains is empty", async () => {
+		const warnings: unknown[][] = [];
+		const ctx: UsageFetchContext = {
+			fetch: makeCtx({ ...okBaseResp() }).fetch,
+			logger: {
+				debug: () => {},
+				warn: (...args: unknown[]) => {
+					warnings.push(args);
+				},
+			},
+		};
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{ provider: "minimax-code", credential: makeCredential(), signal: undefined },
+			ctx,
+		);
+		expect(report).toBeNull();
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]?.[0]).toBe("MiniMax token plan usage response had no model rows");
+	});
+
+	it("rejects non api_key credentials", async () => {
+		const report = await minimaxCodeUsageProvider.fetchUsage!(
+			{
+				provider: "minimax-code",
+				credential: { type: "oauth", accessToken: "x" },
+				signal: undefined,
+			},
+			makeCtx({}),
+		);
+		expect(report).toBeNull();
+	});
+});


### PR DESCRIPTION


## What

Adds minimax code plan /usage feature using undocumented endpoint.

## Notes

Openclaw implements the same endpoint: https://github.com/openclaw/openclaw/blob/main/src/infra/provider-usage.fetch.minimax.ts

This implementation does not attempt to make it work for .cn (china) API domain.

The endpoint returns 'general' and 'video' quotas. I have implemented it to only return 'general' quota.

I have implemented it to match other usage providers in the codebase and with similar Lines of Code.
The base URL is not api.minimax.io but [www.minimax.io](http://www.minimax.io/) and works with an Auth Bearer token.

If the undocumented nature of the usage endpoint is an issue, it could be put behind an experimental settings flag.

## Testing

<img width="437" height="254" alt="minimax omp usage" src="https://github.com/user-attachments/assets/0ee33269-136a-46b3-83fe-e734a115092e" />
<img width="815" height="148" alt="minimax web usage" src="https://github.com/user-attachments/assets/f6dee62f-2895-4ebd-82e4-73e8b61c4e4b" />

- [x] compared web usage to TUI usage

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
