### PR TITLE
fix(prewalk): apply same-model effort downgrades instead of skipping

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed prewalk silently dropping a same-model hand-off that only lowers the thinking level: the arm/switch guard compared model identity alone and discarded the resolved `thinkingLevel`, so a legal effort-downgrade target (e.g. `prewalk: "@task"` resolving to the same model at a cheaper effort) never applied and the session paid the plan/continue nudges for nothing. Prewalk now compares `(provider, id, effective thinking level)`, applies effort-only hand-offs, and emits a notice on a genuine no-op instead of returning silently ([#6659](https://github.com/can1357/oh-my-pi/issues/6659)).
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -901,6 +901,7 @@ export class AgentSession {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
 			model: () => this.model,
+			configuredThinkingLevel: () => this.configuredThinkingLevel(),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),
 			setModelTemporary: (model, thinkingLevel, options) => this.setModelTemporary(model, thinkingLevel, options),
 			setActiveToolsByName: names => this.setActiveToolsByName(names),

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -1,7 +1,6 @@
 import type { Agent, AgentMessage, AgentToolResult, AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
 import { invalidateMessageCache } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Model } from "@oh-my-pi/pi-ai";
-import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { prompt } from "@oh-my-pi/pi-utils";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { resolveApprovedPlan } from "../plan-mode/approved-plan";
@@ -11,7 +10,7 @@ import planYoloHandoffPrompt from "../prompts/system/plan-yolo-handoff.md" with 
 import prewalkChecklistPrompt from "../prompts/system/prewalk-checklist.md" with { type: "text" };
 import prewalkContinuePrompt from "../prompts/system/prewalk-continue.md" with { type: "text" };
 import prewalkPlanPrompt from "../prompts/system/prewalk-plan.md" with { type: "text" };
-import type { ConfiguredThinkingLevel } from "../thinking";
+import { type ConfiguredThinkingLevel, prewalkWouldBeNoop } from "../thinking";
 import type { PlanProposalHandler } from "../tools/resolve";
 import { ToolError } from "../tools/tool-errors";
 import type { PlanYolo, Prewalk } from "./agent-session-types";
@@ -31,6 +30,7 @@ export interface PrewalkCoordinatorHost {
 	agent: Agent;
 	sessionManager: SessionManager;
 	model(): Model | undefined;
+	configuredThinkingLevel(): ConfiguredThinkingLevel | undefined;
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
 	setModelTemporary(
 		model: Model,
@@ -126,8 +126,13 @@ export class PrewalkCoordinator {
 		this.#scrubPlanNudge(liveMessages);
 		const target = prewalk.target;
 		const currentModel = this.#host.model();
-		if (currentModel && modelsAreEqual(currentModel, target)) {
+		if (prewalkWouldBeNoop(currentModel, this.#host.configuredThinkingLevel(), target, prewalk.thinkingLevel)) {
 			this.#prewalk = undefined;
+			this.#host.emitNotice(
+				"info",
+				`Prewalk: target ${target.provider}/${target.id} already matches the active model and thinking level; nothing to switch.`,
+				"prewalk",
+			);
 			return;
 		}
 		await this.#host.setModelTemporary(target, prewalk.thinkingLevel, { ephemeral: true });

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -46,7 +46,7 @@ import type { AuthStorage } from "../session/auth-storage";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../session/messages";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
-import { type ConfiguredThinkingLevel, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
+import { type ConfiguredThinkingLevel, prewalkWouldBeNoop, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
 import type { ContextFileEntry, ToolSession } from "../tools";
 import { resolveEvalBackends } from "../tools/eval-backends";
 import { isIrcEnabled } from "../tools/hub";
@@ -2683,10 +2683,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						pattern: prewalkPattern,
 						warning: resolvedPrewalk.warning,
 					});
-				} else if (model && target.provider === model.provider && target.id === model.id) {
-					// Switching to the starting model is a no-op that would still inject
-					// the plan/checklist nudges — skip.
-					logger.debug("Subagent prewalk target equals starting model; skipping prewalk", {
+				} else if (prewalkWouldBeNoop(model, effectiveThinkingLevel, target, resolvedPrewalk.thinkingLevel)) {
+					// Same model AND same effective thinking level: switching would only
+					// inject the plan/checklist nudges for no gain — skip. An effort-only
+					// delta on the same model still arms (it is a real cheapening hand-off).
+					logger.debug("Subagent prewalk target matches starting model and thinking level; skipping prewalk", {
 						agent: agent.name,
 						pattern: prewalkPattern,
 					});

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -146,14 +146,21 @@ export function concreteThinkingLevel(level: ConfiguredThinkingLevel | undefined
 /**
  * True when a prewalk hand-off from `current`/`currentLevel` to
  * `target`/`targetLevel` would change nothing observable: same model id and the
- * same effective thinking level. Prewalk arms and switches only when this is
- * false.
+ * same model-clamped effective effort. Prewalk arms and switches only when this
+ * is false.
  *
  * An effort-only delta on the same model id is a legitimate cheapening hand-off
  * — on a reasoning model the effort is the bulk of the cost — so it is NOT a
  * no-op and must still switch. A `targetLevel` of `undefined` means the prewalk
  * pattern carried no explicit `:level` suffix (no effort change requested),
  * which on the same model is a no-op.
+ *
+ * Efforts are compared AFTER model clamping, so a target the model cannot honor
+ * (e.g. `:xhigh` on a model capped at `high`) — which `setThinkingLevel` would
+ * clamp straight back to the active effort — is recognized as a no-op instead of
+ * triggering an ephemeral reset and the plan/checklist nudges for nothing.
+ * `auto` maps to a concrete `undefined`, which never clamp-equals a fixed
+ * effort, so toggling `auto` on the same model still counts as a change.
  */
 export function prewalkWouldBeNoop(
 	current: Model | undefined,
@@ -163,7 +170,10 @@ export function prewalkWouldBeNoop(
 ): boolean {
 	if (!modelsAreEqual(current, target)) return false;
 	if (targetLevel === undefined) return true;
-	return concreteThinkingLevel(targetLevel) === concreteThinkingLevel(currentLevel);
+	return (
+		resolveThinkingLevelForModel(target, concreteThinkingLevel(targetLevel)) ===
+		resolveThinkingLevelForModel(target, concreteThinkingLevel(currentLevel))
+	);
 }
 
 /** Metadata used to render the `auto` selector value alongside concrete levels. */

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -1,6 +1,7 @@
 import { type ResolvedThinkingLevel, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Effort, type Model, THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { clampThinkingLevelForModel, getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
+import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 
 /**
  * Metadata used to render thinking selector values in the coding-agent UI.
@@ -140,6 +141,29 @@ export type ConfiguredThinkingLevel = ThinkingLevel | typeof AUTO_THINKING;
 /** Maps the session-level `auto` sentinel to `undefined`; concrete levels pass through. */
 export function concreteThinkingLevel(level: ConfiguredThinkingLevel | undefined): ThinkingLevel | undefined {
 	return level === AUTO_THINKING ? undefined : level;
+}
+
+/**
+ * True when a prewalk hand-off from `current`/`currentLevel` to
+ * `target`/`targetLevel` would change nothing observable: same model id and the
+ * same effective thinking level. Prewalk arms and switches only when this is
+ * false.
+ *
+ * An effort-only delta on the same model id is a legitimate cheapening hand-off
+ * — on a reasoning model the effort is the bulk of the cost — so it is NOT a
+ * no-op and must still switch. A `targetLevel` of `undefined` means the prewalk
+ * pattern carried no explicit `:level` suffix (no effort change requested),
+ * which on the same model is a no-op.
+ */
+export function prewalkWouldBeNoop(
+	current: Model | undefined,
+	currentLevel: ConfiguredThinkingLevel | undefined,
+	target: Model,
+	targetLevel: ConfiguredThinkingLevel | undefined,
+): boolean {
+	if (!modelsAreEqual(current, target)) return false;
+	if (targetLevel === undefined) return true;
+	return concreteThinkingLevel(targetLevel) === concreteThinkingLevel(currentLevel);
 }
 
 /** Metadata used to render the `auto` selector value alongside concrete levels. */

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -145,9 +145,9 @@ export function concreteThinkingLevel(level: ConfiguredThinkingLevel | undefined
 
 /**
  * True when a prewalk hand-off from `current`/`currentLevel` to
- * `target`/`targetLevel` would change nothing observable: same model id and the
- * same model-clamped effective effort. Prewalk arms and switches only when this
- * is false.
+ * `target`/`targetLevel` would change nothing observable: same model id, same
+ * auto/fixed mode, and the same model-clamped effective effort. Prewalk arms and
+ * switches only when this is false.
  *
  * An effort-only delta on the same model id is a legitimate cheapening hand-off
  * — on a reasoning model the effort is the bulk of the cost — so it is NOT a
@@ -155,12 +155,16 @@ export function concreteThinkingLevel(level: ConfiguredThinkingLevel | undefined
  * pattern carried no explicit `:level` suffix (no effort change requested),
  * which on the same model is a no-op.
  *
- * Efforts are compared AFTER model clamping, so a target the model cannot honor
- * (e.g. `:xhigh` on a model capped at `high`) — which `setThinkingLevel` would
- * clamp straight back to the active effort — is recognized as a no-op instead of
- * triggering an ephemeral reset and the plan/checklist nudges for nothing.
- * `auto` maps to a concrete `undefined`, which never clamp-equals a fixed
- * effort, so toggling `auto` on the same model still counts as a change.
+ * `auto` mode is compared before efforts: `auto` and a fixed selector that both
+ * resolve to `undefined` effort (e.g. `:inherit`) are NOT interchangeable —
+ * applying the fixed selector clears per-turn classification, so switching
+ * auto↔fixed is always a real change even when the clamped efforts match.
+ *
+ * Efforts are otherwise compared AFTER model clamping, so a target the model
+ * cannot honor (e.g. `:xhigh` on a model capped at `high`) — which
+ * `setThinkingLevel` would clamp straight back to the active effort — is
+ * recognized as a no-op instead of triggering an ephemeral reset and the
+ * plan/checklist nudges for nothing.
  */
 export function prewalkWouldBeNoop(
 	current: Model | undefined,
@@ -170,6 +174,7 @@ export function prewalkWouldBeNoop(
 ): boolean {
 	if (!modelsAreEqual(current, target)) return false;
 	if (targetLevel === undefined) return true;
+	if ((targetLevel === AUTO_THINKING) !== (currentLevel === AUTO_THINKING)) return false;
 	return (
 		resolveThinkingLevelForModel(target, concreteThinkingLevel(targetLevel)) ===
 		resolveThinkingLevelForModel(target, concreteThinkingLevel(currentLevel))

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, type Model, z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -10,6 +10,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 /**
@@ -705,5 +706,57 @@ describe("AgentSession prewalk", () => {
 		expect(session.thinkingLevel).toBe(Effort.High);
 		expect(notices.some(message => message.includes("nothing to switch"))).toBe(true);
 		expect(calls.every(call => !call.hasChecklist)).toBe(true);
+	});
+
+	it("switches when a same-model target clears auto mode even though efforts both resolve to undefined", async () => {
+		// Review edge case: session in `auto`, same-model prewalk target `:inherit`.
+		// Both selectors resolve to an `undefined` effort, but `:inherit` clears
+		// per-turn classification, so this is a real change and must switch — not
+		// collapse to a no-op.
+		const model = modelOrThrow("claude-sonnet-4-5");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const checklistMarker = "grep for every other call site";
+
+		const mock = createMockModel({
+			responses: [toolCall("t1", "record"), toolCall("t2", "write"), { content: ["done"] }],
+		});
+		const calls: Array<{ hasChecklist: boolean }> = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [recordTool as AgentTool, writeTool as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			streamFn: (streamModel, context, options) => {
+				calls.push({ hasChecklist: contextMessagesHaveMarker(context.messages, checklistMarker) });
+				return mock.stream(streamModel, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: AUTO_THINKING,
+			prewalk: { target: model, thinkingLevel: ThinkingLevel.Inherit },
+		});
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "prewalk") notices.push(event.message);
+		});
+
+		expect(session.isAutoThinking).toBe(true);
+
+		await session.prompt("do the task");
+
+		// The hand-off ran: auto is cleared and the post-switch checklist fired.
+		expect(session.isAutoThinking).toBe(false);
+		expect(notices.some(message => message.includes("nothing to switch"))).toBe(false);
+		expect(calls.at(-1)?.hasChecklist).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -657,4 +657,53 @@ describe("AgentSession prewalk", () => {
 		// The checklist steer only fires on a real switch.
 		expect(calls.every(call => !call.hasChecklist)).toBe(true);
 	});
+
+	it("treats a target effort the model clamps back to the active effort as a no-op", async () => {
+		// Review edge case: a model capped at `high` running at `high` with a
+		// prewalk target of `xhigh`. The raw selectors differ, but the target
+		// clamps to `high`, so switching would reset the model and inject the
+		// nudges for no effective change — it must be recognized as a no-op.
+		const model = modelOrThrow("claude-sonnet-4-6"); // supported efforts cap at high
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const checklistMarker = "grep for every other call site";
+
+		const mock = createMockModel({
+			responses: [toolCall("t1", "record"), toolCall("t2", "write"), { content: ["done"] }],
+		});
+		const calls: Array<{ hasChecklist: boolean }> = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [recordTool as AgentTool, writeTool as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.High,
+			},
+			convertToLlm,
+			streamFn: (streamModel, context, options) => {
+				calls.push({ hasChecklist: contextMessagesHaveMarker(context.messages, checklistMarker) });
+				return mock.stream(streamModel, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: Effort.High,
+			prewalk: { target: model, thinkingLevel: Effort.XHigh },
+		});
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "prewalk") notices.push(event.message);
+		});
+
+		await session.prompt("do the task");
+
+		expect(session.thinkingLevel).toBe(Effort.High);
+		expect(notices.some(message => message.includes("nothing to switch"))).toBe(true);
+		expect(calls.every(call => !call.hasChecklist)).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/agent-session-prewalk.test.ts
+++ b/packages/coding-agent/test/agent-session-prewalk.test.ts
@@ -552,4 +552,109 @@ describe("AgentSession prewalk", () => {
 		expect(requested).toEqual([`${primary.provider}/${primary.id}`, `${target.provider}/${target.id}`]);
 		expect(session.model?.id).toBe(target.id);
 	});
+
+	it("effort-only prewalk on the same model downgrades the thinking level instead of silently skipping", async () => {
+		// Regression (#6659): the switch guard compared model identity only, so a
+		// same-model target at a cheaper thinking level (a legitimate effort
+		// downgrade, common with role aliases like `prewalk: "@task"`) was dropped
+		// as a no-op. On a reasoning model the effort is the bulk of the cost, so
+		// this must still switch.
+		const model = modelOrThrow("claude-sonnet-4-5");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const checklistMarker = "grep for every other call site";
+
+		// todo excluded from the active slate → the gate opens; record then write.
+		const mock = createMockModel({
+			responses: [toolCall("t1", "record"), toolCall("t2", "write"), { content: ["done"] }],
+		});
+		const calls: Array<{ model: string; hasChecklist: boolean }> = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [recordTool as AgentTool, writeTool as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			streamFn: (streamModel, context, options) => {
+				calls.push({
+					model: `${streamModel.provider}/${streamModel.id}`,
+					hasChecklist: contextMessagesHaveMarker(context.messages, checklistMarker),
+				});
+				return mock.stream(streamModel, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: Effort.Medium,
+			prewalk: { target: model, thinkingLevel: Effort.Low },
+		});
+
+		expect(session.thinkingLevel).toBe(Effort.Medium);
+
+		await session.prompt("do the task");
+
+		// The model id never changes, but the effort drops after the first write.
+		expect(session.model?.id).toBe(model.id);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+		// The switch ran: the post-switch checklist is present on the final turn.
+		expect(calls.at(-1)?.hasChecklist).toBe(true);
+	});
+
+	it("emits a notice and skips the checklist when the prewalk target is a genuine no-op", async () => {
+		// Same model AND same effective thinking level: nothing to switch. The
+		// early return must be visible (a notice), not silent, and must not fire
+		// the post-switch checklist.
+		const model = modelOrThrow("claude-sonnet-4-5");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const checklistMarker = "grep for every other call site";
+
+		const mock = createMockModel({
+			responses: [toolCall("t1", "record"), toolCall("t2", "write"), { content: ["done"] }],
+		});
+		const calls: Array<{ hasChecklist: boolean }> = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [recordTool as AgentTool, writeTool as AgentTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			streamFn: (streamModel, context, options) => {
+				calls.push({ hasChecklist: contextMessagesHaveMarker(context.messages, checklistMarker) });
+				return mock.stream(streamModel, context, options);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: Effort.Medium,
+			prewalk: { target: model, thinkingLevel: Effort.Medium },
+		});
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "prewalk") notices.push(event.message);
+		});
+
+		await session.prompt("do the task");
+
+		expect(session.model?.id).toBe(model.id);
+		expect(session.thinkingLevel).toBe(Effort.Medium);
+		// The no-op is announced, not silent.
+		expect(notices.some(message => message.includes("nothing to switch"))).toBe(true);
+		// The checklist steer only fires on a real switch.
+		expect(calls.every(call => !call.hasChecklist)).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro
A prewalk target that resolves to the **same model at a different thinking level** (a legal config: effort suffixes like `openai-codex/gpt-5.6-sol:medium`, or role aliases such as `prewalk: "@task"` whose entry carries a suffix) is silently discarded. With a session running `sol:high` and `prewalk` pointing at the same model at `medium`, the effort downgrade never applies — the session runs the expensive effort for the whole run while still paying the plan/continue nudges. On the session path the skip is silent; on the subagent path it is a `logger.debug` only. Reproduced with two tests in `packages/coding-agent/test/agent-session-prewalk.test.ts`: pre-fix, a same-model `medium→low` prewalk leaves `session.thinkingLevel` at `medium` (expected `low`), and a genuine no-op emits no notice.

## Cause
Both prewalk paths gated the hand-off on model identity alone and never consulted `prewalk.thinkingLevel`. `session/prewalk.ts` (`advanceAtTurnEnd`) used `modelsAreEqual(currentModel, target)` (provider+id only), and `task/executor.ts` used `target.provider === model.provider && target.id === model.id`. Same id at a different effort therefore matched the early return and dropped the resolved level — even though `setModelTemporary(target, prewalk.thinkingLevel, …)` on the next line already does the right thing when allowed to run.

## Fix
- Added `prewalkWouldBeNoop(current, currentLevel, target, targetLevel)` to `src/thinking.ts`: a hand-off is a no-op only when the model id matches AND the effective thinking levels match (a `targetLevel` of `undefined` = no `:level` suffix = no effort change requested). Effort-only deltas on the same model are treated as real cheapening hand-offs.
- `session/prewalk.ts`: the switch guard now calls `prewalkWouldBeNoop` (comparing against `configuredThinkingLevel()`), and the genuine-no-op early return emits a user-visible `"…nothing to switch"` notice instead of returning silently, mirroring the success path's notice. Added `configuredThinkingLevel()` to `PrewalkCoordinatorHost` and wired it in `agent-session.ts`.
- `task/executor.ts`: the subagent pre-arm guard now uses `prewalkWouldBeNoop(model, effectiveThinkingLevel, target, resolvedPrewalk.thinkingLevel)`, so an effort-only target arms (and downgrades at first edit/write) instead of being skipped, while a true no-op still avoids arming (and its nudges).
- CHANGELOG entry under `[Unreleased] > Fixed`.

## Verification
`bun test packages/coding-agent/test/agent-session-prewalk.test.ts` → 10 pass (the 2 new tests fail against the pre-fix guard: `low` expected but `medium` received, and the no-op notice absent). `bun test packages/coding-agent/test/task/executor-prewalk.test.ts packages/coding-agent/test/prewalk-startup-degradation.test.ts` → 14 pass. `bun run check:ts` → clean. Fixes #6659