### PR TITLE
feat(coding-agent): run toolbox executables as agent tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added executable toolbox custom tools: executable files in `.omp/toolbox/` and `~/.omp/toolbox/` declare their JSON Schema through a describe handshake and execute through the standard exec approval gate.
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
 

--- a/packages/coding-agent/src/capability/tool.ts
+++ b/packages/coding-agent/src/capability/tool.ts
@@ -28,7 +28,9 @@ export const toolCapability = defineCapability<CustomTool>({
 	id: "tools",
 	displayName: "Custom Tools",
 	description: "User-defined tools that extend agent capabilities",
-	key: tool => tool.name,
+	// Toolbox descriptors only know their filename until the executable describe handshake.
+	// CustomToolLoader deduplicates them by the declared name after that handshake.
+	key: tool => (tool._source.provider === "toolbox" ? undefined : tool.name),
 	toExtensionId: tool => `tool:${tool.name}`,
 	validate: tool => {
 		if (!tool.name) return "Missing name";

--- a/packages/coding-agent/src/discovery/index.ts
+++ b/packages/coding-agent/src/discovery/index.ts
@@ -37,6 +37,8 @@ import "./omp-plugins";
 import "./ssh";
 import "./vscode";
 import "./windsurf";
+// Toolbox provider registers on import (implementation lives under extensibility).
+import "../extensibility/custom-tools/toolbox";
 
 // Re-export the main API from capability registry
 export {

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -19,6 +19,7 @@ import { getAllPluginToolPaths } from "../../extensibility/plugins/loader";
 import * as PiCodingAgent from "../../index";
 import * as typebox from "../typebox";
 import { createNoOpUIContext, resolvePath, withHostGuard } from "../utils";
+import { loadToolboxTool, TOOLBOX_PROVIDER_ID } from "./toolbox";
 import type { CustomToolAPI, CustomToolFactory, LoadedCustomTool, ToolLoadError } from "./types";
 
 interface LoadToolResult {
@@ -72,6 +73,10 @@ async function loadTool(
 				},
 			],
 		};
+	}
+
+	if (source?.provider === TOOLBOX_PROVIDER_ID) {
+		return loadToolboxTool(resolvedPath, source);
 	}
 
 	try {

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -76,7 +76,7 @@ async function loadTool(
 	}
 
 	if (source?.provider === TOOLBOX_PROVIDER_ID) {
-		return loadToolboxTool(resolvedPath, source);
+		return loadToolboxTool(resolvedPath, source, { cwd: sharedApi.cwd });
 	}
 
 	try {

--- a/packages/coding-agent/src/extensibility/custom-tools/toolbox.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/toolbox.ts
@@ -1,0 +1,284 @@
+/**
+ * Toolbox tools — executable files discovered from `.omp/toolbox/` and `~/.omp/toolbox/`.
+ *
+ * Providers yield capability descriptors (path = executable). Loading runs a describe/execute
+ * handshake instead of `import()`, because shell scripts cannot be imported as modules.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CONFIG_DIR_NAME, logger, ptree, tryParseJson } from "@oh-my-pi/pi-utils";
+import { registerProvider } from "../../capability";
+import { type CustomTool as CustomToolDescriptor, toolCapability } from "../../capability/tool";
+import type { LoadContext, LoadResult } from "../../capability/types";
+import { createSourceMeta } from "../../discovery/helpers";
+import { PREVIEW_LIMITS, replaceTabs } from "../../tools/render-utils";
+import { toolResult } from "../../tools/tool-result";
+import { Type } from "../typebox";
+import type { CustomTool, LoadedCustomTool, ToolLoadError } from "./types";
+
+export const TOOLBOX_PROVIDER_ID = "toolbox";
+
+const DISPLAY_NAME = "Toolbox";
+const DESCRIPTION = "Executable tools from .omp/toolbox/ and ~/.omp/toolbox/";
+const PRIORITY = 80;
+const DESCRIBE_DEADLINE_MS = 5_000;
+/** Owner-execute bit (S_IXUSR). Non-executable files are ignored silently. */
+const OWNER_EXECUTE = 0o100;
+
+interface LoadToolResult {
+	tools: LoadedCustomTool[];
+	errors: ToolLoadError[];
+}
+
+type ToolboxSource = { provider: string; providerName: string; level: "user" | "project" };
+
+interface ToolboxDescribePayload {
+	name: string;
+	description: string;
+	parameters: Record<string, unknown>;
+}
+
+type SpawnOutcome =
+	| { kind: "ok"; stdout: string; stderr: string }
+	| { kind: "nonzero"; exitCode: number; stdout: string; stderr: string }
+	| { kind: "timeout"; stderr: string }
+	| { kind: "killed"; stderr: string };
+
+function isOwnerExecutable(mode: number): boolean {
+	return (mode & OWNER_EXECUTE) !== 0;
+}
+
+function basenameWithoutExtension(fileName: string): string {
+	const dot = fileName.lastIndexOf(".");
+	if (dot <= 0) return fileName;
+	return fileName.slice(0, dot);
+}
+
+function formatPreviewText(text: string): string {
+	const normalized = replaceTabs(text);
+	const lines = normalized.split("\n");
+	const max = PREVIEW_LIMITS.EXPANDED_LINES;
+	if (lines.length <= max) return normalized;
+	return `${lines.slice(0, max).join("\n")}\n… ${lines.length - max} more lines`;
+}
+
+function classifyExecResult(result: ptree.ExecResult): SpawnOutcome {
+	if (result.exitError instanceof ptree.TimeoutError) {
+		return { kind: "timeout", stderr: result.stderr };
+	}
+	if (result.exitError?.aborted) {
+		return { kind: "killed", stderr: result.stderr };
+	}
+	if (result.exitCode !== null && result.exitCode !== 0) {
+		return {
+			kind: "nonzero",
+			exitCode: result.exitCode,
+			stdout: result.stdout,
+			stderr: result.stderr,
+		};
+	}
+	if (!result.ok) {
+		return {
+			kind: "nonzero",
+			exitCode: result.exitCode ?? 1,
+			stdout: result.stdout,
+			stderr: result.stderr,
+		};
+	}
+	return { kind: "ok", stdout: result.stdout, stderr: result.stderr };
+}
+
+function parseDescribePayload(stdout: string, defaultName: string): ToolboxDescribePayload | string {
+	const trimmed = stdout.trim();
+	if (!trimmed) return "describe produced empty stdout";
+
+	const parsed = tryParseJson<unknown>(trimmed);
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return "describe produced unparsable JSON";
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const description = record.description;
+	if (typeof description !== "string" || !description.trim()) {
+		return "describe JSON missing string description";
+	}
+
+	const parameters = record.parameters;
+	if (parameters === null || typeof parameters !== "object" || Array.isArray(parameters)) {
+		return "describe JSON missing parameters object";
+	}
+
+	const name = typeof record.name === "string" && record.name.trim() ? record.name.trim() : defaultName;
+
+	return {
+		name,
+		description: description.trim(),
+		parameters: parameters as Record<string, unknown>,
+	};
+}
+
+function skipTool(resolvedPath: string, reason: string, source?: ToolboxSource): LoadToolResult {
+	logger.warn(`Toolbox tool skipped (${resolvedPath}): ${reason}`);
+	return {
+		tools: [],
+		errors: [{ path: resolvedPath, error: reason, source }],
+	};
+}
+
+async function runToolboxAction(
+	resolvedPath: string,
+	action: "describe" | "execute",
+	options: { input?: string; timeout?: number; signal?: AbortSignal } = {},
+): Promise<SpawnOutcome> {
+	const result = await ptree.exec([resolvedPath], {
+		env: { ...Bun.env, OMP_TOOLBOX_ACTION: action },
+		input: options.input,
+		timeout: options.timeout,
+		signal: options.signal,
+		allowNonZero: true,
+		allowAbort: true,
+		stderr: "full",
+	});
+	return classifyExecResult(result);
+}
+
+function synthesizeToolboxTool(resolvedPath: string, desc: ToolboxDescribePayload): CustomTool {
+	const name = desc.name;
+	const parameters = Type.Unsafe(desc.parameters);
+
+	return {
+		name,
+		label: name,
+		description: desc.description,
+		parameters,
+		approval: "exec",
+		strict: true,
+		async execute(_toolCallId, params, _onUpdate, _ctx, signal) {
+			const outcome = await runToolboxAction(resolvedPath, "execute", {
+				input: JSON.stringify(params),
+				signal,
+			});
+
+			switch (outcome.kind) {
+				case "ok":
+					return toolResult()
+						.text(outcome.stdout || "(no output)")
+						.done();
+				case "nonzero": {
+					const stderr = formatPreviewText(outcome.stderr || `(exit code ${outcome.exitCode})`);
+					return toolResult().text(stderr).error().done();
+				}
+				case "timeout":
+					return toolResult().text("Toolbox tool timed out").error().done();
+				case "killed":
+					return toolResult().text("Toolbox tool was killed before completion").error().done();
+			}
+		},
+	};
+}
+
+/**
+ * Load one toolbox executable via describe/execute handshake.
+ * Failures never throw: they return a ToolLoadError and one logger.warn.
+ */
+export async function loadToolboxTool(
+	resolvedPath: string,
+	source?: ToolboxSource,
+	options?: { describeTimeoutMs?: number },
+): Promise<LoadToolResult> {
+	const defaultName = basenameWithoutExtension(path.basename(resolvedPath));
+
+	let outcome: SpawnOutcome;
+	try {
+		// Overridable so the deadline path is provable without sleeping the real 5s.
+		outcome = await runToolboxAction(resolvedPath, "describe", {
+			timeout: options?.describeTimeoutMs ?? DESCRIBE_DEADLINE_MS,
+		});
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return skipTool(resolvedPath, `describe failed: ${message}`, source);
+	}
+
+	switch (outcome.kind) {
+		case "timeout":
+			return skipTool(resolvedPath, "describe exceeded 5s deadline", source);
+		case "killed":
+			return skipTool(resolvedPath, "describe process was killed", source);
+		case "nonzero":
+			return skipTool(resolvedPath, `describe exited with code ${outcome.exitCode}`, source);
+		case "ok": {
+			const parsed = parseDescribePayload(outcome.stdout, defaultName);
+			if (typeof parsed === "string") {
+				return skipTool(resolvedPath, parsed, source);
+			}
+
+			const tool = synthesizeToolboxTool(resolvedPath, parsed);
+			return {
+				tools: [
+					{
+						path: resolvedPath,
+						resolvedPath,
+						tool,
+						source,
+					},
+				],
+				errors: [],
+			};
+		}
+	}
+}
+
+async function scanToolboxDir(dir: string, level: "user" | "project"): Promise<CustomToolDescriptor[]> {
+	const items: CustomToolDescriptor[] = [];
+	let entries: fs.Dirent[];
+	try {
+		entries = await fs.promises.readdir(dir, { withFileTypes: true });
+	} catch {
+		return items;
+	}
+
+	for (const entry of entries) {
+		if (entry.name.startsWith(".")) continue;
+		if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+
+		const filePath = path.join(dir, entry.name);
+		let stats: fs.Stats;
+		try {
+			stats = await fs.promises.stat(filePath);
+		} catch {
+			continue;
+		}
+		if (!stats.isFile()) continue;
+		if (!isOwnerExecutable(stats.mode)) continue;
+
+		const name = basenameWithoutExtension(entry.name);
+		items.push({
+			name,
+			path: filePath,
+			description: `${name} toolbox tool`,
+			level,
+			_source: createSourceMeta(TOOLBOX_PROVIDER_ID, filePath, level),
+		});
+	}
+
+	return items;
+}
+
+async function loadToolboxDescriptors(ctx: LoadContext): Promise<LoadResult<CustomToolDescriptor>> {
+	const projectDir = path.join(ctx.cwd, CONFIG_DIR_NAME, "toolbox");
+	const userDir = path.join(ctx.home, CONFIG_DIR_NAME, "toolbox");
+	const [projectItems, userItems] = await Promise.all([
+		scanToolboxDir(projectDir, "project"),
+		scanToolboxDir(userDir, "user"),
+	]);
+	// Project first: capability key-dedup keeps the first item per name.
+	return { items: [...projectItems, ...userItems], warnings: [] };
+}
+
+registerProvider<CustomToolDescriptor>(toolCapability.id, {
+	id: TOOLBOX_PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadToolboxDescriptors,
+});

--- a/packages/coding-agent/src/extensibility/custom-tools/toolbox.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/toolbox.ts
@@ -6,6 +6,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { isValidJsonSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { CONFIG_DIR_NAME, logger, ptree, tryParseJson } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../../capability";
 import { type CustomTool as CustomToolDescriptor, toolCapability } from "../../capability/tool";
@@ -22,8 +23,8 @@ const DISPLAY_NAME = "Toolbox";
 const DESCRIPTION = "Executable tools from .omp/toolbox/ and ~/.omp/toolbox/";
 const PRIORITY = 80;
 const DESCRIBE_DEADLINE_MS = 5_000;
-/** Owner-execute bit (S_IXUSR). Non-executable files are ignored silently. */
-const OWNER_EXECUTE = 0o100;
+const EXECUTE_DEADLINE_MS = 30_000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
 
 interface LoadToolResult {
 	tools: LoadedCustomTool[];
@@ -42,11 +43,8 @@ type SpawnOutcome =
 	| { kind: "ok"; stdout: string; stderr: string }
 	| { kind: "nonzero"; exitCode: number; stdout: string; stderr: string }
 	| { kind: "timeout"; stderr: string }
-	| { kind: "killed"; stderr: string };
-
-function isOwnerExecutable(mode: number): boolean {
-	return (mode & OWNER_EXECUTE) !== 0;
-}
+	| { kind: "killed"; stderr: string }
+	| { kind: "output-limit"; stderr: string };
 
 function basenameWithoutExtension(fileName: string): string {
 	const dot = fileName.lastIndexOf(".");
@@ -107,6 +105,9 @@ function parseDescribePayload(stdout: string, defaultName: string): ToolboxDescr
 	if (parameters === null || typeof parameters !== "object" || Array.isArray(parameters)) {
 		return "describe JSON missing parameters object";
 	}
+	if (!isValidJsonSchema(parameters)) {
+		return "describe JSON has invalid parameters schema";
+	}
 
 	const name = typeof record.name === "string" && record.name.trim() ? record.name.trim() : defaultName;
 
@@ -128,21 +129,54 @@ function skipTool(resolvedPath: string, reason: string, source?: ToolboxSource):
 async function runToolboxAction(
 	resolvedPath: string,
 	action: "describe" | "execute",
-	options: { input?: string; timeout?: number; signal?: AbortSignal } = {},
+	options: { cwd?: string; input?: string; timeout?: number; signal?: AbortSignal } = {},
 ): Promise<SpawnOutcome> {
-	const result = await ptree.exec([resolvedPath], {
+	using child = ptree.spawn([resolvedPath], {
+		cwd: options.cwd,
 		env: { ...Bun.env, OMP_TOOLBOX_ACTION: action },
-		input: options.input,
+		stdin: options.input === undefined ? "ignore" : Buffer.from(options.input),
 		timeout: options.timeout,
 		signal: options.signal,
-		allowNonZero: true,
-		allowAbort: true,
-		stderr: "full",
 	});
-	return classifyExecResult(result);
+	const exited = child.exited.catch(() => undefined);
+
+	const decoder = new TextDecoder();
+	let stdout = "";
+	let outputBytes = 0;
+	let exceededOutputLimit = false;
+	for await (const chunk of child.stdout) {
+		if (outputBytes >= MAX_OUTPUT_BYTES) {
+			exceededOutputLimit = true;
+			child.kill();
+			continue;
+		}
+		const remaining = MAX_OUTPUT_BYTES - outputBytes;
+		const captured = chunk.subarray(0, remaining);
+		stdout += decoder.decode(captured, { stream: captured.byteLength === chunk.byteLength });
+		outputBytes += captured.byteLength;
+		if (captured.byteLength !== chunk.byteLength) {
+			exceededOutputLimit = true;
+			child.kill();
+		}
+	}
+	stdout += decoder.decode();
+
+	try {
+		await exited;
+	} catch {}
+
+	const stderr = child.peekStderr();
+	if (exceededOutputLimit) return { kind: "output-limit", stderr };
+	return classifyExecResult({
+		stdout,
+		stderr,
+		exitCode: child.exitCode,
+		ok: child.exitCode === 0,
+		exitError: child.exitReason,
+	});
 }
 
-function synthesizeToolboxTool(resolvedPath: string, desc: ToolboxDescribePayload): CustomTool {
+function synthesizeToolboxTool(resolvedPath: string, desc: ToolboxDescribePayload, cwd?: string): CustomTool {
 	const name = desc.name;
 	const parameters = Type.Unsafe(desc.parameters);
 
@@ -155,7 +189,9 @@ function synthesizeToolboxTool(resolvedPath: string, desc: ToolboxDescribePayloa
 		strict: true,
 		async execute(_toolCallId, params, _onUpdate, _ctx, signal) {
 			const outcome = await runToolboxAction(resolvedPath, "execute", {
+				cwd,
 				input: JSON.stringify(params),
+				timeout: EXECUTE_DEADLINE_MS,
 				signal,
 			});
 
@@ -172,6 +208,8 @@ function synthesizeToolboxTool(resolvedPath: string, desc: ToolboxDescribePayloa
 					return toolResult().text("Toolbox tool timed out").error().done();
 				case "killed":
 					return toolResult().text("Toolbox tool was killed before completion").error().done();
+				case "output-limit":
+					return toolResult().text("Toolbox tool output exceeded the 1 MiB limit").error().done();
 			}
 		},
 	};
@@ -184,7 +222,7 @@ function synthesizeToolboxTool(resolvedPath: string, desc: ToolboxDescribePayloa
 export async function loadToolboxTool(
 	resolvedPath: string,
 	source?: ToolboxSource,
-	options?: { describeTimeoutMs?: number },
+	options?: { cwd?: string; describeTimeoutMs?: number },
 ): Promise<LoadToolResult> {
 	const defaultName = basenameWithoutExtension(path.basename(resolvedPath));
 
@@ -192,6 +230,7 @@ export async function loadToolboxTool(
 	try {
 		// Overridable so the deadline path is provable without sleeping the real 5s.
 		outcome = await runToolboxAction(resolvedPath, "describe", {
+			cwd: options?.cwd,
 			timeout: options?.describeTimeoutMs ?? DESCRIBE_DEADLINE_MS,
 		});
 	} catch (err) {
@@ -204,6 +243,8 @@ export async function loadToolboxTool(
 			return skipTool(resolvedPath, "describe exceeded 5s deadline", source);
 		case "killed":
 			return skipTool(resolvedPath, "describe process was killed", source);
+		case "output-limit":
+			return skipTool(resolvedPath, "describe exceeded 1 MiB output limit", source);
 		case "nonzero":
 			return skipTool(resolvedPath, `describe exited with code ${outcome.exitCode}`, source);
 		case "ok": {
@@ -212,7 +253,7 @@ export async function loadToolboxTool(
 				return skipTool(resolvedPath, parsed, source);
 			}
 
-			const tool = synthesizeToolboxTool(resolvedPath, parsed);
+			const tool = synthesizeToolboxTool(resolvedPath, parsed, options?.cwd);
 			return {
 				tools: [
 					{
@@ -249,7 +290,11 @@ async function scanToolboxDir(dir: string, level: "user" | "project"): Promise<C
 			continue;
 		}
 		if (!stats.isFile()) continue;
-		if (!isOwnerExecutable(stats.mode)) continue;
+		try {
+			await fs.promises.access(filePath, fs.constants.X_OK);
+		} catch {
+			continue;
+		}
 
 		const name = basenameWithoutExtension(entry.name);
 		items.push({

--- a/packages/coding-agent/test/extensibility/toolbox.test.ts
+++ b/packages/coding-agent/test/extensibility/toolbox.test.ts
@@ -29,7 +29,7 @@ const TOOLBOX_SOURCE = {
 const STUB_CTX = {} as CustomToolContext;
 
 const tempRoots: string[] = [];
-const homedirSpies: Array<ReturnType<typeof spyOn>> = [];
+const homedirSpies: Array<{ mockRestore(): void }> = [];
 
 afterEach(async () => {
 	while (homedirSpies.length > 0) {
@@ -164,6 +164,30 @@ describe("toolbox tools", () => {
 		}
 	});
 
+	it("runs describe and execute in the session workspace", async () => {
+		const dir = await makeTemp("omp-toolbox-cwd-");
+		const scriptPath = await writeScript(
+			dir,
+			"cwd.sh",
+			[
+				"#!/bin/sh",
+				'if [ "$OMP_TOOLBOX_ACTION" = "describe" ]; then',
+				`if [ "$(pwd)" != "${dir}" ]; then exit 2; fi`,
+				`printf '%s\n' '{"name":"cwd","description":"prints cwd","parameters":{"type":"object","properties":{}}}'`,
+				"exit 0",
+				"fi",
+				"pwd",
+			].join("\n"),
+		);
+
+		const loaded = await loadCustomTools([{ path: scriptPath, source: TOOLBOX_SOURCE }], dir, []);
+		expect(loaded.errors).toEqual([]);
+		const result = await first(loaded.tools).tool.execute("call-cwd", {}, undefined, STUB_CTX);
+		const text = result.content.find(c => c.type === "text");
+		expect(text?.type).toBe("text");
+		if (text?.type === "text") expect(text.text.trim()).toBe(dir);
+	});
+
 	it("silently ignores files without the owner-execute bit during discovery", async () => {
 		const project = await makeTemp("omp-toolbox-project-");
 		const home = await makeTemp("omp-toolbox-home-");
@@ -256,6 +280,25 @@ describe("toolbox tools", () => {
 		}
 	});
 
+	it("rejects an invalid parameters JSON Schema", async () => {
+		const dir = await makeTemp("omp-toolbox-invalid-schema-");
+		const scriptPath = await writeScript(
+			dir,
+			"invalid_schema.sh",
+			goodFixture(
+				JSON.stringify({ name: "invalid_schema", description: "bad schema", parameters: { type: "bogus" } }),
+			),
+		);
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+			expect(result.tools).toEqual([]);
+			expect(first(result.errors).error).toContain("invalid parameters schema");
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
 	it("surfaces non-zero execute exit as a tool error carrying stderr (not a crash)", async () => {
 		const dir = await makeTemp("omp-toolbox-exec-err-");
 		const scriptPath = await writeScript(
@@ -289,27 +332,48 @@ describe("toolbox tools", () => {
 		}
 	});
 
-	it("lets project .omp/toolbox/ shadow user ~/.omp/toolbox/ for the same tool name", async () => {
+	it("terminates execute when stdout exceeds the output limit", async () => {
+		const dir = await makeTemp("omp-toolbox-output-limit-");
+		const scriptPath = await writeScript(
+			dir,
+			"large_output.sh",
+			[
+				"#!/bin/sh",
+				'if [ "$OMP_TOOLBOX_ACTION" = "describe" ]; then',
+				`printf '%s\n' '{"name":"large_output","description":"prints too much","parameters":{"type":"object","properties":{}}}'`,
+				"exit 0",
+				"fi",
+				"yes x | head -c 1048577",
+			].join("\n"),
+		);
+		const loaded = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+		const result = await first(loaded.tools).tool.execute("call-large", {}, undefined, STUB_CTX);
+		expect(result.isError).toBe(true);
+		const text = result.content.find(c => c.type === "text");
+		expect(text?.type).toBe("text");
+		if (text?.type === "text") expect(text.text).toContain("output exceeded");
+	});
+
+	it("deduplicates toolbox tools by their declared name after discovery", async () => {
 		const project = await makeTemp("omp-toolbox-shadow-project-");
 		const home = await makeTemp("omp-toolbox-shadow-home-");
-
-		await writeScript(
+		const projectPath = await writeScript(
 			path.join(project, ".omp", "toolbox"),
 			"shared.sh",
 			goodFixture(
 				JSON.stringify({
-					name: "shared",
+					name: "project_tool",
 					description: "project copy",
 					parameters: { type: "object", properties: {} },
 				}),
 			),
 		);
-		await writeScript(
+		const userPath = await writeScript(
 			path.join(home, ".omp", "toolbox"),
 			"shared.sh",
 			goodFixture(
 				JSON.stringify({
-					name: "shared",
+					name: "user_tool",
 					description: "user copy",
 					parameters: { type: "object", properties: {} },
 				}),
@@ -317,20 +381,15 @@ describe("toolbox tools", () => {
 		);
 
 		const items = await discoverToolboxDescriptors(project, home);
-		const shared = items.filter(i => i.name === "shared");
-		expect(shared).toHaveLength(1);
-		expect(first(shared).level).toBe("project");
-		expect(first(shared).path).toBe(path.join(project, ".omp", "toolbox", "shared.sh"));
+		expect(items.map(item => item.path).sort()).toEqual([projectPath, userPath].sort());
 
-		// Full load path: project executable wins; describe description confirms which binary ran.
 		const loaded = await loadCustomTools(
-			[{ path: first(shared).path, source: { ...TOOLBOX_SOURCE, level: "project" } }],
+			items.map(item => ({ path: item.path, source: { ...TOOLBOX_SOURCE, level: item.level } })),
 			project,
 			[],
 		);
 		expect(loaded.errors).toEqual([]);
-		expect(loaded.tools).toHaveLength(1);
-		expect(first(loaded.tools).tool.description).toBe("project copy");
+		expect(loaded.tools.map(item => item.tool.name).sort()).toEqual(["project_tool", "user_tool"]);
 	});
 
 	it("skips a tool whose describe exceeds the deadline, without throwing", async () => {

--- a/packages/coding-agent/test/extensibility/toolbox.test.ts
+++ b/packages/coding-agent/test/extensibility/toolbox.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Toolbox tools — real-executable contract tests.
+ *
+ * Shelling out IS the contract: fixtures are `#!/bin/sh` scripts written to a
+ * temp dir and chmod'd executable. Spawn is never mocked.
+ *
+ * Deadline note: `DESCRIBE_DEADLINE_MS` (5s) is a private const in toolbox.ts
+ * with no export or injection seam, so the "describe exceeds 5s deadline"
+ * failure mode is not exercised here (would require sleeping a real 5s).
+ */
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { CustomTool as CustomToolDescriptor } from "@oh-my-pi/pi-coding-agent/capability/tool";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { loadCustomTools } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/loader";
+import { loadToolboxTool, TOOLBOX_PROVIDER_ID } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/toolbox";
+import type { CustomTool, CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import { logger, removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const TOOLBOX_SOURCE = {
+	provider: TOOLBOX_PROVIDER_ID,
+	providerName: "Toolbox",
+	level: "project" as const,
+};
+
+/** Minimal context — toolbox execute ignores session state. */
+const STUB_CTX = {} as CustomToolContext;
+
+const tempRoots: string[] = [];
+const homedirSpies: Array<ReturnType<typeof spyOn>> = [];
+
+afterEach(async () => {
+	while (homedirSpies.length > 0) {
+		homedirSpies.pop()?.mockRestore();
+	}
+	while (tempRoots.length > 0) {
+		const dir = tempRoots.pop();
+		if (dir) await removeWithRetries(dir);
+	}
+});
+
+async function makeTemp(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempRoots.push(dir);
+	return dir;
+}
+
+async function writeScript(dir: string, fileName: string, body: string, mode = 0o755): Promise<string> {
+	await fs.mkdir(dir, { recursive: true });
+	const filePath = path.join(dir, fileName);
+	await fs.writeFile(filePath, body, { encoding: "utf8" });
+	await fs.chmod(filePath, mode);
+	return filePath;
+}
+
+/** Good fixture: JSON schema on describe, echo stdin on execute. */
+function goodFixture(describeJson: string): string {
+	return [
+		"#!/bin/sh",
+		'if [ "$OMP_TOOLBOX_ACTION" = "describe" ]; then',
+		`\tprintf '%s\\n' '${describeJson.replace(/'/g, `'\\''`)}'`,
+		"\texit 0",
+		"fi",
+		'if [ "$OMP_TOOLBOX_ACTION" = "execute" ]; then',
+		"\tcat",
+		"\texit 0",
+		"fi",
+		"exit 1",
+		"",
+	].join("\n");
+}
+
+function isolateHomedir(home: string): void {
+	homedirSpies.push(spyOn(os, "homedir").mockReturnValue(home));
+}
+
+async function discoverToolboxDescriptors(cwd: string, home: string): Promise<CustomToolDescriptor[]> {
+	isolateHomedir(home);
+	const result = await loadCapability<CustomToolDescriptor>("tools", {
+		cwd,
+		providers: [TOOLBOX_PROVIDER_ID],
+	});
+	return result.items;
+}
+
+/**
+ * First element, presence checked. Every call site asserts the length first, so an
+ * empty list here is a genuine test failure and deserves a named error rather than
+ * a `!` that would surface as an opaque "cannot read property of undefined".
+ */
+function first<T>(items: readonly T[]): T {
+	const [head] = items;
+	if (head === undefined) throw new Error("expected at least one element, got none");
+	return head;
+}
+
+describe("toolbox tools", () => {
+	it("loads a valid executable with declared name, description, and parameters", async () => {
+		const dir = await makeTemp("omp-toolbox-valid-");
+		const describeJson = JSON.stringify({
+			name: "roundtrip_tool",
+			description: "Echoes arguments as JSON",
+			parameters: {
+				type: "object",
+				properties: { value: { type: "string" } },
+				required: ["value"],
+			},
+		});
+		const scriptPath = await writeScript(dir, "roundtrip.sh", goodFixture(describeJson));
+
+		const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+		expect(result.errors).toEqual([]);
+		expect(result.tools).toHaveLength(1);
+
+		const tool = first(result.tools).tool;
+		expect(tool.name).toBe("roundtrip_tool");
+		expect(tool.description).toBe("Echoes arguments as JSON");
+		expect(tool.parameters).toBeDefined();
+		expect(typeof tool.execute).toBe("function");
+	});
+
+	it("defaults tool name to basename without extension when describe omits name", async () => {
+		const dir = await makeTemp("omp-toolbox-default-name-");
+		const describeJson = JSON.stringify({
+			description: "Named from basename",
+			parameters: { type: "object", properties: {} },
+		});
+		const scriptPath = await writeScript(dir, "from_basename.sh", goodFixture(describeJson));
+
+		const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+		expect(result.errors).toEqual([]);
+		expect(result.tools).toHaveLength(1);
+		expect(first(result.tools).tool.name).toBe("from_basename");
+	});
+
+	it("round-trips execute: JSON args on stdin, stdout as result (via loader dispatch)", async () => {
+		const dir = await makeTemp("omp-toolbox-exec-");
+		const describeJson = JSON.stringify({
+			name: "echo_args",
+			description: "Echo stdin",
+			parameters: {
+				type: "object",
+				properties: { msg: { type: "string" }, n: { type: "number" } },
+				required: ["msg"],
+			},
+		});
+		const scriptPath = await writeScript(dir, "echo_args.sh", goodFixture(describeJson));
+
+		const loaded = await loadCustomTools([{ path: scriptPath, source: TOOLBOX_SOURCE }], dir, []);
+		expect(loaded.errors).toEqual([]);
+		expect(loaded.tools).toHaveLength(1);
+
+		const tool = first(loaded.tools).tool as CustomTool;
+		const args = { msg: "hello", n: 42 };
+		const execResult = await tool.execute("call-1", args, undefined, STUB_CTX);
+
+		expect(execResult.isError).toBeUndefined();
+		const text = execResult.content.find(c => c.type === "text");
+		expect(text?.type).toBe("text");
+		if (text?.type === "text") {
+			expect(JSON.parse(text.text)).toEqual(args);
+		}
+	});
+
+	it("silently ignores files without the owner-execute bit during discovery", async () => {
+		const project = await makeTemp("omp-toolbox-project-");
+		const home = await makeTemp("omp-toolbox-home-");
+		const toolboxDir = path.join(project, ".omp", "toolbox");
+
+		await writeScript(
+			toolboxDir,
+			"kept.sh",
+			goodFixture(
+				JSON.stringify({
+					name: "kept",
+					description: "executable",
+					parameters: { type: "object", properties: {} },
+				}),
+			),
+			0o755,
+		);
+		await writeScript(
+			toolboxDir,
+			"ignored.sh",
+			goodFixture(
+				JSON.stringify({
+					name: "ignored",
+					description: "not executable",
+					parameters: { type: "object", properties: {} },
+				}),
+			),
+			0o644,
+		);
+
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const items = await discoverToolboxDescriptors(project, home);
+			const names = items.map(i => i.name).sort();
+			expect(names).toEqual(["kept"]);
+			expect(items.every(i => !i.path.endsWith("ignored.sh"))).toBe(true);
+			// Silent: no warn for the non-executable file.
+			expect(warn.mock.calls.some(c => String(c[0]).includes("ignored"))).toBe(false);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("skips describe non-zero exit with one warning and never throws", async () => {
+		const dir = await makeTemp("omp-toolbox-describe-nz-");
+		const scriptPath = await writeScript(
+			dir,
+			"fail_describe.sh",
+			["#!/bin/sh", 'if [ "$OMP_TOOLBOX_ACTION" = "describe" ]; then', "\texit 7", "fi", "exit 0", ""].join("\n"),
+		);
+
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+			expect(result.tools).toEqual([]);
+			expect(result.errors).toHaveLength(1);
+			expect(first(result.errors).error).toContain("describe exited with code 7");
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(String(first(warn.mock.calls)[0])).toContain("Toolbox tool skipped");
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("skips describe unparsable JSON with one warning and never throws", async () => {
+		const dir = await makeTemp("omp-toolbox-bad-json-");
+		const scriptPath = await writeScript(
+			dir,
+			"bad_json.sh",
+			[
+				"#!/bin/sh",
+				'if [ "$OMP_TOOLBOX_ACTION" = "describe" ]; then',
+				"\techo 'not-json-at-all'",
+				"\texit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+			expect(result.tools).toEqual([]);
+			expect(result.errors).toHaveLength(1);
+			expect(first(result.errors).error).toContain("unparsable JSON");
+			expect(warn).toHaveBeenCalledTimes(1);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("surfaces non-zero execute exit as a tool error carrying stderr (not a crash)", async () => {
+		const dir = await makeTemp("omp-toolbox-exec-err-");
+		const scriptPath = await writeScript(
+			dir,
+			"fail_exec.sh",
+			[
+				"#!/bin/sh",
+				'if [ "$OMP_TOOLBOX_ACTION" = "describe" ]; then',
+				`\tprintf '%s\\n' '{"name":"fail_exec","description":"fails on execute","parameters":{"type":"object","properties":{}}}'`,
+				"\texit 0",
+				"fi",
+				'if [ "$OMP_TOOLBOX_ACTION" = "execute" ]; then',
+				'\techo "kaboom from stderr" >&2',
+				"\texit 3",
+				"fi",
+				"exit 1",
+				"",
+			].join("\n"),
+		);
+
+		const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE);
+		expect(result.errors).toEqual([]);
+		const tool = first(result.tools).tool;
+
+		const execResult = await tool.execute("call-err", {}, undefined, STUB_CTX);
+		expect(execResult.isError).toBe(true);
+		const text = execResult.content.find(c => c.type === "text");
+		expect(text?.type).toBe("text");
+		if (text?.type === "text") {
+			expect(text.text).toContain("kaboom from stderr");
+		}
+	});
+
+	it("lets project .omp/toolbox/ shadow user ~/.omp/toolbox/ for the same tool name", async () => {
+		const project = await makeTemp("omp-toolbox-shadow-project-");
+		const home = await makeTemp("omp-toolbox-shadow-home-");
+
+		await writeScript(
+			path.join(project, ".omp", "toolbox"),
+			"shared.sh",
+			goodFixture(
+				JSON.stringify({
+					name: "shared",
+					description: "project copy",
+					parameters: { type: "object", properties: {} },
+				}),
+			),
+		);
+		await writeScript(
+			path.join(home, ".omp", "toolbox"),
+			"shared.sh",
+			goodFixture(
+				JSON.stringify({
+					name: "shared",
+					description: "user copy",
+					parameters: { type: "object", properties: {} },
+				}),
+			),
+		);
+
+		const items = await discoverToolboxDescriptors(project, home);
+		const shared = items.filter(i => i.name === "shared");
+		expect(shared).toHaveLength(1);
+		expect(first(shared).level).toBe("project");
+		expect(first(shared).path).toBe(path.join(project, ".omp", "toolbox", "shared.sh"));
+
+		// Full load path: project executable wins; describe description confirms which binary ran.
+		const loaded = await loadCustomTools(
+			[{ path: first(shared).path, source: { ...TOOLBOX_SOURCE, level: "project" } }],
+			project,
+			[],
+		);
+		expect(loaded.errors).toEqual([]);
+		expect(loaded.tools).toHaveLength(1);
+		expect(first(loaded.tools).tool.description).toBe("project copy");
+	});
+
+	it("skips a tool whose describe exceeds the deadline, without throwing", async () => {
+		const dir = await makeTemp("omp-toolbox-deadline-");
+		const scriptPath = path.join(dir, "slowpoke.sh");
+		await Bun.write(scriptPath, "#!/bin/sh\nsleep 30\n");
+		await fs.chmod(scriptPath, 0o755);
+
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const result = await loadToolboxTool(scriptPath, TOOLBOX_SOURCE, { describeTimeoutMs: 100 });
+			expect(result.tools).toEqual([]);
+			expect(result.errors).toHaveLength(1);
+			// Reported distinctly from a clean non-zero exit.
+			expect(first(result.errors).error).toMatch(/timed out|deadline/i);
+			expect(warn).toHaveBeenCalledTimes(1);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
Discover executable tools from project and user `.omp/toolbox` directories, negotiate metadata with a describe handshake, and execute them under normal tool approvals.
## Included commits
- `ba86659b5` feat(coding-agent): run executables from .omp/toolbox as agent tools
## Verification
`bun --cwd=packages/coding-agent test test/extensibility/toolbox.test.ts`
`bunx tsgo -p packages/coding-agent/tsconfig.json --noEmit`

Closes #6641
