### PR TITLE
feat(utils): add transcript database path helper

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `getTranscriptDbPath` helper for resolving `transcripts.db` location.
+
 ## [17.0.9] - 2026-07-23
 
 ### Breaking Changes

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -740,6 +740,11 @@ export function getHistoryDbPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "history.db", "data");
 }
 
+/** Get the path to transcripts.db (SQLite FTS index over session JSONL). */
+export function getTranscriptDbPath(agentDir?: string): string {
+	return dirs.agentSubdir(agentDir, "transcripts.db", "data");
+}
+
 /** Get the path to models.db (model cache database). */
 export function getModelDbPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "models.db", "data");

--- a/packages/utils/test/profiles.test.ts
+++ b/packages/utils/test/profiles.test.ts
@@ -13,6 +13,7 @@ import {
 	getPythonGatewayDir,
 	getSessionsDir,
 	getStatsDbPath,
+	getTranscriptDbPath,
 	normalizeProfileName,
 	resolveProfileEnv,
 	setAgentDir,
@@ -127,6 +128,7 @@ describe("profile directories", () => {
 		expect(getConfigAgentDirName()).toBe(path.join(configDir, "profiles", "work", "agent"));
 		expect(getAgentDir()).toBe(agent);
 		expect(getAgentDbPath()).toBe(path.join(agent, "agent.db"));
+		expect(getTranscriptDbPath()).toBe(path.join(agent, "transcripts.db"));
 		expect(getSessionsDir()).toBe(path.join(agent, "sessions"));
 		expect(getStatsDbPath()).toBe(path.join(root, "stats.db"));
 	});
@@ -155,6 +157,9 @@ describe("profile directories", () => {
 		setProfile("work");
 
 		expect(getAgentDbPath()).toBe(path.join(process.env.XDG_DATA_HOME, "omp", "profiles", "work", "agent.db"));
+		expect(getTranscriptDbPath()).toBe(
+			path.join(process.env.XDG_DATA_HOME, "omp", "profiles", "work", "transcripts.db"),
+		);
 		expect(getSessionsDir()).toBe(path.join(process.env.XDG_DATA_HOME, "omp", "profiles", "work", "sessions"));
 		expect(getPythonGatewayDir()).toBe(
 			path.join(process.env.XDG_STATE_HOME, "omp", "profiles", "work", "python-gateway"),
@@ -201,6 +206,7 @@ describe("profile directories", () => {
 	it("restores the pre-profile PI_CODING_AGENT_DIR override on reset", () => {
 		const customAgentDir = path.join(tempRoot, "custom-agent");
 		setAgentDir(customAgentDir);
+		expect(getTranscriptDbPath(customAgentDir)).toBe(path.join(customAgentDir, "transcripts.db"));
 		expect(getAgentDir()).toBe(customAgentDir);
 		expect(process.env.PI_CODING_AGENT_DIR).toBe(customAgentDir);
 


### PR DESCRIPTION
## Summary
Add `getTranscriptDbPath()` beside the existing history database path helper so transcript indexing has one canonical storage location.
## Included commits
- `7fdf5cd7f` feat(utils): add getTranscriptDbPath beside getHistoryDbPath
## Verification
`bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit`

Closes #6633
