### PR TITLE
fix(coding-agent): stop the live advisor runtime when /settings disables it

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.
+- Fixed disabling the Advisor from `/settings` updating the persisted setting without stopping the live Advisor runtime until the session restarted: `SelectorController.handleSettingChange` had no case for `advisor.enabled`, unlike other session-managed toggles (`autoCompact`, `steeringMode`, ...), so the change never reached `session.setAdvisorEnabled`.
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -420,6 +420,11 @@ export class SelectorController {
 				this.ctx.session.setAutoCompactionEnabled(value as boolean);
 				this.ctx.statusLine.setAutoCompactEnabled(value as boolean);
 				break;
+			case "advisor.enabled":
+				this.ctx.session.setAdvisorEnabled(value as boolean);
+				this.ctx.statusLine.invalidate();
+				this.ctx.ui.requestRender();
+				break;
 			case "steeringMode":
 				this.ctx.session.setSteeringMode(value as "all" | "one-at-a-time");
 				break;

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -77,6 +77,22 @@ describe("selector setting side effects", () => {
 
 		expect(applyMemoryBackend).toHaveBeenCalledTimes(1);
 	});
+	it("stops the live advisor runtime when advisor.enabled is turned off in /settings", () => {
+		const setAdvisorEnabled = vi.fn();
+		const invalidate = vi.fn();
+		const requestRender = vi.fn();
+		const controller = new SelectorController({
+			session: { setAdvisorEnabled },
+			statusLine: { invalidate },
+			ui: { requestRender },
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("advisor.enabled", false);
+
+		expect(setAdvisorEnabled).toHaveBeenCalledWith(false);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
 
 	for (const id of ["terminal.showImages", "showImages"]) {
 		for (const visible of [false, true]) {


### PR DESCRIPTION
The Advisor toggle in `/settings` doesn't do what I expected: it turns off the setting but leaves the runtime running until the session is restarted, unlike `/advisor off`, which stops it immediately. I'm not sure whether this was intentional or simply an overlooked code path, but I reproduced it by starting the Advisor and disabling it from `/settings`, then added the same call that `/advisor off` already uses.

## What changed

`SelectorController.handleSettingChange` had no case for `advisor.enabled`, unlike the other session-managed toggles such as `autoCompact` and `steeringMode`. As a result, disabling the Advisor from `/settings` persisted the setting but never called `session.setAdvisorEnabled`, leaving the live runtime attached until the session was restarted.

This change adds the missing case and uses the same `setAdvisorEnabled` call already used by `/advisor off`. It also refreshes the status line and requests a UI render after the setting changes.

## Reproduction

1. Start the Advisor, for example with `/advisor on`.
2. Open `/settings` and disable the Advisor.
3. Observe that `advisor.enabled` is persisted as `false`, but the live Advisor runtime remains active until the session is restarted.

With this change, the runtime stops immediately at step 2.

## Verification

- `bun run check` passes (typecheck and lint).
- `bun test packages/coding-agent/test/selector-settings-side-effects.test.ts` passes: 25 tests, 0 failures.
- Added coverage confirming that the `/settings` change path calls `session.setAdvisorEnabled(false)`, invalidates the status line, and requests a UI render.
- Manually exercised the path with real `AgentSession` and `SelectorController` instances and confirmed that the runtime stops immediately without restarting the session.
- Confirmed that the same reproduction fails without the fix: the persisted setting becomes `false`, but the live runtime remains active.
