### PR TITLE
fix(tui): attach drag-dropped image paths with unescaped spaces

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed dragging an image whose path contains unescaped spaces (e.g. macOS screenshot names like `Screenshot 2026-07-24 at 1.55.12 PM.png`) into the terminal — the bracketed-paste image extraction route now has the same whole-text-as-path fallback as the clipboard keybind route, so both routes share identical detection and attach the image instead of inserting the raw path as literal text ([#6578](https://github.com/can1357/oh-my-pi/issues/6578)).
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- Fixed dragging an image whose path contains unescaped spaces (e.g. macOS screenshot names like `Screenshot 2026-07-24 at 1.55.12 PM.png`) into the terminal — the bracketed-paste image extraction route now has the same whole-text-as-path fallback as the clipboard keybind route, so both routes share identical detection and attach the image instead of inserting the raw path as literal text ([#6578](https://github.com/can1357/oh-my-pi/issues/6578)).
+- Fixed dragging an image whose path contains unescaped spaces (e.g. macOS screenshot names like `Screenshot 2026-07-24 at 1.55.12 PM.png`) into the terminal — the bracketed-paste image extraction route now has the same whole-text-as-path fallback as the clipboard keybind route, so both routes share identical detection and attach the image instead of inserting the raw path as literal text ([#6578](https://github.com/can1357/oh-my-pi/issues/6578)). The shared fallback only claims payloads that hold a single path: one carrying a second absolute-path anchor after unescaped whitespace (`/tmp/a.png /tmp/b shot.png` — dragging two files at once when either name has spaces) now pastes as text on both routes instead of being fused into one unresolvable path, which on the clipboard route previously attached nothing and swallowed the text behind an "Image not found" status.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -200,6 +200,26 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(pasted).toEqual([screenshot]);
 		expect(editor.getText()).toBe("");
 	});
+
+	it("keeps a two-file drag with unescaped spaces as text instead of attaching one fused path", () => {
+		// PR #6582 review: selecting two screenshots and dropping them together
+		// emits a single space-separated payload the splitter also refuses
+		// (`PM.png` carries no directory). Fusing it into one path attaches
+		// nothing — `handleImagePathPaste` hits ENOENT and only shows a status,
+		// never restoring the text — so the drop must degrade to a text paste.
+		const { editor } = makeEditor();
+		const dropped =
+			"/Users/me/Desktop/Screenshot 2026-07-24 at 1.55.12 PM.png /Users/me/Desktop/Screenshot 2026-07-24 at 1.56.00 PM.png";
+		const pasted: string[] = [];
+		editor.onPasteImagePath = path => {
+			pasted.push(path);
+		};
+
+		editor.handleInput(bracketedPaste(dropped));
+
+		expect(pasted).toEqual([]);
+		expect(editor.getText()).toBe(dropped);
+	});
 });
 describe("CustomEditor configured paste image keys", () => {
 	it("routes Ghostty Cmd+V kitty key events through the macOS image-paste default", () => {
@@ -268,6 +288,12 @@ describe("extractImagePathFromText (issue #3506)", () => {
 		);
 	});
 
+	it("returns undefined for two spaced paths the splitter could not separate", () => {
+		// Only the whole-text pass survives the splitter here, and it must not
+		// fuse the pair into one path the loader can never resolve.
+		expect(extractImagePathFromText("/tmp/a.png /tmp/b shot.png")).toBeUndefined();
+	});
+
 	it("does not hijack prose that happens to contain a path-shaped fragment", () => {
 		// The whole-text branch is gated on ABSOLUTE_PATH_PREFIX_REGEX, so a
 		// non-anchored prefix ("see ...") never triggers it.
@@ -325,6 +351,55 @@ describe("extractImagePastePathsFromText (issue #6578)", () => {
 			name: "a bare spaced filename with no leading separator",
 			text: "Screenshot 2026-07-24 at 1.55.12 PM.png",
 			expected: undefined,
+		},
+		{
+			name: "two POSIX paths dragged together when one has unescaped spaces",
+			text: "/tmp/a.png /tmp/b shot.png",
+			expected: undefined,
+		},
+		{
+			name: "two macOS screenshots dragged together",
+			text: `${MAC_SCREENSHOT} /var/folders/xx/T/TemporaryItems/NSIRD_screencaptureui_ab/Screenshot 2026-07-24 at 1.56.00 PM.png`,
+			expected: undefined,
+		},
+		{
+			name: "two home-anchored paths with unescaped spaces",
+			text: "~/a.png ~/Pictures/b shot.png",
+			expected: undefined,
+		},
+		{
+			name: "two Windows drive paths with unescaped spaces",
+			text: `C:\\Users\\me\\a.png ${WINDOWS_SPACED}`,
+			expected: undefined,
+		},
+		{
+			name: "two `file://` URLs with unescaped spaces",
+			text: "file:///tmp/a.png file:///tmp/b shot.png",
+			expected: undefined,
+		},
+		{
+			name: "two UNC paths with unescaped spaces",
+			text: "\\\\srv\\share\\a.png \\\\srv\\share\\b shot.png",
+			expected: undefined,
+		},
+		{
+			name: "a tab-separated pair of dragged paths",
+			text: "/tmp/a.png\t/tmp/b shot.png",
+			expected: undefined,
+		},
+		{
+			// The escape asserts the space belongs to the path, so the `/sub`
+			// that follows is a component rather than a second drag payload.
+			name: "a path whose escaped space precedes a slash-led component",
+			text: "/tmp/odd dir\\ /sub/a b.png",
+			expected: ["/tmp/odd dir /sub/a b.png"],
+		},
+		{
+			// Splitter-success path: both segments are explicit, so the
+			// whole-text pass never runs and the pair still attaches as two.
+			name: "two explicit image paths the splitter can separate",
+			text: "/tmp/a.png /tmp/b.png",
+			expected: ["/tmp/a.png", "/tmp/b.png"],
 		},
 	];
 

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -8,6 +8,7 @@ import {
 	CustomEditor,
 	extractBracketedImagePastePaths,
 	extractBracketedPastePaths,
+	extractImagePastePathsFromText,
 	extractImagePathFromText,
 	extractPastePathsFromText,
 	SPACE_HOLD_MECHANICAL_RUN,
@@ -182,6 +183,23 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(editor.getText()).toBe("/tmp/report.csv");
 		expect(imagePathCalls).toBe(0);
 	});
+
+	it("attaches a spaced screenshot path as an image instead of inserting it as literal text", () => {
+		// #6578: the raw macOS "copy screenshot path" payload has unescaped
+		// spaces, which defeats the segment splitter. Before the whole-text
+		// fallback the paste degraded to literal text in the prompt.
+		const { editor } = makeEditor();
+		const screenshot = "/Users/me/Desktop/Screenshot 2026-07-24 at 1.55.12 PM.png";
+		const pasted: string[] = [];
+		editor.onPasteImagePath = path => {
+			pasted.push(path);
+		};
+
+		editor.handleInput(bracketedPaste(screenshot));
+
+		expect(pasted).toEqual([screenshot]);
+		expect(editor.getText()).toBe("");
+	});
 });
 describe("CustomEditor configured paste image keys", () => {
 	it("routes Ghostty Cmd+V kitty key events through the macOS image-paste default", () => {
@@ -262,6 +280,60 @@ describe("extractPastePathsFromText", () => {
 		expect(extractPastePathsFromText("/tmp/a.png /tmp/b.png")).toEqual(["/tmp/a.png", "/tmp/b.png"]);
 		expect(extractPastePathsFromText("just text")).toBeUndefined();
 	});
+});
+
+describe("extractImagePastePathsFromText (issue #6578)", () => {
+	const MAC_SCREENSHOT =
+		"/var/folders/xx/T/TemporaryItems/NSIRD_screencaptureui_ab/Screenshot 2026-07-24 at 1.55.12 PM.png";
+	const WINDOWS_SPACED = "C:\\Users\\me\\My Pictures\\shot 1.png";
+
+	// Every case must resolve identically on the stripped-marker route
+	// (assembled pastes) and the bracketed route, since the latter now
+	// delegates to the former.
+	const cases: { name: string; text: string; expected: string[] | undefined }[] = [
+		{ name: "a macOS screenshot path with unescaped spaces", text: MAC_SCREENSHOT, expected: [MAC_SCREENSHOT] },
+		{ name: "a Windows drive path with unescaped spaces", text: WINDOWS_SPACED, expected: [WINDOWS_SPACED] },
+		{
+			name: "a home-anchored path with unescaped spaces",
+			text: "~/Pictures/Cleanshot 2026-07-24 at 12.00.png",
+			expected: ["~/Pictures/Cleanshot 2026-07-24 at 12.00.png"],
+		},
+		{
+			name: "a shell-escaped spaced path",
+			text: "/tmp/My\\ Photos/shot\\ 1.png",
+			expected: ["/tmp/My Photos/shot 1.png"],
+		},
+		{
+			name: "a double-quoted spaced path",
+			text: '"/tmp/My Photos/shot 1.png"',
+			expected: ["/tmp/My Photos/shot 1.png"],
+		},
+		{ name: "a spaced path with a non-image extension", text: "/tmp/my report 2026.csv", expected: undefined },
+		{
+			// Ends in a real image extension, so only the absolute-prefix
+			// anchor keeps the whole-text fallback from swallowing the prose.
+			name: "prose ending in a path-shaped fragment",
+			text: "see /Users/me/Desktop/Screen Shot 1.png",
+			expected: undefined,
+		},
+		{
+			name: "two spaced image paths on separate lines",
+			text: "/tmp/a shot.png\n/tmp/b shot.png",
+			expected: undefined,
+		},
+		{
+			name: "a bare spaced filename with no leading separator",
+			text: "Screenshot 2026-07-24 at 1.55.12 PM.png",
+			expected: undefined,
+		},
+	];
+
+	for (const { name, text, expected } of cases) {
+		it(`${expected ? "recovers" : "rejects"} ${name} on both paste routes`, () => {
+			expect(extractImagePastePathsFromText(text)).toEqual(expected);
+			expect(extractBracketedImagePastePaths(bracketedPaste(text))).toEqual(expected);
+		});
+	}
 });
 
 describe("CustomEditor space-hold push-to-talk", () => {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -79,13 +79,28 @@ const URI_SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:/i;
 const FILE_URI_REGEX = /^file:\/\//i;
 const WINDOWS_DRIVE_PATH_REGEX = /^[a-z]:[\\/]/i;
 /**
+ * Alternation of the filesystem prefixes that make a path unambiguously
+ * absolute (POSIX root, home, `file://`, UNC, Windows drive). Shared by
+ * {@link ABSOLUTE_PATH_PREFIX_REGEX} and {@link INTERIOR_PATH_ANCHOR_REGEX} so
+ * the leading-anchor test and the second-anchor test can never disagree about
+ * what counts as the start of a path.
+ */
+const ABSOLUTE_PATH_PREFIX_SOURCE = String.raw`(?:\/|~\/|file:\/\/|\\\\|[A-Za-z]:[\\/])`;
+/**
  * Whole-string anchor for paths that are unambiguously absolute. Restricts the
  * "treat the entire text as one path" pass of {@link extractWholeTextImagePath}
  * to inputs that start with a clearly-anchored filesystem prefix, so prose
  * containing a path-shaped fragment (e.g. "see /tmp/x.png") never hijacks the
  * smart fallback.
  */
-const ABSOLUTE_PATH_PREFIX_REGEX = /^(?:\/|~\/|file:\/\/|\\\\|[A-Za-z]:[\\/])/;
+const ABSOLUTE_PATH_PREFIX_REGEX = new RegExp(`^${ABSOLUTE_PATH_PREFIX_SOURCE}`);
+/**
+ * A second absolute-path anchor after *unescaped* whitespace — the signature of
+ * a multi-path payload (`/tmp/a.png /tmp/b shot.png`) rather than of one path
+ * whose name merely contains spaces. Escaped whitespace (`/tmp/My\ Photos/x.png`)
+ * is exempt: the escape is the terminal asserting the space belongs to the path.
+ */
+const INTERIOR_PATH_ANCHOR_REGEX = new RegExp(String.raw`(?<!\\)\s${ABSOLUTE_PATH_PREFIX_SOURCE}`);
 
 /** Max gap (ms) between two spaces for the later one to count as OS key auto-repeat rather than a
  *  deliberate press. OS auto-repeat is fast; a deliberate tap (even a fast one) is slower. */
@@ -234,10 +249,20 @@ export function extractPastePathsFromText(text: string): string[] | undefined {
  * when it is anchored by {@link ABSOLUTE_PATH_PREFIX_REGEX}, contains no
  * newlines, and points at a supported image extension. Recovers single paths
  * whose unescaped spaces defeat the segment splitter (macOS screenshot names).
+ *
+ * Refuses payloads carrying a second {@link INTERIOR_PATH_ANCHOR_REGEX} anchor.
+ * Dragging two files at once emits `/tmp/a.png /tmp/b shot.png`, which the
+ * splitter also refuses (`shot.png` is not explicit); swallowing it as one path
+ * attaches nothing, and `handleImagePathPaste`'s ENOENT branch only surfaces a
+ * status — unlike its other failure branches it never re-pastes the text — so
+ * both paths would vanish. Genuinely ambiguous input lands here too (a
+ * directory whose name ends in a space, as in `/tmp/odd dir /sub/x.png`); a
+ * plain text paste is the losing-nothing outcome, so ambiguity resolves that way.
  */
 function extractWholeTextImagePath(text: string): string | undefined {
 	const trimmed = text.trim();
 	if (!trimmed || /[\r\n]/.test(trimmed) || !ABSOLUTE_PATH_PREFIX_REGEX.test(trimmed)) return undefined;
+	if (INTERIOR_PATH_ANCHOR_REGEX.test(trimmed)) return undefined;
 	const wholePath = normalizePastedPath(trimmed);
 	return wholePath && isExplicitPastedPath(wholePath) && isImagePath(wholePath) ? wholePath : undefined;
 }

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -80,10 +80,10 @@ const FILE_URI_REGEX = /^file:\/\//i;
 const WINDOWS_DRIVE_PATH_REGEX = /^[a-z]:[\\/]/i;
 /**
  * Whole-string anchor for paths that are unambiguously absolute. Restricts the
- * "treat the entire clipboard text as one path" branch of
- * {@link extractImagePathFromText} to inputs that start with a clearly-anchored
- * filesystem prefix, so prose containing a path-shaped fragment (e.g.
- * "see /tmp/x.png") never hijacks the smart fallback.
+ * "treat the entire text as one path" pass of {@link extractWholeTextImagePath}
+ * to inputs that start with a clearly-anchored filesystem prefix, so prose
+ * containing a path-shaped fragment (e.g. "see /tmp/x.png") never hijacks the
+ * smart fallback.
  */
 const ABSOLUTE_PATH_PREFIX_REGEX = /^(?:\/|~\/|file:\/\/|\\\\|[A-Za-z]:[\\/])/;
 
@@ -228,16 +228,18 @@ export function extractPastePathsFromText(text: string): string[] | undefined {
 	return extractExplicitPathSegments(text);
 }
 
-export function extractBracketedPastePaths(data: string): string[] | undefined {
-	if (!data.startsWith(BRACKETED_PASTE_START)) return undefined;
-	const endIndex = data.indexOf(BRACKETED_PASTE_END, BRACKETED_PASTE_START.length);
-	if (endIndex === -1 || endIndex + BRACKETED_PASTE_END.length !== data.length) return undefined;
-	return extractExplicitPathSegments(data.slice(BRACKETED_PASTE_START.length, endIndex));
-}
-
-export function extractBracketedImagePastePaths(data: string): string[] | undefined {
-	const paths = extractBracketedPastePaths(data);
-	return paths?.every(isImagePath) ? paths : undefined;
+/**
+ * Whole-text-as-path pass shared by {@link extractImagePastePathsFromText}
+ * and {@link extractImagePathFromText}: treat the entire text as one path
+ * when it is anchored by {@link ABSOLUTE_PATH_PREFIX_REGEX}, contains no
+ * newlines, and points at a supported image extension. Recovers single paths
+ * whose unescaped spaces defeat the segment splitter (macOS screenshot names).
+ */
+function extractWholeTextImagePath(text: string): string | undefined {
+	const trimmed = text.trim();
+	if (!trimmed || /[\r\n]/.test(trimmed) || !ABSOLUTE_PATH_PREFIX_REGEX.test(trimmed)) return undefined;
+	const wholePath = normalizePastedPath(trimmed);
+	return wholePath && isExplicitPastedPath(wholePath) && isImagePath(wholePath) ? wholePath : undefined;
 }
 
 /**
@@ -245,10 +247,35 @@ export function extractBracketedImagePastePaths(data: string): string[] | undefi
  * payload that has already been stripped of the `\x1b[200~` / `\x1b[201~`
  * markers — used by the assembled-paste router in {@link CustomEditor.handleInput}
  * so split bracketed pastes get the same image-path detection as single-chunk ones.
+ *
+ * When the segment splitter fails (an unescaped space in a real path breaks
+ * its every-segment-is-a-path invariant), falls back to
+ * {@link extractWholeTextImagePath}, so a dropped macOS screenshot
+ * (`Screenshot 2026-06-25 at 1.23.45 PM.png`) attaches as an image instead of
+ * degrading to literal text (#6578).
  */
 export function extractImagePastePathsFromText(text: string): string[] | undefined {
 	const paths = extractPastePathsFromText(text);
-	return paths?.every(isImagePath) ? paths : undefined;
+	if (paths !== undefined) return paths.every(isImagePath) ? paths : undefined;
+	const wholePath = extractWholeTextImagePath(text);
+	return wholePath ? [wholePath] : undefined;
+}
+
+function bracketedPastePayload(data: string): string | undefined {
+	if (!data.startsWith(BRACKETED_PASTE_START)) return undefined;
+	const endIndex = data.indexOf(BRACKETED_PASTE_END, BRACKETED_PASTE_START.length);
+	if (endIndex === -1 || endIndex + BRACKETED_PASTE_END.length !== data.length) return undefined;
+	return data.slice(BRACKETED_PASTE_START.length, endIndex);
+}
+
+export function extractBracketedPastePaths(data: string): string[] | undefined {
+	const payload = bracketedPastePayload(data);
+	return payload === undefined ? undefined : extractExplicitPathSegments(payload);
+}
+
+export function extractBracketedImagePastePaths(data: string): string[] | undefined {
+	const payload = bracketedPastePayload(data);
+	return payload === undefined ? undefined : extractImagePastePathsFromText(payload);
 }
 
 export function extractBracketedImagePastePath(data: string): string | undefined {
@@ -272,25 +299,17 @@ export function extractBracketedImagePastePath(data: string): string | undefined
  *    ambiguous multi-path clipboard text like `/tmp/a.png /tmp/b.png`
  *    still falls through to the text fallback instead of being mis-loaded
  *    as one giant path).
- * 2. Whole-text-as-path pass — only reached when the splitter failed
- *    (every segment must look like an explicit path; an unescaped space in
- *    a real path breaks that). Restricted to inputs anchored by
- *    {@link ABSOLUTE_PATH_PREFIX_REGEX} so prose containing a path-shaped
- *    fragment ("see /tmp/x.png") never hijacks the smart fallback. This
- *    is what recovers macOS screenshot filenames like
+ * 2. {@link extractWholeTextImagePath} — only reached when the splitter
+ *    failed (every segment must look like an explicit path; an unescaped
+ *    space in a real path breaks that). This is what recovers macOS
+ *    screenshot filenames like
  *    `/Users/me/Desktop/Screenshot 2026-06-25 at 1.23.45 PM.png`.
  */
 export function extractImagePathFromText(text: string): string | undefined {
 	const paths = extractPastePathsFromText(text);
 	if (paths?.length === 1 && isImagePath(paths[0])) return paths[0];
 	if (paths !== undefined) return undefined;
-	const trimmed = text.trim();
-	if (!trimmed || /[\r\n]/.test(trimmed) || !ABSOLUTE_PATH_PREFIX_REGEX.test(trimmed)) return undefined;
-	const wholePath = normalizePastedPath(trimmed);
-	if (wholePath && isExplicitPastedPath(wholePath) && isImagePath(wholePath)) {
-		return wholePath;
-	}
-	return undefined;
+	return extractWholeTextImagePath(text);
 }
 
 /**


### PR DESCRIPTION
Fixes #6578.

Dragging an image into the terminal degraded to literal path text when the terminal inserted the path with unescaped spaces (macOS screenshot names) — the bracketed-paste image route required every whitespace-split segment to look path-like, so `Screenshot 2026-07-24 at 1.55.12 PM.png` failed segment checks and the whole paste fell through to text. The keybind-driven clipboard route already recovered exactly this case via a whole-text-as-path fallback.

**Change:** extract that fallback into a shared `extractWholeTextImagePath` helper (ABSOLUTE_PATH_PREFIX anchor + no newlines + image extension), apply it in `extractImagePastePathsFromText` when the segment splitter fails, and route `extractBracketedImagePastePaths` through the stripped-marker extractor so both routes share one detection function. Splitter-success semantics unchanged; guards (prose, non-image extensions, bare filenames, multi-line payloads) still reject.

**Verification:**
- Issue repro extracts on the bracketed, stripped-marker, and keybind routes; escaped/quoted forms unchanged
- 10 new tests (38 pass total in `custom-editor.test.ts`), each verified to fail under targeted mutations of the fix
- `biome check` clean on changed files; `check:types` (tsgo) exit 0
- Manual QA from a source build: dragged a real macOS screenshot with spaces in its name into the prompt — image attachment appears instead of raw path text; guards confirmed by pasting prose/csv paths

I hit this bug myself dragging macOS screenshots into the terminal. I reviewed the change and verified the drag-drop attach works from a source build.

Known edge (inherited by design): a single-line paste of multiple space-separated unescaped image paths passes the fallback as one bogus path and surfaces via `handleImagePathPaste`'s file-existence diagnostic — identical to the pre-existing clipboard-route behavior; the raw-path attachment convention (see the issue's Orca comment) names that existence check as the ecosystem's guard.
