### PR TITLE
fix(utils): contain ptree timeout rejections

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Contained timed-out child lifecycle rejections so `ptree` callers cannot leak an unhandled `TimeoutError` after settling ([#6635](https://github.com/can1357/oh-my-pi/issues/6635)).
+
 ## [17.0.9] - 2026-07-23
 
 ### Breaking Changes

--- a/packages/utils/src/ptree.ts
+++ b/packages/utils/src/ptree.ts
@@ -309,6 +309,7 @@ export class ChildProcess<In extends InMask = InMask> {
 
 	attachTimeout(ms: number): void {
 		if (ms <= 0 || this.proc.killed) return;
+		this.#exited.catch(() => {});
 		Promise.race([
 			Bun.sleep(ms).then(() => true),
 			this.proc.exited.then(

--- a/packages/utils/test/ptree-timeout.test.ts
+++ b/packages/utils/test/ptree-timeout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { spawn, TimeoutError } from "@oh-my-pi/pi-utils/ptree";
+
+describe("ptree timeout", () => {
+	it("contains the lifecycle rejection when the caller does not observe exited", async () => {
+		const unhandled = new Set<unknown>();
+		const onUnhandled = (reason: unknown) => {
+			unhandled.add(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+
+		try {
+			// Bun's subprocess timeout uses the platform clock; fake timers cannot drive this lifecycle.
+			using child = spawn(["bun", "-e", "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0)"], {
+				timeout: 20,
+			});
+			await child.nothrow().text();
+			await child.proc.exited;
+			const nextTurn = Promise.withResolvers<void>();
+			setImmediate(nextTurn.resolve);
+			await nextTurn.promise;
+
+			expect(child.exitReason).toBeInstanceOf(TimeoutError);
+			expect(unhandled.has(child.exitReason)).toBe(false);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A child timed out after its output caller had settled, leaving `ChildProcess.#exited` rejected without an observer. The following command printed an unhandled `TimeoutError` and exited 42 on `main`:

```sh
bun -e 'import { spawn } from "./packages/utils/src/ptree.ts"; process.on("unhandledRejection", error => { console.error(error); process.exitCode = 42; }); const child = spawn(["bun", "-e", "await Bun.sleep(5_000)"], { timeout: 20 }); await child.nothrow().text(); await Bun.sleep(500);'
```

## Cause
`ChildProcess.attachTimeout()` in `packages/utils/src/ptree.ts` killed the child with a `TimeoutError` but, unlike `attachSignal()`, did not attach a rejection handler to the internal `#exited` lifecycle promise. Callers using a non-lifecycle output path such as `nothrow().text()` therefore had no observer for the later rejection.

## Fix
- Attach a containment handler to `#exited` when enabling a child timeout while preserving the rejection for callers that explicitly await it.
- Cover the caller-settled path with a subprocess regression test that watches for the exact lifecycle rejection.
- Record the fix in the utils changelog.

## Verification
`bun test --parallel` in `packages/utils`: 469 passed, 0 failed. `bun run check` in `packages/utils`: passed. The standalone reproduction now prints `no unhandled rejection` and exits 0.

Fixes #6635