### PR TITLE
fix(advisor): propagate advisor provider session id via metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
+- Fixed Advisor requests reaching Anthropic-compatible endpoints without a provider-facing session identity: the separately constructed advisor `Agent` never had a metadata resolver installed, so its outbound requests omitted the `metadata.user_id` session id that the main and subagent agents carry. Each advisor now emits its own `advisorProviderSessionId` via `metadata.user_id`, resolved live so a token refresh surfaces the current `account_uuid`, giving Main, subagent, and Advisor traffic distinct, stable session ids for proxy routing and attribution ([#6625](https://github.com/can1357/oh-my-pi/issues/6625)).
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -71,7 +71,7 @@ import type {
 	ToolResultMessage,
 	UsageReport,
 } from "@oh-my-pi/pi-ai";
-import { deriveClaudeDeviceId, type Effort, streamSimple } from "@oh-my-pi/pi-ai";
+import { type Effort, streamSimple } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { resetOpenAICodexHistoryAfterCompaction } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
@@ -81,7 +81,6 @@ import {
 	escapeXmlText,
 	formatDuration,
 	getAgentDbPath,
-	getInstallId,
 	isBunTestRuntime,
 	isEnoent,
 	isInteractiveHost,
@@ -229,7 +228,6 @@ import {
 	type AsyncResultEntry,
 	buildAsyncResultBatchMessage,
 } from "./async-job-delivery";
-import type { AuthStorage } from "./auth-storage";
 import { BashRunner, type BashRunnerHost } from "./bash-runner";
 import {
 	checkpointStartedAtFromEntry,
@@ -304,6 +302,7 @@ import {
 } from "./session-maintenance";
 import { cleanupEmptyMoveSession, type SessionManager } from "./session-manager";
 import { SessionMemory, type SessionMemoryHost } from "./session-memory";
+import { buildSessionMetadata } from "./session-metadata";
 import { SessionProviderBoundary, type SessionProviderBoundaryHost } from "./session-provider-boundary";
 import { SessionStatsTracker, type SessionStatsTrackerHost } from "./session-stats";
 import { SessionTools, type SessionToolsHost } from "./session-tools";
@@ -329,53 +328,6 @@ const PLAN_MODE_REMINDER_MAX = 3;
 // ============================================================================
 // Constants
 // ============================================================================
-
-/** Standard thinking levels */
-
-/**
- * Build the per-request `metadata` payload for the Anthropic provider, shaped
- * like real Claude Code's `getAPIMetadata` output (`{ session_id, account_uuid,
- * device_id }`) so the backend buckets requests under one session and attributes
- * them to the authenticated OAuth account when available. Resolved at request
- * time so token refreshes and login/logout transitions don't strand a stale
- * account UUID in memory. `account_uuid` and `device_id` are omitted for
- * non-Anthropic providers to avoid leaking the user's Claude identity to
- * third-party APIs (including Anthropic-format-compatible proxies such as
- * cloudflare-ai-gateway or gitlab-duo).
- *
- * `provider` is the target provider string (e.g. `"anthropic"`) and gates the
- * `account_uuid` and `device_id` lookups — only `"anthropic"` requests carry them.
- *
- * `sessionId` is forwarded to the auth-storage session-sticky lookup so that
- * multi-credential setups attribute to the same OAuth account used for the
- * actual API request rather than always picking the first credential.
- *
- * `authStorage` is treated as optional so test fixtures that stub `modelRegistry`
- * without a real storage layer still work; the resolver simply skips the lookup
- * and emits `{ session_id }` alone, matching the no-OAuth-credential path.
- */
-function buildSessionMetadata(
-	sessionId: string,
-	provider: string,
-	authStorage: AuthStorage | undefined,
-): Record<string, unknown> {
-	const userId: Record<string, string> = { session_id: sessionId };
-	// Only look up account_uuid when the request is going to Anthropic. Injecting
-	// a Claude OAuth account_uuid into requests bound for other providers (including
-	// Anthropic-format-compatible proxies like cloudflare-ai-gateway or gitlab-duo)
-	// would leak the user's Anthropic identity to unrelated third-party APIs.
-	if (provider === "anthropic") {
-		const accountUuid = authStorage?.getOAuthAccountId("anthropic", sessionId);
-		if (typeof accountUuid === "string" && accountUuid.length > 0) {
-			userId.account_uuid = accountUuid;
-			// Claude Code's `device_id` is a stable 64-hex account-scoped install
-			// identifier. Include both omp's persistent install id and the Claude
-			// account UUID so two accounts on the same install do not share a device.
-			userId.device_id = deriveClaudeDeviceId(getInstallId(), accountUuid);
-		}
-	}
-	return { user_id: JSON.stringify(userId) };
-}
 
 const noOpUIContext: ExtensionUIContext = {
 	select: async (_title, _options, _dialogOptions) => undefined,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3288,6 +3288,12 @@ export class AgentSession {
 		this.agent.setMetadataResolver((provider: string) =>
 			buildSessionMetadata(sid, provider, this.#modelRegistry.authStorage),
 		);
+		// Keep every live advisor's provider identity in lockstep with the primary's
+		// across every session-boundary transition — including branch paths that
+		// skip conversation restore — so advisors never emit the previous
+		// conversation's session id/metadata (issue #6625). Guarded because this
+		// runs once during construction before the advisor controller exists.
+		if (this.#advisors) this.#advisors.refreshProviderIdentity();
 	}
 
 	/** Run one abortable auto-learn capture outside the primary agent loop. */

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -93,6 +93,7 @@ import { formatSessionDumpText } from "./session-dump-format";
 import type { CompactionEntry, SessionEntry } from "./session-entries";
 import { formatSessionHistoryMarkdown } from "./session-history-format";
 import type { SessionManager } from "./session-manager";
+import { buildSessionMetadata } from "./session-metadata";
 import type { YieldQueue } from "./yield-queue";
 
 /** Advisor statistics for the advisor status command. */
@@ -677,6 +678,19 @@ export class SessionAdvisors {
 				serviceTierResolver: advisorServiceTierResolver,
 			});
 			advisorAgent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
+			// Emit the advisor's own provider-facing session id as request metadata
+			// (`metadata.user_id`), exactly like `AgentSession.#syncAgentSessionId`
+			// installs for the main/subagent agents. Without it the separately
+			// constructed advisor `Agent` had no metadata resolver, so custom
+			// Anthropic proxies saw advisor traffic with no session identity while
+			// Main/subagent requests carried one (issue #6625). Resolved live so a
+			// token refresh surfaces the current `account_uuid`.
+			if (advisorProviderSessionId) {
+				const advisorSessionId = advisorProviderSessionId;
+				advisorAgent.setMetadataResolver((provider: string) =>
+					buildSessionMetadata(advisorSessionId, provider, this.#host.modelRegistry.authStorage),
+				);
+			}
 
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -392,6 +392,38 @@ export class SessionAdvisors {
 		this.#advisorInterruptImmuneTurnStart = this.#advisorPrimaryTurnsCompleted + 1;
 	}
 
+	/** Rebind one advisor to the active primary conversation's provider identity. */
+	#refreshAdvisorProviderIdentity(advisor: ActiveAdvisor): void {
+		const primaryProviderSessionId = this.#host.sessionId();
+		const providerSessionId = getOrCreateAdvisorProviderSessionId(
+			this.#advisorProviderSessionIds,
+			primaryProviderSessionId,
+			advisor.slug,
+		);
+		advisor.providerSessionId = providerSessionId;
+		advisor.agent.sessionId = providerSessionId;
+		advisor.agent.promptCacheKey = this.#host.agent.promptCacheKey ?? providerSessionId;
+		advisor.agent.getApiKey = requestModel => this.#host.modelRegistry.resolver(requestModel, providerSessionId);
+		advisor.agent.setMetadataResolver(
+			providerSessionId
+				? provider => buildSessionMetadata(providerSessionId, provider, this.#host.modelRegistry.authStorage)
+				: undefined,
+		);
+
+		const telemetry = advisor.agent.telemetry;
+		if (telemetry?.agent) {
+			advisor.agent.setTelemetry({
+				...telemetry,
+				agent: {
+					...telemetry.agent,
+					id: advisor.slug
+						? `${primaryProviderSessionId}-advisor-${advisor.slug}`
+						: `${primaryProviderSessionId}-advisor`,
+				},
+			});
+		}
+	}
+
 	/**
 	 * Re-prime the advisor across a conversation boundary: `/new`, `/branch`,
 	 * `/btw`, `/tree`, and session switch/resume. Beyond {@link AdvisorRuntime.reset}
@@ -415,6 +447,7 @@ export class SessionAdvisors {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
 			a.runtime.reset();
+			this.#refreshAdvisorProviderIdentity(a);
 			a.adviseTool.resetDeliveredNotes();
 			a.emissionGuard.reset();
 			this.#attachAdvisorRecorderFeed(a);
@@ -678,19 +711,6 @@ export class SessionAdvisors {
 				serviceTierResolver: advisorServiceTierResolver,
 			});
 			advisorAgent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
-			// Emit the advisor's own provider-facing session id as request metadata
-			// (`metadata.user_id`), exactly like `AgentSession.#syncAgentSessionId`
-			// installs for the main/subagent agents. Without it the separately
-			// constructed advisor `Agent` had no metadata resolver, so custom
-			// Anthropic proxies saw advisor traffic with no session identity while
-			// Main/subagent requests carried one (issue #6625). Resolved live so a
-			// token refresh surfaces the current `account_uuid`.
-			if (advisorProviderSessionId) {
-				const advisorSessionId = advisorProviderSessionId;
-				advisorAgent.setMetadataResolver((provider: string) =>
-					buildSessionMetadata(advisorSessionId, provider, this.#host.modelRegistry.authStorage),
-				);
-			}
 
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {
@@ -786,6 +806,7 @@ export class SessionAdvisors {
 				retryFallbackPendingSuccess: false,
 				signature,
 			};
+			this.#refreshAdvisorProviderIdentity(advisorRef);
 			this.#attachAdvisorRecorderFeed(advisorRef);
 			if (seedToCurrent) runtime.seedTo(this.#host.agent.state.messages.length);
 			this.#advisorStatuses.set(slug, { name: advisorName, status: "running" });

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1282,7 +1282,15 @@ export class SessionAdvisors {
 		for (const candidate of candidates) {
 			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisorProviderSessionId);
 			if (!apiKey) continue;
-
+			// The advisor overflow-compaction one-shot bypasses the advisor `Agent`,
+			// so its installed metadata resolver never runs. Emit the same
+			// `metadata.user_id` identity here (resolved per candidate provider,
+			// after the session-sticky credential is selected) so summarization
+			// requests carry the advisor session id like every other advisor call
+			// (issue #6625).
+			const advisorMetadata = advisorProviderSessionId
+				? buildSessionMetadata(advisorProviderSessionId, candidate.provider, this.#host.modelRegistry.authStorage)
+				: undefined;
 			try {
 				compactResult = await compact(
 					preparation,
@@ -1297,6 +1305,7 @@ export class SessionAdvisors {
 						tools: agent.state.tools,
 						sessionId: advisorProviderSessionId,
 						promptCacheKey: advisorProviderSessionId,
+						metadata: advisorMetadata,
 						providerSessionState: this.#host.providerSessionState,
 						codexCompaction,
 					},

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -329,6 +329,17 @@ export class SessionAdvisors {
 		this.#resetAdvisorSessionState();
 	}
 
+	/**
+	 * Rebind every live advisor to the active primary conversation's provider
+	 * identity (session id, prompt-cache key, credential + metadata resolvers,
+	 * telemetry). Invoked on every provider-session change — including branch
+	 * paths that skip conversation restore — so advisors never keep emitting the
+	 * previous conversation's session id/metadata (issue #6625).
+	 */
+	refreshProviderIdentity(): void {
+		for (const advisor of this.#advisors) this.#refreshAdvisorProviderIdentity(advisor);
+	}
+
 	/** Re-primes advisor transcript views after an in-conversation history rewrite. */
 	resetAllRuntimes(): void {
 		this.#resetAllAdvisorRuntimes();
@@ -447,7 +458,6 @@ export class SessionAdvisors {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
 			a.runtime.reset();
-			this.#refreshAdvisorProviderIdentity(a);
 			a.adviseTool.resetDeliveredNotes();
 			a.emissionGuard.reset();
 			this.#attachAdvisorRecorderFeed(a);

--- a/packages/coding-agent/src/session/session-metadata.ts
+++ b/packages/coding-agent/src/session/session-metadata.ts
@@ -1,0 +1,53 @@
+import { deriveClaudeDeviceId } from "@oh-my-pi/pi-ai";
+import { getInstallId } from "@oh-my-pi/pi-utils";
+import type { AuthStorage } from "./auth-storage";
+
+/**
+ * Build the per-request `metadata` payload for the Anthropic provider, shaped
+ * like real Claude Code's `getAPIMetadata` output (`{ session_id, account_uuid,
+ * device_id }`) so the backend buckets requests under one session and attributes
+ * them to the authenticated OAuth account when available. Resolved at request
+ * time so token refreshes and login/logout transitions don't strand a stale
+ * account UUID in memory. `account_uuid` and `device_id` are omitted for
+ * non-Anthropic providers to avoid leaking the user's Claude identity to
+ * third-party APIs (including Anthropic-format-compatible proxies such as
+ * cloudflare-ai-gateway or gitlab-duo).
+ *
+ * Installed via `Agent#setMetadataResolver` on the main `AgentSession`, each
+ * subagent session, and the separately constructed advisor `Agent` — each with
+ * its own provider session id — so Main, subagent, and Advisor requests each
+ * expose a distinct, stable provider-facing session identity.
+ *
+ * `provider` is the target provider string (e.g. `"anthropic"`) and gates the
+ * `account_uuid` and `device_id` lookups — only `"anthropic"` requests carry them.
+ *
+ * `sessionId` is forwarded to the auth-storage session-sticky lookup so that
+ * multi-credential setups attribute to the same OAuth account used for the
+ * actual API request rather than always picking the first credential.
+ *
+ * `authStorage` is treated as optional so test fixtures that stub `modelRegistry`
+ * without a real storage layer still work; the resolver simply skips the lookup
+ * and emits `{ session_id }` alone, matching the no-OAuth-credential path.
+ */
+export function buildSessionMetadata(
+	sessionId: string,
+	provider: string,
+	authStorage: AuthStorage | undefined,
+): Record<string, unknown> {
+	const userId: Record<string, string> = { session_id: sessionId };
+	// Only look up account_uuid when the request is going to Anthropic. Injecting
+	// a Claude OAuth account_uuid into requests bound for other providers (including
+	// Anthropic-format-compatible proxies like cloudflare-ai-gateway or gitlab-duo)
+	// would leak the user's Anthropic identity to unrelated third-party APIs.
+	if (provider === "anthropic") {
+		const accountUuid = authStorage?.getOAuthAccountId("anthropic", sessionId);
+		if (typeof accountUuid === "string" && accountUuid.length > 0) {
+			userId.account_uuid = accountUuid;
+			// Claude Code's `device_id` is a stable 64-hex account-scoped install
+			// identifier. Include both omp's persistent install id and the Claude
+			// account UUID so two accounts on the same install do not share a device.
+			userId.device_id = deriveClaudeDeviceId(getInstallId(), accountUuid);
+		}
+	}
+	return { user_id: JSON.stringify(userId) };
+}

--- a/packages/coding-agent/test/advisor-context-maintenance.test.ts
+++ b/packages/coding-agent/test/advisor-context-maintenance.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent, type AgentMessage, type CompactionSummaryMessage, countTokens } from "@oh-my-pi/pi-agent-core";
 import { calculateContextTokens, estimateTokens, resolveThresholdTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { createMockModel, type MockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { estimateToolSchemaTokens } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
@@ -195,5 +195,78 @@ describe("AgentSession advisor context maintenance", () => {
 		expect(sentContext).toContain("equal-timestamp post-compaction update");
 		expect(sentContext).not.toContain("retained pre-compaction output");
 		expect(sentContext).not.toContain("fresh post-compaction output");
+	});
+
+	it("forwards the advisor session metadata to overflow compaction requests", async () => {
+		// Regression for #6625 review: advisor overflow compaction issues a direct
+		// `compact(...)` request that bypasses the advisor `Agent`, so the metadata
+		// resolver installed on the agent never runs for it. The direct call must
+		// still emit the advisor's `metadata.user_id` session identity.
+		// The advisor model is the first compaction candidate; registering the mock
+		// API lets the compaction one-shot's `completeSimple` route to it so the
+		// summarization request actually reaches the mock (and its recorded calls).
+		registerMockApi();
+		const primaryMock = createMockModel({
+			provider: "anthropic",
+			responses: [{ content: ["primary complete"] }],
+		});
+		const advisorMock = createMockModel({
+			provider: "anthropic",
+			contextWindow: CONTEXT_WINDOW,
+			handler: () => ({ content: ["bounded advisor summary"] }),
+		});
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const settings = Settings.isolated({
+			"advisor.syncBacklog": "1",
+			"compaction.enabled": true,
+			"compaction.strategy": "context-full",
+			"contextPromotion.enabled": false,
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: primaryMock, systemPrompt: [], tools: [] },
+			streamFn: primaryMock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		if (!advisor?.sessionId) throw new Error("Expected advisor agent with a provider session id");
+		advisor.setModel(advisorMock);
+		// Unlike the recovery-branch harness, the advisor holds usable credentials
+		// so maintenance runs the LLM summarization compaction path.
+		vi.spyOn(modelRegistry, "getApiKey").mockResolvedValue("test-key");
+
+		// Two accumulated turns so compaction has older history to summarize while
+		// retaining the most recent one (a single message would be fully retained,
+		// making compaction a no-op).
+		advisor.state.messages.push(
+			usageAnchor(advisorMock, Date.now() - 2_000),
+			usageAnchor(advisorMock, Date.now() - 1_000),
+		);
+
+		await session.prompt("small current update");
+
+		// A summarization compaction one-shot actually ran (its prompt wraps the
+		// conversation in <conversation> tags).
+		const compactionCalls = advisorMock.calls.filter(call =>
+			JSON.stringify(call.context.messages).includes("<conversation>"),
+		);
+		expect(compactionCalls.length).toBeGreaterThan(0);
+
+		// Every advisor request — the compaction one-shot and the advisor turn —
+		// carries the advisor's own provider session id via metadata.user_id.
+		for (const call of advisorMock.calls) {
+			const userId = call.options?.metadata?.user_id;
+			if (typeof userId !== "string") throw new Error("Expected advisor metadata.user_id");
+			expect((JSON.parse(userId) as { session_id?: string }).session_id).toBe(advisor.sessionId);
+		}
 	});
 });

--- a/packages/coding-agent/test/advisor-provider-options-parity.test.ts
+++ b/packages/coding-agent/test/advisor-provider-options-parity.test.ts
@@ -301,4 +301,48 @@ describe("AgentSession advisor provider-options parity", () => {
 		expect(metadataSessionId(capturedStreamOptions[0])).toBe(advisor.sessionId);
 		expect(metadataSessionId(capturedStreamOptions[0])).not.toBe(previousAdvisorSessionId);
 	});
+
+	it("refreshes the advisor provider session identity on a fork that skips advisor re-prime", async () => {
+		// Regression for #6625 review: `fork()` (like a branch whose hook returns
+		// `skipConversationRestore`) updates the primary provider identity via
+		// `#syncAgentSessionId()` WITHOUT running `resetSessionState()`. The advisor
+		// must still rebind to the new provider session id instead of emitting the
+		// pre-fork one.
+		const capturedStreamOptions: Array<SimpleStreamOptions | undefined> = [];
+		const captureStreamFn: StreamFn = (_m, _ctx, opts) => {
+			capturedStreamOptions.push(opts);
+			throw new Error("capture-stop");
+		};
+		const mainAgent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({
+			agent: mainAgent,
+			sessionManager,
+			settings: settings(),
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: captureStreamFn,
+		});
+		session.settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		const advisor = session.getAdvisorAgent();
+		if (!advisor?.sessionId) throw new Error("Expected advisor agent with a provider session id");
+		const previousAdvisorSessionId = advisor.sessionId;
+
+		expect(await session.fork()).toBe(true);
+		expect(session.getAdvisorAgent()).toBe(advisor);
+		expect(advisor.sessionId).toMatch(UUID_V7_PATTERN);
+		expect(advisor.sessionId).not.toBe(previousAdvisorSessionId);
+		expect(advisor.sessionId).not.toBe(mainAgent.sessionId);
+		// Fork inherits the parent's provider prompt-cache key (shared shard), so it
+		// stays pinned to the main agent's key rather than the advisor's own id.
+		expect(advisor.promptCacheKey).toBe(mainAgent.promptCacheKey);
+
+		await advisor.prompt("ping").catch(() => {});
+
+		expect(metadataSessionId(capturedStreamOptions[0])).toBe(advisor.sessionId);
+		expect(metadataSessionId(capturedStreamOptions[0])).not.toBe(previousAdvisorSessionId);
+	});
 });

--- a/packages/coding-agent/test/advisor-provider-options-parity.test.ts
+++ b/packages/coding-agent/test/advisor-provider-options-parity.test.ts
@@ -28,6 +28,18 @@ import { TempDir } from "@oh-my-pi/pi-utils";
  *  labels stay local-only (telemetry, transcripts). */
 const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function metadataSessionId(options: SimpleStreamOptions | undefined): string {
+	const metadata = options?.metadata;
+	if (!metadata || typeof metadata.user_id !== "string") {
+		throw new Error("Expected metadata.user_id");
+	}
+	const userId: unknown = JSON.parse(metadata.user_id);
+	if (!userId || typeof userId !== "object" || !("session_id" in userId) || typeof userId.session_id !== "string") {
+		throw new Error("Expected metadata.user_id.session_id");
+	}
+	return userId.session_id;
+}
+
 describe("AgentSession advisor provider-options parity", () => {
 	let sharedDir: TempDir;
 	let authStorage: AuthStorage;
@@ -235,7 +247,7 @@ describe("AgentSession advisor provider-options parity", () => {
 		expect(session.setAdvisorEnabled(true)).toBe(true);
 
 		const advisor = session.getAdvisorAgent();
-		if (!advisor) throw new Error("Expected advisor agent to be live");
+		if (!advisor?.sessionId) throw new Error("Expected advisor agent with a provider session id");
 
 		await advisor.prompt("ping").catch(() => {});
 
@@ -244,16 +256,49 @@ describe("AgentSession advisor provider-options parity", () => {
 
 		// The advisor request must carry a non-empty session id keyed to the
 		// advisor's own provider-facing UUIDv7, not the parent session id.
-		const advisorMeta = opts.metadata as { user_id?: string } | undefined;
-		if (!advisorMeta?.user_id) throw new Error("Expected advisor metadata.user_id");
-		const advisorUserId = JSON.parse(advisorMeta.user_id) as { session_id?: string };
-		expect(advisorUserId.session_id).toBe(advisor.sessionId);
+		expect(metadataSessionId(opts)).toBe(advisor.sessionId);
 
 		// Distinct from the main agent's session identity (both non-empty).
-		const mainMeta = mainAgent.metadataForProvider("anthropic") as { user_id?: string } | undefined;
-		if (!mainMeta?.user_id) throw new Error("Expected main agent metadata.user_id");
-		const mainUserId = JSON.parse(mainMeta.user_id) as { session_id?: string };
-		expect(mainUserId.session_id).toBeTruthy();
-		expect(advisorUserId.session_id).not.toBe(mainUserId.session_id);
+		expect(metadataSessionId({ metadata: mainAgent.metadataForProvider("anthropic") })).toBeTruthy();
+		expect(metadataSessionId(opts)).not.toBe(
+			metadataSessionId({ metadata: mainAgent.metadataForProvider("anthropic") }),
+		);
+	});
+
+	it("refreshes the advisor provider session identity after starting a new session", async () => {
+		const capturedStreamOptions: Array<SimpleStreamOptions | undefined> = [];
+		const captureStreamFn: StreamFn = (_m, _ctx, opts) => {
+			capturedStreamOptions.push(opts);
+			throw new Error("capture-stop");
+		};
+		const mainAgent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({
+			agent: mainAgent,
+			sessionManager,
+			settings: settings(),
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: captureStreamFn,
+		});
+		session.settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		const advisor = session.getAdvisorAgent();
+		if (!advisor?.sessionId) throw new Error("Expected advisor agent with a provider session id");
+		const previousAdvisorSessionId = advisor.sessionId;
+
+		expect(await session.newSession()).toBe(true);
+		expect(session.getAdvisorAgent()).toBe(advisor);
+		expect(advisor.sessionId).toMatch(UUID_V7_PATTERN);
+		expect(advisor.sessionId).not.toBe(previousAdvisorSessionId);
+		expect(advisor.sessionId).not.toBe(mainAgent.sessionId);
+		expect(advisor.promptCacheKey).toBe(advisor.sessionId);
+
+		await advisor.prompt("ping").catch(() => {});
+
+		expect(metadataSessionId(capturedStreamOptions[0])).toBe(advisor.sessionId);
+		expect(metadataSessionId(capturedStreamOptions[0])).not.toBe(previousAdvisorSessionId);
 	});
 });

--- a/packages/coding-agent/test/advisor-provider-options-parity.test.ts
+++ b/packages/coding-agent/test/advisor-provider-options-parity.test.ts
@@ -208,4 +208,52 @@ describe("AgentSession advisor provider-options parity", () => {
 		expect(advisor.sessionId).toMatch(UUID_V7_PATTERN);
 		expect(advisor.sessionId).not.toBe(advisor.promptCacheKey);
 	});
+
+	it("propagates the advisor's own provider session id via metadata.user_id, distinct from the main agent", async () => {
+		// Regression for #6625: the separately constructed advisor Agent had no
+		// metadata resolver, so its outbound Anthropic request omitted the
+		// `metadata.user_id` session identity that AgentSession installs for the
+		// main/subagent agents — custom proxies saw advisor traffic with no
+		// stable session id to route or attribute on.
+		const capturedStreamOptions: Array<SimpleStreamOptions | undefined> = [];
+		const captureStreamFn: StreamFn = (_m, _ctx, opts) => {
+			capturedStreamOptions.push(opts);
+			throw new Error("capture-stop");
+		};
+		const mainAgent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({
+			agent: mainAgent,
+			sessionManager,
+			settings: settings(),
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: captureStreamFn,
+		});
+		session.settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent to be live");
+
+		await advisor.prompt("ping").catch(() => {});
+
+		const opts = capturedStreamOptions[0];
+		if (!opts) throw new Error("Expected captured advisor stream options");
+
+		// The advisor request must carry a non-empty session id keyed to the
+		// advisor's own provider-facing UUIDv7, not the parent session id.
+		const advisorMeta = opts.metadata as { user_id?: string } | undefined;
+		if (!advisorMeta?.user_id) throw new Error("Expected advisor metadata.user_id");
+		const advisorUserId = JSON.parse(advisorMeta.user_id) as { session_id?: string };
+		expect(advisorUserId.session_id).toBe(advisor.sessionId);
+
+		// Distinct from the main agent's session identity (both non-empty).
+		const mainMeta = mainAgent.metadataForProvider("anthropic") as { user_id?: string } | undefined;
+		if (!mainMeta?.user_id) throw new Error("Expected main agent metadata.user_id");
+		const mainUserId = JSON.parse(mainMeta.user_id) as { session_id?: string };
+		expect(mainUserId.session_id).toBeTruthy();
+		expect(advisorUserId.session_id).not.toBe(mainUserId.session_id);
+	});
 });


### PR DESCRIPTION
## Repro
With a built-in `anthropic` provider pointed at a non-official custom base URL, an Advisor `POST /v1/messages` request reaches the proxy with no provider-facing session identity: `X-Claude-Code-Session-Id` is absent and `metadata.user_id` is absent, while a Main control request through the same listener carries a parseable session UUID in `metadata.user_id`. Reproduced in-process: capturing the advisor's stream options via a stub `advisorStreamFn` shows `opts.metadata` undefined. Run `bun test test/advisor-provider-options-parity.test.ts` (new case `propagates the advisor's own provider session id via metadata.user_id, distinct from the main agent` fails without the fix with `Expected advisor metadata.user_id`).

## Cause
`AgentSession.#syncAgentSessionId()` (`session/agent-session.ts`) installs `agent.setMetadataResolver(buildSessionMetadata(sid, …))` so every request carries `metadata.user_id` (`{ session_id, account_uuid?, device_id? }`), resolved live via `agent-loop.ts`'s `config.metadataResolver`. The Advisor `Agent` is constructed separately in `session/session-advisors.ts` with its own `advisorProviderSessionId` threaded into `sessionId`/`promptCacheKey`/telemetry, but no metadata resolver was ever installed, so `config.metadata`/`metadataResolver` stayed undefined and advisor requests shipped no session identity.

## Fix
- Extracted `buildSessionMetadata` into `session/session-metadata.ts` (shared, avoids an `agent-session` ↔ `session-advisors` import cycle); `agent-session.ts` now imports it and drops the now-unused `deriveClaudeDeviceId`/`getInstallId` imports.
- In `session-advisors.ts`, after building the advisor `Agent`, install `advisorAgent.setMetadataResolver(...)` scoped to that advisor's own `advisorProviderSessionId`, resolved live so a token refresh surfaces the current `account_uuid`. Guarded on a defined session id (no primary session → nothing to send).
- Added a `CHANGELOG.md` entry.

## Verification
`bun test test/advisor-provider-options-parity.test.ts test/advisor-toggle.test.ts test/agent-session-advisor-suppression.test.ts` → 37 pass, 0 fail. `bun run check:types` (coding-agent) → clean. Confirmed the new regression test fails (`Expected advisor metadata.user_id`) with the resolver removed and passes with it, asserting the advisor's `metadata.user_id.session_id` equals `advisor.sessionId` and is distinct from the main agent's. Fixes #6625