### PR TITLE
fix(catalog): keep reference-less Copilot Claude models reasoning-capable and cache-stable

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot Claude models with no bundled catalog reference (e.g. a freshly served `claude-opus-5`) discovering with `reasoning: false`/`thinking: null` and no effort dial, and disappearing along with their synthesized `-1m` sibling on offline reads: reference-less Copilot models on the anthropic-messages proxy now derive the adaptive reasoning ladder from the model id, and the cache restores their compile-time `COPILOT_API_HEADERS` by value instead of dropping them as unrestorable ([#6664](https://github.com/can1357/oh-my-pi/issues/6664)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -262,6 +262,19 @@ export const modelFamilyToken = memo((modelId: string): string => {
 });
 
 /**
+ * True for Claude generations that support extended thinking: Sonnet/Opus 3.7+,
+ * every 4.x/5+ Opus/Sonnet, and the Fable/Mythos generation. Pre-thinking
+ * models (Claude 3.5 and older) are excluded so no thinking effort dial is
+ * fabricated for a model that rejects thinking parameters. Classifier-based, so
+ * dotted and dashed version forms both match; ids the classifier does not parse
+ * (e.g. Haiku, bare dated ids) return false.
+ */
+export const anthropicModelSupportsThinking = memo((modelId: string): boolean => {
+	const parsed = parseAnthropicModel(bareModelId(modelId));
+	return parsed !== null && semverGte(parsed.version, "3.7");
+});
+
+/**
  * Adaptive thinking `display` is supported starting with Claude Opus 4.7+,
  * Sonnet 5+, and the Claude Fable/Mythos 5 generation. Older adaptive-thinking
  * models (Opus 4.6, Sonnet 4.6) reject the field. Classifier-based, so dotted

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -228,6 +228,7 @@ export function writeModelCache<TApi extends Api>(
 	staticFingerprint: string,
 	dbPath?: string,
 	staticHeaderSources: readonly Model<TApi>[] = [],
+	restorableHeaderFallback?: Record<string, string>,
 ): void {
 	try {
 		withModelCacheDb(dbPath, db => {
@@ -244,7 +245,14 @@ export function writeModelCache<TApi extends Api>(
 					// unrestorable and dropped on the next offline read (#6037, #6284).
 					const staticHeaderSource =
 						staticById.get(model.id) ?? (model.requestModelId ? staticById.get(model.requestModelId) : undefined);
-					if (!headersEqual(model.headers, staticHeaderSource?.headers)) {
+					// A model with no static source is still restorable when its live
+					// headers equal the provider's trusted constant (a compile-time,
+					// non-credential value the reader can reattach by value). This keeps
+					// reference-less Copilot models (e.g. claude-opus-5) alive offline.
+					const matchesStatic = staticHeaderSource
+						? headersEqual(model.headers, staticHeaderSource.headers)
+						: headersEqual(model.headers, restorableHeaderFallback);
+					if (!matchesStatic) {
 						unrestorableHeaderModelIds.push(model.id);
 					}
 				}

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -41,6 +41,14 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	dynamicModelsAuthoritative?: boolean;
 	/** Cached model ids to ignore when the cache was written against a different static catalog fingerprint. */
 	dropCachedModelIdsOnStaticMismatch?: readonly string[];
+	/**
+	 * Trusted, provider-wide request headers (compile-time constants, never
+	 * credentials) that the cache may restore by value for any model whose live
+	 * headers matched them at write time. Lets header-bearing dynamic models
+	 * without a bundled static entry survive offline reads instead of being
+	 * dropped as unrestorable (e.g. GitHub Copilot's User-Agent + API version).
+	 */
+	restorableHeaderFallback?: Record<string, string>;
 	/** Optional dynamic endpoint fetcher. */
 	fetchDynamicModels?: () => Promise<readonly ModelSpec<TApi>[] | null>;
 	/** Optional models.dev fallback hook. */
@@ -123,6 +131,7 @@ function restoreCachedModelHeaders<TApi extends Api>(
 	headerOmittedModelIds: readonly string[],
 	unrestorableHeaderModelIds: readonly string[],
 	legacyHeaderRestoreMarkers: boolean,
+	restorableHeaderFallback: Record<string, string> | undefined,
 ): CachedHeaderRestoreResult<TApi> {
 	const models = passModelList<TApi>(cachedModels);
 	if (headerOmittedModelIds.length === 0) {
@@ -144,6 +153,13 @@ function restoreCachedModelHeaders<TApi extends Api>(
 				: undefined
 			: (staticById.get(model.id) ?? (model.requestModelId ? staticById.get(model.requestModelId) : undefined));
 		if (!staticModel?.headers) {
+			// A non-unrestorable row whose static source is gone was cached with
+			// headers matching the provider's trusted constant (e.g. a Copilot
+			// model with no bundled entry). Reattach the constant by value instead
+			// of dropping the model on this offline read.
+			if (!unrestorable && restorableHeaderFallback) {
+				return { ...model, headers: { ...restorableHeaderFallback } };
+			}
 			unresolvedModelIds.add(model.id);
 			return model;
 		}
@@ -166,6 +182,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const now = options.now ?? Date.now;
 	const ttlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
 	const dbPath = options.cacheDbPath;
+	const restorableHeaderFallback = options.restorableHeaderFallback;
 	const staticModels = options.staticModels
 		? passModelList<TApi>(options.staticModels)
 		: (getBundledModels(options.providerId as GeneratedProvider) as Model<TApi>[]);
@@ -176,6 +193,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		cache?.headerOmittedModelIds ?? [],
 		cache?.unrestorableHeaderModelIds ?? [],
 		cache?.legacyHeaderRestoreMarkers ?? false,
+		restorableHeaderFallback,
 	);
 	const usableCachedModels = restoredCache.models.filter(model => !restoredCache.unresolvedModelIds.has(model.id));
 	const cacheHasUnresolvedHeaders = restoredCache.unresolvedModelIds.size > 0;
@@ -246,6 +264,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				staticFingerprint,
 				dbPath,
 				staticModels,
+				restorableHeaderFallback,
 			);
 		} else {
 			// Dynamic fetch failed — update cache with a non-authoritative snapshot so
@@ -257,6 +276,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				latestCache?.headerOmittedModelIds ?? cache?.headerOmittedModelIds ?? [],
 				latestCache?.unrestorableHeaderModelIds ?? cache?.unrestorableHeaderModelIds ?? [],
 				latestCache?.legacyHeaderRestoreMarkers ?? cache?.legacyHeaderRestoreMarkers ?? false,
+				restorableHeaderFallback,
 			);
 			const latestUsableCacheModels = latestRestoredCache.models.filter(
 				model => !latestRestoredCache.unresolvedModelIds.has(model.id),
@@ -279,6 +299,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				staticFingerprint,
 				dbPath,
 				staticModels,
+				restorableHeaderFallback,
 			);
 		}
 	}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -7,6 +7,7 @@ import {
 import { Effort, THINKING_EFFORTS } from "../effort";
 import { FIREWORKS_FAST_SUFFIX, toFireworksPublicModelId } from "../fireworks-model-id";
 import {
+	anthropicModelSupportsThinking,
 	isGlmVisionModelId,
 	isGrokReasoningEffortCapable,
 	isKimiK3ModelId,
@@ -4385,12 +4386,16 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 									maxTokens,
 									headers: { ...COPILOT_API_HEADERS },
 									// Copilot's `/models` advertises no reasoning bit, so a
-									// Claude model without a bundled reference would fall back
-									// to `reasoning: false` and lose its thinking dial. Every
-									// Claude on Copilot's anthropic-messages proxy reasons;
-									// mark it so `buildModel` derives the adaptive effort
-									// ladder from the id (e.g. a newly served claude-opus-5).
-									...(api === "anthropic-messages" ? { reasoning: true } : {}),
+									// thinking-capable Claude with no bundled reference would
+									// fall back to `reasoning: false` and lose its effort dial.
+									// Gate on the id classifier (not the transport alone) so a
+									// lagging enterprise catalog serving a pre-thinking Claude
+									// (<= 3.5) over the Messages proxy is not handed a fabricated
+									// dial it would reject; a modern reference-less model (e.g.
+									// claude-opus-5) is marked so `buildModel` derives the ladder.
+									...(api === "anthropic-messages" && anthropicModelSupportsThinking(defaults.id)
+										? { reasoning: true }
+										: {}),
 									...(api === "openai-completions"
 										? {
 												compat: {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4279,6 +4279,13 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 	return {
 		providerId: "github-copilot",
 		dropCachedModelIdsOnStaticMismatch: COPILOT_CACHE_INVALIDATED_MODEL_IDS,
+		// COPILOT_API_HEADERS are compile-time constants (User-Agent + API
+		// version), not credentials. The cache omits all request headers for
+		// safety and can only restore them from a bundled static entry — so a
+		// Copilot model with no bundled reference (e.g. a freshly served
+		// claude-opus-5 and its synthesized -1m sibling) is dropped on offline
+		// reads. Declaring the constant lets the cache restore it by value.
+		restorableHeaderFallback: { ...COPILOT_API_HEADERS },
 		...(apiKey && {
 			fetchDynamicModels: async () => {
 				const longContextVariants: ModelSpec<Api>[] = [];
@@ -4377,6 +4384,13 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 									contextWindow: defaultTierWindow,
 									maxTokens,
 									headers: { ...COPILOT_API_HEADERS },
+									// Copilot's `/models` advertises no reasoning bit, so a
+									// Claude model without a bundled reference would fall back
+									// to `reasoning: false` and lose its thinking dial. Every
+									// Claude on Copilot's anthropic-messages proxy reasons;
+									// mark it so `buildModel` derives the adaptive effort
+									// ladder from the id (e.g. a newly served claude-opus-5).
+									...(api === "anthropic-messages" ? { reasoning: true } : {}),
 									...(api === "openai-completions"
 										? {
 												compat: {

--- a/packages/catalog/test/issue-6664-repro.test.ts
+++ b/packages/catalog/test/issue-6664-repro.test.ts
@@ -94,4 +94,26 @@ describe("#6664 github-copilot reference-less Claude model", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("does not fabricate a thinking dial for a pre-thinking reference-less Claude", async () => {
+		// A lagging enterprise catalog could surface an old kind-first Claude on
+		// the Messages proxy. It must stay non-reasoning so no effort dial is
+		// offered for thinking parameters the model would reject.
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ data: [tieredEntry("claude-sonnet-3.5", "Claude Sonnet 3.5")] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+		);
+		const options = githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock });
+		const specs = (await options.fetchDynamicModels?.()) ?? [];
+
+		const base = specs.find(m => m.id === "claude-sonnet-3.5");
+		expect(base).toBeDefined();
+		expect(base?.api).toBe("anthropic-messages");
+		expect(base?.reasoning).toBe(false);
+		if (!base) throw new Error("missing base spec");
+		expect(buildModel(base).thinking).toBeUndefined();
+	});
 });

--- a/packages/catalog/test/issue-6664-repro.test.ts
+++ b/packages/catalog/test/issue-6664-repro.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression for #6664: GitHub Copilot serves a Claude model with no bundled
+ * catalog reference (e.g. `claude-opus-5`). Before the fix such a model was
+ * discovered with `reasoning: false` / `thinking: undefined` (no effort dial),
+ * and it — plus its synthesized `-1m` sibling — vanished on the next offline
+ * read because their `COPILOT_API_HEADERS` could not be restored from any
+ * bundled static entry.
+ */
+import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { createModelManager } from "@oh-my-pi/pi-catalog/model-manager";
+import { githubCopilotModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+
+/** `/models` entry shaped like Copilot under `X-GitHub-Api-Version: 2026-06-01`. */
+function tieredEntry(id: string, name: string) {
+	return {
+		id,
+		name,
+		capabilities: {
+			type: "chat",
+			limits: { max_context_window_tokens: 1_000_000, max_output_tokens: 64_000 },
+			supports: { vision: true },
+		},
+		billing: {
+			token_prices: {
+				default: { context_max: 200_000, input_price: 500, output_price: 2500, cache_price: 50 },
+				long_context: { context_max: 936_000, input_price: 500, output_price: 2500, cache_price: 50 },
+			},
+		},
+	};
+}
+
+function copilotFetch() {
+	return vi.fn(
+		async () =>
+			new Response(JSON.stringify({ data: [tieredEntry("claude-opus-5", "Claude Opus 5")] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+	);
+}
+
+describe("#6664 github-copilot reference-less Claude model", () => {
+	it("derives reasoning + adaptive efforts and synthesizes the 1M sibling", async () => {
+		const options = githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: copilotFetch() });
+		const specs = (await options.fetchDynamicModels?.()) ?? [];
+
+		const base = specs.find(m => m.id === "claude-opus-5");
+		expect(base).toBeDefined();
+		expect(base?.api).toBe("anthropic-messages");
+		expect(base?.reasoning).toBe(true);
+
+		// buildModel derives the adaptive effort ladder from the id, matching how
+		// bundled Copilot Opus 4.7/4.8 resolve.
+		if (!base) throw new Error("missing base spec");
+		const built = buildModel(base);
+		expect(built.thinking?.mode).toBe("anthropic-adaptive");
+		expect(built.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max]);
+
+		const variant = specs.find(m => m.id === "claude-opus-5-1m");
+		expect(variant).toBeDefined();
+		expect(variant?.requestModelId).toBe("claude-opus-5");
+		expect(variant?.contextWindow).toBe(1_000_000);
+	});
+
+	it("keeps the model and its 1M sibling alive across an offline read", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "issue-6664-"));
+		const cacheDbPath = path.join(tempDir, "models.db");
+		try {
+			const manager = createModelManager({
+				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: copilotFetch() }),
+				cacheDbPath,
+			});
+
+			const online = await manager.refresh("online");
+			expect(online.models.find(m => m.id === "claude-opus-5")).toBeDefined();
+			expect(online.models.find(m => m.id === "claude-opus-5-1m")).toBeDefined();
+
+			// The header-restore path drops unrestorable dynamic-only models on
+			// offline reads; the trusted COPILOT_API_HEADERS constant must survive.
+			const offline = await manager.refresh("offline");
+			const opus5 = offline.models.find(m => m.id === "claude-opus-5");
+			const opus5_1m = offline.models.find(m => m.id === "claude-opus-5-1m");
+			expect(opus5).toBeDefined();
+			expect(opus5?.reasoning).toBe(true);
+			expect(opus5?.headers?.["X-GitHub-Api-Version"]).toBe("2026-06-01");
+			expect(opus5_1m).toBeDefined();
+			expect(opus5_1m?.headers?.["X-GitHub-Api-Version"]).toBe("2026-06-01");
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Repro
GitHub Copilot can serve a Claude model that omp's bundled catalog does not yet know (e.g. a freshly rolled-out `claude-opus-5`). Discovering it exposed all three symptoms from the report: the base entry came back with `reasoning: false`/`thinking: null` (no effort dial), and after a refresh both it and its synthesized `-1m` sibling disappeared. Reproduced in-process by feeding a `claude-opus-5` `/models` entry (default 200k + long-context 936k tiers) through `githubCopilotModelManagerOptions` with an injected fetch, then reading the manager offline — pre-fix output: `opus-5 reasoning: false thinking: undefined` online, and `opus-5 present: false` / `opus-5-1m present: false` on the offline read (bundled `opus-4.7`, which has a reference, behaves correctly in the same run). See `packages/catalog/test/issue-6664-repro.test.ts`.

## Cause
Two defects in omp's own discovery/cache code, both triggered only for Copilot Claude models lacking a bundled reference:
- `githubCopilotModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` inherits `reasoning`/`thinking` **only** from the bundled reference (`resolveReference`). Copilot's `/models` advertises no reasoning bit, so a reference-less Claude falls back to `defaults.reasoning === false`, and `resolveModelThinking` short-circuits to `undefined` for `!spec.reasoning` — even though `parseAnthropicModel`/`isAnthropicAdaptiveGenAtLeast` already classify `claude-opus-5` as an adaptive-thinking model.
- The model cache (`model-cache.ts` / `model-manager.ts`) omits all request headers for credential safety and can only restore them from a same-id (or `requestModelId`) bundled static entry. `COPILOT_API_HEADERS` are compile-time constants (User-Agent + `X-GitHub-Api-Version`), but a reference-less model has no static entry, so it is flagged unrestorable and dropped on the next offline read — the same failure class as the `-1m` drops in #6037/#6284, now for the base id itself.

## Fix
- `openai-compat.ts`: for a reference-less Copilot model routed to the `anthropic-messages` proxy, set `reasoning: true` so `buildModel` derives the adaptive effort ladder from the id (matching bundled Opus 4.7/4.8).
- `model-manager.ts`: add an opt-in `ModelManagerOptions.restorableHeaderFallback` — a provider-wide, non-credential trusted header constant — threaded into both `restoreCachedModelHeaders` calls and both `writeModelCache` calls.
- `model-cache.ts`: at write time a header-bearing model with no static source now counts as restorable when its live headers equal the fallback (instead of unconditionally unrestorable); at read time such a model gets the fallback reattached by value rather than being dropped.
- `openai-compat.ts`: `githubCopilotModelManagerOptions` declares `restorableHeaderFallback: { ...COPILOT_API_HEADERS }`. Behavior for every other provider is byte-identical (fallback `undefined`).

## Verification
`bun test` in `packages/catalog` (490 pass), plus `packages/coding-agent` `model-registry-cache-headers.test.ts` + `model-discovery.test.ts` (58 pass — confirms headers still never persisted and copilot cache behavior intact) and `packages/ai` `model-cache.test.ts` (2 pass). `bun run check:ts` passes clean. New regression `packages/catalog/test/issue-6664-repro.test.ts` asserts `claude-opus-5` discovers with `reasoning: true` + the five-tier adaptive ladder, synthesizes `claude-opus-5-1m`, and that both survive an offline read with `X-GitHub-Api-Version` restored. Note: the full `bun check` also runs `check:rs`, which fails on this worktree for an unrelated pre-existing Rust reason; the PR pre-publish gate skips `check:rs` because this diff touches no Rust. Fixes #6664