### PR TITLE
fix(coding-agent): restore legacy pi automode compatibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `@czottmann/pi-automode` failing legacy extension validation because the pi-ai compatibility shim omitted `clampThinkingLevel`, then failing every classified tool call because `ctx.modelRegistry` omitted `getApiKeyAndHeaders`. ([#6648](https://github.com/can1357/oh-my-pi/issues/6648))
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.

--- a/packages/coding-agent/src/config/__tests__/model-registry.test.ts
+++ b/packages/coding-agent/src/config/__tests__/model-registry.test.ts
@@ -6,17 +6,13 @@ import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "../model-registry";
 
-/**
- * Stub AuthStorage that satisfies the surface used by ModelRegistry's
- * constructor (#loadModels → clearConfigApiKeys, constructor →
- * setFallbackResolver). The awaiter under test never reaches auth-gated code
- * paths, so no real credential store is required.
- */
+/** Stub auth storage for registry lifecycle and missing-credential coverage. */
 function createStubAuthStorage(): AuthStorage {
 	const stub = {
 		setFallbackResolver: () => {},
 		clearConfigApiKeys: () => {},
 		hasAuth: () => false,
+		getApiKey: async () => undefined,
 	};
 	return stub as unknown as AuthStorage;
 }
@@ -167,6 +163,13 @@ describe("ModelRegistry", () => {
 			ok: true,
 			apiKey: "test-key",
 			headers: { "x-test": "value" },
+		});
+	});
+
+	test("returns an error when authentication resolves without a credential", async () => {
+		expect(await registry.getApiKeyAndHeaders(testModel)).toEqual({
+			ok: false,
+			error: 'No API key found for "test"',
 		});
 	});
 

--- a/packages/coding-agent/src/config/__tests__/model-registry.test.ts
+++ b/packages/coding-agent/src/config/__tests__/model-registry.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "../model-registry";
 
 /**
@@ -20,7 +21,20 @@ function createStubAuthStorage(): AuthStorage {
 	return stub as unknown as AuthStorage;
 }
 
-describe("ModelRegistry.awaitBackgroundRefresh", () => {
+const testModel = buildModel({
+	id: "test-model",
+	name: "Test Model",
+	api: "openai-completions",
+	provider: "test",
+	baseUrl: "https://example.test",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1000,
+	maxTokens: 100,
+});
+
+describe("ModelRegistry", () => {
 	let tmpDir: string;
 	let registry: ModelRegistry;
 
@@ -143,5 +157,23 @@ describe("ModelRegistry.awaitBackgroundRefresh", () => {
 
 		secondResolve();
 		await registry.awaitBackgroundRefresh();
+	});
+	test("resolves API keys and provider headers for legacy extensions", async () => {
+		const model = testModel;
+		vi.spyOn(registry, "getApiKey").mockResolvedValue("test-key");
+		vi.spyOn(registry, "getProviderHeaders").mockReturnValue({ "x-test": "value" });
+
+		expect(await registry.getApiKeyAndHeaders(model)).toEqual({
+			ok: true,
+			apiKey: "test-key",
+			headers: { "x-test": "value" },
+		});
+	});
+
+	test("maps legacy extension auth failures into the result contract", async () => {
+		const model = testModel;
+		vi.spyOn(registry, "getApiKey").mockRejectedValue(new Error("auth failed"));
+
+		expect(await registry.getApiKeyAndHeaders(model)).toEqual({ ok: false, error: "auth failed" });
 	});
 });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2208,6 +2208,9 @@ export class ModelRegistry {
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
 		try {
 			const apiKey = await this.getApiKey(model);
+			if (apiKey === undefined) {
+				return { ok: false, error: `No API key found for "${model.provider}"` };
+			}
 			const headers = this.getProviderHeaders(model.provider);
 			return { ok: true, apiKey, headers };
 		} catch (error) {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -763,6 +763,16 @@ function getDisabledProviderIdsFromSettings(): Set<string> {
 	}
 }
 
+/** Authentication material returned to legacy extensions for one model request. */
+export type ResolvedRequestAuth =
+	| {
+			ok: true;
+			apiKey?: string;
+			headers?: Record<string, string>;
+			env?: Record<string, string>;
+	  }
+	| { ok: false; error: string };
+
 /**
  * Model registry - loads and manages models, resolves API keys via AuthStorage.
  */
@@ -2192,6 +2202,17 @@ export class ModelRegistry {
 			modelId: model.id,
 			signal: options?.signal,
 		});
+	}
+
+	/** Resolve request authentication through the historical Pi extension facade. */
+	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
+		try {
+			const apiKey = await this.getApiKey(model);
+			const headers = this.getProviderHeaders(model.provider);
+			return { ok: true, apiKey, headers };
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -19,6 +19,9 @@
  * `types.ts` via the `export *` below — pi-ai still exports both as types,
  * only the runtime `Type` builder and `StringEnum()` helper were removed.
  */
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import type { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
 import {
 	calculateCost,
 	getBundledModel,
@@ -69,6 +72,12 @@ export function StringEnum<T extends string | number>(
 		configurable: true,
 	});
 	return schema;
+}
+
+/** Clamp a historical Pi thinking level against OMP's model metadata. */
+export function clampThinkingLevel<TApi extends Api>(model: Model<TApi>, level: Effort | "off"): Effort | "off" {
+	if (level === "off") return "off";
+	return clampThinkingLevelForModel(model, level) ?? "off";
 }
 
 export * from "@oh-my-pi/pi-ai";

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -192,6 +192,20 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 		expect(loaded.models).toBe(getBundledModels);
 	});
 
+	it("exports clampThinkingLevel with the historical off fallback", async () => {
+		const loaded = await loadLegacyPiModule(
+			await writeFixtureExtension(
+				[
+					'import { clampThinkingLevel } from "@earendil-works/pi-ai";',
+					"export const supported = clampThinkingLevel({ reasoning: true, thinking: { efforts: ['low', 'high'] } }, 'high');",
+					"export const disabled = clampThinkingLevel({ reasoning: false }, 'high');",
+				].join("\n"),
+			),
+		);
+
+		expect(loaded).toMatchObject({ supported: "high", disabled: "off" });
+	});
+
 	it("exports StringEnum as a schema builder with options support", async () => {
 		const loaded = (await loadLegacyPiModule(
 			await writeFixtureExtension(


### PR DESCRIPTION
## Repro

On current `main`, `bun packages/coding-agent/src/cli.ts install npm:@czottmann/pi-automode` exits 1 with `Export named 'clampThinkingLevel' not found`; `bun -e` probes report both `clampThinkingLevel` and `ModelRegistry.prototype.getApiKeyAndHeaders` as `undefined`.

## Cause

`packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts` bridged catalog exports moved out of the pi-ai barrel but omitted the historical `clampThinkingLevel` name. `packages/coding-agent/src/config/model-registry.ts` exposed the lower-level `getApiKey` and `getProviderHeaders` methods through extension contexts but omitted upstream Pi's `getApiKeyAndHeaders` result facade.

## Fix

- Export `clampThinkingLevel` from the legacy pi-ai shim, delegating to catalog model metadata and preserving Pi's `"off"` fallback.
- Add `ModelRegistry.getApiKeyAndHeaders` with the historical discriminated success/error result.
- Cover legacy named-import validation, clamp behavior, auth composition, and failure mapping.
- Document the fix under coding-agent's Unreleased changelog.

## Verification

`bun test packages/coding-agent/src/config/__tests__/model-registry.test.ts` passes 7/7; `bun test packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts --test-name-pattern clampThinkingLevel` passes 1/1; `bun run check:types` passes in `packages/coding-agent`; the previously failing `omp install npm:@czottmann/pi-automode` smoke command now installs version 1.9.0 successfully; the pre-publish `bun check` gate passes. Fixes #6648