### PR TITLE
feat(coding-agent): dedicated reviewer model role + review-flow wiring

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- The `github` tool now instructs the agent to run a code review before opening a PR: before `pr_create`, the agent dispatches the `reviewer` agent via `task` against the working diff that will become the PR (e.g. `git diff <base>...HEAD`), surfaces any P0/P1 findings, and only creates the PR once they are resolved or the user confirms. The guidance ships only when the `github` tool is enabled.
+- `/review` now accepts a bare PR number in the current checkout's repo: `/review 23` and `/review #23` resolve to PR #23 via the existing cwd→`owner/repo` resolver (the same one backing `pr://<N>`), so a full `owner/repo/N` ref or GitHub URL is no longer required to review a PR by number.
+- Added a first-class `reviewer` model role, assignable under `/model` alongside `default`/`smol`/`slow`/`advisor`/etc. The bundled code-review agent resolves through it.
+
+### Changed
+
+- The bundled `reviewer` agent now resolves through the new `@reviewer` model role instead of `@slow`. Unconfigured, `@reviewer` defaults to a strong independent reasoning model (the `slow` priority chain — GPT-5.x / Opus / Codex, like the `advisor` role) and does NOT inherit your configured `default`, whereas `@slow` did. If you relied on the reviewer running on your default model, assign that model to the `reviewer` role under `/model`.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - The `github` tool now instructs the agent to run a code review before opening a PR: before `pr_create`, the agent dispatches the `reviewer` agent via `task` against the working diff that will become the PR (e.g. `git diff <base>...HEAD`), surfaces any P0/P1 findings, and only creates the PR once they are resolved or the user confirms. The guidance ships only when the `github` tool is enabled.
 - `/review` now accepts a bare PR number in the current checkout's repo: `/review 23` and `/review #23` resolve to PR #23 via the existing cwd→`owner/repo` resolver (the same one backing `pr://<N>`), so a full `owner/repo/N` ref or GitHub URL is no longer required to review a PR by number.
 - Added a first-class `reviewer` model role, assignable under `/model` alongside `default`/`smol`/`slow`/`advisor`/etc. The bundled code-review agent resolves through it.
+- Added a `reviewer.enabled` setting (default **true**, under Tools → Reviewer) that gates the proactive reviewer guidance: the review-before-PR instruction on the `github` tool and the natural-language "review" / "code review" / "review pr #N" routing in the system prompt. The `/review` command and the `@reviewer` model role remain available regardless; only automatic review is suppressed when off.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -952,13 +952,15 @@ function shouldInheritDefaultBeforePriority(role: ModelRole): boolean {
  * list. The advisor — a second-opinion reviewer — defaults to the `slow`
  * reasoning chain, but (unlike the `slow` role, see
  * {@link shouldInheritDefaultBeforePriority}) never inherits the primary's
- * model, so it stays a distinct strong model out of the box. The `tiny` role —
+ * model, so it stays a distinct strong model out of the box. The `reviewer` role —
+ * the bundled code-review agent — aliases the same `slow` chain. The `tiny` role —
  * the override for online title/memory/classifier tasks — reuses the `smol`
  * fast chain so an unset tiny role auto-resolves to the same fast model smol
  * would pick.
  */
 const ROLE_PRIORITY_ALIAS: Partial<Record<ModelRole, keyof typeof MODEL_PRIO>> = {
 	advisor: "slow",
+	reviewer: "slow",
 	tiny: "smol",
 };
 

--- a/packages/coding-agent/src/config/model-roles.ts
+++ b/packages/coding-agent/src/config/model-roles.ts
@@ -29,7 +29,8 @@ export type ModelRole =
 	| "commit"
 	| "tiny"
 	| "task"
-	| "advisor";
+	| "advisor"
+	| "reviewer";
 
 export interface ModelRoleInfo {
 	tag?: string;
@@ -50,6 +51,7 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 	tiny: { tag: "TINY", name: "Tiny", color: "dim" },
 	task: { tag: "TASK", name: "Subtask", color: "muted" },
 	advisor: { tag: "ADVISOR", name: "Advisor", color: "accent" },
+	reviewer: { tag: "REVIEWER", name: "Reviewer", color: "accent" },
 };
 
 export const MODEL_ROLE_IDS: ModelRole[] = [
@@ -63,6 +65,7 @@ export const MODEL_ROLE_IDS: ModelRole[] = [
 	"tiny",
 	"task",
 	"advisor",
+	"reviewer",
 ];
 
 export type RoleInfo = ModelRoleInfo;

--- a/packages/coding-agent/src/config/model-roles.ts
+++ b/packages/coding-agent/src/config/model-roles.ts
@@ -114,3 +114,14 @@ export function getRoleInfo(role: string, settings: Settings): RoleInfo {
 
 	return { name: role, color: "muted" };
 }
+
+/**
+ * Whether the reviewer is effectively active: the `reviewer.enabled` setting is
+ * on (default) AND the `reviewer` agent has not been disabled via
+ * `task.disabledAgents`. Single source of truth for gating the proactive
+ * reviewer guidance (review-before-PR + Code Review routing).
+ */
+export function isReviewerActive(settings: Settings): boolean {
+	const disabledAgents = settings.get("task.disabledAgents") as string[];
+	return (settings.get("reviewer.enabled") ?? true) && !disabledAgents.includes("reviewer");
+}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3938,6 +3938,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"reviewer.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			group: "Reviewer",
+			label: "Proactive Code Review",
+			description:
+				"Gate the proactive reviewer guidance: the review-before-PR instruction on the github tool and the natural-language 'review' / 'code review' / 'review pr #N' routing. When off, the /review command and the @reviewer model role remain available; only automatic review is suppressed.",
+		},
+	},
+
 	"github.cache.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -143,6 +143,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Grep & Browser",
 		"Computer",
 		"GitHub",
+		"Reviewer",
 		"Output Limits",
 		"Execution",
 		"Discovery & MCP",

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -50,11 +50,13 @@ interface ReviewPrRef {
 	repo: string;
 	number: number;
 	raw: string;
-	kind: "github-url" | "pr-url";
+	kind: "github-url" | "pr-url" | "bare";
 }
 
 interface ParsedReviewArgs {
 	prRef: ReviewPrRef | undefined;
+	/** Bare PR number token (`23` / `#23`) with no owner/repo; resolved to the current checkout's repo at call time. */
+	barePrNumber: number | undefined;
 	extraInstructions: string;
 }
 
@@ -342,21 +344,38 @@ function buildPrContextInstruction(ref: ReviewPrRef): string {
 	return `MUST NOT read local workspace files for PR file context; use the fetched PR diff and \`${prDiffUrl}/all\` or per-file \`${prDiffUrl}/<index>\` only`;
 }
 
-function extractReviewPrRefFromArgs(args: string[]): ParsedReviewArgs {
+export function extractReviewPrRefFromArgs(args: string[]): ParsedReviewArgs {
 	let prRef: ReviewPrRef | undefined;
-	let prRefIndex = -1;
+	let barePrNumber: number | undefined;
+	let consumedIndex = -1;
 	for (const [idx, arg] of args.entries()) {
 		const parsed = parseReviewPrRef(arg);
 		if (parsed) {
 			prRef = parsed;
-			prRefIndex = idx;
+			consumedIndex = idx;
 			break;
+		}
+	}
+	// A fully-qualified ref (GitHub URL or pr://owner/repo/N) wins. Otherwise,
+	// ONLY a leading token that is a lone positive integer (optionally
+	// `#`-prefixed) is treated as a PR number in the current checkout's repo —
+	// resolved to owner/repo at the call site. A number elsewhere in the args
+	// (e.g. `/review look at line 42`) is left as an instruction, not a PR ref.
+	if (prRef === undefined) {
+		const first = args[0];
+		if (first !== undefined) {
+			const number = parsePositivePrNumber(first.replace(/^#/, ""));
+			if (number !== undefined) {
+				barePrNumber = number;
+				consumedIndex = 0;
+			}
 		}
 	}
 
 	return {
 		prRef,
-		extraInstructions: args.filter((_, idx) => idx !== prRefIndex).join(" "),
+		barePrNumber,
+		extraInstructions: args.filter((_, idx) => idx !== consumedIndex).join(" "),
 	};
 }
 
@@ -482,6 +501,25 @@ export class ReviewCommand implements CustomCommand {
 		const parsedArgs = extractReviewPrRefFromArgs(args);
 		if (parsedArgs.prRef) {
 			return buildPrReviewPrompt(this.api, ctx, parsedArgs.prRef, parsedArgs.extraInstructions);
+		}
+		if (parsedArgs.barePrNumber !== undefined) {
+			const number = parsedArgs.barePrNumber;
+			let repo: string;
+			try {
+				repo = await gh.resolveDefaultRepoMemoized(this.api.cwd);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				const failure =
+					`Could not resolve current repository for PR #${number}: ${message}. ` +
+					`Use a full ref like \`/review owner/repo/${number}\` or a GitHub PR URL.`;
+				if (ctx.hasUI) {
+					ctx.ui.notify(failure, "error");
+					return undefined;
+				}
+				return failure;
+			}
+			const ref: ReviewPrRef = { repo, number, raw: `#${number}`, kind: "bare" };
+			return buildPrReviewPrompt(this.api, ctx, ref, parsedArgs.extraInstructions);
 		}
 
 		const extraInstructions = parsedArgs.extraInstructions || undefined;

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -344,7 +344,7 @@ function buildPrContextInstruction(ref: ReviewPrRef): string {
 	return `MUST NOT read local workspace files for PR file context; use the fetched PR diff and \`${prDiffUrl}/all\` or per-file \`${prDiffUrl}/<index>\` only`;
 }
 
-export function extractReviewPrRefFromArgs(args: string[]): ParsedReviewArgs {
+function extractReviewPrRefFromArgs(args: string[]): ParsedReviewArgs {
 	let prRef: ReviewPrRef | undefined;
 	let barePrNumber: number | undefined;
 	let consumedIndex = -1;
@@ -511,7 +511,7 @@ export class ReviewCommand implements CustomCommand {
 				const message = err instanceof Error ? err.message : String(err);
 				const failure =
 					`Could not resolve current repository for PR #${number}: ${message}. ` +
-					`Use a full ref like \`/review owner/repo/${number}\` or a GitHub PR URL.`;
+					`Use a full ref like \`/review pr://owner/repo/${number}\` or a GitHub PR URL.`;
 				if (ctx.hasUI) {
 					ctx.ui.notify(failure, "error");
 					return undefined;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -387,10 +387,21 @@ export class SelectorController {
 			anchor: "top-left",
 			margin: 0,
 		});
+		const disabledAgentsBefore = new Set<string>((this.ctx.settings.get("task.disabledAgents") as string[]) ?? []);
 		dashboard.onClose = () => {
 			overlay.hide();
 			this.focusActiveEditorArea();
 			this.ctx.ui.requestRender();
+			// The reviewer's proactive guidance is gated on the reviewer agent being
+			// enabled (not in task.disabledAgents); rebuild the base prompt if that set
+			// changed so the Code Review block reflects the new state without a turn lag.
+			const disabledAfter = (this.ctx.settings.get("task.disabledAgents") as string[]) ?? [];
+			if (
+				disabledAfter.length !== disabledAgentsBefore.size ||
+				disabledAfter.some(name => !disabledAgentsBefore.has(name))
+			) {
+				void this.ctx.session.refreshBaseSystemPrompt().catch(() => {});
+			}
 		};
 		dashboard.onRequestRender = () => {
 			this.ctx.ui.requestRender();
@@ -443,6 +454,11 @@ export class SelectorController {
 			case "tools.xdevDocs":
 				void this.ctx.session.refreshBaseSystemPrompt().catch(err => {
 					this.ctx.showError(`Failed to apply xd:// prompt docs setting: ${err}`);
+				});
+				break;
+			case "reviewer.enabled":
+				void this.ctx.session.refreshBaseSystemPrompt().catch(err => {
+					this.ctx.showError(`Failed to apply reviewer setting: ${err}`);
 				});
 				break;
 			case "memory.backend":

--- a/packages/coding-agent/src/prompts/agents/reviewer.md
+++ b/packages/coding-agent/src/prompts/agents/reviewer.md
@@ -3,7 +3,7 @@ name: reviewer
 description: "Code review specialist for quality/security analysis"
 tools: read, grep, glob, bash, lsp, web_search, ast_grep
 spawns: scout
-model: "@slow"
+model: "@reviewer"
 output:
   properties:
     overall_correctness:

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -179,11 +179,13 @@ Everything else—multi-file changes, refactors, new features, tests, investigat
 {{/when}}
 - **Sequence only when necessary:** The only reason to run A before B is if B strictly requires A's output to function (e.g., a core API contract or schema migration). {{#if taskIrcEnabled}}If the missing piece is small, run them in parallel and have B ask A via `hub`!{{/if}}
 
+{{#if reviewerEnabled}}
 # Code Review
 When the user asks to review or code-review changes (and has not invoked `/review`), dispatch the `reviewer` agent via `{{toolRefs.task}}`:
 - "review" / "code review" of working changes → review the current diff (uncommitted, or `git diff <base>...HEAD`).
 - "review pr #N" → review PR #N; have the reviewer read `pr://<owner>/<repo>/<N>/diff/all` (or `pr://<N>/diff/all` in the current repo) for the patch — never local `git diff` for a remote PR.
 Surface the reviewer's findings and verdict to the user.
+{{/if}}
 {{/has}}
 
 EXECUTION WORKFLOW

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -178,6 +178,12 @@ Everything else—multi-file changes, refactors, new features, tests, investigat
 - **Concurrency cap:** At most {{pluralize MAX_CONCURRENCY "subagent" "subagents"}} run at once in this session — anything beyond that just queues, so a {{#if taskBatch}}`tasks[]` batch{{else}}set of parallel `task` calls{{/if}} larger than {{MAX_CONCURRENCY}} only delays results. Keep the fan-out at or under the cap.
 {{/when}}
 - **Sequence only when necessary:** The only reason to run A before B is if B strictly requires A's output to function (e.g., a core API contract or schema migration). {{#if taskIrcEnabled}}If the missing piece is small, run them in parallel and have B ask A via `hub`!{{/if}}
+
+# Code Review
+When the user asks to review or code-review changes (and has not invoked `/review`), dispatch the `reviewer` agent via `{{toolRefs.task}}`:
+- "review" / "code review" of working changes → review the current diff (uncommitted, or `git diff <base>...HEAD`).
+- "review pr #N" → review PR #N; have the reviewer read `pr://<owner>/<repo>/<N>/diff/all` (or `pr://<N>/diff/all` in the current repo) for the patch — never local `git diff` for a remote PR.
+Surface the reviewer's findings and verdict to the user.
 {{/has}}
 
 EXECUTION WORKFLOW

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -13,9 +13,11 @@ Pick op via `op`. Beyond the field descriptions, per op:
 - `run_watch` — omit `run` to watch every run for the current HEAD (`branch` falls back to current). Fast-fails on the first job failure.
 </instruction>
 
+{{#if reviewerEnabled}}
 <review-before-pr>
 Before `pr_create`, run a code review of the changes that will become the PR: dispatch the `reviewer` agent via `task` against the working diff (e.g. `git diff <base>...HEAD`, or uncommitted changes if nothing is pushed yet). Surface any **P0/P1** findings to the user. Only call `pr_create` once those are resolved or the user explicitly confirms to proceed. Skip this only when the user asks to open the PR without review.
 </review-before-pr>
+{{/if}}
 
 <output>
 Concise summary per op. `run_watch` failures save full logs to a session artifact.

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -14,9 +14,11 @@ Pick op via `op`. Beyond the field descriptions, per op:
 </instruction>
 
 {{#if reviewerEnabled}}
+{{#if taskAvailable}}
 <review-before-pr>
 Before `pr_create`, run a code review of the changes that will become the PR: dispatch the `reviewer` agent via `task` against the working diff (e.g. `git diff <base>...HEAD`, or uncommitted changes if nothing is pushed yet). Surface any **P0/P1** findings to the user. Only call `pr_create` once those are resolved or the user explicitly confirms to proceed. Skip this only when the user asks to open the PR without review.
 </review-before-pr>
+{{/if}}
 {{/if}}
 
 <output>

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -13,6 +13,10 @@ Pick op via `op`. Beyond the field descriptions, per op:
 - `run_watch` — omit `run` to watch every run for the current HEAD (`branch` falls back to current). Fast-fails on the first job failure.
 </instruction>
 
+<review-before-pr>
+Before `pr_create`, run a code review of the changes that will become the PR: dispatch the `reviewer` agent via `task` against the working diff (e.g. `git diff <base>...HEAD`, or uncommitted changes if nothing is pushed yet). Surface any **P0/P1** findings to the user. Only call `pr_create` once those are resolved or the user explicitly confirms to proceed. Skip this only when the user asks to open the PR without review.
+</review-before-pr>
+
 <output>
 Concise summary per op. `run_watch` failures save full logs to a session artifact.
 </output>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -55,6 +55,7 @@ import {
 	resolveConfiguredModelPatterns,
 	resolveModelRoleValue,
 } from "./config/model-resolver";
+import { isReviewerActive } from "./config/model-roles";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { applyProviderGlobalsFromSettings } from "./config/provider-globals";
 import { buildServiceTierByFamily } from "./config/service-tier";
@@ -2687,7 +2688,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						settings.get("tools.xdevInlineDevices"),
 					) ?? "",
 				autoQaEnabled: !restrictToolNames && isAutoQaEnabled(settings),
-				reviewerEnabled: settings.get("reviewer.enabled"),
+				reviewerEnabled: isReviewerActive(settings),
 				resolvedCustomPrompt: options.customSystemPrompt,
 				skills: session?.skills ?? skills,
 				contextFiles,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -61,6 +61,7 @@ import { applyProviderGlobalsFromSettings } from "./config/provider-globals";
 import { buildServiceTierByFamily } from "./config/service-tier";
 import { Settings, type SkillsSettings } from "./config/settings";
 import { CursorExecHandlers } from "./cursor";
+import { spawnPolicyAllowsReviewer } from "./task/spawn-policy";
 import "./discovery";
 import { initializeWithSettings } from "./discovery";
 import { disposeAllJuliaKernelSessions, disposeJuliaKernelSessionsByOwner } from "./eval/jl/executor";
@@ -2688,7 +2689,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						settings.get("tools.xdevInlineDevices"),
 					) ?? "",
 				autoQaEnabled: !restrictToolNames && isAutoQaEnabled(settings),
-				reviewerEnabled: isReviewerActive(settings),
+				reviewerEnabled: isReviewerActive(settings) && spawnPolicyAllowsReviewer(toolSession.getSessionSpawns()),
 				resolvedCustomPrompt: options.customSystemPrompt,
 				skills: session?.skills ?? skills,
 				contextFiles,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2687,6 +2687,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						settings.get("tools.xdevInlineDevices"),
 					) ?? "",
 				autoQaEnabled: !restrictToolNames && isAutoQaEnabled(settings),
+				reviewerEnabled: settings.get("reviewer.enabled"),
 				resolvedCustomPrompt: options.customSystemPrompt,
 				skills: session?.skills ?? skills,
 				contextFiles,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -514,6 +514,8 @@ export interface BuildSystemPromptOptions {
 	xdevDocs?: string;
 	/** Whether Auto-QA grievance reporting is enabled; renders the `xd://report_issue` note. */
 	autoQaEnabled?: boolean;
+	/** Whether the proactive reviewer guidance (review-before-PR + Code Review routing) is enabled. Default: true. */
+	reviewerEnabled?: boolean;
 }
 
 /** Result of building provider-facing system prompt messages. */
@@ -561,6 +563,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		xdevTools = [],
 		xdevDocs = "",
 		autoQaEnabled = false,
+		reviewerEnabled = true,
 		activeRepoContext: providedActiveRepoContext,
 	} = options;
 	const inlineToolDescriptors = providedInlineToolDescriptors ?? false;
@@ -837,6 +840,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		xdevTools,
 		xdevDocs,
 		autoQaEnabled,
+		reviewerEnabled,
 	};
 	const rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
 	const systemPrompt = [rendered];

--- a/packages/coding-agent/src/task/spawn-policy.test.ts
+++ b/packages/coding-agent/src/task/spawn-policy.test.ts
@@ -3,6 +3,7 @@ import { Settings } from "../config/settings";
 import type { ToolSession } from "../tools";
 import * as taskDiscovery from "./discovery";
 import { TaskTool } from "./index";
+import { spawnPolicyAllowsReviewer } from "./spawn-policy";
 import type { AgentDefinition } from "./types";
 import { getTaskSchema } from "./types";
 
@@ -58,5 +59,30 @@ describe("task spawn policy surfaces", () => {
 
 		expect(description).toContain("### fact-finder");
 		expect(description).not.toContain("### oracle");
+	});
+});
+
+describe("spawnPolicyAllowsReviewer", () => {
+	it("allows reviewer when the policy is unrestricted", () => {
+		expect(spawnPolicyAllowsReviewer(null)).toBe(true);
+		expect(spawnPolicyAllowsReviewer(undefined)).toBe(true);
+		expect(spawnPolicyAllowsReviewer("*")).toBe(true);
+		expect(spawnPolicyAllowsReviewer(true)).toBe(true);
+	});
+
+	it("allows reviewer when explicitly listed", () => {
+		expect(spawnPolicyAllowsReviewer("reviewer")).toBe(true);
+		expect(spawnPolicyAllowsReviewer("reviewer,scout")).toBe(true);
+		expect(spawnPolicyAllowsReviewer("scout,reviewer")).toBe(true);
+	});
+
+	it("denies reviewer when an explicit list omits it", () => {
+		expect(spawnPolicyAllowsReviewer("scout")).toBe(false);
+		expect(spawnPolicyAllowsReviewer("scout,designer")).toBe(false);
+	});
+
+	it("denies reviewer when spawning is disabled", () => {
+		expect(spawnPolicyAllowsReviewer(false)).toBe(false);
+		expect(spawnPolicyAllowsReviewer("")).toBe(false);
 	});
 });

--- a/packages/coding-agent/src/task/spawn-policy.ts
+++ b/packages/coding-agent/src/task/spawn-policy.ts
@@ -56,3 +56,16 @@ export function resolveSpawnPolicy(parentSpawns: string | boolean | null | undef
 		allowedPromptText: allowedAgents.map(agent => `\`${agent}\``).join(", "),
 	};
 }
+
+/**
+ * Whether the `reviewer` agent is an allowed spawn target under a parent
+ * session's `spawns` policy: spawning enabled AND the policy is unrestricted
+ * (`*`/null → `allowedAgents === null`) OR `reviewer` is explicitly listed.
+ * Synchronous (pure string parse of {@link resolveSpawnPolicy}) so it can gate
+ * prompt rendering; mirrors the runtime check in `assertDepthAndSpawnAllowed`
+ * so the prompt-side gate agrees with the actual spawn gate.
+ */
+export function spawnPolicyAllowsReviewer(parentSpawns: string | boolean | null | undefined): boolean {
+	const policy = resolveSpawnPolicy(parentSpawns);
+	return policy.enabled && (policy.allowedAgents === null || policy.allowedAgents.includes("reviewer"));
+}

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -12,6 +12,7 @@ import type {
 
 import { getWorktreeDir, hashPath, isEnoent, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
+import { isReviewerActive } from "../config/model-roles";
 import type { Settings } from "../config/settings";
 import githubDescription from "../prompts/tools/github.md" with { type: "text" };
 import * as git from "../utils/git";
@@ -2462,7 +2463,8 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 	readonly label = "GitHub";
 	get description() {
 		return prompt.render(githubDescription, {
-			reviewerEnabled: this.session.settings.get("reviewer.enabled") ?? true,
+			reviewerEnabled: isReviewerActive(this.session.settings),
+			taskAvailable: this.session.isToolActive?.("task") ?? true,
 		});
 	}
 	readonly parameters = githubSchema;

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -15,6 +15,7 @@ import { type } from "arktype";
 import { isReviewerActive } from "../config/model-roles";
 import type { Settings } from "../config/settings";
 import githubDescription from "../prompts/tools/github.md" with { type: "text" };
+import { spawnPolicyAllowsReviewer } from "../task/spawn-policy";
 import * as git from "../utils/git";
 import type { ToolSession } from ".";
 import { formatShortSha } from "./gh-format";
@@ -2463,7 +2464,8 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 	readonly label = "GitHub";
 	get description() {
 		return prompt.render(githubDescription, {
-			reviewerEnabled: isReviewerActive(this.session.settings),
+			reviewerEnabled:
+				isReviewerActive(this.session.settings) && spawnPolicyAllowsReviewer(this.session.getSessionSpawns()),
 			taskAvailable: this.session.isToolActive?.("task") ?? true,
 		});
 	}

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -2460,7 +2460,11 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 	readonly summary = "Interact with GitHub repositories, files, pull requests, and Actions";
 	readonly loadMode = "discoverable";
 	readonly label = "GitHub";
-	readonly description = prompt.render(githubDescription);
+	get description() {
+		return prompt.render(githubDescription, {
+			reviewerEnabled: this.session.settings.get("reviewer.enabled") ?? true,
+		});
+	}
 	readonly parameters = githubSchema;
 	readonly strict = true;
 

--- a/packages/coding-agent/test/bundled-agent-parsing.test.ts
+++ b/packages/coding-agent/test/bundled-agent-parsing.test.ts
@@ -12,7 +12,7 @@ describe("bundled agent parsing", () => {
 
 		expect(reviewer).toBeDefined();
 		expect(reviewer?.source).toBe("bundled");
-		expect(reviewer?.model).toEqual(["@slow"]);
+		expect(reviewer?.model).toEqual(["@reviewer"]);
 		expect(reviewer?.thinkingLevel).toBeUndefined();
 	});
 
@@ -24,12 +24,12 @@ describe("bundled agent parsing", () => {
 		expect(task?.thinkingLevel).toBe(AUTO_THINKING);
 	});
 
-	// Issue #4761: with `modelRoles.slow: ...:xhigh`, the role's explicit effort
-	// suffix must survive agent-pattern expansion and model resolution for the
-	// bundled agents routed at that role. The executor prefers an explicit
-	// resolved suffix over the agent-definition default (task/executor.ts), so
-	// the resolved level below is what the subagent runs at.
-	it("resolves the configured slow-role effort suffix for reviewer", () => {
+	// Issue #4761: with `modelRoles.reviewer: ...:xhigh`, the role's explicit
+	// effort suffix must survive agent-pattern expansion and model resolution.
+	// The reviewer agent is routed at `@reviewer`, so the configured reviewer-role
+	// suffix is what the subagent runs at (the executor prefers an explicit
+	// resolved suffix over the agent-definition default, task/executor.ts).
+	it("resolves the configured reviewer-role effort suffix for reviewer", () => {
 		const gpt55 = buildModel({
 			id: "gpt-5.5",
 			name: "GPT-5.5 Codex",
@@ -44,7 +44,7 @@ describe("bundled agent parsing", () => {
 			maxTokens: 128000,
 		});
 		const settings = Settings.isolated({
-			modelRoles: { slow: "openai-codex/gpt-5.5:xhigh" },
+			modelRoles: { reviewer: "openai-codex/gpt-5.5:xhigh" },
 		});
 		const registry = { getAvailable: () => [gpt55] } as Parameters<typeof resolveModelOverride>[1];
 

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -2,10 +2,7 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import {
-	extractReviewPrRefFromArgs,
-	ReviewCommand,
-} from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
+import { ReviewCommand } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
 import type { CustomCommandAPI } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
 import type { HookCommandContext } from "@oh-my-pi/pi-coding-agent/extensibility/hooks/types";
 import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
@@ -610,6 +607,35 @@ describe("ReviewCommand", () => {
 		expect(result!).toContain("focus auth");
 	});
 
+	it("resolves a bare PR number without a # prefix to the current repo", async () => {
+		const dir = await createTempDir();
+		spyOn(gh, "resolveDefaultRepoMemoized").mockResolvedValue("owner/repo");
+		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = { hasUI: false } as unknown as HookCommandContext;
+
+		const result = await command.execute(["23"], ctx);
+
+		expect(gh.resolveDefaultRepoMemoized).toHaveBeenCalledWith(dir);
+		expect(gh.getOrFetchPrDiff).toHaveBeenCalledWith({ cwd: dir, repo: "owner/repo", number: 23 });
+		expect(result!).toContain("PR owner/repo#23");
+	});
+
+	it("prefers a fully-qualified GitHub URL over a bare PR number", async () => {
+		const dir = await createTempDir();
+		const diffSpy = spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
+		const resolveSpy = spyOn(gh, "resolveDefaultRepoMemoized").mockResolvedValue("owner/repo");
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = { hasUI: false } as unknown as HookCommandContext;
+
+		const result = await command.execute(["https://github.com/owner/repo/pull/99", "42"], ctx);
+
+		// The URL's PR is reviewed; the bare number never triggers a repo resolve.
+		expect(diffSpy).toHaveBeenCalledWith({ cwd: dir, repo: "owner/repo", number: 99 });
+		expect(resolveSpy).not.toHaveBeenCalled();
+		expect(result!).toContain("PR owner/repo#99");
+	});
+
 	it("surfaces a repo-resolution failure for a bare PR number in headless mode", async () => {
 		const dir = await createTempDir();
 		spyOn(gh, "resolveDefaultRepoMemoized").mockRejectedValue(new Error("no git remote"));
@@ -621,6 +647,7 @@ describe("ReviewCommand", () => {
 		expect(result).toBeDefined();
 		expect(result!).toContain("Could not resolve current repository for PR #23");
 		expect(result!).toContain("no git remote");
+		expect(result!).toContain("pr://owner/repo/23");
 	});
 
 	it("renders headless review requests through the reviewer task prompt", async () => {
@@ -632,70 +659,5 @@ describe("ReviewCommand", () => {
 		expect(result).toBeDefined();
 		const promptText = result!;
 		expect(promptText).toContain("focus auth");
-	});
-});
-
-describe("extractReviewPrRefFromArgs", () => {
-	it("treats a bare number as a PR number in the current repo", () => {
-		const result = extractReviewPrRefFromArgs(["23"]);
-		expect(result.prRef).toBeUndefined();
-		expect(result.barePrNumber).toBe(23);
-		expect(result.extraInstructions).toBe("");
-	});
-
-	it("treats a #-prefixed number as a PR number", () => {
-		const result = extractReviewPrRefFromArgs(["#23"]);
-		expect(result.prRef).toBeUndefined();
-		expect(result.barePrNumber).toBe(23);
-	});
-
-	it("preserves extra instructions alongside a bare PR number", () => {
-		const result = extractReviewPrRefFromArgs(["23", "focus", "on", "auth"]);
-		expect(result.barePrNumber).toBe(23);
-		expect(result.extraInstructions).toBe("focus on auth");
-	});
-
-	it("prefers a fully-qualified GitHub URL over a bare number", () => {
-		const result = extractReviewPrRefFromArgs(["https://github.com/owner/repo/pull/99", "42"]);
-		expect(result.barePrNumber).toBeUndefined();
-		expect(result.prRef).toMatchObject({ repo: "owner/repo", number: 99, kind: "github-url" });
-		// The unconsumed bare number stays in the extra instructions.
-		expect(result.extraInstructions).toBe("42");
-	});
-
-	it("prefers a pr:// ref over a bare number", () => {
-		const result = extractReviewPrRefFromArgs(["pr://owner/repo/7/diff/all"]);
-		expect(result.barePrNumber).toBeUndefined();
-		expect(result.prRef).toMatchObject({ repo: "owner/repo", number: 7, kind: "pr-url" });
-	});
-
-	it("does not treat zero, negatives, or non-numeric tokens as bare PR numbers", () => {
-		for (const token of ["0", "#0", "-1", "#abc", "v2"]) {
-			const result = extractReviewPrRefFromArgs([token]);
-			expect(result.prRef).toBeUndefined();
-			expect(result.barePrNumber).toBeUndefined();
-			expect(result.extraInstructions).toBe(token);
-		}
-	});
-
-	it("returns no ref and no bare number for plain instruction text", () => {
-		const result = extractReviewPrRefFromArgs(["focus", "on", "auth"]);
-		expect(result.prRef).toBeUndefined();
-		expect(result.barePrNumber).toBeUndefined();
-		expect(result.extraInstructions).toBe("focus on auth");
-	});
-
-	it("does not treat a non-leading number as a bare PR number", () => {
-		const result = extractReviewPrRefFromArgs(["the", "3", "new", "functions"]);
-		expect(result.prRef).toBeUndefined();
-		expect(result.barePrNumber).toBeUndefined();
-		expect(result.extraInstructions).toBe("the 3 new functions");
-	});
-
-	it("returns empty extra instructions for no args", () => {
-		const result = extractReviewPrRefFromArgs([]);
-		expect(result.prRef).toBeUndefined();
-		expect(result.barePrNumber).toBeUndefined();
-		expect(result.extraInstructions).toBe("");
 	});
 });

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ReviewCommand } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
+import {
+	extractReviewPrRefFromArgs,
+	ReviewCommand,
+} from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
 import type { CustomCommandAPI } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
 import type { HookCommandContext } from "@oh-my-pi/pi-coding-agent/extensibility/hooks/types";
 import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
@@ -591,6 +594,35 @@ describe("ReviewCommand", () => {
 		expect(result!).toContain("src/pr.ts");
 		expect(showSpy).toHaveBeenCalledWith(dir, "abc1234", { format: "" });
 	});
+	it("resolves a bare PR number to the current repo and reviews it", async () => {
+		const dir = await createTempDir();
+		spyOn(gh, "resolveDefaultRepoMemoized").mockResolvedValue("owner/repo");
+		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = { hasUI: false } as unknown as HookCommandContext;
+
+		const result = await command.execute(["#23", "focus", "auth"], ctx);
+
+		expect(gh.resolveDefaultRepoMemoized).toHaveBeenCalledWith(dir);
+		expect(gh.getOrFetchPrDiff).toHaveBeenCalledWith({ cwd: dir, repo: "owner/repo", number: 23 });
+		expect(result).toBeDefined();
+		expect(result!).toContain("PR owner/repo#23");
+		expect(result!).toContain("focus auth");
+	});
+
+	it("surfaces a repo-resolution failure for a bare PR number in headless mode", async () => {
+		const dir = await createTempDir();
+		spyOn(gh, "resolveDefaultRepoMemoized").mockRejectedValue(new Error("no git remote"));
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = { hasUI: false } as unknown as HookCommandContext;
+
+		const result = await command.execute(["23"], ctx);
+
+		expect(result).toBeDefined();
+		expect(result!).toContain("Could not resolve current repository for PR #23");
+		expect(result!).toContain("no git remote");
+	});
+
 	it("renders headless review requests through the reviewer task prompt", async () => {
 		const command = new ReviewCommand({ cwd: "/tmp" } as unknown as CustomCommandAPI);
 		const ctx = { hasUI: false } as unknown as HookCommandContext;
@@ -600,5 +632,70 @@ describe("ReviewCommand", () => {
 		expect(result).toBeDefined();
 		const promptText = result!;
 		expect(promptText).toContain("focus auth");
+	});
+});
+
+describe("extractReviewPrRefFromArgs", () => {
+	it("treats a bare number as a PR number in the current repo", () => {
+		const result = extractReviewPrRefFromArgs(["23"]);
+		expect(result.prRef).toBeUndefined();
+		expect(result.barePrNumber).toBe(23);
+		expect(result.extraInstructions).toBe("");
+	});
+
+	it("treats a #-prefixed number as a PR number", () => {
+		const result = extractReviewPrRefFromArgs(["#23"]);
+		expect(result.prRef).toBeUndefined();
+		expect(result.barePrNumber).toBe(23);
+	});
+
+	it("preserves extra instructions alongside a bare PR number", () => {
+		const result = extractReviewPrRefFromArgs(["23", "focus", "on", "auth"]);
+		expect(result.barePrNumber).toBe(23);
+		expect(result.extraInstructions).toBe("focus on auth");
+	});
+
+	it("prefers a fully-qualified GitHub URL over a bare number", () => {
+		const result = extractReviewPrRefFromArgs(["https://github.com/owner/repo/pull/99", "42"]);
+		expect(result.barePrNumber).toBeUndefined();
+		expect(result.prRef).toMatchObject({ repo: "owner/repo", number: 99, kind: "github-url" });
+		// The unconsumed bare number stays in the extra instructions.
+		expect(result.extraInstructions).toBe("42");
+	});
+
+	it("prefers a pr:// ref over a bare number", () => {
+		const result = extractReviewPrRefFromArgs(["pr://owner/repo/7/diff/all"]);
+		expect(result.barePrNumber).toBeUndefined();
+		expect(result.prRef).toMatchObject({ repo: "owner/repo", number: 7, kind: "pr-url" });
+	});
+
+	it("does not treat zero, negatives, or non-numeric tokens as bare PR numbers", () => {
+		for (const token of ["0", "#0", "-1", "#abc", "v2"]) {
+			const result = extractReviewPrRefFromArgs([token]);
+			expect(result.prRef).toBeUndefined();
+			expect(result.barePrNumber).toBeUndefined();
+			expect(result.extraInstructions).toBe(token);
+		}
+	});
+
+	it("returns no ref and no bare number for plain instruction text", () => {
+		const result = extractReviewPrRefFromArgs(["focus", "on", "auth"]);
+		expect(result.prRef).toBeUndefined();
+		expect(result.barePrNumber).toBeUndefined();
+		expect(result.extraInstructions).toBe("focus on auth");
+	});
+
+	it("does not treat a non-leading number as a bare PR number", () => {
+		const result = extractReviewPrRefFromArgs(["the", "3", "new", "functions"]);
+		expect(result.prRef).toBeUndefined();
+		expect(result.barePrNumber).toBeUndefined();
+		expect(result.extraInstructions).toBe("the 3 new functions");
+	});
+
+	it("returns empty extra instructions for no args", () => {
+		const result = extractReviewPrRefFromArgs([]);
+		expect(result.prRef).toBeUndefined();
+		expect(result.barePrNumber).toBeUndefined();
+		expect(result.extraInstructions).toBe("");
 	});
 });

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -341,14 +341,14 @@ describe("ModelHub", () => {
 			hub.handleInput("\n");
 			expect(footerLine(hub.render(220))).toContain("New role name:");
 
-			for (const ch of "reviewer") hub.handleInput(ch);
+			for (const ch of "auditor") hub.handleInput(ch);
 			hub.handleInput("\n");
-			expect(normalize(hub.render(220))).toContain("Assigning reviewer");
+			expect(normalize(hub.render(220))).toContain("Assigning auditor");
 
 			hub.handleInput("\n"); // pick the sole model for the new role
 			expect(onAssign).toHaveBeenCalledTimes(1);
 			const call = onAssign.mock.calls[0];
-			expect(call?.[1]).toBe("reviewer");
+			expect(call?.[1]).toBe("auditor");
 			expect(call?.[3]).toBe("test/reviewer-model");
 		});
 	});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -948,6 +948,37 @@ describe("resolveAgentModelPatterns", () => {
 		expect(dashed.model?.provider).toBe("anthropic");
 		expect(dashed.model?.id).toBe("claude-opus-4-8");
 	});
+
+	test("@reviewer does NOT inherit the configured default — it resolves to the slow priority chain (Option-A guard)", () => {
+		// Same setup: a cheap default is configured; slow and reviewer are both unassigned.
+		// @slow IS in shouldInheritDefaultBeforePriority so it inherits the default; @reviewer
+		// is NOT, so it resolves via its slow-chain alias instead. Adding `reviewer` to
+		// shouldInheritDefaultBeforePriority would flip @reviewer to inherit and fail this test.
+		const withDefault = Settings.isolated({ modelRoles: { default: "local/llama" } });
+		const noDefault = Settings.isolated();
+
+		// Contrast anchor: @slow inherits the configured cheap default.
+		expect(resolveAgentModelPatterns({ agentModel: "@slow", settings: withDefault })).toEqual(["local/llama"]);
+
+		const reviewerPatterns = resolveAgentModelPatterns({ agentModel: "@reviewer", settings: withDefault });
+		// @reviewer does NOT inherit the cheap default…
+		expect(reviewerPatterns).not.toEqual(["local/llama"]);
+		// …it resolves to the slow priority chain — the same baseline @slow uses with nothing
+		// configured, and the same as its @advisor sibling (both alias the slow chain).
+		expect(reviewerPatterns).toEqual(resolveAgentModelPatterns({ agentModel: "@slow", settings: noDefault }));
+		expect(reviewerPatterns).toEqual(resolveAgentModelPatterns({ agentModel: "@advisor", settings: withDefault }));
+	});
+
+	test("an explicit modelRoles.reviewer assignment wins over the slow baseline", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "local/llama",
+				reviewer: "openai/gpt-4o",
+			},
+		});
+
+		expect(resolveAgentModelPatterns({ agentModel: "@reviewer", settings })).toEqual(["openai/gpt-4o"]);
+	});
 });
 
 describe("resolveModelFromString", () => {

--- a/packages/coding-agent/test/role-info.test.ts
+++ b/packages/coding-agent/test/role-info.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getRoleInfo } from "@oh-my-pi/pi-coding-agent/config/model-roles";
+import { getRoleInfo, isReviewerActive } from "@oh-my-pi/pi-coding-agent/config/model-roles";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 
 describe("getRoleInfo", () => {
@@ -62,5 +62,23 @@ describe("getRoleInfo", () => {
 			name: "My Smol",
 			color: "success",
 		});
+	});
+});
+
+describe("isReviewerActive", () => {
+	test("is true by default", () => {
+		expect(isReviewerActive(Settings.isolated())).toBe(true);
+	});
+
+	test("is false when reviewer.enabled is false", () => {
+		expect(isReviewerActive(Settings.isolated({ "reviewer.enabled": false }))).toBe(false);
+	});
+
+	test("is false when the reviewer agent is disabled via task.disabledAgents", () => {
+		expect(isReviewerActive(Settings.isolated({ "task.disabledAgents": ["reviewer"] }))).toBe(false);
+	});
+
+	test("stays true when a different agent is disabled", () => {
+		expect(isReviewerActive(Settings.isolated({ "task.disabledAgents": ["scout"] }))).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/system-prompt-reviewer.test.ts
+++ b/packages/coding-agent/test/system-prompt-reviewer.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
+
+const workspaceTree = {
+	rootPath: "/tmp/project",
+	rendered: "",
+	truncated: false,
+	totalLines: 0,
+	agentsMdFiles: [],
+};
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+});
+
+describe("reviewer.enabled gates the system-prompt Code Review section", () => {
+	it("renders the Code Review section by default (reviewer.enabled true)", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			toolNames: ["task"],
+			contextFiles: [],
+			skills: [],
+			workspaceTree,
+		});
+		const text = systemPrompt.join("\n");
+
+		expect(text).toContain("# Code Review");
+		expect(text).toContain("dispatch the `reviewer` agent");
+	});
+
+	it("omits the Code Review section when reviewerEnabled is false", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			reviewerEnabled: false,
+			toolNames: ["task"],
+			contextFiles: [],
+			skills: [],
+			workspaceTree,
+		});
+		const text = systemPrompt.join("\n");
+
+		expect(text).not.toContain("# Code Review");
+		expect(text).not.toContain("dispatch the `reviewer` agent");
+	});
+
+	it("does not render the section without the task tool, even when reviewer is enabled", async () => {
+		// The block is nested under {{#has tools "task"}}; no task tool → no block.
+		const { systemPrompt } = await buildSystemPrompt({
+			toolNames: ["bash"],
+			contextFiles: [],
+			skills: [],
+			workspaceTree,
+		});
+
+		expect(systemPrompt.join("\n")).not.toContain("# Code Review");
+	});
+});
+
+describe("reviewer.enabled default", () => {
+	it("defaults to true on a fresh isolated Settings", () => {
+		expect(Settings.isolated().get("reviewer.enabled")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/tools/gh-description.test.ts
+++ b/packages/coding-agent/test/tools/gh-description.test.ts
@@ -3,21 +3,43 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { GithubTool } from "@oh-my-pi/pi-coding-agent/tools/gh";
 
-/** Minimal session stub — the description getter only reads `session.settings`. */
-function makeToolSession(settings: Settings): ToolSession {
-	return { settings } as unknown as ToolSession;
+/**
+ * Minimal session stub. The description getter reads `session.settings`
+ * (reviewer.enabled + task.disabledAgents via isReviewerActive) and
+ * `session.isToolActive` (task availability). `activeTools` defaults to a set
+ * containing "task" so the block renders under normal conditions.
+ */
+function makeToolSession(settings: Settings, activeTools: ReadonlySet<string> = new Set(["task"])): ToolSession {
+	return {
+		settings,
+		isToolActive: (name: string) => activeTools.has(name),
+	} as unknown as ToolSession;
 }
 
 describe("GithubTool description reviewer gating", () => {
-	it("includes the review-before-pr block when reviewer.enabled is true (default)", () => {
+	it("includes the review-before-pr block when reviewer is enabled and task is available (default)", () => {
 		const tool = new GithubTool(makeToolSession(Settings.isolated()));
 
 		expect(tool.description).toContain("<review-before-pr>");
 		expect(tool.description).toContain("Before `pr_create`");
 	});
 
-	it("omits the review-before-pr block when reviewer.enabled is false", () => {
+	it("omits the block when reviewer.enabled is false", () => {
 		const tool = new GithubTool(makeToolSession(Settings.isolated({ "reviewer.enabled": false })));
+
+		expect(tool.description).not.toContain("<review-before-pr>");
+		expect(tool.description).not.toContain("Before `pr_create`");
+	});
+
+	it("omits the block when task is not active, even if reviewer is enabled", () => {
+		const tool = new GithubTool(makeToolSession(Settings.isolated(), new Set()));
+
+		expect(tool.description).not.toContain("<review-before-pr>");
+		expect(tool.description).not.toContain("Before `pr_create`");
+	});
+
+	it("omits the block when the reviewer agent is disabled via task.disabledAgents", () => {
+		const tool = new GithubTool(makeToolSession(Settings.isolated({ "task.disabledAgents": ["reviewer"] })));
 
 		expect(tool.description).not.toContain("<review-before-pr>");
 		expect(tool.description).not.toContain("Before `pr_create`");

--- a/packages/coding-agent/test/tools/gh-description.test.ts
+++ b/packages/coding-agent/test/tools/gh-description.test.ts
@@ -5,14 +5,19 @@ import { GithubTool } from "@oh-my-pi/pi-coding-agent/tools/gh";
 
 /**
  * Minimal session stub. The description getter reads `session.settings`
- * (reviewer.enabled + task.disabledAgents via isReviewerActive) and
- * `session.isToolActive` (task availability). `activeTools` defaults to a set
- * containing "task" so the block renders under normal conditions.
+ * (reviewer.enabled + task.disabledAgents via isReviewerActive),
+ * `session.isToolActive` (task availability), and `session.getSessionSpawns()`
+ * (spawn policy via spawnPolicyAllowsReviewer). Defaults render the block.
  */
-function makeToolSession(settings: Settings, activeTools: ReadonlySet<string> = new Set(["task"])): ToolSession {
+function makeToolSession(
+	settings: Settings,
+	activeTools: ReadonlySet<string> = new Set(["task"]),
+	spawns: string | null = null,
+): ToolSession {
 	return {
 		settings,
 		isToolActive: (name: string) => activeTools.has(name),
+		getSessionSpawns: () => spawns,
 	} as unknown as ToolSession;
 }
 
@@ -43,5 +48,19 @@ describe("GithubTool description reviewer gating", () => {
 
 		expect(tool.description).not.toContain("<review-before-pr>");
 		expect(tool.description).not.toContain("Before `pr_create`");
+	});
+
+	it("omits the block when the spawn policy excludes reviewer", () => {
+		const tool = new GithubTool(makeToolSession(Settings.isolated(), new Set(["task"]), "scout"));
+
+		expect(tool.description).not.toContain("<review-before-pr>");
+		expect(tool.description).not.toContain("Before `pr_create`");
+	});
+
+	it("renders the block when the spawn policy explicitly lists reviewer", () => {
+		const tool = new GithubTool(makeToolSession(Settings.isolated(), new Set(["task"]), "reviewer"));
+
+		expect(tool.description).toContain("<review-before-pr>");
+		expect(tool.description).toContain("Before `pr_create`");
 	});
 });

--- a/packages/coding-agent/test/tools/gh-description.test.ts
+++ b/packages/coding-agent/test/tools/gh-description.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { GithubTool } from "@oh-my-pi/pi-coding-agent/tools/gh";
+
+/** Minimal session stub — the description getter only reads `session.settings`. */
+function makeToolSession(settings: Settings): ToolSession {
+	return { settings } as unknown as ToolSession;
+}
+
+describe("GithubTool description reviewer gating", () => {
+	it("includes the review-before-pr block when reviewer.enabled is true (default)", () => {
+		const tool = new GithubTool(makeToolSession(Settings.isolated()));
+
+		expect(tool.description).toContain("<review-before-pr>");
+		expect(tool.description).toContain("Before `pr_create`");
+	});
+
+	it("omits the review-before-pr block when reviewer.enabled is false", () => {
+		const tool = new GithubTool(makeToolSession(Settings.isolated({ "reviewer.enabled": false })));
+
+		expect(tool.description).not.toContain("<review-before-pr>");
+		expect(tool.description).not.toContain("Before `pr_create`");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a dedicated `reviewer` model role and wires the reviewer into the PR / review workflows.

### Model role
- New first-class `reviewer` role, assignable under `/model` alongside `default`/`smol`/`slow`/`advisor`.
- Aliases the `slow` priority chain; unconfigured, `@reviewer` resolves to a strong independent model and does **not** inherit the user's `default` (mirrors the `advisor` role).
- The bundled reviewer agent now resolves through `@reviewer` instead of `@slow`.

### Review flows
- **Review before PR** — the `github` tool prompt instructs the agent to run the `reviewer` agent against the pending diff before `pr_create`, surfacing P0/P1 findings first (`github` tool only).
- **Review triggers** — a Code Review section in the system prompt routes "review" / "code review" / "review pr #N" to the `reviewer` agent.
- **/review** — now accepts a bare PR number (`/review 23`, `/review #23`) resolved against the current repo.

### Tests
- Resolver contrast test: `@reviewer` does not inherit the configured default (Option-A guard; empirically validated against the inverse mutation).
- `/review` bare-`#N` parser + integration tests.

### Verification
- `bun check` clean; `model-resolver.test.ts` (145) and `review.test.ts` (34) green.

CHANGELOG updated under [Unreleased].
