### PR TITLE
feat(coding-agent): make push-to-talk key configurable

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -41,7 +41,15 @@ app.history.search: []
 | `app.clipboard.copyLine`    | `Alt+Shift+L`                          | Copy the current line                         |
 | `app.clipboard.copyPrompt`  | `Alt+Shift+C`                          | Copy the whole prompt                         |
 | `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste from the clipboard (image preferred, text fallback) |
-| `app.stt.toggle`            | Unbound (hold `Space`)                 | Toggle speech-to-text. By default there is no key chord — hold the space bar to record (push-to-talk) and release to transcribe; bind a chord here for a press-to-toggle alternative |
+| `app.stt.pushToTalk`        | `Space`                                | Hold to record and release to transcribe. Set this action to `[]` to disable push-to-talk without disabling speech-to-text |
+| `app.stt.toggle`            | Unbound                                | Start or stop speech-to-text recording with each press; bind a chord for a press-to-toggle alternative |
+
+For example, disable push-to-talk while keeping speech-to-text available on a toggle shortcut:
+
+```yaml
+app.stt.pushToTalk: []
+app.stt.toggle: Ctrl+Shift+S
+```
 
 On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. When the clipboard holds no image, `app.clipboard.pasteImage` pastes the clipboard text instead, so hosts that deliver only this chord (VS Code's integrated terminal when configured to forward `Ctrl+V`, Windows clipboard history via `Win+V`) work for both payload kinds. Windows Terminal also swallows `Ctrl+Enter`, so the `app.message.followUp` chord also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses — and the same chord submits the agent dashboard's new-agent description and hook-editor prompts. If your existing `keybindings.yml` already assigns `Ctrl+Q` to another action, that user remap wins and follow-up keeps `Ctrl+Enter` unless you explicitly bind `app.message.followUp`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `app.stt.pushToTalk` keybinding, defaulting to `Space`, so push-to-talk can be remapped or disabled independently from speech-to-text and `app.stt.toggle`.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -52,6 +52,7 @@ interface AppKeybindings {
 	"app.tree.unfoldOrDown": true;
 	"app.plan.toggle": true;
 	"app.history.search": true;
+	"app.stt.pushToTalk": true;
 	"app.stt.toggle": true;
 }
 
@@ -218,9 +219,13 @@ export const KEYBINDINGS = {
 		defaultKeys: "ctrl+r",
 		description: "Search history",
 	},
+	"app.stt.pushToTalk": {
+		defaultKeys: "space",
+		description: "Hold to record speech-to-text",
+	},
 	"app.stt.toggle": {
 		defaultKeys: [],
-		description: "Toggle speech-to-text (default gesture: hold Space)",
+		description: "Toggle speech-to-text recording",
 	},
 } as const satisfies KeybindingDefinitions;
 

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -302,6 +302,46 @@ describe("CustomEditor space-hold push-to-talk", () => {
 		expect(events).toEqual(["start", "end"]);
 	});
 
+	it("uses the configured key and preserves the default space behavior when remapped", () => {
+		const { editor, events } = makeEditor();
+		editor.setActionKeys("app.stt.pushToTalk", ["x"]);
+
+		feedSpaces(editor, SPACE_HOLD_MECHANICAL_RUN + 2, REPEAT_GAP_MS);
+		expect(editor.getText()).toBe(" ".repeat(SPACE_HOLD_MECHANICAL_RUN + 2));
+		expect(events).toEqual([]);
+
+		for (let i = 0; i < SPACE_HOLD_MECHANICAL_RUN + 2; i++) {
+			vi.advanceTimersByTime(REPEAT_GAP_MS);
+			editor.handleInput("x");
+		}
+		expect(editor.getText()).toBe(" ".repeat(SPACE_HOLD_MECHANICAL_RUN + 2));
+		expect(events).toEqual(["start"]);
+
+		vi.advanceTimersByTime(SPACE_HOLD_RELEASE_MS + 1);
+		expect(events).toEqual(["start", "end"]);
+	});
+
+	it("does not combine separate configured keys into one hold", () => {
+		const { editor, events } = makeEditor();
+		editor.setActionKeys("app.stt.pushToTalk", ["x", "y"]);
+
+		for (const key of ["x", "y", "x", "y", "x", "y"]) {
+			vi.advanceTimersByTime(REPEAT_GAP_MS);
+			editor.handleInput(key);
+		}
+
+		expect(editor.getText()).toBe("xyxyxy");
+		expect(events).toEqual([]);
+	});
+
+	it("leaves the default key unchanged when push-to-talk is explicitly unbound", () => {
+		const { editor, events } = makeEditor();
+		editor.setActionKeys("app.stt.pushToTalk", []);
+		feedSpaces(editor, 8, REPEAT_GAP_MS);
+		expect(editor.getText()).toBe(" ".repeat(8));
+		expect(events).toEqual([]);
+	});
+
 	it("does not trigger when the space bar is smashed at an irregular cadence", () => {
 		const { editor, events } = makeEditor();
 		// Fast but jittery, the way a human mashes — not the metronomic delta of OS auto-repeat.

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -39,6 +39,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.pasteTextRaw"
 	| "app.clipboard.copyPrompt"
+	| "app.stt.pushToTalk"
 >;
 
 const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
@@ -61,6 +62,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],
 	"app.clipboard.copyPrompt": ["alt+shift+c"],
+	"app.stt.pushToTalk": ["space"],
 };
 
 function buildMatchKeys(keys: readonly KeyId[]): Set<string> {
@@ -503,14 +505,13 @@ export class CustomEditor extends Editor {
 	/** Called when left-arrow is pressed while the editor is empty (cursor necessarily at start). */
 	onLeftAtStart?: () => void;
 
-	/** Fired when a sustained space-bar hold is recognized — the push-to-talk STT start. The
-	 *  optimistically-typed spaces have already been deleted by the time this runs. */
+	/** Fired when a sustained push-to-talk key hold is recognized. Any optimistically inserted
+	 *  characters have already been deleted by the time this runs. */
 	onSpaceHoldStart?: () => void;
-	/** Fired when the held space bar is released (detected as an idle gap with no further repeated
-	 *  spaces) — the push-to-talk STT stop. */
+	/** Fired when the push-to-talk key is released (detected as an idle gap with no further repeats). */
 	onSpaceHoldEnd?: () => void;
-	/** Gate for the space-hold gesture. Returns false to keep the space bar inserting spaces
-	 *  normally; wired to `stt.enabled` so disabling STT restores plain space behavior. */
+	/** Gate for the push-to-talk gesture. Returns false to keep the configured key's normal behavior;
+	 *  wired to `stt.enabled` so disabling STT restores normal input. */
 	sttHoldEnabled?: () => boolean;
 
 	/** Custom key handlers from extensions and non-built-in app actions. */
@@ -529,17 +530,21 @@ export class CustomEditor extends Editor {
 	/** Input chunks deferred behind an in-flight paste, drained in FIFO order once the paste
 	 *  count returns to zero. */
 	#pendingInput: string[] = [];
-	/** Spaces actually inserted in the current run; tracked back out when a hold is recognized. */
+	/** Characters inserted by the candidate key run; tracked back out when a hold is recognized. */
 	#spaceRunInserted = 0;
-	/** Consecutive "mechanical" deltas (fast + steady); a sustained run of these confirms a held bar. */
+	/** Canonical key for the current candidate run, preventing separate configured keys from combining. */
+	#spaceRunKey: string | undefined;
+	/** Consecutive "mechanical" deltas (fast + steady); a sustained run confirms a held key. */
 	#mechanicalRun = 0;
-	/** Inter-space gap (ms) of the previous space pair, compared against the next to judge steadiness. */
+	/** Gap (ms) of the previous candidate-key pair, compared with the next to judge steadiness. */
 	#prevSpaceGap: number | undefined;
-	/** Monotonic timestamp (ms) of the last space, to measure the gap to the next one. */
+	/** Monotonic timestamp (ms) of the last candidate keypress. */
 	#lastSpaceAt = Number.NEGATIVE_INFINITY;
-	/** True while a recognized space-hold push-to-talk recording is in progress. */
+	/** Canonical key whose recognized hold currently owns push-to-talk recording. */
+	#spaceHoldKey: string | undefined;
+	/** True while a recognized push-to-talk key hold is in progress. */
 	#spaceHoldActive = false;
-	/** Idle timer that fires `onSpaceHoldEnd` once repeated spaces stop arriving. */
+	/** Idle timer that fires `onSpaceHoldEnd` once repeated keypresses stop arriving. */
 	#spaceHoldTimer: NodeJS.Timeout | undefined;
 	#actionKeys = new Map<ConfigurableEditorAction, KeyId[]>(
 		Object.entries(DEFAULT_ACTION_KEYS).map(([action, keys]) => [action as ConfigurableEditorAction, [...keys]]),
@@ -602,61 +607,69 @@ export class CustomEditor extends Editor {
 		return this.onSpaceHoldStart !== undefined && (this.sttHoldEnabled?.() ?? false) && !this.isShowingAutocomplete();
 	}
 
-	/** Drive the space-hold push-to-talk state machine. Returns true when the gesture consumed the
-	 *  input so it must not reach normal editing. A held space bar emits OS auto-repeat: a *steady*
-	 *  stream of spaces at a fixed fast interval. We watch the inter-space deltas and only recognize a
+	/** Drive the configurable push-to-talk key-hold state machine. Returns true when the gesture
+	 *  consumed the input so it must not reach normal editing. A held key emits OS auto-repeat: a
+	 *  steady stream at a fixed fast interval. We watch the inter-key deltas and only recognize a
 	 *  hold once {@link SPACE_HOLD_MECHANICAL_RUN} consecutive deltas are "mechanical" — both
-	 *  auto-repeat-fast and near-identical (see {@link gapsAreMechanical}). Smashing the bar is fast
-	 *  but jittery and deliberate taps are too slow, so neither escalates and both keep typing real
-	 *  spaces; the few spaces typed before a real hold is recognized are tracked back out. */
+	 *  auto-repeat-fast and near-identical (see {@link gapsAreMechanical}). Deliberate taps and
+	 *  irregular key mashing keep their normal behavior; characters inserted before a real hold is
+	 *  recognized are tracked back out. */
 	#handleSpaceHold(data: string, canonical: string | undefined): boolean {
-		const isSpace = canonical === "space";
+		const isPushToTalkKey = canonical !== undefined && this.#matchesAction(canonical, "app.stt.pushToTalk");
 		if (this.#spaceHoldActive) {
-			if (isSpace) {
+			if (canonical === this.#spaceHoldKey) {
 				// Auto-repeat while held: swallow it and keep the release timer alive.
 				this.#armSpaceHoldReleaseTimer();
 				return true;
 			}
-			// Any non-space means the bar was released — stop recording, then let the key through.
+			// Any other key means the held key was released — stop recording, then let it through.
 			this.#endSpaceHold();
 			return false;
 		}
-		if (!isSpace) {
+		if (!isPushToTalkKey) {
 			this.#resetSpaceRun();
 			return false;
 		}
 		if (!this.#spaceHoldGestureEnabled()) return false;
+		if (this.#spaceRunKey !== canonical) {
+			this.#resetSpaceRun();
+			this.#spaceRunKey = canonical;
+		}
 		const now = performance.now();
 		const gap = now - this.#lastSpaceAt;
 		const prevGap = this.#prevSpaceGap;
 		this.#lastSpaceAt = now;
 		this.#prevSpaceGap = gap;
 		if (prevGap === undefined || !gapsAreMechanical(gap, prevGap)) {
-			// First space, a deliberate tap, or jittery smashing: not a steady machine cadence yet, so
-			// type a real space and reset the mechanical run.
+			// First keypress, a deliberate tap, or jittery mashing: preserve its normal behavior and
+			// reset the mechanical run.
 			this.#mechanicalRun = 0;
+			const beforeLength = this.getText().length;
 			super.handleInput(data);
-			this.#spaceRunInserted++;
+			this.#spaceRunInserted += Math.max(0, this.getText().length - beforeLength);
 			return true;
 		}
 		// Steady fast repeat: swallow it. Once the cadence has held for SPACE_HOLD_MECHANICAL_RUN
-		// deltas it's a held bar — track back the few pre-burst spaces already typed and start.
+		// deltas, track back any inserted characters and start recording.
 		if (++this.#mechanicalRun >= SPACE_HOLD_MECHANICAL_RUN) {
+			const holdKey = canonical;
 			this.deleteBeforeCursor(this.#spaceRunInserted);
 			this.#resetSpaceRun();
-			this.#beginSpaceHold();
+			this.#beginSpaceHold(holdKey);
 		}
 		return true;
 	}
 
 	#resetSpaceRun(): void {
 		this.#spaceRunInserted = 0;
+		this.#spaceRunKey = undefined;
 		this.#mechanicalRun = 0;
 		this.#prevSpaceGap = undefined;
 		this.#lastSpaceAt = Number.NEGATIVE_INFINITY;
 	}
 
-	#beginSpaceHold(): void {
+	#beginSpaceHold(key: string): void {
+		this.#spaceHoldKey = key;
 		this.#spaceHoldActive = true;
 		this.#armSpaceHoldReleaseTimer();
 		this.onSpaceHoldStart?.();
@@ -674,6 +687,7 @@ export class CustomEditor extends Editor {
 	#endSpaceHold(): void {
 		if (!this.#spaceHoldActive) return;
 		this.#spaceHoldActive = false;
+		this.#spaceHoldKey = undefined;
 		this.#resetSpaceRun();
 		if (this.#spaceHoldTimer) {
 			clearTimeout(this.#spaceHoldTimer);
@@ -770,7 +784,7 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
-		// Space-hold push-to-talk: a sustained space bar starts/stops STT instead of typing spaces.
+		// Configured key-hold push-to-talk: a sustained key starts/stops STT instead of typing.
 		if (this.#handleSpaceHold(data, canonical)) return;
 
 		if (canonical !== undefined) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -484,12 +484,13 @@ export class InputController {
 		for (const key of this.ctx.keybindings.getKeys("app.message.followUp")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.handleFollowUp());
 		}
+		this.ctx.editor.setActionKeys("app.stt.pushToTalk", this.ctx.keybindings.getKeys("app.stt.pushToTalk"));
 		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
-		// Hold the space bar to push-to-talk: the editor recognizes the auto-repeat burst, tracks
-		// the spam back out, and toggles STT on hold start / release. Gated on `stt.enabled` so a
-		// disabled STT leaves the space bar typing normally.
+		// Holding the configured push-to-talk key toggles STT on hold start / release. The editor
+		// recognizes auto-repeat and tracks any optimistically inserted characters back out. Gated
+		// on `stt.enabled` so disabled STT leaves the key's normal behavior intact.
 		this.ctx.editor.sttHoldEnabled = () => settings.get("stt.enabled");
 		this.ctx.editor.onSpaceHoldStart = () => void this.ctx.handleSTTToggle();
 		this.ctx.editor.onSpaceHoldEnd = () => void this.ctx.handleSTTToggle();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -62,6 +62,7 @@ async function createContext() {
 		"app.model.select": ["alt+m"],
 		"app.retry": ["alt+r"],
 		"app.clipboard.pasteImage": ["ctrl+v"],
+		"app.stt.pushToTalk": [],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -244,6 +245,7 @@ describe("InputController keybinding setup", () => {
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.display.reset", ["ctrl+l"]);
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.model.selectTemporary", ["ctrl+y"]);
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.model.select", ["alt+m"]);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.stt.pushToTalk", []);
 		expect(editor.onDisplayReset).toBeDefined();
 		expect(editor.onSelectModelTemporary).toBeDefined();
 		expect(editor.onSelectModel).toBeDefined();


### PR DESCRIPTION
## What

- Add `app.stt.pushToTalk` as a first-class keybinding with `Space` as its default.
- Route the resolved binding through `InputController` into the editor's held-key recognizer.
- Generalize push-to-talk recognition to respect remapped keys, empty bindings, and multiple configured keys without combining separate key runs.
- Preserve normal input when push-to-talk is disabled, including avoiding deletion for chords that do not insert text.
- Document remapping and the common `app.stt.pushToTalk: []` plus `app.stt.toggle: Ctrl+Shift+S` configuration.
- Add an Unreleased changelog entry.

## Why

The built-in hold-`Space` gesture was gated only by `stt.enabled`. Users could bind `app.stt.toggle`, but they could not disable push-to-talk without disabling speech-to-text entirely. This made the feature unusable when holding Space conflicts with a keyboard or terminal setup.

User context (verbatim): “the fix is to make the keybinding configurable and documented”

## Behavior

```yaml
app.stt.pushToTalk: []
app.stt.toggle: Ctrl+Shift+S
```

With this configuration, Space remains ordinary editor input while `Ctrl+Shift+S` starts and stops speech-to-text recording. Existing users retain the current hold-Space default.

## Testing

- `bun run check` in `packages/coding-agent` — passed.
- `bun test packages/coding-agent/src/modes/components/custom-editor.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/keybindings-display.test.ts` — 61 passed, 0 failed, 161 assertions.
- Built the final CLI with `bun run build` in `packages/coding-agent`.
- Smoke-tested the real `~/.omp/agent/keybindings.yml` through `KeybindingsManager.create()` and `CustomEditor`: resolved `pushToTalk` to `[]`, resolved `toggle` to `["ctrl+shift+s"]`, entered eight Space characters, preserved all eight, and emitted no push-to-talk events.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)