### PR TITLE
fix(coding-agent): prefer auth in deferred model resolution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed deferred CLI model roles resolving ambiguous bare model IDs to a preferred but unauthenticated provider instead of the authenticated provider selected by the eager path ([#6727](https://github.com/can1357/oh-my-pi/issues/6727)).
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2083,7 +2083,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					modelRegistry.refresh("online-if-uncached"),
 				);
 			}
-			const availableModels = modelRegistry.getAll();
+			const allModels = modelRegistry.getAll();
+			const availableModels = modelRegistry.getAvailable();
 			const expandedModelPatterns = deferredModelPatterns.flatMap(pattern =>
 				pattern.split(",").flatMap(selector => {
 					const trimmedSelector = selector.trim();
@@ -2114,7 +2115,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 							modelLookup: modelRegistry,
 						};
 						const originalSelector = resolved.configuredPatterns[0];
-						const originalModel = parseModelPattern(originalSelector, availableModels, matchPreferences).model;
+						const availableOriginal = parseModelPattern(originalSelector, availableModels, matchPreferences);
+						const originalModel =
+							availableOriginal.model ?? parseModelPattern(originalSelector, allModels, matchPreferences).model;
 						const chainKey = resolveRetryFallbackChainKey(
 							fallbackContext,
 							originalSelector,
@@ -2156,10 +2159,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					}));
 				}),
 			);
+			const resolutionModels = expandedModelPatterns.some(
+				({ pattern }) => parseModelPattern(pattern, availableModels, matchPreferences).model,
+			)
+				? availableModels
+				: allModels;
 			let usageFallbackTriggered = false;
 			for (let patternIndex = 0; patternIndex < expandedModelPatterns.length; patternIndex += 1) {
 				const { pattern, retryFallback } = expandedModelPatterns[patternIndex];
-				const primary = parseModelPattern(pattern, availableModels, matchPreferences);
+				const primary = parseModelPattern(pattern, resolutionModels, matchPreferences);
 				if (!primary.model || (retryFallback && !hasModelAuth(primary.model))) continue;
 				let hasUsageFallbackCandidate = false;
 				for (
@@ -2169,7 +2177,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				) {
 					const candidate = parseModelPattern(
 						expandedModelPatterns[candidateIndex].pattern,
-						availableModels,
+						resolutionModels,
 						matchPreferences,
 					);
 					if (candidate.model && hasModelAuth(candidate.model)) {
@@ -2234,7 +2242,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					if (primaryKey !== kNoAuth && !isAuthenticated(primaryKey)) {
 						const fallback = parseModelPattern(
 							options.modelPatternAuthFallback,
-							availableModels,
+							resolutionModels,
 							matchPreferences,
 						);
 						if (fallback.model) {
@@ -2256,7 +2264,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					const seenSelectors = new Set<string>([primarySelector]);
 					const fallbackSelectors: string[] = [];
 					for (const fallbackEntry of expandedModelPatterns.slice(patternIndex + 1)) {
-						const fallback = parseModelPattern(fallbackEntry.pattern, availableModels, matchPreferences);
+						const fallback = parseModelPattern(fallbackEntry.pattern, resolutionModels, matchPreferences);
 						if (!fallback.model) continue;
 						const fallbackSelector = formatModelSelectorValue(
 							formatModelStringWithRouting(fallback.model),

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -353,6 +353,58 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("prefers authenticated providers for deferred bare role candidates", async () => {
+		const settings = Settings.isolated({
+			modelProviderOrder: ["aimlapi", "openai"],
+		});
+		settings.setModelRole("task", "missing-provider/missing-model,gpt-4o-mini");
+		const authStorage = await AuthStorage.create(path.join(tempDir, "ambiguous-role-auth.db"));
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		authStoragesToClose.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "ambiguous-role-models.yml"));
+		const parsed = parseArgs(["--model", "task"]);
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string | null) => {
+			throw new Error(`buildSessionOptions unexpectedly exited with ${code}`);
+		});
+		try {
+			const cliOptions = await buildCliSessionOptions(
+				parsed,
+				[],
+				SessionManager.inMemory(),
+				modelRegistry,
+				settings,
+			);
+			expect(cliOptions.model).toBeUndefined();
+			expect(cliOptions.modelPattern).toBe("task");
+
+			const { session } = await createAgentSession({
+				...cliOptions,
+				cwd: tempDir,
+				agentDir: tempDir,
+				authStorage,
+				modelRegistry,
+				settings,
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+			});
+
+			try {
+				expect(session.model?.provider).toBe("openai");
+				expect(session.model?.id).toBe("gpt-4o-mini");
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			exitSpy.mockRestore();
+		}
+	});
+
 	test("uses a configured suffixed role fallback when its primary model is unavailable", async () => {
 		const settings = Settings.isolated({
 			"retry.fallbackChains": {


### PR DESCRIPTION
## Repro
With only `openai` authenticated, `modelProviderOrder` ranking `aimlapi` first, and `modelRoles.task` set to `missing-provider/missing-model,gpt-4o-mini`, `bun test packages/coding-agent/test/sdk-model-selection.test.ts --test-name-pattern "prefers authenticated providers for deferred bare role candidates"` selected `aimlapi/gpt-4o-mini`; the assertion expected `openai` and received `aimlapi`.

## Cause
`createAgentSession` in `packages/coding-agent/src/sdk.ts` expanded deferred role candidates correctly but parsed every expanded candidate against `modelRegistry.getAll()`. `parseModelPattern` therefore applied `modelProviderOrder` across authenticated and unauthenticated providers, bypassing the authenticated-first behavior in `resolveCliModel`.

## Fix
- Resolve the complete deferred candidate list against `modelRegistry.getAvailable()` when any authenticated candidate matches.
- Fall back to the full catalog only when no available candidate matches, preserving explicit unauthenticated-model diagnostics.
- Cover the eager-to-deferred CLI path with an ambiguous bare-ID regression test and document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/sdk-model-selection.test.ts` passed: 28 tests, 91 assertions. LSP diagnostics reported no errors in `sdk.ts` or the regression test. The pre-publish `bun check` gate passed.

Fixes #6727