### PR TITLE
fix(stt): resolve Windows workspace sherpa addon

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
+- Fixed Parakeet speech-to-text failing to load `sherpa-onnx-node` from Windows source workspaces when Bun installed the wrapper under `packages/coding-agent/node_modules` but hoisted its native platform package to the repository root ([#6690](https://github.com/can1357/oh-my-pi/issues/6690)).
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
 

--- a/packages/coding-agent/src/stt/asr-worker.ts
+++ b/packages/coding-agent/src/stt/asr-worker.ts
@@ -35,6 +35,7 @@ import {
 	type SttModelKey,
 	type TransformersSttModelSpec,
 } from "./models";
+import { loadSourceSherpaRuntime, type SherpaOfflineRecognizer, type SherpaRuntime } from "./sherpa-runtime";
 
 const ASR_TASK = "automatic-speech-recognition";
 const SHERPA_PACKAGE = "sherpa-onnx-node";
@@ -50,7 +51,6 @@ const HF_RESOLVE_BASE = "https://huggingface.co";
 // Coalesce download progress so streaming a multi-hundred-MB model file doesn't
 // flood the IPC channel with one event per chunk.
 const PROGRESS_EMIT_BYTES = 4_000_000;
-const sourceRequire = createRequire(import.meta.url);
 
 const sttModelDevicePreference = resolveTinyModelDevicePreference();
 const sttModelDtypeOverride = resolveTinyModelDtypeOverride();
@@ -88,41 +88,6 @@ interface TransformersRuntime {
 			progress_callback: (info: ProgressInfo) => void;
 		},
 	) => Promise<AutomaticSpeechRecognitionPipeline>;
-}
-
-/** Recognition result returned by `sherpa-onnx-node`'s offline recognizer. */
-interface SherpaOfflineResult {
-	text?: string;
-}
-
-/** A sherpa-onnx offline stream that accepts a single waveform before decoding. */
-interface SherpaOfflineStream {
-	acceptWaveform(audio: { samples: Float32Array; sampleRate: number }): void;
-}
-
-interface SherpaOfflineRecognizer {
-	createStream(): SherpaOfflineStream;
-	decodeAsync(stream: SherpaOfflineStream): Promise<SherpaOfflineResult>;
-}
-
-/** Offline recognizer config passed to `sherpa-onnx-node` (transducer family). */
-interface SherpaOfflineConfig {
-	modelConfig: {
-		transducer: { encoder: string; decoder: string; joiner: string };
-		tokens: string;
-		modelType: string;
-		numThreads: number;
-		provider: string;
-		debug: number;
-	};
-	decodingMethod: string;
-}
-
-/** Subset of the native `sherpa-onnx-node` module surface we use. */
-interface SherpaRuntime {
-	OfflineRecognizer: {
-		createAsync(config: SherpaOfflineConfig): Promise<SherpaOfflineRecognizer>;
-	};
 }
 
 /** A warm model plus the engine that loaded it; cached per tier key. */
@@ -182,7 +147,7 @@ function getSherpaRuntimeDir(): string {
  */
 function loadSherpaRuntime(transport: SttTransport, requestId: string, modelKey: SttModelKey): Promise<SherpaRuntime> {
 	return sherpaRuntime.load(async () => {
-		if (!isCompiledBinary()) return sourceRequire(SHERPA_PACKAGE) as SherpaRuntime;
+		if (!isCompiledBinary()) return loadSourceSherpaRuntime(import.meta.url);
 		const runtimeDir = await ensureRuntimeInstalled({
 			runtimeDir: getSherpaRuntimeDir(),
 			install: { dependencies: { [SHERPA_PACKAGE]: getSherpaVersionSpec() } },

--- a/packages/coding-agent/src/stt/sherpa-runtime.ts
+++ b/packages/coding-agent/src/stt/sherpa-runtime.ts
@@ -37,19 +37,35 @@ export interface SherpaRuntime {
 	};
 }
 
-function getPlatformPackage(): string {
-	const platform = os.platform() === "win32" ? "win" : os.platform();
-	return `sherpa-onnx-${platform}-${os.arch()}`;
-}
-
-/** Loads the source-workspace sherpa wrapper colocated with its native platform package. */
+/** Loads the nearest working source-workspace sherpa wrapper, including hoisted fallbacks. */
 export function loadSourceSherpaRuntime(sourceUrl: string): SherpaRuntime {
 	const sourceRequire = createRequire(sourceUrl);
-	const platformPackage = getPlatformPackage();
-	for (const nodeModules of sourceRequire.resolve.paths(SHERPA_PACKAGE) ?? []) {
-		if (!resolveRuntimeModule(nodeModules, platformPackage)) continue;
-		const entry = resolveRuntimeModule(nodeModules, SHERPA_PACKAGE);
-		if (entry) return createRequire(entry)(entry);
+	const nearestEntry = sourceRequire.resolve(SHERPA_PACKAGE);
+	try {
+		return createRequire(nearestEntry)(nearestEntry);
+	} catch (error) {
+		if (!(error instanceof Error && error.message.startsWith("Could not find sherpa-onnx-node. Tried"))) {
+			throw error;
+		}
+		const platform = os.platform();
+		const platformPackage = `sherpa-onnx-${platform === "win32" ? "win" : platform}-${os.arch()}`;
+		for (const nodeModules of sourceRequire.resolve.paths(SHERPA_PACKAGE) ?? []) {
+			if (!resolveRuntimeModule(nodeModules, platformPackage)) continue;
+			const entry = resolveRuntimeModule(nodeModules, SHERPA_PACKAGE);
+			if (!entry || entry === nearestEntry) continue;
+			try {
+				return createRequire(entry)(entry);
+			} catch (candidateError) {
+				if (
+					!(
+						candidateError instanceof Error &&
+						candidateError.message.startsWith("Could not find sherpa-onnx-node. Tried")
+					)
+				) {
+					throw candidateError;
+				}
+			}
+		}
+		throw error;
 	}
-	return sourceRequire(SHERPA_PACKAGE);
 }

--- a/packages/coding-agent/src/stt/sherpa-runtime.ts
+++ b/packages/coding-agent/src/stt/sherpa-runtime.ts
@@ -1,0 +1,55 @@
+import { createRequire } from "node:module";
+import * as os from "node:os";
+import { resolveRuntimeModule } from "@oh-my-pi/pi-utils";
+
+const SHERPA_PACKAGE = "sherpa-onnx-node";
+
+interface SherpaOfflineResult {
+	text?: string;
+}
+
+interface SherpaOfflineStream {
+	acceptWaveform(audio: { samples: Float32Array; sampleRate: number }): void;
+}
+
+interface SherpaOfflineConfig {
+	modelConfig: {
+		transducer: { encoder: string; decoder: string; joiner: string };
+		tokens: string;
+		modelType: string;
+		numThreads: number;
+		provider: string;
+		debug: number;
+	};
+	decodingMethod: string;
+}
+
+/** A sherpa-onnx recognizer instance used by the STT worker. */
+export interface SherpaOfflineRecognizer {
+	createStream(): SherpaOfflineStream;
+	decodeAsync(stream: SherpaOfflineStream): Promise<SherpaOfflineResult>;
+}
+
+/** The native sherpa-onnx module surface used by the STT worker. */
+export interface SherpaRuntime {
+	OfflineRecognizer: {
+		createAsync(config: SherpaOfflineConfig): Promise<SherpaOfflineRecognizer>;
+	};
+}
+
+function getPlatformPackage(): string {
+	const platform = os.platform() === "win32" ? "win" : os.platform();
+	return `sherpa-onnx-${platform}-${os.arch()}`;
+}
+
+/** Loads the source-workspace sherpa wrapper colocated with its native platform package. */
+export function loadSourceSherpaRuntime(sourceUrl: string): SherpaRuntime {
+	const sourceRequire = createRequire(sourceUrl);
+	const platformPackage = getPlatformPackage();
+	for (const nodeModules of sourceRequire.resolve.paths(SHERPA_PACKAGE) ?? []) {
+		if (!resolveRuntimeModule(nodeModules, platformPackage)) continue;
+		const entry = resolveRuntimeModule(nodeModules, SHERPA_PACKAGE);
+		if (entry) return createRequire(entry)(entry);
+	}
+	return sourceRequire(SHERPA_PACKAGE);
+}

--- a/packages/coding-agent/test/stt-sherpa-runtime.test.ts
+++ b/packages/coding-agent/test/stt-sherpa-runtime.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadSourceSherpaRuntime } from "@oh-my-pi/pi-coding-agent/stt/sherpa-runtime";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const PLATFORM_PACKAGE = `sherpa-onnx-${os.platform() === "win32" ? "win" : os.platform()}-${os.arch()}`;
+
+async function writePackage(nodeModules: string, name: string, source: string): Promise<void> {
+	const dir = path.join(nodeModules, name);
+	await Bun.write(path.join(dir, "package.json"), JSON.stringify({ name, main: "index.js" }));
+	await Bun.write(path.join(dir, "index.js"), source);
+}
+
+describe("sherpa source runtime resolution", () => {
+	let tmp = "";
+
+	afterEach(async () => {
+		await removeWithRetries(tmp);
+	});
+
+	it("loads the wrapper colocated with a workspace-hoisted platform addon", async () => {
+		tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-sherpa-source-"));
+		const rootNodeModules = path.join(tmp, "node_modules");
+		const packageNodeModules = path.join(tmp, "packages", "coding-agent", "node_modules");
+		await writePackage(
+			rootNodeModules,
+			"sherpa-onnx-node",
+			"module.exports = { OfflineRecognizer: { createAsync() {} } };\n",
+		);
+		await writePackage(rootNodeModules, PLATFORM_PACKAGE, "module.exports = {};\n");
+		await writePackage(packageNodeModules, "sherpa-onnx-node", "throw new Error('loaded isolated wrapper');\n");
+
+		const sourceUrl = path.join(tmp, "packages", "coding-agent", "src", "stt", "asr-worker.ts");
+		const runtime = loadSourceSherpaRuntime(sourceUrl);
+
+		expect(runtime.OfflineRecognizer.createAsync).toBeTypeOf("function");
+	});
+});

--- a/packages/coding-agent/test/stt-sherpa-runtime.test.ts
+++ b/packages/coding-agent/test/stt-sherpa-runtime.test.ts
@@ -30,11 +30,42 @@ describe("sherpa source runtime resolution", () => {
 			"module.exports = { OfflineRecognizer: { createAsync() {} } };\n",
 		);
 		await writePackage(rootNodeModules, PLATFORM_PACKAGE, "module.exports = {};\n");
-		await writePackage(packageNodeModules, "sherpa-onnx-node", "throw new Error('loaded isolated wrapper');\n");
+		await writePackage(
+			packageNodeModules,
+			"sherpa-onnx-node",
+			"throw new Error('Could not find sherpa-onnx-node. Tried');\n",
+		);
 
 		const sourceUrl = path.join(tmp, "packages", "coding-agent", "src", "stt", "asr-worker.ts");
 		const runtime = loadSourceSherpaRuntime(sourceUrl);
 
 		expect(runtime.OfflineRecognizer.createAsync).toBeTypeOf("function");
+	});
+
+	it("prefers the nearest wrapper when its nested platform addon is loadable", async () => {
+		tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-sherpa-source-"));
+		const rootNodeModules = path.join(tmp, "node_modules");
+		const packageNodeModules = path.join(tmp, "packages", "coding-agent", "node_modules");
+		await writePackage(
+			rootNodeModules,
+			"sherpa-onnx-node",
+			"module.exports = { OfflineRecognizer: { createAsync: function rootRuntime() {} } };\n",
+		);
+		await writePackage(rootNodeModules, PLATFORM_PACKAGE, "module.exports = {};\n");
+		await writePackage(
+			packageNodeModules,
+			"sherpa-onnx-node",
+			`require("./node_modules/${PLATFORM_PACKAGE}"); module.exports = { OfflineRecognizer: { createAsync: function nestedRuntime() {} } };\n`,
+		);
+		await writePackage(
+			path.join(packageNodeModules, "sherpa-onnx-node", "node_modules"),
+			PLATFORM_PACKAGE,
+			"module.exports = {};\n",
+		);
+
+		const sourceUrl = path.join(tmp, "packages", "coding-agent", "src", "stt", "asr-worker.ts");
+		const runtime = loadSourceSherpaRuntime(sourceUrl);
+
+		expect(runtime.OfflineRecognizer.createAsync.name).toBe("nestedRuntime");
 	});
 });


### PR DESCRIPTION
## Repro

A workspace-layout probe matching Bun's Windows install geometry places `sherpa-onnx-node` both under the repository root and `packages/coding-agent/node_modules`, with `sherpa-onnx-win-x64` only at the root. Before the fix, `bun /tmp/repro-6690.ts` reported `workspace root: OK` and `STT source: FAIL (Could not find sherpa-onnx-node. Tried)`.

## Cause

`packages/coding-agent/src/stt/asr-worker.ts` created its source `require` from the STT module and loaded the first `sherpa-onnx-node` it resolved. In Bun's workspace layout that is the package-local wrapper, while sherpa's fixed sibling lookup cannot reach the platform addon hoisted to the repository root.

## Fix

- Add `stt/sherpa-runtime.ts` to select a sherpa wrapper from a module-search root that also contains the current native platform package.
- Route the source-mode STT loader through that colocated runtime resolver while leaving compiled side-runtime loading unchanged.
- Add a workspace-hoisting regression test and an Unreleased changelog entry.

## Verification

`bun /tmp/verify-6690.ts` reports `workspace root: OK` and `STT source: OK`. `bun test packages/coding-agent/test/stt-preflight.test.ts packages/coding-agent/test/stt-submit-trigger.test.ts packages/coding-agent/test/stt-sherpa-runtime.test.ts` passes 16 tests with 0 failures. `bun run check:types` passes in `packages/coding-agent`; the pre-publish gate also completed successfully.

Fixes #6690