### PR TITLE
fix(ai): preserve custom Anthropic web-search history

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed proxy-stream clients dropping finalized provider-only content blocks, including Anthropic native web-search history, by carrying terminal assistant content in `done` and `error` events ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed proxy-stream clients dropping finalized provider-only content blocks, including Anthropic native web-search history, by carrying terminal assistant content in `done` and `error` events ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
+- Fixed proxy-stream clients dropping finalized provider-only content blocks, including Anthropic native web-search history, by allowing `done` and `error` events to carry terminal assistant content while retaining delta-reconstructed content from older proxy servers that omit it ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
 
 ## [17.1.2] - 2026-07-24
 

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -56,12 +56,14 @@ export type ProxyAssistantMessageEvent =
 			type: "done";
 			reason: Extract<StopReason, "stop" | "length" | "toolUse">;
 			usage: AssistantMessage["usage"];
+			content: AssistantMessage["content"];
 	  }
 	| {
 			type: "error";
 			reason: Extract<StopReason, "aborted" | "error">;
 			errorMessage?: string;
 			usage: AssistantMessage["usage"];
+			content: AssistantMessage["content"];
 	  };
 
 export interface ProxyStreamOptions extends SimpleStreamOptions {
@@ -372,6 +374,7 @@ function processProxyEvent(
 		case "done":
 			partial.stopReason = proxyEvent.reason;
 			partial.usage = proxyEvent.usage;
+			partial.content = proxyEvent.content;
 			calculateCost(model, partial.usage);
 			scrubPartialJson(partial);
 			return { type: "done", reason: proxyEvent.reason, message: partial };
@@ -380,6 +383,7 @@ function processProxyEvent(
 			partial.stopReason = proxyEvent.reason;
 			partial.errorMessage = proxyEvent.errorMessage;
 			partial.usage = proxyEvent.usage;
+			partial.content = proxyEvent.content;
 			calculateCost(model, partial.usage);
 			scrubPartialJson(partial);
 			return { type: "error", reason: proxyEvent.reason, error: partial };

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -56,14 +56,14 @@ export type ProxyAssistantMessageEvent =
 			type: "done";
 			reason: Extract<StopReason, "stop" | "length" | "toolUse">;
 			usage: AssistantMessage["usage"];
-			content: AssistantMessage["content"];
+			content?: AssistantMessage["content"];
 	  }
 	| {
 			type: "error";
 			reason: Extract<StopReason, "aborted" | "error">;
 			errorMessage?: string;
 			usage: AssistantMessage["usage"];
-			content: AssistantMessage["content"];
+			content?: AssistantMessage["content"];
 	  };
 
 export interface ProxyStreamOptions extends SimpleStreamOptions {
@@ -374,7 +374,7 @@ function processProxyEvent(
 		case "done":
 			partial.stopReason = proxyEvent.reason;
 			partial.usage = proxyEvent.usage;
-			partial.content = proxyEvent.content;
+			if (proxyEvent.content !== undefined) partial.content = proxyEvent.content;
 			calculateCost(model, partial.usage);
 			scrubPartialJson(partial);
 			return { type: "done", reason: proxyEvent.reason, message: partial };
@@ -383,7 +383,7 @@ function processProxyEvent(
 			partial.stopReason = proxyEvent.reason;
 			partial.errorMessage = proxyEvent.errorMessage;
 			partial.usage = proxyEvent.usage;
-			partial.content = proxyEvent.content;
+			if (proxyEvent.content !== undefined) partial.content = proxyEvent.content;
 			calculateCost(model, partial.usage);
 			scrubPartialJson(partial);
 			return { type: "error", reason: proxyEvent.reason, error: partial };

--- a/packages/agent/test/proxy-stream-disconnect.test.ts
+++ b/packages/agent/test/proxy-stream-disconnect.test.ts
@@ -178,7 +178,6 @@ describe("streamProxy — server disconnect without terminal event", () => {
 				type: "done",
 				reason: "stop",
 				usage: { ...baseUsage },
-				content: [{ type: "text", text: "Hello" }],
 			},
 		];
 		const body = buildSseBody(events);
@@ -195,7 +194,7 @@ describe("streamProxy — server disconnect without terminal event", () => {
 
 		const result = await stream.result();
 		expect(result.stopReason).toBe("stop");
-		expect(result.content.length).toBeGreaterThan(0);
+		expect(result.content).toEqual([{ type: "text", text: "Hello" }]);
 	});
 
 	it("restores terminal blocks that have no proxy stream events", async () => {
@@ -256,7 +255,6 @@ describe("streamProxy — server disconnect without terminal event", () => {
 				reason: "error",
 				errorMessage: "rate_limit_exceeded",
 				usage: { ...baseUsage },
-				content: [{ type: "text", text: "Hel" }],
 			},
 		];
 		const body = buildSseBody(events);
@@ -274,6 +272,7 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		const result = await stream.result();
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("rate_limit_exceeded");
+		expect(result.content).toEqual([{ type: "text", text: "Hel" }]);
 	});
 
 	it("does not leak partialJson when server disconnects mid-tool-call", async () => {

--- a/packages/agent/test/proxy-stream-disconnect.test.ts
+++ b/packages/agent/test/proxy-stream-disconnect.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ProxyAssistantMessageEvent } from "@oh-my-pi/pi-agent-core/proxy";
 import { type ProxyMessageEventStream, streamProxy } from "@oh-my-pi/pi-agent-core/proxy";
-import type { AssistantMessageEvent, Context, FetchImpl, Model, ToolCall } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, AssistantMessageEvent, Context, FetchImpl, Model, ToolCall } from "@oh-my-pi/pi-ai";
 import { getStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
@@ -178,6 +178,7 @@ describe("streamProxy — server disconnect without terminal event", () => {
 				type: "done",
 				reason: "stop",
 				usage: { ...baseUsage },
+				content: [{ type: "text", text: "Hello" }],
 			},
 		];
 		const body = buildSseBody(events);
@@ -197,6 +198,54 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		expect(result.content.length).toBeGreaterThan(0);
 	});
 
+	it("restores terminal blocks that have no proxy stream events", async () => {
+		const finalizedContent: AssistantMessage["content"] = [
+			{ type: "thinking", thinking: "Search first.", thinkingSignature: "sig-1" },
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "server_tool_use",
+					id: "srvtoolu_1",
+					name: "web_search",
+					input: { query: "current UTC date" },
+				},
+			},
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "web_search_tool_result",
+					tool_use_id: "srvtoolu_1",
+					content: [{ type: "web_search_result", encrypted_content: "opaque-result" }],
+				},
+			},
+			{ type: "thinking", thinking: "Use the result.", thinkingSignature: "sig-2" },
+			{ type: "toolCall", id: "toolu_write", name: "write", arguments: { path: "date.txt" } },
+		];
+		const events: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{ type: "thinking_start", contentIndex: 0 },
+			{ type: "thinking_delta", contentIndex: 0, delta: "Search first." },
+			{ type: "thinking_end", contentIndex: 0, contentSignature: "sig-1" },
+			{ type: "thinking_start", contentIndex: 1 },
+			{ type: "thinking_delta", contentIndex: 1, delta: "Use the result." },
+			{ type: "thinking_end", contentIndex: 1, contentSignature: "sig-2" },
+			{ type: "toolcall_start", contentIndex: 2, id: "toolu_write", toolName: "write" },
+			{ type: "toolcall_delta", contentIndex: 2, delta: '{"path":"date.txt"}' },
+			{ type: "toolcall_end", contentIndex: 2 },
+			{ type: "done", reason: "toolUse", usage: { ...baseUsage }, content: finalizedContent },
+		];
+		const body = buildSseBody(events);
+		const fetchMock: FetchImpl = () => Promise.resolve(new Response(body, { status: 200 }));
+
+		const result = await streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.content).toEqual(finalizedContent);
+	});
+
 	it("completes with error event when server sends an 'error' terminal event", async () => {
 		const events: ProxyAssistantMessageEvent[] = [
 			{ type: "start" },
@@ -207,6 +256,7 @@ describe("streamProxy — server disconnect without terminal event", () => {
 				reason: "error",
 				errorMessage: "rate_limit_exceeded",
 				usage: { ...baseUsage },
+				content: [{ type: "text", text: "Hel" }],
 			},
 		];
 		const body = buildSseBody(events);

--- a/packages/agent/test/proxy-toolcall-partial-json.test.ts
+++ b/packages/agent/test/proxy-toolcall-partial-json.test.ts
@@ -87,7 +87,12 @@ describe("streamProxy — tool-call streaming and partialJson isolation", () => 
 			{ type: "toolcall_delta", contentIndex: 0, delta: '{"comm' },
 			{ type: "toolcall_delta", contentIndex: 0, delta: 'and":"ls"}' },
 			{ type: "toolcall_end", contentIndex: 0 },
-			{ type: "done", reason: "toolUse", usage: { ...baseUsage } },
+			{
+				type: "done",
+				reason: "toolUse",
+				usage: { ...baseUsage },
+				content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } }],
+			},
 		];
 		const body = buildSseBody(events);
 		const fetchMock: FetchImpl = () => Promise.resolve(new Response(body, { status: 200 }));
@@ -119,7 +124,12 @@ describe("streamProxy — tool-call streaming and partialJson isolation", () => 
 			{ type: "toolcall_delta", contentIndex: 0, delta: '{"comm' },
 			{ type: "toolcall_delta", contentIndex: 0, delta: 'and":"ls"}' },
 			{ type: "toolcall_end", contentIndex: 0 },
-			{ type: "done", reason: "toolUse", usage: { ...baseUsage } },
+			{
+				type: "done",
+				reason: "toolUse",
+				usage: { ...baseUsage },
+				content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } }],
+			},
 		];
 		const body = buildSseBody(events);
 		const fetchMock: FetchImpl = () => Promise.resolve(new Response(body, { status: 200 }));
@@ -173,7 +183,12 @@ describe("streamProxy — tool-call streaming and partialJson isolation", () => 
 			{ type: "toolcall_delta", contentIndex: 0, delta: '{"path' },
 			{ type: "toolcall_delta", contentIndex: 0, delta: '":"/tmp/x"}' },
 			{ type: "toolcall_end", contentIndex: 0 },
-			{ type: "done", reason: "toolUse", usage: { ...baseUsage } },
+			{
+				type: "done",
+				reason: "toolUse",
+				usage: { ...baseUsage },
+				content: [{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "/tmp/x" } }],
+			},
 		];
 		const body = buildSseBody(events);
 		const fetchMock: FetchImpl = () => Promise.resolve(new Response(body, { status: 200 }));
@@ -202,7 +217,12 @@ describe("streamProxy — tool-call streaming and partialJson isolation", () => 
 			{ type: "toolcall_delta", contentIndex: 0, delta: '{"path' },
 			{ type: "toolcall_delta", contentIndex: 0, delta: '":"/a"}' },
 			// Missing toolcall_end — stream goes straight to done
-			{ type: "done", reason: "toolUse", usage: { ...baseUsage } },
+			{
+				type: "done",
+				reason: "toolUse",
+				usage: { ...baseUsage },
+				content: [{ type: "toolCall", id: "call_1", name: "edit", arguments: { path: "/a" } }],
+			},
 		];
 		const body = buildSseBody(events);
 		const fetchMock: FetchImpl = () => Promise.resolve(new Response(body, { status: 200 }));
@@ -231,7 +251,15 @@ describe("streamProxy — tool-call streaming and partialJson isolation", () => 
 			{ type: "toolcall_delta", contentIndex: 1, delta: 'ls"}' },
 			{ type: "toolcall_end", contentIndex: 0 },
 			{ type: "toolcall_end", contentIndex: 1 },
-			{ type: "done", reason: "toolUse", usage: { ...baseUsage } },
+			{
+				type: "done",
+				reason: "toolUse",
+				usage: { ...baseUsage },
+				content: [
+					{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a" } },
+					{ type: "toolCall", id: "call_2", name: "bash", arguments: { command: "ls" } },
+				],
+			},
 		];
 		const body = buildSseBody(events);
 		const fetchMock: FetchImpl = () => Promise.resolve(new Response(body, { status: 200 }));

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added `GET /v1/credentials/disabled` to the auth broker and `AuthBrokerClient.listDisabledCredentials`: disabled-credential tombstones (`DisabledCredentialSummary` — identity, verbatim disable cause, disable timestamp; never token material) so auto-disabled accounts stay visible to clients instead of silently vanishing from the snapshot. `AuthStorage.listDisabledCredentials` serves the same data locally from SQLite; clients of brokers predating the endpoint get an empty list (404 mapped, no error).
 - Added `AuthStorage.revalidateCredentials()` and the optional `AuthCredentialStore.refreshSnapshot` hook: remote broker stores re-fetch `GET /v1/snapshot` on demand so callers pairing live per-credential data with stored identities (`omp usage`) never render against the up-to-an-hour-stale disk-cached snapshot; local SQLite stores are always current and only reload.
 
+### Fixed
+
+- Fixed custom `anthropic-messages` endpoints dropping native web-search call/result blocks in the leaked-thinking wrapper, preserving signed continuation history in source order ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
+
 ## [17.1.3] - 2026-07-24
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Fixed custom `anthropic-messages` endpoints dropping native web-search call/result blocks in the leaked-thinking wrapper, preserving signed continuation history in source order ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
+- Fixed custom `anthropic-messages` endpoints dropping native web-search call/result blocks in the leaked-thinking wrapper, preserving signed continuation history in source order without carrying a preceding text signature onto later unsigned blocks ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
 
 ## [17.1.3] - 2026-07-24
 

--- a/packages/ai/src/utils/leaked-thinking-stream.ts
+++ b/packages/ai/src/utils/leaked-thinking-stream.ts
@@ -25,7 +25,15 @@
  * events are forwarded verbatim.
  */
 
-import type { AssistantMessage, ImageContent, TextContent, ThinkingContent, ToolCall } from "../types";
+import { isAnthropicWebSearchHistoryBlock } from "../providers/anthropic-wire";
+import type {
+	AnthropicServerToolContent,
+	AssistantMessage,
+	ImageContent,
+	TextContent,
+	ThinkingContent,
+	ToolCall,
+} from "../types";
 import {
 	clearStreamingPartialJson,
 	getStreamingPartialJson,
@@ -69,7 +77,11 @@ export function wrapLeakedThinkingStream(inner: AssistantMessageEventStream): As
 					case "text_delta": {
 						projector ??= new LeakedThinkingProjector(out, event.partial);
 						const block = event.partial.content[event.contentIndex];
-						projector.text(event.delta, block?.type === "text" ? block.textSignature : undefined);
+						projector.text(
+							event.contentIndex,
+							event.delta,
+							block?.type === "text" ? block.textSignature : undefined,
+						);
 						break;
 					}
 					case "thinking_delta": {
@@ -92,7 +104,7 @@ export function wrapLeakedThinkingStream(inner: AssistantMessageEventStream): As
 					}
 					case "image_end":
 						projector ??= new LeakedThinkingProjector(out, event.partial);
-						projector.image(event.content);
+						projector.image(event.contentIndex, event.content);
 						break;
 					case "toolcall_start": {
 						projector ??= new LeakedThinkingProjector(out, event.partial);
@@ -140,6 +152,8 @@ export function wrapLeakedThinkingStream(inner: AssistantMessageEventStream): As
 }
 
 type OpenBlock = { index: number } | undefined;
+type ProjectedContent = AssistantMessage["content"][number];
+type AnchoredContent = { block: ProjectedContent; sourceIndex: number; order: number };
 
 /**
  * Re-projects an inner stream's events into `out`, healing leaked reasoning out
@@ -151,8 +165,12 @@ class LeakedThinkingProjector {
 	#partial: AssistantMessage;
 	#text: OpenBlock;
 	#thinking: OpenBlock;
-	/** Total visible text length fed to the healer, to replay any un-streamed tail in {@link finish}. */
-	#fedLen = 0;
+	/** Visible text consumed per source block, used to recover terminal-only tails. */
+	#fedTextLengths = new Map<number, number>();
+	/** Source text block whose held healer output has not crossed a content boundary. */
+	#activeTextSourceIndex: number | undefined;
+	/** Original terminal content index for every projected block. */
+	#sourceAnchors = new Map<ProjectedContent, number>();
 	/** Latest non-undefined text signature seen, stamped onto held-back text flushed later. */
 	#lastTextSignature: string | undefined;
 	/** Forwarded native tool calls, keyed by the inner stream's `contentIndex`. */
@@ -169,10 +187,16 @@ class LeakedThinkingProjector {
 	}
 
 	/** Feed a visible-text delta through the healer, splitting leaked fences live. */
-	text(delta: string, signature: string | undefined): void {
-		this.#fedLen += delta.length;
+	text(srcIndex: number, delta: string, signature: string | undefined): void {
+		if (this.#activeTextSourceIndex !== undefined && this.#activeTextSourceIndex !== srcIndex) {
+			this.#flushHealer();
+			this.#closeText();
+			this.#closeThinking();
+		}
+		this.#activeTextSourceIndex = srcIndex;
+		this.#fedTextLengths.set(srcIndex, (this.#fedTextLengths.get(srcIndex) ?? 0) + delta.length);
 		if (signature !== undefined) this.#lastTextSignature = signature;
-		this.#apply(this.#healer.feedEvents(delta), this.#lastTextSignature);
+		this.#apply(this.#healer.feedEvents(delta), this.#lastTextSignature, srcIndex);
 	}
 
 	/** Forward a native thinking delta, preserving its source block identity and signature. */
@@ -180,7 +204,7 @@ class LeakedThinkingProjector {
 		let index = this.#thinkingBlocks.get(srcIndex);
 		if (index === undefined) {
 			if (this.#thinking && this.#pendingThinkingEnds.has(this.#thinking.index)) this.#closeThinking();
-			index = this.#openThinking();
+			index = this.#openThinking(srcIndex);
 			this.#thinkingBlocks.set(srcIndex, index);
 			this.#pendingThinkingEnds.add(index);
 		}
@@ -223,25 +247,28 @@ class LeakedThinkingProjector {
 	 * the signature item must precede the function call it signs.
 	 */
 	#projectSignedThinking(srcIndex: number, thinking: string, signature: string): void {
-		this.#apply(this.#healer.flushEvents(), this.#lastTextSignature);
+		this.#flushHealer();
 		this.#closeText();
 		this.#closeThinking();
 		this.#partial.content.push({ type: "thinking", thinking, thinkingSignature: signature });
 		const index = this.#partial.content.length - 1;
+		this.#anchor(index, srcIndex);
 		this.#thinkingBlocks.set(srcIndex, index);
 		this.#out.push({ type: "thinking_start", contentIndex: index, partial: this.#partial });
 		this.#emitThinkingEnd(index);
 	}
 
 	/** Forward a completed native image after releasing held text. */
-	image(content: ImageContent): void {
-		this.#apply(this.#healer.flushEvents(), this.#lastTextSignature);
+	image(srcIndex: number, content: ImageContent): void {
+		this.#flushHealer();
 		this.#closeText();
 		this.#closeThinking();
 		this.#partial.content.push(content);
+		const index = this.#partial.content.length - 1;
+		this.#anchor(index, srcIndex);
 		this.#out.push({
 			type: "image_end",
-			contentIndex: this.#partial.content.length - 1,
+			contentIndex: index,
 			content,
 			partial: this.#partial,
 		});
@@ -250,12 +277,13 @@ class LeakedThinkingProjector {
 	/** Forward a native tool call's start, releasing any held-back text first. */
 	toolStart(srcIndex: number, source: StreamingToolCall | undefined): void {
 		if (!source) return;
-		this.#apply(this.#healer.flushEvents(), this.#lastTextSignature);
+		this.#flushHealer();
 		this.#closeText();
 		this.#closeThinking();
 		const block = cloneToolCall(source);
 		this.#partial.content.push(block);
 		const index = this.#partial.content.length - 1;
+		this.#anchor(index, srcIndex);
 		this.#toolBlocks.set(srcIndex, { index, block });
 		this.#out.push({ type: "toolcall_start", contentIndex: index, partial: this.#partial });
 	}
@@ -285,12 +313,13 @@ class LeakedThinkingProjector {
 			return;
 		}
 		// `end` without a matching `start` — release held text, then forward whole.
-		this.#apply(this.#healer.flushEvents(), this.#lastTextSignature);
+		this.#flushHealer();
 		this.#closeText();
 		this.#closeThinking();
 		const block = cloneToolCall(toolCall);
 		this.#partial.content.push(block);
 		const index = this.#partial.content.length - 1;
+		this.#anchor(index, srcIndex);
 		this.#out.push({ type: "toolcall_start", contentIndex: index, partial: this.#partial });
 		this.#out.push({ type: "toolcall_end", contentIndex: index, toolCall: block, partial: this.#partial });
 	}
@@ -314,32 +343,34 @@ class LeakedThinkingProjector {
 			if (this.#thinkingBlocks.has(srcIndex)) continue;
 			this.#projectSignedThinking(srcIndex, block.thinking, block.thinkingSignature);
 		}
-		let fullText = "";
-		let tailSignature: string | undefined;
-		for (const block of message.content) {
-			if (block.type === "text") {
-				fullText += block.text;
-				tailSignature = block.textSignature;
+		for (let srcIndex = 0; srcIndex < message.content.length; srcIndex++) {
+			const block = message.content[srcIndex];
+			if (block?.type !== "text") continue;
+			const fedLength = this.#fedTextLengths.get(srcIndex) ?? 0;
+			if (block.text.length <= fedLength) continue;
+			if (this.#activeTextSourceIndex !== undefined && this.#activeTextSourceIndex !== srcIndex) {
+				this.#flushHealer();
+				this.#closeText();
+				this.#closeThinking();
 			}
+			this.#activeTextSourceIndex = srcIndex;
+			if (block.textSignature !== undefined) this.#lastTextSignature = block.textSignature;
+			this.#apply(this.#healer.feedEvents(block.text.slice(fedLength)), this.#lastTextSignature, srcIndex);
 		}
-		if (tailSignature !== undefined) this.#lastTextSignature = tailSignature;
-		if (fullText.length > this.#fedLen) {
-			this.#apply(this.#healer.feedEvents(fullText.slice(this.#fedLen)), this.#lastTextSignature);
-		}
-		this.#apply(this.#healer.flushEvents(), this.#lastTextSignature);
+		this.#flushHealer();
 		this.#closeText();
 		this.#closeThinking();
-		return this.#partial.content;
+		return this.#mergeServerToolHistory(message);
 	}
 
-	#apply(events: readonly StreamMarkupHealingEvent[], signature?: string): void {
+	#apply(events: readonly StreamMarkupHealingEvent[], signature: string | undefined, srcIndex: number): void {
 		for (const event of events) {
-			if (event.type === "text") this.#emitText(event.text, signature);
-			else if (event.type === "thinking") this.#emitHealedThinking(event.thinking);
+			if (event.type === "text") this.#emitText(event.text, signature, srcIndex);
+			else if (event.type === "thinking") this.#emitHealedThinking(event.thinking, srcIndex);
 		}
 	}
 
-	#emitText(text: string, signature: string | undefined): void {
+	#emitText(text: string, signature: string | undefined, srcIndex: number): void {
 		if (text.length === 0) return;
 		this.#closeThinking();
 		if (!this.#text) {
@@ -347,6 +378,7 @@ class LeakedThinkingProjector {
 				signature === undefined ? { type: "text", text: "" } : { type: "text", text: "", textSignature: signature };
 			this.#partial.content.push(block);
 			this.#text = { index: this.#partial.content.length - 1 };
+			this.#anchor(this.#text.index, srcIndex);
 			this.#out.push({ type: "text_start", contentIndex: this.#text.index, partial: this.#partial });
 		} else if (signature !== undefined) {
 			(this.#partial.content[this.#text.index] as TextContent).textSignature = signature;
@@ -357,24 +389,72 @@ class LeakedThinkingProjector {
 	}
 
 	/** Healed (leaked) thinking carries no signature, matching the source fence. */
-	#emitHealedThinking(text: string): void {
+	#emitHealedThinking(text: string, srcIndex: number): void {
 		if (text.length === 0) return;
-		const index = this.#openThinking();
+		const index = this.#openThinking(srcIndex);
 		const block = this.#partial.content[index] as ThinkingContent;
 		block.thinking += text;
 		this.#out.push({ type: "thinking_delta", contentIndex: index, delta: text, partial: this.#partial });
 	}
 
-	#openThinking(): number {
+	#openThinking(srcIndex: number): number {
 		this.#closeText();
 		if (!this.#thinking) {
 			this.#partial.content.push({ type: "thinking", thinking: "" });
 			this.#thinking = { index: this.#partial.content.length - 1 };
+			this.#anchor(this.#thinking.index, srcIndex);
 			this.#out.push({ type: "thinking_start", contentIndex: this.#thinking.index, partial: this.#partial });
 		}
 		return this.#thinking.index;
 	}
 
+	#flushHealer(): void {
+		const srcIndex = this.#activeTextSourceIndex;
+		if (srcIndex !== undefined) {
+			this.#apply(this.#healer.flushEvents(), this.#lastTextSignature, srcIndex);
+		}
+		this.#activeTextSourceIndex = undefined;
+	}
+
+	#anchor(index: number, srcIndex: number): void {
+		const block = this.#partial.content[index];
+		if (block) this.#sourceAnchors.set(block, srcIndex);
+	}
+
+	#mergeServerToolHistory(message: AssistantMessage): AssistantMessage["content"] {
+		const pendingCalls = new Map<string, number>();
+		const pairedIndexes = new Set<number>();
+		for (let srcIndex = 0; srcIndex < message.content.length; srcIndex++) {
+			const content = message.content[srcIndex];
+			if (content?.type !== "anthropicServerTool" || !isAnthropicWebSearchHistoryBlock(content.block)) continue;
+			if (content.block.type === "server_tool_use") {
+				pendingCalls.set(content.block.id, srcIndex);
+				continue;
+			}
+			const callIndex = pendingCalls.get(content.block.tool_use_id);
+			if (callIndex === undefined) continue;
+			pairedIndexes.add(callIndex);
+			pairedIndexes.add(srcIndex);
+			pendingCalls.delete(content.block.tool_use_id);
+		}
+
+		const anchored: AnchoredContent[] = this.#partial.content.map((block, order) => ({
+			block,
+			sourceIndex: this.#sourceAnchors.get(block) ?? message.content.length + order,
+			order,
+		}));
+		for (const srcIndex of pairedIndexes) {
+			const content = message.content[srcIndex];
+			if (content?.type !== "anthropicServerTool") continue;
+			const cloned: AnthropicServerToolContent = {
+				type: "anthropicServerTool",
+				block: structuredClone(content.block),
+			};
+			anchored.push({ block: cloned, sourceIndex: srcIndex, order: srcIndex });
+		}
+		anchored.sort((left, right) => left.sourceIndex - right.sourceIndex || left.order - right.order);
+		return anchored.map(({ block }) => block);
+	}
 	#closeText(): void {
 		if (!this.#text) return;
 		const block = this.#partial.content[this.#text.index] as TextContent;

--- a/packages/ai/src/utils/leaked-thinking-stream.ts
+++ b/packages/ai/src/utils/leaked-thinking-stream.ts
@@ -188,14 +188,15 @@ class LeakedThinkingProjector {
 
 	/** Feed a visible-text delta through the healer, splitting leaked fences live. */
 	text(srcIndex: number, delta: string, signature: string | undefined): void {
-		if (this.#activeTextSourceIndex !== undefined && this.#activeTextSourceIndex !== srcIndex) {
+		const startsSource = this.#activeTextSourceIndex !== srcIndex;
+		if (this.#activeTextSourceIndex !== undefined && startsSource) {
 			this.#flushHealer();
 			this.#closeText();
 			this.#closeThinking();
 		}
 		this.#activeTextSourceIndex = srcIndex;
 		this.#fedTextLengths.set(srcIndex, (this.#fedTextLengths.get(srcIndex) ?? 0) + delta.length);
-		if (signature !== undefined) this.#lastTextSignature = signature;
+		if (startsSource || signature !== undefined) this.#lastTextSignature = signature;
 		this.#apply(this.#healer.feedEvents(delta), this.#lastTextSignature, srcIndex);
 	}
 
@@ -354,7 +355,7 @@ class LeakedThinkingProjector {
 				this.#closeThinking();
 			}
 			this.#activeTextSourceIndex = srcIndex;
-			if (block.textSignature !== undefined) this.#lastTextSignature = block.textSignature;
+			this.#lastTextSignature = block.textSignature;
 			this.#apply(this.#healer.feedEvents(block.text.slice(fedLength)), this.#lastTextSignature, srcIndex);
 		}
 		this.#flushHealer();

--- a/packages/ai/test/leaked-thinking-stream.test.ts
+++ b/packages/ai/test/leaked-thinking-stream.test.ts
@@ -541,6 +541,19 @@ describe("wrapLeakedThinkingStream", () => {
 		]);
 	});
 
+	it("resets terminal text signatures at source block boundaries", async () => {
+		const content: AssistantMessage["content"] = [
+			{ type: "text", text: "signed text", textSignature: "sig-1" },
+			{ type: "text", text: "unsigned text" },
+		];
+		const { result } = await runWrapper(inner => {
+			inner.push({ type: "start", partial: msg() });
+			inner.push({ type: "done", reason: "stop", message: msg({ content }) });
+		});
+
+		expect(result.content).toEqual(content);
+	});
+
 	it("passes clean text through unchanged and forwards native thinking", async () => {
 		const clean = "Just a normal answer.";
 		const cleanRun = await runWrapper(inner => {

--- a/packages/ai/test/leaked-thinking-stream.test.ts
+++ b/packages/ai/test/leaked-thinking-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { stream } from "@oh-my-pi/pi-ai/stream";
 import type {
+	AnthropicServerToolContent,
 	AssistantMessage,
 	AssistantMessageEvent,
 	Context,
@@ -346,6 +347,107 @@ describe("wrapLeakedThinkingStream", () => {
 		expect(thinkingEnd).toBeLessThan(toolStart);
 	});
 
+	it("preserves complete Anthropic web-search history at its source positions", async () => {
+		const firstThinking = { type: "thinking" as const, thinking: "choose source", thinkingSignature: "sig-1" };
+		const serverBlocks: AnthropicServerToolContent[] = [
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "server_tool_use",
+					id: "srvtoolu_search",
+					name: "web_search",
+					input: { query: "current UTC date", nested: { source: "authoritative" } },
+				},
+			},
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "web_search_tool_result",
+					tool_use_id: "srvtoolu_search",
+					content: [
+						{
+							type: "web_search_result",
+							url: "https://example.test/date",
+							encrypted_content: "opaque-ciphertext",
+						},
+					],
+				},
+			},
+		];
+		const secondThinking = { type: "thinking" as const, thinking: "use result", thinkingSignature: "sig-2" };
+		const call: ToolCall = {
+			type: "toolCall",
+			id: "toolu_write",
+			name: "write",
+			arguments: { path: "date.txt", content: "2026-07-26" },
+		};
+		const content: AssistantMessage["content"] = [firstThinking, ...serverBlocks, secondThinking, call];
+
+		const { result } = await runWrapper(inner => {
+			inner.push({ type: "start", partial: msg() });
+			inner.push({
+				type: "thinking_delta",
+				contentIndex: 0,
+				delta: firstThinking.thinking,
+				partial: msg({ content: [firstThinking] }),
+			});
+			inner.push({
+				type: "thinking_end",
+				contentIndex: 0,
+				content: firstThinking.thinking,
+				partial: msg({ content: [firstThinking] }),
+			});
+			inner.push({
+				type: "thinking_delta",
+				contentIndex: 3,
+				delta: secondThinking.thinking,
+				partial: msg({ content: content.slice(0, 4) }),
+			});
+			inner.push({
+				type: "thinking_end",
+				contentIndex: 3,
+				content: secondThinking.thinking,
+				partial: msg({ content: content.slice(0, 4) }),
+			});
+			const terminal = msg({ content, stopReason: "toolUse" });
+			inner.push({ type: "toolcall_start", contentIndex: 4, partial: terminal });
+			inner.push({ type: "toolcall_end", contentIndex: 4, toolCall: call, partial: terminal });
+			inner.push({ type: "done", reason: "toolUse", message: terminal });
+		});
+
+		expect(result.content).toEqual(content);
+		expect(result.content.slice(1, 3)).toEqual(serverBlocks);
+	});
+
+	it("drops incomplete Anthropic web-search history instead of replaying orphan blocks", async () => {
+		const content: AssistantMessage["content"] = [
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "server_tool_use",
+					id: "srvtoolu_unmatched_call",
+					name: "web_search",
+					input: { query: "orphan call" },
+				},
+			},
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "web_search_tool_result",
+					tool_use_id: "srvtoolu_unmatched_result",
+					content: [],
+				},
+			},
+			{ type: "text", text: "safe terminal text" },
+		];
+		const { result } = await runWrapper(inner => {
+			inner.push({ type: "start", partial: msg() });
+			inner.push({ type: "done", reason: "stop", message: msg({ content }) });
+		});
+
+		expect(result.content).toEqual([{ type: "text", text: "safe terminal text" }]);
+	});
+
 	it("recovers a signature-bearing thinking block that emitted no per-block events", async () => {
 		const signature = JSON.stringify({ id: "rs_1", type: "reasoning", encrypted_content: "abc" });
 		const block = { type: "thinking" as const, thinking: "recovered reasoning", thinkingSignature: signature };
@@ -594,5 +696,202 @@ describe("leaked thinking healing through stream()", () => {
 			.join("");
 		expect(thinking).toContain("Deliberate.");
 		expect(texts(result).join("").trim()).toBe("Final answer.");
+	});
+
+	it("replays native web-search history on a custom Anthropic continuation", async () => {
+		const searchResult = {
+			type: "web_search_tool_result",
+			tool_use_id: "srvtoolu_1",
+			content: [
+				{
+					type: "web_search_result",
+					url: "https://example.test/date",
+					title: "UTC date",
+					encrypted_content: "opaque-search-result",
+				},
+			],
+		};
+		const nativeSearchResponse = [
+			sseFrame("message_start", {
+				type: "message_start",
+				message: { id: "msg_native_search", usage: { input_tokens: 12, output_tokens: 0 } },
+			}),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "thinking", thinking: "" },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "thinking_delta", thinking: "Choose an authoritative source." },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "signature_delta", signature: "sig-1" },
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 0 }),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 1,
+				content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search" },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 1,
+				delta: { type: "input_json_delta", partial_json: '{"query":"current UTC date"}' },
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 1 }),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 2,
+				content_block: searchResult,
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 2 }),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 3,
+				content_block: { type: "thinking", thinking: "" },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 3,
+				delta: { type: "thinking_delta", thinking: "Use the result." },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 3,
+				delta: { type: "signature_delta", signature: "sig-2" },
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 3 }),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 4,
+				content_block: { type: "text", text: "" },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 4,
+				delta: { type: "text_delta", text: "Writing the date." },
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 4 }),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 5,
+				content_block: { type: "tool_use", id: "toolu_write", name: "write", input: {} },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 5,
+				delta: { type: "input_json_delta", partial_json: '{"path":"date.txt","content":"2026-07-26"}' },
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 5 }),
+			sseFrame("message_delta", {
+				type: "message_delta",
+				delta: { stop_reason: "tool_use" },
+				usage: {
+					input_tokens: 12,
+					output_tokens: 20,
+					server_tool_use: { web_search_requests: 1 },
+				},
+			}),
+			sseFrame("message_stop", { type: "message_stop" }),
+		].join("");
+		const continuationResponse = [
+			sseFrame("message_start", {
+				type: "message_start",
+				message: { id: "msg_continuation", usage: { input_tokens: 30, output_tokens: 0 } },
+			}),
+			sseFrame("content_block_start", {
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "" },
+			}),
+			sseFrame("content_block_delta", {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "DONE" },
+			}),
+			sseFrame("content_block_stop", { type: "content_block_stop", index: 0 }),
+			sseFrame("message_delta", {
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { input_tokens: 30, output_tokens: 1 },
+			}),
+			sseFrame("message_stop", { type: "message_stop" }),
+		].join("");
+		let requestCount = 0;
+		let continuationRequest: unknown;
+		const customFetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				requestCount++;
+				if (requestCount === 2) {
+					if (typeof init?.body !== "string") throw new Error("Expected JSON request body");
+					continuationRequest = JSON.parse(init.body);
+				}
+				return new Response(requestCount === 1 ? nativeSearchResponse : continuationResponse, {
+					status: 200,
+					headers: { "content-type": "text/event-stream", "request-id": `req_${requestCount}` },
+				});
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		const customModel = anthropicModel({
+			provider: "anthropic",
+			baseUrl: "https://anthropic-proxy.example.test/v1",
+		});
+		const first = await stream(customModel, context, { apiKey: "test", fetch: customFetch }).result();
+		expect(first.content.map(block => block.type)).toEqual([
+			"thinking",
+			"anthropicServerTool",
+			"anthropicServerTool",
+			"thinking",
+			"text",
+			"toolCall",
+		]);
+
+		const continuedContext: Context = {
+			messages: [
+				...context.messages,
+				first,
+				{
+					role: "toolResult",
+					toolCallId: "toolu_write",
+					toolName: "write",
+					content: [{ type: "text", text: "Wrote date.txt" }],
+					isError: false,
+					timestamp: 2,
+				},
+			],
+		};
+		await stream(customModel, continuedContext, { apiKey: "test", fetch: customFetch }).result();
+
+		if (
+			typeof continuationRequest !== "object" ||
+			continuationRequest === null ||
+			!("messages" in continuationRequest) ||
+			!Array.isArray(continuationRequest.messages)
+		) {
+			throw new Error("Expected captured Anthropic messages");
+		}
+		const assistant = continuationRequest.messages.find(
+			message =>
+				typeof message === "object" && message !== null && "role" in message && message.role === "assistant",
+		);
+		if (
+			typeof assistant !== "object" ||
+			assistant === null ||
+			!("content" in assistant) ||
+			!Array.isArray(assistant.content)
+		) {
+			throw new Error("Expected captured assistant content");
+		}
+		const assistantContent: unknown[] = assistant.content;
+		expect(
+			assistantContent.map(block =>
+				typeof block === "object" && block !== null && "type" in block ? block.type : undefined,
+			),
+		).toEqual(["thinking", "server_tool_use", "web_search_tool_result", "thinking", "text", "tool_use"]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed native Anthropic web-search history being recursively truncated during session persistence or retained under a different user turn, preserving opaque replay bytes across reload and stripping them on reparent ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
 - Fixed the Docker `natives-builder` stage failing to build releases ≥ 17.1.1: the native audio stack added bindgen (miniaudio needs libclang) and a bundled-opus CMake build (needs cmake + make), none of which were installed in the slim builder image.
 - Fixed `omp usage` duplicating org-less legacy accounts as "no usage data" rows whenever any sibling report carried an organization (mixed pools of pre-org-capture rows and fresh org-scoped logins): an org-less account is now covered by its own org-less report, while org-attributed sibling reports still never count as its coverage.
 - `omp usage` revalidates the broker credential snapshot before rendering: live usage reports were previously paired with a disk-cached account list up to an hour old, so a just-completed re-login (org-less row upserted to org-scoped) rendered as a phantom duplicate until the cache expired.

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -67,7 +67,7 @@ const REPLAN_TITLE_CONTEXT_TURN_LIMIT = 6;
 export function sanitizeAssistantForReparentedHistory(message: AssistantMessage): AssistantMessage {
 	const content: AssistantMessage["content"] = [];
 	for (const block of message.content) {
-		if (block.type === "redactedThinking") continue;
+		if (block.type === "redactedThinking" || block.type === "anthropicServerTool") continue;
 		if (block.type === "thinking") {
 			content.push({ type: "thinking", thinking: block.thinking });
 			continue;

--- a/packages/coding-agent/src/session/session-persistence.ts
+++ b/packages/coding-agent/src/session/session-persistence.ts
@@ -1,3 +1,4 @@
+import { isAnthropicWebSearchHistoryBlock } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import {
 	type BlobStore,
 	externalizeImageDataSync,
@@ -99,6 +100,21 @@ function truncateForPersistence(obj: unknown, blobStore: BlobStore, key?: string
 	// Persist signed blocks verbatim — never truncate, externalize, or descend.
 	// Unsigned blocks (e.g. an interrupted stream) have no such binding and stay
 	// truncatable for size control.
+	// Anthropic validates native web-search history byte-for-byte on replay.
+	// Keep the complete typed block atomic, including nested encrypted_content.
+	if (typeof obj === "object" && "type" in obj && obj.type === "anthropicServerTool" && "block" in obj) {
+		const block = obj.block;
+		if (typeof block === "object" && block !== null && "type" in block && typeof block.type === "string") {
+			const validationView = {
+				type: block.type,
+				...("name" in block ? { name: block.name } : {}),
+				...("id" in block ? { id: block.id } : {}),
+				...("tool_use_id" in block ? { tool_use_id: block.tool_use_id } : {}),
+				...("content" in block ? { content: block.content } : {}),
+			};
+			if (isAnthropicWebSearchHistoryBlock(validationView)) return obj;
+		}
+	}
 	if (typeof obj === "object" && "type" in obj) {
 		const signed =
 			(obj.type === "thinking" && "thinkingSignature" in obj && isNonEmptyString(obj.thinkingSignature)) ||

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import type {
 	BranchSummaryEntry,
@@ -203,6 +204,62 @@ describe("buildSessionContext", () => {
 			expect((ctx.messages[2] as any).content[0].text).toBe("response2");
 			expect((ctx.messages[3] as any).content).toBe("third");
 			expect((ctx.messages[4] as any).content[0].text).toBe("response3");
+		});
+
+		it("keeps Anthropic native web-search bytes when compaction retains the assistant turn", () => {
+			const nativeContent: AssistantMessage["content"] = [
+				{ type: "thinking", thinking: "search", thinkingSignature: "sig-1" },
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "server_tool_use",
+						id: "srvtoolu_1",
+						name: "web_search",
+						input: { query: "current UTC date" },
+					},
+				},
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvtoolu_1",
+						content: [{ type: "web_search_result", encrypted_content: "opaque-result" }],
+					},
+				},
+				{ type: "thinking", thinking: "write", thinkingSignature: "sig-2" },
+				{ type: "toolCall", id: "toolu_write", name: "write", arguments: { path: "date.txt" } },
+			];
+			const retainedAssistant = msg("4", "3", "assistant", "placeholder");
+			if (retainedAssistant.message.role !== "assistant") throw new Error("Expected assistant fixture");
+			retainedAssistant.message.content = nativeContent;
+			retainedAssistant.message.stopReason = "toolUse";
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "old question"),
+				msg("2", "1", "assistant", "old response"),
+				msg("3", "2", "user", "search then write"),
+				retainedAssistant,
+				{
+					type: "message",
+					id: "5",
+					parentId: "4",
+					timestamp: "2025-01-01T00:00:00Z",
+					message: {
+						role: "toolResult",
+						toolCallId: "toolu_write",
+						toolName: "write",
+						content: [{ type: "text", text: "wrote date.txt" }],
+						isError: false,
+						timestamp: 2,
+					},
+				},
+				compaction("6", "5", "Old history summary", "3"),
+				msg("7", "6", "user", "continue"),
+			];
+
+			const ctx = buildSessionContext(entries);
+			const assistant = ctx.messages.find(message => message.role === "assistant");
+			if (assistant?.role !== "assistant") throw new Error("Expected retained assistant message");
+			expect(assistant.content).toEqual(nativeContent);
 		});
 
 		it("handles compaction keeping from first message", () => {

--- a/packages/coding-agent/test/session-manager/signature-persistence.test.ts
+++ b/packages/coding-agent/test/session-manager/signature-persistence.test.ts
@@ -277,4 +277,55 @@ describe("SessionManager signature persistence", () => {
 		expect(items[0]?.encrypted_content).toBe(encrypted);
 		await reloaded.close();
 	}, 15_000);
+
+	it("preserves oversized Anthropic web-search results byte-for-byte across reload", async () => {
+		using tempDir = TempDir.createSync("@pi-session-anthropic-server-tool-persistence-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		const encryptedContent = `ENCRYPTED_WEB_SEARCH_RESULT_${"W".repeat(600_000)}`;
+		const serverToolContent: AssistantMessage["content"] = [
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "server_tool_use",
+					id: "srvtoolu_search",
+					name: "web_search",
+					input: { query: "current UTC date" },
+				},
+			},
+			{
+				type: "anthropicServerTool",
+				block: {
+					type: "web_search_tool_result",
+					tool_use_id: "srvtoolu_search",
+					content: [{ type: "web_search_result", encrypted_content: encryptedContent }],
+				},
+			},
+		];
+
+		session.appendMessage({
+			role: "assistant",
+			content: serverToolContent,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-opus",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 1,
+		});
+		await session.flush();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		await session.close();
+
+		const reloaded = await SessionManager.open(sessionFile);
+		expect(getAssistantMessage(reloaded).content).toEqual(serverToolContent);
+		await reloaded.close();
+	}, 15_000);
 });

--- a/packages/coding-agent/test/session/empty-error-turn.test.ts
+++ b/packages/coding-agent/test/session/empty-error-turn.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { isEmptyErrorTurn } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { isEmptyErrorTurn, sanitizeAssistantForReparentedHistory } from "@oh-my-pi/pi-coding-agent/session/messages";
 
 type Turn = Pick<AssistantMessage, "stopReason" | "content">;
 
@@ -30,5 +30,57 @@ describe("isEmptyErrorTurn", () => {
 	it("never flags non-error turns, even when empty — only the rejection turn is dropped", () => {
 		expect(isEmptyErrorTurn(turn("stop", []))).toBe(false);
 		expect(isEmptyErrorTurn(turn("aborted", []))).toBe(false);
+	});
+});
+
+describe("sanitizeAssistantForReparentedHistory", () => {
+	it("drops Anthropic server-tool history when moving an assistant turn", () => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "search first", thinkingSignature: "signed-thinking" },
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "server_tool_use",
+						id: "srvtoolu_search",
+						name: "web_search",
+						input: { query: "current UTC date" },
+					},
+				},
+				{
+					type: "anthropicServerTool",
+					block: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvtoolu_search",
+						content: [{ type: "web_search_result", encrypted_content: "opaque-result" }],
+					},
+				},
+				{ type: "text", text: "done" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-opus",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			providerPayload: { type: "openaiResponsesHistory", items: [{ id: "provider-bound" }] },
+			timestamp: 1,
+		};
+
+		expect(sanitizeAssistantForReparentedHistory(message)).toEqual({
+			...message,
+			content: [
+				{ type: "thinking", thinking: "search first" },
+				{ type: "text", text: "done" },
+			],
+			providerPayload: undefined,
+		});
 	});
 });


### PR DESCRIPTION
## Repro
On a custom `anthropic-messages` base URL, a terminal response ordered as `thinking -> server_tool_use -> web_search_tool_result -> thinking -> tool_use` lost both server-tool blocks after `wrapLeakedThinkingStream()`. The focused reproduction was `bun test packages/ai/test/leaked-thinking-stream.test.ts packages/coding-agent/test/session-manager/signature-persistence.test.ts packages/coding-agent/test/session/empty-error-turn.test.ts`: before the fix, wrapper ordering, 600,000-character encrypted-result reload, and reparent sanitization each failed.

## Cause
`LeakedThinkingProjector.finish()` in `packages/ai/src/utils/leaked-thinking-stream.ts` returned only blocks reconstructed from stream events, but Anthropic server-tool blocks have no wrapper events and only exist in the terminal message. `truncateForPersistence()` in `packages/coding-agent/src/session/session-persistence.ts` recursively truncated their nested `encrypted_content`, while `sanitizeAssistantForReparentedHistory()` in `packages/coding-agent/src/session/messages.ts` passed the provider-bound blocks through unchanged.

## Fix
- Track each projected block’s original source index and merge deep-cloned, validated complete web-search call/result pairs into terminal content at those anchors.
- Keep valid `anthropicServerTool` blocks atomic during persistence and drop them when reparenting an assistant turn.
- Cover custom-base-URL continuation request bytes, incomplete-pair filtering, oversized encrypted-result reload, reparent sanitization, and compaction retention.

## Verification
`bun test packages/ai/test/leaked-thinking-stream.test.ts packages/ai/test/auth-gateway-anthropic-messages.test.ts packages/coding-agent/test/session/empty-error-turn.test.ts packages/coding-agent/test/session-manager/signature-persistence.test.ts packages/coding-agent/test/session-manager/build-context.test.ts` passed 77 tests. The direct `anthropic-stream-envelope.test.ts` suite passed 32 tests with `stream.ts` preloaded to avoid its standalone import-order cycle. `bun run check:types` passed in both `packages/ai` and `packages/coding-agent`; the publish gate also passed `bun run fix` and `bun check`.

Fixes #6703