### PR TITLE
fix(tui): hide Markdown source delimiters

### DIFF
--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -49,6 +49,7 @@ function capturePayload(
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	void streamBedrock(bedrockModel, context, {
 		signal: abortedSignal(),
+		bearerToken: "test-token",
 		cacheRetention,
 		onPayload: payload => {
 			resolve(payload as Payload);

--- a/packages/ai/test/oauth-barrel-import.test.ts
+++ b/packages/ai/test/oauth-barrel-import.test.ts
@@ -12,5 +12,5 @@ describe("OAuth barrel imports", () => {
 		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
 
 		expect(exitCode, stderr).toBe(0);
-	});
+	}, 30_000);
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -4887,6 +4887,7 @@ describe("openai-codex streaming", () => {
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
 			reasoning: true,
+			preferWebsockets: false,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 400000,

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,7 +53,6 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: error =>
-			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,6 +53,7 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: error =>
+			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -5,7 +5,7 @@
  * Based on MCP spec 2025-03-26.
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, readSseJson, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -245,7 +245,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			if (!response.ok) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -266,7 +266,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			// Handle JSON response
-			const result = (await response.json()) as JsonRpcResponse;
+			const result = (await untilAborted(operation.signal, response.json())) as JsonRpcResponse;
 
 			if (result.error) {
 				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
@@ -446,7 +446,7 @@ export class HttpTransport implements MCPTransport {
 
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				throw new Error(`HTTP ${response.status}: ${text}`);
 			}
 

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2910,7 +2910,6 @@ export function getMarkdownTheme(): MarkdownTheme {
 		linkUrl: (text: string) => theme.fg("mdLinkUrl", text),
 		code: (text: string) => theme.fg("mdCode", text),
 		codeBlock: (text: string) => theme.fg("mdCodeBlock", text),
-		codeBlockBorder: (text: string) => theme.fg("mdCodeBlockBorder", text),
 		quote: (text: string) => theme.fg("mdQuote", text),
 		quoteBorder: (text: string) => theme.fg("mdQuoteBorder", text),
 		hr: (text: string) => theme.fg("mdHr", text),

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1215,9 +1215,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		return extraction;
 	}
 
-	async #waitForPdfImageExtraction(extraction: PdfImageExtraction, signal: AbortSignal | undefined): Promise<string> {
+	async #waitForPdfImageExtraction(
+		extraction: PdfImageExtraction,
+		signal: AbortSignal | undefined,
+		onJoined?: () => Promise<void>,
+	): Promise<string> {
 		extraction.waiters++;
 		try {
+			await onJoined?.();
 			return await untilAborted(signal, extraction.promise);
 		} finally {
 			extraction.waiters--;
@@ -1235,8 +1240,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const imageDir = this.#pdfImageCacheDir(absolutePdfPath, snapshot.digest);
 		const existing = pdfImageExtractions.get(imageDir);
 		if (existing && !existing.settled && !existing.controller.signal.aborted) {
-			await fs.rm(snapshot.directory, { recursive: true, force: true });
-			return this.#waitForPdfImageExtraction(existing, signal);
+			return this.#waitForPdfImageExtraction(existing, signal, () =>
+				fs.rm(snapshot.directory, { recursive: true, force: true }),
+			);
 		}
 
 		const extraction = this.#createPdfImageExtraction(snapshot, imageDir);

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -119,7 +119,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		return session;
 	}
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;
@@ -1199,7 +1199,7 @@ describe("AgentSession TTSR resume gate", () => {
 		vi.restoreAllMocks();
 	});
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -1349,9 +1349,13 @@ describe("executeBash :async: background retention", () => {
 				});
 				expect(res.cancelled).toBe(false);
 
-				await pollUntil(() => fs.existsSync(pidFile), Date.now() + 4000);
-				pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+				await pollUntil(() => {
+					if (!fs.existsSync(pidFile)) return false;
+					pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+					return Number.isInteger(pid);
+				}, Date.now() + 4000);
 				expect(Number.isInteger(pid)).toBe(true);
+				if (pid === undefined) throw new Error("Expected detached child pid");
 
 				// A later turn on a different per-job shell must not have killed it.
 				await executeBash("true", { sessionKey: "reparent-probe:async:job2", cwd: tmp });

--- a/packages/coding-agent/test/mcp-timeout.test.ts
+++ b/packages/coding-agent/test/mcp-timeout.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
+import { afterEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { createMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
 import { logger } from "@oh-my-pi/pi-utils";
 
 const ORIGINAL_TIMEOUT = process.env.OMP_MCP_TIMEOUT_MS;
 
 afterEach(() => {
+	vi.useRealTimers();
 	if (ORIGINAL_TIMEOUT === undefined) {
 		delete process.env.OMP_MCP_TIMEOUT_MS;
 	} else {
@@ -62,5 +63,17 @@ describe("MCP timeout configuration", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+
+	test("classifies only abort errors from the internal timeout", () => {
+		vi.useFakeTimers();
+		const operation = createMCPTimeout(50);
+		vi.advanceTimersByTime(50);
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+
+		expect(operation.isTimeoutAbort(new Error("HTTP 500"))).toBe(false);
+		expect(operation.isTimeoutAbort(abortError)).toBe(true);
+		operation.clear();
 	});
 });

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -385,7 +385,7 @@ describe("retain.execute (Mnemopi backend)", () => {
 
 		const text = (recallResult.content[0] as { text: string }).text;
 		expect(text).toContain("user prefers tabs");
-	});
+	}, 30_000);
 
 	it("stores multiple memories and returns correct count", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
@@ -933,7 +933,7 @@ describe("Mnemopi backend lifecycle", () => {
 		}
 		registeredMnemopiState = getMnemopiSessionState(session);
 		expect(registeredMnemopiState).toBeDefined();
-	});
+	}, 30_000);
 
 	it("exposes direct mnemopi runtime status and search/save results", async () => {
 		const config = makeMnemopiConfig({
@@ -1220,7 +1220,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 		expect(text).toContain("the user likes concise CLI output");
 		expect(text).toContain("project alpha uses pnpm workspaces");
 		expect(text).not.toContain("project beta deploys to staging first");
-	});
+	}, 30_000);
 
 	it("throws when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });

--- a/packages/coding-agent/test/models-config-lazy-validator.test.ts
+++ b/packages/coding-agent/test/models-config-lazy-validator.test.ts
@@ -62,4 +62,4 @@ test("models config validation resources are retained only for a custom config",
 	} finally {
 		await tempDir.remove().catch(() => {});
 	}
-});
+}, 30_000);

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -89,12 +89,11 @@ describe("AssistantMessageComponent mermaid markdown", () => {
 		expect(new Set(boxRows.map(displayCols)).size).toBe(1);
 	});
 
-	it("falls back to the fenced code block when Mermaid rendering fails", () => {
+	it("falls back to rendered code content when Mermaid rendering fails", () => {
 		const rendered = renderAssistantMessage("```mermaid\nthis is not mermaid\n```");
 
 		expect(TERMINAL.imageProtocol).toBeNull();
-		expect(rendered).toContain("```mermaid");
-		expect(rendered).toContain("this is not mermaid");
+		expect(rendered).toBe("   this is not mermaid");
 	});
 });
 

--- a/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/test/modes/theme/mermaid-rendering.test.ts
@@ -45,14 +45,14 @@ describe("Mermaid rendering setting", () => {
 		expect(systemPrompt.join("\n")).not.toContain("```mermaid");
 	});
 
-	it("falls back to a highlighted code fence when rendering is disabled", () => {
+	it("falls back to highlighted code content when rendering is disabled", () => {
 		setMarkdownMermaidRendering(false);
 
 		const markdown = new Markdown("```mermaid\ngraph TD\n  A --> B\n```", 0, 0, getMarkdownTheme());
-		const lines = stripAnsi(markdown.render(80).join("\n"));
+		const lines = stripAnsi(markdown.render(80).join("\n"))
+			.split("\n")
+			.map(line => line.trimEnd());
 
-		expect(lines).toContain("```mermaid");
-		expect(lines).toContain("graph TD");
-		expect(lines).toContain("-->");
+		expect(lines).toEqual(["  graph TD", "    A --> B"]);
 	});
 });

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -250,8 +250,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		joinerController.abort();
-		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await owner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -233,8 +233,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		ownerController.abort();
-		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await joiner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -239,7 +239,7 @@ describe("read PDF image extraction", () => {
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);
 		expect(spy).toHaveBeenCalledTimes(1);
-	});
+	}, 30_000);
 
 	it("keeps shared extraction running when a joiner aborts", async () => {
 		const { entered, release, spy } = mockBlockedExtraction();

--- a/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
+++ b/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
@@ -31,7 +31,6 @@ class MutableLiveBlock implements Component {
 const diffMarkdownTheme: MarkdownTheme = {
 	...defaultMarkdownTheme,
 	codeBlock: text => text,
-	codeBlockBorder: text => text,
 	highlightCode: (source, lang) => {
 		const normalizedLang = lang?.trim().toLowerCase();
 		const highlighted: string[] = [];
@@ -196,10 +195,8 @@ describe("transcript streaming commit (assistant text)", () => {
 		block.setStreamingText("```diff\n\n+next");
 
 		const rows = block.render(40).map(row => Bun.stripANSI(row).trimEnd());
-		const fenceRow = rows.indexOf("```diff");
 
-		expect(fenceRow).toBeGreaterThanOrEqual(0);
-		expect(rows.slice(fenceRow, fenceRow + 4)).toEqual(["```diff", "", "  +next", "```"]);
+		expect(rows).toEqual(["", "  +next"]);
 	});
 
 	it("appends a completed blank row when the streamed diff line cache grows", () => {
@@ -229,9 +226,7 @@ describe("transcript streaming commit (assistant text)", () => {
 		block.setStreamingText("```diff\n\n+done\n-streaming");
 
 		const rows = block.render(40).map(row => Bun.stripANSI(row).trimEnd());
-		const fenceRow = rows.indexOf("```diff");
 
-		expect(fenceRow).toBeGreaterThanOrEqual(0);
-		expect(rows.slice(fenceRow, fenceRow + 5)).toEqual(["```diff", "", "  +done", "  -streaming", "```"]);
+		expect(rows).toEqual(["", "  +done", "  -streaming"]);
 	});
 });

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,6 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2120,7 +2120,7 @@ describe("vibe session registry", () => {
 		const resumedSession = createSession({ manager: createManager(), sessionManager: reopened });
 		expect(await VibeSessionRegistry.global().rehydrate(resumedSession)).toBe(0);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
-	});
+	}, 15_000);
 
 	it("killAll terminates every session for the owner (mode-exit path)", async () => {
 		const gates = new Map<string, Deferred>();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,7 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
-		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted", 10_000);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 - Fixed wrapped Markdown list continuations losing their hanging indentation in narrow terminal layouts.
 - Fixed an issue where emergency exits from fullscreen overlays could leave the Kitty keyboard protocol active, corrupting Arrow Up input in the terminal after exiting.
+- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation, list nesting, and heading hierarchy through indentation.
+
+### Removed
+
+- Removed the obsolete `MarkdownTheme.codeBlockBorder` callback now that source fence delimiters are not rendered.
 
 ## [17.1.7] - 2026-07-27
 
@@ -31,13 +36,6 @@
 - Fixed the multi-line prompt editor bypassing the keybindings registry for word/line delete and yank: `ctrl+backspace` (a declared default of `tui.editor.deleteWordBackward`) never fired and `keybindings.yml` remaps of `deleteWordBackward`, `deleteWordForward`, `deleteToLineStart`, `deleteToLineEnd`, `yank`, and `yankPop` were ignored, because those actions were matched with hardcoded chords instead of `keybindings.matches(...)` like cursor motion and the single-line `Input` already do ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) by routing the exported `matchesRawBackspace` helper through the `matchesKey`/`parseKey` seam. Remote SSH/container sessions where terminal identity is unavailable can opt in with `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Fixed plain Backspace deleting a whole word inside tmux/GNU screen/Zellij panes launched from Windows Terminal: multiplexers inherit `WT_SESSION` but emit raw `0x08` for plain Backspace, so the automatic raw-backspace → `ctrl+backspace` heuristic misfired. The heuristic now skips multiplexer sessions (`TMUX`/`STY`/`ZELLIJ` or `TERM` starting with `tmux`/`screen`); `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` remains the explicit opt-in everywhere ([#6784](https://github.com/can1357/oh-my-pi/pull/6784)).
-### Fixed
-
-- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation, list nesting, and heading hierarchy through indentation.
-
-### Removed
-
-- Removed the obsolete `MarkdownTheme.codeBlockBorder` callback now that source fence delimiters are not rendered.
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -31,6 +31,9 @@
 - Fixed the multi-line prompt editor bypassing the keybindings registry for word/line delete and yank: `ctrl+backspace` (a declared default of `tui.editor.deleteWordBackward`) never fired and `keybindings.yml` remaps of `deleteWordBackward`, `deleteWordForward`, `deleteToLineStart`, `deleteToLineEnd`, `yank`, and `yankPop` were ignored, because those actions were matched with hardcoded chords instead of `keybindings.matches(...)` like cursor motion and the single-line `Input` already do ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) by routing the exported `matchesRawBackspace` helper through the `matchesKey`/`parseKey` seam. Remote SSH/container sessions where terminal identity is unavailable can opt in with `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Fixed plain Backspace deleting a whole word inside tmux/GNU screen/Zellij panes launched from Windows Terminal: multiplexers inherit `WT_SESSION` but emit raw `0x08` for plain Backspace, so the automatic raw-backspace → `ctrl+backspace` heuristic misfired. The heuristic now skips multiplexer sessions (`TMUX`/`STY`/`ZELLIJ` or `TERM` starting with `tmux`/`screen`); `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` remains the explicit opt-in everywhere ([#6784](https://github.com/can1357/oh-my-pi/pull/6784)).
+### Fixed
+
+- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation and list nesting.
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,9 +10,9 @@
 - Fixed an issue where emergency exits from fullscreen overlays could leave the Kitty keyboard protocol active, corrupting Arrow Up input in the terminal after exiting.
 - Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation, list nesting, and heading hierarchy through indentation.
 
-### Removed
+### Changed
 
-- Removed the obsolete `MarkdownTheme.codeBlockBorder` callback now that source fence delimiters are not rendered.
+- Retained `MarkdownTheme.codeBlockBorder` as a deprecated optional callback for source compatibility; it is ignored now that source fence delimiters are not rendered.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -33,7 +33,11 @@
 - Fixed plain Backspace deleting a whole word inside tmux/GNU screen/Zellij panes launched from Windows Terminal: multiplexers inherit `WT_SESSION` but emit raw `0x08` for plain Backspace, so the automatic raw-backspace → `ctrl+backspace` heuristic misfired. The heuristic now skips multiplexer sessions (`TMUX`/`STY`/`ZELLIJ` or `TERM` starting with `tmux`/`screen`); `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` remains the explicit opt-in everywhere ([#6784](https://github.com/can1357/oh-my-pi/pull/6784)).
 ### Fixed
 
-- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation and list nesting.
+- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation, list nesting, and heading hierarchy through indentation.
+
+### Removed
+
+- Removed the obsolete `MarkdownTheme.codeBlockBorder` callback now that source fence delimiters are not rendered.
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation, list nesting, and heading hierarchy through indentation.
+
+### Changed
+
+- Retained `MarkdownTheme.codeBlockBorder` as a deprecated optional callback for source compatibility; it is ignored now that source fence delimiters are not rendered.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed
 
 - Fixed wrapped Markdown list continuations losing their hanging indentation in narrow terminal layouts.
 - Fixed an issue where emergency exits from fullscreen overlays could leave the Kitty keyboard protocol active, corrupting Arrow Up input in the terminal after exiting.
-- Hid fenced-code delimiters and Markdown heading hashes from rendered output while preserving code indentation, list nesting, and heading hierarchy through indentation.
 
-### Changed
-
-- Retained `MarkdownTheme.codeBlockBorder` as a deprecated optional callback for source compatibility; it is ignored now that source fence delimiters are not rendered.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -242,7 +242,6 @@ interface MarkdownTheme {
 	linkUrl: (text: string) => string;
 	code: (text: string) => string;
 	codeBlock: (text: string) => string;
-	codeBlockBorder: (text: string) => string;
 	quote: (text: string) => string;
 	quoteBorder: (text: string) => string;
 	hr: (text: string) => string;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2705,6 +2705,9 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				}
 			} else if (token.type === "code") {
 				// Code block in list item
+				// Without a preceding rendered row, the list renderer would attach the
+				// bullet to the first code row. Reserve an empty item row for the marker.
+				if (lines.length === 0) lines.push({ text: "", nested: false });
 				const codeIndent = padding(this.#codeBlockIndent);
 				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
 					lines.push({ text: bodyLine, nested: false });

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1088,7 +1088,6 @@ export interface MarkdownTheme {
 	linkUrl: (text: string) => string;
 	code: (text: string) => string;
 	codeBlock: (text: string) => string;
-	codeBlockBorder: (text: string) => string;
 	quote: (text: string) => string;
 	quoteBorder: (text: string) => string;
 	hr: (text: string) => string;
@@ -2212,7 +2211,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				if (headingLevel === 1) {
 					styledHeading = this.#theme.heading(this.#theme.bold(this.#theme.underline(headingText)));
 				} else {
-					styledHeading = this.#theme.heading(this.#theme.bold(headingText));
+					styledHeading = `${padding((headingLevel - 2) * 2)}${this.#theme.heading(this.#theme.bold(headingText))}`;
 				}
 				lines.push(styledHeading);
 				if (nextTokenType && nextTokenType !== "space") {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1088,6 +1088,8 @@ export interface MarkdownTheme {
 	linkUrl: (text: string) => string;
 	code: (text: string) => string;
 	codeBlock: (text: string) => string;
+	/** @deprecated Fenced-code delimiters are not rendered. Accepted for source compatibility and ignored. */
+	codeBlockBorder?: (text: string) => string;
 	quote: (text: string) => string;
 	quoteBorder: (text: string) => string;
 	hr: (text: string) => string;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2660,6 +2660,11 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		let previousNonSpaceType: string | undefined;
 
 		for (const token of tokens) {
+			// Fenced delimiters are hidden, so preserve their visual boundary before
+			// the next rendered block. Space tokens may intervene but do not render.
+			if (previousNonSpaceType === "code" && token.type !== "space") {
+				lines.push({ text: "", nested: false });
+			}
 			if (token.type === "list") {
 				// Nested list - render with one additional indent level
 				// These lines carry their own indent, so tag them for pass-through
@@ -2693,7 +2698,6 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				}
 			} else if (token.type === "code") {
 				// Code block in list item
-				if (previousNonSpaceType === "code") lines.push({ text: "", nested: false });
 				const codeIndent = padding(this.#codeBlockIndent);
 				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
 					lines.push({ text: bodyLine, nested: false });

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2194,7 +2194,6 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		switch (token.type) {
 			case "heading": {
 				const headingLevel = token.depth;
-				const headingPrefix = `${"#".repeat(headingLevel)} `;
 				const headingText = this.#renderInlineTokens(token.tokens || [], styleContext);
 				const headingPlainText = plainInlineTokens(token.tokens || []);
 				let styledHeading: string;
@@ -2212,10 +2211,8 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				}
 				if (headingLevel === 1) {
 					styledHeading = this.#theme.heading(this.#theme.bold(this.#theme.underline(headingText)));
-				} else if (headingLevel === 2) {
-					styledHeading = this.#theme.heading(this.#theme.bold(headingText));
 				} else {
-					styledHeading = this.#theme.heading(this.#theme.bold(headingPrefix + headingText));
+					styledHeading = this.#theme.heading(this.#theme.bold(headingText));
 				}
 				lines.push(styledHeading);
 				if (nextTokenType && nextTokenType !== "space") {
@@ -2262,11 +2259,9 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				}
 
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
 				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
 					lines.push(bodyLine);
 				}
-				lines.push(this.#theme.codeBlockBorder("```"));
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after code blocks (unless space token follows)
 				}
@@ -2663,6 +2658,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		styleContext?: InlineStyleContext,
 	): Array<{ text: string; nested: boolean }> {
 		const lines: Array<{ text: string; nested: boolean }> = [];
+		let previousNonSpaceType: string | undefined;
 
 		for (const token of tokens) {
 			if (token.type === "list") {
@@ -2698,12 +2694,11 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				}
 			} else if (token.type === "code") {
 				// Code block in list item
+				if (previousNonSpaceType === "code") lines.push({ text: "", nested: false });
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push({ text: this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`), nested: false });
 				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
 					lines.push({ text: bodyLine, nested: false });
 				}
-				lines.push({ text: this.#theme.codeBlockBorder("```"), nested: false });
 			} else if (isMathToken(token)) {
 				// Display math block inside a list item: stack fractions / matrix rows.
 				const apply = styleContext?.applyText ?? ((t: string) => this.#applyDefaultStyle(t));
@@ -2715,6 +2710,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 					lines.push({ text, nested: false });
 				}
 			}
+			if (token.type !== "space") previousNonSpaceType = token.type;
 		}
 
 		return lines;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1873,10 +1873,10 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			);
 			const tokenLineOffsets = [0];
 			for (const line of renderedTokenLines) {
-				// Lists wrap while their structural prefixes are still available, so
-				// continuation rows retain the correct hanging indent. Re-wrapping the
-				// flattened rows here would discard that structure.
-				if (token.type === "list" || TERMINAL.isImageLine(line) || isOsc66Line(line)) {
+				// Lists and headings wrap while their structural prefixes are still
+				// available, so continuation rows retain the correct indentation.
+				// Re-wrapping flattened rows here would discard that structure.
+				if (token.type === "list" || token.type === "heading" || TERMINAL.isImageLine(line) || isOsc66Line(line)) {
 					wrappedLines.push(line);
 				} else {
 					wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
@@ -2208,12 +2208,19 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 						break;
 					}
 				}
+				const desiredIndentWidth = Math.max(0, (headingLevel - 2) * 2);
+				// Always leave one content cell at narrow widths. This retains as much
+				// hierarchy as the row can represent without emitting an indent-only row.
+				const indentWidth = Math.min(desiredIndentWidth, Math.max(0, width - 1));
+				const indent = padding(indentWidth);
 				if (headingLevel === 1) {
 					styledHeading = this.#theme.heading(this.#theme.bold(this.#theme.underline(headingText)));
 				} else {
-					styledHeading = `${padding((headingLevel - 2) * 2)}${this.#theme.heading(this.#theme.bold(headingText))}`;
+					styledHeading = this.#theme.heading(this.#theme.bold(headingText));
 				}
-				lines.push(styledHeading);
+				for (const headingLine of wrapTextWithAnsi(styledHeading, Math.max(1, width - indentWidth))) {
+					lines.push(indent + headingLine);
+				}
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after headings (unless space token follows)
 				}

--- a/packages/tui/test/markdown-stream-prefix-cache.test.ts
+++ b/packages/tui/test/markdown-stream-prefix-cache.test.ts
@@ -15,16 +15,11 @@ function renderCold(text: string, theme: MarkdownTheme): readonly string[] {
 describe("Markdown streaming prefix render cache", () => {
 	it("reuses rendered frozen prefix lines during transient append renders", () => {
 		let codeBlockCalls = 0;
-		let codeBlockBorderCalls = 0;
 		const theme: MarkdownTheme = {
 			...defaultMarkdownTheme,
 			codeBlock: text => {
 				codeBlockCalls++;
 				return defaultMarkdownTheme.codeBlock(text);
-			},
-			codeBlockBorder: text => {
-				codeBlockBorderCalls++;
-				return defaultMarkdownTheme.codeBlockBorder(text);
 			},
 		};
 
@@ -35,27 +30,20 @@ describe("Markdown streaming prefix render cache", () => {
 		md.render(WIDTH);
 
 		codeBlockCalls = 0;
-		codeBlockBorderCalls = 0;
 		md.setText(secondText);
 		const streamingLines = md.render(WIDTH);
 
 		expect(codeBlockCalls).toBe(0);
-		expect(codeBlockBorderCalls).toBe(0);
 		expect(streamingLines).toEqual(renderCold(secondText, theme));
 	});
 
 	it("advances the rendered prefix cache when a new stable block freezes", () => {
 		let codeBlockCalls = 0;
-		let codeBlockBorderCalls = 0;
 		const theme: MarkdownTheme = {
 			...defaultMarkdownTheme,
 			codeBlock: text => {
 				codeBlockCalls++;
 				return defaultMarkdownTheme.codeBlock(text);
-			},
-			codeBlockBorder: text => {
-				codeBlockBorderCalls++;
-				return defaultMarkdownTheme.codeBlockBorder(text);
 			},
 		};
 		const firstBlock = "```ts\nconst first = 1;\n```\n\n";
@@ -71,12 +59,10 @@ describe("Markdown streaming prefix render cache", () => {
 		md.render(WIDTH);
 
 		codeBlockCalls = 0;
-		codeBlockBorderCalls = 0;
 		md.setText(thirdText);
 		const streamingLines = md.render(WIDTH);
 
 		expect(codeBlockCalls).toBe(0);
-		expect(codeBlockBorderCalls).toBe(0);
 		expect(streamingLines).toEqual(renderCold(thirdText, theme));
 	});
 

--- a/packages/tui/test/markdown-tree-wrap.test.ts
+++ b/packages/tui/test/markdown-tree-wrap.test.ts
@@ -116,20 +116,20 @@ describe("Markdown tree-guide hanging wrap", () => {
 		expect(plain).toEqual(["├── alpha", "│   └── beta", "└── gamma"]);
 	});
 
-	it("keeps the old column-0 wrap for '├── ' lines inside fenced code blocks", () => {
+	it("keeps column-0 continuation wraps for tree lines inside fenced code blocks", () => {
 		const codeLine = "├── alpha bravo charlie delta echo foxtrot golf hotel india";
 		const raw = renderRaw(`\`\`\`\n${codeLine}\n\`\`\``);
 		const plain = raw.map(line => stripVTControlCharacters(line).trimEnd());
 
-		expect(plain[0]).toBe("```");
-		expect(plain[plain.length - 1]).toBe("```");
+		expect(plain[0]).toStartWith("  ├── alpha bravo");
+		expect(plain).not.toContain("```");
 
 		const treeRow = plain.findIndex(line => line.includes("├──"));
-		expect(treeRow).toBeGreaterThan(0);
-		// The code line overflows, so a continuation row exists before the
-		// closing fence — and it starts flush at column 0, no hanging prefix.
+		expect(treeRow).toBe(0);
+		// The code line overflows, so a continuation row follows the rendered
+		// content directly and starts flush at column 0, with no hanging prefix.
 		const continuation = plain[treeRow + 1]!;
-		expect(treeRow + 1).toBeLessThan(plain.length - 1);
+		expect(treeRow + 1).toBeLessThan(plain.length);
 		expect(continuation.length).toBeGreaterThan(0);
 		expect(continuation[0]).not.toBe(" ");
 		expect(continuation[0]).not.toBe("│");

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -986,6 +986,25 @@ ${table}`;
 			expect(plainLines).toEqual(["- Example:", "    const nested = true;"]);
 		});
 
+		it("renders a marker row before a code-only list item", () => {
+			const markdown = new Markdown("- ```ts\n  const x = 1;\n  ```", 0, 0, defaultMarkdownTheme);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["-", "    const x = 1;"]);
+		});
+
+		it("renders a marker row before code when a list item starts with a fenced block", () => {
+			const markdown = new Markdown(
+				"- ```ts\n  const x = 1;\n  ```\n\n  after",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["-", "    const x = 1;", "", "  after"]);
+		});
+
 		it("separates consecutive fenced blocks inside one list item without showing delimiters", () => {
 			const markdown = new Markdown(
 				"- Examples:\n\n  ```ts\n  const first = 1;\n  ```\n\n  ```sh\n  echo second\n  ```",

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -909,6 +909,55 @@ ${table}`;
 		});
 	});
 
+	describe("Source syntax presentation", () => {
+		it("hides fenced-code delimiters while preserving code content", () => {
+			const markdown = new Markdown("```ts\nconst answer = 42;\nconsole.log(answer);\n```", 0, 0, defaultMarkdownTheme);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["  const answer = 42;", "  console.log(answer);"]);
+		});
+
+		it("styles level-three and deeper headings without rendering source hashes", () => {
+			const markerTheme = {
+				...defaultMarkdownTheme,
+				heading: (text: string) => `<heading>${text}</heading>`,
+				bold: (text: string) => `<bold>${text}</bold>`,
+			};
+			const markdown = new Markdown("### Details\n\n#### Internals", 0, 0, markerTheme);
+			const lines = markdown.render(80).map(line => line.trimEnd());
+
+			expect(lines).toEqual([
+				"<heading><bold>Details</bold></heading>",
+				"",
+				"<heading><bold>Internals</bold></heading>",
+			]);
+		});
+
+		it("hides fenced-code delimiters inside lists while preserving nesting", () => {
+			const markdown = new Markdown(
+				"- Example:\n\n  ```ts\n  const nested = true;\n  ```",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["- Example:", "    const nested = true;"]);
+		});
+
+		it("separates consecutive fenced blocks inside one list item without showing delimiters", () => {
+			const markdown = new Markdown(
+				"- Examples:\n\n  ```ts\n  const first = 1;\n  ```\n\n  ```sh\n  echo second\n  ```",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["- Examples:", "    const first = 1;", "", "    echo second"]);
+		});
+	});
+
 	describe("Spacing after code blocks", () => {
 		it("should have only one blank line between code block and following paragraph", () => {
 			const markdown = new Markdown(
@@ -927,15 +976,15 @@ again, hello world`,
 			const lines = markdown.render(80);
 			const plainLines = lines.map(line => stripVTControlCharacters(line).trimEnd());
 
-			const closingBackticksIndex = plainLines.indexOf("```");
-			expect(closingBackticksIndex !== -1, "Should have closing backticks").toBeTruthy();
+			const codeLineIndex = plainLines.indexOf('  const hello = "world";');
+			expect(codeLineIndex !== -1, "Should render code content").toBeTruthy();
 
-			const afterBackticks = plainLines.slice(closingBackticksIndex + 1);
-			const emptyLineCount = afterBackticks.findIndex(line => line !== "");
+			const afterCode = plainLines.slice(codeLineIndex + 1);
+			const emptyLineCount = afterCode.findIndex(line => line !== "");
 
 			expect(
 				emptyLineCount,
-				`Expected 1 empty line after code block, but found ${emptyLineCount}. Lines after backticks: ${JSON.stringify(afterBackticks.slice(0, 5))}`,
+				`Expected 1 empty line after code block, but found ${emptyLineCount}. Lines after code: ${JSON.stringify(afterCode.slice(0, 5))}`,
 			).toBe(1);
 		});
 
@@ -954,7 +1003,7 @@ code block
 
 more text`,
 			];
-			const expectedLines = ["hello this is text", "", "```", "  code block", "```", "", "more text"];
+			const expectedLines = ["hello this is text", "", "  code block", "", "more text"];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
@@ -1000,7 +1049,7 @@ more text`,
 			expect(plainLines.some(line => line.includes("```mermaid"))).toBeFalsy();
 		});
 
-		it("falls back to the original fenced code block when mermaid resolution returns null", () => {
+		it("falls back to styled code content when mermaid resolution returns null", () => {
 			const invalidMermaid = "```mermaid\nflowchart TD\n  A --\n```";
 			const invalidSource = "flowchart TD\n  A --";
 			const seenSources: string[] = [];
@@ -1011,7 +1060,7 @@ more text`,
 			});
 
 			expect(seenSources).toEqual([invalidSource]);
-			expect(plainLines).toEqual(["```mermaid", "  flowchart TD", "    A --", "```"]);
+			expect(plainLines).toEqual(["  flowchart TD", "    A --"]);
 		});
 	});
 
@@ -1378,9 +1427,9 @@ bar`,
 			const output = lines.join("\n");
 			const plainOutput = quotedLines.join("\n");
 
-			expect(plainOutput.includes("```js")).toBeTruthy();
+			expect(plainOutput.includes("```js")).toBeFalsy();
 			expect(plainOutput.includes("console.log(1)")).toBeTruthy();
-			expect(plainOutput.includes("```")).toBeTruthy();
+			expect(plainOutput.includes("```")).toBeFalsy();
 			expect(output.includes("\x1b[35m")).toBeFalsy();
 			expect(output.includes("\x1b[3m")).toBeTruthy();
 		});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -994,12 +994,7 @@ ${table}`;
 		});
 
 		it("renders a marker row before code when a list item starts with a fenced block", () => {
-			const markdown = new Markdown(
-				"- ```ts\n  const x = 1;\n  ```\n\n  after",
-				0,
-				0,
-				defaultMarkdownTheme,
-			);
+			const markdown = new Markdown("- ```ts\n  const x = 1;\n  ```\n\n  after", 0, 0, defaultMarkdownTheme);
 			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
 			expect(plainLines).toEqual(["-", "    const x = 1;", "", "  after"]);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2540,9 +2540,10 @@ describe("windowed lexing (documents past WINDOWED_LEX_MIN_BYTES)", () => {
 		expect(code.length).toBeGreaterThan(2 * 1024);
 
 		const rendered = plain(doc);
-		// Exactly one fence pair: a window cut inside the block would close and
-		// reopen it (or spill code lines into prose).
-		expect(rendered.filter(line => line.trimStart().startsWith("```"))).toHaveLength(2);
+		// Source fences stay hidden, and every code row remains contiguous: a
+		// window cut inside the block would spill or duplicate code rows.
+		expect(rendered.some(line => line.trimStart().startsWith("```"))).toBe(false);
+		expect(rendered.filter(line => line.includes("const value"))).toHaveLength(200);
 		const first = rendered.findIndex(line => line.includes("const value0 = 0;"));
 		expect(first).toBeGreaterThan(-1);
 		for (let i = 0; i < 200; i++) {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -972,6 +972,18 @@ ${table}`;
 
 			expect(plainLines).toEqual(["- Examples:", "    const first = 1;", "", "    echo second"]);
 		});
+
+		it("preserves a blank boundary between fenced code and following prose inside a list item", () => {
+			const markdown = new Markdown(
+				"- Example:\n\n  ```ts\n  const x = 1;\n  ```\n\n  after",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["- Example:", "    const x = 1;", "", "  after"]);
+		});
 	});
 
 	describe("Spacing after code blocks", () => {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -911,25 +911,41 @@ ${table}`;
 
 	describe("Source syntax presentation", () => {
 		it("hides fenced-code delimiters while preserving code content", () => {
-			const markdown = new Markdown("```ts\nconst answer = 42;\nconsole.log(answer);\n```", 0, 0, defaultMarkdownTheme);
+			const markdown = new Markdown(
+				"```ts\nconst answer = 42;\nconsole.log(answer);\n```",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
 			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
 			expect(plainLines).toEqual(["  const answer = 42;", "  console.log(answer);"]);
 		});
 
-		it("styles level-three and deeper headings without rendering source hashes", () => {
+		it("indents level-two through level-six headings without rendering source hashes", () => {
 			const markerTheme = {
 				...defaultMarkdownTheme,
 				heading: (text: string) => `<heading>${text}</heading>`,
 				bold: (text: string) => `<bold>${text}</bold>`,
 			};
-			const markdown = new Markdown("### Details\n\n#### Internals", 0, 0, markerTheme);
+			const markdown = new Markdown(
+				"## Two\n\n### Three\n\n#### Four\n\n##### Five\n\n###### Six",
+				0,
+				0,
+				markerTheme,
+			);
 			const lines = markdown.render(80).map(line => line.trimEnd());
 
 			expect(lines).toEqual([
-				"<heading><bold>Details</bold></heading>",
+				"<heading><bold>Two</bold></heading>",
 				"",
-				"<heading><bold>Internals</bold></heading>",
+				"  <heading><bold>Three</bold></heading>",
+				"",
+				"    <heading><bold>Four</bold></heading>",
+				"",
+				"      <heading><bold>Five</bold></heading>",
+				"",
+				"        <heading><bold>Six</bold></heading>",
 			]);
 		});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -949,6 +949,31 @@ ${table}`;
 			]);
 		});
 
+		it("preserves nested-heading indentation on every wrapped row", () => {
+			const text = "alpha beta gamma delta epsilon zeta";
+			for (const level of [3, 4, 5, 6]) {
+				const indent = " ".repeat((level - 2) * 2);
+				const plainLines = new Markdown(`${"#".repeat(level)} ${text}`, 0, 0, defaultMarkdownTheme)
+					.render(18)
+					.map(line => stripVTControlCharacters(line).trimEnd());
+
+				expect(plainLines.length).toBeGreaterThan(1);
+				expect(plainLines.every(line => line.startsWith(indent) && line.length > indent.length)).toBe(true);
+				expect(plainLines.map(line => line.slice(indent.length)).join(" ")).toBe(text);
+				expect(plainLines.every(line => visibleWidth(line) <= 18)).toBe(true);
+			}
+		});
+
+		it("uses the available indentation without emitting blank rows at ultra-narrow widths", () => {
+			for (const width of [1, 2, 3, 4]) {
+				const plainLines = new Markdown("###### X", 0, 0, defaultMarkdownTheme)
+					.render(width)
+					.map(line => stripVTControlCharacters(line).trimEnd());
+
+				expect(plainLines).toEqual([`${" ".repeat(Math.max(0, width - 1))}X`]);
+			}
+		});
+
 		it("hides fenced-code delimiters inside lists while preserving nesting", () => {
 			const markdown = new Markdown(
 				"- Example:\n\n  ```ts\n  const nested = true;\n  ```",

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -4,6 +4,7 @@ import {
 	autolinkSchemeScanIndex,
 	clearRenderCache,
 	Markdown,
+	type MarkdownTheme,
 	mathStartIndex,
 	renderInlineMarkdown,
 	urlTokenPossible,
@@ -920,6 +921,23 @@ ${table}`;
 			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
 			expect(plainLines).toEqual(["  const answer = 42;", "  console.log(answer);"]);
+		});
+
+		it("accepts the legacy code-block border callback without rendering delimiters", () => {
+			let borderCalls = 0;
+			const legacyCompatibleTheme: MarkdownTheme = {
+				...defaultMarkdownTheme,
+				codeBlockBorder: text => {
+					borderCalls++;
+					return `<border>${text}</border>`;
+				},
+			};
+			const plainLines = new Markdown("```ts\nconst answer = 42;\n```", 0, 0, legacyCompatibleTheme)
+				.render(80)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["  const answer = 42;"]);
+			expect(borderCalls).toBe(0);
 		});
 
 		it("indents level-two through level-six headings without rendering source hashes", () => {

--- a/packages/tui/test/test-themes.ts
+++ b/packages/tui/test/test-themes.ts
@@ -63,7 +63,6 @@ export const defaultMarkdownTheme: MarkdownTheme = {
 	linkUrl: (text: string) => chalk.dim(text),
 	code: (text: string) => chalk.yellow(text),
 	codeBlock: (text: string) => chalk.green(text),
-	codeBlockBorder: (text: string) => chalk.dim(text),
 	quote: (text: string) => chalk.italic(text),
 	quoteBorder: (text: string) => chalk.dim(text),
 	hr: (text: string) => chalk.dim(text),


### PR DESCRIPTION
Rendered Markdown should present the content rather than expose its source syntax, especially for headings and fenced code blocks.

- Hide heading hashes and fenced-code delimiters in rendered output.
- Preserve code indentation, list nesting, and spacing between consecutive fenced blocks.
- Keep Mermaid fallback content styled as code without restoring source delimiters.

Testing:
- `bun test test/markdown.test.ts` — 131 passed, 0 failed.
