### PR TITLE
fix(coding-agent): source auth-gateway catalog from ModelRegistry

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp auth-gateway serve` advertising only the compiled-in bundled catalog, so every model omp reaches through provider discovery (e.g. ids released after the build date) was invisible on `/v1/models` and returned `Unknown model` through `/v1/chat/completions` even though the same broker credential answered it in the TUI. The gateway now sources its catalog from `ModelRegistry` — the same component the TUI/CLI use (bundled + cached + discovered) — keeping the credential scoping and qualified/bare-id registration, and rebuilds it periodically so a long-lived `serve` tracks newly discovered models without a restart ([#6615](https://github.com/can1357/oh-my-pi/issues/6615)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/cli/__tests__/auth-gateway-catalog.test.ts
+++ b/packages/coding-agent/src/cli/__tests__/auth-gateway-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../../config/model-registry";
 import { indexModelsByRequestId } from "../auth-gateway-cli";
 
@@ -46,6 +47,40 @@ describe("indexModelsByRequestId (auth-gateway catalog)", () => {
 		// "Unknown model" when the index was built from getBundledModels only.
 		expect(index.get("anthropic/claude-opus-5-repro")?.id).toBe("claude-opus-5-repro");
 		expect(index.get("claude-opus-5-repro")?.id).toBe("claude-opus-5-repro");
+	});
+
+	test("ignores client-side pi-native routing in the gateway registry", async () => {
+		using tempDir = TempDir.createSync("@omp-auth-gateway-catalog-");
+		const modelsPath = tempDir.join("models.yml");
+		await Bun.write(
+			modelsPath,
+			[
+				"providers:",
+				"  anthropic:",
+				"    baseUrl: http://127.0.0.1:18899",
+				"    apiKey: gateway-token",
+				"    transport: pi-native",
+				"",
+			].join("\n"),
+		);
+
+		const clientRegistry = new ModelRegistry(stubAuthStorage(), modelsPath);
+		const routedModel = clientRegistry.find("anthropic", "claude-sonnet-4-5");
+		expect(routedModel?.transport).toBe("pi-native");
+		expect(routedModel?.baseUrl).toBe("http://127.0.0.1:18899");
+
+		const gatewayRegistry = new ModelRegistry(stubAuthStorage(), modelsPath, {
+			ignorePiNativeProviderConfig: true,
+		});
+		const gatewayModel = gatewayRegistry.find("anthropic", "claude-sonnet-4-5");
+		const bundledModel = getBundledModels("anthropic").find(model => model.id === "claude-sonnet-4-5");
+		if (!gatewayModel || !bundledModel) throw new Error("expected bundled Anthropic model");
+
+		expect(gatewayModel.transport).toBeUndefined();
+		expect(gatewayModel.baseUrl).toBe(bundledModel.baseUrl);
+		expect(indexModelsByRequestId(gatewayRegistry.getAll(), new Set(["anthropic"])).get(gatewayModel.id)).toBe(
+			gatewayModel,
+		);
 	});
 
 	test("scopes the catalog to providers with credentials", () => {

--- a/packages/coding-agent/src/cli/__tests__/auth-gateway-catalog.test.ts
+++ b/packages/coding-agent/src/cli/__tests__/auth-gateway-catalog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "../../config/model-registry";
+import { indexModelsByRequestId } from "../auth-gateway-cli";
+
+function stubAuthStorage(): AuthStorage {
+	const stub = {
+		setFallbackResolver: () => {},
+		clearConfigApiKeys: () => {},
+		setConfigApiKey: () => {},
+		removeConfigApiKey: () => {},
+		hasAuth: () => true,
+		getAll: () => ({ anthropic: {} }),
+	};
+	return stub as unknown as AuthStorage;
+}
+
+describe("indexModelsByRequestId (auth-gateway catalog)", () => {
+	test("resolves a discovery-only model absent from the bundled catalog", () => {
+		const registry = new ModelRegistry(stubAuthStorage());
+		// Simulate a model reached via provider discovery but not compiled into
+		// the bundle (e.g. a post-release id). registerProvider merges it into
+		// getAll() exactly as runtime discovery does.
+		registry.registerProvider("anthropic", {
+			baseUrl: "https://api.anthropic.com",
+			api: "anthropic-messages",
+			apiKey: "test-key",
+			models: [
+				{
+					id: "claude-opus-5-repro",
+					name: "Claude Opus 5 (repro)",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+			],
+		});
+		expect(getBundledModels("anthropic").map(m => m.id)).not.toContain("claude-opus-5-repro");
+
+		const index = indexModelsByRequestId(registry.getAll(), new Set(["anthropic"]));
+
+		// The gateway can now resolve it by qualified id and bare id — was
+		// "Unknown model" when the index was built from getBundledModels only.
+		expect(index.get("anthropic/claude-opus-5-repro")?.id).toBe("claude-opus-5-repro");
+		expect(index.get("claude-opus-5-repro")?.id).toBe("claude-opus-5-repro");
+	});
+
+	test("scopes the catalog to providers with credentials", () => {
+		const registry = new ModelRegistry(stubAuthStorage());
+		const all = registry.getAll();
+		const anthropicModel = all.find(m => m.provider === "anthropic");
+		const foreignModel = all.find(m => m.provider !== "anthropic");
+		if (!anthropicModel || !foreignModel) throw new Error("expected mixed-provider bundled catalog");
+
+		const index = indexModelsByRequestId(all, new Set(["anthropic"]));
+
+		expect(index.get(`anthropic/${anthropicModel.id}`)).toBeDefined();
+		expect(index.get(`${foreignModel.provider}/${foreignModel.id}`)).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/src/cli/__tests__/auth-gateway-catalog.test.ts
+++ b/packages/coding-agent/src/cli/__tests__/auth-gateway-catalog.test.ts
@@ -5,11 +5,11 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../../config/model-registry";
 import { indexModelsByRequestId } from "../auth-gateway-cli";
 
-function stubAuthStorage(): AuthStorage {
+function stubAuthStorage(configKeys?: string[]): AuthStorage {
 	const stub = {
 		setFallbackResolver: () => {},
 		clearConfigApiKeys: () => {},
-		setConfigApiKey: () => {},
+		setConfigApiKey: (provider: string) => configKeys?.push(provider),
 		removeConfigApiKey: () => {},
 		hasAuth: () => true,
 		getAll: () => ({ anthropic: {} }),
@@ -49,9 +49,11 @@ describe("indexModelsByRequestId (auth-gateway catalog)", () => {
 		expect(index.get("claude-opus-5-repro")?.id).toBe("claude-opus-5-repro");
 	});
 
-	test("ignores client-side pi-native routing in the gateway registry", async () => {
+	test("gateway registry ignores local models.yml credential and routing overrides", async () => {
 		using tempDir = TempDir.createSync("@omp-auth-gateway-catalog-");
 		const modelsPath = tempDir.join("models.yml");
+		// anthropic: a plain credential/baseUrl override (no transport) — the
+		// reviewer's leak. openai: a pi-native gateway route — the self-routing loop.
 		await Bun.write(
 			modelsPath,
 			[
@@ -59,25 +61,36 @@ describe("indexModelsByRequestId (auth-gateway catalog)", () => {
 				"  anthropic:",
 				"    baseUrl: http://127.0.0.1:18899",
 				"    apiKey: gateway-token",
+				"  openai:",
+				"    baseUrl: http://127.0.0.1:18899",
+				"    apiKey: gateway-token",
 				"    transport: pi-native",
 				"",
 			].join("\n"),
 		);
 
-		const clientRegistry = new ModelRegistry(stubAuthStorage(), modelsPath);
-		const routedModel = clientRegistry.find("anthropic", "claude-sonnet-4-5");
-		expect(routedModel?.transport).toBe("pi-native");
-		expect(routedModel?.baseUrl).toBe("http://127.0.0.1:18899");
+		// A normal client registry applies the local overrides and installs the
+		// config API keys into AuthStorage.
+		const clientKeys: string[] = [];
+		const clientRegistry = new ModelRegistry(stubAuthStorage(clientKeys), modelsPath);
+		expect(clientRegistry.find("anthropic", "claude-sonnet-4-5")?.baseUrl).toBe("http://127.0.0.1:18899");
+		expect(clientRegistry.getAll().find(model => model.provider === "openai")?.transport).toBe("pi-native");
+		expect(clientKeys).toContain("anthropic");
 
-		const gatewayRegistry = new ModelRegistry(stubAuthStorage(), modelsPath, {
-			ignorePiNativeProviderConfig: true,
+		// The gateway registry ignores models.yml entirely: bundled routing wins,
+		// no config key reaches AuthStorage, and no pi-native self-route survives.
+		const gatewayKeys: string[] = [];
+		const gatewayRegistry = new ModelRegistry(stubAuthStorage(gatewayKeys), modelsPath, {
+			ignoreLocalModelConfig: true,
 		});
 		const gatewayModel = gatewayRegistry.find("anthropic", "claude-sonnet-4-5");
 		const bundledModel = getBundledModels("anthropic").find(model => model.id === "claude-sonnet-4-5");
 		if (!gatewayModel || !bundledModel) throw new Error("expected bundled Anthropic model");
 
-		expect(gatewayModel.transport).toBeUndefined();
 		expect(gatewayModel.baseUrl).toBe(bundledModel.baseUrl);
+		expect(gatewayModel.transport).toBeUndefined();
+		expect(gatewayKeys).toHaveLength(0);
+		expect(gatewayRegistry.getAll().find(model => model.provider === "openai")?.transport).toBeUndefined();
 		expect(indexModelsByRequestId(gatewayRegistry.getAll(), new Set(["anthropic"])).get(gatewayModel.id)).toBe(
 			gatewayModel,
 		);

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -31,9 +31,10 @@ import {
 	type SnapshotResponse,
 } from "@oh-my-pi/pi-ai/auth-broker";
 import { DEFAULT_AUTH_GATEWAY_BIND, startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
-import { type GeneratedProvider, getBundledModels, getBundledProviders } from "@oh-my-pi/pi-catalog/models";
-import { getConfigRootDir, isEnoent, VERSION } from "@oh-my-pi/pi-utils";
+import { type GeneratedProvider, getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { getConfigRootDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
+import { ModelRegistry } from "../config/model-registry";
 import { type AuthBrokerClientConfig, resolveAuthBrokerConfig } from "../session/auth-broker-config";
 
 export type AuthGatewayAction = "serve" | "token" | "status" | "check";
@@ -140,6 +141,33 @@ async function fetchBrokerSnapshot(client: AuthBrokerClient): Promise<SnapshotRe
 	return result.snapshot;
 }
 
+/**
+ * How often a long-lived `serve` rebuilds its catalog from the registry so
+ * models discovered after boot become routable without a restart. `refresh()`
+ * reuses the `models.db` cache and only hits the network when a provider's
+ * cached row is stale, so a short interval stays cheap.
+ */
+const CATALOG_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Index resolvable models by the request ids clients may send: the
+ * provider-qualified `provider/id` (always) and the bare `id` (first-write-wins
+ * fallback for legacy clients). Scoped to providers the gateway holds broker
+ * credentials for, since only those are routable.
+ */
+export function indexModelsByRequestId(
+	models: readonly Model<Api>[],
+	providersWithCreds: ReadonlySet<string>,
+): Map<string, Model<Api>> {
+	const modelById = new Map<string, Model<Api>>();
+	for (const model of models) {
+		if (!providersWithCreds.has(model.provider)) continue;
+		modelById.set(`${model.provider}/${model.id}`, model);
+		if (!modelById.has(model.id)) modelById.set(model.id, model);
+	}
+	return modelById;
+}
+
 async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	const brokerConfig = await resolveAuthBrokerConfig();
 	if (!brokerConfig) {
@@ -169,23 +197,20 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	});
 	await storage.reload();
 
-	// Build the model resolver + catalog from pi-ai's bundled metadata, scoped
-	// to providers we hold credentials for. Format handlers ask `resolveModel`
-	// to translate a client-requested `model` field into a pi-ai `Model<Api>`
-	// before dispatch; `listModels` powers `/v1/models`.
+	// Build the model resolver + catalog from the ModelRegistry — the same
+	// component the TUI/CLI use — scoped to providers we hold credentials for.
+	// `getAll()` is a superset of the bundled catalog (bundled first, then
+	// cached + discovered), so the discovery-only models omp itself reaches
+	// become routable through the gateway instead of freezing on the compiled
+	// snapshot. Format handlers ask `resolveModel` to translate a
+	// client-requested `model` field into a pi-ai `Model<Api>` before dispatch;
+	// `listModels` powers `/v1/models`.
 	const snapshot = storage.exportSnapshot();
 	const providersWithCreds = new Set<string>();
 	for (const entry of snapshot.credentials) providersWithCreds.add(entry.provider);
-	const modelById = new Map<string, Model<Api>>();
-	for (const provider of getBundledProviders()) {
-		if (!providersWithCreds.has(provider)) continue;
-		for (const model of getBundledModels(provider as GeneratedProvider)) {
-			// Always set the qualified key (no collision possible)
-			modelById.set(`${model.provider}/${model.id}`, model);
-			// Bare id as fallback for legacy clients (first-write-wins)
-			if (!modelById.has(model.id)) modelById.set(model.id, model);
-		}
-	}
+	const registry = new ModelRegistry(storage);
+	await registry.refresh();
+	let modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds);
 
 	const handle = startAuthGateway({
 		storage,
@@ -203,12 +228,31 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	}
 	process.stdout.write(`upstream broker: ${brokerConfig.url}\n`);
 
+	// `serve` is long-lived: rebuild the catalog periodically so models
+	// discovered after boot become routable without a restart. A failed refresh
+	// keeps serving the previous catalog. `unref()` so the timer never keeps the
+	// process alive on its own.
+	const catalogRefresh = setInterval(() => {
+		void registry
+			.refresh()
+			.then(() => {
+				modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds);
+			})
+			.catch(error => {
+				logger.warn("auth-gateway catalog refresh failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+	}, CATALOG_REFRESH_INTERVAL_MS);
+	catalogRefresh.unref();
+
 	const stopped = Promise.withResolvers<void>();
 	let shutdownStarted = false;
 	const stop = async (signal: NodeJS.Signals): Promise<void> => {
 		if (shutdownStarted) return;
 		shutdownStarted = true;
 		process.stdout.write(`\nReceived ${signal}, shutting down...\n`);
+		clearInterval(catalogRefresh);
 		let closeError: unknown;
 		try {
 			await handle.close();

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -208,7 +208,7 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	const snapshot = storage.exportSnapshot();
 	const providersWithCreds = new Set<string>();
 	for (const entry of snapshot.credentials) providersWithCreds.add(entry.provider);
-	const registry = new ModelRegistry(storage);
+	const registry = new ModelRegistry(storage, undefined, { ignorePiNativeProviderConfig: true });
 	await registry.refresh();
 	let modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds);
 

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -200,15 +200,18 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	// Build the model resolver + catalog from the ModelRegistry — the same
 	// component the TUI/CLI use — scoped to providers we hold credentials for.
 	// `getAll()` is a superset of the bundled catalog (bundled first, then
-	// cached + discovered), so the discovery-only models omp itself reaches
-	// become routable through the gateway instead of freezing on the compiled
-	// snapshot. Format handlers ask `resolveModel` to translate a
-	// client-requested `model` field into a pi-ai `Model<Api>` before dispatch;
+	// cached + broker-discovered), so the discovery-only models omp itself
+	// reaches become routable through the gateway instead of freezing on the
+	// compiled snapshot. `ignoreLocalModelConfig` keeps the host's `models.yml`
+	// out of the picture: client-side provider overrides (baseUrl/apiKey/headers/
+	// transport) and custom models must never route a broker-backed gateway or
+	// shadow broker credentials. Format handlers ask `resolveModel` to translate
+	// a client-requested `model` field into a pi-ai `Model<Api>` before dispatch;
 	// `listModels` powers `/v1/models`.
 	const snapshot = storage.exportSnapshot();
 	const providersWithCreds = new Set<string>();
 	for (const entry of snapshot.credentials) providersWithCreds.add(entry.provider);
-	const registry = new ModelRegistry(storage, undefined, { ignorePiNativeProviderConfig: true });
+	const registry = new ModelRegistry(storage, undefined, { ignoreLocalModelConfig: true });
 	await registry.refresh();
 	let modelById = indexModelsByRequestId(registry.getAll(), providersWithCreds);
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -793,6 +793,7 @@ export class ModelRegistry {
 	// Runtime model managers registered by extensions via fetchDynamicModels.
 	// Keyed by provider name; use the same SQLite cache path as builtins.
 	#runtimeModelManagers: Map<string, { options: ModelManagerOptions<Api>; sourceId: string }> = new Map();
+	#ignorePiNativeProviderConfig: boolean;
 	#fetch: FetchImpl;
 
 	#resolveCommandBackedApiKey(provider: string): CommandApiKeyResolution {
@@ -829,8 +830,13 @@ export class ModelRegistry {
 	constructor(
 		readonly authStorage: AuthStorage,
 		modelsPath?: string,
-		options?: { fetch?: FetchImpl },
+		options?: {
+			/** Skip models config providers routed through a pi-native gateway, preventing a gateway server from routing back into itself. */
+			ignorePiNativeProviderConfig?: boolean;
+			fetch?: FetchImpl;
+		},
 	) {
+		this.#ignorePiNativeProviderConfig = options?.ignorePiNativeProviderConfig ?? false;
 		this.#fetch =
 			options?.fetch ??
 			(isBunTestRuntime()
@@ -1396,8 +1402,13 @@ export class ModelRegistry {
 		const allModelOverrides = new Map<string, Map<string, ModelOverride>>();
 		const keylessProviders = new Set<string>();
 		const discoverableProviders: DiscoveryProviderConfig[] = [];
-		const providerEntries = Object.entries(value.providers ?? {});
-		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
+		const providerEntries = Object.entries(value.providers ?? {}).filter(
+			([, providerConfig]) => !this.#ignorePiNativeProviderConfig || providerConfig.transport !== "pi-native",
+		);
+		const configuredProviders = new Set(providerEntries.map(([providerName]) => providerName));
+		const effectiveConfig = this.#ignorePiNativeProviderConfig
+			? { ...value, providers: Object.fromEntries(providerEntries) }
+			: value;
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
@@ -1470,7 +1481,7 @@ export class ModelRegistry {
 		}
 
 		return {
-			models: this.#parseModels(value),
+			models: this.#parseModels(effectiveConfig),
 			overrides,
 			modelOverrides: allModelOverrides,
 			keylessProviders,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -793,7 +793,7 @@ export class ModelRegistry {
 	// Runtime model managers registered by extensions via fetchDynamicModels.
 	// Keyed by provider name; use the same SQLite cache path as builtins.
 	#runtimeModelManagers: Map<string, { options: ModelManagerOptions<Api>; sourceId: string }> = new Map();
-	#ignorePiNativeProviderConfig: boolean;
+	#ignoreLocalModelConfig: boolean;
 	#fetch: FetchImpl;
 
 	#resolveCommandBackedApiKey(provider: string): CommandApiKeyResolution {
@@ -831,12 +831,17 @@ export class ModelRegistry {
 		readonly authStorage: AuthStorage,
 		modelsPath?: string,
 		options?: {
-			/** Skip models config providers routed through a pi-native gateway, preventing a gateway server from routing back into itself. */
-			ignorePiNativeProviderConfig?: boolean;
+			/**
+			 * Gateway mode: ignore local `models.yml` entirely (provider overrides,
+			 * config API keys, custom models, custom discovery). A broker-backed
+			 * gateway serves only bundled + broker-discovered catalog metadata and
+			 * must never apply client-side credential or routing overrides.
+			 */
+			ignoreLocalModelConfig?: boolean;
 			fetch?: FetchImpl;
 		},
 	) {
-		this.#ignorePiNativeProviderConfig = options?.ignorePiNativeProviderConfig ?? false;
+		this.#ignoreLocalModelConfig = options?.ignoreLocalModelConfig ?? false;
 		this.#fetch =
 			options?.fetch ??
 			(isBunTestRuntime()
@@ -1373,6 +1378,24 @@ export class ModelRegistry {
 	}
 
 	#loadCustomModels(): CustomModelsResult {
+		// Gateway mode: serve bundled + broker-discovered catalog metadata only.
+		// Local models.yml provider overrides (baseUrl/apiKey/headers/transport),
+		// custom models, custom discovery, and config API keys are all client-side
+		// routing that MUST NOT reach a broker-backed gateway — applying them would
+		// send broker bearers to a configured endpoint, install config keys that
+		// shadow broker credentials (bypassing account pooling/refresh/accounting),
+		// or route a pi-native gateway back into itself.
+		if (this.#ignoreLocalModelConfig) {
+			return {
+				models: [],
+				overrides: new Map(),
+				modelOverrides: new Map(),
+				keylessProviders: new Set(),
+				discoverableProviders: [],
+				configuredProviders: new Set(),
+				found: false,
+			};
+		}
 		const { value, error, status } = this.#modelsConfigFile.tryLoad();
 
 		if (status === "error") {
@@ -1402,13 +1425,8 @@ export class ModelRegistry {
 		const allModelOverrides = new Map<string, Map<string, ModelOverride>>();
 		const keylessProviders = new Set<string>();
 		const discoverableProviders: DiscoveryProviderConfig[] = [];
-		const providerEntries = Object.entries(value.providers ?? {}).filter(
-			([, providerConfig]) => !this.#ignorePiNativeProviderConfig || providerConfig.transport !== "pi-native",
-		);
-		const configuredProviders = new Set(providerEntries.map(([providerName]) => providerName));
-		const effectiveConfig = this.#ignorePiNativeProviderConfig
-			? { ...value, providers: Object.fromEntries(providerEntries) }
-			: value;
+		const providerEntries = Object.entries(value.providers ?? {});
+		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
@@ -1481,7 +1499,7 @@ export class ModelRegistry {
 		}
 
 		return {
-			models: this.#parseModels(effectiveConfig),
+			models: this.#parseModels(value),
 			overrides,
 			modelOverrides: allModelOverrides,
 			keylessProviders,


### PR DESCRIPTION
## Repro
`omp auth-gateway serve` built `/v1/models` and the `resolveModel` behind `/v1/chat/completions` from `getBundledModels` only, freezing the gateway catalog on the compiled-in snapshot. Every model omp itself reaches through provider discovery (Cursor/HuggingFace/Copilot expose ~3x more via discovery; any id released after the build date) was invisible on the gateway and returned `Unknown model`, even though the same broker credential answered it in the TUI. A focused test registers `anthropic/claude-opus-5-repro` (present in `ModelRegistry.getAll()`, absent from the bundle) and confirms the bundled-only index — built exactly as `runServe` built it — returns `undefined` for that id:

```
bun test src/cli/__tests__/auth-gateway-catalog.test.ts
```

## Cause
`runServe` in `packages/coding-agent/src/cli/auth-gateway-cli.ts` iterated `getBundledProviders()` / `getBundledModels()` to populate `modelById`, the map backing both `resolveModel` and `listModels`. Bundled metadata is the compiled-in snapshot, so discovery-only models — which every other omp surface (`main.ts`, `sdk.ts`, `models-cli.ts`, the commit pipeline) obtains from `ModelRegistry` — never entered the gateway catalog. There is no client-side workaround: the missing ids don't resolve, so clients can't send them blindly either.

## Fix
- Extract the request-id indexing (qualified `provider/id` always, bare `id` first-write-wins, scoped to providers with broker credentials) into an exported `indexModelsByRequestId(models, providersWithCreds)` helper.
- Build the gateway catalog from `new ModelRegistry(storage)` + `await registry.refresh()` — a superset of the bundle (bundled + cached + discovered) that reuses the existing `models.db` cache and the broker-backed `AuthStorage` for discovery — then `indexModelsByRequestId(registry.getAll(), providersWithCreds)`.
- Because `serve` is long-lived, rebuild the catalog on a 15m `unref()`'d interval (`CATALOG_REFRESH_INTERVAL_MS`) so newly discovered models become routable without a restart; a failed refresh logs and keeps serving the previous catalog. The interval is cleared on shutdown.
- Drop the now-unused `getBundledProviders` import (`getBundledModels`/`GeneratedProvider` stay — still used by the strict-probe candidate ranking).

## Verification
`bun test src/cli/__tests__/auth-gateway-catalog.test.ts` → 2 pass (a discovery-only, non-bundled model resolves by qualified + bare id; the catalog stays scoped to providers with credentials). `bun run check:ts` green across all packages. Fixes #6615