### PR TITLE
fix(coding-agent): mask Mnemopi API keys in settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Mnemopi embedding and LLM API keys rendering in plain text in the settings panel and its text editor. Both are now marked `secret` like `hindsight.apiToken`, so the settings row shows dots and the editor input is masked while you type. A schema test now fails when a credential-shaped setting the panel can display is added without masking.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2783,6 +2783,7 @@ export const SETTINGS_SCHEMA = {
 			label: "Mnemopi Embedding API Key",
 			description: "Optional embedding API key passed to Mnemopi",
 			condition: "mnemopiActive",
+			secret: true,
 		},
 	},
 	"mnemopi.llmMode": {
@@ -2827,6 +2828,7 @@ export const SETTINGS_SCHEMA = {
 			label: "Mnemopi LLM API Key",
 			description: "Optional LLM API key for Mnemopi remote mode",
 			condition: "mnemopiActive",
+			secret: true,
 		},
 	},
 	"mnemopi.llmModel": {

--- a/packages/coding-agent/test/settings-schema-secrets.test.ts
+++ b/packages/coding-agent/test/settings-schema-secrets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { getUi, SETTINGS_SCHEMA, type SettingPath } from "../src/config/settings-schema";
+
+/**
+ * Heuristic used only to catch a credential setting that was added without
+ * masking. It is a review aid, never an authorization boundary: a name is not
+ * a security property, and callers must not decide disclosure from it.
+ */
+const CREDENTIAL_NAME = /token|apikey|api_key|password|passwd|credential|secret|bearer/i;
+
+/** Paths the heuristic matches on wording alone; none of them hold a credential. */
+const NOT_CREDENTIALS: Record<string, true> = {
+	"display.showTokenUsage": true,
+	"share.redactSecrets": true,
+	"secrets.enabled": true,
+	"compaction.thresholdTokens": true,
+	"compaction.reserveTokens": true,
+	"compaction.keepRecentTokens": true,
+	"compaction.idleThresholdTokens": true,
+	"branchSummary.reserveTokens": true,
+	"memories.phase1InputTokenLimit": true,
+	"memories.fallbackTokenLimit": true,
+	"memories.summaryInjectionTokenLimit": true,
+	"mnemopi.injectionTokenLimit": true,
+	"hindsight.recallMaxTokens": true,
+	"commit.mapReduceMaxFileTokens": true,
+};
+
+const paths = Object.keys(SETTINGS_SCHEMA) as SettingPath[];
+
+describe("settings schema credential masking", () => {
+	it("masks every credential that the settings panel can display", () => {
+		const unmasked = paths.filter(path => {
+			const ui = getUi(path);
+			if (!ui || ui.secret === true) return false;
+			return CREDENTIAL_NAME.test(path) && NOT_CREDENTIALS[path] !== true;
+		});
+		// A visible setting holding a credential must render as dots, not plain
+		// text: `ui.secret` is what drives masking in the row and the editor.
+		expect(unmasked).toEqual([]);
+	});
+
+	it("keeps the known credential settings marked", () => {
+		for (const path of ["mnemopi.embeddingApiKey", "mnemopi.llmApiKey", "hindsight.apiToken"] as const) {
+			expect(getUi(path)?.secret).toBe(true);
+		}
+	});
+
+	it("only marks string settings secret", () => {
+		for (const path of paths) {
+			if (getUi(path)?.secret !== true) continue;
+			expect(SETTINGS_SCHEMA[path].type).toBe("string");
+		}
+	});
+
+	it("lists every heuristic exemption against a real setting", () => {
+		// Keeps the allowlist honest: a renamed or deleted setting must not leave
+		// a stale exemption that silently excuses a future credential.
+		const known = new Set<string>(paths);
+		expect(Object.keys(NOT_CREDENTIALS).filter(path => !known.has(path))).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

- Mark `mnemopi.embeddingApiKey` and `mnemopi.llmApiKey` as `secret` in `SETTINGS_SCHEMA`.
- Add a schema test that fails when a credential-shaped setting the settings panel can display is added without masking.

## Why

I was walking `SETTINGS_SCHEMA` to see which settings are safe to expose to an external client, and noticed both Mnemopi keys have `ui` metadata but no `secret: true`. Masking is driven by `ui.secret` (`settings-defs.ts` -> `settings-selector.ts`), so today the panel renders both API keys in plain text in the settings row, and the text editor shows them unmasked while you type. Of 439 settings, `hindsight.apiToken` was the only one marked.

To be precise about the fix: the editor still preloads the current value (`settings-selector.ts:1139` passes it to `TextInputSubmenu`, which sets `input.mask` and then `setValue`). What changes is that the row and the input render as dots instead of the key.

The test's name heuristic is a review aid for the test only, deliberately not a runtime check: a setting name is not a security property, and it both misses and false-positives. Its exemption list is itself asserted against real setting paths so a renamed setting cannot leave a stale excuse behind.

Out of scope: `auth.broker.token`, `searxng.token`, `searxng.basicPassword` and `dev.autoqaPush.token` are also credentials, but they have no `ui` block, so the panel never displays them and `ui.secret` has nowhere to live. Marking those needs a metadata field outside `ui`, which felt like a separate change rather than something to fold in here.

## Testing

- `bun test test/settings-schema-secrets.test.ts`: covers that no UI-visible credential-shaped setting is unmasked, that the three known credential settings stay marked, that only string settings are marked secret, and that every heuristic exemption still maps to a real setting path.
- `bun test test/settings-manager.test.ts test/selector-settings-side-effects.test.ts test/settings-schema-secrets.test.ts`: green.
- `bun run check`: clean (biome + tsgo + cargo).
- Confirmed `getUi("mnemopi.embeddingApiKey").secret === true` and that `pathToSettingDef` now yields `{ type: "text", secret: true }`, which is the flag `settings-selector` passes to `TextInputSubmenu` as `input.mask`.

Draft while I confirm the rendered panel on a build with Mnemopi enabled.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

