### PR TITLE
feat(coding-agent): add evidence-first verification command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added `/qa`, an evidence-first verification pass that inventories the affected surface, exercises real checks, and reports findings with reproductions — making no edits unless asked afterwards.
 
 ### Fixed
 

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -45,6 +45,7 @@ export const COLLAB_GUEST_ALLOWED_COMMANDS: Record<string, true> = {
 	copy: true,
 	help: true,
 	hotkeys: true,
+	qa: true,
 	theme: true,
 	settings: true,
 	leave: true,

--- a/packages/coding-agent/src/prompts/qa.md
+++ b/packages/coding-agent/src/prompts/qa.md
@@ -1,0 +1,11 @@
+You are coordinating a QA pass for this session.
+
+Request: {{request}}
+
+<contract>
+- Derive the pass contract from the request plus repository context — existing tests, scripts, skills, and agent guidance. Invent no config format. With an empty request, infer scope from the working tree (`git status` / recent diff) and state the inferred scope before proceeding.
+- Phase 1, inventory: spawn `scout` subagent(s) to map the affected surfaces and name the concrete checks (commands, endpoints, UI flows) that would prove or break the request.
+- Phase 2, exercise: run those checks — real commands, browser/computer tools for UI — and capture evidence artifacts (command output, screenshots, paths).
+- Phase 3, report: findings ordered by severity, each with evidence and a reproduction; end with an explicit verdict per check. Make no code edits in this run.
+- Fixes happen only when the user explicitly asks afterwards; then fix and revalidate each finding by re-running its exact failing check.
+</contract>

--- a/packages/coding-agent/src/prompts/qa.md
+++ b/packages/coding-agent/src/prompts/qa.md
@@ -3,9 +3,9 @@ You are coordinating a QA pass for this session.
 Request: {{request}}
 
 <contract>
-- Derive the pass contract from the request plus repository context — existing tests, scripts, skills, and agent guidance. Invent no config format. With an empty request, infer scope from the working tree (`git status` / recent diff) and state the inferred scope before proceeding.
-- Phase 1, inventory: spawn `scout` subagent(s) to map the affected surfaces and name the concrete checks (commands, endpoints, UI flows) that would prove or break the request.
-- Phase 2, exercise: run those checks — real commands, browser/computer tools for UI — and capture evidence artifacts (command output, screenshots, paths).
+- Derive the pass contract from the request plus repository context — existing tests, scripts, skills, and agent guidance. Invent no config format. With an empty request, infer scope from the workspace VCS (`git status` / `jj diff` / recent diff) or working tree and state the inferred scope before proceeding.
+- Phase 1, inventory: spawn `scout` subagent(s) if available to map the affected surfaces and name the concrete checks (commands, endpoints, UI flows) that would prove or break the request. If subagents are disabled, perform this inventory directly with in-session search tools.
+- Phase 2, exercise: run non-mutating check variants (for example, read-only or `--check` flags) — real commands, browser/computer tools for UI — and capture evidence artifacts (command output, screenshots, paths). Verify that the working tree remains unedited.
 - Phase 3, report: findings ordered by severity, each with evidence and a reproduction; end with an explicit verdict per check. Make no code edits in this run.
 - Fixes happen only when the user explicitly asks afterwards; then fix and revalidate each finding by re-running its exact failing check.
 </contract>

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
-import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { APP_NAME, getProjectDir, prompt, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
@@ -32,6 +32,7 @@ import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
+import qaMd from "../prompts/qa.md" with { type: "text" };
 import type { AgentSession, FreshSessionResult } from "../session/agent-session";
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
@@ -2544,6 +2545,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 			// If a prompt was provided, pass it through as input
 			if (prompt) return { prompt };
+		},
+	},
+	{
+		name: "qa",
+		description: "Verify recent work and report findings with evidence (no edits)",
+		acpDescription: "Run an evidence-first QA pass",
+		inlineHint: "[what to verify]",
+		allowArgs: true,
+		handle: (command, runtime) => {
+			void runtime;
+			return { prompt: prompt.render(qaMd, { request: command.args.trim() }) };
+		},
+		handleTui: (command, runtime) => {
+			runtime.ctx.editor.setText("");
+			return { prompt: prompt.render(qaMd, { request: command.args.trim() }) };
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2553,14 +2553,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		acpDescription: "Run an evidence-first QA pass",
 		inlineHint: "[what to verify]",
 		allowArgs: true,
-		handle: (command, runtime) => {
-			void runtime;
-			return { prompt: prompt.render(qaMd, { request: command.args.trim() }) };
-		},
-		handleTui: (command, runtime) => {
-			runtime.ctx.editor.setText("");
-			return { prompt: prompt.render(qaMd, { request: command.args.trim() }) };
-		},
+		handle: command => ({ prompt: prompt.render(qaMd, { request: command.args.trim() }) }),
 	},
 	{
 		name: "live",

--- a/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
+++ b/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
@@ -48,6 +49,40 @@ function createAcpRuntime(options?: { sessionManager?: SessionManager }) {
 	};
 }
 
+function createCollabQaHarness(readOnly: boolean) {
+	let editorText = "";
+	const sendPrompt = vi.fn();
+	const showStatus = vi.fn();
+	const sessionManager = SessionManager.inMemory();
+	const editor = {
+		setText: (text: string) => {
+			editorText = text;
+		},
+		getText: () => editorText,
+		getExpandedText: () => editorText,
+		addToHistory: vi.fn(),
+		onSubmit: undefined as undefined | ((text: string) => Promise<void>),
+		pendingImages: [],
+		pendingImageLinks: [],
+		clearDraft: vi.fn(() => {
+			editorText = "";
+		}),
+	};
+	const ctx = cast<InteractiveModeContext>({
+		editor,
+		showStatus,
+		sessionManager,
+		session: { isStreaming: false, queuedMessageCount: 0, extensionRunner: undefined },
+		ui: { requestRender: vi.fn() },
+		collabGuest: { readOnly, sendPrompt },
+	});
+
+	const controller = new InputController(ctx);
+	controller.setupEditorSubmitHandler();
+
+	return { editor, sendPrompt, showStatus };
+}
+
 /**
  * Narrow a slash-command result to its prompt text. A real check rather than an
  * inline cast, so a handler that stops returning a prompt fails here loudly
@@ -72,13 +107,22 @@ describe("/qa slash command", () => {
 		expect(prompt).toContain(request);
 	});
 
-	it("with an empty request still returns a non-empty prompt", async () => {
-		const harness = createAcpRuntime();
+	it("forwards rendered QA prompts from writable collaboration guests", async () => {
+		const harness = createCollabQaHarness(false);
+		const request = "verify writable collaboration QA";
 
-		const result = await executeAcpBuiltinSlashCommand("/qa", harness.runtime);
+		await harness.editor.onSubmit?.(`/qa ${request}`);
 
-		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
-		expect(promptTextOf(result)).not.toHaveLength(0);
+		expect(harness.sendPrompt).toHaveBeenCalledWith(expect.stringContaining(request), undefined);
+	});
+
+	it("does not forward QA prompts from read-only collaboration guests", async () => {
+		const harness = createCollabQaHarness(true);
+
+		await harness.editor.onSubmit?.("/qa verify read-only policy");
+
+		expect(harness.sendPrompt).not.toHaveBeenCalled();
+		expect(harness.showStatus).toHaveBeenCalledWith("This collab link is read-only — prompting is disabled");
 	});
 
 	it("ACP and TUI dispatchers submit the same rendered prompt for the same input", async () => {

--- a/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
+++ b/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
@@ -60,18 +60,8 @@ function promptTextOf(result: unknown): string {
 	return result.prompt;
 }
 
-function expectQaPhaseObligations(prompt: string) {
-	expect(prompt).toMatch(/inventory/i);
-	expect(prompt).toMatch(/scout/i);
-	expect(prompt).toMatch(/exercise/i);
-	expect(prompt).toMatch(/evidence/i);
-	expect(prompt).toMatch(/report/i);
-	expect(prompt).toMatch(/verdict/i);
-	expect(prompt).toMatch(/no code edits/i);
-}
-
 describe("/qa slash command", () => {
-	it("returns a prompt carrying the request and each phase obligation", async () => {
+	it("returns a prompt carrying the request", async () => {
 		const harness = createAcpRuntime();
 		const request = "verify the login form submits and surfaces errors";
 
@@ -80,22 +70,18 @@ describe("/qa slash command", () => {
 		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
 		const prompt = promptTextOf(result);
 		expect(prompt).toContain(request);
-		expectQaPhaseObligations(prompt);
 	});
 
-	it("with an empty request still returns a prompt that infers scope from the working tree", async () => {
+	it("with an empty request still returns a non-empty prompt", async () => {
 		const harness = createAcpRuntime();
 
 		const result = await executeAcpBuiltinSlashCommand("/qa", harness.runtime);
 
 		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
-		const prompt = promptTextOf(result);
-		expect(prompt.length).toBeGreaterThan(0);
-		expect(prompt).toMatch(/working tree|git status|recent diff/i);
-		expectQaPhaseObligations(prompt);
+		expect(promptTextOf(result)).not.toHaveLength(0);
 	});
 
-	it("ACP handle and TUI handleTui return the same prompt text for the same input", async () => {
+	it("ACP and TUI dispatchers submit the same rendered prompt for the same input", async () => {
 		const request = "check the slash-command wiring for /qa";
 		const acp = createAcpRuntime();
 		const tui = createTuiRuntime();
@@ -105,8 +91,10 @@ describe("/qa slash command", () => {
 
 		expect(acpResult).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
 		if (typeof tuiResult !== "string") {
-			throw new Error(`expected handleTui to return prompt text, got ${typeof tuiResult}`);
+			throw new Error(`expected TUI dispatch to return prompt text, got ${typeof tuiResult}`);
 		}
+		expect(tuiResult).not.toHaveLength(0);
+		expect(tuiResult).toContain(request);
 		expect(promptTextOf(acpResult)).toBe(tuiResult);
 		expect(tui.setText).toHaveBeenCalledWith("");
 	});

--- a/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
+++ b/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+
+/** Escape hatch for deliberate test fakes that are not structurally comparable to their target types. */
+function cast<T>(value: unknown): T {
+	return value as T;
+}
+
+/** TUI fake runtime — same shape as `btw.test.ts`, extended with session wiring. */
+function createTuiRuntime(options?: { sessionManager?: SessionManager }) {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const sessionManager = options?.sessionManager ?? SessionManager.inMemory();
+
+	return {
+		setText,
+		showStatus,
+		sessionManager,
+		runtime: {
+			ctx: cast<InteractiveModeContext>({
+				editor: { setText },
+				showStatus,
+				sessionManager,
+			}),
+		},
+	};
+}
+
+/** ACP fake runtime — minimal `SlashCommandRuntime` for `handle` branches. */
+function createAcpRuntime(options?: { sessionManager?: SessionManager }) {
+	const output = vi.fn();
+	const sessionManager = options?.sessionManager ?? SessionManager.inMemory();
+
+	return {
+		output,
+		sessionManager,
+		runtime: cast<SlashCommandRuntime>({
+			sessionManager,
+			cwd: sessionManager.getCwd(),
+			output,
+			refreshCommands: () => {},
+			reloadPlugins: async () => {},
+		}),
+	};
+}
+
+/**
+ * Narrow a slash-command result to its prompt text. A real check rather than an
+ * inline cast, so a handler that stops returning a prompt fails here loudly
+ * instead of reading `undefined` off a shape nobody verified.
+ */
+function promptTextOf(result: unknown): string {
+	if (!result || typeof result !== "object" || !("prompt" in result) || typeof result.prompt !== "string") {
+		throw new Error(`expected a { prompt: string } result, got ${JSON.stringify(result)}`);
+	}
+	return result.prompt;
+}
+
+function expectQaPhaseObligations(prompt: string) {
+	expect(prompt).toMatch(/inventory/i);
+	expect(prompt).toMatch(/scout/i);
+	expect(prompt).toMatch(/exercise/i);
+	expect(prompt).toMatch(/evidence/i);
+	expect(prompt).toMatch(/report/i);
+	expect(prompt).toMatch(/verdict/i);
+	expect(prompt).toMatch(/no code edits/i);
+}
+
+describe("/qa slash command", () => {
+	it("returns a prompt carrying the request and each phase obligation", async () => {
+		const harness = createAcpRuntime();
+		const request = "verify the login form submits and surfaces errors";
+
+		const result = await executeAcpBuiltinSlashCommand(`/qa ${request}`, harness.runtime);
+
+		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
+		const prompt = promptTextOf(result);
+		expect(prompt).toContain(request);
+		expectQaPhaseObligations(prompt);
+	});
+
+	it("with an empty request still returns a prompt that infers scope from the working tree", async () => {
+		const harness = createAcpRuntime();
+
+		const result = await executeAcpBuiltinSlashCommand("/qa", harness.runtime);
+
+		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
+		const prompt = promptTextOf(result);
+		expect(prompt.length).toBeGreaterThan(0);
+		expect(prompt).toMatch(/working tree|git status|recent diff/i);
+		expectQaPhaseObligations(prompt);
+	});
+
+	it("ACP handle and TUI handleTui return the same prompt text for the same input", async () => {
+		const request = "check the slash-command wiring for /qa";
+		const acp = createAcpRuntime();
+		const tui = createTuiRuntime();
+
+		const acpResult = await executeAcpBuiltinSlashCommand(`/qa ${request}`, acp.runtime);
+		const tuiResult = await executeBuiltinSlashCommand(`/qa ${request}`, tui.runtime);
+
+		expect(acpResult).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
+		if (typeof tuiResult !== "string") {
+			throw new Error(`expected handleTui to return prompt text, got ${typeof tuiResult}`);
+		}
+		expect(promptTextOf(acpResult)).toBe(tuiResult);
+		expect(tui.setText).toHaveBeenCalledWith("");
+	});
+});


### PR DESCRIPTION
## Summary

Adds `/qa`, an evidence-first verification command that asks the agent to inventory the affected surface, run relevant checks, and report reproductions without making unsolicited edits.

## Validation

- `bun test packages/coding-agent/test/slash-commands/qa-and-session.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

Closes #6673
