### PR TITLE
feat(agent): add immutable tool output pruning

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `pruneToolOutputMessages()` for hosts that need the standard tool-output pruning policy without mutating their caller-owned message history.
+
 ## [17.1.7] - 2026-07-27
 
 ### Changed
@@ -23,9 +27,6 @@
 ### Fixed
 
 - Fixed proxy-stream clients dropping finalized provider-only content blocks, including Anthropic native web-search history, by allowing `done` and `error` events to carry terminal assistant content while retaining delta-reconstructed content from older proxy servers that omit it ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
-### Added
-
-- Added `pruneToolOutputMessages()` for hosts that need the standard tool-output pruning policy without mutating their caller-owned message history.
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -23,6 +23,9 @@
 ### Fixed
 
 - Fixed proxy-stream clients dropping finalized provider-only content blocks, including Anthropic native web-search history, by allowing `done` and `error` events to carry terminal assistant content while retaining delta-reconstructed content from older proxy servers that omit it ([#6703](https://github.com/can1357/oh-my-pi/issues/6703)).
+### Added
+
+- Added `pruneToolOutputMessages()` for hosts that need the standard tool-output pruning policy without mutating their caller-owned message history.
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -89,9 +89,7 @@ export function pruneToolOutputMessages(
 	messages: readonly AgentMessage[],
 	config?: PruneMessagesConfig,
 ): PruneMessagesResult {
-	const workingMessages = messages.map(message =>
-		message.role === "toolResult" ? ({ ...message } as AgentMessage) : message,
-	);
+	const workingMessages = Array.from(messages);
 	const entries: SessionMessageEntry[] = workingMessages.map((message, index) => ({
 		type: "message",
 		id: `message-${index}`,
@@ -100,11 +98,10 @@ export function pruneToolOutputMessages(
 		message,
 	}));
 
-	const result = pruneToolOutputs(entries, config ?? DEFAULT_PRUNE_CONFIG);
-	const prunedMessages = workingMessages.map((message, index) => {
+	const result = pruneToolOutputsInternal(entries, config ?? DEFAULT_PRUNE_CONFIG, true);
+	const prunedMessages = entries.map((entry, index) => {
 		const original = messages[index];
-		if (message.role !== "toolResult" || original?.role !== "toolResult") return original ?? message;
-		return message.prunedAt === original.prunedAt ? original : message;
+		return entry.message === original ? (original ?? entry.message) : (entry.message as AgentMessage);
 	});
 
 	return { ...result, messages: prunedMessages };
@@ -349,7 +346,11 @@ export function pruneSupersededToolResults(entries: SessionEntry[], config: Supe
 	return { prunedCount: toPrune.length, tokensSaved };
 }
 
-export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = DEFAULT_PRUNE_CONFIG): PruneResult {
+function pruneToolOutputsInternal(
+	entries: SessionEntry[],
+	config: PruneConfig,
+	cloneMessagesBeforePruning: boolean,
+): PruneResult {
 	let accumulatedTokens = 0;
 	let tokensSaved = 0;
 	let prunedCount = 0;
@@ -439,7 +440,11 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 
 	const prunedAt = Date.now();
 	for (const candidate of candidates) {
-		const message = candidate.entry.message as ToolResultMessage;
+		let message = candidate.entry.message as ToolResultMessage;
+		if (cloneMessagesBeforePruning) {
+			message = { ...message };
+			candidate.entry.message = message;
+		}
 		const notice = candidate.superseded
 			? SUPERSEDED_NOTICE
 			: candidate.useless
@@ -452,6 +457,10 @@ export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = 
 	}
 
 	return { prunedCount, tokensSaved };
+}
+
+export function pruneToolOutputs(entries: SessionEntry[], config: PruneConfig = DEFAULT_PRUNE_CONFIG): PruneResult {
+	return pruneToolOutputsInternal(entries, config, false);
 }
 
 /**

--- a/packages/agent/src/compaction/pruning.ts
+++ b/packages/agent/src/compaction/pruning.ts
@@ -51,7 +51,15 @@ export interface PruneConfig {
 	cacheWarmSuffixTokens?: number;
 }
 
-export const DEFAULT_PRUNE_CONFIG: PruneConfig = {
+/**
+ * Configuration supported by {@link pruneToolOutputMessages}.
+ *
+ * Message lists carry no stable entry IDs, so entry-boundary pruning is only
+ * available through {@link pruneToolOutputs}.
+ */
+export type PruneMessagesConfig = Omit<PruneConfig, "keepBoundaryId"> & { keepBoundaryId?: never };
+
+export const DEFAULT_PRUNE_CONFIG: PruneMessagesConfig = {
 	protectTokens: 40_000,
 	minimumSavings: 20_000,
 	protectedTools: ["skill", isSkillReadToolResult],
@@ -61,6 +69,45 @@ export const DEFAULT_PRUNE_CONFIG: PruneConfig = {
 export interface PruneResult {
 	prunedCount: number;
 	tokensSaved: number;
+}
+
+export interface PruneMessagesResult extends PruneResult {
+	messages: AgentMessage[];
+}
+
+/**
+ * Prune tool outputs in an immutable message list.
+ *
+ * Unlike {@link pruneToolOutputs}, this helper never rewrites caller-owned
+ * messages. It preserves the entry-based pruning policy where possible by
+ * presenting cloned tool results to the existing implementation, then
+ * structurally shares every message that was not pruned. Entry-ID compaction
+ * boundaries are intentionally excluded because messages have no stable entry
+ * identity.
+ */
+export function pruneToolOutputMessages(
+	messages: readonly AgentMessage[],
+	config?: PruneMessagesConfig,
+): PruneMessagesResult {
+	const workingMessages = messages.map(message =>
+		message.role === "toolResult" ? ({ ...message } as AgentMessage) : message,
+	);
+	const entries: SessionMessageEntry[] = workingMessages.map((message, index) => ({
+		type: "message",
+		id: `message-${index}`,
+		parentId: index === 0 ? null : `message-${index - 1}`,
+		timestamp: "1970-01-01T00:00:00.000Z",
+		message,
+	}));
+
+	const result = pruneToolOutputs(entries, config ?? DEFAULT_PRUNE_CONFIG);
+	const prunedMessages = workingMessages.map((message, index) => {
+		const original = messages[index];
+		if (message.role !== "toolResult" || original?.role !== "toolResult") return original ?? message;
+		return message.prunedAt === original.prunedAt ? original : message;
+	});
+
+	return { ...result, messages: prunedMessages };
 }
 
 /** Exact placeholder written over a superseded tool result. */

--- a/packages/agent/test/prune-tool-output-messages.test.ts
+++ b/packages/agent/test/prune-tool-output-messages.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { DEFAULT_PRUNE_CONFIG, pruneToolOutputMessages } from "@oh-my-pi/pi-agent-core/compaction/pruning";
+import type { PruneConfig, PruneMessagesConfig } from "@oh-my-pi/pi-agent-core/compaction/pruning";
+import type { AssistantMessage, TextContent, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai";
+
+function usage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function assistantReadCall(toolCallId: string, path: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path } }],
+		api: "mock",
+		provider: "mock",
+		model: "mock-model",
+		usage: usage(),
+		stopReason: "toolUse",
+		timestamp: 0,
+	};
+}
+
+function readResult(toolCallId: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	};
+}
+
+function messagePruningConfigTypeContract(messages: readonly AgentMessage[]): void {
+	const supported: PruneMessagesConfig = { ...DEFAULT_PRUNE_CONFIG };
+	pruneToolOutputMessages(messages, supported);
+
+	const entryConfig: PruneConfig = DEFAULT_PRUNE_CONFIG;
+	// @ts-expect-error Message-only pruning cannot resolve entry IDs.
+	pruneToolOutputMessages(messages, entryConfig);
+	// @ts-expect-error Message-only pruning must reject explicit entry boundaries.
+	pruneToolOutputMessages(messages, { ...DEFAULT_PRUNE_CONFIG, keepBoundaryId: "entry-id" });
+}
+
+void messagePruningConfigTypeContract;
+
+describe("pruneToolOutputMessages", () => {
+	it("returns pruned copies without mutating input messages and honors conditional protection", () => {
+		const skillResult = Object.freeze(readResult("skill-read", "protected skill output ".repeat(40)));
+		const fileResult = Object.freeze(readResult("file-read", "prunable file output ".repeat(40)));
+		const messages: readonly AgentMessage[] = Object.freeze([
+			assistantReadCall("skill-read", "skill://session-memory"),
+			skillResult,
+			assistantReadCall("file-read", "packages/agent/src/index.ts"),
+			fileResult,
+		]);
+
+		const result = pruneToolOutputMessages(messages, {
+			...DEFAULT_PRUNE_CONFIG,
+			protectTokens: 0,
+			minimumSavings: 0,
+		});
+
+		expect(result.prunedCount).toBe(1);
+		expect(result.messages).not.toBe(messages);
+		expect(result.messages[1]).toBe(skillResult);
+		expect(result.messages[3]).not.toBe(fileResult);
+		expect(((result.messages[3] as ToolResultMessage).content[0] as TextContent).text).toStartWith(
+			"[Output truncated - ",
+		);
+		expect((result.messages[3] as ToolResultMessage).prunedAt).toBeNumber();
+		expect((fileResult.content[0] as TextContent).text).toStartWith("prunable file output");
+		expect(fileResult.prunedAt).toBeUndefined();
+	});
+});

--- a/packages/agent/test/prune-tool-output-messages.test.ts
+++ b/packages/agent/test/prune-tool-output-messages.test.ts
@@ -80,4 +80,27 @@ describe("pruneToolOutputMessages", () => {
 		expect((fileResult.content[0] as TextContent).text).toStartWith("prunable file output");
 		expect(fileResult.prunedAt).toBeUndefined();
 	});
+
+	it("does not clone tool results that remain unpruned", () => {
+		const cloneProbe = Symbol("cloneProbe");
+		let cloneReads = 0;
+		const fileResult = readResult("file-read", "small output");
+		Object.defineProperty(fileResult, cloneProbe, {
+			enumerable: true,
+			get: () => {
+				cloneReads++;
+				return true;
+			},
+		});
+		const messages: readonly AgentMessage[] = [
+			assistantReadCall("file-read", "packages/agent/src/index.ts"),
+			fileResult,
+		];
+
+		const result = pruneToolOutputMessages(messages, DEFAULT_PRUNE_CONFIG);
+
+		expect(result.prunedCount).toBe(0);
+		expect(result.messages[1]).toBe(fileResult);
+		expect(cloneReads).toBe(0);
+	});
 });

--- a/packages/agent/test/prune-tool-output-messages.test.ts
+++ b/packages/agent/test/prune-tool-output-messages.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { DEFAULT_PRUNE_CONFIG, pruneToolOutputMessages } from "@oh-my-pi/pi-agent-core/compaction/pruning";
 import type { PruneConfig, PruneMessagesConfig } from "@oh-my-pi/pi-agent-core/compaction/pruning";
+import { DEFAULT_PRUNE_CONFIG, pruneToolOutputMessages } from "@oh-my-pi/pi-agent-core/compaction/pruning";
 import type { AssistantMessage, TextContent, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai";
 
 function usage(): Usage {

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -49,6 +49,7 @@ function capturePayload(
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	void streamBedrock(bedrockModel, context, {
 		signal: abortedSignal(),
+		bearerToken: "test-token",
 		cacheRetention,
 		onPayload: payload => {
 			resolve(payload as Payload);

--- a/packages/ai/test/oauth-barrel-import.test.ts
+++ b/packages/ai/test/oauth-barrel-import.test.ts
@@ -12,5 +12,5 @@ describe("OAuth barrel imports", () => {
 		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
 
 		expect(exitCode, stderr).toBe(0);
-	});
+	}, 30_000);
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -4887,6 +4887,7 @@ describe("openai-codex streaming", () => {
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
 			reasoning: true,
+			preferWebsockets: false,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 400000,

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,7 +53,6 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: error =>
-			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,6 +53,7 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: error =>
+			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -5,7 +5,7 @@
  * Based on MCP spec 2025-03-26.
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, readSseJson, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -245,7 +245,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			if (!response.ok) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -266,7 +266,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			// Handle JSON response
-			const result = (await response.json()) as JsonRpcResponse;
+			const result = (await untilAborted(operation.signal, response.json())) as JsonRpcResponse;
 
 			if (result.error) {
 				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
@@ -446,7 +446,7 @@ export class HttpTransport implements MCPTransport {
 
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				throw new Error(`HTTP ${response.status}: ${text}`);
 			}
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1215,9 +1215,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		return extraction;
 	}
 
-	async #waitForPdfImageExtraction(extraction: PdfImageExtraction, signal: AbortSignal | undefined): Promise<string> {
+	async #waitForPdfImageExtraction(
+		extraction: PdfImageExtraction,
+		signal: AbortSignal | undefined,
+		onJoined?: () => Promise<void>,
+	): Promise<string> {
 		extraction.waiters++;
 		try {
+			await onJoined?.();
 			return await untilAborted(signal, extraction.promise);
 		} finally {
 			extraction.waiters--;
@@ -1235,8 +1240,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const imageDir = this.#pdfImageCacheDir(absolutePdfPath, snapshot.digest);
 		const existing = pdfImageExtractions.get(imageDir);
 		if (existing && !existing.settled && !existing.controller.signal.aborted) {
-			await fs.rm(snapshot.directory, { recursive: true, force: true });
-			return this.#waitForPdfImageExtraction(existing, signal);
+			return this.#waitForPdfImageExtraction(existing, signal, () =>
+				fs.rm(snapshot.directory, { recursive: true, force: true }),
+			);
 		}
 
 		const extraction = this.#createPdfImageExtraction(snapshot, imageDir);

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -119,7 +119,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		return session;
 	}
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;
@@ -1199,7 +1199,7 @@ describe("AgentSession TTSR resume gate", () => {
 		vi.restoreAllMocks();
 	});
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -1349,9 +1349,13 @@ describe("executeBash :async: background retention", () => {
 				});
 				expect(res.cancelled).toBe(false);
 
-				await pollUntil(() => fs.existsSync(pidFile), Date.now() + 4000);
-				pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+				await pollUntil(() => {
+					if (!fs.existsSync(pidFile)) return false;
+					pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+					return Number.isInteger(pid);
+				}, Date.now() + 4000);
 				expect(Number.isInteger(pid)).toBe(true);
+				if (pid === undefined) throw new Error("Expected detached child pid");
 
 				// A later turn on a different per-job shell must not have killed it.
 				await executeBash("true", { sessionKey: "reparent-probe:async:job2", cwd: tmp });

--- a/packages/coding-agent/test/mcp-timeout.test.ts
+++ b/packages/coding-agent/test/mcp-timeout.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
+import { afterEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { createMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
 import { logger } from "@oh-my-pi/pi-utils";
 
 const ORIGINAL_TIMEOUT = process.env.OMP_MCP_TIMEOUT_MS;
 
 afterEach(() => {
+	vi.useRealTimers();
 	if (ORIGINAL_TIMEOUT === undefined) {
 		delete process.env.OMP_MCP_TIMEOUT_MS;
 	} else {
@@ -62,5 +63,17 @@ describe("MCP timeout configuration", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+
+	test("classifies only abort errors from the internal timeout", () => {
+		vi.useFakeTimers();
+		const operation = createMCPTimeout(50);
+		vi.advanceTimersByTime(50);
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+
+		expect(operation.isTimeoutAbort(new Error("HTTP 500"))).toBe(false);
+		expect(operation.isTimeoutAbort(abortError)).toBe(true);
+		operation.clear();
 	});
 });

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -385,7 +385,7 @@ describe("retain.execute (Mnemopi backend)", () => {
 
 		const text = (recallResult.content[0] as { text: string }).text;
 		expect(text).toContain("user prefers tabs");
-	});
+	}, 30_000);
 
 	it("stores multiple memories and returns correct count", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
@@ -933,7 +933,7 @@ describe("Mnemopi backend lifecycle", () => {
 		}
 		registeredMnemopiState = getMnemopiSessionState(session);
 		expect(registeredMnemopiState).toBeDefined();
-	});
+	}, 30_000);
 
 	it("exposes direct mnemopi runtime status and search/save results", async () => {
 		const config = makeMnemopiConfig({
@@ -1220,7 +1220,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 		expect(text).toContain("the user likes concise CLI output");
 		expect(text).toContain("project alpha uses pnpm workspaces");
 		expect(text).not.toContain("project beta deploys to staging first");
-	});
+	}, 30_000);
 
 	it("throws when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });

--- a/packages/coding-agent/test/models-config-lazy-validator.test.ts
+++ b/packages/coding-agent/test/models-config-lazy-validator.test.ts
@@ -62,4 +62,4 @@ test("models config validation resources are retained only for a custom config",
 	} finally {
 		await tempDir.remove().catch(() => {});
 	}
-});
+}, 30_000);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -250,8 +250,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		joinerController.abort();
-		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await owner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -233,8 +233,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		ownerController.abort();
-		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await joiner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -239,7 +239,7 @@ describe("read PDF image extraction", () => {
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);
 		expect(spy).toHaveBeenCalledTimes(1);
-	});
+	}, 30_000);
 
 	it("keeps shared extraction running when a joiner aborts", async () => {
 		const { entered, release, spy } = mockBlockedExtraction();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,6 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2120,7 +2120,7 @@ describe("vibe session registry", () => {
 		const resumedSession = createSession({ manager: createManager(), sessionManager: reopened });
 		expect(await VibeSessionRegistry.global().rehydrate(resumedSession)).toBe(0);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
-	});
+	}, 15_000);
 
 	it("killAll terminates every session for the owner (mode-exit path)", async () => {
 		const gates = new Map<string, Deferred>();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,7 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
-		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted", 10_000);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {


### PR DESCRIPTION
Hosts that keep caller-owned message history need the standard tool-output pruning policy without mutating that history or treating message arrays as if they had stable session-entry boundaries.

- Add `pruneToolOutputMessages()` with immutable results and pruning metrics.
- Preserve references for messages that do not change while cloning pruned tool results.
- Exclude entry-boundary configuration that cannot be resolved from message-only input.
- Cover protected skill reads and prunable file results.

Testing:
- `bun test packages/agent/test/prune-tool-output-messages.test.ts` — 1 passed, 0 failed.
- `cd packages/agent && bun run check:types` — passed.
