### PR TITLE
feat(coding-agent): add mission workspace manager

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added crash-recoverable mission workspaces: feature workers receive isolated branches and validators detached checkouts, with ownership checks, reconciliation after interrupted setup, and CAS-protected integration advancement.
+
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
 

--- a/packages/coding-agent/src/missions/index.ts
+++ b/packages/coding-agent/src/missions/index.ts
@@ -1,0 +1,3 @@
+export * from "./state";
+export * from "./types";
+export * from "./workspace";

--- a/packages/coding-agent/src/missions/state.ts
+++ b/packages/coding-agent/src/missions/state.ts
@@ -1,8 +1,10 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
 import type { SessionEntry } from "../session/session-entries";
 import type {
 	MissionFeature,
 	MissionFeatureStatus,
 	MissionHandoff,
+	MissionHandoffDecision,
 	MissionIntegrationPending,
 	MissionPauseReason,
 	MissionPlan,
@@ -53,10 +55,6 @@ const FEATURE_STATUSES = [
 
 const VALIDATOR_ROLES = ["scrutiny", "user-testing"] as const satisfies readonly MissionValidatorRole[];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isNonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
 }
@@ -73,15 +71,19 @@ const PAUSE_REASONS = [
 	"validator_workspace_dirty",
 ] as const satisfies readonly MissionPauseReason[];
 
-const HANDOFF_RESOLVE_DECISIONS = ["accept", "retry_same", "retry_fresh", "cancel_feature", "pause"] as const;
+const HANDOFF_RESOLVE_DECISIONS = [
+	"accept",
+	"retry_same",
+	"retry_fresh",
+	"cancel_feature",
+	"pause",
+] as const satisfies readonly MissionHandoffDecision[];
 
 function isMissionPauseReason(value: unknown): value is MissionPauseReason {
 	return typeof value === "string" && (PAUSE_REASONS as readonly string[]).includes(value);
 }
 
-function isHandoffResolveDecision(
-	value: unknown,
-): value is "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause" {
+function isHandoffResolveDecision(value: unknown): value is MissionHandoffDecision {
 	return typeof value === "string" && (HANDOFF_RESOLVE_DECISIONS as readonly string[]).includes(value);
 }
 
@@ -91,6 +93,11 @@ function assertNever(value: never, message: string): never {
 
 function formatIdList(ids: Iterable<string>): string {
 	return [...ids].join(", ");
+}
+
+/** user-testing needs something to drive: at least one runbook command or one declared service. */
+export function runbookSupportsUserTesting(runbook: MissionPlan["runbook"]): boolean {
+	return runbook.userTests.length > 0 || runbook.services.length > 0;
 }
 
 /** Reject empty goals/milestones/features/expectedBehavior/validators and all structural plan rules. */
@@ -118,6 +125,7 @@ export function validateMissionPlan(plan: MissionPlan): MissionPlanValidationRes
 	const milestoneIndex = new Map<string, number>();
 	const featureById = new Map<string, MissionPlan["features"][number]>();
 	const membershipCount = new Map<string, number>();
+	const supportsUserTesting = runbookSupportsUserTesting(plan.runbook);
 
 	for (let i = 0; i < plan.milestones.length; i++) {
 		const milestone = plan.milestones[i]!;
@@ -158,14 +166,10 @@ export function validateMissionPlan(plan: MissionPlan): MissionPlanValidationRes
 					errors.push(`Milestone "${milestone.id}" has duplicate validator role "${role}"`);
 				}
 				seenRoles.add(role);
-				if (role === "user-testing") {
-					const hasUserTestCommand = plan.runbook.userTests.length > 0;
-					const hasService = plan.runbook.services.length > 0;
-					if (!hasUserTestCommand && !hasService) {
-						errors.push(
-							`Milestone "${milestone.id}" requests user-testing but runbook has no userTests command or service`,
-						);
-					}
+				if (role === "user-testing" && !supportsUserTesting) {
+					errors.push(
+						`Milestone "${milestone.id}" requests user-testing but runbook has no userTests command or service`,
+					);
 				}
 			}
 		}
@@ -894,8 +898,7 @@ export function canAcceptPendingHandoff(handoff: MissionHandoff): boolean {
 
 /** Milestone default validators: scrutiny + user-testing when the runbook supports it, else scrutiny alone. */
 export function defaultMilestoneValidators(runbook: MissionPlan["runbook"]): MissionValidatorRole[] {
-	const supportsUserTesting = runbook.userTests.length > 0 || runbook.services.length > 0;
-	if (supportsUserTesting) {
+	if (runbookSupportsUserTesting(runbook)) {
 		return ["scrutiny", "user-testing"];
 	}
 	return ["scrutiny"];

--- a/packages/coding-agent/src/missions/state.ts
+++ b/packages/coding-agent/src/missions/state.ts
@@ -1,0 +1,910 @@
+import type { SessionEntry } from "../session/session-entries";
+import type {
+	MissionFeature,
+	MissionFeatureStatus,
+	MissionHandoff,
+	MissionIntegrationPending,
+	MissionPauseReason,
+	MissionPlan,
+	MissionProgressEvent,
+	MissionPublishCheck,
+	MissionRepositoryState,
+	MissionState,
+	MissionStatus,
+	MissionValidatorRole,
+	MissionWorkerHandoff,
+	MissionWorkspaceDescriptor,
+} from "./types";
+import { MISSION_PROGRESS_CUSTOM_TYPE, MISSION_STATE_CUSTOM_TYPE } from "./types";
+
+export interface MissionPlanValidationResult {
+	valid: boolean;
+	errors: string[];
+}
+
+export interface NextMissionFeatureResult {
+	state: MissionState;
+	feature: MissionFeature | null;
+}
+
+export class MissionStateError extends Error {
+	override readonly name = "MissionStateError";
+}
+
+const MISSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+const MISSION_STATUSES = [
+	"planning",
+	"awaiting_input",
+	"initializing",
+	"running",
+	"paused",
+	"orchestrator_turn",
+	"completed",
+	"cancelled",
+] as const satisfies readonly MissionStatus[];
+
+const FEATURE_STATUSES = [
+	"pending",
+	"in_progress",
+	"completed",
+	"cancelled",
+] as const satisfies readonly MissionFeatureStatus[];
+
+const VALIDATOR_ROLES = ["scrutiny", "user-testing"] as const satisfies readonly MissionValidatorRole[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+const PAUSE_REASONS = [
+	"user_requested",
+	"feature_retry_limit_exceeded",
+	"worker_inactive",
+	"worker_interrupted",
+	"repository_dirty",
+	"workspace_conflict",
+	"integration_diverged",
+	"parent_diverged",
+	"validator_workspace_dirty",
+] as const satisfies readonly MissionPauseReason[];
+
+const HANDOFF_RESOLVE_DECISIONS = ["accept", "retry_same", "retry_fresh", "cancel_feature", "pause"] as const;
+
+function isMissionPauseReason(value: unknown): value is MissionPauseReason {
+	return typeof value === "string" && (PAUSE_REASONS as readonly string[]).includes(value);
+}
+
+function isHandoffResolveDecision(
+	value: unknown,
+): value is "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause" {
+	return typeof value === "string" && (HANDOFF_RESOLVE_DECISIONS as readonly string[]).includes(value);
+}
+
+function assertNever(value: never, message: string): never {
+	throw new MissionStateError(`${message}: ${JSON.stringify(value)}`);
+}
+
+function formatIdList(ids: Iterable<string>): string {
+	return [...ids].join(", ");
+}
+
+/** Reject empty goals/milestones/features/expectedBehavior/validators and all structural plan rules. */
+export function validateMissionPlan(plan: MissionPlan): MissionPlanValidationResult {
+	const errors: string[] = [];
+
+	if (!isNonEmptyString(plan.goal)) {
+		errors.push("Plan goal must be a non-empty string");
+	}
+
+	if (!Array.isArray(plan.milestones) || plan.milestones.length === 0) {
+		errors.push("Plan must include at least one milestone");
+	}
+
+	if (!Array.isArray(plan.features) || plan.features.length === 0) {
+		errors.push("Plan must include at least one feature");
+	}
+
+	if (errors.length > 0) {
+		return { valid: false, errors };
+	}
+
+	const milestoneIds = new Set<string>();
+	const featureIds = new Set<string>();
+	const milestoneIndex = new Map<string, number>();
+	const featureById = new Map<string, MissionPlan["features"][number]>();
+	const membershipCount = new Map<string, number>();
+
+	for (let i = 0; i < plan.milestones.length; i++) {
+		const milestone = plan.milestones[i]!;
+		if (!isNonEmptyString(milestone.id)) {
+			errors.push(`Milestone at index ${i} has an empty id`);
+			continue;
+		}
+		if (!MISSION_ID_PATTERN.test(milestone.id)) {
+			errors.push(`Milestone id "${milestone.id}" must match ${MISSION_ID_PATTERN}`);
+		}
+		if (milestone.id.startsWith("_")) {
+			errors.push(`User milestone id "${milestone.id}" may not begin with "_"`);
+		}
+		if (milestoneIds.has(milestone.id)) {
+			errors.push(`Duplicate milestone id "${milestone.id}"`);
+		}
+		milestoneIds.add(milestone.id);
+		milestoneIndex.set(milestone.id, i);
+
+		if (!Array.isArray(milestone.featureIds) || milestone.featureIds.length === 0) {
+			errors.push(`Milestone "${milestone.id}" must list at least one feature id`);
+		} else {
+			for (const featureId of milestone.featureIds) {
+				membershipCount.set(featureId, (membershipCount.get(featureId) ?? 0) + 1);
+			}
+		}
+
+		if (!Array.isArray(milestone.validators) || milestone.validators.length === 0) {
+			errors.push(`Milestone "${milestone.id}" must list at least one validator`);
+		} else {
+			const seenRoles = new Set<MissionValidatorRole>();
+			for (const role of milestone.validators) {
+				if (!VALIDATOR_ROLES.includes(role)) {
+					errors.push(`Milestone "${milestone.id}" has unknown validator role "${String(role)}"`);
+					continue;
+				}
+				if (seenRoles.has(role)) {
+					errors.push(`Milestone "${milestone.id}" has duplicate validator role "${role}"`);
+				}
+				seenRoles.add(role);
+				if (role === "user-testing") {
+					const hasUserTestCommand = plan.runbook.userTests.length > 0;
+					const hasService = plan.runbook.services.length > 0;
+					if (!hasUserTestCommand && !hasService) {
+						errors.push(
+							`Milestone "${milestone.id}" requests user-testing but runbook has no userTests command or service`,
+						);
+					}
+				}
+			}
+		}
+	}
+
+	for (let i = 0; i < plan.features.length; i++) {
+		const feature = plan.features[i]!;
+		if (!isNonEmptyString(feature.id)) {
+			errors.push(`Feature at index ${i} has an empty id`);
+			continue;
+		}
+		if (!MISSION_ID_PATTERN.test(feature.id)) {
+			errors.push(`Feature id "${feature.id}" must match ${MISSION_ID_PATTERN}`);
+		}
+		if (feature.id.startsWith("_")) {
+			errors.push(`User feature id "${feature.id}" may not begin with "_"`);
+		}
+		if (featureIds.has(feature.id)) {
+			errors.push(`Duplicate feature id "${feature.id}"`);
+		}
+		featureIds.add(feature.id);
+		featureById.set(feature.id, feature);
+
+		if (!isNonEmptyString(feature.milestoneId)) {
+			errors.push(`Feature "${feature.id}" has an empty milestoneId`);
+		} else if (!milestoneIds.has(feature.milestoneId)) {
+			errors.push(`Feature "${feature.id}" references missing milestone "${feature.milestoneId}"`);
+		}
+
+		if (!Array.isArray(feature.expectedBehavior) || feature.expectedBehavior.length === 0) {
+			errors.push(`Feature "${feature.id}" must list at least one expectedBehavior item`);
+		}
+
+		if (!Array.isArray(feature.preconditions)) {
+			errors.push(`Feature "${feature.id}" preconditions must be an array`);
+		}
+	}
+
+	for (const milestone of plan.milestones) {
+		for (const featureId of milestone.featureIds) {
+			if (!featureIds.has(featureId)) {
+				errors.push(`Milestone "${milestone.id}" references missing feature "${featureId}"`);
+				continue;
+			}
+			const feature = featureById.get(featureId);
+			if (feature && feature.milestoneId !== milestone.id) {
+				errors.push(
+					`Feature "${featureId}" is listed under milestone "${milestone.id}" but feature.milestoneId is "${feature.milestoneId}"`,
+				);
+			}
+		}
+	}
+
+	for (const feature of plan.features) {
+		const count = membershipCount.get(feature.id) ?? 0;
+		if (count === 0) {
+			errors.push(`Feature "${feature.id}" is not listed in any milestone.featureIds`);
+		} else if (count > 1) {
+			errors.push(`Feature "${feature.id}" appears in more than one milestone.featureIds list`);
+		}
+	}
+
+	for (const feature of plan.features) {
+		const featureMilestoneIndex = milestoneIndex.get(feature.milestoneId);
+		if (featureMilestoneIndex === undefined) {
+			continue;
+		}
+		for (const preconditionId of feature.preconditions) {
+			if (!featureIds.has(preconditionId)) {
+				errors.push(`Feature "${feature.id}" references missing precondition "${preconditionId}"`);
+				continue;
+			}
+			const precondition = featureById.get(preconditionId);
+			if (!precondition) {
+				continue;
+			}
+			const preconditionMilestoneIndex = milestoneIndex.get(precondition.milestoneId);
+			if (preconditionMilestoneIndex !== undefined && preconditionMilestoneIndex > featureMilestoneIndex) {
+				errors.push(`Feature "${feature.id}" depends on "${preconditionId}" from a later milestone`);
+			}
+		}
+	}
+
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+	const cycleParticipants = new Set<string>();
+
+	const visit = (featureId: string, stack: string[]): void => {
+		if (visited.has(featureId) || cycleParticipants.has(featureId)) {
+			return;
+		}
+		if (visiting.has(featureId)) {
+			const cycleStart = stack.indexOf(featureId);
+			for (const id of stack.slice(cycleStart >= 0 ? cycleStart : 0)) {
+				cycleParticipants.add(id);
+			}
+			cycleParticipants.add(featureId);
+			return;
+		}
+		visiting.add(featureId);
+		const feature = featureById.get(featureId);
+		if (feature) {
+			for (const preconditionId of feature.preconditions) {
+				if (featureIds.has(preconditionId)) {
+					visit(preconditionId, [...stack, featureId]);
+				}
+			}
+		}
+		visiting.delete(featureId);
+		visited.add(featureId);
+	};
+
+	for (const featureId of featureIds) {
+		visit(featureId, []);
+	}
+	if (cycleParticipants.size > 0) {
+		errors.push(`Feature precondition graph contains a cycle involving: ${formatIdList(cycleParticipants)}`);
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+function isTerminalStatus(status: MissionStatus): boolean {
+	switch (status) {
+		case "completed":
+		case "cancelled":
+			return true;
+		case "planning":
+		case "awaiting_input":
+		case "initializing":
+		case "running":
+		case "paused":
+		case "orchestrator_turn":
+			return false;
+		default:
+			return assertNever(status, "Unknown mission status");
+	}
+}
+
+function isPlanningOrAwaiting(status: MissionStatus): boolean {
+	switch (status) {
+		case "planning":
+		case "awaiting_input":
+			return true;
+		case "initializing":
+		case "running":
+		case "paused":
+		case "orchestrator_turn":
+		case "completed":
+		case "cancelled":
+			return false;
+		default:
+			return assertNever(status, "Unknown mission status");
+	}
+}
+
+function handoffIsSuccessfulImplementation(handoff: MissionHandoff): handoff is MissionWorkerHandoff {
+	if (handoff.kind !== "implementation") {
+		return false;
+	}
+	if (handoff.outcome !== "success") {
+		return false;
+	}
+	return !handoff.issues.some(issue => issue.severity === "blocking");
+}
+
+function expectedIntegrationNewHead(handoff: MissionWorkerHandoff, expectedOldHead: string): string {
+	if (handoff.commits.length === 0) {
+		return expectedOldHead;
+	}
+	return handoff.commits[handoff.commits.length - 1]!;
+}
+
+function workspaceMatchesFeatureKind(feature: MissionFeature, workspace: MissionWorkspaceDescriptor): boolean {
+	switch (feature.kind) {
+		case "implementation":
+			return workspace.kind === "feature";
+		case "validation":
+			return workspace.kind === "validator";
+		default:
+			return assertNever(feature.kind, "Unknown feature kind");
+	}
+}
+
+function collectProgressEvents(entries: readonly SessionEntry[], missionId: string): MissionProgressEvent[] {
+	const events: MissionProgressEvent[] = [];
+	for (const entry of entries) {
+		if (entry.type !== "custom" || entry.customType !== MISSION_PROGRESS_CUSTOM_TYPE) {
+			continue;
+		}
+		const parsed = parseMissionProgressEvent(entry.data);
+		if (parsed.missionId === missionId) {
+			events.push(parsed);
+		}
+	}
+	return events;
+}
+
+function parseMissionProgressEvent(data: unknown): MissionProgressEvent {
+	if (!isRecord(data)) {
+		throw new MissionStateError("mission-progress entry data must be an object");
+	}
+	if (typeof data.missionId !== "string" || typeof data.sequence !== "number" || typeof data.at !== "number") {
+		throw new MissionStateError("mission-progress entry missing missionId, sequence, or at");
+	}
+	if (typeof data.type !== "string") {
+		throw new MissionStateError("mission-progress entry missing type discriminator");
+	}
+
+	const base = {
+		missionId: data.missionId,
+		sequence: data.sequence,
+		at: data.at,
+	};
+
+	switch (data.type) {
+		case "accepted":
+		case "resumed":
+		case "run_started":
+		case "completed":
+		case "cancelled":
+			return { ...base, type: data.type };
+		case "paused":
+			if (!isMissionPauseReason(data.reason)) {
+				throw new MissionStateError("paused progress event requires a valid reason");
+			}
+			return { ...base, type: "paused", reason: data.reason };
+		case "feature_selected":
+			if (typeof data.featureId !== "string") {
+				throw new MissionStateError("feature_selected progress event requires featureId");
+			}
+			return { ...base, type: "feature_selected", featureId: data.featureId };
+		case "worker_started":
+		case "worker_completed":
+			if (typeof data.featureId !== "string" || typeof data.workerSessionId !== "string") {
+				throw new MissionStateError(`${data.type} progress event requires featureId and workerSessionId`);
+			}
+			return {
+				...base,
+				type: data.type,
+				featureId: data.featureId,
+				workerSessionId: data.workerSessionId,
+			};
+		case "worker_failed":
+			if (typeof data.featureId !== "string") {
+				throw new MissionStateError("worker_failed progress event requires featureId");
+			}
+			return {
+				...base,
+				type: "worker_failed",
+				featureId: data.featureId,
+				workerSessionId: typeof data.workerSessionId === "string" ? data.workerSessionId : undefined,
+			};
+		case "heartbeat":
+			if (
+				typeof data.featureId !== "string" ||
+				typeof data.workerSessionId !== "string" ||
+				typeof data.requests !== "number" ||
+				typeof data.tokens !== "number" ||
+				typeof data.cost !== "number"
+			) {
+				throw new MissionStateError(
+					"heartbeat progress event requires featureId, workerSessionId, requests, tokens, and cost",
+				);
+			}
+			return {
+				...base,
+				type: "heartbeat",
+				featureId: data.featureId,
+				workerSessionId: data.workerSessionId,
+				requests: data.requests,
+				tokens: data.tokens,
+				cost: data.cost,
+			};
+		case "handoff_resolved":
+			if (typeof data.featureId !== "string" || !isHandoffResolveDecision(data.decision)) {
+				throw new MissionStateError("handoff_resolved progress event requires featureId and decision");
+			}
+			return {
+				...base,
+				type: "handoff_resolved",
+				featureId: data.featureId,
+				decision: data.decision,
+			};
+		case "milestone_validation_triggered":
+			if (typeof data.milestoneId !== "string") {
+				throw new MissionStateError("milestone_validation_triggered progress event requires milestoneId");
+			}
+			return { ...base, type: "milestone_validation_triggered", milestoneId: data.milestoneId };
+		case "publish_validation_triggered":
+			if (typeof data.generation !== "number") {
+				throw new MissionStateError("publish_validation_triggered progress event requires generation");
+			}
+			return { ...base, type: "publish_validation_triggered", generation: data.generation };
+		default:
+			throw new MissionStateError(`Unknown mission-progress type "${data.type}"`);
+	}
+}
+
+function validateProgressSequences(events: readonly MissionProgressEvent[]): void {
+	if (events.length === 0) {
+		return;
+	}
+	const sorted = [...events].sort((a, b) => a.sequence - b.sequence);
+	for (let i = 0; i < sorted.length; i++) {
+		const expected = i === 0 ? sorted[0]!.sequence : sorted[i - 1]!.sequence + 1;
+		if (sorted[i]!.sequence !== expected) {
+			throw new MissionStateError(
+				`Mission progress event sequences must increase by one (expected ${expected}, got ${sorted[i]!.sequence})`,
+			);
+		}
+	}
+	// Append-only transcript order must match sequence order.
+	for (let i = 0; i < events.length; i++) {
+		if (events[i]!.sequence !== sorted[i]!.sequence) {
+			throw new MissionStateError("Mission progress events are out of sequence order in the transcript");
+		}
+	}
+}
+
+function validatePublishCheck(
+	state: MissionState,
+	publishCheck: MissionPublishCheck,
+	repository: MissionRepositoryState,
+): void {
+	if (publishCheck.integrationHead !== repository.integrationHead) {
+		throw new MissionStateError("Publish check integrationHead must match repository.integrationHead");
+	}
+
+	if (publishCheck.generation === 0) {
+		if (publishCheck.phase === "validated") {
+			for (const milestone of state.milestones) {
+				if (milestone.kind !== "planned") {
+					continue;
+				}
+				for (const role of milestone.validators) {
+					const validator = state.features.find(
+						feature =>
+							feature.kind === "validation" &&
+							feature.milestoneId === milestone.id &&
+							feature.validator === role,
+					);
+					if (validator?.status !== "completed") {
+						throw new MissionStateError(
+							`Generation 0 validated publish check requires completed planned validator ${milestone.id}/${role}`,
+						);
+					}
+				}
+			}
+		}
+		return;
+	}
+
+	const publishMilestones = state.milestones.filter(
+		milestone => milestone.kind === "publish" && milestone.id === `_publish.${publishCheck.generation}`,
+	);
+	if (publishMilestones.length !== 1) {
+		throw new MissionStateError(
+			`Publish generation ${publishCheck.generation} must match exactly one _publish.${publishCheck.generation} milestone`,
+		);
+	}
+	const publishMilestone = publishMilestones[0]!;
+	if (publishMilestone.generation !== publishCheck.generation) {
+		throw new MissionStateError(
+			`Publish milestone generation must equal publish check generation ${publishCheck.generation}`,
+		);
+	}
+
+	if (publishCheck.phase === "validated") {
+		for (const role of publishMilestone.validators) {
+			const validator = state.features.find(
+				feature =>
+					feature.kind === "validation" &&
+					feature.milestoneId === publishMilestone.id &&
+					feature.validator === role,
+			);
+			if (validator?.status !== "completed") {
+				throw new MissionStateError(
+					`Validated publish check requires completed validator ${publishMilestone.id}/${role}`,
+				);
+			}
+			if (validator.validatedHead !== publishCheck.integrationHead) {
+				throw new MissionStateError(
+					`Validated publish validator "${validator.id}" validatedHead must equal publishCheck.integrationHead`,
+				);
+			}
+			if (validator.workspace?.kind !== "validator") {
+				throw new MissionStateError(
+					`Validated publish validator "${validator.id}" must retain a validator workspace`,
+				);
+			}
+			if (validator.validatedHead !== validator.workspace.head) {
+				throw new MissionStateError(
+					`Validated publish validator "${validator.id}" validatedHead must equal workspace.head`,
+				);
+			}
+		}
+	}
+}
+
+function validateIntegrationPending(state: MissionState, marker: MissionIntegrationPending): void {
+	if (!state.repository) {
+		throw new MissionStateError("Integration-pending marker requires repository state");
+	}
+	if (!state.pendingHandoff) {
+		throw new MissionStateError("Integration-pending marker requires a pending handoff");
+	}
+	if (!handoffIsSuccessfulImplementation(state.pendingHandoff)) {
+		throw new MissionStateError("Integration-pending marker requires a successful implementation handoff");
+	}
+
+	const feature = state.features.find(item => item.id === marker.featureId);
+	if (!feature) {
+		throw new MissionStateError(`Integration-pending marker references missing feature "${marker.featureId}"`);
+	}
+	if (feature.kind !== "implementation") {
+		throw new MissionStateError("Integration-pending marker must name an implementation feature");
+	}
+	if (feature.status !== "in_progress") {
+		throw new MissionStateError(
+			"Integration-pending marker must name the current in_progress implementation feature",
+		);
+	}
+	if (feature.workspace?.kind !== "feature") {
+		throw new MissionStateError("Integration-pending marker requires a feature workspace");
+	}
+	if (
+		marker.expectedOldHead !== feature.workspace.baseSha ||
+		marker.expectedOldHead !== state.repository.integrationHead
+	) {
+		throw new MissionStateError(
+			"Integration-pending expectedOldHead must equal workspace.baseSha and repository.integrationHead",
+		);
+	}
+
+	const expectedNewHead = expectedIntegrationNewHead(state.pendingHandoff, marker.expectedOldHead);
+	if (marker.newHead !== expectedNewHead) {
+		throw new MissionStateError(
+			`Integration-pending newHead must be ${expectedNewHead} (empty commits keep expectedOldHead; otherwise last oldest-first commit)`,
+		);
+	}
+}
+
+/** Snapshot invariants for a restored MissionState (throws MissionStateError on violation). */
+export function assertMissionStateInvariants(
+	state: MissionState,
+	progressEvents: readonly MissionProgressEvent[] = [],
+): void {
+	if (state.version !== 1) {
+		throw new MissionStateError(`Unsupported mission state version ${String(state.version)}`);
+	}
+
+	const inProgress = state.features.filter(feature => feature.status === "in_progress");
+	if (inProgress.length > 1) {
+		throw new MissionStateError("At most one feature may be in_progress");
+	}
+	const inProgressFeature = inProgress[0];
+
+	if (state.activeRun) {
+		if (!inProgressFeature || state.activeRun.featureId !== inProgressFeature.id) {
+			throw new MissionStateError("Active-run token must match the in_progress feature");
+		}
+		if (inProgressFeature.currentWorkerSessionId !== state.activeRun.workerSessionId) {
+			throw new MissionStateError("Active-run token must match the in_progress feature current worker");
+		}
+	}
+
+	if (state.pendingHandoff) {
+		if (!inProgressFeature) {
+			throw new MissionStateError("Pending handoff requires an in_progress feature");
+		}
+		if (state.activeRun) {
+			throw new MissionStateError("Pending handoff excludes an active run");
+		}
+	}
+
+	switch (state.status) {
+		case "orchestrator_turn":
+			if (!state.pendingHandoff) {
+				throw new MissionStateError("orchestrator_turn requires a pending handoff");
+			}
+			break;
+		case "planning":
+		case "awaiting_input":
+			if (state.repository) {
+				throw new MissionStateError(`${state.status} must not have a repository`);
+			}
+			for (const feature of state.features) {
+				if (feature.workspace) {
+					throw new MissionStateError(`${state.status} must not have feature workspaces`);
+				}
+			}
+			break;
+		case "completed":
+		case "cancelled":
+			if (state.activeRun) {
+				throw new MissionStateError("Terminal mission states must not have an active run");
+			}
+			if (state.pendingHandoff) {
+				throw new MissionStateError("Terminal mission states must not have a pending handoff");
+			}
+			break;
+		case "initializing":
+		case "running":
+		case "paused":
+			break;
+		default:
+			assertNever(state.status, "Unknown mission status");
+	}
+
+	for (const feature of state.features) {
+		if (feature.workspace && feature.workspace.ownerSessionId !== state.ownerSessionId) {
+			throw new MissionStateError(`Workspace owner for feature "${feature.id}" must equal mission ownerSessionId`);
+		}
+		if (feature.workspace && !workspaceMatchesFeatureKind(feature, feature.workspace)) {
+			throw new MissionStateError(
+				`Workspace kind for feature "${feature.id}" must match feature kind "${feature.kind}"`,
+			);
+		}
+		for (const workerSessionId of feature.workerSessionIds) {
+			if (typeof workerSessionId !== "string" || workerSessionId.length === 0) {
+				throw new MissionStateError(`Feature "${feature.id}" has an empty worker session id`);
+			}
+		}
+
+		if (feature.kind === "validation" && feature.status === "completed") {
+			if (feature.validatedHead === undefined) {
+				throw new MissionStateError(`Completed validator "${feature.id}" must retain validatedHead`);
+			}
+			if (feature.workspace?.kind !== "validator") {
+				throw new MissionStateError(
+					`Completed validator "${feature.id}" must retain a validator workspace descriptor`,
+				);
+			}
+			if (feature.validatedHead !== feature.workspace.head) {
+				throw new MissionStateError(`Completed validator "${feature.id}" validatedHead must equal workspace.head`);
+			}
+		}
+	}
+
+	validateProgressSequences(progressEvents.filter(event => event.missionId === state.id));
+
+	if (state.integrationPending) {
+		validateIntegrationPending(state, state.integrationPending);
+	}
+
+	if (state.repository?.publishCheck) {
+		validatePublishCheck(state, state.repository.publishCheck, state.repository);
+	}
+}
+
+function parseMissionState(data: unknown): MissionState {
+	if (!isRecord(data)) {
+		throw new MissionStateError("mission-state entry data must be an object");
+	}
+	if (data.version !== 1) {
+		throw new MissionStateError("Newest mission-state entry must be version 1");
+	}
+	if (typeof data.id !== "string" || typeof data.ownerSessionId !== "string") {
+		throw new MissionStateError("mission-state missing id or ownerSessionId");
+	}
+	if (typeof data.revision !== "number" || typeof data.goal !== "string") {
+		throw new MissionStateError("mission-state missing revision or goal");
+	}
+	if (typeof data.autoAccept !== "boolean") {
+		throw new MissionStateError("mission-state missing autoAccept");
+	}
+	if (typeof data.status !== "string" || !MISSION_STATUSES.includes(data.status as MissionStatus)) {
+		throw new MissionStateError("mission-state has invalid status");
+	}
+	if (!isRecord(data.runbook) || !Array.isArray(data.milestones) || !Array.isArray(data.features)) {
+		throw new MissionStateError("mission-state missing runbook, milestones, or features");
+	}
+	if (typeof data.createdAt !== "number" || typeof data.updatedAt !== "number") {
+		throw new MissionStateError("mission-state missing createdAt or updatedAt");
+	}
+
+	for (const feature of data.features) {
+		if (!isRecord(feature) || typeof feature.id !== "string" || typeof feature.kind !== "string") {
+			throw new MissionStateError("mission-state feature entries must include id and kind");
+		}
+		if (typeof feature.status !== "string" || !(FEATURE_STATUSES as readonly string[]).includes(feature.status)) {
+			throw new MissionStateError(`mission-state feature "${feature.id}" has invalid status`);
+		}
+		if (feature.kind !== "implementation" && feature.kind !== "validation") {
+			throw new MissionStateError(`mission-state feature "${feature.id}" has invalid kind`);
+		}
+	}
+
+	// Structural checks above + assertMissionStateInvariants cover semantic rules.
+	return data as unknown as MissionState;
+}
+
+/**
+ * Restore the authoritative MissionState from transcript entries.
+ * A malformed newest mission-state entry is an error — never fall back to an older snapshot.
+ */
+export function loadMissionState(entries: readonly SessionEntry[]): MissionState | null {
+	let newest: { data: unknown } | undefined;
+	for (const entry of entries) {
+		if (entry.type === "custom" && entry.customType === MISSION_STATE_CUSTOM_TYPE) {
+			newest = { data: entry.data };
+		}
+	}
+	if (!newest) {
+		return null;
+	}
+
+	let state: MissionState;
+	try {
+		state = parseMissionState(newest.data);
+	} catch (error) {
+		if (error instanceof MissionStateError) {
+			throw error;
+		}
+		throw new MissionStateError(
+			`Malformed newest mission-state entry: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	let progressEvents: MissionProgressEvent[];
+	try {
+		progressEvents = collectProgressEvents(entries, state.id);
+	} catch (error) {
+		if (error instanceof MissionStateError) {
+			throw error;
+		}
+		throw new MissionStateError(
+			`Malformed mission-progress entry: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	assertMissionStateInvariants(state, progressEvents);
+	return state;
+}
+
+/**
+ * Transitively cancel pending implementation features whose implementation precondition was cancelled.
+ * Validation features are left for selection (their preconditions may be completed or cancelled).
+ */
+export function cancelUnsatisfiableFeatures(state: MissionState): MissionState {
+	const features = state.features.map(feature => ({ ...feature }));
+	const byId = new Map(features.map(feature => [feature.id, feature]));
+	let changed = true;
+
+	while (changed) {
+		changed = false;
+		for (const feature of features) {
+			if (feature.kind !== "implementation" || feature.status !== "pending") {
+				continue;
+			}
+			const blocked = feature.preconditions.some(preconditionId => {
+				const precondition = byId.get(preconditionId);
+				return precondition?.kind === "implementation" && precondition.status === "cancelled";
+			});
+			if (!blocked) {
+				continue;
+			}
+			feature.status = "cancelled";
+			feature.currentWorkerSessionId = undefined;
+			feature.nextRunIntent = undefined;
+			changed = true;
+		}
+	}
+
+	const touched = features.some((feature, index) => feature.status !== state.features[index]!.status);
+	if (!touched) {
+		return state;
+	}
+	return {
+		...state,
+		features,
+		updatedAt: state.updatedAt,
+	};
+}
+
+function preconditionsSatisfied(feature: MissionFeature, byId: Map<string, MissionFeature>): boolean {
+	switch (feature.kind) {
+		case "implementation":
+			return feature.preconditions.every(preconditionId => {
+				const precondition = byId.get(preconditionId);
+				return precondition?.status === "completed";
+			});
+		case "validation":
+			return feature.preconditions.every(preconditionId => {
+				const precondition = byId.get(preconditionId);
+				return precondition?.status === "completed" || precondition?.status === "cancelled";
+			});
+		default:
+			return assertNever(feature.kind, "Unknown feature kind");
+	}
+}
+
+/**
+ * Cancel unsatisfiable pending implementation features, then return at most one next pending feature
+ * in plan order. Never schedules in parallel.
+ */
+export function nextMissionFeature(state: MissionState): NextMissionFeatureResult {
+	const cancelledState = cancelUnsatisfiableFeatures(state);
+	const byId = new Map(cancelledState.features.map(feature => [feature.id, feature]));
+
+	for (const feature of cancelledState.features) {
+		if (feature.status !== "pending") {
+			continue;
+		}
+		if (!preconditionsSatisfied(feature, byId)) {
+			continue;
+		}
+		return { state: cancelledState, feature };
+	}
+
+	return { state: cancelledState, feature: null };
+}
+
+/** True when resolveHandoff({ decision: "accept" }) is legal for the pending handoff. */
+export function canAcceptPendingHandoff(handoff: MissionHandoff): boolean {
+	switch (handoff.kind) {
+		case "implementation":
+			return handoff.outcome === "success" && !handoff.issues.some(issue => issue.severity === "blocking");
+		case "validation":
+			return handoff.verdict === "pass";
+		default:
+			return assertNever(handoff, "Unknown handoff kind");
+	}
+}
+
+/** Milestone default validators: scrutiny + user-testing when the runbook supports it, else scrutiny alone. */
+export function defaultMilestoneValidators(runbook: MissionPlan["runbook"]): MissionValidatorRole[] {
+	const supportsUserTesting = runbook.userTests.length > 0 || runbook.services.length > 0;
+	if (supportsUserTesting) {
+		return ["scrutiny", "user-testing"];
+	}
+	return ["scrutiny"];
+}
+
+export function isMissionTerminal(state: MissionState): boolean {
+	return isTerminalStatus(state.status);
+}
+
+export function isMissionPlanningPhase(state: MissionState): boolean {
+	return isPlanningOrAwaiting(state.status);
+}

--- a/packages/coding-agent/src/missions/types.ts
+++ b/packages/coding-agent/src/missions/types.ts
@@ -1,0 +1,265 @@
+export type MissionStatus =
+	| "planning"
+	| "awaiting_input"
+	| "initializing"
+	| "running"
+	| "paused"
+	| "orchestrator_turn"
+	| "completed"
+	| "cancelled";
+
+export type MissionFeatureStatus = "pending" | "in_progress" | "completed" | "cancelled";
+
+export type MissionValidatorRole = "scrutiny" | "user-testing";
+
+export type MissionWorkerOutcome = "success" | "partial" | "failure" | "return_to_orchestrator";
+
+export type MissionIssueSeverity = "blocking" | "non_blocking" | "suggestion";
+
+export type MissionPauseReason =
+	| "user_requested"
+	| "feature_retry_limit_exceeded"
+	| "worker_inactive"
+	| "worker_interrupted"
+	| "repository_dirty"
+	| "workspace_conflict"
+	| "integration_diverged"
+	| "parent_diverged"
+	| "validator_workspace_dirty";
+
+export interface MissionRunbook {
+	setup: string[];
+	services: Array<{
+		name: string;
+		start: string;
+		ready: string;
+		stop?: string;
+		logs?: string;
+	}>;
+	userTests: string[];
+}
+
+export interface MissionFeatureSpec {
+	id: string;
+	description: string;
+	skillName?: string;
+	milestoneId: string;
+	preconditions: string[];
+	expectedBehavior: string[];
+	fulfills?: string[];
+}
+
+export interface MissionRemediationFeatureSpec {
+	id: string;
+	description: string;
+	skillName?: string;
+	preconditions: string[];
+	expectedBehavior: string[];
+	fulfills?: string[];
+}
+
+export interface MissionMilestoneSpec {
+	id: string;
+	description: string;
+	featureIds: string[];
+	validators: MissionValidatorRole[];
+}
+
+export interface MissionPlan {
+	goal: string;
+	runbook: MissionRunbook;
+	milestones: MissionMilestoneSpec[];
+	features: MissionFeatureSpec[];
+}
+
+export interface MissionPublishCheck {
+	parentHead: string;
+	integrationHead: string;
+	generation: number;
+	phase: "validating" | "validated";
+}
+
+export interface MissionRepositoryState {
+	repoRoot: string;
+	parentBranch: string;
+	baseSha: string;
+	integrationBranch: string;
+	integrationHead: string;
+	publishCheck?: MissionPublishCheck;
+}
+
+interface MissionWorkspaceBase {
+	id: string;
+	ownerSessionId: string;
+	repoRoot: string;
+	path: string;
+	featureId: string;
+	phase: "reserved" | "ready";
+}
+
+export interface MissionFeatureWorkspaceDescriptor extends MissionWorkspaceBase {
+	kind: "feature";
+	branch: string;
+	baseSha: string;
+}
+
+export interface MissionValidatorWorkspaceDescriptor extends MissionWorkspaceBase {
+	kind: "validator";
+	head: string;
+}
+
+export type MissionWorkspaceDescriptor = MissionFeatureWorkspaceDescriptor | MissionValidatorWorkspaceDescriptor;
+
+export interface MissionIssue {
+	severity: MissionIssueSeverity;
+	description: string;
+	evidence?: string;
+	affectedFeatureIds?: string[];
+}
+
+export interface MissionWorkerHandoff {
+	kind: "implementation";
+	outcome: MissionWorkerOutcome;
+	summary: string;
+	implementation: string[];
+	remaining: string[];
+	verification: {
+		commands: Array<{ command: string; result: "passed" | "failed" | "not_run"; evidence?: string }>;
+		interactiveChecks: Array<{ check: string; result: "passed" | "failed" | "not_run"; evidence?: string }>;
+	};
+	tests: { added: string[]; coverageNotes: string[] };
+	issues: MissionIssue[];
+	skillDeviations: string[];
+	commits: string[];
+}
+
+export interface MissionValidatorHandoff {
+	kind: "validation";
+	role: MissionValidatorRole;
+	verdict: "pass" | "fail";
+	summary: string;
+	checks: Array<{ check: string; result: "passed" | "failed" | "not_run"; evidence?: string }>;
+	issues: MissionIssue[];
+}
+
+export type MissionHandoff = MissionWorkerHandoff | MissionValidatorHandoff;
+
+export interface MissionMilestone extends MissionMilestoneSpec {
+	kind: "planned" | "publish";
+	generation?: number;
+}
+
+export type MissionNextRunMode = "initial" | "follow_up" | "fresh";
+
+export interface MissionNextRunIntent {
+	mode: MissionNextRunMode;
+	messageToWorker?: string;
+}
+
+export interface MissionFeature extends MissionFeatureSpec {
+	kind: "implementation" | "validation";
+	validator?: MissionValidatorRole;
+	status: MissionFeatureStatus;
+	workerSessionIds: string[];
+	currentWorkerSessionId?: string;
+	completedWorkerSessionId?: string;
+	retryBudgetUsed: number;
+	workspace?: MissionWorkspaceDescriptor;
+	validatedHead?: string;
+	nextRunIntent?: MissionNextRunIntent;
+}
+
+export interface MissionActiveRun {
+	featureId: string;
+	workerSessionId: string;
+	turn: number;
+}
+
+export interface MissionIntegrationPending {
+	featureId: string;
+	expectedOldHead: string;
+	newHead: string;
+}
+
+export interface MissionState {
+	version: 1;
+	id: string;
+	ownerSessionId: string;
+	revision: number;
+	goal: string;
+	autoAccept: boolean;
+	status: MissionStatus;
+	pauseReason?: MissionPauseReason;
+	runbook: MissionRunbook;
+	repository?: MissionRepositoryState;
+	milestones: MissionMilestone[];
+	features: MissionFeature[];
+	activeRun?: MissionActiveRun;
+	pendingHandoff?: MissionHandoff;
+	integrationPending?: MissionIntegrationPending;
+	workerModel?: string | string[];
+	validatorModel?: string | string[];
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface MissionProgressEventBase {
+	missionId: string;
+	sequence: number;
+	at: number;
+}
+
+export type MissionProgressEvent =
+	| (MissionProgressEventBase & { type: "accepted" })
+	| (MissionProgressEventBase & { type: "paused"; reason: MissionPauseReason })
+	| (MissionProgressEventBase & { type: "resumed" })
+	| (MissionProgressEventBase & { type: "run_started" })
+	| (MissionProgressEventBase & { type: "feature_selected"; featureId: string })
+	| (MissionProgressEventBase & { type: "worker_started"; featureId: string; workerSessionId: string })
+	| (MissionProgressEventBase & {
+			type: "heartbeat";
+			featureId: string;
+			workerSessionId: string;
+			requests: number;
+			tokens: number;
+			cost: number;
+	  })
+	| (MissionProgressEventBase & { type: "worker_completed"; featureId: string; workerSessionId: string })
+	| (MissionProgressEventBase & { type: "worker_failed"; featureId: string; workerSessionId?: string })
+	| (MissionProgressEventBase & {
+			type: "handoff_resolved";
+			featureId: string;
+			decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+	  })
+	| (MissionProgressEventBase & { type: "milestone_validation_triggered"; milestoneId: string })
+	| (MissionProgressEventBase & { type: "publish_validation_triggered"; generation: number })
+	| (MissionProgressEventBase & { type: "completed" })
+	| (MissionProgressEventBase & { type: "cancelled" });
+
+export const MISSION_WORKER_TURN_CAP = 5;
+export const MISSION_INACTIVITY_TIMEOUT_MS = 600_000;
+
+export const MISSION_STATE_CUSTOM_TYPE = "mission-state";
+export const MISSION_PROGRESS_CUSTOM_TYPE = "mission-progress";
+
+/** Method/input types for MissionRuntime — recorded now; no runtime stub in this slice. */
+export interface MissionRuntimeContract {
+	snapshot(): MissionState | null;
+	start(
+		goal: string,
+		options?: { workerModel?: string | string[]; validatorModel?: string | string[]; autoAccept?: boolean },
+	): Promise<MissionState>;
+	setPlan(plan: MissionPlan): Promise<MissionState>;
+	accept(): Promise<MissionState>;
+	runNext(signal?: AbortSignal): Promise<MissionHandoff | null>;
+	resolveHandoff(input: {
+		decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+		messageToWorker?: string;
+	}): Promise<MissionState>;
+	revisePending(input: { addFeatures: MissionRemediationFeatureSpec[] }): Promise<MissionState>;
+	pause(reason: MissionPauseReason): Promise<MissionState>;
+	resume(input?: { restartWorker?: boolean; messageToWorker?: string }): Promise<MissionState>;
+	cancel(): Promise<MissionState>;
+	prepareToSuspend(): Promise<void>;
+	restore(): Promise<MissionState | null>;
+}

--- a/packages/coding-agent/src/missions/types.ts
+++ b/packages/coding-agent/src/missions/types.ts
@@ -144,6 +144,9 @@ export interface MissionValidatorHandoff {
 
 export type MissionHandoff = MissionWorkerHandoff | MissionValidatorHandoff;
 
+/** Closed set of decisions a host may apply to a pending handoff. */
+export type MissionHandoffDecision = "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+
 export interface MissionMilestone extends MissionMilestoneSpec {
 	kind: "planned" | "publish";
 	generation?: number;
@@ -229,7 +232,7 @@ export type MissionProgressEvent =
 	| (MissionProgressEventBase & {
 			type: "handoff_resolved";
 			featureId: string;
-			decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+			decision: MissionHandoffDecision;
 	  })
 	| (MissionProgressEventBase & { type: "milestone_validation_triggered"; milestoneId: string })
 	| (MissionProgressEventBase & { type: "publish_validation_triggered"; generation: number })
@@ -252,10 +255,7 @@ export interface MissionRuntimeContract {
 	setPlan(plan: MissionPlan): Promise<MissionState>;
 	accept(): Promise<MissionState>;
 	runNext(signal?: AbortSignal): Promise<MissionHandoff | null>;
-	resolveHandoff(input: {
-		decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
-		messageToWorker?: string;
-	}): Promise<MissionState>;
+	resolveHandoff(input: { decision: MissionHandoffDecision; messageToWorker?: string }): Promise<MissionState>;
 	revisePending(input: { addFeatures: MissionRemediationFeatureSpec[] }): Promise<MissionState>;
 	pause(reason: MissionPauseReason): Promise<MissionState>;
 	resume(input?: { restartWorker?: boolean; messageToWorker?: string }): Promise<MissionState>;

--- a/packages/coding-agent/src/missions/workspace.ts
+++ b/packages/coding-agent/src/missions/workspace.ts
@@ -1,0 +1,632 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getWorktreeDir, hashPath, isEnoent } from "@oh-my-pi/pi-utils";
+import type { GitStatusSummary, GitWorktreeEntry } from "../utils/git";
+import * as git from "../utils/git";
+import type {
+	MissionFeatureSpec,
+	MissionFeatureWorkspaceDescriptor,
+	MissionIssue,
+	MissionPauseReason,
+	MissionRepositoryState,
+	MissionState,
+	MissionValidatorWorkspaceDescriptor,
+	MissionWorkerHandoff,
+	MissionWorkspaceDescriptor,
+} from "./types";
+
+const LOCAL_BRANCH_PREFIX = "refs/heads/";
+
+export type MissionWorkspaceConflict = {
+	kind: "pause";
+	reason: Extract<MissionPauseReason, "workspace_conflict">;
+	descriptorId: string;
+	featureId: string;
+	path: string;
+	branch?: string;
+	expectedHead?: string;
+	actualHead?: string | null;
+	detail: string;
+};
+
+export type MissionIntegrationDiverged = {
+	kind: "pause";
+	reason: Extract<MissionPauseReason, "integration_diverged">;
+	featureId: string;
+	integrationBranch: string;
+	expectedOldHead: string;
+	newHead: string;
+	actualHead: string | null;
+};
+
+export type MissionPartialHandoff = {
+	kind: "partial_handoff";
+	issues: MissionIssue[];
+	featureBranchHead: string | null;
+};
+
+export type MissionReconcileResult =
+	| { kind: "ready"; descriptor: MissionWorkspaceDescriptor }
+	| MissionWorkspaceConflict;
+
+export type MissionAdvanceIntegrationResult =
+	| { kind: "advanced"; repository: MissionRepositoryState }
+	| { kind: "already_applied"; repository: MissionRepositoryState }
+	| MissionPartialHandoff
+	| MissionIntegrationDiverged;
+
+export class MissionWorkspaceError extends Error {
+	override readonly name = "MissionWorkspaceError";
+}
+
+function assertNever(value: never, message: string): never {
+	throw new MissionWorkspaceError(`${message}: ${JSON.stringify(value)}`);
+}
+
+export function toLocalBranchRef(branchName: string): string {
+	return branchName.startsWith(LOCAL_BRANCH_PREFIX) ? branchName : `${LOCAL_BRANCH_PREFIX}${branchName}`;
+}
+
+function workspaceSegment(repoRoot: string, missionId: string, featureId: string): string {
+	return `mission-${hashPath(repoRoot)}-${missionId}-${featureId}`;
+}
+
+function featureBranchName(missionId: string, featureId: string): string {
+	return `omp/mission/${missionId}/feature/${featureId}`;
+}
+
+function featureWorkspaceId(missionId: string, featureId: string): string {
+	return `feature:${missionId}:${featureId}`;
+}
+
+function validatorWorkspaceId(missionId: string, featureId: string): string {
+	return `validator:${missionId}:${featureId}`;
+}
+
+function requireRepository(mission: MissionState): MissionRepositoryState {
+	if (!mission.repository) {
+		throw new MissionWorkspaceError(`Mission "${mission.id}" has no repository state`);
+	}
+	return mission.repository;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+	try {
+		await fs.stat(targetPath);
+		return true;
+	} catch (error) {
+		if (isEnoent(error)) return false;
+		throw error;
+	}
+}
+
+function samePath(left: string, right: string): boolean {
+	return path.resolve(left) === path.resolve(right);
+}
+
+function findWorktreeEntry(entries: readonly GitWorktreeEntry[], targetPath: string): GitWorktreeEntry | undefined {
+	return entries.find(entry => samePath(entry.path, targetPath));
+}
+
+/** A checkout with no staged, unstaged or untracked change. */
+export function isCleanSummary(summary: GitStatusSummary | null): boolean {
+	return summary !== null && summary.staged === 0 && summary.unstaged === 0 && summary.untracked === 0;
+}
+
+function sameCommitList(left: readonly string[], right: readonly string[]): boolean {
+	if (left.length !== right.length) return false;
+	for (let i = 0; i < left.length; i++) {
+		if (left[i] !== right[i]) return false;
+	}
+	return true;
+}
+
+function blockingIssue(description: string, evidence?: string, featureId?: string): MissionIssue {
+	return {
+		severity: "blocking",
+		description,
+		...(evidence !== undefined ? { evidence } : {}),
+		...(featureId !== undefined ? { affectedFeatureIds: [featureId] } : {}),
+	};
+}
+
+function workspaceConflict(
+	descriptor: MissionWorkspaceDescriptor,
+	detail: string,
+	extra: {
+		branch?: string;
+		expectedHead?: string;
+		actualHead?: string | null;
+	} = {},
+): MissionWorkspaceConflict {
+	return {
+		kind: "pause",
+		reason: "workspace_conflict",
+		descriptorId: descriptor.id,
+		featureId: descriptor.featureId,
+		path: descriptor.path,
+		detail,
+		...(extra.branch !== undefined ? { branch: extra.branch } : {}),
+		...(extra.expectedHead !== undefined ? { expectedHead: extra.expectedHead } : {}),
+		...(extra.actualHead !== undefined ? { actualHead: extra.actualHead } : {}),
+	};
+}
+
+function integrationDiverged(
+	descriptor: MissionFeatureWorkspaceDescriptor,
+	repository: MissionRepositoryState,
+	expectedOldHead: string,
+	newHead: string,
+	actualHead: string | null,
+): MissionIntegrationDiverged {
+	return {
+		kind: "pause",
+		reason: "integration_diverged",
+		featureId: descriptor.featureId,
+		integrationBranch: repository.integrationBranch,
+		expectedOldHead,
+		newHead,
+		actualHead,
+	};
+}
+
+async function ensureWorktreeParent(worktreePath: string): Promise<void> {
+	await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+}
+
+async function createFeatureWorkspace(repoRoot: string, descriptor: MissionFeatureWorkspaceDescriptor): Promise<void> {
+	const branchRef = toLocalBranchRef(descriptor.branch);
+	const branchExists = await git.ref.exists(repoRoot, branchRef);
+	if (!branchExists) {
+		await git.branch.create(repoRoot, descriptor.branch, descriptor.baseSha);
+	}
+	await ensureWorktreeParent(descriptor.path);
+	await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
+}
+
+async function createValidatorWorkspace(
+	repoRoot: string,
+	descriptor: MissionValidatorWorkspaceDescriptor,
+): Promise<void> {
+	await ensureWorktreeParent(descriptor.path);
+	await git.worktree.add(repoRoot, descriptor.path, descriptor.head, { detach: true });
+}
+
+function isExactFeatureWorktree(entry: GitWorktreeEntry, descriptor: MissionFeatureWorkspaceDescriptor): boolean {
+	return !entry.detached && entry.branch === toLocalBranchRef(descriptor.branch);
+}
+
+function isExactValidatorWorktree(entry: GitWorktreeEntry, descriptor: MissionValidatorWorkspaceDescriptor): boolean {
+	return entry.detached && entry.head === descriptor.head;
+}
+
+/**
+ * Crash-recoverable native-git workspace manager for missions.
+ * Reserve is pure path/branch computation; only materialize/reconcile/advance/release mutate git.
+ */
+export class MissionWorkspaceManager {
+	async reserveFeature(
+		ownerSessionId: string,
+		mission: MissionState,
+		feature: MissionFeatureSpec,
+	): Promise<MissionFeatureWorkspaceDescriptor> {
+		const repository = requireRepository(mission);
+		const branch = featureBranchName(mission.id, feature.id);
+		const worktreePath = getWorktreeDir(workspaceSegment(repository.repoRoot, mission.id, feature.id));
+		return {
+			id: featureWorkspaceId(mission.id, feature.id),
+			kind: "feature",
+			ownerSessionId,
+			repoRoot: repository.repoRoot,
+			path: worktreePath,
+			featureId: feature.id,
+			phase: "reserved",
+			branch,
+			baseSha: repository.integrationHead,
+		};
+	}
+
+	async reserveValidator(
+		ownerSessionId: string,
+		mission: MissionState,
+		featureId: string,
+	): Promise<MissionValidatorWorkspaceDescriptor> {
+		const repository = requireRepository(mission);
+		const worktreePath = getWorktreeDir(workspaceSegment(repository.repoRoot, mission.id, featureId));
+		return {
+			id: validatorWorkspaceId(mission.id, featureId),
+			kind: "validator",
+			ownerSessionId,
+			repoRoot: repository.repoRoot,
+			path: worktreePath,
+			featureId,
+			phase: "reserved",
+			head: repository.integrationHead,
+		};
+	}
+
+	async materialize(descriptor: MissionWorkspaceDescriptor): Promise<MissionWorkspaceDescriptor> {
+		if (descriptor.phase === "ready") {
+			return descriptor;
+		}
+
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			switch (descriptor.kind) {
+				case "feature": {
+					await createFeatureWorkspace(descriptor.repoRoot, descriptor);
+					return { ...descriptor, phase: "ready" };
+				}
+				case "validator": {
+					await createValidatorWorkspace(descriptor.repoRoot, descriptor);
+					return { ...descriptor, phase: "ready" };
+				}
+				default:
+					return assertNever(descriptor, "Unknown workspace descriptor kind");
+			}
+		});
+	}
+
+	async reconcile(
+		descriptor: MissionWorkspaceDescriptor,
+		hasChildTranscript: boolean,
+	): Promise<MissionReconcileResult> {
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			switch (descriptor.kind) {
+				case "feature":
+					return this.#reconcileFeature(descriptor, hasChildTranscript);
+				case "validator":
+					return this.#reconcileValidator(descriptor, hasChildTranscript);
+				default:
+					return assertNever(descriptor, "Unknown workspace descriptor kind");
+			}
+		});
+	}
+
+	async advanceIntegration(
+		repository: MissionRepositoryState,
+		descriptor: MissionFeatureWorkspaceDescriptor,
+		handoff: MissionWorkerHandoff,
+	): Promise<MissionAdvanceIntegrationResult> {
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			const summary = await git.status.summary(descriptor.path);
+			if (!isCleanSummary(summary)) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead: null,
+					issues: [
+						blockingIssue(
+							"Feature workspace is dirty; handoff cannot be accepted",
+							summary === null
+								? "git.status.summary failed"
+								: `staged=${summary.staged} unstaged=${summary.unstaged} untracked=${summary.untracked}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const branchRef = toLocalBranchRef(descriptor.branch);
+			const featureBranchHead = await git.ref.resolve(descriptor.repoRoot, branchRef);
+			if (featureBranchHead === null) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead: null,
+					issues: [
+						blockingIssue(
+							`Feature branch "${descriptor.branch}" is not resolvable`,
+							undefined,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const ancestorOk = await git.ref.isAncestor(descriptor.repoRoot, descriptor.baseSha, featureBranchHead);
+			if (!ancestorOk) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Feature branch head is not a descendant of workspace baseSha",
+							`baseSha=${descriptor.baseSha} head=${featureBranchHead}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const commits = await git.revList.range(descriptor.repoRoot, descriptor.baseSha, descriptor.branch);
+			if (!sameCommitList(commits, handoff.commits)) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Feature commit list does not match handoff.commits",
+							`expected=${handoff.commits.join(",") || "(empty)"} actual=${commits.join(",") || "(empty)"}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const expectedOldHead = descriptor.baseSha;
+			const newHead = featureBranchHead;
+			const integrationRef = toLocalBranchRef(repository.integrationBranch);
+
+			const ancestryToNew = await git.ref.isAncestor(descriptor.repoRoot, expectedOldHead, newHead);
+			if (!ancestryToNew) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Integration advance requires expectedOldHead to be an ancestor of newHead",
+							`expectedOldHead=${expectedOldHead} newHead=${newHead}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			let actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
+			if (actualHead === newHead) {
+				return {
+					kind: "already_applied",
+					repository: { ...repository, integrationHead: newHead },
+				};
+			}
+			if (actualHead !== expectedOldHead) {
+				return integrationDiverged(descriptor, repository, expectedOldHead, newHead, actualHead);
+			}
+
+			const updated = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
+			if (updated) {
+				return {
+					kind: "advanced",
+					repository: { ...repository, integrationHead: newHead },
+				};
+			}
+
+			// CAS lost: restore semantics — retry while still at expectedOldHead;
+			// equality with newHead means already-applied; anything else diverged.
+			actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
+			if (actualHead === newHead) {
+				return {
+					kind: "already_applied",
+					repository: { ...repository, integrationHead: newHead },
+				};
+			}
+			if (actualHead === expectedOldHead) {
+				const retried = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
+				if (retried) {
+					return {
+						kind: "advanced",
+						repository: { ...repository, integrationHead: newHead },
+					};
+				}
+				actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
+				if (actualHead === newHead) {
+					return {
+						kind: "already_applied",
+						repository: { ...repository, integrationHead: newHead },
+					};
+				}
+				if (actualHead === expectedOldHead) {
+					throw new MissionWorkspaceError(
+						`Integration CAS failed twice while ${repository.integrationBranch} remained at ${expectedOldHead}`,
+					);
+				}
+			}
+			return integrationDiverged(descriptor, repository, expectedOldHead, newHead, actualHead);
+		});
+	}
+
+	async release(descriptor: MissionWorkspaceDescriptor): Promise<void> {
+		await git.withRepoLock(descriptor.repoRoot, () => this.#removeWorkspace(descriptor));
+	}
+
+	async releaseIfEmpty(descriptor: MissionWorkspaceDescriptor): Promise<boolean> {
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			switch (descriptor.kind) {
+				case "feature":
+					return this.#releaseFeatureIfEmpty(descriptor);
+				case "validator":
+					return this.#releaseValidatorIfEmpty(descriptor);
+				default:
+					return assertNever(descriptor, "Unknown workspace descriptor kind");
+			}
+		});
+	}
+
+	async #reconcileFeature(
+		descriptor: MissionFeatureWorkspaceDescriptor,
+		hasChildTranscript: boolean,
+	): Promise<MissionReconcileResult> {
+		const repoRoot = descriptor.repoRoot;
+		const branchRef = toLocalBranchRef(descriptor.branch);
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+		const refSha = await git.ref.resolve(repoRoot, branchRef);
+		const refExists = refSha !== null;
+
+		if (entry && !isExactFeatureWorktree(entry, descriptor)) {
+			return workspaceConflict(descriptor, "Worktree path is registered to an unowned or mismatched branch", {
+				branch: descriptor.branch,
+				expectedHead: descriptor.baseSha,
+				actualHead: entry.head ?? null,
+			});
+		}
+
+		if (!entry && onDisk) {
+			return workspaceConflict(descriptor, "Workspace path exists on disk but is not a registered worktree", {
+				branch: descriptor.branch,
+			});
+		}
+
+		if (!refExists && entry) {
+			return workspaceConflict(descriptor, "Feature worktree exists without its owned branch ref", {
+				branch: descriptor.branch,
+				actualHead: entry.head ?? null,
+			});
+		}
+
+		if (!refExists && !entry) {
+			if (hasChildTranscript) {
+				return workspaceConflict(descriptor, "Missing feature workspace path/ref but a child transcript exists", {
+					branch: descriptor.branch,
+				});
+			}
+			await createFeatureWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
+
+		// Owned ref exists from here.
+		if (refSha === null) {
+			return workspaceConflict(descriptor, "Feature ref ownership check lost resolvable SHA", {
+				branch: descriptor.branch,
+			});
+		}
+		if (!entry) {
+			if (hasChildTranscript) {
+				return workspaceConflict(
+					descriptor,
+					"Owned feature ref exists but path is missing while a child transcript exists",
+					{ branch: descriptor.branch, expectedHead: refSha },
+				);
+			}
+			await ensureWorktreeParent(descriptor.path);
+			await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
+
+		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+	}
+
+	async #reconcileValidator(
+		descriptor: MissionValidatorWorkspaceDescriptor,
+		hasChildTranscript: boolean,
+	): Promise<MissionReconcileResult> {
+		const repoRoot = descriptor.repoRoot;
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+
+		if (!entry && onDisk) {
+			return workspaceConflict(descriptor, "Validator path exists on disk but is not a registered worktree", {
+				expectedHead: descriptor.head,
+			});
+		}
+
+		if (!entry) {
+			if (hasChildTranscript) {
+				return workspaceConflict(descriptor, "Missing validator workspace path while a child transcript exists", {
+					expectedHead: descriptor.head,
+				});
+			}
+			await createValidatorWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
+
+		if (!isExactValidatorWorktree(entry, descriptor)) {
+			return workspaceConflict(descriptor, "Validator worktree is unowned, attached, or at the wrong head", {
+				expectedHead: descriptor.head,
+				actualHead: entry.head ?? null,
+			});
+		}
+
+		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+	}
+
+	/**
+	 * Non-forcible removal for either workspace kind. `{ force: false }` makes git
+	 * refuse a worktree holding uncommitted work, and a path that is not a registered
+	 * worktree is never deleted — unowned state is preserved, never reclaimed. Only a
+	 * feature owns a branch; a validator worktree is detached at a recorded head.
+	 */
+	async #removeWorkspace(descriptor: MissionWorkspaceDescriptor): Promise<void> {
+		const entries = await git.worktree.list(descriptor.repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		if (entry) {
+			await git.worktree.remove(descriptor.repoRoot, descriptor.path, { force: false });
+		} else if (await pathExists(descriptor.path)) {
+			throw new MissionWorkspaceError(
+				`Refusing to remove unowned path at ${descriptor.path} during ${descriptor.kind} release`,
+			);
+		}
+		if (descriptor.kind === "feature") {
+			await git.branch.tryDelete(descriptor.repoRoot, descriptor.branch);
+		}
+	}
+
+	async #releaseFeatureIfEmpty(descriptor: MissionFeatureWorkspaceDescriptor): Promise<boolean> {
+		const repoRoot = descriptor.repoRoot;
+		const branchRef = toLocalBranchRef(descriptor.branch);
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+		const head = await git.ref.resolve(repoRoot, branchRef);
+
+		if (!entry && !onDisk && head === null) {
+			return true;
+		}
+
+		if (entry && !isExactFeatureWorktree(entry, descriptor)) {
+			return false;
+		}
+		if (!entry && onDisk) {
+			return false;
+		}
+		// Branch must still equal base; missing branch with a live worktree is partial.
+		if (entry && (head === null || head !== descriptor.baseSha)) {
+			return false;
+		}
+		if (!entry && head !== null && head !== descriptor.baseSha) {
+			return false;
+		}
+
+		if (entry) {
+			const summary = await git.status.summary(descriptor.path);
+			if (!isCleanSummary(summary)) {
+				return false;
+			}
+			await git.worktree.remove(repoRoot, descriptor.path, { force: false });
+		}
+
+		if (head !== null) {
+			const deleted = await git.branch.tryDelete(repoRoot, descriptor.branch, { force: false });
+			if (!deleted) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	async #releaseValidatorIfEmpty(descriptor: MissionValidatorWorkspaceDescriptor): Promise<boolean> {
+		const repoRoot = descriptor.repoRoot;
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+
+		if (!entry && !onDisk) {
+			return true;
+		}
+		if (!entry && onDisk) {
+			return false;
+		}
+		if (!entry || !isExactValidatorWorktree(entry, descriptor)) {
+			return false;
+		}
+
+		const summary = await git.status.summary(descriptor.path);
+		if (!isCleanSummary(summary)) {
+			return false;
+		}
+
+		await git.worktree.remove(repoRoot, descriptor.path, { force: false });
+		return true;
+	}
+}

--- a/packages/coding-agent/src/missions/workspace.ts
+++ b/packages/coding-agent/src/missions/workspace.ts
@@ -176,9 +176,13 @@ async function ensureWorktreeParent(worktreePath: string): Promise<void> {
 
 async function createFeatureWorkspace(repoRoot: string, descriptor: MissionFeatureWorkspaceDescriptor): Promise<void> {
 	const branchRef = toLocalBranchRef(descriptor.branch);
-	const branchExists = await git.ref.exists(repoRoot, branchRef);
-	if (!branchExists) {
+	const branchHead = await git.ref.resolve(repoRoot, branchRef);
+	if (branchHead === null) {
 		await git.branch.create(repoRoot, descriptor.branch, descriptor.baseSha);
+	} else if (branchHead !== descriptor.baseSha) {
+		throw new MissionWorkspaceError(
+			`Feature branch ${descriptor.branch} already exists at ${branchHead}, expected ${descriptor.baseSha}`,
+		);
 	}
 	await ensureWorktreeParent(descriptor.path);
 	await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
@@ -354,6 +358,27 @@ export class MissionWorkspaceManager {
 			const expectedOldHead = descriptor.baseSha;
 			const newHead = featureBranchHead;
 			const integrationRef = toLocalBranchRef(repository.integrationBranch);
+			const integrationWorktree = (await git.worktree.list(descriptor.repoRoot)).find(
+				entry => !entry.detached && entry.branch === integrationRef,
+			);
+			if (integrationWorktree && !isCleanSummary(await git.status.summary(integrationWorktree.path))) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Integration worktree is dirty; integration branch cannot be advanced",
+							undefined,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+			const synchronizeIntegrationWorktree = async (): Promise<void> => {
+				if (integrationWorktree) {
+					await git.reset(integrationWorktree.path, { hard: true, target: newHead });
+				}
+			};
 
 			const ancestryToNew = await git.ref.isAncestor(descriptor.repoRoot, expectedOldHead, newHead);
 			if (!ancestryToNew) {
@@ -372,6 +397,7 @@ export class MissionWorkspaceManager {
 
 			let actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
 			if (actualHead === newHead) {
+				await synchronizeIntegrationWorktree();
 				return {
 					kind: "already_applied",
 					repository: { ...repository, integrationHead: newHead },
@@ -383,6 +409,7 @@ export class MissionWorkspaceManager {
 
 			const updated = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
 			if (updated) {
+				await synchronizeIntegrationWorktree();
 				return {
 					kind: "advanced",
 					repository: { ...repository, integrationHead: newHead },
@@ -393,6 +420,7 @@ export class MissionWorkspaceManager {
 			// equality with newHead means already-applied; anything else diverged.
 			actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
 			if (actualHead === newHead) {
+				await synchronizeIntegrationWorktree();
 				return {
 					kind: "already_applied",
 					repository: { ...repository, integrationHead: newHead },
@@ -401,6 +429,7 @@ export class MissionWorkspaceManager {
 			if (actualHead === expectedOldHead) {
 				const retried = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
 				if (retried) {
+					await synchronizeIntegrationWorktree();
 					return {
 						kind: "advanced",
 						repository: { ...repository, integrationHead: newHead },
@@ -408,6 +437,7 @@ export class MissionWorkspaceManager {
 				}
 				actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
 				if (actualHead === newHead) {
+					await synchronizeIntegrationWorktree();
 					return {
 						kind: "already_applied",
 						repository: { ...repository, integrationHead: newHead },
@@ -450,7 +480,6 @@ export class MissionWorkspaceManager {
 		const entry = findWorktreeEntry(entries, descriptor.path);
 		const onDisk = await pathExists(descriptor.path);
 		const refSha = await git.ref.resolve(repoRoot, branchRef);
-		const refExists = refSha !== null;
 
 		if (entry && !isExactFeatureWorktree(entry, descriptor)) {
 			return workspaceConflict(descriptor, "Worktree path is registered to an unowned or mismatched branch", {
@@ -459,21 +488,32 @@ export class MissionWorkspaceManager {
 				actualHead: entry.head ?? null,
 			});
 		}
-
+		if (entry && !onDisk) {
+			if (hasChildTranscript) {
+				return workspaceConflict(
+					descriptor,
+					"Registered feature workspace path is missing while a child transcript exists",
+					{
+						branch: descriptor.branch,
+					},
+				);
+			}
+			await git.worktree.prune(repoRoot);
+			await createFeatureWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
 		if (!entry && onDisk) {
 			return workspaceConflict(descriptor, "Workspace path exists on disk but is not a registered worktree", {
 				branch: descriptor.branch,
 			});
 		}
-
-		if (!refExists && entry) {
-			return workspaceConflict(descriptor, "Feature worktree exists without its owned branch ref", {
-				branch: descriptor.branch,
-				actualHead: entry.head ?? null,
-			});
-		}
-
-		if (!refExists && !entry) {
+		if (refSha === null) {
+			if (entry) {
+				return workspaceConflict(descriptor, "Feature worktree exists without its owned branch ref", {
+					branch: descriptor.branch,
+					actualHead: entry.head ?? null,
+				});
+			}
 			if (hasChildTranscript) {
 				return workspaceConflict(descriptor, "Missing feature workspace path/ref but a child transcript exists", {
 					branch: descriptor.branch,
@@ -481,13 +521,6 @@ export class MissionWorkspaceManager {
 			}
 			await createFeatureWorkspace(repoRoot, descriptor);
 			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
-		}
-
-		// Owned ref exists from here.
-		if (refSha === null) {
-			return workspaceConflict(descriptor, "Feature ref ownership check lost resolvable SHA", {
-				branch: descriptor.branch,
-			});
 		}
 		if (!entry) {
 			if (hasChildTranscript) {
@@ -501,7 +534,6 @@ export class MissionWorkspaceManager {
 			await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
 			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 		}
-
 		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 	}
 
@@ -514,12 +546,31 @@ export class MissionWorkspaceManager {
 		const entry = findWorktreeEntry(entries, descriptor.path);
 		const onDisk = await pathExists(descriptor.path);
 
+		if (entry && !isExactValidatorWorktree(entry, descriptor)) {
+			return workspaceConflict(descriptor, "Validator worktree is unowned, attached, or at the wrong head", {
+				expectedHead: descriptor.head,
+				actualHead: entry.head ?? null,
+			});
+		}
+		if (entry && !onDisk) {
+			if (hasChildTranscript) {
+				return workspaceConflict(
+					descriptor,
+					"Registered validator workspace path is missing while a child transcript exists",
+					{
+						expectedHead: descriptor.head,
+					},
+				);
+			}
+			await git.worktree.prune(repoRoot);
+			await createValidatorWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
 		if (!entry && onDisk) {
 			return workspaceConflict(descriptor, "Validator path exists on disk but is not a registered worktree", {
 				expectedHead: descriptor.head,
 			});
 		}
-
 		if (!entry) {
 			if (hasChildTranscript) {
 				return workspaceConflict(descriptor, "Missing validator workspace path while a child transcript exists", {
@@ -529,14 +580,6 @@ export class MissionWorkspaceManager {
 			await createValidatorWorkspace(repoRoot, descriptor);
 			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 		}
-
-		if (!isExactValidatorWorktree(entry, descriptor)) {
-			return workspaceConflict(descriptor, "Validator worktree is unowned, attached, or at the wrong head", {
-				expectedHead: descriptor.head,
-				actualHead: entry.head ?? null,
-			});
-		}
-
 		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 	}
 
@@ -550,6 +593,13 @@ export class MissionWorkspaceManager {
 		const entries = await git.worktree.list(descriptor.repoRoot);
 		const entry = findWorktreeEntry(entries, descriptor.path);
 		if (entry) {
+			const owned =
+				descriptor.kind === "feature"
+					? isExactFeatureWorktree(entry, descriptor)
+					: isExactValidatorWorktree(entry, descriptor);
+			if (!owned) {
+				throw new MissionWorkspaceError(`Refusing to remove unowned worktree at ${descriptor.path}`);
+			}
 			await git.worktree.remove(descriptor.repoRoot, descriptor.path, { force: false });
 		} else if (await pathExists(descriptor.path)) {
 			throw new MissionWorkspaceError(

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1834,6 +1834,49 @@ export const ref = {
 			),
 		);
 	},
+
+	/**
+	 * True when `ancestor` is an ancestor of `descendant` (`git merge-base --is-ancestor`).
+	 * Exit 0 → true, exit 1 → false; any other exit throws.
+	 */
+	async isAncestor(cwd: string, ancestor: string, descendant: string, signal?: AbortSignal): Promise<boolean> {
+		const args = ["merge-base", "--is-ancestor", ancestor, descendant];
+		const result = await git(cwd, args, { readOnly: true, signal });
+		if (result.exitCode === 0) return true;
+		if (result.exitCode === 1) return false;
+		throw new GitCommandError(args, result);
+	},
+
+	/**
+	 * Compare-and-swap a ref via `git update-ref <ref> <new> <old>`.
+	 * Returns true on success, false when the CAS lost because the ref moved,
+	 * and throws on any other failure.
+	 */
+	async update(
+		cwd: string,
+		refName: string,
+		newSha: string,
+		expectedOldSha: string,
+		signal?: AbortSignal,
+	): Promise<boolean> {
+		const args = ["update-ref", refName, newSha, expectedOldSha];
+		const result = await git(cwd, args, { signal });
+		if (result.exitCode === 0) return true;
+		// Git reports a lost CAS as exit 128 with "is at <sha> but expected <sha>".
+		if (/but expected /i.test(result.stderr)) return false;
+		throw new GitCommandError(args, result);
+	},
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: merge
+// ════════════════════════════════════════════════════════════════════════════
+
+export const merge = {
+	/** Fast-forward the current branch to `ref` (`git merge --ff-only`). */
+	async fastForwardOnly(cwd: string, ref: string, signal?: AbortSignal): Promise<void> {
+		await runEffect(cwd, ["merge", "--ff-only", ref], { signal });
+	},
 };
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/test/missions/workspace.test.ts
+++ b/packages/coding-agent/test/missions/workspace.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	MissionWorkspaceManager,
+	type MissionFeatureWorkspaceDescriptor,
+} from "../../src/missions";
+import type { MissionFeatureSpec, MissionRepositoryState, MissionState, MissionWorkerHandoff } from "../../src/missions";
+
+const GIT_ENV = {
+	GIT_AUTHOR_NAME: "workspace-test",
+	GIT_AUTHOR_EMAIL: "workspace-test@example.com",
+	GIT_COMMITTER_NAME: "workspace-test",
+	GIT_COMMITTER_EMAIL: "workspace-test@example.com",
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
+function gitRun(cwd: string, args: string[]): string {
+	const env: Record<string, string | undefined> = { ...process.env, ...GIT_ENV };
+	delete env.GIT_DIR;
+	delete env.GIT_WORK_TREE;
+	delete env.GIT_INDEX_FILE;
+	const result = Bun.spawnSync({ cmd: ["git", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+	}
+	return result.stdout.toString().trim();
+}
+
+async function makeRepository(): Promise<{ root: string; repository: MissionRepositoryState }> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mission-workspace-"));
+	gitRun(root, ["init", "-q", "-b", "main"]);
+	await fs.writeFile(path.join(root, "README.md"), "workspace test\n");
+	gitRun(root, ["add", "README.md"]);
+	gitRun(root, ["commit", "-q", "-m", "initial"]);
+	const head = gitRun(root, ["rev-parse", "HEAD"]);
+	return {
+		root,
+		repository: {
+			repoRoot: root,
+			parentBranch: "main",
+			baseSha: head,
+			integrationBranch: "main",
+			integrationHead: head,
+		},
+	};
+}
+
+function mission(repository: MissionRepositoryState): MissionState {
+	return { id: `mission-${randomUUID()}`, repository } as MissionState;
+}
+
+const feature: MissionFeatureSpec = {
+	id: "feature",
+	description: "exercise the workspace manager",
+	milestoneId: "milestone",
+	preconditions: [],
+	expectedBehavior: [],
+};
+
+function handoff(commits: string[]): MissionWorkerHandoff {
+	return {
+		kind: "implementation",
+		outcome: "success",
+		summary: "done",
+		implementation: [],
+		remaining: [],
+		verification: { commands: [], interactiveChecks: [] },
+		tests: { added: [], coverageNotes: [] },
+		issues: [],
+		skillDeviations: [],
+		commits,
+	};
+}
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("MissionWorkspaceManager", () => {
+	test("reserves a deterministic feature workspace without touching git", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+
+		const descriptor = await manager.reserveFeature("owner", mission(repository), feature);
+
+		expect(descriptor).toMatchObject({
+			id: expect.stringContaining("feature:"),
+			kind: "feature",
+			ownerSessionId: "owner",
+			phase: "reserved",
+			branch: expect.stringContaining("/feature/feature"),
+			baseSha: repository.integrationHead,
+		});
+		await expect(fs.stat(descriptor.path)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(gitRun(root, ["branch", "--list", descriptor.branch])).toBe("");
+	});
+
+	test("materializes a reserved workspace and cleanly releases it", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
+
+		const ready = await manager.materialize(reserved) as MissionFeatureWorkspaceDescriptor;
+		expect(ready.phase).toBe("ready");
+		expect(gitRun(ready.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(ready.branch);
+		expect(await manager.releaseIfEmpty(ready)).toBe(true);
+		await expect(fs.stat(ready.path)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(gitRun(root, ["branch", "--list", ready.branch])).toBe("");
+	});
+
+	test("reconciles an unregistered on-disk workspace as a conflict", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
+		await fs.mkdir(reserved.path, { recursive: true });
+
+		const result = await manager.reconcile(reserved, false);
+
+		expect(result).toMatchObject({
+			kind: "pause",
+			reason: "workspace_conflict",
+			descriptorId: reserved.id,
+			detail: "Workspace path exists on disk but is not a registered worktree",
+		});
+		await fs.rm(reserved.path, { recursive: true, force: true });
+	});
+
+	test("advances the integration ref only for the recorded feature handoff", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+		const featureHead = gitRun(descriptor.path, ["rev-parse", "HEAD"]);
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([featureHead]));
+
+		expect(result).toMatchObject({ kind: "advanced", repository: { integrationHead: featureHead } });
+		expect(gitRun(root, ["rev-parse", "main"])).toBe(featureHead);
+		await manager.release(descriptor);
+	});
+
+	test("rejects a worktree path registered to a branch it does not own", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["worktree", "add", "-b", "unowned-workspace", descriptor.path, "main"]);
+
+		const result = await manager.reconcile(descriptor, false);
+
+		expect(result).toMatchObject({
+			kind: "pause",
+			reason: "workspace_conflict",
+			detail: "Worktree path is registered to an unowned or mismatched branch",
+			branch: descriptor.branch,
+		});
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["branch", "-D", "unowned-workspace"]);
+		gitRun(root, ["branch", "-D", descriptor.branch]);
+	});
+});

--- a/packages/coding-agent/test/missions/workspace.test.ts
+++ b/packages/coding-agent/test/missions/workspace.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { randomUUID } from "node:crypto";
-import {
-	MissionWorkspaceManager,
-	type MissionFeatureWorkspaceDescriptor,
+import type {
+	MissionFeatureSpec,
+	MissionRepositoryState,
+	MissionState,
+	MissionWorkerHandoff,
 } from "../../src/missions";
-import type { MissionFeatureSpec, MissionRepositoryState, MissionState, MissionWorkerHandoff } from "../../src/missions";
+import { type MissionFeatureWorkspaceDescriptor, MissionWorkspaceManager } from "../../src/missions";
 
 const GIT_ENV = {
 	GIT_AUTHOR_NAME: "workspace-test",
@@ -108,7 +110,7 @@ describe("MissionWorkspaceManager", () => {
 		const manager = new MissionWorkspaceManager();
 		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
 
-		const ready = await manager.materialize(reserved) as MissionFeatureWorkspaceDescriptor;
+		const ready = (await manager.materialize(reserved)) as MissionFeatureWorkspaceDescriptor;
 		expect(ready.phase).toBe("ready");
 		expect(gitRun(ready.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(ready.branch);
 		expect(await manager.releaseIfEmpty(ready)).toBe(true);
@@ -138,7 +140,9 @@ describe("MissionWorkspaceManager", () => {
 		const { root, repository } = await makeRepository();
 		roots.push(root);
 		const manager = new MissionWorkspaceManager();
-		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
 		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
 		gitRun(descriptor.path, ["add", "feature.txt"]);
 		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
@@ -148,14 +152,142 @@ describe("MissionWorkspaceManager", () => {
 
 		expect(result).toMatchObject({ kind: "advanced", repository: { integrationHead: featureHead } });
 		expect(gitRun(root, ["rev-parse", "main"])).toBe(featureHead);
+		expect(await fs.readFile(path.join(root, "feature.txt"), "utf8")).toBe("done\n");
+		expect(await manager.advanceIntegration(repository, descriptor, handoff([featureHead]))).toMatchObject({
+			kind: "already_applied",
+			repository: { integrationHead: featureHead },
+		});
 		await manager.release(descriptor);
+	});
+
+	test("refuses to advance a dirty checked-out integration worktree", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+		const featureHead = gitRun(descriptor.path, ["rev-parse", "HEAD"]);
+		await fs.writeFile(path.join(root, "README.md"), "dirty\n");
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([featureHead]));
+
+		expect(result).toMatchObject({
+			kind: "partial_handoff",
+			issues: [{ description: "Integration worktree is dirty; integration branch cannot be advanced" }],
+		});
+		expect(gitRun(root, ["rev-parse", "main"])).toBe(repository.integrationHead);
+	});
+
+	test("rejects a handoff whose commit list differs from the feature branch", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([]));
+
+		expect(result).toMatchObject({
+			kind: "partial_handoff",
+			issues: [{ description: "Feature commit list does not match handoff.commits" }],
+		});
+	});
+
+	test("reports an integration branch that moved since the feature was reserved", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+		const featureHead = gitRun(descriptor.path, ["rev-parse", "HEAD"]);
+		await fs.writeFile(path.join(root, "other.txt"), "other\n");
+		gitRun(root, ["add", "other.txt"]);
+		gitRun(root, ["commit", "-q", "-m", "other"]);
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([featureHead]));
+
+		expect(result).toMatchObject({ kind: "pause", reason: "integration_diverged" });
+	});
+
+	test("rejects a stale reserved feature branch instead of adopting it", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
+		await fs.writeFile(path.join(root, "stale.txt"), "stale\n");
+		gitRun(root, ["add", "stale.txt"]);
+		gitRun(root, ["commit", "-q", "-m", "stale"]);
+		gitRun(root, ["branch", reserved.branch]);
+
+		await expect(manager.materialize(reserved)).rejects.toThrow(`Feature branch ${reserved.branch} already exists`);
+	});
+
+	test("recreates a registered feature worktree whose directory disappeared without a child transcript", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.rm(descriptor.path, { recursive: true, force: true });
+
+		const result = await manager.reconcile(descriptor, false);
+
+		expect(result).toMatchObject({ kind: "ready", descriptor: { id: descriptor.id, phase: "ready" } });
+		expect(gitRun(descriptor.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(descriptor.branch);
+	});
+
+	test("recreates a registered validator worktree whose directory disappeared without a child transcript", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = await manager.materialize(
+			await manager.reserveValidator("owner", mission(repository), feature.id),
+		);
+		await fs.rm(descriptor.path, { recursive: true, force: true });
+
+		const result = await manager.reconcile(descriptor, false);
+
+		expect(result).toMatchObject({ kind: "ready", descriptor: { id: descriptor.id, phase: "ready" } });
+		expect(gitRun(descriptor.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+	});
+
+	test("does not release a worktree registered to an unrelated branch", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["worktree", "add", "-b", "unowned-release", descriptor.path, "main"]);
+
+		await expect(manager.release(descriptor)).rejects.toThrow("Refusing to remove unowned worktree");
+		expect(gitRun(descriptor.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("unowned-release");
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["branch", "-D", "unowned-release"]);
+		gitRun(root, ["branch", "-D", descriptor.branch]);
 	});
 
 	test("rejects a worktree path registered to a branch it does not own", async () => {
 		const { root, repository } = await makeRepository();
 		roots.push(root);
 		const manager = new MissionWorkspaceManager();
-		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
 		gitRun(root, ["worktree", "remove", descriptor.path]);
 		gitRun(root, ["worktree", "add", "-b", "unowned-workspace", descriptor.path, "main"]);
 


### PR DESCRIPTION
## Summary

Adds a native Git worktree manager for multi-feature goals. It reserves isolated workspaces, reconciles drift, advances an integration ref safely, and releases clean workspaces.

## Flattened prerequisites

This fork PR includes the commits from #6636 and #6638 so it can build against `main`. Review this PR's workspace-manager changes separately from those prerequisite commits.

## Validation

- `bun --cwd=packages/coding-agent test test/missions/workspace.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

Closes #6679
