### PR TITLE
perf(auth): reuse AgentStorage auth store for sessions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Fixed an HTTP 400 error when resuming or replaying OpenAI history after an interrupted native Computer Use turn.
 - Fixed connection 404 errors when using Google Vertex AI in multi-region locations (eu and us) by correctly resolving regional endpoint (REP) hosts.
 - Fixed a resource leak in SqliteAuthCredentialStore.close() where unclosed prepared statements kept the SQLite connection alive, preventing database file cleanup (especially on Windows where files remained locked).
+### Added
+
+- Added explicit owned and borrowed credential-store lifecycles to `AuthStorage`, allowing callers to reuse an owner-managed store without closing it while keeping `AuthStorage.create()` owner-closing.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added explicit owned and borrowed credential-store lifecycles to `AuthStorage`, allowing callers to reuse an owner-managed store without closing it while keeping `AuthStorage.create()` owner-closing.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed
@@ -9,9 +13,6 @@
 - Fixed an HTTP 400 error when resuming or replaying OpenAI history after an interrupted native Computer Use turn.
 - Fixed connection 404 errors when using Google Vertex AI in multi-region locations (eu and us) by correctly resolving regional endpoint (REP) hosts.
 - Fixed a resource leak in SqliteAuthCredentialStore.close() where unclosed prepared statements kept the SQLite connection alive, preventing database file cleanup (especially on Windows where files remained locked).
-### Added
-
-- Added explicit owned and borrowed credential-store lifecycles to `AuthStorage`, allowing callers to reuse an owner-managed store without closing it while keeping `AuthStorage.create()` owner-closing.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/ai/src/auth-broker/discover.ts
+++ b/packages/ai/src/auth-broker/discover.ts
@@ -15,7 +15,7 @@ import {
 	MAIN_CONFIG_FILENAMES,
 } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
-import { AuthStorage } from "../auth-storage";
+import { type AuthCredentialStore, AuthStorage } from "../auth-storage";
 import * as AIError from "../error";
 import { AuthBrokerClient, AuthBrokerError } from "./client";
 import { type AuthBrokerAccountPool, RemoteAuthCredentialStore } from "./remote-store";
@@ -37,6 +37,11 @@ export interface DiscoverAuthStorageOptions {
 	configValueResolver?: (config: string) => Promise<string | undefined>;
 	cachePath?: string;
 	sourceLabel?: string;
+	/**
+	 * Lazily open a local credential store after broker resolution selects the
+	 * local branch. Factory-provided stores are borrowed from their caller.
+	 */
+	localStoreFactory?: () => Promise<AuthCredentialStore>;
 	/** Programmatic pool for SDK hosts. Takes precedence over the environment file. */
 	accountPool?: AuthBrokerAccountPool;
 }
@@ -300,6 +305,16 @@ export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = 
 	}
 
 	const dbPath = getAgentDbPath(agentDir);
+	if (options.localStoreFactory) {
+		const store = await options.localStoreFactory();
+		const storage = new AuthStorage(store, {
+			configValueResolver: options.configValueResolver,
+			sourceLabel: options.sourceLabel ?? `local ${dbPath}`,
+			storeOwnership: "borrowed",
+		});
+		await storage.reload();
+		return storage;
+	}
 	const storage = await AuthStorage.create(dbPath, {
 		configValueResolver: options.configValueResolver,
 		sourceLabel: options.sourceLabel ?? `local ${dbPath}`,

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -567,7 +567,16 @@ export interface CredentialDisabledEvent {
 	disabledCause: string;
 }
 
+export type AuthCredentialStoreOwnership = "owned" | "borrowed";
+
 export type AuthStorageOptions = {
+	/**
+	 * Lifecycle of the injected credential store. Owned stores are closed with
+	 * AuthStorage; borrowed stores remain the caller's responsibility.
+	 *
+	 * @default "owned"
+	 */
+	storeOwnership?: AuthCredentialStoreOwnership;
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	usageFetch?: typeof fetch;
@@ -1264,6 +1273,7 @@ export class AuthStorage {
 	#usageLogger?: UsageLogger;
 	#fallbackResolver?: (provider: string) => string | undefined;
 	#store: AuthCredentialStore;
+	#storeOwnership: AuthCredentialStoreOwnership;
 	#configValueResolver: (config: string) => Promise<string | undefined>;
 	#refreshOAuthCredentialOverride?: AuthStorageOptions["refreshOAuthCredential"];
 	#fetchUsageReportsOverride?: AuthStorageOptions["fetchUsageReports"];
@@ -1286,6 +1296,7 @@ export class AuthStorage {
 
 	constructor(store: AuthCredentialStore, options: AuthStorageOptions = {}) {
 		this.#store = store;
+		this.#storeOwnership = options.storeOwnership ?? "owned";
 		this.#configValueResolver = options.configValueResolver ?? defaultConfigValueResolver;
 		this.#usageProviderResolver = options.usageProviderResolver ?? resolveDefaultUsageProvider;
 		this.#rankingStrategyResolver = options.rankingStrategyResolver ?? resolveDefaultRankingStrategy;
@@ -1328,18 +1339,19 @@ export class AuthStorage {
 	 */
 	static async create(dbPath: string, options: AuthStorageOptions = {}): Promise<AuthStorage> {
 		const store = await SqliteAuthCredentialStore.open(dbPath);
-		return new AuthStorage(store, options);
+		return new AuthStorage(store, { ...options, storeOwnership: "owned" });
 	}
 
 	/**
-	 * Close the underlying credential store.
+	 * Close this storage instance and its credential store when owned.
 	 *
-	 * After calling this, the instance must not be reused.
+	 * Borrowed stores remain open for their owner. After calling this, the
+	 * AuthStorage instance must not be reused.
 	 */
 	close(): void {
 		if (this.#closed) return;
 		this.#closed = true;
-		this.#store.close();
+		if (this.#storeOwnership === "owned") this.#store.close();
 	}
 
 	getGeneration(): number {

--- a/packages/ai/test/auth-storage-ownership.test.ts
+++ b/packages/ai/test/auth-storage-ownership.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { discoverAuthStorage, type SnapshotResponse, writeAuthBrokerSnapshotCache } from "@oh-my-pi/pi-ai/auth-broker";
+import {
+	type AuthCredentialStore,
+	AuthStorage,
+	SqliteAuthCredentialStore,
+	type StoredAuthCredential,
+} from "@oh-my-pi/pi-ai/auth-storage";
+import { getAgentDbPath } from "@oh-my-pi/pi-utils";
+import { removeWithRetries } from "../../utils/src/temp";
+import { withEnv } from "./helpers";
+
+const LOCAL_ENV = {
+	OMP_AUTH_BROKER_URL: undefined,
+	OMP_AUTH_BROKER_TOKEN: undefined,
+	OMP_AUTH_BROKER_ACCOUNT_POOL_FILE: undefined,
+} as const;
+
+const ROW = {
+	id: 1,
+	provider: "test-provider",
+	credential: { type: "api_key", key: "test-key", source: "login" },
+	disabledCause: null,
+} satisfies StoredAuthCredential;
+
+function makeStore(onClose: () => void = () => {}): AuthCredentialStore {
+	return {
+		close: onClose,
+		cleanExpiredCache() {},
+		listAuthCredentials: () => [ROW],
+	} as unknown as AuthCredentialStore;
+}
+
+async function withTempDir(run: (tempDir: string) => Promise<void>): Promise<void> {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-ownership-"));
+	try {
+		await run(tempDir);
+	} finally {
+		await removeWithRetries(tempDir);
+	}
+}
+
+function snapshot(generatedAt: number): SnapshotResponse {
+	return {
+		generation: 1,
+		generatedAt,
+		serverNowMs: generatedAt,
+		refresher: {
+			enabled: false,
+			intervalMs: 60_000,
+			skewMs: 300_000,
+			nextSweepInMs: Number.MAX_SAFE_INTEGER,
+		},
+		credentials: [
+			{
+				id: ROW.id,
+				provider: ROW.provider,
+				credential: ROW.credential,
+				identityKey: null,
+				rotatesInMs: null,
+			},
+		],
+	};
+}
+
+describe("AuthStorage store ownership", () => {
+	test("borrowed close is idempotent and does not close the store", () => {
+		const close = vi.fn();
+		const storage = new AuthStorage(makeStore(close), { storeOwnership: "borrowed" });
+
+		storage.close();
+		storage.close();
+
+		expect(close).toHaveBeenCalledTimes(0);
+	});
+
+	test("stores are owned by default and close exactly once", () => {
+		const close = vi.fn();
+		const storage = new AuthStorage(makeStore(close));
+
+		storage.close();
+		storage.close();
+
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	test("create unconditionally owns the store it opens", async () => {
+		const close = vi.fn();
+		const store = makeStore(close);
+		const open = vi
+			.spyOn(SqliteAuthCredentialStore, "open")
+			.mockResolvedValue(store as unknown as SqliteAuthCredentialStore);
+		try {
+			const storage = await AuthStorage.create("unused-agent.db", { storeOwnership: "borrowed" });
+			storage.close();
+			storage.close();
+			expect(close).toHaveBeenCalledTimes(1);
+		} finally {
+			open.mockRestore();
+		}
+	});
+});
+
+describe("discoverAuthStorage local store factory", () => {
+	test("remote discovery never invokes the local factory", async () => {
+		await withTempDir(async tempDir => {
+			const url = "https://broker.test.invalid";
+			const token = "test-token";
+			const cachePath = path.join(tempDir, "snapshot.enc");
+			await writeAuthBrokerSnapshotCache({
+				path: cachePath,
+				url,
+				token,
+				snapshot: snapshot(Date.now()),
+			});
+			const factory = vi.fn(async () => makeStore());
+			const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 500 }));
+			let storage: AuthStorage | undefined;
+			try {
+				await withEnv(
+					{
+						...LOCAL_ENV,
+						OMP_AUTH_BROKER_URL: url,
+						OMP_AUTH_BROKER_TOKEN: token,
+						OMP_AUTH_BROKER_SNAPSHOT_TTL_MS: "60000",
+					},
+					async () => {
+						storage = await discoverAuthStorage({
+							agentDir: tempDir,
+							cachePath,
+							localStoreFactory: factory,
+							sourceLabel: "custom broker source",
+						});
+					},
+				);
+				expect(factory).toHaveBeenCalledTimes(0);
+				expect(storage?.describeCredentialSource(ROW.provider)).toContain("custom broker source");
+			} finally {
+				storage?.close();
+				fetch.mockRestore();
+			}
+		});
+	});
+
+	test("local discovery invokes the factory once and borrows its store", async () => {
+		await withTempDir(async tempDir => {
+			const close = vi.fn();
+			const factory = vi.fn(async () => makeStore(close));
+			await withEnv(LOCAL_ENV, async () => {
+				const storage = await discoverAuthStorage({ agentDir: tempDir, localStoreFactory: factory });
+				expect(factory).toHaveBeenCalledTimes(1);
+				expect(storage.describeCredentialSource(ROW.provider)).toContain(`local ${getAgentDbPath(tempDir)}`);
+				storage.close();
+				storage.close();
+				expect(close).toHaveBeenCalledTimes(0);
+			});
+		});
+	});
+});

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -49,6 +49,7 @@ function capturePayload(
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	void streamBedrock(bedrockModel, context, {
 		signal: abortedSignal(),
+		bearerToken: "test-token",
 		cacheRetention,
 		onPayload: payload => {
 			resolve(payload as Payload);

--- a/packages/ai/test/oauth-barrel-import.test.ts
+++ b/packages/ai/test/oauth-barrel-import.test.ts
@@ -12,5 +12,5 @@ describe("OAuth barrel imports", () => {
 		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
 
 		expect(exitCode, stderr).toBe(0);
-	});
+	}, 30_000);
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -4887,6 +4887,7 @@ describe("openai-codex streaming", () => {
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
 			reasoning: true,
+			preferWebsockets: false,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 400000,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Fixed omp worktree clear prematurely deleting active task-isolation sandboxes owned by running subagents.
 - Fixed /vibe mode preventing the director from completing parent tasks after verifying worker results by keeping the built-in todo tool active.
 - Fixed numeric GitHub issue and pull request autocomplete being suppressed inside skill slash-command arguments.
+### Changed
+
+- Live CLI and SDK session startup now reuses the `AgentStorage`-owned local credential store instead of opening a second `agent.db` connection; standalone discovery and remote broker ownership are unchanged.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Live CLI and SDK session startup now reuses the `AgentStorage`-owned local credential store instead of opening a second `agent.db` connection; standalone discovery and remote broker ownership are unchanged.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes
@@ -36,9 +40,6 @@
 - Fixed omp worktree clear prematurely deleting active task-isolation sandboxes owned by running subagents.
 - Fixed /vibe mode preventing the director from completing parent tasks after verifying worker results by keeping the built-in todo tool active.
 - Fixed numeric GitHub issue and pull request autocomplete being suppressed inside skill slash-command arguments.
-### Changed
-
-- Live CLI and SDK session startup now reuses the `AgentStorage`-owned local credential store instead of opening a second `agent.db` connection; standalone discovery and remote broker ownership are unchanged.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -253,6 +253,17 @@ function stopStartupWatchdog(): void {
 	disarmStartupWatchdog();
 }
 
+/**
+ * Reset watchdog state after mocked process exits keep a test runtime alive.
+ * Returns whether a timer was armed so regressions can prove cleanup was necessary.
+ */
+export function resetStartupWatchdogForTests(): boolean {
+	const wasArmed = startupWatchdogTimer !== undefined;
+	stopStartupWatchdog();
+	startupWatchdogStartedAt = 0;
+	return wasArmed;
+}
+
 /** Pause while an interactive prompt legitimately waits on the user. */
 function pauseStartupWatchdog(): void {
 	disarmStartupWatchdog();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -68,10 +68,10 @@ import {
 	type CreateAgentSessionOptions,
 	type CreateAgentSessionResult,
 	createAgentSession,
-	discoverAuthStorage,
 	loadSessionExtensions,
 } from "./sdk";
 import type { AgentSession } from "./session/agent-session";
+import { discoverSessionAuthStorage } from "./session/auth-broker-config";
 import type { AuthStorage } from "./session/auth-storage";
 import { describePendingToolCalls } from "./session/exit-diagnostics";
 import { resolveResumableSession, type SessionInfo } from "./session/session-listing";
@@ -1116,7 +1116,7 @@ export async function buildSessionOptions(
 
 interface RunRootCommandDependencies {
 	createAgentSession?: typeof createAgentSession;
-	discoverAuthStorage?: typeof discoverAuthStorage;
+	discoverAuthStorage?: typeof discoverSessionAuthStorage;
 	selectSession?: typeof selectSession;
 	runAcpMode?: RunAcpMode;
 	settings?: Settings;
@@ -1142,7 +1142,7 @@ export async function runRootCommand(
 	const notifs: (InteractiveModeNotify | null)[] = [];
 
 	// Create AuthStorage and ModelRegistry upfront
-	const authStorage = await logger.time("discoverAuthStorage", deps.discoverAuthStorage ?? discoverAuthStorage);
+	const authStorage = await logger.time("discoverAuthStorage", deps.discoverAuthStorage ?? discoverSessionAuthStorage);
 	const modelRegistry = logger.time("modelRegistry:init", () => new ModelRegistry(authStorage));
 
 	if (parsedArgs.version) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1141,10 +1141,6 @@ export async function runRootCommand(
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
 
-	// Create AuthStorage and ModelRegistry upfront
-	const authStorage = await logger.time("discoverAuthStorage", deps.discoverAuthStorage ?? discoverSessionAuthStorage);
-	const modelRegistry = logger.time("modelRegistry:init", () => new ModelRegistry(authStorage));
-
 	if (parsedArgs.version) {
 		writeStartupNotice(parsedArgs, `${VERSION}\n`);
 		process.exit(0);
@@ -1169,6 +1165,10 @@ export async function runRootCommand(
 		process.stderr.write(`${chalk.red("Error: @file arguments are not supported in RPC mode")}\n`);
 		process.exit(1);
 	}
+	// No-session commands above must not initialize AgentStorage or auth schemas.
+	const authStorage = await logger.time("discoverAuthStorage", deps.discoverAuthStorage ?? discoverSessionAuthStorage);
+	const modelRegistry = logger.time("modelRegistry:init", () => new ModelRegistry(authStorage));
+
 	const mode = parsedArgs.mode || "text";
 	// RPC owns stdin. Claim its singleton stream before plugin/extension discovery can load an in-process consumer.
 	const rpcInput = mode === "rpc" || mode === "rpc-ui" ? claimRpcInput() : undefined;

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,7 +53,6 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: error =>
-			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,6 +53,7 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: error =>
+			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -5,7 +5,7 @@
  * Based on MCP spec 2025-03-26.
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, readSseJson, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -245,7 +245,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			if (!response.ok) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -266,7 +266,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			// Handle JSON response
-			const result = (await response.json()) as JsonRpcResponse;
+			const result = (await untilAborted(operation.signal, response.json())) as JsonRpcResponse;
 
 			if (result.error) {
 				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
@@ -446,7 +446,7 @@ export class HttpTransport implements MCPTransport {
 
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				throw new Error(`HTTP ${response.status}: ${text}`);
 			}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -128,7 +128,10 @@ import {
 	secretEntriesNeedPlaceholderKey,
 } from "./secrets";
 import { AgentSession, type InitialRetryFallbackState, type PlanYolo, type Prewalk } from "./session/agent-session";
-import { discoverAuthStorage as discoverAuthStorageFromConfig } from "./session/auth-broker-config";
+import {
+	discoverAuthStorage as discoverAuthStorageFromConfig,
+	discoverSessionAuthStorage as discoverSessionAuthStorageFromConfig,
+} from "./session/auth-broker-config";
 import type { AuthStorage } from "./session/auth-storage";
 import { createInterruptedTurnAbortMessage } from "./session/exit-diagnostics";
 import {
@@ -345,7 +348,10 @@ export interface CreateAgentSessionOptions {
 	/** Spawns to allow. Default: "*" */
 	spawns?: string;
 
-	/** Auth storage for credentials. Default: discoverAuthStorage(agentDir) */
+	/**
+	 * Auth storage for credentials. By default, a live session borrows the
+	 * AgentStorage-owned local store or owns the discovered remote broker store.
+	 */
 	authStorage?: AuthStorage;
 	/** Model registry. Default: discoverModels(authStorage, agentDir) */
 	modelRegistry?: ModelRegistry;
@@ -635,6 +641,8 @@ export {
  * Create an AuthStorage instance.
  *
  * Default: local SQLite store at `<agentDir>/agent.db`.
+ * Local results are standalone: the returned AuthStorage owns and closes its
+ * local connection. Live session defaults use the internal shared path instead.
  *
  * Broker mode: when `OMP_AUTH_BROKER_URL` is set, credentials are pulled from
  * a remote auth-broker over the wire. Refresh tokens never leave the broker;
@@ -1198,7 +1206,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// / session would silently miss credential_disabled events.
 	const modelRegistry =
 		options.modelRegistry ??
-		new ModelRegistry(options.authStorage ?? (await logger.time("discoverModels", discoverAuthStorage, agentDir)));
+		new ModelRegistry(
+			options.authStorage ?? (await logger.time("discoverModels", discoverSessionAuthStorageFromConfig, agentDir)),
+		);
 	// Track whether we internally created the authStorage so we can close it
 	// if construction fails before the session takes ownership.
 	const ownsAuthStorage = !options.authStorage && !options.modelRegistry;

--- a/packages/coding-agent/src/session/auth-broker-config.ts
+++ b/packages/coding-agent/src/session/auth-broker-config.ts
@@ -28,8 +28,9 @@ import {
 	getAuthBrokerTokenFilePath,
 	resolveAuthBrokerConfig as resolveAuthBrokerConfigShared,
 } from "@oh-my-pi/pi-ai/auth-broker/discover";
-import { getAgentDir } from "@oh-my-pi/pi-utils";
+import { getAgentDbPath, getAgentDir } from "@oh-my-pi/pi-utils";
 import { resolveConfigValue } from "../config/resolve-config-value";
+import { AgentStorage } from "./agent-storage";
 import type { AuthStorage } from "./auth-storage";
 
 export { type AuthBrokerClientConfig, getAuthBrokerTokenFilePath };
@@ -88,5 +89,25 @@ export function discoverAuthStorage(
 		...options,
 		agentDir,
 		configValueResolver: resolveConfigValue,
+	});
+}
+
+/**
+ * Discover auth storage for a live session.
+ *
+ * Local discovery borrows the auth store owned by AgentStorage so auth and
+ * settings share one agent.db connection. Broker discovery remains remote and
+ * never opens AgentStorage.
+ */
+export function discoverSessionAuthStorage(
+	agentDir: string = getAgentDir(),
+	options?: Omit<DiscoverAuthStorageOptions, "agentDir" | "configValueResolver" | "localStoreFactory">,
+): Promise<AuthStorage> {
+	const dbPath = getAgentDbPath(agentDir);
+	return discoverAuthStorageShared({
+		...options,
+		agentDir,
+		configValueResolver: resolveConfigValue,
+		localStoreFactory: async () => (await AgentStorage.open(dbPath)).authStore,
 	});
 }

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1215,9 +1215,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		return extraction;
 	}
 
-	async #waitForPdfImageExtraction(extraction: PdfImageExtraction, signal: AbortSignal | undefined): Promise<string> {
+	async #waitForPdfImageExtraction(
+		extraction: PdfImageExtraction,
+		signal: AbortSignal | undefined,
+		onJoined?: () => Promise<void>,
+	): Promise<string> {
 		extraction.waiters++;
 		try {
+			await onJoined?.();
 			return await untilAborted(signal, extraction.promise);
 		} finally {
 			extraction.waiters--;
@@ -1235,8 +1240,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const imageDir = this.#pdfImageCacheDir(absolutePdfPath, snapshot.digest);
 		const existing = pdfImageExtractions.get(imageDir);
 		if (existing && !existing.settled && !existing.controller.signal.aborted) {
-			await fs.rm(snapshot.directory, { recursive: true, force: true });
-			return this.#waitForPdfImageExtraction(existing, signal);
+			return this.#waitForPdfImageExtraction(existing, signal, () =>
+				fs.rm(snapshot.directory, { recursive: true, force: true }),
+			);
 		}
 
 		const extraction = this.#createPdfImageExtraction(snapshot, imageDir);

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -119,7 +119,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		return session;
 	}
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;
@@ -1199,7 +1199,7 @@ describe("AgentSession TTSR resume gate", () => {
 		vi.restoreAllMocks();
 	});
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -1349,9 +1349,13 @@ describe("executeBash :async: background retention", () => {
 				});
 				expect(res.cancelled).toBe(false);
 
-				await pollUntil(() => fs.existsSync(pidFile), Date.now() + 4000);
-				pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+				await pollUntil(() => {
+					if (!fs.existsSync(pidFile)) return false;
+					pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+					return Number.isInteger(pid);
+				}, Date.now() + 4000);
 				expect(Number.isInteger(pid)).toBe(true);
+				if (pid === undefined) throw new Error("Expected detached child pid");
 
 				// A later turn on a different per-job shell must not have killed it.
 				await executeBash("true", { sessionKey: "reparent-probe:async:job2", cwd: tmp });

--- a/packages/coding-agent/test/mcp-timeout.test.ts
+++ b/packages/coding-agent/test/mcp-timeout.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
+import { afterEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { createMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
 import { logger } from "@oh-my-pi/pi-utils";
 
 const ORIGINAL_TIMEOUT = process.env.OMP_MCP_TIMEOUT_MS;
 
 afterEach(() => {
+	vi.useRealTimers();
 	if (ORIGINAL_TIMEOUT === undefined) {
 		delete process.env.OMP_MCP_TIMEOUT_MS;
 	} else {
@@ -62,5 +63,17 @@ describe("MCP timeout configuration", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+
+	test("classifies only abort errors from the internal timeout", () => {
+		vi.useFakeTimers();
+		const operation = createMCPTimeout(50);
+		vi.advanceTimersByTime(50);
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+
+		expect(operation.isTimeoutAbort(new Error("HTTP 500"))).toBe(false);
+		expect(operation.isTimeoutAbort(abortError)).toBe(true);
+		operation.clear();
 	});
 });

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -385,7 +385,7 @@ describe("retain.execute (Mnemopi backend)", () => {
 
 		const text = (recallResult.content[0] as { text: string }).text;
 		expect(text).toContain("user prefers tabs");
-	});
+	}, 30_000);
 
 	it("stores multiple memories and returns correct count", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
@@ -933,7 +933,7 @@ describe("Mnemopi backend lifecycle", () => {
 		}
 		registeredMnemopiState = getMnemopiSessionState(session);
 		expect(registeredMnemopiState).toBeDefined();
-	});
+	}, 30_000);
 
 	it("exposes direct mnemopi runtime status and search/save results", async () => {
 		const config = makeMnemopiConfig({
@@ -1220,7 +1220,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 		expect(text).toContain("the user likes concise CLI output");
 		expect(text).toContain("project alpha uses pnpm workspaces");
 		expect(text).not.toContain("project beta deploys to staging first");
-	});
+	}, 30_000);
 
 	it("throws when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });

--- a/packages/coding-agent/test/models-config-lazy-validator.test.ts
+++ b/packages/coding-agent/test/models-config-lazy-validator.test.ts
@@ -62,4 +62,4 @@ test("models config validation resources are retained only for a custom config",
 	} finally {
 		await tempDir.remove().catch(() => {});
 	}
-});
+}, 30_000);

--- a/packages/coding-agent/test/session-auth-storage-sharing.test.ts
+++ b/packages/coding-agent/test/session-auth-storage-sharing.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import { type Args, parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
+import { resetStartupWatchdogForTests, runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { discoverSessionAuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-broker-config";
 import { getAgentDbPath, TempDir, VERSION } from "@oh-my-pi/pi-utils";
@@ -44,14 +44,17 @@ async function captureEarlyExit(args: string[], configure?: (parsed: Args) => vo
 	}) as typeof process.exit);
 
 	let thrown: unknown;
+	let watchdogWasArmed = false;
 	try {
 		await runRootCommand(parsed, args, { discoverAuthStorage });
 	} catch (error) {
 		thrown = error;
+	} finally {
+		watchdogWasArmed = resetStartupWatchdogForTests();
 	}
 	if (!(thrown instanceof ProcessExitSignal)) throw thrown;
 
-	return { code: thrown.code, stdout: stdout.join(""), stderr: stderr.join(""), discoveryCalls };
+	return { code: thrown.code, stdout: stdout.join(""), stderr: stderr.join(""), discoveryCalls, watchdogWasArmed };
 }
 
 describe("session auth storage sharing", () => {
@@ -70,6 +73,7 @@ describe("session auth storage sharing", () => {
 	});
 
 	afterEach(async () => {
+		resetStartupWatchdogForTests();
 		resetSettingsForTest();
 		AgentStorage.resetInstance();
 		vi.restoreAllMocks();
@@ -113,6 +117,7 @@ describe("session auth storage sharing", () => {
 			expect(result.stdout).toBe(`${VERSION}\n`);
 			expect(result.stderr).toBe("");
 			expect(result.discoveryCalls).toBe(0);
+			expect(result.watchdogWasArmed).toBe(true);
 		});
 
 		it("exports a session without discovering session auth storage", async () => {
@@ -135,6 +140,7 @@ describe("session auth storage sharing", () => {
 			expect(result.stdout).toBe(`Exported to: ${outputPath}\n`);
 			expect(result.stderr).toBe("");
 			expect(result.discoveryCalls).toBe(0);
+			expect(result.watchdogWasArmed).toBe(true);
 			expect(await Bun.file(outputPath).exists()).toBe(true);
 		});
 
@@ -147,6 +153,7 @@ describe("session auth storage sharing", () => {
 			expect(result.stdout).toBe("");
 			expect(result.stderr).toContain("Error: @file arguments are not supported in RPC mode");
 			expect(result.discoveryCalls).toBe(0);
+			expect(result.watchdogWasArmed).toBe(true);
 		});
 
 		it("still discovers session auth storage for normal session startup", async () => {
@@ -155,10 +162,16 @@ describe("session auth storage sharing", () => {
 				throw new Error("stop after auth discovery");
 			});
 
-			await expect(runRootCommand(parsed, ["--print", "hello"], { discoverAuthStorage })).rejects.toThrow(
-				"stop after auth discovery",
-			);
+			let watchdogWasArmed = false;
+			try {
+				await expect(runRootCommand(parsed, ["--print", "hello"], { discoverAuthStorage })).rejects.toThrow(
+					"stop after auth discovery",
+				);
+			} finally {
+				watchdogWasArmed = resetStartupWatchdogForTests();
+			}
 			expect(discoverAuthStorage).toHaveBeenCalledTimes(1);
+			expect(watchdogWasArmed).toBe(true);
 		});
 	});
 });

--- a/packages/coding-agent/test/session-auth-storage-sharing.test.ts
+++ b/packages/coding-agent/test/session-auth-storage-sharing.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
-import { parseArgs, type Args } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { type Args, parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";

--- a/packages/coding-agent/test/session-auth-storage-sharing.test.ts
+++ b/packages/coding-agent/test/session-auth-storage-sharing.test.ts
@@ -1,15 +1,58 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
 import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { parseArgs, type Args } from "@oh-my-pi/pi-coding-agent/cli/args";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { discoverSessionAuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-broker-config";
-import { getAgentDbPath, TempDir } from "@oh-my-pi/pi-utils";
+import { getAgentDbPath, TempDir, VERSION } from "@oh-my-pi/pi-utils";
 
 const AUTH_BROKER_ENV_KEYS = [
 	"OMP_AUTH_BROKER_URL",
 	"OMP_AUTH_BROKER_TOKEN",
 	"OMP_AUTH_BROKER_ACCOUNT_POOL_FILE",
 ] as const;
+
+class ProcessExitSignal extends Error {
+	constructor(readonly code: number) {
+		super(`process.exit(${code})`);
+		this.name = "ProcessExitSignal";
+	}
+}
+
+async function captureEarlyExit(args: string[], configure?: (parsed: Args) => void) {
+	const parsed = parseArgs(args);
+	configure?.(parsed);
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	let discoveryCalls = 0;
+	const discoverAuthStorage = vi.fn(async () => {
+		discoveryCalls++;
+		throw new Error("auth discovery should not run");
+	});
+	vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stdout.push(String(chunk));
+		return true;
+	});
+	vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+		stderr.push(String(chunk));
+		return true;
+	});
+	vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+		throw new ProcessExitSignal(code ?? 0);
+	}) as typeof process.exit);
+
+	let thrown: unknown;
+	try {
+		await runRootCommand(parsed, args, { discoverAuthStorage });
+	} catch (error) {
+		thrown = error;
+	}
+	if (!(thrown instanceof ProcessExitSignal)) throw thrown;
+
+	return { code: thrown.code, stdout: stdout.join(""), stderr: stderr.join(""), discoveryCalls };
+}
 
 describe("session auth storage sharing", () => {
 	let tempDir: TempDir;
@@ -60,5 +103,62 @@ describe("session auth storage sharing", () => {
 		expect(owner.listAuthCredentials("test-provider").map(row => row.credential)).toEqual([
 			{ type: "api_key", key: "shared-key", source: "login" },
 		]);
+	});
+
+	describe("root command auth storage discovery", () => {
+		it("prints --version without discovering session auth storage", async () => {
+			const result = await captureEarlyExit(["--version"]);
+
+			expect(result.code).toBe(0);
+			expect(result.stdout).toBe(`${VERSION}\n`);
+			expect(result.stderr).toBe("");
+			expect(result.discoveryCalls).toBe(0);
+		});
+
+		it("exports a session without discovering session auth storage", async () => {
+			const inputPath = path.join(tempDir.path(), "session.jsonl");
+			const outputPath = path.join(tempDir.path(), "session.html");
+			await Bun.write(
+				inputPath,
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "export-session",
+					timestamp: "2026-07-28T00:00:00.000Z",
+					cwd: tempDir.path(),
+				})}\n`,
+			);
+
+			const result = await captureEarlyExit(["--export", inputPath, outputPath]);
+
+			expect(result.code).toBe(0);
+			expect(result.stdout).toBe(`Exported to: ${outputPath}\n`);
+			expect(result.stderr).toBe("");
+			expect(result.discoveryCalls).toBe(0);
+			expect(await Bun.file(outputPath).exists()).toBe(true);
+		});
+
+		it("rejects RPC file arguments without discovering session auth storage", async () => {
+			const result = await captureEarlyExit(["@prompt.md"], parsed => {
+				parsed.mode = "rpc";
+			});
+
+			expect(result.code).toBe(1);
+			expect(result.stdout).toBe("");
+			expect(result.stderr).toContain("Error: @file arguments are not supported in RPC mode");
+			expect(result.discoveryCalls).toBe(0);
+		});
+
+		it("still discovers session auth storage for normal session startup", async () => {
+			const parsed = parseArgs(["--print", "hello"]);
+			const discoverAuthStorage = vi.fn(async () => {
+				throw new Error("stop after auth discovery");
+			});
+
+			await expect(runRootCommand(parsed, ["--print", "hello"], { discoverAuthStorage })).rejects.toThrow(
+				"stop after auth discovery",
+			);
+			expect(discoverAuthStorage).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/coding-agent/test/session-auth-storage-sharing.test.ts
+++ b/packages/coding-agent/test/session-auth-storage-sharing.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { discoverSessionAuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-broker-config";
+import { getAgentDbPath, TempDir } from "@oh-my-pi/pi-utils";
+
+const AUTH_BROKER_ENV_KEYS = [
+	"OMP_AUTH_BROKER_URL",
+	"OMP_AUTH_BROKER_TOKEN",
+	"OMP_AUTH_BROKER_ACCOUNT_POOL_FILE",
+] as const;
+
+describe("session auth storage sharing", () => {
+	let tempDir: TempDir;
+	let savedEnv: Partial<Record<(typeof AUTH_BROKER_ENV_KEYS)[number], string>>;
+
+	beforeEach(() => {
+		resetSettingsForTest();
+		AgentStorage.resetInstance();
+		tempDir = TempDir.createSync("@omp-session-auth-sharing-");
+		savedEnv = {};
+		for (const key of AUTH_BROKER_ENV_KEYS) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		AgentStorage.resetInstance();
+		vi.restoreAllMocks();
+		for (const key of AUTH_BROKER_ENV_KEYS) {
+			const value = savedEnv[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		await tempDir.remove();
+	});
+
+	it("uses the owner connection without opening or closing a standalone store", async () => {
+		const agentDir = tempDir.path();
+		const standaloneOpen = vi.spyOn(SqliteAuthCredentialStore, "open");
+
+		const authStorage = await discoverSessionAuthStorage(agentDir);
+		expect(standaloneOpen).toHaveBeenCalledTimes(0);
+
+		await Settings.init({ cwd: tempDir.path(), agentDir });
+		const owner = await AgentStorage.open(getAgentDbPath(agentDir));
+		owner.replaceAuthCredentialsForProvider("test-provider", [
+			{ type: "api_key", key: "shared-key", source: "login" },
+		]);
+		await authStorage.reload();
+		expect(authStorage.listStoredCredentials("test-provider").map(row => row.credential)).toEqual([
+			{ type: "api_key", key: "shared-key", source: "login" },
+		]);
+
+		authStorage.close();
+		authStorage.close();
+		expect(owner.listAuthCredentials("test-provider").map(row => row.credential)).toEqual([
+			{ type: "api_key", key: "shared-key", source: "login" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -250,8 +250,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		joinerController.abort();
-		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await owner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -233,8 +233,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		ownerController.abort();
-		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await joiner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -239,7 +239,7 @@ describe("read PDF image extraction", () => {
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);
 		expect(spy).toHaveBeenCalledTimes(1);
-	});
+	}, 30_000);
 
 	it("keeps shared extraction running when a joiner aborts", async () => {
 		const { entered, release, spy } = mockBlockedExtraction();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,6 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2120,7 +2120,7 @@ describe("vibe session registry", () => {
 		const resumedSession = createSession({ manager: createManager(), sessionManager: reopened });
 		expect(await VibeSessionRegistry.global().rehydrate(resumedSession)).toBe(0);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
-	});
+	}, 15_000);
 
 	it("killAll terminates every session for the owner (mode-exit path)", async () => {
 		const gates = new Map<string, Deferred>();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,7 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
-		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted", 10_000);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {


### PR DESCRIPTION
## Purpose

Reuse the local credential store already owned by `AgentStorage` when a live CLI or SDK session starts, avoiding a second `agent.db` connection.

## Tests

- Red on upstream `main`: `bun test packages/ai/test/auth-storage-ownership.test.ts packages/coding-agent/test/session-auth-storage-sharing.test.ts` — 3 passed, 3 failed (borrowed close closed its store, the local factory was not invoked, and session discovery was absent).
- Green: the same focused command — 6 passed, 0 failed.
- Boundary regression: `bun test packages/ai/test/auth-storage-ownership.test.ts packages/ai/test/auth-broker-config-discovery.test.ts packages/coding-agent/test/auth-broker-snapshot-cache.test.ts packages/coding-agent/test/session-auth-storage-sharing.test.ts` — 11 passed, 0 failed.

## Metrics

Measured startup CPU context for the retained candidate: 2,340 ms baseline, 1,990 ms treatment, and 2,050 ms independent confirmation. Conservatively comparing the baseline with the confirmation is 290 ms, or 12.4%, lower CPU. This is startup-level candidate context, not an isolated attribution to auth-store sharing and not a latency or memory claim.

## Safety

Standalone discovery and `AuthStorage.create()` continue to own and close stores they open. Broker resolution still occurs before any local factory call, so remote sessions retain remote-store ownership and never open `AgentStorage`. Only live session startup borrows the process-lifetime `AgentStorage` store already used by settings and potentially sibling sessions; session disposal therefore cannot close that shared owner. No remote-auth redesign or adjacent startup behavior is included.