### PR TITLE
fix(ai): preserved Bedrock ARN thinking signatures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bedrock Converse dropping captured Claude thinking signatures when replaying application-inference-profile ARN models, restoring adaptive-thinking multi-turn conversations ([#6610](https://github.com/can1357/oh-my-pi/issues/6610)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -830,10 +830,9 @@ function convertMessages(
 						case "thinking":
 							// Skip empty thinking blocks
 							if (c.thinking.trim().length === 0) continue;
-							// Thinking blocks require a valid signature when sent as reasoningContent.
-							// If the signature is missing (e.g., from an aborted stream), or the model
-							// doesn't support signatures, convert to plain text instead.
-							if (supportsThinkingSignature(model) && c.thinkingSignature) {
+							// A captured signature is authoritative even when the model id is an opaque ARN.
+							// Without one, known non-Claude families use unsigned reasoning; known Claude ids demote to text.
+							if (c.thinkingSignature) {
 								contentBlocks.push({
 									reasoningContent: {
 										reasoningText: { text: c.thinking.toWellFormed(), signature: c.thinkingSignature },

--- a/packages/ai/test/bedrock-inference-profile.test.ts
+++ b/packages/ai/test/bedrock-inference-profile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { withEnv } from "./helpers";
 
 const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
@@ -16,6 +17,11 @@ const profileModel: Model<"bedrock-converse-stream"> = buildModel({
 	cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
 	contextWindow: 1000000,
 	maxTokens: 128000,
+	thinking: {
+		mode: "anthropic-adaptive",
+		efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.Max],
+		supportsDisplay: true,
+	},
 });
 
 function userContext(): Context {
@@ -45,6 +51,72 @@ describe("Bedrock inference profile ARNs", () => {
 		expect(calls).toEqual([
 			`https://bedrock-runtime.us-east-2.amazonaws.com/model/${encodeURIComponent(profileArn)}/converse-stream`,
 		]);
+	});
+
+	test("replays captured thinking signatures for ARN profiles", async () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Plan the change", timestamp: 0 },
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "Inspect the implementation", thinkingSignature: "signed-reasoning" },
+						{ type: "text", text: "I found the relevant code." },
+					],
+					api: "bedrock-converse-stream",
+					provider: "amazon-bedrock",
+					model: profileArn,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: 1,
+				},
+				{ role: "user", content: "Continue", timestamp: 2 },
+			],
+		};
+		const controller = new AbortController();
+		controller.abort();
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+
+		void streamBedrock(profileModel, context, {
+			signal: controller.signal,
+			reasoning: Effort.High,
+			maxTokens: 16,
+			onPayload: payload => {
+				resolve(payload);
+			},
+		});
+
+		expect(await promise).toMatchObject({
+			additionalModelRequestFields: {
+				thinking: { type: "adaptive", display: "summarized" },
+				output_config: { effort: "high" },
+			},
+			messages: [
+				{ role: "user", content: [{ text: "Plan the change" }] },
+				{
+					role: "assistant",
+					content: [
+						{
+							reasoningContent: {
+								reasoningText: {
+									text: "Inspect the implementation",
+									signature: "signed-reasoning",
+								},
+							},
+						},
+						{ text: "I found the relevant code." },
+					],
+				},
+				{ role: "user", content: [{ text: "Continue" }] },
+			],
+		});
 	});
 });
 


### PR DESCRIPTION
## Repro

With a Claude-backed application-inference-profile ARN and a stored assistant thinking block carrying `thinkingSignature`, `bun test packages/ai/test/bedrock-inference-profile.test.ts` captured the second-turn Bedrock request without `reasoningContent.reasoningText.signature`; the focused suite failed 1/12 before the fix.

## Cause

`convertMessages` in `packages/ai/src/providers/amazon-bedrock.ts` gated signed replay on `supportsThinkingSignature(model)`, which infers Claude membership from `model.id`; opaque application-inference-profile ARNs therefore took the unsigned reasoning branch even when the earlier Bedrock stream had supplied a signature.

## Fix

- Replay every captured Bedrock thinking signature as authoritative transport metadata, independent of the model-id form.
- Retain model-family detection only for missing-signature fallback behavior.
- Cover adaptive-thinking ARN replay in `packages/ai/test/bedrock-inference-profile.test.ts` and document the fix in the AI changelog.

## Verification

`bun test packages/ai/test/bedrock-inference-profile.test.ts` passes 12/12; `bun test packages/ai/test/bedrock-inference-profile.test.ts packages/ai/test/bedrock-prompt-cache.test.ts` passes 22/22; the pre-publish `bun run fix` and `bun check` gate passed. Fixes #6610