### PR TITLE
feat(coding-agent): add fixed-workspace child sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added fixed-workspace mission child sessions with owner-scoped revival and parent-mediated approvals.
+
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
 

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -96,6 +96,7 @@ export class AgentLifecycleManager {
 			current.#revivals.clear();
 			current.#parks.clear();
 			current.#persistedReviverFactory = undefined;
+			current.#persistedReviversById.clear();
 		}
 		AgentLifecycleManager.#global = undefined;
 	}
@@ -114,6 +115,12 @@ export class AgentLifecycleManager {
 	#persistedReviverFactory: PersistedSubagentReviverFactory | undefined;
 	/** TTL applied when a cold-revived ref is adopted on demand. */
 	#persistedReviveTtlMs = 0;
+	/**
+	 * Per-agent persisted revivers for concurrent ACP top-level sessions.
+	 * Preferred over {@link #persistedReviverFactory} so one session cannot
+	 * clobber another's cold-worker routing.
+	 */
+	#persistedReviversById = new Map<string, { factory: PersistedSubagentReviverFactory; idleTtlMs: number }>();
 
 	constructor(registry: AgentRegistry = AgentRegistry.global()) {
 		this.#registry = registry;
@@ -129,6 +136,20 @@ export class AgentLifecycleManager {
 	setPersistedSubagentReviverFactory(factory: PersistedSubagentReviverFactory, idleTtlMs: number): void {
 		this.#persistedReviverFactory = factory;
 		this.#persistedReviveTtlMs = idleTtlMs;
+	}
+
+	/**
+	 * Register an id-scoped cold-reviver factory. Concurrent ACP top-level
+	 * sessions each register their own workers so {@link ensureLive} routes to
+	 * the owning session instead of the newest process-global factory.
+	 * Returns an unregister function; safe to call more than once.
+	 */
+	registerPersistedReviver(agentId: string, factory: PersistedSubagentReviverFactory, idleTtlMs: number): () => void {
+		this.#persistedReviversById.set(agentId, { factory, idleTtlMs });
+		return () => {
+			const current = this.#persistedReviversById.get(agentId);
+			if (current?.factory === factory) this.#persistedReviversById.delete(agentId);
+		};
 	}
 
 	/**
@@ -317,12 +338,23 @@ export class AgentLifecycleManager {
 		let adoption = this.#adopted.get(id);
 		let revive = adoption?.ref === ref ? adoption.revive : undefined;
 		let coldAdopted = false;
-		if (!revive && ref.status === "parked" && ref.sessionFile && this.#persistedReviverFactory) {
-			revive = await this.#persistedReviverFactory(ref);
-			if (revive) {
-				adoption = { ref, idleTtlMs: this.#persistedReviveTtlMs, revive };
-				this.#adopted.set(id, adoption);
-				coldAdopted = true;
+		if (!revive && ref.status === "parked" && ref.sessionFile) {
+			const scoped = this.#persistedReviversById.get(id);
+			if (scoped) {
+				revive = await scoped.factory(ref);
+				if (revive) {
+					adoption = { ref, idleTtlMs: scoped.idleTtlMs, revive };
+					this.#adopted.set(id, adoption);
+					coldAdopted = true;
+				}
+			}
+			if (!revive && this.#persistedReviverFactory) {
+				revive = await this.#persistedReviverFactory(ref);
+				if (revive) {
+					adoption = { ref, idleTtlMs: this.#persistedReviveTtlMs, revive };
+					this.#adopted.set(id, adoption);
+					coldAdopted = true;
+				}
 			}
 		}
 		if (this.#registry.get(id) !== ref) {
@@ -391,6 +423,7 @@ export class AgentLifecycleManager {
 		this.#revivals.clear();
 		this.#parks.clear();
 		this.#persistedReviverFactory = undefined;
+		this.#persistedReviversById.clear();
 	}
 
 	async #revive(id: string, revive: AgentReviver, ref: AgentRef, adopted: AdoptedAgent): Promise<AgentSession> {

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -164,6 +164,19 @@ export interface TtsrInjectionEntry extends SessionEntryBase {
 	injectedRules: string[];
 }
 
+/**
+ * JSON-safe mission-child ownership markers for session_init.
+ * Lives beside SessionInitEntry (not the mission domain) so session persistence
+ * never imports MissionRuntime.
+ */
+export interface MissionChildOwnerEntry {
+	missionId: string;
+	ownerSessionId: string;
+	role: "implementation" | "scrutiny" | "user-testing";
+	milestoneId: string;
+	featureId: string;
+}
+
 /** Session init entry - captures initial context for subagent sessions (debugging/replay). */
 export interface SessionInitEntry extends SessionEntryBase {
 	type: "session_init";
@@ -183,6 +196,10 @@ export interface SessionInitEntry extends SessionEntryBase {
 	spawns?: string;
 	/** The agent's `readSummarize` setting (`false` = read summarization disabled); absent uses the session default. */
 	readSummarize?: boolean;
+	/** Fixed mission worktree binding; absent preserves ordinary-task revive-at-parent-cwd semantics. */
+	cwdBinding?: "fixed";
+	/** Mission ownership required to cold-revive a fixed-cwd child in the owning top-level session. */
+	missionOwner?: MissionChildOwnerEntry;
 }
 
 /** Mode change entry - tracks agent mode transitions (e.g. plan mode). */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -40,6 +40,7 @@ import {
 	type CustomMessageEntry,
 	type FileEntry,
 	type LabelEntry,
+	type MissionChildOwnerEntry,
 	type ModeChangeEntry,
 	type ModelChangeEntry,
 	type NewSessionOptions,
@@ -1942,6 +1943,8 @@ export class SessionManager {
 		restrictToolNames?: boolean;
 		spawns?: string;
 		readSummarize?: boolean;
+		cwdBinding?: "fixed";
+		missionOwner?: MissionChildOwnerEntry;
 	}): string {
 		const entry: SessionInitEntry = { type: "session_init", ...this.#freshEntryFields(), ...init };
 		this.#recordEntry(entry);
@@ -2382,6 +2385,8 @@ export class SessionManager {
 			restrictToolNames?: boolean;
 			spawns?: string;
 			readSummarize?: boolean;
+			cwdBinding?: "fixed";
+			missionOwner?: MissionChildOwnerEntry;
 		} | null;
 	} | null> {
 		let loaded: FileEntry[];
@@ -2402,6 +2407,8 @@ export class SessionManager {
 			restrictToolNames?: boolean;
 			spawns?: string;
 			readSummarize?: boolean;
+			cwdBinding?: "fixed";
+			missionOwner?: MissionChildOwnerEntry;
 		} | null = null;
 		for (let index = loaded.length - 1; index >= 0; index--) {
 			const entry = loaded[index];
@@ -2415,6 +2422,8 @@ export class SessionManager {
 					restrictToolNames: entry.restrictToolNames,
 					readSummarize: entry.readSummarize,
 					spawns: entry.spawns,
+					cwdBinding: entry.cwdBinding,
+					missionOwner: entry.missionOwner,
 				};
 				break;
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
-import type { Api, Model, ServiceTier, ServiceTierByFamily, ServiceTierFamily, Usage } from "@oh-my-pi/pi-ai";
+import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -139,6 +139,52 @@ export function createDelegatedParentApprovalUIContext(parent: ExtensionUIContex
 		getToolsExpanded: () => parent.getToolsExpanded(),
 		setToolsExpanded: expanded => parent.setToolsExpanded(expanded),
 	};
+}
+
+export function initializeDelegatedParentApprovalRunner(session: AgentSession, delegatedUi: ExtensionUIContext): void {
+	const runner = session.extensionRunner;
+	if (!runner || runner.hasUI()) return;
+	runner.initialize(
+		{
+			sendMessage: (message, options) => {
+				void session.sendCustomMessage(message, options).catch(error => {
+					logger.error("Delegated extension sendMessage failed", { error: String(error) });
+				});
+			},
+			sendUserMessage: (content, options) => {
+				void session.sendUserMessage(content, options).catch(error => {
+					logger.error("Delegated extension sendUserMessage failed", { error: String(error) });
+				});
+			},
+			appendEntry: (customType, data) => session.sessionManager.appendCustomEntry(customType, data),
+			setLabel: (targetId, label) => session.sessionManager.appendLabelChange(targetId, label),
+			getActiveTools: () => session.getEnabledToolNames(),
+			getAllTools: () => session.getAllToolNames(),
+			setActiveTools: toolNames => session.setActiveToolsByName(toolNames),
+			getCommands: () => getSessionSlashCommands(session),
+			setModel: model => runExtensionSetModel(session, model),
+			getThinkingLevel: () => session.thinkingLevel,
+			setThinkingLevel: level => session.setThinkingLevel(level),
+			getServiceTiers: () => session.serviceTierByFamily,
+			setServiceTier: (family, tier) => session.setServiceTierFamily(family, tier),
+			getSessionName: () => session.sessionManager.getSessionName(),
+			setSessionName: async name => {
+				await session.sessionManager.setSessionName(name, "user");
+			},
+		},
+		{
+			getModel: () => session.model,
+			isIdle: () => !session.isStreaming,
+			abort: () => session.abort({ reason: USER_INTERRUPT_LABEL }),
+			hasPendingMessages: () => session.queuedMessageCount > 0,
+			shutdown: () => {},
+			getContextUsage: () => session.getContextUsage(),
+			getSystemPrompt: () => session.systemPrompt,
+			compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
+		},
+		undefined,
+		delegatedUi,
+	);
 }
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
@@ -2942,53 +2988,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (parentApproval.clientBridge) {
 					childSession.setClientBridge(parentApproval.clientBridge);
 				}
-				// Live/cold revive builds a fresh ExtensionRunner; without initialize the
-				// approval wrapper sees hasUI=false and fails closed even when the parent
-				// UI is available. Bind the delegated UI here (actions are filled by the
-				// initial-run initialize path, or minimal stubs on revive).
-				const runner = childSession.extensionRunner;
-				if (runner && delegatedUi && !runner.hasUI()) {
-					runner.initialize(
-						{
-							sendMessage: () => {},
-							sendUserMessage: () => {},
-							appendEntry: (customType, data) => {
-								childSession.sessionManager.appendCustomEntry(customType, data);
-							},
-							setLabel: (targetId, label) => {
-								childSession.sessionManager.appendLabelChange(targetId, label);
-							},
-							getActiveTools: () => childSession.getEnabledToolNames(),
-							getAllTools: () => childSession.getAllToolNames(),
-							setActiveTools: async toolNames => {
-								await childSession.setActiveToolsByName(toolNames);
-							},
-							getCommands: () => getSessionSlashCommands(childSession),
-							setModel: model => runExtensionSetModel(childSession, model),
-							getThinkingLevel: () => childSession.thinkingLevel,
-							setThinkingLevel: level => childSession.setThinkingLevel(level),
-							getServiceTiers: () => childSession.serviceTierByFamily,
-							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
-								childSession.setServiceTierFamily(family, tier),
-							getSessionName: () => childSession.sessionManager.getSessionName(),
-							setSessionName: async name => {
-								await childSession.sessionManager.setSessionName(name, "user");
-							},
-						},
-						{
-							getModel: () => childSession.model,
-							isIdle: () => !childSession.isStreaming,
-							abort: () => childSession.abort({ reason: USER_INTERRUPT_LABEL }),
-							hasPendingMessages: () => childSession.queuedMessageCount > 0,
-							shutdown: () => {},
-							getContextUsage: () => childSession.getContextUsage(),
-							getSystemPrompt: () => childSession.systemPrompt,
-							compact: instructionsOrOptions => runExtensionCompact(childSession, instructionsOrOptions),
-						},
-						undefined,
-						delegatedUi,
-					);
-				}
 			};
 			applyParentApprovalDelegate(session, setToolUIContext);
 			if (sessionFile !== null && worktree === undefined) {
@@ -2997,6 +2996,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				// (createAgentSession → agent.replaceMessages). Isolated runs are not
 				// resumable (worktree is merged + cleaned) and never get a reviver.
 				reviveSession = async expectedAgentRef => {
+					if (
+						options.missionOwner &&
+						options.missionOwner.ownerSessionId !== options.localProtocolOptions?.getSessionId?.()
+					) {
+						throw new Error(`Cannot revive mission child ${id}: its owning session has changed.`);
+					}
 					const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
 						suppressBreadcrumb: true,
 					});
@@ -3008,6 +3013,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					);
 					installRegistryStatusSync(revived);
 					applyParentApprovalDelegate(revived, setRevivedToolUIContext);
+					if (parentApproval?.uiContext) {
+						initializeDelegatedParentApprovalRunner(
+							revived,
+							createDelegatedParentApprovalUIContext(parentApproval.uiContext),
+						);
+					}
 					return revived;
 				};
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
-import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
+import type { Api, Model, ServiceTier, ServiceTierByFamily, ServiceTierFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -28,6 +28,7 @@ import type { ToolPathWithSource } from "../extensibility/custom-tools";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
+import type { ExtensionUIContext, ExtensionUIDialogOptions } from "../extensibility/extensions/types";
 import { buildSkillPromptMessage, type Skill } from "../extensibility/skills";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
@@ -43,7 +44,9 @@ import type { AgentSession, AgentSessionEvent, Prewalk } from "../session/agent-
 import type { ArtifactManager } from "../session/artifacts";
 import { ASYNC_RESULT_MESSAGE_TYPE } from "../session/async-job-delivery";
 import type { AuthStorage } from "../session/auth-storage";
+import type { ClientBridge } from "../session/client-bridge";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../session/messages";
+import type { MissionChildOwnerEntry } from "../session/session-entries";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import { type ConfiguredThinkingLevel, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
@@ -77,6 +80,66 @@ import {
 import { arrayValuedLabels, assembleYieldResult } from "./yield-assembly";
 
 export type { YieldItem } from "./types";
+
+/** Default parent-approval dialog timeout for mission children (fail closed on expiry). */
+export const MISSION_PARENT_APPROVAL_TIMEOUT_MS = 300_000;
+
+function withMissionParentApprovalTimeout(
+	dialogOptions: ExtensionUIDialogOptions | undefined,
+): ExtensionUIDialogOptions {
+	const requested = dialogOptions?.timeout;
+	const timeout =
+		typeof requested === "number" &&
+		Number.isFinite(requested) &&
+		requested > 0 &&
+		requested < MISSION_PARENT_APPROVAL_TIMEOUT_MS
+			? requested
+			: MISSION_PARENT_APPROVAL_TIMEOUT_MS;
+	return { ...dialogOptions, timeout };
+}
+
+/**
+ * Forward parent UI while enforcing the mission approval timeout unless the child
+ * asked for something shorter. Timeout/denial stay fail-closed in the parent UI.
+ */
+export function createDelegatedParentApprovalUIContext(parent: ExtensionUIContext): ExtensionUIContext {
+	const wrap = (dialogOptions?: ExtensionUIDialogOptions) => withMissionParentApprovalTimeout(dialogOptions);
+	return {
+		get timeoutStartsOnPresentation() {
+			return parent.timeoutStartsOnPresentation;
+		},
+		select: (title, options, dialogOptions) => parent.select(title, options, wrap(dialogOptions)),
+		confirm: (title, message, dialogOptions) => parent.confirm(title, message, wrap(dialogOptions)),
+		input: (title, placeholder, dialogOptions) => parent.input(title, placeholder, wrap(dialogOptions)),
+		askDialog: parent.askDialog
+			? (questions, dialogOptions) => parent.askDialog!(questions, wrap(dialogOptions))
+			: undefined,
+		notify: (message, type) => parent.notify(message, type),
+		onTerminalInput: handler => parent.onTerminalInput(handler),
+		setStatus: (key, text) => parent.setStatus(key, text),
+		setWorkingMessage: message => parent.setWorkingMessage(message),
+		setWidget: (key, content, options) => parent.setWidget(key, content, options),
+		setFooter: factory => parent.setFooter(factory),
+		setHeader: factory => parent.setHeader(factory),
+		setTitle: title => parent.setTitle(title),
+		custom: (factory, options) => parent.custom(factory, options),
+		setEditorText: text => parent.setEditorText(text),
+		pasteToEditor: text => parent.pasteToEditor(text),
+		getEditorText: () => parent.getEditorText(),
+		editor: (title, prefill, dialogOptions, editorOptions) =>
+			parent.editor(title, prefill, wrap(dialogOptions), editorOptions),
+		addAutocompleteProvider: factory => parent.addAutocompleteProvider(factory),
+		setEditorComponent: factory => parent.setEditorComponent(factory),
+		get theme() {
+			return parent.theme;
+		},
+		getAllThemes: () => parent.getAllThemes(),
+		getTheme: name => parent.getTheme(name),
+		setTheme: theme => parent.setTheme(theme),
+		getToolsExpanded: () => parent.getToolsExpanded(),
+		setToolsExpanded: expanded => parent.setToolsExpanded(expanded),
+	};
+}
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
 
@@ -439,6 +502,19 @@ export interface ExecutorOptions {
 	 * set this false so disposal unregisters them instead of leaving idle peers.
 	 */
 	keepAlive?: boolean;
+	/** Fixed mission worktree binding; does not set {@link worktree} (reviver gate unchanged). */
+	workspace?: {
+		cwd: string;
+		binding: "fixed";
+	};
+	/** Parent-mediated approvals; when present, overrides the yolo subagent boundary. */
+	approvalDelegate?: {
+		kind: "parent";
+		uiContext?: ExtensionUIContext;
+		clientBridge?: ClientBridge;
+	};
+	/** Mission ownership markers persisted on session_init for cold revive. */
+	missionOwner?: MissionChildOwnerEntry;
 }
 
 function parseStringifiedJson(value: unknown): unknown {
@@ -2425,12 +2501,22 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	}
 
 	const settings = options.settings ?? Settings.isolated();
+	const parentApproval = options.approvalDelegate?.kind === "parent" ? options.approvalDelegate : undefined;
 	const subagentSettings = createSubagentSettings(
 		settings,
 		{
 			...(agent.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
 			// Isolated runs must not expose roots outside the worktree.
 			...(worktree !== undefined ? { "workspace.additionalDirectories": [] } : undefined),
+			// Mission parent delegate: restore the parent's approval mode/policies
+			// instead of the ordinary yolo subagent boundary. Fail closed — never
+			// leave yolo when a parent delegate was requested.
+			...(parentApproval
+				? {
+						"tools.approvalMode": settings.get("tools.approvalMode"),
+						"tools.approval": settings.get("tools.approval"),
+					}
+				: undefined),
 		},
 		options.parentServiceTier,
 	);
@@ -2801,7 +2887,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
 				},
 				sessionManager: sessionManagerForRun,
-				hasUI: false,
+				hasUI: parentApproval?.uiContext !== undefined,
 				prewalk,
 				spawns: spawnsEnv,
 				taskDepth: childDepth,
@@ -2828,8 +2914,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
 			let session: AgentSession;
+			let setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
 			try {
-				({ session } = await awaitAbortable(sessionPromise));
+				({ session, setToolUIContext } = await awaitAbortable(sessionPromise));
 			} catch (err) {
 				// Abort raced session startup. The session may still resolve later
 				// holding live LSP/MCP child processes — dispose it when it does so
@@ -2841,6 +2928,69 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			monitor.setActiveSession(session);
 			installRegistryStatusSync(session);
+			const applyParentApprovalDelegate = (
+				childSession: AgentSession,
+				setChildToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
+			): void => {
+				if (!parentApproval) return;
+				const delegatedUi = parentApproval.uiContext
+					? createDelegatedParentApprovalUIContext(parentApproval.uiContext)
+					: undefined;
+				if (delegatedUi) {
+					setChildToolUIContext(delegatedUi, true);
+				}
+				if (parentApproval.clientBridge) {
+					childSession.setClientBridge(parentApproval.clientBridge);
+				}
+				// Live/cold revive builds a fresh ExtensionRunner; without initialize the
+				// approval wrapper sees hasUI=false and fails closed even when the parent
+				// UI is available. Bind the delegated UI here (actions are filled by the
+				// initial-run initialize path, or minimal stubs on revive).
+				const runner = childSession.extensionRunner;
+				if (runner && delegatedUi && !runner.hasUI()) {
+					runner.initialize(
+						{
+							sendMessage: () => {},
+							sendUserMessage: () => {},
+							appendEntry: (customType, data) => {
+								childSession.sessionManager.appendCustomEntry(customType, data);
+							},
+							setLabel: (targetId, label) => {
+								childSession.sessionManager.appendLabelChange(targetId, label);
+							},
+							getActiveTools: () => childSession.getEnabledToolNames(),
+							getAllTools: () => childSession.getAllToolNames(),
+							setActiveTools: async toolNames => {
+								await childSession.setActiveToolsByName(toolNames);
+							},
+							getCommands: () => getSessionSlashCommands(childSession),
+							setModel: model => runExtensionSetModel(childSession, model),
+							getThinkingLevel: () => childSession.thinkingLevel,
+							setThinkingLevel: level => childSession.setThinkingLevel(level),
+							getServiceTiers: () => childSession.serviceTierByFamily,
+							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
+								childSession.setServiceTierFamily(family, tier),
+							getSessionName: () => childSession.sessionManager.getSessionName(),
+							setSessionName: async name => {
+								await childSession.sessionManager.setSessionName(name, "user");
+							},
+						},
+						{
+							getModel: () => childSession.model,
+							isIdle: () => !childSession.isStreaming,
+							abort: () => childSession.abort({ reason: USER_INTERRUPT_LABEL }),
+							hasPendingMessages: () => childSession.queuedMessageCount > 0,
+							shutdown: () => {},
+							getContextUsage: () => childSession.getContextUsage(),
+							getSystemPrompt: () => childSession.systemPrompt,
+							compact: instructionsOrOptions => runExtensionCompact(childSession, instructionsOrOptions),
+						},
+						undefined,
+						delegatedUi,
+					);
+				}
+			};
+			applyParentApprovalDelegate(session, setToolUIContext);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
 				// the single-writer lock cleanly and restores the full message history
@@ -2853,10 +3003,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					if (options.parentArtifactManager) {
 						reopened.adoptArtifactManager(options.parentArtifactManager);
 					}
-					const { session: revived } = await createAgentSession(
+					const { session: revived, setToolUIContext: setRevivedToolUIContext } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
 					installRegistryStatusSync(revived);
+					applyParentApprovalDelegate(revived, setRevivedToolUIContext);
 					return revived;
 				};
 			}
@@ -2895,6 +3046,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,
+				...(options.workspace?.binding === "fixed" ? { cwdBinding: "fixed" as const } : {}),
+				...(options.missionOwner ? { missionOwner: options.missionOwner } : {}),
 			});
 
 			abortSignal.addEventListener(
@@ -2963,6 +3116,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						getSystemPrompt: () => session.systemPrompt,
 						compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
 					},
+					undefined,
+					parentApproval?.uiContext ? createDelegatedParentApprovalUIContext(parentApproval.uiContext) : undefined,
 				);
 				extensionRunner.onError(err => {
 					logger.error("Extension error", { path: err.extensionPath, error: err.error });

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs/promises";
-import type { ServiceTier, ServiceTierFamily } from "@oh-my-pi/pi-ai";
 
 import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
@@ -10,7 +9,12 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
-import { createDelegatedParentApprovalUIContext, createMCPProxyTools, createSubagentSettings } from "./executor";
+import {
+	createDelegatedParentApprovalUIContext,
+	createMCPProxyTools,
+	createSubagentSettings,
+	initializeDelegatedParentApprovalRunner,
+} from "./executor";
 
 /**
  * Ambient context the reviver needs at revive time. The top-level session is
@@ -136,7 +140,7 @@ export function createPersistedSubagentReviverFactory(
 				enableLsp: restrictToolNames ? false : ctx.enableLsp,
 				// Fixed mission children run outside the parent checkout — pass the
 				// owner's loaded skills so skill://<name> still resolves.
-				...(isFixedMissionChild ? { skills: [...ctx.session.skills] } : {}),
+				...(isFixedMissionChild ? { skills: [...(ctx.session.skills ?? [])] } : {}),
 				...(restrictToolNames
 					? {
 							enableIrc: false,
@@ -157,49 +161,7 @@ export function createPersistedSubagentReviverFactory(
 				}
 				const bridge = ctx.session.clientBridge;
 				if (bridge) session.setClientBridge(bridge);
-				const runner = session.extensionRunner;
-				if (runner && delegatedUi && !runner.hasUI()) {
-					runner.initialize(
-						{
-							sendMessage: () => {},
-							sendUserMessage: () => {},
-							appendEntry: (customType, data) => {
-								session.sessionManager.appendCustomEntry(customType, data);
-							},
-							setLabel: (targetId, label) => {
-								session.sessionManager.appendLabelChange(targetId, label);
-							},
-							getActiveTools: () => session.getEnabledToolNames(),
-							getAllTools: () => session.getAllToolNames(),
-							setActiveTools: async toolNames => {
-								await session.setActiveToolsByName(toolNames);
-							},
-							getCommands: () => [],
-							setModel: async () => false,
-							getThinkingLevel: () => session.thinkingLevel,
-							setThinkingLevel: level => session.setThinkingLevel(level),
-							getServiceTiers: () => session.serviceTierByFamily,
-							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
-								session.setServiceTierFamily(family, tier),
-							getSessionName: () => session.sessionManager.getSessionName(),
-							setSessionName: async name => {
-								await session.sessionManager.setSessionName(name, "user");
-							},
-						},
-						{
-							getModel: () => session.model,
-							isIdle: () => !session.isStreaming,
-							abort: () => session.abort(),
-							hasPendingMessages: () => session.queuedMessageCount > 0,
-							shutdown: () => {},
-							getContextUsage: () => session.getContextUsage(),
-							getSystemPrompt: () => session.systemPrompt,
-							compact: async () => {},
-						},
-						undefined,
-						delegatedUi,
-					);
-				}
+				if (delegatedUi) initializeDelegatedParentApprovalRunner(session, delegatedUi);
 			}
 			// Clamp the active set to the persisted list: createAgentSession's
 			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import type { ServiceTier, ServiceTierFamily } from "@oh-my-pi/pi-ai";
 
 import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
@@ -9,7 +10,7 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
-import { createMCPProxyTools, createSubagentSettings } from "./executor";
+import { createDelegatedParentApprovalUIContext, createMCPProxyTools, createSubagentSettings } from "./executor";
 
 /**
  * Ambient context the reviver needs at revive time. The top-level session is
@@ -60,6 +61,16 @@ export function createPersistedSubagentReviverFactory(
 			return undefined;
 		}
 		const init = peek.init;
+		const isFixedMissionChild = init.cwdBinding === "fixed";
+		const missionOwner = init.missionOwner;
+		if (isFixedMissionChild) {
+			// Fixed mission children must revive only under their owning top-level
+			// session and only at the recorded worktree cwd — never the parent
+			// checkout or a foreign ACP session.
+			if (!missionOwner || missionOwner.ownerSessionId !== ctx.session.sessionId) {
+				return undefined;
+			}
+		}
 		// taskDepth drives real capability gating (task-spawn allowance, memory
 		// startup, …); derive it from the persisted parent chain rather than
 		// assuming a fixed level.
@@ -84,14 +95,27 @@ export function createPersistedSubagentReviverFactory(
 			const restrictToolNames = init.restrictToolNames === true;
 			const mcpManager = restrictToolNames ? undefined : MCPManager.instance();
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
-			const { session } = await createAgentSession({
-				cwd: ctx.session.sessionManager.getCwd(),
+			const reviveCwd = isFixedMissionChild ? peek.cwd : ctx.session.sessionManager.getCwd();
+			// Mission children inherit the parent's approval mode (never implicit
+			// yolo). Ordinary task/eval children keep createSubagentSettings' yolo.
+			const parentApprovalOverrides = isFixedMissionChild
+				? {
+						"tools.approvalMode": ctx.settings.get("tools.approvalMode"),
+						"tools.approval": ctx.settings.get("tools.approval"),
+					}
+				: undefined;
+			const parentUiContext =
+				isFixedMissionChild && ctx.session.extensionRunner?.hasUI()
+					? ctx.session.extensionRunner.getUIContext()
+					: undefined;
+			const { session, setToolUIContext } = await createAgentSession({
+				cwd: reviveCwd,
 				authStorage: ctx.authStorage,
 				modelRegistry: ctx.modelRegistry,
-				settings: createSubagentSettings(
-					ctx.settings,
-					init.readSummarize === false ? { "read.summarize.enabled": false } : undefined,
-				),
+				settings: createSubagentSettings(ctx.settings, {
+					...(init.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
+					...parentApprovalOverrides,
+				}),
 				sessionManager: reopened,
 				agentId: ref.id,
 				agentDisplayName: ref.displayName,
@@ -108,8 +132,11 @@ export function createPersistedSubagentReviverFactory(
 				// Old files predate persisted spawns: deny re-spawning rather than let
 				// createAgentSession default to wildcard ("*").
 				spawns: init.spawns ?? "",
-				hasUI: false,
+				hasUI: parentUiContext !== undefined,
 				enableLsp: restrictToolNames ? false : ctx.enableLsp,
+				// Fixed mission children run outside the parent checkout — pass the
+				// owner's loaded skills so skill://<name> still resolves.
+				...(isFixedMissionChild ? { skills: [...ctx.session.skills] } : {}),
 				...(restrictToolNames
 					? {
 							enableIrc: false,
@@ -123,6 +150,57 @@ export function createPersistedSubagentReviverFactory(
 							customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
 						}),
 			});
+			if (isFixedMissionChild) {
+				const delegatedUi = parentUiContext ? createDelegatedParentApprovalUIContext(parentUiContext) : undefined;
+				if (delegatedUi) {
+					setToolUIContext(delegatedUi, true);
+				}
+				const bridge = ctx.session.clientBridge;
+				if (bridge) session.setClientBridge(bridge);
+				const runner = session.extensionRunner;
+				if (runner && delegatedUi && !runner.hasUI()) {
+					runner.initialize(
+						{
+							sendMessage: () => {},
+							sendUserMessage: () => {},
+							appendEntry: (customType, data) => {
+								session.sessionManager.appendCustomEntry(customType, data);
+							},
+							setLabel: (targetId, label) => {
+								session.sessionManager.appendLabelChange(targetId, label);
+							},
+							getActiveTools: () => session.getEnabledToolNames(),
+							getAllTools: () => session.getAllToolNames(),
+							setActiveTools: async toolNames => {
+								await session.setActiveToolsByName(toolNames);
+							},
+							getCommands: () => [],
+							setModel: async () => false,
+							getThinkingLevel: () => session.thinkingLevel,
+							setThinkingLevel: level => session.setThinkingLevel(level),
+							getServiceTiers: () => session.serviceTierByFamily,
+							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
+								session.setServiceTierFamily(family, tier),
+							getSessionName: () => session.sessionManager.getSessionName(),
+							setSessionName: async name => {
+								await session.sessionManager.setSessionName(name, "user");
+							},
+						},
+						{
+							getModel: () => session.model,
+							isIdle: () => !session.isStreaming,
+							abort: () => session.abort(),
+							hasPendingMessages: () => session.queuedMessageCount > 0,
+							shutdown: () => {},
+							getContextUsage: () => session.getContextUsage(),
+							getSystemPrompt: () => session.systemPrompt,
+							compact: async () => {},
+						},
+						undefined,
+						delegatedUi,
+					);
+				}
+			}
 			// Clamp the active set to the persisted list: createAgentSession's
 			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools
 			// the original run didn't carry. Unknown/missing names are ignored.

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -9,6 +9,7 @@ import * as os from "node:os";
 import path from "node:path";
 import { $env, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
+import type { ExtensionUIContext } from "../extensibility/extensions/types";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { registerArtifactsDir } from "../internal-urls/registry-helpers";
 import { MCPManager } from "../mcp/manager";
@@ -16,6 +17,8 @@ import { loadOverallPlanReference } from "../plan-mode/plan-handoff";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
 import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.md" with { type: "text" };
 import { MAIN_AGENT_ID } from "../registry/agent-registry";
+import type { ClientBridge } from "../session/client-bridge";
+import type { MissionChildOwnerEntry } from "../session/session-entries";
 import type { TaskEffort } from "../thinking";
 import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
@@ -69,6 +72,22 @@ export interface StructuredSubagentIsolationControls {
 	apply?: boolean;
 }
 
+/**
+ * Parent-mediated approvals for mission children. UI lives on the delegate, never
+ * on ToolSession — AgentSession builds this as a closure over its private UI/bridge.
+ */
+export interface ParentApprovalDelegate {
+	kind: "parent";
+	uiContext?: ExtensionUIContext;
+	clientBridge?: ClientBridge;
+}
+
+/** Fixed worktree cwd for a crash-recoverable mission child (not ordinary isolation). */
+export interface PersistentSubagentWorkspace {
+	cwd: string;
+	binding: "fixed";
+}
+
 /** Identity and presentation metadata supplied by the calling surface. */
 export interface StructuredSubagentIdentity {
 	/** A previously reserved output/registry id. */
@@ -97,6 +116,12 @@ export interface StructuredSubagentRequest {
 	invokedAt?: number;
 	acquiredAt?: number;
 	isolation?: StructuredSubagentIsolationControls;
+	/** Fixed mission worktree; omitted callers keep parent cwd. */
+	workspace?: PersistentSubagentWorkspace;
+	/** Parent-mediated approvals; omitted callers keep the yolo subagent boundary. */
+	approvalDelegate?: ParentApprovalDelegate;
+	/** Mission ownership markers written to session_init for cold revive. */
+	missionOwner?: MissionChildOwnerEntry;
 	/** The parent agent name forbidden from recursively spawning itself. */
 	blockedAgent?: string;
 	/** Preserve a completed temporary artifacts directory for an agent:// handle. */
@@ -375,7 +400,7 @@ function buildExecutorOptions(
 	};
 	const enableMCP = !policy.planMode && (session.enableMCP ?? true);
 	return {
-		cwd: session.cwd,
+		cwd: request.workspace?.cwd ?? session.cwd,
 		additionalDirectories: session.additionalDirectories,
 		agent: policy.effectiveAgent,
 		task: renderSubagentPrompt(request.assignment),
@@ -410,6 +435,9 @@ function buildExecutorOptions(
 		maxRuntimeMs: request.maxRuntimeMs,
 		restrictToolNames: policy.planMode,
 		keepAlive: request.keepAlive,
+		...(request.workspace ? { workspace: request.workspace } : {}),
+		...(request.approvalDelegate ? { approvalDelegate: request.approvalDelegate } : {}),
+		...(request.missionOwner ? { missionOwner: request.missionOwner } : {}),
 		signal: request.signal,
 		eventBus: session.eventBus,
 		onProgress: request.onProgress,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -270,6 +270,12 @@ export async function resolveEffectiveSubagentPolicy(
 	const spawnPolicy = resolveSpawnPolicy(request.session.getSessionSpawns());
 	const agentName = request.agent?.trim() || spawnPolicy.defaultAgent;
 	const planMode = request.session.getPlanModeState?.()?.enabled === true;
+	if (request.workspace?.binding === "fixed" && !request.missionOwner) {
+		throw new StructuredSubagentError(
+			"preflight",
+			"Fixed-workspace subagents require mission ownership for safe revival.",
+		);
+	}
 	assertPlanControlsAllowed(request, planMode);
 	assertDepthAndSpawnAllowed(request, agentName);
 
@@ -446,12 +452,18 @@ function buildExecutorOptions(
 		settings: session.settings,
 		mcpManager: enableMCP ? (session.mcpManager ?? MCPManager.instance()) : undefined,
 		enableMCP,
-		contextFiles: session.contextFiles?.filter(file => path.basename(file.path).toLowerCase() !== "agents.md"),
+		...(request.workspace
+			? {}
+			: {
+					contextFiles: session.contextFiles?.filter(
+						file => path.basename(file.path).toLowerCase() !== "agents.md",
+					),
+					workspaceTree: session.workspaceTree,
+					promptTemplates: session.promptTemplates,
+					rules: session.rules,
+				}),
 		skills,
 		autoloadSkills,
-		workspaceTree: session.workspaceTree,
-		promptTemplates: session.promptTemplates,
-		rules: session.rules,
 		preloadedExtensionPaths: policy.planMode ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: policy.planMode ? [] : session.customToolPaths,
 		localProtocolOptions,

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -209,6 +209,38 @@ describe("AgentLifecycleManager", () => {
 		expect(revived.disposeCalls()).toBe(1);
 	});
 
+	it("routes persisted cold revival to the factory registered for that agent id", async () => {
+		const first = makeSessionStub();
+		const second = makeSessionStub();
+		registry.register({
+			id: "first-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/first-Sub.jsonl",
+			status: "parked",
+		});
+		registry.register({
+			id: "second-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/second-Sub.jsonl",
+			status: "parked",
+		});
+
+		const firstReviver = vi.fn(async () => async () => first.session);
+		const secondReviver = vi.fn(async () => async () => second.session);
+		lifecycle.registerPersistedReviver("first-Sub", firstReviver, TTL);
+		lifecycle.registerPersistedReviver("second-Sub", secondReviver, TTL);
+
+		await expect(lifecycle.ensureLive("second-Sub")).resolves.toBe(second.session);
+		expect(secondReviver).toHaveBeenCalledTimes(1);
+		expect(firstReviver).not.toHaveBeenCalled();
+		expect(registry.get("second-Sub")?.session).toBe(second.session);
+		expect(registry.get("first-Sub")?.status).toBe("parked");
+	});
+
 	it("a persisted factory that declines leaves the parked ref transcript-only", async () => {
 		registry.register({
 			id: "7-Sub",

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -43,7 +43,11 @@ function createRevivedSession(activeToolNames: string[][]): AgentSession {
 	} as unknown as AgentSession;
 }
 
-async function createPersistedSession(cwd: string, restrictToolNames?: boolean): Promise<string> {
+async function createPersistedSession(
+	cwd: string,
+	restrictToolNames?: boolean,
+	missionOwner?: { ownerSessionId: string },
+): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
 	if (!sessionFile) throw new Error("Expected a persisted session file");
@@ -52,6 +56,18 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean):
 		task: "persisted task",
 		tools: ["read", "yield"],
 		restrictToolNames,
+		...(missionOwner
+			? {
+					cwdBinding: "fixed" as const,
+					missionOwner: {
+						missionId: "mission",
+						ownerSessionId: missionOwner.ownerSessionId,
+						role: "implementation" as const,
+						milestoneId: "milestone",
+						featureId: "feature",
+					},
+				}
+			: {}),
 	});
 	manager.appendMessage({
 		role: "assistant",
@@ -74,8 +90,9 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean):
 	return sessionFile;
 }
 
-function createFactory(cwd: string) {
+function createFactory(cwd: string, sessionId?: string) {
 	const parentSession = {
+		sessionId,
 		sessionManager: {
 			getCwd: () => cwd,
 			getArtifactManager: () => undefined,
@@ -154,5 +171,24 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
+	});
+
+	it("revives a fixed child only for its owner and at its recorded workspace", async () => {
+		const cwd = makeTempDir("@pi-fixed-revive-");
+		const sessionFile = await createPersistedSession(cwd, false, { ownerSessionId: "owner" });
+		const ref = createRef(sessionFile);
+
+		expect(await createFactory(cwd, "other")(ref)).toBeUndefined();
+
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]) } as CreateAgentSessionResult;
+		});
+		const reviver = await createFactory("/parent", "owner")(ref);
+		if (!reviver) throw new Error("Expected fixed workspace reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.cwd).toBe(cwd);
 	});
 });

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -340,6 +340,48 @@ describe("structured subagent primitive", () => {
 		await fs.rm(mcpDisabledRun.artifactsDir, { recursive: true, force: true });
 	});
 
+	it("requires mission ownership and rediscovers fixed-workspace context", async () => {
+		await expect(
+			resolveEffectiveSubagentPolicy(request({ workspace: { cwd: "/fixed", binding: "fixed" } })),
+		).rejects.toThrow("Fixed-workspace subagents require mission ownership");
+
+		mockDiscovery();
+		const fixedSession = session();
+		Object.assign(fixedSession, {
+			contextFiles: [{ path: "/parent/AGENTS.md", content: "parent" }],
+			workspaceTree: { cwd: "/parent" },
+			promptTemplates: [{ name: "parent" }],
+			rules: [{ content: "parent" }],
+		});
+		let options: executorModule.ExecutorOptions | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async executorOptions => {
+			options = executorOptions;
+			return result();
+		});
+
+		const run = await runStructuredSubagent(
+			request({
+				session: fixedSession,
+				workspace: { cwd: "/fixed", binding: "fixed" },
+				missionOwner: {
+					missionId: "mission",
+					ownerSessionId: "owner",
+					role: "implementation",
+					milestoneId: "milestone",
+					featureId: "feature",
+				},
+				retainArtifacts: true,
+			}),
+		);
+
+		expect(options).toMatchObject({ cwd: "/fixed", workspace: { cwd: "/fixed", binding: "fixed" } });
+		expect(options?.contextFiles).toBeUndefined();
+		expect(options?.workspaceTree).toBeUndefined();
+		expect(options?.promptTemplates).toBeUndefined();
+		expect(options?.rules).toBeUndefined();
+		await fs.rm(run.artifactsDir, { recursive: true, force: true });
+	});
+
 	it("unregisters and removes a temporary lease when output ID allocation fails", async () => {
 		mockDiscovery();
 		const failingSession = session();


### PR DESCRIPTION
## Summary

Adds fixed-workspace child sessions with parent-delegated approvals and id-scoped cold revival. This keeps child workspace boundaries and approval ownership stable across persistence and revival.

## Validation

- `bun test packages/coding-agent/test/registry/agent-lifecycle.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

Closes #6675
