### PR TITLE
fix(coding-agent): re-export estimateTokens from legacy pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy pi extensions failing extension validation when importing `estimateTokens` from `@earendil-works/pi-coding-agent` (aliased to the legacy shim). Legacy pi re-exported `estimateTokens` from its coding-agent package root; in omp it lives in `@oh-my-pi/pi-agent-core/compaction` and the coding-agent barrel does not forward it, so the shim's `export * from "../index"` left it off the surface and a named import threw Bun's static "Export named 'estimateTokens' not found" error (e.g. `omp plugin install pi-blackhole`). The shim now re-exports it ([#6583](https://github.com/can1357/oh-my-pi/issues/6583)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1366,6 +1366,13 @@ export function getPackageDir(): string {
 	return getOmpPackageDir() ?? (isCompiledBinary() ? path.dirname(process.execPath) : process.cwd());
 }
 
+// Legacy pi's `@earendil-works/pi-coding-agent` re-exported `estimateTokens`
+// from its package root (via `./core/compaction/index.ts`). In omp it lives in
+// `@oh-my-pi/pi-agent-core/compaction`, and the coding-agent barrel below does
+// not forward it, so legacy extensions importing it fail Bun's static export
+// check during validation (issue #6583).
+export { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
+
 export * from "../index";
 export { formatBytes as formatSize } from "../tools/render-utils";
 export { copyToClipboard } from "../utils/clipboard";

--- a/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { estimateTokens } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+
+// Issue #6583: pi extensions import `estimateTokens` from
+// `@earendil-works/pi-coding-agent`, which aliases to this shim. Legacy pi
+// re-exported it from the coding-agent package root (via
+// `./core/compaction/index.ts`); in omp it lives in
+// `@oh-my-pi/pi-agent-core/compaction` and the coding-agent barrel does not
+// forward it, so `export * from "../index"` left the symbol off the shim
+// surface and a named import threw Bun's static "Export named X not found"
+// during plugin validation (e.g. `omp plugin install pi-blackhole`). This pins
+// the re-export through the public package specifier.
+describe("legacy shim compaction helpers", () => {
+	it("re-exports estimateTokens as a callable token estimator", () => {
+		expect(typeof estimateTokens).toBe("function");
+		const tokens = estimateTokens({ role: "user", content: "hello world", timestamp: Date.now() });
+		expect(tokens).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Repro
Installing a legacy pi extension that imports `estimateTokens` from `@earendil-works/pi-coding-agent` fails plugin validation with `Export named 'estimateTokens' not found in module 'omp-legacy-pi-bundled:@oh-my-pi/pi-coding-agent'` (reported via `omp plugin install pi-blackhole`). Reproduced in-process by importing the shim namespace: `typeof shim.estimateTokens === "undefined"`.

## Cause
Legacy pi's `@earendil-works/pi-coding-agent` re-exports `estimateTokens` from its coding-agent package root (via `./core/compaction/index.ts`). In omp the symbol lives in `@oh-my-pi/pi-agent-core/compaction`, and the coding-agent barrel (`packages/coding-agent/src/index.ts`) does not forward it. The legacy compat shim (`src/extensibility/legacy-pi-coding-agent-shim.ts`) reconstructs the package-root surface via `export * from "../index"`, so `estimateTokens` never reaches the shim surface and Bun's static export check fails during extension validation. Same class as `getPackageDir` (#5968), `keyText` (#6470), and `calculateCost` (#4584).

## Fix
- Add a targeted named re-export `export { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";` to `legacy-pi-coding-agent-shim.ts`, with a comment documenting the legacy contract and issue.
- Add `test/extensibility/legacy-pi-compaction-helpers.test.ts` pinning the re-export through the public package specifier (symbol is callable and returns a positive token count).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/extensibility/` → 143 pass, 0 fail (includes the new regression test and the sibling shim export tests). The pre-publish gate (`bun run fix` + `bun check`) passed on push.
Fixes #6583