### PR TITLE
feat(catalog): add Claude Opus 5 entries for Amazon Bedrock

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude Opus 5 model entries for Amazon Bedrock: `anthropic.claude-opus-5` plus its `us.`, `eu.`, `au.`, and `global.` regional/geo IDs.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -52,6 +52,7 @@ import {
 	applyCanonicalLimitFallback,
 	applyGeneratedModelPolicies,
 	CLOUDFLARE_FALLBACK_MODEL,
+	dropUnsupportedBedrockGeoIds,
 	linkOpenAIPromotionTargets,
 } from "./generated-policies";
 
@@ -634,6 +635,7 @@ async function generateModels() {
 	allModels = dropFireworksWireIds(allModels);
 	allModels = dropUnusableZaiContextTierIds(allModels);
 	allModels = dropXiaomiAudioOnlyIds(allModels);
+	allModels = dropUnsupportedBedrockGeoIds(allModels);
 	allModels = normalizeAntigravityEndpoint(allModels);
 	// Normalize display names: gateway author prefixes ("OpenAI: …"), alias
 	// markers ("(latest)"), provider attribution ("(Antigravity)"), and

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -51,6 +51,20 @@ export const CLOUDFLARE_FALLBACK_MODEL: ModelSpec<"anthropic-messages"> = {
 	maxTokens: 64000,
 };
 
+/**
+ * `models.dev` currently lists `jp.anthropic.claude-opus-5`, but AWS's own
+ * Bedrock model card documents only `anthropic.claude-opus-5` plus the `us.`,
+ * `eu.`, `au.`, and `global.` Geo/Global inference-profile IDs under
+ * Programmatic Access; Japan regions are marked unsupported for Geo inference
+ * in the same card's regional-availability table. Bedrock rejects an
+ * undocumented inference-profile ID outright, so drop this specific upstream
+ * row rather than ship a selector that 4xxs on first use (PR #6591 review).
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+ */
+export function dropUnsupportedBedrockGeoIds(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.filter(model => !(model.provider === "amazon-bedrock" && model.id === "jp.anthropic.claude-opus-5"));
+}
+
 const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> = {
 	base: 0,
 	mini: 1,

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -42,6 +42,15 @@ const EXPLICIT_CHECKPOINTS_4096_1H: ResolvedBedrockCompat = {
 	promptCacheMaximumCheckpoints: 4,
 };
 
+// AWS モデルカード: 512 トークン、最大 4 個のキャッシュチェックポイント、5 分と 1 時間の TTL。
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+const EXPLICIT_CHECKPOINTS_512_1H: ResolvedBedrockCompat = {
+	promptCacheMode: "explicit",
+	supportsLongPromptCacheRetention: true,
+	promptCacheMinimumTokens: 512,
+	promptCacheMaximumCheckpoints: 4,
+};
+
 /**
  * Explicit Nova cache points complement Bedrock's automatic prefix caching:
  * AWS recommends them for consistent cache hits and input-cost savings. Keep
@@ -81,6 +90,9 @@ function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
 		id.includes("anthropic.claude-sonnet-5")
 	) {
 		return EXPLICIT_CHECKPOINTS_4096_1H;
+	}
+	if (id.includes("anthropic.claude-opus-5")) {
+		return EXPLICIT_CHECKPOINTS_512_1H;
 	}
 	if (id.includes("anthropic.claude-opus-4-6")) {
 		return EXPLICIT_CHECKPOINTS_4096_5M;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -7966,6 +7966,36 @@
 				"supportsDisplay": true
 			}
 		},
+		"anthropic.claude-opus-5": {
+			"id": "anthropic.claude-opus-5",
+			"name": "Claude Opus 5",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
 		"anthropic.claude-sonnet-5": {
 			"id": "anthropic.claude-sonnet-5",
 			"name": "Claude Sonnet 5",
@@ -8057,6 +8087,36 @@
 		"au.anthropic.claude-opus-4-8": {
 			"id": "au.anthropic.claude-opus-4-8",
 			"name": "Claude Opus 4.8 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"au.anthropic.claude-opus-5": {
+			"id": "au.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (AU)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -8669,6 +8729,36 @@
 				"supportsDisplay": true
 			}
 		},
+		"eu.anthropic.claude-opus-5": {
+			"id": "eu.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (EU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
 		"eu.anthropic.claude-sonnet-4-20250514-v1:0": {
 			"id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
 			"name": "Claude Sonnet 4 (EU)",
@@ -8965,6 +9055,36 @@
 		"global.anthropic.claude-opus-4-8": {
 			"id": "global.anthropic.claude-opus-4-8",
 			"name": "Claude Opus 4.8 (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"global.anthropic.claude-opus-5": {
+			"id": "global.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -10593,6 +10713,36 @@
 		"us.anthropic.claude-opus-4-8": {
 			"id": "us.anthropic.claude-opus-4-8",
 			"name": "Claude Opus 4.8 (US)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				],
+				"supportsDisplay": true
+			}
+		},
+		"us.anthropic.claude-opus-5": {
+			"id": "us.anthropic.claude-opus-5",
+			"name": "Claude Opus 5 (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",

--- a/packages/catalog/test/amazon-bedrock-opus-5.test.ts
+++ b/packages/catalog/test/amazon-bedrock-opus-5.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { buildBedrockCompat } from "@oh-my-pi/pi-catalog/compat/bedrock";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import { dropUnsupportedBedrockGeoIds } from "../scripts/generated-policies";
+
+// AWS's Bedrock model card for Claude Opus 5 lists exactly these Programmatic
+// Access IDs — the bare model ID plus the us./eu./au. Geo and global.
+// inference profiles. Japan is explicitly marked unsupported for Geo
+// inference in the same card's regional-availability table, so no `jp.`
+// profile exists for this model (unlike several Opus 4.x generations).
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+const AWS_DOCUMENTED_OPUS_5_IDS = [
+	"anthropic.claude-opus-5",
+	"us.anthropic.claude-opus-5",
+	"eu.anthropic.claude-opus-5",
+	"au.anthropic.claude-opus-5",
+	"global.anthropic.claude-opus-5",
+];
+
+describe("Amazon Bedrock Claude Opus 5", () => {
+	test("bundles exactly the AWS-documented inference-profile IDs", () => {
+		const bedrockOpus5Ids = getBundledModels("amazon-bedrock")
+			.map(model => model.id)
+			.filter(id => id.endsWith("anthropic.claude-opus-5"));
+
+		expect(new Set(bedrockOpus5Ids)).toEqual(new Set(AWS_DOCUMENTED_OPUS_5_IDS));
+		// `models.dev` currently also lists `jp.anthropic.claude-opus-5`; Bedrock
+		// has no such inference profile for this model and would reject it.
+		expect(bedrockOpus5Ids).not.toContain("jp.anthropic.claude-opus-5");
+	});
+
+	test("dropUnsupportedBedrockGeoIds filters the undocumented jp. profile without touching other providers/ids", () => {
+		const bareSpec = (provider: string, id: string): ModelSpec<"bedrock-converse-stream"> => ({
+			id,
+			name: id,
+			api: "bedrock-converse-stream",
+			provider,
+			baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 64000,
+		});
+		const input = [
+			bareSpec("amazon-bedrock", "jp.anthropic.claude-opus-5"),
+			bareSpec("amazon-bedrock", "us.anthropic.claude-opus-5"),
+			// A `jp.` id on a different Bedrock model, or on a different provider,
+			// must survive — only this exact (provider, id) pair is undocumented.
+			bareSpec("amazon-bedrock", "jp.anthropic.claude-opus-4-8"),
+			bareSpec("some-other-provider", "jp.anthropic.claude-opus-5"),
+		];
+
+		expect(dropUnsupportedBedrockGeoIds(input).map(model => model.id)).toEqual([
+			"us.anthropic.claude-opus-5",
+			"jp.anthropic.claude-opus-4-8",
+			"jp.anthropic.claude-opus-5",
+		]);
+	});
+
+	test("resolves the AWS-documented 512-token/four-checkpoint/1h prompt-cache capability", () => {
+		for (const id of AWS_DOCUMENTED_OPUS_5_IDS) {
+			const spec: ModelSpec<"bedrock-converse-stream"> = {
+				id,
+				name: id,
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+				baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+				contextWindow: 1_000_000,
+				maxTokens: 128_000,
+			};
+			expect(buildBedrockCompat(spec)).toEqual({
+				promptCacheMode: "explicit",
+				supportsLongPromptCacheRetention: true,
+				promptCacheMinimumTokens: 512,
+				promptCacheMaximumCheckpoints: 4,
+			});
+		}
+	});
+});

--- a/packages/catalog/test/amazon-bedrock-opus-5.test.ts
+++ b/packages/catalog/test/amazon-bedrock-opus-5.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildBedrockCompat } from "@oh-my-pi/pi-catalog/compat/bedrock";
-import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { MODELS_DEV_PROVIDER_DESCRIPTORS, mapModelsDevToModels } from "@oh-my-pi/pi-catalog/provider-models";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import { dropUnsupportedBedrockGeoIds } from "../scripts/generated-policies";
 
@@ -18,16 +18,59 @@ const AWS_DOCUMENTED_OPUS_5_IDS = [
 	"global.anthropic.claude-opus-5",
 ];
 
-describe("Amazon Bedrock Claude Opus 5", () => {
-	test("bundles exactly the AWS-documented inference-profile IDs", () => {
-		const bedrockOpus5Ids = getBundledModels("amazon-bedrock")
-			.map(model => model.id)
-			.filter(id => id.endsWith("anthropic.claude-opus-5"));
+// A representative `models.dev` "amazon-bedrock" payload for Claude Opus 5.
+// models.dev lists each inference-profile prefix as its own row (the `eu.`
+// row even carries distinct EU pricing), including the `jp.` profile that AWS
+// does not actually expose for this model. We reproduce that shape so the test
+// exercises the real source → catalog path — `mapModelsDevToModels` plus the
+// `dropUnsupportedBedrockGeoIds` generation policy — rather than the committed
+// `models.json` snapshot. A non-tool model is included to confirm the
+// descriptor's `tool_call` filter still drops it.
+const OPUS_5_MODELS_DEV_FIXTURE = {
+	"amazon-bedrock": {
+		models: Object.fromEntries(
+			[
+				"anthropic.claude-opus-5",
+				"us.anthropic.claude-opus-5",
+				"eu.anthropic.claude-opus-5",
+				"au.anthropic.claude-opus-5",
+				"global.anthropic.claude-opus-5",
+				"jp.anthropic.claude-opus-5",
+			].map(id => [
+				id,
+				{
+					name: "Claude Opus 5",
+					tool_call: true,
+					reasoning: true,
+					limit: { context: 1_000_000, output: 128_000 },
+					cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 },
+					modalities: { input: ["text", "image"] },
+				},
+			]),
+		),
+	},
+};
 
-		expect(new Set(bedrockOpus5Ids)).toEqual(new Set(AWS_DOCUMENTED_OPUS_5_IDS));
-		// `models.dev` currently also lists `jp.anthropic.claude-opus-5`; Bedrock
-		// has no such inference profile for this model and would reject it.
-		expect(bedrockOpus5Ids).not.toContain("jp.anthropic.claude-opus-5");
+describe("Amazon Bedrock Claude Opus 5", () => {
+	test("source mapping plus generation policy yields exactly the AWS-documented inference-profile IDs", () => {
+		// Guard the source (models.dev descriptor + exclusion policy), not the
+		// bundled snapshot: the assertion must break if the mapping or policy
+		// stops reproducing the documented IDs, and must not falsely fail when
+		// upstream metadata legitimately shifts.
+		const mapped = mapModelsDevToModels(OPUS_5_MODELS_DEV_FIXTURE, MODELS_DEV_PROVIDER_DESCRIPTORS).filter(
+			model => model.provider === "amazon-bedrock" && model.id.endsWith("anthropic.claude-opus-5"),
+		);
+		const opus5Ids = dropUnsupportedBedrockGeoIds(mapped).map(model => model.id);
+
+		// Set semantics: the descriptor also derives an `eu.` variant from the
+		// bare `anthropic.` row, so `eu.` legitimately arrives from both that
+		// derivation and the standalone models.dev row (deduped downstream by
+		// the generator). We assert the documented ID coverage, not row count.
+		expect(new Set(opus5Ids)).toEqual(new Set(AWS_DOCUMENTED_OPUS_5_IDS));
+		// `models.dev` lists `jp.anthropic.claude-opus-5`, but Bedrock has no such
+		// inference profile for this model and would reject it, so the generation
+		// policy must drop it before it reaches the catalog.
+		expect(opus5Ids).not.toContain("jp.anthropic.claude-opus-5");
 	});
 
 	test("dropUnsupportedBedrockGeoIds filters the undocumented jp. profile without touching other providers/ids", () => {


### PR DESCRIPTION
## Summary

Adds Claude Opus 5 catalog entries for Amazon Bedrock:

- `anthropic.claude-opus-5`
- `us.anthropic.claude-opus-5`
- `eu.anthropic.claude-opus-5`
- `au.anthropic.claude-opus-5`
- `global.anthropic.claude-opus-5`

The change adds the documented 512-token, four-checkpoint, one-hour Bedrock prompt-cache capability, excludes the unsupported `jp.` Geo profile during generation, and adds targeted regression coverage. The AWS model-card citation sits next to the divergent cache constant.

## Verification

- `npx --yes bun@1.3.14 --cwd=packages/catalog run check` (Biome + type check) passes.
- `bun test packages/catalog/test/amazon-bedrock-opus-5.test.ts` — 3 pass / 0 fail.
- Smoke-tested `buildBedrockCompat` for `global.anthropic.claude-opus-5`: explicit cache mode, 512-token minimum, four checkpoints, long-retention support.
- **End-to-end**: built the native addon and ran `omp --model us.anthropic.claude-opus-5` against Amazon Bedrock; the model resolves from the new catalog entry and responds correctly, confirming the entries work in a live run.

## Review follow-up

Addressed the Codex P1 note: the first regression test now exercises the source path (`mapModelsDevToModels` + `dropUnsupportedBedrockGeoIds`) with a representative models.dev Bedrock payload instead of asserting against the bundled `models.json` snapshot, per AGENTS.md ("test the resolver/descriptor, not the bundled JSON"). It now fails if the mapping or exclusion policy regresses.
