### PR TITLE
fix(utils): correct shell path config guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected Windows shell resolution errors to identify the active global, project, overlay, or runtime source for `shellPath`, including profile and custom configuration directories, instead of directing every user to the retired `settings.json` file ([#6579](https://github.com/can1357/oh-my-pi/issues/6579)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -321,6 +321,10 @@ export class Settings {
 	#project: RawSettings = {};
 	/** Extra config.yml-style overlays passed by CLI */
 	#configOverlay: RawSettings = {};
+	/** Project settings file that most recently supplied shellPath. */
+	#projectShellPathSource: string | undefined;
+	/** Explicit config overlay that most recently supplied shellPath. */
+	#overlayShellPathSource: string | undefined;
 	/** Runtime overrides (not persisted) */
 	#overrides: RawSettings = {};
 	/** Merged view (global + project + overrides) */
@@ -592,8 +596,10 @@ export class Settings {
 		cloned.#configPath = this.#configPath;
 		cloned.#global = structuredClone(this.#global);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
+		if (!this.#persist) cloned.#projectShellPathSource = this.#projectShellPathSource;
 		cloned.#configFiles = [...this.#configFiles];
 		cloned.#configOverlay = structuredClone(this.#configOverlay);
+		cloned.#overlayShellPathSource = this.#overlayShellPathSource;
 		cloned.#overrides = this.#buildOriginalOverrides();
 		cloned.#rebuildMerged();
 		cloned.#fireAllHooks();
@@ -652,7 +658,17 @@ export class Settings {
 	 */
 	getShellConfig() {
 		const shell = this.get("shellPath");
-		return procmgr.getShellConfig(shell);
+		let configSource = this.#configPath ?? path.join(this.#agentDir, MAIN_CONFIG_FILENAMES[0]);
+		if (Object.hasOwn(this.#project, "shellPath")) {
+			configSource = this.#projectShellPathSource ?? "the active project configuration";
+		}
+		if (Object.hasOwn(this.#configOverlay, "shellPath")) {
+			configSource = this.#overlayShellPathSource ?? "the active config overlay";
+		}
+		if (Object.hasOwn(this.#overrides, "shellPath")) {
+			configSource = "the runtime settings override";
+		}
+		return procmgr.getShellConfig(shell, { configSource });
 	}
 
 	/**
@@ -1089,12 +1105,14 @@ export class Settings {
 	}
 
 	async #loadProjectSettings(): Promise<RawSettings> {
+		this.#projectShellPathSource = undefined;
 		try {
 			const result = await loadCapability(settingsCapability.id, { cwd: this.#cwd });
 			let merged: RawSettings = {};
 			for (const item of result.items as SettingsCapabilityItem[]) {
 				if (item.level === "project") {
 					merged = this.#deepMerge(merged, item.data as RawSettings);
+					if (Object.hasOwn(item.data, "shellPath")) this.#projectShellPathSource = item.path;
 				}
 			}
 			const nativeProject = await this.#loadYaml(path.join(this.#cwd, ".omp", "config.yml"));
@@ -1104,14 +1122,18 @@ export class Settings {
 			}
 			return this.#migrateRawSettings(merged);
 		} catch {
+			this.#projectShellPathSource = undefined;
 			return {};
 		}
 	}
 
 	async #loadConfigOverlays(): Promise<RawSettings> {
+		this.#overlayShellPathSource = undefined;
 		let merged: RawSettings = {};
 		for (const filePath of this.#configFiles) {
-			merged = this.#deepMerge(merged, await this.#loadOverlayYaml(filePath));
+			const overlay = await this.#loadOverlayYaml(filePath);
+			merged = this.#deepMerge(merged, overlay);
+			if (Object.hasOwn(overlay, "shellPath")) this.#overlayShellPathSource = filePath;
 		}
 		return merged;
 	}

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -119,6 +119,38 @@ describe("Settings", () => {
 		});
 	});
 
+	describe("shell configuration errors", () => {
+		it("points to the selected global config in the active agent directory", async () => {
+			const configPath = path.join(agentDir, "config.yaml");
+			const missingShell = tempDir.join("missing-global-bash");
+			await Bun.write(configPath, YAML.stringify({ shellPath: missingShell }, null, 2));
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(() => settings.getShellConfig()).toThrow(`Please update shellPath in ${configPath}`);
+		});
+
+		it("points to the project file that supplied shellPath", async () => {
+			const configPath = path.join(getProjectAgentDir(projectDir), "config.yml");
+			const missingShell = tempDir.join("missing-project-bash");
+			await Bun.write(configPath, YAML.stringify({ shellPath: missingShell }, null, 2));
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(() => settings.getShellConfig()).toThrow(`Please update shellPath in ${configPath}`);
+		});
+
+		it("points to the overlay that supplied shellPath", async () => {
+			const configPath = tempDir.join("shell-overlay.yml");
+			const missingShell = tempDir.join("missing-overlay-bash");
+			await Bun.write(configPath, YAML.stringify({ shellPath: missingShell }, null, 2));
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir, configFiles: [configPath] });
+
+			expect(() => settings.getShellConfig()).toThrow(`Please update shellPath in ${configPath}`);
+		});
+	});
+
 	describe("defaults", () => {
 		it("keeps eight inline images live by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Corrected Windows shell resolution errors to direct `shellPath` configuration to `~/.omp/agent/config.yml` instead of the retired `settings.json` file ([#6579](https://github.com/can1357/oh-my-pi/issues/6579)).
+- Corrected Windows shell resolution errors to identify the active global, project, overlay, or runtime source for `shellPath` instead of directing every user to the retired `settings.json` file ([#6579](https://github.com/can1357/oh-my-pi/issues/6579)).
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected Windows shell resolution errors to direct `shellPath` configuration to `~/.omp/agent/config.yml` instead of the retired `settings.json` file ([#6579](https://github.com/can1357/oh-my-pi/issues/6579)).
+
 ## [17.0.9] - 2026-07-23
 
 ### Breaking Changes

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { Subprocess } from "bun";
+import { getAgentDir, MAIN_CONFIG_FILENAMES } from "./dirs";
 import { $env, filterChildShellEnv } from "./env";
 import { $which } from "./which";
 
@@ -10,6 +11,12 @@ export interface ShellConfig {
 	args: string[];
 	env: Record<string, string>;
 	prefix: string | undefined;
+}
+
+/** Identifies the settings source users should edit when shell resolution fails. */
+export interface ShellConfigOptions {
+	/** File path or runtime layer that supplied the active shell setting. */
+	configSource?: string;
 }
 let cachedShellConfig: ShellConfig | null = null;
 
@@ -96,25 +103,23 @@ export function resolveBasicShell(): string | undefined {
 /**
  * Get shell configuration based on platform.
  * Resolution order:
- * 1. User-specified shellPath in settings.json
+ * 1. User-specified shellPath from the active settings source
  * 2. On Windows: Git Bash in known locations, then bash on PATH
  * 3. On Unix: $SHELL if bash/zsh, then fallback paths
  * 4. Fallback: sh
  */
-export function getShellConfig(customShellPath?: string): ShellConfig {
+export function getShellConfig(customShellPath?: string, options: ShellConfigOptions = {}): ShellConfig {
 	if (cachedShellConfig) {
 		return cachedShellConfig;
 	}
-
+	const configSource = options.configSource ?? path.join(getAgentDir(), MAIN_CONFIG_FILENAMES[0]);
 	// 1. Check user-specified shell path
 	if (customShellPath) {
 		if (fs.existsSync(customShellPath)) {
 			cachedShellConfig = buildConfig(customShellPath);
 			return cachedShellConfig;
 		}
-		throw new Error(
-			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ~/.omp/agent/config.yml`,
-		);
+		throw new Error(`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ${configSource}`);
 	}
 
 	if (process.platform === "win32") {
@@ -147,7 +152,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 			`No bash shell found. Options:\n` +
 				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
 				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
-				`  3. Set shellPath in ~/.omp/agent/config.yml\n\n` +
+				`  3. Set shellPath in ${configSource}\n\n` +
 				`Searched Git Bash in:\n${paths.map(p => `  ${p}`).join("\n")}`,
 		);
 	}

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -113,7 +113,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 			return cachedShellConfig;
 		}
 		throw new Error(
-			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ~/.omp/agent/settings.json`,
+			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ~/.omp/agent/config.yml`,
 		);
 	}
 
@@ -147,7 +147,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 			`No bash shell found. Options:\n` +
 				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
 				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
-				`  3. Set shellPath in ~/.omp/agent/settings.json\n\n` +
+				`  3. Set shellPath in ~/.omp/agent/config.yml\n\n` +
 				`Searched Git Bash in:\n${paths.map(p => `  ${p}`).join("\n")}`,
 		);
 	}

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getShellConfig } from "../src/procmgr";
+
+describe("getShellConfig", () => {
+	it("directs invalid custom shell paths to the canonical config file", () => {
+		const missingShell = path.join(os.tmpdir(), `omp-missing-shell-${process.pid}`, "bash");
+		expect(() => getShellConfig(missingShell)).toThrow(
+			`Custom shell path not found: ${missingShell}\nPlease update shellPath in ~/.omp/agent/config.yml`,
+		);
+	});
+});

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getAgentDir, MAIN_CONFIG_FILENAMES } from "../src/dirs";
 import { getShellConfig } from "../src/procmgr";
 
 describe("getShellConfig", () => {
 	it("directs invalid custom shell paths to the canonical config file", () => {
 		const missingShell = path.join(os.tmpdir(), `omp-missing-shell-${process.pid}`, "bash");
+		const configPath = path.join(getAgentDir(), MAIN_CONFIG_FILENAMES[0]);
 		expect(() => getShellConfig(missingShell)).toThrow(
-			`Custom shell path not found: ${missingShell}\nPlease update shellPath in ~/.omp/agent/config.yml`,
+			`Custom shell path not found: ${missingShell}\nPlease update shellPath in ${configPath}`,
 		);
 	});
 });


### PR DESCRIPTION
## Repro
With an existing canonical config plus the legacy file named by the startup error, run:

```sh
bun -e 'import * as fs from "node:fs/promises"; import * as os from "node:os"; import * as path from "node:path"; import { Settings } from "./packages/coding-agent/src/config/settings.ts"; const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-6579-")); await Bun.write(path.join(dir, "config.yml"), "{}\n"); await Bun.write(path.join(dir, "settings.json"), JSON.stringify({ shellPath: "D:/msys64/usr/bin/bash.exe" })); const settings = await Settings.loadIsolated({ agentDir: dir, cwd: dir }); const shellPath = settings.get("shellPath"); console.log(JSON.stringify({ shellPath: shellPath ?? null })); await fs.rm(dir, { recursive: true }); process.exitCode = shellPath === undefined ? 1 : 0;'
```

It prints `{"shellPath":null}` and exits 1.

## Cause
`Settings.#load()` in `packages/coding-agent/src/config/settings.ts` reads `settings.json` only during one-time migration when no `config.yml` exists, while both failure branches in `getShellConfig()` in `packages/utils/src/procmgr.ts` still directed Windows users to that retired JSON file.

## Fix
- Point invalid custom-shell and Windows shell-discovery errors at `~/.omp/agent/config.yml`.
- Cover the canonical configuration guidance with a `getShellConfig()` regression test.
- Record the user-visible fix in the utils changelog.

## Verification
`bun test test/procmgr.test.ts` in `packages/utils` passes (1 test), `bun run check` in `packages/utils` passes, a manual `config.yml` load resolved `/bin/bash`, and the pre-publish `bun check` gate passed. Fixes #6579