### PR TITLE
feat(coding-agent): add interactive session lineage map

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `/qa`, an evidence-first verification pass that inventories the affected surface, exercises real checks, and reports findings with reproductions — making no edits unless asked afterwards.
 - Added a full-transcript search index. `/session search <question>` builds a lazy SQLite/FTS5 index over past session transcripts on first use and spawns a bundled `session-search` agent that answers with `{sessionId, entryId, quote}` citations. Once the index exists, the `/resume` picker also matches on full transcript content instead of only the first 4 KB of each session.
 - Added session tags: `/session tag`, `/session untag`, and `/session tags`.
+- Added `/session map`, an interactive lineage tree of session forks and handoffs with tags, project scope switching, and direct resume selection; ACP and RPC render the same map as plain text.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
 - Added `/qa`, an evidence-first verification pass that inventories the affected surface, exercises real checks, and reports findings with reproductions — making no edits unless asked afterwards.
+- Added a full-transcript search index. `/session search <question>` builds a lazy SQLite/FTS5 index over past session transcripts on first use and spawns a bundled `session-search` agent that answers with `{sessionId, entryId, quote}` citations. Once the index exists, the `/resume` picker also matches on full transcript content instead of only the first 4 KB of each session.
+- Added session tags: `/session tag`, `/session untag`, and `/session tags`.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added `/qa`, an evidence-first verification pass that inventories the affected surface, exercises real checks, and reports findings with reproductions — making no edits unless asked afterwards.
 
 ### Fixed
 

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -1,6 +1,6 @@
 import { ProcessTerminal, TUI } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
-import { SessionSelectorComponent } from "../modes/components/session-selector";
+import { createSessionRankingMatcher, SessionSelectorComponent } from "../modes/components/session-selector";
 import { HistoryStorage } from "../session/history-storage";
 import type { SessionInfo } from "../session/session-listing";
 import { SessionManager } from "../session/session-manager";
@@ -24,14 +24,17 @@ export async function selectSession(
 
 	// Rank sessions with prompt-history matches too, recovering prompts the 4KB
 	// session-list prefix never sees. Best-effort: a missing/locked history.db
-	// must not break the picker.
-	let historyMatcher: ((query: string) => string[]) | undefined;
+	// must not break the picker. Transcript hits fold in ahead of history matches
+	// through the same combined matcher as the in-editor /resume selector, so the
+	// two pickers cannot disagree.
+	let historyOnly: ((query: string) => string[]) | undefined;
 	try {
 		const history = HistoryStorage.open();
-		historyMatcher = (query: string) => history.matchingSessionIds(query);
+		historyOnly = (query: string) => history.matchingSessionIds(query);
 	} catch (error) {
 		logger.warn("History storage unavailable for session ranking", { error: String(error) });
 	}
+	const historyMatcher = createSessionRankingMatcher(historyOnly);
 
 	const showSelector = () => {
 		const selector = new SessionSelectorComponent(

--- a/packages/coding-agent/src/modes/components/index.ts
+++ b/packages/coding-agent/src/modes/components/index.ts
@@ -25,6 +25,7 @@ export * from "./oauth-selector";
 export * from "./queue-mode-selector";
 export * from "./read-tool-group";
 export * from "./segment-track";
+export * from "./session-map";
 export * from "./session-selector";
 export * from "./settings-selector";
 export * from "./show-images-selector";

--- a/packages/coding-agent/src/modes/components/session-map.ts
+++ b/packages/coding-agent/src/modes/components/session-map.ts
@@ -1,0 +1,546 @@
+import * as fs from "node:fs";
+import {
+	type Component,
+	Container,
+	matchesKey,
+	padding,
+	routeSgrMouseInput,
+	ScrollView,
+	Spacer,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
+import { getTranscriptDbPath } from "@oh-my-pi/pi-utils";
+import { theme } from "../../modes/theme/theme";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
+import { type SessionInfo, sessionDisplayName } from "../../session/session-listing";
+import { TranscriptIndex } from "../../session/transcript-index";
+import { shortenPath } from "../../tools/render-utils";
+import { DynamicBorder } from "./dynamic-border";
+
+/** How a child session relates to its parent — inferred from parentSession encoding. */
+export type SessionLineageKind = "fork" | "handoff";
+
+export interface SessionMapRow {
+	session: SessionInfo;
+	depth: number;
+	/** Fork/handoff marker for child rows; omitted for depth-0 roots (including cycle re-roots). */
+	lineage: SessionLineageKind | undefined;
+	tags: string[];
+}
+
+export interface SessionMapOptions {
+	/** Loads sessions across all projects for the all-projects scope toggle (Tab). */
+	loadAllSessions?: () => Promise<SessionInfo[]>;
+	/** Preloaded all-projects list; cached so the first Tab toggle is instant. */
+	allSessions?: SessionInfo[];
+	/**
+	 * Reads the live terminal height so the visible window fits the viewport.
+	 * Omitted only in tests; defaults to a conservative 24 rows.
+	 */
+	getTerminalRows?: () => number;
+	/**
+	 * Fill the whole viewport and pin the footer (hint + bottom border) to the
+	 * last rows. Set by the fullscreen overlay path.
+	 */
+	fillHeight?: boolean;
+	/** Optional tag lookup; when omitted, tags load from TranscriptIndex if its DB exists. */
+	tagsFor?: (sessionId: string) => string[];
+}
+
+/**
+ * fork()/forkFrom() persist parentSession as a session id; handoff (and tree
+ * branch-nav) persist a session file path. That encoding is the only SessionInfo
+ * signal available without new persistence — use it for the map marker.
+ */
+export function sessionLineageKind(parentRef: string): SessionLineageKind {
+	if (parentRef.endsWith(".jsonl") || parentRef.includes("/") || parentRef.includes("\\")) {
+		return "handoff";
+	}
+	return "fork";
+}
+
+function compareSessionRecency(a: SessionInfo, b: SessionInfo): number {
+	return b.modified.getTime() - a.modified.getTime();
+}
+
+function resolveParent(
+	session: SessionInfo,
+	byPath: Map<string, SessionInfo>,
+	byId: Map<string, SessionInfo>,
+): SessionInfo | undefined {
+	const parentRef = session.parentSessionPath;
+	if (!parentRef) return undefined;
+	return byPath.get(parentRef) ?? byId.get(parentRef);
+}
+
+/** Open TranscriptIndex once when its DB exists; otherwise return no tags. */
+function createTagsLookup(): (sessionId: string) => string[] {
+	const dbPath = getTranscriptDbPath();
+	if (!fs.existsSync(dbPath)) return () => [];
+	try {
+		const index = TranscriptIndex.open(dbPath);
+		return (sessionId: string) => {
+			try {
+				return index.tagsFor(sessionId);
+			} catch {
+				return [];
+			}
+		};
+	} catch {
+		return () => [];
+	}
+}
+
+/**
+ * Build a depth-first forest from parentSessionPath edges. Roots are sessions
+ * whose parent is absent or outside the listed set. Cycles are broken by
+ * tracking visited paths on the current walk and emitting a repeat as a new
+ * root later rather than hanging.
+ */
+export function buildSessionMapRows(
+	sessions: SessionInfo[],
+	tagsFor: (sessionId: string) => string[] = createTagsLookup(),
+): SessionMapRow[] {
+	const byPath = new Map<string, SessionInfo>();
+	const byId = new Map<string, SessionInfo>();
+	for (const session of sessions) {
+		byPath.set(session.path, session);
+		byId.set(session.id, session);
+	}
+
+	const childrenOf = new Map<string, SessionInfo[]>();
+	const roots: SessionInfo[] = [];
+
+	for (const session of sessions) {
+		const parent = resolveParent(session, byPath, byId);
+		if (!parent) {
+			roots.push(session);
+			continue;
+		}
+		const list = childrenOf.get(parent.path);
+		if (list) list.push(session);
+		else childrenOf.set(parent.path, [session]);
+	}
+
+	for (const children of childrenOf.values()) {
+		children.sort(compareSessionRecency);
+	}
+	roots.sort(compareSessionRecency);
+
+	const rows: SessionMapRow[] = [];
+	const emitted = new Set<string>();
+
+	const walk = (session: SessionInfo, depth: number, ancestry: Set<string>): void => {
+		if (ancestry.has(session.path)) {
+			return;
+		}
+		if (emitted.has(session.path)) return;
+		emitted.add(session.path);
+
+		const parentRef = session.parentSessionPath;
+		// Depth-0 rows (natural roots and cycle re-roots) omit the marker so the
+		// forest reads cleanly; children keep fork vs handoff.
+		rows.push({
+			session,
+			depth,
+			lineage: depth > 0 && parentRef ? sessionLineageKind(parentRef) : undefined,
+			tags: tagsFor(session.id),
+		});
+
+		const nextAncestry = new Set(ancestry);
+		nextAncestry.add(session.path);
+		const children = childrenOf.get(session.path) ?? [];
+		for (const child of children) {
+			walk(child, depth + 1, nextAncestry);
+		}
+	};
+
+	for (const root of roots) {
+		walk(root, 0, new Set());
+	}
+
+	// Cycle-only components: no natural root, so promote each unemitted node.
+	const remaining = sessions.filter(session => !emitted.has(session.path)).sort(compareSessionRecency);
+	for (const session of remaining) {
+		if (emitted.has(session.path)) continue;
+		walk(session, 0, new Set());
+	}
+
+	return rows;
+}
+
+function formatLineageMarker(kind: SessionLineageKind | undefined, styled: boolean): string {
+	if (kind === undefined) return "";
+	switch (kind) {
+		case "fork":
+			return styled ? `${theme.icon.branch} fork` : "fork";
+		case "handoff":
+			return styled ? `${theme.icon.context} handoff` : "handoff";
+		default: {
+			const _exhaustive: never = kind;
+			return _exhaustive;
+		}
+	}
+}
+
+function formatTags(tags: string[]): string {
+	if (tags.length === 0) return "";
+	return tags.map(tag => `#${tag}`).join(" ");
+}
+
+function formatMapRowPlain(row: SessionMapRow): string {
+	// Plain ASCII — ACP/RPC may call this before TUI theme init.
+	const indent = "  ".repeat(row.depth);
+	const connector = row.depth > 0 ? "|- " : "";
+	const name = sessionDisplayName(row.session);
+	const parts = [`${indent}${connector}${name}`];
+	const marker = formatLineageMarker(row.lineage, false);
+	if (marker) parts.push(marker);
+	const tags = formatTags(row.tags);
+	if (tags) parts.push(tags);
+	return parts.join("  ");
+}
+
+/**
+ * Plain-text session forest for non-TUI `/session map` handlers (ACP/RPC).
+ * Same forest rules as the interactive panel.
+ */
+export function renderSessionMapText(sessions: SessionInfo[], tagsFor?: (sessionId: string) => string[]): string {
+	const rows = buildSessionMapRows(sessions, tagsFor ?? createTagsLookup());
+	if (rows.length === 0) return "No sessions.";
+	return rows.map(formatMapRowPlain).join("\n");
+}
+
+class SessionMapList implements Component {
+	#rows: SessionMapRow[] = [];
+	#selectedIndex = 0;
+	#hitRows: (number | undefined)[] = [];
+	#showCwd = false;
+	readonly #getTerminalRows: () => number;
+	readonly #tagsFor: (sessionId: string) => string[];
+
+	onSelect?: (session: SessionInfo) => void;
+	onCancel?: () => void;
+	onExit: () => void = () => {};
+	onToggleScope?: () => void;
+
+	constructor(
+		sessions: SessionInfo[],
+		showCwd = false,
+		getTerminalRows: () => number = () => 24,
+		tagsFor: (sessionId: string) => string[] = createTagsLookup(),
+	) {
+		this.#getTerminalRows = getTerminalRows;
+		this.#tagsFor = tagsFor;
+		this.#showCwd = showCwd;
+		this.#rows = buildSessionMapRows(sessions, tagsFor);
+	}
+
+	#visibleCount(): number {
+		const CHROME = 12;
+		const PER_ROW = 2;
+		const RESERVE = 1;
+		const budget = this.#getTerminalRows() - CHROME - RESERVE;
+		return Math.max(2, Math.floor(budget / PER_ROW));
+	}
+
+	setSessions(sessions: SessionInfo[], showCwd: boolean): void {
+		this.#showCwd = showCwd;
+		this.#rows = buildSessionMapRows(sessions, this.#tagsFor);
+		this.#selectedIndex = Math.min(this.#selectedIndex, Math.max(0, this.#rows.length - 1));
+	}
+
+	hitTestSession(line: number): number | undefined {
+		return this.#hitRows[line];
+	}
+
+	handleWheel(delta: -1 | 1): void {
+		if (this.#rows.length === 0) return;
+		this.#selectedIndex = Math.max(0, Math.min(this.#rows.length - 1, this.#selectedIndex + delta));
+	}
+
+	selectAndConfirm(index: number): void {
+		const row = this.#rows[index];
+		if (!row) return;
+		this.#selectedIndex = index;
+		this.onSelect?.(row.session);
+	}
+
+	invalidate(): void {}
+
+	render(width: number): readonly string[] {
+		const lines: string[] = [];
+		this.#hitRows = [];
+
+		if (this.#rows.length === 0) {
+			if (this.#showCwd) {
+				lines.push(truncateToWidth(theme.fg("muted", "  No sessions found"), width));
+			} else {
+				lines.push(
+					truncateToWidth(theme.fg("muted", "  No sessions in current folder. Press Tab to view all."), width),
+				);
+			}
+			return lines;
+		}
+
+		const maxVisible = this.#visibleCount();
+		const startIndex = Math.max(
+			0,
+			Math.min(this.#selectedIndex - Math.floor(maxVisible / 2), this.#rows.length - maxVisible),
+		);
+		const endIndex = Math.min(startIndex + maxVisible, this.#rows.length);
+
+		const sessionLines: string[] = [];
+		const sessionRowIndex: number[] = [];
+		const overflow = this.#rows.length > maxVisible;
+		const rowWidth = Math.max(0, width - (overflow ? 1 : 0));
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const blockStart = sessionLines.length;
+			const row = this.#rows[i]!;
+			const isSelected = i === this.#selectedIndex;
+			const cursorSymbol = `${theme.nav.cursor} `;
+			const cursorWidth = visibleWidth(cursorSymbol);
+			const cursor = isSelected ? theme.fg("accent", cursorSymbol) : padding(cursorWidth);
+			const maxWidth = rowWidth - cursorWidth;
+
+			const indent = "  ".repeat(row.depth);
+			const connector = row.depth > 0 ? `${theme.tree.branch} ` : "";
+			const name = sessionDisplayName(row.session);
+			const title = truncateToWidth(`${indent}${connector}${name}`, maxWidth);
+			sessionLines.push(cursor + (isSelected ? theme.bold(title) : title));
+
+			const dim = (s: string) => theme.fg("dim", s);
+			const dot = dim(theme.sep.dot);
+			const metaParts: string[] = [];
+			const marker = formatLineageMarker(row.lineage, true);
+			if (marker) metaParts.push(dim(marker));
+			const tags = formatTags(row.tags);
+			if (tags) metaParts.push(theme.fg("accent", tags));
+			if (this.#showCwd && row.session.cwd) {
+				metaParts.push(dim(shortenPath(row.session.cwd)));
+			}
+			if (metaParts.length > 0) {
+				const meta = truncateToWidth(`  ${metaParts.join(` ${dot} `)}`, rowWidth);
+				sessionLines.push(meta);
+			}
+			sessionLines.push("");
+			for (let k = blockStart; k < sessionLines.length; k++) sessionRowIndex[k] = i;
+		}
+
+		const visibleCount = endIndex - startIndex;
+		const linesPerItem = visibleCount > 0 ? sessionLines.length / visibleCount : 1;
+		const sv = new ScrollView(sessionLines, {
+			height: sessionLines.length,
+			scrollbar: "auto",
+			totalRows: Math.round(this.#rows.length * linesPerItem),
+			theme: { track: t => theme.fg("muted", t), thumb: t => theme.fg("accent", t) },
+		});
+		sv.setScrollOffset(Math.round(startIndex * linesPerItem));
+		const sessionRegionStart = lines.length;
+		const svLines = sv.render(width);
+		for (let k = 0; k < svLines.length; k++) this.#hitRows[sessionRegionStart + k] = sessionRowIndex[k];
+		lines.push(...svLines);
+		return lines;
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesSelectUp(keyData)) {
+			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
+			return;
+		}
+		if (matchesSelectDown(keyData)) {
+			this.#selectedIndex = Math.min(this.#rows.length - 1, this.#selectedIndex + 1);
+			return;
+		}
+		if (matchesKey(keyData, "pageUp")) {
+			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.#visibleCount());
+			return;
+		}
+		if (matchesKey(keyData, "pageDown")) {
+			this.#selectedIndex = Math.min(this.#rows.length - 1, this.#selectedIndex + this.#visibleCount());
+			return;
+		}
+		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
+			const row = this.#rows[this.#selectedIndex];
+			if (row && this.onSelect) this.onSelect(row.session);
+			return;
+		}
+		if (matchesAppInterrupt(keyData)) {
+			this.onCancel?.();
+			return;
+		}
+		if (matchesKey(keyData, "ctrl+c")) {
+			this.onExit();
+			return;
+		}
+		if (matchesKey(keyData, "tab")) {
+			this.onToggleScope?.();
+		}
+	}
+}
+
+/**
+ * Interactive session lineage map — same constructor/overlay conventions as
+ * {@link SessionSelectorComponent}, with Tab project/all scope toggle.
+ */
+export class SessionMapComponent extends Container {
+	#mapList: SessionMapList;
+	#headerText: Text;
+	#messageContainer: Container;
+	#onRequestRender?: () => void;
+	readonly #loadAllSessions?: () => Promise<SessionInfo[]>;
+	#folderSessions: SessionInfo[];
+	#globalSessions: SessionInfo[] | null = null;
+	#scope: "folder" | "all" = "folder";
+	#toggling = false;
+	#inputLocked = false;
+	#listLineOffset = 0;
+	#footerStart = 0;
+	readonly #getTerminalRows: () => number;
+	readonly #fillHeight: boolean;
+	readonly #bottomBorder = new DynamicBorder();
+
+	constructor(
+		sessions: SessionInfo[],
+		onSelect: (session: SessionInfo) => void,
+		onCancel: () => void,
+		onExit: () => void,
+		options: SessionMapOptions = {},
+	) {
+		super();
+
+		this.#messageContainer = new Container();
+		this.#loadAllSessions = options.loadAllSessions;
+		this.#folderSessions = sessions;
+		this.#globalSessions = options.allSessions ?? null;
+		this.#getTerminalRows = options.getTerminalRows ?? (() => 24);
+		this.#fillHeight = options.fillHeight ?? false;
+		const tagsFor = options.tagsFor ?? createTagsLookup();
+
+		this.addChild(new Spacer(1));
+		this.#headerText = new Text(this.#headerLabel(), 1, 0);
+		this.addChild(this.#headerText);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(this.#messageContainer);
+
+		this.#mapList = new SessionMapList(sessions, false, options.getTerminalRows, tagsFor);
+		this.#mapList.onSelect = session => {
+			onSelect(session);
+		};
+		this.#mapList.onCancel = () => {
+			onCancel();
+		};
+		this.#mapList.onExit = () => {
+			onExit();
+		};
+		if (this.#loadAllSessions || this.#globalSessions) {
+			this.#mapList.onToggleScope = () => {
+				void this.#toggleScope();
+			};
+		}
+		this.addChild(this.#mapList);
+	}
+
+	#headerLabel(): string {
+		const scopeLabel = this.#scope === "all" ? "all projects" : "current folder";
+		return `${theme.bold("Session Map")} ${theme.fg("muted", `(${scopeLabel})`)}`;
+	}
+
+	async #toggleScope(): Promise<void> {
+		if (this.#toggling) return;
+		if (this.#scope === "folder") {
+			let global = this.#globalSessions;
+			if (!global) {
+				if (!this.#loadAllSessions) return;
+				this.#toggling = true;
+				this.#messageContainer.clear();
+				this.#messageContainer.addChild(new Text(theme.fg("muted", "  Loading all projects…"), 1, 0));
+				this.#onRequestRender?.();
+				try {
+					global = await this.#loadAllSessions();
+				} catch (err) {
+					this.#messageContainer.clear();
+					this.#messageContainer.addChild(
+						new Text(theme.fg("error", `Error: ${err instanceof Error ? err.message : String(err)}`), 1, 0),
+					);
+					this.#toggling = false;
+					this.#onRequestRender?.();
+					return;
+				}
+				this.#globalSessions = global;
+				this.#messageContainer.clear();
+				this.#toggling = false;
+			}
+			this.#scope = "all";
+			this.#mapList.setSessions(global, true);
+		} else {
+			this.#scope = "folder";
+			this.#mapList.setSessions(this.#folderSessions, false);
+		}
+		this.#headerText.setText(this.#headerLabel());
+		this.#onRequestRender?.();
+	}
+
+	setOnRequestRender(callback: () => void): void {
+		this.#onRequestRender = callback;
+	}
+
+	lockInput(): void {
+		this.#inputLocked = true;
+	}
+
+	unlockInput(): void {
+		this.#inputLocked = false;
+	}
+
+	render(width: number): readonly string[] {
+		const lines: string[] = [];
+		for (const child of this.children) {
+			const childLines = child.render(width);
+			if (child === this.#mapList) this.#listLineOffset = lines.length;
+			for (const line of childLines) lines.push(line);
+		}
+		const footer = this.#footerLines(width);
+		if (this.#fillHeight) {
+			const target = Math.max(0, this.#getTerminalRows() - footer.length);
+			if (lines.length > target) lines.length = target;
+			else for (let i = lines.length; i < target; i++) lines.push("");
+		}
+		this.#footerStart = lines.length;
+		for (const line of footer) lines.push(line);
+		return lines;
+	}
+
+	#footerLines(width: number): string[] {
+		const scopeHint = this.#scope === "all" ? "current folder" : "all projects";
+		const hint = theme.fg("muted", `  [Enter select · Tab ${scopeHint} · Esc cancel]`);
+		return ["", hint, "", ...this.#bottomBorder.render(width)];
+	}
+
+	handleInput(keyData: string): void {
+		if (this.#inputLocked) return;
+		if (keyData.startsWith("\x1b[<")) {
+			this.#handleMouse(keyData);
+			return;
+		}
+		this.#mapList.handleInput(keyData);
+	}
+
+	#handleMouse(data: string): void {
+		routeSgrMouseInput(data, event => {
+			if (event.wheel !== null) {
+				this.#mapList.handleWheel(event.wheel);
+				return true;
+			}
+			if (!event.leftClick || event.row >= this.#footerStart) return true;
+			const index = this.#mapList.hitTestSession(event.row - this.#listLineOffset);
+			if (index !== undefined) this.#mapList.selectAndConfirm(index);
+			return true;
+		});
+	}
+}

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -239,13 +239,14 @@ export function mergeSessionRanking(
  */
 export function createSessionRankingMatcher(
 	historyMatcher: SessionHistoryMatcher | undefined,
+	sessionDir?: string,
 ): SessionHistoryMatcher | undefined {
 	const transcriptDbPath = getTranscriptDbPath();
 	if (!fs.existsSync(transcriptDbPath)) return historyMatcher;
 	return (query: string) => {
 		const historyIds = historyMatcher?.(query) ?? [];
 		try {
-			return [...TranscriptIndex.open(transcriptDbPath).matchingSessionIds(query), ...historyIds];
+			return [...TranscriptIndex.open(transcriptDbPath).matchingSessionIds(query, { sessionDir }), ...historyIds];
 		} catch (error) {
 			logger.warn("Transcript index unavailable for session ranking", { error: String(error) });
 			return historyIds;

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import {
 	type Component,
 	Container,
@@ -13,10 +14,11 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
-import { formatBytes } from "@oh-my-pi/pi-utils";
+import { formatBytes, getTranscriptDbPath, logger } from "@oh-my-pi/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { SessionInfo, SessionStatus } from "../../session/session-listing";
+import { TranscriptIndex } from "../../session/transcript-index";
 import { shortenPath } from "../../tools/render-utils";
 import { DynamicBorder } from "./dynamic-border";
 import { HookSelectorComponent } from "./hook-selector";
@@ -223,6 +225,32 @@ export function mergeSessionRanking(
 
 	const metadataOnly = fuzzy.filter(session => !historyPaths.has(session.path));
 	return [...historyMatches, ...metadataOnly];
+}
+
+/**
+ * Rank sessions with transcript-index matches ahead of prompt-history matches.
+ *
+ * Transcript matches are opt-in: `transcripts.db` exists only after `/session
+ * search` has run, so the file is probed once here at selector build and the
+ * index is never created. Both pickers share this matcher so they cannot
+ * disagree; a missing or unreadable index degrades to history matches alone.
+ * Ordering is significant — transcript hits lead — while duplicates are left to
+ * `mergeSessionRanking`, which resolves IDs to sessions and dedupes by path.
+ */
+export function createSessionRankingMatcher(
+	historyMatcher: SessionHistoryMatcher | undefined,
+): SessionHistoryMatcher | undefined {
+	const transcriptDbPath = getTranscriptDbPath();
+	if (!fs.existsSync(transcriptDbPath)) return historyMatcher;
+	return (query: string) => {
+		const historyIds = historyMatcher?.(query) ?? [];
+		try {
+			return [...TranscriptIndex.open(transcriptDbPath).matchingSessionIds(query), ...historyIds];
+		} catch (error) {
+			logger.warn("Transcript index unavailable for session ranking", { error: String(error) });
+			return historyIds;
+		}
+	};
 }
 
 /**

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -87,6 +87,7 @@ import { PluginSelectorComponent } from "../components/plugin-selector";
 import { ResetUsageSelectorComponent } from "../components/reset-usage-selector";
 import { renderSegmentTrack } from "../components/segment-track";
 import { SessionAccountSelectorComponent } from "../components/session-account-selector";
+import { SessionMapComponent } from "../components/session-map";
 import { createSessionRankingMatcher, SessionSelectorComponent } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
 import { ToolExecutionComponent } from "../components/tool-execution";
@@ -1418,6 +1419,56 @@ export class SelectorController {
 			fullscreen: true,
 		});
 		this.ctx.ui.setFocus(selector);
+		this.ctx.ui.requestRender();
+	}
+
+	async showSessionMap(): Promise<void> {
+		const sessions = await SessionManager.list(
+			this.ctx.sessionManager.getCwd(),
+			this.ctx.sessionManager.getSessionDir(),
+		);
+		let overlayHandle: OverlayHandle | undefined;
+		const done = () => {
+			overlayHandle?.hide();
+			this.focusActiveEditorArea();
+			this.ctx.ui.requestRender();
+		};
+		const map = new SessionMapComponent(
+			sessions,
+			async (session: SessionInfo) => {
+				map.lockInput();
+				let keepOpen = false;
+				try {
+					const success = await this.handleResumeSession(session.path);
+					if (!success) {
+						keepOpen = true;
+						map.unlockInput();
+						this.ctx.ui.requestRender();
+					}
+				} finally {
+					if (!keepOpen) done();
+				}
+			},
+			() => done(),
+			() => {
+				done();
+				void this.ctx.shutdown();
+			},
+			{
+				loadAllSessions: () => SessionManager.listAll(),
+				getTerminalRows: () => this.ctx.ui.terminal.rows,
+				fillHeight: true,
+			},
+		);
+		map.setOnRequestRender(() => this.ctx.ui.requestRender());
+		overlayHandle = this.ctx.ui.showOverlay(map, {
+			anchor: "top-left",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+			fullscreen: true,
+		});
+		this.ctx.ui.setFocus(map);
 		this.ctx.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1350,6 +1350,7 @@ export class SelectorController {
 		const historyStorage = this.ctx.historyStorage;
 		const historyMatcher = createSessionRankingMatcher(
 			historyStorage ? (query: string) => historyStorage.matchingSessionIds(query) : undefined,
+			this.ctx.sessionManager.getSessionDir(),
 		);
 		// Keep the fullscreen picker on the alternate buffer while a selected
 		// session is loaded and its transcript is rebuilt. Closing it first exposes

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -87,7 +87,7 @@ import { PluginSelectorComponent } from "../components/plugin-selector";
 import { ResetUsageSelectorComponent } from "../components/reset-usage-selector";
 import { renderSegmentTrack } from "../components/segment-track";
 import { SessionAccountSelectorComponent } from "../components/session-account-selector";
-import { SessionSelectorComponent } from "../components/session-selector";
+import { createSessionRankingMatcher, SessionSelectorComponent } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
 import { ToolExecutionComponent } from "../components/tool-execution";
 import { TranscriptBlock } from "../components/transcript-container";
@@ -1348,7 +1348,9 @@ export class SelectorController {
 		// invites the user to Tab into all-projects rather than silently surfacing
 		// every project's history when the cwd has nothing to resume. See #3099.
 		const historyStorage = this.ctx.historyStorage;
-		const historyMatcher = historyStorage ? (query: string) => historyStorage.matchingSessionIds(query) : undefined;
+		const historyMatcher = createSessionRankingMatcher(
+			historyStorage ? (query: string) => historyStorage.matchingSessionIds(query) : undefined,
+		);
 		// Keep the fullscreen picker on the alternate buffer while a selected
 		// session is loaded and its transcript is rebuilt. Closing it first exposes
 		// the stale normal buffer for the entire async switch on terminals without

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4670,6 +4670,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#selectorController.showSessionSelector();
 	}
 
+	showSessionMap(): void {
+		void this.#selectorController.showSessionMap();
+	}
+
 	async handleResumeSession(sessionPath: string): Promise<void> {
 		// Flush pending settings writes *before* disposing controllers or resetting
 		// observers: a save failure must leave the session, process project dir,

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -385,6 +385,7 @@ export interface InteractiveModeContext {
 	showCopySelector(): void;
 	showTreeSelector(): void;
 	showSessionSelector(): void;
+	showSessionMap(): void;
 	handleResumeSession(sessionPath: string): Promise<void>;
 	handleSessionDeleteCommand(): Promise<void>;
 	showOAuthSelector(mode: "login" | "logout", providerId?: string): Promise<void>;

--- a/packages/coding-agent/src/prompts/agents/session-search.md
+++ b/packages/coding-agent/src/prompts/agents/session-search.md
@@ -13,7 +13,8 @@ read-summarize: false
 Search local session transcripts and answer with exact citations.
 
 <directives>
-- Query the transcript index first via the read tool's SQLite selector (`<dbPath>:chunks?q=SELECT ...` with an FTS join).
+- Query the transcript index first via the read tool's SQLite selector (`<dbPath>?q=SELECT ...` with an FTS join).
+- Scope every query to files below the rendered `<sessionDir>`; never surface rows from another session directory.
 - Never stop at the first plausible hit — look for later entries that revise, supersede, revert, or contradict it.
 - Treat `tool_use` rows as attempted actions, not outcomes — confirm results in `tool_result` / message rows.
 - For exact wording, commands, code, or chronology, open the cited session JSONL with ranged `read` (and `history://<id>` when the id resolves) instead of trusting summaries.

--- a/packages/coding-agent/src/prompts/agents/session-search.md
+++ b/packages/coding-agent/src/prompts/agents/session-search.md
@@ -1,0 +1,34 @@
+---
+name: session-search
+description: >-
+  Read-only session-transcript specialist. Searches local session transcripts for prior
+  decisions, fixes, commands, and context, and answers with exact citations. Use when
+  the user asks what a past session did, where something was discussed, or to reuse
+  a prior approach.
+tools: read, grep, glob
+model: "@smol"
+read-summarize: false
+---
+
+Search local session transcripts and answer with exact citations.
+
+<directives>
+- Query the transcript index first via the read tool's SQLite selector (`<dbPath>:chunks?q=SELECT ...` with an FTS join).
+- Never stop at the first plausible hit — look for later entries that revise, supersede, revert, or contradict it.
+- Treat `tool_use` rows as attempted actions, not outcomes — confirm results in `tool_result` / message rows.
+- For exact wording, commands, code, or chronology, open the cited session JSONL with ranged `read` (and `history://<id>` when the id resolves) instead of trusting summaries.
+- Answer with citations `{sessionId, entryId, quote}`. Say plainly when nothing matches.
+</directives>
+
+<procedure>
+1. Query the transcript index for the question.
+2. Gather candidate hits; keep scanning for later superseding or contradicting entries.
+3. Confirm attempted tool actions against their results and surrounding messages.
+4. Open cited JSONL with ranged reads when wording, commands, or chronology matter.
+5. Return the answer with citations, or state that nothing matched.
+</procedure>
+
+<critical>
+You MUST operate as read-only. You NEVER write, edit, or modify files.
+You MUST keep going until the question is answered or you can say nothing matches.
+</critical>

--- a/packages/coding-agent/src/prompts/qa.md
+++ b/packages/coding-agent/src/prompts/qa.md
@@ -1,0 +1,11 @@
+You are coordinating a QA pass for this session.
+
+Request: {{request}}
+
+<contract>
+- Derive the pass contract from the request plus repository context — existing tests, scripts, skills, and agent guidance. Invent no config format. With an empty request, infer scope from the working tree (`git status` / recent diff) and state the inferred scope before proceeding.
+- Phase 1, inventory: spawn `scout` subagent(s) to map the affected surfaces and name the concrete checks (commands, endpoints, UI flows) that would prove or break the request.
+- Phase 2, exercise: run those checks — real commands, browser/computer tools for UI — and capture evidence artifacts (command output, screenshots, paths).
+- Phase 3, report: findings ordered by severity, each with evidence and a reproduction; end with an explicit verdict per check. Make no code edits in this run.
+- Fixes happen only when the user explicitly asks afterwards; then fix and revalidate each finding by re-running its exact failing check.
+</contract>

--- a/packages/coding-agent/src/prompts/session-search-command.md
+++ b/packages/coding-agent/src/prompts/session-search-command.md
@@ -1,0 +1,13 @@
+Search past session transcripts for this question.
+
+Question: {{question}}
+
+Transcript DB: `{{dbPath}}`
+Project session directory: `{{sessionDir}}`
+
+<instruction>
+- Spawn the bundled `session-search` agent via the `task` tool with `agent: "session-search"`. Put the question, `{{dbPath}}`, and `{{sessionDir}}` in the task brief so the agent can query the index and open session JSONL.
+- Default scope is this project's session directory only (`{{sessionDir}}`). Do not search other projects.
+- Broaden scope ONLY when the user explicitly asks about other projects: reindex with `sessionDirs` spanning the subdirectories of `getSessionsDir()`, then spawn again. Never broaden otherwise.
+- Relay the agent's cited answer to the user. Keep `{sessionId, entryId, quote}` citations intact. If nothing matched, say so plainly.
+</instruction>

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -24,7 +24,7 @@ const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
 
 // Escape LIKE wildcards so user input is treated as literal text.
 // Matches the `ESCAPE '\\'` clause used by substring-search statements.
-function escapeLikePattern(text: string): string {
+export function escapeLikePattern(text: string): string {
 	return text.replace(/[\\%_]/g, "\\$&");
 }
 

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -142,6 +142,16 @@ export interface LabelEntry extends SessionEntryBase {
 	label: string | undefined;
 }
 
+/**
+ * Namespace for session-level tags stored as {@link LabelEntry} rows.
+ *
+ * A tag is a label whose `targetId` is this prefix plus the tag name, so a session
+ * carries a SET of tags: `SessionEntryIndex` keeps one label per `targetId`, and a
+ * single shared sentinel target would collapse every tag into the newest one.
+ * Clearing a tag appends the same `targetId` with an empty label.
+ */
+export const SESSION_TAG_PREFIX = "__session_tag__:";
+
 /** Append-only audit entry recording a session title change. */
 export interface TitleChangeEntry extends SessionEntryBase {
 	type: typeof TITLE_CHANGE_ENTRY_TYPE;

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -65,7 +65,7 @@ const SESSION_LIST_SUFFIX_BYTES = 32_768;
 const SESSION_LIST_PARALLEL_THRESHOLD = 64;
 const SESSION_LIST_MAX_WORKERS = 16;
 
-function sanitizeSessionName(value: string | undefined): string | undefined {
+export function sanitizeSessionName(value: string | undefined): string | undefined {
 	if (!value) return undefined;
 	const firstLine = value.split(/\r?\n/)[0] ?? "";
 	const stripped = firstLine.replace(/[\x00-\x1F\x7F]/g, "");
@@ -93,7 +93,7 @@ function formatTimeAgo(date: Date): string {
  * then a timestamp-based label. The raw UUID `id` is intentionally never used —
  * it is unfriendly and indistinguishable from neighboring sessions in the UI.
  */
-function sessionDisplayName(info: SessionInfo): string {
+export function sessionDisplayName(info: SessionInfo): string {
 	const title = sanitizeSessionName(info.title);
 	if (title) return title;
 	const first =

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -43,6 +43,7 @@ import {
 	type ModeChangeEntry,
 	type ModelChangeEntry,
 	type NewSessionOptions,
+	SESSION_TAG_PREFIX,
 	type ServiceTierChangeEntry,
 	type SessionEntry,
 	type SessionHeader,
@@ -2079,6 +2080,33 @@ export class SessionManager {
 		if (!this.#index.has(targetId)) throw new Error(`Entry ${targetId} not found`);
 
 		const entry: LabelEntry = { type: "label", ...this.#freshEntryFields(), targetId, label };
+		this.#recordEntry(entry);
+		return entry.id;
+	}
+
+	/**
+	 * Session-level tags, sorted. Tags are {@link LabelEntry} rows namespaced under
+	 * {@link SESSION_TAG_PREFIX}, so the label index already folds them last-write-wins.
+	 */
+	sessionTags(): string[] {
+		const tags: string[] = [];
+		for (const [targetId, label] of this.#index.labelsInEffect()) {
+			if (label && targetId.startsWith(SESSION_TAG_PREFIX)) tags.push(label);
+		}
+		return tags.sort();
+	}
+
+	/**
+	 * Add or remove one session tag. Unlike {@link appendLabelChange} this takes no entry
+	 * guard: a tag's target is a synthetic namespace key, never an existing entry id.
+	 */
+	appendSessionTag(tag: string, present: boolean): string {
+		const entry: LabelEntry = {
+			type: "label",
+			...this.#freshEntryFields(),
+			targetId: SESSION_TAG_PREFIX + tag,
+			label: present ? tag : undefined,
+		};
 		this.#recordEntry(entry);
 		return entry.id;
 	}

--- a/packages/coding-agent/src/session/transcript-index.ts
+++ b/packages/coding-agent/src/session/transcript-index.ts
@@ -83,13 +83,22 @@ function extractChunks(
 	for (const entry of entries) {
 		if (entry.type !== "message") continue;
 		const message = entry.message;
-		if (!isLlmMessage(message)) continue;
-
 		const createdAt = entryCreatedAtMs(entry.timestamp, fileMtimeMs);
 		const push = (kind: PreparedChunk["kind"], role: string, content: string): void => {
 			if (content.length === 0) return;
 			chunks.push({ filePath, sessionId, entryId: entry.id, kind, role, content, createdAt });
 		};
+		if (message.role === "bashExecution") {
+			push("tool_use", message.role, capContent(message.command, TOOL_USE_CONTENT_CAP));
+			push("tool_result", message.role, capContent(message.output, TOOL_RESULT_CONTENT_CAP));
+			continue;
+		}
+		if (message.role === "pythonExecution") {
+			push("tool_use", message.role, capContent(message.code, TOOL_USE_CONTENT_CAP));
+			push("tool_result", message.role, capContent(message.output, TOOL_RESULT_CONTENT_CAP));
+			continue;
+		}
+		if (!isLlmMessage(message)) continue;
 
 		switch (message.role) {
 			case "user":
@@ -173,9 +182,11 @@ function extractSessionTags(entries: FileEntry[]): string[] {
 	return tags;
 }
 
-function listJsonlFiles(sessionDir: string): string[] {
+async function listJsonlFiles(sessionDir: string): Promise<string[]> {
 	try {
-		return Array.from(new Bun.Glob("*.jsonl").scanSync(sessionDir)).map(name => path.join(sessionDir, name));
+		const files: string[] = [];
+		for await (const name of new Bun.Glob("*.jsonl").scan(sessionDir)) files.push(path.join(sessionDir, name));
+		return files;
 	} catch {
 		return [];
 	}
@@ -194,6 +205,9 @@ export class TranscriptIndex {
 	#tagsForStmt: Statement;
 	#sessionIdsByTagStmt: Statement;
 	#searchStmt: Statement;
+	#searchInDirStmt: Statement;
+	#indexedFilesInDirStmt: Statement;
+	#deleteIndexedFileStmt: Statement;
 	#substringStmts = new Map<number, Statement>();
 	#closed = false;
 
@@ -257,6 +271,11 @@ ON CONFLICT(path) DO UPDATE SET
 		this.#searchStmt = this.#db.prepare(
 			"SELECT c.id, c.file_path, c.session_id, c.entry_id, c.kind, c.role, c.content, c.created_at FROM chunks_fts f JOIN chunks c ON c.id = f.rowid WHERE chunks_fts MATCH ? ORDER BY c.created_at DESC, c.id DESC LIMIT ?",
 		);
+		this.#searchInDirStmt = this.#db.prepare(
+			"SELECT c.id, c.file_path, c.session_id, c.entry_id, c.kind, c.role, c.content, c.created_at FROM chunks_fts f JOIN chunks c ON c.id = f.rowid WHERE chunks_fts MATCH ? AND c.file_path LIKE ? ESCAPE '\\' ORDER BY c.created_at DESC, c.id DESC LIMIT ?",
+		);
+		this.#indexedFilesInDirStmt = this.#db.prepare("SELECT path FROM indexed_files WHERE path LIKE ? ESCAPE '\\'");
+		this.#deleteIndexedFileStmt = this.#db.prepare("DELETE FROM indexed_files WHERE path = ?");
 	}
 
 	static open(dbPath: string = getTranscriptDbPath()): TranscriptIndex {
@@ -282,14 +301,15 @@ ON CONFLICT(path) DO UPDATE SET
 
 		for (const sessionDir of opts.sessionDirs) {
 			opts.signal?.throwIfAborted();
-			const jsonlFiles = listJsonlFiles(sessionDir);
+			const jsonlFiles = await listJsonlFiles(sessionDir);
+			this.#purgeMissingFiles(sessionDir, new Set(jsonlFiles));
 			for (const filePath of jsonlFiles) {
 				opts.signal?.throwIfAborted();
 				files += 1;
 
 				let stat: fs.Stats;
 				try {
-					stat = fs.statSync(filePath);
+					stat = await fs.promises.stat(filePath);
 				} catch (error) {
 					logger.warn("TranscriptIndex reindex skipped file", { path: filePath, error: String(error) });
 					continue;
@@ -363,8 +383,9 @@ ON CONFLICT(path) DO UPDATE SET
 		return { files, indexedFiles };
 	}
 
-	search(query: string, opts?: { limit?: number }): TranscriptHit[] {
+	search(query: string, opts?: { limit?: number; sessionDir?: string }): TranscriptHit[] {
 		const safeLimit = this.#normalizeLimit(opts?.limit ?? 100);
+		const sessionDir = opts?.sessionDir;
 		if (safeLimit === 0) return [];
 
 		const tokens = this.#tokenize(query);
@@ -373,47 +394,59 @@ ON CONFLICT(path) DO UPDATE SET
 		const ftsQuery = tokens.map(tok => `"${tok.replace(/"/g, '""')}"*`).join(" ");
 		let ftsRows: ChunkRow[] = [];
 		try {
-			ftsRows = this.#searchStmt.all(ftsQuery, safeLimit) as ChunkRow[];
+			ftsRows = sessionDir
+				? (this.#searchInDirStmt.all(ftsQuery, this.#sessionDirPattern(sessionDir), safeLimit) as ChunkRow[])
+				: (this.#searchStmt.all(ftsQuery, safeLimit) as ChunkRow[]);
 		} catch (error) {
 			logger.debug("TranscriptIndex FTS query failed, using substring only", { error: String(error) });
 		}
 
-		let subRows: ChunkRow[] = [];
+		if (ftsRows.length > 0) return ftsRows.map(row => this.#toHit(row));
+
 		try {
-			subRows = this.#searchSubstring(tokens, safeLimit);
+			return this.#searchSubstring(tokens, safeLimit, sessionDir).map(row => this.#toHit(row));
 		} catch (error) {
 			logger.error("TranscriptIndex substring search failed", { error: String(error) });
+			return [];
 		}
-
-		if (ftsRows.length === 0) {
-			return subRows.map(row => this.#toHit(row));
-		}
-
-		const rowsById = new Map<number, ChunkRow>();
-		for (const row of ftsRows) {
-			rowsById.set(row.id, row);
-		}
-		for (const row of subRows) {
-			if (!rowsById.has(row.id)) rowsById.set(row.id, row);
-		}
-
-		return [...rowsById.values()]
-			.sort((a, b) => b.created_at - a.created_at || b.id - a.id)
-			.slice(0, safeLimit)
-			.map(row => this.#toHit(row));
 	}
 
-	matchingSessionIds(query: string, limit?: number): string[] {
-		const seen = new Set<string>();
-		const ids: string[] = [];
-		for (const hit of this.search(query, { limit: limit ?? 500 })) {
-			if (seen.has(hit.sessionId)) continue;
-			seen.add(hit.sessionId);
-			ids.push(hit.sessionId);
+	matchingSessionIds(query: string, opts?: { limit?: number; sessionDir?: string }): string[] {
+		const safeLimit = this.#normalizeLimit(opts?.limit ?? 500);
+		if (safeLimit === 0) return [];
+		const tokens = this.#tokenize(query);
+		if (tokens.length === 0) return [];
+		const sessionDir = opts?.sessionDir;
+		const scopeClause = sessionDir ? " AND c.file_path LIKE ? ESCAPE '\\'" : "";
+		const ftsQuery = tokens.map(tok => `"${tok.replace(/"/g, '""')}"*`).join(" ");
+		const ftsStmt = this.#db.prepare(
+			`SELECT c.session_id FROM chunks_fts f JOIN chunks c ON c.id = f.rowid WHERE chunks_fts MATCH ?${scopeClause} GROUP BY c.session_id ORDER BY MAX(c.created_at) DESC, MAX(c.id) DESC LIMIT ?`,
+		);
+		try {
+			const params: Array<string | number> = [ftsQuery];
+			if (sessionDir) params.push(this.#sessionDirPattern(sessionDir));
+			params.push(safeLimit);
+			const rows = ftsStmt.all(...params) as Array<{ session_id: string }>;
+			if (rows.length > 0) return rows.map(row => row.session_id);
+		} catch (error) {
+			logger.debug("TranscriptIndex FTS session lookup failed, using substring only", { error: String(error) });
+		} finally {
+			ftsStmt.finalize();
 		}
-		return ids;
-	}
 
+		const whereClause = Array(tokens.length).fill("content LIKE ? ESCAPE '\\' COLLATE NOCASE").join(" AND ");
+		const substringStmt = this.#db.prepare(
+			`SELECT session_id FROM chunks WHERE ${whereClause}${sessionDir ? " AND file_path LIKE ? ESCAPE '\\'" : ""} GROUP BY session_id ORDER BY MAX(created_at) DESC, MAX(id) DESC LIMIT ?`,
+		);
+		try {
+			const params: Array<string | number> = tokens.map(tok => `%${escapeLikePattern(tok)}%`);
+			if (sessionDir) params.push(this.#sessionDirPattern(sessionDir));
+			params.push(safeLimit);
+			return (substringStmt.all(...params) as Array<{ session_id: string }>).map(row => row.session_id);
+		} finally {
+			substringStmt.finalize();
+		}
+	}
 	tagsFor(sessionId: string): string[] {
 		const rows = this.#tagsForStmt.all(sessionId) as Array<{ tag: string }>;
 		return rows.map(row => row.tag);
@@ -438,6 +471,9 @@ ON CONFLICT(path) DO UPDATE SET
 		this.#tagsForStmt.finalize();
 		this.#sessionIdsByTagStmt.finalize();
 		this.#searchStmt.finalize();
+		this.#searchInDirStmt.finalize();
+		this.#indexedFilesInDirStmt.finalize();
+		this.#deleteIndexedFileStmt.finalize();
 		this.#db.close();
 		if (TranscriptIndex.#instance === this) {
 			TranscriptIndex.#instance = undefined;
@@ -462,22 +498,43 @@ ON CONFLICT(path) DO UPDATE SET
 			.filter(tok => tok.length > 0);
 	}
 
-	#searchSubstring(tokens: string[], limit: number): ChunkRow[] {
-		const stmt = this.#getSubstringStmt(tokens.length);
+	#searchSubstring(tokens: string[], limit: number, sessionDir?: string): ChunkRow[] {
+		const stmt = this.#getSubstringStmt(tokens.length, Boolean(sessionDir));
 		const params: unknown[] = tokens.map(tok => `%${escapeLikePattern(tok)}%`);
+		if (sessionDir) params.push(this.#sessionDirPattern(sessionDir));
 		params.push(limit);
 		return stmt.all(...(params as [string, ...unknown[]])) as ChunkRow[];
 	}
 
-	#getSubstringStmt(tokenCount: number): Statement {
-		let stmt = this.#substringStmts.get(tokenCount);
+	#getSubstringStmt(tokenCount: number, scoped: boolean): Statement {
+		const key = tokenCount * 2 + Number(scoped);
+		let stmt = this.#substringStmts.get(key);
 		if (stmt) return stmt;
 		const whereClause = Array(tokenCount).fill("content LIKE ? ESCAPE '\\' COLLATE NOCASE").join(" AND ");
+		const scopeClause = scoped ? " AND file_path LIKE ? ESCAPE '\\'" : "";
 		stmt = this.#db.prepare(
-			`SELECT id, file_path, session_id, entry_id, kind, role, content, created_at FROM chunks WHERE ${whereClause} ORDER BY created_at DESC, id DESC LIMIT ?`,
+			`SELECT id, file_path, session_id, entry_id, kind, role, content, created_at FROM chunks WHERE ${whereClause}${scopeClause} ORDER BY created_at DESC, id DESC LIMIT ?`,
 		);
-		this.#substringStmts.set(tokenCount, stmt);
+		this.#substringStmts.set(key, stmt);
 		return stmt;
+	}
+
+	#sessionDirPattern(sessionDir: string): string {
+		return `${escapeLikePattern(path.resolve(sessionDir))}${path.sep}%`;
+	}
+
+	#purgeMissingFiles(sessionDir: string, presentFiles: ReadonlySet<string>): void {
+		const pattern = this.#sessionDirPattern(sessionDir);
+		const indexed = this.#indexedFilesInDirStmt.all(pattern) as Array<{ path: string }>;
+		const missing = indexed.map(row => row.path).filter(filePath => !presentFiles.has(filePath));
+		if (missing.length === 0) return;
+		this.#db.transaction(() => {
+			for (const filePath of missing) {
+				this.#deleteChunksStmt.run(filePath);
+				this.#deleteTagsStmt.run(filePath);
+				this.#deleteIndexedFileStmt.run(filePath);
+			}
+		})();
 	}
 
 	#toHit(row: ChunkRow): TranscriptHit {

--- a/packages/coding-agent/src/session/transcript-index.ts
+++ b/packages/coding-agent/src/session/transcript-index.ts
@@ -1,0 +1,498 @@
+import { Database, type Statement } from "bun:sqlite";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { Message } from "@oh-my-pi/pi-ai";
+import { getTranscriptDbPath, logger } from "@oh-my-pi/pi-utils";
+import { escapeLikePattern } from "./history-storage";
+import { type FileEntry, type LabelEntry, SESSION_TAG_PREFIX, type SessionHeader } from "./session-entries";
+import { loadEntriesFromFile } from "./session-loader";
+
+export interface TranscriptHit {
+	sessionId: string;
+	filePath: string;
+	entryId: string;
+	kind: "message_text" | "tool_use" | "tool_result";
+	role: string;
+	snippet: string;
+	createdAt: number;
+}
+
+type ChunkKind = TranscriptHit["kind"];
+
+type ChunkRow = {
+	id: number;
+	file_path: string;
+	session_id: string;
+	entry_id: string;
+	kind: string;
+	role: string;
+	content: string;
+	created_at: number;
+};
+
+type IndexedFileRow = {
+	path: string;
+	mtime_ms: number;
+	size: number;
+};
+
+type PreparedChunk = {
+	filePath: string;
+	sessionId: string;
+	entryId: string;
+	kind: ChunkKind;
+	role: string;
+	content: string;
+	createdAt: number;
+};
+
+const TOOL_USE_CONTENT_CAP = 4096;
+const TOOL_RESULT_CONTENT_CAP = 16_384;
+
+function assertNever(value: never): never {
+	throw new Error(`Unexpected value: ${String(value)}`);
+}
+
+function isLlmMessage(message: AgentMessage): message is Message {
+	return (
+		message.role === "user" ||
+		message.role === "developer" ||
+		message.role === "assistant" ||
+		message.role === "toolResult"
+	);
+}
+
+function capContent(text: string, max: number): string {
+	return text.length <= max ? text : text.slice(0, max);
+}
+
+function entryCreatedAtMs(timestamp: string, fileMtimeMs: number): number {
+	const parsed = Date.parse(timestamp);
+	return Number.isFinite(parsed) ? parsed : fileMtimeMs;
+}
+
+function extractChunks(
+	entries: FileEntry[],
+	filePath: string,
+	sessionId: string,
+	fileMtimeMs: number,
+): PreparedChunk[] {
+	const chunks: PreparedChunk[] = [];
+
+	for (const entry of entries) {
+		if (entry.type !== "message") continue;
+		const message = entry.message;
+		if (!isLlmMessage(message)) continue;
+
+		const createdAt = entryCreatedAtMs(entry.timestamp, fileMtimeMs);
+		const push = (kind: PreparedChunk["kind"], role: string, content: string): void => {
+			if (content.length === 0) return;
+			chunks.push({ filePath, sessionId, entryId: entry.id, kind, role, content, createdAt });
+		};
+
+		switch (message.role) {
+			case "user":
+			case "developer": {
+				if (typeof message.content === "string") {
+					push("message_text", message.role, message.content);
+					break;
+				}
+				for (const block of message.content) {
+					switch (block.type) {
+						case "text":
+							push("message_text", message.role, block.text);
+							break;
+						case "image":
+							break;
+						default:
+							assertNever(block);
+					}
+				}
+				break;
+			}
+			case "assistant": {
+				for (const block of message.content) {
+					switch (block.type) {
+						case "text":
+							push("message_text", message.role, block.text);
+							break;
+						case "toolCall": {
+							const raw = `${block.name} ${JSON.stringify(block.arguments)}`;
+							push("tool_use", "", capContent(raw, TOOL_USE_CONTENT_CAP));
+							break;
+						}
+						case "thinking":
+						case "redactedThinking":
+						case "fallback":
+						case "anthropicServerTool":
+						case "image":
+							break;
+						default:
+							assertNever(block);
+					}
+				}
+				break;
+			}
+			case "toolResult": {
+				for (const block of message.content) {
+					switch (block.type) {
+						case "text":
+							push("tool_result", "", capContent(block.text, TOOL_RESULT_CONTENT_CAP));
+							break;
+						case "image":
+							break;
+						default:
+							assertNever(block);
+					}
+				}
+				break;
+			}
+			default:
+				assertNever(message);
+		}
+	}
+
+	return chunks;
+}
+
+function extractSessionTags(entries: FileEntry[]): string[] {
+	// Last label per targetId wins (same fold as SessionEntryIndex), then keep
+	// non-empty labels so a clearing `label: ""` removes the tag.
+	const latestByTarget = new Map<string, string>();
+	for (const entry of entries) {
+		if (entry.type !== "label") continue;
+		const labelEntry = entry as LabelEntry;
+		if (!labelEntry.targetId.startsWith(SESSION_TAG_PREFIX)) continue;
+		latestByTarget.set(labelEntry.targetId, labelEntry.label ?? "");
+	}
+	const tags: string[] = [];
+	for (const label of latestByTarget.values()) {
+		if (label.length > 0) tags.push(label);
+	}
+	return tags;
+}
+
+function listJsonlFiles(sessionDir: string): string[] {
+	try {
+		return Array.from(new Bun.Glob("*.jsonl").scanSync(sessionDir)).map(name => path.join(sessionDir, name));
+	} catch {
+		return [];
+	}
+}
+
+export class TranscriptIndex {
+	#db: Database;
+	static #instance?: TranscriptIndex;
+
+	#insertChunkStmt: Statement;
+	#deleteChunksStmt: Statement;
+	#upsertIndexedFileStmt: Statement;
+	#getIndexedFileStmt: Statement;
+	#deleteTagsStmt: Statement;
+	#insertTagStmt: Statement;
+	#tagsForStmt: Statement;
+	#sessionIdsByTagStmt: Statement;
+	#searchStmt: Statement;
+	#substringStmts = new Map<number, Statement>();
+	#closed = false;
+
+	private constructor(dbPath: string) {
+		this.#ensureDir(dbPath);
+
+		this.#db = new Database(dbPath);
+		this.#db.run("PRAGMA busy_timeout = 5000");
+		this.#db.run(`
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+
+CREATE TABLE IF NOT EXISTS indexed_files (
+  path TEXT PRIMARY KEY, mtime_ms INTEGER NOT NULL, size INTEGER NOT NULL,
+  session_id TEXT NOT NULL, cwd TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS chunks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT, file_path TEXT NOT NULL, session_id TEXT NOT NULL,
+  entry_id TEXT NOT NULL, kind TEXT NOT NULL CHECK (kind IN ('message_text','tool_use','tool_result')),
+  role TEXT NOT NULL DEFAULT '', content TEXT NOT NULL, created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_chunks_file ON chunks(file_path);
+-- The LIKE fallback orders by (created_at DESC, id DESC) on every search; without this it
+-- scans the whole corpus into a temp b-tree just to discard all but the newest page.
+CREATE INDEX IF NOT EXISTS idx_chunks_created_at ON chunks(created_at DESC, id DESC);
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(content, content='chunks', content_rowid='id');
+CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+  INSERT INTO chunks_fts(rowid, content) VALUES (new.id, new.content);
+END;
+CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+  INSERT INTO chunks_fts(chunks_fts, rowid, content) VALUES ('delete', old.id, old.content);
+END;
+CREATE TABLE IF NOT EXISTS session_tags (
+  session_id TEXT NOT NULL, file_path TEXT NOT NULL, tag TEXT NOT NULL,
+  PRIMARY KEY (session_id, tag)
+);
+		`);
+
+		this.#insertChunkStmt = this.#db.prepare(
+			"INSERT INTO chunks (file_path, session_id, entry_id, kind, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		);
+		this.#deleteChunksStmt = this.#db.prepare("DELETE FROM chunks WHERE file_path = ?");
+		this.#upsertIndexedFileStmt = this.#db.prepare(`
+INSERT INTO indexed_files (path, mtime_ms, size, session_id, cwd)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(path) DO UPDATE SET
+  mtime_ms = excluded.mtime_ms,
+  size = excluded.size,
+  session_id = excluded.session_id,
+  cwd = excluded.cwd
+		`);
+		this.#getIndexedFileStmt = this.#db.prepare("SELECT path, mtime_ms, size FROM indexed_files WHERE path = ?");
+		this.#deleteTagsStmt = this.#db.prepare("DELETE FROM session_tags WHERE file_path = ?");
+		this.#insertTagStmt = this.#db.prepare(
+			"INSERT OR REPLACE INTO session_tags (session_id, file_path, tag) VALUES (?, ?, ?)",
+		);
+		this.#tagsForStmt = this.#db.prepare("SELECT tag FROM session_tags WHERE session_id = ? ORDER BY tag");
+		this.#sessionIdsByTagStmt = this.#db.prepare(
+			"SELECT session_id FROM session_tags WHERE tag = ? ORDER BY session_id",
+		);
+		this.#searchStmt = this.#db.prepare(
+			"SELECT c.id, c.file_path, c.session_id, c.entry_id, c.kind, c.role, c.content, c.created_at FROM chunks_fts f JOIN chunks c ON c.id = f.rowid WHERE chunks_fts MATCH ? ORDER BY c.created_at DESC, c.id DESC LIMIT ?",
+		);
+	}
+
+	static open(dbPath: string = getTranscriptDbPath()): TranscriptIndex {
+		if (!TranscriptIndex.#instance) {
+			TranscriptIndex.#instance = new TranscriptIndex(dbPath);
+		}
+		return TranscriptIndex.#instance;
+	}
+
+	/** @internal Reset the singleton and close its database — test-only. */
+	static resetInstance(): void {
+		const instance = TranscriptIndex.#instance;
+		TranscriptIndex.#instance = undefined;
+		if (instance) instance.close();
+	}
+
+	async reindex(opts: {
+		sessionDirs: string[];
+		signal?: AbortSignal;
+	}): Promise<{ files: number; indexedFiles: number }> {
+		let files = 0;
+		let indexedFiles = 0;
+
+		for (const sessionDir of opts.sessionDirs) {
+			opts.signal?.throwIfAborted();
+			const jsonlFiles = listJsonlFiles(sessionDir);
+			for (const filePath of jsonlFiles) {
+				opts.signal?.throwIfAborted();
+				files += 1;
+
+				let stat: fs.Stats;
+				try {
+					stat = fs.statSync(filePath);
+				} catch (error) {
+					logger.warn("TranscriptIndex reindex skipped file", { path: filePath, error: String(error) });
+					continue;
+				}
+
+				const mtimeMs = Math.trunc(stat.mtimeMs);
+				const size = stat.size;
+				const existing = this.#getIndexedFileStmt.get(filePath) as IndexedFileRow | null;
+				if (existing && existing.mtime_ms === mtimeMs && existing.size === size) {
+					continue;
+				}
+
+				let entries: FileEntry[];
+				try {
+					entries = await loadEntriesFromFile(filePath);
+				} catch (error) {
+					logger.warn("TranscriptIndex reindex skipped file", { path: filePath, error: String(error) });
+					continue;
+				}
+
+				if (entries.length === 0) {
+					logger.warn("TranscriptIndex reindex skipped file", {
+						path: filePath,
+						error: "empty or unreadable session file",
+					});
+					continue;
+				}
+
+				const header = entries[0];
+				if (header?.type !== "session" || typeof header.id !== "string") {
+					logger.warn("TranscriptIndex reindex skipped file", {
+						path: filePath,
+						error: "missing session header",
+					});
+					continue;
+				}
+
+				const sessionHeader = header as SessionHeader;
+				const sessionId = sessionHeader.id;
+				const cwd = sessionHeader.cwd ?? "";
+				const chunks = extractChunks(entries, filePath, sessionId, mtimeMs);
+				const tags = extractSessionTags(entries);
+
+				try {
+					this.#db.transaction(() => {
+						this.#deleteChunksStmt.run(filePath);
+						this.#deleteTagsStmt.run(filePath);
+						for (const chunk of chunks) {
+							this.#insertChunkStmt.run(
+								chunk.filePath,
+								chunk.sessionId,
+								chunk.entryId,
+								chunk.kind,
+								chunk.role,
+								chunk.content,
+								chunk.createdAt,
+							);
+						}
+						for (const tag of tags) {
+							this.#insertTagStmt.run(sessionId, filePath, tag);
+						}
+						this.#upsertIndexedFileStmt.run(filePath, mtimeMs, size, sessionId, cwd);
+					})();
+					indexedFiles += 1;
+				} catch (error) {
+					logger.warn("TranscriptIndex reindex skipped file", { path: filePath, error: String(error) });
+				}
+			}
+		}
+
+		return { files, indexedFiles };
+	}
+
+	search(query: string, opts?: { limit?: number }): TranscriptHit[] {
+		const safeLimit = this.#normalizeLimit(opts?.limit ?? 100);
+		if (safeLimit === 0) return [];
+
+		const tokens = this.#tokenize(query);
+		if (tokens.length === 0) return [];
+
+		const ftsQuery = tokens.map(tok => `"${tok.replace(/"/g, '""')}"*`).join(" ");
+		let ftsRows: ChunkRow[] = [];
+		try {
+			ftsRows = this.#searchStmt.all(ftsQuery, safeLimit) as ChunkRow[];
+		} catch (error) {
+			logger.debug("TranscriptIndex FTS query failed, using substring only", { error: String(error) });
+		}
+
+		let subRows: ChunkRow[] = [];
+		try {
+			subRows = this.#searchSubstring(tokens, safeLimit);
+		} catch (error) {
+			logger.error("TranscriptIndex substring search failed", { error: String(error) });
+		}
+
+		if (ftsRows.length === 0) {
+			return subRows.map(row => this.#toHit(row));
+		}
+
+		const rowsById = new Map<number, ChunkRow>();
+		for (const row of ftsRows) {
+			rowsById.set(row.id, row);
+		}
+		for (const row of subRows) {
+			if (!rowsById.has(row.id)) rowsById.set(row.id, row);
+		}
+
+		return [...rowsById.values()]
+			.sort((a, b) => b.created_at - a.created_at || b.id - a.id)
+			.slice(0, safeLimit)
+			.map(row => this.#toHit(row));
+	}
+
+	matchingSessionIds(query: string, limit?: number): string[] {
+		const seen = new Set<string>();
+		const ids: string[] = [];
+		for (const hit of this.search(query, { limit: limit ?? 500 })) {
+			if (seen.has(hit.sessionId)) continue;
+			seen.add(hit.sessionId);
+			ids.push(hit.sessionId);
+		}
+		return ids;
+	}
+
+	tagsFor(sessionId: string): string[] {
+		const rows = this.#tagsForStmt.all(sessionId) as Array<{ tag: string }>;
+		return rows.map(row => row.tag);
+	}
+
+	sessionIdsByTag(tag: string): string[] {
+		const rows = this.#sessionIdsByTagStmt.all(tag) as Array<{ session_id: string }>;
+		return rows.map(row => row.session_id);
+	}
+
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		for (const stmt of this.#substringStmts.values()) stmt.finalize();
+		this.#substringStmts.clear();
+		this.#insertChunkStmt.finalize();
+		this.#deleteChunksStmt.finalize();
+		this.#upsertIndexedFileStmt.finalize();
+		this.#getIndexedFileStmt.finalize();
+		this.#deleteTagsStmt.finalize();
+		this.#insertTagStmt.finalize();
+		this.#tagsForStmt.finalize();
+		this.#sessionIdsByTagStmt.finalize();
+		this.#searchStmt.finalize();
+		this.#db.close();
+		if (TranscriptIndex.#instance === this) {
+			TranscriptIndex.#instance = undefined;
+		}
+	}
+
+	#ensureDir(dbPath: string): void {
+		const dir = path.dirname(dbPath);
+		fs.mkdirSync(dir, { recursive: true });
+	}
+
+	#normalizeLimit(limit: number): number {
+		if (!Number.isFinite(limit)) return 0;
+		const clamped = Math.max(0, Math.floor(limit));
+		return Math.min(clamped, 1000);
+	}
+
+	#tokenize(query: string): string[] {
+		return query
+			.toLowerCase()
+			.split(/[^\p{L}\p{N}]+/u)
+			.filter(tok => tok.length > 0);
+	}
+
+	#searchSubstring(tokens: string[], limit: number): ChunkRow[] {
+		const stmt = this.#getSubstringStmt(tokens.length);
+		const params: unknown[] = tokens.map(tok => `%${escapeLikePattern(tok)}%`);
+		params.push(limit);
+		return stmt.all(...(params as [string, ...unknown[]])) as ChunkRow[];
+	}
+
+	#getSubstringStmt(tokenCount: number): Statement {
+		let stmt = this.#substringStmts.get(tokenCount);
+		if (stmt) return stmt;
+		const whereClause = Array(tokenCount).fill("content LIKE ? ESCAPE '\\' COLLATE NOCASE").join(" AND ");
+		stmt = this.#db.prepare(
+			`SELECT id, file_path, session_id, entry_id, kind, role, content, created_at FROM chunks WHERE ${whereClause} ORDER BY created_at DESC, id DESC LIMIT ?`,
+		);
+		this.#substringStmts.set(tokenCount, stmt);
+		return stmt;
+	}
+
+	#toHit(row: ChunkRow): TranscriptHit {
+		const kind = row.kind;
+		if (kind !== "message_text" && kind !== "tool_use" && kind !== "tool_result") {
+			throw new Error(`Unexpected chunk kind: ${kind}`);
+		}
+		return {
+			sessionId: row.session_id,
+			filePath: row.file_path,
+			entryId: row.entry_id,
+			kind,
+			role: row.role,
+			snippet: row.content,
+			createdAt: row.created_at,
+		};
+	}
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
-import { APP_NAME, getProjectDir, prompt, setProjectDir } from "@oh-my-pi/pi-utils";
+import { APP_NAME, getProjectDir, getTranscriptDbPath, prompt, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
@@ -33,10 +33,13 @@ import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
 import qaMd from "../prompts/qa.md" with { type: "text" };
+import sessionSearchCommandMd from "../prompts/session-search-command.md" with { type: "text" };
 import type { AgentSession, FreshSessionResult } from "../session/agent-session";
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
+import { SessionManager } from "../session/session-manager";
+import { TranscriptIndex } from "../session/transcript-index";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
 import { urlHyperlinkAlways } from "../tui";
@@ -109,6 +112,34 @@ async function applyComputerUseToggle(session: AgentSession, enable: boolean): P
 	}
 	session.settings.override("computer.enabled", enable);
 	return `Computer use ${enable ? "enabled" : "disabled"} for this session.`;
+}
+
+const SESSION_USAGE = "Usage: /session [info|delete|pin [account]|search <question>|tag <name>|untag <name>|tags]";
+
+/**
+ * Reindex this project's transcripts, then render the prompt that dispatches the bundled
+ * `session-search` agent.
+ *
+ * The first invocation is what creates the database — that is deliberately the opt-in
+ * moment, so a user who never searches pays nothing and the `/resume` selector keeps
+ * falling back to prompt-history matches alone.
+ */
+async function renderSessionSearchPrompt(question: string, cwd: string): Promise<string> {
+	const sessionDir = SessionManager.getDefaultSessionDir(cwd);
+	await TranscriptIndex.open().reindex({ sessionDirs: [sessionDir] });
+	return prompt.render(sessionSearchCommandMd, { question, dbPath: getTranscriptDbPath(), sessionDir });
+}
+
+/** `/session tag|untag|tags` semantics, owned in one place so the ACP and TUI hosts cannot drift. */
+function runSessionTagVerb(manager: SessionManager, verb: string, rest: string): string {
+	if (verb === "tags") {
+		const tags = manager.sessionTags();
+		return tags.length > 0 ? `Tags: ${tags.join(", ")}` : "No tags on this session.";
+	}
+	const name = rest.trim();
+	if (!name) return `Usage: /session ${verb} <name>`;
+	manager.appendSessionTag(name, verb === "tag");
+	return `${verb === "tag" ? "Tagged" : "Untagged"} session: ${name}`;
 }
 
 const AUTOCOMPLETE_DETAIL_LIMIT = 48;
@@ -1116,7 +1147,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		name: "session",
 		description: "Session management commands",
 		acpDescription: "Show or configure the current session",
-		acpInputHint: "[info|delete|pin [account]]",
+		acpInputHint: "[info|delete|pin [account]|search <question>|tag <name>|untag <name>|tags]",
 		subcommands: [
 			{ name: "info", description: "Show session info and stats" },
 			{ name: "delete", description: "Delete current session and return to selector" },
@@ -1125,6 +1156,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				description: "Pin the current provider to a stored OAuth account",
 				usage: "[account]",
 			},
+			{ name: "tag", description: "Add a tag to this session", usage: "<name>" },
+			{ name: "untag", description: "Remove a tag from this session", usage: "<name>" },
+			{ name: "tags", description: "List this session's tags" },
+			{ name: "search", description: "Search past session transcripts", usage: "<question>" },
 		],
 		allowArgs: true,
 		handle: async (command, runtime) => {
@@ -1162,7 +1197,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				await handleSessionPinCommand(rest, runtime.session, runtime.output);
 				return commandConsumed();
 			}
-			return usage("Usage: /session [info|delete|pin [account]]", runtime);
+			if (verb === "tag" || verb === "untag" || (verb === "tags" && !rest)) {
+				await runtime.output(runSessionTagVerb(runtime.sessionManager, verb, rest));
+				return commandConsumed();
+			}
+			if (verb === "search") {
+				if (!rest.trim()) return usage("Usage: /session search <question>", runtime);
+				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.cwd) };
+			}
+			return usage(SESSION_USAGE, runtime);
 		},
 		handleTui: async (command, runtime) => {
 			const { verb, rest } = parseSubcommand(command.args);
@@ -1181,10 +1224,23 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.editor.setText("");
 				return;
 			}
+			if (verb === "tag" || verb === "untag" || (verb === "tags" && !rest)) {
+				runtime.ctx.editor.setText("");
+				runtime.ctx.showStatus(runSessionTagVerb(runtime.ctx.sessionManager, verb, rest));
+				return;
+			}
+			if (verb === "search") {
+				runtime.ctx.editor.setText("");
+				if (!rest.trim()) {
+					runtime.ctx.showStatus("Usage: /session search <question>");
+					return;
+				}
+				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.ctx.sessionManager.getCwd()) };
+			}
 			if (!verb || (verb === "info" && !rest)) {
 				await runtime.ctx.handleSessionCommand();
 			} else {
-				runtime.ctx.showStatus("Usage: /session [info|delete|pin [account]]");
+				runtime.ctx.showStatus(SESSION_USAGE);
 			}
 			runtime.ctx.editor.setText("");
 		},

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -28,6 +28,7 @@ import {
 } from "../extensibility/plugins/marketplace";
 import { resolveMemoryBackend } from "../memory-backend";
 import { runPauseScreen } from "../modes/components/pause-screen";
+import { renderSessionMapText } from "../modes/components/session-map";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import { sanitizeStatusText } from "../modes/shared";
 import { theme } from "../modes/theme/theme";
@@ -39,7 +40,7 @@ import type { AgentSession, FreshSessionResult } from "../session/agent-session"
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
-import type { SessionManager } from "../session/session-manager";
+import { SessionManager } from "../session/session-manager";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { TranscriptIndex } from "../session/transcript-index";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
@@ -115,7 +116,7 @@ async function applyComputerUseToggle(session: AgentSession, enable: boolean): P
 	return `Computer use ${enable ? "enabled" : "disabled"} for this session.`;
 }
 
-const SESSION_USAGE = "Usage: /session [info|delete|pin [account]|search <question>|tag <name>|untag <name>|tags]";
+const SESSION_USAGE = "Usage: /session [info|delete|pin [account]|search <question>|tag <name>|untag <name>|tags|map]";
 
 /**
  * Reindex this project's transcripts, then render the prompt that dispatches the bundled
@@ -1147,7 +1148,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		name: "session",
 		description: "Session management commands",
 		acpDescription: "Show or configure the current session",
-		acpInputHint: "[info|delete|pin [account]|search <question>|tag <name>|untag <name>|tags]",
+		acpInputHint: "[info|delete|pin [account]|search <question>|tag <name>|untag <name>|tags|map]",
 		subcommands: [
 			{ name: "info", description: "Show session info and stats" },
 			{ name: "delete", description: "Delete current session and return to selector" },
@@ -1159,6 +1160,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			{ name: "tag", description: "Add a tag to this session", usage: "<name>" },
 			{ name: "untag", description: "Remove a tag from this session", usage: "<name>" },
 			{ name: "tags", description: "List this session's tags" },
+			{ name: "map", description: "Show the session lineage map" },
 			{ name: "search", description: "Search past session transcripts", usage: "<question>" },
 		],
 		allowArgs: true,
@@ -1205,6 +1207,11 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				if (!rest.trim()) return usage("Usage: /session search <question>", runtime);
 				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.sessionManager.getSessionDir()) };
 			}
+			if (verb === "map" && !rest) {
+				const sessions = await SessionManager.list(runtime.cwd, runtime.sessionManager.getSessionDir());
+				await runtime.output(renderSessionMapText(sessions));
+				return commandConsumed();
+			}
 			return usage(SESSION_USAGE, runtime);
 		},
 		handleTui: async (command, runtime) => {
@@ -1236,6 +1243,11 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					return;
 				}
 				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.ctx.sessionManager.getSessionDir()) };
+			}
+			if (verb === "map" && !rest) {
+				runtime.ctx.editor.setText("");
+				await runtime.ctx.showSessionMap();
+				return;
 			}
 			if (!verb || (verb === "info" && !rest)) {
 				await runtime.ctx.handleSessionCommand();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
-import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { APP_NAME, getProjectDir, prompt, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
@@ -32,6 +32,7 @@ import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
+import qaMd from "../prompts/qa.md" with { type: "text" };
 import type { AgentSession, FreshSessionResult } from "../session/agent-session";
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
@@ -2544,6 +2545,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 			// If a prompt was provided, pass it through as input
 			if (prompt) return { prompt };
+		},
+	},
+	{
+		name: "qa",
+		description: "Verify recent work and report findings with evidence (no edits)",
+		acpDescription: "Run an evidence-first QA pass",
+		inlineHint: "[what to verify]",
+		allowArgs: true,
+		handle: (command, runtime) => {
+			void runtime;
+			return { prompt: prompt.render(qaMd, { request: command.args.trim() }) };
+		},
+		handleTui: (command, runtime) => {
+			runtime.ctx.editor.setText("");
+			return { prompt: prompt.render(qaMd, { request: command.args.trim() }) };
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -29,6 +29,7 @@ import {
 import { resolveMemoryBackend } from "../memory-backend";
 import { runPauseScreen } from "../modes/components/pause-screen";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
+import { sanitizeStatusText } from "../modes/shared";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
@@ -38,9 +39,9 @@ import type { AgentSession, FreshSessionResult } from "../session/agent-session"
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
-import { SessionManager } from "../session/session-manager";
-import { TranscriptIndex } from "../session/transcript-index";
+import type { SessionManager } from "../session/session-manager";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
+import { TranscriptIndex } from "../session/transcript-index";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
 import { urlHyperlinkAlways } from "../tui";
 import {
@@ -124,8 +125,7 @@ const SESSION_USAGE = "Usage: /session [info|delete|pin [account]|search <questi
  * moment, so a user who never searches pays nothing and the `/resume` selector keeps
  * falling back to prompt-history matches alone.
  */
-async function renderSessionSearchPrompt(question: string, cwd: string): Promise<string> {
-	const sessionDir = SessionManager.getDefaultSessionDir(cwd);
+async function renderSessionSearchPrompt(question: string, sessionDir: string): Promise<string> {
 	await TranscriptIndex.open().reindex({ sessionDirs: [sessionDir] });
 	return prompt.render(sessionSearchCommandMd, { question, dbPath: getTranscriptDbPath(), sessionDir });
 }
@@ -136,7 +136,7 @@ function runSessionTagVerb(manager: SessionManager, verb: string, rest: string):
 		const tags = manager.sessionTags();
 		return tags.length > 0 ? `Tags: ${tags.join(", ")}` : "No tags on this session.";
 	}
-	const name = rest.trim();
+	const name = sanitizeStatusText(rest);
 	if (!name) return `Usage: /session ${verb} <name>`;
 	manager.appendSessionTag(name, verb === "tag");
 	return `${verb === "tag" ? "Tagged" : "Untagged"} session: ${name}`;
@@ -1203,7 +1203,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			}
 			if (verb === "search") {
 				if (!rest.trim()) return usage("Usage: /session search <question>", runtime);
-				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.cwd) };
+				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.sessionManager.getSessionDir()) };
 			}
 			return usage(SESSION_USAGE, runtime);
 		},
@@ -1235,7 +1235,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					runtime.ctx.showStatus("Usage: /session search <question>");
 					return;
 				}
-				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.ctx.sessionManager.getCwd()) };
+				return { prompt: await renderSessionSearchPrompt(rest.trim(), runtime.ctx.sessionManager.getSessionDir()) };
 			}
 			if (!verb || (verb === "info" && !rest)) {
 				await runtime.ctx.handleSessionCommand();

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -10,6 +10,7 @@ import designerMd from "../prompts/agents/designer.md" with { type: "text" };
 // Embed agent markdown files at build time
 import agentFrontmatterTemplate from "../prompts/agents/frontmatter.md" with { type: "text" };
 import librarianMd from "../prompts/agents/librarian.md" with { type: "text" };
+import sessionSearchMd from "../prompts/agents/session-search.md" with { type: "text" };
 import reviewerMd from "../prompts/agents/reviewer.md" with { type: "text" };
 import scoutMd from "../prompts/agents/scout.md" with { type: "text" };
 import taskMd from "../prompts/agents/task.md" with { type: "text" };
@@ -45,6 +46,7 @@ const EMBEDDED_AGENT_DEFS: EmbeddedAgentDef[] = [
 	{ fileName: "designer.md", template: designerMd },
 	{ fileName: "reviewer.md", template: reviewerMd },
 	{ fileName: "librarian.md", template: librarianMd },
+	{ fileName: "session-search.md", template: sessionSearchMd },
 	{
 		fileName: "task.md",
 		frontmatter: {

--- a/packages/coding-agent/test/modes/components/session-map.test.ts
+++ b/packages/coding-agent/test/modes/components/session-map.test.ts
@@ -1,0 +1,181 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import {
+	buildSessionMapRows,
+	renderSessionMapText,
+	SessionMapComponent,
+	sessionLineageKind,
+} from "@oh-my-pi/pi-coding-agent/modes/components/session-map";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-listing";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function makeSession(overrides: Partial<SessionInfo> & Pick<SessionInfo, "path" | "id">): SessionInfo {
+	return {
+		cwd: "/work",
+		created: new Date("2024-01-01T00:00:00Z"),
+		modified: new Date("2024-01-02T00:00:00Z"),
+		messageCount: 1,
+		size: 1024,
+		firstMessage: "(no messages)",
+		allMessagesText: "",
+		title: overrides.id,
+		...overrides,
+	};
+}
+
+describe("buildSessionMapRows", () => {
+	it("places children under their parent at depth 1", () => {
+		const A = makeSession({
+			path: "/sessions/A.jsonl",
+			id: "A",
+			title: "Session A",
+			modified: new Date("2024-01-03T00:00:00Z"),
+		});
+		const B = makeSession({
+			path: "/sessions/B.jsonl",
+			id: "B",
+			title: "Session B",
+			parentSessionPath: A.path,
+			modified: new Date("2024-01-02T12:00:00Z"),
+		});
+		const C = makeSession({
+			path: "/sessions/C.jsonl",
+			id: "C",
+			title: "Session C",
+			parentSessionPath: A.path,
+			modified: new Date("2024-01-02T00:00:00Z"),
+		});
+
+		const rows = buildSessionMapRows([A, B, C], () => []);
+		expect(rows.map(r => ({ id: r.session.id, depth: r.depth }))).toEqual([
+			{ id: "A", depth: 0 },
+			{ id: "B", depth: 1 },
+			{ id: "C", depth: 1 },
+		]);
+	});
+
+	it("treats a session whose parent is absent as a root and keeps its subtree", () => {
+		const orphanParentPath = "/sessions/missing-parent.jsonl";
+		const child = makeSession({
+			path: "/sessions/child.jsonl",
+			id: "child",
+			title: "Orphan Root",
+			parentSessionPath: orphanParentPath,
+		});
+		const grand = makeSession({
+			path: "/sessions/grand.jsonl",
+			id: "grand",
+			title: "Grandchild",
+			parentSessionPath: child.path,
+			modified: new Date("2024-01-01T12:00:00Z"),
+		});
+
+		const rows = buildSessionMapRows([child, grand], () => []);
+		expect(rows).toHaveLength(2);
+		expect(rows[0]!.session.id).toBe("child");
+		expect(rows[0]!.depth).toBe(0);
+		expect(rows[1]!.session.id).toBe("grand");
+		expect(rows[1]!.depth).toBe(1);
+	});
+
+	it("terminates parentSessionPath cycles by re-rooting instead of looping forever", () => {
+		const A = makeSession({
+			path: "/sessions/A.jsonl",
+			id: "A",
+			title: "Cycle A",
+			parentSessionPath: "/sessions/B.jsonl",
+			modified: new Date("2024-01-03T00:00:00Z"),
+		});
+		const B = makeSession({
+			path: "/sessions/B.jsonl",
+			id: "B",
+			title: "Cycle B",
+			parentSessionPath: "/sessions/A.jsonl",
+			modified: new Date("2024-01-02T00:00:00Z"),
+		});
+
+		const rows = buildSessionMapRows([A, B], () => []);
+
+		expect(rows).toHaveLength(2);
+		expect(rows.every(r => r.session.id === "A" || r.session.id === "B")).toBe(true);
+		// One node is promoted to a depth-0 root; the other hangs under it.
+		const depths = rows.map(r => r.depth).sort();
+		expect(depths).toEqual([0, 1]);
+		expect(rows.filter(r => r.depth === 0)).toHaveLength(1);
+		expect(rows.filter(r => r.depth === 1)).toHaveLength(1);
+	});
+
+	it("attaches tags from tagsFor only to the matching session", () => {
+		const tagged = makeSession({
+			path: "/sessions/tagged.jsonl",
+			id: "tagged",
+			title: "Tagged",
+			modified: new Date("2024-01-03T00:00:00Z"),
+		});
+		const plain = makeSession({
+			path: "/sessions/plain.jsonl",
+			id: "plain",
+			title: "Plain",
+			modified: new Date("2024-01-02T00:00:00Z"),
+		});
+
+		const rows = buildSessionMapRows([tagged, plain], sessionId => (sessionId === "tagged" ? ["hot", "wip"] : []));
+
+		const taggedRow = rows.find(r => r.session.id === "tagged");
+		const plainRow = rows.find(r => r.session.id === "plain");
+		expect(taggedRow?.tags).toEqual(["hot", "wip"]);
+		expect(plainRow?.tags).toEqual([]);
+	});
+});
+
+describe("sessionLineageKind", () => {
+	it("classifies a file-path parent as handoff and a bare session-id parent as fork", () => {
+		expect(sessionLineageKind("/sessions/parent.jsonl")).toBe("handoff");
+		expect(sessionLineageKind("C:\\sessions\\parent.jsonl")).toBe("handoff");
+		expect(sessionLineageKind("parent-session-id")).toBe("fork");
+	});
+});
+
+describe("renderSessionMapText", () => {
+	it("returns the empty-state string for an empty session list", () => {
+		expect(renderSessionMapText([])).toBe("No sessions.");
+	});
+});
+
+
+describe("SessionMapComponent", () => {
+	it("renders lineage metadata, switches scope, and selects the navigated row", async () => {
+		const parent = makeSession({ path: "/sessions/parent.jsonl", id: "parent", title: "Parent" });
+		const child = makeSession({
+			path: "/sessions/child.jsonl",
+			id: "child",
+			title: "Child",
+			parentSessionPath: parent.path,
+			modified: new Date("2024-01-03T00:00:00Z"),
+		});
+		const remote = makeSession({ path: "/sessions/remote.jsonl", id: "remote", title: "Remote", cwd: "/other" });
+		const selected: string[] = [];
+		const map = new SessionMapComponent(
+			[parent, child],
+			session => selected.push(session.id),
+			() => {},
+			() => {},
+			{ loadAllSessions: async () => [parent, child, remote], tagsFor: id => (id === "child" ? ["hot"] : []) },
+		);
+
+		expect(map.render(100).join("\n")).toContain("#hot");
+		expect(map.render(100).join("\n")).toContain("handoff");
+		map.handleInput("\x1b[B");
+		map.handleInput("\n");
+		expect(selected).toEqual(["child"]);
+
+		map.handleInput("\t");
+		await Bun.sleep(0);
+		const rendered = map.render(100).join("\n");
+		expect(rendered).toContain("(all projects)");
+		expect(rendered).toContain("/other");
+	});
+});

--- a/packages/coding-agent/test/session/transcript-index.test.ts
+++ b/packages/coding-agent/test/session/transcript-index.test.ts
@@ -1,0 +1,395 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { SESSION_TAG_PREFIX } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { TranscriptIndex } from "@oh-my-pi/pi-coding-agent/session/transcript-index";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+let tempDir: TempDir | null = null;
+let dbPath = "";
+
+function freshIndex(): TranscriptIndex {
+	tempDir = TempDir.createSync("@omp-transcript-index-");
+	TranscriptIndex.resetInstance();
+	dbPath = tempDir.join("transcripts.db");
+	return TranscriptIndex.open(dbPath);
+}
+
+function writeJsonl(sessionDir: string, fileName: string, lines: unknown[]): string {
+	fs.mkdirSync(sessionDir, { recursive: true });
+	const filePath = path.join(sessionDir, fileName);
+	fs.writeFileSync(filePath, `${lines.map(line => JSON.stringify(line)).join("\n")}\n`, "utf8");
+	return filePath;
+}
+
+function tableCounts(fileDbPath: string): { chunks: number; fts: number } {
+	const db = new Database(fileDbPath, { readonly: true });
+	try {
+		const chunks = (db.prepare("SELECT count(*) AS n FROM chunks").get() as { n: number }).n;
+		const fts = (db.prepare("SELECT count(*) AS n FROM chunks_fts").get() as { n: number }).n;
+		return { chunks, fts };
+	} finally {
+		db.close();
+	}
+}
+
+function kindCounts(fileDbPath: string): Record<string, number> {
+	const db = new Database(fileDbPath, { readonly: true });
+	try {
+		const rows = db.prepare("SELECT kind, count(*) AS n FROM chunks GROUP BY kind").all() as Array<{
+			kind: string;
+			n: number;
+		}>;
+		const out: Record<string, number> = {};
+		for (const row of rows) out[row.kind] = row.n;
+		return out;
+	} finally {
+		db.close();
+	}
+}
+
+function sessionHeader(id: string, cwd = "/tmp/workspace") {
+	return {
+		type: "session",
+		version: 3,
+		id,
+		timestamp: "2026-07-25T12:00:00.000Z",
+		cwd,
+	};
+}
+
+function messageEntry(
+	id: string,
+	parentId: string | null,
+	message: Record<string, unknown>,
+	timestamp = "2026-07-25T12:00:01.000Z",
+) {
+	return { type: "message", id, parentId, timestamp, message };
+}
+
+beforeEach(() => {
+	TranscriptIndex.resetInstance();
+});
+
+afterEach(async () => {
+	TranscriptIndex.resetInstance();
+	if (tempDir) {
+		await Bun.sleep(0);
+		await tempDir.remove().catch(() => {});
+		tempDir = null;
+	}
+	dbPath = "";
+});
+
+describe("TranscriptIndex", () => {
+	it("reindex extracts message_text, tool_use, and tool_result chunks and skips non-message entries", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		writeJsonl(sessionDir, "extract.jsonl", [
+			sessionHeader("sess-extract"),
+			{
+				type: "model_change",
+				id: "mc1",
+				parentId: null,
+				timestamp: "2026-07-25T12:00:00.500Z",
+				model: "anthropic/claude-sonnet-4",
+			},
+			{
+				type: "thinking_level_change",
+				id: "tl1",
+				parentId: "mc1",
+				timestamp: "2026-07-25T12:00:00.750Z",
+				thinkingLevel: "high",
+			},
+			messageEntry("m-user", null, {
+				role: "user",
+				content: "extract-user-alpha",
+			}),
+			messageEntry(
+				"m-asst",
+				"m-user",
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "should-not-be-indexed" },
+						{ type: "text", text: "extract-assistant-beta" },
+						{
+							type: "toolCall",
+							id: "tc1",
+							name: "bash",
+							arguments: { command: "extract-tool-use-gamma" },
+						},
+					],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "test-model",
+					usage: {},
+					stopReason: "toolUse",
+					timestamp: Date.parse("2026-07-25T12:00:02.000Z"),
+				},
+				"2026-07-25T12:00:02.000Z",
+			),
+			messageEntry(
+				"m-tool",
+				"m-asst",
+				{
+					role: "toolResult",
+					toolCallId: "tc1",
+					toolName: "bash",
+					content: [{ type: "text", text: "extract-tool-result-delta" }],
+					isError: false,
+					timestamp: Date.parse("2026-07-25T12:00:03.000Z"),
+				},
+				"2026-07-25T12:00:03.000Z",
+			),
+			{
+				type: "label",
+				id: "lbl1",
+				parentId: "m-tool",
+				timestamp: "2026-07-25T12:00:04.000Z",
+				targetId: "m-user",
+				label: "bookmark-not-a-session-tag",
+			},
+		]);
+
+		const result = await index.reindex({ sessionDirs: [sessionDir] });
+		expect(result).toEqual({ files: 1, indexedFiles: 1 });
+
+		expect(kindCounts(dbPath)).toEqual({
+			message_text: 2,
+			tool_use: 1,
+			tool_result: 1,
+		});
+		expect(tableCounts(dbPath)).toEqual({ chunks: 4, fts: 4 });
+
+		expect(index.search("extract-user-alpha").map(h => h.kind)).toEqual(["message_text"]);
+		expect(index.search("extract-assistant-beta").map(h => h.kind)).toEqual(["message_text"]);
+		expect(index.search("extract-tool-use-gamma").map(h => ({ kind: h.kind, snippet: h.snippet }))).toEqual([
+			{ kind: "tool_use", snippet: 'bash {"command":"extract-tool-use-gamma"}' },
+		]);
+		expect(index.search("extract-tool-result-delta").map(h => h.kind)).toEqual(["tool_result"]);
+		expect(index.search("should-not-be-indexed")).toEqual([]);
+		expect(index.search("bookmark-not-a-session-tag")).toEqual([]);
+		expect(index.search("claude-sonnet-4")).toEqual([]);
+	});
+
+	it("second reindex over an unchanged tree indexes zero files (mtime+size skip)", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		writeJsonl(sessionDir, "stable-a.jsonl", [
+			sessionHeader("sess-a"),
+			messageEntry("m1", null, { role: "user", content: "stable-alpha" }),
+		]);
+		writeJsonl(sessionDir, "stable-b.jsonl", [
+			sessionHeader("sess-b"),
+			messageEntry("m1", null, { role: "user", content: "stable-beta" }),
+		]);
+
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 2, indexedFiles: 2 });
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 2, indexedFiles: 0 });
+		expect(tableCounts(dbPath)).toEqual({ chunks: 2, fts: 2 });
+	});
+
+	it("touching one file reindexes only that file with no duplicate rows (chunks_ad FTS delete trigger)", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		const untouchedPath = writeJsonl(sessionDir, "untouched.jsonl", [
+			sessionHeader("sess-untouched"),
+			messageEntry("m1", null, { role: "user", content: "keep-me-one" }),
+			messageEntry("m2", "m1", {
+				role: "assistant",
+				content: [{ type: "text", text: "keep-me-two" }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "test-model",
+				usage: {},
+				stopReason: "endTurn",
+				timestamp: Date.parse("2026-07-25T12:00:02.000Z"),
+			}),
+		]);
+		const touchedPath = writeJsonl(sessionDir, "touched.jsonl", [
+			sessionHeader("sess-touched"),
+			messageEntry("m1", null, { role: "user", content: "rewrite-me-old" }),
+		]);
+
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 2, indexedFiles: 2 });
+		expect(tableCounts(dbPath)).toEqual({ chunks: 3, fts: 3 });
+
+		// Change content + mtime so the skip check fails for only this file.
+		writeJsonl(sessionDir, "touched.jsonl", [
+			sessionHeader("sess-touched"),
+			messageEntry("m1", null, { role: "user", content: "rewrite-me-new" }),
+			messageEntry("m2", "m1", {
+				role: "assistant",
+				content: [{ type: "text", text: "rewrite-me-extra" }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "test-model",
+				usage: {},
+				stopReason: "endTurn",
+				timestamp: Date.parse("2026-07-25T12:00:02.000Z"),
+			}),
+		]);
+		const later = new Date(Date.now() + 10_000);
+		fs.utimesSync(touchedPath, later, later);
+		// Ensure the untouched file's mtime/size still match the indexed row.
+		const untouchedStat = fs.statSync(untouchedPath);
+		fs.utimesSync(untouchedPath, new Date(untouchedStat.mtimeMs), new Date(untouchedStat.mtimeMs));
+
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 2, indexedFiles: 1 });
+
+		const counts = tableCounts(dbPath);
+		expect(counts.chunks).toBe(4); // 2 untouched + 2 rewritten
+		expect(counts.fts).toBe(counts.chunks);
+		expect(index.search("rewrite-me-old")).toEqual([]);
+		expect(index.search("rewrite-me-new")).toHaveLength(1);
+		expect(index.search("rewrite-me-extra")).toHaveLength(1);
+		expect(index.search("keep-me-one")).toHaveLength(1);
+		expect(index.search("keep-me-two")).toHaveLength(1);
+
+		const db = new Database(dbPath, { readonly: true });
+		try {
+			const touchedRows = db
+				.prepare("SELECT content FROM chunks WHERE file_path = ? ORDER BY content")
+				.all(touchedPath) as Array<{ content: string }>;
+			expect(touchedRows.map(r => r.content)).toEqual(["rewrite-me-extra", "rewrite-me-new"]);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("search finds content past the first 4096 transcript bytes via FTS prefix and LIKE fallback", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		const needle = "Uniqueneedlezebra99";
+		const padding = "P".repeat(4500);
+		const filePath = writeJsonl(sessionDir, "deep.jsonl", [
+			sessionHeader("sess-deep"),
+			messageEntry("m-pad", null, { role: "user", content: padding }),
+			messageEntry("m-needle", "m-pad", {
+				role: "user",
+				content: `prefix ${needle} suffix with precommit flavor`,
+			}),
+		]);
+
+		const raw = fs.readFileSync(filePath, "utf8");
+		expect(raw.indexOf(needle)).toBeGreaterThan(4096);
+
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 1, indexedFiles: 1 });
+
+		// FTS prefix path: full token matches `"Uniqueneedlezebra99"*`.
+		const ftsHits = index.search(needle);
+		expect(ftsHits).toHaveLength(1);
+		expect(ftsHits[0]?.snippet).toContain(needle);
+		expect(ftsHits[0]?.sessionId).toBe("sess-deep");
+
+		// LIKE fallback: infix `eedleze` cannot match via FTS5 prefix-only `*`.
+		const likeHits = index.search("eedleze");
+		expect(likeHits).toHaveLength(1);
+		expect(likeHits[0]?.snippet).toContain(needle);
+	});
+
+	it("skips a malformed jsonl without aborting; other files still index", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+		fs.writeFileSync(path.join(sessionDir, "broken.jsonl"), "this is not json\n{{{also-broken\n", "utf8");
+		writeJsonl(sessionDir, "good.jsonl", [
+			sessionHeader("sess-good"),
+			messageEntry("m1", null, { role: "user", content: "malformed-sibling-ok" }),
+		]);
+
+		const result = await index.reindex({ sessionDirs: [sessionDir] });
+		expect(result.files).toBe(2);
+		expect(result.indexedFiles).toBe(1);
+		expect(index.search("malformed-sibling-ok")).toHaveLength(1);
+		expect(tableCounts(dbPath)).toEqual({ chunks: 1, fts: 1 });
+	});
+
+	it("tagsFor and sessionIdsByTag agree; cleared labels disappear (last-write-wins per targetId)", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		const filePath = writeJsonl(sessionDir, "tagged.jsonl", [
+			sessionHeader("sess-tags"),
+			messageEntry("m1", null, { role: "user", content: "tagged-session-body" }),
+			{
+				type: "label",
+				id: "t1",
+				parentId: "m1",
+				timestamp: "2026-07-25T12:00:05.000Z",
+				targetId: `${SESSION_TAG_PREFIX}alpha`,
+				label: "alpha",
+			},
+			{
+				type: "label",
+				id: "t2",
+				parentId: "t1",
+				timestamp: "2026-07-25T12:00:06.000Z",
+				targetId: `${SESSION_TAG_PREFIX}beta`,
+				label: "beta",
+			},
+			{
+				// Earlier write for gamma — should be overwritten by the empty clear below.
+				type: "label",
+				id: "t3",
+				parentId: "t2",
+				timestamp: "2026-07-25T12:00:07.000Z",
+				targetId: `${SESSION_TAG_PREFIX}gamma`,
+				label: "gamma",
+			},
+			{
+				type: "label",
+				id: "t4",
+				parentId: "t3",
+				timestamp: "2026-07-25T12:00:08.000Z",
+				targetId: `${SESSION_TAG_PREFIX}gamma`,
+				label: "",
+			},
+		]);
+
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 1, indexedFiles: 1 });
+
+		expect(index.tagsFor("sess-tags")).toEqual(["alpha", "beta"]);
+		expect(index.sessionIdsByTag("alpha")).toEqual(["sess-tags"]);
+		expect(index.sessionIdsByTag("beta")).toEqual(["sess-tags"]);
+		expect(index.sessionIdsByTag("gamma")).toEqual([]);
+
+		// Rewrite: clear alpha (empty label), keep beta — proves last-write-wins + reindex refresh.
+		writeJsonl(sessionDir, "tagged.jsonl", [
+			sessionHeader("sess-tags"),
+			messageEntry("m1", null, { role: "user", content: "tagged-session-body" }),
+			{
+				type: "label",
+				id: "t1",
+				parentId: "m1",
+				timestamp: "2026-07-25T12:00:05.000Z",
+				targetId: `${SESSION_TAG_PREFIX}alpha`,
+				label: "alpha",
+			},
+			{
+				type: "label",
+				id: "t2",
+				parentId: "t1",
+				timestamp: "2026-07-25T12:00:06.000Z",
+				targetId: `${SESSION_TAG_PREFIX}beta`,
+				label: "beta",
+			},
+			{
+				type: "label",
+				id: "t5",
+				parentId: "t2",
+				timestamp: "2026-07-25T12:00:09.000Z",
+				targetId: `${SESSION_TAG_PREFIX}alpha`,
+				label: "",
+			},
+		]);
+		const later = new Date(Date.now() + 10_000);
+		fs.utimesSync(filePath, later, later);
+
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 1, indexedFiles: 1 });
+		expect(index.tagsFor("sess-tags")).toEqual(["beta"]);
+		expect(index.sessionIdsByTag("alpha")).toEqual([]);
+		expect(index.sessionIdsByTag("beta")).toEqual(["sess-tags"]);
+	});
+});

--- a/packages/coding-agent/test/session/transcript-index.test.ts
+++ b/packages/coding-agent/test/session/transcript-index.test.ts
@@ -392,4 +392,80 @@ describe("TranscriptIndex", () => {
 		expect(index.sessionIdsByTag("alpha")).toEqual([]);
 		expect(index.sessionIdsByTag("beta")).toEqual(["sess-tags"]);
 	});
+
+	it("purges chunks and tags for deleted session files", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		const filePath = writeJsonl(sessionDir, "deleted.jsonl", [
+			sessionHeader("sess-deleted"),
+			messageEntry("m1", null, { role: "user", content: "purge-me-token" }),
+		]);
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 1, indexedFiles: 1 });
+		expect(index.search("purge-me-token")).toHaveLength(1);
+		fs.unlinkSync(filePath);
+		expect(await index.reindex({ sessionDirs: [sessionDir] })).toEqual({ files: 0, indexedFiles: 0 });
+		expect(index.search("purge-me-token")).toEqual([]);
+		expect(tableCounts(dbPath)).toEqual({ chunks: 0, fts: 0 });
+	});
+
+	it("encloses scoped searches and session ranking to the requested directory", async () => {
+		const index = freshIndex();
+		const firstDir = tempDir!.join("first");
+		const secondDir = tempDir!.join("second");
+		writeJsonl(firstDir, "first.jsonl", [
+			sessionHeader("sess-first"),
+			messageEntry("m1", null, { role: "user", content: "shared-scope-token" }),
+		]);
+		writeJsonl(secondDir, "second.jsonl", [
+			sessionHeader("sess-second"),
+			messageEntry("m1", null, { role: "user", content: "shared-scope-token" }),
+		]);
+		await index.reindex({ sessionDirs: [firstDir, secondDir] });
+		expect(index.search("shared-scope-token", { sessionDir: firstDir }).map(hit => hit.sessionId)).toEqual([
+			"sess-first",
+		]);
+		expect(index.matchingSessionIds("shared-scope-token", { sessionDir: secondDir })).toEqual(["sess-second"]);
+	});
+
+	it("indexes bash and Python execution source and output", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		writeJsonl(sessionDir, "execution.jsonl", [
+			sessionHeader("sess-execution"),
+			messageEntry("bash", null, {
+				role: "bashExecution",
+				command: "bash-command-token",
+				output: "bash-output-token",
+			}),
+			messageEntry("python", "bash", {
+				role: "pythonExecution",
+				code: "python-code-token",
+				output: "python-output-token",
+			}),
+		]);
+		await index.reindex({ sessionDirs: [sessionDir] });
+		expect(index.search("bash-command-token")[0]?.kind).toBe("tool_use");
+		expect(index.search("bash-output-token")[0]?.kind).toBe("tool_result");
+		expect(index.search("python-code-token")[0]?.kind).toBe("tool_use");
+		expect(index.search("python-output-token")[0]?.kind).toBe("tool_result");
+	});
+
+	it("deduplicates session ids before applying the ranking limit", async () => {
+		const index = freshIndex();
+		const sessionDir = tempDir!.join("sessions");
+		writeJsonl(sessionDir, "chatty.jsonl", [
+			sessionHeader("sess-chatty"),
+			...Array.from({ length: 5 }, (_, i) =>
+				messageEntry(`m${i}`, null, { role: "user", content: "rank-limit-token" }),
+			),
+		]);
+		writeJsonl(sessionDir, "other.jsonl", [
+			sessionHeader("sess-other"),
+			messageEntry("m1", null, { role: "user", content: "rank-limit-token" }),
+		]);
+		await index.reindex({ sessionDirs: [sessionDir] });
+		expect(index.matchingSessionIds("rank-limit-token", { limit: 2 })).toEqual(
+			expect.arrayContaining(["sess-other", "sess-chatty"]),
+		);
+	});
 });

--- a/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
+++ b/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs";
-import { getTranscriptDbPath } from "@oh-my-pi/pi-utils";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TranscriptIndex } from "@oh-my-pi/pi-coding-agent/session/transcript-index";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import { getTranscriptDbPath } from "@oh-my-pi/pi-utils";
 
 /** Escape hatch for deliberate test fakes that are not structurally comparable to their target types. */
 function cast<T>(value: unknown): T {
@@ -137,6 +137,17 @@ describe("/session tag subcommands", () => {
 		expect(sessionManager.sessionTags()).toEqual([]);
 	});
 
+	it("sanitizes tags before storing and echoing them", async () => {
+		const sessionManager = SessionManager.inMemory();
+		const harness = createAcpRuntime({ sessionManager });
+
+		expect(await executeAcpBuiltinSlashCommand("/session tag safe\u001b[31m tag\nname", harness.runtime)).toEqual({
+			consumed: true,
+		});
+		expect(harness.output).toHaveBeenCalledWith("Tagged session: safe tag name");
+		expect(sessionManager.sessionTags()).toEqual(["safe tag name"]);
+	});
+
 	it("tag with no name is consumed and reports usage without appending an empty tag", async () => {
 		const sessionManager = SessionManager.inMemory();
 		const harness = createAcpRuntime({ sessionManager });
@@ -154,6 +165,25 @@ describe("/session tag subcommands", () => {
 describe("/session search", () => {
 	afterEach(() => {
 		spyOn(TranscriptIndex, "open").mockRestore();
+	});
+
+	it("returns an executable search prompt and reindexes the effective session directory in both hosts", async () => {
+		const sessionManager = SessionManager.inMemory();
+		const reindex = vi.fn(async () => ({ files: 0, indexedFiles: 0 }));
+		const openSpy = spyOn(TranscriptIndex, "open").mockReturnValue(cast<TranscriptIndex>({ reindex }));
+		const acp = createAcpRuntime({ sessionManager });
+		const tui = createTuiRuntime({ sessionManager });
+
+		const acpPrompt = promptTextOf(
+			await executeAcpBuiltinSlashCommand("/session search previous decision", acp.runtime),
+		);
+		const tuiPrompt = await executeBuiltinSlashCommand("/session search previous decision", tui.runtime);
+		if (typeof tuiPrompt !== "string") throw new Error("expected TUI session search prompt");
+		expect(acpPrompt).toBe(tuiPrompt);
+		expect(acpPrompt).toContain("previous decision");
+		expect(reindex).toHaveBeenCalledTimes(2);
+		expect(reindex).toHaveBeenCalledWith({ sessionDirs: [sessionManager.getSessionDir()] });
+		expect(openSpy).toHaveBeenCalledTimes(2);
 	});
 
 	it("with no question reports usage and does not create the transcript database", async () => {

--- a/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
+++ b/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import * as fs from "node:fs";
+import { getTranscriptDbPath } from "@oh-my-pi/pi-utils";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TranscriptIndex } from "@oh-my-pi/pi-coding-agent/session/transcript-index";
 import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
@@ -109,5 +112,64 @@ describe("/qa slash command", () => {
 		}
 		expect(promptTextOf(acpResult)).toBe(tuiResult);
 		expect(tui.setText).toHaveBeenCalledWith("");
+	});
+});
+
+describe("/session tag subcommands", () => {
+	it("tag then tags reports the tag; untag then tags no longer reports it", async () => {
+		const sessionManager = SessionManager.inMemory();
+		const harness = createAcpRuntime({ sessionManager });
+
+		expect(await executeAcpBuiltinSlashCommand("/session tag foo", harness.runtime)).toEqual({ consumed: true });
+		expect(harness.output).toHaveBeenCalledWith("Tagged session: foo");
+		harness.output.mockClear();
+
+		expect(await executeAcpBuiltinSlashCommand("/session tags", harness.runtime)).toEqual({ consumed: true });
+		expect(harness.output).toHaveBeenCalledWith("Tags: foo");
+		harness.output.mockClear();
+
+		expect(await executeAcpBuiltinSlashCommand("/session untag foo", harness.runtime)).toEqual({ consumed: true });
+		expect(harness.output).toHaveBeenCalledWith("Untagged session: foo");
+		harness.output.mockClear();
+
+		expect(await executeAcpBuiltinSlashCommand("/session tags", harness.runtime)).toEqual({ consumed: true });
+		expect(harness.output).toHaveBeenCalledWith("No tags on this session.");
+		expect(sessionManager.sessionTags()).toEqual([]);
+	});
+
+	it("tag with no name is consumed and reports usage without appending an empty tag", async () => {
+		const sessionManager = SessionManager.inMemory();
+		const harness = createAcpRuntime({ sessionManager });
+
+		expect(await executeAcpBuiltinSlashCommand("/session tag", harness.runtime)).toEqual({ consumed: true });
+		expect(harness.output).toHaveBeenCalledWith("Usage: /session tag <name>");
+		expect(sessionManager.sessionTags()).toEqual([]);
+
+		const tui = createTuiRuntime({ sessionManager });
+		expect(await executeBuiltinSlashCommand("/session tag", tui.runtime)).toBe(true);
+		expect(tui.showStatus).toHaveBeenCalledWith("Usage: /session tag <name>");
+	});
+});
+
+describe("/session search", () => {
+	afterEach(() => {
+		spyOn(TranscriptIndex, "open").mockRestore();
+	});
+
+	it("with no question reports usage and does not create the transcript database", async () => {
+		const dbPath = getTranscriptDbPath();
+		const existedBefore = fs.existsSync(dbPath);
+		const openSpy = spyOn(TranscriptIndex, "open");
+		const acp = createAcpRuntime();
+
+		expect(await executeAcpBuiltinSlashCommand("/session search", acp.runtime)).toEqual({ consumed: true });
+		expect(acp.output).toHaveBeenCalledWith("Usage: /session search <question>");
+
+		const tui = createTuiRuntime();
+		expect(await executeBuiltinSlashCommand("/session search", tui.runtime)).toBe(true);
+		expect(tui.showStatus).toHaveBeenCalledWith("Usage: /session search <question>");
+		expect(tui.setText).toHaveBeenCalledWith("");
+		expect(openSpy).not.toHaveBeenCalled();
+		if (!existedBefore) expect(fs.existsSync(dbPath)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
+++ b/packages/coding-agent/test/slash-commands/qa-and-session.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+
+/** Escape hatch for deliberate test fakes that are not structurally comparable to their target types. */
+function cast<T>(value: unknown): T {
+	return value as T;
+}
+
+/** TUI fake runtime — same shape as `btw.test.ts`, extended with session wiring. */
+function createTuiRuntime(options?: { sessionManager?: SessionManager }) {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const sessionManager = options?.sessionManager ?? SessionManager.inMemory();
+
+	return {
+		setText,
+		showStatus,
+		sessionManager,
+		runtime: {
+			ctx: cast<InteractiveModeContext>({
+				editor: { setText },
+				showStatus,
+				sessionManager,
+			}),
+		},
+	};
+}
+
+/** ACP fake runtime — minimal `SlashCommandRuntime` for `handle` branches. */
+function createAcpRuntime(options?: { sessionManager?: SessionManager }) {
+	const output = vi.fn();
+	const sessionManager = options?.sessionManager ?? SessionManager.inMemory();
+
+	return {
+		output,
+		sessionManager,
+		runtime: cast<SlashCommandRuntime>({
+			sessionManager,
+			cwd: sessionManager.getCwd(),
+			output,
+			refreshCommands: () => {},
+			reloadPlugins: async () => {},
+		}),
+	};
+}
+
+/**
+ * Narrow a slash-command result to its prompt text. A real check rather than an
+ * inline cast, so a handler that stops returning a prompt fails here loudly
+ * instead of reading `undefined` off a shape nobody verified.
+ */
+function promptTextOf(result: unknown): string {
+	if (!result || typeof result !== "object" || !("prompt" in result) || typeof result.prompt !== "string") {
+		throw new Error(`expected a { prompt: string } result, got ${JSON.stringify(result)}`);
+	}
+	return result.prompt;
+}
+
+function expectQaPhaseObligations(prompt: string) {
+	expect(prompt).toMatch(/inventory/i);
+	expect(prompt).toMatch(/scout/i);
+	expect(prompt).toMatch(/exercise/i);
+	expect(prompt).toMatch(/evidence/i);
+	expect(prompt).toMatch(/report/i);
+	expect(prompt).toMatch(/verdict/i);
+	expect(prompt).toMatch(/no code edits/i);
+}
+
+describe("/qa slash command", () => {
+	it("returns a prompt carrying the request and each phase obligation", async () => {
+		const harness = createAcpRuntime();
+		const request = "verify the login form submits and surfaces errors";
+
+		const result = await executeAcpBuiltinSlashCommand(`/qa ${request}`, harness.runtime);
+
+		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
+		const prompt = promptTextOf(result);
+		expect(prompt).toContain(request);
+		expectQaPhaseObligations(prompt);
+	});
+
+	it("with an empty request still returns a prompt that infers scope from the working tree", async () => {
+		const harness = createAcpRuntime();
+
+		const result = await executeAcpBuiltinSlashCommand("/qa", harness.runtime);
+
+		expect(result).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
+		const prompt = promptTextOf(result);
+		expect(prompt.length).toBeGreaterThan(0);
+		expect(prompt).toMatch(/working tree|git status|recent diff/i);
+		expectQaPhaseObligations(prompt);
+	});
+
+	it("ACP handle and TUI handleTui return the same prompt text for the same input", async () => {
+		const request = "check the slash-command wiring for /qa";
+		const acp = createAcpRuntime();
+		const tui = createTuiRuntime();
+
+		const acpResult = await executeAcpBuiltinSlashCommand(`/qa ${request}`, acp.runtime);
+		const tuiResult = await executeBuiltinSlashCommand(`/qa ${request}`, tui.runtime);
+
+		expect(acpResult).toEqual(expect.objectContaining({ prompt: expect.any(String) }));
+		if (typeof tuiResult !== "string") {
+			throw new Error(`expected handleTui to return prompt text, got ${typeof tuiResult}`);
+		}
+		expect(promptTextOf(acpResult)).toBe(tuiResult);
+		expect(tui.setText).toHaveBeenCalledWith("");
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exported `getTranscriptDbPath()` for transcript-index consumers.
+
 ## [17.0.9] - 2026-07-23
 
 ### Breaking Changes

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -740,6 +740,11 @@ export function getHistoryDbPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "history.db", "data");
 }
 
+/** Get the path to transcripts.db (SQLite FTS index over session JSONL). */
+export function getTranscriptDbPath(agentDir?: string): string {
+	return dirs.agentSubdir(agentDir, "transcripts.db", "data");
+}
+
 /** Get the path to models.db (model cache database). */
 export function getModelDbPath(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "models.db", "data");


### PR DESCRIPTION
## Summary

Related sessions can now be inspected as one navigable lineage instead of a flat list. The map shows branch ancestry, keeps labels terminal-safe, and lets users switch through the same interaction from the keyboard or `/session map`.

## Dependency

This fork PR includes the commits from the transcript-search branch so it builds against `main`. Review the lineage-map commit separately; its session-tag lookup uses the index introduced by #6676.

## Validation

- `bun --cwd=packages/coding-agent test test/modes/components/session-map.test.ts` — 7 passed, 22 assertions
- `bun --cwd=packages/coding-agent run check:types`

Closes #6686
