### PR TITLE
fix(coding-agent): handle vibe session commands safely

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/new`, `/drop`, `/fork`, and `/move` crashing or doing unnecessary work when invoked during vibe mode; interactive session transitions now show the existing exit-vibe warning and leave the session unchanged ([#6607](https://github.com/can1357/oh-my-pi/issues/6607)).
+- Fixed `/new`, `/drop`, `/fork`, and `/move` crashing or doing unnecessary work when invoked during vibe mode; interactive session transitions now show the existing exit-vibe warning and leave the session unchanged, and reset loops disable themselves instead of resubmitting into that unchanged session ([#6607](https://github.com/can1357/oh-my-pi/issues/6607)).
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/new`, `/drop`, `/fork`, and `/move` crashing or doing unnecessary work when invoked during vibe mode; interactive session transitions now show the existing exit-vibe warning and leave the session unchanged ([#6607](https://github.com/can1357/oh-my-pi/issues/6607)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4432,6 +4432,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#commandController.handleContextCommand();
 	}
 
+	#vibeSessionTransitionBlocked(): boolean {
+		if (!this.vibeModeEnabled) return false;
+		this.showWarning("Exit vibe mode first.");
+		return true;
+	}
+
 	#prepareSessionSwitch(): void {
 		this.#btwController.dispose();
 		this.#omfgController.dispose();
@@ -4440,28 +4446,32 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#hidePlanReview();
 	}
 
-	handleClearCommand(): Promise<void> {
+	async handleClearCommand(): Promise<void> {
+		if (this.#vibeSessionTransitionBlocked()) return;
 		this.#prepareSessionSwitch();
-		return this.#commandController.handleClearCommand();
+		await this.#commandController.handleClearCommand();
 	}
 
 	handleFreshCommand(): Promise<void> {
 		return this.#commandController.handleFreshCommand();
 	}
 
-	handleDropCommand(): Promise<void> {
+	async handleDropCommand(): Promise<void> {
+		if (this.#vibeSessionTransitionBlocked()) return;
 		this.#prepareSessionSwitch();
-		return this.#commandController.handleDropCommand();
+		await this.#commandController.handleDropCommand();
 	}
 
-	handleForkCommand(): Promise<void> {
+	async handleForkCommand(): Promise<void> {
+		if (this.#vibeSessionTransitionBlocked()) return;
 		this.#btwController.dispose();
 		this.#omfgController.dispose();
-		return this.#commandController.handleForkCommand();
+		await this.#commandController.handleForkCommand();
 	}
 
-	handleMoveCommand(targetPath?: string): Promise<void> {
-		return this.#commandController.handleMoveCommand(targetPath);
+	async handleMoveCommand(targetPath?: string): Promise<void> {
+		if (this.#vibeSessionTransitionBlocked()) return;
+		await this.#commandController.handleMoveCommand(targetPath);
 	}
 
 	handleRenameCommand(title: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1395,6 +1395,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		if (action === "reset" && this.vibeModeEnabled) {
+			this.disableLoopMode("Exit vibe mode before using reset loops. Loop mode disabled.");
+			return;
+		}
+
 		if (!consumeLoopLimitIteration(this.loopLimit)) {
 			this.disableLoopMode("Loop limit reached. Loop mode disabled.");
 			return;

--- a/packages/coding-agent/test/interactive-mode-loop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-loop.test.ts
@@ -138,6 +138,25 @@ describe("InteractiveMode loop auto-submit", () => {
 		expect(resolved[0].text).toBe("deliver this");
 	});
 
+	it("disables reset loops when vibe blocks the session transition", async () => {
+		vi.useFakeTimers();
+		settings.set("loop.mode", "reset");
+		mode.vibeModeEnabled = true;
+		mode.loopModeEnabled = true;
+		mode.loopPrompt = "do not resubmit";
+		const showStatus = vi.spyOn(mode, "showStatus");
+		const resolved: SubmittedUserInput[] = [];
+		void mode.getUserInput().then(input => resolved.push(input));
+
+		vi.advanceTimersByTime(800);
+		await flushMicrotasks();
+
+		expect(resolved).toHaveLength(0);
+		expect(mode.loopModeEnabled).toBe(false);
+		expect(mode.loopPrompt).toBeUndefined();
+		expect(showStatus).toHaveBeenCalledWith("Exit vibe mode before using reset loops. Loop mode disabled.");
+	});
+
 	it("reports waiting, running, paused, resumed, and disabled loop states", async () => {
 		const setLoopModeStatus = vi.spyOn(mode.statusLine, "setLoopModeStatus");
 

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -272,6 +272,25 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(mode.vibeModeEnabled).toBe(true);
 	});
 
+	it("warns instead of rejecting for interactive session transitions while vibe is active", async () => {
+		await mode.init({ suppressWelcomeIntro: true });
+		await mode.handleVibeModeCommand();
+		await session.sessionManager.ensureOnDisk();
+		const sessionFile = session.sessionFile;
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		const warning = vi.spyOn(mode, "showWarning");
+
+		await expect(mode.handleClearCommand()).resolves.toBeUndefined();
+		await expect(mode.handleDropCommand()).resolves.toBeUndefined();
+		await expect(mode.handleForkCommand()).resolves.toBeUndefined();
+		await expect(mode.handleMoveCommand(path.join(tempDir.path(), "other-project"))).resolves.toBeUndefined();
+
+		expect(warning).toHaveBeenCalledTimes(4);
+		expect(warning).toHaveBeenCalledWith("Exit vibe mode first.");
+		expect(session.sessionFile).toBe(sessionFile);
+		expect(mode.vibeModeEnabled).toBe(true);
+	});
+
 	it("keeps vibe mode and tools active after a real storage failure, then allows a retry", async () => {
 		await mode.init({ suppressWelcomeIntro: true });
 		await mode.handleVibeModeCommand();


### PR DESCRIPTION
## Repro

Enable `/vibe`, then invoke `/new` or `/fork`. The focused reproduction `cd packages/coding-agent && bun test test/interactive-mode-vibe-toggle.test.ts -t "warns instead of rejecting"` failed before the fix because `InteractiveMode.handleClearCommand()` returned a rejected promise instead of resolving after showing a warning.

## Cause

`AgentSession.newSession()` and `AgentSession.fork()` correctly enforce the vibe lifecycle invariant by throwing from `#assertVibeSessionTransitionAllowed()` in `packages/coding-agent/src/session/agent-session.ts`, but `InteractiveMode.handleClearCommand()` and `handleForkCommand()` in `packages/coding-agent/src/modes/interactive-mode.ts` forwarded those expected rejections through the input callback without an interactive guard.

## Fix

- Guard interactive `/new`, `/drop`, `/fork`, and `/move` transitions while vibe mode is active.
- Render the existing `Exit vibe mode first.` warning before controller side effects and leave the active session unchanged.
- Cover all guarded interactive transitions in the vibe-mode regression suite.
- Record the fix under the coding-agent changelog's `[Unreleased]` section.

## Verification

`cd packages/coding-agent && bun test test/interactive-mode-vibe-toggle.test.ts` — 8 passed, 0 failed, 61 assertions.

`cd packages/coding-agent && bun run check` — passed (Biome and TypeScript).

Fixes #6607