### PR TITLE
fix(catalog): retry empty model discovery

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Retried empty successful provider discovery responses after the short non-authoritative interval instead of caching them for the full catalog TTL ([#6620](https://github.com/can1357/oh-my-pi/issues/6620)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -53,7 +53,7 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
  * Resolution result.
  *
  * `stale` is false when the resolved catalog is authoritative for the selected provider:
- * - dynamic endpoint data was fetched in this call,
+ * - a non-empty dynamic endpoint catalog was fetched in this call,
  * - a still-fresh authoritative cache was reused in `online-if-uncached` mode, or
  * - the provider has no dynamic fetcher configured.
  */
@@ -226,12 +226,13 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				options.dropCachedModelIdsOnStaticMismatch,
 			);
 	const dynamicModels = fetchedDynamicModels ?? [];
+	const dynamicResultAuthoritative = dynamicFetchSucceeded && dynamicModels.length > 0;
 	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
 	const mergedModels = mergeDynamicModels(mergedWithCache, dynamicModels);
 	const models = collapseBuiltModelVariants(
 		dynamicModelsAuthoritative && dynamicFetchSucceeded ? retainModelIds(mergedModels, dynamicModels) : mergedModels,
 	);
-	const dynamicAuthoritative = !hasDynamicFetcher || dynamicFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
+	const dynamicAuthoritative = !hasDynamicFetcher || dynamicResultAuthoritative || shouldUseFreshCacheAsAuthoritative;
 	if (shouldFetchFromNetwork) {
 		if (dynamicFetchSucceeded) {
 			const mergedSnapshot = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
@@ -242,7 +243,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				cacheProviderId,
 				now(),
 				collapseBuiltModelVariants(snapshotModels),
-				true,
+				dynamicResultAuthoritative,
 				staticFingerprint,
 				dbPath,
 				staticModels,

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -53,7 +53,8 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
  * Resolution result.
  *
  * `stale` is false when the resolved catalog is authoritative for the selected provider:
- * - a non-empty dynamic endpoint catalog was fetched in this call,
+ * - a dynamic endpoint fetch succeeded in this call (an empty catalog is still
+ *   authoritative for the cycle, so downstream pruning of removed models runs),
  * - a still-fresh authoritative cache was reused in `online-if-uncached` mode, or
  * - the provider has no dynamic fetcher configured.
  */
@@ -226,13 +227,18 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				options.dropCachedModelIdsOnStaticMismatch,
 			);
 	const dynamicModels = fetchedDynamicModels ?? [];
-	const dynamicResultAuthoritative = dynamicFetchSucceeded && dynamicModels.length > 0;
+	// A successful empty result stays authoritative for THIS cycle (so an
+	// intentional catalog emptying still prunes removed models downstream), but
+	// is NOT pinned into the cache as authoritative — that would suppress the
+	// short retry that recovers a transient empty response (#6620). The two
+	// concerns are deliberately separate: result authority vs. cache retry.
+	const dynamicCacheAuthoritative = dynamicFetchSucceeded && dynamicModels.length > 0;
 	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
 	const mergedModels = mergeDynamicModels(mergedWithCache, dynamicModels);
 	const models = collapseBuiltModelVariants(
 		dynamicModelsAuthoritative && dynamicFetchSucceeded ? retainModelIds(mergedModels, dynamicModels) : mergedModels,
 	);
-	const dynamicAuthoritative = !hasDynamicFetcher || dynamicResultAuthoritative || shouldUseFreshCacheAsAuthoritative;
+	const dynamicAuthoritative = !hasDynamicFetcher || dynamicFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
 	if (shouldFetchFromNetwork) {
 		if (dynamicFetchSucceeded) {
 			const mergedSnapshot = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
@@ -243,7 +249,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				cacheProviderId,
 				now(),
 				collapseBuiltModelVariants(snapshotModels),
-				dynamicResultAuthoritative,
+				dynamicCacheAuthoritative,
 				staticFingerprint,
 				dbPath,
 				staticModels,

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -671,6 +671,58 @@ describe("model cache spec round trip", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it("retries an empty discovery result after the short interval and caches recovery", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-empty-discovery-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const recoveredModel = completionsSpec({ id: "recovered-model", provider: "empty-discovery-test" });
+		let discoveredModels: readonly ModelSpec<"openai-completions">[] = [];
+		let fetches = 0;
+		let currentTime = 1_000_000;
+		const options = {
+			providerId: "empty-discovery-test",
+			staticModels: [],
+			dynamicModelsAuthoritative: true,
+			cacheDbPath: dbPath,
+			now: () => currentTime,
+			fetchDynamicModels: async () => {
+				fetches++;
+				return discoveredModels;
+			},
+		};
+		try {
+			const empty = await resolveProviderModels(options, "online");
+			expect(empty.models).toEqual([]);
+			expect(empty.stale).toBe(true);
+			expect(fetches).toBe(1);
+
+			const db = new Database(dbPath, { readonly: true });
+			const row = db
+				.query<{ authoritative: number }, [string]>("SELECT authoritative FROM model_cache WHERE provider_id = ?")
+				.get(options.providerId);
+			db.close();
+			expect(row?.authoritative).toBe(0);
+
+			discoveredModels = [recoveredModel];
+			currentTime += 5 * 60 * 1_000 - 1;
+			const beforeRetry = await resolveProviderModels(options, "online-if-uncached");
+			expect(beforeRetry.models).toEqual([]);
+			expect(fetches).toBe(1);
+
+			currentTime++;
+			const recovered = await resolveProviderModels(options, "online-if-uncached");
+			expect(recovered.models.map(model => model.id)).toEqual([recoveredModel.id]);
+			expect(recovered.stale).toBe(false);
+			expect(fetches).toBe(2);
+
+			currentTime++;
+			const cached = await resolveProviderModels(options, "online-if-uncached");
+			expect(cached.models.map(model => model.id)).toEqual([recoveredModel.id]);
+			expect(cached.stale).toBe(false);
+			expect(fetches).toBe(2);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 	it("restores static model headers on fresh cache reads", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-static-headers-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -692,7 +692,9 @@ describe("model cache spec round trip", () => {
 		try {
 			const empty = await resolveProviderModels(options, "online");
 			expect(empty.models).toEqual([]);
-			expect(empty.stale).toBe(true);
+			// Authoritative for the cycle (drives downstream pruning) yet not pinned
+			// into the cache as authoritative (keeps the short retry interval).
+			expect(empty.stale).toBe(false);
 			expect(fetches).toBe(1);
 
 			const db = new Database(dbPath, { readonly: true });
@@ -719,6 +721,40 @@ describe("model cache spec round trip", () => {
 			expect(cached.models.map(model => model.id)).toEqual([recoveredModel.id]);
 			expect(cached.stale).toBe(false);
 			expect(fetches).toBe(2);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	it("reports an authoritative catalog emptying as non-stale so removed models prune", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-empty-transition-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const model = completionsSpec({ id: "going-away", provider: "empty-transition-test" });
+		let discoveredModels: readonly ModelSpec<"openai-completions">[] = [model];
+		const options = {
+			providerId: "empty-transition-test",
+			staticModels: [],
+			dynamicModelsAuthoritative: true,
+			cacheDbPath: dbPath,
+			fetchDynamicModels: async () => discoveredModels,
+		};
+		try {
+			const populated = await resolveProviderModels(options, "online");
+			expect(populated.models.map(candidate => candidate.id)).toEqual([model.id]);
+			expect(populated.stale).toBe(false);
+
+			discoveredModels = [];
+			const emptied = await resolveProviderModels(options, "online");
+			expect(emptied.models).toEqual([]);
+			// The successful empty fetch must stay authoritative so ModelRegistry
+			// prunes the removed model instead of leaving it selectable forever.
+			expect(emptied.stale).toBe(false);
+
+			const db = new Database(dbPath, { readonly: true });
+			const row = db
+				.query<{ authoritative: number }, [string]>("SELECT authoritative FROM model_cache WHERE provider_id = ?")
+				.get(options.providerId);
+			db.close();
+			expect(row?.authoritative).toBe(0);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Repro

With a custom OpenAI-compatible discovery endpoint, return `{"data":[]}`, run `omp models refresh`, change the endpoint to return `{"data":[{"id":"some-model"}]}`, then run `omp models refresh` again within the catalog TTL. Before this change the second refresh made no request: the cached row remained `authoritative=1`, `models=[]`, and `some-model` stayed absent.

## Cause

`resolveProviderModels` in `packages/catalog/src/model-manager.ts` used `fetchedDynamicModels !== null` for both transport success and cache authority. An empty normalized result therefore entered the successful write path with `authoritative=true`, preventing `shouldFetchRemoteSources` from applying `NON_AUTHORITATIVE_RETRY_MS`.

## Fix

- Treat only non-empty dynamic discovery results as authoritative while still serving an empty result for the current refresh.
- Persist empty snapshots as non-authoritative so the existing five-minute retry path applies.
- Cover the empty response, retry boundary, recovery, and subsequent authoritative cache reuse in one regression test.
- Record the fix in the catalog changelog.

## Verification

`bun test packages/catalog/test/build.test.ts` passed: 37 tests, 0 failures. `bun run check` in `packages/catalog` passed. A cache-level smoke script changed from `fetches=1`, `retryModels=[]`, `authoritative=1` before the fix to `fetches=2`, `retryModels=["some-model"]` after six minutes. `bun run fix` fails identically on a clean `origin/main` snapshot because this workstation lacks CMake/Opus and libclang for unchanged audio crates; skipped the pre-publish gate.

Fixes #6620