### PR TITLE
feat(coding-agent): add mission RPC control

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -81,6 +81,7 @@ Legacy clients may ignore the added ready fields and remain on v1. V1 retains it
 9. Prompt lifecycle hints (`{ type: "prompt_result", id?, agentInvoked }`) for scheduled prompts that later resolve without invoking the agent
 10. Subagent frames (`subagent_lifecycle`, `subagent_progress`, `subagent_event`), gated by `set_subagent_subscription`
 11. Builtin slash-command side channels (`command_output`, `session_info_update`, `config_update`)
+12. Mission frames (`mission_updated`, `mission_progress`) for persisted state transitions and worker progress
 
 ### Inbound frame categories (stdin)
 
@@ -181,6 +182,21 @@ correlate it via `id`. Ordering across concurrent commands is not guaranteed
 - `{ id?, type: "get_last_assistant_text" }`
 - `{ id?, type: "set_session_name", name: string }`
 - `{ id?, type: "handoff", customInstructions?: string }`
+
+### Mission
+
+- `{ id?, type: "mission_start", goal: string, workerModel?: string | string[], validatorModel?: string | string[] }`
+- `{ id?, type: "get_mission" }`
+- `{ id?, type: "mission_accept" }`
+- `{ id?, type: "mission_pause" }`
+- `{ id?, type: "mission_resume", messageToWorker?: string }`
+- `{ id?, type: "mission_restart", messageToWorker?: string }`
+- `{ id?, type: "mission_cancel" }`
+
+Mutating commands return the persisted mission snapshot and also produce
+`mission_updated` frames. Worker lifecycle changes produce `mission_progress`
+frames. `mission_restart` requires an idle mission and starts a fresh worker when
+the paused state has a runnable child.
 
 ### Messages
 
@@ -639,6 +655,10 @@ Failures are `success: false` with string `error`.
   "error": "Model not found: provider/model"
 }
 ```
+
+Mission command failures may include `code: "MISSION_BUSY"` while work is in
+flight or `code: "INVALID_MISSION_TRANSITION"` when the requested state change is
+not legal. Clients SHOULD branch on `code` and display `error` to the user.
 
 ### Recoverability expectations
 

--- a/docs/tools/schedule.md
+++ b/docs/tools/schedule.md
@@ -1,0 +1,67 @@
+# schedule
+
+> Arm a one-shot wake that re-enters the model with a stored prompt later in this same session.
+
+## Surface
+
+The public surface is the `schedule` tool. There is no `/session schedules` slash command; create and cancel calls use the tool fields described below.
+
+## Source
+- Entry: `packages/coding-agent/src/tools/schedule.ts`
+- Model-facing prompt: `packages/coding-agent/src/prompts/tools/schedule.md`
+- Key collaborators:
+  - `packages/coding-agent/src/session/session-schedule.ts` — entry shape, newest-per-id fold, timer arming, `SessionScheduleController`.
+  - `packages/coding-agent/src/session/agent-session.ts` — owns the controller, samples `schedule.enabled` when re-arming on construction and after every branch swap, exposes `getSessionSchedule()`.
+  - `packages/coding-agent/src/extensibility/extensions/managed-timers.ts` — the contained timer pool the wakes are armed on.
+  - `packages/coding-agent/src/tools/index.ts` — registers the tool and limits it to an enabled top-level session.
+  - `packages/coding-agent/src/config/settings-schema.ts` — defines the disabled-by-default flag.
+
+## Inputs
+
+One call is either a **create** or a **cancel**; `cancel` may not be combined with the create fields.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `delayMs` | `number` (integer ≥ 0) | Exactly one of `delayMs` / `atIso` for a create | Relative delay in milliseconds. |
+| `atIso` | `string` | Exactly one of `delayMs` / `atIso` for a create | Future absolute due time as ISO-8601. |
+| `prompt` | `string` | For a create | Text enqueued when the wake fires. |
+| `cancel` | `string` | For a cancel | Id of a pending schedule. |
+
+Supplying both `delayMs` and `atIso`, or neither, is a validation error rather than a silent default.
+
+## Outputs
+A single text result plus structured details.
+
+- create → `Scheduled <id> for <ISO due time>.`, details `{ op: "create", id, dueAtMs, prompt, createdAt }`
+- cancel → `Cancelled schedule <id>.`, or `No pending schedule <id>; cancel recorded.` when nothing matched, details `{ op: "cancel", id, cancelled }`
+
+## Flow
+1. Intent is persisted through `SessionManager.appendCustomEntry` under customType `session-schedule`, payload `{ id, dueAtMs, prompt, createdAt }`.
+2. `SessionScheduleController` arms one timeout per pending schedule on a `ManagedTimers` pool dedicated to schedules.
+3. On fire, the controller appends a `{ id, fired: true }` tombstone and enqueues the stored prompt as a hidden next-turn message — the same continuation mechanism goal mode uses. It never invokes a tool directly, so the model decides what the wake means.
+4. Cancelling appends `{ id, cancelled: true }` for the same id.
+5. `foldPendingSessionSchedules` takes the newest entry per id and drops cancelled and fired ids, so a restored session re-arms what is still pending and never re-fires what already ran on the active branch.
+6. A schedule whose `dueAtMs` has already passed stays pending through the fold and fires once at the next turn boundary rather than being dropped or fired repeatedly.
+
+## Side Effects
+- Appends `session-schedule` custom entries to the transcript (create, cancel, and fired tombstones).
+- Arms and clears timers on the session's dedicated `ManagedTimers` pool.
+- Enqueues one hidden next-turn message per fired wake, which starts a normal model turn under normal approvals.
+
+## Limits & Caps
+- Gated by `schedule.enabled`, default `false`, and limited to top-level sessions. Enablement is sampled when the controller is constructed or re-armed, not observed live.
+- **One-shot only.** There is no recurrence and no cron expression.
+- **In-session only.** Timers live in the process. A wake never fires in a process the user did not start, and nothing is scheduled across restarts beyond re-arming still-pending intents when that same session is resumed.
+- Approval tier is `write`: creating a schedule mutates session state but runs nothing external at call time.
+- The schedule pool is deliberately not the extension runner's `ManagedTimers`; that pool's `clearAll()` on extension teardown would silently disarm every pending wake.
+- A future wake may be at most `2_147_483_647` ms (about 24.8 days) away. Longer delays are rejected instead of overflowing the runtime timer.
+
+## Errors
+- `ToolError("cancel must be a non-empty schedule id.")` — blank `cancel`.
+- `ToolError("cancel cannot be combined with delayMs, atIso, or prompt.")` — mixed create/cancel call.
+- `ToolError("prompt is required when creating a schedule.")` — missing or blank create prompt.
+- `ToolError` from `resolveScheduleDueAtMs` — both or neither of `delayMs` / `atIso`, an unparsable or non-future `atIso`, or a due time more than 24.8 days ahead.
+- `ToolError("Session schedule controller is unavailable.")` — the session cannot own live wake timers.
+
+## Notes
+- Unknown or malformed `session-schedule` payloads are ignored by the fold rather than throwing, so a hand-edited transcript cannot break session restore.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added crash-recoverable mission workspaces: feature workers receive isolated branches and validators detached checkouts, with ownership checks, reconciliation after interrupted setup, and CAS-protected integration advancement.
 - Added fixed-workspace mission child sessions with owner-scoped revival and parent-mediated approvals.
@@ -28,6 +30,7 @@
 ## [17.1.2] - 2026-07-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added in-process moreutils-style shell builtins to the bash tool's embedded shell: `ts` (timestamp lines; `-i`/`-s` elapsed modes, `-m` monotonic clock, `-r` relative rewriting of RFC3339/syslog timestamps, `%.S`/`%.s`/`%.T` subsecond extensions), `sponge` (soak stdin fully before atomically writing the target, so `foo file | ... | sponge file` works; `-a` appends), `ifne` (run a command only when stdin is non-empty; `-n` inverts and passes non-empty stdin through), `isutf8` (streaming UTF-8 validation with line/char/byte diagnostics; `-q`, `-l`, `-i`), `combine` (boolean `and`/`not`/`or`/`xor` on the lines of two files, `-` for stdin), and `errno` (errno name/number/description lookup with `-l` list and `-s` search; unix only). Like the uutils-backed builtins, they run in-process against the command's own stdio, resolve paths against the shell working directory, honor cancellation, and are disabled by `PI_DISABLE_UUTILS_BUILTINS`.
 - The bash tool prompt now lists the available shell builtins (`mkdir` through `jq`, `rm`/`mv`/`ln`, and the moreutils set) so the model relies on them without existence checks; the line is dropped when `PI_DISABLE_UUTILS_BUILTINS` disables the builtins and omits unix-only `errno` on Windows.
@@ -59,6 +62,7 @@
 ## [17.1.1] - 2026-07-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `/session pin` subcommand and account picker to pin provider OAuth accounts for the current session
 - Added the disabled-by-default `computer` essential tool with configurable enablement, backend, display, and maximum width/height settings. Native desktop execution runs through a `DesktopSession` worker; observation uses read approval, input uses exec approval, and provider checks always prompt and fail closed.
@@ -87,6 +91,7 @@
 - Replaced the `providers.webSearch` and `providers.image` single-preference configuration options with `providers.webSearchOrder` and `providers.imageOrder` priority lists. Existing configurations migrate automatically on startup.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added dynamic multi-root workspace context support, allowing users to manage multiple workspace directories mid-session via `/add-dir`, `/remove-dir`, and `/dirs` slash commands, or seed them at launch using the `--add-dir` CLI flag.
 - Added `/live`, a Codex-authenticated real-time voice interface that streams microphone audio over WebRTC and routes coding tasks through the active agent session.
@@ -137,6 +142,7 @@
 ## [17.0.9] - 2026-07-23
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added per-call `model` selection to the `task` tool, including per-item batch selectors, fallback chains, and explicit reasoning suffixes.
 - Added Firecrawl keyless mode: explicitly selecting `firecrawl` as the web-search provider now works without `FIRECRAWL_API_KEY` by calling the Firecrawl REST API without an `Authorization` header; the automatic provider chain remains credential-gated (#4332).
@@ -170,6 +176,7 @@
 ## [17.0.8] - 2026-07-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `/tree` re-answer option for past `ask` tool results, allowing users to re-open the picker with original questions and branch the new answer as a sibling while keeping the original branch reachable.
 - Added configurable Hindsight client request deadlines via `hindsight.requestTimeoutMs`, `reflectTimeoutMs`, `recallTimeoutMs`, and `retainTimeoutMs` settings (and matching `HINDSIGHT_*_TIMEOUT_MS` environment variables).
@@ -236,6 +243,7 @@
 - Fixed failed plan-mode exits leaving the session on the restored execution model while plan mode remained active and silently changing ambient `xd://` tool presentation; rollback now restores the plan model, thinking level, and exact top-level-versus-mounted tool partition so exit can be retried safely ([#6013](https://github.com/can1357/oh-my-pi/pull/6013)).
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added native Warp CLI-agent events for rich session status, tool approvals, and completion notifications ([#5592](https://github.com/can1357/oh-my-pi/pull/5592) by [@metaphorics](https://github.com/metaphorics)).
 - Added Codex (ChatGPT subscription) support to `generate_image`. The tool now resolves a connected `openai-codex` OAuth credential and drives OpenAI's hosted `image_generation` tool through the ChatGPT backend (`chatgpt.com/backend-api/codex/responses`, `chatgpt-account-id` header) **independent of the active chat model** — so image generation works on a ChatGPT/Codex subscription with no metered `OPENAI_API_KEY`, even when the active model is Claude/Gemini/etc. A new `providers.image: "openai-codex"` option forces it; `auto` now auto-detects a connected subscription (priority: active GPT image tool > Codex subscription > Antigravity > xAI > OpenRouter > Gemini), and the `openai` preference falls back to it when no `OPENAI_API_KEY`/active GPT model is present.
@@ -355,6 +363,7 @@
 ## [17.0.5] - 2026-07-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for Codex (ChatGPT subscription) in `generate_image` via the `providers.image: "openai-codex"` option, including automatic subscription detection and fallback logic.
 - Added an optional `provider` parameter to `generate_image` to override the global image provider setting for a single request.
@@ -453,6 +462,7 @@
 ## [17.0.2] - 2026-07-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added native Warp CLI-agent events for rich session status, tool approvals, and completion notifications.
 - Added support for ChatGPT/Codex subscriptions in the `generate_image` tool, allowing image generation without a metered `OPENAI_API_KEY` even when using other active models.
@@ -602,6 +612,7 @@
 - Fixed prewalk repeatedly continuing after a bash-only task such as `commit` had already completed ([#5551](https://github.com/can1357/oh-my-pi/issues/5551)).
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Fixed the Codex `config.toml` MCP importer dropping `cwd` and leaving relative `command` values unrooted, which broke the bundled Codex Computer Use server (`ENOENT` on spawn); relative `command`/`cwd` now resolve against the Codex config directory like the claude-plugins/omp-plugins providers ([#5561](https://github.com/can1357/oh-my-pi/issues/5561)).
 - Fixed streamed replace-mode edits with `ssh://` paths terminating the active prompt before normal tool dispatch ([#5552](https://github.com/can1357/oh-my-pi/issues/5552)).
@@ -635,6 +646,7 @@
 - Removed the `tools.essentialOverride` setting, the `mcp_tool_selection` session message type, and the `xdev` `--tools` token.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `xd://` virtual tool devices (controlled by the `tools.xdev` setting, default on), allowing mounted tools to be discovered via `read xd://`, documented via `read xd://<tool>`, and executed via `write xd://<tool>`.
 - Added the `edit.enforceSeenLines` setting (default off) to gate the hashline seen-line guard. When enabled, edits anchored on lines that a prior `read` or `grep` never displayed are rejected.
@@ -676,6 +688,7 @@
 - Removed the separate `selector` parameters from `read` and `grep`; line ranges and read modes must now be appended to `path`.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `generate_image.enabled` setting (Settings › Tools › Generate Image) to allow toggling the image generation tool.
 
@@ -747,6 +760,7 @@
 - Replaced the `--reasoning-slide-*` flag family with a unified `--prewalk` mechanism (`--prewalk`, `--prewalk-into <model>`, and `--no-prewalk`) to manage model handoffs during execution.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a new `--prewalk` execution flow (with `--prewalk-into <model>` and `--no-prewalk` overrides) that starts tasks on a strong model for planning and todo initialization before handing off to a faster, cheaper model for implementation.
  - Added a status line annotation for the active prewalk phase (armed or active).
@@ -786,6 +800,7 @@
 ## [16.4.8] - 2026-07-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added invocation-specific schemas to task subagents and unified task/eval agent execution, including host-enforced read-only plan-mode agents ([#5279](https://github.com/can1357/oh-my-pi/issues/5279))
 
@@ -812,6 +827,7 @@
 ## [16.4.8] - 2026-07-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a predicate form to the browser run's `wait()` helper: `wait(fn, { timeout?, interval? })` polls the function (sync or async) until truthy and resolves with that value, failing with a named timeout error (deadline clamped under the cell budget so it always beats the opaque whole-cell timeout) instead of Bun's `sleep expects a number` or a whole-cell stall from in-page polling Promises; both `wait` forms now register in the stall diagnosis of cell timeouts
 - Added `--reasoning-slide-model` and `--reasoning-slide-turns` to switch a running agent from its initial model after a fixed number of completed assistant turns
@@ -839,6 +855,7 @@
 ## [16.4.7] - 2026-07-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Enabled Home and End keyboard navigation in the model browser
 - Added a `c` hotkey in the plan-review overlay that copies the current reviewed plan markdown to the system clipboard, including in-overlay edits.
@@ -857,6 +874,7 @@
 ## [16.4.6] - 2026-07-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `invalidate` action to the usage command to clear cached usage reports
 - Added model-oriented keys and wildcard entries to `retry.fallbackChains`: a `provider/model-id` key attaches a fallback chain to that exact model, a `provider/*` key covers every current or future model of a provider, and a `provider/*` chain entry keeps the failing model's id while swapping the provider (`google-antigravity/x` → `google/x`) — so fallbacks survive role and model reassignments without config edits. Keys resolve by specificity: exact model, then provider wildcard, then role, then `default`.
@@ -890,6 +908,7 @@
 - Reworked the task tool wire schema: moved the top-level agent field into individual task items, renamed assignment to task and id to name, and removed the role and description fields. UI labels are now automatically generated from the task text.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Introduced a fullscreen, mouse-supported Model Hub (via /model) featuring a sidebar of scopes, metadata-aligned model tables, inline role/thinking assignment strips, custom role creation, quick-switch cycle editing, and manual provider refreshing.
 - Added a /pause command to freeze all active agents (main, subagents, and advisor) at their next safe step, allowing manual repository edits mid-run before resuming.
@@ -932,6 +951,7 @@
 ## [16.4.3] - 2026-07-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added /vibe mode, allowing the model to act as a director driving persistent background worker sessions (fast and good tiers) with dedicated session tools (vibe_spawn, vibe_send, vibe_wait, vibe_kill, vibe_list) and a live TUI "TV wall" showing active worker activity, tool traces, and streamed output.
 - Added multiple credential-free web search providers (Google, Bing, Yahoo, Startpage, Ecosia, Mojeek) with stealth-browser escalation, bot challenge detection, and recency filters, alongside a parallel public ("Public Web") provider that aggregates and deduplicates results across all engines.
@@ -998,6 +1018,7 @@
 - Changed the public `selectLaunchAdapter()` result from `DapResolvedAdapter | null` to `LaunchAdapterSelection`; callers must handle `adapter`, `unavailable`, and `none` outcomes.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a native, first-class max thinking tier for supported models, including a new thinkingBudgets.max configuration setting, support in CLI flags (--thinking, :max model suffixes), and terminal theme customization (thinkingMax border color and icons).
 
@@ -1053,6 +1074,7 @@
 ## [16.3.12] - 2026-07-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Typing `#<number>` (e.g. `#3164`) in the prompt now offers PR and Issue autocomplete candidates that rewrite to the `pr://`/`issue://` internal URL, resolved from the current repo's git remote via the existing `read` tool → InternalUrlRouter → `gh` pipeline. Naming the type (`pr #3164` / `issue #3164`) constrains the candidates to that kind, and embedded hashes like `owner/repo#N`, `foo#N`, or URL fragments are left untouched ([#3218](https://github.com/can1357/oh-my-pi/issues/3218))
 
@@ -1133,6 +1155,7 @@
 ## [16.3.9] - 2026-07-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `--file` flag to the `say` command to read input text directly from files.
 - Enabled streaming text synthesis in the `say` command for gapless, long-form audio generation.
@@ -1157,6 +1180,7 @@
 ## [16.3.7] - 2026-07-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for reading full memory rows (working or episodic) via `read memory://<id>` under the mnemopi backend, returning a YAML-frontmatter header with metadata to prevent blind overwrites during edits.
 - Updated the URI grammar to support `memory://root[/…]` for file-backed summaries and `memory://<memory-id>` for specific mnemopi IDs.
@@ -1331,6 +1355,7 @@
 - Changed the `grep`, `glob`, and `ast_grep` tools to take a single optional `path` argument instead of a `paths` array. `path` accepts one path or a semicolon-delimited list (`src; tests`); omitting it searches the workspace root (`.`). Multi-path search, delimited expansion, and internal-URL scopes are unchanged. (`ast_edit` continues to take `paths`.)
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `speech.enhanced` setting to rewrite assistant output into natural spoken prose
 - Added `speech.enhanced` setting: assistant output is rewritten into natural spoken prose by the tiny/smol model before synthesis — code blocks become one-clause descriptions, links speak their label or site name, numbers and symbols read naturally, lists become flowing sentences. Blocks are rewritten fence-aware and coalesced (bounded to two concurrent completions); any failed or timed-out rewrite falls back to the mechanical cleanup so speech never blocks on the model.
@@ -1350,6 +1375,7 @@
 ## [16.3.0] - 2026-07-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `providers.anthropic.serverSideFallback` configuration option to opt into Anthropic's server-side-fallback beta chain, allowing Claude requests to automatically retry on alternative models when blocked by classifiers.
 - Added `task.softRequestBudgetNotice` configuration option to enable subagent soft-budget wrap-up steering notices while keeping the graceful abort guard active.
@@ -1462,6 +1488,7 @@
 - Renamed the built-in quick_task subagent to sonic; update any task spawns or configurations referencing quick_task by name.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the llama3.2:3b local model option for memory and auto-thinking tasks, utilizing a quantized ONNX model.
 - Added a built-in Tester subagent designed to write high-signal tests for behavior, invariants, and edge cases while avoiding redundant or low-value tests.
@@ -1488,6 +1515,7 @@
 ## [16.2.8] - 2026-06-30
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added built-in Go coding rules including `go-add-cleanup`, `go-bench-loop`, `go-exp-promoted`, `go-ioutil`, `go-join-hostport`, `go-new-expr`, `go-rand-v2`, and `go-range-int`
 
@@ -1582,6 +1610,7 @@
 ## [16.2.3] - 2026-06-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for multiple configurable advisors via WATCHDOG.yml/WATCHDOG.yaml files, allowing per-advisor models, tool subsets, and instructions.
 - Added /advisor configure, a full-screen, mouse-driven TUI to easily manage the advisor roster, configure models, toggle tool permissions, and edit instructions.
@@ -1631,6 +1660,7 @@
 ## [16.2.2] - 2026-06-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a new `tiny` model role for consolidated online task handling.
 - Added a `textVerbosity` setting to control OpenAI and Codex response detail.
@@ -1654,6 +1684,7 @@
 ## [16.2.1] - 2026-06-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Included project context files (AGENTS.md, etc.) in the advisor's system prompt to ensure adherence to user-defined project rules
 - Added project context files (AGENTS.md and the like) to the advisor's system prompt, so the read-only reviewer judges against the user's standing project rules the same way the main agent does.
@@ -1670,6 +1701,7 @@
 - Renamed the `search` tool to `grep` and the `find` tool to `glob`. Existing user settings are automatically migrated to the new configuration keys.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ssh://host/path` support to `read`, `search`, and `write` tools for single text files and directory listings on pre-configured POSIX SSH hosts.
 - Added an interactive `/move` overlay with path autocompletion and directory creation prompts, starting a fresh session in the target directory while leaving the previous session resumable.
@@ -1736,6 +1768,7 @@
 ## [16.1.23] - 2026-06-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `compaction.midTurnEnabled` for mid-turn threshold auto-compaction before the next tool-loop provider request. ([#3525](https://github.com/can1357/oh-my-pi/issues/3525))
 - Added `grep -q`/`--quiet`/`--silent` and `-x`/`--line-regexp` to the in-process `grep` builtin used by the bash tool. `-q` suppresses all stdout and exits 0 on the first match (short-circuiting, with match status taking precedence over read errors per GNU); `-x` anchors each pattern to whole lines. Unblocks shell conditionals such as `grep -qx "$applet" <(strings bin)`.
@@ -1805,6 +1838,7 @@
 ## [16.1.18] - 2026-06-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added --list flag to view stored OAuth accounts for a provider
 - Added --account flag to select a specific OAuth account by index for token retrieval
@@ -1859,6 +1893,7 @@
 - Changed the `eval` tool to take a single cell per call (`{ language, code, title?, timeout?, reset? }`) instead of a `cells` array. State still persists per language across separate eval calls, tool calls, and `task` subagents, so each call is one logical step that reuses everything earlier calls defined — the array only encouraged re-importing/re-declaring the same setup in every batch. The schema, field descriptions, examples, system `eval.md`/`workflowz` helper docs, and the `[i/n]` cell-counter (now hidden for single cells) were updated to match; the renderer, ACP start-text, copy-targets, and collab-web tool view still parse legacy multi-cell transcripts.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `isolated`, `apply`, and `merge` options to eval `agent()` across every workflow runtime (Python, JavaScript, Ruby, Julia) so `workflowz`-driven fan-outs can request the same copy-on-write worktree isolation the `task` tool offers (strict opt-in via `isolated: true`, matching the `task` tool; `apply: false` keeps captured patches/branches without merging back; `merge: false` forces patch mode). Extracted the task-isolation lifecycle into `task/isolation-runner.ts` so the eval bridge and `TaskTool` share one implementation ([#3196](https://github.com/can1357/oh-my-pi/issues/3196))
 
@@ -1902,6 +1937,7 @@
 ## [16.1.15] - 2026-06-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `share.store` setting (`blob` "Encrypted Blob" | `gist` "GitHub Gist", default `blob`) controlling where `/share` uploads the encrypted session blob — the share server (`blob`) or a secret GitHub gist with share-server fallback (`gist`).
 
@@ -1923,6 +1959,7 @@
 ## [16.1.14] - 2026-06-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a Ruby eval backend (`language: "rb"`): a persistent subprocess Ruby kernel that shares the standard agent tool bridge and evaluation model, supporting IRB-style auto-display of results in a persistent session
 - Added a Julia eval backend (`language: "jl"`): a persistent subprocess Julia kernel that shares the standard agent tool bridge and evaluation model, supporting Julia REPL-style auto-display of results in a persistent session
@@ -1964,6 +2001,7 @@
 ## [16.1.11] - 2026-06-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `tab.waitForSelector` for more robust element-wait behavior
 - Added `tab.waitForNavigation` to monitor and await page transitions
@@ -1995,6 +2033,7 @@
 ## [16.1.10] - 2026-06-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `tab.ariaSnapshot(selector?)` to the browser tool for Playwright-format ARIA-tree YAML
 - Added `tab.ref("e5")` and support for `aria-ref=e5` selectors in all `tab` action methods
@@ -2010,6 +2049,7 @@
 ## [16.1.9] - 2026-06-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added LLM request JSON export functionality to `/dump`
 
@@ -2035,6 +2075,7 @@
 ## [16.1.8] - 2026-06-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added "Prose Only Thinking" setting to opt-out of rendering code blocks within AI thinking traces
 - Replaced code blocks in AI thinking traces with an ellipsis when "Prose Only Thinking" is enabled
@@ -2087,6 +2128,7 @@
 ## [16.1.6] - 2026-06-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Enabled inline prompts with `/loop` commands (e.g., `/loop 10 fix the bug`)
 - Added support for compound duration formats in `/loop` (e.g., `1h30m`)
@@ -2143,6 +2185,7 @@
 ## [16.1.2] - 2026-06-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a welcome-screen tip for the `/advisor` runtime. Tips ending in a `[NEW]` marker now render a bold rainbow `NEW!` tag (it shimmers across the welcome intro's animation frames, then settles into a still rainbow) and are weighted to surface more often in the random tip rotation.
 
@@ -2178,6 +2221,7 @@
 ## [16.1.0] - 2026-06-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a prompt-cache miss marker: a slim `⊘ cache miss · <n> tokens` divider above an assistant turn whose request lost the provider prompt cache. Detected from per-turn usage — the previous turn cached a meaningful prefix but this request read none of it back and reprocessed the prompt (e.g. after a thinking-level / service-tier / model change, tool or system-prompt change, or a history rewrite). Reports the reprocessed token count. Toggle with the `display.cacheMissMarker` setting (Appearance → Display, on by default).
 
@@ -2200,6 +2244,7 @@
 ## [16.0.11] - 2026-06-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `__advisor.jsonl` transcript persistence for advisor model usage attribution and visibility in the Agent Hub
 - Added defensive reservation against naming a task `__advisor` to prevent filesystem collisions with internal transcripts
@@ -2235,6 +2280,7 @@
 ## [16.0.10] - 2026-06-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Updated the `pi` option of the `tools.format` setting to use the new compact sigil-delimited owned tool-calling dialect (`§`/`«…»`/`¤`/`‡‡`) that uses ~46% fewer tokens than the legacy format on typical calls.
 - Integrated terminal QR codes directly into `/collab` and `/collab view` to display both deep links and scannable codes, and added a `collab.webUrl` setting for separately hosted collab web clients.
@@ -2258,6 +2304,7 @@
 ## [16.0.9] - 2026-06-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `--print-thoughts` flag for single-shot print mode that includes sanitized thinking blocks in the text output; default print output stays the final answer only. When thinking is hidden by the `hideThinkingBlock` setting, `--print-thoughts` un-hides it for the print run so the flag is not a silent no-op (an explicit `--hide-thinking` still wins).
 
@@ -2306,6 +2353,7 @@
 ## [16.0.6] - 2026-06-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `model.loopGuard.enabled` (default `true`) and `model.loopGuard.checkAssistantContent` (default `true`) settings to configure thinking and assistant prose loop detection.
 - Added explicit ArkType schema descriptions to parameters across all agent tools to improve model tool-calling instructions and parameter guidance
@@ -2359,6 +2407,7 @@
 ## [16.0.5] - 2026-06-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `tui.tight` setting (default `false`) to enable tight layout by removing the 1-character horizontal padding from terminal output.
 - Added a `providers.antigravityEndpoint` setting (`auto`, `production`, `sandbox`) to control google-antigravity routing for chat, search, image, and discovery calls
@@ -2408,6 +2457,7 @@
 ## [16.0.3] - 2026-06-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for LaTeX color commands (`\textcolor`, `\colorbox`, and `\fcolorbox`) in user-visible terminal prose and final chat to colorize output
 
@@ -2453,6 +2503,7 @@
 ## [16.0.2] - 2026-06-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `UMANS_WEBSEARCH_PROVIDER` environment variable to CLI help for Umans gateway web search backend selection.
 
@@ -2487,6 +2538,7 @@
 - **Key detection functions removed from `@mariozechner/pi-tui`**: All `isXxx()` key detection functions (`isEnter()`, `isEscape()`, `isCtrlC()`, etc.) have been removed. Use `matchesKey(data, keyId)` instead (e.g., `matchesKey(data, "enter")`, `matchesKey(data, "ctrl+c")`). This affects hooks and custom tools that use `ctx.ui.custom()` with keyboard input handling. ([#405](https://github.com/badlogic/pi-mono/pull/405))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added GitHub Copilot user-global discovery to the `github` provider: it now loads user-global instructions from `~/.copilot/copilot-instructions.md`, honors the `COPILOT_HOME` relocation override, reads each directory listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` for an `AGENTS.md` and `.github/instructions/**/*.instructions.md` (matching Copilot CLI), scans the project `.github/instructions/` tree recursively, and surfaces VS Code Copilot prompt files (`*.prompt.md`) from `.github/prompts/` as slash commands. Previously only the project `.github/` tree was scanned, so Copilot CLI users' cross-repo config was silently ignored. Closes #1913, #1915, #1916.
 - Added web search provider exclusions so `web_search` can skip configured providers without disabling them for model use ([#2608](https://github.com/can1357/oh-my-pi/issues/2608)).
@@ -2592,6 +2644,7 @@
 - Changed `/dump` transcript output to render messages with the selected model's native dialect turn and thinking envelopes instead of markdown role headings.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `advisor.syncBacklog` setting (`off`, `1`, `3`, `5`) to pause turn completion until advisor review backlog drops below the threshold, with a maximum 30-second wait
 - Added advisor backlog synchronization at turn end when enabled so the main session stays aligned with the advisor's pending review turns
@@ -2627,6 +2680,7 @@
 ## [15.13.3] - 2026-06-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Unexpected stop detection: optional tiny/smol classifier that continues the turn when the assistant says it will act but emits no tool calls.
 - Settings `features.unexpectedStopDetection` and `providers.unexpectedStopModel`.
@@ -2649,6 +2703,7 @@
 ## [15.13.2] - 2026-06-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added tool examples data to exported RPC session tool metadata, so tool dumps and other clients can receive model-call examples
 - Added `supportsTools` to model definitions and overrides so custom model configs can declare whether a model supports native tool calls
@@ -2674,6 +2729,7 @@
 ## [15.13.1] - 2026-06-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added isolated profile support via `--profile <name>` / `OMP_PROFILE` and shell alias bootstrap via `--alias <command>`, including launch/ACP bootstrap handling, extension-flag-safe parsing, profile-scoped user config discovery, and symlinked extension-directory discovery.
 - Fixed paste and image placeholders crashing when the editor renders before theme initialization.
@@ -2712,6 +2768,7 @@
 - Renamed the `tts.enabled` setting to `speechgen.enabled` (same boolean, default off; no alias). It still gates the on-demand `tts` speech-generation tool, now labelled "Speech Generation" in the settings panel.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `paste.largeMenuThreshold` setting (0/100/250/500/1000, default 100) to control when large pasted content triggers the large-paste menu or stays as a normal `[Paste]` marker
 - Added a large-paste editor menu for pasted text over the threshold that lets users choose to wrap the paste in a fenced code block, wrap it in `<pasted_text>` XML tags, or save it as `local://attachment-N` for on-demand reading
@@ -2803,6 +2860,7 @@
 - Removed the `writeLine` and `writeLineSync` methods from the public `SessionStorageWriter` contract, requiring custom `SessionStorage` backends to switch to the `append` API
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added package-level exports for `SessionContext`, session entry types, session listing/loader helpers, and migration APIs via `session/session-context`, `session/session-entries`, `session/session-listing`, `session/session-loader`, and `session/session-migrations`
 - Added asynchronous session-write `append(...)`-based persistence API in session storage implementations so callers can stream writes without sync line-appending methods
@@ -2843,6 +2901,7 @@
 - Removed the top-level `--list-models` flag path and migrated model listing to the new `omp models` command
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `omp models` command to list and manage models with `ls`, `find`, `canonical`, and `refresh` actions
 - Added `--json` output plus `-e/--extension`, `--no-extensions`, and `--config` controls to `omp models` listings
@@ -2894,6 +2953,7 @@
 ## [15.12.1] - 2026-06-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `compaction.dropUseless` setting (default on): tool results flagged contextually useless are elided by the per-turn cache-aware prune pass and the pre-compaction threshold prune, replaced with `[Uneventful result elided]`. Built-in tools flag their uneventful outcomes — zero-match/zero-result `search`/`find`/`ast_grep`/`recall` (warnings included; the follow-up call has already corrected course), empty LSP lookups, `job` polls where everything is still running (plus nothing-to-wait-for and unknown-id polls), `irc` wait timeouts and empty inbox drains, and zero-result `github` searches / run-watch give-ups
 
@@ -2904,6 +2964,7 @@
 ## [15.12.0] - 2026-06-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/collab view` command to create a read-only spectator join link
 - Added read-only hints and status text for guest-only participation in collab sessions
@@ -2938,6 +2999,7 @@
 ## [15.11.8] - 2026-06-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Updated collab link handling to accept compact `roomId#key` links and relay hosts without explicit scheme when joining or starting sessions
 - Added `/collab stop` and `/collab status` options to control and inspect active shared sessions
@@ -2966,6 +3028,7 @@
 ## [15.11.7] - 2026-06-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added mouse support to the setup wizard, including hover, wheel scrolling, and click-to-select for provider sign-in, web-search provider, glyph, and theme option lists
 - Added pointer support for the providers tab bar so tabs can be selected by click and wheel scrolling works inside the active panel
@@ -3006,6 +3069,7 @@
 ## [15.11.5] - 2026-06-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `codexResets.autoRedeem`, `codexResets.minBlockedMinutes`, and `codexResets.keepCredits` settings so Codex users can opt in to automatic spending of saved rate-limit resets
 - Added automatic Codex reset redemption flow so a blocked weekly usage-limit request can be retried immediately after consuming a saved reset when auto-redeem is enabled
@@ -3047,6 +3111,7 @@
 ## [15.11.4] - 2026-06-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added mouse-driven interaction to `/settings`, including tab and setting row hover highlighting, wheel scrolling, and left-click activation for entries and submenus
 - Added fullscreen `/settings` mouse-event handling so scrolling and clicks work in an alternate-screen overlay
@@ -3109,6 +3174,7 @@
 ## [15.11.2] - 2026-06-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the Expert Elixir language server (`expert`, invoked as `expert --stdio`) to the built-in LSP server list, auto-detected for Mix projects (`mix.exs`/`mix.lock`). When both are installed, `elixir-ls` remains the primary navigation server (Expert is ordered after it).
 - Added `magicKeywords.enabled` and per-keyword `magicKeywords.ultrathink`, `magicKeywords.orchestrate`, and `magicKeywords.workflow` settings to disable hidden magic-keyword notices and ultrathink auto-thinking escalation ([#1796](https://github.com/can1357/oh-my-pi/issues/1796)).
@@ -3134,6 +3200,7 @@
 ## [15.11.1] - 2026-06-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `statusLine.transparent` appearance setting (default off): when enabled, the status line skips the theme's `statusLineBg` fill and powerline end caps so the bar inherits the terminal's default background — useful in Ghostty and other terminals whose theme background does not match the theme's hardcoded status-line color ([#2306](https://github.com/can1357/oh-my-pi/issues/2306))
 
@@ -3174,6 +3241,7 @@
 - Replaced the standalone session-observer overlay with the Agent Hub: `app.session.observe` (`ctrl+s`) now opens the hub, whose chat view absorbed the observer's transcript renderer
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Snapcompact compaction now passes the session model so frames render in the provider-optimal shape (unscii `8x8r-bw` for Anthropic-family/unknown APIs, `8x8r-sent` for Google, Lanczos-stretched `6x6u-sent` with `detail: "original"` for OpenAI), per the snapcompact 200k-token evals
 - Added per-turn supersede pruning of stale `read` results: when a file is re-read, older copies of the same path/selector are pruned from context at cache-favorable moments (small suffix, idle gap, or alongside overflow pruning). Gated by the new `compaction.supersedeReads` setting (default on)
@@ -3221,6 +3289,7 @@
 ## [15.10.12] - 2026-06-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added RPC subagent subscription frames, snapshots, and transcript catch-up APIs for desktop clients embedding `omp --mode rpc`.
 - Added opt-in `shellMinimizer.sourceOutlineLevel` and `shellMinimizer.legacyFilters` settings so shell minimization can tune source outlining and selectively fall back to conservative legacy routing.
@@ -3265,6 +3334,7 @@
 ## [15.10.11] - 2026-06-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `supportsReasoningParams`, `alwaysSendMaxTokens`, `strictResponsesPairing`, and a recursive `whenThinking` overlay (alongside `streamIdleTimeoutMs`/`supportsLongPromptCacheRetention`/`requiresToolResultId`/`replayUnsignedThinking`) to the OpenAI/Anthropic `compat` schema so custom model entries can configure those provider-specific capabilities
 - Custom model `thinking` config now uses the catalog's explicit vocabulary: `efforts` (ordered list) plus optional `defaultLevel`, `effortMap`, and `supportsDisplay` overrides; the legacy `minLevel`/`maxLevel`/`levels` range shape is still accepted and normalized at parse time. Wire facts (`effortMap`/`supportsDisplay`) are backfilled from model identity when not set, so existing claude-proxy configs keep the 5-tier adaptive scale and summarized display without changes.
@@ -3382,6 +3452,7 @@
 ## [15.10.10] - 2026-06-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a read-only `view` op to the `todo` tool that echoes the current list without mutating state, so the agent can recover exact task text instead of guessing it from memory.
 
@@ -3420,6 +3491,7 @@
 ## [15.10.8] - 2026-06-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added an optional `fetch` option to `CustomToolContext` so custom tools can use a caller-provided HTTP implementation
 - Added optional `fetch` overrides to `ModelRegistry` construction and MCP/web search/tool network calls, enabling callers to inject custom HTTP clients instead of relying on global `fetch`
@@ -3440,6 +3512,7 @@
 ## [15.10.6] - 2026-06-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `/plan-review` command that manually (re-)opens the plan-review overlay while plan mode is active. Since there is no fixed plan filename, it reviews the newest `local://<slug>-plan.md` the agent wrote — useful for pulling the review back up after dismissing it, or reviewing a plan the agent wrote without calling `resolve`.
 
@@ -3462,6 +3535,7 @@
 ## [15.10.5] - 2026-06-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Homebrew and mise package-manager update paths to the self-update command so installations launched from those tools are updated through their native workflows
 - Added detection of Homebrew and mise install locations so self-update chooses the manager-specific updater when the active `omp` binary comes from a package-manager-managed path
@@ -3514,6 +3588,7 @@
 ## [15.10.4] - 2026-06-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - macOS release binaries are now signed with a Developer ID Application identity (hardened runtime + secure timestamp + JIT/library-validation entitlements) and notarized in CI when the `APPLE_*` signing secrets are configured; releases auto-fall back to ad-hoc signing until then. This makes the shipped binaries Gatekeeper-acceptable, unblocking an official Homebrew submission ([#776](https://github.com/can1357/oh-my-pi/issues/776)). See `docs/macos-signing-notarization.md`.
 - Added a Homebrew install path: `brew install can1357/tap/omp`. The [can1357/homebrew-tap](https://github.com/can1357/homebrew-tap) formula installs the prebuilt release binary, and a `release_brew` CI job regenerates it (version + per-asset sha256) from each published release via `scripts/ci-update-brew-formula.ts` ([#776](https://github.com/can1357/oh-my-pi/issues/776)).
@@ -3534,6 +3609,7 @@
 ## [15.10.3] - 2026-06-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added clickable file path hyperlinks to read tool outputs (read-call rows, grouped summaries, and inline previews) using resolved or absolute file targets with selector-based line anchors for quick navigation
 - Added a resolved-span echo to `replace block`/`delete block` edits: a successful block op now prints `replace block N → resolved lines A-B (K lines)` between the section header and the diff preview, so the model can confirm tree-sitter matched the construct it intended (e.g. catch a decorator left outside the block) instead of inferring the span from the diff after the fact.
@@ -3578,6 +3654,7 @@
 ## [15.10.2] - 2026-06-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `raw-sse.txt` to debug report bundles, exporting recent raw provider SSE diagnostics when captured
 - Added `/model` visibility for auto-selected role defaults: inferred `pi/smol`/`pi/slow`/designer choices now show as compact `[ROLE auto]` badges, while explicitly configured roles keep the existing solid badges and thinking labels.
@@ -3646,6 +3723,7 @@
 ## [15.10.1] - 2026-06-07
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `display.smoothStreaming` setting (default `true`) to let users enable or disable smooth assistant-stream text reveal
 - Added `/tan <work>` slash command to fork the current conversation into a background agent so tangential work can continue asynchronously while your main session stays active
@@ -3721,6 +3799,7 @@
 - Replaced the `providers.parallelFetch` boolean setting with the `providers.fetch` enum (`auto` / `native` / `trafilatura` / `lynx` / `parallel` / `jina`) that selects the URL reader-backend priority for the `read`/`fetch` tool, mirroring `providers.image`/`providers.webSearch`. Existing configs are migrated automatically: the legacy key is dropped and the new `auto` default applies.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a GitHub Actions read handler to the `read`/web-fetch GitHub scraper. Fetching `github.com/{owner}/{repo}/actions/runs/{id}` renders the run metadata plus a per-job breakdown (steps listed for any job that did not succeed), and `…/actions/runs/{id}/job/{id}` (also the API-style `…/jobs/{id}`) renders a single job's metadata, step table, and full plain-text logs. Logs are fetched via the `actions/jobs/{id}/logs` redirect using `GITHUB_TOKEN`/`GH_TOKEN` when present, with the per-line ISO timestamp prefix and leading BOM stripped; the section degrades to an explicit notice when logs are unavailable (no token, private repo, or expired/unfinalized run).
 
@@ -3747,6 +3826,7 @@
 ## [15.9.69] - 2026-06-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added anonymous fallback for Perplexity web search, allowing `web_search` and explicit Perplexity provider usage when no Perplexity credentials are configured
 - Added `gallery` CLI command to render built-in tool renderer output across streaming, in-progress, success, and failure states
@@ -3778,6 +3858,7 @@
 ## [15.9.67] - 2026-06-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `timeout-pause` and `timeout-resume` eval bridge status events emitted around `agent()`/`llm()` operations
 - Added a `/copy` picker: `/copy` now opens a fullscreen, outlined tree of recent assistant messages with their code blocks nested beneath (like `/tree`). Navigate with ↑↓, and Enter copies the highlighted node — a whole message, an individual code block, "All N blocks", or a bash/eval command interleaved with the assistant turn that issued it. A live preview pane shows the selected target, wrapping prose and syntax-highlighting code/commands.
@@ -3812,6 +3893,7 @@
 ## [15.9.5] - 2026-06-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a persistent error banner pinned above the editor when an assistant turn ends on a provider error (e.g. Anthropic's "Output blocked by content filtering policy"). The transcript `Error: …` line scrolls away as the conversation grows, so terminal turns that ended on a stream error could pass unnoticed; the banner stays in the fixed region above the input and is cleared when the next turn starts.
 - Added bold, underlined, clickable `[Image #N]` placeholders in the draft editor and sent user-message bubbles, backed by extension-bearing blob-store sidecar files so terminal `file://` links open in image viewers.
@@ -3857,6 +3939,7 @@
 ## [15.9.2] - 2026-06-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added an encrypted local auth-broker snapshot cache for `discoverAuthStorage`, with `OMP_AUTH_BROKER_SNAPSHOT_TTL_MS` and `OMP_AUTH_BROKER_SNAPSHOT_CACHE`, so fresh cached broker credentials can boot without a blocking `/v1/snapshot` fetch and survive broker-down startup windows.
 - Added `dry-balance` CLI command to perform a dry-run OAuth account balancing check across configurable random session IDs, with sample and concurrency options, JSON output, and success/failure summary reporting
@@ -3880,6 +3963,7 @@
 ## [15.9.1] - 2026-06-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added deferred session-title generation so greetings no longer become the session title. A first user message that is only a greeting / acknowledgement / filler ("hi", "thanks", "ok", a bare number, emoji-only, etc.) is now detected deterministically and skips titling entirely — no title model is invoked. Title generation then retries on each subsequent user message while the session stays unnamed, so the title is deduced from the first message that actually describes work. A capable online title model may additionally answer `none` to decline a non-greeting taskless message (normalized to "no title").
 
@@ -3922,6 +4006,7 @@
 - Replaced the public `SessionStorage` `readTextPrefix(path, maxBytes)` and `readTextSuffix(path, maxBytes)` methods with `readTextSlices(path, prefixBytes, suffixBytes): Promise<[string, string]>`; custom session storage backends must implement the new combined slice API.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added env-driven OpenTelemetry trace export. When `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, `omp` registers a global OTLP/proto trace exporter and switches on the agent loop's telemetry, so the `invoke_agent` / `chat` / `execute_tool` spans actually reach a collector instead of a no-op tracer. Honors the standard `OTEL_*` env contract (endpoint, headers, `OTEL_SERVICE_NAME`, `OTEL_SDK_DISABLED` and `OTEL_TRACES_EXPORTER=none` parsed case-insensitively) and the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` capture toggle; it is a no-op when no endpoint is configured. Only the `http/protobuf` transport is supported — a `grpc` or `http/json` `OTEL_EXPORTER_OTLP*_PROTOCOL` declines rather than misrouting spans. This makes the existing telemetry usable from headless hosts that run `omp` as a spawned child process, where an in-process `TracerProvider` registered by the parent can't reach the child. Uses the `@opentelemetry/exporter-trace-otlp-proto` 2.x line, which exports cleanly under Bun.
 ## Fixed
@@ -3969,6 +4054,7 @@
 ## [15.8.2] - 2026-06-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a bundled TypeScript rule that warns against leaving `@deprecated` compatibility shims behind instead of finishing a refactor.
 
@@ -3994,6 +4080,7 @@
 ## [15.8.0] - 2026-06-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added an all-projects scope to the session picker (`pi --resume` / `/resume`). Press `Tab` to toggle between the current folder's sessions and every session across all projects; the all-projects list is loaded lazily and shows each session's directory. When the current folder has no sessions the picker now opens straight into all-projects scope instead of printing "No sessions found".
 - Migrated the Kagi web search provider to Kagi's V1 Search API (`POST /api/v1/search`), replacing the sunset V0 endpoint while keeping the `kagi` provider id, `KAGI_API_KEY` credential, and `/login kagi` flow unchanged ([#1272](https://github.com/can1357/oh-my-pi/pull/1272) by [@thismat](https://github.com/thismat))
@@ -4030,6 +4117,7 @@
 ## [15.7.6] - 2026-06-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ask` option descriptions so agents can keep short labels and render explanatory text as separate muted rows in the selector.
 - Added an extension API for rendering supplemental UI below visible assistant thinking blocks.
@@ -4066,6 +4154,7 @@
 ## [15.7.3] - 2026-05-31
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for decimal and `k`/`m` suffix turn-budget directives, enabling budgets like `+1.5k` and `+2m` in eval message parsing
 - Changed eval budget resolution to honor a user `+Nk` directive over an active Goal Mode limit while falling back to Goal Mode when no per-turn ceiling is set
@@ -4118,6 +4207,7 @@
 ## [15.7.2] - 2026-05-31
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `providers.autoThinkingModel` setting so users can choose the `auto` thinking classifier backend (online smol or local tiny-memory model)
 - Added an `auto` thinking level that classifies each real user turn and resolves to a concrete low-through-xhigh effort, with online smol classification by default and an opt-in local on-device classifier.
@@ -4139,6 +4229,7 @@
 ## [15.7.0] - 2026-05-31
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `Web search` setup tab that lets users choose the preferred `providers.webSearch` provider during onboarding
 - Added manual authorization-code/redirect URL prompts for OAuth providers that require non-callback login in the setup wizard
@@ -4174,6 +4265,7 @@
 ## [15.6.0] - 2026-05-30
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added prompt-mode autocomplete for supported internal URL schemes (`skill://`, `rule://`, `agent://`, `artifact://`, `local://`, `memory://`, and `omp://`) so typing those tokens now suggests existing resources as completion candidates
 - Added fuzzy matching and ranked suggestion ordering for internal URL completion, including rule and skill descriptions, with accepted completion replacing just the typed token and inserting the chosen URL followed by a space
@@ -4235,6 +4327,7 @@
 ## [15.5.14] - 2026-05-29
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added progress status output for `llm()` calls in `eval`, including the resolved model, tier, and returned character count
 - Added an `llm(prompt, opts)` helper to both `eval` runtimes (JavaScript and Python) for oneshot, stateless LLM calls. `opts.model` selects a tier — `"smol"` (`pi/smol`), `"default"` (the session's active model, falling back to `pi/default`), or `"slow"` (`pi/slow`, with high reasoning effort on reasoning-capable models). Pass `system` for a system prompt and a plain JSON-Schema `schema` to force a structured response (the helper returns the parsed object instead of the completion string). Calls carry no conversation history and expose no agent-visible tools; they route host-side through the existing tool bridge under the reserved name `__llm__` (`packages/coding-agent/src/eval/llm-bridge.ts`).
@@ -4269,6 +4362,7 @@
 ## [15.5.12] - 2026-05-29
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `omp-plugins` discovery provider, which scans every extension package directory configured via `extensions:` (in `~/.omp/agent/settings.json` or `<cwd>/.omp/settings.json`) or `--extension`/`-e` on the CLI for `skills/`, `hooks/pre|post/`, `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json`. Prior to this, only the extension's TypeScript factory module ran; every sibling capability the docs (https://omp.sh/docs/extension-authoring) advertised was silently ignored ([#1496](https://github.com/can1357/oh-my-pi/issues/1496)).
 - Added the top-level `omp install <target>` subcommand documented at https://omp.sh/docs/extension-authoring. Local paths route to `omp plugin link` (so the directory is symlinked into the plugin set), and npm/marketplace specs route to `omp plugin install`. Before this, `install` was not a registered subcommand and the CLI runner silently forwarded `install ./my-extension` to `launch` as an initial LLM prompt ([#1496](https://github.com/can1357/oh-my-pi/issues/1496)).
@@ -4282,6 +4376,7 @@
 ## [15.5.11] - 2026-05-29
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `SqlSessionStorage`, a `bun:sql`-backed implementation of `SessionStorage` that persists session JSONL into PostgreSQL, MySQL/MariaDB, or SQLite. Pass a connected `Bun.SQL` instance (the constructor accepts `postgres://`, `mysql://`, or `sqlite:` URLs) to `SqlSessionStorage.create({ client, table?, adapter?, createTable? })` and hand the returned storage to any `SessionManager` factory. The dialect is auto-detected from `client.options.adapter` and used to pick the correct DDL plus upsert-with-append syntax (`ON CONFLICT … DO UPDATE` for PG/SQLite, `ON DUPLICATE KEY UPDATE` for MySQL), so the agent's append-only persist pattern works in a single round-trip per line. Same in-memory mirror and `drain()` semantics as the Redis backend; blobs and tool artifacts still live on disk via `ArtifactManager`/`BlobStore`.
 - Added `RedisSessionStorage`, a `bun:redis`-backed implementation of the `SessionStorage` interface that lets API consumers route session JSONL through Redis instead of local disk. Pass a connected `Bun.RedisClient` (or any compatible adapter) to `RedisSessionStorage.create({ client, prefix? })` and hand the returned storage to `SessionManager.create(cwd, sessionDir, storage)` (or any other static factory that accepts a storage argument). An in-memory mirror is loaded on creation so the interface's synchronous methods (`existsSync`, `statSync`, `listFilesSync`, …) keep their contracts; `drain()` waits for queued background writes. Tool artifacts and image blobs still live on disk via `ArtifactManager`/`BlobStore` — Redis only owns the session JSONL keyspace under the configured prefix.
@@ -4299,6 +4394,7 @@
 ## [15.5.10] - 2026-05-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/drop-images` slash command that strips every `ImageContent` block from the current session's branch — `user`/`developer`/`custom`/`hookMessage`/`toolResult` content arrays plus `toolResult.details.images` and `fileMention.files[].image` — rewrites the session JSONL, rebuilds the agent's in-memory message list, tears down Codex Responses provider sessions, and rebuilds the TUI chat container so the change is visible immediately. ACP clients receive the same handler (returns `"Dropped N images …"` / `"No images found …"` through `runtime.output`). Stripping content that would leave a `toolResult` or `user` message with zero blocks inserts a single `[image removed]` placeholder so providers do not reject empty content arrays.
 
@@ -4313,6 +4409,7 @@
 - Changed hashline edit parsing to require wrapped hunk headers such as `@@ A..B @@` (including `@@ BOF @@` and `@@ EOF @@`), with empty `@@ A..B @@` blocks deleting the anchored range and legacy inline payload forms treated as malformed
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `vault.enabled` setting (Tools → Obsidian Vault, default `false`) gating the `vault://` internal URL. When disabled, `VaultProtocolHandler.resolve` / `write`, `resolveVaultUrlToPath`, and `hasObsidian()` all refuse — the latter hides the `vault://` entry from the system prompt's Handlebars `{{#if hasObsidian}}` block. Tests can opt in via `vi.spyOn(vaultProtocol, "isVaultEnabled").mockReturnValue(true)`.
 - Added support for `vault://` URLs in path resolution utilities, including plan mode and internal selector parsing so `read` and edit paths can target Obsidian vault files directly
@@ -4360,6 +4457,7 @@
 ## [15.5.7] - 2026-05-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `providers.openrouterVariant` setting (Settings → Providers → "OpenRouter Routing") to default OpenRouter requests to a routing-variant suffix (`:nitro`, `:floor`, `:online`, `:exacto`). Selectors that already name a variant (e.g. `openrouter/anthropic/claude-haiku:nitro`) keep precedence.
 - `generate_image` supports xAI Grok Imagine via `providers.image=xai`. Supports `grok-imagine-image` (default) and `grok-imagine-image-quality` at aspect ratios `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`. Uses the xAI Grok OAuth credential when available, otherwise `XAI_API_KEY`.
@@ -4373,6 +4471,7 @@
 ## [15.5.6] - 2026-05-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for multi-range line selectors on URLs (e.g., `:5-10,20-30`) to fetch and display multiple non-contiguous sections
 - Support for combining `:raw` mode with line range selectors on URLs (e.g., `:raw:1-120` or `:1-120:raw`)
@@ -4405,6 +4504,7 @@
 - Removed the package root `hashline` export so imports from the top-level entrypoint can no longer access `hashline` helpers directly
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `read.summarize.minTotalLines` setting (default 100) to set the minimum file length that triggers read summarization
 - Added `<file>:<lines>` support to `search` `paths`, allowing file-scoped constraints such as `:N-M`, `:N+K`, and comma-separated ranges
@@ -4458,6 +4558,7 @@
 ## [15.5.0] - 2026-05-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added per-tool approval declarations so each built-in, custom, or extension tool can declare its capability tier and approval prompt details.
 - Added `OMP_MCP_TIMEOUT_MS` environment variable to override MCP client request timeout for every server (in milliseconds); set to `0` to disable client-side timeouts. Invalid (negative or non-numeric) values are ignored with a warning and fall back to the per-server timeout or default 30s ([#1415](https://github.com/can1357/oh-my-pi/pull/1415)).
@@ -4502,6 +4603,7 @@
 - Hashline payload semantics are now strictly inline-first: the first payload line is whatever follows the sigil on the op line itself, and subsequent lines append after it. A newline immediately after `↑`/`↓`/`:` is no longer a free separator — it produces a blank first payload line. Use `LINE↓content` for a one-line insert, `LINE↓firstline\nsecondline` for two lines; bare `LINE↓` / `LINE↑` / `LINE:` (no inline payload) still insert/replace with one blank line as before.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `irc.timeoutMs` setting to configure IRC message timeout duration with a default of 120 seconds
 - Added timeout enforcement for IRC send operations to prevent indefinite hangs when recipients are unresponsive
@@ -4571,6 +4673,7 @@
 - Replaced the hashline patch format from `§`, `«`, `»`, `≔`, and `..` to `¶`, `↑`, `↓`, `→` with range separators written as `A-B`, requiring users to migrate hashline edit inputs
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `codex` and `gemini` to the web search provider settings so users can configure OpenAI and Gemini web search directly from provider selection
 - Added OpenAI (`codex`) and Gemini web search options with updated setup descriptions for `omp /login openai-codex` and Gemini OAuth login
@@ -4598,6 +4701,7 @@
 ## [15.3.2] - 2026-05-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added inline `|TEXT` payload support to `»` and `«` hashline insert operations, allowing single-line inserts on the op line and still supporting additional payload lines
 - Added support for using inline payloads with BOF/EOF inserts so `|TEXT` is treated as inserted content at file boundaries
@@ -4612,6 +4716,7 @@
 ## [15.3.0] - 2026-05-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `OMP_NO_WEBP` environment variable to disable WebP encoding in image resize, fixing HTTP 400 errors when attaching browser snapshots to vision models running on local llama.cpp (which uses STB library that lacks WebP support)
 - Fixed loop mode submitting the next prompt while a background async-job delivery turn (idle flush) was still pending, which could cause the job result to be silently dropped and make the session appear to keep firing while work was ongoing ([#1294](https://github.com/can1357/oh-my-pi/issues/1294))
@@ -4630,6 +4735,7 @@
 - Replaced the legacy `@@` header and `+`/`<`/`=`/`-` hashline syntax with the new `§PATH` header and `«`/`»`/`≔` operation format, so existing hashline scripts and prompts using old symbols must be updated
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added one-anchor `≔ANCHOR` shorthand equivalent to `≔ANCHOR..ANCHOR` for single-line replace/delete
 
@@ -4652,6 +4758,7 @@
 - Changed PR and task-isolation worktree directory layout to hash-based `~/.omp/wt/<identifier>-<path-hash>` style paths, replacing the previous nested encoded-repo layout
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `omp worktree` command (alias `wt`) to list and manage agent-managed worktrees under `~/.omp/wt`
 - Added `omp worktree clear` to remove orphaned worktree directories, with `--all` to include live PR-checkouts, `--dry-run` for preview, and `--json` reporting
@@ -4725,6 +4832,7 @@
 - Fixed the status-line fast-mode indicator (`⚡`) rendering for scoped service tiers (`openai-only`, `claude-only`) even when the active model's provider didn't realize them — e.g. `serviceTier: "openai-only"` would still show the indicator next to a Claude model the wire request couldn't apply fast mode to. The indicator now consults a new `AgentSession.isFastModeActive()` predicate that runs the configured tier through `resolveServiceTier(tier, model.provider)` and only lights up when the result is `"priority"` for the current model. `isFastModeEnabled()` keeps its scope-aware semantics so `/fast on|off|toggle` and `/fast status` continue to reflect the user's configured intent.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added scoped service tier values to the `serviceTier` setting: `priority (OpenAI only)` and `priority (Claude only)`. They let you opt into premium processing on one provider family without paying premium costs on the other when switching models mid-session. `/fast on` continues to set the unscoped `"priority"` (active everywhere supported); `/fast status` and `isFastModeEnabled()` now report `on` for any scoped value too.
 
@@ -4766,6 +4874,7 @@
 - Replaced the `eval` tool's LARK-grammar `input` string with a structured `cells` array. Each cell is `{ language: "py" | "js", code, title?, timeout?, reset? }`. Removed the implicit/sniffed language path, the `*** Cell` / `*** End` / `*** Abort` markers, and the per-cell `t:<duration>` unit suffixes — `timeout` is now seconds (1-600).
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `providers.<name>.transport: "pi-native"` to `models.yml`. When set, every model under that provider routes its streaming dispatch through the auth-gateway's `POST /v1/pi/stream` endpoint instead of the per-provider SDK. The provider's `baseUrl` must point at a compatible `omp auth-gateway` and `apiKey` must carry the gateway bearer. The slot's `models.json` still resolves locally for pricing/capabilities/thinking config; only the wire dispatch is redirected. Use case: containerized omp installs (robomp slots, swarm extension) where the slot must stay credential-free and a sidecar gateway holds the real provider tokens. Also surfaced as `transport` on `ProviderConfigInput` for extension-registered providers.
 - Added optional backend push for the auto-QA grievance database (`dev.autoqaPush.enabled`, `dev.autoqaPush.endpoint`, `dev.autoqaPush.token`; env overrides `PI_AUTO_QA_PUSH`, `PI_AUTO_QA_PUSH_URL`, `PI_AUTO_QA_PUSH_TOKEN`). When enabled, every `report_tool_issue` call schedules a background flush that `POST`s pending rows to the configured endpoint and deletes them on HTTP 2xx. Each push carries a stable per-install UUID (`installId`) generated on first use and persisted at `~/.omp/install-id` via `getInstallId()` (new export from `@oh-my-pi/pi-utils`), so the receiver can dedup retries across host renames and `autoqa.db` wipes. Single-flight, 5s request timeout, 30s in-memory cooldown after failure, and a row-id watermark so rows inserted during an in-flight push survive and ship next time. Tool execution remains non-blocking and never throws.
@@ -4820,6 +4929,7 @@
 - Changed the extension and hook runtime API by moving schema typing from direct TypeBox imports to `TSchema` from `@oh-my-pi/pi-ai`, requiring callers who use TypeScript imports of `Type` to migrate via provided injected modules
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a cancellable handoff progress indicator in `/handoff` that displays while handoff generation runs and can be aborted with `Esc`
 - Added `apiKey` as a supported provider override field in model config, allowing API-key-only overrides to provide fallback credentials for built-in models
@@ -4872,6 +4982,7 @@
 ## [15.0.2] - 2026-05-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `set_host_uri_schemes` RPC command so hosts can register and replace writable/read-only internal URI schemes with scheme metadata (`writable`, `immutable`) at runtime
 - Enabled the `write` tool to dispatch `write(url, content)` to registered internal URL handlers, allowing edits to non-filesystem resources via host-managed URI schemes
@@ -4908,6 +5019,7 @@
 - Removed the dedicated `exit_plan_mode` tool and its prompt, requiring plan-mode completion to use the existing `resolve` tool path instead
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added optional `extra` metadata object to the `resolve` tool so callers can pass context-specific payloads, including plan approval titles
 - Added `hide: true` frontmatter option for skill `SKILL.md` files. Hidden skills are still loaded and remain reachable via `skill://<name>` URLs and (when enabled) `/skill:<name>` slash commands, but are omitted from the rendered system prompt's `<skills>` listing so the model won't auto-discover them. Use for skills the user opts into explicitly rather than ones the model should pick up from descriptions.
@@ -4952,6 +5064,7 @@
 - Renamed ACP custom extension methods from `omp/*` to `_omp/*` to comply with the ACP spec's `_`-prefix requirement for non-spec methods; existing callers must update method names
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added markdown rendering for `read` results when content type is `text/markdown`, so GitHub internal-URL outputs are shown as formatted markdown instead of plain code blocks
 - Added `pr://<N>/diff`, `pr://<N>/diff/<i>`, and `pr://<N>/diff/all` internal-URL shapes covering changed-file listings, per-file slices, and the full unified diff. They share one `pr-diff` SQLite cache row with the same TTL knobs as `pr://<N>` views (`github.cache.softTtlSec` / `github.cache.hardTtlSec` / `github.cache.enabled`). Single PR views now advertise the diff entry point via a `Diff: pr://<owner>/<repo>/<N>/diff` note. Cache schema bumped to `user_version = 3`; older rows are dropped on first open to add credential-scoped keys and relax the `kind` CHECK constraint.
@@ -5030,6 +5143,7 @@
 ## [14.9.9] - 2026-05-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added new `task.isolation.mode` values `auto`, `apfs`, `btrfs`, `zfs`, `reflink`, `overlayfs`, `projfs`, `block-clone`, and `rcopy` for native PAL-backed task isolation backends
 - Added automatic PAL-backed isolation backend selection so `task.isolation.mode` uses the host's best-available backend
@@ -5053,6 +5167,7 @@
 - Changed the `eval` tool input format to a single-line `*** Cell <lang>:"<title>" [t:<duration>] [rst]` header per cell, replacing the `*** Begin <LANG>` / `*** End <LANG>` envelope and the standalone `*** Title:` / `*** Timeout:` / `*** Reset` directives. The lark grammar enforces a fixed attribute order; the runtime parser remains lenient (alias keys, bare positional tokens, single-quoted titles).
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `:conflicts` read selector (`read <path>:conflicts`) to return a one-line index of all unresolved merge conflicts with stable `#N` IDs for quick inspection
 - Added bulk conflict resolution with `write({ path: "conflict://*", content })` to resolve all currently registered conflicts across files in one call, expanding `@ours`/`@theirs`/`@base`/`@both` per conflict and returning per-file counts
@@ -5088,6 +5203,7 @@
 - Replaced the Jupyter kernel gateway + WebSocket protocol behind the Python `eval` backend with a subprocess-backed runner that speaks NDJSON over stdin/stdout; removed the `jupyter_kernel_gateway`/`ipykernel` pip dependencies, the `python.sharedGateway` setting, the `omp jupyter` CLI command, and the `PI_PYTHON_GATEWAY_URL` / `PI_PYTHON_GATEWAY_TOKEN` environment variables
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Python `tool.<name>(args)` support to `executePython` sessions so evaluated Python code can invoke session tools through the prelude `tool` proxy
 - Added per-execution Python tool bridge session registration and loopback endpoint wiring so Python tool calls resolve to host tools and return tool results
@@ -5122,6 +5238,7 @@
 - Removed the `jobs://` internal URL protocol; inspect background jobs via the `job` tool's `list: true` operation instead
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `since` and `until` date-range filters to `search_issues`, `search_prs`, `search_commits`, and `search_repos`, accepting relative durations (`m`/`h`/`d`/`w`/`mo`/`y`), ISO dates, and ISO datetimes
 - Added `dateField` support for date filtering (`created` or `updated`) so search results can be constrained by creation, update, pushed (for repos), or committer date (for commits)
@@ -5165,6 +5282,7 @@
 - Removed the `sectionSeparator` re-export from `config/prompt-templates`, so existing imports from `@oh-my-pi/pi-coding-agent/config/prompt-templates` now need to resolve `sectionSeparator` from its utility package
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for the `*** Abort` recovery marker in eval and hashline parsing to terminate processing safely when stream corruption is detected
 - Added support for wrapping hashline edits in `*** Begin Patch` and `*** End Patch` markers so patch input with these envelopes is parsed and applied
@@ -5206,6 +5324,7 @@
 ## [14.9.2] - 2026-05-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `agentsMdFiles` to `WorkspaceTree` so AGENTS.md discovery results are returned with the workspace scan output
 
@@ -5245,6 +5364,7 @@
 - Fixed legacy Pi plugin extensions failing to load on Windows when their entry path contains a drive letter ([#990](https://github.com/can1357/oh-my-pi/pull/990) by [@jiwangyihao](https://github.com/jiwangyihao)).
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a debug-panel raw SSE stream viewer so stuck model/tool-call streams can be inspected live from the TUI.
 - Added `get_login_providers` RPC command to list registered OAuth providers with their current authentication status (`id`, `name`, `available`, `authenticated`)
@@ -5255,6 +5375,7 @@
 ## [14.8.0] - 2026-05-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added hashline stale-anchor recovery by replaying edits against a session-scoped `read`/`search` snapshot and 3-way-merging them onto the current file when anchors no longer match
 
@@ -5288,6 +5409,7 @@
 ## [14.7.5] - 2026-05-07
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added optional `/loop` limits: `/loop 10` stops after 10 auto-iterations, while duration forms such as `/loop 10m` and `/loop 10min` stop after the time limit.
 
@@ -5340,6 +5462,7 @@
 ## [14.7.1] - 2026-05-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `pr_create` operation to the GitHub tool to create pull requests with title/body (or `fill`), base/head branch, draft, reviewer, assignee, and label options and return a summarized result including the new PR URL
 - Added `read.summarize.prose` setting to keep Markdown and plain-text reads out of the structural summarizer by default.
@@ -5358,6 +5481,7 @@
 - Removed the top-level `sel` parameter from the `read` tool schema, requiring callers to migrate to `path`-embedded selectors (for example `path:50-100`, `path:raw`, or `https://...:L1-L40`)
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a separate `projectPrompt` artifact containing per-session project context (workstation, context files, AGENTS.md rules, workspace tree, and append prompt) so dynamic context is decoupled from the static system prompt
 - Added `Project prompt` token accounting to context-usage breakdowns and charts
@@ -5391,12 +5515,14 @@
 ## [14.6.6] - 2026-05-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Ctrl+D draft persistence: pressing Ctrl+D with text in the editor now exits the app and saves the unsent text as a per-session draft. Resuming the same session (e.g. via `--resume`) restores the draft into the editor (one-shot, removed after restore).
 
 ## [14.6.4] - 2026-05-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `hindsight.mentalModelsEnabled`, `hindsight.mentalModelAutoSeed`, `hindsight.mentalModelRefreshIntervalMs`, and `hindsight.mentalModelMaxRenderChars` settings to control curated Hindsight mental-model activation, seeding, refresh cadence, and prompt render budget
 - Added `<mental_models>` injection to developer instructions, loading bank-level curated summaries as stable background context
@@ -5426,6 +5552,7 @@
 - Renamed hashline separator configuration from `PI_HASHLINE_SEP` to `PI_HL_SEP` and changed the default payload separator from `\\` to `>`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added inline hashline edit syntax so `< ANCHOR${sep}TEXT` prepended text to an anchored line and `+ ANCHOR${sep}TEXT` appended text to it without requiring a multi-line payload block
 - Added a `memory.backend` setting (off, local, hindsight) under a new Memory settings tab to control which memory subsystem is active
@@ -5472,6 +5599,7 @@
 ## [14.6.2] - 2026-05-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `statusLine.sessionAccent` to disable session-name accent coloring for the editor border and status line gap ([#918](https://github.com/can1357/oh-my-pi/issues/918))
 
@@ -5509,6 +5637,7 @@
 - Changed `search`, `find`, `ast_grep`, and `ast_edit` to accept `paths: string[]` instead of comma- or whitespace-delimited path strings.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `update_notes` tool with `body` (replace) and `append_idea` (append a bullet under an `## Ideas` section). Notes are injected into the system prompt every iteration and replace the file-based `autoresearch.md` / `.program.md` / `.ideas.md` ecosystem.
 
@@ -5550,6 +5679,7 @@
 - Changed the `eval` tool wire format to a single `input` string composed of markdown fenced code blocks (with per-fence language, timeout, title, and reset metadata in the info string) instead of top-level `cells`, `language`, `timeout`, and `reset` fields
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a JavaScript backend to the `eval` tool with an in-process VM runtime and JS helper bridge (`read`, `write`, `glob`, etc.)
 - Added `eval.py` and `eval.js` settings so Python and JavaScript `eval` backends can be enabled or disabled independently
@@ -5579,6 +5709,7 @@
 - Removed the legacy browser action verbs (`goto`, `observe`, `click`, `type`, `fill`, `press`, `scroll`, `drag`, `wait_for_selector`, `extract_readable`, and `screenshot`) in favor of invoking those workflows through `run`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `browser` tool `open`/`run`/`close` flow with a `run` action that executes async JavaScript and provides `page`, `browser`, `tab`, `display`, `assert`, and `wait` in scope
 - Added named tabs on `open` with default name `main` so browser state can be reused across `run` calls and subagents
@@ -5623,6 +5754,7 @@
 - Stopped reading the `branch` parameter for `github` `pr_checkout`. The local branch is now always `pr-<number>`; the `branch` schema field is still accepted by `pr_push`, `repo_view`, and `run_watch`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `checkouts` summary entries to `pr_checkout` results, including each checkout's branch, worktree path, remote, and reuse status
 - Added combined summaries for `pr_view` and `pr_diff` when `pr` is an array, so multi-request responses now include all requested pull requests in one return
@@ -5651,6 +5783,7 @@
 ## [14.5.9] - 2026-04-30
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added the `/context` slash command to display an estimated context-usage breakdown panel for the current session
 - Added `-LidA..LidB` syntax to delete inclusive line ranges in a single atom operation
@@ -5679,6 +5812,7 @@
 - Renamed the built-in tool API from `just` to `run_command`, so clients requesting/handling the old tool name must update
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a new `run_command` tool that runs project tasks via a single `op` argument, auto-detecting and supporting recipes from justfiles, `package.json` scripts (including workspace packages), Cargo bin/example/test targets, Makefiles, and Taskfiles
 - Added support for explicit runner-qualified tasks via `run_command` with `runnerId:task` syntax in the prompt guidance
@@ -5711,6 +5845,7 @@
 - Rejected atom diffs with unrecognized operations (including lone '-' lines) by throwing parse errors instead of treating them as inserts
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added duplicate-line post-edit detection that warns on newly introduced adjacent identical lines and auto-removes one duplicate when bracket-balance is restored
 - Added a warning when suspicious adjacent duplicates are introduced after edits so users can review potential stale-line issues
@@ -5732,6 +5867,7 @@
 - Renamed the built-in content-search tool from `grep` to `search`, including SDK/tool event names and settings keys (`search.enabled`, `search.contextBefore`, `search.contextAfter`), so integrations using `grep` and `grep.*` references must be updated
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added internal URL support to the `search` tool, allowing `artifact://`-style paths that resolve to local files to be searched directly
 - Added IRC relay observation in the main agent UI so every IRC exchange between agents is rendered in the main transcript, even when the main agent is not a direct participant
@@ -5753,6 +5889,7 @@
 ## [14.5.3] - 2026-04-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added bracketed `loc` forms `(anchor)`, `[anchor]`, `[anchor`, `(anchor`, `anchor]`, and `anchor)` to `atom` `splice` editing so a single anchor can target a block body, whole node, or partial node region
 - Added automatic block-delimiter inference for block splices using file extension, defaulting to `{` and using `(` for Lisp-family files
@@ -5804,6 +5941,7 @@
 ## [14.4.3] - 2026-04-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `irc` tool for agent-to-agent messaging with `list` and `send` operations, including optional broadcast to `all` and optional suppression of reply waits
 - Added `irc.enabled` tool setting (default `true`) to toggle agent-to-agent messaging
@@ -5828,6 +5966,7 @@
 - Changed `/todo append` from JSON payload input to `/todo append [<phase>] <task...>` with optional quoted tokens and automatic phase creation
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `note` to todo-write operations so you can append follow-up text notes to a task via `op: "note"` and `text`
 - Added markdown note-block support to `/todo export` and `/todo import` so task notes are written as blockquote lines and reloaded with the todo list
@@ -5866,6 +6005,7 @@
 - Replaced the legacy `gh_repo_view`, `gh_issue_view`, `gh_pr_view`, `gh_pr_diff`, `gh_pr_checkout`, `gh_pr_push`, `gh_run_watch`, `gh_search_issues`, and `gh_search_prs` tool names with only `github`, which requires updating existing callers that invoked the old `gh_*` tools
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added a `sed` verb to the `atom` edit tool for line-local substitutions using sed-style syntax (`s/pattern/replacement/`) with `g`, `i`, and `F` flags and model-tolerant delimiter choices
 - Added the unified `github` tool with op-based dispatch for repository, issue, pull request, search, checkout, push, and Actions watch workflows
@@ -5900,6 +6040,7 @@
 - Changed the hashline and chunk anchor ID format from the prior hex-like tokens to two-letter BPE bigrams (for example `#th`), which invalidates previously captured `LINE#ID`/chunk selectors and requires re-reading to refresh anchors
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added inline file overrides in atom locators (`loc: "a.ts:160sr"`) so cross-file edits can be written without a separate per-entry `path` field
 - Added `openai` to the `providers.image` options, allowing image generation to be explicitly routed through the active GPT Responses/Codex model
@@ -5959,6 +6100,7 @@
 ## [14.3.0] - 2026-04-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Markdown pipe-table `row_N` chunk selectors for row-level table edits.
 - Added `resolveToolAlias` export so tool names in CLI and session setup are normalized to canonical names, including mapping legacy `read` references to `open`
@@ -6018,6 +6160,7 @@
 ## [14.2.0] - 2026-04-23
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added an `apply_patch` edit mode that accepts Codex `*** Begin Patch` envelopes, shares patch-mode execution and diagnostics, and renders streaming per-file diffs in the TUI.
 
@@ -6048,6 +6191,7 @@
 - Phased task definitions in `todo_write` now reject `notes` on initial creation, so notes must be added later with `add_notes`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `complete`, `start`, `abandon`, `remove`, `add_notes`, and `add_tasks` parameters to `todo_write` so callers can complete, jump to, drop, and annotate tasks without op wrappers
 - Added direct `add_phase` support as a top-level argument for inserting a new phase in `todo_write`
@@ -6072,6 +6216,7 @@
 - Changed the `edit` schemas for patch, replace, hashline, and chunk modes from top-level request fields to `edits` array entries, requiring path/mode details on each edit and breaking callers that send legacy top-level `path`, `old_text`, `new_text`, `op`, `move`, or `delete` payloads
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Vim ex aliases `:del`, `:ya`, `:co`, and `:mo` as shorthand for existing delete, yank, copy, and move commands
 - Added support for additional Vim ex command aliases `:write`/`write!`, `:edit`/`edit!`, and `:update`/`:up` in command parsing
@@ -6139,6 +6284,7 @@
 ## [14.1.0] - 2026-04-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added richer tool rendering details in session export HTML, including metadata badges, argument formatting, and todo task tree styling for exported tool and workflow messages
 - Added a persistent `js` tool backed by `node:vm`, with cross-session `highway` KV/pubsub, tool calls from inside JS cells, and `$` / `$$` interactive JavaScript execution
@@ -6181,6 +6327,7 @@
 ## [14.0.5] - 2026-04-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `designer` model role for UI/UX design tasks with Gemini 3.1 Pro as default model
 - Added support for model role fallback lists — roles can now resolve to multiple model patterns with automatic fallback to next available model
@@ -6224,6 +6371,7 @@
 ## [14.0.4] - 2026-04-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `PI_CHUNK_AUTOINDENT` environment variable to control whether chunk read/edit tools normalize indentation to canonical tabs or preserve literal file whitespace
 - Added dynamic chunk tool prompts that automatically adjust guidance based on `PI_CHUNK_AUTOINDENT` setting without exposing a tool parameter
@@ -6251,6 +6399,7 @@
 ## [14.0.2] - 2026-04-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/force` slash command to force the next agent turn to use a specific tool
 - Added `ToolChoiceQueue` for managing tool-choice directives with lifecycle callbacks and requeue semantics
@@ -6332,6 +6481,7 @@
 - Removed checksum requirement from insert operations (`before`, `after`, `prepend`, `append`); only `replace` requires `#CRC` suffix
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Auto QA tool (`report_tool_issue`) for automated tracking of unexpected tool behavior; enabled via `PI_AUTO_QA=1` environment variable or `dev.autoqa` setting
 - `dev.autoqa` setting to enable automated tool issue reporting for all agents
@@ -6508,6 +6658,7 @@
 ## [13.19.0] - 2026-04-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added idle auto-compaction settings and scheduling so sessions can compact after inactive turns without auto-continuing.
 - Added `onExternalEditor` callback to extension UI dialog options for handling external editor shortcut in select dialogs
@@ -6560,6 +6711,7 @@
 - Removed standalone `fetch` tool; URL fetching is now integrated into the `read` tool
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added URL reading capability to `read` tool with support for web pages, GitHub issues, Stack Overflow, Wikipedia, Reddit, NPM, arXiv, technical blogs, RSS/Atom feeds, and JSON endpoints
 - Added `offset` and `limit` parameter support for paginating cached URL fetch results
@@ -6579,6 +6731,7 @@
 ## [13.17.5] - 2026-04-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for writing to ZIP archives using fflate library for cross-platform compatibility
 
@@ -6593,6 +6746,7 @@
 ## [13.17.4] - 2026-04-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for writing to archive entries in `.tar`, `.tar.gz`, `.tgz`, and `.zip` files using `archive.ext:path/inside/archive` syntax
 - Ability to create new archives when writing to archive subpaths that don't yet exist
@@ -6600,6 +6754,7 @@
 ## [13.17.3] - 2026-04-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for converting Jupyter notebooks (`.ipynb`) to markdown via markit
 - Added `markit-ai` npm package for native document and notebook conversion
@@ -6618,6 +6773,7 @@
 ## [13.17.2] - 2026-04-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/marketplace help` command to display usage guide for all marketplace operations
 - Added dedicated `gh-renderer.ts` module for rich terminal rendering of GitHub Actions workflow runs with live status snapshots and job details
@@ -6686,6 +6842,7 @@
 ## [13.17.0] - 2026-03-30
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `marketplace.autoUpdate` setting (`off`/`notify`/`auto`, default `notify`) for automatic plugin update checking on startup
 - Added background marketplace catalog refresh on startup when catalogs are stale (>24h)
@@ -6749,6 +6906,7 @@
 ## [13.16.1] - 2026-03-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `searchDb` parameter to `PromptActionAutocompleteProvider` constructor for native search database integration in autocomplete workflows
 - Added `searchDb` parameter to enable native search database integration for grep and find operations
@@ -6763,6 +6921,7 @@
 ## [13.16.0] - 2026-03-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Implemented root path alias: bare `/` in tool inputs now resolves to the session working directory instead of the filesystem root
 - Added `browser.screenshotDir` setting to configure screenshot save directory with path expansion
@@ -6777,6 +6936,7 @@
 ## [13.15.3] - 2026-03-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added configurable `app.model.selectTemporary` keybinding for temporary model selection.
 
@@ -6793,6 +6953,7 @@
 - Made `pos` parameter required for `replace_line`, `append`, and `prepend` operations; `append_eof` and `prepend_bof` no longer accept anchors
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added prompt for tradeoff metrics during autoresearch setup to collect secondary metrics alongside primary metric
 - Added validation of contract path specifications to reject absolute paths and parent directory references
@@ -6908,6 +7069,7 @@
 ## [13.14.0] - 2026-03-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Auto-reconnect MCP servers on connection loss with proactive SSE stream monitoring and retry backoff
 - Tool-level reconnect: retriable connection errors (ECONNREFUSED, ECONNRESET, stale session 404/502/503) trigger automatic reconnection and single retry
@@ -6934,6 +7096,7 @@
 ## [13.13.2] - 2026-03-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added automatic stripping of hashline display prefixes (LINE#ID:) from write tool content when hashline edit mode is enabled, preventing the model from accidentally copying display markers into files
 - Added `mcpServerName` and `mcpToolName` optional properties to custom tools for MCP server discovery and search metadata
@@ -6941,12 +7104,14 @@
 ## [13.13.1] - 2026-03-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Automatic deduplication of identical context files by content, keeping the closest (lowest depth) copy when duplicates are discovered
 
 ## [13.13.0] - 2026-03-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `edit.blockAutoGenerated` setting to control whether auto-generated file detection is enforced (enabled by default)
 - Improved auto-generated file detection to use language-specific comment parsing instead of broad regex patterns, reducing false positives
@@ -6960,6 +7125,7 @@
 ## [13.12.10] - 2026-03-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `args` field to ShellResult to capture the executed command
 - Added `exit_code` property to ShellResult as an alias for `returncode`
@@ -6973,6 +7139,7 @@
 ## [13.12.9] - 2026-03-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/session delete` command to delete current session with confirmation and return to session selector
 - Added session deletion in session selector via Delete key with confirmation dialog
@@ -6997,6 +7164,7 @@
 - Changed `SessionManager.list()` signature to accept only `sessionDir` parameter instead of `cwd` and optional `sessionDir`—callers must now compute and pass the session directory explicitly
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `SessionManager.getDefaultSessionDir()` static method to explicitly resolve the canonical default session directory for a working directory
 - Added support for quoted paths in grep, ast_grep, and find tools to handle directory names with spaces
@@ -7042,6 +7210,7 @@
 ## [13.12.5] - 2026-03-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Automatic discovery of Ollama model context window from model metadata, enabling accurate token limit configuration
 - Added `attribution` option to `PromptOptions` to explicitly control billing/initiator attribution for prompts
@@ -7066,6 +7235,7 @@
 ## [13.12.4] - 2026-03-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exposed `settings` instance in `CustomToolContext` for session-specific configuration access
 
@@ -7077,6 +7247,7 @@
 ## [13.12.2] - 2026-03-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `compaction.thresholdTokens` setting as a fixed token limit alternative to percentage-based compaction threshold
 - Added more artifact spill threshold options (1 KB to 1 MB) with size descriptions
@@ -7104,6 +7275,7 @@
 ## [13.12.1] - 2026-03-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for move-only operations that preserve exact bytes including binary files
 
@@ -7115,6 +7287,7 @@
 ## [13.12.0] - 2026-03-14
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added per-rule TTSR interrupt mode override via `interruptMode` field in rule frontmatter to allow fine-grained control over when TTSR interrupts stream processing
 - Added `task` model role to allow configuring a dedicated model for subtask execution via `modelRoles.task` setting
@@ -7169,6 +7342,7 @@
 ## [13.11.1] - 2026-03-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `llama.cpp` as local provider
 - Added `code_search` tool supporting both Exa and grep.app providers for code snippet and documentation search
@@ -7197,6 +7371,7 @@
 ## [13.11.0] - 2026-03-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Parallel as a web search provider with support for fast and research modes
 - Added Parallel extract API integration for URL content fetching and YouTube video extraction
@@ -7239,6 +7414,7 @@
 ## [13.10.1] - 2026-03-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `submitInteractiveInput()` function for programmatic submission of user input in interactive mode
 - Added proactive OAuth token refresh for MCP server connections with 5-minute expiry buffer
@@ -7260,6 +7436,7 @@
 - Removed `no_fallback` option from search parameters
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `before_provider_request` extension event to intercept and modify provider request payloads before sending
 - Added `emitBeforeProviderRequest()` method to ExtensionRunner for chaining payload transformations across extensions
@@ -7294,6 +7471,7 @@
 ## [13.9.15] - 2026-03-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ensureLoadingAnimation()` method to manage loading animation lifecycle and prevent duplicate spinners
 
@@ -7305,6 +7483,7 @@
 ## [13.9.12] - 2026-03-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Tavily as a supported web search provider with `TAVILY_API_KEY` credential discovery and provider fallback support
 - Added `#`-triggered prompt action suggestions in the editor, with keybinding hints for line navigation and prompt copy actions
@@ -7323,6 +7502,7 @@
 ## [13.9.10] - 2026-03-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `env` parameter to bash tool to pass environment variables safely without shell re-parsing, preventing quote and special character bugs with multiline or untrusted values
 - Added support for rendering partial `env` assignments in command preview while tool arguments are still streaming
@@ -7335,12 +7515,14 @@
 ## [13.9.8] - 2026-03-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added docs.rs scraper for extracting Rust crate documentation from rustdoc JSON, including support for modules, functions, structs, traits, enums, and other Rust items with caching
 
 ## [13.9.7] - 2026-03-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `skipPostPromptRecoveryWait` option to handoff operations to defer recovery work until after handoff completion
 - Added deferred auto-compaction scheduling to allow threshold-triggered handoffs to complete while the original prompt is still unwinding
@@ -7356,6 +7538,7 @@
 ## [13.9.6] - 2026-03-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `glob` parameter to `ast_grep` and `ast_edit` tools for additional glob filtering relative to the `path` parameter
 - Added `combineSearchGlobs` utility function to merge glob patterns from `path` and `glob` parameters
@@ -7370,6 +7553,7 @@
 ## [13.9.4] - 2026-03-07
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Automatic detection of Ollama model capabilities including reasoning/thinking support and vision input via the `/api/show` endpoint
 - Improved Kagi API error handling with extraction of detailed error messages from JSON and plain text responses
@@ -7389,6 +7573,7 @@
 - Changed `thinkingLevel` in session context to be optional (`ThinkingLevel | undefined`) instead of always present
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `thinking.ts` module with `getThinkingLevelMetadata()` and `resolveThinkingLevelForModel()` utilities for thinking level handling
 - Added `ThinkingConfig` support to model definitions for specifying supported thinking effort levels per model
@@ -7434,6 +7619,7 @@
 ## [13.9.2] - 2026-03-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for Python code execution messages with output display and error handling
 - Support for mode change entries in session exports
@@ -7458,6 +7644,7 @@
 ## [13.9.0] - 2026-03-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `read.defaultLimit` setting to configure default number of lines returned by read tool when no limit is specified (default: 300 lines)
 - Added preset options for read default limit (200, 300, 500, 1000, 5000 lines) in settings UI
@@ -7487,6 +7674,7 @@
 ## [13.8.0] - 2026-03-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `buildCompactHashlineDiffPreview()` function to generate compact diff previews for model-visible tool responses, collapsing long unchanged runs and consecutive additions/removals to show edit shape without full file content
 - Added project-level discovery for `.agent/` and `.agents/` directories, walking up from cwd to repo root (matching behavior of other providers like `.omp`, `.claude`, `.codex`). Applies to skills, rules, prompts, commands, context files (AGENTS.md), and system prompts (SYSTEM.md)
@@ -7503,6 +7691,7 @@
 ## [13.7.6] - 2026-03-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `dedupeParseErrors` utility function to deduplicate parse error messages while preserving order
 
@@ -7514,6 +7703,7 @@
 ## [13.7.4] - 2026-03-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `fetch.useKagiSummarizer` setting to toggle Kagi Universal Summarizer usage in the fetch tool.
 
@@ -7525,6 +7715,7 @@
 ## [13.7.3] - 2026-03-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Kagi Universal Summarizer integration for URL summarization, now prioritized before Jina and other methods
 - Added Kagi Universal Summarizer support for YouTube video summaries when credentials are available
@@ -7547,6 +7738,7 @@
 ## [13.7.2] - 2026-03-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for direct OAuth provider login via `/login <provider>` command (e.g., `/login kagi`)
 - Added optional `providerId` parameter to `showOAuthSelector()` to enable direct provider selection without UI selector
@@ -7581,6 +7773,7 @@
 ## [13.6.0] - 2026-03-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `mcp://` internal URL protocol for reading MCP server resources directly via the read tool (e.g., `read(path="mcp://resource-uri")`)
 - Added LM Studio integration to the model registry and discovery flow.
@@ -7622,12 +7815,14 @@
 ## [13.5.5] - 2026-03-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Kagi web search provider (Search API v0) with related searches support and automatic `KAGI_API_KEY` detection
 
 ## [13.5.4] - 2026-03-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `authServerUrl` field to `AuthDetectionResult` to capture OAuth server metadata from `Mcp-Auth-Server` headers
 - Added `extractMcpAuthServerUrl()` function to parse and validate `Mcp-Auth-Server` URLs from error messages
@@ -7649,6 +7844,7 @@
 ## [13.5.3] - 2026-03-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Auto-include `ast_grep` and `ast_edit` tools when their text-based counterparts (`grep`, `edit`) are requested and the AST tools are enabled
 - Enforced tool decision in plan mode—agent now requires calling either `ask` or `exit_plan_mode` when a turn ends without a required tool call
@@ -7670,6 +7866,7 @@
 ## [13.5.2] - 2026-03-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `checkpoint` tool to create context checkpoints before exploratory work, allowing you to investigate with many intermediate tool calls and minimize context cost afterward
 - Added `rewind` tool to end an active checkpoint and replace intermediate exploration messages with a concise investigation report
@@ -7685,6 +7882,7 @@
 ## [13.5.0] - 2026-03-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `hlinejsonref` Handlebars helper for embedding hashline references inside JSON blocks in prompts
 - Added `librarian` agent for researching external libraries and APIs by reading source code
@@ -7712,6 +7910,7 @@
 - `ast_edit` parameters `pattern` + `rewrite` replaced by `ops: Array<{ pat: string; out: string }>`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `resolve` tool to apply or discard pending preview actions with required reasoning
 - AST edit now registers pending actions after preview, allowing explicit apply/discard workflow via `resolve` tool
@@ -7761,6 +7960,7 @@
 ## [13.3.14] - 2026-02-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Expanded AST tool language support from 7 to all 25 ast-grep tree-sitter languages (Bash, C, C++, C#, CSS, Elixir, Go, Haskell, HCL, HTML, Java, JavaScript, JSON, Kotlin, Lua, Nix, PHP, Python, Ruby, Rust, Scala, Solidity, Swift, TSX, TypeScript, YAML)
 - AST find now emits all lines of multiline matches with hashline tags (LINE#HASH:content) consistent with read/grep output
@@ -7783,6 +7983,7 @@
 ## [13.3.8] - 2026-02-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ast_find` tool for structural code search using AST matching via ast-grep, enabling syntax-aware pattern discovery across codebases
 - Added `ast_replace` tool for structural AST-aware rewrites via ast-grep, enabling safe syntax-level codemods without text-based fragility
@@ -7905,6 +8106,7 @@
 ## [13.3.5] - 2026-02-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for setting array and record configuration values using JSON syntax
 
@@ -7920,6 +8122,7 @@
 ## [13.3.3] - 2026-02-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for `move` parameter in `computeHashlineDiff` to enable file move operations alongside content edits
 
@@ -7930,6 +8133,7 @@
 ## [13.3.1] - 2026-02-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `topP` setting to control nucleus sampling cutoff for model output diversity
 - Added `topK` setting to sample from top-K tokens for controlled generation
@@ -7948,6 +8152,7 @@
 - Renamed `task.isolation.enabled` (boolean) setting to `task.isolation.mode` (enum: `none`, `worktree`, `fuse-overlay`). Existing `true`/`false` values are auto-migrated to `worktree`/`none`.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `PERPLEXITY_COOKIES` env var for Perplexity web search via session cookies extracted from desktop app
 - Added `fuse-overlay` isolation mode for subagents using `fuse-overlayfs` (copy-on-write overlay, no baseline patch apply needed)
@@ -8006,6 +8211,7 @@
 - Renamed `file` parameter to `path` in replace, patch, and hashline edit operations
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added clarification in hashline edit documentation that the `end` tag must include closing braces/brackets when replacing blocks to prevent syntax errors
 
@@ -8027,6 +8233,7 @@
 ## [13.0.0] - 2026-02-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `getTodoPhases()` and `setTodoPhases()` methods to ToolSession API for managing todo state programmatically
 - Added `getLatestTodoPhasesFromEntries()` export to retrieve todo phases from session history
@@ -8068,6 +8275,7 @@
 ## [12.19.3] - 2026-02-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `pty` parameter to bash tool to enable PTY mode for commands requiring a real terminal (e.g., sudo, ssh, top, less)
 
@@ -8089,6 +8297,7 @@
 ## [12.19.0] - 2026-02-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `poll_jobs` tool to block until background jobs complete, providing an alternative to polling `read jobs://` in loops
 - Added `task.maxConcurrency` setting to limit the number of concurrently executing subagent tasks
@@ -8137,12 +8346,14 @@
 ## [12.18.1] - 2026-02-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Buffer.toBase64() polyfill for Bun compatibility to enable base64 encoding of buffers
 
 ## [12.18.0] - 2026-02-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `overlay` option to custom UI hooks to display components as bottom-centered overlays instead of replacing the editor
 - Added automatic chat transcript rebuild when returning from custom or debug UI to prevent message duplication
@@ -8178,6 +8389,7 @@
 ## [12.17.1] - 2026-02-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `filterBrowser` option to filter out browser automation MCP servers when builtin browser tool is enabled
 - Added `isBrowserMCPServer()` function to detect browser automation MCP servers by name, URL, or command patterns
@@ -8187,6 +8399,7 @@
 ## [12.17.0] - 2026-02-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added timeout protection (5 seconds) for system prompt preparation with graceful fallback to minimal context on timeout
 
@@ -8199,6 +8412,7 @@
 ## [12.16.0] - 2026-02-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `peekApiKey` method to AuthStorage for non-blocking API key retrieval during model discovery without triggering OAuth token refresh
 - Exported `finalizeSubprocessOutput` function to handle subprocess output finalization with submit_result validation
@@ -8236,6 +8450,7 @@
 ## [12.15.0] - 2026-02-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `includeDisabled` parameter to `listAuthCredentials()` to optionally retrieve disabled credentials
 - Added `disableAuthCredential()` method for soft-deleting auth credentials while preserving database records
@@ -8254,6 +8469,7 @@
 ## [12.14.0] - 2026-02-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for `docs://` internal URL protocol to access embedded documentation files (e.g., `docs://sdk.md`)
 - Added `generate-docs-index` npm script to automatically index and embed documentation files at build time
@@ -8295,6 +8511,7 @@
 - Removed automatic line relocation when hash references become stale; edits with mismatched line hashes now fail with an error instead of silently relocating to matching lines elsewhere in the file
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ssh` command for managing SSH host configurations (add, list, remove)
 - Added `/ssh` slash command in interactive mode to manage SSH hosts with subcommands
@@ -8322,6 +8539,7 @@
 ## [12.12.1] - 2026-02-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Kimi (Moonshot) as a web search provider with OAuth and API key support ([#110](https://github.com/can1357/oh-my-pi/pull/110) by [@oglassdev](https://github.com/oglassdev))
 
@@ -8336,6 +8554,7 @@
 ## [12.12.0] - 2026-02-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Display streaming text preview during agent specification generation to show real-time progress
 - Added `onRequestRender` callback to agent dashboard for triggering UI updates during async operations
@@ -8366,6 +8585,7 @@
 ## [12.11.0] - 2026-02-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Support for Synthetic model provider in web search command
 - Model sorting by priority field and version number in model selector for improved model ranking
@@ -8396,6 +8616,7 @@
 ## [12.10.1] - 2026-02-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/login` support for Cerebras and Synthetic API-key providers
 
@@ -8406,6 +8627,7 @@
 - Changed keyless provider auth sentinel from `"<no-auth>"` to `kNoAuth` (`"N/A"`) for `ModelRegistry.getApiKey()` and `ModelRegistry.getApiKeyForProvider()`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `--no-rules` CLI flag to disable rules discovery and loading
 - Added `sessionDir` option to RpcClientOptions for specifying agent session directory
@@ -8442,6 +8664,7 @@
 ## [12.9.0] - 2026-02-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added OpenCode discovery provider to load configuration from ~/.config/opencode/ and .opencode/ directories
 - Added support for loading MCP servers from opencode.json mcp key
@@ -8500,6 +8723,7 @@
 ## [12.7.0] - 2026-02-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Z.AI web search provider support via remote MCP endpoint (webSearchPrime)
 - Added `zai` as a selectable web search provider option in settings
@@ -8508,6 +8732,7 @@
 ## [12.6.0] - 2026-02-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added runtime tests covering extension provider registration and deferred model pattern resolution behavior.
 
@@ -8524,6 +8749,7 @@
 ## [12.5.1] - 2026-02-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `repeatToolDescriptions` setting to render full tool descriptions in the system prompt instead of a tool name list
 
@@ -8534,6 +8760,7 @@
 - Replaced `theme` setting with `theme.dark` and `theme.light` (auto-migrated)
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `previewTheme()` function for non-destructive theme preview during settings browsing
 - Added animated microphone icon with color cycling during voice recording
@@ -8597,6 +8824,7 @@
 ## [12.3.0] - 2026-02-14
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added autonomous memory extraction and consolidation system with configurable settings
 - Added `/memory` slash command with subcommands: `view`, `clear`, `reset`, `enqueue`, `rebuild`
@@ -8613,6 +8841,7 @@
 ## [12.2.0] - 2026-02-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `providerSessionState` property to AgentSession for managing provider-scoped transport and session caches
 - Added automatic cleanup of provider session state resources on session disposal
@@ -8643,6 +8872,7 @@
 ## [12.1.0] - 2026-02-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Filesystem scan cache invalidation helpers (`invalidateFsScanAfterWrite`, `invalidateFsScanAfterDelete`, `invalidateFsScanAfterRename`) to properly invalidate shared caches after file mutations
 - Named discovery profile for file mention candidates to standardize cache visibility and ignore semantics across callers
@@ -8660,6 +8890,7 @@
 ## [12.0.0] - 2026-02-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `getAllServerNames()` method to MCPManager for enumerating all known servers
 
@@ -8677,6 +8908,7 @@
 ## [11.14.4] - 2026-02-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `renderPromptTemplate` function for programmatic prompt template rendering
 - Exported `computeLineHash` function from patch utilities
@@ -8705,6 +8937,7 @@
 ## [11.14.0] - 2026-02-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added SwiftLint linter client with JSON reporter support for Swift file linting
 - Added `--no-pty` flag to disable PTY-based interactive bash execution
@@ -8723,6 +8956,7 @@
 ## [11.13.1] - 2026-02-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/move` slash command to move session to a different working directory
 - Added `moveTo()` method to SessionManager for relocating sessions with file migration and header updates
@@ -8748,6 +8982,7 @@
 - Removed support for `.pi` configuration directory alias; use `.omp` instead
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `openPath` utility function to centralize cross-platform URL and file path opening
 
@@ -8758,6 +8993,7 @@
 ## [11.12.0] - 2026-02-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `resolveFileDisplayMode` utility to centralize file display mode resolution across tools (read, grep, file mentions)
 - Added automatic hashline formatting to @file mentions when hashline mode is active
@@ -8832,6 +9068,7 @@
 ## [11.10.4] - 2026-02-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Hashline diff computation with `computeHashlineDiff` function for preview rendering of hashline-mode edits
 - Streaming preview display for hashline edits in tool execution UI showing edit sources and destinations
@@ -8847,12 +9084,14 @@
 ## [11.10.3] - 2026-02-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `./patch/*` subpath for direct access to patch utilities
 
 ## [11.10.2] - 2026-02-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `streamHashLinesFromUtf8` and `streamHashLinesFromLines` functions for streaming hashline-formatted output with configurable chunking
 - Added `HashlineStreamOptions` interface to control streaming behavior (startLine, maxChunkLines, maxChunkBytes)
@@ -8900,6 +9139,7 @@
 - Changed `HashlineEdit.src` from newline-separated line ref lists to range syntax: `"5:ab"` (single), `"5:ab..9:ef"` (range), `"5:ab.."` (insert after); comma and newline-separated lists are no longer supported
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added substring-based source matching for hashline edits when line reference format is invalid, allowing fallback to unique substring search within the file
 - Added automatic detection and repair of single-line merges where models absorb adjacent lines, preventing content duplication
@@ -8972,6 +9212,7 @@
 ## [11.9.0] - 2026-02-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/mcp` slash command for runtime MCP server management (add, list, remove, enable, disable, test, reauth)
 - Added interactive multi-step wizard for adding MCP servers with transport auto-detection
@@ -9014,6 +9255,7 @@
 ## [11.8.1] - 2026-02-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added current date to system prompt context in YYYY-MM-DD format for date-aware agent reasoning
 - Added file size display in UI when files are skipped due to size limits
@@ -9039,6 +9281,7 @@
 ## [11.8.0] - 2026-02-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ctx.reload()` method to extension command context to reload extensions, skills, prompts, and themes from disk
 - Added `ctx.ui.pasteToEditor()` method to paste text into the editor with proper handling (e.g., large paste markers in interactive mode)
@@ -9089,6 +9332,7 @@
 - Fixed queued messages not delivered after auto-compaction completes
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/quit` slash command as alias for `/exit`
 - Added per-model overrides (`modelOverrides`) in `models.json` for customizing built-in model properties
@@ -9103,6 +9347,7 @@
 ## [11.5.0] - 2026-02-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added terminal breadcrumb tracking to remember the last session per terminal, enabling `--continue` to work correctly with concurrent sessions in different terminals
 
@@ -9128,6 +9373,7 @@
 ## [11.4.0] - 2026-02-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Visualize leading whitespace (indentation) in diff output with dim glyphs—tabs display as `→` and spaces as `·` for improved readability
 
@@ -9142,6 +9388,7 @@
 ## [11.3.0] - 2026-02-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added resumption hint printed to stderr on session exit showing command to resume the session (e.g., `Resume this session with claude --resume <session-id>`)
 - New `BlobStore` class for content-addressed storage of large binary data (images) externalized from session files
@@ -9248,6 +9495,7 @@
 ## [11.2.0] - 2026-02-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `omp commit` command to generate commit messages and update changelogs with `--push`, `--dry-run`, `--no-changelog`, and model override flags
 - Added `omp config` command to manage configuration settings with actions: list, get, set, reset, path
@@ -9306,6 +9554,7 @@
 ## [11.1.0] - 2026-02-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `sortDiagnostics()` utility function to sort diagnostics by severity, location, and message for consistent output ordering
 - Added `task.isolation.enabled` setting to control whether subagents run in isolated git worktrees
@@ -9338,6 +9587,7 @@
 ## [11.0.3] - 2026-02-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added new subcommands to help text: `commit` for AI-assisted git commits, `stats` for AI usage statistics dashboard, and `jupyter` for managing the shared Jupyter gateway
 - Added `grep` subcommand to help text for testing the grep tool
@@ -9379,6 +9629,7 @@
 ## [11.0.0] - 2026-02-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added UI dropdown options for `task.maxRecursion Depth` setting with presets (Unlimited, None, Single, Double, Triple)
 - Added UI dropdown options for `grep.contextBefore` setting with presets (0-5 lines)
@@ -9423,6 +9674,7 @@
 ## [10.6.1] - 2026-02-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `commit` model role for dedicated commit message generation
 - Exported `resolveModelOverride` function from model resolver for external use
@@ -9450,6 +9702,7 @@
 - Removed `n` (show line numbers) parameter—line numbers are now always displayed in grep results
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Jina as a web search provider option alongside Exa, Perplexity, and Anthropic
 - Added support for Jina Reader API integration with automatic provider detection when JINA_API_KEY is configured
@@ -9477,6 +9730,7 @@
 - Removed support for local Python kernel gateway startup; shared gateway is now required
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added browser tool powered by Ulixee Hero with support for navigation, DOM interaction, screenshots, and readable content extraction
 - Added `/browser` command to toggle browser headless vs visible mode in interactive sessions
@@ -9506,6 +9760,7 @@
 ## [10.3.2] - 2026-02-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `renderCall` and `renderResult` methods to MCP tools for structured TUI display of tool calls and results
 - Added new `mcp/render.ts` module providing JSON tree rendering for MCP tool output with collapsible/expandable views
@@ -9532,6 +9787,7 @@
 ## [10.2.3] - 2026-02-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `find.enabled`, `grep.enabled`, `ls.enabled`, `notebook.enabled`, `fetch.enabled`, `web_search.enabled`, `lsp.enabled`, and `calc.enabled` settings to control availability of individual tools
 - Added conditional tool documentation in system prompt that dynamically lists only enabled specialized tools
@@ -9585,6 +9841,7 @@
 ## [10.1.0] - 2026-02-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added work scheduling profiler to debug menu for analyzing CPU scheduling patterns over the last 30 seconds
 - Added support for work profile data in report bundles including folded stacks, summary, and flamegraph visualization
@@ -9592,6 +9849,7 @@
 ## [10.0.0] - 2026-02-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `shell` subcommand for interactive shell console testing with brush-core
 - Added `--cwd` / `-C` option to set working directory for shell commands
@@ -9609,6 +9867,7 @@
 - Removed persistent shell session support; bash execution now uses native bindings via brush-core for improved reliability
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `sessionKey` option to bash executor to isolate shell sessions per agent instance
 - Added shell snapshot support for bash execution to preserve shell state across commands
@@ -9664,6 +9923,7 @@
 - Removed example file `examples/sdk/10-settings.ts` demonstrating old SettingsManager API
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - New `Settings` singleton class with sync get/set operations and background persistence
 - Added `Settings.isolated()` factory for creating isolated settings instances in tests
@@ -9701,6 +9961,7 @@
 ## [9.5.0] - 2026-02-01
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `head` and `tail` parameters to bash tool to limit output lines without breaking streaming
 - Added automatic normalization of bash commands to extract `| head -n N` and `| tail -n N` patterns into native parameters
@@ -9754,6 +10015,7 @@
 ## [9.3.1] - 2026-01-31
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `getCompactContext()` API to retrieve parent conversation context for subagents, excluding system prompts and tool results
 - Added automatic `submit_result` tool injection for subagents with explicit tool lists
@@ -9785,6 +10047,7 @@
 ## [9.2.3] - 2026-01-31
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Persistent shell session support for bash tool with environment variable preservation across commands
 - New `shellForceBasic` setting to force bash/sh even if user's default shell is different (default: true)
@@ -9813,6 +10076,7 @@
 ## [9.2.2] - 2026-01-31
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added grep CLI subcommand (`omp grep`) for testing pattern matching
 - Added fuzzy matching for model resolution with scoring and ranking fallback
@@ -9876,6 +10140,7 @@
 ## [8.13.0] - 2026-01-29
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/debug` command with interactive menu for bug report generation:
   - `Report: performance issue` - CPU profiling with reproduction flow
@@ -9911,6 +10176,7 @@
 ## [8.8.8] - 2026-01-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/fork` command to create a new session with the exact same state (entries and artifacts) as the current session
 
@@ -9921,6 +10187,7 @@
 ## [8.6.0] - 2026-01-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `plan` model role for specifying the model used by the plan agent
 - Added `--plan` CLI flag and `OMP_PLAN_MODEL` environment variable for ephemeral plan model override
@@ -9939,6 +10206,7 @@
 ## [8.5.0] - 2026-01-27
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added subagent support for preloading skill contents into the system prompt instead of listing available skills
 - Added session init entries to capture system prompt, task, tools, and output schema for subagent session logs
@@ -9955,6 +10223,7 @@
 ## [8.4.5] - 2026-01-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Model usage tracking to record and retrieve most recently used models
 - Model sorting in selector based on usage history
@@ -9979,6 +10248,7 @@
 ## [8.4.1] - 2026-01-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added core plan mode with plan file approval workflow and tool gating
 - Added plan:// internal URLs for plan file access and subagent plan-mode system prompt
@@ -9993,6 +10263,7 @@
 ## [8.4.0] - 2026-01-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added extension API to set working/loading messages during streaming
 - Added task worker propagation of context files, skills, and prompt templates
@@ -10037,6 +10308,7 @@
 ## [8.2.0] - 2026-01-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `omp commit` command to generate conventional commits with changelog updates
 - Added agentic commit mode with commit-specific tools and `--legacy` fallback
@@ -10166,6 +10438,7 @@
 ## [8.0.0] - 2026-01-23
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added antigravity provider support for image generation with Google Cloud authentication
 - Added support for google-antigravity API credentials in model registry
@@ -10254,6 +10527,7 @@
 ## [7.0.0] - 2026-01-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added usage report deduplication to prevent duplicate account entries
 - Added debug logging for usage fetch operations to aid diagnostics
@@ -10312,6 +10586,7 @@
 ## [6.9.69] - 2026-01-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added cell-by-cell status tracking with duration and exit code for Python execution
 - Added syntax highlighting for Python code in execution display
@@ -10430,6 +10705,7 @@
 ## [6.8.0] - 2026-01-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added streaming abort setting to control edit tool behavior when patch preview fails
 
@@ -10458,6 +10734,7 @@
 ## [6.7.67] - 2026-01-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added normative rewrite setting to control tool call argument normalization in session history
 - Added read line numbers setting to prepend line numbers to read tool output by default
@@ -10473,6 +10750,7 @@
 ## [6.7.0] - 2026-01-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Normative patch generation to canonicalize edit tool output with tool call argument rewriting for session history
 - Patch matching fallback variants: trimmed context, collapsed duplicates, single-line reduction, comment-prefix normalization
@@ -10530,6 +10808,7 @@
 ## [6.1.0] - 2026-01-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added lspmux integration for LSP server multiplexing to reduce startup time and memory usage
 - Added LSP tool proxy support for subagent workers
@@ -10545,6 +10824,7 @@
 ## [6.0.0] - 2026-01-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Cursor and OpenAI Codex OAuth providers
 - Added Windows installer bash shell auto-configuration
@@ -10581,6 +10861,7 @@
 ## [5.6.70] - 2026-01-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added support for loading Python prelude extension modules from user and project directories
 - Added automatic discovery of Python modules from `.omp/modules` and `.pi/modules` directories
@@ -10589,6 +10870,7 @@
 ## [5.6.7] - 2026-01-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Python shared gateway setting to enable resource-efficient kernel reuse across sessions
 - Added Python tool cancellation support with proper timeout and cleanup handling
@@ -10714,6 +10996,7 @@
 ## [5.2.0] - 2026-01-14
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `withLines` parameter to read tool for optional line number output (default: true, cat -n format)
 
@@ -10760,6 +11043,7 @@
 ## [5.0.0] - 2026-01-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Implemented `xhigh` thinking level for Anthropic models with increased reasoning limits
 
@@ -10784,6 +11068,7 @@
 ## [4.7.0] - 2026-01-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Add `omp config` subcommand for managing settings (`list`, `get`, `set`, `reset`, `path`)
 - Add `todoCompletion` setting to warn agent when it stops with incomplete todos (up to 3 reminders)
@@ -10802,6 +11087,7 @@
 ## [4.6.0] - 2026-01-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Add `/skill:name` slash commands for quick skill access (toggle via `skills.enableSkillCommands` setting)
 - Add `cwd` to SessionInfo for session list display
@@ -10837,6 +11123,7 @@
 ## [4.4.4] - 2026-01-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `todo_write` tool for creating and managing structured task lists during coding sessions
 - Added persistent todo panel above the editor that displays task progress
@@ -10886,6 +11173,7 @@
 ## [4.3.0] - 2026-01-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Cursor provider support with browser-based OAuth authentication
 - Added default model configuration for Cursor provider (claude-sonnet-4-5)
@@ -10908,6 +11196,7 @@
 ## [4.2.2] - 2026-01-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added persistent cache storage for Codex usage data that survives application restarts
 - Added `--no-lsp` to disable LSP tools, formatting, diagnostics, and warmup for a session
@@ -10929,6 +11218,7 @@
 ## [4.2.1] - 2026-01-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added automatic discovery and listing of AGENTS.md files in the system prompt, providing agents with an authoritative list of project-specific instruction files without runtime searching
 - Added `planner` built-in agent for comprehensive implementation planning with slow model
@@ -10956,6 +11246,7 @@
 ## [4.2.0] - 2026-01-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `/dump` slash command to copy the full session transcript to the clipboard
 - Added automatic Nerd Fonts detection for terminals like iTerm, WezTerm, Kitty, Ghostty, and Alacritty to set appropriate symbol preset
@@ -10996,6 +11287,7 @@
 ## [4.1.0] - 2026-01-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added persistent prompt history with SQLite-backed storage and Ctrl+R search
 
@@ -11006,6 +11298,7 @@
 ## [4.0.1] - 2026-01-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added usage limit error detection to enable automatic credential switching when Codex accounts hit rate limits
 - Added Codex usage API integration to proactively check account limits before credential selection
@@ -11023,6 +11316,7 @@
 ## [4.0.0] - 2026-01-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `InteractiveModeOptions` type for programmatic SDK usage
 - Exported additional UI components for extensions: `ArminComponent`, `AssistantMessageComponent`, `BashExecutionComponent`, `BranchSummaryMessageComponent`, `CompactionSummaryMessageComponent`, `CustomEditor`, `CustomMessageComponent`, `FooterComponent`, `ExtensionEditorComponent`, `ExtensionInputComponent`, `ExtensionSelectorComponent`, `LoginDialogComponent`, `ModelSelectorComponent`, `OAuthSelectorComponent`, `SessionSelectorComponent`, `SettingsSelectorComponent`, `ShowImagesSelectorComponent`, `ThemeSelectorComponent`, `ThinkingSelectorComponent`, `ToolExecutionComponent`, `TreeSelectorComponent`, `UserMessageComponent`, `UserMessageSelectorComponent`
@@ -11116,6 +11410,7 @@
 ## [3.36.0] - 2026-01-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `calc` tool for basic mathematical calculations with support for arithmetic operators, parentheses, and hex/binary/octal literals
 - Added support for multiple API credentials per provider with round-robin distribution across sessions
@@ -11135,6 +11430,7 @@
 ## [3.35.0] - 2026-01-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added retry logic with exponential backoff for auto-compaction failures
 - Added fallback to alternative models when auto-compaction fails with the primary model
@@ -11160,6 +11456,7 @@
 ## [3.34.0] - 2026-01-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added caching for system environment detection to improve startup performance
 - Added disk usage information to automatic environment detection in system prompt
@@ -11179,6 +11476,7 @@
 ## [3.33.0] - 2026-01-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `env` support in `settings.json` for automatically setting environment variables on startup
 - Added environment variable management methods to SettingsManager (get/set/clear)
@@ -11196,6 +11494,7 @@
 ## [3.32.0] - 2026-01-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added progress indicator when starting LSP servers at session startup
 - Added bundled `/init` slash command available by default
@@ -11211,6 +11510,7 @@
 ## [3.31.0] - 2026-01-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added temporary model selection: `Ctrl+Y` opens model selector for session-only model switching (not persisted to settings)
 - Added `setModelTemporary()` method to AgentSession for ephemeral model changes
@@ -11279,6 +11579,7 @@
 ## [3.30.0] - 2026-01-07
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added environment variable configuration for task limits: `OMP_TASK_MAX_PARALLEL`, `OMP_TASK_MAX_CONCURRENCY`, `OMP_TASK_MAX_OUTPUT_BYTES`, `OMP_TASK_MAX_OUTPUT_LINES`, and `OMP_TASK_MAX_AGENTS_IN_DESCRIPTION`
 - Added specialized web-fetch handlers for 50+ platforms including GitHub, GitLab, npm, PyPI, crates.io, Stack Overflow, Wikipedia, arXiv, PubMed, Hacker News, Reddit, Mastodon, Bluesky, and many more
@@ -11299,6 +11600,7 @@
 ## [3.25.0] - 2026-01-07
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `complete` tool for structured subagent output with JSON schema validation
 - Added `query` parameter to output tool for jq-like JSON querying
@@ -11315,6 +11617,7 @@
 ## [3.24.0] - 2026-01-07
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `ToolSession` interface to unify tool creation with session context including cwd, UI availability, and rulebook rules
 - Added Bun Worker-based execution for subagent tasks, replacing subprocess spawning for improved performance and event streaming
@@ -11374,6 +11677,7 @@
 - Changed image tool name from `gemini_image` to `generate_image` with label `GenerateImage`
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `webSearchProvider` setting to override auto-detection priority (Exa > Perplexity > Anthropic)
 - Added `imageProvider` setting to override auto-detection priority (OpenRouter > Gemini)
@@ -11413,6 +11717,7 @@
 ## [3.20.0] - 2026-01-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added extensions API with auto-discovery (`.omp/extensions`) and `--extension`/`-e` loading for custom tools, commands, and lifecycle hooks
 - Added prompt templates loaded from global and project `.omp/prompts` directories with `/template` expansion in the input box
@@ -11464,6 +11769,7 @@
 ## [3.15.1] - 2026-01-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added 65 new built-in color themes including dark variants (abyss, aurora, cavern, copper, cosmos, eclipse, ember, equinox, lavender, lunar, midnight, nebula, rainforest, reef, sakura, slate, solstice, starfall, swamp, taiga, terminal, tundra, twilight, volcanic), light variants (aurora-day, canyon, cirrus, coral, dawn, dunes, eucalyptus, frost, glacier, haze, honeycomb, lagoon, lavender, meadow, mint, opal, orchard, paper, prism, sand, savanna, soleil, wetland, zenith), and material themes (alabaster, amethyst, anthracite, basalt, birch, graphite, limestone, mahogany, marble, obsidian, onyx, pearl, porcelain, quartz, sandstone, titanium)
 
@@ -11474,6 +11780,7 @@
 ## [3.15.0] - 2026-01-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added spinner type variants (status and activity) with distinct animation frames per symbol preset
 - Added animated spinner for task tool progress display during subagent execution
@@ -11553,6 +11860,7 @@
 ## [3.14.0] - 2026-01-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `getUsageStatistics()` method to SessionManager for tracking cumulative token usage and costs across session messages
 
@@ -11576,6 +11884,7 @@
 ## [3.8.1337] - 2026-01-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added automatic browser opening after exporting session to HTML
 - Added automatic browser opening after sharing session as a Gist
@@ -11587,6 +11896,7 @@
 ## [3.7.1337] - 2026-01-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `EditMatchError` class for structured error handling in edit operations
 - Added `utils` module export with `once` and `untilAborted` helper functions
@@ -11605,6 +11915,7 @@
 ## [3.5.1337] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added session header and footer output in text mode showing version, model, provider, thinking level, and session ID
 - Added Extension Control Center dashboard accessible via `/extensions` command for unified management of all providers and extensions
@@ -11625,6 +11936,7 @@
 ## [3.4.1337] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Time Traveling Stream Rules (TTSR) feature that monitors agent output for pattern matches and injects rule reminders mid-stream
 - Added `ttsr_trigger` frontmatter field for rules to define regex patterns that trigger mid-stream injection
@@ -11644,6 +11956,7 @@
 ## [3.1.1337] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `spawns` frontmatter field for agent definitions to control which sub-agents can be spawned
 - Added spawn restriction enforcement preventing agents from spawning unauthorized sub-agents
@@ -11655,6 +11968,7 @@
 ## [3.0.1337] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added unified capability-based discovery system for loading configuration from multiple AI coding tools (Claude Code, Cursor, Windsurf, Gemini, Codex, Cline, GitHub Copilot, VS Code)
 - Added support for discovering MCP servers, rules, skills, hooks, tools, slash commands, prompts, and context files from tool-specific config directories
@@ -11683,6 +11997,7 @@
 ## [2.1.1337] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `pi update` command to check for and install updates from GitHub releases or via bun
 
@@ -11696,6 +12011,7 @@
 ## [2.0.1337] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added shell environment snapshot to preserve user aliases, functions, and shell options when executing bash commands
 - Added support for `PI_BASH_NO_CI`, `PI_BASH_NO_LOGIN`, and `PI_SHELL_PREFIX` environment variables for shell customization
@@ -11709,6 +12025,7 @@
 ## [1.500.0] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added provider tabs to model selector with Tab/Arrow navigation for filtering models by provider
 - Added context menu to model selector for choosing model role (Default, Smol, Slow) instead of keyboard shortcuts
@@ -11771,6 +12088,7 @@
 ## [1.341.0] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added interruptMode setting to control when queued messages are processed during tool execution.
 - Implemented getter and setter methods in SettingsManager for interrupt mode persistence.
@@ -11821,6 +12139,7 @@
 ## [1.339.0] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - MCP project config setting to disable loading `.mcp.json`/`mcp.json` from project root
 - Support for both `mcp.json` and `.mcp.json` filenames (prefers `mcp.json` if both exist)
@@ -11829,6 +12148,7 @@
 ## [1.338.0] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Bash interceptor setting to block shell commands that have dedicated tools (disabled by default, enable via `/settings`)
 
@@ -11845,6 +12165,7 @@
 ## [1.337.1] - 2026-01-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - MCP support and plugin system for external tool integration
 - Git context to system prompt for repo awareness
@@ -11874,6 +12195,7 @@ Initial release under @oh-my-pi scope. See previous releases at [badlogic/pi-mon
 ## [1.5.1] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added shell environment snapshot to preserve user aliases, functions, and shell options when executing bash commands
 - Added support for `PI_BASH_NO_CI`, `PI_BASH_NO_LOGIN`, and `PI_SHELL_PREFIX` environment variables for shell customization
@@ -11887,6 +12209,7 @@ Initial release under @oh-my-pi scope. See previous releases at [badlogic/pi-mon
 ## [1.5.0] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added provider tabs to model selector with Tab/Arrow navigation for filtering models by provider
 - Added context menu to model selector for choosing model role (Default, Smol, Slow) instead of keyboard shortcuts
@@ -11985,6 +12308,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - Removed `discoverAuthStorage` and `discoverModels` from the SDK. `AuthStorage` and `ModelRegistry` now default to `~/.pi/agent` paths unless you pass an `agentDir` ([#645](https://github.com/badlogic/pi-mono/issues/645))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Session renaming in `/resume` picker via `Ctrl+R` without opening the session ([#863](https://github.com/badlogic/pi-mono/pull/863) by [@svkozak](https://github.com/svkozak))
 - Session selector keybindings are now configurable ([#948](https://github.com/badlogic/pi-mono/pull/948) by [@aos](https://github.com/aos))
@@ -12058,6 +12382,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.49.3] - 2026-01-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `markdown.codeBlockIndent` setting to customize code block indentation in rendered output ([#855](https://github.com/badlogic/pi-mono/pull/855) by [@terrorobe](https://github.com/terrorobe))
 - Added `inline-bash.ts` example extension for expanding `!{command}` patterns in prompts ([#881](https://github.com/badlogic/pi-mono/pull/881) by [@scutifer](https://github.com/scutifer))
@@ -12085,6 +12410,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.49.2] - 2026-01-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added widget placement option for extension widgets via `widgetPlacement` in `pi.addWidget()` ([#850](https://github.com/badlogic/pi-mono/pull/850) by [@marckrenn](https://github.com/marckrenn))
 - Added AWS credential detection for ECS/Kubernetes environments: `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_WEB_IDENTITY_TOKEN_FILE` ([#848](https://github.com/badlogic/pi-mono/issues/848))
@@ -12108,6 +12434,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.49.1] - 2026-01-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `strictResponsesPairing` compat option for custom OpenAI Responses models on Azure ([#768](https://github.com/badlogic/pi-mono/pull/768) by [@nicobako](https://github.com/nicobako))
 - Session selector (`/resume`) now supports path display toggle (`Ctrl+P`) and session deletion (`Ctrl+D`) with inline confirmation ([#816](https://github.com/badlogic/pi-mono/pull/816) by [@w-winter](https://github.com/w-winter))
@@ -12128,6 +12455,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.49.0] - 2026-01-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `pi.setLabel(entryId, label)` in ExtensionAPI for setting per-entry labels from extensions ([#806](https://github.com/badlogic/pi-mono/issues/806))
 - Export `keyHint`, `appKeyHint`, `editorKey`, `appKey`, `rawKeyHint` for extensions to format keybinding hints consistently ([#802](https://github.com/badlogic/pi-mono/pull/802) by [@dannote](https://github.com/dannote))
@@ -12157,6 +12485,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.48.0] - 2026-01-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `quietStartup` setting to silence startup output (version header, loaded context info, model scope line). Changelog notifications are still shown. ([#777](https://github.com/badlogic/pi-mono/pull/777) by [@ribelo](https://github.com/ribelo))
 - Added `editorPaddingX` setting for horizontal padding in input editor (0-3, default: 0)
@@ -12192,6 +12521,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - Extensions using `Editor` directly must now pass `TUI` as the first constructor argument: `new Editor(tui, theme)`. The `tui` parameter is available in extension factory functions. ([#732](https://github.com/badlogic/pi-mono/issues/732))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **OpenAI Codex official support**: Full compatibility with OpenAI's Codex CLI models (`gpt-5.1`, `gpt-5.2`, `gpt-5.1-codex-mini`, `gpt-5.2-codex`). Features include static system prompt for OpenAI allowlisting, prompt caching via session ID, and reasoning signature retention across turns. Set `OPENAI_API_KEY` and use `--provider openai-codex` or select a Codex model. ([#737](https://github.com/badlogic/pi-mono/pull/737))
 - `pi-internal://` URL scheme in read tool for accessing internal documentation. The model can read files from the coding-agent package (README, docs, examples) to learn about extending pi.
@@ -12228,6 +12558,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - Keyboard shortcuts (Ctrl+C, Ctrl+D, etc.) now work on non-Latin keyboard layouts (Russian, Ukrainian, Bulgarian, etc.) in terminals supporting Kitty keyboard protocol with alternate key reporting ([#718](https://github.com/badlogic/pi-mono/pull/718) by [@dannote](https://github.com/dannote))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Edit tool now uses fuzzy matching as fallback when exact match fails, tolerating trailing whitespace, smart quotes, Unicode dashes, and special spaces ([#713](https://github.com/badlogic/pi-mono/pull/713) by [@dannote](https://github.com/dannote))
 - Support `APPEND_SYSTEM.md` to append instructions to the system prompt ([#716](https://github.com/badlogic/pi-mono/pull/716) by [@tallshort](https://github.com/tallshort))
@@ -12247,12 +12578,14 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.45.7] - 2026-01-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Exported `highlightCode` and `getLanguageFromPath` for extensions ([#703](https://github.com/badlogic/pi-mono/pull/703) by [@dannote](https://github.com/dannote))
 
 ## [0.45.6] - 2026-01-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `ctx.ui.custom()` now accepts `overlayOptions` for overlay positioning and sizing (anchor, margins, offsets, percentages, absolute positioning) ([#667](https://github.com/badlogic/pi-mono/pull/667) by [@nicobailon](https://github.com/nicobailon))
 - `ctx.ui.custom()` now accepts `onHandle` callback to receive the `OverlayHandle` for controlling overlay visibility ([#667](https://github.com/badlogic/pi-mono/pull/667) by [@nicobailon](https://github.com/nicobailon))
@@ -12273,6 +12606,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - Replaced `sharp` with `wasm-vips` for image processing (resize, PNG conversion). Eliminates native build requirements that caused installation failures on some systems. ([#696](https://github.com/badlogic/pi-mono/issues/696))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Extension example: `summarize.ts` for summarizing conversations using custom UI and an external model ([#684](https://github.com/badlogic/pi-mono/pull/684) by [@scutifer](https://github.com/scutifer))
 - Extension example: `question.ts` enhanced with custom UI for asking user questions ([#693](https://github.com/badlogic/pi-mono/pull/693) by [@ferologics](https://github.com/ferologics))
@@ -12302,6 +12636,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.45.0] - 2026-01-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - MiniMax provider support: set `MINIMAX_API_KEY` and use `minimax/MiniMax-M2.1` ([#656](https://github.com/badlogic/pi-mono/pull/656) by [@dannote](https://github.com/dannote))
 - `/scoped-models`: Alt+Up/Down to reorder enabled models. Order is preserved when saving with Ctrl+S and determines Ctrl+P cycling order. ([#676](https://github.com/badlogic/pi-mono/pull/676) by [@thomasmhr](https://github.com/thomasmhr))
@@ -12315,6 +12650,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - `pi.getAllTools()` now returns `ToolInfo[]` (with `name` and `description`) instead of `string[]`. Extensions that only need names can use `.map(t => t.name)`. ([#648](https://github.com/badlogic/pi-mono/pull/648) by [@carsonfarmer](https://github.com/carsonfarmer))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Session naming: `/name <name>` command sets a display name shown in the session selector instead of the first message. Useful for distinguishing forked sessions. Extensions can use `pi.setSessionName()` and `pi.getSessionName()`. ([#650](https://github.com/badlogic/pi-mono/pull/650) by [@scutifer](https://github.com/scutifer))
 - Extension example: `notify.ts` for desktop notifications via OSC 777 escape sequence ([#658](https://github.com/badlogic/pi-mono/pull/658) by [@ferologics](https://github.com/ferologics))
@@ -12341,6 +12677,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - `SessionManager.list()` and `SessionManager.listAll()` are now async, returning `Promise<SessionInfo[]>`. Callers must await them. ([#620](https://github.com/badlogic/pi-mono/pull/620) by [@tmustier](https://github.com/tmustier))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `/resume` selector now toggles between current-folder and all sessions with Tab, showing the session cwd in the All view and loading progress. ([#620](https://github.com/badlogic/pi-mono/pull/620) by [@tmustier](https://github.com/tmustier))
 - `SessionManager.list()` and `SessionManager.listAll()` accept optional `onProgress` callback for progress updates
@@ -12385,6 +12722,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.42.2] - 2026-01-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `/model <search>` now pre-filters the model selector or auto-selects on exact match. Use `provider/model` syntax to disambiguate (e.g., `/model openai/gpt-4`). ([#587](https://github.com/badlogic/pi-mono/pull/587) by [@zedrdave](https://github.com/zedrdave))
 - `FooterDataProvider` for custom footers: `ctx.ui.setFooter()` now receives a third `footerData` parameter providing `getGitBranch()`, `getExtensionStatuses()`, and `onBranchChange()` for reactive updates ([#600](https://github.com/badlogic/pi-mono/pull/600) by [@nicobailon](https://github.com/nicobailon))
@@ -12403,12 +12741,14 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.42.0] - 2026-01-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added OpenCode Zen provider support. Set `OPENCODE_API_KEY` env var and use `opencode/<model-id>` (e.g., `opencode/claude-opus-4-5`).
 
 ## [0.41.0] - 2026-01-09
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Anthropic OAuth support is back! Use `/login` to authenticate with your Claude Pro/Max subscription.
 
@@ -12421,6 +12761,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.40.0] - 2026-01-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Documentation on component invalidation and theme changes in `docs/tui.md`
 
@@ -12443,6 +12784,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - `discoverSkills()` now returns `{ skills: Skill[], warnings: SkillWarning[] }` instead of `Skill[]`. This allows callers to handle skill loading warnings. ([#577](https://github.com/badlogic/pi-mono/pull/577) by [@cv](https://github.com/cv))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `ctx.ui.getAllThemes()`, `ctx.ui.getTheme(name)`, and `ctx.ui.setTheme(name | Theme)` methods for extensions to list, load, and switch themes at runtime ([#576](https://github.com/badlogic/pi-mono/pull/576))
 - `--no-tools` flag to disable all built-in tools, allowing extension-only tool setups ([#557](https://github.com/badlogic/pi-mono/pull/557) by [@cv](https://github.com/cv))
@@ -12479,6 +12821,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 - OpenAI Codex model aliases removed (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `codex-mini-latest`). Use canonical IDs: `gpt-5.1`, `gpt-5.1-codex-mini`, `gpt-5.2`, `gpt-5.2-codex`. ([#536](https://github.com/badlogic/pi-mono/pull/536) by [@ghoulr](https://github.com/ghoulr))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `--no-extensions` flag to disable extension discovery while still allowing explicit `-e` paths ([#524](https://github.com/badlogic/pi-mono/pull/524) by [@cv](https://github.com/cv))
 - SDK: `InteractiveMode`, `runPrintMode()`, `runRpcMode()` exported for building custom run modes. See `docs/sdk.md`.
@@ -12502,6 +12845,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.37.6] - 2026-01-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Extension UI dialogs (`ctx.ui.select()`, `ctx.ui.confirm()`, `ctx.ui.input()`) now accept an optional `AbortSignal` to programmatically dismiss dialogs. Useful for implementing timeouts. See `examples/extensions/timed-confirm.ts`. ([#474](https://github.com/badlogic/pi-mono/issues/474))
 - HTML export now shows bridge prompts in model change messages for Codex sessions ([#510](https://github.com/badlogic/pi-mono/pull/510) by [@mitsuhiko](https://github.com/mitsuhiko))
@@ -12509,6 +12853,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.37.5] - 2026-01-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - ExtensionAPI: `setModel()`, `getThinkingLevel()`, `setThinkingLevel()` methods for extensions to change model and thinking level at runtime ([#509](https://github.com/badlogic/pi-mono/issues/509))
 - Exported truncation utilities for custom tools: `truncateHead`, `truncateTail`, `truncateLine`, `formatSize`, `DEFAULT_MAX_BYTES`, `DEFAULT_MAX_LINES`, `TruncationOptions`, `TruncationResult`
@@ -12524,6 +12869,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.37.4] - 2026-01-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Session picker (`pi -r`) and `--session` flag now support searching/resuming by session ID (UUID prefix) ([#495](https://github.com/badlogic/pi-mono/issues/495) by [@arunsathiya](https://github.com/arunsathiya))
 - Extensions can now replace the startup header with `ctx.ui.setHeader()`, see `examples/extensions/custom-header.ts` ([#500](https://github.com/badlogic/pi-mono/pull/500) by [@tudoroancea](https://github.com/tudoroancea))
@@ -12541,6 +12887,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.37.3] - 2026-01-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Extensions can now replace the footer with `ctx.ui.setFooter()`, see `examples/extensions/custom-footer.ts` ([#481](https://github.com/badlogic/pi-mono/issues/481))
 - Session ID is now forwarded to LLM providers for session-based caching (used by OpenAI Codex for prompt caching).
@@ -12570,6 +12917,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.37.0] - 2026-01-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Share viewer: copy-link button on messages to share URLs that navigate directly to a specific message ([#477](https://github.com/badlogic/pi-mono/pull/477) by [@lockmeister](https://github.com/lockmeister))
 - Extension example: add `claude-rules` to load `.claude/rules/` entries into the system prompt ([#461](https://github.com/badlogic/pi-mono/pull/461) by [@vaayne](https://github.com/vaayne))
@@ -12594,6 +12942,7 @@ There are multiple SDK breaking changes since v0.49.3. For the quickest migratio
 ## [0.36.0] - 2026-01-05
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Experimental: OpenAI Codex OAuth provider support: access Codex models via ChatGPT Plus/Pro subscription using `/login openai-codex` ([#451](https://github.com/badlogic/pi-mono/pull/451) by [@kim0](https://github.com/kim0))
 
@@ -12789,6 +13138,7 @@ pi --extension ./safety.ts -e ./todo.ts
 ## [0.34.0] - 2026-01-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Hook API: `before_agent_start` handlers can now return `systemPromptAppend` to dynamically append text to the system prompt for that turn. Multiple hooks' appends are concatenated.
 - Hook API: `before_agent_start` handlers can now return multiple messages (all are injected, not just the first)
@@ -12814,6 +13164,7 @@ pi --extension ./safety.ts -e ./todo.ts
 - **Key detection functions removed from `@mariozechner/pi-tui`**: All `isXxx()` key detection functions (`isEnter()`, `isEscape()`, `isCtrlC()`, etc.) have been removed. Use `matchesKey(data, keyId)` instead (e.g., `matchesKey(data, "enter")`, `matchesKey(data, "ctrl+c")`). This affects hooks and custom tools that use `ctx.ui.custom()` with keyboard input handling. ([#405](https://github.com/badlogic/pi-mono/pull/405))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Clipboard image paste support via `Ctrl+V`. Images are saved to a temp file and attached to the message. Works on macOS, Windows, and Linux (X11). ([#419](https://github.com/badlogic/pi-mono/issues/419))
 - Configurable keybindings via `~/.pi/agent/keybindings.json`. All keyboard shortcuts (editor navigation, deletion, app actions like model cycling, etc.) can now be customized. Supports multiple bindings per action. ([#405](https://github.com/badlogic/pi-mono/pull/405) by [@hjanuschka](https://github.com/hjanuschka))
@@ -12835,6 +13186,7 @@ pi --extension ./safety.ts -e ./todo.ts
 ## [0.32.2] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `$ARGUMENTS` syntax for custom slash commands as alternative to `$@` for all arguments joined. Aligns with patterns used by Claude, Codex, and OpenCode. Both syntaxes remain fully supported. ([#418](https://github.com/badlogic/pi-mono/pull/418) by [@skuridin](https://github.com/skuridin))
 
@@ -12855,6 +13207,7 @@ pi --extension ./safety.ts -e ./todo.ts
 ## [0.32.1] - 2026-01-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Shell commands without context contribution: use `!!command` to execute a bash command that is shown in the TUI and saved to session history but excluded from LLM context. Useful for running commands you don't want the AI to see. ([#414](https://github.com/badlogic/pi-mono/issues/414))
 
@@ -13120,6 +13473,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 - `enabledModels`: allowlist models in `settings.json` (same format as `--models` CLI)
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `ctx.ui.setStatus(key, text)` for hooks to display persistent status text in the footer ([#385](https://github.com/badlogic/pi-mono/pull/385) by [@prateekmedia](https://github.com/prateekmedia))
 - `ctx.ui.theme` getter for styling status text and other output with theme colors
@@ -13176,6 +13530,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 - **SessionManager API**: The second parameter of `create()`, `continueRecent()`, and `list()` changed from `agentDir` to `sessionDir`. When provided, it specifies the session directory directly (no cwd encoding). When omitted, uses default (`~/.pi/agent/sessions/<encoded-cwd>/`). `open()` no longer takes `agentDir`. ([#313](https://github.com/badlogic/pi-mono/pull/313))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **`--session-dir` flag**: Use a custom directory for sessions instead of the default `~/.pi/agent/sessions/<encoded-cwd>/`. Works with `-c` (continue) and `-r` (resume) flags. ([#313](https://github.com/badlogic/pi-mono/pull/313) by [@scutifer](https://github.com/scutifer))
 - **Reverse model cycling and model selector**: Shift+Ctrl+P cycles models backward, Ctrl+L opens model selector (retaining text in editor). ([#315](https://github.com/badlogic/pi-mono/pull/315) by [@mitsuhiko](https://github.com/mitsuhiko))
@@ -13183,6 +13538,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.29.1] - 2025-12-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Automatic custom system prompt loading**: Pi now auto-loads `SYSTEM.md` files to replace the default system prompt. Project-local `.pi/SYSTEM.md` takes precedence over global `~/.pi/agent/SYSTEM.md`. CLI `--system-prompt` flag overrides both. ([#309](https://github.com/badlogic/pi-mono/issues/309))
 - **Unified `/settings` command**: New settings menu consolidating thinking level, theme, queue mode, auto-compact, show images, hide thinking, and collapse changelog. Replaces individual `/thinking`, `/queue`, `/theme`, `/autocompact`, and `/show-images` commands. ([#310](https://github.com/badlogic/pi-mono/issues/310))
@@ -13198,6 +13554,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 - **Renamed `/clear` to `/new`**: The command to start a fresh session is now `/new`. Hook event reasons `before_clear`/`clear` are now `before_new`/`new`. Merry Christmas [@mitsuhiko](https://github.com/mitsuhiko)! ([#305](https://github.com/badlogic/pi-mono/pull/305))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Auto-space before pasted file paths**: When pasting a file path (starting with `/`, `~`, or `.`) after a word character, a space is automatically prepended. ([#307](https://github.com/badlogic/pi-mono/pull/307) by [@mitsuhiko](https://github.com/mitsuhiko))
 - **Word navigation in input fields**: Added Ctrl+Left/Right and Alt+Left/Right for word-by-word cursor movement. ([#306](https://github.com/badlogic/pi-mono/pull/306) by [@kim0](https://github.com/kim0))
@@ -13248,6 +13605,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.27.6] - 2025-12-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Compaction hook improvements**: The `before_compact` session event now includes:
   - `previousSummary`: Summary from the last compaction (if any), so hooks can preserve accumulated context
@@ -13262,6 +13620,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.27.5] - 2025-12-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **HTML export syntax highlighting**: Code blocks in markdown and tool outputs (read, write) now have syntax highlighting using highlight.js with theme-aware colors matching the TUI.
 - **HTML export improvements**: Render markdown server-side using marked (tables, headings, code blocks, etc.), honor user's chosen theme (light/dark), add image rendering for user messages, and style code blocks with TUI-like language markers. ([@scutifer](https://github.com/scutifer))
@@ -13279,6 +13638,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.27.3] - 2025-12-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **API keys in settings.json**: Store API keys in `~/.pi/agent/settings.json` under the `apiKeys` field (e.g., `{ "apiKeys": { "anthropic": "sk-..." } }`). Settings keys take priority over environment variables. ([#295](https://github.com/badlogic/pi-mono/issues/295))
 
@@ -13290,6 +13650,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.27.2] - 2025-12-23
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Skip conversation restore on branch**: Hooks can return `{ skipConversationRestore: true }` from `before_branch` to create the branched session file without restoring conversation messages. Useful for checkpoint hooks that restore files separately. ([#286](https://github.com/badlogic/pi-mono/pull/286) by [@nicobarray](https://github.com/nicobarray))
 
@@ -13300,6 +13661,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 - **Skill discovery performance**: Skip `node_modules` directories when recursively scanning for skills. Fixes ~60ms startup delay when skill directories contain npm dependencies.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Startup timing instrumentation**: Set `PI_TIMING=1` to see startup performance breakdown (interactive mode only).
 
@@ -13310,6 +13672,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 - **Session hooks API redesign**: Merged `branch` event into `session` event. `BranchEvent`, `BranchEventResult` types and `pi.on("branch", ...)` removed. Use `pi.on("session", ...)` with `reason: "before_branch" | "branch"` instead. `AgentSession.branch()` returns `{ cancelled }` instead of `{ skipped }`. `AgentSession.reset()` and `switchSession()` now return `boolean` (false if cancelled by hook). RPC commands `reset`, `switch_session`, and `branch` now include `cancelled` in response data. ([#278](https://github.com/badlogic/pi-mono/issues/278))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Session lifecycle hooks**: Added `before_*` variants (`before_switch`, `before_clear`, `before_branch`) that fire before actions and can be cancelled with `{ cancel: true }`. Added `shutdown` reason for graceful exit handling. ([#278](https://github.com/badlogic/pi-mono/issues/278))
 
@@ -13327,6 +13690,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.26.0] - 2025-12-22
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **SDK for programmatic usage**: New `createAgentSession()` factory with full control over model, tools, hooks, skills, session persistence, and settings. Philosophy: "omit to discover, provide to override". Includes 12 examples and comprehensive documentation. ([#272](https://github.com/badlogic/pi-mono/issues/272))
 - **Project-specific settings**: Settings now load from both `~/.pi/agent/settings.json` (global) and `<cwd>/.pi/settings.json` (project). Project settings override global with deep merge for nested objects. Project settings are read-only (for version control). ([#276](https://github.com/badlogic/pi-mono/pull/276))
@@ -13342,6 +13706,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.25.3] - 2025-12-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Gemini 3 preview models**: Added `gemini-3-pro-preview` and `gemini-3-flash-preview` to the google-gemini-cli provider. ([#264](https://github.com/badlogic/pi-mono/pull/264) by [@LukeFost](https://github.com/LukeFost))
 - **External editor support**: Press `Ctrl+G` to edit your message in an external editor. Uses `$VISUAL` or `$EDITOR` environment variable. On successful save, the message is replaced; on cancel, the original is kept. ([#266](https://github.com/badlogic/pi-mono/pull/266) by [@aliou](https://github.com/aliou))
@@ -13365,6 +13730,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.25.0] - 2025-12-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Interruptible tool execution**: Queuing a message while tools are executing now interrupts the current tool batch. Remaining tools are skipped with an error result, and your queued message is processed immediately. Useful for redirecting the agent mid-task. ([#259](https://github.com/badlogic/pi-mono/pull/259) by [@steipete](https://github.com/steipete))
 - **Google Gemini CLI OAuth provider**: Access Gemini 2.0/2.5 models for free via Google Cloud Code Assist. Login with `/login` and select "Google Gemini CLI". Uses your Google account with rate limits.
@@ -13407,6 +13773,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.24.1] - 2025-12-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **OAuth and model config exports**: Scripts using `AgentSession` directly can now import `getAvailableModels`, `getApiKeyForModel`, `findModel`, `login`, `logout`, and `getOAuthProviders` from `@oh-my-pi/pi-coding-agent` to reuse OAuth token storage and model resolution. ([#245](https://github.com/badlogic/pi-mono/issues/245))
 - **xhigh thinking level for gpt-5.2 models**: The thinking level selector and shift+tab cycling now show xhigh option for gpt-5.2 and gpt-5.2-codex models (in addition to gpt-5.1-codex-max). ([#236](https://github.com/badlogic/pi-mono/pull/236) by [@theBucky](https://github.com/theBucky))
@@ -13424,6 +13791,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.24.0] - 2025-12-19
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Subagent orchestration example**: Added comprehensive custom tool example for spawning and orchestrating sub-agents with isolated context windows. Includes scout/planner/reviewer/worker agents and workflow commands for multi-agent pipelines. ([#215](https://github.com/badlogic/pi-mono/pull/215) by [@nicobailon](https://github.com/nicobailon))
 - **`getMarkdownTheme()` export**: Custom tools can now import `getMarkdownTheme()` from `@oh-my-pi/pi-coding-agent` to use the same markdown styling as the main UI.
@@ -13458,6 +13826,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.23.4] - 2025-12-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Syntax highlighting**: Added syntax highlighting for markdown code blocks, read tool output, and write tool content. Uses cli-highlight with theme-aware color mapping and VS Code-style syntax colors. ([#214](https://github.com/badlogic/pi-mono/pull/214) by [@svkozak](https://github.com/svkozak))
 - **Intra-line diff highlighting**: Edit tool now shows word-level changes with inverse highlighting when a single line is modified. Multi-line changes show all removed lines first, then all added lines.
@@ -13508,6 +13877,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.23.0] - 2025-12-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Custom tools**: Extend pi with custom tools written in TypeScript. Tools can provide custom TUI rendering, interact with users via `pi.ui` (select, confirm, input, notify), and maintain state across sessions via `onSession` callback. See [docs/custom-tools.md](docs/custom-tools.md) and [examples/custom-tools/](examples/custom-tools/). ([#190](https://github.com/badlogic/pi-mono/issues/190))
 - **Hook and tool examples**: Added `examples/hooks/` and `examples/custom-tools/` with working examples. Examples are now bundled in npm and binary releases.
@@ -13525,6 +13895,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.22.4] - 2025-12-17
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `--list-models [search]` CLI flag to list available models with optional fuzzy search. Shows provider, model ID, context window, max output, thinking support, and image support. Only lists models with configured API keys. ([#203](https://github.com/badlogic/pi-mono/issues/203))
 
@@ -13535,6 +13906,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 ## [0.22.3] - 2025-12-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Streaming bash output**: Bash tool now streams output in real-time during execution. The TUI displays live progress with the last 5 lines visible (expandable with ctrl+o). ([#44](https://github.com/badlogic/pi-mono/issues/44))
 
@@ -13566,6 +13938,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.22.0] - 2025-12-15
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **GitHub Copilot support**: Use GitHub Copilot models via OAuth login (`/login` -> "GitHub Copilot"). Supports both github.com and GitHub Enterprise. Models are sourced from models.dev and include Claude, GPT, Gemini, Grok, and more. All models are automatically enabled after login. ([#191](https://github.com/badlogic/pi-mono/pull/191) by [@cau1k](https://github.com/cau1k))
 
@@ -13576,6 +13949,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.21.0] - 2025-12-14
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Inline image rendering**: Terminals supporting Kitty graphics protocol (Kitty, Ghostty, WezTerm) or iTerm2 inline images now render images inline in tool output. Aspect ratio is preserved by querying terminal cell dimensions on startup. Toggle with `/show-images` command or `terminal.showImages` setting. Falls back to text placeholder on unsupported terminals or when disabled. ([#177](https://github.com/badlogic/pi-mono/pull/177) by [@nicobailon](https://github.com/nicobailon))
 - **Gemini 3 Pro thinking levels**: Thinking level selector now works with Gemini 3 Pro models. Minimal/low map to Google's LOW, medium/high map to Google's HIGH. ([#176](https://github.com/badlogic/pi-mono/pull/176) by [@markusylisiurunen](https://github.com/markusylisiurunen))
@@ -13588,6 +13962,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.20.1] - 2025-12-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Exported skills API**: `loadSkillsFromDir`, `formatSkillsForPrompt`, and related types are now exported for use by other packages (e.g., mom).
 
@@ -13598,6 +13973,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 - **Pi skills now use `SKILL.md` convention**: Pi skills must now be named `SKILL.md` inside a directory, matching Codex CLI format. Previously any `*.md` file was treated as a skill. Migrate by renaming `~/.pi/agent/skills/foo.md` to `~/.pi/agent/skills/foo/SKILL.md`.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Display loaded skills on startup in interactive mode
 
@@ -13610,6 +13986,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.19.0] - 2025-12-12
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Skills system**: Auto-discover and load instruction files on-demand. Supports Claude Code (`~/.claude/skills/*/SKILL.md`), Codex CLI (`~/.codex/skills/`), and Pi-native formats (`~/.pi/agent/skills/`, `.pi/skills/`). Skills are listed in system prompt with descriptions, agent loads them via read tool when needed. Supports `{baseDir}` placeholder. Disable with `--no-skills` or `skills.enabled: false` in settings. ([#169](https://github.com/badlogic/pi-mono/issues/169))
 - **Version flag**: Added `--version` / `-v` flag to display the current version and exit. ([#170](https://github.com/badlogic/pi-mono/pull/170))
@@ -13617,6 +13994,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.18.2] - 2025-12-11
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Auto-retry on transient errors**: Automatically retries requests when providers return overloaded, rate limit, or server errors (429, 500, 502, 503, 504). Uses exponential backoff (2s, 4s, 8s). Shows retry status in TUI with option to cancel via Escape. Configurable in `settings.json` via `retry.enabled`, `retry.maxRetries`, `retry.baseDelayMs`. RPC mode emits `auto_retry_start` and `auto_retry_end` events. ([#157](https://github.com/badlogic/pi-mono/issues/157))
 - **HTML export line numbers**: Read tool calls in HTML exports now display line number ranges (e.g., `file.txt:10-20`) when offset/limit parameters are used, matching the TUI display format. Line numbers appear in yellow color for better visibility. ([#166](https://github.com/badlogic/pi-mono/issues/166))
@@ -13630,6 +14008,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.18.1] - 2025-12-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Mistral provider**: Added support for Mistral AI models. Set `MISTRAL_API_KEY` environment variable to use.
 
@@ -13640,6 +14019,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.18.0] - 2025-12-10
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Hooks system**: TypeScript modules that extend agent behavior by subscribing to lifecycle events. Hooks can intercept tool calls, prompt for confirmation, modify results, and inject messages from external sources. Auto-discovered from `~/.pi/agent/hooks/*.ts` and `.pi/hooks/*.ts`. Thanks to [@nicobailon](https://github.com/nicobailon) for the collaboration on the design and implementation. ([#145](https://github.com/badlogic/pi-mono/issues/145), supersedes [#158](https://github.com/badlogic/pi-mono/pull/158))
 - **`pi.send()` API**: Hooks can inject messages into the agent session from external sources (file watchers, webhooks, CI systems). If streaming, messages are queued; otherwise a new agent loop starts immediately.
@@ -13657,6 +14037,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 - **Merged turn prefix summary**: When a turn is split during compaction, the turn prefix summary is now merged into the main history summary instead of being stored separately.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **`isCompacting` property on AgentSession**: Check if auto-compaction is currently running.
 - **Session compaction indicator**: When resuming a compacted session, displays "Session compacted N times" status message.
@@ -13685,6 +14066,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.14.2] - 2025-12-08
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `/debug` command now includes agent messages as JSONL in the output
 
@@ -13705,6 +14087,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 - **Custom themes require new color tokens**: Themes must now include `thinkingXhigh` and `bashMode` color tokens. The theme loader provides helpful error messages listing missing tokens. See built-in themes (dark.json, light.json) for reference values.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **OpenAI compatibility overrides in models.json**: Custom models using `openai-completions` API can now specify a `compat` object to override provider quirks (`supportsStore`, `supportsDeveloperRole`, `supportsReasoningEffort`, `maxTokensField`). Useful for LiteLLM, custom proxies, and other non-standard endpoints. ([#133](https://github.com/badlogic/pi-mono/issues/133), thanks @fink-andreas for the initial idea and PR)
 - **xhigh thinking level**: Added `xhigh` thinking level for OpenAI codex-max models. Cycle through thinking levels with Shift+Tab; `xhigh` appears only when using a codex-max model. ([#143](https://github.com/badlogic/pi-mono/issues/143))
@@ -13726,6 +14109,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.13.1] - 2025-12-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Flexible Windows shell configuration**: The bash tool now supports multiple shell sources beyond Git Bash. Resolution order: (1) custom `shellPath` in settings.json, (2) Git Bash in standard locations, (3) any bash.exe on PATH. This enables Cygwin, MSYS2, and other bash environments. Configure with `~/.pi/agent/settings.json`: `{"shellPath": "C:\\cygwin64\\bin\\bash.exe"}`.
 
@@ -13742,6 +14126,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.14] - 2025-12-06
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Double-Escape Branch Shortcut**: Press Escape twice with an empty editor to quickly open the `/branch` selector for conversation branching.
 
@@ -13763,6 +14148,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 - **Line wrapping escape codes**: Fixed underline style bleeding into padding when wrapping long URLs. ANSI codes now attach to the correct content, and line-end resets only turn off underline (preserving background colors). ([#109](https://github.com/badlogic/pi-mono/issues/109))
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Fuzzy search models and sessions**: Implemented a simple fuzzy search for models and sessions (e.g., `codexmax` now finds `gpt-5.1-codex-max`). ([#122](https://github.com/badlogic/pi-mono/pull/122) by [@markusylisiurunen](https://github.com/markusylisiurunen))
 - **Prompt History Navigation**: Browse previously submitted prompts using Up/Down arrow keys when the editor is empty. Press Up to cycle through older prompts, Down to return to newer ones or clear the editor. Similar to shell history and Claude Code's prompt history feature. History is session-scoped and stores up to 100 entries. ([#121](https://github.com/badlogic/pi-mono/pull/121) by [@nicobailon](https://github.com/nicobailon))
@@ -13782,6 +14168,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 - **Footer overflow crash**: Fixed TUI crash when terminal width is too narrow for the footer stats line. The footer now truncates gracefully instead of overflowing.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **`authHeader` option in models.json**: Custom providers can set `"authHeader": true` to automatically add `Authorization: Bearer <apiKey>` header. Useful for providers that require explicit auth headers. ([#81](https://github.com/badlogic/pi-mono/issues/81))
 - **`--append-system-prompt` Flag**: Append additional text or file contents to the system prompt. Supports both inline text and file paths. Complements `--system-prompt` for layering custom instructions without replacing the base system prompt. ([#114](https://github.com/badlogic/pi-mono/pull/114) by [@markusylisiurunen](https://github.com/markusylisiurunen))
@@ -13790,12 +14177,14 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.10] - 2025-12-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `gpt-5.1-codex-max` model support
 
 ## [0.12.9] - 2025-12-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **`/copy` Command**: Copy the last agent message to clipboard. Works cross-platform (macOS, Windows, Linux). Useful for extracting text from rendered Markdown output. ([#105](https://github.com/badlogic/pi-mono/pull/105) by [@markusylisiurunen](https://github.com/markusylisiurunen))
 
@@ -13806,6 +14195,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.7] - 2025-12-04
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Context Compaction**: Long sessions can now be compacted to reduce context usage while preserving recent conversation history. ([#92](https://github.com/badlogic/pi-mono/issues/92), [docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md#context-compaction))
   - `/compact [instructions]`: Manually compact context with optional custom instructions for the summary
@@ -13820,6 +14210,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.5] - 2025-12-03
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Forking/Rebranding Support**: All branding (app name, config directory, environment variable names) is now configurable via `piConfig` in `package.json`. Forks can change `piConfig.name` and `piConfig.configDir` to rebrand the CLI without code changes. Affects CLI banner, help text, config paths, and error messages. ([#95](https://github.com/badlogic/pi-mono/pull/95))
 
@@ -13830,6 +14221,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.4] - 2025-12-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **RPC Termination Safeguard**: When running as an RPC worker (stdin pipe detected), the CLI now exits immediately if the parent process terminates unexpectedly. Prevents orphaned RPC workers from persisting indefinitely and consuming system resources.
 
@@ -13849,6 +14241,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.1] - 2025-12-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Models**: Added support for OpenAI's new models:
   - `gpt-4.1` (128K context)
@@ -13860,6 +14253,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.12.0] - 2025-12-02
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **`-p, --print` Flag**: Run in non-interactive batch mode. Processes input message or piped stdin without TUI, prints agent response directly to stdout. Ideal for scripting, piping, and CI/CD integration. Exits after first response.
 - **`-P, --print-streaming` Flag**: Like `-p`, but streams response tokens as they arrive. Use `--print-streaming --no-markdown` for raw unformatted output.
@@ -13929,6 +14323,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.11.1] - 2025-11-29
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added `fd` integration for file path autocompletion. Now uses `fd` for faster fuzzy file search
 
@@ -13939,6 +14334,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.11.0] - 2025-11-29
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **File-based Slash Commands**: Create custom reusable prompts as `.txt` files in `~/.pi/slash-commands/`. Files become `/filename` commands with first-line descriptions. Supports `{{selection}}` placeholder for referencing selected/attached content.
 - **`/branch` Command**: Create conversation branches from any previous user message. Opens a selector to pick a message, then creates a new session file starting from that point. Original message text is placed in the editor for modification.
@@ -13974,6 +14370,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.10.5] - 2025-11-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Full multimodal support: attach images (PNG, JPEG, GIF, WebP) and PDFs to prompts using `@path` syntax or `--file` flag
 
@@ -13991,6 +14388,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.10.3] - 2025-11-28
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added RPC mode (`--rpc`) for programmatic integration. Accepts JSON commands on stdin, emits JSON events on stdout. See [RPC mode documentation](https://github.com/nicobailon/pi-mono/blob/main/packages/coding-agent/README.md#rpc-mode) for protocol details.
 
@@ -14001,6 +14399,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.10.2] - 2025-11-26
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added thinking level persistence. Default level stored in `~/.pi/settings.json`, restored on startup. Per-session overrides saved in session files.
 - Added model cycling shortcut: `Ctrl+I` cycles through available models (or scoped models with `-m` flag).
@@ -14018,6 +14417,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 ## [0.10.1] - 2025-11-25
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Add custom model configuration via `~/.pi/models.json`
 
@@ -14026,6 +14426,7 @@ _Dedicated to Peter's shoulder ([@steipete](https://twitter.com/steipete))_
 Initial public release.
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Interactive TUI with streaming responses
 - Conversation session management with `--continue`, `--resume`, and `--session` flags
@@ -14046,6 +14447,7 @@ Initial public release.
 ## [0.9.3] - 2025-11-24
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Added Anthropic Claude Opus 4.5 support
 
@@ -14058,6 +14460,7 @@ Initial public release.
 ## [0.9.0] - 2025-11-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **`/clear` Command**: New slash command to reset the conversation context and start a fresh session. Aborts any in-flight agent work, clears all messages, and creates a new session file. ([#48](https://github.com/badlogic/pi-mono/pull/48))
 - **Model Cycling with Thinking Levels**: The `--models` flag now supports thinking level syntax (e.g., `--models sonnet:high,haiku:low`). When cycling models with `Ctrl+P`, the associated thinking level is automatically applied. The first model in the scope is used as the initial model when starting a new session. Both model and thinking level changes are now saved to session and settings for persistence. ([#47](https://github.com/badlogic/pi-mono/pull/47))
@@ -14096,6 +14499,7 @@ Initial public release.
 ## [0.8.0] - 2025-11-21
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Theme System**: Full theming support with 44 customizable color tokens. Two built-in themes (`dark`, `light`) with auto-detection based on terminal background. Use `/theme` command to select themes interactively. Custom themes in `~/.pi/agent/themes/*.json` support live editing - changes apply immediately when the file is saved. Themes use RGB hex values for consistent rendering across terminals. VS Code users: set `terminal.integrated.minimumContrastRatio` to `1` for proper color rendering. See [Theme Documentation](docs/theme.md) for details.
 
@@ -14108,6 +14512,7 @@ Initial public release.
 ## [0.7.28] - 2025-11-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Message Queuing**: You can now send multiple messages while the agent is processing without waiting for the previous response to complete. Messages submitted during streaming are queued and processed based on your queue mode setting. Queued messages are shown in a pending area below the chat. Press Escape to abort and restore all queued messages to the editor. Use `/queue` to select between "one-at-a-time" (process queued messages sequentially, recommended) or "all" (process all queued messages at once). The queue mode setting is saved and persists across sessions. ([#15](https://github.com/badlogic/pi-mono/issues/15))
 
@@ -14121,6 +14526,7 @@ Initial public release.
 ## [0.7.26] - 2025-11-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Tool Output Expansion**: Press `Ctrl+O` to toggle between collapsed and expanded tool output display. Expands all tool call outputs (bash, read, write, etc.) to show full content instead of truncated previews. ([#31](https://github.com/badlogic/pi-mono/issues/31))
 - **Custom Headers**: Added support for custom HTTP headers in `models.json` configuration. Headers can be specified at both provider and model level, with model-level headers overriding provider-level ones. This enables bypassing Cloudflare bot detection and other proxy requirements. ([#39](https://github.com/badlogic/pi-mono/issues/39))
@@ -14134,18 +14540,21 @@ Initial public release.
 ## [0.7.25] - 2025-11-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Model Cycling**: Press `Ctrl+P` to quickly cycle through models. Use `--models` CLI argument to scope to specific models (e.g., `--models claude-sonnet,gpt-4o`). Supports pattern matching and smart version selection (prefers aliases over dated versions). ([#37](https://github.com/badlogic/pi-mono/pull/37) by [@fightbulc](https://github.com/fightbulc))
 
 ## [0.7.24] - 2025-11-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Thinking Level Cycling**: Press `Shift+Tab` to cycle through thinking levels (off → minimal → low → medium → high) for reasoning-capable models. Editor border color changes to indicate current level (gray → blue → cyan → magenta).
 
 ## [0.7.23] - 2025-11-20
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Update Notifications**: Interactive mode now checks for new versions on startup and displays a notification if an update is available.
 
@@ -14188,6 +14597,7 @@ Initial public release.
 ## [0.7.17] - 2025-11-18
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **New Model**: Added `gemini-3-pro-preview` to Google provider.
 - **OAuth Authentication**: Added `/login` and `/logout` commands for OAuth-based authentication with Claude Pro/Max subscriptions. Tokens are stored in `~/.pi/agent/oauth.json` with 0600 permissions and automatically refreshed when expired. OAuth tokens take priority over API keys for Anthropic models.
@@ -14227,6 +14637,7 @@ Initial public release.
 ## [0.7.12] - 2025-11-16
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - **Custom Models and Providers**: Support for custom models and providers via `~/.pi/agent/models.json` configuration file. Add local models (Ollama, vLLM, LM Studio) or any OpenAI-compatible, Anthropic-compatible, or Google-compatible API. File is reloaded on every `/model` selector open, allowing live updates without restart. ([#21](https://github.com/badlogic/pi-mono/issues/21))
 - Added `gpt-5.1-codex` model to OpenAI provider (400k context, 128k max output, reasoning-capable).
@@ -14254,6 +14665,7 @@ Initial public release.
 ## [0.7.10] - 2025-11-14
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - `/branch` command for creating conversation branches. Opens a selector showing all user messages in chronological order. Selecting a message creates a new session with all messages before the selected one, and places the selected message in the editor for modification or resubmission. This allows exploring alternative conversation paths without losing the current session. (fixes [#16](https://github.com/badlogic/pi-mono/issues/16))
 
@@ -14277,6 +14689,7 @@ Initial public release.
 ## [0.7.7] - 2025-11-13
 
 ### Added
+\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 
 - Automatic changelog display on startup in interactive mode. When starting a new session (not continuing/resuming), the agent will display all changelog entries since the last version you used. The last shown version is tracked in `~/.pi/agent/settings.json`.
 - `/changelog` command to display the changelog in the TUI

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
+- Added an opt-in `schedule` tool (`schedule.enabled`, default off) letting the agent arm or cancel a one-shot wake for later in the same session. There is no `/session schedules` slash command; wakes are in-session only and nothing fires in a process the user did not start.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added crash-recoverable mission workspaces: feature workers receive isolated branches and validators detached checkouts, with ownership checks, reconciliation after interrupted setup, and CAS-protected integration advancement.
+- Added fixed-workspace mission child sessions with owner-scoped revival and parent-mediated approvals.
 
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added typed RPC mission controls for starting, inspecting, accepting, pausing, resuming, restarting, and cancelling missions; the protocol emits durable mission updates and exposes progress frames to clients. Active missions now refuse destructive session changes through RPC.
 - Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
 - Mission launch flags now start the persisted runtime, and active missions guard destructive session transitions while preserving owner-scoped child revival.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
-\n- Added a persisted mission runtime with injected host boundaries: it validates plans and remediation graphs, serializes pause/cancel/handoff transitions before effects, and recovers interrupted workers without silent redispatch.
+- Mission launch flags now start the persisted runtime, and active missions guard destructive session transitions while preserving owner-scoped child revival.
 
 - Added crash-recoverable mission workspaces: feature workers receive isolated branches and validators detached checkouts, with ownership checks, reconciliation after interrupted setup, and CAS-protected integration advancement.
 - Added fixed-workspace mission child sessions with owner-scoped revival and parent-mediated approvals.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added crash-recoverable mission workspaces: feature workers receive isolated branches and validators detached checkouts, with ownership checks, reconciliation after interrupted setup, and CAS-protected integration advancement.
+
 - `omp usage` now surfaces auto-disabled credentials as red `✗` tombstone rows (identity, how long ago, the shortened upstream cause — e.g. `Refresh token expired` — and a re-login hint), including a provider section when no active credential remains. User-driven tombstones (`replaced by newer credential`, `deleted by user`) and API-key rows stay hidden. Requires a broker with `GET /v1/credentials/disabled`; older brokers degrade to no tombstone rows.
 - `omp usage` warns about Anthropic's ~30-day OAuth grant lifetime: accounts whose interactive login (`authorizedAt`) is within a week of the deadline get a yellow `⚠ re-login within <time>` line, and past-deadline accounts a red one. Grants die server-side exactly ~30 days after login regardless of refresh rotation, so this is the only warning before the broker auto-disables the row.
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -35,6 +35,9 @@ export interface Args {
 	prewalkInto?: string;
 	planYolo?: boolean;
 	planYoloInto?: string;
+	mission?: boolean;
+	missionWorkerModel?: string;
+	missionValidatorModel?: string;
 	maxTime?: number;
 	apiKey?: string;
 	systemPrompt?: string;
@@ -245,6 +248,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.noPrewalk = true;
 		} else if (arg === "--plan-yolo") {
 			result.planYolo = true;
+		} else if (arg === "--mission") {
+			result.mission = true;
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
 		} else if (arg === "--print-thoughts") {
@@ -292,7 +297,35 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 		}
 	}
 
+	assertMissionLaunchFlags(result);
 	return result;
+}
+
+function assertMissionLaunchFlags(result: Args): void {
+	const used = [
+		...(result.mission ? ["--mission"] : []),
+		...(result.missionWorkerModel !== undefined ? ["--mission-worker-model"] : []),
+		...(result.missionValidatorModel !== undefined ? ["--mission-validator-model"] : []),
+	];
+	if (used.length === 0) return;
+	if (!result.mission)
+		throw new CliUsageError("--mission-worker-model and --mission-validator-model require --mission");
+	if (result.mode === "rpc" || result.mode === "rpc-ui" || result.mode === "acp") {
+		throw new CliUsageError(`${used.join(", ")} cannot be used with --mode ${result.mode}`);
+	}
+	if (result.noSession) throw new CliUsageError(`${used.join(", ")} cannot be used with --no-session`);
+	if (result.print) throw new CliUsageError(`${used.join(", ")} cannot be used with --print`);
+	const existingSessionFlag = result.continue
+		? "--continue"
+		: result.resume !== undefined
+			? "--resume"
+			: result.fork !== undefined
+				? "--fork"
+				: undefined;
+	if (existingSessionFlag) throw new CliUsageError(`${used.join(", ")} cannot be used with ${existingSessionFlag}`);
+	if (result.messages.join(" ").trim().length === 0) {
+		throw new CliUsageError("--mission requires a goal");
+	}
 }
 
 /**

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -149,6 +149,12 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--plan-yolo-into": (result, value) => {
 		result.planYoloInto = value;
 	},
+	"--mission-worker-model": (result, value) => {
+		result.missionWorkerModel = value;
+	},
+	"--mission-validator-model": (result, value) => {
+		result.missionValidatorModel = value;
+	},
 	"--max-time": (result, value) => {
 		result.maxTime = parseMaxTimeSeconds(value);
 	},
@@ -299,6 +305,7 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--prewalk",
 	"--no-prewalk",
 	"--plan-yolo",
+	"--mission",
 	"--print",
 	"--print-thoughts",
 	"--no-extensions",

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -179,6 +179,15 @@ export default class Index extends Command {
 			options: ["always-ask", "write", "yolo"],
 			description: "Override tools.approvalMode for this session (always-ask|write|yolo)",
 		}),
+		mission: Flags.boolean({
+			description: "Start a mission using the initial prompt as its goal",
+		}),
+		"mission-worker-model": Flags.string({
+			description: "Model override for mission implementation workers",
+		}),
+		"mission-validator-model": Flags.string({
+			description: "Model override for mission validation workers",
+		}),
 	};
 
 	static examples = [

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3842,6 +3842,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	// Default-off: an armed wake re-enters the model on a timer, so it stays opt-in.
+	"schedule.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Available Tools",
+			label: "Schedule",
+			description: "Let the agent schedule a one-shot wake prompt for this session (fires only while it runs)",
+		},
+	},
+
 	"computer.backend": {
 		type: "enum",
 		values: ["auto", "native"] as const,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1506,16 +1506,24 @@ export async function runRootCommand(
 		// its persisted JSONL (see persisted-revive.ts). Scoped to the non-ACP
 		// bootstrap: ACP keeps several concurrent top-level sessions and a single
 		// process-global factory must not be clobbered by the most recent one.
-		AgentLifecycleManager.global().setPersistedSubagentReviverFactory(
-			createPersistedSubagentReviverFactory({
-				session,
-				authStorage,
-				modelRegistry,
-				settings: settingsInstance,
-				enableLsp: sessionOptions.enableLsp ?? true,
-			}),
-			Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0),
-		);
+		const persistedReviverFactory = createPersistedSubagentReviverFactory({
+			session,
+			authStorage,
+			modelRegistry,
+			settings: settingsInstance,
+			enableLsp: sessionOptions.enableLsp ?? true,
+		});
+		const persistedReviveTtlMs = Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0);
+		AgentLifecycleManager.global().setPersistedSubagentReviverFactory(persistedReviverFactory, persistedReviveTtlMs);
+		session.setMissionPersistedReviverFactory(persistedReviverFactory, persistedReviveTtlMs);
+		await session.restoreMission();
+		if (parsedArgs.mission) {
+			const missionGoal = initialMessage ?? initialArgs.messages.join(" ");
+			await session.startMission(missionGoal, {
+				workerModel: parsedArgs.missionWorkerModel,
+				validatorModel: parsedArgs.missionValidatorModel,
+			});
+		}
 		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
 			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
 		}

--- a/packages/coding-agent/src/missions/index.ts
+++ b/packages/coding-agent/src/missions/index.ts
@@ -1,3 +1,4 @@
+export * from "./runtime";
 export * from "./state";
 export * from "./types";
 export * from "./workspace";

--- a/packages/coding-agent/src/missions/index.ts
+++ b/packages/coding-agent/src/missions/index.ts
@@ -1,0 +1,3 @@
+export * from "./state";
+export * from "./types";
+export * from "./workspace";

--- a/packages/coding-agent/src/missions/runtime.ts
+++ b/packages/coding-agent/src/missions/runtime.ts
@@ -1975,15 +1975,35 @@ export class MissionRuntime implements MissionRuntimeContract {
 
 	// ── resume branches ─────────────────────────────────────────────────────
 
-	async #resumeSimple(state: MissionState, input?: { messageToWorker?: string }): Promise<MissionState> {
+	async #resumeSimple(
+		state: MissionState,
+		input?: { restartWorker?: boolean; messageToWorker?: string },
+	): Promise<MissionState> {
 		const status = state.pendingHandoff ? "orchestrator_turn" : "running";
-		const features = input?.messageToWorker
-			? state.features.map(feature =>
-					feature.status === "pending" && feature.nextRunIntent
-						? { ...feature, nextRunIntent: { ...feature.nextRunIntent, messageToWorker: input.messageToWorker } }
-						: feature,
-				)
-			: state.features;
+		let features = state.features;
+		const active =
+			!state.pendingHandoff && input?.restartWorker
+				? state.features.find(feature => feature.status === "in_progress")
+				: undefined;
+		if (active) {
+			await this.#releaseWorkerId(active.currentWorkerSessionId);
+			features = state.features.map(feature =>
+				feature.id === active.id
+					? {
+							...feature,
+							status: "pending",
+							currentWorkerSessionId: undefined,
+							nextRunIntent: { mode: "fresh", messageToWorker: input?.messageToWorker },
+						}
+					: feature,
+			);
+		} else if (input?.messageToWorker) {
+			features = state.features.map(feature =>
+				feature.status === "pending" && feature.nextRunIntent
+					? { ...feature, nextRunIntent: { ...feature.nextRunIntent, messageToWorker: input.messageToWorker } }
+					: feature,
+			);
+		}
 		this.#pauseRequested = false;
 		return this.#withTransitionTail(() =>
 			this.#commit(

--- a/packages/coding-agent/src/missions/runtime.ts
+++ b/packages/coding-agent/src/missions/runtime.ts
@@ -1,0 +1,2527 @@
+/**
+ * MissionRuntime — the single writer of mission state.
+ *
+ * Composes the pure append-only fold (`./state`), the crash-recoverable native-git
+ * workspace manager (`./workspace`), and the structured-subagent primitives
+ * (`../task/structured-subagent`, `../task/executor`) behind
+ * {@link MissionRuntimeContract}.
+ *
+ * Three rules hold everywhere in this file:
+ *
+ * 1. **Persistence precedes effect.** Every transition appends its `mission-state`
+ *    snapshot, zero or one progress event, and any mode marker through one
+ *    {@link SessionManager.appendEntriesAtomically} batch and awaits it BEFORE any
+ *    emit, child dispatch, or Git mutation. A persistence error leaves the prior
+ *    in-memory state authoritative and blocks the effect.
+ * 2. **The transition tail is short.** `#withTransitionTail` serializes state +
+ *    persistence only. It never encloses Git work, a model turn, or an awaited child.
+ * 3. **Ownership is checked, never assumed.** A restored snapshot whose
+ *    `ownerSessionId` differs from the active session is read-only: it can be
+ *    inspected but never resumes, dispatches, or touches a workspace.
+ */
+
+import { logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import activePromptTemplate from "../prompts/missions/active.md" with { type: "text" };
+import continuationPromptTemplate from "../prompts/missions/continuation.md" with { type: "text" };
+import interruptedPromptTemplate from "../prompts/missions/interrupted.md" with { type: "text" };
+import planningPromptTemplate from "../prompts/missions/planning.md" with { type: "text" };
+import scrutinyPromptTemplate from "../prompts/missions/scrutiny.md" with { type: "text" };
+import userTestingPromptTemplate from "../prompts/missions/user-testing.md" with { type: "text" };
+import workerPromptTemplate from "../prompts/missions/worker.md" with { type: "text" };
+import type { AgentLifecycleManager } from "../registry/agent-lifecycle";
+import { AgentRegistry } from "../registry/agent-registry";
+import type { MissionChildOwnerEntry, SessionEntry } from "../session/session-entries";
+import type { SessionManager } from "../session/session-manager";
+import { getBundledAgent } from "../task/agents";
+import { runSubagentFollowUpTurn } from "../task/executor";
+import {
+	type ParentApprovalDelegate,
+	reserveStructuredSubagentId,
+	runStructuredSubagent,
+} from "../task/structured-subagent";
+import type { AgentProgress, SingleResult } from "../task/types";
+import type { ToolSession } from "../tools";
+import { buildOutputValidator } from "../tools/output-schema-validator";
+import { getPreviewLines, PREVIEW_LIMITS, replaceTabs, TRUNCATE_LENGTHS } from "../tools/render-utils";
+import * as git from "../utils/git";
+import {
+	assertMissionStateInvariants,
+	canAcceptPendingHandoff,
+	cancelUnsatisfiableFeatures,
+	expectedIntegrationNewHead,
+	isMissionTerminal,
+	loadMissionState,
+	MISSION_ID_PATTERN,
+	nextMissionFeature,
+	validateMissionPlan,
+} from "./state";
+import {
+	MISSION_INACTIVITY_TIMEOUT_MS,
+	MISSION_PROGRESS_CUSTOM_TYPE,
+	MISSION_STATE_CUSTOM_TYPE,
+	MISSION_WORKER_TURN_CAP,
+	type MissionFeature,
+	type MissionFeatureWorkspaceDescriptor,
+	type MissionHandoff,
+	type MissionHandoffDecision,
+	type MissionMilestone,
+	type MissionNextRunMode,
+	type MissionPauseReason,
+	type MissionPlan,
+	type MissionProgressEvent,
+	type MissionProgressEventBase,
+	type MissionRemediationFeatureSpec,
+	type MissionRepositoryState,
+	type MissionRuntimeContract,
+	type MissionState,
+	type MissionValidatorRole,
+	type MissionWorkerHandoff,
+	type MissionWorkspaceDescriptor,
+} from "./types";
+import { isCleanSummary, MissionWorkspaceManager, toLocalBranchRef } from "./workspace";
+
+// ════════════════════════════════════════════════════════════════════════════
+// Constants
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Hidden parent-only tool activated while a mission is nonterminal. */
+const MISSION_TOOL_NAME = "mission";
+
+/**
+ * Heartbeats coalesce to this interval. The aggregated task `onProgress` callback
+ * fires on every tool/token update; each persisted heartbeat rewrites the journal
+ * atomically, so an unthrottled 1:1 mapping is quadratic in transcript length.
+ * Inactivity is still reset by EVERY callback — only the persisted event coalesces.
+ */
+export const MISSION_HEARTBEAT_INTERVAL_MS = 15_000;
+
+/** Idle TTL for id-scoped cold revivers registered for mission workers. */
+export const MISSION_WORKER_IDLE_TTL_MS = 30 * 60 * 1000;
+
+const RESULT_ENUM = ["passed", "failed", "not_run"] as const;
+
+const CHECK_ITEM_SCHEMA = {
+	type: "object",
+	properties: {
+		check: { type: "string" },
+		result: { type: "string", enum: RESULT_ENUM },
+		evidence: { type: "string" },
+	},
+	required: ["check", "result"],
+	additionalProperties: false,
+};
+
+const COMMAND_ITEM_SCHEMA = {
+	type: "object",
+	properties: {
+		command: { type: "string" },
+		result: { type: "string", enum: RESULT_ENUM },
+		evidence: { type: "string" },
+	},
+	required: ["command", "result"],
+	additionalProperties: false,
+};
+
+const ISSUE_SCHEMA = {
+	type: "object",
+	properties: {
+		severity: { type: "string", enum: ["blocking", "non_blocking", "suggestion"] },
+		description: { type: "string" },
+		evidence: { type: "string" },
+		affectedFeatureIds: { type: "array", items: { type: "string" } },
+	},
+	required: ["severity", "description"],
+	additionalProperties: false,
+};
+
+const STRING_ARRAY_SCHEMA = { type: "array", items: { type: "string" } };
+
+/** Strict output contract for an implementation worker handoff. */
+export const MISSION_IMPLEMENTATION_HANDOFF_SCHEMA = {
+	type: "object",
+	properties: {
+		kind: { type: "string", enum: ["implementation"] },
+		outcome: { type: "string", enum: ["success", "partial", "failure", "return_to_orchestrator"] },
+		summary: { type: "string" },
+		implementation: STRING_ARRAY_SCHEMA,
+		remaining: STRING_ARRAY_SCHEMA,
+		verification: {
+			type: "object",
+			properties: {
+				commands: { type: "array", items: COMMAND_ITEM_SCHEMA },
+				interactiveChecks: { type: "array", items: CHECK_ITEM_SCHEMA },
+			},
+			required: ["commands", "interactiveChecks"],
+			additionalProperties: false,
+		},
+		tests: {
+			type: "object",
+			properties: { added: STRING_ARRAY_SCHEMA, coverageNotes: STRING_ARRAY_SCHEMA },
+			required: ["added", "coverageNotes"],
+			additionalProperties: false,
+		},
+		issues: { type: "array", items: ISSUE_SCHEMA },
+		skillDeviations: STRING_ARRAY_SCHEMA,
+		commits: STRING_ARRAY_SCHEMA,
+	},
+	required: [
+		"kind",
+		"outcome",
+		"summary",
+		"implementation",
+		"remaining",
+		"verification",
+		"tests",
+		"issues",
+		"skillDeviations",
+		"commits",
+	],
+	additionalProperties: false,
+};
+
+/** Strict output contract for a validator handoff (both roles). */
+export const MISSION_VALIDATION_HANDOFF_SCHEMA = {
+	type: "object",
+	properties: {
+		kind: { type: "string", enum: ["validation"] },
+		role: { type: "string", enum: ["scrutiny", "user-testing"] },
+		verdict: { type: "string", enum: ["pass", "fail"] },
+		summary: { type: "string" },
+		checks: { type: "array", items: CHECK_ITEM_SCHEMA },
+		issues: { type: "array", items: ISSUE_SCHEMA },
+	},
+	required: ["kind", "role", "verdict", "summary", "checks", "issues"],
+	additionalProperties: false,
+};
+
+const implementationHandoffValidator = buildOutputValidator(MISSION_IMPLEMENTATION_HANDOFF_SCHEMA).validator;
+const validationHandoffValidator = buildOutputValidator(MISSION_VALIDATION_HANDOFF_SCHEMA).validator;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Host contract
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Everything MissionRuntime needs from the owning top-level `AgentSession`.
+ * Mirrors `GoalRuntimeHost`: plain callbacks only, never UI objects — the parent
+ * approval delegate is produced on demand as a closure over AgentSession privates.
+ */
+export interface MissionRuntimeHost {
+	/** Session id of the owning top-level session; re-read on every check so `/new` is followed. */
+	ownerSessionId(): string;
+	/** Parent checkout directory. */
+	cwd(): string;
+	sessionManager: Pick<
+		SessionManager,
+		"appendEntriesAtomically" | "appendCustomEntry" | "appendModeChange" | "getEntries" | "flush"
+	>;
+	emitUpdated(state: MissionState): void | Promise<void>;
+	emitProgress(event: MissionProgressEvent): void | Promise<void>;
+	sendHiddenMessage(message: {
+		customType: string;
+		content: string;
+		deliverAs?: "steer" | "followUp" | "nextTurn";
+	}): Promise<void>;
+	getEnabledToolNames(): string[];
+	/** Applying an active tool set also rebuilds the system prompt (SessionTools owns that). */
+	setActiveToolsByName(names: string[]): Promise<void>;
+	/** Parent-mediated approvals for one mission child; `undefined` fails the child closed. */
+	parentApprovalDelegate(owner: MissionChildOwnerEntry): ParentApprovalDelegate | undefined;
+	/** Resolve both child model patterns through the ModelRegistry; throws on an unknown model. */
+	resolveChildModels(worker?: string | string[], validator?: string | string[]): Promise<void>;
+	/** Throw when any name is absent from the session's loaded skill inventory. */
+	assertSkillsExist(names: readonly string[]): void;
+	getToolSession(): ToolSession;
+	isPlanModeActive(): boolean;
+	isGoalModeActive(): boolean;
+	isVibeModeActive(): boolean;
+	/**
+	 * Register an id-scoped cold reviver for one mission worker; returns an
+	 * unregister handle, or `undefined` when this host cannot revive (no
+	 * auth/model/settings context). The factory itself is built by AgentSession —
+	 * it needs private state the runtime must not hold.
+	 */
+	registerPersistedReviver(agentId: string): (() => void) | undefined;
+	agentLifecycle(): AgentLifecycleManager;
+	now?(): number;
+}
+
+export class MissionRuntimeError extends Error {
+	override readonly name = "MissionRuntimeError";
+}
+
+/** Thrown when a session transition would interrupt in-flight mission work. */
+export const MISSION_BUSY = "MISSION_BUSY";
+
+/** Thrown when a transition would rewrite or relocate the transcript a live mission owns. */
+export const INVALID_MISSION_TRANSITION = "INVALID_MISSION_TRANSITION";
+
+// ════════════════════════════════════════════════════════════════════════════
+// Prompt rendering
+// ════════════════════════════════════════════════════════════════════════════
+
+export type MissionPromptKind =
+	| "active"
+	| "planning"
+	| "continuation"
+	| "interrupted"
+	| "worker"
+	| "scrutiny"
+	| "user-testing";
+
+const MISSION_PROMPTS: Record<MissionPromptKind, string> = {
+	active: activePromptTemplate,
+	planning: planningPromptTemplate,
+	continuation: continuationPromptTemplate,
+	interrupted: interruptedPromptTemplate,
+	worker: workerPromptTemplate,
+	scrutiny: scrutinyPromptTemplate,
+	"user-testing": userTestingPromptTemplate,
+};
+
+/** Render one static mission prompt. Prompts are `.md` files; never build them in code. */
+export function renderMissionPrompt(kind: MissionPromptKind, context: prompt.TemplateContext = {}): string {
+	return prompt.render(MISSION_PROMPTS[kind], context);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Local helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+type MissionProgressDraft = DistributiveOmit<MissionProgressEvent, keyof MissionProgressEventBase>;
+type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
+
+type MissionModeMarker = "mission" | "mission_paused" | "none";
+
+function assertNever(value: never, message: string): never {
+	throw new MissionRuntimeError(`${message}: ${JSON.stringify(value)}`);
+}
+
+/** Attach the base fields to a progress draft. The union spread is exact by construction. */
+function withProgressBase(draft: MissionProgressDraft, base: MissionProgressEventBase): MissionProgressEvent {
+	return { ...base, ...draft } as MissionProgressEvent;
+}
+
+/** Truncate untrusted evidence: tabs replaced, capped by the shared preview limits. */
+function sanitizeEvidence(text: string): string {
+	return getPreviewLines(replaceTabs(text), PREVIEW_LIMITS.EXPANDED_LINES, TRUNCATE_LENGTHS.LINE).join("\n");
+}
+
+/**
+ * Schema evidence from at most the first ten validation errors, using ONLY each
+ * error's path and message. The received value never appears.
+ */
+function schemaEvidenceFrom(issues: ReadonlyArray<{ path: PropertyKey[]; message: string }>): string {
+	const lines = issues.slice(0, 10).map(issue => {
+		const at = issue.path.map(segment => String(segment)).join(".");
+		return at ? `${at}: ${issue.message}` : issue.message;
+	});
+	return sanitizeEvidence(lines.join("\n"));
+}
+
+function syntheticImplementationHandoff(schemaEvidence: string, description: string): MissionWorkerHandoff {
+	return {
+		kind: "implementation",
+		outcome: "failure",
+		summary: "Invalid structured handoff",
+		implementation: [],
+		remaining: [],
+		verification: { commands: [], interactiveChecks: [] },
+		tests: { added: [], coverageNotes: [] },
+		issues: [{ severity: "blocking", description, evidence: schemaEvidence }],
+		skillDeviations: [],
+		commits: [],
+	};
+}
+
+function syntheticValidationHandoff(
+	expectedRole: MissionValidatorRole,
+	schemaEvidence: string,
+	description: string,
+): MissionHandoff {
+	return {
+		kind: "validation",
+		role: expectedRole,
+		verdict: "fail",
+		summary: "Invalid structured handoff",
+		checks: [],
+		issues: [{ severity: "blocking", description, evidence: schemaEvidence }],
+	};
+}
+
+/** Actionable gap text carried into a retry turn. Pure data — no invented prose. */
+function handoffGapText(handoff: MissionHandoff): string | undefined {
+	const lines: string[] = [];
+	for (const issue of handoff.issues) {
+		if (issue.severity !== "blocking") continue;
+		lines.push(issue.evidence ? `- ${issue.description} (${issue.evidence})` : `- ${issue.description}`);
+	}
+	if (handoff.kind === "implementation") {
+		for (const remaining of handoff.remaining) lines.push(`- ${remaining}`);
+	} else {
+		for (const check of handoff.checks) {
+			if (check.result === "failed") {
+				lines.push(check.evidence ? `- ${check.check} (${check.evidence})` : `- ${check.check}`);
+			}
+		}
+	}
+	if (lines.length === 0) return undefined;
+	return sanitizeEvidence(lines.join("\n"));
+}
+
+function featureById(state: MissionState, featureId: string): MissionFeature | undefined {
+	return state.features.find(feature => feature.id === featureId);
+}
+
+function assertAcyclicFeaturePreconditions(features: readonly MissionFeature[]): void {
+	const byId = new Map(features.map(feature => [feature.id, feature]));
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+
+	const visit = (featureId: string, stack: string[]): void => {
+		if (visited.has(featureId)) return;
+		if (visiting.has(featureId)) {
+			const cycle = [...stack.slice(stack.indexOf(featureId)), featureId];
+			throw new MissionRuntimeError(`Remediation precondition graph contains a cycle: ${cycle.join(" -> ")}`);
+		}
+		const feature = byId.get(featureId);
+		if (!feature) return;
+		visiting.add(featureId);
+		for (const precondition of feature.preconditions) visit(precondition, [...stack, featureId]);
+		visiting.delete(featureId);
+		visited.add(featureId);
+	};
+
+	for (const feature of features) visit(feature.id, []);
+}
+
+function milestoneOf(state: MissionState, feature: MissionFeature): MissionMilestone {
+	const milestone = state.milestones.find(item => item.id === feature.milestoneId);
+	if (!milestone) {
+		throw new MissionRuntimeError(`Feature "${feature.id}" references unknown milestone "${feature.milestoneId}"`);
+	}
+	return milestone;
+}
+
+function replaceFeature(state: MissionState, updated: MissionFeature): MissionState {
+	return { ...state, features: state.features.map(feature => (feature.id === updated.id ? updated : feature)) };
+}
+
+function roleOf(feature: MissionFeature): MissionChildOwnerEntry["role"] {
+	switch (feature.kind) {
+		case "implementation":
+			return "implementation";
+		case "validation":
+			if (!feature.validator) {
+				throw new MissionRuntimeError(`Validation feature "${feature.id}" has no validator role`);
+			}
+			return feature.validator;
+		default:
+			return assertNever(feature.kind, "Unknown feature kind");
+	}
+}
+
+function agentNameForRole(role: MissionChildOwnerEntry["role"]): string {
+	switch (role) {
+		case "implementation":
+		case "user-testing":
+			return "task";
+		case "scrutiny":
+			return "reviewer";
+		default:
+			return assertNever(role, "Unknown mission child role");
+	}
+}
+
+function promptKindForRole(role: MissionChildOwnerEntry["role"]): MissionPromptKind {
+	switch (role) {
+		case "implementation":
+			return "worker";
+		case "scrutiny":
+			return "scrutiny";
+		case "user-testing":
+			return "user-testing";
+		default:
+			return assertNever(role, "Unknown mission child role");
+	}
+}
+
+/** Highest persisted progress sequence for this mission on the active branch. */
+function latestProgressSequence(entries: readonly SessionEntry[], missionId: string): number {
+	let sequence = 0;
+	for (const entry of entries) {
+		if (entry.type !== "custom" || entry.customType !== MISSION_PROGRESS_CUSTOM_TYPE) continue;
+		const data = entry.data;
+		if (typeof data !== "object" || data === null) continue;
+		const record: Record<string, unknown> = data as Record<string, unknown>;
+		if (record.missionId !== missionId) continue;
+		if (typeof record.sequence === "number" && record.sequence > sequence) sequence = record.sequence;
+	}
+	return sequence;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// MissionRuntime
+// ════════════════════════════════════════════════════════════════════════════
+
+interface DispatchReservation {
+	feature: MissionFeature;
+	milestone: MissionMilestone;
+	descriptor: MissionWorkspaceDescriptor;
+	/** True when this runNext reserved a brand-new descriptor (materialize) instead of reusing one (reconcile). */
+	freshlyReserved: boolean;
+}
+
+/**
+ * Result of the runNext selection tail. `idle` means nothing is runnable, so the
+ * caller checks completion OUTSIDE the tail (publication does Git work and takes
+ * the tail again). `halted` means the tail already paused the mission.
+ */
+type SelectionOutcome = { kind: "dispatch"; reservation: DispatchReservation } | { kind: "idle" } | { kind: "halted" };
+
+/** One committed child dispatch: the feature/workspace it owns plus the active-run token's turn. */
+interface MissionDispatch {
+	feature: MissionFeature;
+	milestone: MissionMilestone;
+	descriptor: MissionWorkspaceDescriptor;
+	mode: MissionNextRunMode;
+	workerSessionId: string;
+	messageToWorker?: string;
+	turn: number;
+}
+
+export class MissionRuntime implements MissionRuntimeContract {
+	readonly #host: MissionRuntimeHost;
+	readonly #workspaces = new MissionWorkspaceManager();
+	readonly #reviverHandles = new Map<string, () => void>();
+
+	#state: MissionState | null = null;
+	#sequence = 0;
+	#tail: Promise<void> = Promise.resolve();
+
+	#pauseRequested = false;
+	#cancelRequested = false;
+	#suspended = false;
+
+	#childAbort: AbortController | undefined;
+	#inFlight: Promise<unknown> | undefined;
+	#externalWork = 0;
+
+	#inactivityTimer: NodeJS.Timeout | undefined;
+	#lastHeartbeatAt = 0;
+
+	#toolsActivated = false;
+	#savedToolNames: string[] | undefined;
+
+	constructor(host: MissionRuntimeHost) {
+		this.#host = host;
+	}
+
+	// ── contract ────────────────────────────────────────────────────────────
+
+	snapshot(): MissionState | null {
+		return this.#state ? structuredClone(this.#state) : null;
+	}
+
+	async start(
+		goal: string,
+		options?: { workerModel?: string | string[]; validatorModel?: string | string[]; autoAccept?: boolean },
+	): Promise<MissionState> {
+		if (this.#host.isPlanModeActive())
+			throw new MissionRuntimeError("Missions cannot start while plan mode is active.");
+		if (this.#host.isGoalModeActive())
+			throw new MissionRuntimeError("Missions cannot start while goal mode is active.");
+		if (this.#host.isVibeModeActive())
+			throw new MissionRuntimeError("Missions cannot start while vibe mode is active.");
+		if (this.#state && !isMissionTerminal(this.#state)) {
+			throw new MissionRuntimeError(`Mission ${this.#state.id} is already active (${this.#state.status}).`);
+		}
+		if (goal.trim().length === 0) {
+			throw new MissionRuntimeError("Mission goal must not be blank.");
+		}
+
+		const now = this.#now();
+		const created: MissionState = {
+			version: 1,
+			id: Snowflake.next(),
+			ownerSessionId: this.#host.ownerSessionId(),
+			revision: 0,
+			goal,
+			autoAccept: options?.autoAccept === true,
+			status: "planning",
+			runbook: { setup: [], services: [], userTests: [] },
+			milestones: [],
+			features: [],
+			workerModel: options?.workerModel,
+			validatorModel: options?.validatorModel,
+			createdAt: now,
+			updatedAt: now,
+		};
+
+		const state = await this.#withTransitionTail(() => this.#commit(created, { mode: "mission" }));
+		this.#pauseRequested = false;
+		this.#cancelRequested = false;
+		await this.#activateTool();
+		await this.#host.sendHiddenMessage({
+			customType: "mission-planning",
+			content: renderMissionPrompt("planning", { goal: goal.trim() || undefined }),
+			deliverAs: "nextTurn",
+		});
+		return state;
+	}
+
+	async setPlan(plan: MissionPlan): Promise<MissionState> {
+		const state = this.#requireOwnedState();
+		if (state.status !== "planning" && state.status !== "awaiting_input") {
+			throw new MissionRuntimeError(`set_plan is valid only while planning (status is "${state.status}").`);
+		}
+		const validation = validateMissionPlan(plan);
+		if (!validation.valid) {
+			throw new MissionRuntimeError(`Invalid mission plan:\n${validation.errors.map(e => `- ${e}`).join("\n")}`);
+		}
+
+		const milestones: MissionMilestone[] = plan.milestones.map(milestone => ({
+			...milestone,
+			featureIds: [...milestone.featureIds],
+			validators: [...milestone.validators],
+			kind: "planned",
+		}));
+		const features: MissionFeature[] = plan.features.map(feature => ({
+			...feature,
+			preconditions: [...feature.preconditions],
+			expectedBehavior: [...feature.expectedBehavior],
+			kind: "implementation",
+			status: "pending",
+			workerSessionIds: [],
+			retryBudgetUsed: 0,
+		}));
+
+		return this.#withTransitionTail(() =>
+			this.#commit({
+				...state,
+				revision: state.revision + 1,
+				goal: plan.goal,
+				runbook: {
+					setup: [...plan.runbook.setup],
+					services: plan.runbook.services.map(service => ({ ...service })),
+					userTests: [...plan.runbook.userTests],
+				},
+				milestones,
+				features,
+				status: "awaiting_input",
+			}),
+		);
+	}
+
+	async accept(): Promise<MissionState> {
+		const state = this.#requireOwnedState();
+		if (state.status !== "awaiting_input") {
+			throw new MissionRuntimeError(`accept is valid only in awaiting_input (status is "${state.status}").`);
+		}
+
+		// Resolution errors leave awaiting_input untouched — nothing is persisted yet.
+		await this.#host.resolveChildModels(state.workerModel, state.validatorModel);
+		const skills = [...new Set(state.features.flatMap(feature => (feature.skillName ? [feature.skillName] : [])))];
+		if (skills.length > 0) this.#host.assertSkillsExist(skills);
+
+		await this.#withTransitionTail(() =>
+			this.#commit({ ...state, status: "initializing" }, { progress: { type: "accepted" } }),
+		);
+		return this.#initializeRepository();
+	}
+
+	async runNext(signal?: AbortSignal): Promise<MissionHandoff | null> {
+		const state = this.#requireOwnedState();
+		if (isMissionTerminal(state)) return null;
+		if (state.pendingHandoff) {
+			throw new MissionRuntimeError("A pending handoff must be resolved before run_next.");
+		}
+		if (state.status !== "running") {
+			throw new MissionRuntimeError(`run_next requires status "running" (status is "${state.status}").`);
+		}
+
+		// (a) tail: select one feature, reserve its descriptor, persist feature_selected.
+		const selection = await this.#withTransitionTail(() => this.#selectAndReserve());
+		if (selection.kind === "idle") {
+			await this.#maybeFinishMission(this.#requireState());
+			return null;
+		}
+		if (selection.kind === "halted") return null;
+		const reservation = selection.reservation;
+
+		// (b) outside the tail: mutate Git for the workspace, then reserve the worker id.
+		const ready = await this.#materializeWorkspace(reservation);
+		if (!ready) return null;
+		const dispatch = await this.#prepareDispatch(reservation);
+
+		// (c) tail: persist ready + revalidate the race, then persist the active-run token.
+		const started = await this.#withTransitionTail(() => this.#commitDispatch(reservation, ready, dispatch));
+		if (!started) return null;
+
+		const turn = this.#runChildTurn(started, signal);
+		this.#inFlight = turn;
+		try {
+			return await turn;
+		} finally {
+			this.#inFlight = undefined;
+		}
+	}
+
+	async resolveHandoff(input: { decision: MissionHandoffDecision; messageToWorker?: string }): Promise<MissionState> {
+		const state = this.#requireOwnedState();
+		const handoff = state.pendingHandoff;
+		if (!handoff) throw new MissionRuntimeError("There is no pending handoff to resolve.");
+		if (state.status !== "orchestrator_turn") {
+			throw new MissionRuntimeError(
+				`resolve_handoff requires status "orchestrator_turn" (status is "${state.status}"); resume the mission first.`,
+			);
+		}
+		const feature = state.features.find(item => item.status === "in_progress");
+		if (!feature) throw new MissionRuntimeError("Pending handoff has no in_progress feature.");
+
+		switch (input.decision) {
+			case "accept":
+				return this.#acceptHandoff(state, feature, handoff);
+			case "retry_same":
+			case "retry_fresh":
+				return this.#retryHandoff(feature, handoff, input.decision, input.messageToWorker);
+			case "cancel_feature":
+				return this.#cancelFeature(feature);
+			case "pause":
+				// Latch first: no successor dispatches even if persistence is slow.
+				this.#pauseRequested = true;
+				return this.#withTransitionTail(() =>
+					this.#commit(
+						{ ...state, status: "paused", pauseReason: "user_requested" },
+						{
+							progress: { type: "handoff_resolved", featureId: feature.id, decision: "pause" },
+							mode: "mission_paused",
+						},
+					),
+				);
+			default:
+				return assertNever(input.decision, "Unknown handoff decision");
+		}
+	}
+
+	async revisePending(input: { addFeatures: MissionRemediationFeatureSpec[] }): Promise<MissionState> {
+		const state = this.#requireOwnedState();
+		const handoff = state.pendingHandoff;
+		if (handoff?.kind !== "validation" || handoff.verdict !== "fail") {
+			throw new MissionRuntimeError("revise_pending requires a failed validator handoff.");
+		}
+		if (state.status !== "orchestrator_turn") {
+			throw new MissionRuntimeError(
+				`revise_pending requires status "orchestrator_turn" (status is "${state.status}").`,
+			);
+		}
+		if (input.addFeatures.length === 0) {
+			throw new MissionRuntimeError("revise_pending requires at least one remediation feature.");
+		}
+		const failed = state.features.find(item => item.status === "in_progress");
+		if (failed?.kind !== "validation") {
+			throw new MissionRuntimeError("revise_pending has no in_progress validator feature.");
+		}
+		const milestone = milestoneOf(state, failed);
+
+		const existingIds = new Set(state.features.map(item => item.id));
+		const remediations: MissionFeature[] = [];
+		for (const spec of input.addFeatures) {
+			if (!MISSION_ID_PATTERN.test(spec.id)) {
+				throw new MissionRuntimeError(`Remediation feature id "${spec.id}" must match ${MISSION_ID_PATTERN}.`);
+			}
+			if (existingIds.has(spec.id)) {
+				throw new MissionRuntimeError(`Remediation feature id "${spec.id}" already exists.`);
+			}
+			if (spec.expectedBehavior.length === 0) {
+				throw new MissionRuntimeError(`Remediation feature "${spec.id}" requires nonempty expectedBehavior.`);
+			}
+			existingIds.add(spec.id);
+			remediations.push({
+				id: spec.id,
+				description: spec.description,
+				skillName: spec.skillName,
+				milestoneId: milestone.id,
+				preconditions: [...spec.preconditions],
+				expectedBehavior: [...spec.expectedBehavior],
+				fulfills: spec.fulfills ? [...spec.fulfills] : undefined,
+				kind: "implementation",
+				status: "pending",
+				workerSessionIds: [],
+				retryBudgetUsed: 0,
+			});
+		}
+		for (const remediation of remediations) {
+			for (const precondition of remediation.preconditions) {
+				if (!existingIds.has(precondition)) {
+					throw new MissionRuntimeError(
+						`Remediation feature "${remediation.id}" references unknown precondition "${precondition}".`,
+					);
+				}
+			}
+		}
+		assertAcyclicFeaturePreconditions([...state.features, ...remediations]);
+
+		// Every validator checkout released here must be clean; a dirty one is preserved.
+		const validators = state.features.filter(item => item.kind === "validation" && item.milestoneId === milestone.id);
+		for (const validator of validators) {
+			const workspace = validator.workspace;
+			if (!workspace) continue;
+			await this.#releaseWorkers(validator);
+			const released = await this.#guardExternal(() => this.#workspaces.releaseIfEmpty(workspace));
+			if (!released) {
+				await this.#pauseWith("validator_workspace_dirty");
+				throw new MissionRuntimeError(
+					`Validator workspace for "${validator.id}" is not clean at ${workspace.path}; clean it and use /mission restart.`,
+				);
+			}
+		}
+
+		const remediationIds = remediations.map(item => item.id);
+		const resetValidatorIds = new Set(validators.map(item => item.id));
+		const features = state.features.map(item => {
+			if (!resetValidatorIds.has(item.id)) return item;
+			return {
+				...item,
+				status: "pending" as const,
+				currentWorkerSessionId: undefined,
+				completedWorkerSessionId: undefined,
+				workspace: undefined,
+				validatedHead: undefined,
+				nextRunIntent: undefined,
+				preconditions: [...item.preconditions, ...remediationIds.filter(id => !item.preconditions.includes(id))],
+			};
+		});
+
+		// Ordered insert: remediation runs immediately before the first validator of this milestone.
+		const firstValidatorIndex = features.findIndex(item => resetValidatorIds.has(item.id));
+		const insertAt = firstValidatorIndex === -1 ? features.length : firstValidatorIndex;
+		features.splice(insertAt, 0, ...remediations);
+
+		const milestones = state.milestones.map(item =>
+			item.id === milestone.id ? { ...item, featureIds: [...item.featureIds, ...remediationIds] } : item,
+		);
+
+		return this.#withTransitionTail(() =>
+			this.#commit(
+				{
+					...state,
+					revision: state.revision + 1,
+					milestones,
+					features,
+					pendingHandoff: undefined,
+					status: "running",
+				},
+				{ progress: { type: "milestone_validation_triggered", milestoneId: milestone.id } },
+			),
+		);
+	}
+
+	async pause(reason: MissionPauseReason): Promise<MissionState> {
+		const state = this.#requireState();
+		if (isMissionTerminal(state)) {
+			throw new MissionRuntimeError(`Mission ${state.id} is already ${state.status}.`);
+		}
+		// Latch first: an in-flight child may settle, but no successor dispatches.
+		this.#pauseRequested = true;
+		if (state.status === "paused") return state;
+		return this.#withTransitionTail(() =>
+			this.#commit(
+				{ ...state, status: "paused", pauseReason: reason },
+				{ progress: { type: "paused", reason }, mode: "mission_paused" },
+			),
+		);
+	}
+
+	async resume(input?: { restartWorker?: boolean; messageToWorker?: string }): Promise<MissionState> {
+		const state = this.#requireOwnedState();
+		if (state.status !== "paused") {
+			throw new MissionRuntimeError(`resume requires status "paused" (status is "${state.status}").`);
+		}
+		const reason = state.pauseReason;
+		if (!reason) throw new MissionRuntimeError("Paused mission has no recorded pause reason.");
+
+		let resumed: MissionState;
+		switch (reason) {
+			case "user_requested":
+				resumed = await this.#resumeSimple(state, input);
+				break;
+			case "feature_retry_limit_exceeded":
+				resumed = await this.#resumeRetryBudget(state, input);
+				break;
+			case "worker_inactive":
+				resumed = await this.#resumeWithIntent(state, "fresh", input?.messageToWorker);
+				break;
+			case "worker_interrupted":
+				resumed = await this.#resumeInterrupted(state, input);
+				break;
+			case "repository_dirty":
+				this.#pauseRequested = false;
+				resumed = await this.#initializeRepository();
+				break;
+			case "workspace_conflict":
+				resumed = await this.#resumeWorkspaceConflict(state, input);
+				break;
+			case "integration_diverged":
+				resumed = await this.#resumeIntegrationDiverged(state);
+				break;
+			case "parent_diverged":
+				resumed = await this.#resumePublication(state);
+				break;
+			case "validator_workspace_dirty":
+				throw new MissionRuntimeError(
+					"A dirty validator checkout cannot be resumed. Clean the checkout, then use /mission restart.",
+				);
+			default:
+				return assertNever(reason, "Unknown mission pause reason");
+		}
+
+		if (resumed.status === "running" || resumed.status === "orchestrator_turn") {
+			await this.#enqueueContinuation();
+		}
+		return resumed;
+	}
+
+	async cancel(): Promise<MissionState> {
+		const state = this.#requireState();
+		if (isMissionTerminal(state)) return state;
+
+		this.#cancelRequested = true;
+		this.#pauseRequested = true;
+		this.#childAbort?.abort(new MissionRuntimeError("Mission cancelled"));
+		this.#clearInactivity();
+		if (this.#inFlight) await this.#inFlight.catch(() => {});
+
+		const current = this.#requireState();
+		const owner = this.#isOwner();
+		if (owner) {
+			// Preserve every nonempty workspace; only clean, unmodified ones are removed.
+			for (const feature of current.features) {
+				if (feature.status === "completed") continue;
+				await this.#releaseWorkers(feature);
+				const workspace = feature.workspace;
+				if (!workspace) continue;
+				const released = await this.#guardExternal(() => this.#workspaces.releaseIfEmpty(workspace)).catch(
+					error => {
+						logger.warn("Mission workspace release failed during cancel", {
+							featureId: feature.id,
+							error: String(error),
+						});
+						return false;
+					},
+				);
+				if (!released) {
+					logger.info("Mission workspace preserved during cancel", {
+						featureId: feature.id,
+						path: workspace.path,
+					});
+				}
+			}
+		}
+
+		const features = current.features.map(feature =>
+			feature.status === "pending" || feature.status === "in_progress"
+				? { ...feature, status: "cancelled" as const, currentWorkerSessionId: undefined, nextRunIntent: undefined }
+				: feature,
+		);
+		const cancelled = await this.#withTransitionTail(() =>
+			this.#commit(
+				{
+					...current,
+					features,
+					activeRun: undefined,
+					pendingHandoff: undefined,
+					integrationPending: undefined,
+					status: "cancelled",
+					pauseReason: undefined,
+				},
+				{ progress: { type: "cancelled" }, mode: "none" },
+			),
+		);
+		await this.#deactivateTool();
+		this.#unregisterAllRevivers();
+		return cancelled;
+	}
+
+	async prepareToSuspend(): Promise<void> {
+		const state = this.#state;
+		this.#clearInactivity();
+		this.#childAbort = undefined;
+		this.#suspended = true;
+		if (!state || isMissionTerminal(state)) return;
+		if (state.status !== "paused") {
+			await this.pause("user_requested");
+		} else {
+			this.#pauseRequested = true;
+		}
+		await this.#host.sessionManager.flush();
+	}
+
+	async restore(): Promise<MissionState | null> {
+		this.#clearInactivity();
+		this.#childAbort = undefined;
+		this.#inFlight = undefined;
+		this.#pauseRequested = false;
+		this.#cancelRequested = false;
+		this.#suspended = false;
+		this.#unregisterAllRevivers();
+
+		const entries = this.#host.sessionManager.getEntries();
+		const loaded = loadMissionState(entries);
+		if (!loaded) {
+			await this.#deactivateTool();
+			this.#state = null;
+			this.#sequence = 0;
+			return null;
+		}
+		this.#state = loaded;
+		this.#sequence = latestProgressSequence(entries, loaded.id);
+
+		if (!this.#isOwner()) {
+			// A forked or copied transcript inspects only: never resume, dispatch, or clean up.
+			await this.#deactivateTool();
+			return this.snapshot();
+		}
+
+		if (isMissionTerminal(loaded)) {
+			await this.#deactivateTool();
+			await this.#restoreTerminalCleanup(loaded);
+			return this.snapshot();
+		}
+
+		await this.#activateTool();
+		for (const feature of loaded.features) {
+			for (const workerSessionId of feature.workerSessionIds) this.#registerReviver(workerSessionId);
+		}
+
+		if (loaded.status === "initializing") {
+			await this.#initializeRepository();
+		}
+		if (this.#state?.integrationPending) {
+			await this.#recoverIntegrationPending();
+		}
+		await this.#restoreInterruptedWorker();
+		return this.snapshot();
+	}
+
+	// ── host-facing extras (not part of MissionRuntimeContract) ─────────────
+
+	/** True while a child turn, workspace/Git mutation, or state flush is in flight. */
+	isBusy(): boolean {
+		return this.#inFlight !== undefined || this.#externalWork > 0;
+	}
+
+	/** Nonterminal owned mission that blocks destructive session transitions. */
+	hasActiveMission(): boolean {
+		return this.#state !== null && !isMissionTerminal(this.#state) && this.#isOwner();
+	}
+
+	/** Parent system-prompt context while a mission is active; null when there is none. */
+	buildActivePrompt(): string | null {
+		const state = this.#state;
+		if (!state || isMissionTerminal(state)) return null;
+		return renderMissionPrompt("active");
+	}
+
+	/**
+	 * Hidden autonomous-continuation nudge. Non-null only while the mission is
+	 * running or holding an unresolved handoff on the orchestrator's turn.
+	 */
+	buildContinuationPrompt(): string | null {
+		const state = this.#state;
+		if (!state || !this.#isOwner()) return null;
+		if (state.status !== "running" && state.status !== "orchestrator_turn") return null;
+		return renderMissionPrompt("continuation");
+	}
+
+	// ── transition tail + persistence ───────────────────────────────────────
+
+	#now(): number {
+		return this.#host.now?.() ?? Date.now();
+	}
+
+	async #withTransitionTail<T>(fn: () => Promise<T> | T): Promise<T> {
+		const previous = this.#tail;
+		const { promise, resolve } = Promise.withResolvers<void>();
+		this.#tail = previous.then(
+			() => promise,
+			() => promise,
+		);
+		await previous.catch(() => {});
+		try {
+			return await fn();
+		} finally {
+			resolve();
+		}
+	}
+
+	/**
+	 * Persist one transition atomically, then publish it. MUST run inside the tail.
+	 * A persistence error leaves `#state` (the prior snapshot) authoritative.
+	 */
+	async #commit(
+		next: MissionState,
+		options: { progress?: MissionProgressDraft; mode?: MissionModeMarker } = {},
+	): Promise<MissionState> {
+		const at = this.#now();
+		const state: MissionState = { ...next, updatedAt: at };
+		assertMissionStateInvariants(state);
+
+		const sequence = this.#sequence + 1;
+		const event = options.progress
+			? withProgressBase(options.progress, { missionId: state.id, sequence, at })
+			: undefined;
+		const manager = this.#host.sessionManager;
+		const mode = options.mode;
+
+		await manager.appendEntriesAtomically(() => {
+			manager.appendCustomEntry(MISSION_STATE_CUSTOM_TYPE, state);
+			if (event) manager.appendCustomEntry(MISSION_PROGRESS_CUSTOM_TYPE, event);
+			if (mode) manager.appendModeChange(mode, mode === "none" ? undefined : { missionId: state.id });
+		});
+
+		this.#state = state;
+		if (event) this.#sequence = sequence;
+		await this.#host.emitUpdated(state);
+		if (event) await this.#host.emitProgress(event);
+		return state;
+	}
+
+	/** Heartbeat path: append only the progress event, never mission state. */
+	async #appendProgressOnly(draft: MissionProgressDraft): Promise<void> {
+		const state = this.#state;
+		if (!state) return;
+		const sequence = this.#sequence + 1;
+		const event = withProgressBase(draft, { missionId: state.id, sequence, at: this.#now() });
+		const manager = this.#host.sessionManager;
+		await manager.appendEntriesAtomically(() => {
+			manager.appendCustomEntry(MISSION_PROGRESS_CUSTOM_TYPE, event);
+		});
+		this.#sequence = sequence;
+		await this.#host.emitProgress(event);
+	}
+
+	#requireState(): MissionState {
+		if (!this.#state) throw new MissionRuntimeError("No mission is active.");
+		return this.#state;
+	}
+
+	#isOwner(): boolean {
+		return this.#state?.ownerSessionId === this.#host.ownerSessionId();
+	}
+
+	#requireOwnedState(): MissionState {
+		const state = this.#requireState();
+		if (!this.#isOwner()) {
+			throw new MissionRuntimeError(
+				`Mission ${state.id} belongs to session ${state.ownerSessionId}; this transcript copy is read-only.`,
+			);
+		}
+		return state;
+	}
+
+	/** Mark an external (Git/worktree) critical section so session transitions report MISSION_BUSY. */
+	async #guardExternal<T>(fn: () => Promise<T>): Promise<T> {
+		this.#externalWork++;
+		try {
+			return await fn();
+		} finally {
+			this.#externalWork--;
+		}
+	}
+
+	async #pauseWith(reason: MissionPauseReason): Promise<MissionState> {
+		const state = this.#requireState();
+		this.#pauseRequested = true;
+		return this.#withTransitionTail(() =>
+			this.#commit(
+				{ ...this.#requireState(), status: "paused", pauseReason: reason },
+				{ progress: { type: "paused", reason }, mode: "mission_paused" },
+			),
+		).then(next => {
+			logger.info("Mission paused", { missionId: state.id, reason });
+			return next;
+		});
+	}
+
+	// ── tool activation + continuation ──────────────────────────────────────
+
+	async #activateTool(): Promise<void> {
+		if (this.#toolsActivated) return;
+		const enabled = this.#host.getEnabledToolNames();
+		this.#savedToolNames = enabled.filter(name => name !== MISSION_TOOL_NAME);
+		this.#toolsActivated = true;
+		await this.#host.setActiveToolsByName([...this.#savedToolNames, MISSION_TOOL_NAME]);
+	}
+
+	async #deactivateTool(): Promise<void> {
+		if (!this.#toolsActivated) return;
+		const restored = this.#savedToolNames ?? this.#host.getEnabledToolNames().filter(n => n !== MISSION_TOOL_NAME);
+		this.#savedToolNames = undefined;
+		this.#toolsActivated = false;
+		await this.#host.setActiveToolsByName(restored);
+	}
+
+	async #enqueueContinuation(): Promise<void> {
+		const content = this.buildContinuationPrompt();
+		if (!content) return;
+		await this.#host.sendHiddenMessage({
+			customType: "mission-continuation",
+			content,
+			deliverAs: "nextTurn",
+		});
+	}
+
+	// ── acceptance / repository initialization ──────────────────────────────
+
+	async #initializeRepository(): Promise<MissionState> {
+		const state = this.#requireOwnedState();
+		if (state.status !== "initializing") return state;
+
+		const existing = state.repository;
+		const repoRoot = existing?.repoRoot ?? (await this.#guardExternal(() => git.repo.root(this.#host.cwd())));
+		if (!repoRoot) return this.#pauseWith("repository_dirty");
+
+		const preflight = await this.#guardExternal(async () => {
+			const parentBranch = await git.branch.current(repoRoot);
+			const summary = await git.status.summary(repoRoot);
+			const headSha = await git.ref.resolve(repoRoot, "HEAD");
+			return { parentBranch, clean: isCleanSummary(summary), headSha };
+		});
+		if (!preflight.parentBranch || !preflight.clean || !preflight.headSha) {
+			logger.info("Mission acceptance preflight refused", {
+				missionId: state.id,
+				attached: preflight.parentBranch !== null,
+				clean: preflight.clean,
+			});
+			return this.#pauseWith("repository_dirty");
+		}
+		if (existing && existing.parentBranch !== preflight.parentBranch) {
+			return this.#pauseWith("repository_dirty");
+		}
+
+		const repository: MissionRepositoryState = existing ?? {
+			repoRoot,
+			parentBranch: preflight.parentBranch,
+			baseSha: preflight.headSha,
+			integrationBranch: `omp/mission/${state.id}/integration`,
+			integrationHead: preflight.headSha,
+		};
+		if (!existing) {
+			// The descriptor is durable before any ref is created.
+			await this.#withTransitionTail(() => this.#commit({ ...this.#requireState(), repository }));
+		}
+
+		const integrationRef = toLocalBranchRef(repository.integrationBranch);
+		const outcome = await this.#guardExternal(() =>
+			git.withRepoLock(repoRoot, async (): Promise<"ready" | "repository_dirty" | "workspace_conflict"> => {
+				const branch = await git.branch.current(repoRoot);
+				const summary = await git.status.summary(repoRoot);
+				const headSha = await git.ref.resolve(repoRoot, "HEAD");
+				if (branch !== repository.parentBranch || !isCleanSummary(summary) || headSha === null) {
+					return "repository_dirty";
+				}
+				const current = await git.ref.resolve(repoRoot, integrationRef);
+				if (current === null) {
+					await git.branch.create(repoRoot, repository.integrationBranch, repository.integrationHead);
+					return "ready";
+				}
+				return current === repository.integrationHead ? "ready" : "workspace_conflict";
+			}),
+		);
+		if (outcome !== "ready") return this.#pauseWith(outcome);
+
+		return this.#withTransitionTail(() =>
+			this.#commit(
+				{ ...this.#requireState(), repository, status: "running", pauseReason: undefined },
+				{ progress: { type: "run_started" }, mode: "mission" },
+			),
+		);
+	}
+
+	// ── runNext: part (a) ───────────────────────────────────────────────────
+
+	async #selectAndReserve(): Promise<SelectionOutcome> {
+		let state = this.#requireState();
+
+		// Milestone validators are injected before selection so the next milestone
+		// can never run ahead of this milestone's validation.
+		const injected = await this.#injectPendingValidators(state);
+		if (injected) state = injected;
+
+		const selection = nextMissionFeature(state);
+		if (selection.state !== state) {
+			state = await this.#commit(selection.state);
+		}
+		const feature = selection.feature;
+		if (!feature) return { kind: "idle" };
+		if (feature.retryBudgetUsed >= MISSION_WORKER_TURN_CAP) {
+			this.#pauseRequested = true;
+			await this.#commit(
+				{ ...state, status: "paused", pauseReason: "feature_retry_limit_exceeded" },
+				{ progress: { type: "paused", reason: "feature_retry_limit_exceeded" }, mode: "mission_paused" },
+			);
+			return { kind: "halted" };
+		}
+
+		const milestone = milestoneOf(state, feature);
+		const existing = feature.workspace;
+		const descriptor: MissionWorkspaceDescriptor =
+			existing ??
+			(feature.kind === "implementation"
+				? await this.#workspaces.reserveFeature(state.ownerSessionId, state, feature)
+				: await this.#workspaces.reserveValidator(state.ownerSessionId, state, feature.id));
+
+		const reserved: MissionFeature = { ...feature, workspace: descriptor };
+		const next = await this.#commit(replaceFeature(state, reserved), {
+			progress: { type: "feature_selected", featureId: feature.id },
+		});
+		const persisted = featureById(next, feature.id);
+		if (!persisted) throw new MissionRuntimeError(`Selected feature "${feature.id}" vanished during persistence.`);
+		return {
+			kind: "dispatch",
+			reservation: { feature: persisted, milestone, descriptor, freshlyReserved: existing === undefined },
+		};
+	}
+
+	/**
+	 * Inject `_validate.<milestoneId>.<role>` features for the first milestone whose
+	 * implementation features are all completed or cancelled. One milestone per
+	 * transition (each carries its own `milestone_validation_triggered`).
+	 */
+	async #injectPendingValidators(state: MissionState): Promise<MissionState | null> {
+		for (const milestone of state.milestones) {
+			const implementations = state.features.filter(
+				feature => feature.kind === "implementation" && feature.milestoneId === milestone.id,
+			);
+			const settled = implementations.every(
+				feature => feature.status === "completed" || feature.status === "cancelled",
+			);
+			if (!settled) continue;
+
+			const missing = milestone.validators.filter(
+				role =>
+					!state.features.some(
+						feature =>
+							feature.kind === "validation" &&
+							feature.milestoneId === milestone.id &&
+							feature.validator === role,
+					),
+			);
+			if (missing.length === 0) continue;
+
+			const preconditions = implementations.map(feature => feature.id);
+			const expectedBehavior = [...new Set(implementations.flatMap(feature => feature.expectedBehavior))];
+			const injected: MissionFeature[] = missing.map(role => ({
+				id: `_validate.${milestone.id}.${role}`,
+				description: `${role} validation for milestone ${milestone.id}`,
+				milestoneId: milestone.id,
+				preconditions,
+				expectedBehavior:
+					expectedBehavior.length > 0 ? expectedBehavior : [`Milestone ${milestone.id}: ${milestone.description}`],
+				kind: "validation",
+				validator: role,
+				status: "pending",
+				workerSessionIds: [],
+				retryBudgetUsed: 0,
+			}));
+
+			// Place immediately after this milestone's last implementation feature.
+			const features = [...state.features];
+			let insertAt = features.length;
+			for (let index = features.length - 1; index >= 0; index--) {
+				const candidate = features[index];
+				if (candidate && candidate.kind === "implementation" && candidate.milestoneId === milestone.id) {
+					insertAt = index + 1;
+					break;
+				}
+			}
+			features.splice(insertAt, 0, ...injected);
+
+			return this.#commit(
+				{ ...state, features },
+				{ progress: { type: "milestone_validation_triggered", milestoneId: milestone.id } },
+			);
+		}
+		return null;
+	}
+
+	// ── runNext: part (b) ───────────────────────────────────────────────────
+
+	async #materializeWorkspace(reservation: DispatchReservation): Promise<MissionWorkspaceDescriptor | null> {
+		const hasTranscript = this.#hasChildTranscript(reservation.feature.currentWorkerSessionId);
+		try {
+			if (reservation.freshlyReserved && !hasTranscript) {
+				return await this.#guardExternal(() => this.#workspaces.materialize(reservation.descriptor));
+			}
+			const result = await this.#guardExternal(() =>
+				this.#workspaces.reconcile(reservation.descriptor, hasTranscript),
+			);
+			if (result.kind === "ready") return result.descriptor;
+			logger.info("Mission workspace conflict", {
+				featureId: result.featureId,
+				path: result.path,
+				detail: result.detail,
+			});
+			await this.#pauseWith("workspace_conflict");
+			return null;
+		} catch (error) {
+			logger.warn("Mission workspace materialization failed", {
+				featureId: reservation.feature.id,
+				error: String(error),
+			});
+			await this.#pauseWith("workspace_conflict");
+			return null;
+		}
+	}
+
+	async #prepareDispatch(
+		reservation: DispatchReservation,
+	): Promise<{ mode: MissionNextRunMode; workerSessionId: string; messageToWorker?: string }> {
+		const feature = reservation.feature;
+		const intent = feature.nextRunIntent;
+		let mode: MissionNextRunMode = intent?.mode ?? (feature.currentWorkerSessionId ? "follow_up" : "initial");
+		if (mode === "follow_up" && !this.#hasChildTranscript(feature.currentWorkerSessionId)) {
+			// No exact transcript survives: a fresh worker in the same workspace, never a wrong follow-up.
+			mode = "fresh";
+		}
+		if (
+			mode === "initial" &&
+			feature.currentWorkerSessionId &&
+			this.#hasChildTranscript(feature.currentWorkerSessionId)
+		) {
+			mode = "follow_up";
+		}
+
+		let workerSessionId: string;
+		if (mode === "follow_up") {
+			const current = feature.currentWorkerSessionId;
+			if (!current) throw new MissionRuntimeError(`follow_up for "${feature.id}" has no current worker session id.`);
+			workerSessionId = current;
+		} else if (mode === "initial" && feature.currentWorkerSessionId) {
+			workerSessionId = feature.currentWorkerSessionId;
+		} else {
+			workerSessionId = await reserveStructuredSubagentId(this.#host.getToolSession(), {
+				label: `mission-${feature.id}`,
+			});
+		}
+		return { mode, workerSessionId, messageToWorker: intent?.messageToWorker };
+	}
+
+	// ── runNext: part (c) ───────────────────────────────────────────────────
+
+	async #commitDispatch(
+		reservation: DispatchReservation,
+		ready: MissionWorkspaceDescriptor,
+		dispatch: { mode: MissionNextRunMode; workerSessionId: string; messageToWorker?: string },
+	): Promise<MissionDispatch | null> {
+		const state = this.#requireState();
+		const current = featureById(state, reservation.feature.id);
+		if (!current) return null;
+
+		// The owned ready descriptor is persisted even when the race was lost.
+		const readyState = await this.#commit(replaceFeature(state, { ...current, workspace: ready }));
+		const settled = featureById(readyState, reservation.feature.id);
+		if (!settled) return null;
+
+		if (
+			this.#pauseRequested ||
+			this.#cancelRequested ||
+			this.#suspended ||
+			readyState.status !== "running" ||
+			readyState.pendingHandoff !== undefined ||
+			settled.status !== "pending"
+		) {
+			return null;
+		}
+
+		const workerSessionIds = settled.workerSessionIds.includes(dispatch.workerSessionId)
+			? settled.workerSessionIds
+			: [...settled.workerSessionIds, dispatch.workerSessionId];
+		const turn = settled.retryBudgetUsed + 1;
+		const started: MissionFeature = {
+			...settled,
+			status: "in_progress",
+			workerSessionIds,
+			currentWorkerSessionId: dispatch.workerSessionId,
+			retryBudgetUsed: turn,
+			nextRunIntent: undefined,
+		};
+
+		await this.#commit(
+			{
+				...replaceFeature(readyState, started),
+				activeRun: { featureId: started.id, workerSessionId: dispatch.workerSessionId, turn },
+			},
+			{ progress: { type: "worker_started", featureId: started.id, workerSessionId: dispatch.workerSessionId } },
+		);
+		this.#registerReviver(dispatch.workerSessionId);
+		return {
+			feature: started,
+			milestone: reservation.milestone,
+			descriptor: ready,
+			mode: dispatch.mode,
+			workerSessionId: dispatch.workerSessionId,
+			messageToWorker: dispatch.messageToWorker,
+			turn,
+		};
+	}
+
+	// ── child turn ──────────────────────────────────────────────────────────
+
+	async #runChildTurn(dispatch: MissionDispatch, signal?: AbortSignal): Promise<MissionHandoff | null> {
+		const state = this.#requireState();
+		const feature = dispatch.feature;
+		const role = roleOf(feature);
+		const controller = new AbortController();
+		this.#childAbort = controller;
+		const onExternalAbort = (): void => controller.abort(signal?.reason);
+		signal?.addEventListener("abort", onExternalAbort, { once: true });
+
+		let inactive = false;
+		const armInactivity = (): void => {
+			this.#clearInactivity();
+			this.#inactivityTimer = setTimeout(() => {
+				inactive = true;
+				controller.abort(new MissionRuntimeError("Mission worker inactivity timeout"));
+			}, MISSION_INACTIVITY_TIMEOUT_MS);
+		};
+		armInactivity();
+		this.#lastHeartbeatAt = 0;
+
+		const owner: MissionChildOwnerEntry = {
+			missionId: state.id,
+			ownerSessionId: state.ownerSessionId,
+			role,
+			milestoneId: feature.milestoneId,
+			featureId: feature.id,
+		};
+		const onProgress = (progress: AgentProgress): void => {
+			armInactivity();
+			const at = this.#now();
+			if (at - this.#lastHeartbeatAt < MISSION_HEARTBEAT_INTERVAL_MS) return;
+			this.#lastHeartbeatAt = at;
+			void this.#withTransitionTail(async () => {
+				if (!this.#activeRunFor(feature.id, dispatch.workerSessionId, dispatch.turn)) return;
+				await this.#appendProgressOnly({
+					type: "heartbeat",
+					featureId: feature.id,
+					workerSessionId: dispatch.workerSessionId,
+					requests: progress.requests,
+					tokens: progress.tokens,
+					cost: progress.cost,
+				});
+			}).catch(error => logger.warn("Mission heartbeat persistence failed", { error: String(error) }));
+		};
+
+		let result: SingleResult | undefined;
+		let failure: string | undefined;
+		try {
+			result = await this.#invokeChild(state, dispatch, role, owner, controller.signal, onProgress);
+		} catch (error) {
+			failure = error instanceof Error ? error.message : String(error);
+		} finally {
+			this.#clearInactivity();
+			signal?.removeEventListener("abort", onExternalAbort);
+			if (this.#childAbort === controller) this.#childAbort = undefined;
+		}
+
+		if (inactive) {
+			await this.#settleInactivity(dispatch, feature.id);
+			return null;
+		}
+		return this.#settleTurn(dispatch, result, failure);
+	}
+
+	async #invokeChild(
+		state: MissionState,
+		dispatch: Omit<MissionDispatch, "turn">,
+		role: MissionChildOwnerEntry["role"],
+		owner: MissionChildOwnerEntry,
+		signal: AbortSignal,
+		onProgress: (progress: AgentProgress) => void,
+	): Promise<SingleResult> {
+		const feature = dispatch.feature;
+		const agentName = agentNameForRole(role);
+		const outputSchema =
+			feature.kind === "implementation" ? MISSION_IMPLEMENTATION_HANDOFF_SCHEMA : MISSION_VALIDATION_HANDOFF_SCHEMA;
+		const model = feature.kind === "implementation" ? state.workerModel : state.validatorModel;
+		const message =
+			dispatch.mode === "follow_up" && dispatch.messageToWorker
+				? dispatch.messageToWorker
+				: renderMissionPrompt(promptKindForRole(role), {
+						feature: { id: feature.id, description: feature.description },
+						milestone: { id: dispatch.milestone.id, description: dispatch.milestone.description },
+						skillName: feature.skillName,
+						expectedBehavior: feature.expectedBehavior,
+						priorHandoffGap: dispatch.messageToWorker,
+						runbook: state.runbook,
+					});
+
+		if (dispatch.mode === "follow_up") {
+			const agent = getBundledAgent(agentName);
+			if (!agent) throw new MissionRuntimeError(`Bundled agent "${agentName}" is unavailable.`);
+			return runSubagentFollowUpTurn({
+				id: dispatch.workerSessionId,
+				agent,
+				message,
+				description: `mission ${state.id} ${feature.id}`,
+				outputSchema,
+				outputSchemaMode: "strict",
+				outputSchemaSource: "caller",
+				signal,
+				onProgress,
+				maxRuntimeMs: 0,
+			});
+		}
+
+		const invocation = await runStructuredSubagent({
+			session: this.#host.getToolSession(),
+			invocationKind: "task",
+			assignment: message,
+			agent: agentName,
+			model,
+			outputSchema,
+			schemaMode: "strict",
+			identity: { id: dispatch.workerSessionId, label: `mission-${feature.id}` },
+			workspace: { cwd: dispatch.descriptor.path, binding: "fixed" },
+			approvalDelegate: this.#host.parentApprovalDelegate(owner),
+			missionOwner: owner,
+			keepAlive: true,
+			maxRuntimeMs: 0,
+			signal,
+			onProgress,
+		});
+		return invocation.result;
+	}
+
+	/**
+	 * The live state when its active-run token still names exactly this feature/worker/turn,
+	 * otherwise undefined. A settling child must never overwrite a newer paused/cancelled state,
+	 * so every mutation on a child's completion path passes through this one check.
+	 */
+	#activeRunFor(featureId: string, workerSessionId: string, turn: number): MissionState | undefined {
+		const state = this.#state;
+		const active = state?.activeRun;
+		if (!state || !active) return undefined;
+		if (active.featureId !== featureId || active.workerSessionId !== workerSessionId || active.turn !== turn) {
+			return undefined;
+		}
+		return state;
+	}
+
+	/** Inactivity: the turn is consumed, the worker id is dropped, and no handoff is recorded. */
+	async #settleInactivity(dispatch: { workerSessionId: string; turn: number }, featureId: string): Promise<void> {
+		await this.#releaseWorkerId(dispatch.workerSessionId);
+		await this.#withTransitionTail(async () => {
+			const state = this.#activeRunFor(featureId, dispatch.workerSessionId, dispatch.turn);
+			if (!state) return;
+			const feature = featureById(state, featureId);
+			if (!feature) return;
+			const reset: MissionFeature = {
+				...feature,
+				status: "pending",
+				currentWorkerSessionId: undefined,
+				nextRunIntent: { mode: "fresh" },
+			};
+			const cleared = await this.#commit(
+				{ ...replaceFeature(state, reset), activeRun: undefined },
+				{ progress: { type: "worker_failed", featureId, workerSessionId: dispatch.workerSessionId } },
+			);
+			await this.#commit(
+				{ ...cleared, status: "paused", pauseReason: "worker_inactive" },
+				{ progress: { type: "paused", reason: "worker_inactive" }, mode: "mission_paused" },
+			);
+			this.#pauseRequested = true;
+		});
+	}
+
+	async #settleTurn(
+		dispatch: {
+			feature: MissionFeature;
+			workerSessionId: string;
+			turn: number;
+		},
+		result: SingleResult | undefined,
+		failure: string | undefined,
+	): Promise<MissionHandoff | null> {
+		const parsed = this.#parseHandoff(dispatch.feature, result, failure);
+		return this.#withTransitionTail(async () => {
+			// Pause or cancel already won this race; the settling result never overwrites it.
+			const state = this.#activeRunFor(dispatch.feature.id, dispatch.workerSessionId, dispatch.turn);
+			if (!state) return null;
+			const nextStatus = state.status === "paused" || this.#pauseRequested ? "paused" : "orchestrator_turn";
+			await this.#commit(
+				{
+					...state,
+					activeRun: undefined,
+					pendingHandoff: parsed.handoff,
+					status: nextStatus,
+					pauseReason: nextStatus === "paused" ? (state.pauseReason ?? "user_requested") : undefined,
+				},
+				{
+					progress: parsed.failed
+						? { type: "worker_failed", featureId: dispatch.feature.id, workerSessionId: dispatch.workerSessionId }
+						: {
+								type: "worker_completed",
+								featureId: dispatch.feature.id,
+								workerSessionId: dispatch.workerSessionId,
+							},
+				},
+			);
+			return parsed.handoff;
+		});
+	}
+
+	#parseHandoff(
+		feature: MissionFeature,
+		result: SingleResult | undefined,
+		failure: string | undefined,
+	): { handoff: MissionHandoff; failed: boolean } {
+		const expectedRole = feature.kind === "validation" ? feature.validator : undefined;
+		const synth = (evidence: string, description: string): MissionHandoff =>
+			expectedRole
+				? syntheticValidationHandoff(expectedRole, evidence, description)
+				: syntheticImplementationHandoff(evidence, description);
+
+		if (failure !== undefined) {
+			return {
+				handoff: synth(sanitizeEvidence(failure), "Worker turn failed before producing a handoff"),
+				failed: true,
+			};
+		}
+		if (!result) {
+			return { handoff: synth("", "Worker turn produced no result"), failed: true };
+		}
+		if (result.aborted) {
+			return {
+				handoff: synth(sanitizeEvidence(result.abortReason ?? "aborted"), "Worker turn was aborted"),
+				failed: true,
+			};
+		}
+		if (result.exitCode !== 0 || result.error !== undefined) {
+			return {
+				handoff: synth(sanitizeEvidence(result.error ?? `exit ${result.exitCode}`), "Worker turn ended in error"),
+				failed: true,
+			};
+		}
+
+		const data = result.structuredOutput?.data;
+		const validator = expectedRole ? validationHandoffValidator : implementationHandoffValidator;
+		const validation = validator?.validate(data);
+		if (!validator || !validation?.success) {
+			const description = expectedRole
+				? "Validator handoff did not match the required schema"
+				: "Worker handoff did not match the required schema";
+			return { handoff: synth(schemaEvidenceFrom(validation?.issues ?? []), description), failed: true };
+		}
+
+		// Validated against the handoff JSON schema immediately above; kind/role are re-checked below.
+		const handoff = data as MissionHandoff;
+		if (expectedRole && (handoff.kind !== "validation" || handoff.role !== expectedRole)) {
+			return {
+				handoff: synth(
+					schemaEvidenceFrom([{ path: ["role"], message: `expected "${expectedRole}"` }]),
+					"Validator handoff did not match the required schema",
+				),
+				failed: true,
+			};
+		}
+		if (!expectedRole && handoff.kind !== "implementation") {
+			return {
+				handoff: synth(
+					schemaEvidenceFrom([{ path: ["kind"], message: 'expected "implementation"' }]),
+					"Worker handoff did not match the required schema",
+				),
+				failed: true,
+			};
+		}
+		return { handoff, failed: false };
+	}
+
+	// ── handoff resolution ──────────────────────────────────────────────────
+
+	async #acceptHandoff(state: MissionState, feature: MissionFeature, handoff: MissionHandoff): Promise<MissionState> {
+		if (!canAcceptPendingHandoff(handoff)) {
+			throw new MissionRuntimeError(
+				handoff.kind === "implementation"
+					? "Only a successful implementation handoff with no blocking issues can be accepted."
+					: "Only a passing validator handoff can be accepted.",
+			);
+		}
+		if (handoff.kind === "implementation") return this.#acceptImplementation(state, feature, handoff);
+		return this.#acceptValidator(feature);
+	}
+
+	async #acceptImplementation(
+		state: MissionState,
+		feature: MissionFeature,
+		handoff: MissionWorkerHandoff,
+	): Promise<MissionState> {
+		const repository = state.repository;
+		const workspace = feature.workspace;
+		if (!repository) throw new MissionRuntimeError("Mission has no repository state.");
+		if (workspace?.kind !== "feature") {
+			throw new MissionRuntimeError(`Feature "${feature.id}" has no feature workspace to integrate.`);
+		}
+		const expectedOldHead = workspace.baseSha;
+		const newHead = expectedIntegrationNewHead(handoff, expectedOldHead);
+
+		// Phase one: the intent is durable before the CAS.
+		await this.#withTransitionTail(() =>
+			this.#commit({
+				...this.#requireState(),
+				integrationPending: { featureId: feature.id, expectedOldHead, newHead },
+			}),
+		);
+		return this.#applyIntegration(feature.id, workspace, handoff);
+	}
+
+	/** Phase two: ancestry-checked CAS on the un-checked-out integration ref, then completion. */
+	async #applyIntegration(
+		featureId: string,
+		workspace: MissionFeatureWorkspaceDescriptor,
+		handoff: MissionWorkerHandoff,
+	): Promise<MissionState> {
+		const state = this.#requireState();
+		const repository = state.repository;
+		if (!repository) throw new MissionRuntimeError("Mission has no repository state.");
+
+		const outcome = await this.#guardExternal(() =>
+			this.#workspaces.advanceIntegration(repository, workspace, handoff),
+		);
+		switch (outcome.kind) {
+			case "advanced":
+			case "already_applied":
+				return this.#completeImplementation(featureId, workspace, outcome.repository);
+			case "partial_handoff": {
+				// Not provably safe: the handoff degrades to partial and stays on the orchestrator's turn.
+				const degraded: MissionWorkerHandoff = {
+					...handoff,
+					outcome: "partial",
+					issues: [...handoff.issues, ...outcome.issues],
+				};
+				return this.#withTransitionTail(() =>
+					this.#commit({ ...this.#requireState(), pendingHandoff: degraded, integrationPending: undefined }),
+				);
+			}
+			case "pause":
+				logger.info("Mission integration diverged", {
+					featureId,
+					integrationBranch: outcome.integrationBranch,
+					expectedOldHead: outcome.expectedOldHead,
+					actualHead: outcome.actualHead,
+				});
+				return this.#pauseWith(outcome.reason);
+			default:
+				return assertNever(outcome, "Unknown advanceIntegration result");
+		}
+	}
+
+	async #completeImplementation(
+		featureId: string,
+		workspace: MissionFeatureWorkspaceDescriptor,
+		repository: MissionRepositoryState,
+	): Promise<MissionState> {
+		const completed = await this.#withTransitionTail(async () => {
+			const state = this.#requireState();
+			const feature = featureById(state, featureId);
+			if (!feature) throw new MissionRuntimeError(`Feature "${featureId}" vanished during integration.`);
+			const milestone = milestoneOf(state, feature);
+			const publishCheck =
+				milestone.kind === "publish" && repository.publishCheck
+					? {
+							...repository.publishCheck,
+							integrationHead: repository.integrationHead,
+							phase: "validating" as const,
+						}
+					: repository.publishCheck;
+			const done: MissionFeature = {
+				...feature,
+				status: "completed",
+				completedWorkerSessionId: feature.currentWorkerSessionId,
+				currentWorkerSessionId: undefined,
+				nextRunIntent: undefined,
+			};
+			return this.#commit(
+				{
+					...replaceFeature(state, done),
+					repository: { ...repository, publishCheck },
+					pendingHandoff: undefined,
+					integrationPending: undefined,
+					status: "running",
+					pauseReason: undefined,
+				},
+				{ progress: { type: "handoff_resolved", featureId, decision: "accept" } },
+			);
+		});
+
+		// Only after the completed snapshot is durable may children and the worktree go.
+		const feature = featureById(completed, featureId);
+		if (feature) {
+			await this.#releaseWorkers(feature);
+			await this.#guardExternal(() => this.#workspaces.release(workspace)).catch(error =>
+				logger.warn("Mission feature workspace release failed", { featureId, error: String(error) }),
+			);
+		}
+		return this.#requireState();
+	}
+
+	async #acceptValidator(feature: MissionFeature): Promise<MissionState> {
+		const workspace = feature.workspace;
+		if (workspace?.kind !== "validator") {
+			throw new MissionRuntimeError(`Validator "${feature.id}" has no validator workspace.`);
+		}
+		const completed = await this.#withTransitionTail(() => {
+			const current = this.#requireState();
+			const done: MissionFeature = {
+				...feature,
+				status: "completed",
+				validatedHead: workspace.head,
+				completedWorkerSessionId: feature.currentWorkerSessionId,
+				currentWorkerSessionId: undefined,
+				nextRunIntent: undefined,
+			};
+			return this.#commit(
+				{ ...replaceFeature(current, done), pendingHandoff: undefined, status: "running", pauseReason: undefined },
+				{ progress: { type: "handoff_resolved", featureId: feature.id, decision: "accept" } },
+			);
+		});
+
+		await this.#releaseWorkers(feature);
+		const released = await this.#guardExternal(() => this.#workspaces.releaseIfEmpty(workspace)).catch(error => {
+			logger.warn("Mission validator workspace release failed", { featureId: feature.id, error: String(error) });
+			return false;
+		});
+		if (!released) return this.#pauseWith("validator_workspace_dirty");
+
+		await this.#maybeFinishMission(completed);
+		return this.#requireState();
+	}
+
+	async #retryHandoff(
+		feature: MissionFeature,
+		handoff: MissionHandoff,
+		decision: "retry_same" | "retry_fresh",
+		messageToWorker: string | undefined,
+	): Promise<MissionState> {
+		const mode: MissionNextRunMode = decision === "retry_same" ? "follow_up" : "fresh";
+		const message = messageToWorker?.trim() || handoffGapText(handoff);
+		if (decision === "retry_fresh") {
+			await this.#releaseWorkerId(feature.currentWorkerSessionId);
+		}
+
+		const retried = await this.#withTransitionTail(() => {
+			const current = this.#requireState();
+			const next: MissionFeature = {
+				...feature,
+				status: "pending",
+				currentWorkerSessionId: decision === "retry_same" ? feature.currentWorkerSessionId : undefined,
+				nextRunIntent: { mode, messageToWorker: message },
+			};
+			return this.#commit(
+				{ ...replaceFeature(current, next), pendingHandoff: undefined, status: "running", pauseReason: undefined },
+				{ progress: { type: "handoff_resolved", featureId: feature.id, decision } },
+			);
+		});
+
+		if (feature.retryBudgetUsed >= MISSION_WORKER_TURN_CAP) {
+			return this.#withTransitionTail(() =>
+				this.#commit(
+					{ ...this.#requireState(), status: "paused", pauseReason: "feature_retry_limit_exceeded" },
+					{ progress: { type: "paused", reason: "feature_retry_limit_exceeded" }, mode: "mission_paused" },
+				),
+			).then(paused => {
+				this.#pauseRequested = true;
+				return paused;
+			});
+		}
+		return retried;
+	}
+
+	async #cancelFeature(feature: MissionFeature): Promise<MissionState> {
+		if (feature.kind !== "implementation") {
+			throw new MissionRuntimeError("cancel_feature is legal only for implementation features.");
+		}
+		await this.#releaseWorkers(feature);
+		const workspace = feature.workspace;
+		if (workspace) {
+			await this.#guardExternal(() => this.#workspaces.releaseIfEmpty(workspace)).catch(error =>
+				logger.warn("Mission workspace preserved after cancel_feature", {
+					featureId: feature.id,
+					error: String(error),
+				}),
+			);
+		}
+		return this.#withTransitionTail(() => {
+			const current = this.#requireState();
+			const cancelled: MissionFeature = {
+				...feature,
+				status: "cancelled",
+				currentWorkerSessionId: undefined,
+				nextRunIntent: undefined,
+			};
+			const pruned = cancelUnsatisfiableFeatures(replaceFeature(current, cancelled));
+			return this.#commit(
+				{ ...pruned, pendingHandoff: undefined, status: "running", pauseReason: undefined },
+				{ progress: { type: "handoff_resolved", featureId: feature.id, decision: "cancel_feature" } },
+			);
+		});
+	}
+
+	// ── resume branches ─────────────────────────────────────────────────────
+
+	async #resumeSimple(state: MissionState, input?: { messageToWorker?: string }): Promise<MissionState> {
+		const status = state.pendingHandoff ? "orchestrator_turn" : "running";
+		const features = input?.messageToWorker
+			? state.features.map(feature =>
+					feature.status === "pending" && feature.nextRunIntent
+						? { ...feature, nextRunIntent: { ...feature.nextRunIntent, messageToWorker: input.messageToWorker } }
+						: feature,
+				)
+			: state.features;
+		this.#pauseRequested = false;
+		return this.#withTransitionTail(() =>
+			this.#commit(
+				{ ...this.#requireState(), features, status, pauseReason: undefined },
+				{ progress: { type: "resumed" }, mode: "mission" },
+			),
+		);
+	}
+
+	async #resumeRetryBudget(
+		state: MissionState,
+		input?: { restartWorker?: boolean; messageToWorker?: string },
+	): Promise<MissionState> {
+		const target =
+			state.features.find(
+				feature => feature.status === "pending" && feature.retryBudgetUsed >= MISSION_WORKER_TURN_CAP,
+			) ??
+			state.features.find(feature => feature.status === "pending" && feature.nextRunIntent) ??
+			state.features.find(feature => feature.status === "in_progress");
+		if (!target) return this.#resumeSimple(state, input);
+		const mode: MissionNextRunMode = input?.restartWorker
+			? "fresh"
+			: (target.nextRunIntent?.mode ?? (target.currentWorkerSessionId ? "follow_up" : "initial"));
+		if (mode === "fresh") await this.#releaseWorkerId(target.currentWorkerSessionId);
+		this.#pauseRequested = false;
+		return this.#withTransitionTail(() => {
+			const current = this.#requireState();
+			// A user resume resets only retryBudgetUsed; workerSessionIds are history.
+			const reset: MissionFeature = {
+				...target,
+				status: "pending",
+				retryBudgetUsed: 0,
+				currentWorkerSessionId: mode === "fresh" ? undefined : target.currentWorkerSessionId,
+				nextRunIntent: { mode, messageToWorker: input?.messageToWorker ?? target.nextRunIntent?.messageToWorker },
+			};
+			return this.#commit(
+				{ ...replaceFeature(current, reset), status: "running", pauseReason: undefined },
+				{ progress: { type: "resumed" }, mode: "mission" },
+			);
+		});
+	}
+
+	async #resumeWithIntent(
+		state: MissionState,
+		mode: MissionNextRunMode,
+		messageToWorker: string | undefined,
+	): Promise<MissionState> {
+		const target =
+			state.features.find(feature => feature.status === "pending" && feature.nextRunIntent) ??
+			state.features.find(feature => feature.status === "in_progress");
+		if (!target) return this.#resumeSimple(state, { messageToWorker });
+		if (mode === "fresh") await this.#releaseWorkerId(target.currentWorkerSessionId);
+		this.#pauseRequested = false;
+		return this.#withTransitionTail(() => {
+			const current = this.#requireState();
+			const next: MissionFeature = {
+				...target,
+				status: "pending",
+				currentWorkerSessionId: mode === "fresh" ? undefined : target.currentWorkerSessionId,
+				nextRunIntent: { mode, messageToWorker: messageToWorker ?? target.nextRunIntent?.messageToWorker },
+			};
+			return this.#commit(
+				{ ...replaceFeature(current, next), status: "running", pauseReason: undefined },
+				{ progress: { type: "resumed" }, mode: "mission" },
+			);
+		});
+	}
+
+	async #resumeInterrupted(
+		state: MissionState,
+		input?: { restartWorker?: boolean; messageToWorker?: string },
+	): Promise<MissionState> {
+		const target = state.features.find(feature => feature.status === "pending" && feature.nextRunIntent);
+		if (!target) return this.#resumeSimple(state, input);
+		const recovered = target.nextRunIntent?.mode ?? "initial";
+		const mode: MissionNextRunMode = input?.restartWorker ? "fresh" : recovered;
+		return this.#resumeWithIntent(state, mode, input?.messageToWorker ?? target.nextRunIntent?.messageToWorker);
+	}
+
+	async #resumeWorkspaceConflict(
+		state: MissionState,
+		input?: { restartWorker?: boolean; messageToWorker?: string },
+	): Promise<MissionState> {
+		const target = state.features.find(feature => feature.workspace && feature.status !== "completed");
+		const workspace = target?.workspace;
+		if (!target || !workspace) return this.#resumeSimple(state, input);
+		const result = await this.#guardExternal(() =>
+			this.#workspaces.reconcile(workspace, this.#hasChildTranscript(target.currentWorkerSessionId)),
+		);
+		if (result.kind !== "ready") {
+			throw new MissionRuntimeError(
+				`Workspace for "${target.id}" is still conflicted at ${result.path}: ${result.detail}`,
+			);
+		}
+		const reconciled = result.descriptor;
+		this.#pauseRequested = false;
+		return this.#withTransitionTail(() => {
+			const current = this.#requireState();
+			return this.#commit(
+				{
+					...replaceFeature(current, { ...target, workspace: reconciled }),
+					status: current.pendingHandoff ? "orchestrator_turn" : "running",
+					pauseReason: undefined,
+				},
+				{ progress: { type: "resumed" }, mode: "mission" },
+			);
+		});
+	}
+
+	async #resumeIntegrationDiverged(state: MissionState): Promise<MissionState> {
+		if (!state.integrationPending) return this.#resumeSimple(state);
+		const recovered = await this.#recoverIntegrationPending();
+		if (recovered.status === "paused") {
+			throw new MissionRuntimeError(
+				`Integration branch still diverged; reconcile ${state.repository?.integrationBranch ?? "the integration ref"} manually.`,
+			);
+		}
+		return recovered;
+	}
+
+	// ── integration-pending recovery ────────────────────────────────────────
+
+	async #recoverIntegrationPending(): Promise<MissionState> {
+		const state = this.#requireState();
+		const marker = state.integrationPending;
+		const repository = state.repository;
+		if (!marker || !repository) return state;
+		const feature = featureById(state, marker.featureId);
+		const workspace = feature?.workspace;
+		const handoff = state.pendingHandoff;
+		if (!feature || !workspace || workspace.kind !== "feature" || handoff?.kind !== "implementation") {
+			return this.#pauseWith("integration_diverged");
+		}
+
+		const integrationRef = toLocalBranchRef(repository.integrationBranch);
+		const actual = await this.#guardExternal(() => git.ref.resolve(repository.repoRoot, integrationRef));
+		if (actual === marker.newHead) {
+			return this.#completeImplementation(marker.featureId, workspace, {
+				...repository,
+				integrationHead: marker.newHead,
+			});
+		}
+		if (actual === marker.expectedOldHead) {
+			return this.#applyIntegration(marker.featureId, workspace, handoff);
+		}
+		logger.info("Mission integration ref moved outside the mission", {
+			featureId: marker.featureId,
+			expectedOldHead: marker.expectedOldHead,
+			newHead: marker.newHead,
+			actualHead: actual,
+		});
+		return this.#pauseWith("integration_diverged");
+	}
+
+	// ── publication ─────────────────────────────────────────────────────────
+
+	async #maybeFinishMission(state: MissionState): Promise<void> {
+		if (state.status !== "running" && state.status !== "orchestrator_turn") return;
+		if (state.pendingHandoff) return;
+		const unfinished = state.features.some(
+			feature => feature.status !== "completed" && feature.status !== "cancelled",
+		);
+		if (unfinished) return;
+		const pendingValidators = state.milestones.some(milestone =>
+			milestone.validators.some(
+				role =>
+					!state.features.some(
+						feature =>
+							feature.kind === "validation" &&
+							feature.milestoneId === milestone.id &&
+							feature.validator === role,
+					),
+			),
+		);
+		if (pendingValidators) return;
+		if (!state.repository) return;
+		await this.#publish(state.repository);
+	}
+
+	async #publish(repository: MissionRepositoryState): Promise<void> {
+		const repoRoot = repository.repoRoot;
+		const integrationRef = toLocalBranchRef(repository.integrationBranch);
+		const observed = await this.#guardExternal(async () => {
+			const branch = await git.branch.current(repoRoot);
+			const summary = await git.status.summary(repoRoot);
+			return {
+				branch,
+				clean: isCleanSummary(summary),
+				parentHead: await git.ref.resolve(repoRoot, "HEAD"),
+				integrationHead: await git.ref.resolve(repoRoot, integrationRef),
+			};
+		});
+		const parentHead = observed.parentHead;
+		const integrationHead = observed.integrationHead;
+		if (observed.branch !== repository.parentBranch || !observed.clean || !parentHead || !integrationHead) {
+			await this.#pauseWith("parent_diverged");
+			return;
+		}
+		if (parentHead === integrationHead) {
+			// Already applied (crash after the fast-forward, or an out-of-band merge of the exact head).
+			await this.#finishCompleted();
+			return;
+		}
+
+		const existing = repository.publishCheck;
+		const generation = existing?.generation ?? 0;
+		const expectedParent = existing ? existing.parentHead : repository.baseSha;
+		if (parentHead !== expectedParent || integrationHead !== repository.integrationHead) {
+			await this.#pauseWith("parent_diverged");
+			return;
+		}
+
+		// The exact heads are durable before the lock, so a crash after the merge is idempotent.
+		await this.#withTransitionTail(() => {
+			const state = this.#requireState();
+			const current = state.repository;
+			if (!current) throw new MissionRuntimeError("Mission has no repository state.");
+			return this.#commit({
+				...state,
+				repository: {
+					...current,
+					publishCheck: { parentHead, integrationHead: current.integrationHead, generation, phase: "validated" },
+				},
+			});
+		});
+
+		const merged = await this.#guardExternal(() =>
+			git.withRepoLock(repoRoot, async (): Promise<boolean> => {
+				const branch = await git.branch.current(repoRoot);
+				const summary = await git.status.summary(repoRoot);
+				if (
+					branch !== repository.parentBranch ||
+					!isCleanSummary(summary) ||
+					(await git.ref.resolve(repoRoot, "HEAD")) !== parentHead ||
+					(await git.ref.resolve(repoRoot, integrationRef)) !== integrationHead
+				) {
+					return false;
+				}
+				await git.merge.fastForwardOnly(repoRoot, repository.integrationBranch);
+				// The merge command succeeding is not evidence on its own: reread everything.
+				const afterBranch = await git.branch.current(repoRoot);
+				const afterSummary = await git.status.summary(repoRoot);
+				return (
+					afterBranch === repository.parentBranch &&
+					isCleanSummary(afterSummary) &&
+					(await git.ref.resolve(repoRoot, "HEAD")) === integrationHead &&
+					(await git.ref.resolve(repoRoot, integrationRef)) === integrationHead
+				);
+			}),
+		).catch(error => {
+			logger.warn("Mission publication fast-forward failed", { error: String(error) });
+			return false;
+		});
+
+		if (!merged) {
+			await this.#pauseWith("parent_diverged");
+			return;
+		}
+		await this.#finishCompleted();
+	}
+
+	async #finishCompleted(): Promise<void> {
+		await this.#withTransitionTail(() =>
+			this.#commit(
+				{
+					...this.#requireState(),
+					status: "completed",
+					pauseReason: undefined,
+					activeRun: undefined,
+					pendingHandoff: undefined,
+					integrationPending: undefined,
+				},
+				{ progress: { type: "completed" }, mode: "none" },
+			),
+		);
+		await this.#deactivateTool();
+		this.#unregisterAllRevivers();
+		const state = this.#requireState();
+		await this.#restoreTerminalCleanup(state);
+	}
+
+	/** parent_diverged resume: accept a manually rebased integration ref and open a new publication generation. */
+	async #resumePublication(state: MissionState): Promise<MissionState> {
+		const repository = state.repository;
+		if (!repository) throw new MissionRuntimeError("Mission has no repository state.");
+		const repoRoot = repository.repoRoot;
+		const integrationRef = toLocalBranchRef(repository.integrationBranch);
+		const observed = await this.#guardExternal(async () => {
+			const branch = await git.branch.current(repoRoot);
+			const summary = await git.status.summary(repoRoot);
+			const parentHead = await git.ref.resolve(repoRoot, "HEAD");
+			const integrationHead = await git.ref.resolve(repoRoot, integrationRef);
+			return { branch, clean: isCleanSummary(summary), parentHead, integrationHead };
+		});
+		const parentHead = observed.parentHead;
+		const integrationHead = observed.integrationHead;
+		if (observed.branch !== repository.parentBranch || !observed.clean || !parentHead || !integrationHead) {
+			throw new MissionRuntimeError(
+				`Publication requires a clean checkout attached to "${repository.parentBranch}" before resume.`,
+			);
+		}
+		const rebased = await this.#guardExternal(() => git.ref.isAncestor(repoRoot, parentHead, integrationHead));
+		if (!rebased) {
+			throw new MissionRuntimeError(
+				`Rebase "${repository.integrationBranch}" onto ${parentHead} before resuming publication.`,
+			);
+		}
+
+		const generation = (repository.publishCheck?.generation ?? 0) + 1;
+		const roles: MissionValidatorRole[] = [];
+		for (const milestone of state.milestones) {
+			if (milestone.kind !== "planned") continue;
+			for (const role of milestone.validators) {
+				if (!roles.includes(role)) roles.push(role);
+			}
+		}
+		const milestoneId = `_publish.${generation}`;
+		const publishMilestone: MissionMilestone = {
+			id: milestoneId,
+			kind: "publish",
+			generation,
+			description: "Publication validation",
+			featureIds: [],
+			validators: roles,
+		};
+		const publishFeatures: MissionFeature[] = roles.map(role => ({
+			id: `_validate.publish.${generation}.${role}`,
+			description: `${role} validation for publication generation ${generation}`,
+			milestoneId,
+			preconditions: [],
+			expectedBehavior: [
+				`Integration branch ${repository.integrationBranch} is safe to fast-forward onto ${repository.parentBranch}.`,
+			],
+			kind: "validation",
+			validator: role,
+			status: "pending",
+			workerSessionIds: [],
+			retryBudgetUsed: 0,
+		}));
+
+		this.#pauseRequested = false;
+		return this.#withTransitionTail(() =>
+			this.#commit(
+				{
+					...this.#requireState(),
+					repository: {
+						...repository,
+						integrationHead,
+						publishCheck: { parentHead, integrationHead, generation, phase: "validating" },
+					},
+					milestones: [...state.milestones, publishMilestone],
+					features: [...state.features, ...publishFeatures],
+					status: "running",
+					pauseReason: undefined,
+				},
+				{ progress: { type: "publish_validation_triggered", generation } },
+			),
+		);
+	}
+
+	// ── restore helpers ─────────────────────────────────────────────────────
+
+	/**
+	 * No model turn survives a process exit: an `in_progress` feature with a matching
+	 * token and no handoff is recovered, never silently redispatched.
+	 */
+	async #restoreInterruptedWorker(): Promise<void> {
+		const state = this.#state;
+		if (!state || state.pendingHandoff) return;
+		const active = state.activeRun;
+		if (!active) return;
+		const feature = featureById(state, active.featureId);
+		if (feature?.status !== "in_progress") return;
+		if (feature.currentWorkerSessionId !== active.workerSessionId) return;
+
+		const workspace = feature.workspace;
+		let mode: MissionNextRunMode = "initial";
+		let messageToWorker: string | undefined;
+		let conflicted = false;
+
+		if (!workspace) {
+			conflicted = true;
+		} else {
+			const result = await this.#guardExternal(() =>
+				this.#workspaces.reconcile(workspace, this.#hasChildTranscript(active.workerSessionId)),
+			).catch(error => {
+				logger.warn("Mission workspace reconcile failed during restore", {
+					featureId: feature.id,
+					error: String(error),
+				});
+				return null;
+			});
+			if (result?.kind !== "ready") {
+				conflicted = true;
+			} else if (this.#hasExactChildWorkspace(active.workerSessionId, result.descriptor)) {
+				mode = "follow_up";
+				const milestone = milestoneOf(state, feature);
+				messageToWorker = renderMissionPrompt("interrupted", {
+					feature: { id: feature.id, description: feature.description },
+					milestone: { id: milestone.id, description: milestone.description },
+					skillName: feature.skillName,
+					priorHandoffGap: undefined,
+				});
+			}
+		}
+
+		// The already-counted turn is preserved; only the token is cleared.
+		const recovered: MissionFeature = {
+			...feature,
+			status: "pending",
+			nextRunIntent: { mode, messageToWorker },
+		};
+		const reason: MissionPauseReason = conflicted ? "workspace_conflict" : "worker_interrupted";
+		await this.#withTransitionTail(async () => {
+			const current = this.#requireState();
+			const cleared = await this.#commit({ ...replaceFeature(current, recovered), activeRun: undefined });
+			await this.#commit(
+				{ ...cleared, status: "paused", pauseReason: reason },
+				{ progress: { type: "paused", reason }, mode: "mission_paused" },
+			);
+		});
+		this.#pauseRequested = true;
+	}
+
+	/** Terminal cleanup is idempotent, non-forcible, and preserves anything it cannot prove safe. */
+	async #restoreTerminalCleanup(state: MissionState): Promise<void> {
+		if (!this.#isOwner()) return;
+		for (const feature of state.features) {
+			const workspace = feature.workspace;
+			if (!workspace) continue;
+			const released = await this.#guardExternal(() => this.#workspaces.releaseIfEmpty(workspace)).catch(error => {
+				logger.warn("Mission workspace cleanup failed", { featureId: feature.id, error: String(error) });
+				return false;
+			});
+			if (!released) {
+				logger.info("workspace_cleanup_conflict", { featureId: feature.id, path: workspace.path });
+			}
+		}
+		if (state.status !== "completed") return;
+		const repository = state.repository;
+		if (!repository) return;
+		const integrationRef = toLocalBranchRef(repository.integrationBranch);
+		await this.#guardExternal(async () => {
+			const head = await git.ref.resolve(repository.repoRoot, integrationRef);
+			if (head === null) return;
+			if (head !== repository.integrationHead) {
+				logger.info("Mission integration branch preserved: ref changed", {
+					branch: repository.integrationBranch,
+					expected: repository.integrationHead,
+					actual: head,
+				});
+				return;
+			}
+			await git.branch.tryDelete(repository.repoRoot, repository.integrationBranch, { force: false });
+		}).catch(error => logger.warn("Mission integration branch cleanup failed", { error: String(error) }));
+	}
+
+	// ── child bookkeeping ───────────────────────────────────────────────────
+
+	#hasChildTranscript(workerSessionId: string | undefined): boolean {
+		if (!workerSessionId) return false;
+		const ref = AgentRegistry.global().get(workerSessionId);
+		return Boolean(ref?.sessionFile ?? ref?.session);
+	}
+
+	#hasExactChildWorkspace(workerSessionId: string, descriptor: MissionWorkspaceDescriptor): boolean {
+		if (!this.#hasChildTranscript(workerSessionId)) return false;
+		const session = AgentRegistry.global().get(workerSessionId)?.session;
+		if (!session) return true;
+		return session.sessionManager.getCwd() === descriptor.path;
+	}
+
+	#registerReviver(workerSessionId: string): void {
+		if (this.#reviverHandles.has(workerSessionId)) return;
+		const unregister = this.#host.registerPersistedReviver(workerSessionId);
+		if (unregister) this.#reviverHandles.set(workerSessionId, unregister);
+	}
+
+	#unregisterAllRevivers(): void {
+		for (const unregister of this.#reviverHandles.values()) unregister();
+		this.#reviverHandles.clear();
+	}
+
+	async #releaseWorkerId(workerSessionId: string | undefined): Promise<void> {
+		if (!workerSessionId) return;
+		this.#reviverHandles.get(workerSessionId)?.();
+		this.#reviverHandles.delete(workerSessionId);
+		await this.#host
+			.agentLifecycle()
+			.release(workerSessionId)
+			.catch(error => {
+				logger.warn("Mission worker release failed", { workerSessionId, error: String(error) });
+				return false;
+			});
+	}
+
+	async #releaseWorkers(feature: MissionFeature): Promise<void> {
+		for (const workerSessionId of feature.workerSessionIds) await this.#releaseWorkerId(workerSessionId);
+	}
+
+	#clearInactivity(): void {
+		if (this.#inactivityTimer) {
+			clearTimeout(this.#inactivityTimer);
+			this.#inactivityTimer = undefined;
+		}
+	}
+}
+
+/** The runtime surface `restartMission` drives; keeps the helper testable with a stub. */
+export type MissionRestartRuntime = Pick<MissionRuntime, "snapshot" | "resume" | "resolveHandoff">;
+
+/**
+ * `/mission restart` semantics expressed over the runtime primitives: release the
+ * current child and dispatch a fresh worker in the preserved feature workspace.
+ *
+ * A paused mission resumes with `restartWorker`, which clears the current worker id
+ * and records a `fresh` next-run intent. If that lands back on an unresolved handoff
+ * (the paused-handoff case), it is resolved as `retry_fresh` so the same workspace is
+ * reused by a brand-new child. Every other status is refused rather than guessed at.
+ *
+ * Callers MUST reject a busy runtime first — restart is illegal while a turn is in
+ * flight, and no primitive here can interrupt one.
+ *
+ * Exported so `/mission restart` and `mission_restart` share one definition of
+ * restart instead of drifting apart in two hosts.
+ */
+export async function restartMission(
+	runtime: MissionRestartRuntime,
+	messageToWorker?: string,
+): Promise<MissionState | null> {
+	const state = runtime.snapshot();
+	if (!state) throw new MissionRuntimeError("There is no mission to restart.");
+	if (isMissionTerminal(state)) {
+		throw new MissionRuntimeError(`Mission ${state.id} is already ${state.status}.`);
+	}
+
+	const resumed = state.status === "paused" ? await runtime.resume({ restartWorker: true, messageToWorker }) : state;
+	if (resumed.status === "orchestrator_turn" && resumed.pendingHandoff) {
+		return runtime.resolveHandoff({ decision: "retry_fresh", messageToWorker });
+	}
+	if (state.status === "paused") return resumed;
+	throw new MissionRuntimeError(
+		`restart requires a paused mission or a pending handoff (status is "${state.status}"); pause the mission first.`,
+	);
+}

--- a/packages/coding-agent/src/missions/runtime.ts
+++ b/packages/coding-agent/src/missions/runtime.ts
@@ -869,9 +869,13 @@ export class MissionRuntime implements MissionRuntimeContract {
 				resumed = await this.#resumePublication(state);
 				break;
 			case "validator_workspace_dirty":
-				throw new MissionRuntimeError(
-					"A dirty validator checkout cannot be resumed. Clean the checkout, then use /mission restart.",
-				);
+				if (!input?.restartWorker) {
+					throw new MissionRuntimeError(
+						"A dirty validator checkout cannot be resumed. Clean the checkout, then restart the mission.",
+					);
+				}
+				resumed = await this.#resumeValidatorWorkspaceDirty(state);
+				break;
 			default:
 				return assertNever(reason, "Unknown mission pause reason");
 		}
@@ -1987,6 +1991,28 @@ export class MissionRuntime implements MissionRuntimeContract {
 				{ progress: { type: "resumed" }, mode: "mission" },
 			),
 		);
+	}
+
+	async #resumeValidatorWorkspaceDirty(state: MissionState): Promise<MissionState> {
+		const validators = state.features.filter(
+			feature => feature.kind === "validation" && feature.workspace?.kind === "validator",
+		);
+		if (validators.length === 0) {
+			throw new MissionRuntimeError("Paused mission has no validator workspace to recover.");
+		}
+		for (const validator of validators) {
+			const workspace = validator.workspace;
+			if (workspace?.kind !== "validator") continue;
+			const released = await this.#guardExternal(() => this.#workspaces.releaseIfEmpty(workspace));
+			if (!released) {
+				throw new MissionRuntimeError(
+					`Validator workspace for "${validator.id}" is still dirty at ${workspace.path}.`,
+				);
+			}
+		}
+		const resumed = await this.#resumeSimple(state);
+		await this.#maybeFinishMission(resumed);
+		return this.#requireState();
 	}
 
 	async #resumeRetryBudget(

--- a/packages/coding-agent/src/missions/state.ts
+++ b/packages/coding-agent/src/missions/state.ts
@@ -33,7 +33,7 @@ export class MissionStateError extends Error {
 	override readonly name = "MissionStateError";
 }
 
-const MISSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+export const MISSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 
 const MISSION_STATUSES = [
 	"planning",
@@ -336,7 +336,7 @@ function handoffIsSuccessfulImplementation(handoff: MissionHandoff): handoff is 
 	return !handoff.issues.some(issue => issue.severity === "blocking");
 }
 
-function expectedIntegrationNewHead(handoff: MissionWorkerHandoff, expectedOldHead: string): string {
+export function expectedIntegrationNewHead(handoff: MissionWorkerHandoff, expectedOldHead: string): string {
 	if (handoff.commits.length === 0) {
 		return expectedOldHead;
 	}

--- a/packages/coding-agent/src/missions/state.ts
+++ b/packages/coding-agent/src/missions/state.ts
@@ -1,8 +1,10 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
 import type { SessionEntry } from "../session/session-entries";
 import type {
 	MissionFeature,
 	MissionFeatureStatus,
 	MissionHandoff,
+	MissionHandoffDecision,
 	MissionIntegrationPending,
 	MissionPauseReason,
 	MissionPlan,
@@ -53,10 +55,6 @@ const FEATURE_STATUSES = [
 
 const VALIDATOR_ROLES = ["scrutiny", "user-testing"] as const satisfies readonly MissionValidatorRole[];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isNonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
 }
@@ -73,15 +71,19 @@ const PAUSE_REASONS = [
 	"validator_workspace_dirty",
 ] as const satisfies readonly MissionPauseReason[];
 
-const HANDOFF_RESOLVE_DECISIONS = ["accept", "retry_same", "retry_fresh", "cancel_feature", "pause"] as const;
+const HANDOFF_RESOLVE_DECISIONS = [
+	"accept",
+	"retry_same",
+	"retry_fresh",
+	"cancel_feature",
+	"pause",
+] as const satisfies readonly MissionHandoffDecision[];
 
 function isMissionPauseReason(value: unknown): value is MissionPauseReason {
 	return typeof value === "string" && (PAUSE_REASONS as readonly string[]).includes(value);
 }
 
-function isHandoffResolveDecision(
-	value: unknown,
-): value is "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause" {
+function isHandoffResolveDecision(value: unknown): value is MissionHandoffDecision {
 	return typeof value === "string" && (HANDOFF_RESOLVE_DECISIONS as readonly string[]).includes(value);
 }
 
@@ -91,6 +93,11 @@ function assertNever(value: never, message: string): never {
 
 function formatIdList(ids: Iterable<string>): string {
 	return [...ids].join(", ");
+}
+
+/** user-testing needs something to drive: at least one runbook command or one declared service. */
+export function runbookSupportsUserTesting(runbook: MissionPlan["runbook"]): boolean {
+	return runbook.userTests.length > 0 || runbook.services.length > 0;
 }
 
 /** Reject empty goals/milestones/features/expectedBehavior/validators and all structural plan rules. */
@@ -118,6 +125,7 @@ export function validateMissionPlan(plan: MissionPlan): MissionPlanValidationRes
 	const milestoneIndex = new Map<string, number>();
 	const featureById = new Map<string, MissionPlan["features"][number]>();
 	const membershipCount = new Map<string, number>();
+	const supportsUserTesting = runbookSupportsUserTesting(plan.runbook);
 
 	for (let i = 0; i < plan.milestones.length; i++) {
 		const milestone = plan.milestones[i]!;
@@ -158,14 +166,10 @@ export function validateMissionPlan(plan: MissionPlan): MissionPlanValidationRes
 					errors.push(`Milestone "${milestone.id}" has duplicate validator role "${role}"`);
 				}
 				seenRoles.add(role);
-				if (role === "user-testing") {
-					const hasUserTestCommand = plan.runbook.userTests.length > 0;
-					const hasService = plan.runbook.services.length > 0;
-					if (!hasUserTestCommand && !hasService) {
-						errors.push(
-							`Milestone "${milestone.id}" requests user-testing but runbook has no userTests command or service`,
-						);
-					}
+				if (role === "user-testing" && !supportsUserTesting) {
+					errors.push(
+						`Milestone "${milestone.id}" requests user-testing but runbook has no userTests command or service`,
+					);
 				}
 			}
 		}
@@ -894,8 +898,7 @@ export function canAcceptPendingHandoff(handoff: MissionHandoff): boolean {
 
 /** Milestone default validators: scrutiny + user-testing when the runbook supports it, else scrutiny alone. */
 export function defaultMilestoneValidators(runbook: MissionPlan["runbook"]): MissionValidatorRole[] {
-	const supportsUserTesting = runbook.userTests.length > 0 || runbook.services.length > 0;
-	if (supportsUserTesting) {
+	if (runbookSupportsUserTesting(runbook)) {
 		return ["scrutiny", "user-testing"];
 	}
 	return ["scrutiny"];

--- a/packages/coding-agent/src/missions/state.ts
+++ b/packages/coding-agent/src/missions/state.ts
@@ -1,0 +1,910 @@
+import type { SessionEntry } from "../session/session-entries";
+import type {
+	MissionFeature,
+	MissionFeatureStatus,
+	MissionHandoff,
+	MissionIntegrationPending,
+	MissionPauseReason,
+	MissionPlan,
+	MissionProgressEvent,
+	MissionPublishCheck,
+	MissionRepositoryState,
+	MissionState,
+	MissionStatus,
+	MissionValidatorRole,
+	MissionWorkerHandoff,
+	MissionWorkspaceDescriptor,
+} from "./types";
+import { MISSION_PROGRESS_CUSTOM_TYPE, MISSION_STATE_CUSTOM_TYPE } from "./types";
+
+export interface MissionPlanValidationResult {
+	valid: boolean;
+	errors: string[];
+}
+
+export interface NextMissionFeatureResult {
+	state: MissionState;
+	feature: MissionFeature | null;
+}
+
+export class MissionStateError extends Error {
+	override readonly name = "MissionStateError";
+}
+
+const MISSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+const MISSION_STATUSES = [
+	"planning",
+	"awaiting_input",
+	"initializing",
+	"running",
+	"paused",
+	"orchestrator_turn",
+	"completed",
+	"cancelled",
+] as const satisfies readonly MissionStatus[];
+
+const FEATURE_STATUSES = [
+	"pending",
+	"in_progress",
+	"completed",
+	"cancelled",
+] as const satisfies readonly MissionFeatureStatus[];
+
+const VALIDATOR_ROLES = ["scrutiny", "user-testing"] as const satisfies readonly MissionValidatorRole[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+const PAUSE_REASONS = [
+	"user_requested",
+	"feature_retry_limit_exceeded",
+	"worker_inactive",
+	"worker_interrupted",
+	"repository_dirty",
+	"workspace_conflict",
+	"integration_diverged",
+	"parent_diverged",
+	"validator_workspace_dirty",
+] as const satisfies readonly MissionPauseReason[];
+
+const HANDOFF_RESOLVE_DECISIONS = ["accept", "retry_same", "retry_fresh", "cancel_feature", "pause"] as const;
+
+function isMissionPauseReason(value: unknown): value is MissionPauseReason {
+	return typeof value === "string" && (PAUSE_REASONS as readonly string[]).includes(value);
+}
+
+function isHandoffResolveDecision(
+	value: unknown,
+): value is "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause" {
+	return typeof value === "string" && (HANDOFF_RESOLVE_DECISIONS as readonly string[]).includes(value);
+}
+
+function assertNever(value: never, message: string): never {
+	throw new MissionStateError(`${message}: ${JSON.stringify(value)}`);
+}
+
+function formatIdList(ids: Iterable<string>): string {
+	return [...ids].join(", ");
+}
+
+/** Reject empty goals/milestones/features/expectedBehavior/validators and all structural plan rules. */
+export function validateMissionPlan(plan: MissionPlan): MissionPlanValidationResult {
+	const errors: string[] = [];
+
+	if (!isNonEmptyString(plan.goal)) {
+		errors.push("Plan goal must be a non-empty string");
+	}
+
+	if (!Array.isArray(plan.milestones) || plan.milestones.length === 0) {
+		errors.push("Plan must include at least one milestone");
+	}
+
+	if (!Array.isArray(plan.features) || plan.features.length === 0) {
+		errors.push("Plan must include at least one feature");
+	}
+
+	if (errors.length > 0) {
+		return { valid: false, errors };
+	}
+
+	const milestoneIds = new Set<string>();
+	const featureIds = new Set<string>();
+	const milestoneIndex = new Map<string, number>();
+	const featureById = new Map<string, MissionPlan["features"][number]>();
+	const membershipCount = new Map<string, number>();
+
+	for (let i = 0; i < plan.milestones.length; i++) {
+		const milestone = plan.milestones[i]!;
+		if (!isNonEmptyString(milestone.id)) {
+			errors.push(`Milestone at index ${i} has an empty id`);
+			continue;
+		}
+		if (!MISSION_ID_PATTERN.test(milestone.id)) {
+			errors.push(`Milestone id "${milestone.id}" must match ${MISSION_ID_PATTERN}`);
+		}
+		if (milestone.id.startsWith("_")) {
+			errors.push(`User milestone id "${milestone.id}" may not begin with "_"`);
+		}
+		if (milestoneIds.has(milestone.id)) {
+			errors.push(`Duplicate milestone id "${milestone.id}"`);
+		}
+		milestoneIds.add(milestone.id);
+		milestoneIndex.set(milestone.id, i);
+
+		if (!Array.isArray(milestone.featureIds) || milestone.featureIds.length === 0) {
+			errors.push(`Milestone "${milestone.id}" must list at least one feature id`);
+		} else {
+			for (const featureId of milestone.featureIds) {
+				membershipCount.set(featureId, (membershipCount.get(featureId) ?? 0) + 1);
+			}
+		}
+
+		if (!Array.isArray(milestone.validators) || milestone.validators.length === 0) {
+			errors.push(`Milestone "${milestone.id}" must list at least one validator`);
+		} else {
+			const seenRoles = new Set<MissionValidatorRole>();
+			for (const role of milestone.validators) {
+				if (!VALIDATOR_ROLES.includes(role)) {
+					errors.push(`Milestone "${milestone.id}" has unknown validator role "${String(role)}"`);
+					continue;
+				}
+				if (seenRoles.has(role)) {
+					errors.push(`Milestone "${milestone.id}" has duplicate validator role "${role}"`);
+				}
+				seenRoles.add(role);
+				if (role === "user-testing") {
+					const hasUserTestCommand = plan.runbook.userTests.length > 0;
+					const hasService = plan.runbook.services.length > 0;
+					if (!hasUserTestCommand && !hasService) {
+						errors.push(
+							`Milestone "${milestone.id}" requests user-testing but runbook has no userTests command or service`,
+						);
+					}
+				}
+			}
+		}
+	}
+
+	for (let i = 0; i < plan.features.length; i++) {
+		const feature = plan.features[i]!;
+		if (!isNonEmptyString(feature.id)) {
+			errors.push(`Feature at index ${i} has an empty id`);
+			continue;
+		}
+		if (!MISSION_ID_PATTERN.test(feature.id)) {
+			errors.push(`Feature id "${feature.id}" must match ${MISSION_ID_PATTERN}`);
+		}
+		if (feature.id.startsWith("_")) {
+			errors.push(`User feature id "${feature.id}" may not begin with "_"`);
+		}
+		if (featureIds.has(feature.id)) {
+			errors.push(`Duplicate feature id "${feature.id}"`);
+		}
+		featureIds.add(feature.id);
+		featureById.set(feature.id, feature);
+
+		if (!isNonEmptyString(feature.milestoneId)) {
+			errors.push(`Feature "${feature.id}" has an empty milestoneId`);
+		} else if (!milestoneIds.has(feature.milestoneId)) {
+			errors.push(`Feature "${feature.id}" references missing milestone "${feature.milestoneId}"`);
+		}
+
+		if (!Array.isArray(feature.expectedBehavior) || feature.expectedBehavior.length === 0) {
+			errors.push(`Feature "${feature.id}" must list at least one expectedBehavior item`);
+		}
+
+		if (!Array.isArray(feature.preconditions)) {
+			errors.push(`Feature "${feature.id}" preconditions must be an array`);
+		}
+	}
+
+	for (const milestone of plan.milestones) {
+		for (const featureId of milestone.featureIds) {
+			if (!featureIds.has(featureId)) {
+				errors.push(`Milestone "${milestone.id}" references missing feature "${featureId}"`);
+				continue;
+			}
+			const feature = featureById.get(featureId);
+			if (feature && feature.milestoneId !== milestone.id) {
+				errors.push(
+					`Feature "${featureId}" is listed under milestone "${milestone.id}" but feature.milestoneId is "${feature.milestoneId}"`,
+				);
+			}
+		}
+	}
+
+	for (const feature of plan.features) {
+		const count = membershipCount.get(feature.id) ?? 0;
+		if (count === 0) {
+			errors.push(`Feature "${feature.id}" is not listed in any milestone.featureIds`);
+		} else if (count > 1) {
+			errors.push(`Feature "${feature.id}" appears in more than one milestone.featureIds list`);
+		}
+	}
+
+	for (const feature of plan.features) {
+		const featureMilestoneIndex = milestoneIndex.get(feature.milestoneId);
+		if (featureMilestoneIndex === undefined) {
+			continue;
+		}
+		for (const preconditionId of feature.preconditions) {
+			if (!featureIds.has(preconditionId)) {
+				errors.push(`Feature "${feature.id}" references missing precondition "${preconditionId}"`);
+				continue;
+			}
+			const precondition = featureById.get(preconditionId);
+			if (!precondition) {
+				continue;
+			}
+			const preconditionMilestoneIndex = milestoneIndex.get(precondition.milestoneId);
+			if (preconditionMilestoneIndex !== undefined && preconditionMilestoneIndex > featureMilestoneIndex) {
+				errors.push(`Feature "${feature.id}" depends on "${preconditionId}" from a later milestone`);
+			}
+		}
+	}
+
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+	const cycleParticipants = new Set<string>();
+
+	const visit = (featureId: string, stack: string[]): void => {
+		if (visited.has(featureId) || cycleParticipants.has(featureId)) {
+			return;
+		}
+		if (visiting.has(featureId)) {
+			const cycleStart = stack.indexOf(featureId);
+			for (const id of stack.slice(cycleStart >= 0 ? cycleStart : 0)) {
+				cycleParticipants.add(id);
+			}
+			cycleParticipants.add(featureId);
+			return;
+		}
+		visiting.add(featureId);
+		const feature = featureById.get(featureId);
+		if (feature) {
+			for (const preconditionId of feature.preconditions) {
+				if (featureIds.has(preconditionId)) {
+					visit(preconditionId, [...stack, featureId]);
+				}
+			}
+		}
+		visiting.delete(featureId);
+		visited.add(featureId);
+	};
+
+	for (const featureId of featureIds) {
+		visit(featureId, []);
+	}
+	if (cycleParticipants.size > 0) {
+		errors.push(`Feature precondition graph contains a cycle involving: ${formatIdList(cycleParticipants)}`);
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+function isTerminalStatus(status: MissionStatus): boolean {
+	switch (status) {
+		case "completed":
+		case "cancelled":
+			return true;
+		case "planning":
+		case "awaiting_input":
+		case "initializing":
+		case "running":
+		case "paused":
+		case "orchestrator_turn":
+			return false;
+		default:
+			return assertNever(status, "Unknown mission status");
+	}
+}
+
+function isPlanningOrAwaiting(status: MissionStatus): boolean {
+	switch (status) {
+		case "planning":
+		case "awaiting_input":
+			return true;
+		case "initializing":
+		case "running":
+		case "paused":
+		case "orchestrator_turn":
+		case "completed":
+		case "cancelled":
+			return false;
+		default:
+			return assertNever(status, "Unknown mission status");
+	}
+}
+
+function handoffIsSuccessfulImplementation(handoff: MissionHandoff): handoff is MissionWorkerHandoff {
+	if (handoff.kind !== "implementation") {
+		return false;
+	}
+	if (handoff.outcome !== "success") {
+		return false;
+	}
+	return !handoff.issues.some(issue => issue.severity === "blocking");
+}
+
+function expectedIntegrationNewHead(handoff: MissionWorkerHandoff, expectedOldHead: string): string {
+	if (handoff.commits.length === 0) {
+		return expectedOldHead;
+	}
+	return handoff.commits[handoff.commits.length - 1]!;
+}
+
+function workspaceMatchesFeatureKind(feature: MissionFeature, workspace: MissionWorkspaceDescriptor): boolean {
+	switch (feature.kind) {
+		case "implementation":
+			return workspace.kind === "feature";
+		case "validation":
+			return workspace.kind === "validator";
+		default:
+			return assertNever(feature.kind, "Unknown feature kind");
+	}
+}
+
+function collectProgressEvents(entries: readonly SessionEntry[], missionId: string): MissionProgressEvent[] {
+	const events: MissionProgressEvent[] = [];
+	for (const entry of entries) {
+		if (entry.type !== "custom" || entry.customType !== MISSION_PROGRESS_CUSTOM_TYPE) {
+			continue;
+		}
+		const parsed = parseMissionProgressEvent(entry.data);
+		if (parsed.missionId === missionId) {
+			events.push(parsed);
+		}
+	}
+	return events;
+}
+
+function parseMissionProgressEvent(data: unknown): MissionProgressEvent {
+	if (!isRecord(data)) {
+		throw new MissionStateError("mission-progress entry data must be an object");
+	}
+	if (typeof data.missionId !== "string" || typeof data.sequence !== "number" || typeof data.at !== "number") {
+		throw new MissionStateError("mission-progress entry missing missionId, sequence, or at");
+	}
+	if (typeof data.type !== "string") {
+		throw new MissionStateError("mission-progress entry missing type discriminator");
+	}
+
+	const base = {
+		missionId: data.missionId,
+		sequence: data.sequence,
+		at: data.at,
+	};
+
+	switch (data.type) {
+		case "accepted":
+		case "resumed":
+		case "run_started":
+		case "completed":
+		case "cancelled":
+			return { ...base, type: data.type };
+		case "paused":
+			if (!isMissionPauseReason(data.reason)) {
+				throw new MissionStateError("paused progress event requires a valid reason");
+			}
+			return { ...base, type: "paused", reason: data.reason };
+		case "feature_selected":
+			if (typeof data.featureId !== "string") {
+				throw new MissionStateError("feature_selected progress event requires featureId");
+			}
+			return { ...base, type: "feature_selected", featureId: data.featureId };
+		case "worker_started":
+		case "worker_completed":
+			if (typeof data.featureId !== "string" || typeof data.workerSessionId !== "string") {
+				throw new MissionStateError(`${data.type} progress event requires featureId and workerSessionId`);
+			}
+			return {
+				...base,
+				type: data.type,
+				featureId: data.featureId,
+				workerSessionId: data.workerSessionId,
+			};
+		case "worker_failed":
+			if (typeof data.featureId !== "string") {
+				throw new MissionStateError("worker_failed progress event requires featureId");
+			}
+			return {
+				...base,
+				type: "worker_failed",
+				featureId: data.featureId,
+				workerSessionId: typeof data.workerSessionId === "string" ? data.workerSessionId : undefined,
+			};
+		case "heartbeat":
+			if (
+				typeof data.featureId !== "string" ||
+				typeof data.workerSessionId !== "string" ||
+				typeof data.requests !== "number" ||
+				typeof data.tokens !== "number" ||
+				typeof data.cost !== "number"
+			) {
+				throw new MissionStateError(
+					"heartbeat progress event requires featureId, workerSessionId, requests, tokens, and cost",
+				);
+			}
+			return {
+				...base,
+				type: "heartbeat",
+				featureId: data.featureId,
+				workerSessionId: data.workerSessionId,
+				requests: data.requests,
+				tokens: data.tokens,
+				cost: data.cost,
+			};
+		case "handoff_resolved":
+			if (typeof data.featureId !== "string" || !isHandoffResolveDecision(data.decision)) {
+				throw new MissionStateError("handoff_resolved progress event requires featureId and decision");
+			}
+			return {
+				...base,
+				type: "handoff_resolved",
+				featureId: data.featureId,
+				decision: data.decision,
+			};
+		case "milestone_validation_triggered":
+			if (typeof data.milestoneId !== "string") {
+				throw new MissionStateError("milestone_validation_triggered progress event requires milestoneId");
+			}
+			return { ...base, type: "milestone_validation_triggered", milestoneId: data.milestoneId };
+		case "publish_validation_triggered":
+			if (typeof data.generation !== "number") {
+				throw new MissionStateError("publish_validation_triggered progress event requires generation");
+			}
+			return { ...base, type: "publish_validation_triggered", generation: data.generation };
+		default:
+			throw new MissionStateError(`Unknown mission-progress type "${data.type}"`);
+	}
+}
+
+function validateProgressSequences(events: readonly MissionProgressEvent[]): void {
+	if (events.length === 0) {
+		return;
+	}
+	const sorted = [...events].sort((a, b) => a.sequence - b.sequence);
+	for (let i = 0; i < sorted.length; i++) {
+		const expected = i === 0 ? sorted[0]!.sequence : sorted[i - 1]!.sequence + 1;
+		if (sorted[i]!.sequence !== expected) {
+			throw new MissionStateError(
+				`Mission progress event sequences must increase by one (expected ${expected}, got ${sorted[i]!.sequence})`,
+			);
+		}
+	}
+	// Append-only transcript order must match sequence order.
+	for (let i = 0; i < events.length; i++) {
+		if (events[i]!.sequence !== sorted[i]!.sequence) {
+			throw new MissionStateError("Mission progress events are out of sequence order in the transcript");
+		}
+	}
+}
+
+function validatePublishCheck(
+	state: MissionState,
+	publishCheck: MissionPublishCheck,
+	repository: MissionRepositoryState,
+): void {
+	if (publishCheck.integrationHead !== repository.integrationHead) {
+		throw new MissionStateError("Publish check integrationHead must match repository.integrationHead");
+	}
+
+	if (publishCheck.generation === 0) {
+		if (publishCheck.phase === "validated") {
+			for (const milestone of state.milestones) {
+				if (milestone.kind !== "planned") {
+					continue;
+				}
+				for (const role of milestone.validators) {
+					const validator = state.features.find(
+						feature =>
+							feature.kind === "validation" &&
+							feature.milestoneId === milestone.id &&
+							feature.validator === role,
+					);
+					if (validator?.status !== "completed") {
+						throw new MissionStateError(
+							`Generation 0 validated publish check requires completed planned validator ${milestone.id}/${role}`,
+						);
+					}
+				}
+			}
+		}
+		return;
+	}
+
+	const publishMilestones = state.milestones.filter(
+		milestone => milestone.kind === "publish" && milestone.id === `_publish.${publishCheck.generation}`,
+	);
+	if (publishMilestones.length !== 1) {
+		throw new MissionStateError(
+			`Publish generation ${publishCheck.generation} must match exactly one _publish.${publishCheck.generation} milestone`,
+		);
+	}
+	const publishMilestone = publishMilestones[0]!;
+	if (publishMilestone.generation !== publishCheck.generation) {
+		throw new MissionStateError(
+			`Publish milestone generation must equal publish check generation ${publishCheck.generation}`,
+		);
+	}
+
+	if (publishCheck.phase === "validated") {
+		for (const role of publishMilestone.validators) {
+			const validator = state.features.find(
+				feature =>
+					feature.kind === "validation" &&
+					feature.milestoneId === publishMilestone.id &&
+					feature.validator === role,
+			);
+			if (validator?.status !== "completed") {
+				throw new MissionStateError(
+					`Validated publish check requires completed validator ${publishMilestone.id}/${role}`,
+				);
+			}
+			if (validator.validatedHead !== publishCheck.integrationHead) {
+				throw new MissionStateError(
+					`Validated publish validator "${validator.id}" validatedHead must equal publishCheck.integrationHead`,
+				);
+			}
+			if (validator.workspace?.kind !== "validator") {
+				throw new MissionStateError(
+					`Validated publish validator "${validator.id}" must retain a validator workspace`,
+				);
+			}
+			if (validator.validatedHead !== validator.workspace.head) {
+				throw new MissionStateError(
+					`Validated publish validator "${validator.id}" validatedHead must equal workspace.head`,
+				);
+			}
+		}
+	}
+}
+
+function validateIntegrationPending(state: MissionState, marker: MissionIntegrationPending): void {
+	if (!state.repository) {
+		throw new MissionStateError("Integration-pending marker requires repository state");
+	}
+	if (!state.pendingHandoff) {
+		throw new MissionStateError("Integration-pending marker requires a pending handoff");
+	}
+	if (!handoffIsSuccessfulImplementation(state.pendingHandoff)) {
+		throw new MissionStateError("Integration-pending marker requires a successful implementation handoff");
+	}
+
+	const feature = state.features.find(item => item.id === marker.featureId);
+	if (!feature) {
+		throw new MissionStateError(`Integration-pending marker references missing feature "${marker.featureId}"`);
+	}
+	if (feature.kind !== "implementation") {
+		throw new MissionStateError("Integration-pending marker must name an implementation feature");
+	}
+	if (feature.status !== "in_progress") {
+		throw new MissionStateError(
+			"Integration-pending marker must name the current in_progress implementation feature",
+		);
+	}
+	if (feature.workspace?.kind !== "feature") {
+		throw new MissionStateError("Integration-pending marker requires a feature workspace");
+	}
+	if (
+		marker.expectedOldHead !== feature.workspace.baseSha ||
+		marker.expectedOldHead !== state.repository.integrationHead
+	) {
+		throw new MissionStateError(
+			"Integration-pending expectedOldHead must equal workspace.baseSha and repository.integrationHead",
+		);
+	}
+
+	const expectedNewHead = expectedIntegrationNewHead(state.pendingHandoff, marker.expectedOldHead);
+	if (marker.newHead !== expectedNewHead) {
+		throw new MissionStateError(
+			`Integration-pending newHead must be ${expectedNewHead} (empty commits keep expectedOldHead; otherwise last oldest-first commit)`,
+		);
+	}
+}
+
+/** Snapshot invariants for a restored MissionState (throws MissionStateError on violation). */
+export function assertMissionStateInvariants(
+	state: MissionState,
+	progressEvents: readonly MissionProgressEvent[] = [],
+): void {
+	if (state.version !== 1) {
+		throw new MissionStateError(`Unsupported mission state version ${String(state.version)}`);
+	}
+
+	const inProgress = state.features.filter(feature => feature.status === "in_progress");
+	if (inProgress.length > 1) {
+		throw new MissionStateError("At most one feature may be in_progress");
+	}
+	const inProgressFeature = inProgress[0];
+
+	if (state.activeRun) {
+		if (!inProgressFeature || state.activeRun.featureId !== inProgressFeature.id) {
+			throw new MissionStateError("Active-run token must match the in_progress feature");
+		}
+		if (inProgressFeature.currentWorkerSessionId !== state.activeRun.workerSessionId) {
+			throw new MissionStateError("Active-run token must match the in_progress feature current worker");
+		}
+	}
+
+	if (state.pendingHandoff) {
+		if (!inProgressFeature) {
+			throw new MissionStateError("Pending handoff requires an in_progress feature");
+		}
+		if (state.activeRun) {
+			throw new MissionStateError("Pending handoff excludes an active run");
+		}
+	}
+
+	switch (state.status) {
+		case "orchestrator_turn":
+			if (!state.pendingHandoff) {
+				throw new MissionStateError("orchestrator_turn requires a pending handoff");
+			}
+			break;
+		case "planning":
+		case "awaiting_input":
+			if (state.repository) {
+				throw new MissionStateError(`${state.status} must not have a repository`);
+			}
+			for (const feature of state.features) {
+				if (feature.workspace) {
+					throw new MissionStateError(`${state.status} must not have feature workspaces`);
+				}
+			}
+			break;
+		case "completed":
+		case "cancelled":
+			if (state.activeRun) {
+				throw new MissionStateError("Terminal mission states must not have an active run");
+			}
+			if (state.pendingHandoff) {
+				throw new MissionStateError("Terminal mission states must not have a pending handoff");
+			}
+			break;
+		case "initializing":
+		case "running":
+		case "paused":
+			break;
+		default:
+			assertNever(state.status, "Unknown mission status");
+	}
+
+	for (const feature of state.features) {
+		if (feature.workspace && feature.workspace.ownerSessionId !== state.ownerSessionId) {
+			throw new MissionStateError(`Workspace owner for feature "${feature.id}" must equal mission ownerSessionId`);
+		}
+		if (feature.workspace && !workspaceMatchesFeatureKind(feature, feature.workspace)) {
+			throw new MissionStateError(
+				`Workspace kind for feature "${feature.id}" must match feature kind "${feature.kind}"`,
+			);
+		}
+		for (const workerSessionId of feature.workerSessionIds) {
+			if (typeof workerSessionId !== "string" || workerSessionId.length === 0) {
+				throw new MissionStateError(`Feature "${feature.id}" has an empty worker session id`);
+			}
+		}
+
+		if (feature.kind === "validation" && feature.status === "completed") {
+			if (feature.validatedHead === undefined) {
+				throw new MissionStateError(`Completed validator "${feature.id}" must retain validatedHead`);
+			}
+			if (feature.workspace?.kind !== "validator") {
+				throw new MissionStateError(
+					`Completed validator "${feature.id}" must retain a validator workspace descriptor`,
+				);
+			}
+			if (feature.validatedHead !== feature.workspace.head) {
+				throw new MissionStateError(`Completed validator "${feature.id}" validatedHead must equal workspace.head`);
+			}
+		}
+	}
+
+	validateProgressSequences(progressEvents.filter(event => event.missionId === state.id));
+
+	if (state.integrationPending) {
+		validateIntegrationPending(state, state.integrationPending);
+	}
+
+	if (state.repository?.publishCheck) {
+		validatePublishCheck(state, state.repository.publishCheck, state.repository);
+	}
+}
+
+function parseMissionState(data: unknown): MissionState {
+	if (!isRecord(data)) {
+		throw new MissionStateError("mission-state entry data must be an object");
+	}
+	if (data.version !== 1) {
+		throw new MissionStateError("Newest mission-state entry must be version 1");
+	}
+	if (typeof data.id !== "string" || typeof data.ownerSessionId !== "string") {
+		throw new MissionStateError("mission-state missing id or ownerSessionId");
+	}
+	if (typeof data.revision !== "number" || typeof data.goal !== "string") {
+		throw new MissionStateError("mission-state missing revision or goal");
+	}
+	if (typeof data.autoAccept !== "boolean") {
+		throw new MissionStateError("mission-state missing autoAccept");
+	}
+	if (typeof data.status !== "string" || !MISSION_STATUSES.includes(data.status as MissionStatus)) {
+		throw new MissionStateError("mission-state has invalid status");
+	}
+	if (!isRecord(data.runbook) || !Array.isArray(data.milestones) || !Array.isArray(data.features)) {
+		throw new MissionStateError("mission-state missing runbook, milestones, or features");
+	}
+	if (typeof data.createdAt !== "number" || typeof data.updatedAt !== "number") {
+		throw new MissionStateError("mission-state missing createdAt or updatedAt");
+	}
+
+	for (const feature of data.features) {
+		if (!isRecord(feature) || typeof feature.id !== "string" || typeof feature.kind !== "string") {
+			throw new MissionStateError("mission-state feature entries must include id and kind");
+		}
+		if (typeof feature.status !== "string" || !(FEATURE_STATUSES as readonly string[]).includes(feature.status)) {
+			throw new MissionStateError(`mission-state feature "${feature.id}" has invalid status`);
+		}
+		if (feature.kind !== "implementation" && feature.kind !== "validation") {
+			throw new MissionStateError(`mission-state feature "${feature.id}" has invalid kind`);
+		}
+	}
+
+	// Structural checks above + assertMissionStateInvariants cover semantic rules.
+	return data as unknown as MissionState;
+}
+
+/**
+ * Restore the authoritative MissionState from transcript entries.
+ * A malformed newest mission-state entry is an error — never fall back to an older snapshot.
+ */
+export function loadMissionState(entries: readonly SessionEntry[]): MissionState | null {
+	let newest: { data: unknown } | undefined;
+	for (const entry of entries) {
+		if (entry.type === "custom" && entry.customType === MISSION_STATE_CUSTOM_TYPE) {
+			newest = { data: entry.data };
+		}
+	}
+	if (!newest) {
+		return null;
+	}
+
+	let state: MissionState;
+	try {
+		state = parseMissionState(newest.data);
+	} catch (error) {
+		if (error instanceof MissionStateError) {
+			throw error;
+		}
+		throw new MissionStateError(
+			`Malformed newest mission-state entry: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	let progressEvents: MissionProgressEvent[];
+	try {
+		progressEvents = collectProgressEvents(entries, state.id);
+	} catch (error) {
+		if (error instanceof MissionStateError) {
+			throw error;
+		}
+		throw new MissionStateError(
+			`Malformed mission-progress entry: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	assertMissionStateInvariants(state, progressEvents);
+	return state;
+}
+
+/**
+ * Transitively cancel pending implementation features whose implementation precondition was cancelled.
+ * Validation features are left for selection (their preconditions may be completed or cancelled).
+ */
+export function cancelUnsatisfiableFeatures(state: MissionState): MissionState {
+	const features = state.features.map(feature => ({ ...feature }));
+	const byId = new Map(features.map(feature => [feature.id, feature]));
+	let changed = true;
+
+	while (changed) {
+		changed = false;
+		for (const feature of features) {
+			if (feature.kind !== "implementation" || feature.status !== "pending") {
+				continue;
+			}
+			const blocked = feature.preconditions.some(preconditionId => {
+				const precondition = byId.get(preconditionId);
+				return precondition?.kind === "implementation" && precondition.status === "cancelled";
+			});
+			if (!blocked) {
+				continue;
+			}
+			feature.status = "cancelled";
+			feature.currentWorkerSessionId = undefined;
+			feature.nextRunIntent = undefined;
+			changed = true;
+		}
+	}
+
+	const touched = features.some((feature, index) => feature.status !== state.features[index]!.status);
+	if (!touched) {
+		return state;
+	}
+	return {
+		...state,
+		features,
+		updatedAt: state.updatedAt,
+	};
+}
+
+function preconditionsSatisfied(feature: MissionFeature, byId: Map<string, MissionFeature>): boolean {
+	switch (feature.kind) {
+		case "implementation":
+			return feature.preconditions.every(preconditionId => {
+				const precondition = byId.get(preconditionId);
+				return precondition?.status === "completed";
+			});
+		case "validation":
+			return feature.preconditions.every(preconditionId => {
+				const precondition = byId.get(preconditionId);
+				return precondition?.status === "completed" || precondition?.status === "cancelled";
+			});
+		default:
+			return assertNever(feature.kind, "Unknown feature kind");
+	}
+}
+
+/**
+ * Cancel unsatisfiable pending implementation features, then return at most one next pending feature
+ * in plan order. Never schedules in parallel.
+ */
+export function nextMissionFeature(state: MissionState): NextMissionFeatureResult {
+	const cancelledState = cancelUnsatisfiableFeatures(state);
+	const byId = new Map(cancelledState.features.map(feature => [feature.id, feature]));
+
+	for (const feature of cancelledState.features) {
+		if (feature.status !== "pending") {
+			continue;
+		}
+		if (!preconditionsSatisfied(feature, byId)) {
+			continue;
+		}
+		return { state: cancelledState, feature };
+	}
+
+	return { state: cancelledState, feature: null };
+}
+
+/** True when resolveHandoff({ decision: "accept" }) is legal for the pending handoff. */
+export function canAcceptPendingHandoff(handoff: MissionHandoff): boolean {
+	switch (handoff.kind) {
+		case "implementation":
+			return handoff.outcome === "success" && !handoff.issues.some(issue => issue.severity === "blocking");
+		case "validation":
+			return handoff.verdict === "pass";
+		default:
+			return assertNever(handoff, "Unknown handoff kind");
+	}
+}
+
+/** Milestone default validators: scrutiny + user-testing when the runbook supports it, else scrutiny alone. */
+export function defaultMilestoneValidators(runbook: MissionPlan["runbook"]): MissionValidatorRole[] {
+	const supportsUserTesting = runbook.userTests.length > 0 || runbook.services.length > 0;
+	if (supportsUserTesting) {
+		return ["scrutiny", "user-testing"];
+	}
+	return ["scrutiny"];
+}
+
+export function isMissionTerminal(state: MissionState): boolean {
+	return isTerminalStatus(state.status);
+}
+
+export function isMissionPlanningPhase(state: MissionState): boolean {
+	return isPlanningOrAwaiting(state.status);
+}

--- a/packages/coding-agent/src/missions/types.ts
+++ b/packages/coding-agent/src/missions/types.ts
@@ -1,0 +1,265 @@
+export type MissionStatus =
+	| "planning"
+	| "awaiting_input"
+	| "initializing"
+	| "running"
+	| "paused"
+	| "orchestrator_turn"
+	| "completed"
+	| "cancelled";
+
+export type MissionFeatureStatus = "pending" | "in_progress" | "completed" | "cancelled";
+
+export type MissionValidatorRole = "scrutiny" | "user-testing";
+
+export type MissionWorkerOutcome = "success" | "partial" | "failure" | "return_to_orchestrator";
+
+export type MissionIssueSeverity = "blocking" | "non_blocking" | "suggestion";
+
+export type MissionPauseReason =
+	| "user_requested"
+	| "feature_retry_limit_exceeded"
+	| "worker_inactive"
+	| "worker_interrupted"
+	| "repository_dirty"
+	| "workspace_conflict"
+	| "integration_diverged"
+	| "parent_diverged"
+	| "validator_workspace_dirty";
+
+export interface MissionRunbook {
+	setup: string[];
+	services: Array<{
+		name: string;
+		start: string;
+		ready: string;
+		stop?: string;
+		logs?: string;
+	}>;
+	userTests: string[];
+}
+
+export interface MissionFeatureSpec {
+	id: string;
+	description: string;
+	skillName?: string;
+	milestoneId: string;
+	preconditions: string[];
+	expectedBehavior: string[];
+	fulfills?: string[];
+}
+
+export interface MissionRemediationFeatureSpec {
+	id: string;
+	description: string;
+	skillName?: string;
+	preconditions: string[];
+	expectedBehavior: string[];
+	fulfills?: string[];
+}
+
+export interface MissionMilestoneSpec {
+	id: string;
+	description: string;
+	featureIds: string[];
+	validators: MissionValidatorRole[];
+}
+
+export interface MissionPlan {
+	goal: string;
+	runbook: MissionRunbook;
+	milestones: MissionMilestoneSpec[];
+	features: MissionFeatureSpec[];
+}
+
+export interface MissionPublishCheck {
+	parentHead: string;
+	integrationHead: string;
+	generation: number;
+	phase: "validating" | "validated";
+}
+
+export interface MissionRepositoryState {
+	repoRoot: string;
+	parentBranch: string;
+	baseSha: string;
+	integrationBranch: string;
+	integrationHead: string;
+	publishCheck?: MissionPublishCheck;
+}
+
+interface MissionWorkspaceBase {
+	id: string;
+	ownerSessionId: string;
+	repoRoot: string;
+	path: string;
+	featureId: string;
+	phase: "reserved" | "ready";
+}
+
+export interface MissionFeatureWorkspaceDescriptor extends MissionWorkspaceBase {
+	kind: "feature";
+	branch: string;
+	baseSha: string;
+}
+
+export interface MissionValidatorWorkspaceDescriptor extends MissionWorkspaceBase {
+	kind: "validator";
+	head: string;
+}
+
+export type MissionWorkspaceDescriptor = MissionFeatureWorkspaceDescriptor | MissionValidatorWorkspaceDescriptor;
+
+export interface MissionIssue {
+	severity: MissionIssueSeverity;
+	description: string;
+	evidence?: string;
+	affectedFeatureIds?: string[];
+}
+
+export interface MissionWorkerHandoff {
+	kind: "implementation";
+	outcome: MissionWorkerOutcome;
+	summary: string;
+	implementation: string[];
+	remaining: string[];
+	verification: {
+		commands: Array<{ command: string; result: "passed" | "failed" | "not_run"; evidence?: string }>;
+		interactiveChecks: Array<{ check: string; result: "passed" | "failed" | "not_run"; evidence?: string }>;
+	};
+	tests: { added: string[]; coverageNotes: string[] };
+	issues: MissionIssue[];
+	skillDeviations: string[];
+	commits: string[];
+}
+
+export interface MissionValidatorHandoff {
+	kind: "validation";
+	role: MissionValidatorRole;
+	verdict: "pass" | "fail";
+	summary: string;
+	checks: Array<{ check: string; result: "passed" | "failed" | "not_run"; evidence?: string }>;
+	issues: MissionIssue[];
+}
+
+export type MissionHandoff = MissionWorkerHandoff | MissionValidatorHandoff;
+
+export interface MissionMilestone extends MissionMilestoneSpec {
+	kind: "planned" | "publish";
+	generation?: number;
+}
+
+export type MissionNextRunMode = "initial" | "follow_up" | "fresh";
+
+export interface MissionNextRunIntent {
+	mode: MissionNextRunMode;
+	messageToWorker?: string;
+}
+
+export interface MissionFeature extends MissionFeatureSpec {
+	kind: "implementation" | "validation";
+	validator?: MissionValidatorRole;
+	status: MissionFeatureStatus;
+	workerSessionIds: string[];
+	currentWorkerSessionId?: string;
+	completedWorkerSessionId?: string;
+	retryBudgetUsed: number;
+	workspace?: MissionWorkspaceDescriptor;
+	validatedHead?: string;
+	nextRunIntent?: MissionNextRunIntent;
+}
+
+export interface MissionActiveRun {
+	featureId: string;
+	workerSessionId: string;
+	turn: number;
+}
+
+export interface MissionIntegrationPending {
+	featureId: string;
+	expectedOldHead: string;
+	newHead: string;
+}
+
+export interface MissionState {
+	version: 1;
+	id: string;
+	ownerSessionId: string;
+	revision: number;
+	goal: string;
+	autoAccept: boolean;
+	status: MissionStatus;
+	pauseReason?: MissionPauseReason;
+	runbook: MissionRunbook;
+	repository?: MissionRepositoryState;
+	milestones: MissionMilestone[];
+	features: MissionFeature[];
+	activeRun?: MissionActiveRun;
+	pendingHandoff?: MissionHandoff;
+	integrationPending?: MissionIntegrationPending;
+	workerModel?: string | string[];
+	validatorModel?: string | string[];
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface MissionProgressEventBase {
+	missionId: string;
+	sequence: number;
+	at: number;
+}
+
+export type MissionProgressEvent =
+	| (MissionProgressEventBase & { type: "accepted" })
+	| (MissionProgressEventBase & { type: "paused"; reason: MissionPauseReason })
+	| (MissionProgressEventBase & { type: "resumed" })
+	| (MissionProgressEventBase & { type: "run_started" })
+	| (MissionProgressEventBase & { type: "feature_selected"; featureId: string })
+	| (MissionProgressEventBase & { type: "worker_started"; featureId: string; workerSessionId: string })
+	| (MissionProgressEventBase & {
+			type: "heartbeat";
+			featureId: string;
+			workerSessionId: string;
+			requests: number;
+			tokens: number;
+			cost: number;
+	  })
+	| (MissionProgressEventBase & { type: "worker_completed"; featureId: string; workerSessionId: string })
+	| (MissionProgressEventBase & { type: "worker_failed"; featureId: string; workerSessionId?: string })
+	| (MissionProgressEventBase & {
+			type: "handoff_resolved";
+			featureId: string;
+			decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+	  })
+	| (MissionProgressEventBase & { type: "milestone_validation_triggered"; milestoneId: string })
+	| (MissionProgressEventBase & { type: "publish_validation_triggered"; generation: number })
+	| (MissionProgressEventBase & { type: "completed" })
+	| (MissionProgressEventBase & { type: "cancelled" });
+
+export const MISSION_WORKER_TURN_CAP = 5;
+export const MISSION_INACTIVITY_TIMEOUT_MS = 600_000;
+
+export const MISSION_STATE_CUSTOM_TYPE = "mission-state";
+export const MISSION_PROGRESS_CUSTOM_TYPE = "mission-progress";
+
+/** Method/input types for MissionRuntime — recorded now; no runtime stub in this slice. */
+export interface MissionRuntimeContract {
+	snapshot(): MissionState | null;
+	start(
+		goal: string,
+		options?: { workerModel?: string | string[]; validatorModel?: string | string[]; autoAccept?: boolean },
+	): Promise<MissionState>;
+	setPlan(plan: MissionPlan): Promise<MissionState>;
+	accept(): Promise<MissionState>;
+	runNext(signal?: AbortSignal): Promise<MissionHandoff | null>;
+	resolveHandoff(input: {
+		decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+		messageToWorker?: string;
+	}): Promise<MissionState>;
+	revisePending(input: { addFeatures: MissionRemediationFeatureSpec[] }): Promise<MissionState>;
+	pause(reason: MissionPauseReason): Promise<MissionState>;
+	resume(input?: { restartWorker?: boolean; messageToWorker?: string }): Promise<MissionState>;
+	cancel(): Promise<MissionState>;
+	prepareToSuspend(): Promise<void>;
+	restore(): Promise<MissionState | null>;
+}

--- a/packages/coding-agent/src/missions/types.ts
+++ b/packages/coding-agent/src/missions/types.ts
@@ -144,6 +144,9 @@ export interface MissionValidatorHandoff {
 
 export type MissionHandoff = MissionWorkerHandoff | MissionValidatorHandoff;
 
+/** Closed set of decisions a host may apply to a pending handoff. */
+export type MissionHandoffDecision = "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+
 export interface MissionMilestone extends MissionMilestoneSpec {
 	kind: "planned" | "publish";
 	generation?: number;
@@ -229,7 +232,7 @@ export type MissionProgressEvent =
 	| (MissionProgressEventBase & {
 			type: "handoff_resolved";
 			featureId: string;
-			decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
+			decision: MissionHandoffDecision;
 	  })
 	| (MissionProgressEventBase & { type: "milestone_validation_triggered"; milestoneId: string })
 	| (MissionProgressEventBase & { type: "publish_validation_triggered"; generation: number })
@@ -252,10 +255,7 @@ export interface MissionRuntimeContract {
 	setPlan(plan: MissionPlan): Promise<MissionState>;
 	accept(): Promise<MissionState>;
 	runNext(signal?: AbortSignal): Promise<MissionHandoff | null>;
-	resolveHandoff(input: {
-		decision: "accept" | "retry_same" | "retry_fresh" | "cancel_feature" | "pause";
-		messageToWorker?: string;
-	}): Promise<MissionState>;
+	resolveHandoff(input: { decision: MissionHandoffDecision; messageToWorker?: string }): Promise<MissionState>;
 	revisePending(input: { addFeatures: MissionRemediationFeatureSpec[] }): Promise<MissionState>;
 	pause(reason: MissionPauseReason): Promise<MissionState>;
 	resume(input?: { restartWorker?: boolean; messageToWorker?: string }): Promise<MissionState>;

--- a/packages/coding-agent/src/missions/workspace.ts
+++ b/packages/coding-agent/src/missions/workspace.ts
@@ -1,0 +1,632 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getWorktreeDir, hashPath, isEnoent } from "@oh-my-pi/pi-utils";
+import type { GitStatusSummary, GitWorktreeEntry } from "../utils/git";
+import * as git from "../utils/git";
+import type {
+	MissionFeatureSpec,
+	MissionFeatureWorkspaceDescriptor,
+	MissionIssue,
+	MissionPauseReason,
+	MissionRepositoryState,
+	MissionState,
+	MissionValidatorWorkspaceDescriptor,
+	MissionWorkerHandoff,
+	MissionWorkspaceDescriptor,
+} from "./types";
+
+const LOCAL_BRANCH_PREFIX = "refs/heads/";
+
+export type MissionWorkspaceConflict = {
+	kind: "pause";
+	reason: Extract<MissionPauseReason, "workspace_conflict">;
+	descriptorId: string;
+	featureId: string;
+	path: string;
+	branch?: string;
+	expectedHead?: string;
+	actualHead?: string | null;
+	detail: string;
+};
+
+export type MissionIntegrationDiverged = {
+	kind: "pause";
+	reason: Extract<MissionPauseReason, "integration_diverged">;
+	featureId: string;
+	integrationBranch: string;
+	expectedOldHead: string;
+	newHead: string;
+	actualHead: string | null;
+};
+
+export type MissionPartialHandoff = {
+	kind: "partial_handoff";
+	issues: MissionIssue[];
+	featureBranchHead: string | null;
+};
+
+export type MissionReconcileResult =
+	| { kind: "ready"; descriptor: MissionWorkspaceDescriptor }
+	| MissionWorkspaceConflict;
+
+export type MissionAdvanceIntegrationResult =
+	| { kind: "advanced"; repository: MissionRepositoryState }
+	| { kind: "already_applied"; repository: MissionRepositoryState }
+	| MissionPartialHandoff
+	| MissionIntegrationDiverged;
+
+export class MissionWorkspaceError extends Error {
+	override readonly name = "MissionWorkspaceError";
+}
+
+function assertNever(value: never, message: string): never {
+	throw new MissionWorkspaceError(`${message}: ${JSON.stringify(value)}`);
+}
+
+export function toLocalBranchRef(branchName: string): string {
+	return branchName.startsWith(LOCAL_BRANCH_PREFIX) ? branchName : `${LOCAL_BRANCH_PREFIX}${branchName}`;
+}
+
+function workspaceSegment(repoRoot: string, missionId: string, featureId: string): string {
+	return `mission-${hashPath(repoRoot)}-${missionId}-${featureId}`;
+}
+
+function featureBranchName(missionId: string, featureId: string): string {
+	return `omp/mission/${missionId}/feature/${featureId}`;
+}
+
+function featureWorkspaceId(missionId: string, featureId: string): string {
+	return `feature:${missionId}:${featureId}`;
+}
+
+function validatorWorkspaceId(missionId: string, featureId: string): string {
+	return `validator:${missionId}:${featureId}`;
+}
+
+function requireRepository(mission: MissionState): MissionRepositoryState {
+	if (!mission.repository) {
+		throw new MissionWorkspaceError(`Mission "${mission.id}" has no repository state`);
+	}
+	return mission.repository;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+	try {
+		await fs.stat(targetPath);
+		return true;
+	} catch (error) {
+		if (isEnoent(error)) return false;
+		throw error;
+	}
+}
+
+function samePath(left: string, right: string): boolean {
+	return path.resolve(left) === path.resolve(right);
+}
+
+function findWorktreeEntry(entries: readonly GitWorktreeEntry[], targetPath: string): GitWorktreeEntry | undefined {
+	return entries.find(entry => samePath(entry.path, targetPath));
+}
+
+/** A checkout with no staged, unstaged or untracked change. */
+export function isCleanSummary(summary: GitStatusSummary | null): boolean {
+	return summary !== null && summary.staged === 0 && summary.unstaged === 0 && summary.untracked === 0;
+}
+
+function sameCommitList(left: readonly string[], right: readonly string[]): boolean {
+	if (left.length !== right.length) return false;
+	for (let i = 0; i < left.length; i++) {
+		if (left[i] !== right[i]) return false;
+	}
+	return true;
+}
+
+function blockingIssue(description: string, evidence?: string, featureId?: string): MissionIssue {
+	return {
+		severity: "blocking",
+		description,
+		...(evidence !== undefined ? { evidence } : {}),
+		...(featureId !== undefined ? { affectedFeatureIds: [featureId] } : {}),
+	};
+}
+
+function workspaceConflict(
+	descriptor: MissionWorkspaceDescriptor,
+	detail: string,
+	extra: {
+		branch?: string;
+		expectedHead?: string;
+		actualHead?: string | null;
+	} = {},
+): MissionWorkspaceConflict {
+	return {
+		kind: "pause",
+		reason: "workspace_conflict",
+		descriptorId: descriptor.id,
+		featureId: descriptor.featureId,
+		path: descriptor.path,
+		detail,
+		...(extra.branch !== undefined ? { branch: extra.branch } : {}),
+		...(extra.expectedHead !== undefined ? { expectedHead: extra.expectedHead } : {}),
+		...(extra.actualHead !== undefined ? { actualHead: extra.actualHead } : {}),
+	};
+}
+
+function integrationDiverged(
+	descriptor: MissionFeatureWorkspaceDescriptor,
+	repository: MissionRepositoryState,
+	expectedOldHead: string,
+	newHead: string,
+	actualHead: string | null,
+): MissionIntegrationDiverged {
+	return {
+		kind: "pause",
+		reason: "integration_diverged",
+		featureId: descriptor.featureId,
+		integrationBranch: repository.integrationBranch,
+		expectedOldHead,
+		newHead,
+		actualHead,
+	};
+}
+
+async function ensureWorktreeParent(worktreePath: string): Promise<void> {
+	await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+}
+
+async function createFeatureWorkspace(repoRoot: string, descriptor: MissionFeatureWorkspaceDescriptor): Promise<void> {
+	const branchRef = toLocalBranchRef(descriptor.branch);
+	const branchExists = await git.ref.exists(repoRoot, branchRef);
+	if (!branchExists) {
+		await git.branch.create(repoRoot, descriptor.branch, descriptor.baseSha);
+	}
+	await ensureWorktreeParent(descriptor.path);
+	await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
+}
+
+async function createValidatorWorkspace(
+	repoRoot: string,
+	descriptor: MissionValidatorWorkspaceDescriptor,
+): Promise<void> {
+	await ensureWorktreeParent(descriptor.path);
+	await git.worktree.add(repoRoot, descriptor.path, descriptor.head, { detach: true });
+}
+
+function isExactFeatureWorktree(entry: GitWorktreeEntry, descriptor: MissionFeatureWorkspaceDescriptor): boolean {
+	return !entry.detached && entry.branch === toLocalBranchRef(descriptor.branch);
+}
+
+function isExactValidatorWorktree(entry: GitWorktreeEntry, descriptor: MissionValidatorWorkspaceDescriptor): boolean {
+	return entry.detached && entry.head === descriptor.head;
+}
+
+/**
+ * Crash-recoverable native-git workspace manager for missions.
+ * Reserve is pure path/branch computation; only materialize/reconcile/advance/release mutate git.
+ */
+export class MissionWorkspaceManager {
+	async reserveFeature(
+		ownerSessionId: string,
+		mission: MissionState,
+		feature: MissionFeatureSpec,
+	): Promise<MissionFeatureWorkspaceDescriptor> {
+		const repository = requireRepository(mission);
+		const branch = featureBranchName(mission.id, feature.id);
+		const worktreePath = getWorktreeDir(workspaceSegment(repository.repoRoot, mission.id, feature.id));
+		return {
+			id: featureWorkspaceId(mission.id, feature.id),
+			kind: "feature",
+			ownerSessionId,
+			repoRoot: repository.repoRoot,
+			path: worktreePath,
+			featureId: feature.id,
+			phase: "reserved",
+			branch,
+			baseSha: repository.integrationHead,
+		};
+	}
+
+	async reserveValidator(
+		ownerSessionId: string,
+		mission: MissionState,
+		featureId: string,
+	): Promise<MissionValidatorWorkspaceDescriptor> {
+		const repository = requireRepository(mission);
+		const worktreePath = getWorktreeDir(workspaceSegment(repository.repoRoot, mission.id, featureId));
+		return {
+			id: validatorWorkspaceId(mission.id, featureId),
+			kind: "validator",
+			ownerSessionId,
+			repoRoot: repository.repoRoot,
+			path: worktreePath,
+			featureId,
+			phase: "reserved",
+			head: repository.integrationHead,
+		};
+	}
+
+	async materialize(descriptor: MissionWorkspaceDescriptor): Promise<MissionWorkspaceDescriptor> {
+		if (descriptor.phase === "ready") {
+			return descriptor;
+		}
+
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			switch (descriptor.kind) {
+				case "feature": {
+					await createFeatureWorkspace(descriptor.repoRoot, descriptor);
+					return { ...descriptor, phase: "ready" };
+				}
+				case "validator": {
+					await createValidatorWorkspace(descriptor.repoRoot, descriptor);
+					return { ...descriptor, phase: "ready" };
+				}
+				default:
+					return assertNever(descriptor, "Unknown workspace descriptor kind");
+			}
+		});
+	}
+
+	async reconcile(
+		descriptor: MissionWorkspaceDescriptor,
+		hasChildTranscript: boolean,
+	): Promise<MissionReconcileResult> {
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			switch (descriptor.kind) {
+				case "feature":
+					return this.#reconcileFeature(descriptor, hasChildTranscript);
+				case "validator":
+					return this.#reconcileValidator(descriptor, hasChildTranscript);
+				default:
+					return assertNever(descriptor, "Unknown workspace descriptor kind");
+			}
+		});
+	}
+
+	async advanceIntegration(
+		repository: MissionRepositoryState,
+		descriptor: MissionFeatureWorkspaceDescriptor,
+		handoff: MissionWorkerHandoff,
+	): Promise<MissionAdvanceIntegrationResult> {
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			const summary = await git.status.summary(descriptor.path);
+			if (!isCleanSummary(summary)) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead: null,
+					issues: [
+						blockingIssue(
+							"Feature workspace is dirty; handoff cannot be accepted",
+							summary === null
+								? "git.status.summary failed"
+								: `staged=${summary.staged} unstaged=${summary.unstaged} untracked=${summary.untracked}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const branchRef = toLocalBranchRef(descriptor.branch);
+			const featureBranchHead = await git.ref.resolve(descriptor.repoRoot, branchRef);
+			if (featureBranchHead === null) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead: null,
+					issues: [
+						blockingIssue(
+							`Feature branch "${descriptor.branch}" is not resolvable`,
+							undefined,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const ancestorOk = await git.ref.isAncestor(descriptor.repoRoot, descriptor.baseSha, featureBranchHead);
+			if (!ancestorOk) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Feature branch head is not a descendant of workspace baseSha",
+							`baseSha=${descriptor.baseSha} head=${featureBranchHead}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const commits = await git.revList.range(descriptor.repoRoot, descriptor.baseSha, descriptor.branch);
+			if (!sameCommitList(commits, handoff.commits)) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Feature commit list does not match handoff.commits",
+							`expected=${handoff.commits.join(",") || "(empty)"} actual=${commits.join(",") || "(empty)"}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			const expectedOldHead = descriptor.baseSha;
+			const newHead = featureBranchHead;
+			const integrationRef = toLocalBranchRef(repository.integrationBranch);
+
+			const ancestryToNew = await git.ref.isAncestor(descriptor.repoRoot, expectedOldHead, newHead);
+			if (!ancestryToNew) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Integration advance requires expectedOldHead to be an ancestor of newHead",
+							`expectedOldHead=${expectedOldHead} newHead=${newHead}`,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+
+			let actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
+			if (actualHead === newHead) {
+				return {
+					kind: "already_applied",
+					repository: { ...repository, integrationHead: newHead },
+				};
+			}
+			if (actualHead !== expectedOldHead) {
+				return integrationDiverged(descriptor, repository, expectedOldHead, newHead, actualHead);
+			}
+
+			const updated = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
+			if (updated) {
+				return {
+					kind: "advanced",
+					repository: { ...repository, integrationHead: newHead },
+				};
+			}
+
+			// CAS lost: restore semantics — retry while still at expectedOldHead;
+			// equality with newHead means already-applied; anything else diverged.
+			actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
+			if (actualHead === newHead) {
+				return {
+					kind: "already_applied",
+					repository: { ...repository, integrationHead: newHead },
+				};
+			}
+			if (actualHead === expectedOldHead) {
+				const retried = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
+				if (retried) {
+					return {
+						kind: "advanced",
+						repository: { ...repository, integrationHead: newHead },
+					};
+				}
+				actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
+				if (actualHead === newHead) {
+					return {
+						kind: "already_applied",
+						repository: { ...repository, integrationHead: newHead },
+					};
+				}
+				if (actualHead === expectedOldHead) {
+					throw new MissionWorkspaceError(
+						`Integration CAS failed twice while ${repository.integrationBranch} remained at ${expectedOldHead}`,
+					);
+				}
+			}
+			return integrationDiverged(descriptor, repository, expectedOldHead, newHead, actualHead);
+		});
+	}
+
+	async release(descriptor: MissionWorkspaceDescriptor): Promise<void> {
+		await git.withRepoLock(descriptor.repoRoot, () => this.#removeWorkspace(descriptor));
+	}
+
+	async releaseIfEmpty(descriptor: MissionWorkspaceDescriptor): Promise<boolean> {
+		return git.withRepoLock(descriptor.repoRoot, async () => {
+			switch (descriptor.kind) {
+				case "feature":
+					return this.#releaseFeatureIfEmpty(descriptor);
+				case "validator":
+					return this.#releaseValidatorIfEmpty(descriptor);
+				default:
+					return assertNever(descriptor, "Unknown workspace descriptor kind");
+			}
+		});
+	}
+
+	async #reconcileFeature(
+		descriptor: MissionFeatureWorkspaceDescriptor,
+		hasChildTranscript: boolean,
+	): Promise<MissionReconcileResult> {
+		const repoRoot = descriptor.repoRoot;
+		const branchRef = toLocalBranchRef(descriptor.branch);
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+		const refSha = await git.ref.resolve(repoRoot, branchRef);
+		const refExists = refSha !== null;
+
+		if (entry && !isExactFeatureWorktree(entry, descriptor)) {
+			return workspaceConflict(descriptor, "Worktree path is registered to an unowned or mismatched branch", {
+				branch: descriptor.branch,
+				expectedHead: descriptor.baseSha,
+				actualHead: entry.head ?? null,
+			});
+		}
+
+		if (!entry && onDisk) {
+			return workspaceConflict(descriptor, "Workspace path exists on disk but is not a registered worktree", {
+				branch: descriptor.branch,
+			});
+		}
+
+		if (!refExists && entry) {
+			return workspaceConflict(descriptor, "Feature worktree exists without its owned branch ref", {
+				branch: descriptor.branch,
+				actualHead: entry.head ?? null,
+			});
+		}
+
+		if (!refExists && !entry) {
+			if (hasChildTranscript) {
+				return workspaceConflict(descriptor, "Missing feature workspace path/ref but a child transcript exists", {
+					branch: descriptor.branch,
+				});
+			}
+			await createFeatureWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
+
+		// Owned ref exists from here.
+		if (refSha === null) {
+			return workspaceConflict(descriptor, "Feature ref ownership check lost resolvable SHA", {
+				branch: descriptor.branch,
+			});
+		}
+		if (!entry) {
+			if (hasChildTranscript) {
+				return workspaceConflict(
+					descriptor,
+					"Owned feature ref exists but path is missing while a child transcript exists",
+					{ branch: descriptor.branch, expectedHead: refSha },
+				);
+			}
+			await ensureWorktreeParent(descriptor.path);
+			await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
+
+		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+	}
+
+	async #reconcileValidator(
+		descriptor: MissionValidatorWorkspaceDescriptor,
+		hasChildTranscript: boolean,
+	): Promise<MissionReconcileResult> {
+		const repoRoot = descriptor.repoRoot;
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+
+		if (!entry && onDisk) {
+			return workspaceConflict(descriptor, "Validator path exists on disk but is not a registered worktree", {
+				expectedHead: descriptor.head,
+			});
+		}
+
+		if (!entry) {
+			if (hasChildTranscript) {
+				return workspaceConflict(descriptor, "Missing validator workspace path while a child transcript exists", {
+					expectedHead: descriptor.head,
+				});
+			}
+			await createValidatorWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
+
+		if (!isExactValidatorWorktree(entry, descriptor)) {
+			return workspaceConflict(descriptor, "Validator worktree is unowned, attached, or at the wrong head", {
+				expectedHead: descriptor.head,
+				actualHead: entry.head ?? null,
+			});
+		}
+
+		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+	}
+
+	/**
+	 * Non-forcible removal for either workspace kind. `{ force: false }` makes git
+	 * refuse a worktree holding uncommitted work, and a path that is not a registered
+	 * worktree is never deleted — unowned state is preserved, never reclaimed. Only a
+	 * feature owns a branch; a validator worktree is detached at a recorded head.
+	 */
+	async #removeWorkspace(descriptor: MissionWorkspaceDescriptor): Promise<void> {
+		const entries = await git.worktree.list(descriptor.repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		if (entry) {
+			await git.worktree.remove(descriptor.repoRoot, descriptor.path, { force: false });
+		} else if (await pathExists(descriptor.path)) {
+			throw new MissionWorkspaceError(
+				`Refusing to remove unowned path at ${descriptor.path} during ${descriptor.kind} release`,
+			);
+		}
+		if (descriptor.kind === "feature") {
+			await git.branch.tryDelete(descriptor.repoRoot, descriptor.branch);
+		}
+	}
+
+	async #releaseFeatureIfEmpty(descriptor: MissionFeatureWorkspaceDescriptor): Promise<boolean> {
+		const repoRoot = descriptor.repoRoot;
+		const branchRef = toLocalBranchRef(descriptor.branch);
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+		const head = await git.ref.resolve(repoRoot, branchRef);
+
+		if (!entry && !onDisk && head === null) {
+			return true;
+		}
+
+		if (entry && !isExactFeatureWorktree(entry, descriptor)) {
+			return false;
+		}
+		if (!entry && onDisk) {
+			return false;
+		}
+		// Branch must still equal base; missing branch with a live worktree is partial.
+		if (entry && (head === null || head !== descriptor.baseSha)) {
+			return false;
+		}
+		if (!entry && head !== null && head !== descriptor.baseSha) {
+			return false;
+		}
+
+		if (entry) {
+			const summary = await git.status.summary(descriptor.path);
+			if (!isCleanSummary(summary)) {
+				return false;
+			}
+			await git.worktree.remove(repoRoot, descriptor.path, { force: false });
+		}
+
+		if (head !== null) {
+			const deleted = await git.branch.tryDelete(repoRoot, descriptor.branch, { force: false });
+			if (!deleted) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	async #releaseValidatorIfEmpty(descriptor: MissionValidatorWorkspaceDescriptor): Promise<boolean> {
+		const repoRoot = descriptor.repoRoot;
+		const entries = await git.worktree.list(repoRoot);
+		const entry = findWorktreeEntry(entries, descriptor.path);
+		const onDisk = await pathExists(descriptor.path);
+
+		if (!entry && !onDisk) {
+			return true;
+		}
+		if (!entry && onDisk) {
+			return false;
+		}
+		if (!entry || !isExactValidatorWorktree(entry, descriptor)) {
+			return false;
+		}
+
+		const summary = await git.status.summary(descriptor.path);
+		if (!isCleanSummary(summary)) {
+			return false;
+		}
+
+		await git.worktree.remove(repoRoot, descriptor.path, { force: false });
+		return true;
+	}
+}

--- a/packages/coding-agent/src/missions/workspace.ts
+++ b/packages/coding-agent/src/missions/workspace.ts
@@ -176,9 +176,13 @@ async function ensureWorktreeParent(worktreePath: string): Promise<void> {
 
 async function createFeatureWorkspace(repoRoot: string, descriptor: MissionFeatureWorkspaceDescriptor): Promise<void> {
 	const branchRef = toLocalBranchRef(descriptor.branch);
-	const branchExists = await git.ref.exists(repoRoot, branchRef);
-	if (!branchExists) {
+	const branchHead = await git.ref.resolve(repoRoot, branchRef);
+	if (branchHead === null) {
 		await git.branch.create(repoRoot, descriptor.branch, descriptor.baseSha);
+	} else if (branchHead !== descriptor.baseSha) {
+		throw new MissionWorkspaceError(
+			`Feature branch ${descriptor.branch} already exists at ${branchHead}, expected ${descriptor.baseSha}`,
+		);
 	}
 	await ensureWorktreeParent(descriptor.path);
 	await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
@@ -354,6 +358,27 @@ export class MissionWorkspaceManager {
 			const expectedOldHead = descriptor.baseSha;
 			const newHead = featureBranchHead;
 			const integrationRef = toLocalBranchRef(repository.integrationBranch);
+			const integrationWorktree = (await git.worktree.list(descriptor.repoRoot)).find(
+				entry => !entry.detached && entry.branch === integrationRef,
+			);
+			if (integrationWorktree && !isCleanSummary(await git.status.summary(integrationWorktree.path))) {
+				return {
+					kind: "partial_handoff",
+					featureBranchHead,
+					issues: [
+						blockingIssue(
+							"Integration worktree is dirty; integration branch cannot be advanced",
+							undefined,
+							descriptor.featureId,
+						),
+					],
+				};
+			}
+			const synchronizeIntegrationWorktree = async (): Promise<void> => {
+				if (integrationWorktree) {
+					await git.reset(integrationWorktree.path, { hard: true, target: newHead });
+				}
+			};
 
 			const ancestryToNew = await git.ref.isAncestor(descriptor.repoRoot, expectedOldHead, newHead);
 			if (!ancestryToNew) {
@@ -372,6 +397,7 @@ export class MissionWorkspaceManager {
 
 			let actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
 			if (actualHead === newHead) {
+				await synchronizeIntegrationWorktree();
 				return {
 					kind: "already_applied",
 					repository: { ...repository, integrationHead: newHead },
@@ -383,6 +409,7 @@ export class MissionWorkspaceManager {
 
 			const updated = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
 			if (updated) {
+				await synchronizeIntegrationWorktree();
 				return {
 					kind: "advanced",
 					repository: { ...repository, integrationHead: newHead },
@@ -393,6 +420,7 @@ export class MissionWorkspaceManager {
 			// equality with newHead means already-applied; anything else diverged.
 			actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
 			if (actualHead === newHead) {
+				await synchronizeIntegrationWorktree();
 				return {
 					kind: "already_applied",
 					repository: { ...repository, integrationHead: newHead },
@@ -401,6 +429,7 @@ export class MissionWorkspaceManager {
 			if (actualHead === expectedOldHead) {
 				const retried = await git.ref.update(descriptor.repoRoot, integrationRef, newHead, expectedOldHead);
 				if (retried) {
+					await synchronizeIntegrationWorktree();
 					return {
 						kind: "advanced",
 						repository: { ...repository, integrationHead: newHead },
@@ -408,6 +437,7 @@ export class MissionWorkspaceManager {
 				}
 				actualHead = await git.ref.resolve(descriptor.repoRoot, integrationRef);
 				if (actualHead === newHead) {
+					await synchronizeIntegrationWorktree();
 					return {
 						kind: "already_applied",
 						repository: { ...repository, integrationHead: newHead },
@@ -450,7 +480,6 @@ export class MissionWorkspaceManager {
 		const entry = findWorktreeEntry(entries, descriptor.path);
 		const onDisk = await pathExists(descriptor.path);
 		const refSha = await git.ref.resolve(repoRoot, branchRef);
-		const refExists = refSha !== null;
 
 		if (entry && !isExactFeatureWorktree(entry, descriptor)) {
 			return workspaceConflict(descriptor, "Worktree path is registered to an unowned or mismatched branch", {
@@ -459,21 +488,32 @@ export class MissionWorkspaceManager {
 				actualHead: entry.head ?? null,
 			});
 		}
-
+		if (entry && !onDisk) {
+			if (hasChildTranscript) {
+				return workspaceConflict(
+					descriptor,
+					"Registered feature workspace path is missing while a child transcript exists",
+					{
+						branch: descriptor.branch,
+					},
+				);
+			}
+			await git.worktree.prune(repoRoot);
+			await createFeatureWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
 		if (!entry && onDisk) {
 			return workspaceConflict(descriptor, "Workspace path exists on disk but is not a registered worktree", {
 				branch: descriptor.branch,
 			});
 		}
-
-		if (!refExists && entry) {
-			return workspaceConflict(descriptor, "Feature worktree exists without its owned branch ref", {
-				branch: descriptor.branch,
-				actualHead: entry.head ?? null,
-			});
-		}
-
-		if (!refExists && !entry) {
+		if (refSha === null) {
+			if (entry) {
+				return workspaceConflict(descriptor, "Feature worktree exists without its owned branch ref", {
+					branch: descriptor.branch,
+					actualHead: entry.head ?? null,
+				});
+			}
 			if (hasChildTranscript) {
 				return workspaceConflict(descriptor, "Missing feature workspace path/ref but a child transcript exists", {
 					branch: descriptor.branch,
@@ -481,13 +521,6 @@ export class MissionWorkspaceManager {
 			}
 			await createFeatureWorkspace(repoRoot, descriptor);
 			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
-		}
-
-		// Owned ref exists from here.
-		if (refSha === null) {
-			return workspaceConflict(descriptor, "Feature ref ownership check lost resolvable SHA", {
-				branch: descriptor.branch,
-			});
 		}
 		if (!entry) {
 			if (hasChildTranscript) {
@@ -501,7 +534,6 @@ export class MissionWorkspaceManager {
 			await git.worktree.add(repoRoot, descriptor.path, descriptor.branch);
 			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 		}
-
 		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 	}
 
@@ -514,12 +546,31 @@ export class MissionWorkspaceManager {
 		const entry = findWorktreeEntry(entries, descriptor.path);
 		const onDisk = await pathExists(descriptor.path);
 
+		if (entry && !isExactValidatorWorktree(entry, descriptor)) {
+			return workspaceConflict(descriptor, "Validator worktree is unowned, attached, or at the wrong head", {
+				expectedHead: descriptor.head,
+				actualHead: entry.head ?? null,
+			});
+		}
+		if (entry && !onDisk) {
+			if (hasChildTranscript) {
+				return workspaceConflict(
+					descriptor,
+					"Registered validator workspace path is missing while a child transcript exists",
+					{
+						expectedHead: descriptor.head,
+					},
+				);
+			}
+			await git.worktree.prune(repoRoot);
+			await createValidatorWorkspace(repoRoot, descriptor);
+			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
+		}
 		if (!entry && onDisk) {
 			return workspaceConflict(descriptor, "Validator path exists on disk but is not a registered worktree", {
 				expectedHead: descriptor.head,
 			});
 		}
-
 		if (!entry) {
 			if (hasChildTranscript) {
 				return workspaceConflict(descriptor, "Missing validator workspace path while a child transcript exists", {
@@ -529,14 +580,6 @@ export class MissionWorkspaceManager {
 			await createValidatorWorkspace(repoRoot, descriptor);
 			return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 		}
-
-		if (!isExactValidatorWorktree(entry, descriptor)) {
-			return workspaceConflict(descriptor, "Validator worktree is unowned, attached, or at the wrong head", {
-				expectedHead: descriptor.head,
-				actualHead: entry.head ?? null,
-			});
-		}
-
 		return { kind: "ready", descriptor: { ...descriptor, phase: "ready" } };
 	}
 
@@ -550,6 +593,13 @@ export class MissionWorkspaceManager {
 		const entries = await git.worktree.list(descriptor.repoRoot);
 		const entry = findWorktreeEntry(entries, descriptor.path);
 		if (entry) {
+			const owned =
+				descriptor.kind === "feature"
+					? isExactFeatureWorktree(entry, descriptor)
+					: isExactValidatorWorktree(entry, descriptor);
+			if (!owned) {
+				throw new MissionWorkspaceError(`Refusing to remove unowned worktree at ${descriptor.path}`);
+			}
 			await git.worktree.remove(descriptor.repoRoot, descriptor.path, { force: false });
 		} else if (await pathExists(descriptor.path)) {
 			throw new MissionWorkspaceError(

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -208,6 +208,8 @@ export class EventController {
 				this.ctx.ui.resetDisplay();
 			},
 			goal_updated: async () => {},
+			mission_updated: async () => {},
+			mission_progress: async () => {},
 		} satisfies AgentSessionEventHandlers;
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -31,6 +31,9 @@ import type {
 	RpcHostToolDefinition,
 	RpcHostToolResult,
 	RpcHostToolUpdate,
+	RpcMissionProgressFrame,
+	RpcMissionResult,
+	RpcMissionUpdatedFrame,
 	RpcResponse,
 	RpcSessionState,
 	RpcSubagentEventFrame,
@@ -73,6 +76,8 @@ export type RpcSessionEventListener = (event: AgentSessionEvent) => void;
 export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["payload"]) => void;
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
+export type RpcMissionUpdatedListener = (mission: RpcMissionUpdatedFrame["mission"]) => void;
+export type RpcMissionProgressListener = (event: RpcMissionProgressFrame["event"]) => void;
 export type RpcAvailableCommandsUpdateListener = (commands: RpcAvailableSlashCommand[]) => void;
 
 export interface RpcClientToolContext<TDetails = unknown> {
@@ -182,6 +187,14 @@ function isRpcSubagentEventFrame(value: unknown): value is RpcSubagentEventFrame
 	return value.type === "subagent_event" && isRecord(value.payload);
 }
 
+function isRpcMissionUpdatedFrame(value: unknown): value is RpcMissionUpdatedFrame {
+	return isRecord(value) && value.type === "mission_updated" && isRecord(value.mission);
+}
+
+function isRpcMissionProgressFrame(value: unknown): value is RpcMissionProgressFrame {
+	return isRecord(value) && value.type === "mission_progress" && isRecord(value.event);
+}
+
 function isRpcAvailableCommandsUpdateFrame(value: unknown): value is RpcAvailableCommandsUpdateFrame {
 	if (!isRecord(value)) return false;
 	return value.type === "available_commands_update" && Array.isArray(value.commands);
@@ -249,6 +262,8 @@ export class RpcClient {
 	#subagentLifecycleListeners = new Set<RpcSubagentLifecycleListener>();
 	#subagentProgressListeners = new Set<RpcSubagentProgressListener>();
 	#subagentEventListeners = new Set<RpcSubagentEventListener>();
+	#missionUpdatedListeners = new Set<RpcMissionUpdatedListener>();
+	#missionProgressListeners = new Set<RpcMissionProgressListener>();
 	#availableCommandsUpdateListeners = new Set<RpcAvailableCommandsUpdateListener>();
 	#pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
 		new Map();
@@ -520,6 +535,18 @@ export class RpcClient {
 		return () => this.#subagentEventListeners.delete(listener);
 	}
 
+	/** Subscribe to durable mission-state updates emitted by the RPC server. */
+	onMissionUpdated(listener: RpcMissionUpdatedListener): () => void {
+		this.#missionUpdatedListeners.add(listener);
+		return () => this.#missionUpdatedListeners.delete(listener);
+	}
+
+	/** Subscribe to mission progress emitted by the RPC server. */
+	onMissionProgress(listener: RpcMissionProgressListener): () => void {
+		this.#missionProgressListeners.add(listener);
+		return () => this.#missionProgressListeners.delete(listener);
+	}
+
 	/**
 	 * Subscribe to slash-command availability updates emitted by the RPC server.
 	 */
@@ -785,6 +812,40 @@ export class RpcClient {
 		return this.#getData(response);
 	}
 
+	/** Start a mission and return its persisted planning snapshot. */
+	async startMission(
+		goal: string,
+		options?: { workerModel?: string | string[]; validatorModel?: string | string[] },
+	): Promise<RpcMissionResult> {
+		const response = await this.#send({ type: "mission_start", goal, ...options }, 300_000);
+		return this.#getData(response);
+	}
+
+	/** Return the current mission snapshot, including while mission work is active. */
+	async getMission(): Promise<RpcMissionResult> {
+		return this.#getData(await this.#send({ type: "get_mission" }));
+	}
+
+	async acceptMission(): Promise<RpcMissionResult> {
+		return this.#getData(await this.#send({ type: "mission_accept" }, 300_000));
+	}
+
+	async pauseMission(): Promise<RpcMissionResult> {
+		return this.#getData(await this.#send({ type: "mission_pause" }));
+	}
+
+	async resumeMission(messageToWorker?: string): Promise<RpcMissionResult> {
+		return this.#getData(await this.#send({ type: "mission_resume", messageToWorker }, 300_000));
+	}
+
+	async restartMission(messageToWorker?: string): Promise<RpcMissionResult> {
+		return this.#getData(await this.#send({ type: "mission_restart", messageToWorker }, 300_000));
+	}
+
+	async cancelMission(): Promise<RpcMissionResult> {
+		return this.#getData(await this.#send({ type: "mission_cancel" }, 300_000));
+	}
+
 	/**
 	 * Get messages available for branching.
 	 */
@@ -1044,6 +1105,16 @@ export class RpcClient {
 			for (const listener of this.#subagentEventListeners) {
 				listener(data.payload);
 			}
+			return;
+		}
+
+		if (isRpcMissionUpdatedFrame(data)) {
+			for (const listener of this.#missionUpdatedListeners) listener(data.mission);
+			return;
+		}
+
+		if (isRpcMissionProgressFrame(data)) {
+			for (const listener of this.#missionProgressListeners) listener(data.event);
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -25,6 +25,12 @@ import {
 } from "../../extensibility/extensions";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
+import {
+	INVALID_MISSION_TRANSITION,
+	MISSION_BUSY,
+	type MissionRestartRuntime,
+	restartMission,
+} from "../../missions/runtime";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
@@ -51,6 +57,7 @@ import type {
 	RpcHostUriCancelRequest,
 	RpcHostUriRequest,
 	RpcHostUriResult,
+	RpcMissionResult,
 	RpcResponse,
 	RpcSessionState,
 	RpcSubagentSubscriptionLevel,
@@ -112,6 +119,48 @@ export type RpcSessionChangeSession = Pick<AgentSession, "newSession" | "switchS
 
 export type RpcSkillCommandSession = Pick<AgentSession, "promptCustomMessage" | "skills" | "skillsSettings">;
 export type RpcSkillCommandResult = { agentInvoked: true };
+
+export type RpcMissionCommand = Extract<RpcCommand, { type: `mission_${string}` } | { type: "get_mission" }>;
+export type RpcMissionSession = Pick<AgentSession, "startMission"> & {
+	missionRuntime: MissionRestartRuntime &
+		Pick<AgentSession["missionRuntime"], "accept" | "pause" | "cancel" | "isBusy">;
+};
+
+/** Execute the mission protocol through the session-owned runtime. */
+export async function handleRpcMissionCommand(
+	session: RpcMissionSession,
+	command: RpcMissionCommand,
+): Promise<RpcMissionResult> {
+	const result = (mission: RpcMissionResult["mission"]): RpcMissionResult => ({ mission });
+	switch (command.type) {
+		case "mission_start":
+			return result(
+				await session.startMission(command.goal, {
+					workerModel: command.workerModel,
+					validatorModel: command.validatorModel,
+				}),
+			);
+		case "get_mission":
+			return result(session.missionRuntime.snapshot());
+		case "mission_accept":
+			return result(await session.missionRuntime.accept());
+		case "mission_pause":
+			return result(await session.missionRuntime.pause("user_requested"));
+		case "mission_resume":
+			return result(await session.missionRuntime.resume({ messageToWorker: command.messageToWorker }));
+		case "mission_restart":
+			if (session.missionRuntime.isBusy()) {
+				throw new Error(`${MISSION_BUSY}: cannot restart while mission work is in flight.`);
+			}
+			return result(await restartMission(session.missionRuntime, command.messageToWorker));
+		case "mission_cancel":
+			return result(await session.missionRuntime.cancel());
+	}
+}
+
+function isMissionTransitionBlocked(session: Pick<AgentSession, "missionRuntime">): boolean {
+	return session.missionRuntime.hasActiveMission();
+}
 
 export async function tryRunRpcSkillCommand(
 	session: RpcSkillCommandSession,
@@ -1049,6 +1098,14 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
+				if (isMissionTransitionBlocked(session)) {
+					return error(
+						id,
+						command.type,
+						"Cannot change sessions while a mission is active; cancel or complete it first.",
+						INVALID_MISSION_TRANSITION,
+					);
+				}
 				const result = await handleRpcSessionChange(session, command, subagentRegistry);
 				if (!result.data.cancelled) await emitAvailableCommandsUpdate();
 				return success(id, result.type, result.data);
@@ -1303,6 +1360,14 @@ export async function runRpcMode(
 			}
 
 			case "handoff": {
+				if (isMissionTransitionBlocked(session)) {
+					return error(
+						id,
+						"handoff",
+						"Cannot hand off while a mission is active; cancel or complete it first.",
+						INVALID_MISSION_TRANSITION,
+					);
+				}
 				// Resetting the agent mid-stream lets the live turn keep emitting into a
 				// session that handoff has already torn down. Refuse while a prompt is in
 				// flight (mirrors the TUI /handoff guard).
@@ -1410,6 +1475,22 @@ export async function runRpcMode(
 					return success(id, "login", { providerId: command.providerId });
 				} catch (err: unknown) {
 					return error(id, "login", err instanceof Error ? err.message : String(err));
+				}
+			}
+
+			case "mission_start":
+			case "get_mission":
+			case "mission_accept":
+			case "mission_pause":
+			case "mission_resume":
+			case "mission_restart":
+			case "mission_cancel": {
+				try {
+					return success(id, command.type, await handleRpcMissionCommand(session, command));
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					const code = message.startsWith(MISSION_BUSY) ? MISSION_BUSY : undefined;
+					return error(id, command.type, message, code);
 				}
 			}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -9,6 +9,7 @@ import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
+import type { MissionProgressEvent, MissionState } from "../../missions/types";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
 import type { FileEntry } from "../../session/session-entries";
 import type { AvailableSlashCommandSource } from "../../slash-commands/available-commands";
@@ -83,6 +84,21 @@ export type RpcCommand =
 	| { id?: string; type: "set_session_name"; name: string }
 	| { id?: string; type: "handoff"; customInstructions?: string }
 
+	// Mission
+	| {
+			id?: string;
+			type: "mission_start";
+			goal: string;
+			workerModel?: string | string[];
+			validatorModel?: string | string[];
+	  }
+	| { id?: string; type: "get_mission" }
+	| { id?: string; type: "mission_accept" }
+	| { id?: string; type: "mission_pause" }
+	| { id?: string; type: "mission_resume"; messageToWorker?: string }
+	| { id?: string; type: "mission_restart"; messageToWorker?: string }
+	| { id?: string; type: "mission_cancel" }
+
 	// Messages
 	| { id?: string; type: "get_messages" }
 	| { id?: string; type: "get_messages_page"; cursor?: string; limit?: number }
@@ -156,6 +172,11 @@ export interface RpcChunkFrame {
 
 export interface RpcHandoffResult {
 	savedPath?: string;
+}
+
+/** Durable snapshot returned by every mission RPC command. */
+export interface RpcMissionResult {
+	mission: MissionState | null;
 }
 
 export type RpcSubagentSubscriptionLevel = "off" | "progress" | "events";
@@ -313,6 +334,15 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "set_session_name"; success: true }
 	| { id?: string; type: "response"; command: "handoff"; success: true; data: RpcHandoffResult | null }
 
+	// Mission
+	| { id?: string; type: "response"; command: "mission_start"; success: true; data: RpcMissionResult }
+	| { id?: string; type: "response"; command: "get_mission"; success: true; data: RpcMissionResult }
+	| { id?: string; type: "response"; command: "mission_accept"; success: true; data: RpcMissionResult }
+	| { id?: string; type: "response"; command: "mission_pause"; success: true; data: RpcMissionResult }
+	| { id?: string; type: "response"; command: "mission_resume"; success: true; data: RpcMissionResult }
+	| { id?: string; type: "response"; command: "mission_restart"; success: true; data: RpcMissionResult }
+	| { id?: string; type: "response"; command: "mission_cancel"; success: true; data: RpcMissionResult }
+
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }
 	| { id?: string; type: "response"; command: "get_messages_page"; success: true; data: RpcMessagesPage }
@@ -350,6 +380,18 @@ export interface RpcSubagentEventFrame {
 }
 
 export type RpcSubagentFrame = RpcSubagentLifecycleFrame | RpcSubagentProgressFrame | RpcSubagentEventFrame;
+
+export interface RpcMissionUpdatedFrame {
+	type: "mission_updated";
+	mission: MissionState;
+}
+
+export interface RpcMissionProgressFrame {
+	type: "mission_progress";
+	event: MissionProgressEvent;
+}
+
+export type RpcMissionFrame = RpcMissionUpdatedFrame | RpcMissionProgressFrame;
 
 export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
 

--- a/packages/coding-agent/src/prompts/missions/active.md
+++ b/packages/coding-agent/src/prompts/missions/active.md
@@ -1,0 +1,26 @@
+<mission_context>
+A mission is active. You are the parent orchestrator. Drive progress only through the `mission` tool. Feature work runs in child workers; you select, resolve, and revise — you NEVER implement inside the parent checkout.
+
+<tool>
+Use one `op` per call:
+- `get` — current mission snapshot (status, plan, active feature, pending handoff, retry budget).
+- `set_plan` — submit one complete `MissionPlan` (goal, runbook, milestones, features). Valid only while planning.
+- `run_next` — dispatch exactly one next pending feature. Returns its handoff or null.
+- `resolve_handoff` — clear the pending handoff with `decision`: `accept` | `retry_same` | `retry_fresh` | `cancel_feature` | `pause`. Optional `message_to_worker` for retries.
+- `revise_pending` — after a failed validator, supply nonempty `add_features` remediation specs. Runtime inserts them before that milestone's validators and resets those validators.
+</tool>
+
+<host_controls>
+`accept`, `pause`, `resume`, and `cancel` are HOST controls (`/mission` or RPC). You NEVER assume they happened, NEVER ask the user to type them as a substitute for tool work, and NEVER invent a transition the snapshot does not show. Call `get` when status is unclear.
+</host_controls>
+
+<rules>
+1. Exactly one feature runs at a time. NEVER attempt parallel dispatch.
+2. While a handoff is pending, resolve it before `run_next`.
+3. Accept only a successful implementation handoff with no blocking issues, or a passing validator handoff.
+4. On validator failure, prefer `revise_pending` with concrete remediation features over blind retries.
+5. Retry with `retry_same` (follow-up same worker) or `retry_fresh` (new worker, same feature workspace) when the gap is recoverable; `cancel_feature` only for implementation features that cannot proceed.
+6. You NEVER mutate Git in the parent checkout for mission work. Publication and workspace mutations belong to the runtime.
+7. You NEVER narrate idle status. Call the tool, then keep going while status is `running` or `orchestrator_turn`.
+</rules>
+</mission_context>

--- a/packages/coding-agent/src/prompts/missions/continuation.md
+++ b/packages/coding-agent/src/prompts/missions/continuation.md
@@ -1,0 +1,12 @@
+<!-- Hidden continuation steer. role=user, suppressed from visible transcript. -->
+
+Continue the active mission autonomously.
+
+Call `mission({op:"get"})` if you need the current snapshot, then do the next load-bearing step:
+- Pending handoff → `resolve_handoff` (or `revise_pending` after a failed validator).
+- Status `running` with no pending handoff → `run_next`.
+- Status `orchestrator_turn` → resolve the pending handoff before anything else.
+
+Exactly one feature at a time. Host-only controls (`accept` / `pause` / `resume` / `cancel`) are not yours to assume.
+
+If the work is not done, keep executing through the `mission` tool. NEVER narrate that you are continuing — execute.

--- a/packages/coding-agent/src/prompts/missions/interrupted.md
+++ b/packages/coding-agent/src/prompts/missions/interrupted.md
@@ -1,0 +1,28 @@
+<!-- Worker recovery after the process died mid-turn. -->
+
+Your previous turn was interrupted before a handoff was recorded. Resume the same feature from the preserved workspace. Do not restart from scratch unless the workspace evidence shows prior work is unusable.
+
+<feature>
+`{{feature.id}}` — {{feature.description}}
+</feature>
+
+<milestone>
+`{{milestone.id}}` — {{milestone.description}}
+</milestone>
+
+{{#if priorHandoffGap}}
+<prior_gap>
+{{priorHandoffGap}}
+</prior_gap>
+{{/if}}
+
+<procedure>
+1. Inspect the worktree and recent commits. Continue unfinished work; avoid redoing completed commits.
+2. {{#if skillName}}Re-read skill `skill://{{skillName}}` if you need its contract.{{else}}Follow the feature's expected behavior and preconditions.{{/if}}
+3. Finish the feature, verify, and produce a complete structured implementation handoff.
+4. Before `success`: require a clean committed worktree and list commit SHAs oldest-first from the reserved base (empty list for a no-op).
+</procedure>
+
+<critical>
+You NEVER mutate mission state. You NEVER invent commits or verification results. If you cannot recover cleanly, hand off `failure` or `return_to_orchestrator` with concrete evidence.
+</critical>

--- a/packages/coding-agent/src/prompts/missions/planning.md
+++ b/packages/coding-agent/src/prompts/missions/planning.md
@@ -1,0 +1,26 @@
+<!-- Hidden planning turn. role=user, suppressed from visible transcript. -->
+
+Plan this mission, then call `mission({op:"set_plan", plan})` once with a complete plan.
+
+{{#if goal}}
+<goal>
+{{goal}}
+</goal>
+{{else}}
+No goal was supplied. Ask for one through the existing UI bridge (`ask` / parent approval UI). Do not call `set_plan` until the goal is nonempty.
+{{/if}}
+
+<procedure>
+1. Take the goal above, or obtain a nonempty goal via the UI when empty.
+2. Build one complete plan: `goal`, `runbook` (`setup`, `services`, `userTests`), ordered `milestones`, and ordered `features`.
+3. Every implementation feature appears in exactly one milestone's `featureIds`, and that milestone id equals the feature's `milestoneId`.
+4. Default every milestone's `validators` to `scrutiny` plus `user-testing` when the runbook supports user-testing (at least one `userTests` command or service); otherwise `scrutiny` alone.
+5. Give each feature concrete `preconditions`, nonempty `expectedBehavior`, and optional `skillName` only when an existing loaded skill applies.
+6. Call `mission({op:"set_plan", ...})` with that full plan. This turn's job ends at a successful `set_plan`.
+</procedure>
+
+<critical>
+- You NEVER start workers or call `run_next` on this turn.
+- You NEVER submit a partial plan. Empty goals, empty validator lists, mismatched milestone membership, or `user-testing` without runbook support will be rejected.
+- You NEVER invent skills that are not in the session inventory.
+</critical>

--- a/packages/coding-agent/src/prompts/missions/scrutiny.md
+++ b/packages/coding-agent/src/prompts/missions/scrutiny.md
@@ -1,0 +1,49 @@
+You are the scrutiny validator for one mission milestone. Review the implementation at the current integration head. Read-only: no file edits, no state-changing commands, no mission-state mutation.
+
+<feature>
+`{{feature.id}}` — {{feature.description}}
+</feature>
+
+<milestone>
+`{{milestone.id}}` — {{milestone.description}}
+</milestone>
+
+<expected_behavior>
+{{#each expectedBehavior}}
+- {{this}}
+{{/each}}
+</expected_behavior>
+
+{{#if priorHandoffGap}}
+<prior_gap>
+Prior handoff context for this validation:
+{{priorHandoffGap}}
+</prior_gap>
+{{/if}}
+
+{{#if skillName}}
+<skill>
+The implementation claimed skill `{{skillName}}`. Check conformance against `skill://{{skillName}}` where relevant.
+</skill>
+{{/if}}
+
+<procedure>
+1. Inspect the diff and surrounding code for this milestone's completed implementation features.
+2. For every expected-behavior item, determine whether the code and available evidence support it.
+3. Report only provable, actionable defects introduced by the change — same rigor as a merge-blocking review.
+4. Yield a structured validation handoff (`kind: "validation"`, `role: "scrutiny"`).
+</procedure>
+
+<handoff>
+Required fields:
+- `verdict`: `pass` | `fail`
+- `summary`: one short plain-text verdict
+- `checks`: one entry per expected-behavior item (and any additional checks you ran), each with `passed` | `failed` | `not_run` and sanitized evidence
+- `issues`: blocking / non_blocking / suggestion with evidence when present
+</handoff>
+
+<critical>
+- `pass` only when no blocking issues remain and expected behavior is evidenced.
+- You NEVER invent findings or evidence. If you could not run a check, mark it `not_run` and fail closed when that check is load-bearing.
+- You NEVER modify the tree. Bash stays read-only (`git diff`, `git log`, `git show`, reads).
+</critical>

--- a/packages/coding-agent/src/prompts/missions/user-testing.md
+++ b/packages/coding-agent/src/prompts/missions/user-testing.md
@@ -1,0 +1,57 @@
+You are the user-testing validator for one mission milestone. Exercise the declared runbook against the current integration head. You NEVER invent results.
+
+<feature>
+`{{feature.id}}` — {{feature.description}}
+</feature>
+
+<milestone>
+`{{milestone.id}}` — {{milestone.description}}
+</milestone>
+
+<expected_behavior>
+{{#each expectedBehavior}}
+- {{this}}
+{{/each}}
+</expected_behavior>
+
+{{#if priorHandoffGap}}
+<prior_gap>
+Prior handoff context for this validation:
+{{priorHandoffGap}}
+</prior_gap>
+{{/if}}
+
+<runbook>
+Services:
+{{#each runbook.services}}
+- `{{name}}` — start: `{{start}}`; ready: `{{ready}}`{{#if stop}}; stop: `{{stop}}`{{/if}}
+{{/each}}
+
+User tests (run ONLY these):
+{{#each runbook.userTests}}
+- `{{this}}`
+{{/each}}
+</runbook>
+
+<procedure>
+1. Start each declared runbook service through the existing process tools (`hub` process ops: `start`, readiness wait, `logs`, `stop`). Wait for readiness; process creation alone is not ready.
+2. Run ONLY `runbook.userTests`. Do not invent extra tests or skip listed ones.
+3. Capture sanitized evidence for every check (stdout/stderr excerpts, exit status, readiness failures). Strip secrets.
+4. Stop every service you started before handing off — including on failure paths.
+5. Yield a structured validation handoff (`kind: "validation"`, `role: "user-testing"`).
+</procedure>
+
+<handoff>
+Required fields:
+- `verdict`: `pass` | `fail`
+- `summary`
+- `checks`: one entry per user-test (and service readiness), each with `passed` | `failed` | `not_run` and sanitized evidence
+- `issues`: blocking / non_blocking / suggestion with evidence when present
+</handoff>
+
+<critical>
+- Denied, unavailable, or unstartable setup returns `not_run` on affected checks and a `fail` verdict when those checks are required — NEVER an invented pass.
+- You NEVER mutate mission state.
+- You NEVER leave services running after handoff.
+- You NEVER treat a command you did not run as `passed`.
+</critical>

--- a/packages/coding-agent/src/prompts/missions/worker.md
+++ b/packages/coding-agent/src/prompts/missions/worker.md
@@ -1,0 +1,62 @@
+You are the implementation worker for one mission feature. Stay inside this fixed worktree. Hyperfocus on this feature only.
+
+<feature>
+`{{feature.id}}` — {{feature.description}}
+</feature>
+
+<milestone>
+`{{milestone.id}}` — {{milestone.description}}
+</milestone>
+
+{{#if skillName}}
+<skill>
+Read and follow skill `skill://{{skillName}}` before editing. Record any unavoidable deviations in the handoff `skillDeviations` list.
+</skill>
+{{/if}}
+
+<expected_behavior>
+{{#each expectedBehavior}}
+- {{this}}
+{{/each}}
+</expected_behavior>
+
+{{#if priorHandoffGap}}
+<prior_gap>
+Address this gap from the prior handoff before claiming success:
+{{priorHandoffGap}}
+</prior_gap>
+{{/if}}
+
+<runbook>
+Setup commands (run idempotently before implementation work):
+{{#each runbook.setup}}
+- `{{this}}`
+{{/each}}
+</runbook>
+
+<procedure>
+1. {{#if skillName}}Read `skill://{{skillName}}`.{{else}}Confirm expected behavior and preconditions from the feature spec.{{/if}}
+2. Run each `runbook.setup` command idempotently. Setup prepares the environment; it is not proof of feature success.
+3. Implement only this feature. Prefer edits to existing files. Do not expand scope.
+4. Verify against every expected-behavior item with real commands or checks. Record each in the handoff.
+5. Commit your work in this feature worktree when there are changes. Leave the tree clean.
+6. Yield a structured implementation handoff (`kind: "implementation"`).
+</procedure>
+
+<handoff>
+Required fields:
+- `outcome`: `success` | `partial` | `failure` | `return_to_orchestrator`
+- `summary`, `implementation`, `remaining`
+- `verification.commands` / `verification.interactiveChecks` with `passed` | `failed` | `not_run` and sanitized evidence
+- `tests.added`, `tests.coverageNotes`
+- `issues` (blocking / non_blocking / suggestion)
+- `skillDeviations`
+- `commits`: full SHAs oldest-first from the reserved feature base to HEAD. Empty list for a no-op success.
+</handoff>
+
+<critical>
+- You NEVER mutate mission state (no `mission` tool, no parent-checkout mission edits).
+- You NEVER claim `success` with a dirty worktree or uncommitted changes.
+- You NEVER invent command results. Denied, unavailable, or unrun checks are `not_run` or drive `failure`/`partial` — never fabricated passes.
+- You NEVER push, force-update shared refs, or touch the parent checkout.
+</critical>

--- a/packages/coding-agent/src/prompts/tools/schedule.md
+++ b/packages/coding-agent/src/prompts/tools/schedule.md
@@ -1,0 +1,22 @@
+Wake this session later with a one-shot timer.
+
+Timers stop when the process exits. A pending intent can re-arm when this same session is resumed with scheduling enabled.
+
+## Create
+
+Supply **exactly one** of:
+
+- `delayMs` — relative delay in milliseconds (non-negative integer, at most 2_147_483_647)
+- `atIso` — absolute due time as an ISO-8601 timestamp, at most about 24.8 days ahead
+
+Plus a non-empty `prompt` that will be enqueued as a hidden next-turn message when the timer fires. Returns the created schedule `id`.
+
+## Cancel
+
+Pass `cancel` with a schedule id to cancel a pending wake. Do not combine cancel with create fields.
+
+## Rules
+
+- One-shot only — no recurrence or cron.
+- No wake runs while the session process is offline.
+- Cancelling an unknown id records a tombstone so an older create entry cannot reappear.

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -96,6 +96,7 @@ export class AgentLifecycleManager {
 			current.#revivals.clear();
 			current.#parks.clear();
 			current.#persistedReviverFactory = undefined;
+			current.#persistedReviversById.clear();
 		}
 		AgentLifecycleManager.#global = undefined;
 	}
@@ -114,6 +115,12 @@ export class AgentLifecycleManager {
 	#persistedReviverFactory: PersistedSubagentReviverFactory | undefined;
 	/** TTL applied when a cold-revived ref is adopted on demand. */
 	#persistedReviveTtlMs = 0;
+	/**
+	 * Per-agent persisted revivers for concurrent ACP top-level sessions.
+	 * Preferred over {@link #persistedReviverFactory} so one session cannot
+	 * clobber another's cold-worker routing.
+	 */
+	#persistedReviversById = new Map<string, { factory: PersistedSubagentReviverFactory; idleTtlMs: number }>();
 
 	constructor(registry: AgentRegistry = AgentRegistry.global()) {
 		this.#registry = registry;
@@ -129,6 +136,20 @@ export class AgentLifecycleManager {
 	setPersistedSubagentReviverFactory(factory: PersistedSubagentReviverFactory, idleTtlMs: number): void {
 		this.#persistedReviverFactory = factory;
 		this.#persistedReviveTtlMs = idleTtlMs;
+	}
+
+	/**
+	 * Register an id-scoped cold-reviver factory. Concurrent ACP top-level
+	 * sessions each register their own workers so {@link ensureLive} routes to
+	 * the owning session instead of the newest process-global factory.
+	 * Returns an unregister function; safe to call more than once.
+	 */
+	registerPersistedReviver(agentId: string, factory: PersistedSubagentReviverFactory, idleTtlMs: number): () => void {
+		this.#persistedReviversById.set(agentId, { factory, idleTtlMs });
+		return () => {
+			const current = this.#persistedReviversById.get(agentId);
+			if (current?.factory === factory) this.#persistedReviversById.delete(agentId);
+		};
 	}
 
 	/**
@@ -317,12 +338,23 @@ export class AgentLifecycleManager {
 		let adoption = this.#adopted.get(id);
 		let revive = adoption?.ref === ref ? adoption.revive : undefined;
 		let coldAdopted = false;
-		if (!revive && ref.status === "parked" && ref.sessionFile && this.#persistedReviverFactory) {
-			revive = await this.#persistedReviverFactory(ref);
-			if (revive) {
-				adoption = { ref, idleTtlMs: this.#persistedReviveTtlMs, revive };
-				this.#adopted.set(id, adoption);
-				coldAdopted = true;
+		if (!revive && ref.status === "parked" && ref.sessionFile) {
+			const scoped = this.#persistedReviversById.get(id);
+			if (scoped) {
+				revive = await scoped.factory(ref);
+				if (revive) {
+					adoption = { ref, idleTtlMs: scoped.idleTtlMs, revive };
+					this.#adopted.set(id, adoption);
+					coldAdopted = true;
+				}
+			}
+			if (!revive && this.#persistedReviverFactory) {
+				revive = await this.#persistedReviverFactory(ref);
+				if (revive) {
+					adoption = { ref, idleTtlMs: this.#persistedReviveTtlMs, revive };
+					this.#adopted.set(id, adoption);
+					coldAdopted = true;
+				}
 			}
 		}
 		if (this.#registry.get(id) !== ref) {
@@ -391,6 +423,7 @@ export class AgentLifecycleManager {
 		this.#revivals.clear();
 		this.#parks.clear();
 		this.#persistedReviverFactory = undefined;
+		this.#persistedReviversById.clear();
 	}
 
 	async #revive(id: string, revive: AgentReviver, ref: AgentRef, adopted: AdoptedAgent): Promise<AgentSession> {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3105,6 +3105,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			sessionManager,
 			settings,
 			autoApprove: options.autoApprove,
+			toolSession,
 			evalKernelOwnerId,
 			// Defined only for top-level sessions (creation is gated above).
 			// AgentSession uses this to decide whether it may dispose the global

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1606,6 +1606,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// mutation (any tool) bumped it in the meantime.
 		const fileMutationVersions = new Map<string, number>();
 		const activeToolNames = new Set<string>();
+		const isTopLevelSession = (): boolean => agentKind === "main";
 		const setActiveToolNames = (names: Iterable<string>): void => {
 			activeToolNames.clear();
 			for (const name of names) {
@@ -1645,6 +1646,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			requireYieldTool: options.requireYieldTool,
 			prewalkArmed: options.prewalk !== undefined,
 			taskDepth: options.taskDepth ?? 0,
+			isTopLevelSession,
 			getSessionFile: () => sessionManager.getSessionFile() ?? null,
 			sessionManager,
 			getEvalKernelOwnerId: () => evalKernelOwnerId,
@@ -1674,6 +1676,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getPlanReferencePath: () => session?.getPlanReferencePath() ?? "local://PLAN.md",
 			getGoalModeState: () => session?.getGoalModeState(),
 			getGoalRuntime: () => session?.goalRuntime,
+			getSessionSchedule: () => (isTopLevelSession() ? session?.getSessionSchedule() : undefined),
 			getUsageStatistics: () => sessionManager.getUsageStatistics(),
 			getTurnBudget: () => sessionManager.getTurnBudget(),
 			recordEvalSubagentUsage: output => sessionManager.recordEvalSubagentOutput(output),

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -4,6 +4,7 @@ import type { Effort } from "@oh-my-pi/pi-ai";
 import type { Rule } from "../capability/rule";
 import type { RecoveredRetryError } from "../extensibility/shared-events";
 import type { Goal, GoalModeState } from "../goals/state";
+import type { MissionProgressEvent, MissionState } from "../missions/types";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { TodoItem } from "../tools/todo";
 import type { CustomMessage } from "./messages";
@@ -60,7 +61,9 @@ export type AgentSessionEvent =
 			/** The level `auto` resolved to this turn, once classified. */
 			resolved?: Effort;
 	  }
-	| { type: "goal_updated"; goal: Goal | null; state?: GoalModeState };
+	| { type: "goal_updated"; goal: Goal | null; state?: GoalModeState }
+	| { type: "mission_updated"; mission: MissionState }
+	| { type: "mission_progress"; event: MissionProgressEvent };
 
 /** Listener function for agent session events. */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -23,8 +23,10 @@ import type { ExtensionRunner } from "../extensibility/extensions";
 import type { ContextUsage } from "../extensibility/extensions/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
+import type { PersistedSubagentReviverFactory } from "../registry/agent-lifecycle";
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import type { ConfiguredThinkingLevel } from "../thinking";
+import type { ToolSession } from "../tools";
 import type { XdevRegistry } from "../tools/xdev";
 import type { SessionManager } from "./session-manager";
 
@@ -218,6 +220,12 @@ export interface AgentSessionConfig {
 	disconnectOwnedMcpManager?: () => Promise<void>;
 	/** System prompt used by automatic session-title generation. */
 	titleSystemPrompt?: string;
+	/** Tool session retained for mission worker construction. */
+	toolSession?: ToolSession;
+	/** Session-scoped factory used to revive persisted mission children by id. */
+	persistedSubagentReviverFactory?: PersistedSubagentReviverFactory;
+	/** Idle TTL applied to revived mission children. */
+	missionIdleTtlMs?: number;
 }
 
 /** Options for AgentSession.prompt(). */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -97,7 +97,12 @@ import type { AdvisorConfig, AdvisorRuntimeStatus } from "../advisor";
 import { type AsyncJob, AsyncJobManager } from "../async";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
-import { type ResolvedModelRoleValue, resolveModelOverride } from "../config/model-resolver";
+import {
+	getModelMatchPreferences,
+	type ResolvedModelRoleValue,
+	resolveModelOverride,
+	resolveModelScope,
+} from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily } from "../config/service-tier";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -139,6 +144,8 @@ import type { GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import type { IrcMessage } from "../irc/bus";
+import { MissionRuntime, type MissionRuntimeHost } from "../missions/runtime";
+import type { MissionState } from "../missions/types";
 import { shutdownMnemopiEmbedClient } from "../mnemopi/embed-client";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
@@ -162,6 +169,7 @@ import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool
 import rewindReportTemplate from "../prompts/system/rewind-report.md" with { type: "text" };
 import sideChannelNoToolsReminder from "../prompts/system/side-channel-no-tools.md" with { type: "text" };
 import vibeModeActivePrompt from "../prompts/system/vibe-mode-active.md" with { type: "text" };
+import { AgentLifecycleManager, type PersistedSubagentReviverFactory } from "../registry/agent-lifecycle";
 import {
 	deobfuscateAssistantContent,
 	deobfuscateSessionContext,
@@ -169,6 +177,7 @@ import {
 	obfuscateProviderContext,
 	type SecretObfuscator,
 } from "../secrets/obfuscator";
+import type { ParentApprovalDelegate } from "../task/structured-subagent";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -177,6 +186,7 @@ import {
 	toReasoningEffort,
 } from "../thinking";
 import { shutdownTinyTitleClient } from "../tiny/title-client";
+import type { ToolSession } from "../tools";
 import { type AskToolDetails, type AskToolInput, recoverAskQuestions } from "../tools/ask";
 import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import type { CheckpointState, CompletedRewindState } from "../tools/checkpoint";
@@ -481,6 +491,9 @@ export class AgentSession {
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
+	readonly #missionRuntime: MissionRuntime;
+	#missionPersistedReviverFactory: PersistedSubagentReviverFactory | undefined;
+	#missionIdleTtlMs = 0;
 	/**
 	 * Dedicated timer pool for session schedules. Deliberately NOT the extension
 	 * runner's `ManagedTimers`: its `clearAll()` runs on extension teardown, which
@@ -1273,6 +1286,7 @@ export class AgentSession {
 				);
 			},
 		});
+		this.#missionRuntime = new MissionRuntime(this.#missionHost(config));
 		this.#rearmSessionSchedules();
 		this.#cancelExitRecorder = postmortem.register(`agent-session:${this.sessionManager.getSessionId()}`, reason => {
 			this.#recordSessionExit(reason);
@@ -1405,6 +1419,7 @@ export class AgentSession {
 			sessionFile: () => this.sessionFile,
 			baseSystemPrompt: () => this.#tools.baseSystemPrompt,
 			assertVibeSessionTransitionAllowed: action => this.#assertVibeSessionTransitionAllowed(action),
+			assertMissionTransitionAllowed: action => this.#assertMissionTransitionAllowed(action),
 			setSkipPostTurnMaintenance: timestamp => {
 				this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp = timestamp;
 			},
@@ -4247,6 +4262,89 @@ export class AgentSession {
 		return this.#goalRuntime;
 	}
 
+	get missionRuntime(): MissionRuntime {
+		return this.#missionRuntime;
+	}
+
+	async restoreMission(): Promise<MissionState | null> {
+		return this.#missionRuntime.restore();
+	}
+
+	async startMission(
+		goal: string,
+		options?: { workerModel?: string | string[]; validatorModel?: string | string[]; autoAccept?: boolean },
+	): Promise<MissionState> {
+		return this.#missionRuntime.start(goal, options);
+	}
+
+	setMissionPersistedReviverFactory(factory: PersistedSubagentReviverFactory, idleTtlMs: number): void {
+		this.#missionPersistedReviverFactory = factory;
+		this.#missionIdleTtlMs = idleTtlMs;
+	}
+
+	#missionHost(config: AgentSessionConfig): MissionRuntimeHost {
+		return {
+			ownerSessionId: () => this.sessionManager.getSessionId(),
+			cwd: () => this.sessionManager.getCwd(),
+			sessionManager: this.sessionManager,
+			emitUpdated: () => {},
+			emitProgress: () => {},
+			sendHiddenMessage: async message => {
+				await this.sendCustomMessage(
+					{ customType: message.customType, content: message.content, display: false, attribution: "agent" },
+					{ deliverAs: message.deliverAs },
+				);
+			},
+			getEnabledToolNames: () => this.getEnabledToolNames(),
+			setActiveToolsByName: names => this.setActiveToolsByName(names),
+			parentApprovalDelegate: (): ParentApprovalDelegate | undefined => {
+				const uiContext = this.#extensionRunner?.hasUI() ? this.#extensionRunner.getUIContext() : undefined;
+				return uiContext || this.#clientBridge
+					? { kind: "parent", uiContext, clientBridge: this.#clientBridge }
+					: undefined;
+			},
+			resolveChildModels: async (worker, validator) => {
+				for (const model of [worker, validator]) {
+					const patterns = model === undefined ? [] : Array.isArray(model) ? model : [model];
+					if (
+						patterns.length > 0 &&
+						(
+							await resolveModelScope(
+								patterns,
+								this.#modelRegistry,
+								getModelMatchPreferences(this.settings),
+								this.settings,
+							)
+						).length === 0
+					) {
+						throw new Error(`Unknown mission model: ${patterns.join(", ")}`);
+					}
+				}
+			},
+			assertSkillsExist: names => {
+				const available = new Set(this.skills.map(skill => skill.name));
+				for (const name of names) if (!available.has(name)) throw new Error(`Unknown mission skill: ${name}`);
+			},
+			getToolSession: () => config.toolSession as ToolSession,
+			isPlanModeActive: () => this.#planModeState?.enabled === true,
+			isGoalModeActive: () => this.#goalModeState?.enabled === true,
+			isVibeModeActive: () => this.#vibeModeState?.enabled === true,
+			registerPersistedReviver: agentId => {
+				const factory = this.#missionPersistedReviverFactory;
+				return factory
+					? AgentLifecycleManager.global().registerPersistedReviver(agentId, factory, this.#missionIdleTtlMs)
+					: undefined;
+			},
+			agentLifecycle: () => AgentLifecycleManager.global(),
+		};
+	}
+
+	#assertMissionTransitionAllowed(action: string): void {
+		if (this.#missionRuntime.isBusy() || this.#missionRuntime.hasActiveMission()) {
+			throw new Error(`MISSION_BUSY: Cannot ${action} while a mission is active.`);
+		}
+	}
+
 	/** Deliver an agent-authored message that stays hidden from the transcript. */
 	async #sendHiddenMessage(message: {
 		customType: string;
@@ -5954,6 +6052,7 @@ export class AgentSession {
 	 * @returns true if completed, false if cancelled by hook
 	 */
 	async newSession(options?: NewSessionOptions): Promise<boolean> {
+		this.#assertMissionTransitionAllowed("start a new session");
 		this.#assertVibeSessionTransitionAllowed("start a new session");
 		const previousSessionFile = this.sessionFile;
 
@@ -5970,6 +6069,7 @@ export class AgentSession {
 		}
 
 		this.#disconnectFromAgent();
+		await this.#missionRuntime.prepareToSuspend();
 		await this.abort();
 		this.#cancelOwnAsyncJobs();
 		this.#closeAllProviderSessions("new session");
@@ -6039,6 +6139,7 @@ export class AgentSession {
 			});
 		}
 
+		await this.#missionRuntime.restore();
 		return true;
 	}
 
@@ -6057,6 +6158,7 @@ export class AgentSession {
 	 * @returns true if completed, false if cancelled by hook or not persisting
 	 */
 	async fork(): Promise<boolean> {
+		this.#assertMissionTransitionAllowed("fork the session");
 		this.#assertVibeSessionTransitionAllowed("fork the session");
 		const previousSessionFile = this.sessionFile;
 
@@ -6128,11 +6230,13 @@ export class AgentSession {
 			});
 		}
 
+		await this.#missionRuntime.restore();
 		return true;
 	}
 
 	/** Move the active session and artifacts after enforcing mode transition invariants. */
 	async moveSession(newCwd: string, targetSessionDir?: string): Promise<void> {
+		this.#assertMissionTransitionAllowed("move the session");
 		this.#assertVibeSessionTransitionAllowed("move the session");
 		await this.sessionManager.moveTo(newCwd, targetSessionDir);
 	}
@@ -6300,6 +6404,7 @@ export class AgentSession {
 	 * @returns The handoff document text, or undefined if cancelled/failed
 	 */
 	handoff(customInstructions?: string, options?: SessionHandoffOptions): Promise<HandoffResult | undefined> {
+		this.#assertMissionTransitionAllowed("handoff the session");
 		return this.#handoff.handoff(customInstructions, options);
 	}
 
@@ -6949,6 +7054,7 @@ export class AgentSession {
 	 * @returns true if switch completed, false if cancelled by hook
 	 */
 	async switchSession(sessionPath: string): Promise<boolean> {
+		this.#assertMissionTransitionAllowed("switch sessions");
 		const previousSessionFile = this.sessionManager.getSessionFile();
 		const switchingToDifferentSession = previousSessionFile
 			? path.resolve(previousSessionFile) !== path.resolve(sessionPath)
@@ -6967,6 +7073,7 @@ export class AgentSession {
 		}
 
 		this.#disconnectFromAgent();
+		await this.#missionRuntime.prepareToSuspend();
 		await this.abort({ goalReason: "internal" });
 		await this.#sessionBeforeSwitchReconciler?.();
 
@@ -7137,6 +7244,7 @@ export class AgentSession {
 				this.#clearSessionScopedToolState();
 			}
 			this.#reconnectToAgent();
+			await this.#missionRuntime.restore();
 			try {
 				await this.#sessionSwitchReconciler?.();
 			} catch (error) {
@@ -7211,6 +7319,7 @@ export class AgentSession {
 		selectedText: string;
 		cancelled: boolean;
 	}> {
+		this.#assertMissionTransitionAllowed("branch the session");
 		const previousSessionFile = this.sessionFile;
 		const selectedEntry = this.sessionManager.getEntry(entryId);
 
@@ -7293,6 +7402,7 @@ export class AgentSession {
 		question: string,
 		assistantMessage: AssistantMessage,
 	): Promise<{ cancelled: boolean; sessionFile: string | undefined }> {
+		this.#assertMissionTransitionAllowed("branch the session");
 		const previousSessionFile = this.sessionFile;
 		if (!this.sessionManager.getSessionFile()) {
 			throw new Error("Cannot branch /btw: session is not persisted");

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4287,8 +4287,8 @@ export class AgentSession {
 			ownerSessionId: () => this.sessionManager.getSessionId(),
 			cwd: () => this.sessionManager.getCwd(),
 			sessionManager: this.sessionManager,
-			emitUpdated: () => {},
-			emitProgress: () => {},
+			emitUpdated: mission => this.#emitSessionEvent({ type: "mission_updated", mission }),
+			emitProgress: event => this.#emitSessionEvent({ type: "mission_progress", event }),
 			sendHiddenMessage: async message => {
 				await this.sendCustomMessage(
 					{ customType: message.customType, content: message.content, display: false, attribution: "agent" },

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -305,6 +305,7 @@ import {
 import { cleanupEmptyMoveSession, type SessionManager } from "./session-manager";
 import { SessionMemory, type SessionMemoryHost } from "./session-memory";
 import { SessionProviderBoundary, type SessionProviderBoundaryHost } from "./session-provider-boundary";
+import { initSessionSchedules, type SessionScheduleController } from "./session-schedule";
 import { SessionStatsTracker, type SessionStatsTrackerHost } from "./session-stats";
 import { SessionTools, type SessionToolsHost } from "./session-tools";
 import type { ShakeMode, ShakeResult } from "./shake-types";
@@ -480,6 +481,15 @@ export class AgentSession {
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
+	/**
+	 * Dedicated timer pool for session schedules. Deliberately NOT the extension
+	 * runner's `ManagedTimers`: its `clearAll()` runs on extension teardown, which
+	 * would silently disarm every pending wake.
+	 */
+	readonly #sessionScheduleTimers = new ManagedTimers((event, error) =>
+		logger.warn("Session schedule timer callback threw", { event, error }),
+	);
+	#sessionSchedule: SessionScheduleController | undefined;
 	readonly #advisors: SessionAdvisors;
 	#goalTurnCounter = 0;
 	#planReferenceSent = false;
@@ -1263,6 +1273,7 @@ export class AgentSession {
 				);
 			},
 		});
+		this.#rearmSessionSchedules();
 		this.#cancelExitRecorder = postmortem.register(`agent-session:${this.sessionManager.getSessionId()}`, reason => {
 			this.#recordSessionExit(reason);
 		});
@@ -1425,6 +1436,7 @@ export class AgentSession {
 			buildDisplaySessionContext: () => this.buildDisplaySessionContext(),
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
+			rearmSessionSchedules: () => this.#rearmSessionSchedules(),
 		};
 		this.#handoff = new SessionHandoff(handoffHost);
 
@@ -3505,6 +3517,9 @@ export class AgentSession {
 		this.#recordSessionExit(options.reason ?? "dispose");
 		this.#cancelExitRecorder?.();
 		this.#cancelExitRecorder = undefined;
+		this.#sessionSchedule?.dispose();
+		this.#sessionSchedule = undefined;
+		this.#sessionScheduleTimers.clearAll();
 		try {
 			await emitSessionShutdownEvent(this.#extensionRunner);
 		} catch (error) {
@@ -3513,6 +3528,9 @@ export class AgentSession {
 
 		// Stop fallback extension timers before aborting deferred work they could enqueue.
 		this.#fallbackExtensionTimers?.clearAll();
+		// Same reason, and one more: an armed wake closes over this session's manager, so a
+		// schedule surviving teardown would both pin the disposed session and later fire
+		// getEntries/appendCustomEntry against a SessionManager already closed below.
 		this.abortRetry();
 		this.abortCompaction();
 		const postPromptDrain = this.#cancelPostPromptTasks();
@@ -4227,6 +4245,48 @@ export class AgentSession {
 
 	get goalRuntime(): GoalRuntime {
 		return this.#goalRuntime;
+	}
+
+	/** Deliver an agent-authored message that stays hidden from the transcript. */
+	async #sendHiddenMessage(message: {
+		customType: string;
+		content: string;
+		deliverAs?: "steer" | "followUp" | "nextTurn";
+		triggerTurn?: boolean;
+	}): Promise<void> {
+		if (this.#isDisposed) return;
+		await this.sendCustomMessage(
+			{
+				customType: message.customType,
+				content: message.content,
+				display: false,
+				attribution: "agent",
+			},
+			{ deliverAs: message.deliverAs, triggerTurn: message.triggerTurn },
+		);
+	}
+
+	/**
+	 * (Re)arm persisted one-shot wakes for the active branch. Called at construction and
+	 * after any branch swap, since `newSession`/`switchSession` replace the entry set the
+	 * pending fold derives from.
+	 */
+	#rearmSessionSchedules(): void {
+		this.#sessionSchedule?.dispose();
+		this.#sessionSchedule = undefined;
+		if (!this.settings.get("schedule.enabled") || this.#agentKind === "sub") return;
+		this.#sessionSchedule = initSessionSchedules(this.sessionManager.getBranch(), this.#sessionScheduleTimers, {
+			getEntries: () => this.sessionManager.getBranch(),
+			appendCustomEntry: (customType, data) => this.sessionManager.appendCustomEntry(customType, data),
+			flush: () => this.sessionManager.flush(),
+			sendHiddenMessage: message => this.#sendHiddenMessage(message),
+			isLive: () => !this.#isDisposed,
+		});
+	}
+
+	/** Live schedule controller read by the schedule tool. */
+	getSessionSchedule(): SessionScheduleController | undefined {
+		return this.#sessionSchedule;
 	}
 
 	markPlanReferenceSent(): void {
@@ -5966,6 +6026,10 @@ export class AgentSession {
 		// not the previous session's — refresh before the next turn goes out.
 		await this.refreshBaseSystemPrompt();
 
+		// The branch just changed, so the previous branch's wakes are no longer ours to
+		// fire and this branch's have never been armed.
+		this.#rearmSessionSchedules();
+
 		// Emit session_switch event with reason "new" to hooks
 		if (this.#extensionRunner) {
 			await this.#extensionRunner.emit({
@@ -6053,6 +6117,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		await this.#memory.resetContextForNewTranscript();
+		this.#rearmSessionSchedules();
 
 		// Emit session_switch event with reason "fork" to hooks
 		if (this.#extensionRunner) {
@@ -6362,6 +6427,7 @@ export class AgentSession {
 		this.agent.replaceMessages(activeMessages ?? sessionContext.messages);
 		this.#advisors.resetSessionState();
 		this.#todo.syncFromBranch();
+		this.#rearmSessionSchedules();
 		this.#closeCodexProviderSessionsForHistoryRewrite();
 		this.#checkpointState = undefined;
 		this.#pendingRewindReport = undefined;
@@ -6980,6 +7046,9 @@ export class AgentSession {
 			this.agent.replaceMessages(sessionContext.messages);
 			this.#advisors.resetSessionState();
 			this.#todo.syncFromBranch();
+			// Same reason as newSession: the entry set the pending fold derives from was
+			// just replaced, so re-arm against the branch we actually switched to.
+			this.#rearmSessionSchedules();
 			if (switchingToDifferentSession) {
 				this.#closeAllProviderSessions("session switch");
 			} else if (didReloadConversationChange) {
@@ -7113,6 +7182,7 @@ export class AgentSession {
 			this.#models.restoreThinkingSnapshot(previousThinkingLevel, previousAutoThinking, previousAutoResolvedLevel);
 			this.#models.restoreServiceTiers(previousServiceTierByFamily);
 			this.#todo.syncFromBranch();
+			this.#rearmSessionSchedules();
 			this.#advisors.resetAllRuntimes();
 			this.#reconnectToAgent();
 			try {
@@ -7197,6 +7267,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		await this.#memory.resetContextForNewTranscript();
+		this.#rearmSessionSchedules();
 
 		// Reload messages from entries (works for both file and in-memory mode)
 		const sessionContext = this.buildDisplaySessionContext();
@@ -7301,6 +7372,7 @@ export class AgentSession {
 		this.#syncAgentSessionId();
 		this.#memory.rekeyForCurrentSessionId();
 		await this.#memory.resetContextForNewTranscript();
+		this.#rearmSessionSchedules();
 
 		const sessionContext = this.buildDisplaySessionContext();
 
@@ -7600,6 +7672,7 @@ export class AgentSession {
 		this.#rehydrateCheckpointRewindState();
 		this.#advisors.resetSessionState();
 		this.#todo.syncFromBranch();
+		this.#rearmSessionSchedules();
 		this.#closeCodexProviderSessionsForHistoryRewrite();
 
 		this.#branchSummaryAbortController = undefined;

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -164,6 +164,19 @@ export interface TtsrInjectionEntry extends SessionEntryBase {
 	injectedRules: string[];
 }
 
+/**
+ * JSON-safe mission-child ownership markers for session_init.
+ * Lives beside SessionInitEntry (not the mission domain) so session persistence
+ * never imports MissionRuntime.
+ */
+export interface MissionChildOwnerEntry {
+	missionId: string;
+	ownerSessionId: string;
+	role: "implementation" | "scrutiny" | "user-testing";
+	milestoneId: string;
+	featureId: string;
+}
+
 /** Session init entry - captures initial context for subagent sessions (debugging/replay). */
 export interface SessionInitEntry extends SessionEntryBase {
 	type: "session_init";
@@ -183,6 +196,10 @@ export interface SessionInitEntry extends SessionEntryBase {
 	spawns?: string;
 	/** The agent's `readSummarize` setting (`false` = read summarization disabled); absent uses the session default. */
 	readSummarize?: boolean;
+	/** Fixed mission worktree binding; absent preserves ordinary-task revive-at-parent-cwd semantics. */
+	cwdBinding?: "fixed";
+	/** Mission ownership required to cold-revive a fixed-cwd child in the owning top-level session. */
+	missionOwner?: MissionChildOwnerEntry;
 }
 
 /** Mode change entry - tracks agent mode transitions (e.g. plan mode). */

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -66,6 +66,7 @@ export interface SessionHandoffHost {
 	buildDisplaySessionContext(): SessionContext;
 	resetAdvisorRuntimes(): void;
 	syncTodoPhasesFromBranch(): void;
+	rearmSessionSchedules(): void;
 }
 
 /** Generates handoff documents and owns the handoff session transition. */
@@ -284,6 +285,7 @@ export class SessionHandoff {
 			// Rebuild agent messages from session
 			const sessionContext = this.#host.buildDisplaySessionContext();
 			this.#host.agent.replaceMessages(sessionContext.messages);
+			this.#host.rearmSessionSchedules();
 			this.#host.resetAdvisorRuntimes();
 			this.#host.syncTodoPhasesFromBranch();
 			if (this.#host.extensionRunner) {

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -44,6 +44,7 @@ export interface SessionHandoffHost {
 	sessionFile(): string | undefined;
 	baseSystemPrompt(): string[];
 	assertVibeSessionTransitionAllowed(action: string): void;
+	assertMissionTransitionAllowed(action: string): void;
 	setSkipPostTurnMaintenance(timestamp: number | undefined): void;
 	obfuscateTextForProvider(text: string | undefined): string | undefined;
 	deobfuscateFromProvider(text: string): string;
@@ -99,6 +100,7 @@ export class SessionHandoff {
 	 * @returns The handoff document text, or undefined if cancelled/failed
 	 */
 	async handoff(customInstructions?: string, options?: SessionHandoffOptions): Promise<HandoffResult | undefined> {
+		this.#host.assertMissionTransitionAllowed("handoff to a new session");
 		this.#host.assertVibeSessionTransitionAllowed("handoff to a new session");
 		const entries = this.#host.sessionManager.getBranch();
 		const messageCount = entries.filter(e => e.type === "message").length;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -40,6 +40,7 @@ import {
 	type CustomMessageEntry,
 	type FileEntry,
 	type LabelEntry,
+	type MissionChildOwnerEntry,
 	type ModeChangeEntry,
 	type ModelChangeEntry,
 	type NewSessionOptions,
@@ -1942,6 +1943,8 @@ export class SessionManager {
 		restrictToolNames?: boolean;
 		spawns?: string;
 		readSummarize?: boolean;
+		cwdBinding?: "fixed";
+		missionOwner?: MissionChildOwnerEntry;
 	}): string {
 		const entry: SessionInitEntry = { type: "session_init", ...this.#freshEntryFields(), ...init };
 		this.#recordEntry(entry);
@@ -2382,6 +2385,8 @@ export class SessionManager {
 			restrictToolNames?: boolean;
 			spawns?: string;
 			readSummarize?: boolean;
+			cwdBinding?: "fixed";
+			missionOwner?: MissionChildOwnerEntry;
 		} | null;
 	} | null> {
 		let loaded: FileEntry[];
@@ -2402,6 +2407,8 @@ export class SessionManager {
 			restrictToolNames?: boolean;
 			spawns?: string;
 			readSummarize?: boolean;
+			cwdBinding?: "fixed";
+			missionOwner?: MissionChildOwnerEntry;
 		} | null = null;
 		for (let index = loaded.length - 1; index >= 0; index--) {
 			const entry = loaded[index];
@@ -2415,6 +2422,8 @@ export class SessionManager {
 					restrictToolNames: entry.restrictToolNames,
 					readSummarize: entry.readSummarize,
 					spawns: entry.spawns,
+					cwdBinding: entry.cwdBinding,
+					missionOwner: entry.missionOwner,
 				};
 				break;
 			}

--- a/packages/coding-agent/src/session/session-schedule.ts
+++ b/packages/coding-agent/src/session/session-schedule.ts
@@ -1,0 +1,350 @@
+/**
+ * Session self-scheduling — persist wake intent in the transcript, fold the
+ * newest entry per id, and arm one ManagedTimers timeout per pending schedule.
+ *
+ * Schedules are one-shot and live only while the process does. Firing never
+ * invokes a tool; it enqueues the stored prompt as a hidden nextTurn message
+ * through the same sendHiddenMessage seam GoalRuntime uses.
+ */
+import { isRecord, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import type { ManagedTimers } from "../extensibility/extensions/managed-timers";
+import type { SessionEntry } from "./session-entries";
+
+export const SESSION_SCHEDULE_CUSTOM_TYPE = "session-schedule";
+export const SESSION_SCHEDULE_MESSAGE_TYPE = "session-schedule-wake";
+
+/** Largest delay Bun can represent without firing its timeout almost immediately. */
+export const SESSION_SCHEDULE_MAX_DELAY_MS = 2_147_483_647;
+
+/** Create payload persisted via appendCustomEntry. */
+export type SessionScheduleCreateData = {
+	id: string;
+	dueAtMs: number;
+	prompt: string;
+	createdAt: number;
+};
+
+/** Cancellation tombstone for the same id. */
+export type SessionScheduleCancelData = {
+	id: string;
+	cancelled: true;
+};
+
+/** Fired tombstone so restore does not re-arm an already-delivered wake. */
+export type SessionScheduleFiredData = {
+	id: string;
+	fired: true;
+};
+
+export type SessionScheduleData = SessionScheduleCreateData | SessionScheduleCancelData | SessionScheduleFiredData;
+
+export type SessionScheduleClassification =
+	| { kind: "create"; data: SessionScheduleCreateData }
+	| { kind: "cancel"; data: SessionScheduleCancelData }
+	| { kind: "fired"; data: SessionScheduleFiredData };
+
+/** Pending wake after the newest-per-id fold drops cancelled and fired ids. */
+export type PendingSessionSchedule = SessionScheduleCreateData;
+
+export type SessionScheduleCreateInput = {
+	delayMs?: number;
+	atIso?: string;
+	prompt: string;
+};
+
+/** Timer surface compatible with {@link ManagedTimers}. */
+export type SessionScheduleTimerHost = Pick<ManagedTimers, "setTimeout" | "clear">;
+
+/**
+ * Fire host — mirrors GoalRuntimeHost.sendHiddenMessage and adds the persistence
+ * + triggerTurn hooks schedules need. Orchestrator wires this from AgentSession.
+ */
+export type SessionScheduleFireHost = {
+	getEntries: () => readonly SessionEntry[];
+	appendCustomEntry: (customType: string, data?: unknown) => string;
+	flush?: () => Promise<void>;
+	sendHiddenMessage: (message: {
+		customType: string;
+		content: string;
+		deliverAs?: "steer" | "followUp" | "nextTurn";
+		triggerTurn?: boolean;
+	}) => Promise<void>;
+	now?: () => number;
+	isLive?: () => boolean;
+};
+
+export type ArmSessionSchedulesResult = {
+	pending: PendingSessionSchedule[];
+	disarm: () => void;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Classify a custom-entry payload; unknown shapes are ignored (not authoritative). */
+export function classifySessionScheduleData(data: unknown): SessionScheduleClassification | undefined {
+	if (!isRecord(data) || typeof data.id !== "string" || data.id.length === 0) return undefined;
+
+	if (data.cancelled === true) {
+		return { kind: "cancel", data: { id: data.id, cancelled: true } };
+	}
+	if (data.fired === true) {
+		return { kind: "fired", data: { id: data.id, fired: true } };
+	}
+	if (
+		isFiniteNumber(data.dueAtMs) &&
+		typeof data.prompt === "string" &&
+		data.prompt.length > 0 &&
+		isFiniteNumber(data.createdAt)
+	) {
+		return {
+			kind: "create",
+			data: {
+				id: data.id,
+				dueAtMs: data.dueAtMs,
+				prompt: data.prompt,
+				createdAt: data.createdAt,
+			},
+		};
+	}
+	return undefined;
+}
+
+/**
+ * Newest entry per id wins. Cancelled and fired ids are dropped; overdue creates
+ * remain pending so restore can fire them once at the next turn boundary.
+ */
+export function foldPendingSessionSchedules(entries: readonly SessionEntry[]): PendingSessionSchedule[] {
+	const newest = new Map<string, SessionScheduleClassification>();
+	for (const entry of entries) {
+		if (entry.type !== "custom" || entry.customType !== SESSION_SCHEDULE_CUSTOM_TYPE) continue;
+		const classified = classifySessionScheduleData(entry.data);
+		if (!classified) continue;
+		newest.set(classified.data.id, classified);
+	}
+
+	const pending: PendingSessionSchedule[] = [];
+	for (const classified of newest.values()) {
+		switch (classified.kind) {
+			case "create":
+				pending.push(classified.data);
+				break;
+			case "cancel":
+			case "fired":
+				break;
+			default: {
+				const _exhaustive: never = classified;
+				void _exhaustive;
+				break;
+			}
+		}
+	}
+	return pending;
+}
+
+export function resolveScheduleDueAtMs(
+	input: SessionScheduleCreateInput,
+	nowMs: number,
+): { dueAtMs: number } | { error: string } {
+	const hasDelay = input.delayMs !== undefined;
+	const hasAt = input.atIso !== undefined;
+	if (hasDelay === hasAt) {
+		return { error: "Exactly one of delayMs or atIso must be supplied." };
+	}
+	if (hasDelay) {
+		const delayMs = input.delayMs;
+		if (delayMs === undefined || !Number.isInteger(delayMs) || delayMs < 0) {
+			return { error: "delayMs must be a non-negative integer." };
+		}
+		if (delayMs > SESSION_SCHEDULE_MAX_DELAY_MS) {
+			return { error: `delayMs must not exceed ${SESSION_SCHEDULE_MAX_DELAY_MS}.` };
+		}
+		return { dueAtMs: nowMs + delayMs };
+	}
+	const atIso = input.atIso;
+	if (atIso === undefined || atIso.trim().length === 0) {
+		return { error: "atIso must be a non-empty ISO-8601 timestamp." };
+	}
+	const parsed = Date.parse(atIso);
+	if (!Number.isFinite(parsed)) {
+		return { error: `atIso is not a valid ISO-8601 timestamp: ${atIso}` };
+	}
+	if (parsed <= nowMs) {
+		return { error: "atIso must be in the future." };
+	}
+	if (parsed - nowMs > SESSION_SCHEDULE_MAX_DELAY_MS) {
+		return { error: `atIso must not be more than ${SESSION_SCHEDULE_MAX_DELAY_MS}ms in the future.` };
+	}
+	return { dueAtMs: parsed };
+}
+
+async function persistFiredAndEnqueue(
+	host: SessionScheduleFireHost,
+	schedule: PendingSessionSchedule,
+	triggerTurn: boolean,
+	isArmLive: () => boolean,
+): Promise<void> {
+	if (!isArmLive() || (host.isLive && !host.isLive())) return;
+	const stillPending = foldPendingSessionSchedules(host.getEntries()).some(entry => entry.id === schedule.id);
+	if (!stillPending) return;
+
+	const firedEntryId = host.appendCustomEntry(SESSION_SCHEDULE_CUSTOM_TYPE, {
+		id: schedule.id,
+		fired: true,
+	} satisfies SessionScheduleFiredData);
+	if (host.flush) await host.flush();
+	if ((host.isLive && !host.isLive()) || !host.getEntries().some(entry => entry.id === firedEntryId)) return;
+
+	await host.sendHiddenMessage({
+		customType: SESSION_SCHEDULE_MESSAGE_TYPE,
+		content: schedule.prompt,
+		deliverAs: "nextTurn",
+		triggerTurn,
+	});
+}
+
+/**
+ * Arm one timeout per pending schedule. A schedule whose dueAtMs has already
+ * passed fires once at the next turn boundary (triggerTurn: false) rather than
+ * being dropped or re-armed as a late repeating wake.
+ */
+export function armSessionSchedules(
+	entries: readonly SessionEntry[],
+	timers: SessionScheduleTimerHost,
+	host: SessionScheduleFireHost,
+	options?: { now?: () => number },
+): ArmSessionSchedulesResult {
+	const now = options?.now ?? (() => host.now?.() ?? Date.now());
+	const pending = foldPendingSessionSchedules(entries);
+	const armed = new Map<string, Timer>();
+	let active = true;
+
+	const disarm = (): void => {
+		active = false;
+		for (const timer of armed.values()) timers.clear(timer);
+		armed.clear();
+	};
+
+	const armOne = (schedule: PendingSessionSchedule): void => {
+		const dueAtMs = schedule.dueAtMs;
+		const nowMs = now();
+		const overdue = dueAtMs <= nowMs;
+		const delayMs = overdue ? 0 : Math.max(0, dueAtMs - nowMs);
+		// Overdue: enqueue as nextTurn context without starting a turn (boundary).
+		// Future: wake the session when the timer fires.
+		const triggerTurn = !overdue;
+		if (!overdue && delayMs > SESSION_SCHEDULE_MAX_DELAY_MS) {
+			logger.warn("session-schedule not armed: persisted delay exceeds timer maximum", {
+				id: schedule.id,
+				dueAtMs,
+				delayMs,
+			});
+			return;
+		}
+
+		const timer = timers.setTimeout(() => {
+			armed.delete(schedule.id);
+			void persistFiredAndEnqueue(host, schedule, triggerTurn, () => active).catch(err => {
+				logger.warn("session-schedule fire failed", {
+					id: schedule.id,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			});
+		}, delayMs);
+		armed.set(schedule.id, timer);
+	};
+
+	for (const schedule of pending) armOne(schedule);
+
+	return { pending, disarm };
+}
+
+/** Live controller: create/cancel persist first, then (re)arm timers. */
+export class SessionScheduleController {
+	readonly #timers: SessionScheduleTimerHost;
+	readonly #host: SessionScheduleFireHost;
+	readonly #now: () => number;
+	#disarm: (() => void) | undefined;
+	#disposed = false;
+
+	constructor(timers: SessionScheduleTimerHost, host: SessionScheduleFireHost, now?: () => number) {
+		this.#timers = timers;
+		this.#host = host;
+		this.#now = now ?? (() => host.now?.() ?? Date.now());
+	}
+
+	listPending(entries: readonly SessionEntry[] = this.#host.getEntries()): PendingSessionSchedule[] {
+		return foldPendingSessionSchedules(entries);
+	}
+
+	/** Disarm previous timers and arm every currently pending schedule. */
+	rearmFromEntries(entries: readonly SessionEntry[] = this.#host.getEntries()): PendingSessionSchedule[] {
+		this.#assertLive();
+		this.#disarm?.();
+		const result = armSessionSchedules(entries, this.#timers, this.#host, { now: this.#now });
+		this.#disarm = result.disarm;
+		return result.pending;
+	}
+
+	create(input: SessionScheduleCreateInput): PendingSessionSchedule {
+		this.#assertLive();
+		const prompt = input.prompt.trim();
+		if (!prompt) throw new Error("prompt must be a non-empty string.");
+
+		const nowMs = this.#now();
+		const due = resolveScheduleDueAtMs(input, nowMs);
+		if ("error" in due) throw new Error(due.error);
+
+		const schedule: PendingSessionSchedule = {
+			id: String(Snowflake.next()),
+			dueAtMs: due.dueAtMs,
+			prompt,
+			createdAt: nowMs,
+		};
+		this.#host.appendCustomEntry(SESSION_SCHEDULE_CUSTOM_TYPE, schedule);
+		this.rearmFromEntries();
+		return schedule;
+	}
+
+	cancel(id: string): boolean {
+		this.#assertLive();
+		const trimmed = id.trim();
+		if (!trimmed) throw new Error("cancel id must be a non-empty string.");
+
+		const pending = this.listPending();
+		const existed = pending.some(schedule => schedule.id === trimmed);
+		this.#host.appendCustomEntry(SESSION_SCHEDULE_CUSTOM_TYPE, {
+			id: trimmed,
+			cancelled: true,
+		} satisfies SessionScheduleCancelData);
+		this.rearmFromEntries();
+		return existed;
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#disarm?.();
+		this.#disarm = undefined;
+	}
+
+	#assertLive(): void {
+		if (this.#disposed) throw new Error("SessionScheduleController has been disposed.");
+	}
+}
+
+/**
+ * Named init the orchestrator calls from AgentSession construction and after
+ * newSession/switchSession.
+ */
+export function initSessionSchedules(
+	entries: readonly SessionEntry[],
+	timers: SessionScheduleTimerHost,
+	host: SessionScheduleFireHost,
+	options?: { now?: () => number },
+): SessionScheduleController {
+	const controller = new SessionScheduleController(timers, host, options?.now);
+	controller.rearmFromEntries(entries);
+	return controller;
+}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
-import type { Api, Model, ServiceTier, ServiceTierByFamily, ServiceTierFamily, Usage } from "@oh-my-pi/pi-ai";
+import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -139,6 +139,52 @@ export function createDelegatedParentApprovalUIContext(parent: ExtensionUIContex
 		getToolsExpanded: () => parent.getToolsExpanded(),
 		setToolsExpanded: expanded => parent.setToolsExpanded(expanded),
 	};
+}
+
+export function initializeDelegatedParentApprovalRunner(session: AgentSession, delegatedUi: ExtensionUIContext): void {
+	const runner = session.extensionRunner;
+	if (!runner || runner.hasUI()) return;
+	runner.initialize(
+		{
+			sendMessage: (message, options) => {
+				void session.sendCustomMessage(message, options).catch(error => {
+					logger.error("Delegated extension sendMessage failed", { error: String(error) });
+				});
+			},
+			sendUserMessage: (content, options) => {
+				void session.sendUserMessage(content, options).catch(error => {
+					logger.error("Delegated extension sendUserMessage failed", { error: String(error) });
+				});
+			},
+			appendEntry: (customType, data) => session.sessionManager.appendCustomEntry(customType, data),
+			setLabel: (targetId, label) => session.sessionManager.appendLabelChange(targetId, label),
+			getActiveTools: () => session.getEnabledToolNames(),
+			getAllTools: () => session.getAllToolNames(),
+			setActiveTools: toolNames => session.setActiveToolsByName(toolNames),
+			getCommands: () => getSessionSlashCommands(session),
+			setModel: model => runExtensionSetModel(session, model),
+			getThinkingLevel: () => session.thinkingLevel,
+			setThinkingLevel: level => session.setThinkingLevel(level),
+			getServiceTiers: () => session.serviceTierByFamily,
+			setServiceTier: (family, tier) => session.setServiceTierFamily(family, tier),
+			getSessionName: () => session.sessionManager.getSessionName(),
+			setSessionName: async name => {
+				await session.sessionManager.setSessionName(name, "user");
+			},
+		},
+		{
+			getModel: () => session.model,
+			isIdle: () => !session.isStreaming,
+			abort: () => session.abort({ reason: USER_INTERRUPT_LABEL }),
+			hasPendingMessages: () => session.queuedMessageCount > 0,
+			shutdown: () => {},
+			getContextUsage: () => session.getContextUsage(),
+			getSystemPrompt: () => session.systemPrompt,
+			compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
+		},
+		undefined,
+		delegatedUi,
+	);
 }
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
@@ -2942,53 +2988,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (parentApproval.clientBridge) {
 					childSession.setClientBridge(parentApproval.clientBridge);
 				}
-				// Live/cold revive builds a fresh ExtensionRunner; without initialize the
-				// approval wrapper sees hasUI=false and fails closed even when the parent
-				// UI is available. Bind the delegated UI here (actions are filled by the
-				// initial-run initialize path, or minimal stubs on revive).
-				const runner = childSession.extensionRunner;
-				if (runner && delegatedUi && !runner.hasUI()) {
-					runner.initialize(
-						{
-							sendMessage: () => {},
-							sendUserMessage: () => {},
-							appendEntry: (customType, data) => {
-								childSession.sessionManager.appendCustomEntry(customType, data);
-							},
-							setLabel: (targetId, label) => {
-								childSession.sessionManager.appendLabelChange(targetId, label);
-							},
-							getActiveTools: () => childSession.getEnabledToolNames(),
-							getAllTools: () => childSession.getAllToolNames(),
-							setActiveTools: async toolNames => {
-								await childSession.setActiveToolsByName(toolNames);
-							},
-							getCommands: () => getSessionSlashCommands(childSession),
-							setModel: model => runExtensionSetModel(childSession, model),
-							getThinkingLevel: () => childSession.thinkingLevel,
-							setThinkingLevel: level => childSession.setThinkingLevel(level),
-							getServiceTiers: () => childSession.serviceTierByFamily,
-							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
-								childSession.setServiceTierFamily(family, tier),
-							getSessionName: () => childSession.sessionManager.getSessionName(),
-							setSessionName: async name => {
-								await childSession.sessionManager.setSessionName(name, "user");
-							},
-						},
-						{
-							getModel: () => childSession.model,
-							isIdle: () => !childSession.isStreaming,
-							abort: () => childSession.abort({ reason: USER_INTERRUPT_LABEL }),
-							hasPendingMessages: () => childSession.queuedMessageCount > 0,
-							shutdown: () => {},
-							getContextUsage: () => childSession.getContextUsage(),
-							getSystemPrompt: () => childSession.systemPrompt,
-							compact: instructionsOrOptions => runExtensionCompact(childSession, instructionsOrOptions),
-						},
-						undefined,
-						delegatedUi,
-					);
-				}
 			};
 			applyParentApprovalDelegate(session, setToolUIContext);
 			if (sessionFile !== null && worktree === undefined) {
@@ -2997,6 +2996,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				// (createAgentSession → agent.replaceMessages). Isolated runs are not
 				// resumable (worktree is merged + cleaned) and never get a reviver.
 				reviveSession = async expectedAgentRef => {
+					if (
+						options.missionOwner &&
+						options.missionOwner.ownerSessionId !== options.localProtocolOptions?.getSessionId?.()
+					) {
+						throw new Error(`Cannot revive mission child ${id}: its owning session has changed.`);
+					}
 					const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
 						suppressBreadcrumb: true,
 					});
@@ -3008,6 +3013,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					);
 					installRegistryStatusSync(revived);
 					applyParentApprovalDelegate(revived, setRevivedToolUIContext);
+					if (parentApproval?.uiContext) {
+						initializeDelegatedParentApprovalRunner(
+							revived,
+							createDelegatedParentApprovalUIContext(parentApproval.uiContext),
+						);
+					}
 					return revived;
 				};
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
-import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
+import type { Api, Model, ServiceTier, ServiceTierByFamily, ServiceTierFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -28,6 +28,7 @@ import type { ToolPathWithSource } from "../extensibility/custom-tools";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
+import type { ExtensionUIContext, ExtensionUIDialogOptions } from "../extensibility/extensions/types";
 import { buildSkillPromptMessage, type Skill } from "../extensibility/skills";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
@@ -43,7 +44,9 @@ import type { AgentSession, AgentSessionEvent, Prewalk } from "../session/agent-
 import type { ArtifactManager } from "../session/artifacts";
 import { ASYNC_RESULT_MESSAGE_TYPE } from "../session/async-job-delivery";
 import type { AuthStorage } from "../session/auth-storage";
+import type { ClientBridge } from "../session/client-bridge";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../session/messages";
+import type { MissionChildOwnerEntry } from "../session/session-entries";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import { type ConfiguredThinkingLevel, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
@@ -77,6 +80,66 @@ import {
 import { arrayValuedLabels, assembleYieldResult } from "./yield-assembly";
 
 export type { YieldItem } from "./types";
+
+/** Default parent-approval dialog timeout for mission children (fail closed on expiry). */
+export const MISSION_PARENT_APPROVAL_TIMEOUT_MS = 300_000;
+
+function withMissionParentApprovalTimeout(
+	dialogOptions: ExtensionUIDialogOptions | undefined,
+): ExtensionUIDialogOptions {
+	const requested = dialogOptions?.timeout;
+	const timeout =
+		typeof requested === "number" &&
+		Number.isFinite(requested) &&
+		requested > 0 &&
+		requested < MISSION_PARENT_APPROVAL_TIMEOUT_MS
+			? requested
+			: MISSION_PARENT_APPROVAL_TIMEOUT_MS;
+	return { ...dialogOptions, timeout };
+}
+
+/**
+ * Forward parent UI while enforcing the mission approval timeout unless the child
+ * asked for something shorter. Timeout/denial stay fail-closed in the parent UI.
+ */
+export function createDelegatedParentApprovalUIContext(parent: ExtensionUIContext): ExtensionUIContext {
+	const wrap = (dialogOptions?: ExtensionUIDialogOptions) => withMissionParentApprovalTimeout(dialogOptions);
+	return {
+		get timeoutStartsOnPresentation() {
+			return parent.timeoutStartsOnPresentation;
+		},
+		select: (title, options, dialogOptions) => parent.select(title, options, wrap(dialogOptions)),
+		confirm: (title, message, dialogOptions) => parent.confirm(title, message, wrap(dialogOptions)),
+		input: (title, placeholder, dialogOptions) => parent.input(title, placeholder, wrap(dialogOptions)),
+		askDialog: parent.askDialog
+			? (questions, dialogOptions) => parent.askDialog!(questions, wrap(dialogOptions))
+			: undefined,
+		notify: (message, type) => parent.notify(message, type),
+		onTerminalInput: handler => parent.onTerminalInput(handler),
+		setStatus: (key, text) => parent.setStatus(key, text),
+		setWorkingMessage: message => parent.setWorkingMessage(message),
+		setWidget: (key, content, options) => parent.setWidget(key, content, options),
+		setFooter: factory => parent.setFooter(factory),
+		setHeader: factory => parent.setHeader(factory),
+		setTitle: title => parent.setTitle(title),
+		custom: (factory, options) => parent.custom(factory, options),
+		setEditorText: text => parent.setEditorText(text),
+		pasteToEditor: text => parent.pasteToEditor(text),
+		getEditorText: () => parent.getEditorText(),
+		editor: (title, prefill, dialogOptions, editorOptions) =>
+			parent.editor(title, prefill, wrap(dialogOptions), editorOptions),
+		addAutocompleteProvider: factory => parent.addAutocompleteProvider(factory),
+		setEditorComponent: factory => parent.setEditorComponent(factory),
+		get theme() {
+			return parent.theme;
+		},
+		getAllThemes: () => parent.getAllThemes(),
+		getTheme: name => parent.getTheme(name),
+		setTheme: theme => parent.setTheme(theme),
+		getToolsExpanded: () => parent.getToolsExpanded(),
+		setToolsExpanded: expanded => parent.setToolsExpanded(expanded),
+	};
+}
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
 
@@ -439,6 +502,19 @@ export interface ExecutorOptions {
 	 * set this false so disposal unregisters them instead of leaving idle peers.
 	 */
 	keepAlive?: boolean;
+	/** Fixed mission worktree binding; does not set {@link worktree} (reviver gate unchanged). */
+	workspace?: {
+		cwd: string;
+		binding: "fixed";
+	};
+	/** Parent-mediated approvals; when present, overrides the yolo subagent boundary. */
+	approvalDelegate?: {
+		kind: "parent";
+		uiContext?: ExtensionUIContext;
+		clientBridge?: ClientBridge;
+	};
+	/** Mission ownership markers persisted on session_init for cold revive. */
+	missionOwner?: MissionChildOwnerEntry;
 }
 
 function parseStringifiedJson(value: unknown): unknown {
@@ -2425,12 +2501,22 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	}
 
 	const settings = options.settings ?? Settings.isolated();
+	const parentApproval = options.approvalDelegate?.kind === "parent" ? options.approvalDelegate : undefined;
 	const subagentSettings = createSubagentSettings(
 		settings,
 		{
 			...(agent.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
 			// Isolated runs must not expose roots outside the worktree.
 			...(worktree !== undefined ? { "workspace.additionalDirectories": [] } : undefined),
+			// Mission parent delegate: restore the parent's approval mode/policies
+			// instead of the ordinary yolo subagent boundary. Fail closed — never
+			// leave yolo when a parent delegate was requested.
+			...(parentApproval
+				? {
+						"tools.approvalMode": settings.get("tools.approvalMode"),
+						"tools.approval": settings.get("tools.approval"),
+					}
+				: undefined),
 		},
 		options.parentServiceTier,
 	);
@@ -2801,7 +2887,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
 				},
 				sessionManager: sessionManagerForRun,
-				hasUI: false,
+				hasUI: parentApproval?.uiContext !== undefined,
 				prewalk,
 				spawns: spawnsEnv,
 				taskDepth: childDepth,
@@ -2828,8 +2914,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
 			let session: AgentSession;
+			let setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
 			try {
-				({ session } = await awaitAbortable(sessionPromise));
+				({ session, setToolUIContext } = await awaitAbortable(sessionPromise));
 			} catch (err) {
 				// Abort raced session startup. The session may still resolve later
 				// holding live LSP/MCP child processes — dispose it when it does so
@@ -2841,6 +2928,69 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			monitor.setActiveSession(session);
 			installRegistryStatusSync(session);
+			const applyParentApprovalDelegate = (
+				childSession: AgentSession,
+				setChildToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
+			): void => {
+				if (!parentApproval) return;
+				const delegatedUi = parentApproval.uiContext
+					? createDelegatedParentApprovalUIContext(parentApproval.uiContext)
+					: undefined;
+				if (delegatedUi) {
+					setChildToolUIContext(delegatedUi, true);
+				}
+				if (parentApproval.clientBridge) {
+					childSession.setClientBridge(parentApproval.clientBridge);
+				}
+				// Live/cold revive builds a fresh ExtensionRunner; without initialize the
+				// approval wrapper sees hasUI=false and fails closed even when the parent
+				// UI is available. Bind the delegated UI here (actions are filled by the
+				// initial-run initialize path, or minimal stubs on revive).
+				const runner = childSession.extensionRunner;
+				if (runner && delegatedUi && !runner.hasUI()) {
+					runner.initialize(
+						{
+							sendMessage: () => {},
+							sendUserMessage: () => {},
+							appendEntry: (customType, data) => {
+								childSession.sessionManager.appendCustomEntry(customType, data);
+							},
+							setLabel: (targetId, label) => {
+								childSession.sessionManager.appendLabelChange(targetId, label);
+							},
+							getActiveTools: () => childSession.getEnabledToolNames(),
+							getAllTools: () => childSession.getAllToolNames(),
+							setActiveTools: async toolNames => {
+								await childSession.setActiveToolsByName(toolNames);
+							},
+							getCommands: () => getSessionSlashCommands(childSession),
+							setModel: model => runExtensionSetModel(childSession, model),
+							getThinkingLevel: () => childSession.thinkingLevel,
+							setThinkingLevel: level => childSession.setThinkingLevel(level),
+							getServiceTiers: () => childSession.serviceTierByFamily,
+							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
+								childSession.setServiceTierFamily(family, tier),
+							getSessionName: () => childSession.sessionManager.getSessionName(),
+							setSessionName: async name => {
+								await childSession.sessionManager.setSessionName(name, "user");
+							},
+						},
+						{
+							getModel: () => childSession.model,
+							isIdle: () => !childSession.isStreaming,
+							abort: () => childSession.abort({ reason: USER_INTERRUPT_LABEL }),
+							hasPendingMessages: () => childSession.queuedMessageCount > 0,
+							shutdown: () => {},
+							getContextUsage: () => childSession.getContextUsage(),
+							getSystemPrompt: () => childSession.systemPrompt,
+							compact: instructionsOrOptions => runExtensionCompact(childSession, instructionsOrOptions),
+						},
+						undefined,
+						delegatedUi,
+					);
+				}
+			};
+			applyParentApprovalDelegate(session, setToolUIContext);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
 				// the single-writer lock cleanly and restores the full message history
@@ -2853,10 +3003,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					if (options.parentArtifactManager) {
 						reopened.adoptArtifactManager(options.parentArtifactManager);
 					}
-					const { session: revived } = await createAgentSession(
+					const { session: revived, setToolUIContext: setRevivedToolUIContext } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
 					installRegistryStatusSync(revived);
+					applyParentApprovalDelegate(revived, setRevivedToolUIContext);
 					return revived;
 				};
 			}
@@ -2895,6 +3046,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,
+				...(options.workspace?.binding === "fixed" ? { cwdBinding: "fixed" as const } : {}),
+				...(options.missionOwner ? { missionOwner: options.missionOwner } : {}),
 			});
 
 			abortSignal.addEventListener(
@@ -2963,6 +3116,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						getSystemPrompt: () => session.systemPrompt,
 						compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
 					},
+					undefined,
+					parentApproval?.uiContext ? createDelegatedParentApprovalUIContext(parentApproval.uiContext) : undefined,
 				);
 				extensionRunner.onError(err => {
 					logger.error("Extension error", { path: err.extensionPath, error: err.error });

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs/promises";
-import type { ServiceTier, ServiceTierFamily } from "@oh-my-pi/pi-ai";
 
 import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
@@ -10,7 +9,12 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
-import { createDelegatedParentApprovalUIContext, createMCPProxyTools, createSubagentSettings } from "./executor";
+import {
+	createDelegatedParentApprovalUIContext,
+	createMCPProxyTools,
+	createSubagentSettings,
+	initializeDelegatedParentApprovalRunner,
+} from "./executor";
 
 /**
  * Ambient context the reviver needs at revive time. The top-level session is
@@ -136,7 +140,7 @@ export function createPersistedSubagentReviverFactory(
 				enableLsp: restrictToolNames ? false : ctx.enableLsp,
 				// Fixed mission children run outside the parent checkout — pass the
 				// owner's loaded skills so skill://<name> still resolves.
-				...(isFixedMissionChild ? { skills: [...ctx.session.skills] } : {}),
+				...(isFixedMissionChild ? { skills: [...(ctx.session.skills ?? [])] } : {}),
 				...(restrictToolNames
 					? {
 							enableIrc: false,
@@ -157,49 +161,7 @@ export function createPersistedSubagentReviverFactory(
 				}
 				const bridge = ctx.session.clientBridge;
 				if (bridge) session.setClientBridge(bridge);
-				const runner = session.extensionRunner;
-				if (runner && delegatedUi && !runner.hasUI()) {
-					runner.initialize(
-						{
-							sendMessage: () => {},
-							sendUserMessage: () => {},
-							appendEntry: (customType, data) => {
-								session.sessionManager.appendCustomEntry(customType, data);
-							},
-							setLabel: (targetId, label) => {
-								session.sessionManager.appendLabelChange(targetId, label);
-							},
-							getActiveTools: () => session.getEnabledToolNames(),
-							getAllTools: () => session.getAllToolNames(),
-							setActiveTools: async toolNames => {
-								await session.setActiveToolsByName(toolNames);
-							},
-							getCommands: () => [],
-							setModel: async () => false,
-							getThinkingLevel: () => session.thinkingLevel,
-							setThinkingLevel: level => session.setThinkingLevel(level),
-							getServiceTiers: () => session.serviceTierByFamily,
-							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
-								session.setServiceTierFamily(family, tier),
-							getSessionName: () => session.sessionManager.getSessionName(),
-							setSessionName: async name => {
-								await session.sessionManager.setSessionName(name, "user");
-							},
-						},
-						{
-							getModel: () => session.model,
-							isIdle: () => !session.isStreaming,
-							abort: () => session.abort(),
-							hasPendingMessages: () => session.queuedMessageCount > 0,
-							shutdown: () => {},
-							getContextUsage: () => session.getContextUsage(),
-							getSystemPrompt: () => session.systemPrompt,
-							compact: async () => {},
-						},
-						undefined,
-						delegatedUi,
-					);
-				}
+				if (delegatedUi) initializeDelegatedParentApprovalRunner(session, delegatedUi);
 			}
 			// Clamp the active set to the persisted list: createAgentSession's
 			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -71,7 +71,7 @@ export function createPersistedSubagentReviverFactory(
 			// Fixed mission children must revive only under their owning top-level
 			// session and only at the recorded worktree cwd — never the parent
 			// checkout or a foreign ACP session.
-			if (!missionOwner || missionOwner.ownerSessionId !== ctx.session.sessionId) {
+			if (!missionOwner || missionOwner.ownerSessionId !== ctx.session.sessionManager.getSessionId()) {
 				return undefined;
 			}
 		}

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import type { ServiceTier, ServiceTierFamily } from "@oh-my-pi/pi-ai";
 
 import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
@@ -9,7 +10,7 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
-import { createMCPProxyTools, createSubagentSettings } from "./executor";
+import { createDelegatedParentApprovalUIContext, createMCPProxyTools, createSubagentSettings } from "./executor";
 
 /**
  * Ambient context the reviver needs at revive time. The top-level session is
@@ -60,6 +61,16 @@ export function createPersistedSubagentReviverFactory(
 			return undefined;
 		}
 		const init = peek.init;
+		const isFixedMissionChild = init.cwdBinding === "fixed";
+		const missionOwner = init.missionOwner;
+		if (isFixedMissionChild) {
+			// Fixed mission children must revive only under their owning top-level
+			// session and only at the recorded worktree cwd — never the parent
+			// checkout or a foreign ACP session.
+			if (!missionOwner || missionOwner.ownerSessionId !== ctx.session.sessionId) {
+				return undefined;
+			}
+		}
 		// taskDepth drives real capability gating (task-spawn allowance, memory
 		// startup, …); derive it from the persisted parent chain rather than
 		// assuming a fixed level.
@@ -84,14 +95,27 @@ export function createPersistedSubagentReviverFactory(
 			const restrictToolNames = init.restrictToolNames === true;
 			const mcpManager = restrictToolNames ? undefined : MCPManager.instance();
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
-			const { session } = await createAgentSession({
-				cwd: ctx.session.sessionManager.getCwd(),
+			const reviveCwd = isFixedMissionChild ? peek.cwd : ctx.session.sessionManager.getCwd();
+			// Mission children inherit the parent's approval mode (never implicit
+			// yolo). Ordinary task/eval children keep createSubagentSettings' yolo.
+			const parentApprovalOverrides = isFixedMissionChild
+				? {
+						"tools.approvalMode": ctx.settings.get("tools.approvalMode"),
+						"tools.approval": ctx.settings.get("tools.approval"),
+					}
+				: undefined;
+			const parentUiContext =
+				isFixedMissionChild && ctx.session.extensionRunner?.hasUI()
+					? ctx.session.extensionRunner.getUIContext()
+					: undefined;
+			const { session, setToolUIContext } = await createAgentSession({
+				cwd: reviveCwd,
 				authStorage: ctx.authStorage,
 				modelRegistry: ctx.modelRegistry,
-				settings: createSubagentSettings(
-					ctx.settings,
-					init.readSummarize === false ? { "read.summarize.enabled": false } : undefined,
-				),
+				settings: createSubagentSettings(ctx.settings, {
+					...(init.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
+					...parentApprovalOverrides,
+				}),
 				sessionManager: reopened,
 				agentId: ref.id,
 				agentDisplayName: ref.displayName,
@@ -108,8 +132,11 @@ export function createPersistedSubagentReviverFactory(
 				// Old files predate persisted spawns: deny re-spawning rather than let
 				// createAgentSession default to wildcard ("*").
 				spawns: init.spawns ?? "",
-				hasUI: false,
+				hasUI: parentUiContext !== undefined,
 				enableLsp: restrictToolNames ? false : ctx.enableLsp,
+				// Fixed mission children run outside the parent checkout — pass the
+				// owner's loaded skills so skill://<name> still resolves.
+				...(isFixedMissionChild ? { skills: [...ctx.session.skills] } : {}),
 				...(restrictToolNames
 					? {
 							enableIrc: false,
@@ -123,6 +150,57 @@ export function createPersistedSubagentReviverFactory(
 							customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
 						}),
 			});
+			if (isFixedMissionChild) {
+				const delegatedUi = parentUiContext ? createDelegatedParentApprovalUIContext(parentUiContext) : undefined;
+				if (delegatedUi) {
+					setToolUIContext(delegatedUi, true);
+				}
+				const bridge = ctx.session.clientBridge;
+				if (bridge) session.setClientBridge(bridge);
+				const runner = session.extensionRunner;
+				if (runner && delegatedUi && !runner.hasUI()) {
+					runner.initialize(
+						{
+							sendMessage: () => {},
+							sendUserMessage: () => {},
+							appendEntry: (customType, data) => {
+								session.sessionManager.appendCustomEntry(customType, data);
+							},
+							setLabel: (targetId, label) => {
+								session.sessionManager.appendLabelChange(targetId, label);
+							},
+							getActiveTools: () => session.getEnabledToolNames(),
+							getAllTools: () => session.getAllToolNames(),
+							setActiveTools: async toolNames => {
+								await session.setActiveToolsByName(toolNames);
+							},
+							getCommands: () => [],
+							setModel: async () => false,
+							getThinkingLevel: () => session.thinkingLevel,
+							setThinkingLevel: level => session.setThinkingLevel(level),
+							getServiceTiers: () => session.serviceTierByFamily,
+							setServiceTier: (family: ServiceTierFamily, tier: ServiceTier | undefined) =>
+								session.setServiceTierFamily(family, tier),
+							getSessionName: () => session.sessionManager.getSessionName(),
+							setSessionName: async name => {
+								await session.sessionManager.setSessionName(name, "user");
+							},
+						},
+						{
+							getModel: () => session.model,
+							isIdle: () => !session.isStreaming,
+							abort: () => session.abort(),
+							hasPendingMessages: () => session.queuedMessageCount > 0,
+							shutdown: () => {},
+							getContextUsage: () => session.getContextUsage(),
+							getSystemPrompt: () => session.systemPrompt,
+							compact: async () => {},
+						},
+						undefined,
+						delegatedUi,
+					);
+				}
+			}
 			// Clamp the active set to the persisted list: createAgentSession's
 			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools
 			// the original run didn't carry. Unknown/missing names are ignored.

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -9,6 +9,7 @@ import * as os from "node:os";
 import path from "node:path";
 import { $env, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
+import type { ExtensionUIContext } from "../extensibility/extensions/types";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { registerArtifactsDir } from "../internal-urls/registry-helpers";
 import { MCPManager } from "../mcp/manager";
@@ -16,6 +17,8 @@ import { loadOverallPlanReference } from "../plan-mode/plan-handoff";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
 import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.md" with { type: "text" };
 import { MAIN_AGENT_ID } from "../registry/agent-registry";
+import type { ClientBridge } from "../session/client-bridge";
+import type { MissionChildOwnerEntry } from "../session/session-entries";
 import type { TaskEffort } from "../thinking";
 import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
@@ -69,6 +72,22 @@ export interface StructuredSubagentIsolationControls {
 	apply?: boolean;
 }
 
+/**
+ * Parent-mediated approvals for mission children. UI lives on the delegate, never
+ * on ToolSession — AgentSession builds this as a closure over its private UI/bridge.
+ */
+export interface ParentApprovalDelegate {
+	kind: "parent";
+	uiContext?: ExtensionUIContext;
+	clientBridge?: ClientBridge;
+}
+
+/** Fixed worktree cwd for a crash-recoverable mission child (not ordinary isolation). */
+export interface PersistentSubagentWorkspace {
+	cwd: string;
+	binding: "fixed";
+}
+
 /** Identity and presentation metadata supplied by the calling surface. */
 export interface StructuredSubagentIdentity {
 	/** A previously reserved output/registry id. */
@@ -97,6 +116,12 @@ export interface StructuredSubagentRequest {
 	invokedAt?: number;
 	acquiredAt?: number;
 	isolation?: StructuredSubagentIsolationControls;
+	/** Fixed mission worktree; omitted callers keep parent cwd. */
+	workspace?: PersistentSubagentWorkspace;
+	/** Parent-mediated approvals; omitted callers keep the yolo subagent boundary. */
+	approvalDelegate?: ParentApprovalDelegate;
+	/** Mission ownership markers written to session_init for cold revive. */
+	missionOwner?: MissionChildOwnerEntry;
 	/** The parent agent name forbidden from recursively spawning itself. */
 	blockedAgent?: string;
 	/** Preserve a completed temporary artifacts directory for an agent:// handle. */
@@ -375,7 +400,7 @@ function buildExecutorOptions(
 	};
 	const enableMCP = !policy.planMode && (session.enableMCP ?? true);
 	return {
-		cwd: session.cwd,
+		cwd: request.workspace?.cwd ?? session.cwd,
 		additionalDirectories: session.additionalDirectories,
 		agent: policy.effectiveAgent,
 		task: renderSubagentPrompt(request.assignment),
@@ -410,6 +435,9 @@ function buildExecutorOptions(
 		maxRuntimeMs: request.maxRuntimeMs,
 		restrictToolNames: policy.planMode,
 		keepAlive: request.keepAlive,
+		...(request.workspace ? { workspace: request.workspace } : {}),
+		...(request.approvalDelegate ? { approvalDelegate: request.approvalDelegate } : {}),
+		...(request.missionOwner ? { missionOwner: request.missionOwner } : {}),
 		signal: request.signal,
 		eventBus: session.eventBus,
 		onProgress: request.onProgress,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -270,6 +270,12 @@ export async function resolveEffectiveSubagentPolicy(
 	const spawnPolicy = resolveSpawnPolicy(request.session.getSessionSpawns());
 	const agentName = request.agent?.trim() || spawnPolicy.defaultAgent;
 	const planMode = request.session.getPlanModeState?.()?.enabled === true;
+	if (request.workspace?.binding === "fixed" && !request.missionOwner) {
+		throw new StructuredSubagentError(
+			"preflight",
+			"Fixed-workspace subagents require mission ownership for safe revival.",
+		);
+	}
 	assertPlanControlsAllowed(request, planMode);
 	assertDepthAndSpawnAllowed(request, agentName);
 
@@ -446,12 +452,18 @@ function buildExecutorOptions(
 		settings: session.settings,
 		mcpManager: enableMCP ? (session.mcpManager ?? MCPManager.instance()) : undefined,
 		enableMCP,
-		contextFiles: session.contextFiles?.filter(file => path.basename(file.path).toLowerCase() !== "agents.md"),
+		...(request.workspace
+			? {}
+			: {
+					contextFiles: session.contextFiles?.filter(
+						file => path.basename(file.path).toLowerCase() !== "agents.md",
+					),
+					workspaceTree: session.workspaceTree,
+					promptTemplates: session.promptTemplates,
+					rules: session.rules,
+				}),
 		skills,
 		autoloadSkills,
-		workspaceTree: session.workspaceTree,
-		promptTemplates: session.promptTemplates,
-		rules: session.rules,
 		preloadedExtensionPaths: policy.planMode ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: policy.planMode ? [] : session.customToolPaths,
 		localProtocolOptions,

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -27,6 +27,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"reflect",
 	"learn",
 	"manage_skill",
+	"schedule",
 ] as const;
 
 export type BuiltinToolName = (typeof BUILTIN_TOOL_NAMES)[number];

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -27,6 +27,7 @@ import type { ClientBridge } from "../session/client-bridge";
 import type { CustomMessage } from "../session/messages";
 import type { UsageStatistics } from "../session/session-entries";
 import type { SessionManager } from "../session/session-manager";
+import type { SessionScheduleController } from "../session/session-schedule";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
@@ -59,6 +60,7 @@ import { MemoryRetainTool } from "./memory-retain";
 import { wrapToolWithMetaNotice } from "./output-meta";
 import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
+import { ScheduleTool } from "./schedule";
 import { type TodoPhase, TodoTool } from "./todo";
 import { WriteTool } from "./write";
 import { isMountableUnderXdev, XdevRegistry } from "./xdev";
@@ -217,6 +219,8 @@ export interface ToolSession {
 	restrictToolNames?: boolean;
 	/** Task recursion depth (0 = top-level, 1 = first child, etc.) */
 	taskDepth?: number;
+	/** Whether this tool session owns the top-level agent turn loop. */
+	isTopLevelSession?(): boolean;
 	/** Get shared eval executor session ID. Subagents inherit this to share JS/Python/Ruby/Julia state. */
 	getEvalSessionId?: () => string | null;
 	/** Get session file */
@@ -300,6 +304,8 @@ export interface ToolSession {
 	getGoalModeState?: () => GoalModeState | undefined;
 	/** Goal runtime for the active agent session. */
 	getGoalRuntime?: () => GoalRuntime | undefined;
+	/** Live one-shot wake controller for the active top-level agent session. */
+	getSessionSchedule?: () => SessionScheduleController | undefined;
 	/** Get cumulative session usage statistics (input/output tokens, cost). */
 	getUsageStatistics?: () => UsageStatistics;
 	/** Current per-turn token budget {total, spent, hard} for the eval `budget` helper. */
@@ -416,6 +422,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	reflect: MemoryReflectTool.createIf,
 	learn: LearnTool.createIf,
 	manage_skill: ManageSkillTool.createIf,
+	schedule: ScheduleTool.createIf,
 };
 
 export const HIDDEN_TOOLS: Record<HiddenToolName, ToolFactory> = {
@@ -540,6 +547,15 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 				requestedTools.push("learn");
 			}
 		}
+		// Wakes are delivered into the top-level session's turn loop, so a subagent
+		// session would die before its own schedule ever fired.
+		if (
+			session.settings.get("schedule.enabled") &&
+			session.isTopLevelSession?.() === true &&
+			!requestedTools.includes("schedule")
+		) {
+			requestedTools.push("schedule");
+		}
 	}
 	const allTools: Record<string, ToolFactory> = { ...BUILTIN_TOOLS, ...HIDDEN_TOOLS };
 	const isToolAllowed = (name: string) => {
@@ -571,6 +587,8 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		}
 		if (name === "memory_edit") return session.settings.get("memory.backend") === "mnemopi";
 		if (name === "manage_skill") return session.settings.get("autolearn.enabled") && (session.taskDepth ?? 0) === 0;
+		if (name === "schedule")
+			return session.settings.get("schedule.enabled") && session.isTopLevelSession?.() === true;
 		if (name === "learn") {
 			return (
 				session.settings.get("autolearn.enabled") &&

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -27,6 +27,7 @@ import { inspectImageToolRenderer } from "./inspect-image-renderer";
 import { recallToolRenderer, reflectToolRenderer, retainToolRenderer } from "./memory-render";
 import { readToolRenderer } from "./read";
 import { resolveRenderer } from "./resolve";
+import { scheduleToolRenderer } from "./schedule";
 import { todoToolRenderer } from "./todo";
 import { createVibeToolRenderer } from "./vibe";
 import { writeToolRenderer } from "./write";
@@ -118,6 +119,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	todo: todoToolRenderer as ToolRenderer,
 	github: githubToolRenderer as ToolRenderer,
 	goal: goalToolRenderer as ToolRenderer,
+	schedule: scheduleToolRenderer as ToolRenderer,
 	web_search: webSearchToolRenderer as ToolRenderer,
 	vibe_spawn: createVibeToolRenderer("spawn") as ToolRenderer,
 	vibe_send: createVibeToolRenderer("send") as ToolRenderer,

--- a/packages/coding-agent/src/tools/schedule.ts
+++ b/packages/coding-agent/src/tools/schedule.ts
@@ -1,0 +1,226 @@
+/**
+ * Builtin `schedule` tool — one-shot session self-wake via session-schedule entries.
+ *
+ * Opt-in: the orchestrator gates construction/enablement on `schedule.enabled`
+ * (default false). This module only exports the tool + renderer.
+ */
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type { Component } from "@oh-my-pi/pi-tui";
+import { Text } from "@oh-my-pi/pi-tui";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme } from "../modes/theme/theme";
+import scheduleDescription from "../prompts/tools/schedule.md" with { type: "text" };
+import { resolveScheduleDueAtMs } from "../session/session-schedule";
+import { framedBlock, renderStatusLine, truncateToWidth } from "../tui";
+import type { ToolSession } from ".";
+import type { OutputMeta } from "./output-meta";
+import { formatErrorDetail, TRUNCATE_LENGTHS } from "./render-utils";
+import { ToolError } from "./tool-errors";
+import { toolResult } from "./tool-result";
+
+const scheduleSchema = type({
+	"delayMs?": type("number.integer >= 0").describe("relative delay in milliseconds"),
+	"atIso?": type("string").describe("absolute due time as ISO-8601"),
+	"prompt?": type("string").describe("prompt enqueued when the schedule fires"),
+	"cancel?": type("string").describe("id of a pending schedule to cancel"),
+});
+
+export type ScheduleToolInput = typeof scheduleSchema.infer;
+
+export type ScheduleToolDetails =
+	| {
+			op: "create";
+			id: string;
+			dueAtMs: number;
+			prompt: string;
+			createdAt: number;
+			meta?: OutputMeta;
+	  }
+	| {
+			op: "cancel";
+			id: string;
+			cancelled: boolean;
+			meta?: OutputMeta;
+	  };
+
+function validateCreateInput(params: ScheduleToolInput): {
+	delayMs?: number;
+	atIso?: string;
+	prompt: string;
+} {
+	const promptText = params.prompt?.trim();
+	if (!promptText) {
+		throw new ToolError("prompt is required when creating a schedule.");
+	}
+	const input = {
+		delayMs: params.delayMs,
+		atIso: params.atIso,
+		prompt: promptText,
+	};
+	// Reuse the fold's due-time rules so the tool cannot drift from them; the
+	// resolved time is discarded because the live controller resolves against its
+	// own clock, but every rejection surfaces here as a ToolError.
+	const due = resolveScheduleDueAtMs(input, Date.now());
+	if ("error" in due) throw new ToolError(due.error);
+	return input;
+}
+
+function validateCancelInput(params: ScheduleToolInput): string {
+	const id = params.cancel?.trim();
+	if (!id) throw new ToolError("cancel must be a non-empty schedule id.");
+	if (params.delayMs !== undefined || params.atIso !== undefined || params.prompt !== undefined) {
+		throw new ToolError("cancel cannot be combined with delayMs, atIso, or prompt.");
+	}
+	return id;
+}
+
+export class ScheduleTool implements AgentTool<typeof scheduleSchema, ScheduleToolDetails> {
+	readonly name = "schedule";
+	readonly approval = "write" as const;
+	readonly label = "Schedule";
+	readonly summary = "Schedule a one-shot wake prompt for this session";
+	readonly description: string;
+	readonly parameters = scheduleSchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable";
+	readonly intent = (args: Partial<ScheduleToolInput>) =>
+		args.cancel ? `cancel schedule ${args.cancel}` : args.prompt ? `schedule: ${args.prompt}` : "schedule";
+
+	readonly #session: ToolSession;
+
+	constructor(session: ToolSession) {
+		this.#session = session;
+		this.description = prompt.render(scheduleDescription);
+	}
+
+	static createIf(session: ToolSession): ScheduleTool | null {
+		if (!session.settings.get("schedule.enabled") || session.isTopLevelSession?.() !== true) return null;
+		return new ScheduleTool(session);
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: ScheduleToolInput,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<ScheduleToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<ScheduleToolDetails>> {
+		if (params.cancel !== undefined) {
+			const id = validateCancelInput(params);
+			const controller = this.#session.getSessionSchedule?.();
+			if (!controller) throw new ToolError("Session schedule controller is unavailable.");
+			const cancelled = controller.cancel(id);
+			return toolResult<ScheduleToolDetails>({ op: "cancel", id, cancelled })
+				.text(cancelled ? `Cancelled schedule ${id}.` : `No pending schedule ${id}; cancel recorded.`)
+				.done();
+		}
+
+		const input = validateCreateInput(params);
+		const controller = this.#session.getSessionSchedule?.();
+		if (!controller) throw new ToolError("Session schedule controller is unavailable.");
+		const created = controller.create(input);
+
+		const dueLabel = new Date(created.dueAtMs).toISOString();
+		return toolResult<ScheduleToolDetails>({
+			op: "create",
+			id: created.id,
+			dueAtMs: created.dueAtMs,
+			prompt: created.prompt,
+			createdAt: created.createdAt,
+		})
+			.text(`Scheduled ${created.id} for ${dueLabel}.`)
+			.done();
+	}
+}
+
+interface ScheduleRenderArgs {
+	delayMs?: number;
+	atIso?: string;
+	prompt?: string;
+	cancel?: string;
+}
+
+function describeCall(args: ScheduleRenderArgs | undefined): string {
+	if (args?.cancel) return "cancel";
+	if (args?.delayMs !== undefined) return `in ${args.delayMs}ms`;
+	if (args?.atIso) return `at ${args.atIso}`;
+	return "create";
+}
+
+export const scheduleToolRenderer = {
+	renderCall(args: ScheduleRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		const description = describeCall(args);
+		const meta: string[] = [];
+		const trimmed = args?.prompt?.trim();
+		if (trimmed) {
+			meta.push(uiTheme.italic(uiTheme.fg("muted", `"${truncateToWidth(trimmed, TRUNCATE_LENGTHS.TITLE)}"`)));
+		}
+		if (args?.cancel) {
+			meta.push(uiTheme.fg("muted", args.cancel));
+		}
+		return new Text(renderStatusLine({ icon: "pending", title: "Schedule", description, meta }, uiTheme), 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: ScheduleToolDetails; isError?: boolean },
+		_options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: ScheduleRenderArgs,
+	): Component {
+		const fallbackText = result.content?.find(part => part.type === "text")?.text ?? "";
+		const details = result.details;
+		let description: string;
+		if (details?.op === "cancel") {
+			description = "cancel";
+		} else if (details?.op === "create") {
+			description = "create";
+		} else {
+			description = describeCall(args);
+		}
+
+		if (result.isError) {
+			const header = renderStatusLine({ icon: "error", title: "Schedule", description }, uiTheme);
+			return framedBlock(uiTheme, width => ({
+				header,
+				sections: [{ lines: formatErrorDetail(fallbackText || "Schedule tool failed", uiTheme).split("\n") }],
+				state: "error",
+				borderColor: "error",
+				width,
+			}));
+		}
+
+		const meta: string[] = [];
+		if (details) {
+			switch (details.op) {
+				case "create":
+					meta.push(uiTheme.fg("muted", details.id));
+					meta.push(uiTheme.fg("muted", new Date(details.dueAtMs).toISOString()));
+					break;
+				case "cancel":
+					meta.push(uiTheme.fg("muted", details.id));
+					break;
+				default: {
+					const _exhaustive: never = details;
+					void _exhaustive;
+					break;
+				}
+			}
+		}
+
+		return new Text(
+			renderStatusLine(
+				{
+					icon: "success",
+					title: "Schedule",
+					description,
+					meta,
+				},
+				uiTheme,
+			),
+			0,
+			0,
+		);
+	},
+};

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1834,6 +1834,49 @@ export const ref = {
 			),
 		);
 	},
+
+	/**
+	 * True when `ancestor` is an ancestor of `descendant` (`git merge-base --is-ancestor`).
+	 * Exit 0 → true, exit 1 → false; any other exit throws.
+	 */
+	async isAncestor(cwd: string, ancestor: string, descendant: string, signal?: AbortSignal): Promise<boolean> {
+		const args = ["merge-base", "--is-ancestor", ancestor, descendant];
+		const result = await git(cwd, args, { readOnly: true, signal });
+		if (result.exitCode === 0) return true;
+		if (result.exitCode === 1) return false;
+		throw new GitCommandError(args, result);
+	},
+
+	/**
+	 * Compare-and-swap a ref via `git update-ref <ref> <new> <old>`.
+	 * Returns true on success, false when the CAS lost because the ref moved,
+	 * and throws on any other failure.
+	 */
+	async update(
+		cwd: string,
+		refName: string,
+		newSha: string,
+		expectedOldSha: string,
+		signal?: AbortSignal,
+	): Promise<boolean> {
+		const args = ["update-ref", refName, newSha, expectedOldSha];
+		const result = await git(cwd, args, { signal });
+		if (result.exitCode === 0) return true;
+		// Git reports a lost CAS as exit 128 with "is at <sha> but expected <sha>".
+		if (/but expected /i.test(result.stderr)) return false;
+		throw new GitCommandError(args, result);
+	},
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: merge
+// ════════════════════════════════════════════════════════════════════════════
+
+export const merge = {
+	/** Fast-forward the current branch to `ref` (`git merge --ff-only`). */
+	async fastForwardOnly(cwd: string, ref: string, signal?: AbortSignal): Promise<void> {
+		await runEffect(cwd, ["merge", "--ff-only", ref], { signal });
+	},
 };
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -103,6 +103,7 @@ describe("AgentSession handoff", () => {
 			settings: Settings.isolated({
 				"compaction.enabled": true,
 				"compaction.autoContinue": false,
+				"schedule.enabled": true,
 			}),
 			modelRegistry,
 			obfuscator,
@@ -161,6 +162,20 @@ describe("AgentSession handoff", () => {
 		expect(events.filter(event => event.type === "auto_compaction_start")).toHaveLength(0);
 		expect(events.filter(event => event.type === "auto_compaction_end")).toHaveLength(0);
 		expect(sessionManager.getEntries().filter(entry => entry.type === "compaction")).toHaveLength(0);
+	});
+
+	it("re-arms schedules after handoff replaces the transcript", async () => {
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockResolvedValue("## Goal\nContinue from here");
+		const oldController = session.getSessionSchedule();
+		if (!oldController) throw new Error("Expected initial schedule controller");
+		oldController.create({ delayMs: 60_000, prompt: "old transcript wake" });
+
+		await session.handoff();
+
+		const replacementController = session.getSessionSchedule();
+		expect(replacementController).toBeDefined();
+		expect(replacementController).not.toBe(oldController);
+		expect(replacementController?.listPending()).toEqual([]);
 	});
 
 	it("clears staged preview state when handoff creates the replacement session", async () => {

--- a/packages/coding-agent/test/mission-launch-flags.test.ts
+++ b/packages/coding-agent/test/mission-launch-flags.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { CliUsageError } from "@oh-my-pi/pi-coding-agent/cli/usage-error";
+
+describe("mission launch flags", () => {
+	it("parses mission worker and validator model overrides", () => {
+		expect(
+			parseArgs(["--mission", "--mission-worker-model", "worker", "--mission-validator-model", "validator", "goal"]),
+		).toMatchObject({
+			mission: true,
+			missionWorkerModel: "worker",
+			missionValidatorModel: "validator",
+			messages: ["goal"],
+		});
+	});
+
+	it("rejects model overrides without a mission", () => {
+		expect(() => parseArgs(["--mission-worker-model", "worker"])).toThrow(CliUsageError);
+	});
+
+	it("rejects launch modes that cannot drive a mission", () => {
+		expect(() => parseArgs(["--mission"])).toThrow("--mission requires a goal");
+		expect(() => parseArgs(["--mission", "--print", "goal"])).toThrow("cannot be used with --print");
+		expect(() => parseArgs(["--mission", "--continue", "goal"])).toThrow("cannot be used with --continue");
+		expect(() => parseArgs(["--mission", "--resume", "session", "goal"])).toThrow("cannot be used with --resume");
+		expect(() => parseArgs(["--mission", "--fork", "session", "goal"])).toThrow("cannot be used with --fork");
+	});
+});

--- a/packages/coding-agent/test/missions/runtime.test.ts
+++ b/packages/coding-agent/test/missions/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import {
 	MISSION_STATE_CUSTOM_TYPE,
 	type MissionFeature,
@@ -8,6 +8,7 @@ import {
 	type MissionRuntimeHost,
 	type MissionState,
 } from "../../src/missions";
+import { MissionWorkspaceManager } from "../../src/missions/workspace";
 import type { AgentLifecycleManager } from "../../src/registry/agent-lifecycle";
 import type { SessionEntry } from "../../src/session/session-entries";
 import type { ToolSession } from "../../src/tools";
@@ -114,6 +115,10 @@ function runtime(initial: MissionState | null = null, failPersistence = false): 
 	return new MissionRuntime(host);
 }
 
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 describe("MissionRuntime", () => {
 	test("rejects a blank goal before any mission state is persisted", async () => {
 		const mission = runtime();
@@ -207,6 +212,49 @@ describe("MissionRuntime", () => {
 		const retried = await mission.resolveHandoff({ decision: "retry_same" });
 		expect(retried).toMatchObject({ status: "running", pendingHandoff: undefined });
 		expect(retried.features[0]).toMatchObject({ status: "pending", nextRunIntent: { mode: "follow_up" } });
+	});
+
+	test("restarts after a cleaned validator workspace without bypassing ordinary resume", async () => {
+		const workspace = {
+			id: "validator-workspace",
+			ownerSessionId: "owner",
+			repoRoot: "/repo",
+			path: "/repo-validator",
+			featureId: "validate",
+			phase: "ready" as const,
+			kind: "validator" as const,
+			head: "abc123",
+		};
+		const validator = {
+			...validation("validate"),
+			status: "completed" as const,
+			workspace,
+			validatedHead: workspace.head,
+		};
+		const mission = runtime(
+			state({
+				status: "paused",
+				pauseReason: "validator_workspace_dirty",
+				milestones: [
+					{
+						id: "milestone",
+						description: "M",
+						featureIds: ["validate"],
+						validators: ["scrutiny"],
+						kind: "planned",
+					},
+				],
+				features: [validator],
+			}),
+		);
+		await mission.restore();
+		await expect(mission.resume()).rejects.toThrow("restart the mission");
+		const release = vi.spyOn(MissionWorkspaceManager.prototype, "releaseIfEmpty").mockResolvedValue(true);
+
+		const resumed = await mission.resume({ restartWorker: true });
+
+		expect(release).toHaveBeenCalledWith(workspace);
+		expect(resumed).toMatchObject({ status: "running", pauseReason: undefined });
 	});
 
 	test("keeps prior state authoritative when persistence fails", async () => {

--- a/packages/coding-agent/test/missions/runtime.test.ts
+++ b/packages/coding-agent/test/missions/runtime.test.ts
@@ -65,7 +65,11 @@ function validatorFailure(): MissionHandoff {
 	};
 }
 
-function runtime(initial: MissionState | null = null, failPersistence = false): MissionRuntime {
+function runtime(
+	initial: MissionState | null = null,
+	failPersistence = false,
+	released: string[] = [],
+): MissionRuntime {
 	const entries: SessionEntry[] = initial
 		? [
 				{
@@ -109,7 +113,13 @@ function runtime(initial: MissionState | null = null, failPersistence = false): 
 		isGoalModeActive: () => false,
 		isVibeModeActive: () => false,
 		registerPersistedReviver: () => undefined,
-		agentLifecycle: () => ({}) as AgentLifecycleManager,
+		agentLifecycle: () =>
+			({
+				release: async (workerSessionId: string) => {
+					released.push(workerSessionId);
+					return true;
+				},
+			}) as AgentLifecycleManager,
 		now: () => 1,
 	};
 	return new MissionRuntime(host);
@@ -255,6 +265,35 @@ describe("MissionRuntime", () => {
 
 		expect(release).toHaveBeenCalledWith(workspace);
 		expect(resumed).toMatchObject({ status: "running", pauseReason: undefined });
+	});
+
+	test("a fresh restart after a user pause releases and replaces the active worker", async () => {
+		const released: string[] = [];
+		const active = {
+			...implementation("feature"),
+			status: "in_progress" as const,
+			currentWorkerSessionId: "worker",
+			workerSessionIds: ["worker"],
+		};
+		const mission = runtime(
+			state({
+				status: "paused",
+				pauseReason: "user_requested",
+				features: [active],
+			}),
+			false,
+			released,
+		);
+		await mission.restore();
+
+		const resumed = await mission.resume({ restartWorker: true, messageToWorker: "try cleanly" });
+
+		expect(released).toEqual(["worker"]);
+		expect(resumed.features[0]).toMatchObject({
+			status: "pending",
+			currentWorkerSessionId: undefined,
+			nextRunIntent: { mode: "fresh", messageToWorker: "try cleanly" },
+		});
 	});
 
 	test("keeps prior state authoritative when persistence fails", async () => {

--- a/packages/coding-agent/test/missions/runtime.test.ts
+++ b/packages/coding-agent/test/missions/runtime.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import {
+	MISSION_STATE_CUSTOM_TYPE,
+	type MissionFeature,
+	type MissionHandoff,
+	MissionRuntime,
+	MissionRuntimeError,
+	type MissionRuntimeHost,
+	type MissionState,
+} from "../../src/missions";
+import type { AgentLifecycleManager } from "../../src/registry/agent-lifecycle";
+import type { SessionEntry } from "../../src/session/session-entries";
+import type { ToolSession } from "../../src/tools";
+
+function state(overrides: Partial<MissionState> = {}): MissionState {
+	const now = 1;
+	return {
+		version: 1,
+		id: "mission-test",
+		ownerSessionId: "owner",
+		revision: 0,
+		goal: "Ship the mission runtime",
+		autoAccept: false,
+		status: "running",
+		runbook: { setup: [], services: [], userTests: [] },
+		milestones: [],
+		features: [],
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+function implementation(id: string, preconditions: string[] = []): MissionFeature {
+	return {
+		id,
+		description: id,
+		milestoneId: "milestone",
+		preconditions,
+		expectedBehavior: ["works"],
+		kind: "implementation",
+		status: "pending",
+		workerSessionIds: [],
+		retryBudgetUsed: 0,
+	};
+}
+
+function validation(id: string): MissionFeature {
+	return {
+		...implementation(id),
+		kind: "validation",
+		validator: "scrutiny",
+	};
+}
+
+function validatorFailure(): MissionHandoff {
+	return {
+		kind: "validation",
+		role: "scrutiny",
+		verdict: "fail",
+		summary: "needs remediation",
+		checks: [],
+		issues: [],
+	};
+}
+
+function runtime(initial: MissionState | null = null, failPersistence = false): MissionRuntime {
+	const entries: SessionEntry[] = initial
+		? [
+				{
+					type: "custom",
+					id: "state",
+					parentId: null,
+					timestamp: "1",
+					customType: MISSION_STATE_CUSTOM_TYPE,
+					data: initial,
+				},
+			]
+		: [];
+	const sessionManager = {
+		appendEntriesAtomically: async <T>(append: () => T): Promise<T> => {
+			if (failPersistence) throw new Error("disk full");
+			return append();
+		},
+		appendCustomEntry: (customType: string, data?: unknown) => {
+			const id = `${entries.length}`;
+			entries.push({ type: "custom", id, parentId: null, timestamp: "1", customType, data });
+			return id;
+		},
+		appendModeChange: () => `${entries.length}`,
+		getEntries: () => entries,
+		flush: async () => undefined,
+	};
+	const host: MissionRuntimeHost = {
+		ownerSessionId: () => "owner",
+		cwd: () => process.cwd(),
+		sessionManager: sessionManager satisfies MissionRuntimeHost["sessionManager"],
+		emitUpdated: () => undefined,
+		emitProgress: () => undefined,
+		sendHiddenMessage: async () => undefined,
+		getEnabledToolNames: () => [],
+		setActiveToolsByName: async () => undefined,
+		parentApprovalDelegate: () => undefined,
+		resolveChildModels: async () => undefined,
+		assertSkillsExist: () => undefined,
+		getToolSession: () => ({}) as ToolSession,
+		isPlanModeActive: () => false,
+		isGoalModeActive: () => false,
+		isVibeModeActive: () => false,
+		registerPersistedReviver: () => undefined,
+		agentLifecycle: () => ({}) as AgentLifecycleManager,
+		now: () => 1,
+	};
+	return new MissionRuntime(host);
+}
+
+describe("MissionRuntime", () => {
+	test("rejects a blank goal before any mission state is persisted", async () => {
+		const mission = runtime();
+		await expect(mission.start(" \t ")).rejects.toBeInstanceOf(MissionRuntimeError);
+		expect(mission.snapshot()).toBeNull();
+	});
+
+	test("rejects remediation dependency cycles before releasing validator workspaces", async () => {
+		const failed = { ...validation("validate"), status: "in_progress" as const };
+		const mission = runtime(
+			state({
+				status: "orchestrator_turn",
+				milestones: [
+					{
+						id: "milestone",
+						description: "M",
+						featureIds: ["validate"],
+						validators: ["scrutiny"],
+						kind: "planned",
+					},
+				],
+				features: [failed],
+				pendingHandoff: validatorFailure(),
+			}),
+		);
+		await mission.restore();
+
+		await expect(
+			mission.revisePending({
+				addFeatures: [
+					{ id: "repair-a", description: "a", preconditions: ["repair-b"], expectedBehavior: ["a"] },
+					{ id: "repair-b", description: "b", preconditions: ["repair-a"], expectedBehavior: ["b"] },
+				],
+			}),
+		).rejects.toThrow("cycle");
+		expect(mission.snapshot()?.status).toBe("orchestrator_turn");
+	});
+
+	test("recovers an interrupted validator without redispatching it", async () => {
+		const interrupted = {
+			...validation("validate"),
+			status: "in_progress" as const,
+			currentWorkerSessionId: "worker",
+		};
+		const mission = runtime(
+			state({
+				milestones: [
+					{
+						id: "milestone",
+						description: "M",
+						featureIds: ["validate"],
+						validators: ["scrutiny"],
+						kind: "planned",
+					},
+				],
+				features: [interrupted],
+				activeRun: { featureId: "validate", workerSessionId: "worker", turn: 1 },
+			}),
+		);
+		const restored = await mission.restore();
+		expect(restored).toMatchObject({ status: "paused", pauseReason: "workspace_conflict" });
+		expect(restored?.features[0]).toMatchObject({ status: "pending", nextRunIntent: { mode: "initial" } });
+	});
+
+	test("pause and cancel form dispatch barriers", async () => {
+		const mission = runtime();
+		await mission.start("goal");
+		await mission.pause("user_requested");
+		await expect(mission.runNext()).rejects.toThrow('status "running"');
+		const cancelled = await mission.cancel();
+		expect(cancelled.status).toBe("cancelled");
+		expect(await mission.runNext()).toBeNull();
+	});
+
+	test("moves a failed worker handoff into an explicit retry transition", async () => {
+		const worker = { ...implementation("worker"), status: "in_progress" as const, currentWorkerSessionId: "child" };
+		const handoff: MissionHandoff = {
+			kind: "implementation",
+			outcome: "partial",
+			summary: "unfinished",
+			implementation: [],
+			remaining: ["finish"],
+			verification: { commands: [], interactiveChecks: [] },
+			tests: { added: [], coverageNotes: [] },
+			issues: [],
+			skillDeviations: [],
+			commits: [],
+		};
+		const mission = runtime(state({ status: "orchestrator_turn", features: [worker], pendingHandoff: handoff }));
+		await mission.restore();
+		const retried = await mission.resolveHandoff({ decision: "retry_same" });
+		expect(retried).toMatchObject({ status: "running", pendingHandoff: undefined });
+		expect(retried.features[0]).toMatchObject({ status: "pending", nextRunIntent: { mode: "follow_up" } });
+	});
+
+	test("keeps prior state authoritative when persistence fails", async () => {
+		const mission = runtime(null, true);
+		await expect(mission.start("goal")).rejects.toThrow("disk full");
+		expect(mission.snapshot()).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/missions/workspace.test.ts
+++ b/packages/coding-agent/test/missions/workspace.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	MissionWorkspaceManager,
+	type MissionFeatureWorkspaceDescriptor,
+} from "../../src/missions";
+import type { MissionFeatureSpec, MissionRepositoryState, MissionState, MissionWorkerHandoff } from "../../src/missions";
+
+const GIT_ENV = {
+	GIT_AUTHOR_NAME: "workspace-test",
+	GIT_AUTHOR_EMAIL: "workspace-test@example.com",
+	GIT_COMMITTER_NAME: "workspace-test",
+	GIT_COMMITTER_EMAIL: "workspace-test@example.com",
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
+function gitRun(cwd: string, args: string[]): string {
+	const env: Record<string, string | undefined> = { ...process.env, ...GIT_ENV };
+	delete env.GIT_DIR;
+	delete env.GIT_WORK_TREE;
+	delete env.GIT_INDEX_FILE;
+	const result = Bun.spawnSync({ cmd: ["git", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+	}
+	return result.stdout.toString().trim();
+}
+
+async function makeRepository(): Promise<{ root: string; repository: MissionRepositoryState }> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mission-workspace-"));
+	gitRun(root, ["init", "-q", "-b", "main"]);
+	await fs.writeFile(path.join(root, "README.md"), "workspace test\n");
+	gitRun(root, ["add", "README.md"]);
+	gitRun(root, ["commit", "-q", "-m", "initial"]);
+	const head = gitRun(root, ["rev-parse", "HEAD"]);
+	return {
+		root,
+		repository: {
+			repoRoot: root,
+			parentBranch: "main",
+			baseSha: head,
+			integrationBranch: "main",
+			integrationHead: head,
+		},
+	};
+}
+
+function mission(repository: MissionRepositoryState): MissionState {
+	return { id: `mission-${randomUUID()}`, repository } as MissionState;
+}
+
+const feature: MissionFeatureSpec = {
+	id: "feature",
+	description: "exercise the workspace manager",
+	milestoneId: "milestone",
+	preconditions: [],
+	expectedBehavior: [],
+};
+
+function handoff(commits: string[]): MissionWorkerHandoff {
+	return {
+		kind: "implementation",
+		outcome: "success",
+		summary: "done",
+		implementation: [],
+		remaining: [],
+		verification: { commands: [], interactiveChecks: [] },
+		tests: { added: [], coverageNotes: [] },
+		issues: [],
+		skillDeviations: [],
+		commits,
+	};
+}
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("MissionWorkspaceManager", () => {
+	test("reserves a deterministic feature workspace without touching git", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+
+		const descriptor = await manager.reserveFeature("owner", mission(repository), feature);
+
+		expect(descriptor).toMatchObject({
+			id: expect.stringContaining("feature:"),
+			kind: "feature",
+			ownerSessionId: "owner",
+			phase: "reserved",
+			branch: expect.stringContaining("/feature/feature"),
+			baseSha: repository.integrationHead,
+		});
+		await expect(fs.stat(descriptor.path)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(gitRun(root, ["branch", "--list", descriptor.branch])).toBe("");
+	});
+
+	test("materializes a reserved workspace and cleanly releases it", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
+
+		const ready = await manager.materialize(reserved) as MissionFeatureWorkspaceDescriptor;
+		expect(ready.phase).toBe("ready");
+		expect(gitRun(ready.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(ready.branch);
+		expect(await manager.releaseIfEmpty(ready)).toBe(true);
+		await expect(fs.stat(ready.path)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(gitRun(root, ["branch", "--list", ready.branch])).toBe("");
+	});
+
+	test("reconciles an unregistered on-disk workspace as a conflict", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
+		await fs.mkdir(reserved.path, { recursive: true });
+
+		const result = await manager.reconcile(reserved, false);
+
+		expect(result).toMatchObject({
+			kind: "pause",
+			reason: "workspace_conflict",
+			descriptorId: reserved.id,
+			detail: "Workspace path exists on disk but is not a registered worktree",
+		});
+		await fs.rm(reserved.path, { recursive: true, force: true });
+	});
+
+	test("advances the integration ref only for the recorded feature handoff", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+		const featureHead = gitRun(descriptor.path, ["rev-parse", "HEAD"]);
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([featureHead]));
+
+		expect(result).toMatchObject({ kind: "advanced", repository: { integrationHead: featureHead } });
+		expect(gitRun(root, ["rev-parse", "main"])).toBe(featureHead);
+		await manager.release(descriptor);
+	});
+
+	test("rejects a worktree path registered to a branch it does not own", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["worktree", "add", "-b", "unowned-workspace", descriptor.path, "main"]);
+
+		const result = await manager.reconcile(descriptor, false);
+
+		expect(result).toMatchObject({
+			kind: "pause",
+			reason: "workspace_conflict",
+			detail: "Worktree path is registered to an unowned or mismatched branch",
+			branch: descriptor.branch,
+		});
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["branch", "-D", "unowned-workspace"]);
+		gitRun(root, ["branch", "-D", descriptor.branch]);
+	});
+});

--- a/packages/coding-agent/test/missions/workspace.test.ts
+++ b/packages/coding-agent/test/missions/workspace.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { randomUUID } from "node:crypto";
-import {
-	MissionWorkspaceManager,
-	type MissionFeatureWorkspaceDescriptor,
+import type {
+	MissionFeatureSpec,
+	MissionRepositoryState,
+	MissionState,
+	MissionWorkerHandoff,
 } from "../../src/missions";
-import type { MissionFeatureSpec, MissionRepositoryState, MissionState, MissionWorkerHandoff } from "../../src/missions";
+import { type MissionFeatureWorkspaceDescriptor, MissionWorkspaceManager } from "../../src/missions";
 
 const GIT_ENV = {
 	GIT_AUTHOR_NAME: "workspace-test",
@@ -108,7 +110,7 @@ describe("MissionWorkspaceManager", () => {
 		const manager = new MissionWorkspaceManager();
 		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
 
-		const ready = await manager.materialize(reserved) as MissionFeatureWorkspaceDescriptor;
+		const ready = (await manager.materialize(reserved)) as MissionFeatureWorkspaceDescriptor;
 		expect(ready.phase).toBe("ready");
 		expect(gitRun(ready.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(ready.branch);
 		expect(await manager.releaseIfEmpty(ready)).toBe(true);
@@ -138,7 +140,9 @@ describe("MissionWorkspaceManager", () => {
 		const { root, repository } = await makeRepository();
 		roots.push(root);
 		const manager = new MissionWorkspaceManager();
-		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
 		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
 		gitRun(descriptor.path, ["add", "feature.txt"]);
 		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
@@ -148,14 +152,142 @@ describe("MissionWorkspaceManager", () => {
 
 		expect(result).toMatchObject({ kind: "advanced", repository: { integrationHead: featureHead } });
 		expect(gitRun(root, ["rev-parse", "main"])).toBe(featureHead);
+		expect(await fs.readFile(path.join(root, "feature.txt"), "utf8")).toBe("done\n");
+		expect(await manager.advanceIntegration(repository, descriptor, handoff([featureHead]))).toMatchObject({
+			kind: "already_applied",
+			repository: { integrationHead: featureHead },
+		});
 		await manager.release(descriptor);
+	});
+
+	test("refuses to advance a dirty checked-out integration worktree", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+		const featureHead = gitRun(descriptor.path, ["rev-parse", "HEAD"]);
+		await fs.writeFile(path.join(root, "README.md"), "dirty\n");
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([featureHead]));
+
+		expect(result).toMatchObject({
+			kind: "partial_handoff",
+			issues: [{ description: "Integration worktree is dirty; integration branch cannot be advanced" }],
+		});
+		expect(gitRun(root, ["rev-parse", "main"])).toBe(repository.integrationHead);
+	});
+
+	test("rejects a handoff whose commit list differs from the feature branch", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([]));
+
+		expect(result).toMatchObject({
+			kind: "partial_handoff",
+			issues: [{ description: "Feature commit list does not match handoff.commits" }],
+		});
+	});
+
+	test("reports an integration branch that moved since the feature was reserved", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.writeFile(path.join(descriptor.path, "feature.txt"), "done\n");
+		gitRun(descriptor.path, ["add", "feature.txt"]);
+		gitRun(descriptor.path, ["commit", "-q", "-m", "feature"]);
+		const featureHead = gitRun(descriptor.path, ["rev-parse", "HEAD"]);
+		await fs.writeFile(path.join(root, "other.txt"), "other\n");
+		gitRun(root, ["add", "other.txt"]);
+		gitRun(root, ["commit", "-q", "-m", "other"]);
+
+		const result = await manager.advanceIntegration(repository, descriptor, handoff([featureHead]));
+
+		expect(result).toMatchObject({ kind: "pause", reason: "integration_diverged" });
+	});
+
+	test("rejects a stale reserved feature branch instead of adopting it", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const reserved = await manager.reserveFeature("owner", mission(repository), feature);
+		await fs.writeFile(path.join(root, "stale.txt"), "stale\n");
+		gitRun(root, ["add", "stale.txt"]);
+		gitRun(root, ["commit", "-q", "-m", "stale"]);
+		gitRun(root, ["branch", reserved.branch]);
+
+		await expect(manager.materialize(reserved)).rejects.toThrow(`Feature branch ${reserved.branch} already exists`);
+	});
+
+	test("recreates a registered feature worktree whose directory disappeared without a child transcript", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		await fs.rm(descriptor.path, { recursive: true, force: true });
+
+		const result = await manager.reconcile(descriptor, false);
+
+		expect(result).toMatchObject({ kind: "ready", descriptor: { id: descriptor.id, phase: "ready" } });
+		expect(gitRun(descriptor.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(descriptor.branch);
+	});
+
+	test("recreates a registered validator worktree whose directory disappeared without a child transcript", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = await manager.materialize(
+			await manager.reserveValidator("owner", mission(repository), feature.id),
+		);
+		await fs.rm(descriptor.path, { recursive: true, force: true });
+
+		const result = await manager.reconcile(descriptor, false);
+
+		expect(result).toMatchObject({ kind: "ready", descriptor: { id: descriptor.id, phase: "ready" } });
+		expect(gitRun(descriptor.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+	});
+
+	test("does not release a worktree registered to an unrelated branch", async () => {
+		const { root, repository } = await makeRepository();
+		roots.push(root);
+		const manager = new MissionWorkspaceManager();
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["worktree", "add", "-b", "unowned-release", descriptor.path, "main"]);
+
+		await expect(manager.release(descriptor)).rejects.toThrow("Refusing to remove unowned worktree");
+		expect(gitRun(descriptor.path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("unowned-release");
+		gitRun(root, ["worktree", "remove", descriptor.path]);
+		gitRun(root, ["branch", "-D", "unowned-release"]);
+		gitRun(root, ["branch", "-D", descriptor.branch]);
 	});
 
 	test("rejects a worktree path registered to a branch it does not own", async () => {
 		const { root, repository } = await makeRepository();
 		roots.push(root);
 		const manager = new MissionWorkspaceManager();
-		const descriptor = await manager.materialize(await manager.reserveFeature("owner", mission(repository), feature)) as MissionFeatureWorkspaceDescriptor;
+		const descriptor = (await manager.materialize(
+			await manager.reserveFeature("owner", mission(repository), feature),
+		)) as MissionFeatureWorkspaceDescriptor;
 		gitRun(root, ["worktree", "remove", descriptor.path]);
 		gitRun(root, ["worktree", "add", "-b", "unowned-workspace", descriptor.path, "main"]);
 

--- a/packages/coding-agent/test/modes/rpc-mission.test.ts
+++ b/packages/coding-agent/test/modes/rpc-mission.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { MissionState } from "@oh-my-pi/pi-coding-agent/missions/types";
+import { handleRpcMissionCommand, type RpcMissionSession } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+
+const mission = { id: "mission-1", status: "paused" } as MissionState;
+
+function createSession(busy = false): { session: RpcMissionSession; calls: string[] } {
+	const calls: string[] = [];
+	const session: RpcMissionSession = {
+		startMission: async () => {
+			calls.push("start");
+			return mission;
+		},
+		missionRuntime: {
+			snapshot: () => mission,
+			isBusy: () => busy,
+			accept: async () => {
+				calls.push("accept");
+				return mission;
+			},
+			pause: async () => {
+				calls.push("pause");
+				return mission;
+			},
+			resume: async input => {
+				const worker = input?.restartWorker ? "fresh" : "same";
+				calls.push(`resume:${worker}:${input?.messageToWorker ?? ""}`);
+				return mission;
+			},
+			cancel: async () => {
+				calls.push("cancel");
+				return mission;
+			},
+			resolveHandoff: async () => {
+				calls.push("resolveHandoff");
+				return mission;
+			},
+		},
+	};
+	return { session, calls };
+}
+
+describe("mission RPC commands", () => {
+	test("returns durable snapshots and preserves resume versus restart semantics", async () => {
+		const { session, calls } = createSession();
+		const commands = [
+			{ type: "mission_start", goal: "Ship it" },
+			{ type: "get_mission" },
+			{ type: "mission_accept" },
+			{ type: "mission_pause" },
+			{ type: "mission_resume", messageToWorker: "continue" },
+			{ type: "mission_restart", messageToWorker: "fresh" },
+			{ type: "mission_cancel" },
+		] as const;
+
+		for (const command of commands) {
+			expect((await handleRpcMissionCommand(session, command)).mission).toBe(mission);
+		}
+
+		expect(calls).toEqual(["start", "accept", "pause", "resume:same:continue", "resume:fresh:fresh", "cancel"]);
+	});
+
+	test("rejects restart while mission work is active with the machine-readable busy sentinel", async () => {
+		const { session } = createSession(true);
+		await expect(handleRpcMissionCommand(session, { type: "mission_restart" })).rejects.toThrow("MISSION_BUSY");
+	});
+});

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -209,6 +209,38 @@ describe("AgentLifecycleManager", () => {
 		expect(revived.disposeCalls()).toBe(1);
 	});
 
+	it("routes persisted cold revival to the factory registered for that agent id", async () => {
+		const first = makeSessionStub();
+		const second = makeSessionStub();
+		registry.register({
+			id: "first-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/first-Sub.jsonl",
+			status: "parked",
+		});
+		registry.register({
+			id: "second-Sub",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/second-Sub.jsonl",
+			status: "parked",
+		});
+
+		const firstReviver = vi.fn(async () => async () => first.session);
+		const secondReviver = vi.fn(async () => async () => second.session);
+		lifecycle.registerPersistedReviver("first-Sub", firstReviver, TTL);
+		lifecycle.registerPersistedReviver("second-Sub", secondReviver, TTL);
+
+		await expect(lifecycle.ensureLive("second-Sub")).resolves.toBe(second.session);
+		expect(secondReviver).toHaveBeenCalledTimes(1);
+		expect(firstReviver).not.toHaveBeenCalled();
+		expect(registry.get("second-Sub")?.session).toBe(second.session);
+		expect(registry.get("first-Sub")?.status).toBe("parked");
+	});
+
 	it("a persisted factory that declines leaves the parked ref transcript-only", async () => {
 		registry.register({
 			id: "7-Sub",

--- a/packages/coding-agent/test/session-handoff-mission-guard.test.ts
+++ b/packages/coding-agent/test/session-handoff-mission-guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { SessionHandoff, type SessionHandoffHost } from "@oh-my-pi/pi-coding-agent/session/session-handoff";
+
+describe("SessionHandoff mission transition guard", () => {
+	it("rejects direct handoff before inspecting or rewriting session state", async () => {
+		let inspected = false;
+		const unreachable = (): never => {
+			throw new Error("must not inspect handoff state");
+		};
+		const host: SessionHandoffHost = {
+			agent: null as never,
+			sessionManager: {
+				getBranch: () => {
+					inspected = true;
+					return [];
+				},
+			} as never,
+			settings: null as never,
+			modelRegistry: null as never,
+			extensionRunner: undefined,
+			sideStreamFn: unreachable,
+			obfuscator: undefined,
+			model: unreachable,
+			thinkingLevel: unreachable,
+			sessionId: unreachable,
+			sessionFile: unreachable,
+			baseSystemPrompt: unreachable,
+			assertMissionTransitionAllowed: () => {
+				throw new Error("MISSION_BUSY");
+			},
+			assertVibeSessionTransitionAllowed: unreachable,
+			setSkipPostTurnMaintenance: unreachable,
+			obfuscateTextForProvider: unreachable,
+			deobfuscateFromProvider: unreachable,
+			convertMessagesToLlm: unreachable,
+			prepareSimpleStreamOptions: unreachable,
+			effectiveServiceTier: unreachable,
+			flushPendingBash: unreachable,
+			beginBashSessionTransition: unreachable,
+			markBashSessionTransition: unreachable,
+			finishBashSessionTransition: unreachable,
+			cancelOwnAsyncJobs: unreachable,
+			clearCheckpointRuntimeState: unreachable,
+			clearSessionScopedToolState: unreachable,
+			clearFreshProviderSessionId: unreachable,
+			syncAgentSessionId: unreachable,
+			rekeyMemoryForCurrentSessionId: unreachable,
+			resetMemoryContextForNewTranscript: unreachable,
+			clearPendingNextTurnMessages: unreachable,
+			resetTodoCycle: unreachable,
+			buildDisplaySessionContext: unreachable,
+			resetAdvisorRuntimes: unreachable,
+			syncTodoPhasesFromBranch: unreachable,
+			rearmSessionSchedules: unreachable,
+		};
+
+		await expect(new SessionHandoff(host).handoff()).rejects.toThrow("MISSION_BUSY");
+		expect(inspected).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/session/session-schedule.test.ts
+++ b/packages/coding-agent/test/session/session-schedule.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Contracts for session self-scheduling: fold, arming, controller fire/cancel/restore,
+ * overdue turn-boundary delivery, due-time resolution, and schedule-tool input validation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { ManagedTimers } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/managed-timers";
+import type { CustomEntry, SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import {
+	armSessionSchedules,
+	foldPendingSessionSchedules,
+	resolveScheduleDueAtMs,
+	SESSION_SCHEDULE_CUSTOM_TYPE,
+	SESSION_SCHEDULE_MAX_DELAY_MS,
+	SESSION_SCHEDULE_MESSAGE_TYPE,
+	SessionScheduleController,
+	type SessionScheduleFireHost,
+} from "@oh-my-pi/pi-coding-agent/session/session-schedule";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ScheduleTool } from "@oh-my-pi/pi-coding-agent/tools/schedule";
+import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+import { logger } from "@oh-my-pi/pi-utils";
+
+type HiddenMessage = {
+	customType: string;
+	content: string;
+	deliverAs?: "steer" | "followUp" | "nextTurn";
+	triggerTurn?: boolean;
+};
+
+async function flushMicrotasks(rounds = 8): Promise<void> {
+	for (let i = 0; i < rounds; i++) await Promise.resolve();
+}
+
+function scheduleCustomEntry(data: unknown, id = "entry"): CustomEntry {
+	return {
+		type: "custom",
+		customType: SESSION_SCHEDULE_CUSTOM_TYPE,
+		data,
+		id,
+		parentId: null,
+		timestamp: "1970-01-01T00:00:00.000Z",
+	};
+}
+
+function scheduleEntriesOf(entries: readonly SessionEntry[]): CustomEntry[] {
+	return entries.filter(
+		(entry): entry is CustomEntry => entry.type === "custom" && entry.customType === SESSION_SCHEDULE_CUSTOM_TYPE,
+	);
+}
+
+function createHarness(initialNowMs = 1_000_000) {
+	let nowMs = initialNowMs;
+	const entries: SessionEntry[] = [];
+	const hiddenMessages: HiddenMessage[] = [];
+	let entrySeq = 0;
+
+	const timers = new ManagedTimers((_event, _error) => {});
+	const host: SessionScheduleFireHost = {
+		getEntries: () => entries,
+		appendCustomEntry: (customType, data) => {
+			const id = `entry-${++entrySeq}`;
+			entries.push({
+				type: "custom",
+				customType,
+				data,
+				id,
+				parentId: null,
+				timestamp: new Date(nowMs).toISOString(),
+			});
+			return id;
+		},
+		sendHiddenMessage: async message => {
+			hiddenMessages.push({ ...message });
+		},
+	};
+
+	const controller = new SessionScheduleController(timers, host, () => nowMs);
+
+	return {
+		controller,
+		entries,
+		hiddenMessages,
+		timers,
+		host,
+		now: () => nowMs,
+		setNow: (next: number) => {
+			nowMs = next;
+		},
+		dispose: () => {
+			controller.dispose();
+			timers.clearAll();
+		},
+	};
+}
+
+describe("session-schedule", () => {
+	let harness: ReturnType<typeof createHarness> | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		harness = undefined;
+	});
+
+	afterEach(() => {
+		harness?.dispose();
+		harness = undefined;
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it("creating a schedule appends exactly one session-schedule entry and arms one timer", () => {
+		harness = createHarness(1_000_000);
+		const created = harness.controller.create({ delayMs: 2_000, prompt: "wake me" });
+
+		const scheduleEntries = scheduleEntriesOf(harness.entries);
+		expect(scheduleEntries).toHaveLength(1);
+		expect(scheduleEntries[0]?.data).toEqual({
+			id: created.id,
+			dueAtMs: 1_002_000,
+			prompt: "wake me",
+			createdAt: 1_000_000,
+		});
+		expect(vi.getTimerCount()).toBe(1);
+		expect(harness.controller.listPending()).toHaveLength(1);
+		expect(harness.hiddenMessages).toHaveLength(0);
+	});
+
+	it("advancing past dueAtMs enqueues exactly one hidden message with the stored prompt", async () => {
+		harness = createHarness(1_000_000);
+		const prompt = "check the build";
+		harness.controller.create({ delayMs: 1_500, prompt });
+
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(1_499);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(0);
+
+		vi.advanceTimersByTime(1);
+		await flushMicrotasks();
+
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]).toEqual({
+			customType: SESSION_SCHEDULE_MESSAGE_TYPE,
+			content: prompt,
+			deliverAs: "nextTurn",
+			triggerTurn: true,
+		});
+		expect(foldPendingSessionSchedules(harness.entries)).toEqual([]);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("cancelling before the deadline appends a cancel tombstone and fires nothing", async () => {
+		harness = createHarness(1_000_000);
+		const created = harness.controller.create({ delayMs: 5_000, prompt: "should not fire" });
+
+		expect(vi.getTimerCount()).toBe(1);
+		expect(harness.controller.cancel(created.id)).toBe(true);
+
+		const scheduleEntries = scheduleEntriesOf(harness.entries);
+		expect(scheduleEntries).toHaveLength(2);
+		expect(scheduleEntries[1]?.data).toEqual({ id: created.id, cancelled: true });
+		expect(harness.controller.listPending()).toHaveLength(0);
+		expect(vi.getTimerCount()).toBe(0);
+
+		vi.advanceTimersByTime(10_000);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(0);
+	});
+
+	it("re-fold after fire does not re-arm that id; a still-pending schedule does re-arm", async () => {
+		harness = createHarness(1_000_000);
+		const first = harness.controller.create({ delayMs: 1_000, prompt: "first wake" });
+
+		vi.advanceTimersByTime(1_000);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]?.content).toBe("first wake");
+		expect(vi.getTimerCount()).toBe(0);
+
+		// Fired tombstone keeps the id out of the pending fold.
+		expect(foldPendingSessionSchedules(harness.entries).some(entry => entry.id === first.id)).toBe(false);
+		harness.controller.rearmFromEntries();
+		expect(vi.getTimerCount()).toBe(0);
+
+		const second = harness.controller.create({ delayMs: 4_000, prompt: "second wake" });
+		expect(vi.getTimerCount()).toBe(1);
+		expect(foldPendingSessionSchedules(harness.entries).map(entry => entry.id)).toEqual([second.id]);
+
+		harness.controller.rearmFromEntries();
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(4_000);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(2);
+		expect(harness.hiddenMessages.map(message => message.content)).toEqual(["first wake", "second wake"]);
+	});
+
+	it("does not arm malformed persisted future entries beyond the timer maximum", () => {
+		harness = createHarness(1_000_000);
+		harness.entries.push(
+			scheduleCustomEntry({
+				id: "too-far",
+				dueAtMs: harness.now() + SESSION_SCHEDULE_MAX_DELAY_MS + 1,
+				prompt: "do not overflow",
+				createdAt: harness.now(),
+			}),
+		);
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		const armed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => harness!.now() });
+
+		expect(armed.pending.map(schedule => schedule.id)).toEqual(["too-far"]);
+		expect(vi.getTimerCount()).toBe(0);
+		expect(scheduleEntriesOf(harness.entries)).toHaveLength(1);
+		expect(harness.hiddenMessages).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(
+			"session-schedule not armed: persisted delay exceeds timer maximum",
+			expect.objectContaining({ id: "too-far" }),
+		);
+		armed.disarm();
+	});
+
+	it("does not deliver after a fire loses session liveness during flush", async () => {
+		harness = createHarness(1_000_000);
+		let live = true;
+		let releaseFlush: (() => void) | undefined;
+		const flushStarted = new Promise<void>(resolve => {
+			releaseFlush = resolve;
+		});
+		harness.host.isLive = () => live;
+		harness.host.flush = () => flushStarted;
+		harness.entries.push(
+			scheduleCustomEntry({ id: "liveness", dueAtMs: harness.now(), prompt: "must not deliver", createdAt: 0 }),
+		);
+		const nowMs = harness.now();
+		armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => nowMs });
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(scheduleEntriesOf(harness.entries)).toHaveLength(2);
+		live = false;
+		releaseFlush?.();
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toEqual([]);
+	});
+
+	it("does not deliver after the transcript branch changes during flush", async () => {
+		harness = createHarness(1_000_000);
+		const flush = Promise.withResolvers<void>();
+		harness.host.flush = () => flush.promise;
+		harness.entries.push(
+			scheduleCustomEntry({
+				id: "old-branch",
+				dueAtMs: harness.now(),
+				prompt: "must not cross branches",
+				createdAt: 0,
+			}),
+		);
+		armSessionSchedules(harness.entries, harness.timers, harness.host, { now: harness.now });
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(scheduleEntriesOf(harness.entries)).toHaveLength(2);
+
+		harness.host.getEntries = () => [];
+		flush.resolve();
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toEqual([]);
+	});
+
+	it("delivers a committed wake after an unrelated same-branch rearm during flush", async () => {
+		harness = createHarness(1_000_000);
+		const flush = Promise.withResolvers<void>();
+		harness.host.flush = () => flush.promise;
+		harness.entries.push(
+			scheduleCustomEntry({ id: "same-branch", dueAtMs: harness.now(), prompt: "deliver once", createdAt: 0 }),
+		);
+		const armed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: harness.now });
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		armed.disarm();
+		flush.resolve();
+		await flushMicrotasks();
+		expect(harness.hiddenMessages.map(message => message.content)).toEqual(["deliver once"]);
+	});
+
+	it("overdue creates stay pending after fold and fire once at the next turn boundary", async () => {
+		harness = createHarness(10_000);
+		harness.entries.push(
+			scheduleCustomEntry(
+				{
+					id: "overdue-1",
+					dueAtMs: 1_000,
+					prompt: "catch up",
+					createdAt: 0,
+				},
+				"seed-overdue",
+			),
+		);
+
+		const pending = foldPendingSessionSchedules(harness.entries);
+		expect(pending).toHaveLength(1);
+		expect(pending[0]?.id).toBe("overdue-1");
+
+		const armed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => harness!.now() });
+		expect(armed.pending).toHaveLength(1);
+		expect(vi.getTimerCount()).toBe(1);
+
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]).toEqual({
+			customType: SESSION_SCHEDULE_MESSAGE_TYPE,
+			content: "catch up",
+			deliverAs: "nextTurn",
+			triggerTurn: false,
+		});
+		expect(vi.getTimerCount()).toBe(0);
+
+		// Fired tombstone: another arm + zero-delay tick must not repeat delivery.
+		const rearmed = armSessionSchedules(harness.entries, harness.timers, harness.host, { now: () => harness!.now() });
+		expect(rearmed.pending).toHaveLength(0);
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(0);
+		await flushMicrotasks();
+		expect(harness.hiddenMessages).toHaveLength(1);
+
+		armed.disarm();
+		rearmed.disarm();
+	});
+
+	it("resolveScheduleDueAtMs rejects both delayMs+atIso and neither", () => {
+		const neither = resolveScheduleDueAtMs({ prompt: "wake" }, 1_000);
+		expect(neither).toEqual({ error: "Exactly one of delayMs or atIso must be supplied." });
+
+		const both = resolveScheduleDueAtMs(
+			{
+				prompt: "wake",
+				delayMs: 500,
+				atIso: "2020-01-01T00:00:00.000Z",
+			},
+			1_000,
+		);
+		expect(both).toEqual({ error: "Exactly one of delayMs or atIso must be supplied." });
+
+		const fromDelay = resolveScheduleDueAtMs({ prompt: "wake", delayMs: 250 }, 1_000);
+		expect(fromDelay).toEqual({ dueAtMs: 1_250 });
+
+		const atMs = Date.parse("2020-01-01T00:00:00.000Z");
+		const fromAt = resolveScheduleDueAtMs({ prompt: "wake", atIso: "2020-01-01T00:00:00.000Z" }, atMs - 1);
+		expect(fromAt).toEqual({ dueAtMs: atMs });
+
+		expect(resolveScheduleDueAtMs({ prompt: "wake", atIso: new Date(atMs - 1).toISOString() }, atMs)).toEqual({
+			error: "atIso must be in the future.",
+		});
+
+		expect(resolveScheduleDueAtMs({ prompt: "wake", delayMs: SESSION_SCHEDULE_MAX_DELAY_MS + 1 }, 1_000)).toEqual({
+			error: `delayMs must not exceed ${SESSION_SCHEDULE_MAX_DELAY_MS}.`,
+		});
+		expect(
+			resolveScheduleDueAtMs(
+				{
+					prompt: "wake",
+					atIso: new Date(1_000 + SESSION_SCHEDULE_MAX_DELAY_MS + 1).toISOString(),
+				},
+				1_000,
+			),
+		).toEqual({ error: `atIso must not be more than ${SESSION_SCHEDULE_MAX_DELAY_MS}ms in the future.` });
+	});
+
+	it("schedule tool input validation rejects both and neither create combinations", async () => {
+		const tool = new ScheduleTool({ cwd: "/tmp/schedule-test" } as ToolSession);
+
+		await expect(tool.execute("call-neither", { prompt: "wake" })).rejects.toBeInstanceOf(ToolError);
+		await expect(tool.execute("call-neither", { prompt: "wake" })).rejects.toThrow(
+			"Exactly one of delayMs or atIso must be supplied.",
+		);
+
+		await expect(
+			tool.execute("call-both", {
+				prompt: "wake",
+				delayMs: 100,
+				atIso: "2020-01-01T00:00:00.000Z",
+			}),
+		).rejects.toBeInstanceOf(ToolError);
+		await expect(
+			tool.execute("call-both-again", {
+				prompt: "wake",
+				delayMs: 100,
+				atIso: "2020-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow("Exactly one of delayMs or atIso must be supplied.");
+	});
+
+	it("only exposes schedule to top-level sessions", () => {
+		const settings = { get: () => true };
+		expect(
+			ScheduleTool.createIf({
+				cwd: "/tmp/schedule-test",
+				settings,
+				isTopLevelSession: () => true,
+			} as unknown as ToolSession),
+		).toBeInstanceOf(ScheduleTool);
+		expect(
+			ScheduleTool.createIf({
+				cwd: "/tmp/schedule-test",
+				settings,
+				isTopLevelSession: () => false,
+			} as unknown as ToolSession),
+		).toBeNull();
+	});
+
+	it("rejects creates and cancels when the live controller is unavailable", async () => {
+		const tool = new ScheduleTool({ cwd: "/tmp/schedule-test" } as ToolSession);
+
+		await expect(tool.execute("create", { prompt: "wake", delayMs: 1 })).rejects.toThrow(
+			"Session schedule controller is unavailable.",
+		);
+		await expect(tool.execute("cancel", { cancel: "schedule-1" })).rejects.toThrow(
+			"Session schedule controller is unavailable.",
+		);
+	});
+
+	it("forwards cancel ids to the live controller and reports unknown ids", async () => {
+		const cancel = vi.fn((id: string) => id === "known");
+		const tool = new ScheduleTool({
+			cwd: "/tmp/schedule-test",
+			getSessionSchedule: () => ({ cancel }) as never,
+		} as unknown as ToolSession);
+
+		const known = await tool.execute("cancel-known", { cancel: "known" });
+		const unknown = await tool.execute("cancel-unknown", { cancel: "unknown" });
+
+		expect(cancel).toHaveBeenNthCalledWith(1, "known");
+		expect(cancel).toHaveBeenNthCalledWith(2, "unknown");
+		expect(known.details).toMatchObject({ op: "cancel", id: "known", cancelled: true });
+		expect(unknown.details).toMatchObject({ op: "cancel", id: "unknown", cancelled: false });
+	});
+
+	it("rejects mixed cancel and create input before touching the controller", async () => {
+		const cancel = vi.fn(() => true);
+		const tool = new ScheduleTool({
+			cwd: "/tmp/schedule-test",
+			getSessionSchedule: () => ({ cancel }) as never,
+		} as unknown as ToolSession);
+
+		await expect(tool.execute("mixed", { cancel: "schedule-1", prompt: "wake", delayMs: 1 })).rejects.toThrow(
+			"cancel cannot be combined with delayMs, atIso, or prompt.",
+		);
+		expect(cancel).not.toHaveBeenCalled();
+	});
+
+	it("a tool-created schedule reaches the live controller and actually fires", async () => {
+		// Regression: the tool used to read its controller through a synthetic cast that was
+		// never populated on ToolSession, so every create silently took the controller-less
+		// fallback — the entry persisted but no timer was ever armed and the wake never fired.
+		harness = createHarness();
+		const local = harness;
+		const tool = new ScheduleTool({
+			cwd: "/tmp/schedule-test",
+			getSessionSchedule: () => local.controller,
+		} as ToolSession);
+
+		await tool.execute("call-1", { prompt: "wake up", delayMs: 5_000 });
+
+		local.setNow(local.now() + 5_000);
+		vi.advanceTimersByTime(5_000);
+		await flushMicrotasks();
+
+		expect(local.hiddenMessages).toHaveLength(1);
+		expect(local.hiddenMessages[0]?.content).toContain("wake up");
+	});
+
+	it("fold ignores unknown or garbage custom-entry payloads without throwing", () => {
+		const entries: SessionEntry[] = [
+			scheduleCustomEntry(undefined, "u1"),
+			scheduleCustomEntry(null, "u2"),
+			scheduleCustomEntry("not-an-object", "u3"),
+			scheduleCustomEntry({ id: "" }, "u4"),
+			scheduleCustomEntry({ id: "partial" }, "u5"),
+			scheduleCustomEntry({ id: "bad-due", dueAtMs: Number.NaN, prompt: "x", createdAt: 1 }, "u6"),
+			scheduleCustomEntry({ id: "empty-prompt", dueAtMs: 1, prompt: "", createdAt: 1 }, "u7"),
+			scheduleCustomEntry({ id: "cancel-noise", cancelled: "yes" }, "u8"),
+			{
+				type: "custom",
+				customType: "other-extension",
+				data: { id: "other", dueAtMs: 1, prompt: "ignore", createdAt: 1 },
+				id: "other",
+				parentId: null,
+				timestamp: "1970-01-01T00:00:00.000Z",
+			},
+			scheduleCustomEntry(
+				{
+					id: "good",
+					dueAtMs: 42,
+					prompt: "keep me",
+					createdAt: 7,
+				},
+				"good-entry",
+			),
+		];
+
+		expect(() => foldPendingSessionSchedules(entries)).not.toThrow();
+		expect(foldPendingSessionSchedules(entries)).toEqual([
+			{
+				id: "good",
+				dueAtMs: 42,
+				prompt: "keep me",
+				createdAt: 7,
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -90,11 +90,12 @@ async function createPersistedSession(
 	return sessionFile;
 }
 
-function createFactory(cwd: string, sessionId?: string) {
+function createFactory(cwd: string, persistedSessionId = "", providerSessionId = "provider-session") {
 	const parentSession = {
-		sessionId,
+		sessionId: providerSessionId,
 		sessionManager: {
 			getCwd: () => cwd,
+			getSessionId: () => persistedSessionId,
 			getArtifactManager: () => undefined,
 		},
 	} as unknown as AgentSession;

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -43,7 +43,11 @@ function createRevivedSession(activeToolNames: string[][]): AgentSession {
 	} as unknown as AgentSession;
 }
 
-async function createPersistedSession(cwd: string, restrictToolNames?: boolean): Promise<string> {
+async function createPersistedSession(
+	cwd: string,
+	restrictToolNames?: boolean,
+	missionOwner?: { ownerSessionId: string },
+): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
 	if (!sessionFile) throw new Error("Expected a persisted session file");
@@ -52,6 +56,18 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean):
 		task: "persisted task",
 		tools: ["read", "yield"],
 		restrictToolNames,
+		...(missionOwner
+			? {
+					cwdBinding: "fixed" as const,
+					missionOwner: {
+						missionId: "mission",
+						ownerSessionId: missionOwner.ownerSessionId,
+						role: "implementation" as const,
+						milestoneId: "milestone",
+						featureId: "feature",
+					},
+				}
+			: {}),
 	});
 	manager.appendMessage({
 		role: "assistant",
@@ -74,8 +90,9 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean):
 	return sessionFile;
 }
 
-function createFactory(cwd: string) {
+function createFactory(cwd: string, sessionId?: string) {
 	const parentSession = {
+		sessionId,
 		sessionManager: {
 			getCwd: () => cwd,
 			getArtifactManager: () => undefined,
@@ -154,5 +171,24 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
+	});
+
+	it("revives a fixed child only for its owner and at its recorded workspace", async () => {
+		const cwd = makeTempDir("@pi-fixed-revive-");
+		const sessionFile = await createPersistedSession(cwd, false, { ownerSessionId: "owner" });
+		const ref = createRef(sessionFile);
+
+		expect(await createFactory(cwd, "other")(ref)).toBeUndefined();
+
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]) } as CreateAgentSessionResult;
+		});
+		const reviver = await createFactory("/parent", "owner")(ref);
+		if (!reviver) throw new Error("Expected fixed workspace reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.cwd).toBe(cwd);
 	});
 });

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -340,6 +340,48 @@ describe("structured subagent primitive", () => {
 		await fs.rm(mcpDisabledRun.artifactsDir, { recursive: true, force: true });
 	});
 
+	it("requires mission ownership and rediscovers fixed-workspace context", async () => {
+		await expect(
+			resolveEffectiveSubagentPolicy(request({ workspace: { cwd: "/fixed", binding: "fixed" } })),
+		).rejects.toThrow("Fixed-workspace subagents require mission ownership");
+
+		mockDiscovery();
+		const fixedSession = session();
+		Object.assign(fixedSession, {
+			contextFiles: [{ path: "/parent/AGENTS.md", content: "parent" }],
+			workspaceTree: { cwd: "/parent" },
+			promptTemplates: [{ name: "parent" }],
+			rules: [{ content: "parent" }],
+		});
+		let options: executorModule.ExecutorOptions | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async executorOptions => {
+			options = executorOptions;
+			return result();
+		});
+
+		const run = await runStructuredSubagent(
+			request({
+				session: fixedSession,
+				workspace: { cwd: "/fixed", binding: "fixed" },
+				missionOwner: {
+					missionId: "mission",
+					ownerSessionId: "owner",
+					role: "implementation",
+					milestoneId: "milestone",
+					featureId: "feature",
+				},
+				retainArtifacts: true,
+			}),
+		);
+
+		expect(options).toMatchObject({ cwd: "/fixed", workspace: { cwd: "/fixed", binding: "fixed" } });
+		expect(options?.contextFiles).toBeUndefined();
+		expect(options?.workspaceTree).toBeUndefined();
+		expect(options?.promptTemplates).toBeUndefined();
+		expect(options?.rules).toBeUndefined();
+		await fs.rm(run.artifactsDir, { recursive: true, force: true });
+	});
+
 	it("unregisters and removes a temporary lease when output ID allocation fails", async () => {
 		mockDiscovery();
 		const failingSession = session();

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { BUILTIN_TOOLS, createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
 Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 
@@ -43,6 +43,27 @@ function createActiveGoalState() {
 describe("createTools", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("self-gates the public schedule factory", () => {
+		expect(BUILTIN_TOOLS.schedule(createTestSession())).toBeNull();
+		expect(
+			BUILTIN_TOOLS.schedule(
+				createTestSession({
+					settings: createSettingsWithOverrides({ "schedule.enabled": true }),
+					taskDepth: 1,
+				}),
+			),
+		).toBeNull();
+		expect(
+			BUILTIN_TOOLS.schedule(
+				createTestSession({
+					settings: createSettingsWithOverrides({ "schedule.enabled": true }),
+					taskDepth: 0,
+					isTopLevelSession: () => true,
+				}),
+			),
+		).not.toBeNull();
 	});
 
 	it("creates all builtin tools by default", async () => {


### PR DESCRIPTION
## Summary

RPC clients can now start, inspect, accept, pause, resume, restart, and cancel missions. Persisted state changes and worker progress arrive as real session events, so subscribers observe runtime activity rather than command echoes.

Busy and invalid transitions retain stable machine-readable codes while returning readable errors. The TypeScript client and protocol reference cover the same commands and outbound frames.

## Dependency

This branch includes the mission runtime and host-lifecycle commits so it builds against `main`. Review the final RPC commit separately.

Closes #6704

## Validation

- `bun --cwd=packages/coding-agent test test/modes/rpc-mission.test.ts test/missions/runtime.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:ts`
