### PR TITLE
fix(session): retry reasonless tool-call aborts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed transient reasonless request aborts that arrived after a tool call finished streaming ending the turn instead of entering recovery, which left edit calls and task subagents dead until the user manually resumed. The session now continues from the synthetic unexecuted tool result under the normal retry policy without replaying completed side effects ([#6668](https://github.com/can1357/oh-my-pi/issues/6668)).
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2632,8 +2632,14 @@ export class AgentSession {
 				return;
 			}
 
-			if (this.#recovery.isRetryableReasonlessAbort(msg)) {
-				const didRetry = await this.#recovery.handleRetryableError(msg, { allowModelFallback: false });
+			const resolvedInterruptedToolTurn = this.#recovery.classifyResolvedInterruptedToolTurn(msg);
+			if (this.#recovery.isRetryableReasonlessAbort(msg) || resolvedInterruptedToolTurn === "reasonless-abort") {
+				const didRetry = await this.#recovery.handleRetryableError(
+					msg,
+					resolvedInterruptedToolTurn === "reasonless-abort"
+						? { allowModelFallback: false, preserveFailedTurn: true }
+						: { allowModelFallback: false },
+				);
 				if (didRetry) {
 					await emitAgentEndNotification({ willContinue: true });
 					return;
@@ -2659,7 +2665,7 @@ export class AgentSession {
 					return;
 				}
 			}
-			const resumeResolvedStreamStall = this.#recovery.canResumeResolvedStreamStall(msg);
+			const resumeResolvedStreamStall = resolvedInterruptedToolTurn === "stream-stall";
 			if (resumeResolvedStreamStall || this.#recovery.isRetryableError(msg)) {
 				const didRetry = await this.#recovery.handleRetryableError(
 					msg,

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -774,10 +774,6 @@ export class TurnRecovery {
 		return id;
 	}
 
-	#isGenericAbortSentinel(message: AssistantMessage): boolean {
-		return message.errorMessage === "Request was aborted" || message.errorMessage === "Request was aborted.";
-	}
-
 	/**
 	 * Retry an empty, reason-less provider abort: a turn with no content that
 	 * carries the generic sentinel (bare `abort()`), whether the provider
@@ -806,7 +802,9 @@ export class TurnRecovery {
 
 		const id = this.#classifyRetryMessage(message);
 		if (message.stopReason === "aborted" && AIError.is(id, AIError.Flag.Abort)) return true;
-		if (!this.#isGenericAbortSentinel(message)) return false;
+		if (message.errorMessage !== "Request was aborted" && message.errorMessage !== "Request was aborted.") {
+			return false;
+		}
 
 		message.errorId = AIError.create(AIError.Flag.Abort);
 		return true;
@@ -830,17 +828,27 @@ export class TurnRecovery {
 	}
 
 	/**
-	 * Resume a stalled turn after every emitted tool call has produced a result.
-	 * Cursor calls must also carry the server-execution marker. The failed
-	 * assistant/tool-result pair stays in context so completed side effects are
-	 * continued from rather than replayed.
+	 * Classify a reasonless abort or stream stall whose emitted tool calls all
+	 * have results. The failed assistant/tool-result pair stays in context so
+	 * continuation cannot replay completed side effects; synthetic results tell
+	 * the next turn that an unexecuted call must be reissued.
 	 */
-	canResumeResolvedStreamStall(message: AssistantMessage): boolean {
-		if (message.stopReason !== "error" || !message.errorMessage?.toLowerCase().includes("stream stall")) {
-			return false;
-		}
+	classifyResolvedInterruptedToolTurn(message: AssistantMessage): "reasonless-abort" | "stream-stall" | undefined {
 		const id = this.#classifyRetryMessage(message);
-		if (!AIError.retriable(id)) return false;
+		const genericAbort =
+			message.errorMessage === "Request was aborted" || message.errorMessage === "Request was aborted.";
+		const reasonlessAbort =
+			(message.stopReason === "aborted" || message.stopReason === "error") &&
+			!this.#host.abortInProgress() &&
+			!this.#host.isDisposed() &&
+			!this.#host.streamingEditAbortTriggered() &&
+			((message.stopReason === "aborted" && AIError.is(id, AIError.Flag.Abort)) || genericAbort);
+		const streamStall =
+			message.stopReason === "error" &&
+			message.errorMessage?.toLowerCase().includes("stream stall") === true &&
+			AIError.retriable(id);
+		if (!reasonlessAbort && !streamStall) return undefined;
+		if (reasonlessAbort && genericAbort) message.errorId = AIError.create(AIError.Flag.Abort);
 
 		const resolvedToolCallIds: string[] = [];
 		for (const block of message.content) {
@@ -849,11 +857,11 @@ export class TurnRecovery {
 				message.provider === "cursor" &&
 				(!(kCursorExecResolved in block) || block[kCursorExecResolved] !== true)
 			) {
-				return false;
+				return undefined;
 			}
 			resolvedToolCallIds.push(block.id);
 		}
-		if (resolvedToolCallIds.length === 0) return false;
+		if (resolvedToolCallIds.length === 0) return undefined;
 
 		const messages = this.#host.agent.state.messages;
 		let assistantIndex = -1;
@@ -864,14 +872,15 @@ export class TurnRecovery {
 				break;
 			}
 		}
-		if (assistantIndex < 0) return false;
+		if (assistantIndex < 0) return undefined;
 
 		const unresolvedToolCallIds = new Set(resolvedToolCallIds);
 		for (let i = assistantIndex + 1; i < messages.length; i++) {
 			const candidate = messages[i];
 			if (candidate.role === "toolResult") unresolvedToolCallIds.delete(candidate.toolCallId);
 		}
-		return unresolvedToolCallIds.size === 0;
+		if (unresolvedToolCallIds.size > 0) return undefined;
+		return reasonlessAbort ? "reasonless-abort" : "stream-stall";
 	}
 	/**
 	 * Retried turns remove the failed assistant message from active context.

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -850,10 +850,18 @@ export class TurnRecovery {
 		if (!reasonlessAbort && !streamStall) return undefined;
 		if (reasonlessAbort && genericAbort) message.errorId = AIError.create(AIError.Flag.Abort);
 
+		// The Cursor server-execution marker gate applies only to the stream-stall
+		// path: an unmarked/unresolved Cursor block there means the server has not
+		// finished executing, so resuming would race it. A reasonless abort instead
+		// ends the turn and the agent loop pairs every un-run call (Cursor's unmarked
+		// `todo`/MCP blocks included) with a synthetic `executed: false` result, so
+		// the tool-result reconciliation below is the safety gate and the marker is
+		// irrelevant.
 		const resolvedToolCallIds: string[] = [];
 		for (const block of message.content) {
 			if (block.type !== "toolCall") continue;
 			if (
+				streamStall &&
 				message.provider === "cursor" &&
 				(!(kCursorExecResolved in block) || block[kCursorExecResolved] !== true)
 			) {

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -767,8 +767,10 @@ describe("AgentSession retry delay cap", () => {
 		expect(terminalError?.errorMessage).toBe("The operation timed out.");
 	});
 
-	it("resumes an OpenAI-completions stall after a synthetic unexecuted tool result", async () => {
-		const stallMessage = "OpenAI completions stream stalled while waiting for the next event";
+	it.each([
+		["OpenAI-completions stall", "error", "OpenAI completions stream stalled while waiting for the next event"],
+		["reasonless abort", "aborted", "Request was aborted"],
+	] as const)("resumes a %s after a synthetic unexecuted tool result", async (_case, stopReason, errorMessage) => {
 		const model = createMockModel({
 			id: "grok-4",
 			provider: "openrouter",
@@ -802,7 +804,7 @@ describe("AgentSession retry delay cap", () => {
 						matchingResult.details !== null &&
 						"executed" in matchingResult.details &&
 						matchingResult.details.executed === false;
-					model.push({ content: ["Recovered after Grok stall"] });
+					model.push({ content: ["Recovered after interrupted tool call"] });
 					return model.stream(model, context, options);
 				}
 
@@ -836,11 +838,11 @@ describe("AgentSession retry delay cap", () => {
 					stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
 					stream.push({
 						type: "error",
-						reason: "error",
+						reason: stopReason,
 						error: {
 							...partial,
-							stopReason: "error",
-							errorMessage: stallMessage,
+							stopReason,
+							errorMessage,
 						},
 					});
 				});
@@ -879,7 +881,10 @@ describe("AgentSession retry delay cap", () => {
 		).toHaveLength(1);
 		expect(retryStartEvents).toHaveLength(1);
 		expect(retryEndEvents).toContainEqual(expect.objectContaining({ success: true, attempt: 1 }));
-		expect(lastAssistant(session).content).toContainEqual({ type: "text", text: "Recovered after Grok stall" });
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered after interrupted tool call",
+		});
 	});
 
 	it("resumes a stalled Cursor stream after its exec tool result", async () => {

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -1006,6 +1006,124 @@ describe("AgentSession retry delay cap", () => {
 		expect(retryEndEvents).toContainEqual(expect.objectContaining({ success: true, attempt: 1 }));
 		expect(lastAssistant(session).content).toContainEqual({ type: "text", text: "Recovered after Cursor stall" });
 	});
+	it("resumes a Cursor reasonless abort after an unmarked client-side tool call", async () => {
+		const model = createMockModel({
+			id: "composer-2.5",
+			provider: "cursor",
+		});
+		authStorage.setRuntimeApiKey("cursor", "cursor-test-key");
+		// Cursor emits `todo` client-side without the server-execution marker; a
+		// reasonless abort after it must still recover (issue #6668 review).
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "cursor-todo-1",
+			name: "todo",
+			arguments: { ops: [] },
+		};
+		let streamCalls = 0;
+		let resumedWithSyntheticResult = false;
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (_requestedModel, context, options) => {
+				streamCalls += 1;
+				if (streamCalls > 1) {
+					const matchingResult = context.messages.find(
+						message => message.role === "toolResult" && message.toolCallId === toolCall.id,
+					);
+					resumedWithSyntheticResult =
+						matchingResult?.role === "toolResult" &&
+						typeof matchingResult.details === "object" &&
+						matchingResult.details !== null &&
+						"executed" in matchingResult.details &&
+						matchingResult.details.executed === false;
+					model.push({ content: ["Recovered after Cursor reasonless abort"] });
+					return model.stream(model, context, options);
+				}
+
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial: AssistantMessage = {
+						role: "assistant",
+						content: [toolCall],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial });
+					stream.push({ type: "toolcall_start", contentIndex: 0, partial });
+					stream.push({
+						type: "toolcall_delta",
+						contentIndex: 0,
+						delta: JSON.stringify(toolCall.arguments),
+						partial,
+					});
+					stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
+					stream.push({
+						type: "error",
+						reason: "aborted",
+						error: {
+							...partial,
+							stopReason: "aborted",
+							errorMessage: "Request was aborted",
+						},
+					});
+				});
+				return stream;
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Update the todo list");
+		await session.waitForIdle();
+
+		expect(streamCalls).toBe(2);
+		expect(resumedWithSyntheticResult).toBe(true);
+		expect(
+			session.agent.state.messages.filter(
+				message => message.role === "toolResult" && message.toolCallId === toolCall.id,
+			),
+		).toHaveLength(1);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toContainEqual(expect.objectContaining({ success: true, attempt: 1 }));
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered after Cursor reasonless abort",
+		});
+	});
 
 	it("retries a transient socket close after partial text and thinking", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");


### PR DESCRIPTION
## Repro
A streamed tool call that completes its arguments and then receives a reasonless request abort leaves a synthetic unexecuted tool result, but the session settles after one stream attempt instead of recovering. Reproduced with `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts -t "resumes a reasonless abort"`: before the fix, `streamCalls` was 1 instead of the expected 2.

## Cause
`TurnRecovery.isRetryableReasonlessAbort()` in `packages/coding-agent/src/session/turn-recovery.ts` only accepted empty assistant content. A completed streamed tool call is retained in assistant content and paired with a synthetic result by `packages/agent/src/agent-loop.ts`, so `AgentSession.#processAgentEvent()` reached its unconditional aborted-turn settlement branch before retry recovery.

## Fix
- Classify reasonless aborts and retryable stream stalls whose emitted tool calls all have matching results.
- Continue from the retained assistant/synthetic-result pair so unexecuted calls can be reissued without replaying completed side effects.
- Keep user, lifecycle, dispose, and streaming-edit guard aborts terminal.
- Cover both the existing stream-stall path and the reasonless-abort regression.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-cap.test.ts packages/coding-agent/test/streaming-edit-abort.test.ts` passed: 27 tests, 0 failures. The publish gate also completed `bun run fix` and `bun check` successfully. Fixes #6668