### PR TITLE
fix(utils): contain timeout rejection in ptree

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a process timeout leaking an unhandled rejection: `attachTimeout` observed the child lifecycle without the no-op catch its sibling `attachSignal` already had, so a timed-out process could surface an unhandled `TimeoutError` after the caller had already settled.
+
 ## [17.0.9] - 2026-07-23
 
 ### Breaking Changes

--- a/packages/utils/src/ptree.ts
+++ b/packages/utils/src/ptree.ts
@@ -316,7 +316,13 @@ export class ChildProcess<In extends InMask = InMask> {
 				() => false,
 			),
 		]).then(timedOut => {
-			if (timedOut) this.kill(new TimeoutError(ms, this.#stderrTail));
+			if (timedOut) {
+				// Mirror attachSignal: killing rejects #exited, and the watchdog is a
+				// second observer of that lifecycle. Without its own no-op catch the
+				// rejection surfaces unhandled when the caller settles first.
+				this.#exited.catch(() => {});
+				this.kill(new TimeoutError(ms, this.#stderrTail));
+			}
 		});
 	}
 

--- a/packages/utils/test/ptree-timeout.test.ts
+++ b/packages/utils/test/ptree-timeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { spawn, TimeoutError } from "@oh-my-pi/pi-utils/ptree";
+
+describe("ptree.ChildProcess.attachTimeout()", () => {
+	it("contains the watchdog rejection without hiding TimeoutError from callers", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const child = spawn(["bun", "-e", "setInterval(() => {}, 1_000)"], { timeout: 10 });
+
+			// Let the watchdog reject before the caller observes a derived promise.
+			await Bun.sleep(100);
+			await expect(child.exitedCleanly).rejects.toBeInstanceOf(TimeoutError);
+			await Bun.sleep(0);
+
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+});

--- a/packages/utils/test/ptree-timeout.test.ts
+++ b/packages/utils/test/ptree-timeout.test.ts
@@ -1,23 +1,65 @@
 import { describe, expect, it } from "bun:test";
-import { spawn, TimeoutError } from "@oh-my-pi/pi-utils/ptree";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ptreeModuleUrl = pathToFileURL(join(import.meta.dir, "../src/ptree.ts")).href;
+const postmortemModuleUrl = pathToFileURL(join(import.meta.dir, "../src/index.ts")).href;
+
+async function runPtreeTimeoutProbe(
+	source: string,
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+	const root = await mkdtemp(join(tmpdir(), "omp-ptree-timeout-"));
+	const probePath = join(root, "probe.ts");
+	try {
+		await Bun.write(probePath, source);
+		const proc = Bun.spawn([process.execPath, probePath], {
+			cwd: process.cwd(),
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, OMP_AGENT_DIR: join(root, "agent") },
+		});
+		const watchdog = Bun.sleep(5000).then(() => {
+			proc.kill();
+			return -999;
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			Promise.race([proc.exited, watchdog]),
+		]);
+		return { exitCode, stdout, stderr };
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
 
 describe("ptree.ChildProcess.attachTimeout()", () => {
 	it("contains the watchdog rejection without hiding TimeoutError from callers", async () => {
-		const unhandled: unknown[] = [];
-		const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
-		process.on("unhandledRejection", onUnhandledRejection);
+		const result = await runPtreeTimeoutProbe(`
+			import "${postmortemModuleUrl}";
+			import { spawn, TimeoutError } from "${ptreeModuleUrl}";
 
-		try {
 			const child = spawn(["bun", "-e", "setInterval(() => {}, 1_000)"], { timeout: 10 });
-
-			// Let the watchdog reject before the caller observes a derived promise.
 			await Bun.sleep(100);
-			await expect(child.exitedCleanly).rejects.toBeInstanceOf(TimeoutError);
-			await Bun.sleep(0);
 
-			expect(unhandled).toEqual([]);
-		} finally {
-			process.off("unhandledRejection", onUnhandledRejection);
-		}
+			try {
+				await child.exitedCleanly;
+				process.stdout.write("NOT_TIMEOUT\\n");
+			} catch (err) {
+				if (err instanceof TimeoutError) {
+					process.stdout.write("TIMEOUT_OK\\n");
+				} else {
+					process.stdout.write("UNEXPECTED_ERROR\\n");
+					throw err;
+				}
+			}
+			await Bun.sleep(0);
+		`);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("TIMEOUT_OK");
+		expect(result.stderr).not.toContain("[Unhandled Rejection]");
 	});
 });


### PR DESCRIPTION
## Summary
Contain the rejected child lifecycle promise created by `attachTimeout`, matching `attachSignal`, so a timed-out process cannot leak an unhandled `TimeoutError` after its caller settles.
## Included commits
- `3fa4a3728` fix(utils): contain the timeout rejection in ptree attachTimeout
## Verification
`bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit`

Closes #6635
