### PR TITLE
fix(advisor): notify the user when a quarantined turn drops advice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed the advisor silently swallowing its own quarantined turns: when an advisor called an ungranted tool (e.g. `bash`) its whole turn was discarded before dispatch, so its advice never reached the primary agent and the failure surfaced only in advisor diagnostics — every other non-recovering failure branch notifies the host UI, but quarantine re-primed silently with no bound. A persistently-quarantining advisor now surfaces a `notifyFailure` warning in the main UI (deduped, cleared on the next successful turn) and stops the unbounded silent re-prime loop ([#6661](https://github.com/can1357/oh-my-pi/issues/6661)).
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -3938,6 +3938,59 @@ describe("advisor", () => {
 			expect(promptInputs[1]).toContain("bbb");
 		});
 
+		it("notifies the host after the advisor persistently quarantines its output (issue #6661)", async () => {
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptCalls++;
+					state.messages.push({ role: "user", content: input, timestamp: Date.now() } as AgentMessage);
+					state.messages.push({
+						role: "assistant",
+						content: [
+							{ type: "text", text: "The agent skipped the required plan step." },
+							{ type: "toolCall", id: `tc-${promptCalls}`, name: "bash", arguments: { command: "ls" } },
+						],
+						stopReason: "toolUse",
+						timestamp: Date.now(),
+					} as unknown as AgentMessage);
+					throw new AdvisorOutputQuarantinedError("Advisor response quarantined: requested unavailable tool bash");
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				rollbackTo: count => {
+					if (count < state.messages.length) state.messages.length = count;
+					state.error = undefined;
+				},
+				state,
+			};
+			const notifyFailures: string[] = [];
+			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: err => notifyFailures.push(err instanceof Error ? err.message : String(err)),
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			// Every advisor turn calls an ungranted tool and is quarantined, so its
+			// advice never reaches the primary. A persistently-quarantining advisor is
+			// a supervision failure the user must see in the main UI, not an unbounded
+			// silent re-prime loop.
+			for (let i = 2; i <= 5; i++) {
+				messages.push({ role: "user", content: `msg-${i}`, timestamp: i } as AgentMessage);
+				runtime.onTurnEnd(messages);
+				await settleUntil(() => runtime.backlog === 0);
+			}
+
+			expect(promptCalls).toBeGreaterThanOrEqual(2);
+			expect(notifyFailures.length).toBeGreaterThanOrEqual(1);
+			expect(notifyFailures[0]).toContain("quarantined");
+		});
+
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {
 			const promptInputs: string[] = [];
 			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -3941,20 +3941,30 @@ describe("advisor", () => {
 		it("notifies the host after the advisor persistently quarantines its output (issue #6661)", async () => {
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let promptCalls = 0;
+			let shouldQuarantine = true;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptCalls++;
 					state.messages.push({ role: "user", content: input, timestamp: Date.now() } as AgentMessage);
+					if (shouldQuarantine) {
+						state.messages.push({
+							role: "assistant",
+							content: [
+								{ type: "text", text: "The agent skipped the required plan step." },
+								{ type: "toolCall", id: `tc-${promptCalls}`, name: "bash", arguments: { command: "ls" } },
+							],
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						} as unknown as AgentMessage);
+						throw new AdvisorOutputQuarantinedError(
+							"Advisor response quarantined: requested unavailable tool bash",
+						);
+					}
 					state.messages.push({
 						role: "assistant",
-						content: [
-							{ type: "text", text: "The agent skipped the required plan step." },
-							{ type: "toolCall", id: `tc-${promptCalls}`, name: "bash", arguments: { command: "ls" } },
-						],
-						stopReason: "toolUse",
+						content: [{ type: "text", text: "ok" }],
 						timestamp: Date.now(),
 					} as unknown as AgentMessage);
-					throw new AdvisorOutputQuarantinedError("Advisor response quarantined: requested unavailable tool bash");
 				},
 				abort: () => {},
 				reset: () => {
@@ -3987,8 +3997,15 @@ describe("advisor", () => {
 			}
 
 			expect(promptCalls).toBeGreaterThanOrEqual(2);
-			expect(notifyFailures.length).toBeGreaterThanOrEqual(1);
-			expect(notifyFailures[0]).toContain("quarantined");
+			expect(notifyFailures).toEqual(["Advisor response quarantined: requested unavailable tool bash"]);
+			expect(runtime.failureNotified).toBe(true);
+
+			shouldQuarantine = false;
+			messages.push({ role: "user", content: "recovered", timestamp: 6 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await settleUntil(() => runtime.backlog === 0);
+
+			expect(runtime.failureNotified).toBe(false);
 		});
 
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -461,7 +461,6 @@ export class AdvisorRuntime {
 
 	#clearAdvisorContextAtCurrentCursor(): void {
 		this.#consecutiveFailures = 0;
-		this.#failureNotified = false;
 		this.#clearSeenContext();
 		try {
 			this.agent.reset();
@@ -517,6 +516,7 @@ export class AdvisorRuntime {
 		this.#failing = false;
 		this.#droppedBacklogs = 0;
 		this.#consecutiveQuarantines = 0;
+		this.#failureNotified = false;
 		this.#resetAdvisorContext(true, true);
 	}
 

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -218,6 +218,15 @@ export function buildAdvisorQuarantineSourceText(currentInput: string, messages:
  */
 const MAX_COALESCE_ROUNDS = 3;
 
+/**
+ * Consecutive quarantined advisor turns tolerated before the failure is surfaced
+ * to the host UI. A quarantine discards the advisor's whole turn before dispatch,
+ * so its advice never reaches the primary; one silent re-prime is allowed to
+ * recover a one-off hallucination, but a persistent quarantine loop is a real
+ * supervision gap the user must see (issue #6661). Reset on any successful turn.
+ */
+const MAX_QUARANTINE_RETRIES = 2;
+
 const ADVISOR_RENDER_OPTIONS = {
 	includeThinking: true,
 	includeToolIntent: true,
@@ -279,6 +288,8 @@ export class AdvisorRuntime {
 	#backlog = 0;
 	#consecutiveFailures = 0;
 	#failureNotified = false;
+	/** Consecutive quarantined turns since the last success/reset (issue #6661). */
+	#consecutiveQuarantines = 0;
 	/** Completed 3-failure backlog-drop cycles since the last success/reset. */
 	#droppedBacklogs = 0;
 	/**
@@ -505,6 +516,7 @@ export class AdvisorRuntime {
 		this.#halted = false;
 		this.#failing = false;
 		this.#droppedBacklogs = 0;
+		this.#consecutiveQuarantines = 0;
 		this.#resetAdvisorContext(true, true);
 	}
 
@@ -865,6 +877,7 @@ export class AdvisorRuntime {
 					this.#consecutiveFailures = 0;
 					this.#failureNotified = false;
 					this.#droppedBacklogs = 0;
+					this.#consecutiveQuarantines = 0;
 					if (this.host.onTurnSuccess) {
 						try {
 							await this.host.onTurnSuccess();
@@ -906,6 +919,19 @@ export class AdvisorRuntime {
 						logger.debug("advisor onTurnError hook failed", { err: String(hookErr) });
 					}
 					if (err instanceof AdvisorOutputQuarantinedError) {
+						// A quarantine discards the advisor's whole turn before dispatch, so
+						// its advice never reaches the primary. One re-prime is allowed to
+						// recover a one-off hallucination silently; a persistent quarantine
+						// loop is a supervision gap the user must see in the main UI — not an
+						// unbounded silent retry. Surface it (deduped by #notifyFailureOnce)
+						// and drop the batch to break the loop (issue #6661).
+						this.#consecutiveQuarantines++;
+						if (this.#consecutiveQuarantines >= MAX_QUARANTINE_RETRIES) {
+							this.#notifyFailureOnce(err);
+							this.#consecutiveQuarantines = 0;
+							this.#resetAdvisorContext(true, true);
+							continue;
+						}
 						const rePrime = this.#pending.length > 0 ? this.#latestMessages : undefined;
 						// Wake catchup waiters only when nothing is re-primed; otherwise the
 						// re-primed turn restores the backlog and waiters resolve on its completion.


### PR DESCRIPTION
## Repro
An advisor whose every turn calls an ungranted tool (e.g. `bash`) has each turn quarantined before dispatch, so its advice never reaches the primary agent. Driving an `AdvisorRuntime` across four such primary turns, the host's `notifyFailure` callback fires **0 times** — the failure is visible only in advisor diagnostics. Reproduced by the new test:

```
bun test src/advisor/__tests__/advisor.test.ts -t "persistently quarantines"
# before fix: expect(notifyFailures.length).toBeGreaterThanOrEqual(1) -> Received: 0
```

## Cause
The quarantine branch in `AdvisorRuntime.#drain` (`packages/coding-agent/src/advisor/runtime.ts`) caught `AdvisorOutputQuarantinedError`, reset advisor context, optionally re-primed with the latest primary messages, and `continue`d — silently and with no bound. Every other non-recovering failure branch (non-retriable terminal, fresh-context overflow, 3-consecutive-failures) calls `#notifyFailureOnce` -> `host.notifyFailure` -> `emitNotice('warning', ..., 'advisor')`. Quarantine was the one failure mode that discarded the advisor's turn without any main-UI signal, so a persistently-quarantining advisor supervised nothing while the user believed it was watching.

## Fix
- Added `MAX_QUARANTINE_RETRIES` and a `#consecutiveQuarantines` counter on `AdvisorRuntime`.
- The quarantine branch now increments the counter; one silent re-prime is still allowed to recover a one-off hallucination, but at the threshold it calls `#notifyFailureOnce(err)` (deduped, so no spam), resets the counter, and drops the batch instead of looping silently — breaking the unbounded silent re-prime loop.
- The counter resets on any successful turn and in `reset()`, so the warning clears once the advisor recovers.
- Changelog entry under `[Unreleased]`.

Scope note: the report's "should also consider" items (retry with granted tools; preserve a same-turn `advise` alongside an ungranted tool for non-Cursor providers) change quarantine semantics and are left for a maintainer call; this PR targets the unambiguous broken contract — the missing notification.

## Verification
`bun test src/advisor/__tests__/advisor.test.ts` — 149 pass, 0 fail (including the new regression `notifies the host after the advisor persistently quarantines its output (issue #6661)` and the existing single-quarantine reset/re-prime tests, which stay green because a lone quarantine still re-primes silently). Pre-publish `bun run fix` + `bun check` passed on push.

Fixes #6661