### PR TITLE
fix(tui): restore GitHub refs in slash arguments

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed numeric GitHub issue/PR autocomplete being suppressed inside prompt-bearing skill slash-command arguments while preserving literal prompt-action tokens such as `#copy` ([#6604](https://github.com/can1357/oh-my-pi/issues/6604)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -158,9 +158,11 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
 				const argumentSuggestions = await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
 				if (argumentSuggestions) return argumentSuggestions;
-				// No slash-argument completion for this input: fall through to
-				// internal-url completion only. `#` prompt-action tokens stay
-				// literal text inside slash command arguments.
+				// No slash-argument completion for this input: preserve numeric
+				// GitHub references and internal URLs while keeping prompt-action
+				// tokens such as `#copy` literal.
+				const githubRefSuggestions = getGithubRefSuggestions(textBeforeCursor);
+				if (githubRefSuggestions) return githubRefSuggestions;
 				return getInternalUrlSuggestions(textBeforeCursor, this.#basePath);
 			}
 		}

--- a/packages/coding-agent/test/modes/github-ref-autocomplete.test.ts
+++ b/packages/coding-agent/test/modes/github-ref-autocomplete.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "bun:test";
 import { KeybindingsManager as AppKeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { getGithubRefContext, getGithubRefSuggestions } from "@oh-my-pi/pi-coding-agent/modes/github-ref-autocomplete";
 import { createPromptActionAutocompleteProvider } from "@oh-my-pi/pi-coding-agent/modes/prompt-action-autocomplete";
+import type { SlashCommand } from "@oh-my-pi/pi-tui";
 
-function makeProvider() {
+function makeProvider(commands: SlashCommand[] = []) {
 	return createPromptActionAutocompleteProvider({
-		commands: [],
+		commands,
 		basePath: "/tmp",
 		keybindings: AppKeybindingsManager.inMemory({}),
 		copyCurrentLine: () => {},
@@ -117,6 +118,21 @@ describe("github-ref autocomplete — provider integration", () => {
 
 		const issueResult = provider.applyCompletion(["review #3164"], 0, 12, issue, suggestions!.prefix);
 		expect(issueResult.lines).toEqual(["review issue://3164 "]);
+	});
+
+	it("offers GitHub references inside prompt-bearing skill command arguments", async () => {
+		const provider = makeProvider([{ name: "skill:code-review", description: "Review code", allowArgs: true }]);
+		const line = "/skill:code-review inspect #123";
+
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions).toEqual({
+			prefix: "#123",
+			items: [
+				{ value: "pr://123", label: "PR #123", description: "GitHub pull request" },
+				{ value: "issue://123", label: "Issue #123", description: "GitHub issue" },
+			],
+		});
 	});
 
 	it("constrains to the named type and consumes the qualifier on accept", async () => {


### PR DESCRIPTION
## Repro
A provider-level regression using `/skill:code-review inspect #123` reproduced the suppression on current `main`: `bun test packages/coding-agent/test/modes/github-ref-autocomplete.test.ts` returned `null` for the draft and failed with 13 passing tests and 1 failing test.

## Cause
`PromptActionAutocompleteProvider.getSuggestions()` in `packages/coding-agent/src/modes/prompt-action-autocomplete.ts` returned from the matched `allowArgs` branch after checking only slash argument and internal-URL completion, so execution never reached `getGithubRefSuggestions()` for numeric references.

## Fix
- Check the existing numeric GitHub-reference grammar after slash-specific argument completion declines the input.
- Preserve literal prompt-action tokens such as `#copy` and the existing internal-URL fallback.
- Cover a registered prompt-bearing skill command with an exact provider-level regression.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/github-ref-autocomplete.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts` passes: 24 tests, 0 failures. The pre-publish `bun check` gate also passes.

Fixes #6604