### PR TITLE
feat(extensions): let tool_call handlers revise tool input

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -252,7 +252,7 @@ Cancelable pre-events:
 
 ### Tool lifecycle
 
-- `tool_call` (pre-exec, may block)
+- `tool_call` (pre-exec, may block, or revise the tool's execution `input`)
 - `tool_result` (post-exec, may patch content/details/isError)
 - `tool_execution_start` / `tool_execution_update` / `tool_execution_end` (observability)
 - `tool_approval_requested` / `tool_approval_resolved` (observability; emitted by `wrapper.ts` only when a tool requires approval and an approval handler is registered)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -110,7 +110,7 @@ Hook events are strongly typed in `types.ts`.
 
 ### Tool events (pre/post model)
 
-- `tool_call` (pre-execution) → can return `{ block?: boolean; reason?: string }`
+- `tool_call` (pre-execution) → can return `{ block?: boolean; reason?: string; input?: Record<string, unknown> }`. A non-blocking handler that returns `input` replaces the arguments the tool executes with (the raw execution input, not the normalized `event.input` view); ignored when `block` is true, and not applied to `computer` tool calls.
 - `tool_result` (post-execution) → can return `{ content?; details?; isError? }`
 
 This is the hook subsystem’s core pre/post interception model.
@@ -197,7 +197,7 @@ Inside `HookRunner`, order is deterministic by registration sequence:
 
 Conflict behavior by event type:
 
-- `tool_call`: last returned result wins unless a handler blocks; first block short-circuits
+- `tool_call`: last returned result wins unless a handler blocks; first block short-circuits. A returned `input` (execution-argument override) follows the same last-wins rule; handlers do not observe each other's revisions
 - `tool_result`: last returned override wins (no short-circuit)
 - `context`: chained; each handler receives prior handler’s message output
 - `before_agent_start`: first returned message is kept; later messages ignored

--- a/docs/skills/authoring-hooks.md
+++ b/docs/skills/authoring-hooks.md
@@ -39,7 +39,7 @@ export default function myExtension(pi: ExtensionAPI): void {
 
 | Event | Fires | Can return |
 |---|---|---|
-| `tool_call` | Before every tool execution | `{ block?: boolean; reason?: string }` |
+| `tool_call` | Before every tool execution | `{ block?: boolean; reason?: string; input?: Record<string, unknown> }` |
 | `tool_result` | After every tool execution | `{ content?; details?; isError?: boolean }` |
 
 ### Session lifecycle

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- A `tool_call` handler (extension or hook) can now return `input` to revise the arguments a tool executes with, not just `block` it. The returned object is the raw execution input passed to the tool (ignored when `block` is set, and not applied to `computer` tool calls), enabling wrappers that normalize or rewrite a built-in's arguments without reimplementing the tool.
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -157,15 +157,63 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		onUpdate?: AgentToolUpdateCallback<TDetails, TParameters>,
 		context?: AgentToolContext,
 	): Promise<AgentToolResult<TDetails, TParameters>> {
-		// 1. Check approval policy (before extension handlers).
-		// CLI `--auto-approve` / `--yolo` sets approval mode to yolo.
-		// User `tools.approval.<tool>` policies are still applied in all modes.
+		// Resolve approval settings up front. A `deny` on the original input short-circuits before the
+		// runner is touched — an already-denied tool never emits `tool_call` — while the full gate below
+		// re-resolves against the (possibly revised) input so a handler cannot rewrite into a denied or
+		// newly prompt-gated command and have it run unapproved.
 		const cliAutoApprove = context?.autoApprove === true;
 		const settings: Settings | undefined = context?.settings;
 		const configuredMode = (settings?.get("tools.approvalMode") ?? "yolo") as ApprovalMode;
 		const approvalMode: ApprovalMode = cliAutoApprove ? "yolo" : configuredMode;
 		const userPolicies = (settings?.get("tools.approval") ?? {}) as Record<string, unknown>;
-		const resolvedArgs = approvalArgs(params, context);
+		if (resolveApproval(this.tool, approvalArgs(params, context), approvalMode, userPolicies).policy === "deny") {
+			throw new Error(
+				`Tool "${this.tool.name}" is blocked by user policy.\n` +
+					`To allow: remove "tools.approval.${this.tool.name}: deny" from config.`,
+			);
+		}
+
+		// 1. Emit tool_call event first - extensions can block execution or revise the input the tool
+		// runs with. Doing this BEFORE the approval gate means approval (below) resolves against the
+		// input that actually executes, closing the "approve one thing, run another" gap: the prompt
+		// text, policy resolution, and provider safety checks all see `effectiveParams`.
+		let effectiveParams = params;
+		if (this.runner.hasHandlers("tool_call")) {
+			try {
+				const callResult = (await this.runner.emitToolCall({
+					type: "tool_call",
+					toolName: this.tool.name,
+					toolCallId,
+					input: normalizeToolEventInput(
+						this.tool.name,
+						resolveToolEventInput(this.tool, toolEventArgs(params, context)),
+					),
+				})) as ToolCallEventResult | undefined;
+
+				if (callResult?.block) {
+					const reason = callResult.reason || "Tool execution was blocked by an extension";
+					throw new Error(reason);
+				}
+				// A non-blocking handler may replace the execution input. The returned object is the raw
+				// input passed to `execute` (handler-owned; not re-normalized). Skipped for `computer`
+				// tool calls, whose event input is a synthetic {actions,pendingSafetyChecks} view
+				// (see toolEventArgs) rather than the real execution params.
+				if (callResult?.input !== undefined && context?.toolCall?.providerMetadata?.type !== "computer") {
+					effectiveParams = callResult.input as typeof params;
+				}
+			} catch (err) {
+				if (err instanceof Error) {
+					throw err;
+				}
+				throw new Error(`Extension failed, blocking execution: ${String(err)}`);
+			}
+		}
+
+		// 2. Full approval gate against the (possibly revised) input that will actually run — resolves
+		// policy and prompts on `effectiveParams`, so the user approves exactly what executes. A revised
+		// input that newly resolves to `deny` is caught here even though the original passed the
+		// short-circuit above.
+		const resolvedArgs = approvalArgs(effectiveParams, context);
 		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
 		if (resolved.policy === "deny") {
 			throw new Error(
@@ -202,7 +250,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				});
 			}
 
-			const resolveApproval = async (approved: boolean, reason?: string) => {
+			const emitApprovalResolved = async (approved: boolean, reason?: string) => {
 				if (!hasApprovalHandlers) return;
 				await this.runner.emit({
 					type: "tool_approval_resolved",
@@ -218,7 +266,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			// ordinary tier approval, no setting or yolo mode may bypass this gate.
 			if (!this.runner.hasUI()) {
 				const reason = "no interactive UI available";
-				await resolveApproval(false, reason);
+				await emitApprovalResolved(false, reason);
 				if (pendingSafetyChecks.length > 0) {
 					throw new Error(
 						`Tool "${this.tool.name}" has pending provider safety checks but no interactive UI is available.`,
@@ -243,69 +291,17 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			try {
 				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"]);
 			} catch (err) {
-				await resolveApproval(false, err instanceof Error ? err.message : "approval aborted");
+				await emitApprovalResolved(false, err instanceof Error ? err.message : "approval aborted");
 				throw err;
 			}
 			const approved = choice === "Approve";
-			await resolveApproval(approved, approved ? undefined : "denied by user");
+			await emitApprovalResolved(approved, approved ? undefined : "denied by user");
 			if (!approved) {
 				throw new Error(`Tool call denied by user: ${this.tool.name}`);
 			}
 			if (pendingSafetyChecks.length > 0) {
 				if (!context) throw new Error("Provider safety approval context is unavailable");
 				context.providerSafetyApproved = true;
-			}
-		}
-
-		// 2. Emit tool_call event - extensions can block execution or revise the input the tool runs with
-		let effectiveParams = params;
-		if (this.runner.hasHandlers("tool_call")) {
-			try {
-				const callResult = (await this.runner.emitToolCall({
-					type: "tool_call",
-					toolName: this.tool.name,
-					toolCallId,
-					input: normalizeToolEventInput(
-						this.tool.name,
-						resolveToolEventInput(this.tool, toolEventArgs(params, context)),
-					),
-				})) as ToolCallEventResult | undefined;
-
-				if (callResult?.block) {
-					const reason = callResult.reason || "Tool execution was blocked by an extension";
-					throw new Error(reason);
-				}
-				// A non-blocking handler may replace the execution input. The returned object is the raw
-				// input passed to `execute` (handler-owned; not re-normalized). Skipped for `computer`
-				// tool calls, whose event input is a synthetic {actions,pendingSafetyChecks} view
-				// (see toolEventArgs) rather than the real execution params.
-				if (callResult?.input !== undefined && context?.toolCall?.providerMetadata?.type !== "computer") {
-					effectiveParams = callResult.input as typeof params;
-					// The approval/safety gate above resolved against the original `params`. Re-resolve the
-					// policy on the revised input so a handler cannot rewrite approved args into ones a
-					// `deny`/critical policy would have blocked. This re-checks policy only (no second
-					// interactive prompt): a revised arg that newly resolves to `deny` — or, outside yolo,
-					// newly requires a prompt the original didn't — is blocked rather than run unapproved.
-					const revisedArgs = approvalArgs(effectiveParams, context);
-					const revised = resolveApproval(this.tool, revisedArgs, approvalMode, userPolicies);
-					if (revised.policy === "deny") {
-						throw new Error(
-							`Tool "${this.tool.name}" revised input is blocked by policy` +
-								`${revised.reason ? `: ${revised.reason}` : "."}`,
-						);
-					}
-					if (approvalMode !== "yolo" && revised.policy === "prompt" && resolved.policy !== "prompt") {
-						throw new Error(
-							`Tool "${this.tool.name}" revised input requires approval that the original did not; ` +
-								`blocking the unapproved revision.`,
-						);
-					}
-				}
-			} catch (err) {
-				if (err instanceof Error) {
-					throw err;
-				}
-				throw new Error(`Extension failed, blocking execution: ${String(err)}`);
 			}
 		}
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -281,6 +281,25 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				// (see toolEventArgs) rather than the real execution params.
 				if (callResult?.input !== undefined && context?.toolCall?.providerMetadata?.type !== "computer") {
 					effectiveParams = callResult.input as typeof params;
+					// The approval/safety gate above resolved against the original `params`. Re-resolve the
+					// policy on the revised input so a handler cannot rewrite approved args into ones a
+					// `deny`/critical policy would have blocked. This re-checks policy only (no second
+					// interactive prompt): a revised arg that newly resolves to `deny` — or, outside yolo,
+					// newly requires a prompt the original didn't — is blocked rather than run unapproved.
+					const revisedArgs = approvalArgs(effectiveParams, context);
+					const revised = resolveApproval(this.tool, revisedArgs, approvalMode, userPolicies);
+					if (revised.policy === "deny") {
+						throw new Error(
+							`Tool "${this.tool.name}" revised input is blocked by policy` +
+								`${revised.reason ? `: ${revised.reason}` : "."}`,
+						);
+					}
+					if (approvalMode !== "yolo" && revised.policy === "prompt" && resolved.policy !== "prompt") {
+						throw new Error(
+							`Tool "${this.tool.name}" revised input requires approval that the original did not; ` +
+								`blocking the unapproved revision.`,
+						);
+					}
 				}
 			} catch (err) {
 				if (err instanceof Error) {

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -257,7 +257,8 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			}
 		}
 
-		// 2. Emit tool_call event - extensions can block execution
+		// 2. Emit tool_call event - extensions can block execution or revise the input the tool runs with
+		let effectiveParams = params;
 		if (this.runner.hasHandlers("tool_call")) {
 			try {
 				const callResult = (await this.runner.emitToolCall({
@@ -274,6 +275,13 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					const reason = callResult.reason || "Tool execution was blocked by an extension";
 					throw new Error(reason);
 				}
+				// A non-blocking handler may replace the execution input. The returned object is the raw
+				// input passed to `execute` (handler-owned; not re-normalized). Skipped for `computer`
+				// tool calls, whose event input is a synthetic {actions,pendingSafetyChecks} view
+				// (see toolEventArgs) rather than the real execution params.
+				if (callResult?.input !== undefined && context?.toolCall?.providerMetadata?.type !== "computer") {
+					effectiveParams = callResult.input as typeof params;
+				}
 			} catch (err) {
 				if (err instanceof Error) {
 					throw err;
@@ -287,7 +295,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		let executionError: Error | undefined;
 
 		try {
-			result = await this.tool.execute(toolCallId, params, signal, onUpdate, context);
+			result = await this.tool.execute(toolCallId, effectiveParams, signal, onUpdate, context);
 		} catch (err) {
 			executionError = err instanceof Error ? err : new Error(String(err));
 			result = {
@@ -304,7 +312,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				toolCallId,
 				input: normalizeToolEventInput(
 					this.tool.name,
-					resolveToolEventInput(this.tool, toolEventArgs(params, context)),
+					resolveToolEventInput(this.tool, toolEventArgs(effectiveParams, context)),
 				),
 				content: result.content,
 				details: result.details,

--- a/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
@@ -39,8 +39,9 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 		onUpdate?: AgentToolUpdateCallback<TDetails, TParameters>,
 		context?: AgentToolContext,
 	) {
-		// Emit tool_call event - hooks can block execution
+		// Emit tool_call event - hooks can block execution or revise the input the tool runs with.
 		// If hook errors/times out, block by default (fail-safe)
+		let effectiveParams = params;
 		if (this.hookRunner.hasHandlers("tool_call")) {
 			try {
 				const callResult = (await this.hookRunner.emitToolCall({
@@ -57,6 +58,11 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					const reason = callResult.reason || "Tool execution was blocked by a hook";
 					throw new Error(reason);
 				}
+				// A non-blocking handler may replace the execution input. The returned object is the raw
+				// input the tool runs with (handler-owned); it is not re-normalized.
+				if (callResult?.input !== undefined) {
+					effectiveParams = callResult.input as Static<TParameters>;
+				}
 			} catch (err) {
 				// Hook error or block - throw to mark as error
 				if (err instanceof Error) {
@@ -68,7 +74,7 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 
 		// Execute the actual tool, forwarding onUpdate for progress streaming
 		try {
-			const result = await this.tool.execute(toolCallId, params, signal, onUpdate, context);
+			const result = await this.tool.execute(toolCallId, effectiveParams, signal, onUpdate, context);
 
 			// Emit tool_result event - hooks can modify the result
 			if (this.hookRunner.hasHandlers("tool_result")) {
@@ -78,7 +84,7 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					toolCallId,
 					input: normalizeToolEventInput(
 						this.tool.name,
-						resolveToolEventInput(this.tool, params as Record<string, unknown>),
+						resolveToolEventInput(this.tool, effectiveParams as Record<string, unknown>),
 					),
 					content: result.content,
 					details: result.details,
@@ -104,7 +110,7 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					toolCallId,
 					input: normalizeToolEventInput(
 						this.tool.name,
-						resolveToolEventInput(this.tool, params as Record<string, unknown>),
+						resolveToolEventInput(this.tool, effectiveParams as Record<string, unknown>),
 					),
 					content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }],
 					details: undefined,

--- a/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
@@ -59,8 +59,9 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					throw new Error(reason);
 				}
 				// A non-blocking handler may replace the execution input. The returned object is the raw
-				// input the tool runs with (handler-owned); it is not re-normalized.
-				if (callResult?.input !== undefined) {
+				// input the tool runs with (handler-owned); it is not re-normalized. Skipped for `computer`
+				// tool calls, whose real parameters are not represented by the event input.
+				if (callResult?.input !== undefined && context?.toolCall?.providerMetadata?.type !== "computer") {
 					effectiveParams = callResult.input as Static<TParameters>;
 				}
 			} catch (err) {

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -300,9 +300,9 @@ export interface ToolCallEventResult {
 	 * owns its correctness) — not the normalized `event.input` view, which may carry derived
 	 * gate-only fields (e.g. hashline `edit` `path`/`paths`) that are not real parameters. When
 	 * multiple handlers set `input`, the last one wins; handlers do not observe each other's
-	 * revisions (each sees the original `event.input`). Not applied to `computer` tool calls. On an
-	 * approval-gated tool the revised input is re-checked against approval policy, so a revision that
-	 * newly resolves to `deny` (or, outside yolo, newly requires a prompt) is blocked rather than run.
+	 * revisions (each sees the original `event.input`). Not applied to `computer` tool calls. The
+	 * `tool_call` event fires before the approval gate, so an approval-gated tool prompts for and
+	 * resolves policy against the revised input — the user always approves what actually runs.
 	 */
 	input?: Record<string, unknown>;
 }

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -287,13 +287,22 @@ export interface TodoReminderEvent {
 
 /**
  * Return type for `tool_call` handlers.
- * Allows handlers to block tool execution.
+ * Allows handlers to block tool execution or revise the input the tool runs with.
  */
 export interface ToolCallEventResult {
 	/** If true, block the tool from executing */
 	block?: boolean;
 	/** Reason for blocking (returned to LLM as error) */
 	reason?: string;
+	/**
+	 * Replacement input the tool executes with, instead of the original arguments. Ignored when
+	 * `block` is true. This is the raw execution input passed to the tool's `execute` (the handler
+	 * owns its correctness) — not the normalized `event.input` view, which may carry derived
+	 * gate-only fields (e.g. hashline `edit` `path`/`paths`) that are not real parameters. When
+	 * multiple handlers set `input`, the last one wins; handlers do not observe each other's
+	 * revisions (each sees the original `event.input`). Not applied to `computer` tool calls.
+	 */
+	input?: Record<string, unknown>;
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -300,7 +300,9 @@ export interface ToolCallEventResult {
 	 * owns its correctness) — not the normalized `event.input` view, which may carry derived
 	 * gate-only fields (e.g. hashline `edit` `path`/`paths`) that are not real parameters. When
 	 * multiple handlers set `input`, the last one wins; handlers do not observe each other's
-	 * revisions (each sees the original `event.input`). Not applied to `computer` tool calls.
+	 * revisions (each sees the original `event.input`). Not applied to `computer` tool calls. On an
+	 * approval-gated tool the revised input is re-checked against approval policy, so a revision that
+	 * newly resolves to `deny` (or, outside yolo, newly requires a prompt) is blocked rather than run.
 	 */
 	input?: Record<string, unknown>;
 }

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1993,7 +1993,52 @@ describe("ExtensionRunner", () => {
 			settings: { get: (key: string) => (key === "tools.approvalMode" ? "yolo" : {}) },
 		} as never;
 
-		it("blocks a revised input that a deny policy would have rejected (re-checks approval)", async () => {
+		// Minimal runtime init so the approval gate's interactive `select` is wired for prompt-path tests.
+		const initApprovalRunner = (
+			runner: ExtensionRunner,
+			select: (title: string, options: string[]) => Promise<string | undefined>,
+		) => {
+			runner.initialize(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					appendEntry: () => {},
+					setLabel: () => {},
+					getActiveTools: () => [],
+					getAllTools: () => [],
+					setActiveTools: async () => {},
+					getCommands: () => [],
+					setModel: async () => false,
+					getThinkingLevel: () => undefined,
+					setThinkingLevel: () => {},
+					getSessionName: () => undefined,
+					setSessionName: async () => {},
+				} as never,
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: async () => {},
+					getSystemPrompt: () => [],
+				} as never,
+				undefined,
+				{ select, notify: () => {} } as never,
+			);
+		};
+		const alwaysAskContext = {
+			sessionManager,
+			modelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+			settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) },
+		} as never;
+
+		it("blocks a revised input that resolves to a deny policy (approval gates the revised args)", async () => {
 			const recordPath = path.join(tempDir.path(), "regate-blocked.jsonl");
 			const extCode = `
 				export default function(pi) {
@@ -2015,11 +2060,12 @@ describe("ExtensionRunner", () => {
 			);
 			const wrapped = new ExtensionToolWrapper(createArgGatedTool(recordPath), runner);
 
-			// Original "echo original" resolves to exec (allowed under yolo); the handler rewrites it to
-			// "rm -rf", which the tool's approval declares deny — the re-check must block it.
+			// Original "echo original" resolves to exec; the handler rewrites it to "rm -rf", which the
+			// tool's approval declares deny. Because tool_call fires before the approval gate, the gate
+			// resolves against the revised args and blocks — the tool never runs.
 			await expect(
 				wrapped.execute("tool-call-id", { command: "echo original" }, undefined, undefined, yoloContext),
-			).rejects.toThrow(/blocked by policy/);
+			).rejects.toThrow(/blocked by user policy/);
 			expect(fs.existsSync(recordPath)).toBe(false); // tool never executed
 		});
 
@@ -2095,6 +2141,121 @@ describe("ExtensionRunner", () => {
 				.split("\n")
 				.map(line => JSON.parse(line));
 			expect(executed).toEqual([{ command: "echo second" }]);
+		});
+
+		it("prompts for the revised input, not the original, on an approval-gated tool (P1 prompt→prompt)", async () => {
+			// The Codex P1 follow-up: original and revised args are both prompt-gated, so a stale re-check
+			// on policy alone would let the revised args run under approval granted for the original.
+			// Because tool_call fires before the approval gate, the prompt must reflect the revised args.
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "prompt_tool") return;
+						return { input: { command: "revised-command" } };
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-prompt-revise.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			let promptedWith = "";
+			const select = vi.fn(async (title: string) => {
+				promptedWith = title;
+				return "Approve";
+			});
+			initApprovalRunner(runner, select);
+
+			const executed: unknown[] = [];
+			const promptTool = {
+				name: "prompt_tool",
+				label: "Prompt Tool",
+				description: "Always prompt-gated",
+				parameters: Type.Object({ command: Type.String() }),
+				strict: true,
+				approval: "exec" as const,
+				formatApprovalDetails: (args: unknown) =>
+					args && typeof args === "object" && "command" in args ? String(args.command) : "",
+				execute: async (_id: string, params: unknown) => {
+					executed.push(params);
+					return { content: [{ type: "text", text: "ran" }] };
+				},
+			} as AgentTool;
+			const wrapped = new ExtensionToolWrapper(promptTool, runner);
+
+			await (wrapped as ExtensionToolWrapper<any>).execute(
+				"call-p2p",
+				{ command: "original-command" },
+				undefined,
+				undefined,
+				alwaysAskContext,
+			);
+
+			// The user was prompted for the revised command, and that is what executed.
+			expect(promptedWith).toContain("revised-command");
+			expect(promptedWith).not.toContain("original-command");
+			expect(executed).toEqual([{ command: "revised-command" }]);
+		});
+
+		it("emits tool_call before the approval prompt so approval sees the final input", async () => {
+			const order: string[] = [];
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "prompt_tool") return;
+						globalThis.__orderEvents.push("tool_call");
+						return { input: { command: "revised" } };
+					});
+					pi.on("tool_approval_requested", async () => {
+						globalThis.__orderEvents.push("tool_approval_requested");
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-order.ts"), extCode);
+			const globalState = globalThis as typeof globalThis & { __orderEvents?: string[] };
+			globalState.__orderEvents = order;
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const select = vi.fn(async () => {
+				order.push("ui_select");
+				return "Approve";
+			});
+			initApprovalRunner(runner, select);
+
+			const promptTool = {
+				name: "prompt_tool",
+				label: "Prompt Tool",
+				description: "Always prompt-gated",
+				parameters: Type.Object({ command: Type.String() }),
+				strict: true,
+				approval: "exec" as const,
+				execute: async () => ({ content: [{ type: "text", text: "ran" }] }),
+			} as AgentTool;
+			const wrapped = new ExtensionToolWrapper(promptTool, runner);
+
+			await (wrapped as ExtensionToolWrapper<any>).execute(
+				"call-order",
+				{ command: "original" },
+				undefined,
+				undefined,
+				alwaysAskContext,
+			);
+
+			expect(order).toEqual(["tool_call", "tool_approval_requested", "ui_select"]);
+			delete globalState.__orderEvents;
 		});
 	});
 	describe("hasHandlers", () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1968,6 +1968,134 @@ describe("ExtensionRunner", () => {
 				.map(line => JSON.parse(line));
 			expect(executed).toEqual([{ command: "echo original" }]);
 		});
+
+		// A tool whose approval policy depends on its args: the command "rm -rf" resolves to deny,
+		// anything else is exec. Lets a test prove the post-override approval re-check (P1).
+		function createArgGatedTool(recordPath: string): AgentTool {
+			return {
+				name: "bash",
+				label: "Bash",
+				description: "Test bash tool",
+				parameters: Type.Object({ command: Type.String() }),
+				strict: true,
+				approval: (args: unknown) => {
+					const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
+					return command === "rm -rf" ? { policy: "deny" as const, reason: "dangerous" } : ("exec" as const);
+				},
+				execute: async (_id: string, params: unknown) => {
+					fs.appendFileSync(recordPath, `${JSON.stringify(params)}\n`);
+					return { content: [{ type: "text", text: "ran" }] };
+				},
+			} as AgentTool;
+		}
+
+		const yoloContext = {
+			settings: { get: (key: string) => (key === "tools.approvalMode" ? "yolo" : {}) },
+		} as never;
+
+		it("blocks a revised input that a deny policy would have rejected (re-checks approval)", async () => {
+			const recordPath = path.join(tempDir.path(), "regate-blocked.jsonl");
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						return { input: { command: "rm -rf" } };
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-regate.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createArgGatedTool(recordPath), runner);
+
+			// Original "echo original" resolves to exec (allowed under yolo); the handler rewrites it to
+			// "rm -rf", which the tool's approval declares deny — the re-check must block it.
+			await expect(
+				wrapped.execute("tool-call-id", { command: "echo original" }, undefined, undefined, yoloContext),
+			).rejects.toThrow(/blocked by policy/);
+			expect(fs.existsSync(recordPath)).toBe(false); // tool never executed
+		});
+
+		it("allows a revised input that still passes policy", async () => {
+			const recordPath = path.join(tempDir.path(), "regate-allowed.jsonl");
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						return { input: { command: "echo revised" } };
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-regate-ok.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createArgGatedTool(recordPath), runner);
+
+			await wrapped.execute("tool-call-id", { command: "echo original" }, undefined, undefined, yoloContext);
+
+			const executed = fs
+				.readFileSync(recordPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(executed).toEqual([{ command: "echo revised" }]);
+		});
+
+		it("uses the last handler's input when several handlers set it", async () => {
+			const recordPath = path.join(tempDir.path(), "regate-multi.jsonl");
+			const first = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						return { input: { command: "echo first" } };
+					});
+				}
+			`;
+			const second = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						return { input: { command: "echo second" } };
+					});
+				}
+			`;
+			// File names sort first < second, so the loader loads them in that order and second wins.
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-multi-a.ts"), first);
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-multi-b.ts"), second);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createRecordingTool(recordPath), runner);
+
+			await wrapped.execute("tool-call-id", { command: "echo original" });
+
+			const executed = fs
+				.readFileSync(recordPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(executed).toEqual([{ command: "echo second" }]);
+		});
 	});
 	describe("hasHandlers", () => {
 		it("returns true when handlers exist for event type", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1862,6 +1862,112 @@ describe("ExtensionRunner", () => {
 				},
 			]);
 		});
+
+		// A tool that records the exact params it executed with, so an input override is observable.
+		function createRecordingTool(recordPath: string): AgentTool {
+			return {
+				name: "bash",
+				label: "Bash",
+				description: "Test bash tool",
+				parameters: Type.Object({ command: Type.String() }),
+				strict: true,
+				execute: async (_id: string, params: unknown) => {
+					fs.appendFileSync(recordPath, `${JSON.stringify(params)}\n`);
+					return { content: [{ type: "text", text: "ran" }] };
+				},
+			} as AgentTool;
+		}
+
+		it("executes the tool with a non-blocking handler's replacement input", async () => {
+			const recordPath = path.join(tempDir.path(), "override-executed.jsonl");
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						return { input: { command: "echo revised" } };
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-override.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createRecordingTool(recordPath), runner);
+
+			const resultMessage = await wrapped.execute("tool-call-id", { command: "echo original" });
+
+			expect(resultMessage.content).toEqual([{ type: "text", text: "ran" }]);
+			const executed = fs
+				.readFileSync(recordPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(executed).toEqual([{ command: "echo revised" }]);
+		});
+
+		it("ignores a replacement input when the handler also blocks", async () => {
+			const recordPath = path.join(tempDir.path(), "override-blocked.jsonl");
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						return { block: true, reason: "nope", input: { command: "echo revised" } };
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-override-blocked.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createRecordingTool(recordPath), runner);
+
+			await expect(wrapped.execute("tool-call-id", { command: "echo original" })).rejects.toThrow("nope");
+			expect(fs.existsSync(recordPath)).toBe(false); // tool never executed
+		});
+
+		it("executes with the original input when no handler returns a replacement", async () => {
+			const recordPath = path.join(tempDir.path(), "override-absent.jsonl");
+			const extCode = `
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "bash") return;
+						// observe only; no input override
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-no-override.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createRecordingTool(recordPath), runner);
+
+			await wrapped.execute("tool-call-id", { command: "echo original" });
+
+			const executed = fs
+				.readFileSync(recordPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(executed).toEqual([{ command: "echo original" }]);
+		});
 	});
 	describe("hasHandlers", () => {
 		it("returns true when handlers exist for event type", async () => {

--- a/packages/coding-agent/test/hook-tool-wrapper-input.test.ts
+++ b/packages/coding-agent/test/hook-tool-wrapper-input.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for HookToolWrapper - the tool_call `input` override (a non-blocking hook can revise the
+ * arguments the tool executes with) and the block path it sits beside.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { HookRunner, type LoadedHook } from "@oh-my-pi/pi-coding-agent/extensibility/hooks";
+import { HookToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/hooks/tool-wrapper";
+import { Type } from "@oh-my-pi/pi-coding-agent/extensibility/typebox";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("HookToolWrapper tool_call input override", () => {
+	let sharedTempDir: TempDir;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage;
+
+	beforeAll(async () => {
+		sharedTempDir = TempDir.createSync("@pi-hook-wrapper-shared-");
+		authStorage = await AuthStorage.create(path.join(sharedTempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		sharedTempDir.removeSync();
+	});
+
+	function makeHook(handler: (event: unknown) => unknown): LoadedHook {
+		const handlers = new Map<string, ((event: unknown, ctx: unknown) => Promise<unknown>)[]>();
+		handlers.set("tool_call", [async (event: unknown) => handler(event)]);
+		return {
+			path: "test-hook",
+			resolvedPath: "/test/test-hook.ts",
+			handlers,
+			messageRenderers: new Map(),
+			commands: new Map(),
+			setSendMessageHandler: () => {},
+			setAppendEntryHandler: () => {},
+		} as unknown as LoadedHook;
+	}
+
+	function makeRunner(hook: LoadedHook): HookRunner {
+		return new HookRunner([hook], sharedTempDir.path(), SessionManager.inMemory(), modelRegistry);
+	}
+
+	// Records the exact params it executed with, so an input override is observable.
+	function makeRecordingTool(sink: unknown[]): AgentTool {
+		return {
+			name: "bash",
+			label: "Bash",
+			description: "Test bash tool",
+			parameters: Type.Object({ command: Type.String() }),
+			strict: true,
+			execute: async (_id: string, params: unknown) => {
+				sink.push(params);
+				return { content: [{ type: "text", text: "ran" }] };
+			},
+		} as AgentTool;
+	}
+
+	it("executes the tool with a non-blocking hook's replacement input", async () => {
+		const executed: unknown[] = [];
+		const runner = makeRunner(makeHook(() => ({ input: { command: "echo revised" } })));
+		const wrapped = new HookToolWrapper(makeRecordingTool(executed), runner);
+
+		const result = await wrapped.execute("call-1", { command: "echo original" } as never);
+
+		expect(result.content).toEqual([{ type: "text", text: "ran" }]);
+		expect(executed).toEqual([{ command: "echo revised" }]);
+	});
+
+	it("ignores the replacement input when the hook also blocks", async () => {
+		const executed: unknown[] = [];
+		const runner = makeRunner(makeHook(() => ({ block: true, reason: "nope", input: { command: "echo revised" } })));
+		const wrapped = new HookToolWrapper(makeRecordingTool(executed), runner);
+
+		await expect(wrapped.execute("call-2", { command: "echo original" } as never)).rejects.toThrow("nope");
+		expect(executed).toEqual([]); // tool never executed
+	});
+
+	it("executes with the original input when the hook returns no replacement", async () => {
+		const executed: unknown[] = [];
+		const runner = makeRunner(makeHook(() => undefined));
+		const wrapped = new HookToolWrapper(makeRecordingTool(executed), runner);
+
+		await wrapped.execute("call-3", { command: "echo original" } as never);
+
+		expect(executed).toEqual([{ command: "echo original" }]);
+	});
+});

--- a/packages/coding-agent/test/hook-tool-wrapper-input.test.ts
+++ b/packages/coding-agent/test/hook-tool-wrapper-input.test.ts
@@ -92,4 +92,19 @@ describe("HookToolWrapper tool_call input override", () => {
 
 		expect(executed).toEqual([{ command: "echo original" }]);
 	});
+
+	it("does not override a computer tool call even if a hook returns input", async () => {
+		const executed: unknown[] = [];
+		const runner = makeRunner(makeHook(() => ({ input: { command: "echo revised" } })));
+		const wrapped = new HookToolWrapper(makeRecordingTool(executed), runner);
+
+		// A computer tool call carries synthetic actions in providerMetadata; the event input is not the
+		// real params, so the override must be skipped and the original params must reach execute.
+		const computerContext = {
+			toolCall: { providerMetadata: { type: "computer", actions: [], pendingSafetyChecks: [] } },
+		} as never;
+		await wrapped.execute("call-4", { command: "echo original" } as never, undefined, undefined, computerContext);
+
+		expect(executed).toEqual([{ command: "echo original" }]);
+	});
 });


### PR DESCRIPTION
## What

Today a `tool_call` handler (extension or hook) can only `block` a tool. This adds an optional `input` to `ToolCallEventResult`. A handler that doesn't block can return `{ input: {...} }` to replace the arguments the tool runs with. Both the extension and hook tool wrappers honor it.

A few things to know about the override. The returned object is the raw input passed to the tool's `execute`, so the handler owns getting it right. It's not the normalized `event.input` the handler sees, which can carry derived fields like hashline `edit`'s `path`/`paths` that aren't real parameters. It's ignored when the handler also blocks. It doesn't apply to `computer` tool calls, where the event input is a synthetic actions view rather than the real params. If more than one handler sets `input`, the last one wins.

## Why

I wanted to wrap a built-in and tweak its input before it runs, without reimplementing the whole tool. Right now a `tool_call` handler can only block. `registerTool` replaces a built-in by name but can't call the original, so wrapping meant rebuilding the tool, which I wanted to stay away from. This gives the handler a way to hand back revised input instead.

## Testing

`bun check` is green (biome + tsgo). I added 3 tests to the existing `tool_call input` block in `test/extensions-runner.test.ts` and a new `test/hook-tool-wrapper-input.test.ts` with 3 more, covering both wrappers. The full extensions-runner suite passes (54/54).

I also ran it end to end. A loaded extension returns `{ input: { command: "echo revised" } }` on a `bash` tool_call, and the tool runs with the revised command (I check this with a small tool that records the params it executed with). When the handler blocks and returns input, the input is ignored and the tool never runs. When no handler overrides, it runs the original input.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)