### PR TITLE
fix(natives): preserve newer cache versions

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed older running OMP versions deleting newer native addon cache directories during cleanup, which could race a new version's first-run extraction and crash with `ENOENT`.
+
 ## [17.1.3] - 2026-07-24
 
 ### Changed

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -178,6 +178,23 @@ export function resolveLoaderCandidates({
 
 // =========================================================================
 
+function parseReleaseVersion(version) {
+	const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+	return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+function isOlderReleaseVersion(candidate, current) {
+	const candidateParts = parseReleaseVersion(candidate);
+	const currentParts = parseReleaseVersion(current);
+	if (!candidateParts || !currentParts) return false;
+	for (let index = 0; index < candidateParts.length; index++) {
+		if (candidateParts[index] !== currentParts[index]) {
+			return candidateParts[index] < currentParts[index];
+		}
+	}
+	return false;
+}
+
 /**
  * Remove version-pinned native cache directories older than the loaded package.
  * Best-effort by design: permission errors and concurrent processes must not
@@ -196,7 +213,7 @@ export function cleanupStaleNativeVersions({ nativesDir, currentVersion }) {
 	}
 
 	for (const entry of entries) {
-		if (!entry.isDirectory() || entry.name === currentVersion) continue;
+		if (!entry.isDirectory() || !isOlderReleaseVersion(entry.name, currentVersion)) continue;
 		const targetPath = path.join(nativesDir, entry.name);
 		try {
 			fs.rmSync(targetPath, { recursive: true, force: true });

--- a/packages/natives/test/windows-staging.test.ts
+++ b/packages/natives/test/windows-staging.test.ts
@@ -134,17 +134,23 @@ describe("windows native addon staging", () => {
 		expect(candidates).toContain(nodeModulesBaseline);
 	});
 
-	it("removes stale version directories after the current native version loads", async () => {
+	it("removes only older version directories after the current native version loads", async () => {
 		const nativesDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-natives-cache-"));
+		const currentMajor = Number.parseInt(packageJson.version, 10);
+		const futureVersion = `${currentMajor + 1}.0.0`;
 		try {
 			await fs.mkdir(path.join(nativesDir, "15.10.11"));
 			await fs.mkdir(path.join(nativesDir, packageJson.version));
+			await fs.mkdir(path.join(nativesDir, futureVersion));
+			await fs.mkdir(path.join(nativesDir, "not-a-version"));
 			await Bun.write(path.join(nativesDir, "README.txt"), "not a version directory");
 
 			const removed = cleanupStaleNativeVersions({ nativesDir, currentVersion: packageJson.version });
 
 			expect(removed.map(filePath => path.basename(filePath))).toEqual(["15.10.11"]);
-			expect((await fs.readdir(nativesDir)).sort()).toEqual(["README.txt", packageJson.version].sort());
+			expect((await fs.readdir(nativesDir)).sort()).toEqual(
+				["README.txt", packageJson.version, futureVersion, "not-a-version"].sort(),
+			);
 		} finally {
 			await fs.rm(nativesDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## What

- Restrict native cache cleanup to release directories older than the running package version.
- Preserve the current version, newer versions, and unrecognized directory names.

## Why

I hit this native addon extraction failure in 17.1.3, and this fix preserves newer cache directories while older OMP sessions are still running.

A process previously removed every native cache directory whose name differed from its own version. An older process could therefore delete a newly updated process's cache directory during first-run extraction, causing the temporary addon write to fail with `ENOENT` and leaving no loadable addon.

## Testing

- Reproduced before the fix with a cache containing older, current, newer, and unrecognized directories; cleanup incorrectly removed the newer and unrecognized directories.
- Confirmed the same scenario now removes only the older directory:
  - `CI=1 bun --cwd=packages/natives test test/windows-staging.test.ts`
- Confirmed compiled-addon candidate and extraction coverage remains green:
  - `CI=1 bun --cwd=packages/natives test test/windows-staging.test.ts test/issue-823-repro.test.ts`
- `CI=1 bun --cwd=packages/natives run check`
- Root `bun check` remains blocked by pre-existing formatter drift in unrelated AI, catalog, coding-agent, and snapcompact tests on `main`.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
