### PR TITLE
fix(ai): break anthropic oauth↔providers circular import (claudeCodeVersion TDZ)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added `GET /v1/credentials/disabled` to the auth broker and `AuthBrokerClient.listDisabledCredentials`: disabled-credential tombstones (`DisabledCredentialSummary` — identity, verbatim disable cause, disable timestamp; never token material) so auto-disabled accounts stay visible to clients instead of silently vanishing from the snapshot. `AuthStorage.listDisabledCredentials` serves the same data locally from SQLite; clients of brokers predating the endpoint get an empty list (404 mapped, no error).
 - Added `AuthStorage.revalidateCredentials()` and the optional `AuthCredentialStore.refreshSnapshot` hook: remote broker stores re-fetch `GET /v1/snapshot` on demand so callers pairing live per-credential data with stored identities (`omp usage`) never render against the up-to-an-hour-stale disk-cached snapshot; local SQLite stores are always current and only reload.
 
+### Fixed
+
+- Fixed a deterministic circular-import TDZ that crashed `packages/catalog`'s test process with `ReferenceError: Cannot access 'claudeCodeVersion' before initialization`: `registry/oauth/anthropic.ts` imported `claudeCodeVersion` from `providers/anthropic.ts`, which transitively pulls the registry back in (`providers/anthropic` → `stream` → `registry` → `registry/oauth/anthropic`), so the module-level `claude-code/${claudeCodeVersion}` bootstrap user-agent const read the binding while `providers/anthropic.ts` was still mid-initialization. `claudeCodeVersion` now lives in a zero-import leaf module (`providers/claude-code-version.ts`) that `providers/anthropic.ts`, `registry/oauth/anthropic.ts`, and `usage/claude.ts` all import from, removing the cycle at the source rather than deferring the read.
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -84,6 +84,7 @@ import {
 	type RawMessageStreamEvent,
 	type TextBlockParam,
 } from "./anthropic-wire";
+import { claudeCodeVersion } from "./claude-code-version";
 import {
 	buildCopilotDynamicHeaders,
 	hasCopilotVisionInput,
@@ -464,7 +465,8 @@ function getCacheControl(
 }
 
 // Stealth mode: mimic Claude Code's request fingerprint.
-export const claudeCodeVersion = "2.1.165";
+// `claudeCodeVersion` is imported from "./claude-code-version" (leaf module) to
+// avoid a circular import with registry/oauth/anthropic.ts; see that file for detail.
 export const claudeAgentSdkVersion = "0.3.165";
 export const claudeClientVersion = "1.11187.4";
 export const claudeToolPrefix: string = "_";

--- a/packages/ai/src/providers/claude-code-version.ts
+++ b/packages/ai/src/providers/claude-code-version.ts
@@ -1,0 +1,13 @@
+/**
+ * Claude Code fingerprint version.
+ *
+ * Lives in a leaf module (zero imports) so `registry/oauth/anthropic.ts` and
+ * `usage/claude.ts` can consume it without dragging in `providers/anthropic.ts`.
+ * Importing `providers/anthropic.ts` from the registry path creates a cycle —
+ * `providers/anthropic.ts` → `stream.ts` → `registry` → `registry/oauth/anthropic.ts`
+ * → back to `providers/anthropic.ts` — and reading this const at module-init time
+ * then hits the temporal dead zone (`Cannot access 'claudeCodeVersion' before
+ * initialization`). The other Claude Code fingerprint constants stay in
+ * `providers/anthropic.ts` because only this one is referenced across that edge.
+ */
+export const claudeCodeVersion = "2.1.165";

--- a/packages/ai/src/registry/oauth/anthropic.ts
+++ b/packages/ai/src/registry/oauth/anthropic.ts
@@ -3,7 +3,7 @@
  */
 
 import * as AIError from "../../error";
-import { claudeCodeVersion } from "../../providers/anthropic";
+import { claudeCodeVersion } from "../../providers/claude-code-version";
 import type { FetchImpl } from "../../types";
 import { OAuthCallbackFlow } from "./callback-server";
 import { generatePKCE } from "./pkce";

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -2,7 +2,7 @@ import { scheduler } from "node:timers/promises";
 import { bareModelId, parseAnthropicModel } from "@oh-my-pi/pi-catalog/identity";
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import * as AIError from "../error";
-import { claudeCodeVersion } from "../providers/anthropic";
+import { claudeCodeVersion } from "../providers/claude-code-version";
 import {
 	type CredentialRankingContext,
 	type CredentialRankingStrategy,

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -11,7 +11,6 @@ import {
 	buildAnthropicSystemBlocks,
 	claudeAgentSdkVersion,
 	claudeCodeSystemInstruction,
-	claudeCodeVersion,
 	claudeToolPrefix,
 	deriveClaudeDeviceId,
 	generateClaudeCloakingUserId,
@@ -21,6 +20,7 @@ import {
 	streamAnthropic,
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-version";
 import { getEnvApiKey, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type {
 	AssistantMessage,

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-version";
 import { AnthropicOAuthFlow, refreshAnthropicToken } from "@oh-my-pi/pi-ai/registry/oauth/anthropic";
 import {
 	buildAnthropicAuthConfig,

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-version";
 import type { UsageFetchContext, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { claudeRankingStrategy, claudeUsageProvider } from "@oh-my-pi/pi-ai/usage/claude";
 


### PR DESCRIPTION
## What

Breaks a deterministic circular-import TDZ that has the **`Test TS workspace fast` CI job red on `main`** (and therefore every PR).

## Root cause

`registry/oauth/anthropic.ts` imported `claudeCodeVersion` from `providers/anthropic.ts`, and `providers/anthropic.ts` transitively pulls the registry back in:

```
providers/anthropic → stream → registry/index (export * ./oauth)
  → registry/oauth/index (export * ./anthropic)
  → registry/oauth/anthropic → providers/anthropic   ← cycle closes
```

The module-level const at `registry/oauth/anthropic.ts:18` reads `claudeCodeVersion` at init time, while `providers/anthropic.ts` is still mid-initialization →

```
ReferenceError: Cannot access 'claudeCodeVersion' before initialization
```

which crashes `packages/catalog`'s test process (catalog transitively imports the ai oauth module). Deterministic — fails serial and parallel.

## Fix

Extract `claudeCodeVersion` into a **zero-import leaf** `packages/ai/src/providers/claude-code-version.ts`, and repoint **every** importer at the leaf:

- `packages/ai/src/providers/anthropic.ts`
- `packages/ai/src/registry/oauth/anthropic.ts`  ← removes the cycle-closing edge
- `packages/ai/src/usage/claude.ts`
- 3 tests (`anthropic-alignment`, `anthropic-oauth`, `claude-usage-headers`)

This removes the cycle **at the source** (no lazy getter / deferred read). **Clean cutover — no barrel re-export**: `claudeCodeVersion` is an internal Claude Code fingerprint constant, and a monorepo-wide grep confirmed zero consumers import it from the top-level `@oh-my-pi/pi-ai` barrel (the only path that previously surfaced it, via `export * from "./providers/anthropic"`).

## Verify

| Check | Before | After |
| --- | --- | --- |
| `packages/catalog` `bun test --parallel` | 479 pass / 2 fail / 2 err (`Cannot access 'claudeCodeVersion' before initialization`) | **488 pass / 0 fail / 0 err** |
| `packages/ai` `bun test` (full) | 3300 / 2 / 2 | 3300 / 2 / 2 (identical; the 2 fails are pre-existing cross-file flakes, unrelated — proven via isolation + clean-`main` full run) |
| `packages/ai` `bun run check` (biome + tsgo) | — | clean (594 files) |
| `packages/catalog` `bun run check` | — | clean (116 files) |
| `packages/coding-agent` `bun run check` | — | clean (2301 files) |

Cycle edge `registry/oauth/anthropic → providers/anthropic` confirmed removed; leaf confirmed import-free (no new cycle possible).

This unblocks the pre-existing `Test TS workspace fast` CI failure on `main`.