### PR TITLE
feat(coding-agent): add git ref CAS and fast-forward helpers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added `git.ref.isAncestor`, `git.ref.update` (CAS), and `git.merge.fastForwardOnly` helpers.
 
 ### Fixed
 

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1834,6 +1834,49 @@ export const ref = {
 			),
 		);
 	},
+
+	/**
+	 * True when `ancestor` is an ancestor of `descendant` (`git merge-base --is-ancestor`).
+	 * Exit 0 → true, exit 1 → false; any other exit throws.
+	 */
+	async isAncestor(cwd: string, ancestor: string, descendant: string, signal?: AbortSignal): Promise<boolean> {
+		const args = ["merge-base", "--is-ancestor", ancestor, descendant];
+		const result = await git(cwd, args, { readOnly: true, signal });
+		if (result.exitCode === 0) return true;
+		if (result.exitCode === 1) return false;
+		throw new GitCommandError(args, result);
+	},
+
+	/**
+	 * Compare-and-swap a ref via `git update-ref <ref> <new> <old>`.
+	 * Returns true on success, false when the CAS lost because the ref moved,
+	 * and throws on any other failure.
+	 */
+	async update(
+		cwd: string,
+		refName: string,
+		newSha: string,
+		expectedOldSha: string,
+		signal?: AbortSignal,
+	): Promise<boolean> {
+		const args = ["update-ref", refName, newSha, expectedOldSha];
+		const result = await git(cwd, args, { signal });
+		if (result.exitCode === 0) return true;
+		// Git reports a lost CAS as exit 128 with "is at <sha> but expected <sha>".
+		if (/but expected /i.test(result.stderr)) return false;
+		throw new GitCommandError(args, result);
+	},
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: merge
+// ════════════════════════════════════════════════════════════════════════════
+
+export const merge = {
+	/** Fast-forward the current branch to `ref` (`git merge --ff-only`). */
+	async fastForwardOnly(cwd: string, ref: string, signal?: AbortSignal): Promise<void> {
+		await runEffect(cwd, ["merge", "--ff-only", ref], { signal });
+	},
 };
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1862,8 +1862,8 @@ export const ref = {
 		const args = ["update-ref", refName, newSha, expectedOldSha];
 		const result = await git(cwd, args, { signal });
 		if (result.exitCode === 0) return true;
-		// Git reports a lost CAS as exit 128 with "is at <sha> but expected <sha>".
-		if (/but expected /i.test(result.stderr)) return false;
+		// Git reports a lost CAS with "but expected", "unable to resolve reference", or "reference already exists".
+		if (/but expected |unable to resolve reference|reference already exists/i.test(result.stderr)) return false;
 		throw new GitCommandError(args, result);
 	},
 };
@@ -1875,7 +1875,7 @@ export const ref = {
 export const merge = {
 	/** Fast-forward the current branch to `ref` (`git merge --ff-only`). */
 	async fastForwardOnly(cwd: string, ref: string, signal?: AbortSignal): Promise<void> {
-		await runEffect(cwd, ["merge", "--ff-only", ref], { signal });
+		await runEffect(cwd, ["merge", "--ff-only", "--", ref], { signal });
 	},
 };
 

--- a/packages/coding-agent/test/utils/git.test.ts
+++ b/packages/coding-agent/test/utils/git.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const GIT_ENV = {
+	GIT_AUTHOR_NAME: "t",
+	GIT_AUTHOR_EMAIL: "t@example.com",
+	GIT_COMMITTER_NAME: "t",
+	GIT_COMMITTER_EMAIL: "t@example.com",
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
+const ZERO_SHA = "0".repeat(40);
+
+function gitRun(cwd: string, args: string[]): string {
+	const env: Record<string, string | undefined> = { ...process.env, ...GIT_ENV };
+	delete env.GIT_DIR;
+	delete env.GIT_WORK_TREE;
+	delete env.GIT_INDEX_FILE;
+	delete env.GIT_OBJECT_DIRECTORY;
+	delete env.GIT_ALTERNATE_OBJECT_DIRECTORIES;
+	const result = Bun.spawnSync({
+		cmd: ["git", ...args],
+		cwd,
+		env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (result.exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+	}
+	return result.stdout.toString().trim();
+}
+
+describe("git ref compare-and-swap and fast-forward helpers", () => {
+	let tmpRoot: string;
+	let repository: string;
+	let initialSha: string;
+	let nextSha: string;
+
+	beforeAll(async () => {
+		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-git-helpers-test-"));
+	});
+
+	beforeEach(async () => {
+		repository = await fs.mkdtemp(path.join(tmpRoot, "repository-"));
+		gitRun(repository, ["init", "-q", "-b", "main"]);
+		gitRun(repository, ["commit", "-q", "--allow-empty", "-m", "initial"]);
+		initialSha = gitRun(repository, ["rev-parse", "HEAD"]);
+		gitRun(repository, ["commit", "-q", "--allow-empty", "-m", "next"]);
+		nextSha = gitRun(repository, ["rev-parse", "HEAD"]);
+	});
+
+	afterAll(async () => {
+		await removeWithRetries(tmpRoot);
+	});
+
+	test("updates a ref when its expected value matches", async () => {
+		const refName = "refs/heads/cas-success";
+
+		expect(await git.ref.update(repository, refName, initialSha, ZERO_SHA)).toBe(true);
+		expect(gitRun(repository, ["rev-parse", refName])).toBe(initialSha);
+	});
+
+	test("returns false when a ref moved after its expected value was read", async () => {
+		const refName = "refs/heads/cas-moved";
+		expect(await git.ref.update(repository, refName, initialSha, ZERO_SHA)).toBe(true);
+
+		expect(await git.ref.update(repository, refName, nextSha, nextSha)).toBe(false);
+		expect(gitRun(repository, ["rev-parse", refName])).toBe(initialSha);
+	});
+
+	test("returns false when an expected-absent ref was created", async () => {
+		const refName = "refs/heads/cas-created";
+		expect(await git.ref.update(repository, refName, initialSha, ZERO_SHA)).toBe(true);
+
+		expect(await git.ref.update(repository, refName, nextSha, ZERO_SHA)).toBe(false);
+		expect(gitRun(repository, ["rev-parse", refName])).toBe(initialSha);
+	});
+
+	test("returns false when an expected ref was deleted", async () => {
+		expect(await git.ref.update(repository, "refs/heads/cas-deleted", nextSha, initialSha)).toBe(false);
+	});
+
+	test("throws for an invalid ref instead of treating it as a CAS loss", async () => {
+		await expect(git.ref.update(repository, "refs/heads/not valid", initialSha, ZERO_SHA)).rejects.toThrow();
+	});
+
+	test("treats a dash-prefixed branch name as a merge target", async () => {
+		gitRun(repository, ["reset", "-q", "--hard", initialSha]);
+		gitRun(repository, ["update-ref", "refs/heads/--no-ff", nextSha]);
+
+		await git.merge.fastForwardOnly(repository, "--no-ff");
+
+		expect(gitRun(repository, ["rev-parse", "HEAD"])).toBe(nextSha);
+	});
+});


### PR DESCRIPTION
## Summary
Add native git helpers for ancestry checks, compare-and-swap ref updates, and fast-forward-only merges used by mission workspace integration.
## Included commits
- `84f9f97aa` feat(coding-agent): add git ref CAS, ancestry, and ff-only merge helpers
## Verification
`bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit`

Closes #6637
