### PR TITLE
feat(catalog): add Claude Opus 5 model entries for Amazon Bedrock

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude Opus 5 model entries for Amazon Bedrock: `anthropic.claude-opus-5` plus its `us.`, `eu.`, `au.`, and `global.` regional/geo IDs.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -52,6 +52,7 @@ import {
 	applyCanonicalLimitFallback,
 	applyGeneratedModelPolicies,
 	CLOUDFLARE_FALLBACK_MODEL,
+	dropUnsupportedBedrockGeoIds,
 	linkOpenAIPromotionTargets,
 } from "./generated-policies";
 
@@ -634,6 +635,7 @@ async function generateModels() {
 	allModels = dropFireworksWireIds(allModels);
 	allModels = dropUnusableZaiContextTierIds(allModels);
 	allModels = dropXiaomiAudioOnlyIds(allModels);
+	allModels = dropUnsupportedBedrockGeoIds(allModels);
 	allModels = normalizeAntigravityEndpoint(allModels);
 	// Normalize display names: gateway author prefixes ("OpenAI: …"), alias
 	// markers ("(latest)"), provider attribution ("(Antigravity)"), and

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -51,6 +51,20 @@ export const CLOUDFLARE_FALLBACK_MODEL: ModelSpec<"anthropic-messages"> = {
 	maxTokens: 64000,
 };
 
+/**
+ * `models.dev` currently lists `jp.anthropic.claude-opus-5`, but AWS's own
+ * Bedrock model card documents only `anthropic.claude-opus-5` plus the `us.`,
+ * `eu.`, `au.`, and `global.` Geo/Global inference-profile IDs under
+ * Programmatic Access; Japan regions are marked unsupported for Geo inference
+ * in the same card's regional-availability table. Bedrock rejects an
+ * undocumented inference-profile ID outright, so drop this specific upstream
+ * row rather than ship a selector that 4xxs on first use (PR #6591 review).
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+ */
+export function dropUnsupportedBedrockGeoIds(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.filter(model => !(model.provider === "amazon-bedrock" && model.id === "jp.anthropic.claude-opus-5"));
+}
+
 const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> = {
 	base: 0,
 	mini: 1,

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -42,6 +42,13 @@ const EXPLICIT_CHECKPOINTS_4096_1H: ResolvedBedrockCompat = {
 	promptCacheMaximumCheckpoints: 4,
 };
 
+const EXPLICIT_CHECKPOINTS_512_1H: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: true,
+	promptCacheMinimumTokens: 512,
+	promptCacheMaximumCheckpoints: 4,
+};
+
 /**
  * Explicit Nova cache points complement Bedrock's automatic prefix caching:
  * AWS recommends them for consistent cache hits and input-cost savings. Keep
@@ -81,6 +88,9 @@ function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
 		id.includes("anthropic.claude-sonnet-5")
 	) {
 		return EXPLICIT_CHECKPOINTS_4096_1H;
+	}
+	if (id.includes("anthropic.claude-opus-5")) {
+		return EXPLICIT_CHECKPOINTS_512_1H;
 	}
 	if (id.includes("anthropic.claude-opus-4-6")) {
 		return EXPLICIT_CHECKPOINTS_4096_5M;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -7966,6 +7966,36 @@
 				"supportsDisplay": true
 			}
 		},
+		"anthropic.claude-opus-5": {
+			"id": "anthropic.claude-opus-5",
+			"name": "Claude Opus 5",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
 		"anthropic.claude-sonnet-5": {
 			"id": "anthropic.claude-sonnet-5",
 			"name": "Claude Sonnet 5",
@@ -8057,6 +8087,36 @@
 		"au.anthropic.claude-opus-4-8": {
 			"id": "au.anthropic.claude-opus-4-8",
 			"name": "Claude Opus 4.8 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"au.anthropic.claude-opus-5": {
+			"id": "au.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (AU)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -8476,10 +8536,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 1.1,
+				"output": 5.5,
+				"cacheRead": 0.11,
+				"cacheWrite": 1.375
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -8651,10 +8711,40 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"eu.anthropic.claude-opus-5": {
+			"id": "eu.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -8739,10 +8829,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3.3,
-				"output": 16.5,
-				"cacheRead": 0.33,
-				"cacheWrite": 4.125
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
@@ -8768,10 +8858,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.2,
-				"output": 11,
-				"cacheRead": 0.22,
-				"cacheWrite": 2.75
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -8876,7 +8966,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Claude Opus 4.5 (Global)",
+			"name": "Claude Opus 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -8992,6 +9082,36 @@
 				"supportsDisplay": true
 			}
 		},
+		"global.anthropic.claude-opus-5": {
+			"id": "global.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
 		"global.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Claude Sonnet 4 (Global)",
@@ -9052,7 +9172,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Claude Sonnet 4.6 (Global)",
+			"name": "Claude Sonnet 4.6",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -10446,7 +10566,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Claude Opus 4.1 (US)",
+			"name": "Claude Opus 4.1",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -10593,6 +10713,36 @@
 		"us.anthropic.claude-opus-4-8": {
 			"id": "us.anthropic.claude-opus-4-8",
 			"name": "Claude Opus 4.8 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"us.anthropic.claude-opus-5": {
+			"id": "us.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -20812,6 +20962,37 @@
 			"api": "anthropic-messages",
 			"provider": "google-vertex",
 			"baseUrl": "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/anthropic/models/claude-opus-4-8@default:streamRawPredict",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"claude-opus-5@default": {
+			"id": "claude-opus-5@default",
+			"name": "Claude Opus 5",
+			"api": "anthropic-messages",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/anthropic/models/claude-opus-5@default:streamRawPredict",
 			"reasoning": true,
 			"input": [
 				"text",

--- a/packages/catalog/test/amazon-bedrock-opus-5.test.ts
+++ b/packages/catalog/test/amazon-bedrock-opus-5.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { buildBedrockCompat } from "@oh-my-pi/pi-catalog/compat/bedrock";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import { dropUnsupportedBedrockGeoIds } from "../scripts/generated-policies";
+
+// AWS's Bedrock model card for Claude Opus 5 lists exactly these Programmatic
+// Access IDs — the bare model ID plus the us./eu./au. Geo and global.
+// inference profiles. Japan is explicitly marked unsupported for Geo
+// inference in the same card's regional-availability table, so no `jp.`
+// profile exists for this model (unlike several Opus 4.x generations).
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+const AWS_DOCUMENTED_OPUS_5_IDS = [
+	"anthropic.claude-opus-5",
+	"us.anthropic.claude-opus-5",
+	"eu.anthropic.claude-opus-5",
+	"au.anthropic.claude-opus-5",
+	"global.anthropic.claude-opus-5",
+];
+
+describe("Amazon Bedrock Claude Opus 5", () => {
+	test("bundles exactly the AWS-documented inference-profile IDs", () => {
+		const bedrockOpus5Ids = getBundledModels("amazon-bedrock")
+			.map(model => model.id)
+			.filter(id => id.endsWith("anthropic.claude-opus-5"));
+
+		expect(new Set(bedrockOpus5Ids)).toEqual(new Set(AWS_DOCUMENTED_OPUS_5_IDS));
+		// `models.dev` currently also lists `jp.anthropic.claude-opus-5`; Bedrock
+		// has no such inference profile for this model and would reject it.
+		expect(bedrockOpus5Ids).not.toContain("jp.anthropic.claude-opus-5");
+	});
+
+	test("dropUnsupportedBedrockGeoIds filters the undocumented jp. profile without touching other providers/ids", () => {
+		const bareSpec = (provider: string, id: string): ModelSpec<"bedrock-converse-stream"> => ({
+			id,
+			name: id,
+			api: "bedrock-converse-stream",
+			provider,
+			baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 64000,
+		});
+		const input = [
+			bareSpec("amazon-bedrock", "jp.anthropic.claude-opus-5"),
+			bareSpec("amazon-bedrock", "us.anthropic.claude-opus-5"),
+			// A `jp.` id on a different Bedrock model, or on a different provider,
+			// must survive — only this exact (provider, id) pair is undocumented.
+			bareSpec("amazon-bedrock", "jp.anthropic.claude-opus-4-8"),
+			bareSpec("some-other-provider", "jp.anthropic.claude-opus-5"),
+		];
+
+		expect(dropUnsupportedBedrockGeoIds(input).map(model => model.id)).toEqual([
+			"us.anthropic.claude-opus-5",
+			"jp.anthropic.claude-opus-4-8",
+			"jp.anthropic.claude-opus-5",
+		]);
+	});
+
+	test("resolves the AWS-documented 512-token/four-checkpoint/1h prompt-cache capability", () => {
+		for (const id of AWS_DOCUMENTED_OPUS_5_IDS) {
+			const spec: ModelSpec<"bedrock-converse-stream"> = {
+				id,
+				name: id,
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+				baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+				contextWindow: 1_000_000,
+				maxTokens: 128_000,
+			};
+			expect(buildBedrockCompat(spec)).toEqual({
+				promptCacheMode: "explicit",
+				supportsLongPromptCacheRetention: true,
+				promptCacheMinimumTokens: 512,
+				promptCacheMaximumCheckpoints: 4,
+			});
+		}
+	});
+});


### PR DESCRIPTION
This is my first open PR to this project — I recently switched from Claude Code to omp and it's been working great so far.

## Summary

Adds **Claude Opus 5** to the Amazon Bedrock catalog (`packages/catalog/src/models.json`), published upstream on `models.dev` as of 2026-07-24. Regenerated via `bun --cwd=packages/catalog run gen:models`, then rescoped to touch only `amazon-bedrock`/`google-vertex` — see history below for why.

New ids (Amazon Bedrock):
- `anthropic.claude-opus-5`
- `us.anthropic.claude-opus-5`
- `eu.anthropic.claude-opus-5`
- `au.anthropic.claude-opus-5`
- `global.anthropic.claude-opus-5`

All five come out at `$5`/`$25` per MTok, 1M context / 128K max output, `anthropic-adaptive` thinking with efforts `low/medium/high/max`, matching the [AWS Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html) and the [Anthropic models overview](https://docs.claude.com/en/docs/about-claude/models/overview).

## Review history (4 commits)

- `fd022be` — initial wholesale regen picked up Opus 5 but incidentally dropped 8 Google Vertex MaaS ids (`deepseek-*-maas`, `llama-3.3-70b-instruct-maas`, `kimi-k2-thinking-maas`, `gpt-oss-20b-maas`, `qwen3-235b-a22b-instruct-2507-maas`, `glm-4.7-maas`, `glm-5-maas`) because Vertex has no dynamic discovery and models.dev's current Vertex snapshot is missing them (Codex P1).
- `1eb389d` — restored those 8 ids via `GOOGLE_VERTEX_MAAS_FALLBACK_MODELS`, a curated seed in `generated-policies.ts` wired into `generateModels()`, matching the existing Anthropic/Meta/Sakana curated-seed pattern. A real models.dev id still takes priority over its seed twin (first-inserted-wins dedup).
- `c33ed03` — reverted every provider except `amazon-bedrock`/`google-vertex` back to the previously committed `models.json` (roboomp flagged 1,151 unrelated changed records across 21 providers from live catalogs refreshing between commits — none of that is part of this change). Also: dropped `jp.anthropic.claude-opus-5` (models.dev has it, but AWS's model card only documents the bare id + `us./eu./au./global.`, and marks Japan unsupported for Geo inference — Bedrock would reject it) via a new `dropUnsupportedBedrockGeoIds` filter; registered Opus 5 in `detectedBedrockCompat()` with a new 512-token/4-checkpoint/1h bucket instead of the default `promptCacheMode: "none"` (Codex P2, roboomp blocking).
- `7480d58` — removed the now-stale `jp.` mention from CHANGELOG.md; moved `dropUnsupportedBedrockGeoIds` into `generated-policies.ts` (exported) and added a fixture-based test that exercises the filter directly instead of only reading the bundled snapshot (Codex P2).

## Why no engine changes

Anthropic version/thinking handling in `model-thinking.ts` is generic policy-driven, not string-matched per version, so Opus 5 comes out correctly shaped (`bedrock-converse-stream`, `anthropic-adaptive` thinking) without engine changes — same as the prior Opus 4.8 addition (#1487).

## Verification

- `bun --cwd=packages/catalog run gen:models` — clean regen, then rescoped: diff now touches only `amazon-bedrock` (+5 ids, 0 removed, 7 incidental EU-pricing/name corrections) and `google-vertex` (+1 id, 0 removed)
- `bun test packages/catalog/test` — 491 pass, 0 fail
- `bun test packages/coding-agent/test/model-registry.test.ts` — 85 pass, 0 fail
- `bun --cwd=packages/catalog run check` — biome + tsgo clean
