### PR TITLE
fix(natives): stabilize forwarded PulseAudio capture and playback

### DIFF
--- a/crates/pi-natives/src/audio.rs
+++ b/crates/pi-natives/src/audio.rs
@@ -39,6 +39,11 @@ const PLAYBACK_PERIOD_MS: u32 = 20;
 const CAPTURE_PERIOD_MS: u32 = 50;
 #[cfg(not(target_os = "linux"))]
 const CAPTURE_PERIOD_MS: u32 = 20;
+// PulseAudio can retain its default three periods after the producer closes.
+// Wait for all of them before stopping the device so the tail reaches the sink.
+#[cfg(target_os = "linux")]
+const PLAYBACK_DRAIN_CALLBACKS: usize = 3;
+#[cfg(not(target_os = "linux"))]
 const PLAYBACK_DRAIN_CALLBACKS: usize = 2;
 
 #[cfg(target_os = "macos")]
@@ -270,6 +275,31 @@ fn fill_playback(
 	}
 }
 
+fn start_capture_device<C>(sample_rate: u32, mut on_audio: C) -> NativeResult<Device<f32>>
+where
+	C: FnMut(&[f32]) + Send + 'static,
+{
+	let sample_rate = audio_sample_rate(sample_rate)?;
+	let mut builder = DeviceBuilder::capture().f32();
+	builder
+		.sample_rate(sample_rate)
+		.capture_channels(AUDIO_CHANNELS)
+		.period_size_millis(CAPTURE_PERIOD_MS)
+		.performance_profile(PerformanceProfile::LowLatency)
+		.backends(AUDIO_BACKENDS);
+	let mut device = builder
+		.with_callback(move |_device, samples| {
+			if !samples.is_empty() {
+				on_audio(samples);
+			}
+		})
+		.map_err(|error| format!("Failed to open the default microphone: {error}"))?;
+	device
+		.device_start()
+		.map_err(|error| format!("Failed to start microphone capture: {error}"))?;
+	Ok(device)
+}
+
 /// Default-microphone capture converted to mono `f32` at the requested sample
 /// rate.
 #[napi]
@@ -286,30 +316,11 @@ impl AudioCapture {
 		#[napi(ts_arg_type = "(error: Error | null, samples: Float32Array) => void")]
 		on_audio: CaptureCallback,
 	) -> Result<Self> {
-		let sample_rate = audio_sample_rate(sample_rate).map_err(napi::Error::from_reason)?;
-		let mut builder = DeviceBuilder::capture().f32();
-		builder
-			.sample_rate(sample_rate)
-			.capture_channels(AUDIO_CHANNELS)
-			.period_size_millis(CAPTURE_PERIOD_MS)
-			.performance_profile(PerformanceProfile::LowLatency)
-			.backends(AUDIO_BACKENDS);
-		let mut device = builder
-			.with_callback(move |_device, samples| {
-				if samples.is_empty() {
-					return;
-				}
-				on_audio.call(
-					Ok(Float32Array::new(samples.to_vec())),
-					ThreadsafeFunctionCallMode::NonBlocking,
-				);
-			})
-			.map_err(|error| {
-				napi::Error::from_reason(format!("Failed to open the default microphone: {error}"))
-			})?;
-		device.device_start().map_err(|error| {
-			napi::Error::from_reason(format!("Failed to start microphone capture: {error}"))
-		})?;
+		let device = start_capture_device(sample_rate, move |samples| {
+			on_audio
+				.call(Ok(Float32Array::new(samples.to_vec())), ThreadsafeFunctionCallMode::NonBlocking);
+		})
+		.map_err(napi::Error::from_reason)?;
 		Ok(Self { device: Mutex::new(Some(device)) })
 	}
 
@@ -417,6 +428,7 @@ impl Drop for AudioPlayback {
 #[cfg(test)]
 mod tests {
 	use std::{
+		env,
 		mem::forget,
 		sync::atomic::AtomicUsize,
 		thread::sleep,
@@ -443,36 +455,29 @@ mod tests {
 		assert_eq!(output, [0.5, -0.5, 0.25, -0.25, 0.0]);
 		assert!(!state.drained.load(Ordering::Acquire));
 		let mut silence = [1.0; 2];
-		fill_playback(&rx, &mut current, &mut cursor, &mut silence, &state, &mut empty_callbacks);
-		assert_eq!(silence, [0.0, 0.0]);
-		assert!(state.drained.load(Ordering::Acquire));
+		while empty_callbacks < PLAYBACK_DRAIN_CALLBACKS {
+			silence.fill(1.0);
+			fill_playback(&rx, &mut current, &mut cursor, &mut silence, &state, &mut empty_callbacks);
+			assert_eq!(silence, [0.0, 0.0]);
+			assert_eq!(
+				state.drained.load(Ordering::Acquire),
+				empty_callbacks >= PLAYBACK_DRAIN_CALLBACKS
+			);
+		}
 	}
 
 	#[test]
 	fn opt_in_default_capture_receives_frames() {
-		if std::env::var_os("OMP_NATIVE_AUDIO_CAPTURE_TEST").is_none() {
+		if env::var_os("OMP_NATIVE_AUDIO_CAPTURE_TEST").is_none() {
 			return;
 		}
 
 		let callbacks = Arc::new(AtomicUsize::new(0));
 		let callback_count = Arc::clone(&callbacks);
-		let mut builder = DeviceBuilder::capture().f32();
-		builder
-			.sample_rate(audio_sample_rate(16_000).expect("sample rate is supported"))
-			.capture_channels(AUDIO_CHANNELS)
-			.period_size_millis(CAPTURE_PERIOD_MS)
-			.performance_profile(PerformanceProfile::LowLatency)
-			.backends(AUDIO_BACKENDS);
-		let mut device = builder
-			.with_callback(move |_device, samples| {
-				if !samples.is_empty() {
-					callback_count.fetch_add(1, Ordering::Relaxed);
-				}
-			})
-			.expect("default capture device opens");
-		device
-			.device_start()
-			.expect("default capture device starts");
+		let mut device = start_capture_device(16_000, move |_samples| {
+			callback_count.fetch_add(1, Ordering::Relaxed);
+		})
+		.expect("default capture device starts");
 
 		let deadline = Instant::now() + Duration::from_secs(5);
 		while callbacks.load(Ordering::Relaxed) == 0 && Instant::now() < deadline {

--- a/crates/pi-natives/src/audio.rs
+++ b/crates/pi-natives/src/audio.rs
@@ -416,6 +416,13 @@ impl Drop for AudioPlayback {
 
 #[cfg(test)]
 mod tests {
+	use std::{
+		mem::forget,
+		sync::atomic::AtomicUsize,
+		thread::sleep,
+		time::{Duration, Instant},
+	};
+
 	use super::*;
 
 	#[test]
@@ -447,7 +454,7 @@ mod tests {
 			return;
 		}
 
-		let callbacks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+		let callbacks = Arc::new(AtomicUsize::new(0));
 		let callback_count = Arc::clone(&callbacks);
 		let mut builder = DeviceBuilder::capture().f32();
 		builder
@@ -467,12 +474,12 @@ mod tests {
 			.device_start()
 			.expect("default capture device starts");
 
-		let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-		while callbacks.load(Ordering::Relaxed) == 0 && std::time::Instant::now() < deadline {
-			std::thread::sleep(std::time::Duration::from_millis(20));
+		let deadline = Instant::now() + Duration::from_secs(5);
+		while callbacks.load(Ordering::Relaxed) == 0 && Instant::now() < deadline {
+			sleep(Duration::from_millis(20));
 		}
 		if callbacks.load(Ordering::Relaxed) == 0 {
-			std::mem::forget(device);
+			forget(device);
 			panic!("capture device started but delivered no frames within five seconds");
 		}
 		device.device_stop().expect("capture device stops");

--- a/crates/pi-natives/src/audio.rs
+++ b/crates/pi-natives/src/audio.rs
@@ -27,13 +27,18 @@ use parking_lot::Mutex;
 use tokio::sync::Notify;
 
 const AUDIO_CHANNELS: u32 = 1;
+// PulseAudio TCP playback stutters with a 20 ms target buffer; 50 ms absorbs
+// transport jitter while preserving interactive latency.
+#[cfg(target_os = "linux")]
+const PLAYBACK_PERIOD_MS: u32 = 50;
+#[cfg(not(target_os = "linux"))]
 const PLAYBACK_PERIOD_MS: u32 = 20;
 // miniaudio's PulseAudio backend reserves three periods. Android's OpenSL ES
 // source emits 125 ms fragments, so Linux capture needs at least 150 ms queued.
 #[cfg(target_os = "linux")]
 const CAPTURE_PERIOD_MS: u32 = 50;
 #[cfg(not(target_os = "linux"))]
-const CAPTURE_PERIOD_MS: u32 = PLAYBACK_PERIOD_MS;
+const CAPTURE_PERIOD_MS: u32 = 20;
 const PLAYBACK_DRAIN_CALLBACKS: usize = 2;
 
 #[cfg(target_os = "macos")]

--- a/crates/pi-natives/src/audio.rs
+++ b/crates/pi-natives/src/audio.rs
@@ -27,7 +27,13 @@ use parking_lot::Mutex;
 use tokio::sync::Notify;
 
 const AUDIO_CHANNELS: u32 = 1;
-const AUDIO_PERIOD_MS: u32 = 20;
+const PLAYBACK_PERIOD_MS: u32 = 20;
+// miniaudio's PulseAudio backend reserves three periods. Android's OpenSL ES
+// source emits 125 ms fragments, so Linux capture needs at least 150 ms queued.
+#[cfg(target_os = "linux")]
+const CAPTURE_PERIOD_MS: u32 = 50;
+#[cfg(not(target_os = "linux"))]
+const CAPTURE_PERIOD_MS: u32 = PLAYBACK_PERIOD_MS;
 const PLAYBACK_DRAIN_CALLBACKS: usize = 2;
 
 #[cfg(target_os = "macos")]
@@ -133,7 +139,7 @@ impl PlaybackStream {
 		builder
 			.sample_rate(sample_rate)
 			.playback_channels(AUDIO_CHANNELS)
-			.period_size_millis(AUDIO_PERIOD_MS)
+			.period_size_millis(PLAYBACK_PERIOD_MS)
 			.performance_profile(PerformanceProfile::LowLatency)
 			.backends(AUDIO_BACKENDS);
 		let mut device = builder
@@ -280,7 +286,7 @@ impl AudioCapture {
 		builder
 			.sample_rate(sample_rate)
 			.capture_channels(AUDIO_CHANNELS)
-			.period_size_millis(AUDIO_PERIOD_MS)
+			.period_size_millis(CAPTURE_PERIOD_MS)
 			.performance_profile(PerformanceProfile::LowLatency)
 			.backends(AUDIO_BACKENDS);
 		let mut device = builder
@@ -428,5 +434,42 @@ mod tests {
 		fill_playback(&rx, &mut current, &mut cursor, &mut silence, &state, &mut empty_callbacks);
 		assert_eq!(silence, [0.0, 0.0]);
 		assert!(state.drained.load(Ordering::Acquire));
+	}
+
+	#[test]
+	fn opt_in_default_capture_receives_frames() {
+		if std::env::var_os("OMP_NATIVE_AUDIO_CAPTURE_TEST").is_none() {
+			return;
+		}
+
+		let callbacks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+		let callback_count = Arc::clone(&callbacks);
+		let mut builder = DeviceBuilder::capture().f32();
+		builder
+			.sample_rate(audio_sample_rate(16_000).expect("sample rate is supported"))
+			.capture_channels(AUDIO_CHANNELS)
+			.period_size_millis(CAPTURE_PERIOD_MS)
+			.performance_profile(PerformanceProfile::LowLatency)
+			.backends(AUDIO_BACKENDS);
+		let mut device = builder
+			.with_callback(move |_device, samples| {
+				if !samples.is_empty() {
+					callback_count.fetch_add(1, Ordering::Relaxed);
+				}
+			})
+			.expect("default capture device opens");
+		device
+			.device_start()
+			.expect("default capture device starts");
+
+		let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+		while callbacks.load(Ordering::Relaxed) == 0 && std::time::Instant::now() < deadline {
+			std::thread::sleep(std::time::Duration::from_millis(20));
+		}
+		if callbacks.load(Ordering::Relaxed) == 0 {
+			std::mem::forget(device);
+			panic!("capture device started but delivered no frames within five seconds");
+		}
+		device.device_stop().expect("capture device stops");
 	}
 }

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added `GET /v1/credentials/disabled` to the auth broker and `AuthBrokerClient.listDisabledCredentials`: disabled-credential tombstones (`DisabledCredentialSummary` — identity, verbatim disable cause, disable timestamp; never token material) so auto-disabled accounts stay visible to clients instead of silently vanishing from the snapshot. `AuthStorage.listDisabledCredentials` serves the same data locally from SQLite; clients of brokers predating the endpoint get an empty list (404 mapped, no error).
 - Added `AuthStorage.revalidateCredentials()` and the optional `AuthCredentialStore.refreshSnapshot` hook: remote broker stores re-fetch `GET /v1/snapshot` on demand so callers pairing live per-credential data with stored identities (`omp usage`) never render against the up-to-an-hour-stale disk-cached snapshot; local SQLite stores are always current and only reload.
 
+### Fixed
+
+- Fixed a circular initialization between the Anthropic provider and OAuth registry that could throw before `claudeCodeVersion` was initialized when package tests or consumers loaded modules in parallel ([#6628](https://github.com/can1357/oh-my-pi/pull/6628) by [@anatoli-tsinovoy](https://github.com/anatoli-tsinovoy)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic-versions.ts
+++ b/packages/ai/src/providers/anthropic-versions.ts
@@ -1,0 +1,6 @@
+// Claude client versions shared by transport, OAuth, and usage code. Keep this
+// module dependency-free so registry initialization cannot cycle through the
+// Anthropic provider.
+export const claudeCodeVersion = "2.1.165";
+export const claudeAgentSdkVersion = "0.3.165";
+export const claudeClientVersion = "1.11187.4";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -72,6 +72,7 @@ import {
 	calculateAnthropicRetryDelayMs,
 	retryDelayFromHeaders,
 } from "./anthropic-client";
+import { claudeAgentSdkVersion, claudeClientVersion, claudeCodeVersion } from "./anthropic-versions";
 import {
 	type ToolInputSchema as AnthropicToolInputSchema,
 	type Tool as AnthropicWireTool,
@@ -91,6 +92,8 @@ import {
 } from "./github-copilot-headers";
 import { transformMessages } from "./transform-messages";
 import { NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
+
+export * from "./anthropic-versions";
 
 export type AnthropicHeaderOptions = {
 	apiKey: string;
@@ -464,9 +467,6 @@ function getCacheControl(
 }
 
 // Stealth mode: mimic Claude Code's request fingerprint.
-export const claudeCodeVersion = "2.1.165";
-export const claudeAgentSdkVersion = "0.3.165";
-export const claudeClientVersion = "1.11187.4";
 export const claudeToolPrefix: string = "_";
 export const claudeCodeSystemInstruction = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 // Claude Code caps requested output at 64k tokens even when the model ceiling is

--- a/packages/ai/src/registry/oauth/anthropic.ts
+++ b/packages/ai/src/registry/oauth/anthropic.ts
@@ -3,7 +3,7 @@
  */
 
 import * as AIError from "../../error";
-import { claudeCodeVersion } from "../../providers/anthropic";
+import { claudeCodeVersion } from "../../providers/anthropic-versions";
 import type { FetchImpl } from "../../types";
 import { OAuthCallbackFlow } from "./callback-server";
 import { generatePKCE } from "./pkce";

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -2,7 +2,7 @@ import { scheduler } from "node:timers/promises";
 import { bareModelId, parseAnthropicModel } from "@oh-my-pi/pi-catalog/identity";
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import * as AIError from "../error";
-import { claudeCodeVersion } from "../providers/anthropic";
+import { claudeCodeVersion } from "../providers/anthropic-versions";
 import {
 	type CredentialRankingContext,
 	type CredentialRankingStrategy,

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Linux `AudioCapture` stalling on PulseAudio sources that emit fragments larger than miniaudio's previous 60 ms capture buffer, including Android OpenSL ES microphones reached through a forwarded PulseAudio server.
+- Fixed Linux native audio over forwarded PulseAudio servers: capture now handles 125 ms Android fragments without stalling, and playback buffers enough audio to avoid TCP underruns and stuttering.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Linux native audio over forwarded PulseAudio servers: capture now handles 125 ms Android fragments without stalling, and playback buffers enough audio to avoid TCP underruns and stuttering.
+- Fixed Linux native audio over forwarded PulseAudio servers: capture now handles 125 ms Android fragments without stalling, and playback buffers enough audio to avoid TCP underruns and stuttering ([#6628](https://github.com/can1357/oh-my-pi/pull/6628) by [@anatoli-tsinovoy](https://github.com/anatoli-tsinovoy)).
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Linux `AudioCapture` stalling on PulseAudio sources that emit fragments larger than miniaudio's previous 60 ms capture buffer, including Android OpenSL ES microphones reached through a forwarded PulseAudio server.
+
 ## [17.1.3] - 2026-07-24
 
 ### Changed


### PR DESCRIPTION
## Summary

- give Linux capture a 50 ms period so miniaudio's three-period PulseAudio buffer can accept 125 ms source fragments
- give Linux playback a 50 ms target buffer so forwarded PulseAudio TCP streams tolerate transport jitter instead of underrunning
- wait for all three PulseAudio periods after playback input closes so the buffered tail reaches the sink
- preserve the existing 20 ms low-latency period on macOS, Windows, and other non-Linux backends
- route the opt-in hardware regression probe through the same capture-device setup used by `AudioCapture`
- break a pre-existing Anthropic provider/OAuth registry initialization cycle exposed by the required parallel workspace CI job

## Root cause

The native audio path requested a 20 ms period for every backend and both directions. In miniaudio's PulseAudio backend, capture `maxlength` is three periods while `fragsize` is one period. That limited the capture buffer to 60 ms, but the forwarded Android OpenSL ES source delivers roughly 125 ms fragments. The Pulse stream opened and started successfully, yet no capture callbacks reached `AudioCapture`; the external bridge only appeared necessary because it rechunked those fragments.

The same 20 ms setting made playback's PulseAudio target buffer too shallow for a TCP-forwarded server. PCM was already queued in the native player, but the server stream repeatedly underrun, producing stutter throughout each synthesized sentence. A 50 ms Linux period yields a 150 ms capture maximum and enough playback headroom without changing non-Linux latency. Playback drain now also waits for the server's full three-period depth before stopping the device, preventing clipped utterance endings.

## CI follow-up

The workspace-fast job reproducibly failed before reaching this PR's code because `registry/oauth/anthropic.ts` imported `claudeCodeVersion` from the full Anthropic provider while that provider was still initializing through the catalog/registry cycle. The version constants now live in a dependency-free module shared by the provider, OAuth, and usage paths; the provider re-exports them to preserve its API.

## Reproduction

Capture, using the native PulseAudio backend against the forwarded OpenSL ES source:

- 20 ms period / 60 ms capacity: 0 callbacks
- 40 ms period / 120 ms capacity: 0 callbacks
- 50 ms period / 150 ms capacity: frames delivered continuously

Playback, using the same forwarded server and Kokoro utterance:

- 20 ms target: stutter throughout all three synthesized segments
- 50 ms target: smooth playback with the same PCM and sink
- three-period drain: short utterance remained smooth and its final word was fully audible

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p pi-natives` — 218 passed
- `OMP_NATIVE_AUDIO_CAPTURE_TEST=1 cargo test -p pi-natives audio::tests::opt_in_default_capture_receives_frames -- --nocapture` against the forwarded default source — passed
- `bun test --parallel=8` in `packages/catalog` — 488 passed, 0 failed (the exact previously failing CI command)
- `bun check` — passed across the workspace
- full-duplex hardware exercise against the forwarded PulseAudio server: native capture delivered 398 callbacks / 318,400 frames over 20 seconds while a 12.5-second two-segment Kokoro utterance played concurrently; playback remained smooth
- `bun packages/natives/scripts/build-native.ts` completed without warnings

---

- [x] `bun check` passes
- [x] Rust formatting and tests pass
- [x] Exact workspace-fast failure reproduced and fixed locally
- [x] Tested capture and playback concurrently against forwarded PulseAudio
- [x] CHANGELOG entries updated with contributor attribution