### PR TITLE
fix(catalog): downgrade forced tool choice for thinking-locked Kimi Code aliases

### DIFF
--- a/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
+++ b/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
@@ -271,7 +271,7 @@ describe("Kimi K2.7 Code thinking policy", () => {
 		expect(model.compat.disableReasoningOnForcedToolChoice).toBe(true);
 	});
 
-	it("keeps the forced tool choice and omits thinking on Kimi Code's Anthropic endpoint", async () => {
+	it("downgrades the forced tool choice on Kimi Code's Anthropic endpoint", async () => {
 		const model = getBundledModel<"openai-completions">("kimi-code", "kimi-for-coding");
 		let payload: MessageCreateParamsStreaming | undefined;
 		const stream = streamOpenAIAnthropicShim(
@@ -295,10 +295,45 @@ describe("Kimi K2.7 Code thinking policy", () => {
 
 		await stream.result();
 
-		// With reasoning disabled the Anthropic wire carries no thinking block,
-		// and the forced tool choice survives (thinking yields to the choice).
-		expect(payload?.thinking).toBeUndefined();
-		expect(payload?.tool_choice).toEqual({ type: "tool", name: "set_title" });
+		// api.kimi.com keeps thinking enabled server-side no matter what the
+		// request carries: an omitted thinking block defaults to enabled, and an
+		// explicit disabled block is rejected (#3852). Either way a forced
+		// tool_choice 400s (`tool_choice 'specified' is incompatible with
+		// thinking enabled`), so the only viable path is downgrading the choice
+		// to auto while keeping the tool available — thinking stays on.
+		expect(payload?.tool_choice).toEqual({ type: "auto" });
+		expect(payload?.thinking).toBeDefined();
+	});
+
+	it("downgrades forced tool choice for every thinking-locked Kimi Code alias", async () => {
+		// The kimi-code catalog aliases the mandatory-thinking K2.7 Code family
+		// as `kimi-for-coding[-highspeed]` and K3 as `k3`; none match the native
+		// `kimi-k2.7-code*` id pattern, so each must be recognised explicitly.
+		for (const id of ["k3", "kimi-for-coding", "kimi-for-coding-highspeed"]) {
+			const model = getBundledModel<"openai-completions">("kimi-code", id);
+			let payload: MessageCreateParamsStreaming | undefined;
+			const stream = streamOpenAIAnthropicShim(
+				model,
+				TITLE_CONTEXT,
+				{
+					apiKey: "test-key",
+					maxTokens: 1024,
+					toolChoice: { type: "tool", name: "set_title" },
+					onPayload: body => {
+						payload = body as MessageCreateParamsStreaming;
+						throw new Error("stop after payload capture");
+					},
+				},
+				{
+					anthropicBaseUrl: "https://api.kimi.com/coding",
+					defaultFormat: "anthropic",
+				},
+			);
+
+			await stream.result();
+
+			expect(payload?.tool_choice).toEqual({ type: "auto" });
+		}
 	});
 
 	it("uses the configured Kimi base URL for Anthropic requests", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed forced `tool_choice` 400s (`tool_choice 'specified' is incompatible with thinking enabled`) on Kimi Code's Anthropic-compatible endpoint for the `kimi-for-coding`, `kimi-for-coding-highspeed`, and `k3` aliases: the Anthropic-surface compat matcher only recognised Moonshot's native `kimi-k2.7-code*` ids, so thinking-locked kimi-code models kept `supportsForcedToolChoice: true` and the forced selector was sent to a host that always thinks. These models now resolve `requiresThinkingEnabled`, keeping thinking on and downgrading forced choices to `auto`.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -8,6 +8,7 @@ import { modelMatchesHost } from "../hosts";
 import {
 	hasOpus47ApiRestrictions,
 	isAnthropicFableOrMythosModel,
+	isKimiK3ModelId,
 	supportsMidConversationSystemMessages,
 } from "../identity/family";
 import type { ModelSpec, ResolvedAnthropicCompat } from "../types";
@@ -28,12 +29,25 @@ export function isOfficialAnthropicApiUrl(baseUrl?: string): boolean {
 	return lower === OFFICIAL_ANTHROPIC_URL || lower.startsWith(`${OFFICIAL_ANTHROPIC_URL}/`);
 }
 
-/** Mirrors `compat/openai.ts`; native-only host gating is the caller's responsibility. */
+/**
+ * Kimi models whose native endpoints (api.kimi.com, api.moonshot.ai) keep
+ * thinking enabled server-side no matter what the request carries: they
+ * reject disabled thinking (#3852) AND reject forced tool_choice
+ * (`tool_choice 'specified' is incompatible with thinking enabled`), so compat
+ * must keep thinking on and downgrade forced choices to `auto`. Covers the
+ * K2.7 Code family — public id, its Highspeed variant, and the kimi-code
+ * `kimi-for-coding[-highspeed]` aliases — plus K3 (`kimi-k3`, bare `k3` on
+ * kimi-code). Broader than the `compat/openai.ts` mirror: the OpenAI surface
+ * has its own per-dialect policies (K3 forced-choice guard, explicit disable
+ * shapes), while this surface has no working way to force a tool.
+ * Native-only host gating is the caller's responsibility.
+ */
 const KIMI_K27_CODE_MODEL_PATTERN = /(?:^|\/)kimi[-._]?k2(?:[._-]?|p)7[-._]?code(?:[-._]?highspeed)?$/i;
 
-function matchesKimiK27CodeFamily(spec: ModelSpec<"anthropic-messages">): boolean {
+function matchesKimiMandatoryThinkingModel(spec: ModelSpec<"anthropic-messages">): boolean {
 	if (KIMI_K27_CODE_MODEL_PATTERN.test(spec.id)) return true;
-	return spec.id === "kimi-for-coding" && /k2\.?7 code/i.test(spec.name ?? "");
+	if (spec.id === "kimi-for-coding" || spec.id === "kimi-for-coding-highspeed") return true;
+	return isKimiK3ModelId(spec.id) || spec.id === "k3";
 }
 
 const CLOUDFLARE_ANTHROPIC_GATEWAY_URL_MARKER = /gateway\.ai\.cloudflare\.com\/.+\/anthropic(?:\/|$)/i;
@@ -98,7 +112,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 	// signature-enforcing Anthropic — same failure class as GitHub Copilot #2851
 	// (issue #4192).
 	const isZenmux = modelMatchesHost(spec, "zenmux");
-	const requiresThinkingEnabled = modelMatchesHost(spec, "moonshotNative") && matchesKimiK27CodeFamily(spec);
+	const requiresThinkingEnabled = modelMatchesHost(spec, "moonshotNative") && matchesKimiMandatoryThinkingModel(spec);
 	const isVertex = isVertexAnthropicRoute(baseUrl);
 	const isBedrock = isBedrockAnthropicRoute(baseUrl);
 	const isAzure = isAzureAnthropicRoute(baseUrl);


### PR DESCRIPTION
## Problem

Every fresh session on the Kimi Code (coding-plan) models `k3`, `kimi-for-coding`, or `kimi-for-coding-highspeed` fails its first request with:

```
400 tool_choice 'specified' is incompatible with thinking enabled
```

whenever a forced `tool_choice` is attached (e.g. `todo.eager: always` pinning the `todo` tool on the first user message). The retry succeeds, so the rest of the session is clean.

## Root cause

On the Anthropic-compatible surface (the kimi-code default via `streamOpenAIAnthropicShim`), `buildAnthropicCompat` only sets `requiresThinkingEnabled` for Moonshot's **native** K2.7 Code ids (`kimi[-._]?k2...7[-._]?code[-highspeed]`). The coding-plan endpoint serves the same mandatory-thinking models under **alias** ids:

| Moonshot API | Coding plan (api.kimi.com/coding) |
|---|---|
| `kimi-k2.7-code` | `kimi-for-coding` |
| `kimi-k2.7-code-highspeed` | `kimi-for-coding-highspeed` |
| `kimi-k3` | `k3` |

None of the aliases matched (the `kimi-for-coding` name fallback also fails against the bundled name "K2.7 Coding", and K3 was never covered), so `supportsForcedToolChoice` stayed `true` and the forced selector went to a host that keeps thinking enabled server-side — where forced choice can never succeed (an omitted `thinking` block defaults to enabled, and an explicit disabled block is rejected per #3852).

Confirmed with real 400 request logs: the wire body carries `tool_choice: {type: "tool", name: "todo"}` and no `thinking` field, and the server still reports thinking enabled.

## Fix

Broaden the Anthropic-surface matcher (`matchesKimiK27CodeFamily` → `matchesKimiMandatoryThinkingModel`) in `packages/catalog/src/compat/anthropic.ts` to also cover the `kimi-for-coding[-highspeed]` aliases and K3 (`kimi-k3*`, bare `k3`). Host gating (`moonshotNative`) is unchanged, so no other provider is affected. These models now resolve `requiresThinkingEnabled`: thinking stays on and forced choices downgrade to `auto` — the same treatment native `kimi-k2.7-code` already gets.

The OpenAI-completions surface is intentionally untouched: K3 has its own forced-choice guard there, and the K2.7 aliases have an explicit per-dialect policy with existing test coverage; no evidence of failure on that surface.

## Tests

- Rewrote `keeps the forced tool choice and omits thinking on Kimi Code's Anthropic endpoint` — it asserted the behavior that produces the 400 (forced choice preserved, thinking omitted). It now asserts the choice downgrades to `auto` and thinking stays on.
- Added a regression test covering all three bundled aliases (`k3`, `kimi-for-coding`, `kimi-for-coding-highspeed`) through the shim: each must emit `tool_choice: {type: "auto"}`.
- Suites: kimi-code-thinking 13/13, catalog 488/488, moonshot repros (827/1838/2123) 16/16, providers dir 30/30; `bun run check` clean in `catalog` and `ai`.