### PR TITLE
feat(coding-agent): add in-session schedule tool

### DIFF
--- a/docs/tools/schedule.md
+++ b/docs/tools/schedule.md
@@ -1,0 +1,67 @@
+# schedule
+
+> Arm a one-shot wake that re-enters the model with a stored prompt later in this same session.
+
+## Surface
+
+The public surface is the `schedule` tool. There is no `/session schedules` slash command; create and cancel calls use the tool fields described below.
+
+## Source
+- Entry: `packages/coding-agent/src/tools/schedule.ts`
+- Model-facing prompt: `packages/coding-agent/src/prompts/tools/schedule.md`
+- Key collaborators:
+  - `packages/coding-agent/src/session/session-schedule.ts` — entry shape, newest-per-id fold, timer arming, `SessionScheduleController`.
+  - `packages/coding-agent/src/session/agent-session.ts` — owns the controller, samples `schedule.enabled` when re-arming on construction and after every branch swap, exposes `getSessionSchedule()`.
+  - `packages/coding-agent/src/extensibility/extensions/managed-timers.ts` — the contained timer pool the wakes are armed on.
+  - `packages/coding-agent/src/tools/index.ts` — registers the tool and limits it to an enabled top-level session.
+  - `packages/coding-agent/src/config/settings-schema.ts` — defines the disabled-by-default flag.
+
+## Inputs
+
+One call is either a **create** or a **cancel**; `cancel` may not be combined with the create fields.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `delayMs` | `number` (integer ≥ 0) | Exactly one of `delayMs` / `atIso` for a create | Relative delay in milliseconds. |
+| `atIso` | `string` | Exactly one of `delayMs` / `atIso` for a create | Future absolute due time as ISO-8601. |
+| `prompt` | `string` | For a create | Text enqueued when the wake fires. |
+| `cancel` | `string` | For a cancel | Id of a pending schedule. |
+
+Supplying both `delayMs` and `atIso`, or neither, is a validation error rather than a silent default.
+
+## Outputs
+A single text result plus structured details.
+
+- create → `Scheduled <id> for <ISO due time>.`, details `{ op: "create", id, dueAtMs, prompt, createdAt }`
+- cancel → `Cancelled schedule <id>.`, or `No pending schedule <id>; cancel recorded.` when nothing matched, details `{ op: "cancel", id, cancelled }`
+
+## Flow
+1. Intent is persisted through `SessionManager.appendCustomEntry` under customType `session-schedule`, payload `{ id, dueAtMs, prompt, createdAt }`.
+2. `SessionScheduleController` arms one timeout per pending schedule on a `ManagedTimers` pool dedicated to schedules.
+3. On fire, the controller appends a `{ id, fired: true }` tombstone and enqueues the stored prompt as a hidden next-turn message — the same continuation mechanism goal mode uses. It never invokes a tool directly, so the model decides what the wake means.
+4. Cancelling appends `{ id, cancelled: true }` for the same id.
+5. `foldPendingSessionSchedules` takes the newest entry per id and drops cancelled and fired ids, so a restored session re-arms what is still pending and never re-fires what already ran on the active branch.
+6. A schedule whose `dueAtMs` has already passed stays pending through the fold and fires once at the next turn boundary rather than being dropped or fired repeatedly.
+
+## Side Effects
+- Appends `session-schedule` custom entries to the transcript (create, cancel, and fired tombstones).
+- Arms and clears timers on the session's dedicated `ManagedTimers` pool.
+- Enqueues one hidden next-turn message per fired wake, which starts a normal model turn under normal approvals.
+
+## Limits & Caps
+- Gated by `schedule.enabled`, default `false`, and limited to top-level sessions. Enablement is sampled when the controller is constructed or re-armed, not observed live.
+- **One-shot only.** There is no recurrence and no cron expression.
+- **In-session only.** Timers live in the process. A wake never fires in a process the user did not start, and nothing is scheduled across restarts beyond re-arming still-pending intents when that same session is resumed.
+- Approval tier is `write`: creating a schedule mutates session state but runs nothing external at call time.
+- The schedule pool is deliberately not the extension runner's `ManagedTimers`; that pool's `clearAll()` on extension teardown would silently disarm every pending wake.
+- A future wake may be at most `2_147_483_647` ms (about 24.8 days) away. Longer delays are rejected instead of overflowing the runtime timer.
+
+## Errors
+- `ToolError("cancel must be a non-empty schedule id.")` — blank `cancel`.
+- `ToolError("cancel cannot be combined with delayMs, atIso, or prompt.")` — mixed create/cancel call.
+- `ToolError("prompt is required when creating a schedule.")` — missing or blank create prompt.
+- `ToolError` from `resolveScheduleDueAtMs` — both or neither of `delayMs` / `atIso`, an unparsable or non-future `atIso`, or a due time more than 24.8 days ahead.
+- `ToolError("Session schedule controller is unavailable.")` — the session cannot own live wake timers.
+
+## Notes
+- Unknown or malformed `session-schedule` payloads are ignored by the fold rather than throwing, so a hand-edited transcript cannot break session restore.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added an opt-in `schedule` tool (`schedule.enabled`, default off) letting the agent arm or cancel a one-shot wake for later in the same session. There is no `/session schedules` slash command; wakes are in-session only and nothing fires in a process the user did not start.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3842,6 +3842,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	// Default-off: an armed wake re-enters the model on a timer, so it stays opt-in.
+	"schedule.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Available Tools",
+			label: "Schedule",
+			description: "Let the agent schedule a one-shot wake prompt for this session (fires only while it runs)",
+		},
+	},
+
 	"computer.backend": {
 		type: "enum",
 		values: ["auto", "native"] as const,

--- a/packages/coding-agent/src/prompts/tools/schedule.md
+++ b/packages/coding-agent/src/prompts/tools/schedule.md
@@ -1,0 +1,22 @@
+Wake this session later with a one-shot timer.
+
+Timers stop when the process exits. A pending intent can re-arm when this same session is resumed with scheduling enabled.
+
+## Create
+
+Supply **exactly one** of:
+
+- `delayMs` — relative delay in milliseconds (non-negative integer, at most 2_147_483_647)
+- `atIso` — absolute due time as an ISO-8601 timestamp, at most about 24.8 days ahead
+
+Plus a non-empty `prompt` that will be enqueued as a hidden next-turn message when the timer fires. Returns the created schedule `id`.
+
+## Cancel
+
+Pass `cancel` with a schedule id to cancel a pending wake. Do not combine cancel with create fields.
+
+## Rules
+
+- One-shot only — no recurrence or cron.
+- No wake runs while the session process is offline.
+- Cancelling an unknown id records a tombstone so an older create entry cannot reappear.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1606,6 +1606,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// mutation (any tool) bumped it in the meantime.
 		const fileMutationVersions = new Map<string, number>();
 		const activeToolNames = new Set<string>();
+		const isTopLevelSession = (): boolean => agentKind === "main";
 		const setActiveToolNames = (names: Iterable<string>): void => {
 			activeToolNames.clear();
 			for (const name of names) {
@@ -1645,6 +1646,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			requireYieldTool: options.requireYieldTool,
 			prewalkArmed: options.prewalk !== undefined,
 			taskDepth: options.taskDepth ?? 0,
+			isTopLevelSession,
 			getSessionFile: () => sessionManager.getSessionFile() ?? null,
 			sessionManager,
 			getEvalKernelOwnerId: () => evalKernelOwnerId,
@@ -1674,6 +1676,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getPlanReferencePath: () => session?.getPlanReferencePath() ?? "local://PLAN.md",
 			getGoalModeState: () => session?.getGoalModeState(),
 			getGoalRuntime: () => session?.goalRuntime,
+			getSessionSchedule: () => (isTopLevelSession() ? session?.getSessionSchedule() : undefined),
 			getUsageStatistics: () => sessionManager.getUsageStatistics(),
 			getTurnBudget: () => sessionManager.getTurnBudget(),
 			recordEvalSubagentUsage: output => sessionManager.recordEvalSubagentOutput(output),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -305,6 +305,7 @@ import {
 import { cleanupEmptyMoveSession, type SessionManager } from "./session-manager";
 import { SessionMemory, type SessionMemoryHost } from "./session-memory";
 import { SessionProviderBoundary, type SessionProviderBoundaryHost } from "./session-provider-boundary";
+import { initSessionSchedules, type SessionScheduleController } from "./session-schedule";
 import { SessionStatsTracker, type SessionStatsTrackerHost } from "./session-stats";
 import { SessionTools, type SessionToolsHost } from "./session-tools";
 import type { ShakeMode, ShakeResult } from "./shake-types";
@@ -480,6 +481,15 @@ export class AgentSession {
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
+	/**
+	 * Dedicated timer pool for session schedules. Deliberately NOT the extension
+	 * runner's `ManagedTimers`: its `clearAll()` runs on extension teardown, which
+	 * would silently disarm every pending wake.
+	 */
+	readonly #sessionScheduleTimers = new ManagedTimers((event, error) =>
+		logger.warn("Session schedule timer callback threw", { event, error }),
+	);
+	#sessionSchedule: SessionScheduleController | undefined;
 	readonly #advisors: SessionAdvisors;
 	#goalTurnCounter = 0;
 	#planReferenceSent = false;
@@ -1263,6 +1273,7 @@ export class AgentSession {
 				);
 			},
 		});
+		this.#rearmSessionSchedules();
 		this.#cancelExitRecorder = postmortem.register(`agent-session:${this.sessionManager.getSessionId()}`, reason => {
 			this.#recordSessionExit(reason);
 		});
@@ -1425,6 +1436,7 @@ export class AgentSession {
 			buildDisplaySessionContext: () => this.buildDisplaySessionContext(),
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
+			rearmSessionSchedules: () => this.#rearmSessionSchedules(),
 		};
 		this.#handoff = new SessionHandoff(handoffHost);
 
@@ -3505,6 +3517,9 @@ export class AgentSession {
 		this.#recordSessionExit(options.reason ?? "dispose");
 		this.#cancelExitRecorder?.();
 		this.#cancelExitRecorder = undefined;
+		this.#sessionSchedule?.dispose();
+		this.#sessionSchedule = undefined;
+		this.#sessionScheduleTimers.clearAll();
 		try {
 			await emitSessionShutdownEvent(this.#extensionRunner);
 		} catch (error) {
@@ -3513,6 +3528,9 @@ export class AgentSession {
 
 		// Stop fallback extension timers before aborting deferred work they could enqueue.
 		this.#fallbackExtensionTimers?.clearAll();
+		// Same reason, and one more: an armed wake closes over this session's manager, so a
+		// schedule surviving teardown would both pin the disposed session and later fire
+		// getEntries/appendCustomEntry against a SessionManager already closed below.
 		this.abortRetry();
 		this.abortCompaction();
 		const postPromptDrain = this.#cancelPostPromptTasks();
@@ -4227,6 +4245,48 @@ export class AgentSession {
 
 	get goalRuntime(): GoalRuntime {
 		return this.#goalRuntime;
+	}
+
+	/** Deliver an agent-authored message that stays hidden from the transcript. */
+	async #sendHiddenMessage(message: {
+		customType: string;
+		content: string;
+		deliverAs?: "steer" | "followUp" | "nextTurn";
+		triggerTurn?: boolean;
+	}): Promise<void> {
+		if (this.#isDisposed) return;
+		await this.sendCustomMessage(
+			{
+				customType: message.customType,
+				content: message.content,
+				display: false,
+				attribution: "agent",
+			},
+			{ deliverAs: message.deliverAs, triggerTurn: message.triggerTurn },
+		);
+	}
+
+	/**
+	 * (Re)arm persisted one-shot wakes for the active branch. Called at construction and
+	 * after any branch swap, since `newSession`/`switchSession` replace the entry set the
+	 * pending fold derives from.
+	 */
+	#rearmSessionSchedules(): void {
+		this.#sessionSchedule?.dispose();
+		this.#sessionSchedule = undefined;
+		if (!this.settings.get("schedule.enabled") || this.#agentKind === "sub") return;
+		this.#sessionSchedule = initSessionSchedules(this.sessionManager.getBranch(), this.#sessionScheduleTimers, {
+			getEntries: () => this.sessionManager.getBranch(),
+			appendCustomEntry: (customType, data) => this.sessionManager.appendCustomEntry(customType, data),
+			flush: () => this.sessionManager.flush(),
+			sendHiddenMessage: message => this.#sendHiddenMessage(message),
+			isLive: () => !this.#isDisposed,
+		});
+	}
+
+	/** Live schedule controller read by the schedule tool. */
+	getSessionSchedule(): SessionScheduleController | undefined {
+		return this.#sessionSchedule;
 	}
 
 	markPlanReferenceSent(): void {
@@ -5966,6 +6026,10 @@ export class AgentSession {
 		// not the previous session's — refresh before the next turn goes out.
 		await this.refreshBaseSystemPrompt();
 
+		// The branch just changed, so the previous branch's wakes are no longer ours to
+		// fire and this branch's have never been armed.
+		this.#rearmSessionSchedules();
+
 		// Emit session_switch event with reason "new" to hooks
 		if (this.#extensionRunner) {
 			await this.#extensionRunner.emit({
@@ -6053,6 +6117,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		await this.#memory.resetContextForNewTranscript();
+		this.#rearmSessionSchedules();
 
 		// Emit session_switch event with reason "fork" to hooks
 		if (this.#extensionRunner) {
@@ -6362,6 +6427,7 @@ export class AgentSession {
 		this.agent.replaceMessages(activeMessages ?? sessionContext.messages);
 		this.#advisors.resetSessionState();
 		this.#todo.syncFromBranch();
+		this.#rearmSessionSchedules();
 		this.#closeCodexProviderSessionsForHistoryRewrite();
 		this.#checkpointState = undefined;
 		this.#pendingRewindReport = undefined;
@@ -6980,6 +7046,9 @@ export class AgentSession {
 			this.agent.replaceMessages(sessionContext.messages);
 			this.#advisors.resetSessionState();
 			this.#todo.syncFromBranch();
+			// Same reason as newSession: the entry set the pending fold derives from was
+			// just replaced, so re-arm against the branch we actually switched to.
+			this.#rearmSessionSchedules();
 			if (switchingToDifferentSession) {
 				this.#closeAllProviderSessions("session switch");
 			} else if (didReloadConversationChange) {
@@ -7113,6 +7182,7 @@ export class AgentSession {
 			this.#models.restoreThinkingSnapshot(previousThinkingLevel, previousAutoThinking, previousAutoResolvedLevel);
 			this.#models.restoreServiceTiers(previousServiceTierByFamily);
 			this.#todo.syncFromBranch();
+			this.#rearmSessionSchedules();
 			this.#advisors.resetAllRuntimes();
 			this.#reconnectToAgent();
 			try {
@@ -7197,6 +7267,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		await this.#memory.resetContextForNewTranscript();
+		this.#rearmSessionSchedules();
 
 		// Reload messages from entries (works for both file and in-memory mode)
 		const sessionContext = this.buildDisplaySessionContext();
@@ -7301,6 +7372,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		await this.#memory.resetContextForNewTranscript();
+		this.#rearmSessionSchedules();
 
 		const sessionContext = this.buildDisplaySessionContext();
 
@@ -7600,6 +7672,7 @@ export class AgentSession {
 		this.#rehydrateCheckpointRewindState();
 		this.#advisors.resetSessionState();
 		this.#todo.syncFromBranch();
+		this.#rearmSessionSchedules();
 		this.#closeCodexProviderSessionsForHistoryRewrite();
 
 		this.#branchSummaryAbortController = undefined;

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -66,6 +66,7 @@ export interface SessionHandoffHost {
 	buildDisplaySessionContext(): SessionContext;
 	resetAdvisorRuntimes(): void;
 	syncTodoPhasesFromBranch(): void;
+	rearmSessionSchedules(): void;
 }
 
 /** Generates handoff documents and owns the handoff session transition. */
@@ -284,6 +285,7 @@ export class SessionHandoff {
 			// Rebuild agent messages from session
 			const sessionContext = this.#host.buildDisplaySessionContext();
 			this.#host.agent.replaceMessages(sessionContext.messages);
+			this.#host.rearmSessionSchedules();
 			this.#host.resetAdvisorRuntimes();
 			this.#host.syncTodoPhasesFromBranch();
 			if (this.#host.extensionRunner) {

--- a/packages/coding-agent/src/session/session-schedule.ts
+++ b/packages/coding-agent/src/session/session-schedule.ts
@@ -1,0 +1,350 @@
+/**
+ * Session self-scheduling — persist wake intent in the transcript, fold the
+ * newest entry per id, and arm one ManagedTimers timeout per pending schedule.
+ *
+ * Schedules are one-shot and live only while the process does. Firing never
+ * invokes a tool; it enqueues the stored prompt as a hidden nextTurn message
+ * through the same sendHiddenMessage seam GoalRuntime uses.
+ */
+import { isRecord, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import type { ManagedTimers } from "../extensibility/extensions/managed-timers";
+import type { SessionEntry } from "./session-entries";
+
+export const SESSION_SCHEDULE_CUSTOM_TYPE = "session-schedule";
+export const SESSION_SCHEDULE_MESSAGE_TYPE = "session-schedule-wake";
+
+/** Largest delay Bun can represent without firing its timeout almost immediately. */
+export const SESSION_SCHEDULE_MAX_DELAY_MS = 2_147_483_647;
+
+/** Create payload persisted via appendCustomEntry. */
+export type SessionScheduleCreateData = {
+	id: string;
+	dueAtMs: number;
+	prompt: string;
+	createdAt: number;
+};
+
+/** Cancellation tombstone for the same id. */
+export type SessionScheduleCancelData = {
+	id: string;
+	cancelled: true;
+};
+
+/** Fired tombstone so restore does not re-arm an already-delivered wake. */
+export type SessionScheduleFiredData = {
+	id: string;
+	fired: true;
+};
+
+export type SessionScheduleData = SessionScheduleCreateData | SessionScheduleCancelData | SessionScheduleFiredData;
+
+export type SessionScheduleClassification =
+	| { kind: "create"; data: SessionScheduleCreateData }
+	| { kind: "cancel"; data: SessionScheduleCancelData }
+	| { kind: "fired"; data: SessionScheduleFiredData };
+
+/** Pending wake after the newest-per-id fold drops cancelled and fired ids. */
+export type PendingSessionSchedule = SessionScheduleCreateData;
+
+export type SessionScheduleCreateInput = {
+	delayMs?: number;
+	atIso?: string;
+	prompt: string;
+};
+
+/** Timer surface compatible with {@link ManagedTimers}. */
+export type SessionScheduleTimerHost = Pick<ManagedTimers, "setTimeout" | "clear">;
+
+/**
+ * Fire host — mirrors GoalRuntimeHost.sendHiddenMessage and adds the persistence
+ * + triggerTurn hooks schedules need. Orchestrator wires this from AgentSession.
+ */
+export type SessionScheduleFireHost = {
+	getEntries: () => readonly SessionEntry[];
+	appendCustomEntry: (customType: string, data?: unknown) => string;
+	flush?: () => Promise<void>;
+	sendHiddenMessage: (message: {
+		customType: string;
+		content: string;
+		deliverAs?: "steer" | "followUp" | "nextTurn";
+		triggerTurn?: boolean;
+	}) => Promise<void>;
+	now?: () => number;
+	isLive?: () => boolean;
+};
+
+export type ArmSessionSchedulesResult = {
+	pending: PendingSessionSchedule[];
+	disarm: () => void;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Classify a custom-entry payload; unknown shapes are ignored (not authoritative). */
+export function classifySessionScheduleData(data: unknown): SessionScheduleClassification | undefined {
+	if (!isRecord(data) || typeof data.id !== "string" || data.id.length === 0) return undefined;
+
+	if (data.cancelled === true) {
+		return { kind: "cancel", data: { id: data.id, cancelled: true } };
+	}
+	if (data.fired === true) {
+		return { kind: "fired", data: { id: data.id, fired: true } };
+	}
+	if (
+		isFiniteNumber(data.dueAtMs) &&
+		typeof data.prompt === "string" &&
+		data.prompt.length > 0 &&
+		isFiniteNumber(data.createdAt)
+	) {
+		return {
+			kind: "create",
+			data: {
+				id: data.id,
+				dueAtMs: data.dueAtMs,
+				prompt: data.prompt,
+				createdAt: data.createdAt,
+			},
+		};
+	}
+	return undefined;
+}
+
+/**
+ * Newest entry per id wins. Cancelled and fired ids are dropped; overdue creates
+ * remain pending so restore can fire them once at the next turn boundary.
+ */
+export function foldPendingSessionSchedules(entries: readonly SessionEntry[]): PendingSessionSchedule[] {
+	const newest = new Map<string, SessionScheduleClassification>();
+	for (const entry of entries) {
+		if (entry.type !== "custom" || entry.customType !== SESSION_SCHEDULE_CUSTOM_TYPE) continue;
+		const classified = classifySessionScheduleData(entry.data);
+		if (!classified) continue;
+		newest.set(classified.data.id, classified);
+	}
+
+	const pending: PendingSessionSchedule[] = [];
+	for (const classified of newest.values()) {
+		switch (classified.kind) {
+			case "create":
+				pending.push(classified.data);
+				break;
+			case "cancel":
+			case "fired":
+				break;
+			default: {
+				const _exhaustive: never = classified;
+				void _exhaustive;
+				break;
+			}
+		}
+	}
+	return pending;
+}
+
+export function resolveScheduleDueAtMs(
+	input: SessionScheduleCreateInput,
+	nowMs: number,
+): { dueAtMs: number } | { error: string } {
+	const hasDelay = input.delayMs !== undefined;
+	const hasAt = input.atIso !== undefined;
+	if (hasDelay === hasAt) {
+		return { error: "Exactly one of delayMs or atIso must be supplied." };
+	}
+	if (hasDelay) {
+		const delayMs = input.delayMs;
+		if (delayMs === undefined || !Number.isInteger(delayMs) || delayMs < 0) {
+			return { error: "delayMs must be a non-negative integer." };
+		}
+		if (delayMs > SESSION_SCHEDULE_MAX_DELAY_MS) {
+			return { error: `delayMs must not exceed ${SESSION_SCHEDULE_MAX_DELAY_MS}.` };
+		}
+		return { dueAtMs: nowMs + delayMs };
+	}
+	const atIso = input.atIso;
+	if (atIso === undefined || atIso.trim().length === 0) {
+		return { error: "atIso must be a non-empty ISO-8601 timestamp." };
+	}
+	const parsed = Date.parse(atIso);
+	if (!Number.isFinite(parsed)) {
+		return { error: `atIso is not a valid ISO-8601 timestamp: ${atIso}` };
+	}
+	if (parsed <= nowMs) {
+		return { error: "atIso must be in the future." };
+	}
+	if (parsed - nowMs > SESSION_SCHEDULE_MAX_DELAY_MS) {
+		return { error: `atIso must not be more than ${SESSION_SCHEDULE_MAX_DELAY_MS}ms in the future.` };
+	}
+	return { dueAtMs: parsed };
+}
+
+async function persistFiredAndEnqueue(
+	host: SessionScheduleFireHost,
+	schedule: PendingSessionSchedule,
+	triggerTurn: boolean,
+	isArmLive: () => boolean,
+): Promise<void> {
+	if (!isArmLive() || (host.isLive && !host.isLive())) return;
+	const stillPending = foldPendingSessionSchedules(host.getEntries()).some(entry => entry.id === schedule.id);
+	if (!stillPending) return;
+
+	const firedEntryId = host.appendCustomEntry(SESSION_SCHEDULE_CUSTOM_TYPE, {
+		id: schedule.id,
+		fired: true,
+	} satisfies SessionScheduleFiredData);
+	if (host.flush) await host.flush();
+	if ((host.isLive && !host.isLive()) || !host.getEntries().some(entry => entry.id === firedEntryId)) return;
+
+	await host.sendHiddenMessage({
+		customType: SESSION_SCHEDULE_MESSAGE_TYPE,
+		content: schedule.prompt,
+		deliverAs: "nextTurn",
+		triggerTurn,
+	});
+}
+
+/**
+ * Arm one timeout per pending schedule. A schedule whose dueAtMs has already
+ * passed fires once at the next turn boundary (triggerTurn: false) rather than
+ * being dropped or re-armed as a late repeating wake.
+ */
+export function armSessionSchedules(
+	entries: readonly SessionEntry[],
+	timers: SessionScheduleTimerHost,
+	host: SessionScheduleFireHost,
+	options?: { now?: () => number },
+): ArmSessionSchedulesResult {
+	const now = options?.now ?? (() => host.now?.() ?? Date.now());
+	const pending = foldPendingSessionSchedules(entries);
+	const armed = new Map<string, Timer>();
+	let active = true;
+
+	const disarm = (): void => {
+		active = false;
+		for (const timer of armed.values()) timers.clear(timer);
+		armed.clear();
+	};
+
+	const armOne = (schedule: PendingSessionSchedule): void => {
+		const dueAtMs = schedule.dueAtMs;
+		const nowMs = now();
+		const overdue = dueAtMs <= nowMs;
+		const delayMs = overdue ? 0 : Math.max(0, dueAtMs - nowMs);
+		// Overdue: enqueue as nextTurn context without starting a turn (boundary).
+		// Future: wake the session when the timer fires.
+		const triggerTurn = !overdue;
+		if (!overdue && delayMs > SESSION_SCHEDULE_MAX_DELAY_MS) {
+			logger.warn("session-schedule not armed: persisted delay exceeds timer maximum", {
+				id: schedule.id,
+				dueAtMs,
+				delayMs,
+			});
+			return;
+		}
+
+		const timer = timers.setTimeout(() => {
+			armed.delete(schedule.id);
+			void persistFiredAndEnqueue(host, schedule, triggerTurn, () => active).catch(err => {
+				logger.warn("session-schedule fire failed", {
+					id: schedule.id,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			});
+		}, delayMs);
+		armed.set(schedule.id, timer);
+	};
+
+	for (const schedule of pending) armOne(schedule);
+
+	return { pending, disarm };
+}
+
+/** Live controller: create/cancel persist first, then (re)arm timers. */
+export class SessionScheduleController {
+	readonly #timers: SessionScheduleTimerHost;
+	readonly #host: SessionScheduleFireHost;
+	readonly #now: () => number;
+	#disarm: (() => void) | undefined;
+	#disposed = false;
+
+	constructor(timers: SessionScheduleTimerHost, host: SessionScheduleFireHost, now?: () => number) {
+		this.#timers = timers;
+		this.#host = host;
+		this.#now = now ?? (() => host.now?.() ?? Date.now());
+	}
+
+	listPending(entries: readonly SessionEntry[] = this.#host.getEntries()): PendingSessionSchedule[] {
+		return foldPendingSessionSchedules(entries);
+	}
+
+	/** Disarm previous timers and arm every currently pending schedule. */
+	rearmFromEntries(entries: readonly SessionEntry[] = this.#host.getEntries()): PendingSessionSchedule[] {
+		this.#assertLive();
+		this.#disarm?.();
+		const result = armSessionSchedules(entries, this.#timers, this.#host, { now: this.#now });
+		this.#disarm = result.disarm;
+		return result.pending;
+	}
+
+	create(input: SessionScheduleCreateInput): PendingSessionSchedule {
+		this.#assertLive();
+		const prompt = input.prompt.trim();
+		if (!prompt) throw new Error("prompt must be a non-empty string.");
+
+		const nowMs = this.#now();
+		const due = resolveScheduleDueAtMs(input, nowMs);
+		if ("error" in due) throw new Error(due.error);
+
+		const schedule: PendingSessionSchedule = {
+			id: String(Snowflake.next()),
+			dueAtMs: due.dueAtMs,
+			prompt,
+			createdAt: nowMs,
+		};
+		this.#host.appendCustomEntry(SESSION_SCHEDULE_CUSTOM_TYPE, schedule);
+		this.rearmFromEntries();
+		return schedule;
+	}
+
+	cancel(id: string): boolean {
+		this.#assertLive();
+		const trimmed = id.trim();
+		if (!trimmed) throw new Error("cancel id must be a non-empty string.");
+
+		const pending = this.listPending();
+		const existed = pending.some(schedule => schedule.id === trimmed);
+		this.#host.appendCustomEntry(SESSION_SCHEDULE_CUSTOM_TYPE, {
+			id: trimmed,
+			cancelled: true,
+		} satisfies SessionScheduleCancelData);
+		this.rearmFromEntries();
+		return existed;
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#disarm?.();
+		this.#disarm = undefined;
+	}
+
+	#assertLive(): void {
+		if (this.#disposed) throw new Error("SessionScheduleController has been disposed.");
+	}
+}
+
+/**
+ * Named init the orchestrator calls from AgentSession construction and after
+ * newSession/switchSession.
+ */
+export function initSessionSchedules(
+	entries: readonly SessionEntry[],
+	timers: SessionScheduleTimerHost,
+	host: SessionScheduleFireHost,
+	options?: { now?: () => number },
+): SessionScheduleController {
+	const controller = new SessionScheduleController(timers, host, options?.now);
+	controller.rearmFromEntries(entries);
+	return controller;
+}

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -27,6 +27,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"reflect",
 	"learn",
 	"manage_skill",
+	"schedule",
 ] as const;
 
 export type BuiltinToolName = (typeof BUILTIN_TOOL_NAMES)[number];

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -27,6 +27,7 @@ import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
 import type { UsageStatistics } from "../session/session-entries";
 import type { SessionManager } from "../session/session-manager";
+import type { SessionScheduleController } from "../session/session-schedule";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
@@ -59,6 +60,7 @@ import { MemoryRetainTool } from "./memory-retain";
 import { wrapToolWithMetaNotice } from "./output-meta";
 import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
+import { ScheduleTool } from "./schedule";
 import { type TodoPhase, TodoTool } from "./todo";
 import { WriteTool } from "./write";
 import { isMountableUnderXdev, XdevRegistry } from "./xdev";
@@ -217,6 +219,8 @@ export interface ToolSession {
 	restrictToolNames?: boolean;
 	/** Task recursion depth (0 = top-level, 1 = first child, etc.) */
 	taskDepth?: number;
+	/** Whether this tool session owns the top-level agent turn loop. */
+	isTopLevelSession?(): boolean;
 	/** Get shared eval executor session ID. Subagents inherit this to share JS/Python/Ruby/Julia state. */
 	getEvalSessionId?: () => string | null;
 	/** Get session file */
@@ -300,6 +304,8 @@ export interface ToolSession {
 	getGoalModeState?: () => GoalModeState | undefined;
 	/** Goal runtime for the active agent session. */
 	getGoalRuntime?: () => GoalRuntime | undefined;
+	/** Live one-shot wake controller for the active top-level agent session. */
+	getSessionSchedule?: () => SessionScheduleController | undefined;
 	/** Get cumulative session usage statistics (input/output tokens, cost). */
 	getUsageStatistics?: () => UsageStatistics;
 	/** Current per-turn token budget {total, spent, hard} for the eval `budget` helper. */
@@ -416,6 +422,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	reflect: MemoryReflectTool.createIf,
 	learn: LearnTool.createIf,
 	manage_skill: ManageSkillTool.createIf,
+	schedule: ScheduleTool.createIf,
 };
 
 export const HIDDEN_TOOLS: Record<HiddenToolName, ToolFactory> = {
@@ -540,6 +547,15 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 				requestedTools.push("learn");
 			}
 		}
+		// Wakes are delivered into the top-level session's turn loop, so a subagent
+		// session would die before its own schedule ever fired.
+		if (
+			session.settings.get("schedule.enabled") &&
+			session.isTopLevelSession?.() === true &&
+			!requestedTools.includes("schedule")
+		) {
+			requestedTools.push("schedule");
+		}
 	}
 	const allTools: Record<string, ToolFactory> = { ...BUILTIN_TOOLS, ...HIDDEN_TOOLS };
 	const isToolAllowed = (name: string) => {
@@ -571,6 +587,8 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		}
 		if (name === "memory_edit") return session.settings.get("memory.backend") === "mnemopi";
 		if (name === "manage_skill") return session.settings.get("autolearn.enabled") && (session.taskDepth ?? 0) === 0;
+		if (name === "schedule")
+			return session.settings.get("schedule.enabled") && session.isTopLevelSession?.() === true;
 		if (name === "learn") {
 			return (
 				session.settings.get("autolearn.enabled") &&

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -27,6 +27,7 @@ import { inspectImageToolRenderer } from "./inspect-image-renderer";
 import { recallToolRenderer, reflectToolRenderer, retainToolRenderer } from "./memory-render";
 import { readToolRenderer } from "./read";
 import { resolveRenderer } from "./resolve";
+import { scheduleToolRenderer } from "./schedule";
 import { todoToolRenderer } from "./todo";
 import { createVibeToolRenderer } from "./vibe";
 import { writeToolRenderer } from "./write";
@@ -118,6 +119,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	todo: todoToolRenderer as ToolRenderer,
 	github: githubToolRenderer as ToolRenderer,
 	goal: goalToolRenderer as ToolRenderer,
+	schedule: scheduleToolRenderer as ToolRenderer,
 	web_search: webSearchToolRenderer as ToolRenderer,
 	vibe_spawn: createVibeToolRenderer("spawn") as ToolRenderer,
 	vibe_send: createVibeToolRenderer("send") as ToolRenderer,

--- a/packages/coding-agent/src/tools/schedule.ts
+++ b/packages/coding-agent/src/tools/schedule.ts
@@ -1,0 +1,226 @@
+/**
+ * Builtin `schedule` tool — one-shot session self-wake via session-schedule entries.
+ *
+ * Opt-in: the orchestrator gates construction/enablement on `schedule.enabled`
+ * (default false). This module only exports the tool + renderer.
+ */
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type { Component } from "@oh-my-pi/pi-tui";
+import { Text } from "@oh-my-pi/pi-tui";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme } from "../modes/theme/theme";
+import scheduleDescription from "../prompts/tools/schedule.md" with { type: "text" };
+import { resolveScheduleDueAtMs } from "../session/session-schedule";
+import { framedBlock, renderStatusLine, truncateToWidth } from "../tui";
+import type { ToolSession } from ".";
+import type { OutputMeta } from "./output-meta";
+import { formatErrorDetail, TRUNCATE_LENGTHS } from "./render-utils";
+import { ToolError } from "./tool-errors";
+import { toolResult } from "./tool-result";
+
+const scheduleSchema = type({
+	"delayMs?": type("number.integer >= 0").describe("relative delay in milliseconds"),
+	"atIso?": type("string").describe("absolute due time as ISO-8601"),
+	"prompt?": type("string").describe("prompt enqueued when the schedule fires"),
+	"cancel?": type("string").describe("id of a pending schedule to cancel"),
+});
+
+export type ScheduleToolInput = typeof scheduleSchema.infer;
+
+export type ScheduleToolDetails =
+	| {
+			op: "create";
+			id: string;
+			dueAtMs: number;
+			prompt: string;
+			createdAt: number;
+			meta?: OutputMeta;
+	  }
+	| {
+			op: "cancel";
+			id: string;
+			cancelled: boolean;
+			meta?: OutputMeta;
+	  };
+
+function validateCreateInput(params: ScheduleToolInput): {
+	delayMs?: number;
+	atIso?: string;
+	prompt: string;
+} {
+	const promptText = params.prompt?.trim();
+	if (!promptText) {
+		throw new ToolError("prompt is required when creating a schedule.");
+	}
+	const input = {
+		delayMs: params.delayMs,
+		atIso: params.atIso,
+		prompt: promptText,
+	};
+	// Reuse the fold's due-time rules so the tool cannot drift from them; the
+	// resolved time is discarded because the live controller resolves against its
+	// own clock, but every rejection surfaces here as a ToolError.
+	const due = resolveScheduleDueAtMs(input, Date.now());
+	if ("error" in due) throw new ToolError(due.error);
+	return input;
+}
+
+function validateCancelInput(params: ScheduleToolInput): string {
+	const id = params.cancel?.trim();
+	if (!id) throw new ToolError("cancel must be a non-empty schedule id.");
+	if (params.delayMs !== undefined || params.atIso !== undefined || params.prompt !== undefined) {
+		throw new ToolError("cancel cannot be combined with delayMs, atIso, or prompt.");
+	}
+	return id;
+}
+
+export class ScheduleTool implements AgentTool<typeof scheduleSchema, ScheduleToolDetails> {
+	readonly name = "schedule";
+	readonly approval = "write" as const;
+	readonly label = "Schedule";
+	readonly summary = "Schedule a one-shot wake prompt for this session";
+	readonly description: string;
+	readonly parameters = scheduleSchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable";
+	readonly intent = (args: Partial<ScheduleToolInput>) =>
+		args.cancel ? `cancel schedule ${args.cancel}` : args.prompt ? `schedule: ${args.prompt}` : "schedule";
+
+	readonly #session: ToolSession;
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+		this.description = prompt.render(scheduleDescription);
+	}
+
+	static createIf(session: ToolSession): ScheduleTool | null {
+		if (!session.settings.get("schedule.enabled") || session.isTopLevelSession?.() !== true) return null;
+		return new ScheduleTool(session);
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: ScheduleToolInput,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<ScheduleToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<ScheduleToolDetails>> {
+		if (params.cancel !== undefined) {
+			const id = validateCancelInput(params);
+			const controller = this.#session.getSessionSchedule?.();
+			if (!controller) throw new ToolError("Session schedule controller is unavailable.");
+			const cancelled = controller.cancel(id);
+			return toolResult<ScheduleToolDetails>({ op: "cancel", id, cancelled })
+				.text(cancelled ? `Cancelled schedule ${id}.` : `No pending schedule ${id}; cancel recorded.`)
+				.done();
+		}
+
+		const input = validateCreateInput(params);
+		const controller = this.#session.getSessionSchedule?.();
+		if (!controller) throw new ToolError("Session schedule controller is unavailable.");
+		const created = controller.create(input);
+
+		const dueLabel = new Date(created.dueAtMs).toISOString();
+		return toolResult<ScheduleToolDetails>({
+			op: "create",
+			id: created.id,
+			dueAtMs: created.dueAtMs,
+			prompt: created.prompt,
+			createdAt: created.createdAt,
+		})
+			.text(`Scheduled ${created.id} for ${dueLabel}.`)
+			.done();
+	}
+}
+
+interface ScheduleRenderArgs {
+	delayMs?: number;
+	atIso?: string;
+	prompt?: string;
+	cancel?: string;
+}
+
+function describeCall(args: ScheduleRenderArgs | undefined): string {
+	if (args?.cancel) return "cancel";
+	if (args?.delayMs !== undefined) return `in ${args.delayMs}ms`;
+	if (args?.atIso) return `at ${args.atIso}`;
+	return "create";
+}
+
+export const scheduleToolRenderer = {
+	renderCall(args: ScheduleRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		const description = describeCall(args);
+		const meta: string[] = [];
+		const trimmed = args?.prompt?.trim();
+		if (trimmed) {
+			meta.push(uiTheme.italic(uiTheme.fg("muted", `"${truncateToWidth(trimmed, TRUNCATE_LENGTHS.TITLE)}"`)));
+		}
+		if (args?.cancel) {
+			meta.push(uiTheme.fg("muted", args.cancel));
+		}
+		return new Text(renderStatusLine({ icon: "pending", title: "Schedule", description, meta }, uiTheme), 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: ScheduleToolDetails; isError?: boolean },
+		_options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: ScheduleRenderArgs,
+	): Component {
+		const fallbackText = result.content?.find(part => part.type === "text")?.text ?? "";
+		const details = result.details;
+		let description: string;
+		if (details?.op === "cancel") {
+			description = "cancel";
+		} else if (details?.op === "create") {
+			description = "create";
+		} else {
+			description = describeCall(args);
+		}
+
+		if (result.isError) {
+			const header = renderStatusLine({ icon: "error", title: "Schedule", description }, uiTheme);
+			return framedBlock(uiTheme, width => ({
+				header,
+				sections: [{ lines: formatErrorDetail(fallbackText || "Schedule tool failed", uiTheme).split("\n") }],
+				state: "error",
+				borderColor: "error",
+				width,
+			}));
+		}
+
+		const meta: string[] = [];
+		if (details) {
+			switch (details.op) {
+				case "create":
+					meta.push(uiTheme.fg("muted", details.id));
+					meta.push(uiTheme.fg("muted", new Date(details.dueAtMs).toISOString()));
+					break;
+				case "cancel":
+					meta.push(uiTheme.fg("muted", details.id));
+					break;
+				default: {
+					const _exhaustive: never = details;
+					void _exhaustive;
+					break;
+				}
+			}
+		}
+
+		return new Text(
+			renderStatusLine(
+				{
+					icon: "success",
+					title: "Schedule",
+					description,
+					meta,
+				},
+				uiTheme,
+			),
+			0,
+			0,
+		);
+	},
+};

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -103,6 +103,7 @@ describe("AgentSession handoff", () => {
 			settings: Settings.isolated({
 				"compaction.enabled": true,
 				"compaction.autoContinue": false,
+				"schedule.enabled": true,
 			}),
 			modelRegistry,
 			obfuscator,
@@ -161,6 +162,20 @@ describe("AgentSession handoff", () => {
 		expect(events.filter(event => event.type === "auto_compaction_start")).toHaveLength(0);
 		expect(events.filter(event => event.type === "auto_compaction_end")).toHaveLength(0);
 		expect(sessionManager.getEntries().filter(entry => entry.type === "compaction")).toHaveLength(0);
+	});
+
+	it("re-arms schedules after handoff replaces the transcript", async () => {
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockResolvedValue("## Goal\nContinue from here");
+		const oldController = session.getSessionSchedule();
+		if (!oldController) throw new Error("Expected initial schedule controller");
+		oldController.create({ delayMs: 60_000, prompt: "old transcript wake" });
+
+		await session.handoff();
+
+		const replacementController = session.getSessionSchedule();
+		expect(replacementController).toBeDefined();
+		expect(replacementController).not.toBe(oldController);
+		expect(replacementController?.listPending()).toEqual([]);
 	});
 
 	it("clears staged preview state when handoff creates the replacement session", async () => {

--- a/packages/coding-agent/test/session/session-schedule.test.ts
+++ b/packages/coding-agent/test/session/session-schedule.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Contracts for session self-scheduling: fold, arming, controller fire/cancel/restore,
+ * overdue turn-boundary delivery, due-time resolution, and schedule-tool input validation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { ManagedTimers } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/managed-timers";
+import type { CustomEntry, SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import {
+	armSessionSchedules,
+	foldPendingSessionSchedules,
+	resolveScheduleDueAtMs,
+	SESSION_SCHEDULE_CUSTOM_TYPE,
+	SESSION_SCHEDULE_MAX_DELAY_MS,
+	SESSION_SCHEDULE_MESSAGE_TYPE,
+	SessionScheduleController,
+	type SessionScheduleFireHost,
+} from "@oh-my-pi/pi-coding-agent/session/session-schedule";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ScheduleTool } from "@oh-my-pi/pi-coding-agent/tools/schedule";
+import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+import { logger } from "@oh-my-pi/pi-utils";
+
+type HiddenMessage = {
+	customType: string;
+	content: string;
+	deliverAs?: "steer" | "followUp" | "nextTurn";
+	triggerTurn?: boolean;
+};
+
+async function flushMicrotasks(rounds = 8): Promise<void> {
+	for (let i = 0; i < rounds; i++) await Promise.resolve();
+}
+
+function scheduleCustomEntry(data: unknown, id = "entry"): CustomEntry {
+	return {
+		type: "custom",
+		customType: SESSION_SCHEDULE_CUSTOM_TYPE,
+		data,
+		id,
+		parentId: null,
+		timestamp: "1970-01-01T00:00:00.000Z",
+	};
+}
+
+function scheduleEntriesOf(entries: readonly SessionEntry[]): CustomEntry[] {
+	return entries.filter(
+		(entry): entry is CustomEntry => entry.type === "custom" && entry.customType === SESSION_SCHEDULE_CUSTOM_TYPE,
+	);
+}
+
+function createHarness(initialNowMs = 1_000_000) {
+	let nowMs = initialNowMs;
+	const entries: SessionEntry[] = [];
+	const hiddenMessages: HiddenMessage[] = [];
+	let entrySeq = 0;
+
+	const timers = new ManagedTimers((_event, _error) => {});
+	const host: SessionScheduleFireHost = {
+		getEntries: () => entries,
+		appendCustomEntry: (customType, data) => {
+			const id = `entry-${++entrySeq}`;
+			entries.push({
+				type: "custom",
+				customType,
+				data,
+				id,
+				parentId: null,
+				timestamp: new Date(nowMs).toISOString(),
+			});
+			return id;
+		},
+		sendHiddenMessage: async message => {
+			hiddenMessages.push({ ...message });
+		},
+	};
+
+	const controller = new SessionScheduleController(timers, host, () => nowMs);
+
+	return {
+		controller,
+		entries,
+		hiddenMessages,
+		timers,
+		host,
+		now: () => nowMs,
+		setNow: (next: number) => {
+			nowMs = next;
+		},
+		dispose: () => {
+			controller.dispose();
+			timers.clearAll();
+		},
+	};
+}
+
+describe("session-schedule", () => {
+	let harness: ReturnType<typeof createHarness> | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		harness = undefined;
+	});
+
+	afterEach(() => {
+		harness?.dispose();
+		harness = undefined;
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it("creating a schedule appends exactly one session-schedule entry and arms one timer", () => {
+		harness = createHarness(1_000_000);
+		const created = harness.controller.create({ delayMs: 2_000, prompt: "wake me" });
+
+		const scheduleEntries = scheduleEntriesOf(harness.entries);
+		expect(scheduleEntries).toHaveLength(1);
+		expect(scheduleEntries[0]?.data).toEqual({
+			id: created.id,
+			dueAtMs: 1_002_000,
+			prompt: "wake me",
+			createdAt: 1_000_000,
+		});
+		expect(vi.getTimerCount()).toBe(1);
+		expect(harness.controller.listPending()).toHaveLength(1);
+		expect(harness.hiddenMessages).toHaveLength(0);
+	});
+
+	it("advancing past dueAtMs enqueues exactly one hidden message with the stored prompt", async () => {
+		harness = createHarness(1_000_000);
+		const prompt = "check the build";
+		harness.controller.create({ delayMs: 1_500, prompt });
+
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(1_499);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(0);
+
+		vi.advanceTimersByTime(1);
+		await flushMicrotasks();
+
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]).toEqual({
+			customType: SESSION_SCHEDULE_MESSAGE_TYPE,
+			content: prompt,
+			deliverAs: "nextTurn",
+			triggerTurn: true,
+		});
+		expect(foldPendingSessionSchedules(harness.entries)).toEqual([]);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("cancelling before the deadline appends a cancel tombstone and fires nothing", async () => {
+		harness = createHarness(1_000_000);
+		const created = harness.controller.create({ delayMs: 5_000, prompt: "should not fire" });
+
+		expect(vi.getTimerCount()).toBe(1);
+		expect(harness.controller.cancel(created.id)).toBe(true);
+
+		const scheduleEntries = scheduleEntriesOf(harness.entries);
+		expect(scheduleEntries).toHaveLength(2);
+		expect(scheduleEntries[1]?.data).toEqual({ id: created.id, cancelled: true });
+		expect(harness.controller.listPending()).toHaveLength(0);
+		expect(vi.getTimerCount()).toBe(0);
+
+		vi.advanceTimersByTime(10_000);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(0);
+	});
+
+	it("re-fold after fire does not re-arm that id; a still-pending schedule does re-arm", async () => {
+		harness = createHarness(1_000_000);
+		const first = harness.controller.create({ delayMs: 1_000, prompt: "first wake" });
+
+		vi.advanceTimersByTime(1_000);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]?.content).toBe("first wake");
+		expect(vi.getTimerCount()).toBe(0);
+
+		// Fired tombstone keeps the id out of the pending fold.
+		expect(foldPendingSessionSchedules(harness.entries).some(entry => entry.id === first.id)).toBe(false);
+		harness.controller.rearmFromEntries();
+		expect(vi.getTimerCount()).toBe(0);
+
+		const second = harness.controller.create({ delayMs: 4_000, prompt: "second wake" });
+		expect(vi.getTimerCount()).toBe(1);
+		expect(foldPendingSessionSchedules(harness.entries).map(entry => entry.id)).toEqual([second.id]);
+
+		harness.controller.rearmFromEntries();
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(4_000);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(2);
+		expect(harness.hiddenMessages.map(message => message.content)).toEqual(["first wake", "second wake"]);
+	});
+
+	it("does not arm malformed persisted future entries beyond the timer maximum", () => {
+		harness = createHarness(1_000_000);
+		harness.entries.push(
+			scheduleCustomEntry({
+				id: "too-far",
+				dueAtMs: harness.now() + SESSION_SCHEDULE_MAX_DELAY_MS + 1,
+				prompt: "do not overflow",
+				createdAt: harness.now(),
+			}),
+		);
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		const armed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => harness!.now() });
+
+		expect(armed.pending.map(schedule => schedule.id)).toEqual(["too-far"]);
+		expect(vi.getTimerCount()).toBe(0);
+		expect(scheduleEntriesOf(harness.entries)).toHaveLength(1);
+		expect(harness.hiddenMessages).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(
+			"session-schedule not armed: persisted delay exceeds timer maximum",
+			expect.objectContaining({ id: "too-far" }),
+		);
+		armed.disarm();
+	});
+
+	it("does not deliver after a fire loses session liveness during flush", async () => {
+		harness = createHarness(1_000_000);
+		let live = true;
+		let releaseFlush: (() => void) | undefined;
+		const flushStarted = new Promise<void>(resolve => {
+			releaseFlush = resolve;
+		});
+		harness.host.isLive = () => live;
+		harness.host.flush = () => flushStarted;
+		harness.entries.push(
+			scheduleCustomEntry({ id: "liveness", dueAtMs: harness.now(), prompt: "must not deliver", createdAt: 0 }),
+		);
+		const nowMs = harness.now();
+		armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => nowMs });
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(scheduleEntriesOf(harness.entries)).toHaveLength(2);
+		live = false;
+		releaseFlush?.();
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toEqual([]);
+	});
+
+	it("does not deliver after the transcript branch changes during flush", async () => {
+		harness = createHarness(1_000_000);
+		const flush = Promise.withResolvers<void>();
+		harness.host.flush = () => flush.promise;
+		harness.entries.push(
+			scheduleCustomEntry({
+				id: "old-branch",
+				dueAtMs: harness.now(),
+				prompt: "must not cross branches",
+				createdAt: 0,
+			}),
+		);
+		armSessionSchedules(harness.entries, harness.timers, harness.host, { now: harness.now });
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(scheduleEntriesOf(harness.entries)).toHaveLength(2);
+
+		harness.host.getEntries = () => [];
+		flush.resolve();
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toEqual([]);
+	});
+
+	it("delivers a committed wake after an unrelated same-branch rearm during flush", async () => {
+		harness = createHarness(1_000_000);
+		const flush = Promise.withResolvers<void>();
+		harness.host.flush = () => flush.promise;
+		harness.entries.push(
+			scheduleCustomEntry({ id: "same-branch", dueAtMs: harness.now(), prompt: "deliver once", createdAt: 0 }),
+		);
+		const armed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: harness.now });
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		armed.disarm();
+		flush.resolve();
+		await flushMicrotasks();
+		expect(harness.hiddenMessages.map(message => message.content)).toEqual(["deliver once"]);
+	});
+
+	it("overdue creates stay pending after fold and fire once at the next turn boundary", async () => {
+		harness = createHarness(10_000);
+		harness.entries.push(
+			scheduleCustomEntry(
+				{
+					id: "overdue-1",
+					dueAtMs: 1_000,
+					prompt: "catch up",
+					createdAt: 0,
+				},
+				"seed-overdue",
+			),
+		);
+
+		const pending = foldPendingSessionSchedules(harness.entries);
+		expect(pending).toHaveLength(1);
+		expect(pending[0]?.id).toBe("overdue-1");
+
+		const armed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => harness!.now() });
+		expect(armed.pending).toHaveLength(1);
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]).toEqual({
+			customType: SESSION_SCHEDULE_MESSAGE_TYPE,
+			content: "catch up",
+			deliverAs: "nextTurn",
+			triggerTurn: false,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+
+		// Fired tombstone: another arm + zero-delay tick must not repeat delivery.
+		const rearmed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => harness!.now() });
+		expect(rearmed.pending).toHaveLength(0);
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(1);
+
+		armed.disarm();
+		rearmed.disarm();
+	});
+
+	it("resolveScheduleDueAtMs rejects both delayMs+atIso and neither", () => {
+		const neither = resolveScheduleDueAtMs({ prompt: "wake" }, 1_000);
+		expect(neither).toEqual({ error: "Exactly one of delayMs or atIso must be supplied." });
+
+		const both = resolveScheduleDueAtMs(
+			{
+				prompt: "wake",
+				delayMs: 500,
+				atIso: "2020-01-01T00:00:00.000Z",
+			},
+			1_000,
+		);
+		expect(both).toEqual({ error: "Exactly one of delayMs or atIso must be supplied." });
+
+		const fromDelay = resolveScheduleDueAtMs({ prompt: "wake", delayMs: 250 }, 1_000);
+		expect(fromDelay).toEqual({ dueAtMs: 1_250 });
+
+		const atMs = Date.parse("2020-01-01T00:00:00.000Z");
+		const fromAt = resolveScheduleDueAtMs({ prompt: "wake", atIso: "2020-01-01T00:00:00.000Z" }, atMs - 1);
+		expect(fromAt).toEqual({ dueAtMs: atMs });
+
+		expect(resolveScheduleDueAtMs({ prompt: "wake", atIso: new Date(atMs - 1).toISOString() }, atMs)).toEqual({
+			error: "atIso must be in the future.",
+		});
+
+		expect(resolveScheduleDueAtMs({ prompt: "wake", delayMs: SESSION_SCHEDULE_MAX_DELAY_MS + 1 }, 1_000)).toEqual({
+			error: `delayMs must not exceed ${SESSION_SCHEDULE_MAX_DELAY_MS}.`,
+		});
+		expect(
+			resolveScheduleDueAtMs(
+				{
+					prompt: "wake",
+					atIso: new Date(1_000 + SESSION_SCHEDULE_MAX_DELAY_MS + 1).toISOString(),
+				},
+				1_000,
+			),
+		).toEqual({ error: `atIso must not be more than ${SESSION_SCHEDULE_MAX_DELAY_MS}ms in the future.` });
+	});
+
+	it("schedule tool input validation rejects both and neither create combinations", async () => {
+		const tool = new ScheduleTool({ cwd: "/tmp/schedule-test" } as ToolSession);
+
+		await expect(tool.execute("call-neither", { prompt: "wake" })).rejects.toBeInstanceOf(ToolError);
+		await expect(tool.execute("call-neither", { prompt: "wake" })).rejects.toThrow(
+			"Exactly one of delayMs or atIso must be supplied.",
+		);
+
+		await expect(
+			tool.execute("call-both", {
+				prompt: "wake",
+				delayMs: 100,
+				atIso: "2020-01-01T00:00:00.000Z",
+			}),
+		).rejects.toBeInstanceOf(ToolError);
+		await expect(
+			tool.execute("call-both-again", {
+				prompt: "wake",
+				delayMs: 100,
+				atIso: "2020-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow("Exactly one of delayMs or atIso must be supplied.");
+	});
+
+	it("only exposes schedule to top-level sessions", () => {
+		const settings = { get: () => true };
+		expect(
+			ScheduleTool.createIf({
+				cwd: "/tmp/schedule-test",
+				settings,
+				isTopLevelSession: () => true,
+			} as unknown as ToolSession),
+		).toBeInstanceOf(ScheduleTool);
+		expect(
+			ScheduleTool.createIf({
+				cwd: "/tmp/schedule-test",
+				settings,
+				isTopLevelSession: () => false,
+			} as unknown as ToolSession),
+		).toBeNull();
+	});
+
+	it("rejects creates and cancels when the live controller is unavailable", async () => {
+		const tool = new ScheduleTool({ cwd: "/tmp/schedule-test" } as ToolSession);
+
+		await expect(tool.execute("create", { prompt: "wake", delayMs: 1 })).rejects.toThrow(
+			"Session schedule controller is unavailable.",
+		);
+		await expect(tool.execute("cancel", { cancel: "schedule-1" })).rejects.toThrow(
+			"Session schedule controller is unavailable.",
+		);
+	});
+
+	it("forwards cancel ids to the live controller and reports unknown ids", async () => {
+		const cancel = vi.fn((id: string) => id === "known");
+		const tool = new ScheduleTool({
+			cwd: "/tmp/schedule-test",
+			getSessionSchedule: () => ({ cancel }) as never,
+		} as unknown as ToolSession);
+
+		const known = await tool.execute("cancel-known", { cancel: "known" });
+		const unknown = await tool.execute("cancel-unknown", { cancel: "unknown" });
+
+		expect(cancel).toHaveBeenNthCalledWith(1, "known");
+		expect(cancel).toHaveBeenNthCalledWith(2, "unknown");
+		expect(known.details).toMatchObject({ op: "cancel", id: "known", cancelled: true });
+		expect(unknown.details).toMatchObject({ op: "cancel", id: "unknown", cancelled: false });
+	});
+
+	it("rejects mixed cancel and create input before touching the controller", async () => {
+		const cancel = vi.fn(() => true);
+		const tool = new ScheduleTool({
+			cwd: "/tmp/schedule-test",
+			getSessionSchedule: () => ({ cancel }) as never,
+		} as unknown as ToolSession);
+
+		await expect(tool.execute("mixed", { cancel: "schedule-1", prompt: "wake", delayMs: 1 })).rejects.toThrow(
+			"cancel cannot be combined with delayMs, atIso, or prompt.",
+		);
+		expect(cancel).not.toHaveBeenCalled();
+	});
+
+	it("a tool-created schedule reaches the live controller and actually fires", async () => {
+		// Regression: the tool used to read its controller through a synthetic cast that was
+		// never populated on ToolSession, so every create silently took the controller-less
+		// fallback — the entry persisted but no timer was ever armed and the wake never fired.
+		harness = createHarness();
+		const local = harness;
+		const tool = new ScheduleTool({
+			cwd: "/tmp/schedule-test",
+			getSessionSchedule: () => local.controller,
+		} as ToolSession);
+
+		await tool.execute("call-1", { prompt: "wake up", delayMs: 5_000 });
+
+		local.setNow(local.now() + 5_000);
+		vi.advanceTimersByTime(5_000);
+		await flushMicrotasks();
+
+		expect(local.hiddenMessages).toHaveLength(1);
+		expect(local.hiddenMessages[0]?.content).toContain("wake up");
+	});
+
+	it("fold ignores unknown or garbage custom-entry payloads without throwing", () => {
+		const entries: SessionEntry[] = [
+			scheduleCustomEntry(undefined, "u1"),
+			scheduleCustomEntry(null, "u2"),
+			scheduleCustomEntry("not-an-object", "u3"),
+			scheduleCustomEntry({ id: "" }, "u4"),
+			scheduleCustomEntry({ id: "partial" }, "u5"),
+			scheduleCustomEntry({ id: "bad-due", dueAtMs: Number.NaN, prompt: "x", createdAt: 1 }, "u6"),
+			scheduleCustomEntry({ id: "empty-prompt", dueAtMs: 1, prompt: "", createdAt: 1 }, "u7"),
+			scheduleCustomEntry({ id: "cancel-noise", cancelled: "yes" }, "u8"),
+			{
+				type: "custom",
+				customType: "other-extension",
+				data: { id: "other", dueAtMs: 1, prompt: "ignore", createdAt: 1 },
+				id: "other",
+				parentId: null,
+				timestamp: "1970-01-01T00:00:00.000Z",
+			},
+			scheduleCustomEntry(
+				{
+					id: "good",
+					dueAtMs: 42,
+					prompt: "keep me",
+					createdAt: 7,
+				},
+				"good-entry",
+			),
+		];
+
+		expect(() => foldPendingSessionSchedules(entries)).not.toThrow();
+		expect(foldPendingSessionSchedules(entries)).toEqual([
+			{
+				id: "good",
+				dueAtMs: 42,
+				prompt: "keep me",
+				createdAt: 7,
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { BUILTIN_TOOLS, createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
 Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 
@@ -43,6 +43,27 @@ function createActiveGoalState() {
 describe("createTools", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("self-gates the public schedule factory", () => {
+		expect(BUILTIN_TOOLS.schedule(createTestSession())).toBeNull();
+		expect(
+			BUILTIN_TOOLS.schedule(
+				createTestSession({
+					settings: createSettingsWithOverrides({ "schedule.enabled": true }),
+					taskDepth: 1,
+				}),
+			),
+		).toBeNull();
+		expect(
+			BUILTIN_TOOLS.schedule(
+				createTestSession({
+					settings: createSettingsWithOverrides({ "schedule.enabled": true }),
+					taskDepth: 0,
+					isTopLevelSession: () => true,
+				}),
+			),
+		).not.toBeNull();
 	});
 
 	it("creates all builtin tools by default", async () => {


### PR DESCRIPTION
## Summary

A top-level session can now arm a one-shot wake that returns a stored prompt to the same conversation at a later time. Scheduling is opt-in and unavailable to child or clone sessions, so background turns cannot escape the session that owns them.

Pending intent lives in the transcript rather than timer memory alone. Resuming the same session re-arms valid pending wakes, while cancellation, firing, branch changes, handoffs, and disposal preserve at-most-once delivery. Deadlines beyond the runtime timer limit and non-future absolute timestamps fail before arming.

## Validation

- `bun --cwd=packages/coding-agent test test/session/session-schedule.test.ts test/tools/index.test.ts test/agent-session-handoff.test.ts` — 77 passed, 268 assertions
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:ts`
- Mutation check: removing the post-flush branch-membership guard makes the branch-change delivery regression test fail

Closes #6684
