### PR TITLE
fix(plan-mode): prefer newest draft during review

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan approval presenting a completed plan instead of the newest draft when the submitted title did not match the draft filename ([#6569](https://github.com/can1357/oh-my-pi/issues/6569)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1691,6 +1691,12 @@ export class AcpAgent implements Agent {
 			planExists: true,
 		};
 		if (!approved) {
+			// Rejection keeps plan mode active for another planning turn. Promote the
+			// reviewed path into plan-mode state so the next `#buildPlanModeMessage()`
+			// targets the plan just reviewed, not the stale state path.
+			if (state.planFilePath !== planFilePath) {
+				session.setPlanModeState({ ...state, planFilePath });
+			}
 			const normalizedTitle = normalizePlanTitle(resolvedTitle).title;
 			return {
 				content: [

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3708,6 +3708,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		// resolveApprovedPlan may return a newer draft than the path recorded in
+		// plan-mode state. `AgentSession.#buildPlanModeMessage()` reads that state,
+		// so if the operator refines (or dismisses and keeps planning) the next
+		// planning turn must target the plan just reviewed — promote the reviewed
+		// path into plan-mode state now, mirroring the print-mode approval handler.
+		const planState = this.session.getPlanModeState();
+		if (planState?.enabled && planState.planFilePath !== planFilePath) {
+			this.session.setPlanModeState({ ...planState, planFilePath });
+			this.sessionManager.appendModeChange("plan", { planFilePath });
+		}
+
 		const contextUsage = this.#getPlanApprovalContextUsage();
 		const keepContextLabel = this.#formatKeepContextLabel(contextUsage);
 		const keepContextDisabled = this.#isKeepContextDisabled(contextUsage);

--- a/packages/coding-agent/src/plan-mode/approved-plan.ts
+++ b/packages/coding-agent/src/plan-mode/approved-plan.ts
@@ -149,8 +149,8 @@ export interface ResolvedApprovedPlan {
 
 /** Locate the plan file the agent wrote and finalize its title — without
  *  renaming anything. Tries, in order: the slug derived from `extra.title`
- *  (`local://<slug>-plan.md`), the plan path from plan-mode state, then a scan
- *  of recent plan files. Throws a `ToolError` guiding the agent when none exist. */
+ *  (`local://<slug>-plan.md`), recent plan files from newest to oldest, then
+ *  the plan path from plan-mode state. Throws a `ToolError` guiding the agent when none exist. */
 export async function resolveApprovedPlan(input: ResolveApprovedPlanInput): Promise<ResolvedApprovedPlan> {
 	const ordered: string[] = [];
 	const consider = (url: string | undefined): void => {
@@ -159,19 +159,15 @@ export async function resolveApprovedPlan(input: ResolveApprovedPlanInput): Prom
 
 	const slug = planSlugFromSupplied(input.suppliedTitle);
 	consider(slug ? planFileUrlForSlug(slug) : undefined);
+
+	if (input.listPlanFiles) {
+		for (const url of await input.listPlanFiles()) consider(url);
+	}
 	consider(input.statePlanFilePath);
 
 	for (const url of ordered) {
 		const content = await input.readPlan(url);
 		if (content !== null) return finalizeApprovedPlan(url, content, input.suppliedTitle);
-	}
-
-	if (input.listPlanFiles) {
-		for (const url of await input.listPlanFiles()) {
-			if (ordered.includes(url)) continue;
-			const content = await input.readPlan(url);
-			if (content !== null) return finalizeApprovedPlan(url, content, input.suppliedTitle);
-		}
 	}
 
 	const target = ordered[0] ?? input.statePlanFilePath;

--- a/packages/coding-agent/src/plan-mode/approved-plan.ts
+++ b/packages/coding-agent/src/plan-mode/approved-plan.ts
@@ -1,3 +1,4 @@
+import { normalizeLocalScheme } from "../tools/path-utils";
 import { ToolError } from "../tools/tool-errors";
 
 /** Shape forwarded from the plan-proposal handler to InteractiveMode's
@@ -167,7 +168,10 @@ export async function resolveApprovedPlan(input: ResolveApprovedPlanInput): Prom
 	// it keeps precedence over scanned artifacts — otherwise a stale older draft
 	// could shadow the deliberately-set current plan. A state plan already inside
 	// the scan competes purely on the newest-first ordering below (issue #6569).
-	if (input.statePlanFilePath && !listed.includes(input.statePlanFilePath)) {
+	// Compare canonical `local://` spellings so a resumed `local:/…` state path
+	// still matches the scanner's `local://…` entry (normalizeLocalScheme).
+	const canonicalListed = new Set(listed.map(normalizeLocalScheme));
+	if (input.statePlanFilePath && !canonicalListed.has(normalizeLocalScheme(input.statePlanFilePath))) {
 		consider(input.statePlanFilePath);
 	}
 	for (const url of listed) consider(url);

--- a/packages/coding-agent/src/plan-mode/approved-plan.ts
+++ b/packages/coding-agent/src/plan-mode/approved-plan.ts
@@ -149,8 +149,9 @@ export interface ResolvedApprovedPlan {
 
 /** Locate the plan file the agent wrote and finalize its title — without
  *  renaming anything. Tries, in order: the slug derived from `extra.title`
- *  (`local://<slug>-plan.md`), recent plan files from newest to oldest, then
- *  the plan path from plan-mode state. Throws a `ToolError` guiding the agent when none exist. */
+ *  (`local://<slug>-plan.md`), a state plan that the artifact scan can't see,
+ *  scanned plan files newest-to-oldest, then the state plan path as a final
+ *  fallback. Throws a `ToolError` guiding the agent when none exist. */
 export async function resolveApprovedPlan(input: ResolveApprovedPlanInput): Promise<ResolvedApprovedPlan> {
 	const ordered: string[] = [];
 	const consider = (url: string | undefined): void => {
@@ -160,9 +161,16 @@ export async function resolveApprovedPlan(input: ResolveApprovedPlanInput): Prom
 	const slug = planSlugFromSupplied(input.suppliedTitle);
 	consider(slug ? planFileUrlForSlug(slug) : undefined);
 
-	if (input.listPlanFiles) {
-		for (const url of await input.listPlanFiles()) consider(url);
+	const listed = input.listPlanFiles ? await input.listPlanFiles() : [];
+	// A state plan the scan cannot surface (cwd-relative, or a local file whose
+	// name does not end in `plan.md`) has no mtime in `listed` to compete on, so
+	// it keeps precedence over scanned artifacts — otherwise a stale older draft
+	// could shadow the deliberately-set current plan. A state plan already inside
+	// the scan competes purely on the newest-first ordering below (issue #6569).
+	if (input.statePlanFilePath && !listed.includes(input.statePlanFilePath)) {
+		consider(input.statePlanFilePath);
 	}
+	for (const url of listed) consider(url);
 	consider(input.statePlanFilePath);
 
 	for (const url of ordered) {

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -394,6 +394,34 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(onInput).toHaveBeenCalledTimes(1);
 	});
 
+	it("promotes the reviewed plan path into plan-mode state before refining", async () => {
+		const resolve = (url: string) =>
+			resolveLocalUrlToPath(url, {
+				getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+				getSessionId: () => session.sessionManager.getSessionId(),
+			});
+		const oldPlanPath = "local://old-plan.md";
+		const newPlanPath = "local://new-draft-plan.md";
+		await Bun.write(resolve(oldPlanPath), "# Old\n\nold body");
+		await Bun.write(resolve(newPlanPath), "# New\n\nnew body");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = oldPlanPath;
+		// State still points at the previously reviewed (older) plan.
+		session.setPlanModeState({ enabled: true, planFilePath: oldPlanPath, workflow: "parallel", reentry: true });
+
+		const feedback = "Refinement feedback:\n- add more detail\n";
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, _options, dialogOptions) => {
+			dialogOptions?.onFeedbackChange?.(feedback);
+			return "Refine plan";
+		});
+		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({ planFilePath: newPlanPath, planExists: true, title: "NEW" });
+
+		expect(session.getPlanModeState()?.planFilePath).toBe(newPlanPath);
+	});
+
 	it("opens the annotation external editor from the real plan review overlay", async () => {
 		const editorPath = path.join(tempDir.path(), "annotation-editor.sh");
 		await Bun.write(

--- a/packages/coding-agent/test/plan-mode/approved-plan.test.ts
+++ b/packages/coding-agent/test/plan-mode/approved-plan.test.ts
@@ -62,6 +62,21 @@ describe("resolveApprovedPlan", () => {
 		expect(result.planContent).toContain("New plan");
 	});
 
+	it("keeps a state plan the scan can't see ahead of older scanned artifacts", async () => {
+		const result = await resolveApprovedPlan({
+			suppliedTitle: undefined,
+			// A cwd-relative / non-`plan.md` state path never appears in listPlanFiles().
+			statePlanFilePath: "docs/CURRENT.md",
+			readPlan: reader({
+				"docs/CURRENT.md": "# Current\n\nCurrent plan",
+				"local://old-artifact-plan.md": "# Old\n\nOld plan",
+			}),
+			listPlanFiles: async () => ["local://old-artifact-plan.md"],
+		});
+		expect(result.planFilePath).toBe("docs/CURRENT.md");
+		expect(result.planContent).toContain("Current plan");
+	});
+
 	it("scans listed plan files when the title was dropped and state path is empty", async () => {
 		const result = await resolveApprovedPlan({
 			suppliedTitle: undefined,

--- a/packages/coding-agent/test/plan-mode/approved-plan.test.ts
+++ b/packages/coding-agent/test/plan-mode/approved-plan.test.ts
@@ -48,6 +48,20 @@ describe("resolveApprovedPlan", () => {
 		expect(result.planFilePath).toBe("local://existing-plan.md");
 	});
 
+	it("prefers the newest listed plan over a completed state plan", async () => {
+		const result = await resolveApprovedPlan({
+			suppliedTitle: "Different title",
+			statePlanFilePath: "local://completed-plan.md",
+			readPlan: reader({
+				"local://completed-plan.md": "# Completed\n\nOld plan",
+				"local://new-draft-plan.md": "# New\n\nNew plan",
+			}),
+			listPlanFiles: async () => ["local://new-draft-plan.md", "local://completed-plan.md"],
+		});
+		expect(result.planFilePath).toBe("local://new-draft-plan.md");
+		expect(result.planContent).toContain("New plan");
+	});
+
 	it("scans listed plan files when the title was dropped and state path is empty", async () => {
 		const result = await resolveApprovedPlan({
 			suppliedTitle: undefined,

--- a/packages/coding-agent/test/plan-mode/approved-plan.test.ts
+++ b/packages/coding-agent/test/plan-mode/approved-plan.test.ts
@@ -6,6 +6,7 @@ import {
 	resolveApprovedPlan,
 	resolvePlanTitle,
 } from "@oh-my-pi/pi-coding-agent/plan-mode/approved-plan";
+import { normalizeLocalScheme } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 
 describe("planFileUrlForSlug", () => {
 	it("maps a slug to its local plan URL", () => {
@@ -53,6 +54,28 @@ describe("resolveApprovedPlan", () => {
 			suppliedTitle: "Different title",
 			statePlanFilePath: "local://completed-plan.md",
 			readPlan: reader({
+				"local://completed-plan.md": "# Completed\n\nOld plan",
+				"local://new-draft-plan.md": "# New\n\nNew plan",
+			}),
+			listPlanFiles: async () => ["local://new-draft-plan.md", "local://completed-plan.md"],
+		});
+		expect(result.planFilePath).toBe("local://new-draft-plan.md");
+		expect(result.planContent).toContain("New plan");
+	});
+
+	it("treats a single-slash state URL as in-scan and prefers the newer draft", async () => {
+		// Mirror the real reader: canonicalize the local scheme before lookup, so a
+		// `local:/…` state path resolves the same file as the scanner's `local://…`.
+		const canonical = (files: Record<string, string>) => {
+			const map: Record<string, string> = {};
+			for (const url in files) map[normalizeLocalScheme(url)] = files[url];
+			return async (url: string) => map[normalizeLocalScheme(url)] ?? null;
+		};
+		const result = await resolveApprovedPlan({
+			suppliedTitle: undefined,
+			// Resumed sessions can persist the accepted single-slash spelling.
+			statePlanFilePath: "local:/completed-plan.md",
+			readPlan: canonical({
 				"local://completed-plan.md": "# Completed\n\nOld plan",
 				"local://new-draft-plan.md": "# New\n\nNew plan",
 			}),


### PR DESCRIPTION
## Repro
In one session, keep `local://completed-plan.md`, write the newer `local://new-draft-plan.md`, then submit a title that does not reconstruct the new filename. `cd packages/coding-agent && bun -e '<call resolveApprovedPlan with the completed state path and newest-first list>'` returned `local://completed-plan.md` and exited 1 because review received the completed plan instead of the new draft.

## Cause
`resolveApprovedPlan()` in `packages/coding-agent/src/plan-mode/approved-plan.ts` tried the title-derived URL and then the plan-mode state's existing path before consulting `listPlanFiles()`. On re-entry, that state path can name the completed prior plan; when a local model's submitted title differs from its new draft filename, the existing file short-circuited resolution before the newest artifact was considered.

## Fix
- Keep an exact title-derived URL as the strongest candidate.
- Consider session-local plan artifacts next, preserving their newest-first order, before falling back to the state path.
- Add regression coverage for a completed state plan plus a newer draft with a mismatched submitted title.
- Record the fix in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/plan-mode/approved-plan.test.ts` → 27 pass, 0 fail. Re-ran the minimal resolver scenario after the change; it returned `local://new-draft-plan.md` and exited 0. The publish gate also completed `bun run fix` and `bun check`. Fixes #6569