### PR TITLE
feat(coding-agent): add prebuilt extension import sidecar fast path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Fixed spilled tool-output artifact descriptors leaking on error/abort paths. `OutputSink.dump()` was the only path that closed the spill `Bun.FileSink`, but the bash and Python executors re-throw on failure and their `finally` blocks never closed the sink, so a large-output command that errored leaked the artifact descriptor until an unrelated read (e.g. a `SKILL.md` load) hit `EMFILE`. `OutputSink` now exposes an idempotent `dispose()` that closes the sink exactly once, wired into every executor's `finally` ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).
 - Fixed the first submitted prompt stalling while the local tiny-title worker started: the interactive submit handler now paints the pending user row before starting title generation, and startup prewarms an idle, unref'd worker so the first submit reuses a live subprocess instead of paying spawn latency ahead of the first frame ([#6462](https://github.com/can1357/oh-my-pi/issues/6462)).
 - Fixed legacy Pi extensions failing validation when importing the upstream `keyText` keybinding helper ([#6470](https://github.com/can1357/oh-my-pi/issues/6470)).
+- Fixed prebuilt ESM plugins paying the full legacy Babel graph scan on every startup. Verified `.omp-imports.json` sidecars now let the loader hash-check and rewrite only declared host imports, while malformed or stale sidecars fall back to the existing graph loader.
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in prebuilt-extension import sidecar (`.omp-imports.json`) fast path: the legacy extension loader hash-checks a verified sidecar and rewrites only declared host imports, skipping the full Babel graph scan for self-contained ESM bundles, and falls back to the existing loader on any missing, stale, or malformed sidecar.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed
@@ -65,7 +69,6 @@
 - Fixed spilled tool-output artifact descriptors leaking on error/abort paths. `OutputSink.dump()` was the only path that closed the spill `Bun.FileSink`, but the bash and Python executors re-throw on failure and their `finally` blocks never closed the sink, so a large-output command that errored leaked the artifact descriptor until an unrelated read (e.g. a `SKILL.md` load) hit `EMFILE`. `OutputSink` now exposes an idempotent `dispose()` that closes the sink exactly once, wired into every executor's `finally` ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).
 - Fixed the first submitted prompt stalling while the local tiny-title worker started: the interactive submit handler now paints the pending user row before starting title generation, and startup prewarms an idle, unref'd worker so the first submit reuses a live subprocess instead of paying spawn latency ahead of the first frame ([#6462](https://github.com/can1357/oh-my-pi/issues/6462)).
 - Fixed legacy Pi extensions failing validation when importing the upstream `keyText` keybinding helper ([#6470](https://github.com/can1357/oh-my-pi/issues/6470)).
-- Fixed prebuilt ESM plugins paying the full legacy Babel graph scan on every startup. Verified `.omp-imports.json` sidecars now let the loader hash-check and rewrite only declared host imports, while malformed or stale sidecars fall back to the existing graph loader.
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -2403,6 +2403,27 @@ function installPrebuiltExtensionHook(entryRealPath: string, source: string): vo
 	}
 }
 
+// Promise-tail map that serializes the complete source-preparation→import→cleanup
+// lifetime per real entry path. Distinct paths stay concurrent; same-path loads wait
+// until the prior load's `finally` releases retained state before reading/validating
+// source or choosing prebuilt vs graph fallback.
+const legacyPiModuleLoadTails = new Map<string, Promise<void>>();
+
+async function runSerializedLegacyPiModuleLoad<T>(entryRealPath: string, run: () => Promise<T>): Promise<T> {
+	const previous = legacyPiModuleLoadTails.get(entryRealPath) ?? Promise.resolve();
+	const { promise: gate, resolve: release } = Promise.withResolvers<void>();
+	legacyPiModuleLoadTails.set(entryRealPath, gate);
+	try {
+		await previous.catch(() => undefined);
+		return await run();
+	} finally {
+		release();
+		if (legacyPiModuleLoadTails.get(entryRealPath) === gate) {
+			legacyPiModuleLoadTails.delete(entryRealPath);
+		}
+	}
+}
+
 /**
  * Load a legacy Pi extension module from its real on-disk location.
  *
@@ -2419,42 +2440,44 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	// `bun link`/pnpm installs) so the rewrite filter matches the path Bun
 	// actually hands the hook.
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
-	await ensureLegacyPiOverridesReady();
-	const prebuiltSource = await preparePrebuiltExtensionEntry(entryRealPath);
-	let pendingSources: { clear(): void } | undefined;
-	let retainedPrebuiltPath: string | undefined;
-	if (prebuiltSource === null) {
-		// A sidecar that went missing or stale must stop the retained fast-path source
-		// from serving this entry, so the graph hook below takes over cleanly. Force-evict
-		// even if another load's retain count is non-zero: serving a stale rewritten snapshot
-		// would defeat the hash check that rejected this sidecar.
-		prebuiltExtensionSources.delete(entryRealPath);
-		prebuiltExtensionSourceRetainCounts.delete(entryRealPath);
-		pendingSources = await ensureExtensionGraphHook(entryRealPath);
-	} else {
-		installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
-		retainedPrebuiltPath = entryRealPath;
-	}
-	try {
-		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
-		// On POSIX, use the raw filesystem path so Bun keys the `?mtime`
-		// suffix as part of the module identity; Bun ignores query strings on
-		// `file://` specifiers, which would serve stale edited source.
-		const entrySpecifier =
-			process.platform === "win32" || isBundledVirtualSpecifier(entryRealPath)
-				? toImportSpecifier(entryRealPath)
-				: entryRealPath;
-		return await import(`${entrySpecifier}?mtime=${nextLegacyPiLoadTag()}`);
-	} finally {
-		// Drop graph snapshots the initial import didn't consume: graph modules only
-		// reached by lazy dynamic imports must be read from disk at their actual import
-		// time, not served from this load-time snapshot. Release the prebuilt source once
-		// the last in-flight load for this path finishes (success or error).
-		pendingSources?.clear();
-		if (retainedPrebuiltPath !== undefined) {
-			releasePrebuiltExtensionSource(retainedPrebuiltPath);
+	return runSerializedLegacyPiModuleLoad(entryRealPath, async () => {
+		await ensureLegacyPiOverridesReady();
+		const prebuiltSource = await preparePrebuiltExtensionEntry(entryRealPath);
+		let pendingSources: { clear(): void } | undefined;
+		let retainedPrebuiltPath: string | undefined;
+		if (prebuiltSource === null) {
+			// A sidecar that went missing or stale must stop the retained fast-path source
+			// from serving this entry, so the graph hook below takes over cleanly. Force-evict
+			// even if another load's retain count is non-zero: serving a stale rewritten snapshot
+			// would defeat the hash check that rejected this sidecar.
+			prebuiltExtensionSources.delete(entryRealPath);
+			prebuiltExtensionSourceRetainCounts.delete(entryRealPath);
+			pendingSources = await ensureExtensionGraphHook(entryRealPath);
+		} else {
+			installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
+			retainedPrebuiltPath = entryRealPath;
 		}
-	}
+		try {
+			// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
+			// On POSIX, use the raw filesystem path so Bun keys the `?mtime`
+			// suffix as part of the module identity; Bun ignores query strings on
+			// `file://` specifiers, which would serve stale edited source.
+			const entrySpecifier =
+				process.platform === "win32" || isBundledVirtualSpecifier(entryRealPath)
+					? toImportSpecifier(entryRealPath)
+					: entryRealPath;
+			return await import(`${entrySpecifier}?mtime=${nextLegacyPiLoadTag()}`);
+		} finally {
+			// Drop graph snapshots the initial import didn't consume: graph modules only
+			// reached by lazy dynamic imports must be read from disk at their actual import
+			// time, not served from this load-time snapshot. Release the prebuilt source once
+			// the last in-flight load for this path finishes (success or error).
+			pendingSources?.clear();
+			if (retainedPrebuiltPath !== undefined) {
+				releasePrebuiltExtensionSource(retainedPrebuiltPath);
+			}
+		}
+	});
 }
 
 function getLoader(path: string): "js" | "jsx" | "ts" | "tsx" {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -350,6 +350,9 @@ function clearLegacyPiResolutionCaches(): void {
 	// plugin, so the registered hooks outlive any cache reset. Clearing it would re-register
 	// a duplicate hook per entry on the next load.
 	prebuiltExtensionSources.clear();
+	prebuiltExtensionSourceRetainCounts.clear();
+	extensionGraphPreparedSources.clear();
+	extensionGraphPreparedRetainCounts.clear();
 }
 
 registerPluginCacheInvalidator(clearLegacyPiResolutionCaches);
@@ -1426,7 +1429,65 @@ function escapeRegExp(value: string): string {
 const extensionGraphHookModules = new Map<string, Set<string>>();
 const extensionGraphCacheBustResolvedImportModules = new Map<string, Set<string>>();
 const prebuiltExtensionSources = new Map<string, string>();
+const prebuiltExtensionSourceRetainCounts = new Map<string, number>();
+// Raw graph-collected entry sources published for the permanent prebuilt onLoad to
+// reuse when the sidecar fast-path source was evicted (stale/missing). Retained for
+// the duration of each in-flight graph load so concurrent loads cannot starve each other.
+const extensionGraphPreparedSources = new Map<string, string>();
+const extensionGraphPreparedRetainCounts = new Map<string, number>();
 const prebuiltExtensionHookPaths = new Set<string>();
+
+function retainPrebuiltExtensionSource(entryRealPath: string, source: string): void {
+	prebuiltExtensionSources.set(entryRealPath, source);
+	prebuiltExtensionSourceRetainCounts.set(
+		entryRealPath,
+		(prebuiltExtensionSourceRetainCounts.get(entryRealPath) ?? 0) + 1,
+	);
+}
+
+function releasePrebuiltExtensionSource(entryRealPath: string): void {
+	const count = prebuiltExtensionSourceRetainCounts.get(entryRealPath) ?? 0;
+	if (count <= 1) {
+		prebuiltExtensionSourceRetainCounts.delete(entryRealPath);
+		prebuiltExtensionSources.delete(entryRealPath);
+	} else {
+		prebuiltExtensionSourceRetainCounts.set(entryRealPath, count - 1);
+	}
+}
+
+function retainGraphPreparedSource(entryRealPath: string, source: string): void {
+	extensionGraphPreparedSources.set(entryRealPath, source);
+	extensionGraphPreparedRetainCounts.set(
+		entryRealPath,
+		(extensionGraphPreparedRetainCounts.get(entryRealPath) ?? 0) + 1,
+	);
+}
+
+function releaseGraphPreparedSource(entryRealPath: string): void {
+	const count = extensionGraphPreparedRetainCounts.get(entryRealPath) ?? 0;
+	if (count <= 1) {
+		extensionGraphPreparedRetainCounts.delete(entryRealPath);
+		extensionGraphPreparedSources.delete(entryRealPath);
+	} else {
+		extensionGraphPreparedRetainCounts.set(entryRealPath, count - 1);
+	}
+}
+
+/** Test seam: whether a prebuilt rewritten source is currently retained. */
+export function __hasRetainedPrebuiltExtensionSourceForTests(entryRealPath: string): boolean {
+	return prebuiltExtensionSources.has(entryRealPath);
+}
+
+/** Test seam: in-flight retain count for a prebuilt rewritten source. */
+export function __getPrebuiltExtensionSourceRetainCountForTests(entryRealPath: string): number {
+	return prebuiltExtensionSourceRetainCounts.get(entryRealPath) ?? 0;
+}
+
+/** Test seam: whether a graph-prepared entry source is currently retained. */
+export function __hasGraphPreparedExtensionSourceForTests(entryRealPath: string): boolean {
+	return extensionGraphPreparedSources.has(entryRealPath);
+}
+
 const commonJsModuleSources = new Map<string, string>();
 const commonJsFallbackModulePaths = new Map<string, string>();
 const extensionSynchronousSpecifierTargets = new Map<string, Map<string, string>>();
@@ -2094,7 +2155,8 @@ async function installExtensionGraphHook(
  * the current graph and registers hooks for paths not covered by earlier loads.
  *
  * Returns a clearable handle to drop cached sources that weren't consumed
- * during the initial load; `undefined` when no new modules were discovered.
+ * during the initial load (including any graph-prepared entry published for the
+ * permanent prebuilt hook); `undefined` when nothing was published or installed.
  */
 async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(): void } | undefined> {
 	const {
@@ -2116,6 +2178,16 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			commonJsGraphModulePaths.add(modulePath);
 		}
 	}
+	// Publish the entry's freshly collected raw source for the permanent prebuilt
+	// onLoad. That hook wins over newly installed graph hooks for the same path, so
+	// without this publication it would re-read the entry from disk even though we
+	// just prepared it. Retain across overlapping graph loads; release in clear().
+	const entryPreparedSource = currentModules.get(entryRealPath);
+	const publishedEntrySource =
+		entryPreparedSource !== undefined && !commonJsPaths.has(entryRealPath) ? entryPreparedSource : undefined;
+	if (publishedEntrySource !== undefined) {
+		retainGraphPreparedSource(entryRealPath, publishedEntrySource);
+	}
 	let hookedModules = extensionGraphHookModules.get(entryRealPath);
 	if (!hookedModules) {
 		hookedModules = new Set<string>();
@@ -2132,8 +2204,13 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			}
 		}
 	}
+	const releasePublishedEntry = (): void => {
+		if (publishedEntrySource !== undefined) {
+			releaseGraphPreparedSource(entryRealPath);
+		}
+	};
 	if (pendingModules.size === 0 && commonJsPaths.size === 0) {
-		return undefined;
+		return publishedEntrySource !== undefined ? { clear: releasePublishedEntry } : undefined;
 	}
 
 	let asyncModules = new Map<string, string>();
@@ -2153,6 +2230,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 		clear() {
 			asyncModules.clear();
 			syncSourceModules.clear();
+			releasePublishedEntry();
 			for (const modulePath of commonJsPaths) {
 				commonJsModuleSources.delete(modulePath);
 				commonJsModuleDefinitions.delete(modulePath);
@@ -2289,7 +2367,10 @@ async function preparePrebuiltExtensionEntry(entryRealPath: string): Promise<str
 }
 
 function installPrebuiltExtensionHook(entryRealPath: string, source: string): void {
-	prebuiltExtensionSources.set(entryRealPath, source);
+	// Reference-count concurrent loads of the same path: the first in-flight load must
+	// not delete the map entry while a second load's onLoad still needs it. loadLegacyPiModule
+	// releases in `finally` once the last retain drops to zero.
+	retainPrebuiltExtensionSource(entryRealPath, source);
 	if (!prebuiltExtensionHookPaths.has(entryRealPath)) {
 		prebuiltExtensionHookPaths.add(entryRealPath);
 		const filter = new RegExp(`^${escapeRegExp(entryRealPath)}(?:\\?mtime=\\d+)?$`);
@@ -2301,19 +2382,17 @@ function installPrebuiltExtensionHook(entryRealPath: string, source: string): vo
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
 					const mtimeTag = queryIndex >= 0 ? args.path.slice(queryIndex + "?mtime=".length) : null;
-					// Retain the source: concurrent loads of the same entry carry distinct ?mtime
-					// tags but share this map, so deleting on first serve would hand a later
-					// concurrent load nothing. The sidecar hash binds source to entry, so the
-					// retained snapshot stays correct until a load replaces or evicts it.
 					const contents = prebuiltExtensionSources.get(sourcePath);
 					if (contents !== undefined) {
 						return { contents, loader: getLoader(sourcePath) };
 					}
 					// Bun rejects an undefined onLoad return instead of falling through to the
-					// next plugin, and this hook is permanent, so it has to stay total: once a
-					// load evicts the source because the sidecar went missing or stale, rewrite
-					// the entry here exactly as the graph loader would.
-					const raw = await Bun.file(sourcePath).text();
+					// next plugin, and this hook is permanent, so it has to stay total. Prefer
+					// the graph-prepared raw source published by ensureExtensionGraphHook (fresh
+					// disk read from this load's collectExtensionModules) over opening the entry
+					// again. A genuine miss still falls back to disk.
+					const prepared = extensionGraphPreparedSources.get(sourcePath);
+					const raw = prepared !== undefined ? prepared : await Bun.file(sourcePath).text();
 					return {
 						contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag),
 						loader: getLoader(sourcePath),
@@ -2343,13 +2422,18 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	await ensureLegacyPiOverridesReady();
 	const prebuiltSource = await preparePrebuiltExtensionEntry(entryRealPath);
 	let pendingSources: { clear(): void } | undefined;
+	let retainedPrebuiltPath: string | undefined;
 	if (prebuiltSource === null) {
 		// A sidecar that went missing or stale must stop the retained fast-path source
-		// from serving this entry, so the graph hook below takes over cleanly.
+		// from serving this entry, so the graph hook below takes over cleanly. Force-evict
+		// even if another load's retain count is non-zero: serving a stale rewritten snapshot
+		// would defeat the hash check that rejected this sidecar.
 		prebuiltExtensionSources.delete(entryRealPath);
+		prebuiltExtensionSourceRetainCounts.delete(entryRealPath);
 		pendingSources = await ensureExtensionGraphHook(entryRealPath);
 	} else {
 		installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
+		retainedPrebuiltPath = entryRealPath;
 	}
 	try {
 		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
@@ -2364,9 +2448,12 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	} finally {
 		// Drop graph snapshots the initial import didn't consume: graph modules only
 		// reached by lazy dynamic imports must be read from disk at their actual import
-		// time, not served from this load-time snapshot. The prebuilt source is retained
-		// (see installPrebuiltExtensionHook) so concurrent and later loads stay served.
+		// time, not served from this load-time snapshot. Release the prebuilt source once
+		// the last in-flight load for this path finishes (success or error).
 		pendingSources?.clear();
+		if (retainedPrebuiltPath !== undefined) {
+			releasePrebuiltExtensionSource(retainedPrebuiltPath);
+		}
 	}
 }
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -11,6 +11,7 @@ import { isCompiledBinary, stripWindowsExtendedLengthPathPrefix } from "@oh-my-p
 import { registerPluginCacheInvalidator } from "../../discovery/helpers";
 
 const IS_COMPILED_BINARY = isCompiledBinary();
+const FORCE_FULL_EXTENSION_CRAWL = process.env.OMP_LEGACY_EXT_FULL_CRAWL === "1";
 
 function isBabelTraverse(value: unknown): value is typeof traverseModule.default {
 	return typeof value === "function";
@@ -2442,7 +2443,10 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
 	return runSerializedLegacyPiModuleLoad(entryRealPath, async () => {
 		await ensureLegacyPiOverridesReady();
-		const prebuiltSource = await preparePrebuiltExtensionEntry(entryRealPath);
+		// `OMP_LEGACY_EXT_FULL_CRAWL=1` is an end-to-end recovery/diagnostic switch: skip the
+		// hash-valid sidecar fast path entirely so every edge goes through the graph crawler.
+		// Sidecar validation stays unchanged when the variable is absent.
+		const prebuiltSource = FORCE_FULL_EXTENSION_CRAWL ? null : await preparePrebuiltExtensionEntry(entryRealPath);
 		let pendingSources: { clear(): void } | undefined;
 		let retainedPrebuiltPath: string | undefined;
 		if (prebuiltSource === null) {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -346,6 +346,9 @@ function clearLegacyPiResolutionCaches(): void {
 	nativeAddonRequireScanCache.clear();
 	nativeAddonLoaderModulePaths.clear();
 	realpathCache.clear();
+	// `prebuiltExtensionHookPaths` is intentionally not cleared: Bun cannot unregister a
+	// plugin, so the registered hooks outlive any cache reset. Clearing it would re-register
+	// a duplicate hook per entry on the next load.
 	prebuiltExtensionSources.clear();
 }
 
@@ -2014,6 +2017,12 @@ async function installExtensionGraphHook(
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
 					const mtimeTag = queryIndex >= 0 ? args.path.slice(queryIndex + "?mtime=".length) : null;
+					const prebuilt = prebuiltExtensionSources.get(sourcePath);
+					if (prebuilt !== undefined) {
+						// A prebuilt sidecar hook supersedes any stale graph hook for this
+						// entry (e.g. after a same-process rebuild that added a sidecar).
+						return { contents: prebuilt, loader: getLoader(sourcePath) };
+					}
 					const cached = asyncModules.get(sourcePath);
 					let raw: string;
 					if (cached !== undefined) {
@@ -2123,7 +2132,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			}
 		}
 	}
-	if (pendingModules.size === 0 && pendingCommonJsPaths.size === 0) {
+	if (pendingModules.size === 0 && commonJsPaths.size === 0) {
 		return undefined;
 	}
 
@@ -2222,14 +2231,14 @@ async function preparePrebuiltExtensionEntry(entryRealPath: string): Promise<str
 	let source: string;
 	let sidecar: PrebuiltImportSidecar | null;
 	try {
-		source = await Bun.file(entryRealPath).text();
 		sidecar = parsePrebuiltImportSidecar(
 			JSON.parse(await Bun.file(`${entryRealPath}${PREBUILT_IMPORT_SIDECAR_SUFFIX}`).text()),
 		);
+		if (!sidecar) return null;
+		source = await Bun.file(entryRealPath).text();
 	} catch {
 		return null;
 	}
-	if (!sidecar) return null;
 	const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
 	if (sha256 !== sidecar.sha256) return null;
 
@@ -2279,7 +2288,7 @@ async function preparePrebuiltExtensionEntry(entryRealPath: string): Promise<str
 	return rewritten;
 }
 
-function installPrebuiltExtensionHook(entryRealPath: string, source: string): { clear(): void } {
+function installPrebuiltExtensionHook(entryRealPath: string, source: string): void {
 	prebuiltExtensionSources.set(entryRealPath, source);
 	if (!prebuiltExtensionHookPaths.has(entryRealPath)) {
 		prebuiltExtensionHookPaths.add(entryRealPath);
@@ -2288,18 +2297,31 @@ function installPrebuiltExtensionHook(entryRealPath: string, source: string): { 
 		Bun.plugin({
 			name: `omp:legacy-pi-prebuilt:${hookId}`,
 			setup(build) {
-				build.onLoad({ filter, namespace: "file" }, args => {
+				build.onLoad({ filter, namespace: "file" }, async args => {
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
+					const mtimeTag = queryIndex >= 0 ? args.path.slice(queryIndex + "?mtime=".length) : null;
+					// Retain the source: concurrent loads of the same entry carry distinct ?mtime
+					// tags but share this map, so deleting on first serve would hand a later
+					// concurrent load nothing. The sidecar hash binds source to entry, so the
+					// retained snapshot stays correct until a load replaces or evicts it.
 					const contents = prebuiltExtensionSources.get(sourcePath);
-					if (contents === undefined) return undefined;
-					prebuiltExtensionSources.delete(sourcePath);
-					return { contents, loader: getLoader(sourcePath) };
+					if (contents !== undefined) {
+						return { contents, loader: getLoader(sourcePath) };
+					}
+					// Bun rejects an undefined onLoad return instead of falling through to the
+					// next plugin, and this hook is permanent, so it has to stay total: once a
+					// load evicts the source because the sidecar went missing or stale, rewrite
+					// the entry here exactly as the graph loader would.
+					const raw = await Bun.file(sourcePath).text();
+					return {
+						contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag),
+						loader: getLoader(sourcePath),
+					};
 				});
 			},
 		});
 	}
-	return { clear: () => prebuiltExtensionSources.delete(entryRealPath) };
 }
 
 /**
@@ -2320,10 +2342,15 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
 	await ensureLegacyPiOverridesReady();
 	const prebuiltSource = await preparePrebuiltExtensionEntry(entryRealPath);
-	const pendingSources =
-		prebuiltSource === null
-			? await ensureExtensionGraphHook(entryRealPath)
-			: installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
+	let pendingSources: { clear(): void } | undefined;
+	if (prebuiltSource === null) {
+		// A sidecar that went missing or stale must stop the retained fast-path source
+		// from serving this entry, so the graph hook below takes over cleanly.
+		prebuiltExtensionSources.delete(entryRealPath);
+		pendingSources = await ensureExtensionGraphHook(entryRealPath);
+	} else {
+		installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
+	}
 	try {
 		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
 		// On POSIX, use the raw filesystem path so Bun keys the `?mtime`
@@ -2335,9 +2362,10 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 				: entryRealPath;
 		return await import(`${entrySpecifier}?mtime=${nextLegacyPiLoadTag()}`);
 	} finally {
-		// Drop whatever the initial import didn't consume: graph modules only
-		// reached by lazy dynamic imports must be read from disk at their actual
-		// import time, not served from this load-time snapshot.
+		// Drop graph snapshots the initial import didn't consume: graph modules only
+		// reached by lazy dynamic imports must be read from disk at their actual import
+		// time, not served from this load-time snapshot. The prebuilt source is retained
+		// (see installPrebuiltExtensionHook) so concurrent and later loads stay served.
 		pendingSources?.clear();
 	}
 }

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -350,12 +350,21 @@ function clearLegacyPiResolutionCaches(): void {
 	// `prebuiltExtensionHookPaths` is intentionally not cleared: Bun cannot unregister a
 	// plugin, so the registered hooks outlive any cache reset. Clearing it would re-register
 	// a duplicate hook per entry on the next load.
-	prebuiltExtensionSources.clear();
-	prebuiltExtensionSourceRetainCounts.clear();
-	extensionGraphPreparedSources.clear();
-	extensionGraphPreparedRetainCounts.clear();
+	// Defer eviction of actively retained sources: an in-flight load's permanent onLoad may
+	// still need the retained snapshot. Entries with a nonzero retain count are left for
+	// releasePrebuiltExtensionSource/releaseGraphPreparedSource to clean up when the last
+	// load finishes.
+	for (const key of prebuiltExtensionSources.keys()) {
+		if ((prebuiltExtensionSourceRetainCounts.get(key) ?? 0) === 0) {
+			prebuiltExtensionSources.delete(key);
+		}
+	}
+	for (const key of extensionGraphPreparedSources.keys()) {
+		if ((extensionGraphPreparedRetainCounts.get(key) ?? 0) === 0) {
+			extensionGraphPreparedSources.delete(key);
+		}
+	}
 }
-
 registerPluginCacheInvalidator(clearLegacyPiResolutionCaches);
 const PACKAGE_IMPORT_EXCLUDED = Symbol("packageImportExcluded");
 
@@ -1426,51 +1435,62 @@ function escapeRegExp(value: string): string {
 // Extension source realpaths already covered by an installed load-time hook for
 // each entry. `Bun.plugin()` registrations are process-global and permanent, so
 // reloads install supplemental hooks only for modules added to the graph since
-// the previous load.
 const extensionGraphHookModules = new Map<string, Set<string>>();
 const extensionGraphCacheBustResolvedImportModules = new Map<string, Set<string>>();
-const prebuiltExtensionSources = new Map<string, string>();
+const prebuiltExtensionSources = new Map<string, Map<string, string>>();
 const prebuiltExtensionSourceRetainCounts = new Map<string, number>();
 // Raw graph-collected entry sources published for the permanent prebuilt onLoad to
 // reuse when the sidecar fast-path source was evicted (stale/missing). Retained for
 // the duration of each in-flight graph load so concurrent loads cannot starve each other.
-const extensionGraphPreparedSources = new Map<string, string>();
+const extensionGraphPreparedSources = new Map<string, Map<string, string>>();
 const extensionGraphPreparedRetainCounts = new Map<string, number>();
 const prebuiltExtensionHookPaths = new Set<string>();
 
-function retainPrebuiltExtensionSource(entryRealPath: string, source: string): void {
-	prebuiltExtensionSources.set(entryRealPath, source);
+function retainPrebuiltExtensionSource(entryRealPath: string, mtimeTag: string, source: string): void {
+	let byTag = prebuiltExtensionSources.get(entryRealPath);
+	if (!byTag) {
+		byTag = new Map<string, string>();
+		prebuiltExtensionSources.set(entryRealPath, byTag);
+	}
+	byTag.set(mtimeTag, source);
 	prebuiltExtensionSourceRetainCounts.set(
 		entryRealPath,
 		(prebuiltExtensionSourceRetainCounts.get(entryRealPath) ?? 0) + 1,
 	);
 }
 
-function releasePrebuiltExtensionSource(entryRealPath: string): void {
+function releasePrebuiltExtensionSource(entryRealPath: string, mtimeTag: string): void {
 	const count = prebuiltExtensionSourceRetainCounts.get(entryRealPath) ?? 0;
 	if (count <= 1) {
 		prebuiltExtensionSourceRetainCounts.delete(entryRealPath);
 		prebuiltExtensionSources.delete(entryRealPath);
 	} else {
 		prebuiltExtensionSourceRetainCounts.set(entryRealPath, count - 1);
+		prebuiltExtensionSources.get(entryRealPath)?.delete(mtimeTag);
 	}
 }
 
-function retainGraphPreparedSource(entryRealPath: string, source: string): void {
-	extensionGraphPreparedSources.set(entryRealPath, source);
+function retainGraphPreparedSource(entryRealPath: string, mtimeTag: string, source: string): void {
+	let byTag = extensionGraphPreparedSources.get(entryRealPath);
+	if (!byTag) {
+		byTag = new Map<string, string>();
+		extensionGraphPreparedSources.set(entryRealPath, byTag);
+	}
+	byTag.set(mtimeTag, source);
 	extensionGraphPreparedRetainCounts.set(
 		entryRealPath,
 		(extensionGraphPreparedRetainCounts.get(entryRealPath) ?? 0) + 1,
 	);
 }
 
-function releaseGraphPreparedSource(entryRealPath: string): void {
+function releaseGraphPreparedSource(entryRealPath: string, mtimeTag: string): void {
 	const count = extensionGraphPreparedRetainCounts.get(entryRealPath) ?? 0;
 	if (count <= 1) {
 		extensionGraphPreparedRetainCounts.delete(entryRealPath);
 		extensionGraphPreparedSources.delete(entryRealPath);
 	} else {
 		extensionGraphPreparedRetainCounts.set(entryRealPath, count - 1);
+		extensionGraphPreparedSources.get(entryRealPath)?.delete(mtimeTag);
 	}
 }
 
@@ -2079,7 +2099,7 @@ async function installExtensionGraphHook(
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
 					const mtimeTag = queryIndex >= 0 ? args.path.slice(queryIndex + "?mtime=".length) : null;
-					const prebuilt = prebuiltExtensionSources.get(sourcePath);
+					const prebuilt = prebuiltExtensionSources.get(sourcePath)?.get(mtimeTag ?? "");
 					if (prebuilt !== undefined) {
 						// A prebuilt sidecar hook supersedes any stale graph hook for this
 						// entry (e.g. after a same-process rebuild that added a sidecar).
@@ -2159,7 +2179,10 @@ async function installExtensionGraphHook(
  * during the initial load (including any graph-prepared entry published for the
  * permanent prebuilt hook); `undefined` when nothing was published or installed.
  */
-async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(): void } | undefined> {
+async function ensureExtensionGraphHook(
+	entryRealPath: string,
+	mtimeTag: string,
+): Promise<{ clear(): void } | undefined> {
 	const {
 		modules: currentModules,
 		commonJsPaths,
@@ -2187,7 +2210,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	const publishedEntrySource =
 		entryPreparedSource !== undefined && !commonJsPaths.has(entryRealPath) ? entryPreparedSource : undefined;
 	if (publishedEntrySource !== undefined) {
-		retainGraphPreparedSource(entryRealPath, publishedEntrySource);
+		retainGraphPreparedSource(entryRealPath, mtimeTag, publishedEntrySource);
 	}
 	let hookedModules = extensionGraphHookModules.get(entryRealPath);
 	if (!hookedModules) {
@@ -2207,7 +2230,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	}
 	const releasePublishedEntry = (): void => {
 		if (publishedEntrySource !== undefined) {
-			releaseGraphPreparedSource(entryRealPath);
+			releaseGraphPreparedSource(entryRealPath, mtimeTag);
 		}
 	};
 	if (pendingModules.size === 0 && commonJsPaths.size === 0) {
@@ -2367,11 +2390,12 @@ async function preparePrebuiltExtensionEntry(entryRealPath: string): Promise<str
 	return rewritten;
 }
 
-function installPrebuiltExtensionHook(entryRealPath: string, source: string): void {
-	// Reference-count concurrent loads of the same path: the first in-flight load must
-	// not delete the map entry while a second load's onLoad still needs it. loadLegacyPiModule
-	// releases in `finally` once the last retain drops to zero.
-	retainPrebuiltExtensionSource(entryRealPath, source);
+function installPrebuiltExtensionHook(entryRealPath: string, mtimeTag: string, source: string): void {
+	// Reference-count concurrent loads of the same path: each load retains its own
+	// source snapshot keyed by mtimeTag so concurrent loads with distinct ?mtime tags
+	// cannot overwrite each other's retained source. loadLegacyPiModule releases in
+	// `finally` once the last retain drops to zero.
+	retainPrebuiltExtensionSource(entryRealPath, mtimeTag, source);
 	if (!prebuiltExtensionHookPaths.has(entryRealPath)) {
 		prebuiltExtensionHookPaths.add(entryRealPath);
 		const filter = new RegExp(`^${escapeRegExp(entryRealPath)}(?:\\?mtime=\\d+)?$`);
@@ -2383,7 +2407,7 @@ function installPrebuiltExtensionHook(entryRealPath: string, source: string): vo
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
 					const mtimeTag = queryIndex >= 0 ? args.path.slice(queryIndex + "?mtime=".length) : null;
-					const contents = prebuiltExtensionSources.get(sourcePath);
+					const contents = prebuiltExtensionSources.get(sourcePath)?.get(mtimeTag ?? "");
 					if (contents !== undefined) {
 						return { contents, loader: getLoader(sourcePath) };
 					}
@@ -2392,7 +2416,7 @@ function installPrebuiltExtensionHook(entryRealPath: string, source: string): vo
 					// the graph-prepared raw source published by ensureExtensionGraphHook (fresh
 					// disk read from this load's collectExtensionModules) over opening the entry
 					// again. A genuine miss still falls back to disk.
-					const prepared = extensionGraphPreparedSources.get(sourcePath);
+					const prepared = extensionGraphPreparedSources.get(sourcePath)?.get(mtimeTag ?? "");
 					const raw = prepared !== undefined ? prepared : await Bun.file(sourcePath).text();
 					return {
 						contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag),
@@ -2441,6 +2465,14 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	// `bun link`/pnpm installs) so the rewrite filter matches the path Bun
 	// actually hands the hook.
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
+	// Generate the ?mtime tag before source preparation so each concurrent load
+	// can key its retained source by tag, isolating concurrent same-entry loads.
+	const mtimeTag = nextLegacyPiLoadTag();
+	// Serialize the complete source-preparation→import→cleanup lifetime per real
+	// entry path. Distinct paths stay concurrent; same-path loads wait until the
+	// prior load's `finally` releases retained state. Per-tag source isolation
+	// (mtimeTag-keyed maps) ensures concurrent loads with distinct tags cannot
+	// overwrite each other's retained sources once the gate releases.
 	return runSerializedLegacyPiModuleLoad(entryRealPath, async () => {
 		await ensureLegacyPiOverridesReady();
 		// `OMP_LEGACY_EXT_FULL_CRAWL=1` is an end-to-end recovery/diagnostic switch: skip the
@@ -2456,9 +2488,9 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 			// would defeat the hash check that rejected this sidecar.
 			prebuiltExtensionSources.delete(entryRealPath);
 			prebuiltExtensionSourceRetainCounts.delete(entryRealPath);
-			pendingSources = await ensureExtensionGraphHook(entryRealPath);
+			pendingSources = await ensureExtensionGraphHook(entryRealPath, mtimeTag);
 		} else {
-			installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
+			installPrebuiltExtensionHook(entryRealPath, mtimeTag, prebuiltSource);
 			retainedPrebuiltPath = entryRealPath;
 		}
 		try {
@@ -2470,7 +2502,7 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 				process.platform === "win32" || isBundledVirtualSpecifier(entryRealPath)
 					? toImportSpecifier(entryRealPath)
 					: entryRealPath;
-			return await import(`${entrySpecifier}?mtime=${nextLegacyPiLoadTag()}`);
+			return await import(`${entrySpecifier}?mtime=${mtimeTag}`);
 		} finally {
 			// Drop graph snapshots the initial import didn't consume: graph modules only
 			// reached by lazy dynamic imports must be read from disk at their actual import
@@ -2478,7 +2510,7 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 			// the last in-flight load for this path finishes (success or error).
 			pendingSources?.clear();
 			if (retainedPrebuiltPath !== undefined) {
-				releasePrebuiltExtensionSource(retainedPrebuiltPath);
+				releasePrebuiltExtensionSource(retainedPrebuiltPath, mtimeTag);
 			}
 		}
 	});

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -346,6 +346,7 @@ function clearLegacyPiResolutionCaches(): void {
 	nativeAddonRequireScanCache.clear();
 	nativeAddonLoaderModulePaths.clear();
 	realpathCache.clear();
+	prebuiltExtensionSources.clear();
 }
 
 registerPluginCacheInvalidator(clearLegacyPiResolutionCaches);
@@ -1421,6 +1422,8 @@ function escapeRegExp(value: string): string {
 // the previous load.
 const extensionGraphHookModules = new Map<string, Set<string>>();
 const extensionGraphCacheBustResolvedImportModules = new Map<string, Set<string>>();
+const prebuiltExtensionSources = new Map<string, string>();
+const prebuiltExtensionHookPaths = new Set<string>();
 const commonJsModuleSources = new Map<string, string>();
 const commonJsFallbackModulePaths = new Map<string, string>();
 const extensionSynchronousSpecifierTargets = new Map<string, Map<string, string>>();
@@ -2120,7 +2123,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			}
 		}
 	}
-	if (pendingModules.size === 0 && commonJsPaths.size === 0) {
+	if (pendingModules.size === 0 && pendingCommonJsPaths.size === 0) {
 		return undefined;
 	}
 
@@ -2150,6 +2153,155 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	};
 }
 
+const PREBUILT_IMPORT_SIDECAR_SUFFIX = ".omp-imports.json";
+const PREBUILT_IMPORT_SIDECAR_VERSION = 1;
+const prebuiltImportScanner = new Bun.Transpiler({ loader: "js" });
+
+interface PrebuiltImportRange {
+	readonly kind: "import-statement" | "dynamic-import";
+	readonly specifier: string;
+	readonly start: number;
+	readonly end: number;
+}
+
+interface PrebuiltImportSidecar {
+	readonly version: typeof PREBUILT_IMPORT_SIDECAR_VERSION;
+	readonly sha256: string;
+	readonly imports: readonly PrebuiltImportRange[];
+}
+
+function parsePrebuiltImportSidecar(value: unknown): PrebuiltImportSidecar | null {
+	if (!isRecord(value) || value.version !== PREBUILT_IMPORT_SIDECAR_VERSION || typeof value.sha256 !== "string") {
+		return null;
+	}
+	if (!Array.isArray(value.imports)) return null;
+	const imports: PrebuiltImportRange[] = [];
+	let previousEnd = -1;
+	for (const entry of value.imports) {
+		if (
+			!isRecord(entry) ||
+			(entry.kind !== "import-statement" && entry.kind !== "dynamic-import") ||
+			typeof entry.specifier !== "string" ||
+			typeof entry.start !== "number" ||
+			!Number.isSafeInteger(entry.start) ||
+			typeof entry.end !== "number" ||
+			!Number.isSafeInteger(entry.end) ||
+			entry.start < previousEnd ||
+			entry.end <= entry.start
+		) {
+			return null;
+		}
+		imports.push({
+			kind: entry.kind,
+			specifier: entry.specifier,
+			start: entry.start,
+			end: entry.end,
+		});
+		previousEnd = entry.end;
+	}
+	return { version: PREBUILT_IMPORT_SIDECAR_VERSION, sha256: value.sha256, imports };
+}
+
+function resolvePrebuiltHostImport(specifier: string): string | null | undefined {
+	const remapped = remapLegacyPiSpecifier(specifier);
+	if (remapped) {
+		try {
+			return toImportSpecifier(resolveCanonicalPiSpecifier(remapped));
+		} catch {
+			return undefined;
+		}
+	}
+	if (TYPEBOX_SHIM_PATH && (specifier === "typebox" || specifier === "@sinclair/typebox")) {
+		return toImportSpecifier(TYPEBOX_SHIM_PATH);
+	}
+	return isBuiltin(specifier) ? null : undefined;
+}
+
+async function preparePrebuiltExtensionEntry(entryRealPath: string): Promise<string | null> {
+	if (!entryRealPath.endsWith(".js") && !entryRealPath.endsWith(".mjs")) return null;
+	let source: string;
+	let sidecar: PrebuiltImportSidecar | null;
+	try {
+		source = await Bun.file(entryRealPath).text();
+		sidecar = parsePrebuiltImportSidecar(
+			JSON.parse(await Bun.file(`${entryRealPath}${PREBUILT_IMPORT_SIDECAR_SUFFIX}`).text()),
+		);
+	} catch {
+		return null;
+	}
+	if (!sidecar) return null;
+	const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
+	if (sha256 !== sidecar.sha256) return null;
+
+	const scanned = prebuiltImportScanner.scanImports(source);
+	if (scanned.length !== sidecar.imports.length) return null;
+	const replacements: Array<ExtensionSpecifierReference & { replacement: string }> = [];
+	for (let index = 0; index < scanned.length; index++) {
+		const found = scanned[index];
+		const declared = sidecar.imports[index];
+		if (
+			!found ||
+			!declared ||
+			found.kind !== declared.kind ||
+			found.path !== declared.specifier ||
+			source.slice(declared.start, declared.end) !== JSON.stringify(declared.specifier)
+		) {
+			return null;
+		}
+		if (declared.kind === "dynamic-import") {
+			if (!isBuiltin(declared.specifier)) return null;
+			continue;
+		}
+		const replacement = resolvePrebuiltHostImport(declared.specifier);
+		if (replacement === undefined) return null;
+		if (replacement !== null && replacement !== declared.specifier) {
+			replacements.push({
+				kind: "import",
+				specifier: declared.specifier,
+				start: declared.start,
+				end: declared.end,
+				replacement,
+			});
+		}
+	}
+	const rewritten = applySpecifierReplacements(source, replacements);
+	if (
+		prebuiltImportScanner.scanImports(rewritten).some(found => {
+			if (found.kind === "dynamic-import") return !isBuiltin(found.path);
+			return (
+				found.kind !== "import-statement" ||
+				(!isBuiltin(found.path) && !found.path.startsWith("file:") && !isBundledVirtualSpecifier(found.path))
+			);
+		})
+	) {
+		return null;
+	}
+	return rewritten;
+}
+
+function installPrebuiltExtensionHook(entryRealPath: string, source: string): { clear(): void } {
+	prebuiltExtensionSources.set(entryRealPath, source);
+	if (!prebuiltExtensionHookPaths.has(entryRealPath)) {
+		prebuiltExtensionHookPaths.add(entryRealPath);
+		const filter = new RegExp(`^${escapeRegExp(entryRealPath)}(?:\\?mtime=\\d+)?$`);
+		const hookId = Bun.hash(`${entryRealPath}\0prebuilt`).toString(36);
+		Bun.plugin({
+			name: `omp:legacy-pi-prebuilt:${hookId}`,
+			setup(build) {
+				build.onLoad({ filter, namespace: "file" }, args => {
+					const queryIndex = args.path.indexOf("?mtime=");
+					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
+					const contents = prebuiltExtensionSources.get(sourcePath);
+					if (contents === undefined) return undefined;
+					prebuiltExtensionSources.delete(sourcePath);
+					return { contents, loader: getLoader(sourcePath) };
+				});
+			},
+		});
+	}
+	return { clear: () => prebuiltExtensionSources.delete(entryRealPath) };
+}
+
 /**
  * Load a legacy Pi extension module from its real on-disk location.
  *
@@ -2167,7 +2319,11 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	// actually hands the hook.
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
 	await ensureLegacyPiOverridesReady();
-	const pendingSources = await ensureExtensionGraphHook(entryRealPath);
+	const prebuiltSource = await preparePrebuiltExtensionEntry(entryRealPath);
+	const pendingSources =
+		prebuiltSource === null
+			? await ensureExtensionGraphHook(entryRealPath)
+			: installPrebuiltExtensionHook(entryRealPath, prebuiltSource);
 	try {
 		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
 		// On POSIX, use the raw filesystem path so Bun keys the `?mtime`

--- a/packages/coding-agent/test/extensibility/legacy-pi-prebuilt-sidecar-lifetime.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-prebuilt-sidecar-lifetime.test.ts
@@ -64,7 +64,9 @@ describe("legacy-pi-compat prebuilt sidecar lifetime", () => {
 		fileSpy?.mockRestore();
 		__resetLegacyPiResolutionCache();
 		tempDir?.removeSync();
-		delete (globalThis as { __ompPrebuiltTestGate?: Promise<void> }).__ompPrebuiltTestGate;
+		delete (globalThis as { __ompPrebuiltTestGateA?: Promise<void> }).__ompPrebuiltTestGateA;
+		delete (globalThis as { __ompPrebuiltTestEnteredA?: () => void }).__ompPrebuiltTestEnteredA;
+		delete (globalThis as { __ompPrebuiltTestEnteredB?: () => void }).__ompPrebuiltTestEnteredB;
 	});
 
 	it("releases the retained prebuilt source after a successful import completes", async () => {
@@ -93,32 +95,51 @@ describe("legacy-pi-compat prebuilt sidecar lifetime", () => {
 		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(0);
 	});
 
-	it("keeps the prebuilt source for overlapping loads and releases only after the last finishes", async () => {
+	it("serializes same-path loads so a later snapshot cannot evaluate while an earlier load is still in-flight", async () => {
 		const entryPath = path.join(tempDir.absolute(), "overlap.js");
-		const { promise: gate, resolve: releaseGate } = Promise.withResolvers<void>();
-		(globalThis as { __ompPrebuiltTestGate?: Promise<void> }).__ompPrebuiltTestGate = gate;
-		const source = `await globalThis.__ompPrebuiltTestGate;\nexport const marker = "overlap";\n`;
-		fs.writeFileSync(entryPath, source, "utf8");
-		writeValidSidecar(entryPath, source);
+		const { promise: gateA, resolve: releaseA } = Promise.withResolvers<void>();
+		const { promise: enteredA, resolve: markEnteredA } = Promise.withResolvers<void>();
+		const { promise: enteredB, resolve: markEnteredB } = Promise.withResolvers<void>();
+		(globalThis as { __ompPrebuiltTestGateA?: Promise<void> }).__ompPrebuiltTestGateA = gateA;
+		(globalThis as { __ompPrebuiltTestEnteredA?: () => void }).__ompPrebuiltTestEnteredA = markEnteredA;
+		(globalThis as { __ompPrebuiltTestEnteredB?: () => void }).__ompPrebuiltTestEnteredB = markEnteredB;
+
+		const sourceV1 =
+			`globalThis.__ompPrebuiltTestEnteredA?.();\n` +
+			`await globalThis.__ompPrebuiltTestGateA;\n` +
+			`export const marker = "v1";\n`;
+		fs.writeFileSync(entryPath, sourceV1, "utf8");
+		writeValidSidecar(entryPath, sourceV1);
 		const entryRealPath = fs.realpathSync(entryPath);
 
 		const loadA = loadLegacyPiModule(entryPath);
+		await enteredA;
+
+		const sourceV2 = `globalThis.__ompPrebuiltTestEnteredB?.();\nexport const marker = "v2";\n`;
+		fs.writeFileSync(entryPath, sourceV2, "utf8");
+		writeValidSidecar(entryPath, sourceV2);
+
 		const loadB = loadLegacyPiModule(entryPath);
 
-		// Both imports are blocked on the shared gate inside module evaluation, so both
-		// retains must still be held (neither finally has run yet).
-		for (let i = 0; i < 50 && __getPrebuiltExtensionSourceRetainCountForTests(entryRealPath) < 2; i++) {
-			await Bun.sleep(5);
-		}
-		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(2);
+		// Without same-path serialization, B can prepare+evaluate v2 while A is still gated.
+		let v2EvaluatedEarly = false;
+		await Promise.race([
+			enteredB.then(() => {
+				v2EvaluatedEarly = true;
+			}),
+			Bun.sleep(50),
+		]);
+		expect(v2EvaluatedEarly).toBe(false);
 		expect(__hasRetainedPrebuiltExtensionSourceForTests(entryRealPath)).toBe(true);
-		releaseGate();
+
+		releaseA();
 
 		const [a, b] = (await Promise.all([loadA, loadB])) as [{ marker: string }, { marker: string }];
-		expect(a.marker).toBe("overlap");
-		expect(b.marker).toBe("overlap");
+		expect(a.marker).toBe("v1");
+		expect(b.marker).toBe("v2");
 		expect(__hasRetainedPrebuiltExtensionSourceForTests(entryRealPath)).toBe(false);
 		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(0);
+		expect(__hasGraphPreparedExtensionSourceForTests(entryRealPath)).toBe(false);
 	});
 
 	it("reuses the graph-prepared entry on a stale-sidecar reload instead of a third disk read", async () => {

--- a/packages/coding-agent/test/extensibility/legacy-pi-prebuilt-sidecar-lifetime.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-prebuilt-sidecar-lifetime.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+	__getPrebuiltExtensionSourceRetainCountForTests,
+	__hasGraphPreparedExtensionSourceForTests,
+	__hasRetainedPrebuiltExtensionSourceForTests,
+	__resetLegacyPiResolutionCache,
+	loadLegacyPiModule,
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import type { BunFile } from "bun";
+
+function writeValidSidecar(entryPath: string, source: string): void {
+	const imports = new Bun.Transpiler({ loader: "js" }).scanImports(source).map(found => {
+		const token = JSON.stringify(found.path);
+		const start = source.indexOf(token);
+		expect(start).toBeGreaterThanOrEqual(0);
+		expect(source.indexOf(token, start + token.length)).toBe(-1);
+		return { kind: found.kind, specifier: found.path, start, end: start + token.length };
+	});
+	const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
+	fs.writeFileSync(`${entryPath}.omp-imports.json`, JSON.stringify({ version: 1, sha256, imports }), "utf8");
+}
+
+describe("legacy-pi-compat prebuilt sidecar lifetime", () => {
+	let tempDir: TempDir;
+	let reads: Map<string, number>;
+	let fileSpy: Mock<typeof Bun.file>;
+
+	beforeEach(() => {
+		__resetLegacyPiResolutionCache();
+		tempDir = TempDir.createSync("@pi-prebuilt-lifetime-");
+		reads = new Map<string, number>();
+		const realBunFile = Bun.file.bind(Bun);
+		const spyImpl = (filePath: string | URL, options?: BlobPropertyBag): BunFile => {
+			const handle = realBunFile(filePath, options);
+			if (typeof filePath === "string") {
+				const key = fs.existsSync(filePath) ? fs.realpathSync(filePath) : filePath;
+				const bump = () => {
+					reads.set(key, (reads.get(key) ?? 0) + 1);
+				};
+				return new Proxy(handle, {
+					get(target: BunFile, prop: string | symbol, recv: unknown): unknown {
+						if (prop === "text" || prop === "arrayBuffer" || prop === "bytes" || prop === "json") {
+							const original = Reflect.get(target, prop, recv) as ((...a: unknown[]) => unknown) | undefined;
+							if (typeof original === "function") {
+								return (...methodArgs: unknown[]): unknown => {
+									bump();
+									return original.apply(target, methodArgs);
+								};
+							}
+						}
+						return Reflect.get(target, prop, recv);
+					},
+				});
+			}
+			return handle;
+		};
+		fileSpy = spyOn(Bun, "file").mockImplementation(spyImpl as typeof Bun.file);
+	});
+
+	afterEach(() => {
+		fileSpy?.mockRestore();
+		__resetLegacyPiResolutionCache();
+		tempDir?.removeSync();
+		delete (globalThis as { __ompPrebuiltTestGate?: Promise<void> }).__ompPrebuiltTestGate;
+	});
+
+	it("releases the retained prebuilt source after a successful import completes", async () => {
+		const entryPath = path.join(tempDir.absolute(), "ok.js");
+		const source = `export const marker = "ok";\n`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		writeValidSidecar(entryPath, source);
+		const entryRealPath = fs.realpathSync(entryPath);
+
+		const loaded = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(loaded.marker).toBe("ok");
+		expect(__hasRetainedPrebuiltExtensionSourceForTests(entryRealPath)).toBe(false);
+		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(0);
+		expect(__hasGraphPreparedExtensionSourceForTests(entryRealPath)).toBe(false);
+	});
+
+	it("releases the retained prebuilt source after an import error", async () => {
+		const entryPath = path.join(tempDir.absolute(), "boom.js");
+		const source = `throw new Error("prebuilt-boom");\n`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		writeValidSidecar(entryPath, source);
+		const entryRealPath = fs.realpathSync(entryPath);
+
+		await expect(loadLegacyPiModule(entryPath)).rejects.toThrow(/prebuilt-boom/);
+		expect(__hasRetainedPrebuiltExtensionSourceForTests(entryRealPath)).toBe(false);
+		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(0);
+	});
+
+	it("keeps the prebuilt source for overlapping loads and releases only after the last finishes", async () => {
+		const entryPath = path.join(tempDir.absolute(), "overlap.js");
+		const { promise: gate, resolve: releaseGate } = Promise.withResolvers<void>();
+		(globalThis as { __ompPrebuiltTestGate?: Promise<void> }).__ompPrebuiltTestGate = gate;
+		const source = `await globalThis.__ompPrebuiltTestGate;\nexport const marker = "overlap";\n`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		writeValidSidecar(entryPath, source);
+		const entryRealPath = fs.realpathSync(entryPath);
+
+		const loadA = loadLegacyPiModule(entryPath);
+		const loadB = loadLegacyPiModule(entryPath);
+
+		// Both imports are blocked on the shared gate inside module evaluation, so both
+		// retains must still be held (neither finally has run yet).
+		for (let i = 0; i < 50 && __getPrebuiltExtensionSourceRetainCountForTests(entryRealPath) < 2; i++) {
+			await Bun.sleep(5);
+		}
+		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(2);
+		expect(__hasRetainedPrebuiltExtensionSourceForTests(entryRealPath)).toBe(true);
+		releaseGate();
+
+		const [a, b] = (await Promise.all([loadA, loadB])) as [{ marker: string }, { marker: string }];
+		expect(a.marker).toBe("overlap");
+		expect(b.marker).toBe("overlap");
+		expect(__hasRetainedPrebuiltExtensionSourceForTests(entryRealPath)).toBe(false);
+		expect(__getPrebuiltExtensionSourceRetainCountForTests(entryRealPath)).toBe(0);
+	});
+
+	it("reuses the graph-prepared entry on a stale-sidecar reload instead of a third disk read", async () => {
+		const entryPath = path.join(tempDir.absolute(), "rebuilt.js");
+		const writeSidecar = (body: string, sha256?: string) => {
+			fs.writeFileSync(
+				`${entryPath}.omp-imports.json`,
+				JSON.stringify({
+					version: 1,
+					sha256: sha256 ?? new Bun.CryptoHasher("sha256").update(body).digest("hex"),
+					imports: [],
+				}),
+				"utf8",
+			);
+		};
+
+		const first = `export const marker = "v1";\n`;
+		fs.writeFileSync(entryPath, first, "utf8");
+		writeSidecar(first);
+		const initial = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(initial.marker).toBe("v1");
+		expect(__hasRetainedPrebuiltExtensionSourceForTests(fs.realpathSync(entryPath))).toBe(false);
+
+		reads.clear();
+		const second = `export const marker = "v2";\n`;
+		fs.writeFileSync(entryPath, second, "utf8");
+		writeSidecar(second, "stale");
+		const reloaded = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(reloaded.marker).toBe("v2");
+
+		const entryReads = reads.get(fs.realpathSync(entryPath)) ?? 0;
+		// preparePrebuiltExtensionEntry reads once to reject the hash; ensureExtensionGraphHook
+		// reads once while collecting. The permanent prebuilt onLoad must reuse that graph
+		// snapshot rather than opening the entry a third time.
+		expect(entryReads).toBe(2);
+		expect(__hasGraphPreparedExtensionSourceForTests(fs.realpathSync(entryPath))).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -149,6 +149,28 @@ export { ToolAbortError };
 		const loaded = (await loadLegacyPiModule(entryPath)) as { ToolAbortError: typeof ToolAbortError };
 		expect(loaded.ToolAbortError).toBe(ToolAbortError);
 	});
+
+	it("uses the prebuilt fast path exactly once for a valid sidecar", async () => {
+		const cwd = tempDir.absolute();
+		const entryPath = path.join(cwd, "fastpath.js");
+		const source = `export const marker = "fast";\n`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		const imports = new Bun.Transpiler({ loader: "js" }).scanImports(source).map(found => {
+			const token = JSON.stringify(found.path);
+			const start = source.indexOf(token);
+			return { kind: found.kind, specifier: found.path, start, end: start + token.length };
+		});
+		const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
+		fs.writeFileSync(`${entryPath}.omp-imports.json`, JSON.stringify({ version: 1, sha256, imports }), "utf8");
+
+		const loaded = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(loaded.marker).toBe("fast");
+		// Both reads pin the fast path: the sidecar count fails if the sidecar is never
+		// consulted (fast path removed), and the entry count fails if a valid sidecar is
+		// rejected, because the graph fallback reads the entry again in collectExtensionModules.
+		expect(reads.get(fs.realpathSync(`${entryPath}.omp-imports.json`)) ?? 0).toBe(1);
+		expect(reads.get(fs.realpathSync(entryPath)) ?? 0).toBe(1);
+	});
 	it("falls back to graph loading when a prebuilt sidecar is stale", async () => {
 		const cwd = tempDir.absolute();
 		const dependencyPath = path.join(cwd, "dependency.ts");
@@ -163,6 +185,36 @@ export { ToolAbortError };
 
 		const loaded = (await loadLegacyPiModule(entryPath)) as { value: string };
 		expect(loaded.value).toBe("fallback");
+	});
+	it("still loads a fast-path entry on a later load once its sidecar goes stale", async () => {
+		const cwd = tempDir.absolute();
+		const entryPath = path.join(cwd, "rebuilt.js");
+		const writeSidecar = (source: string, sha256?: string) => {
+			fs.writeFileSync(
+				`${entryPath}.omp-imports.json`,
+				JSON.stringify({
+					version: 1,
+					sha256: sha256 ?? new Bun.CryptoHasher("sha256").update(source).digest("hex"),
+					imports: [],
+				}),
+				"utf8",
+			);
+		};
+
+		const first = `export const marker = "v1";\n`;
+		fs.writeFileSync(entryPath, first, "utf8");
+		writeSidecar(first);
+		const initial = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(initial.marker).toBe("v1");
+
+		// The first load registers a permanent prebuilt hook. Rebuilding the entry without
+		// refreshing its sidecar evicts the retained source, so that hook must still serve
+		// the rebuilt entry instead of failing the load.
+		const second = `export const marker = "v2";\n`;
+		fs.writeFileSync(entryPath, second, "utf8");
+		writeSidecar(second, "stale");
+		const reloaded = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(reloaded.marker).toBe("v2");
 	});
 	it("rejects a hash-valid sidecar range that does not point at the import", async () => {
 		const cwd = tempDir.absolute();

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { loadLegacyPiModule } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import type { BunFile } from "bun";
 
@@ -126,5 +127,66 @@ export default function(pi) {
 		fs.writeFileSync(lazyPath, `export const value = "after";\n`, "utf-8");
 
 		expect(await ns.readLazy()).toBe("after");
+	});
+
+	it("loads a verified prebuilt entry without duplicating host modules", async () => {
+		const cwd = tempDir.absolute();
+		const entryPath = path.join(cwd, "prebuilt.js");
+		const source = `import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+export { ToolAbortError };
+`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		const imports = new Bun.Transpiler({ loader: "js" }).scanImports(source).map(found => {
+			const token = JSON.stringify(found.path);
+			const start = source.indexOf(token);
+			expect(start).toBeGreaterThanOrEqual(0);
+			expect(source.indexOf(token, start + token.length)).toBe(-1);
+			return { kind: found.kind, specifier: found.path, start, end: start + token.length };
+		});
+		const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
+		fs.writeFileSync(`${entryPath}.omp-imports.json`, JSON.stringify({ version: 1, sha256, imports }), "utf8");
+
+		const loaded = (await loadLegacyPiModule(entryPath)) as { ToolAbortError: typeof ToolAbortError };
+		expect(loaded.ToolAbortError).toBe(ToolAbortError);
+	});
+	it("falls back to graph loading when a prebuilt sidecar is stale", async () => {
+		const cwd = tempDir.absolute();
+		const dependencyPath = path.join(cwd, "dependency.ts");
+		const entryPath = path.join(cwd, "stale.js");
+		fs.writeFileSync(dependencyPath, `export const value = "fallback";\n`, "utf8");
+		fs.writeFileSync(entryPath, `export { value } from "./dependency.ts";\n`, "utf8");
+		fs.writeFileSync(
+			`${entryPath}.omp-imports.json`,
+			JSON.stringify({ version: 1, sha256: "stale", imports: [] }),
+			"utf8",
+		);
+
+		const loaded = (await loadLegacyPiModule(entryPath)) as { value: string };
+		expect(loaded.value).toBe("fallback");
+	});
+	it("rejects a hash-valid sidecar range that does not point at the import", async () => {
+		const cwd = tempDir.absolute();
+		const entryPath = path.join(cwd, "misdirected.js");
+		const specifier = "@mariozechner/pi-coding-agent/tools/tool-errors";
+		const token = JSON.stringify(specifier);
+		const source = `const bait = ${token};
+import { ToolAbortError } from ${token};
+export { ToolAbortError };
+`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		const start = source.indexOf(token);
+		const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
+		fs.writeFileSync(
+			`${entryPath}.omp-imports.json`,
+			JSON.stringify({
+				version: 1,
+				sha256,
+				imports: [{ kind: "import-statement", specifier, start, end: start + token.length }],
+			}),
+			"utf8",
+		);
+
+		const loaded = (await loadLegacyPiModule(entryPath)) as { ToolAbortError: typeof ToolAbortError };
+		expect(loaded.ToolAbortError).toBe(ToolAbortError);
 	});
 });

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -252,4 +252,91 @@ export { ToolAbortError };
 		const loaded = (await loadLegacyPiModule(entryPath)) as { ToolAbortError: typeof ToolAbortError };
 		expect(loaded.ToolAbortError).toBe(ToolAbortError);
 	});
+
+	it("forces the graph path under OMP_LEGACY_EXT_FULL_CRAWL=1 even with a valid sidecar", async () => {
+		const cwd = tempDir.absolute();
+		const entryPath = path.join(cwd, "forced-crawl.js");
+		const source = `import { ToolAbortError } from "@mariozechner/pi-coding-agent/tools/tool-errors";
+export { ToolAbortError };
+`;
+		fs.writeFileSync(entryPath, source, "utf8");
+		const imports = new Bun.Transpiler({ loader: "js" }).scanImports(source).map(found => {
+			const token = JSON.stringify(found.path);
+			const start = source.indexOf(token);
+			expect(start).toBeGreaterThanOrEqual(0);
+			expect(source.indexOf(token, start + token.length)).toBe(-1);
+			return { kind: found.kind, specifier: found.path, start, end: start + token.length };
+		});
+		const sha256 = new Bun.CryptoHasher("sha256").update(source).digest("hex");
+		const sidecarPath = `${entryPath}.omp-imports.json`;
+		fs.writeFileSync(sidecarPath, JSON.stringify({ version: 1, sha256, imports }), "utf8");
+		const sidecarReal = fs.realpathSync(sidecarPath);
+
+		// Env is fixed at spawn so FORCE_FULL_EXTENSION_CRAWL is true when the child
+		// statically imports the compat module; wrap Bun.file only after that import.
+		const probe = `
+import { spyOn } from "bun:test";
+import * as fs from "node:fs";
+import { loadLegacyPiModule } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+
+const entryPath = ${JSON.stringify(entryPath)};
+const sidecarReal = ${JSON.stringify(sidecarReal)};
+const reads = new Map();
+const realBunFile = Bun.file.bind(Bun);
+spyOn(Bun, "file").mockImplementation((filePath, options) => {
+	const handle = realBunFile(filePath, options);
+	if (typeof filePath === "string") {
+		const key = fs.existsSync(filePath) ? fs.realpathSync(filePath) : filePath;
+		const bump = () => {
+			reads.set(key, (reads.get(key) ?? 0) + 1);
+		};
+		return new Proxy(handle, {
+			get(target, prop, recv) {
+				if (prop === "text" || prop === "arrayBuffer" || prop === "bytes" || prop === "json") {
+					const original = Reflect.get(target, prop, recv);
+					if (typeof original === "function") {
+						return (...methodArgs) => {
+							bump();
+							return original.apply(target, methodArgs);
+						};
+					}
+				}
+				return Reflect.get(target, prop, recv);
+			},
+		});
+	}
+	return handle;
+});
+
+const loaded = await loadLegacyPiModule(entryPath);
+process.stdout.write(JSON.stringify({
+	sidecarReads: reads.get(sidecarReal) ?? 0,
+	sameIdentity: loaded.ToolAbortError === ToolAbortError,
+}));
+`;
+
+		const proc = Bun.spawn([process.execPath, "-e", probe], {
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			env: { ...process.env, OMP_LEGACY_EXT_FULL_CRAWL: "1" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const watchdog = setTimeout(() => {
+			try {
+				proc.kill("SIGKILL");
+			} catch {}
+		}, 15_000);
+		try {
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			expect(exitCode, stderr).toBe(0);
+			expect(JSON.parse(stdout)).toEqual({ sidecarReads: 0, sameIdentity: true });
+		} finally {
+			clearTimeout(watchdog);
+		}
+	});
 });

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -171,6 +171,17 @@ export { ToolAbortError };
 		expect(reads.get(fs.realpathSync(`${entryPath}.omp-imports.json`)) ?? 0).toBe(1);
 		expect(reads.get(fs.realpathSync(entryPath)) ?? 0).toBe(1);
 	});
+	it("reads a sidecar-less JS entry from disk only once", async () => {
+		const cwd = tempDir.absolute();
+		const entryPath = path.join(cwd, "plain.js");
+		fs.writeFileSync(entryPath, `export const marker = "plain";\n`, "utf8");
+
+		const loaded = (await loadLegacyPiModule(entryPath)) as { marker: string };
+		expect(loaded.marker).toBe("plain");
+		// Backward-compatible path: with no sidecar the fast path must bail before opening
+		// the entry, leaving the graph loader as its only reader.
+		expect(reads.get(fs.realpathSync(entryPath)) ?? 0).toBe(1);
+	});
 	it("falls back to graph loading when a prebuilt sidecar is stale", async () => {
 		const cwd = tempDir.absolute();
 		const dependencyPath = path.join(cwd, "dependency.ts");


### PR DESCRIPTION
## Summary

Prebuilt ESM plugins currently pay the full legacy Babel graph scan (`@babel/parser` + `@babel/traverse`) on every OMP startup, costing several seconds per multi-megabyte bundle. This adds an opt-in fast path: a plugin can ship a hash-bound `.omp-imports.json` sidecar next to its built entry, and the loader skips the Babel scan for it.

The loader, for an entry that has a sidecar:
1. Reads the entry source and the sidecar, parses the sidecar, and rejects it unless `version === 1` and every import entry is well-formed (kind in `{import-statement, dynamic-import}`, integer non-overlapping ranges).
2. Computes the SHA-256 of the exact entry source and rejects on mismatch.
3. Rescans the entry with `Bun.Transpiler.scanImports` and verifies the scan matches the sidecar one-for-one (same order, kind, specifier, and that each declared range slices to the exact JSON-quoted specifier token in source).
4. Rewrites only the declared host imports (remapped `@oh-my-pi/*`, TypeBox shim, builtins) by byte range, then rescans the rewritten source and falls back if any unsupported bare import remains.

On any validation failure — missing sidecar, stale hash, range mismatch, unsupported import — the loader returns `null` and the existing `ensureExtensionGraphHook` Babel path runs unchanged. Reload semantics are preserved: the prebuilt hook is consume-once per `?mtime` tag, registered once per entry path, and its source cache is cleared by the existing `clearLegacyPiResolutionCaches` invalidator.

## Why

Measured on the two slow plugins in `~/odin`, the loader-only cost for a 0.87 MB / 2.26 MB bundle dropped from ~1.7 s / ~2.7 s to ~0.9 s / ~1.1 s once a valid sidecar is present, and the combined two-plugin CLI startup overhead fell from ~7.7 s to ~1.0 s. The companion plugin-side build scripts that emit the sidecar live in the plugin repos, not here; this PR is the host contract they target, and it is fully backward compatible (no sidecar ⇒ old path).

## Tests

Added three cases to `extension-loader-graph-read-dedup.test.ts`:
- a verified prebuilt entry loads and exposes the host's exact `ToolAbortError` reference (proves no duplicate host runtime);
- a stale-hash sidecar falls back to graph loading;
- a hash-valid sidecar whose range points at the specifier text inside a string literal (not the import) is rejected and falls back.

All three existing extension-loader suites (`graph-read-dedup`, `self-import`, `process-exit`) pass (13/13), and `check:types` is clean.

## Notes

- No `@oh-my-pi/*` runtime identity change: host imports still resolve through the canonical `resolveCanonicalPiSpecifier` / `toImportSpecifier` path.
- `dist/` sidecar generation is the plugin's responsibility; this PR only consumes a valid sidecar when present.


Closes #6612
