### PR TITLE
fix(snapcompact): report all foveated frame widths

### DIFF
--- a/packages/snapcompact/CHANGELOG.md
+++ b/packages/snapcompact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed snapcompact resume guides reporting only the HQ grid width for mixed-width foveated archives ([#6712](https://github.com/can1357/oh-my-pi/issues/6712)).
+
 ## [17.1.0] - 2026-07-24
 
 ### Added

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -1963,6 +1963,11 @@ export async function compact<TMessage = Message>(
 
 	const frames = await Promise.all(newFrames);
 	const totalChars = frames.reduce((sum, frame) => sum + frame.chars, 0) + textChars;
+	const frameCols: number[] = [];
+	for (const frame of frames) {
+		if (!frameCols.includes(frame.cols)) frameCols.push(frame.cols);
+	}
+	const summaryCols = frameCols.length > 0 ? frameCols.join(" or ") : geo.cols;
 
 	const { readFiles, modifiedFiles } = computeFileLists(fileOps);
 	const files = formatFileList(readFiles, modifiedFiles, fileOps.read);
@@ -1975,7 +1980,7 @@ export async function compact<TMessage = Message>(
 			frameCount: frames.length,
 			multipleFrames: frames.length > 1,
 			docColumns: high.columns === 2,
-			cols: geo.cols,
+			cols: summaryCols,
 			rows: geo.rows,
 			sentenceInk: high.variant === "sent",
 			stopwordDimmed: high.stopwordDim === true,

--- a/packages/snapcompact/test/snapcompact.test.ts
+++ b/packages/snapcompact/test/snapcompact.test.ts
@@ -924,6 +924,7 @@ describe("compact", () => {
 		expect(cols.slice(0, 3)).toEqual([hiCols, hiCols, hiCols]);
 		expect(cols.slice(-3)).toEqual([hiCols, hiCols, hiCols]);
 		expect(cols[3]).toBeGreaterThan(hiCols);
+		expect(result.summary).toContain(`${hiCols} or ${cols[3]} characters wide`);
 	});
 
 	it("keeps foveated Silver archives on the Silver font", async () => {


### PR DESCRIPTION
## Repro

A foveated seven-frame archive contains mixed HQ/LQ widths (`[29, 29, 29, 40, 29, 29, 29]`), while its resume summary reports only `29 characters wide`. Reproduce with `cd packages/snapcompact && bun test test/snapcompact.test.ts -t "uses three HQ image frames on each edge when the budget allows"` using the regression assertion from this change.

## Cause

`planArchive()` in `packages/snapcompact/src/snapcompact.ts` assigns the dense companion shape to the LQ middle frames, but `compact()` rendered `snapcompact-summary.md` with only the HQ `geo.cols`, so the summary could not describe the rendered LQ width.

## Fix

- Collect distinct widths from the rendered frames in archive order.
- Supply the joined widths to the existing resume-summary template while retaining the homogeneous-frame output.
- Assert the mixed-width summary in the existing HQ/LQ foveation regression and document the fix.

## Verification

`cd packages/snapcompact && bun test` passed: 82 tests, 0 failures. `cd packages/snapcompact && bun run check` passed. The focused regression passed with 1 test and 5 assertions.

Fixes #6712