### PR TITLE
fix(ai): disable adaptive-only thinking on disableReasoning and forced tool choice

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native Anthropic adaptive-only models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) keeping thinking ON when reasoning was meant to be off. `mapOptionsForApi` never consulted `disableReasoning` on the Anthropic branch, so a caller-side disable left adaptive thinking at full effort; and `disableThinkingIfToolChoiceForced` deleted `output_config.effort` alongside `thinking`, which for adaptive-only models silently re-enabled adaptive thinking (a bare omission defaults to adaptive-ON). Both paths now omit `thinking` and pin the lowest adaptive effort, so `disableReasoning` and forced `tool_choice` turns (e.g. the delivery reviewer's `report_delivery`) actually suppress reasoning instead of returning a thinking block with `end_turn` ([#6589](https://github.com/can1357/oh-my-pi/issues/6589)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -130,6 +130,22 @@ export function buildBetaHeader(baseBetas: readonly string[], extraBetas: readon
 	return result.join(",");
 }
 
+/**
+ * Merge an extra Anthropic beta into a caller-provided `anthropic-beta` header,
+ * preserving the caller's key casing and deduping the tokens. Returns a
+ * single-entry header record for a per-request `headers` override — used to
+ * attach a required beta to injected SDK clients that bypass the client-level
+ * beta construction.
+ */
+function mergeAnthropicBetaHeader(callerHeaders: Record<string, string>, beta: string): Record<string, string> {
+	for (const key in callerHeaders) {
+		if (key.toLowerCase() === "anthropic-beta") {
+			return { [key]: buildBetaHeader(normalizeExtraBetas(callerHeaders[key]), [beta]) };
+		}
+	}
+	return { "anthropic-beta": beta };
+}
+
 const midConversationSystemBeta = "mid-conversation-system-2026-04-07";
 const contextManagementBeta = "context-management-2025-06-27";
 const structuredOutputsBeta = "structured-outputs-2025-12-15";
@@ -2064,10 +2080,27 @@ const streamAnthropicOnce = (
 				// to zero even when no watchdog timeout is configured (the helper only
 				// pins it alongside a timeout; a client retry budget of 5 would otherwise
 				// multiply with PROVIDER_MAX_RETRIES into up to 66 wire attempts).
+				// Injected SDK clients (`options.client`) bypass the client-level
+				// `anthropic-beta` construction below, so any `output_config.effort` the
+				// body carries — the adaptive-only thinking-off / forced-tool pins and
+				// enabled-effort turns alike — would reach Anthropic without the required
+				// `effort-2025-11-24` beta and 400. `create()` accepts per-request headers
+				// (already used for the gateway web-search header), so merge the beta with
+				// any caller-provided `anthropic-beta` (deduped) and attach it there. Vertex
+				// never carries the effort field (dropped in buildParams), so it is unaffected.
+				const injectedClientEffortHeaders =
+					options?.client !== undefined &&
+					(params.output_config as AnthropicOutputConfig | undefined)?.effort !== undefined
+						? mergeAnthropicBetaHeader(mergedCallerHeaders, effortBeta)
+						: undefined;
+				const perRequestHeaders =
+					umansGatewayWebSearchHeader || injectedClientEffortHeaders
+						? { ...umansGatewayWebSearchHeader, ...injectedClientEffortHeaders }
+						: undefined;
 				const requestOptions = {
 					...createSdkStreamRequestOptions(requestSignal, requestTimeoutMs),
 					maxRetries: 0,
-					...(umansGatewayWebSearchHeader ? { headers: umansGatewayWebSearchHeader } : {}),
+					...(perRequestHeaders ? { headers: perRequestHeaders } : {}),
 				};
 				const anthropicRequest: unknown =
 					isOAuthToken && client.beta
@@ -2963,7 +2996,6 @@ function createClient(
 function disableThinkingIfToolChoiceForced(
 	params: MessageCreateParamsStreaming,
 	model: Model<"anthropic-messages">,
-	canDeliverEffortBeta: boolean,
 ): void {
 	const toolChoice = params.tool_choice;
 	if (!toolChoice) return;
@@ -2975,12 +3007,12 @@ function disableThinkingIfToolChoiceForced(
 	// Adaptive-only models can't be switched off by omitting `thinking` — a bare
 	// omission defaults to adaptive thinking ON, so a forced-tool turn would still
 	// reason instead of calling the tool (#6589). Pin the lowest adaptive effort
-	// instead of dropping it, mirroring the disable branch in buildParams. The pin
-	// only lands when the effort beta can ride along: Vertex rawPredict needs it in
-	// the body (dropped here too, see buildParams) and injected SDK clients own
-	// their own headers, so both fall back to the delete behavior rather than
-	// shipping `output_config.effort` the API would 400 without the beta.
-	if (isAdaptiveOnlyThinking(model) && model.provider !== "google-vertex" && canDeliverEffortBeta) {
+	// instead of dropping it, mirroring the disable branch in buildParams. Vertex
+	// rawPredict is the sole exception: it can only carry the effort beta in the
+	// body (dropped there too, see buildParams), so it keeps the delete behavior.
+	// The effort beta itself is attached at the request site — including per-request
+	// for injected SDK clients that bypass client-level beta construction.
+	if (isAdaptiveOnlyThinking(model) && model.provider !== "google-vertex") {
 		const outputConfig = (params.output_config as AnthropicOutputConfig | undefined) ?? {};
 		outputConfig.effort = "low";
 		params.output_config = outputConfig;
@@ -3394,10 +3426,9 @@ function buildParams(
 				// Omit the thinking field (the API defaults to adaptive) and pin the
 				// lowest effort so "thinking off" calls stay cheap instead of failing
 				// the request with a 400 (a hidden-thinking toggle must never break it).
-				// Injected SDK clients own their headers and can't receive the effort
-				// beta this code would otherwise attach, so omit the pin for them —
-				// the request stays valid (adaptive defaults on) instead of 400ing.
-				if (!options?.client) outputConfigEffort = "low";
+				// The effort field requires the `effort-2025-11-24` beta; it is attached
+				// at the request site, including per-request for injected SDK clients.
+				outputConfigEffort = "low";
 			} else {
 				thinking = { type: "disabled" };
 			}
@@ -3518,7 +3549,7 @@ function buildParams(
 		}
 	}
 
-	disableThinkingIfToolChoiceForced(params, model, !options?.client);
+	disableThinkingIfToolChoiceForced(params, model);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
 	applyPromptCaching(params, cacheControl);
 	enforceCacheControlLimit(params, 4);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -63,6 +63,7 @@ import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { spillToDescription } from "../utils/schema/spill";
 import { createSdkStreamRequestOptions } from "../utils/sdk-stream-timeout";
 import { notifyRawSseEvent } from "../utils/sse-debug";
+import { isForcedToolChoice } from "../utils/tool-choice";
 import {
 	AnthropicApiError,
 	AnthropicConnectionTimeoutError,
@@ -1840,20 +1841,19 @@ const streamAnthropicOnce = (
 				if (options?.taskBudget && !extraBetas.includes(taskBudgetBeta)) {
 					extraBetas.push(taskBudgetBeta);
 				}
-				// `output_config.effort` ships on thinking-on requests AND on the
-				// thinking-off adaptive pin (adaptive-only models get effort:"low" so
-				// the toggle cannot 400); the beta must accompany the field in both.
-				// MiniMax uses `thinking.type:"adaptive"` itself as the control surface,
-				// so the sentinel "adaptive" value intentionally sends no output_config.
-				// Skip Vertex rawPredict: that adapter needs betas in the body
-				// (`anthropic_beta`), not as an `anthropic-beta` HTTP header, so the
-				// effort field is dropped from the body there too (see buildParams) and
-				// advertising the beta would only earn a 400 (#5614).
+				// `output_config.effort` ships on thinking-on requests, explicit
+				// thinking-off adaptive pins, and forced-tool adaptive pins. The beta
+				// must accompany the field even when direct streamAnthropic callers omit
+				// thinkingEnabled (#6589). MiniMax uses `thinking.type:"adaptive"` itself
+				// as the control surface, so the sentinel "adaptive" value intentionally
+				// sends no output_config. Skip Vertex rawPredict: that adapter needs betas
+				// in the body (`anthropic_beta`), not as an `anthropic-beta` HTTP header,
+				// so the effort field is dropped from the body there too (see buildParams)
+				// and advertising the beta would only earn a 400 (#5614).
 				const sendsAdaptiveEffortPin =
-					options?.thinkingEnabled === false &&
-					model.thinking?.mode === "anthropic-adaptive" &&
-					!model.compat.disableAdaptiveThinking &&
-					!usesAdaptiveThinkingTagOnly(model);
+					isAdaptiveOnlyThinking(model) &&
+					(options?.thinkingEnabled === false ||
+						(model.compat.supportsForcedToolChoice && isForcedToolChoice(options?.toolChoice)));
 				if (
 					model.reasoning &&
 					model.provider !== "google-vertex" &&

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2963,6 +2963,7 @@ function createClient(
 function disableThinkingIfToolChoiceForced(
 	params: MessageCreateParamsStreaming,
 	model: Model<"anthropic-messages">,
+	canDeliverEffortBeta: boolean,
 ): void {
 	const toolChoice = params.tool_choice;
 	if (!toolChoice) return;
@@ -2974,10 +2975,12 @@ function disableThinkingIfToolChoiceForced(
 	// Adaptive-only models can't be switched off by omitting `thinking` — a bare
 	// omission defaults to adaptive thinking ON, so a forced-tool turn would still
 	// reason instead of calling the tool (#6589). Pin the lowest adaptive effort
-	// instead of dropping it, mirroring the disable branch in buildParams. Vertex
-	// rawPredict can't carry the effort beta as an HTTP header, so it keeps the
-	// delete behavior (the field is stripped there anyway; see buildParams).
-	if (isAdaptiveOnlyThinking(model) && model.provider !== "google-vertex") {
+	// instead of dropping it, mirroring the disable branch in buildParams. The pin
+	// only lands when the effort beta can ride along: Vertex rawPredict needs it in
+	// the body (dropped here too, see buildParams) and injected SDK clients own
+	// their own headers, so both fall back to the delete behavior rather than
+	// shipping `output_config.effort` the API would 400 without the beta.
+	if (isAdaptiveOnlyThinking(model) && model.provider !== "google-vertex" && canDeliverEffortBeta) {
 		const outputConfig = (params.output_config as AnthropicOutputConfig | undefined) ?? {};
 		outputConfig.effort = "low";
 		params.output_config = outputConfig;
@@ -3391,7 +3394,10 @@ function buildParams(
 				// Omit the thinking field (the API defaults to adaptive) and pin the
 				// lowest effort so "thinking off" calls stay cheap instead of failing
 				// the request with a 400 (a hidden-thinking toggle must never break it).
-				outputConfigEffort = "low";
+				// Injected SDK clients own their headers and can't receive the effort
+				// beta this code would otherwise attach, so omit the pin for them —
+				// the request stays valid (adaptive defaults on) instead of 400ing.
+				if (!options?.client) outputConfigEffort = "low";
 			} else {
 				thinking = { type: "disabled" };
 			}
@@ -3512,7 +3518,7 @@ function buildParams(
 		}
 	}
 
-	disableThinkingIfToolChoiceForced(params, model);
+	disableThinkingIfToolChoiceForced(params, model, !options?.client);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
 	applyPromptCaching(params, cacheControl);
 	enforceCacheControlLimit(params, 4);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2960,13 +2960,30 @@ function createClient(
 	return { client, isOAuthToken: oauthToken };
 }
 
-function disableThinkingIfToolChoiceForced(params: MessageCreateParamsStreaming): void {
+function disableThinkingIfToolChoiceForced(
+	params: MessageCreateParamsStreaming,
+	model: Model<"anthropic-messages">,
+): void {
 	const toolChoice = params.tool_choice;
 	if (!toolChoice) return;
 	if (toolChoice.type !== "any" && toolChoice.type !== "tool") return;
 
 	delete params.thinking;
 	delete params.context_management;
+
+	// Adaptive-only models can't be switched off by omitting `thinking` — a bare
+	// omission defaults to adaptive thinking ON, so a forced-tool turn would still
+	// reason instead of calling the tool (#6589). Pin the lowest adaptive effort
+	// instead of dropping it, mirroring the disable branch in buildParams. Vertex
+	// rawPredict can't carry the effort beta as an HTTP header, so it keeps the
+	// delete behavior (the field is stripped there anyway; see buildParams).
+	if (isAdaptiveOnlyThinking(model) && model.provider !== "google-vertex") {
+		const outputConfig = (params.output_config as AnthropicOutputConfig | undefined) ?? {};
+		outputConfig.effort = "low";
+		params.output_config = outputConfig;
+		return;
+	}
+
 	const outputConfig = params.output_config as AnthropicOutputConfig | undefined;
 	if (!outputConfig) return;
 
@@ -3229,6 +3246,22 @@ function usesAdaptiveThinkingTagOnly(model: Model<"anthropic-messages">): boolea
 	return thinking.efforts.length > 0;
 }
 
+/**
+ * True for adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5)
+ * that reject `thinking.type: "disabled"`. Turning thinking off on these models
+ * means omitting the `thinking` field entirely and pinning the lowest adaptive
+ * effort — a bare omission defaults to adaptive thinking ON. Excludes MiniMax,
+ * which drives adaptive thinking through the `thinking.type: "adaptive"` tag
+ * itself rather than `output_config.effort`.
+ */
+function isAdaptiveOnlyThinking(model: Model<"anthropic-messages">): boolean {
+	return (
+		model.thinking?.mode === "anthropic-adaptive" &&
+		!model.compat.disableAdaptiveThinking &&
+		!usesAdaptiveThinkingTagOnly(model)
+	);
+}
+
 function resolveAnthropicAdaptiveEffort(
 	model: Model<"anthropic-messages">,
 	options: AnthropicOptions,
@@ -3352,12 +3385,7 @@ function buildParams(
 				if (mode === "anthropic-budget-effort" && effort && effort !== "adaptive") outputConfigEffort = effort;
 			}
 		} else if (options?.thinkingEnabled === false) {
-			const compat = model.compat;
-			if (
-				model.thinking?.mode === "anthropic-adaptive" &&
-				!compat.disableAdaptiveThinking &&
-				!usesAdaptiveThinkingTagOnly(model)
-			) {
+			if (isAdaptiveOnlyThinking(model)) {
 				// Adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) reject
 				// `thinking.type: "disabled"` — adaptive thinking cannot be switched off.
 				// Omit the thinking field (the API defaults to adaptive) and pin the
@@ -3484,7 +3512,7 @@ function buildParams(
 		}
 	}
 
-	disableThinkingIfToolChoiceForced(params);
+	disableThinkingIfToolChoiceForced(params, model);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
 	applyPromptCaching(params, cacheControl);
 	enforceCacheControlLimit(params, 4);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1477,9 +1477,13 @@ function mapOptionsForApi<TApi extends Api>(
 
 	switch (model.api) {
 		case "anthropic-messages": {
-			// Explicitly disable thinking when reasoning is not specified or model doesn't support it
+			// Explicitly disable thinking when reasoning is not specified, the caller
+			// disabled it, or the model doesn't support it. `disableReasoning` is a
+			// SimpleStreamOptions flag that never reaches AnthropicOptions on its own,
+			// so it must be folded into `thinkingEnabled` here (mandatory-reasoning
+			// models already clamp it away in normalizeMandatoryReasoningOptions).
 			const reasoning = options?.reasoning;
-			if (!reasoning || !model.reasoning) {
+			if (!reasoning || !model.reasoning || options?.disableReasoning) {
 				return castApi<"anthropic-messages">({
 					...base,
 					requestModelId: resolveWireModelId(model, undefined),

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -2326,7 +2326,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		});
 	});
 
-	it("preserves task budget when forced tool choice disables thinking", async () => {
+	it("pins low effort (not a bare omission) when forced tool choice disables adaptive-only thinking", async () => {
 		const payload = (await captureAnthropicPayload(
 			buildModel({
 				...ANTHROPIC_MODEL_SPEC,
@@ -2362,10 +2362,77 @@ describe("Anthropic request fingerprint alignment", () => {
 			};
 		};
 
+		// Adaptive-only Opus 4.7 rejects `thinking.type: "disabled"`, and a bare
+		// omission defaults to adaptive thinking ON — so the forced-tool turn must
+		// pin the lowest effort to actually suppress reasoning (#6589), while the
+		// caller's task budget still rides along on output_config.
 		expect(payload.thinking).toBeUndefined();
 		expect(payload.output_config).toEqual({
+			effort: "low",
 			task_budget: { type: "tokens", total: 64_000 },
 		});
+	});
+
+	it("disables adaptive-only thinking when the caller sets disableReasoning via the public stream() path", async () => {
+		// #6589: disableReasoning is a SimpleStreamOptions flag that never reaches
+		// AnthropicOptions directly; mapOptionsForApi must fold it into
+		// thinkingEnabled:false so adaptive-only Opus 4.7 omits thinking + pins low
+		// effort instead of defaulting to adaptive-ON at the requested effort.
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamSimple(
+			buildModel({
+				...ANTHROPIC_MODEL_SPEC,
+				id: "claude-opus-4-7",
+				name: "Claude Opus 4.7",
+				thinking: {
+					mode: "anthropic-adaptive",
+					efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+				},
+			}),
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "sk-ant-oat-test",
+				signal: createAbortedSignal(),
+				reasoning: Effort.High,
+				disableReasoning: true,
+				onPayload: payload => resolve(payload),
+			},
+		);
+		const payload = (await promise) as { thinking?: unknown; output_config?: { effort?: string } };
+
+		expect(payload.thinking).toBeUndefined();
+		expect(payload.output_config).toEqual({ effort: "low" });
+	});
+
+	it("deletes thinking without an effort pin for non-adaptive reasoning models on forced tool choice", async () => {
+		// Budget-thinking models (Sonnet 4.5) turn thinking off by simple omission,
+		// so the forced-tool guard must NOT leak an adaptive effort:"low" pin onto
+		// them (that pin is exclusive to adaptive-only families — #6589).
+		const payload = (await captureAnthropicPayload(
+			ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Use the tool", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "lookup",
+						description: "Lookup a value",
+						parameters: { type: "object", properties: {}, additionalProperties: false },
+					},
+				],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.High,
+				toolChoice: { type: "tool", name: "lookup" },
+			},
+		)) as { thinking?: unknown; output_config?: unknown };
+
+		expect(payload.thinking).toBeUndefined();
+		expect(payload.output_config).toBeUndefined();
 	});
 
 	it("downgrades forced tool choice for Claude Fable/Mythos without deleting adaptive thinking", async () => {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -427,6 +427,51 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(capturedBeta).toContain("mid-conversation-system-2026-04-07");
 	});
 
+	it("adds the effort beta when a direct forced tool choice creates an adaptive effort pin", async () => {
+		let capturedBeta: string | undefined;
+		let capturedBody: { output_config?: { effort?: string }; tool_choice?: { type?: string } } | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBeta = (init?.headers as Record<string, string> | undefined)?.["anthropic-beta"];
+			capturedBody = JSON.parse(String(init?.body ?? "{}")) as {
+				output_config?: { effort?: string };
+				tool_choice?: { type?: string };
+			};
+			return new Response(
+				JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
+		const adaptiveModel: Model<"anthropic-messages"> = buildModel({
+			...ANTHROPIC_MODEL_SPEC,
+			id: "claude-opus-4-8-20260528",
+			name: "Claude Opus 4.8",
+			thinking: {
+				mode: "anthropic-adaptive",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+		});
+
+		await streamAnthropic(
+			adaptiveModel,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Use the tool", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "lookup",
+						description: "Lookup a value",
+						parameters: { type: "object", properties: {}, additionalProperties: false },
+					},
+				],
+			},
+			{ apiKey: "sk-ant-api-test", toolChoice: "any", fetch: fetchMock },
+		).result();
+
+		expect(capturedBody?.tool_choice).toEqual({ type: "any" });
+		expect(capturedBody?.output_config).toEqual({ effort: "low" });
+		expect(capturedBeta).toContain("effort-2025-11-24");
+	});
+
 	it("adds the extended-cache-ttl beta to API-key requests that default to 1h caching", async () => {
 		const captureBeta = () => {
 			let captured: string | undefined;

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -21,6 +21,7 @@ import {
 	streamAnthropic,
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { MessageCreateParamsStreaming } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import { getEnvApiKey, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type {
 	AssistantMessage,
@@ -472,11 +473,11 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(capturedBeta).toContain("effort-2025-11-24");
 	});
 
-	it("omits the adaptive effort pin for injected clients on forced tool choice (can't carry the effort beta)", async () => {
-		// Injected SDK clients own their headers, so this code can't attach the
-		// effort beta. Shipping output_config.effort without it would 400 an
-		// otherwise ordinary forced-tool request (#6590 review) — omit the pin
-		// instead, keeping the request valid.
+	it("attaches the effort beta per-request for injected clients on forced tool choice", async () => {
+		// Injected SDK clients bypass client-level `anthropic-beta` construction, so
+		// the forced-tool effort pin's required beta must ride the per-request headers
+		// instead of being dropped (#6590 review) — otherwise Anthropic 400s the
+		// otherwise valid forced-tool request.
 		const adaptiveModel: Model<"anthropic-messages"> = buildModel({
 			...ANTHROPIC_MODEL_SPEC,
 			id: "claude-opus-4-8-20260528",
@@ -486,11 +487,9 @@ describe("Anthropic request fingerprint alignment", () => {
 				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
 			},
 		});
-		const injectedClient = {
-			messages: { create: () => (async function* () {})() },
-		};
-		const { promise, resolve } = Promise.withResolvers<unknown>();
-		streamAnthropic(
+		let capturedParams: MessageCreateParamsStreaming | undefined;
+		let capturedOptions: { headers?: Record<string, string> } | undefined;
+		await streamAnthropic(
 			adaptiveModel,
 			{
 				systemPrompt: ["Stay concise."],
@@ -505,21 +504,25 @@ describe("Anthropic request fingerprint alignment", () => {
 			},
 			{
 				apiKey: "sk-ant-api-test",
-				signal: createAbortedSignal(),
 				toolChoice: "any",
-				client: injectedClient,
-				onPayload: payload => resolve(payload),
+				client: {
+					messages: {
+						create: (params, requestOptions) => {
+							capturedParams = params;
+							capturedOptions = requestOptions as { headers?: Record<string, string> } | undefined;
+							throw new Error("stop-after-capture");
+						},
+					},
+				},
 			},
-		);
-		const payload = (await promise) as {
-			thinking?: unknown;
-			output_config?: unknown;
-			tool_choice?: { type?: string };
-		};
+		)
+			.result()
+			.catch(() => undefined);
 
-		expect(payload.tool_choice).toEqual({ type: "any" });
-		expect(payload.thinking).toBeUndefined();
-		expect(payload.output_config).toBeUndefined();
+		expect(capturedParams?.tool_choice).toEqual({ type: "any" });
+		expect(capturedParams?.thinking).toBeUndefined();
+		expect(capturedParams?.output_config).toEqual({ effort: "low" });
+		expect(capturedOptions?.headers?.["anthropic-beta"] ?? "").toContain("effort-2025-11-24");
 	});
 
 	it("adds the extended-cache-ttl beta to API-key requests that default to 1h caching", async () => {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -472,6 +472,56 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(capturedBeta).toContain("effort-2025-11-24");
 	});
 
+	it("omits the adaptive effort pin for injected clients on forced tool choice (can't carry the effort beta)", async () => {
+		// Injected SDK clients own their headers, so this code can't attach the
+		// effort beta. Shipping output_config.effort without it would 400 an
+		// otherwise ordinary forced-tool request (#6590 review) — omit the pin
+		// instead, keeping the request valid.
+		const adaptiveModel: Model<"anthropic-messages"> = buildModel({
+			...ANTHROPIC_MODEL_SPEC,
+			id: "claude-opus-4-8-20260528",
+			name: "Claude Opus 4.8",
+			thinking: {
+				mode: "anthropic-adaptive",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+		});
+		const injectedClient = {
+			messages: { create: () => (async function* () {})() },
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(
+			adaptiveModel,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Use the tool", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "lookup",
+						description: "Lookup a value",
+						parameters: { type: "object", properties: {}, additionalProperties: false },
+					},
+				],
+			},
+			{
+				apiKey: "sk-ant-api-test",
+				signal: createAbortedSignal(),
+				toolChoice: "any",
+				client: injectedClient,
+				onPayload: payload => resolve(payload),
+			},
+		);
+		const payload = (await promise) as {
+			thinking?: unknown;
+			output_config?: unknown;
+			tool_choice?: { type?: string };
+		};
+
+		expect(payload.tool_choice).toEqual({ type: "any" });
+		expect(payload.thinking).toBeUndefined();
+		expect(payload.output_config).toBeUndefined();
+	});
+
 	it("adds the extended-cache-ttl beta to API-key requests that default to 1h caching", async () => {
 		const captureBeta = () => {
 			let captured: string | undefined;


### PR DESCRIPTION
## Repro
On a native Anthropic adaptive-only model (`claude-opus-4-7`, `thinking.mode: anthropic-adaptive`, `supportsForcedToolChoice: true`) the outgoing request body kept thinking ON whenever reasoning was meant to be off. Captured via `onPayload`: (a) `stream()` with `reasoning: high` + `disableReasoning: true` (no forced tool) produced `thinking: {type:adaptive, display:summarized}` / `output_config: {effort:high}`; (b) with a forced `tool_choice` it produced `thinking: undefined` / `output_config: undefined` — and for adaptive-only models a bare omission defaults to adaptive-ON. The delivery reviewer (`setForcedToolChoice("report_delivery")` + `setDisableReasoning(true)`) then failed with "Reviewer completed without calling report_delivery" because the model returned a thinking block + `end_turn` instead of calling the tool.

## Cause
Two independent paths in `packages/ai`:
- `mapOptionsForApi` (`stream.ts`) only checked `options.reasoning` on the `anthropic-messages` branch and never consulted `options.disableReasoning`, which is a `SimpleStreamOptions` flag that never reaches `AnthropicOptions` on its own — so a caller-side disable never became `thinkingEnabled: false`.
- `disableThinkingIfToolChoiceForced` (`providers/anthropic.ts`) deleted both `thinking` and `output_config.effort`. Adaptive-only Claude models reject `thinking.type: "disabled"`; the sanctioned "off" representation is to omit `thinking` **and** pin `output_config.effort: "low"`. Deleting the effort left a bare omission, which the API treats as adaptive-ON.

## Fix
- `stream.ts`: fold `options?.disableReasoning` into the Anthropic thinking-off condition in `mapOptionsForApi` (mandatory-reasoning models already clamp it away in `normalizeMandatoryReasoningOptions`).
- `providers/anthropic.ts`: extract the three-condition adaptive-only guard into `isAdaptiveOnlyThinking(model)`, reused by the buildParams disable branch and by `disableThinkingIfToolChoiceForced`, which now pins `output_config.effort: "low"` for adaptive-only models (skipping Vertex rawPredict, which can't carry the effort beta) instead of deleting it. Non-adaptive models keep the delete behavior.
- Tests: updated the forced-tool alignment test to assert the low-effort pin; added a `disableReasoning`-via-`stream()` regression and a guard that non-adaptive models get no spurious effort pin. Added the CHANGELOG entry.

## Verification
`bun test packages/ai/test/anthropic-alignment.test.ts` → 89 pass / 0 fail (includes the 2 new + 1 updated cases). Full `bun test packages/ai/test packages/ai/src` shows only two failures (`proxy.test.ts` env normalization, GLM-5.2 OpenRouter Responses tier) that are cross-file test-pollution artifacts reproducing identically on a clean stash of `main` — unrelated to this diff. Fixes #6589