### PR TITLE
perf(coding-agent): avoid unused compact tool metadata

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -153,7 +153,7 @@ import { unmountAll } from "./ssh/sshfs-mount";
 import {
 	type BuildSystemPromptResult,
 	buildSystemPrompt as buildSystemPromptInternal,
-	buildSystemPromptToolMetadata,
+	projectSystemPromptToolMetadata,
 	loadProjectContextFiles as loadContextFilesInternal,
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
@@ -813,7 +813,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	const toolNames = options.tools?.map(tool => tool.name);
 	const toolMap = options.tools ? new Map(options.tools.map(tool => [tool.name, tool])) : undefined;
 	const promptTools = toolMap
-		? buildSystemPromptToolMetadata(
+		? projectSystemPromptToolMetadata(
 				toolMap,
 				options.inlineToolDescriptors ? { mode: "full" } : { mode: "compact", toolNames: toolNames ?? [] },
 			)
@@ -2682,7 +2682,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Owned/in-band tool dialects (non-native) require the catalog as `# Tool:`
 			// sections; native tool calling lets the compact name list suffice.
 			const nativeTools = resolveDialect(settings.get("tools.format"), agent?.state.model ?? model) === undefined;
-			const promptTools = buildSystemPromptToolMetadata(
+			const promptTools = projectSystemPromptToolMetadata(
 				tools,
 				nativeTools && !inlineToolDescriptors ? { mode: "compact", toolNames } : { mode: "full" },
 			);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -810,7 +810,14 @@ export interface BuildSystemPromptOptions {
  * as separate entries so providers can cache prompt prefixes without concatenating blocks.
  */
 export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
+	const toolNames = options.tools?.map(tool => tool.name);
 	const toolMap = options.tools ? new Map(options.tools.map(tool => [tool.name, tool])) : undefined;
+	const promptTools = toolMap
+		? buildSystemPromptToolMetadata(
+				toolMap,
+				options.inlineToolDescriptors ? { mode: "full" } : { mode: "compact", toolNames: toolNames ?? [] },
+			)
+		: undefined;
 	return await buildSystemPromptInternal({
 		cwd: options.cwd,
 		customPrompt: options.customPrompt,
@@ -819,8 +826,8 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		appendSystemPrompt: options.appendPrompt,
 		inlineToolDescriptors: options.inlineToolDescriptors,
 		includeWorkspaceTree: options.includeWorkspaceTree,
-		toolNames: options.tools?.map(tool => tool.name),
-		tools: toolMap ? buildSystemPromptToolMetadata(toolMap) : undefined,
+		toolNames,
+		tools: promptTools,
 	});
 }
 
@@ -2629,7 +2636,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: Map<string, AgentTool>,
 		): Promise<BuildSystemPromptResult> => {
 			toolContextStore.setToolNames(toolNames);
-			const promptTools = buildSystemPromptToolMetadata(tools);
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);
 			const memoryInstructions = memoryBackend
 				? await memoryBackend.buildDeveloperInstructions(agentDir, settings, session)
@@ -2676,6 +2682,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Owned/in-band tool dialects (non-native) require the catalog as `# Tool:`
 			// sections; native tool calling lets the compact name list suffice.
 			const nativeTools = resolveDialect(settings.get("tools.format"), agent?.state.model ?? model) === undefined;
+			const promptTools = buildSystemPromptToolMetadata(
+				tools,
+				nativeTools && !inlineToolDescriptors ? { mode: "compact", toolNames } : { mode: "full" },
+			);
 			if (options.appendSystemPrompt) {
 				appendPrompt = appendPrompt
 					? `${appendPrompt}\n\n${options.appendSystemPrompt}`

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -153,8 +153,8 @@ import { unmountAll } from "./ssh/sshfs-mount";
 import {
 	type BuildSystemPromptResult,
 	buildSystemPrompt as buildSystemPromptInternal,
-	projectSystemPromptToolMetadata,
 	loadProjectContextFiles as loadContextFilesInternal,
+	projectSystemPromptToolMetadata,
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
 import { wrapStreamFnWithProviderConcurrency } from "./task/provider-concurrency";

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -417,30 +417,54 @@ export interface SystemPromptToolMetadata {
 	examples?: readonly ToolExample[];
 }
 
+export type SystemPromptToolMetadataProjection =
+	| {
+			mode: "compact";
+			toolNames: readonly string[];
+			overrides?: Partial<Record<string, Partial<SystemPromptToolMetadata>>>;
+	  }
+	| {
+			mode: "full";
+			overrides?: Partial<Record<string, Partial<SystemPromptToolMetadata>>>;
+	  };
+
 export function buildSystemPromptToolMetadata(
 	tools: Map<string, AgentTool>,
-	overrides: Partial<Record<string, Partial<SystemPromptToolMetadata>>> = {},
+	projection: SystemPromptToolMetadataProjection,
 ): Map<string, SystemPromptToolMetadata> {
-	return new Map(
-		Array.from(tools.entries(), ([name, tool]) => {
-			const toolRecord = tool as AgentTool & { label?: string; description?: string };
-			const override = overrides[name];
-			const wireName =
-				override?.wireName ??
-				(typeof toolRecord.customWireName === "string" ? toolRecord.customWireName : undefined);
-			return [
-				name,
-				{
-					label: override?.label ?? (typeof toolRecord.label === "string" ? toolRecord.label : ""),
-					description:
-						override?.description ?? (typeof toolRecord.description === "string" ? toolRecord.description : ""),
-					parameters: toolRecord.parameters,
-					examples: toolRecord.examples,
-					wireName,
-				},
-			] as const;
-		}),
-	);
+	const metadata = new Map<string, SystemPromptToolMetadata>();
+	const addTool = (name: string, tool: AgentTool): void => {
+		const override = projection.overrides?.[name];
+		const labelValue = override?.label ?? tool.label;
+		const wireNameValue = override?.wireName ?? tool.customWireName;
+		const label = typeof labelValue === "string" ? labelValue : "";
+		const wireName = typeof wireNameValue === "string" ? wireNameValue : undefined;
+
+		if (projection.mode === "compact") {
+			metadata.set(name, { label, description: "", wireName });
+			return;
+		}
+
+		const descriptionValue = override?.description ?? tool.description;
+		metadata.set(name, {
+			label,
+			description: typeof descriptionValue === "string" ? descriptionValue : "",
+			parameters: tool.parameters,
+			examples: tool.examples,
+			wireName,
+		});
+	};
+
+	if (projection.mode === "compact") {
+		for (const name of projection.toolNames) {
+			const tool = tools.get(name);
+			if (tool) addTool(name, tool);
+		}
+	} else {
+		for (const [name, tool] of tools) addTool(name, tool);
+	}
+
+	return metadata;
 }
 
 export interface BuildSystemPromptOptions {
@@ -743,6 +767,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		toolNames = tools ? Array.from(tools.keys()) : [...DEFAULT_SYSTEM_PROMPT_TOOL_NAMES];
 	}
 
+	// List mode shows a compact tool-name list; it only applies when descriptors
+	// stay in provider-native tool schemas AND native tool calling is active.
+	// Otherwise render full `# Tool:` sections inline in the system prompt.
+	const toolListMode = !inlineToolDescriptors && nativeTools;
 	// Build tool descriptions for system prompt rendering.
 	const toolPromptNames = new Map<string, string>(toolNames.map(name => [name, tools?.get(name)?.wireName ?? name]));
 	// xd://-mounted tools count as present for prompt gates ({{#has tools "lsp"}})
@@ -761,22 +789,21 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		name: toolPromptNames.get(name) ?? name,
 		internalName: name,
 		label: tools?.get(name)?.label ?? "",
-		description: tools?.get(name)?.description ?? "",
 	}));
-	const inventoryTools = inventoryToolNames.map(name => {
-		const meta = tools?.get(name);
-		return {
-			name: toolPromptNames.get(name) ?? name,
-			description: meta?.description ?? "",
-			parameters: meta?.parameters ?? ({ type: "object" } as TSchema),
-			examples: meta?.examples,
-		};
-	});
-	// List mode shows a compact tool-name list; it only applies when descriptors
-	// stay in provider-native tool schemas AND native tool calling is active.
-	// Otherwise render full `# Tool:` sections inline in the system prompt.
-	const toolListMode = !inlineToolDescriptors && nativeTools;
-	const toolInventory = toolListMode ? "" : renderToolInventory(inventoryTools, model ?? "");
+	const toolInventory = toolListMode
+		? ""
+		: renderToolInventory(
+				inventoryToolNames.map(name => {
+					const meta = tools?.get(name);
+					return {
+						name: toolPromptNames.get(name) ?? name,
+						description: meta?.description ?? "",
+						parameters: meta?.parameters ?? ({ type: "object" } as TSchema),
+						examples: meta?.examples,
+					};
+				}),
+				model ?? "",
+			);
 
 	// Filter skills for the rendered system prompt:
 	// - require the `read` tool so the model can actually fetch skill content;

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -430,6 +430,14 @@ export type SystemPromptToolMetadataProjection =
 
 export function buildSystemPromptToolMetadata(
 	tools: Map<string, AgentTool>,
+	overrides: Partial<Record<string, Partial<SystemPromptToolMetadata>>> = {},
+): Map<string, SystemPromptToolMetadata> {
+	return projectSystemPromptToolMetadata(tools, { mode: "full", overrides });
+}
+
+/** Builds a mode-specific metadata snapshot for internal prompt assembly. */
+export function projectSystemPromptToolMetadata(
+	tools: Map<string, AgentTool>,
 	projection: SystemPromptToolMetadataProjection,
 ): Map<string, SystemPromptToolMetadata> {
 	const metadata = new Map<string, SystemPromptToolMetadata>();

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -57,6 +57,18 @@ const SDK_TOOL: Tool = {
 	},
 };
 
+interface MetadataGetterCounts {
+	label: number;
+	wireName: number;
+	description: number;
+	parameters: number;
+	examples: number;
+}
+
+function emptyMetadataGetterCounts(): MetadataGetterCounts {
+	return { label: 0, wireName: 0, description: 0, parameters: 0, examples: 0 };
+}
+
 describe("system prompt tool inventory", () => {
 	let tempDir = "";
 	let tempHomeDir = "";
@@ -132,6 +144,242 @@ describe("system prompt tool inventory", () => {
 			settings,
 		} as ToolSession;
 	}
+
+	it("snapshots every full metadata getter once per rebuild and keeps fresh values", async () => {
+		let revision = 1;
+		const reads = new Map<string, MetadataGetterCounts>();
+		const makeTool = (name: string): Tool => {
+			const counts = emptyMetadataGetterCounts();
+			reads.set(name, counts);
+			return {
+				name,
+				approval: "read",
+				get label() {
+					counts.label += 1;
+					return `${name} label r${revision}`;
+				},
+				get customWireName() {
+					counts.wireName += 1;
+					return `${name}_wire_r${revision}`;
+				},
+				get description() {
+					counts.description += 1;
+					return `${name} description r${revision}`;
+				},
+				get parameters() {
+					counts.parameters += 1;
+					return {
+						type: "object",
+						properties: { [`arg_r${revision}`]: { type: "string" } },
+						required: [`arg_r${revision}`],
+					};
+				},
+				get examples() {
+					counts.examples += 1;
+					return [{ caption: `${name} example r${revision}`, note: `note r${revision}` }];
+				},
+				async execute() {
+					return { content: [{ type: "text", text: "ok" }] };
+				},
+			};
+		};
+		const tools = new Map<string, Tool>([
+			["read", makeTool("read")],
+			["edit", makeTool("edit")],
+		]);
+
+		const first = buildSystemPromptToolMetadata(tools, { mode: "full" });
+		expect(Array.from(first.keys())).toEqual(["read", "edit"]);
+		expect(first.get("edit")).toEqual({
+			label: "edit label r1",
+			description: "edit description r1",
+			parameters: {
+				type: "object",
+				properties: { arg_r1: { type: "string" } },
+				required: ["arg_r1"],
+			},
+			examples: [{ caption: "edit example r1", note: "note r1" }],
+			wireName: "edit_wire_r1",
+		});
+		expect(Array.from(reads.values())).toEqual([
+			{ label: 1, wireName: 1, description: 1, parameters: 1, examples: 1 },
+			{ label: 1, wireName: 1, description: 1, parameters: 1, examples: 1 },
+		]);
+
+		const firstPrompt = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["edit", "read"],
+			tools: first,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools: false,
+			inlineToolDescriptors: false,
+		});
+		const firstText = firstPrompt.systemPrompt.join("\n\n");
+		expect(firstText.indexOf("# Tool: edit_wire_r1")).toBeLessThan(firstText.indexOf("# Tool: read_wire_r1"));
+		expect(firstText).toContain("edit description r1");
+		expect(firstText).toContain("arg_r1: string;");
+
+		revision = 2;
+		const second = buildSystemPromptToolMetadata(tools, { mode: "full" });
+		expect(second.get("edit")?.description).toBe("edit description r2");
+		expect(second.get("edit")?.wireName).toBe("edit_wire_r2");
+		expect(first.get("edit")?.description).toBe("edit description r1");
+		expect(Array.from(reads.values())).toEqual([
+			{ label: 2, wireName: 2, description: 2, parameters: 2, examples: 2 },
+			{ label: 2, wireName: 2, description: 2, parameters: 2, examples: 2 },
+		]);
+
+		const secondPrompt = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["edit", "read"],
+			tools: second,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools: false,
+			inlineToolDescriptors: false,
+		});
+		const secondText = secondPrompt.systemPrompt.join("\n\n");
+		expect(secondText.indexOf("# Tool: edit_wire_r2")).toBeLessThan(secondText.indexOf("# Tool: read_wire_r2"));
+		expect(secondText).toContain("edit description r2");
+		expect(secondText).toContain("arg_r2: string;");
+		expect(secondText).not.toContain("edit description r1");
+	});
+
+	it("projects compact metadata in active order without reading descriptors or inactive tools", async () => {
+		const reads = new Map<string, MetadataGetterCounts>();
+		const makeTool = (name: string, label: string, wireName?: string): Tool => {
+			const counts = emptyMetadataGetterCounts();
+			reads.set(name, counts);
+			return {
+				name,
+				approval: "read",
+				get label() {
+					counts.label += 1;
+					return label;
+				},
+				get customWireName() {
+					counts.wireName += 1;
+					return wireName;
+				},
+				get description(): string {
+					counts.description += 1;
+					throw new Error(`${name} description getter was read`);
+				},
+				get parameters(): Tool["parameters"] {
+					counts.parameters += 1;
+					throw new Error(`${name} parameters getter was read`);
+				},
+				get examples(): Tool["examples"] {
+					counts.examples += 1;
+					throw new Error(`${name} examples getter was read`);
+				},
+				async execute() {
+					return { content: [{ type: "text", text: "ok" }] };
+				},
+			};
+		};
+		const tools = new Map<string, Tool>([
+			["inactive", makeTool("inactive", "Inactive")],
+			["read", makeTool("read", "Read")],
+			["edit", makeTool("edit", "Edit", "apply_patch")],
+		]);
+
+		const metadata = buildSystemPromptToolMetadata(tools, {
+			mode: "compact",
+			toolNames: ["edit", "read"],
+		});
+		expect(Array.from(metadata.keys())).toEqual(["edit", "read"]);
+		expect(metadata.get("edit")).toMatchObject({ label: "Edit", wireName: "apply_patch" });
+		expect(metadata.get("read")).toMatchObject({ label: "Read" });
+		expect(reads.get("inactive")).toEqual(emptyMetadataGetterCounts());
+		expect(reads.get("edit")).toEqual({
+			label: 1,
+			wireName: 1,
+			description: 0,
+			parameters: 0,
+			examples: 0,
+		});
+		expect(reads.get("read")).toEqual({
+			label: 1,
+			wireName: 1,
+			description: 0,
+			parameters: 0,
+			examples: 0,
+		});
+
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["edit", "read"],
+			tools: metadata,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools: true,
+			inlineToolDescriptors: false,
+		});
+		expect(inventoryFrom(systemPrompt.join("\n\n")).trim()).toBe(
+			"# Tool Inventory\n- Edit: `apply_patch`\n- Read: `read`",
+		);
+	});
+
+	it("does not construct descriptor records for a compact native inventory", async () => {
+		const reads = new Map<string, MetadataGetterCounts>();
+		const makeMetadata = (name: string, label: string, wireName?: string): SystemPromptToolMetadata => {
+			const counts = emptyMetadataGetterCounts();
+			reads.set(name, counts);
+			return {
+				get label() {
+					counts.label += 1;
+					return label;
+				},
+				get wireName() {
+					counts.wireName += 1;
+					return wireName;
+				},
+				get description(): string {
+					counts.description += 1;
+					throw new Error(`${name} description getter was read`);
+				},
+				get parameters(): SystemPromptToolMetadata["parameters"] {
+					counts.parameters += 1;
+					throw new Error(`${name} parameters getter was read`);
+				},
+				get examples(): SystemPromptToolMetadata["examples"] {
+					counts.examples += 1;
+					throw new Error(`${name} examples getter was read`);
+				},
+			};
+		};
+		const metadata = new Map<string, SystemPromptToolMetadata>([
+			["read", makeMetadata("read", "Read")],
+			["edit", makeMetadata("edit", "Edit", "apply_patch")],
+		]);
+
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["edit", "read"],
+			tools: metadata,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools: true,
+			inlineToolDescriptors: false,
+		});
+		expect(inventoryFrom(systemPrompt.join("\n\n")).trim()).toBe(
+			"# Tool Inventory\n- Edit: `apply_patch`\n- Read: `read`",
+		);
+		expect(Array.from(reads.values())).toEqual([
+			{ label: 1, wireName: 1, description: 0, parameters: 0, examples: 0 },
+			{ label: 1, wireName: 1, description: 0, parameters: 0, examples: 0 },
+		]);
+	});
 
 	it("renders a compact name list only when native tools are active and descriptors stay in schemas", async () => {
 		const text = await render({ nativeTools: true, inlineToolDescriptors: false });
@@ -252,7 +500,7 @@ describe("system prompt tool inventory", () => {
 			skills: [],
 			rules: [],
 			toolNames,
-			tools: buildSystemPromptToolMetadata(new Map(tools.map(tool => [tool.name, tool]))),
+			tools: buildSystemPromptToolMetadata(new Map(tools.map(tool => [tool.name, tool])), { mode: "full" }),
 			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
 			nativeTools: true,
 			inlineToolDescriptors: true,

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -7,8 +7,8 @@ import { buildSystemPrompt as buildSdkSystemPrompt } from "@oh-my-pi/pi-coding-a
 import {
 	buildSystemPrompt,
 	buildSystemPromptToolMetadata,
-	projectSystemPromptToolMetadata,
 	DEFAULT_SYSTEM_PROMPT_TOOL_NAMES,
+	projectSystemPromptToolMetadata,
 	type SystemPromptToolMetadata,
 } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -7,6 +7,7 @@ import { buildSystemPrompt as buildSdkSystemPrompt } from "@oh-my-pi/pi-coding-a
 import {
 	buildSystemPrompt,
 	buildSystemPromptToolMetadata,
+	projectSystemPromptToolMetadata,
 	DEFAULT_SYSTEM_PROMPT_TOOL_NAMES,
 	type SystemPromptToolMetadata,
 } from "@oh-my-pi/pi-coding-agent/system-prompt";
@@ -145,6 +146,34 @@ describe("system prompt tool inventory", () => {
 		} as ToolSession;
 	}
 
+	it("preserves the one-argument full metadata builder", () => {
+		const metadata = buildSystemPromptToolMetadata(new Map([[SDK_TOOL.name, SDK_TOOL]]));
+
+		expect(Array.from(metadata.keys())).toEqual(["sdk_custom"]);
+		expect(metadata.get("sdk_custom")).toMatchObject({
+			label: "SDK Custom",
+			description: "SDK-provided custom tool.",
+			parameters: { type: "object", properties: {} },
+		});
+	});
+
+	it("preserves the legacy metadata overrides map", () => {
+		const metadata = buildSystemPromptToolMetadata(new Map([[SDK_TOOL.name, SDK_TOOL]]), {
+			sdk_custom: {
+				label: "Overridden label",
+				description: "Overridden description.",
+				wireName: "sdk_custom_wire",
+			},
+		});
+
+		expect(metadata.get("sdk_custom")).toMatchObject({
+			label: "Overridden label",
+			description: "Overridden description.",
+			parameters: { type: "object", properties: {} },
+			wireName: "sdk_custom_wire",
+		});
+	});
+
 	it("snapshots every full metadata getter once per rebuild and keeps fresh values", async () => {
 		let revision = 1;
 		const reads = new Map<string, MetadataGetterCounts>();
@@ -188,7 +217,7 @@ describe("system prompt tool inventory", () => {
 			["edit", makeTool("edit")],
 		]);
 
-		const first = buildSystemPromptToolMetadata(tools, { mode: "full" });
+		const first = projectSystemPromptToolMetadata(tools, { mode: "full" });
 		expect(Array.from(first.keys())).toEqual(["read", "edit"]);
 		expect(first.get("edit")).toEqual({
 			label: "edit label r1",
@@ -223,7 +252,7 @@ describe("system prompt tool inventory", () => {
 		expect(firstText).toContain("arg_r1: string;");
 
 		revision = 2;
-		const second = buildSystemPromptToolMetadata(tools, { mode: "full" });
+		const second = projectSystemPromptToolMetadata(tools, { mode: "full" });
 		expect(second.get("edit")?.description).toBe("edit description r2");
 		expect(second.get("edit")?.wireName).toBe("edit_wire_r2");
 		expect(first.get("edit")?.description).toBe("edit description r1");
@@ -289,7 +318,7 @@ describe("system prompt tool inventory", () => {
 			["edit", makeTool("edit", "Edit", "apply_patch")],
 		]);
 
-		const metadata = buildSystemPromptToolMetadata(tools, {
+		const metadata = projectSystemPromptToolMetadata(tools, {
 			mode: "compact",
 			toolNames: ["edit", "read"],
 		});
@@ -500,7 +529,7 @@ describe("system prompt tool inventory", () => {
 			skills: [],
 			rules: [],
 			toolNames,
-			tools: buildSystemPromptToolMetadata(new Map(tools.map(tool => [tool.name, tool])), { mode: "full" }),
+			tools: buildSystemPromptToolMetadata(new Map(tools.map(tool => [tool.name, tool]))),
 			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
 			nativeTools: true,
 			inlineToolDescriptors: true,


### PR DESCRIPTION
## Purpose

In provider-native compact inventory mode, project only active tool identity metadata in active order. This avoids reading unused descriptions, parameters, examples, and inactive tool records; inline and non-native modes still snapshot full metadata.

## Tests

- Initial RED on current `main`: `bun test packages/coding-agent/test/system-prompt-inventory.test.ts` — 16 passed, 3 failed. The failures showed duplicate full-metadata getter reads, an inactive description read during compact projection, and descriptor construction for a compact native inventory.
- Compatibility RED on the reviewed head: the same file — 19 passed, 2 failed. The one-argument public builder threw, and the legacy overrides map was ignored.
- Focused GREEN: the same file — 21 passed, 0 failed (87 expectations).
- Nearest prompt GREEN: five `system-prompt-*.test.ts` files — 43 passed, 0 failed (134 expectations).
- CI-equivalent diagnosis: `bun run ci:check:full` reproduced two organize-imports errors in the new import lists; both were fixed, and focused Biome checks now pass. `bun run collab:web:build` also passes.
- The retained source treatment also passed 72 focused/nearest tests.

## Metrics

Three accepted-parent startup measurements used 1,800, 1,810, and 1,820 ms CPU; two treatment runs used 1,730 ms and 1,700 ms. That is about 5.4% lower CPU in this repeated startup sample. RSS medians in the treatment confirmations were 310,968 and 310,304 KiB, effectively flat; no RSS improvement or end-to-end latency claim is made.

## Safety

Rendered tool inventory behavior is unchanged. Compact projection is limited to provider-native mode without inline descriptors and reads each active label/wire name once. The public `buildSystemPromptToolMetadata(tools, overrides?)` contract remains intact for one-argument and legacy overrides-map callers; mode selection uses a separate internal-facing projector. Full mode reads every live metadata getter once per rebuild and preserves fresh values. Non-native and inline descriptor paths remain full.