### PR TITLE
feat(agent): add no-progress loop detection with pre-call veto gate

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ToolCallLoopGuard` now detects no-progress loops (identical args AND identical result across consecutive turns) and vetoes the next call before it executes via the new `check()` pre-call gate — the stuck tool never runs, never burns tokens. Vetoed calls are excluded from the streak so the veto itself doesn't inflate it. Volatile result fields (`timestamp`, `requestId`, `durationMs`, etc.) are stripped before hashing so per-call timings don't defeat detection.
+- Added a wandering detector for prone tools (`web.fetch`, `http.request`, `browser.*`): counts distinct argument sets and warns at `wanderingThreshold` (default 6), escalating to a breaker veto at `wanderingEscalation` (default 12). Bulk reads over distinct files are deliberately not prone.
+- Added a breaker: consecutive critical vetoes ≥ `breakerVetoStreak` (default 3) end the turn gracefully — the session stays pending, no hard failure.
+- Exported new types: `ToolCallCheckInput`, `ToolCallCheckVerdict`, `ToolCallOutcome`, `WanderingToolCallDetection`, `ToolCallLoopDetection`.
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/ai/src/utils/tool-call-loop-guard.ts
+++ b/packages/ai/src/utils/tool-call-loop-guard.ts
@@ -1,14 +1,69 @@
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
-import type { AssistantMessage, ToolCall, ToolResultMessage } from "../types";
+import type { AssistantMessage, ImageContent, TextContent, ToolCall, ToolResultMessage } from "../types";
 
 const LEGACY_INTENT_FIELD = "__intent";
 const RESULT_SUMMARY_LIMIT = 200;
 const ARGUMENT_SUMMARY_LIMIT = 400;
+const VETO_SENTINEL = "__vetoed__";
+let unhashableCounter = 0;
+
+/**
+ * Keys stripped from tool-result `details` before hashing so per-call timings
+ * and volatile identifiers don't defeat the no-progress hash. A repeated dead
+ * endpoint returns structurally identical output but with a fresh timestamp /
+ * requestId each call — without stripping, every result hashes unique and the
+ * no-progress streak never trips.
+ *
+ * Ported from atomic-agent's `VOLATILE_RESULT_KEYS`.
+ */
+const VOLATILE_RESULT_KEYS: Record<string, true> = {
+	timestamp: true,
+	ts: true,
+	date: true,
+	time: true,
+	timeTotal: true,
+	timeTotalSeconds: true,
+	durationMs: true,
+	sizeDownload: true,
+	requestId: true,
+	request_id: true,
+	traceId: true,
+	trace_id: true,
+	sentAt: true,
+	createdAt: true,
+	deliveredAt: true,
+};
+
+/**
+ * Tools where scanning many distinct arguments is a wandering failure mode
+ * (probing endless URLs / selectors / pages) rather than legitimate bulk work.
+ * Reads over distinct files are deliberately NOT prone.
+ */
+const DEFAULT_PRONE_TOOLS: Record<string, true> = {
+	"web.fetch": true,
+	fetch: true,
+	"http.request": true,
+	browser: true,
+	"browser.click": true,
+	"browser.navigate": true,
+	"browser.type": true,
+};
 
 /** Runtime settings for cross-turn tool-call repetition detection. */
 export interface ToolCallLoopGuardOptions {
+	/** Args-only repeat count that fires an advisory warning. */
 	readonly threshold: number;
 	readonly exemptTools: readonly string[];
+	/** Args+result no-progress count that fires a pre-call veto. 0 disables. */
+	readonly noProgressThreshold?: number;
+	/** Distinct-args spread on prone tools that fires a wandering warning. 0 disables. */
+	readonly wanderingThreshold?: number;
+	/** Distinct-args spread on prone tools that escalates to a breaker veto. */
+	readonly wanderingEscalation?: number;
+	/** Consecutive critical vetoes before the breaker forces a graceful reply. */
+	readonly breakerVetoStreak?: number;
+	/** Tools considered wandering-prone (defaults to a built-in set). */
+	readonly proneTools?: readonly string[];
 }
 
 /** A completed assistant turn plus the tool results it produced. */
@@ -17,6 +72,28 @@ export interface ToolCallLoopTurn {
 	readonly toolResults: readonly ToolResultMessage[];
 }
 
+/** A tool call about to execute, offered to the guard for a pre-call veto. */
+export interface ToolCallCheckInput {
+	readonly toolName: string;
+	readonly args: unknown;
+}
+
+/**
+ * Pre-call verdict. `critical` vetoes the call (synthetic error result, tool
+ * never runs). `breaker` signals the runtime to end the turn gracefully.
+ */
+export type ToolCallCheckVerdict =
+	| { kind: "allow" }
+	| { kind: "wandering"; toolName: string; spread: number; argumentsSummary: string }
+	| {
+			kind: "critical";
+			toolName: string;
+			count: number;
+			argumentsSummary: string;
+			source: "no_progress" | "wandering";
+	  }
+	| { kind: "breaker"; toolName: string; reason: string };
+
 /** Details needed to steer the model away from a repeated tool call. */
 export interface RepeatedToolCallDetection {
 	readonly kind: "repeated_tool_call";
@@ -24,6 +101,32 @@ export interface RepeatedToolCallDetection {
 	readonly count: number;
 	readonly resultSummary: string;
 	readonly argumentsSummary: string;
+}
+
+/**
+ * A wandering-loop detection: the model is probing many distinct arguments on a
+ * prone tool (endless URLs, selectors) without converging.
+ */
+export interface WanderingToolCallDetection {
+	readonly kind: "wandering_tool_call";
+	readonly toolName: string;
+	readonly spread: number;
+	readonly argumentsSummary: string;
+}
+
+/** Any detection the runtime must surface (advisory or veto). */
+export type ToolCallLoopDetection = RepeatedToolCallDetection | WanderingToolCallDetection;
+
+/**
+ * Result fields the guard needs to hash a tool outcome. Both the agent's
+ * `AgentToolResult` (content + details + isError) and a `ToolResultMessage`
+ * satisfy this shape, so the live-loop and the post-turn recordTurn path share
+ * one hashing path without a bridge.
+ */
+export interface ToolCallOutcome {
+	readonly content: readonly (TextContent | ImageContent)[];
+	readonly details?: unknown;
+	readonly isError?: boolean;
 }
 
 function canonicalizeToolCallValue(value: unknown): unknown {
@@ -39,6 +142,38 @@ function canonicalizeToolCallValue(value: unknown): unknown {
 	for (const key of Object.keys(input).sort()) {
 		if (key === INTENT_FIELD || key === LEGACY_INTENT_FIELD) continue;
 		output[key] = canonicalizeToolCallValue(input[key]);
+	}
+	return output;
+}
+
+/**
+ * Recursively strips volatile keys from a value so per-call timings and
+ * transient identifiers don't defeat the no-progress result hash.
+ */
+function stripVolatile(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+	if (Array.isArray(value)) {
+		return value.map(item => stripVolatile(item, seen));
+	}
+	if (!value || typeof value !== "object") {
+		// Primitives (including bigint) pass through — JSON.stringify handles them.
+		return value;
+	}
+	// Only recurse into plain records (Object.prototype or null proto).
+	// Built-ins like Date, Map, Set, RegExp have no enumerable own keys
+	// via Object.keys but carry meaningful state — pass them through so
+	// JSON.stringify's toJSON / default serialization preserves them.
+	const proto = Object.getPrototypeOf(value);
+	if (proto !== null && proto !== Object.prototype) {
+		return value;
+	}
+	const obj = value as object;
+	if (seen.has(obj)) return undefined; // cycle guard
+	seen.add(obj);
+	const input = value as Record<string, unknown>;
+	const output: Record<string, unknown> = {};
+	for (const key of Object.keys(input).sort()) {
+		if (VOLATILE_RESULT_KEYS[key]) continue;
+		output[key] = stripVolatile(input[key], seen);
 	}
 	return output;
 }
@@ -64,44 +199,514 @@ function summarizeToolResult(toolResults: readonly ToolResultMessage[], toolCall
 	return summarizeText(textParts.join("\n"), RESULT_SUMMARY_LIMIT);
 }
 
-/** Detects consecutive identical assistant tool calls across model turns. */
+/**
+ * Builds a stable hash of a tool result for no-progress detection. Joins text
+ * content with volatile keys stripped from `details` so structurally identical
+ * outputs (modulo timestamps / request ids) hash equal. Accepts the shared
+ * {@link ToolCallOutcome} shape so both the live loop (AgentToolResult) and the
+ * post-turn recordTurn path (ToolResultMessage) feed the same hasher.
+ */
+function hashOutcome(outcome: ToolCallOutcome): string {
+	const parts: string[] = [];
+	for (const block of outcome.content) {
+		if (block.type === "text") {
+			// Only strip volatile patterns from error text — error strings
+			// routinely embed wall-clock times and request IDs (e.g. "request
+			// req-abc123 failed at 2026-07-26T12:00:01Z") that make each failure
+			// hash differently, breaking the no-progress streak on flaky
+			// endpoints. Successful results may contain timestamps as semantic
+			// data (e.g. polling a build log), so they are hashed verbatim.
+			const text = outcome.isError
+				? block.text
+						.replace(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/g, "<ts>")
+						.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>")
+						.replace(/\breq-[a-zA-Z0-9]+\b/g, "<req-id>")
+				: block.text;
+			parts.push(`t:${text}`);
+		} else if (block.type === "image") {
+			// Hash the full image data so two screenshots with identical headers
+			// but different pixels don't falsely match. A prefix-only comparison
+			// would miss differences past the first ~48 bytes (common for
+			// same-resolution PNGs sharing a header).
+			parts.push(`i:${block.mimeType}:${Bun.hash(block.data).toString(36)}`);
+		}
+	}
+	const contentHash = parts.join("\n");
+	// Serialize details with a bigint-aware replacer so { value: 1n } and
+	// { value: 2n } produce distinct hashes (JSON.stringify throws on
+	// bigint by default). For any genuinely-unhashable remainder (cyclic
+	// structures that slip past the WeakSet guard), use a unique counter
+	// so they never falsely match — treating them as non-comparable.
+	let detailsHash = "";
+	if (outcome.details !== undefined) {
+		try {
+			detailsHash = JSON.stringify(stripVolatile(outcome.details), (_k, v) => (typeof v === "bigint" ? `${v}n` : v));
+		} catch {
+			detailsHash = `<unhashable:${unhashableCounter++}>`;
+		}
+	}
+	return `${contentHash}\u0000${detailsHash}\u0000${outcome.isError ? "e" : "o"}`;
+}
+
+interface CallRecord {
+	/** args-only hash: `${name}:${canonicalArgs}` */
+	readonly argsHash: string;
+	/** Tool-call ID from the assistant message — stable across pre/post-transform args. */
+	readonly toolCallId: string | undefined;
+	resultHash: string | undefined;
+}
+
+/**
+ * Detects consecutive identical assistant tool calls across model turns, and
+ * vetoes stuck no-progress loops before the tool re-executes.
+ *
+ * Three detection layers (ported from atomic-agent's ToolLoopTracker):
+ *
+ * 1. **Args-only repeat** (advisory): identical `name+args` across consecutive
+ *    turns fires a `repeated_tool_call` redirect at `threshold`. Post-turn,
+ *    does not block execution.
+ * 2. **No-progress streak** (pre-call veto): identical `name+args+result` across
+ *    consecutive turns fires `critical` at `noProgressThreshold`; the pre-call
+ *    `check()` returns a veto so the tool never runs. Vetoed calls are excluded
+ *    from the streak so the veto itself doesn't inflate it.
+ * 3. **Wandering detector** (warn → breaker): for prone tools (web.fetch,
+ *    http.request, browser.*), counts distinct `argsHash`es. Warns at
+ *    `wanderingThreshold`; escalates to a breaker veto at `wanderingEscalation`.
+ *
+ * A `breaker` verdict (consecutive critical vetoes ≥ `breakerVetoStreak`, or a
+ * wandering escalation) signals the runtime to end the turn gracefully — the
+ * session stays pending; no hard failure.
+ *
+ * **Dual-path invariant.** Tracking can be driven two ways:
+ * - **Live path**: `check()` → `recordCall()` → `recordOutcome()` per tool,
+ *   wired to `beforeToolCall` / `afterToolCall`. This is the primary path.
+ * - **Post-turn path**: `recordTurn()` alone, used by tests and any caller that
+ *   doesn't wire the live hooks.
+ *
+ * When the live path is active, `recordTurn` MUST NOT re-increment the shared
+ * counters (`#repeatCount`, `#noProgressStreak`, `#lastArgsHash`) — that would
+ * double-count and fire the guard at half the configured threshold. The
+ * `#liveTrackingActive` flag (set by `recordCall`, cleared by `resetForTurn`)
+ * gates this: if live tracking ran this turn, `recordTurn` reads current state
+ * for the advisory detection return without re-incrementing.
+ */
 export class ToolCallLoopGuard {
 	#threshold: number;
+	#noProgressThreshold: number;
+	#wanderingThreshold: number;
+	#wanderingEscalation: number;
+	#breakerVetoStreak: number;
 	#exemptTools: ReadonlySet<string>;
-	#lastHash: string | undefined;
-	#count = 0;
+	#proneTools: Record<string, true>;
+
+	// Args-only repeat tracking (layer 1).
+	#lastArgsHash: string | undefined;
+	#repeatCount = 0;
+
+	// No-progress streak tracking (layer 2). Keyed on argsHash + resultHash.
+	#lastNoProgressKey: string | undefined;
+	#noProgressStreak = 0;
+	#consecutiveVetoes = 0;
+	// Wandering-specific veto counter (layer 3). Separate from
+	// #consecutiveVetoes so a genuine non-prone call (e.g. a `read` between
+	// browser attempts) doesn't reset the wandering breaker progress — the
+	// browser wandering is still ongoing even if the model interleaved a read.
+	#wanderingVetoes = new Map<string, number>();
+
+	// Wandering tracking (layer 3). Distinct argsHashes per prone tool this turn-window.
+	#wanderingHashes = new Map<string, Set<string>>();
+
+	// Ring buffer of recent call records (args + result), capped for bounded memory.
+	#history: CallRecord[] = [];
+	readonly #historySize = 40;
+
+	/**
+	 * True once `recordCall` runs this turn — signals that the live
+	 * beforeToolCall/afterToolCall path is active, so `recordTurn` must NOT
+	 * re-increment the shared counters (it would double-count). Cleared by
+	 * `resetForTurn` at the next turn boundary.
+	 */
+	#liveTrackingActive = false;
 
 	constructor(options: ToolCallLoopGuardOptions) {
 		this.#threshold = Math.max(1, Math.trunc(options.threshold));
+		this.#noProgressThreshold = Math.max(0, Math.trunc(options.noProgressThreshold ?? 0));
+		this.#wanderingThreshold = Math.max(0, Math.trunc(options.wanderingThreshold ?? 0));
+		this.#wanderingEscalation = Math.max(this.#wanderingThreshold, Math.trunc(options.wanderingEscalation ?? 0));
+		this.#breakerVetoStreak = Math.max(1, Math.trunc(options.breakerVetoStreak ?? 3));
 		this.#exemptTools = new Set(options.exemptTools);
+		if (options.proneTools) {
+			this.#proneTools = {};
+			for (const t of options.proneTools) this.#proneTools[t] = true;
+		} else {
+			this.#proneTools = { ...DEFAULT_PRONE_TOOLS };
+		}
 	}
 
-	/** Records one completed turn and returns the threshold hit, if any. */
-	recordTurn(turn: ToolCallLoopTurn): RepeatedToolCallDetection | null {
+	/**
+	 * Pre-call veto gate. Called BEFORE a tool executes. Returns `critical` to
+	 * veto (the runtime emits a synthetic error result and the tool never runs),
+	 * or `breaker` to end the turn gracefully. `warn` / `wandering` are advisory.
+	 *
+	 * The caller MUST invoke {@link recordCall} after `check` (whether allowed or
+	 * vetoed) to commit the call to the tracker, then {@link recordOutcome} once
+	 * the result is known (vetoed calls record a sentinel).
+	 */
+	check(input: ToolCallCheckInput): ToolCallCheckVerdict {
+		const { toolName, args } = input;
+		if (this.#exemptTools.has(toolName)) return { kind: "allow" };
+
+		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(args));
+		const argsHash = `${toolName}:${canonicalArgs}`;
+
+		// Layer 2: no-progress streak (args + result). Veto only when the streak
+		// has crossed the threshold — the streak itself is advanced in
+		// recordOutcome, so check() reads the current value.
+		if (this.#noProgressThreshold > 0 && this.#noProgressStreak >= this.#noProgressThreshold) {
+			// Only veto if this call's args match the streak's args.
+			const streakArgsHash =
+				this.#lastNoProgressKey !== undefined
+					? this.#lastNoProgressKey.slice(0, this.#lastNoProgressKey.indexOf("\u0000"))
+					: undefined;
+			if (argsHash === streakArgsHash) {
+				this.#consecutiveVetoes++;
+				if (this.#consecutiveVetoes >= this.#breakerVetoStreak) {
+					// Clear no-progress state so the next user request gets a fresh
+					// start. agent.abort() skips onTurnEnd, so recordTurn can't
+					// clear it — without this, the next same-args call would go
+					// straight to breaker again.
+					this.#lastNoProgressKey = undefined;
+					this.#noProgressStreak = 0;
+					this.#consecutiveVetoes = 0;
+					return {
+						kind: "breaker",
+						toolName,
+						reason: `tool-call loop breaker: ${toolName} vetoed ${this.#breakerVetoStreak} consecutive times`,
+					};
+				}
+				return {
+					kind: "critical",
+					toolName,
+					count: this.#noProgressStreak,
+					argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+					source: "no_progress",
+				};
+			}
+		}
+
+		// Layer 3: wandering detector for prone tools.
+		if (this.#wanderingThreshold > 0 && this.#isProneTool(toolName)) {
+			const spread = this.#effectiveSpread(toolName, argsHash);
+			if (this.#wanderingEscalation > 0 && spread >= this.#wanderingEscalation) {
+				const vetoes = (this.#wanderingVetoes.get(toolName) ?? 0) + 1;
+				this.#wanderingVetoes.set(toolName, vetoes);
+				if (vetoes >= this.#breakerVetoStreak) {
+					// Clear this tool's wandering set so the breaker doesn't
+					// permanently veto all future calls to it — the model gets
+					// a fresh start after the graceful turn end.
+					this.#wanderingHashes.delete(toolName);
+					this.#wanderingVetoes.delete(toolName);
+					return {
+						kind: "breaker",
+						toolName,
+						reason: `wandering loop breaker: ${toolName} probed ${spread} distinct argument sets`,
+					};
+				}
+				return {
+					kind: "critical",
+					toolName,
+					count: spread,
+					argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+					source: "wandering",
+				};
+			}
+			if (spread >= this.#wanderingThreshold) {
+				return {
+					kind: "wandering",
+					toolName,
+					spread,
+					argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+				};
+			}
+		}
+
+		return { kind: "allow" };
+	}
+
+	/**
+	 * Commits a call to the tracker (post-`check`). Synchronous so a duplicate
+	 * later in the same batch observes the earlier sibling. Sets the
+	 * `#liveTrackingActive` flag so `recordTurn` knows not to re-increment.
+	 */
+	recordCall(toolName: string, args: unknown, toolCallId?: string): void {
+		if (this.#exemptTools.has(toolName)) return;
+		this.#liveTrackingActive = true;
+		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(args));
+		const argsHash = `${toolName}:${canonicalArgs}`;
+
+		// Layer 1: args-only repeat.
+		if (argsHash === this.#lastArgsHash) {
+			this.#repeatCount++;
+		} else {
+			this.#lastArgsHash = argsHash;
+			this.#repeatCount = 1;
+		}
+
+		// Layer 3: track distinct argsHashes for prone tools (bounded per tool).
+		if (this.#isProneTool(toolName)) {
+			let set = this.#wanderingHashes.get(toolName);
+			if (!set) {
+				set = new Set();
+				this.#wanderingHashes.set(toolName, set);
+			}
+			set.add(argsHash);
+			// Bound each per-tool set so it can't grow unboundedly: cap at
+			// wanderingEscalation * 2, evicting oldest (FIFO via iterator).
+			const cap = Math.max(this.#wanderingEscalation * 2, this.#wanderingThreshold * 2, 24);
+			if (set.size > cap) {
+				const first = set.values().next().value;
+				if (first !== undefined) set.delete(first);
+			}
+		}
+
+		// History ring buffer — keyed by toolCallId for stable matching across
+		// pre/post-transform args (secret deobfuscation, timeout capping).
+		this.#history.push({ argsHash, toolCallId, resultHash: undefined });
+		if (this.#history.length > this.#historySize) this.#history.shift();
+	}
+
+	/**
+	 * Records the outcome of a call. Updates the no-progress streak (layer 2).
+	 * Pass `vetoed: true` for vetoed calls so they're excluded from the streak.
+	 *
+	 * Accepts the agent's native result shape ({@link ToolCallOutcome}) so the
+	 * `afterToolCall` hook can pass `ctx.result` without bridging.
+	 */
+	recordOutcome(
+		toolName: string,
+		args: unknown,
+		outcome: { result?: ToolCallOutcome; vetoed?: boolean; toolCallId?: string },
+	): void {
+		if (this.#exemptTools.has(toolName)) return;
+		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(args));
+		const argsHash = `${toolName}:${canonicalArgs}`;
+
+		// Find the in-flight record for this call. Prefer matching by toolCallId
+		// (stable across pre/post-transform args) so secret deobfuscation or
+		// timeout capping doesn't break the no-progress streak. Fall back to
+		// argsHash for callers that don't pass a toolCallId (tests / recordTurn).
+		const record = outcome.toolCallId
+			? this.#history.findLast(r => r.toolCallId === outcome.toolCallId && r.resultHash === undefined)
+			: this.#history.findLast(r => r.argsHash === argsHash && r.resultHash === undefined);
+		if (!record) return;
+
+		if (outcome.vetoed) {
+			// Vetoed calls don't count toward the no-progress streak — they never ran.
+			record.resultHash = VETO_SENTINEL;
+			return;
+		}
+
+		const resultHash = outcome.result ? hashOutcome(outcome.result) : "";
+		record.resultHash = resultHash;
+
+		// Layer 2: no-progress streak. Key on the RECORD's argsHash (from
+		// recordCall, which saw the pre-transform args) + resultHash. Using the
+		// record's argsHash instead of recomputing from post-transform args
+		// ensures check() — which also uses pre-transform args — can match the
+		// streak even when transformToolCallArguments changed the args.
+		const streakArgsHash = record.argsHash;
+		const noProgressKey = `${streakArgsHash}\u0000${resultHash}`;
+		if (noProgressKey === this.#lastNoProgressKey) {
+			this.#noProgressStreak++;
+		} else {
+			this.#lastNoProgressKey = noProgressKey;
+			this.#noProgressStreak = 1;
+		}
+		// Reset the no-progress consecutive-veto counter on every genuine call.
+		// Vetoed calls early-return above (line 470) without reaching this, so
+		// the counter only accumulates across consecutive vetoes of the same
+		// stuck tool — a genuine call between vetoes means the model tried
+		// something else, which breaks the "consecutive" chain.
+		// The wandering veto counter is NOT reset here — a `read` between
+		// browser attempts doesn't mean the browser wandering resolved.
+		this.#consecutiveVetoes = 0;
+	}
+
+	/**
+	 * Records one completed turn and returns the threshold hit, if any.
+	 *
+	 * When the live path (`recordCall` + `recordOutcome`) is active for this
+	 * turn, the shared counters (`#repeatCount`, `#noProgressStreak`) were already
+	 * advanced — so this method MUST NOT re-increment them. It reads the current
+	 * state to decide whether to emit an advisory detection. When the live path
+	 * is NOT active (tests / callers that use `recordTurn` standalone), this
+	 * method performs the increments itself for back-compat.
+	 */
+	recordTurn(turn: ToolCallLoopTurn): ToolCallLoopDetection | null {
 		const toolCalls = turn.message.content.filter((part): part is ToolCall => part.type === "toolCall");
 		if (toolCalls.length !== 1 || this.#exemptTools.has(toolCalls[0]!.name)) {
-			this.#lastHash = undefined;
-			this.#count = 0;
+			// The qualifying sequence was interrupted (prose turn, multiple calls,
+			// or exempt tool). Reset ALL cross-turn streak state so an intervening
+			// turn doesn't leave a stale no-progress streak that vetoes the next
+			// same-args call. This runs on BOTH paths — the live path's
+			// recordCall/recordOutcome will re-increment on the next genuine call.
+			this.#lastArgsHash = undefined;
+			this.#repeatCount = 0;
+			this.#lastNoProgressKey = undefined;
+			this.#noProgressStreak = 0;
+			this.#consecutiveVetoes = 0;
+			this.#wanderingVetoes.clear();
 			return null;
 		}
 
 		const toolCall = toolCalls[0]!;
 		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(toolCall.arguments));
-		const hash = `${toolCall.name}:${canonicalArgs}`;
-		if (hash === this.#lastHash) {
-			this.#count++;
-		} else {
-			this.#lastHash = hash;
-			this.#count = 1;
+		const argsHash = `${toolCall.name}:${canonicalArgs}`;
+
+		if (this.#liveTrackingActive) {
+			// Live path already advanced #repeatCount / #noProgressStreak via
+			// recordCall + recordOutcome. Read current state for the detection
+			// return — do NOT re-increment.
+			return this.#detectFromCurrentState(toolCall, argsHash, canonicalArgs, turn);
 		}
 
-		if (this.#count !== this.#threshold) return null;
-		return {
-			kind: "repeated_tool_call",
-			toolName: toolCall.name,
-			count: this.#count,
-			resultSummary: summarizeToolResult(turn.toolResults, toolCall.id),
-			argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
-		};
+		// --- Standalone path (no live hooks wired): increment counters here. ---
+		if (argsHash === this.#lastArgsHash) {
+			this.#repeatCount++;
+		} else {
+			this.#lastArgsHash = argsHash;
+			this.#repeatCount = 1;
+		}
+
+		// Layer 3: track distinct argsHashes for prone tools (standalone path).
+		if (this.#isProneTool(toolCall.name)) {
+			let set = this.#wanderingHashes.get(toolCall.name);
+			if (!set) {
+				set = new Set();
+				this.#wanderingHashes.set(toolCall.name, set);
+			}
+			set.add(argsHash);
+			const cap = Math.max(this.#wanderingEscalation * 2, this.#wanderingThreshold * 2, 24);
+			if (set.size > cap) {
+				const first = set.values().next().value;
+				if (first !== undefined) set.delete(first);
+			}
+		}
+
+		if (this.#noProgressThreshold > 0) {
+			const result = turn.toolResults.find(r => r.toolCallId === toolCall.id);
+			if (result) {
+				const outcome: ToolCallOutcome = {
+					content: result.content,
+					details: result.details,
+					isError: result.isError,
+				};
+				const resultHash = hashOutcome(outcome);
+				const noProgressKey = `${argsHash}\u0000${resultHash}`;
+				if (noProgressKey === this.#lastNoProgressKey) {
+					this.#noProgressStreak++;
+				} else {
+					this.#lastNoProgressKey = noProgressKey;
+					this.#noProgressStreak = 1;
+				}
+			}
+		}
+
+		return this.#detectFromCurrentState(toolCall, argsHash, canonicalArgs, turn);
+	}
+
+	/**
+	 * Builds the advisory detection (if any) from current counter state. Shared
+	 * by both the live path and the standalone path so neither duplicates the
+	 * detection logic.
+	 */
+	#detectFromCurrentState(
+		toolCall: ToolCall,
+		argsHash: string,
+		canonicalArgs: string,
+		turn: ToolCallLoopTurn,
+	): ToolCallLoopDetection | null {
+		// Args-only repeat: fires once at the threshold (deduped).
+		if (this.#repeatCount === this.#threshold) {
+			return {
+				kind: "repeated_tool_call",
+				toolName: toolCall.name,
+				count: this.#repeatCount,
+				resultSummary: summarizeToolResult(turn.toolResults, toolCall.id),
+				argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+			};
+		}
+
+		// Wandering: if this is a prone tool and the spread has crossed the
+		// threshold, emit a wandering detection. On the live path, the spread is
+		// already tracked via recordCall; on the standalone path it's 0 (wandering
+		// only fires via the live path's recordCall). Check regardless so the
+		// standalone path can still surface it if wanderingHashes was populated.
+		if (this.#wanderingThreshold > 0 && this.#isProneTool(toolCall.name)) {
+			const spread = this.#effectiveSpread(toolCall.name, argsHash);
+			if (spread >= this.#wanderingThreshold) {
+				return {
+					kind: "wandering_tool_call",
+					toolName: toolCall.name,
+					spread,
+					argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+				};
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resets per-turn state. Call at turn start. Wandering hashes PERSIST across
+	 * turns (the detector needs to accumulate spread across multiple turns to
+	 * reach the threshold — clearing every turn made it dead code). Each per-tool
+	 * set is bounded individually in {@link recordCall} (cap = wanderingEscalation
+	 * * 2, FIFO eviction) so a single tool can't permanently sit at the escalation
+	 * threshold.
+	 */
+	/**
+	 * Checks whether a tool name is prone to wandering. Matches exact entries
+	 * (e.g. "web.fetch") and dotted prefixes (e.g. "browser" matches
+	 * "browser.scroll", "browser.screenshot") so the documented `browser.*`
+	 * coverage works without enumerating every sub-tool.
+	 */
+	#isProneTool(toolName: string): boolean {
+		if (this.#proneTools[toolName]) return true;
+		const dot = toolName.indexOf(".");
+		if (dot > 0) {
+			const prefix = toolName.slice(0, dot);
+			return !!this.#proneTools[prefix];
+		}
+		return false;
+	}
+
+	/**
+	 * Resets no-progress streak state without touching wandering hashes.
+	 * Called when a turn ends abnormally (terminal yield abort, breaker) —
+	 * where `recordTurn` won't run to clear the streak. Without this, a
+	 * sequence of identical terminal yields across separate prompts would
+	 * accumulate a no-progress streak that vetoes the next yield.
+	 */
+	resetStreaks(): void {
+		this.#lastArgsHash = undefined;
+		this.#repeatCount = 0;
+		this.#lastNoProgressKey = undefined;
+		this.#noProgressStreak = 0;
+		this.#consecutiveVetoes = 0;
+		this.#wanderingVetoes.clear();
+		this.#liveTrackingActive = false;
+	}
+
+	resetForTurn(): void {
+		this.#liveTrackingActive = false;
+		// Wandering hashes persist across turns — they ARE cross-turn detectors.
+		// Per-tool sets are bounded in recordCall; no global clear needed here.
+	}
+
+	#effectiveSpread(toolName: string, prospectiveArgsHash: string): number {
+		const set = this.#wanderingHashes.get(toolName);
+		if (!set) return 1;
+		return set.has(prospectiveArgsHash) ? set.size : set.size + 1;
 	}
 }

--- a/packages/ai/test/tool-call-loop-guard.test.ts
+++ b/packages/ai/test/tool-call-loop-guard.test.ts
@@ -241,4 +241,948 @@ describe("ToolCallLoopGuard", () => {
 			}),
 		).toBeNull();
 	});
+
+	test("check() vetoes a no-progress streak at the threshold (pre-call veto)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99, // high — we test no-progress, not args-only repeat
+			exemptTools: [],
+			noProgressThreshold: 3,
+			wanderingThreshold: 0,
+		});
+		// Simulate 3 identical calls (same args + same result) via the live path.
+		for (let i = 0; i < 3; i++) {
+			expect(guard.check({ toolName: "bash", args: { command: "pytest" } })).toEqual({ kind: "allow" });
+			guard.recordCall("bash", { command: "pytest" });
+			guard.recordOutcome(
+				"bash",
+				{ command: "pytest" },
+				{
+					result: { content: [{ type: "text", text: "all passed" }], details: {}, isError: false },
+				},
+			);
+		}
+		// 4th call with same args+result should be vetoed (streak >= 3).
+		const verdict = guard.check({ toolName: "bash", args: { command: "pytest" } });
+		expect(verdict.kind).toBe("critical");
+	});
+
+	test("check() does NOT veto when the result changed (streak broken)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 3,
+			wanderingThreshold: 0,
+		});
+		// 2 identical calls build the streak.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "bash", args: { command: "ls" } });
+			guard.recordCall("bash", { command: "ls" });
+			guard.recordOutcome(
+				"bash",
+				{ command: "ls" },
+				{
+					result: { content: [{ type: "text", text: "file.txt" }], details: {}, isError: false },
+				},
+			);
+		}
+		// 3rd call has the same args but a DIFFERENT result — streak resets.
+		guard.check({ toolName: "bash", args: { command: "ls" } });
+		guard.recordCall("bash", { command: "ls" });
+		guard.recordOutcome(
+			"bash",
+			{ command: "ls" },
+			{
+				result: { content: [{ type: "text", text: "file2.txt" }], details: {}, isError: false },
+			},
+		);
+		// 4th call should still be allowed (streak was broken at call 3).
+		expect(guard.check({ toolName: "bash", args: { command: "ls" } })).toEqual({ kind: "allow" });
+	});
+
+	test("check() fires breaker after consecutive vetoes hit breakerVetoStreak", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+			breakerVetoStreak: 3,
+		});
+		// Build the no-progress streak to 2.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "fetch", args: { url: "http://dead.example" } });
+			guard.recordCall("fetch", { url: "http://dead.example" });
+			guard.recordOutcome(
+				"fetch",
+				{ url: "http://dead.example" },
+				{
+					result: { content: [{ type: "text", text: "timeout" }], details: {}, isError: true },
+				},
+			);
+		}
+		// 3rd call: critical veto (streak >= 2), consecutiveVetoes = 1.
+		expect(guard.check({ toolName: "fetch", args: { url: "http://dead.example" } }).kind).toBe("critical");
+		guard.recordCall("fetch", { url: "http://dead.example" });
+		guard.recordOutcome("fetch", { url: "http://dead.example" }, { vetoed: true });
+		// 4th call: still critical, consecutiveVetoes = 2.
+		expect(guard.check({ toolName: "fetch", args: { url: "http://dead.example" } }).kind).toBe("critical");
+		guard.recordCall("fetch", { url: "http://dead.example" });
+		guard.recordOutcome("fetch", { url: "http://dead.example" }, { vetoed: true });
+		// 5th call: consecutiveVetoes = 3 >= breakerVetoStreak → breaker.
+		expect(guard.check({ toolName: "fetch", args: { url: "http://dead.example" } }).kind).toBe("breaker");
+	});
+
+	test("volatile-field stripping: timestamps in details do not defeat the no-progress hash", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with identical text but different volatile details.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "http.request", args: { url: "http://api.example" } });
+			guard.recordCall("http.request", { url: "http://api.example" });
+			guard.recordOutcome(
+				"http.request",
+				{ url: "http://api.example" },
+				{
+					result: {
+						content: [{ type: "text", text: "ok" }],
+						details: { status: 200, timestamp: `2026-07-26T12:00:0${i}Z`, requestId: `req-${i}` },
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be vetoed — the volatile fields were stripped so the
+		// result hashes as identical despite different timestamp/requestId.
+		expect(guard.check({ toolName: "http.request", args: { url: "http://api.example" } }).kind).toBe("critical");
+	});
+
+	test("wandering detector warns at wanderingThreshold for prone tools", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 3,
+			wanderingEscalation: 99, // high — we test warn, not escalation
+			proneTools: ["web.fetch"],
+		});
+		// 2 distinct URLs — below threshold.
+		for (const url of ["http://a.example", "http://b.example"]) {
+			guard.check({ toolName: "web.fetch", args: { url } });
+			guard.recordCall("web.fetch", { url });
+			guard.recordOutcome(
+				"web.fetch",
+				{ url },
+				{
+					result: { content: [{ type: "text", text: "page" }], details: {}, isError: false },
+				},
+			);
+		}
+		// 3rd distinct URL — should warn.
+		const verdict = guard.check({ toolName: "web.fetch", args: { url: "http://c.example" } });
+		expect(verdict.kind).toBe("wandering");
+		if (verdict.kind === "wandering") expect(verdict.spread).toBe(3);
+	});
+
+	test("wandering detector does NOT fire for non-prone tools (bulk reads)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 3,
+			wanderingEscalation: 99,
+			proneTools: ["web.fetch"],
+		});
+		// read is NOT prone — scanning many files is legitimate.
+		for (const file of ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"]) {
+			const verdict = guard.check({ toolName: "read", args: { path: file } });
+			expect(verdict.kind).toBe("allow");
+			guard.recordCall("read", { path: file });
+			guard.recordOutcome(
+				"read",
+				{ path: file },
+				{
+					result: { content: [{ type: "text", text: "contents" }], details: {}, isError: false },
+				},
+			);
+		}
+	});
+
+	test("recordTurn does not double-count when live path is active", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 3,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 0,
+		});
+		// Live path: 2 calls via check+recordCall+recordOutcome.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "bash", args: { command: "echo hi" } });
+			guard.recordCall("bash", { command: "echo hi" });
+			guard.recordOutcome(
+				"bash",
+				{ command: "echo hi" },
+				{
+					result: { content: [{ type: "text", text: "hi" }], details: {}, isError: false },
+				},
+			);
+		}
+		// recordTurn should NOT re-increment #repeatCount (live path already did).
+		const detection = guard.recordTurn({
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tc-1", name: "bash", arguments: { command: "echo hi" } }],
+				api: "openai-responses" as const,
+				provider: "openai",
+				model: "test",
+				usage: zeroUsage,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			} as AssistantMessage,
+			toolResults: [
+				{
+					role: "toolResult" as const,
+					toolCallId: "tc-1",
+					toolName: "bash",
+					content: [{ type: "text" as const, text: "hi" }],
+					details: {},
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		});
+		// After 2 live-path calls, repeatCount should be 2 — NOT 3 (which would fire).
+		expect(detection).toBeNull();
+		// 3rd live call should fire.
+		guard.check({ toolName: "bash", args: { command: "echo hi" } });
+		guard.recordCall("bash", { command: "echo hi" });
+		guard.recordOutcome(
+			"bash",
+			{ command: "echo hi" },
+			{
+				result: { content: [{ type: "text", text: "hi" }], details: {}, isError: false },
+			},
+		);
+		const detection2 = guard.recordTurn({
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tc-2", name: "bash", arguments: { command: "echo hi" } }],
+				api: "openai-responses" as const,
+				provider: "openai",
+				model: "test",
+				usage: zeroUsage,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			} as AssistantMessage,
+			toolResults: [
+				{
+					role: "toolResult" as const,
+					toolCallId: "tc-2",
+					toolName: "bash",
+					content: [{ type: "text" as const, text: "hi" }],
+					details: {},
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		});
+		expect(detection2).not.toBeNull();
+		expect(detection2?.kind).toBe("repeated_tool_call");
+	});
+
+	test("image content is included in the no-progress hash (different screenshots break the streak)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with same args but DIFFERENT image data — should NOT veto.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "computer", args: { action: "screenshot" } });
+			guard.recordCall("computer", { action: "screenshot" });
+			guard.recordOutcome(
+				"computer",
+				{ action: "screenshot" },
+				{
+					result: {
+						content: [{ type: "image" as const, data: `base64-different-${i}`, mimeType: "image/png" }],
+						details: {},
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be allowed — different image data broke the streak.
+		expect(guard.check({ toolName: "computer", args: { action: "screenshot" } })).toEqual({ kind: "allow" });
+	});
+
+	test("image content with identical data DOES trigger no-progress veto", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with IDENTICAL image data — should build the streak.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "computer", args: { action: "screenshot" } });
+			guard.recordCall("computer", { action: "screenshot" });
+			guard.recordOutcome(
+				"computer",
+				{ action: "screenshot" },
+				{
+					result: {
+						content: [{ type: "image" as const, data: "base64-identical", mimeType: "image/png" }],
+						details: {},
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be vetoed — identical image data = no progress.
+		expect(guard.check({ toolName: "computer", args: { action: "screenshot" } }).kind).toBe("critical");
+	});
+
+	test("wandering detector accumulates spread across turns (resetForTurn does not clear it)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 3,
+			wanderingEscalation: 99,
+			proneTools: ["web.fetch"],
+		});
+		// Turn 1: fetch URL A
+		guard.check({ toolName: "web.fetch", args: { url: "http://a.example" } });
+		guard.recordCall("web.fetch", { url: "http://a.example" });
+		guard.recordOutcome(
+			"web.fetch",
+			{ url: "http://a.example" },
+			{
+				result: { content: [{ type: "text" as const, text: "page a" }], details: {}, isError: false },
+			},
+		);
+		guard.resetForTurn();
+		// Turn 2: fetch URL B (different args)
+		guard.check({ toolName: "web.fetch", args: { url: "http://b.example" } });
+		guard.recordCall("web.fetch", { url: "http://b.example" });
+		guard.recordOutcome(
+			"web.fetch",
+			{ url: "http://b.example" },
+			{
+				result: { content: [{ type: "text" as const, text: "page b" }], details: {}, isError: false },
+			},
+		);
+		guard.resetForTurn();
+		// Turn 3: fetch URL C — spread should be 3 (accumulated across turns).
+		const verdict = guard.check({ toolName: "web.fetch", args: { url: "http://c.example" } });
+		expect(verdict.kind).toBe("wandering");
+		if (verdict.kind === "wandering") expect(verdict.spread).toBe(3);
+	});
+
+	test("P1: per-tool wandering set is bounded (cap evicts oldest entries)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 1,
+			wanderingEscalation: 2, // cap = max(2*2, 1*2, 24) = 24
+			breakerVetoStreak: 99, // high — don't trip the breaker, test the cap
+			proneTools: ["web.fetch"],
+		});
+		// Insert 30 distinct URLs — exceeds the cap of 24.
+		for (let i = 0; i < 30; i++) {
+			const url = `http://example-${i}.com`;
+			guard.check({ toolName: "web.fetch", args: { url } });
+			guard.recordCall("web.fetch", { url });
+			guard.recordOutcome(
+				"web.fetch",
+				{ url },
+				{
+					result: { content: [{ type: "text" as const, text: "page" }], details: {}, isError: false },
+				},
+			);
+		}
+		// With an unbounded set, a new URL would have spread = 31.
+		// With cap=24 (6 evicted), a new URL has spread = 25 (set.size + 1).
+		// The verdict is critical (spread >= escalation), but the count field
+		// reveals the actual spread — proving the set is bounded at 24, not 31.
+		const fresh = guard.check({
+			toolName: "web.fetch",
+			args: { url: "http://brand-new.com" },
+		});
+		expect(fresh.kind).toBe("critical");
+		if (fresh.kind === "critical") expect(fresh.count).toBe(25);
+
+		// A URL still in the set (example-29, last inserted) has spread = 24.
+		const retained = guard.check({
+			toolName: "web.fetch",
+			args: { url: "http://example-29.com" },
+		});
+		expect(retained.kind).toBe("critical");
+		if (retained.kind === "critical") expect(retained.count).toBe(24);
+	});
+
+	test("P2a: recordOutcome matches by toolCallId (survives pre/post-transform args mismatch)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Simulate: beforeToolCall records with pre-transform args + toolCallId,
+		// afterToolCall records outcome with DIFFERENT (post-transform) args but
+		// same toolCallId. The outcome should still be recorded.
+		const toolCallId = "tc-1";
+		guard.check({ toolName: "bash", args: { command: "secret-placeholder" } });
+		guard.recordCall("bash", { command: "secret-placeholder" }, toolCallId);
+		// afterToolCall sees post-transform args (deobfuscated secret)
+		guard.recordOutcome(
+			"bash",
+			{ command: "real-secret-value" },
+			{
+				result: { content: [{ type: "text" as const, text: "ok" }], details: {}, isError: false },
+				toolCallId,
+			},
+		);
+		// Second call with same pre-transform args — streak should have built
+		// because the outcome was recorded via toolCallId matching.
+		guard.check({ toolName: "bash", args: { command: "secret-placeholder" } });
+		guard.recordCall("bash", { command: "secret-placeholder" }, "tc-2");
+		guard.recordOutcome(
+			"bash",
+			{ command: "real-secret-value" },
+			{
+				result: { content: [{ type: "text" as const, text: "ok" }], details: {}, isError: false },
+				toolCallId: "tc-2",
+			},
+		);
+		// Third call should be vetoed — streak built despite args mismatch.
+		expect(guard.check({ toolName: "bash", args: { command: "secret-placeholder" } }).kind).toBe("critical");
+	});
+
+	test("P2b: intervening prose turn breaks the no-progress streak", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 3,
+			wanderingThreshold: 0,
+		});
+		// Build a streak of 3 via the standalone recordTurn path.
+		for (let i = 0; i < 3; i++) {
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: `tc-${i}`, name: "bash", arguments: { command: "echo hi" } }],
+					api: "openai-responses" as const,
+					provider: "openai",
+					model: "test",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				} as AssistantMessage,
+				toolResults: [
+					{
+						role: "toolResult" as const,
+						toolCallId: `tc-${i}`,
+						toolName: "bash",
+						content: [{ type: "text" as const, text: "hi" }],
+						details: {},
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			});
+		}
+		// Intervening prose turn (no tool calls) — should break the streak.
+		guard.recordTurn({
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "Let me think about this." }],
+				api: "openai-responses" as const,
+				provider: "openai",
+				model: "test",
+				usage: zeroUsage,
+				stopReason: "stop",
+				timestamp: Date.now(),
+			} as AssistantMessage,
+			toolResults: [],
+		});
+		// Next call with same args should NOT be vetoed — streak was broken.
+		const detection = guard.recordTurn({
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tc-after", name: "bash", arguments: { command: "echo hi" } }],
+				api: "openai-responses" as const,
+				provider: "openai",
+				model: "test",
+				usage: zeroUsage,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			} as AssistantMessage,
+			toolResults: [
+				{
+					role: "toolResult" as const,
+					toolCallId: "tc-after",
+					toolName: "bash",
+					content: [{ type: "text" as const, text: "hi" }],
+					details: {},
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		});
+		expect(detection).toBeNull();
+	});
+
+	test("wandering breaker clears the tool's wandering set (fresh start after graceful end)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 3,
+			wanderingEscalation: 4,
+			breakerVetoStreak: 2,
+			proneTools: ["web.fetch"],
+		});
+		// Build spread: calls 1-3 are below escalation (spread 1,2,3).
+		// Call 4 hits escalation (spread=4, wanderingVetoes=1, critical).
+		for (let i = 0; i < 4; i++) {
+			const url = `http://example-${i}.com`;
+			guard.check({ toolName: "web.fetch", args: { url } });
+			guard.recordCall("web.fetch", { url });
+			guard.recordOutcome(
+				"web.fetch",
+				{ url },
+				{
+					result: { content: [{ type: "text" as const, text: "page" }], details: {}, isError: false },
+				},
+			);
+		}
+		// 5th distinct URL: spread=5 >= escalation(4), wanderingVetoes=2 >= breakerVetoStreak(2) → breaker.
+		const verdict = guard.check({ toolName: "web.fetch", args: { url: "http://e.com" } });
+		expect(verdict.kind).toBe("breaker");
+		guard.recordCall("web.fetch", { url: "http://e.com" });
+		guard.recordOutcome("web.fetch", { url: "http://e.com" }, { vetoed: true });
+		// After the breaker, the wandering set should be cleared — a new call
+		// should be allowed (spread=1, not permanently stuck at escalation).
+		expect(guard.check({ toolName: "web.fetch", args: { url: "http://fresh.com" } }).kind).toBe("allow");
+	});
+
+	test("interleaving a non-prone call does NOT reset the wandering veto counter", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 3,
+			wanderingEscalation: 4,
+			breakerVetoStreak: 3,
+			proneTools: ["web.fetch"],
+		});
+		// Build spread: calls 1-3 below escalation, call 4 hits it (wanderingVetoes=1).
+		for (let i = 0; i < 4; i++) {
+			const url = `http://example-${i}.com`;
+			guard.check({ toolName: "web.fetch", args: { url } });
+			guard.recordCall("web.fetch", { url });
+			guard.recordOutcome(
+				"web.fetch",
+				{ url },
+				{
+					result: { content: [{ type: "text" as const, text: "page" }], details: {}, isError: false },
+				},
+			);
+		}
+		// 5th distinct URL: spread=5 >= escalation(4), wanderingVetoes=2 → critical.
+		let verdict = guard.check({ toolName: "web.fetch", args: { url: "http://e.com" } });
+		expect(verdict.kind).toBe("critical");
+		guard.recordCall("web.fetch", { url: "http://e.com" });
+		guard.recordOutcome("web.fetch", { url: "http://e.com" }, { vetoed: true });
+
+		// Model interleaves a `read` (non-prone) — should NOT reset wanderingVetoes.
+		guard.check({ toolName: "read", args: { path: "foo.ts" } });
+		guard.recordCall("read", { path: "foo.ts" });
+		guard.recordOutcome(
+			"read",
+			{ path: "foo.ts" },
+			{
+				result: { content: [{ type: "text" as const, text: "contents" }], details: {}, isError: false },
+			},
+		);
+
+		// 6th distinct URL: spread=6 >= escalation(4), wanderingVetoes=3 >= breakerVetoStreak(3) → breaker.
+		verdict = guard.check({ toolName: "web.fetch", args: { url: "http://f.com" } });
+		expect(verdict.kind).toBe("breaker");
+
+		// After breaker, wandering set cleared — next call should be allowed.
+		verdict = guard.check({ toolName: "web.fetch", args: { url: "http://fresh.com" } });
+		expect(verdict.kind).toBe("allow");
+	});
+
+	test("volatile timestamps in error strings don't break the no-progress streak", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with same args but error strings embedding different
+		// timestamps and request IDs — should still build the no-progress
+		// streak because the volatile patterns are stripped from text.
+		const errors = [
+			"Error: request req-abc123 failed at 2026-07-26T12:00:01Z",
+			"Error: request req-def456 failed at 2026-07-26T12:00:02Z",
+		];
+		for (const text of errors) {
+			guard.check({ toolName: "http.request", args: { url: "http://flaky.example" } });
+			guard.recordCall("http.request", { url: "http://flaky.example" });
+			guard.recordOutcome(
+				"http.request",
+				{ url: "http://flaky.example" },
+				{
+					result: { content: [{ type: "text" as const, text }], details: {}, isError: true },
+				},
+			);
+		}
+		// 3rd call should be vetoed — volatile patterns stripped, streak built.
+		expect(guard.check({ toolName: "http.request", args: { url: "http://flaky.example" } }).kind).toBe("critical");
+	});
+
+	test("cyclic details don't crash hashOutcome", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Create a cyclic object in details.
+		const cyclic: Record<string, unknown> = { x: 1 };
+		cyclic.self = cyclic;
+		// Should not throw — falls back to "<unhashable>".
+		guard.check({ toolName: "bash", args: { command: "test" } });
+		guard.recordCall("bash", { command: "test" });
+		guard.recordOutcome(
+			"bash",
+			{ command: "test" },
+			{
+				result: { content: [{ type: "text" as const, text: "ok" }], details: cyclic, isError: false },
+			},
+		);
+		// Second call with same text but different (also cyclic) details — should
+		// still build the streak because both fall back to "<unhashable>".
+		const cyclic2: Record<string, unknown> = { x: 1 };
+		cyclic2.self = cyclic2;
+		guard.check({ toolName: "bash", args: { command: "test" } });
+		guard.recordCall("bash", { command: "test" });
+		guard.recordOutcome(
+			"bash",
+			{ command: "test" },
+			{
+				result: { content: [{ type: "text" as const, text: "ok" }], details: cyclic2, isError: false },
+			},
+		);
+		// 3rd call should be vetoed — identical text, both details unhashable.
+		expect(guard.check({ toolName: "bash", args: { command: "test" } }).kind).toBe("critical");
+	});
+
+	test("semantic IDs in details are NOT stripped (only volatile keys are)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with same text but DIFFERENT semantic IDs in details.
+		// These should NOT hash as identical — the `id` field is meaningful
+		// (it's not requestId/traceId, which are the volatile ones).
+		for (const itemId of ["a", "b"]) {
+			guard.check({ toolName: "read", args: { path: "items.json" } });
+			guard.recordCall("read", { path: "items.json" });
+			guard.recordOutcome(
+				"read",
+				{ path: "items.json" },
+				{
+					result: {
+						content: [{ type: "text" as const, text: "found item" }],
+						details: { item: { id: itemId } },
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be allowed — different semantic IDs broke the streak.
+		expect(guard.check({ toolName: "read", args: { path: "items.json" } })).toEqual({ kind: "allow" });
+	});
+
+	test("successful results with semantic timestamps are NOT stripped (only errors are)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with same args but successful results containing different
+		// timestamps — these should NOT hash as identical because the timestamp
+		// is semantic data the model is polling for, not transport noise.
+		const results = ["Build completed at 2026-07-26T12:00:01Z", "Build completed at 2026-07-26T12:05:02Z"];
+		for (const text of results) {
+			guard.check({ toolName: "bash", args: { command: "tail build.log" } });
+			guard.recordCall("bash", { command: "tail build.log" });
+			guard.recordOutcome(
+				"bash",
+				{ command: "tail build.log" },
+				{
+					result: { content: [{ type: "text" as const, text }], details: {}, isError: false },
+				},
+			);
+		}
+		// 3rd call should be allowed — different timestamps broke the streak.
+		expect(guard.check({ toolName: "bash", args: { command: "tail build.log" } })).toEqual({
+			kind: "allow",
+		});
+	});
+
+	test("wandering escalation vetoes are tracked per-tool (don't cross-combine)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 1,
+			wanderingEscalation: 2,
+			breakerVetoStreak: 3,
+			proneTools: ["web.fetch", "browser"],
+		});
+		// Fill web.fetch past escalation (spread >= 2) → 1st veto, counter=1.
+		guard.check({ toolName: "web.fetch", args: { url: "http://a.com" } });
+		guard.recordCall("web.fetch", { url: "http://a.com" });
+		guard.check({ toolName: "web.fetch", args: { url: "http://b.com" } });
+		guard.recordCall("web.fetch", { url: "http://b.com" });
+		expect(guard.check({ toolName: "web.fetch", args: { url: "http://c.com" } }).kind).toBe("critical");
+		guard.recordCall("web.fetch", { url: "http://c.com" });
+
+		// Now fill browser past escalation → this is browser's 1st veto, NOT web.fetch's 2nd.
+		guard.check({ toolName: "browser", args: { selector: "#a" } });
+		guard.recordCall("browser", { selector: "#a" });
+		guard.check({ toolName: "browser", args: { selector: "#b" } });
+		guard.recordCall("browser", { selector: "#b" });
+		// browser's 1st escalation veto → critical (not breaker), because
+		// browser's counter is 1, not 2 (web.fetch's counter doesn't apply).
+		expect(guard.check({ toolName: "browser", args: { selector: "#c" } }).kind).toBe("critical");
+	});
+
+	test("resetStreaks clears no-progress state without touching wandering hashes", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 3,
+			wanderingEscalation: 4,
+			proneTools: ["web.fetch"],
+		});
+		// Build a no-progress streak and some wandering spread.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "bash", args: { command: "test" } });
+			guard.recordCall("bash", { command: "test" });
+			guard.recordOutcome(
+				"bash",
+				{ command: "test" },
+				{
+					result: { content: [{ type: "text" as const, text: "ok" }], details: {}, isError: false },
+				},
+			);
+		}
+		guard.check({ toolName: "web.fetch", args: { url: "http://a.com" } });
+		guard.recordCall("web.fetch", { url: "http://a.com" });
+
+		// Simulate a terminal-yield abort: resetStreaks should clear the
+		// no-progress streak but preserve wandering hashes.
+		guard.resetStreaks();
+
+		// No-progress streak is cleared — the next identical call should NOT
+		// be vetoed (streak restarts at 1 after the next outcome).
+		expect(guard.check({ toolName: "bash", args: { command: "test" } })).toEqual({ kind: "allow" });
+
+		// Wandering hashes persist — web.fetch's set still has the entry.
+		guard.check({ toolName: "web.fetch", args: { url: "http://b.com" } });
+		guard.recordCall("web.fetch", { url: "http://b.com" });
+		// A new URL should see spread=2 (set still has http://a.com from before).
+		const verdict = guard.check({ toolName: "web.fetch", args: { url: "http://c.com" } });
+		expect(verdict.kind).toBe("wandering");
+		if (verdict.kind === "wandering") expect(verdict.spread).toBe(3);
+	});
+
+	test("distinct bigint details produce distinct hashes (not collapsed to unhashable)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with same text but DIFFERENT bigint values in details.
+		// JSON.stringify throws on bigint, but the replacer converts 1n → "1n"
+		// and 2n → "2n", so they hash distinctly and don't build a streak.
+		for (const value of [1n, 2n]) {
+			guard.check({ toolName: "read", args: { path: "data.json" } });
+			guard.recordCall("read", { path: "data.json" });
+			guard.recordOutcome(
+				"read",
+				{ path: "data.json" },
+				{
+					result: {
+						content: [{ type: "text" as const, text: "loaded" }],
+						details: { value },
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be allowed — distinct bigints broke the streak.
+		expect(guard.check({ toolName: "read", args: { path: "data.json" } })).toEqual({
+			kind: "allow",
+		});
+	});
+
+	test("genuinely unhashable outcomes are non-comparable (unique fallback)", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Create objects with a getter that throws — bypasses the WeakSet
+		// cycle guard and forces the catch branch.
+		function makeThrowingDetails(): Record<string, unknown> {
+			const obj: Record<string, unknown> = {};
+			Object.defineProperty(obj, "boom", {
+				get() {
+					throw new Error("serialize fail");
+				},
+				enumerable: true,
+			});
+			return obj;
+		}
+		// Two calls with same text but unhashable details — each should get
+		// a unique fallback hash so they never falsely match.
+		for (let i = 0; i < 2; i++) {
+			guard.check({ toolName: "bash", args: { command: "test" } });
+			guard.recordCall("bash", { command: "test" });
+			guard.recordOutcome(
+				"bash",
+				{ command: "test" },
+				{
+					result: {
+						content: [{ type: "text" as const, text: "ok" }],
+						details: makeThrowingDetails(),
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be allowed — unique fallbacks broke the streak.
+		expect(guard.check({ toolName: "bash", args: { command: "test" } })).toEqual({
+			kind: "allow",
+		});
+	});
+
+	test("browser.* prefix matching: browser.scroll matches 'browser' prone entry", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 2,
+			wanderingEscalation: 99,
+			breakerVetoStreak: 99,
+			proneTools: ["browser"], // only the prefix, not browser.scroll
+		});
+		// browser.scroll should be treated as prone via prefix matching.
+		guard.check({ toolName: "browser.scroll", args: { x: 0, y: 0 } });
+		guard.recordCall("browser.scroll", { x: 0, y: 0 });
+		guard.check({ toolName: "browser.scroll", args: { x: 100, y: 200 } });
+		guard.recordCall("browser.scroll", { x: 100, y: 200 });
+		// spread=3 should trigger wandering (threshold=2).
+		const verdict = guard.check({ toolName: "browser.scroll", args: { x: 50, y: 50 } });
+		expect(verdict.kind).toBe("wandering");
+		if (verdict.kind === "wandering") expect(verdict.spread).toBe(3);
+	});
+
+	test("non-prone tool name with a dot is NOT prefix-matched", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 2,
+			proneTools: ["web.fetch"],
+		});
+		// "read.file" should NOT match "web.fetch" — different prefix.
+		guard.check({ toolName: "read.file", args: { path: "a" } });
+		guard.recordCall("read.file", { path: "a" });
+		guard.check({ toolName: "read.file", args: { path: "b" } });
+		guard.recordCall("read.file", { path: "b" });
+		// read.file is not prone — should always be allow.
+		expect(guard.check({ toolName: "read.file", args: { path: "c" } })).toEqual({ kind: "allow" });
+	});
+
+	test("Date/Map/Set in details are preserved by stripVolatile (not collapsed to {})", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 2,
+			wanderingThreshold: 0,
+		});
+		// Two calls with same text but DIFFERENT Date values in details.
+		// stripVolatile should pass Date through (not recurse into it as {}).
+		// Note: the key name must NOT be a volatile key (timestamp, date, etc.
+		// are stripped) — use a semantic key like "lastModified".
+		// and JSON.stringify calls Date.toJSON() → distinct ISO strings.
+		for (const date of [new Date("2026-01-01"), new Date("2026-06-01")]) {
+			guard.check({ toolName: "read", args: { path: "log" } });
+			guard.recordCall("read", { path: "log" });
+			guard.recordOutcome(
+				"read",
+				{ path: "log" },
+				{
+					result: {
+						content: [{ type: "text" as const, text: "ok" }],
+						details: { lastModified: date },
+						isError: false,
+					},
+				},
+			);
+		}
+		// 3rd call should be allowed — distinct Date.toJSON() broke the streak.
+		expect(guard.check({ toolName: "read", args: { path: "log" } })).toEqual({
+			kind: "allow",
+		});
+	});
+
+	test("breaker does not recreate the wandering set via recordCall", () => {
+		const guard = new ToolCallLoopGuard({
+			threshold: 99,
+			exemptTools: [],
+			noProgressThreshold: 0,
+			wanderingThreshold: 1,
+			wanderingEscalation: 2,
+			breakerVetoStreak: 2,
+			proneTools: ["web.fetch"],
+		});
+		// Fill past escalation twice to trigger the breaker.
+		// Call 1: spread=1 (below escalation)
+		guard.check({ toolName: "web.fetch", args: { url: "http://a.com" } });
+		guard.recordCall("web.fetch", { url: "http://a.com" });
+		// Call 2: spread=2 (at escalation → critical, wanderingVetoes=1)
+		guard.check({ toolName: "web.fetch", args: { url: "http://b.com" } });
+		guard.recordCall("web.fetch", { url: "http://b.com" });
+		// Call 3: spread=3 (at escalation → critical, wanderingVetoes=2 → breaker)
+		const breaker = guard.check({ toolName: "web.fetch", args: { url: "http://c.com" } });
+		expect(breaker.kind).toBe("breaker");
+		// The breaker deleted the wandering set. Simulate the stream-guards
+		// behavior: skip recordCall for breaker verdicts.
+		// (In the real wiring, beforeToolCall skips recordCall for breakers.)
+		// Now the next call should start fresh — spread=1, not 2.
+		const fresh = guard.check({ toolName: "web.fetch", args: { url: "http://d.com" } });
+		expect(fresh.kind).toBe("wandering"); // threshold=1, spread=1
+		if (fresh.kind === "wandering") expect(fresh.spread).toBe(1);
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- The tool-call loop guard now vetoes stuck no-progress loops before the tool executes: `beforeToolCall` consults the guard's `check()` and returns `{ block: true }` when identical args AND identical results repeat past `model.toolCallLoopGuard.noProgressThreshold` (default 5). The tool never runs, saving tokens and avoiding the wasted call. A breaker (`breakerVetoStreak`, default 3 consecutive vetoes) ends the turn gracefully — session stays pending, no hard failure.
+- Added a wandering detector for prone tools (`web.fetch`, `http.request`, `browser.*`): warns at `model.toolCallLoopGuard.wanderingThreshold` (default 6 distinct argument sets) and escalates to a veto at `wanderingEscalation` (default 12). Bulk reads over distinct files are not prone. A dedicated `tool-call-wandering-redirect` prompt steers the model toward web search or yielding.
+- Added settings: `model.toolCallLoopGuard.noProgressThreshold`, `.wanderingThreshold`, `.wanderingEscalation`, `.breakerVetoStreak`, `.proneTools`.
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -313,6 +313,15 @@ const EMPTY_STRING_RECORD: Record<string, string> = {};
 const EMPTY_NUMBER_RECORD: Record<string, number> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const DEFAULT_TOOL_CALL_LOOP_EXEMPT_TOOLS: string[] = ["hub"];
+const DEFAULT_TOOL_CALL_LOOP_PRONE_TOOLS: string[] = [
+	"web.fetch",
+	"fetch",
+	"http.request",
+	"browser",
+	"browser.click",
+	"browser.navigate",
+	"browser.type",
+];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
@@ -1174,6 +1183,66 @@ export const SETTINGS_SCHEMA = {
 			group: "Thinking",
 			label: "Tool-Call Loop Exempt Tools",
 			description: "Tool names that may repeat consecutively without triggering the cross-turn loop guard",
+		},
+	},
+
+	"model.toolCallLoopGuard.noProgressThreshold": {
+		type: "number",
+		default: 5,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call No-Progress Threshold",
+			description:
+				"Consecutive identical tool calls (same args AND same result) before the guard vetoes the next call before it runs. 0 disables the no-progress veto.",
+		},
+	},
+
+	"model.toolCallLoopGuard.wanderingThreshold": {
+		type: "number",
+		default: 6,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Wandering Threshold",
+			description:
+				"Distinct argument sets on a prone tool (web.fetch, http.request, browser.*) before the guard warns about wandering. 0 disables.",
+		},
+	},
+
+	"model.toolCallLoopGuard.wanderingEscalation": {
+		type: "number",
+		default: 12,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Wandering Escalation",
+			description:
+				"Distinct argument sets on a prone tool before the guard escalates wandering to a veto / breaker. Must be >= wanderingThreshold.",
+		},
+	},
+
+	"model.toolCallLoopGuard.breakerVetoStreak": {
+		type: "number",
+		default: 3,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Breaker Veto Streak",
+			description:
+				"Consecutive no-progress vetoes before the breaker ends the turn gracefully (session stays pending, no hard failure).",
+		},
+	},
+
+	"model.toolCallLoopGuard.proneTools": {
+		type: "array",
+		default: DEFAULT_TOOL_CALL_LOOP_PRONE_TOOLS,
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "Tool-Call Wandering-Prone Tools",
+			description:
+				"Tool names where many distinct argument sets indicate wandering (probing) rather than legitimate bulk work.",
 		},
 	},
 

--- a/packages/coding-agent/src/prompts/system/tool-call-wandering-redirect.md
+++ b/packages/coding-agent/src/prompts/system/tool-call-wandering-redirect.md
@@ -1,0 +1,8 @@
+<system-interrupt reason="tool_call_loop_detected">
+You called `{{tool_name}}` with {{spread}} distinct argument sets without converging on an answer:
+`{{arguments_summary}}`
+
+This looks like wandering — probing many different inputs hoping one works, rather than making targeted progress.
+
+NEVER call `{{tool_name}}` again this turn. Instead: run a web search to find the correct input, ask the user for the target, or summarize what you found and yield if complete.
+</system-interrupt>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -35,6 +35,8 @@ import {
 	type AgentTurnEndContext,
 	AppendOnlyContextManager,
 	type AsideMessage,
+	type BeforeToolCallContext,
+	type BeforeToolCallResult,
 	resolveTelemetry,
 	type StreamFn,
 	TERMINAL_TOOL_RESULT_ABORT_REASON,
@@ -1175,6 +1177,9 @@ export class AgentSession {
 		});
 		// Tool-result hook owns synchronous post-tool actions that must affect the current loop.
 		this.agent.afterToolCall = ctx => this.#afterToolCall(ctx);
+		// Pre-call hook owns the loop-guard veto gate (blocks no-progress / wandering
+		// calls before they execute) and must run before any tool dispatch.
+		this.agent.beforeToolCall = (ctx, signal) => this.#beforeToolCall(ctx, signal);
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#syncAgentSessionId();
 		this.#todo.syncFromBranch();
@@ -2945,7 +2950,23 @@ export class AgentSession {
 		}
 	}
 
+	#beforeToolCall(ctx: BeforeToolCallContext, signal?: AbortSignal): BeforeToolCallResult | undefined {
+		// The loop-guard veto gate runs first — if it blocks, the tool never executes.
+		const loopResult = this.#loopGuards.beforeToolCall(ctx, signal);
+		if (loopResult?.block) return loopResult;
+		return undefined;
+	}
+
 	#afterToolCall(ctx: AfterToolCallContext): AfterToolCallResult | undefined {
+		// Run TTSR first — it may prepend a reminder to the result content that
+		// the model sees. The loop guard must hash the TTSR-transformed result,
+		// not the raw one, so two calls with the same raw output but different
+		// TTSR rules don't falsely match (or vice versa).
+		const ttsrResult = this.#ttsr.afterToolCall(ctx);
+		const effectiveCtx =
+			ttsrResult?.content !== undefined ? { ...ctx, result: { ...ctx.result, content: ttsrResult.content } } : ctx;
+		// Feed the effective (TTSR-transformed) outcome into the loop-guard tracker.
+		this.#loopGuards.afterToolCall(effectiveCtx);
 		if (
 			this.#isTerminalYieldToolResult({
 				toolName: ctx.toolCall.name,
@@ -2956,8 +2977,13 @@ export class AgentSession {
 			this.#markTerminalYieldToolCall(ctx.toolCall.id);
 			this.#synchronouslyTerminatedYieldToolCallIds.add(ctx.toolCall.id);
 			this.agent.abort(TERMINAL_TOOL_RESULT_ABORT_REASON);
+			// Terminal yields abort the turn, which skips onTurnEnd → recordTurn.
+			// Without resetting here, identical terminal yields across separate
+			// prompts accumulate a no-progress streak that would eventually
+			// veto the next yield and block task completion.
+			this.#loopGuards.resetStreaks();
 		}
-		return this.#ttsr.afterToolCall(ctx);
+		return ttsrResult;
 	}
 
 	/** Find the last assistant message in agent state (including aborted ones) */

--- a/packages/coding-agent/src/session/stream-guards.ts
+++ b/packages/coding-agent/src/session/stream-guards.ts
@@ -1,14 +1,29 @@
 import * as fs from "node:fs";
-import type { Agent, AgentEvent, AgentMessage, AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
+import type {
+	AfterToolCallContext,
+	AfterToolCallResult,
+	Agent,
+	AgentEvent,
+	AgentMessage,
+	AgentTurnEndContext,
+	BeforeToolCallContext,
+	BeforeToolCallResult,
+} from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, AssistantMessageEvent, Model, ToolCall } from "@oh-my-pi/pi-ai";
 import { GeminiHeaderRunDetector, isGeminiThinkingModel } from "@oh-my-pi/pi-ai/utils/thinking-loop";
-import { type RepeatedToolCallDetection, ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import {
+	type RepeatedToolCallDetection,
+	type ToolCallLoopDetection,
+	ToolCallLoopGuard,
+	type WanderingToolCallDetection,
+} from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
 import { isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import { normalizeDiff, normalizeToLF, ParseError, previewPatch, stripBom } from "../edit";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import geminiToolReminderTemplate from "../prompts/system/gemini-tool-call-reminder.md" with { type: "text" };
 import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redirect.md" with { type: "text" };
+import toolCallWanderingRedirectTemplate from "../prompts/system/tool-call-wandering-redirect.md" with { type: "text" };
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import { isInternalUrlPath, normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
@@ -19,6 +34,8 @@ import type { SessionManager } from "./session-manager";
 const GEMINI_HEADER_INTERRUPT_REASON = "Interrupted: emit a tool call instead of more planning";
 const GEMINI_TOOL_REMINDER_TYPE = "gemini-tool-call-reminder";
 const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
+const TOOL_CALL_WANDERING_REDIRECT_TYPE = "tool-call-wandering-redirect";
+const TOOL_CALL_LOOP_BREAKER_REASON = "tool-call loop breaker: ended turn gracefully";
 
 /** Capabilities borrowed by the session's streaming and loop guards. */
 export interface StreamGuardsHost {
@@ -267,25 +284,171 @@ export class StreamingEditGuard {
 	}
 }
 
-/** Detects cross-turn tool loops and Gemini reasoning-header runaways. */
+/**
+ * Detects cross-turn tool loops and Gemini reasoning-header runaways.
+ *
+ * Wires three atomic-agent loop-detection layers to the agent's
+ * `beforeToolCall` / `afterToolCall` hooks:
+ *
+ * - **Pre-call veto** (`beforeToolCall`): consults `guard.check()` before a tool
+ *   runs. `critical` returns `{ block: true }` so the tool never executes and
+ *   the runtime emits a synthetic error result. `breaker` aborts the turn
+ *   gracefully (session stays pending).
+ * - **Outcome recording** (`afterToolCall`): feeds the executed result into the
+ *   tracker so the no-progress streak (args + result hash) advances.
+ * - **Post-turn redirect** (`recordTurn`): emits the advisory
+ *   `repeated_tool_call` / `wandering_tool_call` redirect into the next prompt.
+ */
 export class LoopGuards {
 	readonly #host: StreamGuardsHost;
 	#geminiHeaderDetector: GeminiHeaderRunDetector | undefined;
 	#toolCallLoopGuard: ToolCallLoopGuard | undefined;
 	#toolCallLoopGuardSettingsKey: string | undefined;
+	/**
+	 * Tool-call IDs vetoed by `beforeToolCall` this turn. `afterToolCall` checks
+	 * membership to skip recording a real outcome (the veto path already recorded
+	 * `{ vetoed: true }`), avoiding double-counting. Deterministic — no
+	 * string-matching on result content. Cleared in `recordTurn`.
+	 */
+	#vetoedCallIds = new Set<string>();
+	/** Set when resetStreaks() fires during an abort. afterToolCall checks
+	 * this to skip recording outcomes from siblings that complete after the
+	 * abort — they can't repopulate the just-cleared streak. Cleared at the
+	 * next turn boundary (recordTurn / resetForTurn). */
+	#resetPending = false;
 
 	constructor(host: StreamGuardsHost) {
 		this.#host = host;
 	}
 
+	/**
+	 * Pre-call veto gate. Called from `Agent.beforeToolCall` before each tool
+	 * executes. Returns `{ block: true, reason }` on `critical` to prevent the
+	 * call from running (the loop emits a synthetic error result). Returns
+	 * normally on `breaker` after aborting the turn — the caller still sees
+	 * `block: false` because the abort path handles result emission.
+	 */
+	beforeToolCall(ctx: BeforeToolCallContext, _signal?: AbortSignal): BeforeToolCallResult | undefined {
+		const guard = this.#activeToolCallLoopGuard();
+		if (!guard) return undefined;
+
+		const verdict = guard.check({ toolName: ctx.toolCall.name, args: ctx.args });
+		if (verdict.kind === "allow") {
+			guard.recordCall(ctx.toolCall.name, ctx.args, ctx.toolCall.id);
+			return undefined;
+		}
+
+		// All non-allow verdicts still record the call so a later sibling in the
+		// same batch observes it (and so recordOutcome can pair with the record).
+		// EXCEPT the breaker — check() just deleted the tool's wandering set to
+		// give a fresh start, and recordCall would immediately recreate it.
+		if (verdict.kind !== "breaker") {
+			guard.recordCall(ctx.toolCall.name, ctx.args, ctx.toolCall.id);
+		}
+
+		if (verdict.kind === "breaker") {
+			logger.warn("tool-call loop breaker fired; ending turn gracefully", { reason: verdict.reason });
+			this.#host.emitNotice("warning", verdict.reason, "loop-guard");
+			// Record a vetoed outcome so the streak isn't inflated.
+			guard.recordOutcome(ctx.toolCall.name, ctx.args, { vetoed: true, toolCallId: ctx.toolCall.id });
+			// Abort the turn — the agent-loop synthesizes a graceful end.
+			this.#host.agent.abort(TOOL_CALL_LOOP_BREAKER_REASON);
+			// The abort skips onTurnEnd → recordTurn, so reset streak state
+			// here to prevent leaking no-progress/veto counters to the next
+			// prompt — same class as the terminal-yield abort path.
+			guard.resetStreaks();
+			return undefined;
+		}
+
+		if (verdict.kind === "critical") {
+			logger.warn("tool-call loop veto (critical)", {
+				toolName: verdict.toolName,
+				count: verdict.count,
+				source: verdict.source,
+			});
+			// Record a vetoed outcome so the no-progress streak isn't inflated.
+			guard.recordOutcome(ctx.toolCall.name, ctx.args, { vetoed: true, toolCallId: ctx.toolCall.id });
+			// Track the vetoed call ID so afterToolCall skips recording a real
+			// outcome (the tool never ran — the block threw ToolCallBlockedError).
+			this.#vetoedCallIds.add(ctx.toolCall.id);
+			const reason =
+				verdict.source === "wandering"
+					? `tool-call loop guard: ${verdict.toolName} probed ${verdict.count} distinct argument sets without converging. Run a web search, ask the user, or summarize and yield.`
+					: `tool-call loop guard: ${verdict.toolName} has made no progress ${verdict.count} consecutive times. Change arguments, switch tools, or summarize and yield.`;
+			return { block: true, reason };
+		}
+
+		if (verdict.kind === "wandering") {
+			logger.warn("tool-call wandering detected", {
+				toolName: verdict.toolName,
+				spread: verdict.spread,
+			});
+			// Wandering is advisory — let the call run, but the model will see a
+			// redirect next turn via recordTurn if it crosses the threshold.
+			return undefined;
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Post-call outcome recorder. Called from `Agent.afterToolCall` after each
+	 * tool finishes. Feeds the result into the no-progress tracker. Skips
+	 * vetoed calls (tracked via `#vetoedCallIds`) since the veto path already
+	 * recorded `{ vetoed: true }`.
+	 */
+	afterToolCall(ctx: AfterToolCallContext, _signal?: AbortSignal): AfterToolCallResult | undefined {
+		const guard = this.#activeToolCallLoopGuard();
+		if (!guard) return undefined;
+		// If beforeToolCall vetoed (block), the tool didn't run — don't record a
+		// real outcome. The veto path already recorded { vetoed: true }.
+		if (this.#vetoedCallIds.has(ctx.toolCall.id)) {
+			this.#vetoedCallIds.delete(ctx.toolCall.id);
+			return undefined;
+		}
+		// Skip recording outcomes from siblings that complete after an abort
+		// triggered resetStreaks() — they would repopulate the just-cleared
+		// streak, and since onTurnEnd is skipped, the stale outcome would
+		// carry into the next prompt.
+		if (this.#resetPending) return undefined;
+		guard.recordOutcome(ctx.toolCall.name, ctx.args, {
+			result: { content: ctx.result.content, details: ctx.result.details, isError: ctx.isError },
+			toolCallId: ctx.toolCall.id,
+		});
+		return undefined;
+	}
+
+	/**
+	 * Resets no-progress streak state without touching wandering hashes.
+	 * Called when a turn ends abnormally (terminal yield abort) where
+	 * `recordTurn` won't run to clear the streak.
+	 */
+	resetStreaks(): void {
+		this.#activeToolCallLoopGuard()?.resetStreaks();
+		this.#resetPending = true;
+	}
+
 	/** Records a completed turn and injects a redirect when calls repeat. */
 	recordTurn(messages: AgentMessage[], context: AgentTurnEndContext | undefined): void {
-		if (context?.message.role !== "assistant") return;
-		const detection = this.#activeToolCallLoopGuard()?.recordTurn({
+		// Reset turn-scoped flags for the next turn.
+		this.#vetoedCallIds.clear();
+		this.#resetPending = false;
+		const guard = this.#activeToolCallLoopGuard();
+
+		if (context?.message.role !== "assistant") {
+			// Still reset wandering/live-tracking state for the next turn.
+			if (guard) guard.resetForTurn();
+			this.#resetPending = false;
+			return;
+		}
+		// recordTurn reads #liveTrackingActive to decide whether to re-increment
+		// counters — so resetForTurn (which clears it) MUST run AFTER, not before.
+		const detection = guard?.recordTurn({
 			message: context.message,
 			toolResults: context.toolResults,
 		});
-		if (detection) this.#injectToolCallLoopRedirect(messages, detection);
+		if (guard) guard.resetForTurn();
+		if (detection) this.#injectLoopRedirect(messages, detection);
 	}
 
 	/** Feeds a streamed assistant event to the Gemini header-runaway detector. */
@@ -313,15 +476,38 @@ export class LoopGuards {
 		const exemptTools = this.#host.settings
 			.get("model.toolCallLoopGuard.exemptTools")
 			.filter((tool): tool is string => typeof tool === "string" && tool.length > 0);
-		const settingsKey = `${threshold}:${JSON.stringify(exemptTools)}`;
+		const noProgressThreshold = this.#host.settings.get("model.toolCallLoopGuard.noProgressThreshold");
+		const wanderingThreshold = this.#host.settings.get("model.toolCallLoopGuard.wanderingThreshold");
+		const wanderingEscalation = this.#host.settings.get("model.toolCallLoopGuard.wanderingEscalation");
+		const breakerVetoStreak = this.#host.settings.get("model.toolCallLoopGuard.breakerVetoStreak");
+		const proneTools = this.#host.settings
+			.get("model.toolCallLoopGuard.proneTools")
+			.filter((tool): tool is string => typeof tool === "string" && tool.length > 0);
+		const settingsKey = `${threshold}:${JSON.stringify(exemptTools)}:${noProgressThreshold}:${wanderingThreshold}:${wanderingEscalation}:${breakerVetoStreak}:${JSON.stringify(proneTools)}`;
 		if (!this.#toolCallLoopGuard || this.#toolCallLoopGuardSettingsKey !== settingsKey) {
-			this.#toolCallLoopGuard = new ToolCallLoopGuard({ threshold, exemptTools });
+			this.#toolCallLoopGuard = new ToolCallLoopGuard({
+				threshold,
+				exemptTools,
+				noProgressThreshold,
+				wanderingThreshold,
+				wanderingEscalation,
+				breakerVetoStreak,
+				proneTools,
+			});
 			this.#toolCallLoopGuardSettingsKey = settingsKey;
 		}
 		return this.#toolCallLoopGuard;
 	}
 
-	#injectToolCallLoopRedirect(messages: AgentMessage[], detection: RepeatedToolCallDetection): void {
+	#injectLoopRedirect(messages: AgentMessage[], detection: ToolCallLoopDetection): void {
+		if (detection.kind === "repeated_tool_call") {
+			this.#injectRepeatedRedirect(messages, detection);
+			return;
+		}
+		this.#injectWanderingRedirect(messages, detection);
+	}
+
+	#injectRepeatedRedirect(messages: AgentMessage[], detection: RepeatedToolCallDetection): void {
 		const content = prompt.render(toolCallLoopRedirectTemplate, {
 			tool_name: detection.toolName,
 			count: detection.count,
@@ -348,6 +534,41 @@ export class LoopGuards {
 		if (this.#host.agent.state.messages !== messages) this.#host.agent.appendMessage(redirectMessage);
 		this.#host.sessionManager.appendCustomMessageEntry(
 			TOOL_CALL_LOOP_REDIRECT_TYPE,
+			content,
+			false,
+			details,
+			"agent",
+		);
+	}
+
+	#injectWanderingRedirect(messages: AgentMessage[], detection: WanderingToolCallDetection): void {
+		const content = prompt.render(toolCallWanderingRedirectTemplate, {
+			tool_name: detection.toolName,
+			spread: detection.spread,
+			arguments_summary: detection.argumentsSummary,
+		});
+		const details = {
+			toolName: detection.toolName,
+			spread: detection.spread,
+			argumentsSummary: detection.argumentsSummary,
+		};
+		logger.warn("cross-turn tool-call wandering detected", {
+			toolName: detection.toolName,
+			spread: detection.spread,
+		});
+		const redirectMessage: CustomMessage = {
+			role: "custom",
+			customType: TOOL_CALL_WANDERING_REDIRECT_TYPE,
+			content,
+			display: false,
+			details,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		messages.push(redirectMessage);
+		if (this.#host.agent.state.messages !== messages) this.#host.agent.appendMessage(redirectMessage);
+		this.#host.sessionManager.appendCustomMessageEntry(
+			TOOL_CALL_WANDERING_REDIRECT_TYPE,
 			content,
 			false,
 			details,

--- a/packages/coding-agent/test/agent-session-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-call-loop-guard.test.ts
@@ -94,6 +94,8 @@ describe("AgentSession tool-call loop guard", () => {
 			"todo.enabled": false,
 			"model.toolCallLoopGuard.enabled": true,
 			"model.toolCallLoopGuard.threshold": 5,
+			"model.toolCallLoopGuard.noProgressThreshold": 0,
+			"model.toolCallLoopGuard.wanderingThreshold": 0,
 			"model.toolCallLoopGuard.exemptTools": ["hub"],
 		});
 		settings.setModelRole("default", `${model.provider}/${model.id}`);
@@ -117,5 +119,96 @@ describe("AgentSession tool-call loop guard", () => {
 		);
 		expect(redirects).toHaveLength(1);
 		expect(redirects[0]!.display).toBe(false);
+	});
+
+	it("blocks a stuck tool call via beforeToolCall veto when no-progress threshold is hit", async () => {
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+		let executeCount = 0;
+		const bashTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "Mock bash tool",
+			parameters: type({ "command?": "string" }),
+			execute: async () => {
+				executeCount++;
+				return { content: [{ type: "text" as const, text: "same output" }] };
+			},
+		};
+		let callCount = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [bashTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const toolCallTurn = callCount < 8;
+				const toolCallId = `tc-${callCount}`;
+				callCount++;
+				const message: AssistantMessage = toolCallTurn
+					? {
+							role: "assistant",
+							content: [
+								{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "echo stuck" } },
+							],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						}
+					: {
+							role: "assistant",
+							content: [{ type: "text", text: "Done." }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "stop",
+							timestamp: Date.now(),
+						};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: toolCallTurn ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"todo.enabled": false,
+			"model.toolCallLoopGuard.enabled": true,
+			"model.toolCallLoopGuard.threshold": 99,
+			"model.toolCallLoopGuard.noProgressThreshold": 3,
+			"model.toolCallLoopGuard.wanderingThreshold": 0,
+			"model.toolCallLoopGuard.exemptTools": ["hub"],
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[bashTool.name, bashTool]]),
+		});
+
+		await session.prompt("run checks");
+		await session.waitForIdle();
+
+		// With noProgressThreshold=3 (default breakerVetoStreak=3):
+		//   Turns 0-2: bash executes (executeCount=3), builds the no-progress streak.
+		//   Turn 3: veto (critical, consecutiveVetoes=1) — tool never runs.
+		//   Turn 4: veto (critical, consecutiveVetoes=2) — tool never runs.
+		//   Turn 5: veto (breaker, consecutiveVetoes=3) — agent.abort() ends the turn.
+		// The breaker force-aborts before the mock's full 8 tool-call turns run.
+		expect(executeCount).toBe(3);
+		expect(callCount).toBeLessThan(8);
+		// At least one tool result should contain the veto reason.
+		const messages = JSON.stringify(session.agent.state.messages);
+		expect(messages).toContain("tool-call loop guard");
+		expect(messages).toContain("loop breaker");
 	});
 });


### PR DESCRIPTION
## What

Adds a pre-call veto gate, no-progress streak detection, volatile-field stripping, a wandering detector, and a breaker to oh-my-pi's `ToolCallLoopGuard`. The existing advisory-only guard (identical args → redirect next turn) is preserved as layer 1.

## Why

oh-my-pi's existing loop guard was advisory-only and ran *after* the stuck tool already executed — a stuck agent calling `web.fetch` against a dead endpoint, or `browser.click` on a non-resolving selector, burned a full tool call + tokens on every iteration before any notice fired. Worse, distinct args reset the counter (the inverse of catching wandering), and per-call timestamps in results meant even a result-aware hash would never match.

## What changed

### Guard core (`packages/ai/src/utils/tool-call-loop-guard.ts`)

- **No-progress streak** — detects identical args AND identical result across consecutive turns (the old guard only checked args). When the streak crosses `noProgressThreshold` (default 5), the new `check()` method returns a `critical` veto.
- **Pre-call veto gate** — `check()` runs BEFORE the tool executes, returning `{ block: true }` so the stuck tool never runs and never burns tokens.
- **Volatile-field stripping** — strips `timestamp`, `requestId`, `durationMs`, etc. from result details before hashing, so per-call timings don't defeat the no-progress hash.
- **Image content in hash** — image blocks (MIME type + data digest) are included in the result hash, so changing screenshots with same args don't trigger a false no-progress veto.
- **Wandering detector** — for prone tools (`web.fetch`, `http.request`, `browser.*`), counts distinct argument sets. Warns at `wanderingThreshold` (6); escalates to a veto at `wanderingEscalation` (12). Bulk reads over distinct files are deliberately not prone. Wandering hashes persist across turns (bounded) so the detector can accumulate spread.
- **Breaker** — consecutive critical vetoes ≥ `breakerVetoStreak` (3) end the turn gracefully. Session stays pending; no hard failure. The breaker flag clears at the start of each `beforeToolCall` (abort may skip `onTurnEnd` where it was previously cleared).
- **Dual-path invariant** — a `#liveTrackingActive` flag prevents double-counting when both the live path (`check()`/`recordCall()`/`recordOutcome()`) and the post-turn path (`recordTurn()`) fire for the same call.

### Wiring (`packages/coding-agent/src/session/stream-guards.ts`, `agent-session.ts`)

- Wired `beforeToolCall` → `guard.check()` for the pre-call veto.
- Wired `afterToolCall` → `guard.recordOutcome()` to feed results into the tracker.
- `#vetoedCallIds` Set tracks vetoed calls deterministically (no string-matching on result content).
- Breaker aborts the turn via `agent.abort()`.
- Fixed turn-ordering: `resetForTurn()` runs AFTER `recordTurn()` (not before) so `#liveTrackingActive` is still set when `recordTurn` reads it.

### Settings (`settings-schema.ts`)

5 new configurable thresholds: `noProgressThreshold`, `wanderingThreshold`, `wanderingEscalation`, `breakerVetoStreak`, `proneTools`.

### Prompt

New `tool-call-wandering-redirect.md` template steers the model toward web search or yielding when wandering is detected.

## Tests

- 10 new tests in `packages/ai/test/tool-call-loop-guard.test.ts` covering: no-progress veto, streak-breaking on result change, breaker escalation, volatile-field stripping, wandering warn, non-prone bulk reads, dual-path no-double-count, image-content hash (different screenshots break streak, identical images trigger veto), and cross-turn wandering accumulation.
- Existing session test updated to disable the new veto layers (keeps it focused on the advisory redirect).
- All 15 guard tests + 1 session test pass.
- `bun check` clean (no new type errors).

## Back-compat

The existing advisory redirect (layer 1) is unchanged. The new layers default to enabled but can be disabled by setting `noProgressThreshold: 0` and `wanderingThreshold: 0`. The `recordTurn` standalone path (used by tests) still works without the live hooks.