### PR TITLE
perf(coding-agent): lazily construct computer schema

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced default startup resident memory by constructing the default-off ComputerTool ArkType schema only on first parameter access, then reusing it across tool instances without changing validation or tool behavior ([#6742](https://github.com/can1357/oh-my-pi/pull/6742) by [@usr-bin-roygbiv](https://github.com/usr-bin-roygbiv)).
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -14,8 +14,8 @@ import type {
 	DesktopDisplay,
 	DesktopSessionOptions,
 } from "@oh-my-pi/pi-natives";
-import { prompt, sanitizeText } from "@oh-my-pi/pi-utils";
-import { type } from "arktype";
+import { once, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
+import { type Type, type } from "arktype";
 import computerDescription from "../prompts/tools/computer.md" with { type: "text" };
 import { truncateForPrompt } from "./approval";
 import { type ComputerController, ComputerSupervisor, registerComputerController } from "./computer/supervisor";
@@ -57,46 +57,69 @@ function captureOptions(session: ToolSession, coordinateSafeImageSizing: boolean
 const INT32_MIN = -2_147_483_648;
 const INT32_MAX = 2_147_483_647;
 
-const coordinateSchema = type("0 <= number.integer <= 2147483647");
-const scrollDeltaSchema = type("-2147483648 <= number.integer <= 2147483647");
+type ComputerSchemaPoint = {
+	x: number;
+	y: number;
+};
 
-const pointSchema = type({
-	x: coordinateSchema.describe("x pixel coordinate"),
-	y: coordinateSchema.describe("y pixel coordinate"),
-	"+": "reject",
+type ComputerSchemaAction = {
+	type: ComputerAction["type"];
+	x?: number;
+	y?: number;
+	button?: "left" | "right" | "wheel" | "back" | "forward";
+	path?: ComputerSchemaPoint[];
+	keys?: string[] | null;
+	scroll_x?: number;
+	scroll_y?: number;
+	text?: string;
+};
+
+export type ComputerParams = {
+	actions?: ComputerSchemaAction[];
+};
+
+type ComputerSchema = Type<ComputerParams>;
+
+const getComputerSchema: () => ComputerSchema = once(() => {
+	const coordinateSchema = type("0 <= number.integer <= 2147483647");
+	const scrollDeltaSchema = type("-2147483648 <= number.integer <= 2147483647");
+
+	const pointSchema = type({
+		x: coordinateSchema.describe("x pixel coordinate"),
+		y: coordinateSchema.describe("y pixel coordinate"),
+		"+": "reject",
+	});
+
+	const computerActionSchema = type({
+		type: type(
+			"'click' | 'double_click' | 'drag' | 'keypress' | 'move' | 'screenshot' | 'scroll' | 'type' | 'wait'",
+		).describe("action kind"),
+		"x?": coordinateSchema.describe(
+			"x pixel coordinate in the most recent screenshot (click, double_click, move, scroll)",
+		),
+		"y?": coordinateSchema.describe(
+			"y pixel coordinate in the most recent screenshot (click, double_click, move, scroll)",
+		),
+		"button?": type("'left' | 'right' | 'wheel' | 'back' | 'forward'").describe("mouse button; required for click"),
+		"path?": pointSchema.array().atLeastLength(2).describe("waypoints from press to release; required for drag"),
+		"keys?": type("string[] | null").describe(
+			"key names (e.g. CTRL, SHIFT, ENTER, A); required chord for keypress, optional held modifiers for pointer actions",
+		),
+		"scroll_x?": scrollDeltaSchema.describe("horizontal scroll delta in pixels; required for scroll"),
+		"scroll_y?": scrollDeltaSchema.describe(
+			"vertical scroll delta in pixels, positive scrolls content down; required for scroll",
+		),
+		"text?": type("string").describe("literal text to type; required for type"),
+		"+": "reject",
+	});
+
+	return type({
+		"actions?": computerActionSchema
+			.array()
+			.describe("ordered actions executed as one batch; omit or pass [] to just capture a screenshot"),
+		"+": "reject",
+	});
 });
-
-const computerActionSchema = type({
-	type: type(
-		"'click' | 'double_click' | 'drag' | 'keypress' | 'move' | 'screenshot' | 'scroll' | 'type' | 'wait'",
-	).describe("action kind"),
-	"x?": coordinateSchema.describe(
-		"x pixel coordinate in the most recent screenshot (click, double_click, move, scroll)",
-	),
-	"y?": coordinateSchema.describe(
-		"y pixel coordinate in the most recent screenshot (click, double_click, move, scroll)",
-	),
-	"button?": type("'left' | 'right' | 'wheel' | 'back' | 'forward'").describe("mouse button; required for click"),
-	"path?": pointSchema.array().atLeastLength(2).describe("waypoints from press to release; required for drag"),
-	"keys?": type("string[] | null").describe(
-		"key names (e.g. CTRL, SHIFT, ENTER, A); required chord for keypress, optional held modifiers for pointer actions",
-	),
-	"scroll_x?": scrollDeltaSchema.describe("horizontal scroll delta in pixels; required for scroll"),
-	"scroll_y?": scrollDeltaSchema.describe(
-		"vertical scroll delta in pixels, positive scrolls content down; required for scroll",
-	),
-	"text?": type("string").describe("literal text to type; required for type"),
-	"+": "reject",
-});
-
-const computerSchema = type({
-	"actions?": computerActionSchema
-		.array()
-		.describe("ordered actions executed as one batch; omit or pass [] to just capture a screenshot"),
-	"+": "reject",
-});
-
-export type ComputerParams = typeof computerSchema.infer;
 
 export interface ComputerToolDetails {
 	width: number;
@@ -374,14 +397,16 @@ function approvalActionSummary(actions: unknown): string[] {
 	return truncateForPrompt(lines.join("\n"), 2_000).split("\n");
 }
 
-export class ComputerTool implements AgentTool<typeof computerSchema, ComputerToolDetails> {
+export class ComputerTool implements AgentTool<ComputerSchema, ComputerToolDetails> {
 	readonly name = "computer";
 	readonly native = { type: "computer" } as const;
 	readonly label = "Computer";
 	readonly loadMode = "essential" as const;
 	readonly concurrency = "exclusive" as const;
 	readonly summary = "Capture and control the host desktop through native OS APIs";
-	readonly parameters = computerSchema;
+	get parameters(): ComputerSchema {
+		return getComputerSchema();
+	}
 	readonly strict = false;
 	readonly approval = computerApproval;
 	readonly formatApprovalDetails = (args: unknown): string[] => {

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -78,7 +78,13 @@ export type ComputerParams = {
 	actions?: ComputerSchemaAction[];
 };
 
-type ComputerSchema = Type<ComputerParams>;
+type IsSameType<Left, Right> = [Left] extends [Right] ? ([Right] extends [Left] ? true : false) : false;
+type ComputerSchema<Schema extends Type = Type<ComputerParams>> = IsSameType<
+	ComputerParams,
+	Schema["infer"]
+> extends true
+	? Schema
+	: never;
 
 const getComputerSchema: () => ComputerSchema = once(() => {
 	const coordinateSchema = type("0 <= number.integer <= 2147483647");
@@ -113,12 +119,13 @@ const getComputerSchema: () => ComputerSchema = once(() => {
 		"+": "reject",
 	});
 
-	return type({
+	const computerSchema = type({
 		"actions?": computerActionSchema
 			.array()
 			.describe("ordered actions executed as one batch; omit or pass [] to just capture a screenshot"),
 		"+": "reject",
 	});
+	return computerSchema satisfies ComputerSchema<typeof computerSchema>;
 });
 
 export interface ComputerToolDetails {

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -79,12 +79,8 @@ export type ComputerParams = {
 };
 
 type IsSameType<Left, Right> = [Left] extends [Right] ? ([Right] extends [Left] ? true : false) : false;
-type ComputerSchema<Schema extends Type = Type<ComputerParams>> = IsSameType<
-	ComputerParams,
-	Schema["infer"]
-> extends true
-	? Schema
-	: never;
+type ComputerSchema<Schema extends Type = Type<ComputerParams>> =
+	IsSameType<ComputerParams, Schema["infer"]> extends true ? Schema : never;
 
 const getComputerSchema: () => ComputerSchema = once(() => {
 	const coordinateSchema = type("0 <= number.integer <= 2147483647");

--- a/packages/coding-agent/test/computer-lazy-schema.test.ts
+++ b/packages/coding-agent/test/computer-lazy-schema.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+
+const preloadPath = path.join(import.meta.dir, "fixtures", "computer-schema-construction-preload.ts");
+const probePath = path.join(import.meta.dir, "fixtures", "computer-schema-construction-probe.ts");
+
+test("computer schema is constructed once on first parameters access", async () => {
+	const proc = Bun.spawn([process.execPath, "--preload", preloadPath, probePath], {
+		cwd: path.join(import.meta.dir, "../../.."),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	expect(exitCode, stderr).toBe(0);
+	expect(JSON.parse(stdout)).toEqual({
+		counts: {
+			afterModuleImport: 0,
+			afterDefaultOffFactory: 0,
+			afterToolConstruction: 0,
+			afterFirstParametersAccess: 1,
+			afterRepeatedParametersAccess: 1,
+			afterSecondToolParametersAccess: 1,
+			afterValidation: 1,
+		},
+		disabledToolCount: 0,
+		schema: {
+			callable: true,
+			repeatedIdentity: true,
+			crossToolIdentity: true,
+			validAccepted: true,
+			validOutput: {
+				actions: [
+					{ type: "click", x: 1, y: 2, button: "left", keys: null },
+					{ type: "double_click", x: 3, y: 4 },
+					{
+						type: "drag",
+						path: [
+							{ x: 0, y: 0 },
+							{ x: 9, y: 9 },
+						],
+					},
+					{ type: "keypress", keys: ["CTRL", "A"] },
+					{ type: "move", x: 5, y: 6 },
+					{ type: "screenshot" },
+					{ type: "scroll", x: 7, y: 8, scroll_x: -10, scroll_y: 20 },
+					{ type: "type", text: "hello" },
+					{ type: "wait" },
+				],
+			},
+			invalidRejected: [true, true, true, true, true, true],
+		},
+	});
+}, 20_000);

--- a/packages/coding-agent/test/fixtures/computer-schema-construction-preload.ts
+++ b/packages/coding-agent/test/fixtures/computer-schema-construction-preload.ts
@@ -1,0 +1,19 @@
+import { spyOn } from "bun:test";
+import * as arktype from "arktype";
+
+declare global {
+	var __computerCoordinateSchemaConstructionCount: number;
+}
+
+const coordinateDefinition = "0 <= number.integer <= 2147483647";
+globalThis.__computerCoordinateSchemaConstructionCount = 0;
+const originalType = arktype.type;
+const countedType = ((...args: unknown[]) => {
+	if (args[0] === coordinateDefinition) {
+		globalThis.__computerCoordinateSchemaConstructionCount += 1;
+	}
+	return Reflect.apply(originalType, undefined, args);
+}) as typeof originalType;
+Object.assign(countedType, originalType);
+const typeSpy = spyOn(arktype, "type").mockImplementation(countedType);
+Object.assign(typeSpy, originalType);

--- a/packages/coding-agent/test/fixtures/computer-schema-construction-probe.ts
+++ b/packages/coding-agent/test/fixtures/computer-schema-construction-probe.ts
@@ -1,0 +1,101 @@
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { BUILTIN_TOOLS, ComputerTool, createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { type as arkType } from "arktype";
+
+declare global {
+	var __computerCoordinateSchemaConstructionCount: number;
+}
+
+const count = () => globalThis.__computerCoordinateSchemaConstructionCount;
+const toolSession = (settings: Settings): ToolSession =>
+	({
+		cwd: ".",
+		hasUI: false,
+		settings,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+	}) as ToolSession;
+
+const counts = {
+	afterModuleImport: count(),
+	afterDefaultOffFactory: -1,
+	afterToolConstruction: -1,
+	afterFirstParametersAccess: -1,
+	afterRepeatedParametersAccess: -1,
+	afterSecondToolParametersAccess: -1,
+	afterValidation: -1,
+};
+
+const disabledTools = await createTools(toolSession(Settings.isolated()), ["computer"]);
+counts.afterDefaultOffFactory = count();
+
+const firstTool = await BUILTIN_TOOLS.computer(toolSession(Settings.isolated()));
+const secondTool = await BUILTIN_TOOLS.computer(toolSession(Settings.isolated()));
+if (!(firstTool instanceof ComputerTool) || !(secondTool instanceof ComputerTool)) {
+	throw new Error("Expected the built-in computer factory to construct ComputerTool instances");
+}
+counts.afterToolConstruction = count();
+
+const firstSchema = firstTool.parameters;
+counts.afterFirstParametersAccess = count();
+const repeatedSchema = firstTool.parameters;
+counts.afterRepeatedParametersAccess = count();
+const secondToolSchema = secondTool.parameters;
+counts.afterSecondToolParametersAccess = count();
+
+const validInput = {
+	actions: [
+		{ type: "click", x: 1, y: 2, button: "left", keys: null },
+		{ type: "double_click", x: 3, y: 4 },
+		{
+			type: "drag",
+			path: [
+				{ x: 0, y: 0 },
+				{ x: 9, y: 9 },
+			],
+		},
+		{ type: "keypress", keys: ["CTRL", "A"] },
+		{ type: "move", x: 5, y: 6 },
+		{ type: "screenshot" },
+		{ type: "scroll", x: 7, y: 8, scroll_x: -10, scroll_y: 20 },
+		{ type: "type", text: "hello" },
+		{ type: "wait" },
+	],
+};
+const validOutput = firstSchema(validInput);
+const invalidOutputs = [
+	firstSchema({ actions: [{ type: "click", x: -1, y: 2, button: "left" }] }),
+	firstSchema({ actions: [{ type: "move", x: 0.5, y: 0 }] }),
+	firstSchema({ actions: [{ type: "scroll", x: 0, y: 0, scroll_x: 2 ** 31, scroll_y: 0 }] }),
+	firstSchema({ actions: [{ type: "drag", path: [{ x: 0, y: 0 }] }] }),
+	firstSchema({
+		actions: [
+			{
+				type: "drag",
+				path: [
+					{ x: 0, y: 0, label: "unexpected" },
+					{ x: 1, y: 1 },
+				],
+			},
+		],
+	}),
+	firstSchema({ actions: [], unexpected: true }),
+];
+counts.afterValidation = count();
+
+await Promise.all([firstTool.close(), secondTool.close()]);
+
+process.stdout.write(
+	JSON.stringify({
+		counts,
+		disabledToolCount: disabledTools.length,
+		schema: {
+			callable: typeof firstSchema === "function",
+			repeatedIdentity: firstSchema === repeatedSchema,
+			crossToolIdentity: firstSchema === secondToolSchema,
+			validAccepted: !(validOutput instanceof arkType.errors),
+			validOutput,
+			invalidRejected: invalidOutputs.map(output => output instanceof arkType.errors),
+		},
+	}),
+);


### PR DESCRIPTION
## Purpose

Defer construction of the default-off `ComputerTool` ArkType schema until the first `parameters` access, then reuse that schema across accesses and tool instances. Import, default-off factory resolution, and tool construction no longer build the schema.

## Tests

- RED on upstream `main`: the focused lifecycle test observed one coordinate-schema construction after module import, default-off factory resolution, and tool construction, where zero was expected.
- GREEN: `bun test test/computer-lazy-schema.test.ts test/tools/computer.test.ts` — 29 passed, 110 assertions.
- `bun run ci:check:full` — workspace TypeScript formatting, lint, and type checks passed.

## Metrics

In repeated startup benchmark samples, median RSS was 310.3–311.0 MiB on the parent and 301.6–306.5 MiB with this change, a reproducible 1.4–3.0% reduction. These are process-level median RSS ranges from repeated parent/treatment runs. CPU measurements were neutral/noisy, so this PR makes no CPU improvement claim.

## Safety

The schema rules, validation behavior, and `ComputerTool` execution behavior are unchanged; only schema construction timing changes. The focused regression verifies zero construction through import/factory/tool creation, exactly one construction on first access, stable identity on repeated and cross-instance access, and unchanged valid/invalid validation outcomes. A compile-time exact type parity guard prevents the exported parameters type from drifting from the lazy schema.