### PR TITLE
perf(catalog): lazily materialize provider models

### DIFF
--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -10,27 +10,27 @@ import type { Api, KnownProvider, Model, ModelSpec, Usage } from "./types";
  *
  * For runtime-aware resolution, use `createModelManager()` / `resolveProviderModels()`.
  */
-let modelRegistry: Map<string, Map<string, Model<Api>>> | undefined;
+const modelRegistry = new Map<string, Map<string, Model<Api>>>();
 
-/** Build (once) and return the enriched bundled-model registry. Lazy: enrichment of ~12K models is deferred off module load. */
-function getModelRegistry(): Map<string, Map<string, Model<Api>>> {
-	if (modelRegistry === undefined) {
-		modelRegistry = new Map();
-		for (const [provider, models] of Object.entries(MODELS)) {
-			const providerModels = new Map<string, Model<Api>>();
-			for (const [id, model] of Object.entries(models)) {
-				providerModels.set(id, buildModel(model as ModelSpec<Api>));
-			}
-			modelRegistry.set(provider, providerModels);
-		}
+/** Build (once) and return one provider's enriched bundled models. */
+function getProviderModels(provider: string): Map<string, Model<Api>> | undefined {
+	const cachedModels = modelRegistry.get(provider);
+	if (cachedModels !== undefined) return cachedModels;
+	if (!Object.hasOwn(MODELS, provider)) return undefined;
+
+	const providerModels = new Map<string, Model<Api>>();
+	const rawModels = MODELS[provider as keyof typeof MODELS];
+	for (const [id, model] of Object.entries(rawModels)) {
+		providerModels.set(id, buildModel(model as ModelSpec<Api>));
 	}
-	return modelRegistry;
+	modelRegistry.set(provider, providerModels);
+	return providerModels;
 }
 
 export type GeneratedProvider = keyof typeof MODELS;
 
 export function getBundledModel<TApi extends Api = Api>(provider: GeneratedProvider, modelId: string): Model<TApi> {
-	const providerModels = getModelRegistry().get(provider);
+	const providerModels = getProviderModels(provider);
 	return providerModels?.get(modelId) as Model<TApi>;
 }
 
@@ -39,7 +39,7 @@ export function getBundledProviders(): KnownProvider[] {
 }
 
 export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
-	const models = getModelRegistry().get(provider);
+	const models = getProviderModels(provider);
 	return models ? (Array.from(models.values()) as Model<Api>[]) : [];
 }
 

--- a/packages/catalog/src/provider-models/bundled-references.ts
+++ b/packages/catalog/src/provider-models/bundled-references.ts
@@ -23,9 +23,7 @@ export function createBundledReferenceMap<TApi extends Api>(
 	return references;
 }
 
-type ProviderReferenceSource<TApi extends Api> =
-	| Map<string, ModelSpec<TApi>>
-	| (() => Map<string, ModelSpec<TApi>>);
+type ProviderReferenceSource<TApi extends Api> = Map<string, ModelSpec<TApi>> | (() => Map<string, ModelSpec<TApi>>);
 
 let globalReferences: Map<string, Model<Api>> | undefined;
 

--- a/packages/catalog/src/provider-models/bundled-references.ts
+++ b/packages/catalog/src/provider-models/bundled-references.ts
@@ -23,33 +23,54 @@ export function createBundledReferenceMap<TApi extends Api>(
 	return references;
 }
 
-export function createReferenceResolver<TApi extends Api>(
-	providerRefs: Map<string, ModelSpec<TApi>>,
-): (modelId: string) => ModelSpec<TApi> | undefined {
-	const globalRefs = new Map<string, Model<Api>>();
+type ProviderReferenceSource<TApi extends Api> =
+	| Map<string, ModelSpec<TApi>>
+	| (() => Map<string, ModelSpec<TApi>>);
+
+let globalReferences: Map<string, Model<Api>> | undefined;
+
+function getGlobalReferences(): Map<string, Model<Api>> {
+	if (globalReferences) {
+		return globalReferences;
+	}
+	const references = new Map<string, Model<Api>>();
 	for (const provider of getBundledProviders()) {
 		for (const model of getBundledModels(provider as Parameters<typeof getBundledModels>[0])) {
 			const candidate = model as Model<Api>;
 			if (isZeroCostXaiOAuthReference(candidate)) {
 				continue;
 			}
-			const existing = globalRefs.get(candidate.id);
+			const existing = references.get(candidate.id);
 			if (!existing) {
-				globalRefs.set(candidate.id, candidate);
+				references.set(candidate.id, candidate);
 			} else if (candidate.contextWindow !== existing.contextWindow) {
 				if ((candidate.contextWindow ?? 0) > (existing.contextWindow ?? 0)) {
-					globalRefs.set(candidate.id, candidate);
+					references.set(candidate.id, candidate);
 				}
 			} else if (candidate.maxTokens !== existing.maxTokens) {
 				if ((candidate.maxTokens ?? 0) > (existing.maxTokens ?? 0)) {
-					globalRefs.set(candidate.id, candidate);
+					references.set(candidate.id, candidate);
 				}
 			} else if (existing.provider !== "openai" && candidate.provider === "openai") {
-				globalRefs.set(candidate.id, candidate);
+				references.set(candidate.id, candidate);
 			}
 		}
 	}
+	globalReferences = references;
+	return references;
+}
+
+export function createReferenceResolver<TApi extends Api>(
+	providerReferenceSource: ProviderReferenceSource<TApi>,
+): (modelId: string) => ModelSpec<TApi> | undefined {
+	let lazyProviderReferences: Map<string, ModelSpec<TApi>> | undefined;
+	const getProviderReferences =
+		typeof providerReferenceSource === "function"
+			? () => (lazyProviderReferences ??= providerReferenceSource())
+			: () => providerReferenceSource;
 	return (modelId: string) => {
+		const providerRefs = getProviderReferences();
+		const globalRefs = getGlobalReferences();
 		const providerRef = providerRefs.get(modelId);
 		if (providerRef) return providerRef;
 		const globalRef = globalRefs.get(modelId);

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -1,0 +1,47 @@
+export interface ModelCacheProviderIdOptions {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function getDefaultModelDiscoveryBaseUrl(providerId: string): string | undefined {
+	switch (providerId) {
+		case "litellm":
+			return Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1";
+		case "opencode-go":
+			return "https://opencode.ai/zen/go/v1";
+		case "opencode-zen":
+			return "https://opencode.ai/zen/v1";
+		case "vllm":
+			return "http://127.0.0.1:8000/v1";
+		default:
+			return undefined;
+	}
+}
+
+/** Resolve the cache namespace used by a provider's model-manager options without constructing those options. */
+export function resolveModelCacheProviderId(providerId: string, options: ModelCacheProviderIdOptions = {}): string {
+	switch (providerId) {
+		case "cursor":
+			return "cursor:max-mode-v2";
+		case "litellm": {
+			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
+			return `litellm:rich-v5:${Bun.hash(baseUrl).toString(36)}`;
+		}
+		case "opencode-go":
+		case "opencode-zen": {
+			const configuredBaseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
+			const trimmedBaseUrl = configuredBaseUrl.endsWith("/") ? configuredBaseUrl.slice(0, -1) : configuredBaseUrl;
+			const discoveryBaseUrl = trimmedBaseUrl.endsWith("/v1") ? trimmedBaseUrl : `${trimmedBaseUrl}/v1`;
+			const scope = `${options.apiKey ?? ""}\u0000${discoveryBaseUrl}`;
+			return `${providerId}:models-v1:${Bun.hash(scope).toString(36)}`;
+		}
+		case "openrouter":
+			return "openrouter:pseudo-api";
+		case "vllm": {
+			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
+			return `vllm:${Bun.hash(baseUrl).toString(36)}`;
+		}
+		default:
+			return providerId;
+	}
+}

--- a/packages/catalog/src/provider-models/index.ts
+++ b/packages/catalog/src/provider-models/index.ts
@@ -1,3 +1,4 @@
+export * from "./cache-provider-id";
 export * from "./descriptor-types";
 export * from "./descriptors";
 export * from "./google";

--- a/packages/catalog/src/provider-models/ollama.ts
+++ b/packages/catalog/src/provider-models/ollama.ts
@@ -2,7 +2,7 @@ import { fetchWithRetry } from "@oh-my-pi/pi-utils";
 import { Effort } from "../effort";
 import { isGlm52ReasoningEffortModelId } from "../identity/family";
 import type { ModelManagerOptions } from "../model-manager";
-import type { FetchImpl, ThinkingConfig } from "../types";
+import type { FetchImpl, ModelSpec, ThinkingConfig } from "../types";
 import { discoveryFetch } from "../utils";
 import { createBundledReferenceMap, createReferenceResolver } from "./bundled-references";
 
@@ -96,8 +96,10 @@ export function ollamaCloudModelManagerOptions(
 ): ModelManagerOptions<"ollama-chat"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = normalizeOllamaCloudBaseUrl(config?.baseUrl);
-	const providerReferences = createBundledReferenceMap<"ollama-chat">("ollama-cloud");
-	const resolveReference = createReferenceResolver(providerReferences);
+	let providerReferences: Map<string, ModelSpec<"ollama-chat">> | undefined;
+	const getProviderReferences = () =>
+		(providerReferences ??= createBundledReferenceMap<"ollama-chat">("ollama-cloud"));
+	const resolveReference = createReferenceResolver(getProviderReferences);
 	return {
 		providerId: "ollama-cloud",
 		fetchDynamicModels: async () => {
@@ -121,8 +123,8 @@ export function ollamaCloudModelManagerOptions(
 					if (!id) {
 						return undefined;
 					}
-					const providerReference = providerReferences.get(id);
 					const reference = resolveReference(id);
+					const providerReference = getProviderReferences().get(id);
 					let metadata: OllamaShowResponse | undefined;
 					try {
 						metadata = await fetchShowMetadata(baseUrl, apiKey, id, config?.fetch);

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4281,8 +4281,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 				? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
 				: configuredBaseUrl;
 	let providerReferences: Map<string, ModelSpec<Api>> | undefined;
-	const getProviderReferences = () =>
-		(providerReferences ??= createBundledReferenceMap<Api>("github-copilot"));
+	const getProviderReferences = () => (providerReferences ??= createBundledReferenceMap<Api>("github-copilot"));
 	const resolveReference = createReferenceResolver(getProviderReferences);
 	return {
 		providerId: "github-copilot",
@@ -4372,7 +4371,10 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 									input,
 									contextWindow: defaultTierWindow,
 									maxTokens,
-									headers: { ...COPILOT_API_HEADERS, ...(getProviderReferences().get(defaults.id)?.headers ?? {}) },
+									headers: {
+										...COPILOT_API_HEADERS,
+										...(getProviderReferences().get(defaults.id)?.headers ?? {}),
+									},
 									...(api === "openai-completions"
 										? {
 												compat: {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1826,7 +1826,9 @@ export function fireworksModelManagerOptions(
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? "https://api.fireworks.ai/inference/v1";
-	const bundledReferences = createReferenceResolver(createBundledReferenceMap<"openai-completions">("fireworks"));
+	const bundledReferences = createReferenceResolver(() =>
+		createBundledReferenceMap<"openai-completions">("fireworks"),
+	);
 	return {
 		providerId: "fireworks",
 		...(apiKey && {
@@ -4063,7 +4065,7 @@ export function nanoGptModelManagerOptions(
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? "https://nano-gpt.com/api/v1";
-	const resolveReference = createReferenceResolver(
+	const resolveReference = createReferenceResolver(() =>
 		createBundledReferenceMap<"openai-completions">("nanogpt" as Parameters<typeof getBundledModels>[0]),
 	);
 	return {
@@ -4278,8 +4280,10 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 			: parsedApiKey?.enterpriseUrl && configuredBaseUrl.includes("githubcopilot.com")
 				? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
 				: configuredBaseUrl;
-	const providerRefs = createBundledReferenceMap<Api>("github-copilot");
-	const resolveReference = createReferenceResolver(providerRefs);
+	let providerReferences: Map<string, ModelSpec<Api>> | undefined;
+	const getProviderReferences = () =>
+		(providerReferences ??= createBundledReferenceMap<Api>("github-copilot"));
+	const resolveReference = createReferenceResolver(getProviderReferences);
 	return {
 		providerId: "github-copilot",
 		dropCachedModelIdsOnStaticMismatch: COPILOT_CACHE_INVALIDATED_MODEL_IDS,
@@ -4368,7 +4372,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 									input,
 									contextWindow: defaultTierWindow,
 									maxTokens,
-									headers: { ...COPILOT_API_HEADERS, ...(providerRefs.get(defaults.id)?.headers ?? {}) },
+									headers: { ...COPILOT_API_HEADERS, ...(getProviderReferences().get(defaults.id)?.headers ?? {}) },
 									...(api === "openai-completions"
 										? {
 												compat: {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -27,6 +27,7 @@ import {
 	parseGitHubCopilotApiKey,
 } from "../wire/github-copilot";
 import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
+import { getDefaultModelDiscoveryBaseUrl, resolveModelCacheProviderId } from "./cache-provider-id";
 
 const MODELS_DEV_URL = "https://models.dev/api.json";
 
@@ -2065,28 +2066,19 @@ function openCodeBaseUrlForApi(api: Api, basePath: string): string {
 	return api === "anthropic-messages" ? basePath : `${basePath}/v1`;
 }
 
-function openCodeModelCacheProviderId(
-	providerId: "opencode-go" | "opencode-zen",
-	apiKey: string | undefined,
-	discoveryBaseUrl: string,
-): string {
-	// OpenCode catalogs are entitlement-scoped; isolate authoritative rows by credential and endpoint.
-	const scope = `${apiKey ?? ""}\u0000${discoveryBaseUrl}`;
-	return `${providerId}:models-v1:${Bun.hash(scope).toString(36)}`;
-}
-
 function openCodeModelManagerOptions(
 	providerId: "opencode-go" | "opencode-zen",
-	defaultBasePath: string,
 	config?: OpenCodeModelManagerConfig,
 ): ModelManagerOptions<Api> {
 	const apiKey = config?.apiKey;
+	const defaultBaseUrl = getDefaultModelDiscoveryBaseUrl(providerId)!;
+	const defaultBasePath = defaultBaseUrl.endsWith("/v1") ? defaultBaseUrl.slice(0, -3) : defaultBaseUrl;
 	const basePath = normalizeOpenCodeBasePath(config?.baseUrl, defaultBasePath);
 	const discoveryBaseUrl = openCodeBaseUrlForApi("openai-completions", basePath);
 	const references = createBundledReferenceMap<Api>(providerId);
 	return {
 		providerId,
-		cacheProviderId: openCodeModelCacheProviderId(providerId, apiKey, discoveryBaseUrl),
+		cacheProviderId: resolveModelCacheProviderId(providerId, { apiKey, baseUrl: discoveryBaseUrl }),
 		dynamicModelsAuthoritative: true,
 		...(apiKey && {
 			fetchDynamicModels: () =>
@@ -2120,11 +2112,11 @@ function openCodeModelManagerOptions(
 }
 
 export function opencodeZenModelManagerOptions(config?: OpenCodeModelManagerConfig): ModelManagerOptions<Api> {
-	return openCodeModelManagerOptions("opencode-zen", "https://opencode.ai/zen", config);
+	return openCodeModelManagerOptions("opencode-zen", config);
 }
 
 export function opencodeGoModelManagerOptions(config?: OpenCodeModelManagerConfig): ModelManagerOptions<Api> {
-	return openCodeModelManagerOptions("opencode-go", "https://opencode.ai/zen/go", config);
+	return openCodeModelManagerOptions("opencode-go", config);
 }
 
 // ---------------------------------------------------------------------------
@@ -2211,7 +2203,7 @@ export function openrouterModelManagerOptions(
 		// Older builds cached OpenRouter discovery rows as `api: "openai-completions"`.
 		// Namespace the refreshed pseudo-API cache separately so those rows cannot
 		// override bundled `api: "openrouter"` models during online-if-uncached startup.
-		cacheProviderId: "openrouter:pseudo-api",
+		cacheProviderId: resolveModelCacheProviderId("openrouter"),
 		fetchDynamicModels: () =>
 			fetchOpenAICompatibleModels({
 				api: "openrouter",
@@ -3970,7 +3962,7 @@ export function litellmModelManagerOptions(
 	config?: LiteLLMModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = config?.baseUrl ?? Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1";
+	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("litellm")!;
 	return {
 		providerId: "litellm",
 		// rich-v5 invalidates rows cached before rich metadata pricing was mapped.
@@ -3979,7 +3971,7 @@ export function litellmModelManagerOptions(
 		// and filtered placeholder-only `all-team-models` rows. Bump the version
 		// whenever the mappers below change, or warm authoritative caches keep
 		// serving pre-change rows for the full TTL.
-		cacheProviderId: `litellm:rich-v5:${Bun.hash(baseUrl).toString(36)}`,
+		cacheProviderId: resolveModelCacheProviderId("litellm", { baseUrl }),
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer
 		// management metadata, then enrich ids against models.dev with the bundled
@@ -4026,11 +4018,11 @@ export interface VllmModelManagerConfig {
 
 export function vllmModelManagerOptions(config?: VllmModelManagerConfig): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
-	const baseUrl = config?.baseUrl ?? "http://127.0.0.1:8000/v1";
+	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("vllm")!;
 	const references = createBundledReferenceMap<"openai-completions">("vllm" as Parameters<typeof getBundledModels>[0]);
 	return {
 		providerId: "vllm",
-		cacheProviderId: `vllm:${Bun.hash(baseUrl).toString(36)}`,
+		cacheProviderId: resolveModelCacheProviderId("vllm", { baseUrl }),
 		fetchDynamicModels: () =>
 			fetchOpenAICompatibleModels({
 				api: "openai-completions",

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -4,6 +4,7 @@ import type { DevinModelDiscoveryOptions } from "../discovery/devin";
 import { buildGitLabDuoWorkflowFallbackModel, fetchGitLabDuoWorkflowModels } from "../discovery/gitlab-duo-workflow";
 import type { ModelManagerOptions } from "../model-manager";
 import type { FetchImpl, ModelSpec } from "../types";
+import { resolveModelCacheProviderId } from "./cache-provider-id";
 
 // ---------------------------------------------------------------------------
 // OpenAI Codex
@@ -94,13 +95,11 @@ export interface CursorModelManagerConfig {
 	clientVersion?: string;
 }
 
-const CURSOR_CACHE_PROVIDER_ID = "cursor:max-mode-v2";
-
 export function cursorModelManagerOptions(config: CursorModelManagerConfig = {}): ModelManagerOptions<"cursor-agent"> {
 	const { apiKey, baseUrl, clientVersion } = config;
 	return {
 		providerId: "cursor",
-		cacheProviderId: CURSOR_CACHE_PROVIDER_ID,
+		cacheProviderId: resolveModelCacheProviderId("cursor"),
 		...(apiKey
 			? {
 					fetchDynamicModels: async () => {

--- a/packages/catalog/test/bundled-reference-laziness.test.ts
+++ b/packages/catalog/test/bundled-reference-laziness.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { createReferenceResolver } from "../src/provider-models/bundled-references";
+import type { ModelSpec } from "../src/types";
+
+const FIXTURE = `${import.meta.dir}/fixtures/bundled-reference-laziness.ts`;
+
+describe("bundled reference laziness", () => {
+	test("constructing bundled model-manager options does not materialize reference maps", () => {
+		const result = Bun.spawnSync({
+			cmd: [process.execPath, FIXTURE],
+			env: process.env,
+		});
+		expect(result.exitCode).toBe(0);
+		expect(JSON.parse(result.stdout.toString())).toEqual({ mapWrites: 0 });
+	});
+
+	test("a lazy provider-reference factory initializes on first resolution and only once", () => {
+		const reference = {
+			id: "fixture-model",
+			name: "Fixture Model",
+			api: "openai-completions",
+			provider: "fixture",
+			baseUrl: "https://example.test/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 1024,
+		} satisfies ModelSpec<"openai-completions">;
+		let factoryCalls = 0;
+		const resolveReference = createReferenceResolver(() => {
+			factoryCalls++;
+			return new Map([[reference.id, reference]]);
+		});
+
+		expect(factoryCalls).toBe(0);
+		expect(resolveReference(reference.id)).toBe(reference);
+		expect(resolveReference(reference.id)).toBe(reference);
+		expect(factoryCalls).toBe(1);
+	});
+});

--- a/packages/catalog/test/bundled-reference-laziness.test.ts
+++ b/packages/catalog/test/bundled-reference-laziness.test.ts
@@ -5,13 +5,13 @@ import type { ModelSpec } from "../src/types";
 const FIXTURE = `${import.meta.dir}/fixtures/bundled-reference-laziness.ts`;
 
 describe("bundled reference laziness", () => {
-	test("constructing bundled model-manager options does not materialize reference maps", () => {
+	test("constructing bundled model-manager options does not enrich bundled models", () => {
 		const result = Bun.spawnSync({
 			cmd: [process.execPath, FIXTURE],
 			env: process.env,
 		});
 		expect(result.exitCode).toBe(0);
-		expect(JSON.parse(result.stdout.toString())).toEqual({ mapWrites: 0 });
+		expect(JSON.parse(result.stdout.toString())).toEqual({ buildCalls: 0 });
 	});
 
 	test("a lazy provider-reference factory initializes on first resolution and only once", () => {

--- a/packages/catalog/test/bundled-reference-laziness.test.ts
+++ b/packages/catalog/test/bundled-reference-laziness.test.ts
@@ -5,13 +5,14 @@ import type { ModelSpec } from "../src/types";
 const FIXTURE = `${import.meta.dir}/fixtures/bundled-reference-laziness.ts`;
 
 describe("bundled reference laziness", () => {
-	test("constructing bundled model-manager options does not enrich bundled models", () => {
+	test("constructing bundled model-manager options retains less than 8 MiB of RSS", () => {
 		const result = Bun.spawnSync({
 			cmd: [process.execPath, FIXTURE],
 			env: process.env,
 		});
 		expect(result.exitCode).toBe(0);
-		expect(JSON.parse(result.stdout.toString())).toEqual({ buildCalls: 0 });
+		const { retainedRssBytes } = JSON.parse(result.stdout.toString()) as { retainedRssBytes: number };
+		expect(retainedRssBytes).toBeLessThan(8 * 1024 * 1024);
 	});
 
 	test("a lazy provider-reference factory initializes on first resolution and only once", () => {

--- a/packages/catalog/test/fixtures/bundled-reference-laziness.ts
+++ b/packages/catalog/test/fixtures/bundled-reference-laziness.ts
@@ -1,18 +1,16 @@
+import { spyOn } from "bun:test";
+import * as buildModule from "../../src/build";
 import { ollamaCloudModelManagerOptions } from "../../src/provider-models/ollama";
 import { nanoGptModelManagerOptions } from "../../src/provider-models/openai-compat";
 
-const originalSet = Map.prototype.set;
-let mapWrites = 0;
-Map.prototype.set = function (key, value) {
-	mapWrites++;
-	return originalSet.call(this, key, value);
-};
-
+const buildSpy = spyOn(buildModule, "buildModel");
+let buildCalls = 0;
 try {
 	nanoGptModelManagerOptions();
 	ollamaCloudModelManagerOptions();
+	buildCalls = buildSpy.mock.calls.length;
 } finally {
-	Map.prototype.set = originalSet;
+	buildSpy.mockRestore();
 }
 
-console.log(JSON.stringify({ mapWrites }));
+console.log(JSON.stringify({ buildCalls }));

--- a/packages/catalog/test/fixtures/bundled-reference-laziness.ts
+++ b/packages/catalog/test/fixtures/bundled-reference-laziness.ts
@@ -1,16 +1,11 @@
-import { spyOn } from "bun:test";
-import * as buildModule from "../../src/build";
 import { ollamaCloudModelManagerOptions } from "../../src/provider-models/ollama";
 import { nanoGptModelManagerOptions } from "../../src/provider-models/openai-compat";
 
-const buildSpy = spyOn(buildModule, "buildModel");
-let buildCalls = 0;
-try {
-	nanoGptModelManagerOptions();
-	ollamaCloudModelManagerOptions();
-	buildCalls = buildSpy.mock.calls.length;
-} finally {
-	buildSpy.mockRestore();
-}
+Bun.gc(true);
+const rssBefore = process.memoryUsage().rss;
+nanoGptModelManagerOptions();
+ollamaCloudModelManagerOptions();
+Bun.gc(true);
+const retainedRssBytes = process.memoryUsage().rss - rssBefore;
 
-console.log(JSON.stringify({ buildCalls }));
+console.log(JSON.stringify({ retainedRssBytes }));

--- a/packages/catalog/test/fixtures/bundled-reference-laziness.ts
+++ b/packages/catalog/test/fixtures/bundled-reference-laziness.ts
@@ -1,0 +1,18 @@
+import { nanoGptModelManagerOptions } from "../../src/provider-models/openai-compat";
+import { ollamaCloudModelManagerOptions } from "../../src/provider-models/ollama";
+
+const originalSet = Map.prototype.set;
+let mapWrites = 0;
+Map.prototype.set = function (key, value) {
+	mapWrites++;
+	return originalSet.call(this, key, value);
+};
+
+try {
+	nanoGptModelManagerOptions();
+	ollamaCloudModelManagerOptions();
+} finally {
+	Map.prototype.set = originalSet;
+}
+
+console.log(JSON.stringify({ mapWrites }));

--- a/packages/catalog/test/fixtures/bundled-reference-laziness.ts
+++ b/packages/catalog/test/fixtures/bundled-reference-laziness.ts
@@ -1,5 +1,5 @@
-import { nanoGptModelManagerOptions } from "../../src/provider-models/openai-compat";
 import { ollamaCloudModelManagerOptions } from "../../src/provider-models/ollama";
+import { nanoGptModelManagerOptions } from "../../src/provider-models/openai-compat";
 
 const originalSet = Map.prototype.set;
 let mapWrites = 0;

--- a/packages/catalog/test/fixtures/models-lazy-provider-cache.ts
+++ b/packages/catalog/test/fixtures/models-lazy-provider-cache.ts
@@ -1,0 +1,42 @@
+import { expect, spyOn } from "bun:test";
+import * as buildModule from "../../src/build";
+import { getBundledModel, getBundledModels, getBundledProviders, type GeneratedProvider } from "../../src/models";
+import MODELS from "../../src/models.json" with { type: "json" };
+
+const buildSpy = spyOn(buildModule, "buildModel");
+const rawProviders = Object.keys(MODELS);
+const firstProviders = getBundledProviders();
+const secondProviders = getBundledProviders();
+
+expect(buildSpy).toHaveBeenCalledTimes(0);
+expect(firstProviders as string[]).toEqual(rawProviders);
+expect(secondProviders as string[]).toEqual(rawProviders);
+expect(secondProviders).not.toBe(firstProviders);
+
+const provider = "sakana" satisfies GeneratedProvider;
+const rawModelIds = Object.keys(MODELS[provider]);
+const firstModels = getBundledModels(provider);
+
+expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+expect(firstModels.map(model => model.id)).toEqual(rawModelIds);
+
+const secondModels = getBundledModels(provider);
+expect(secondModels).not.toBe(firstModels);
+expect(secondModels).toHaveLength(firstModels.length);
+for (let index = 0; index < firstModels.length; index++) {
+	expect(secondModels[index]).toBe(firstModels[index]);
+}
+expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+
+const firstModelId = rawModelIds[0];
+if (firstModelId === undefined) throw new Error(`${provider} must have a bundled model`);
+expect(getBundledModel(provider, firstModelId)).toBe(firstModels[0]);
+expect(getBundledModel(provider, firstModelId)).toBe(firstModels[0]);
+expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+
+const unknownProvider = "not-a-bundled-provider" as GeneratedProvider;
+expect(getBundledModels(unknownProvider)).toEqual([]);
+expect(getBundledModel(unknownProvider, "missing-model")).toBeUndefined();
+expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+
+buildSpy.mockRestore();

--- a/packages/catalog/test/fixtures/models-lazy-provider-cache.ts
+++ b/packages/catalog/test/fixtures/models-lazy-provider-cache.ts
@@ -1,6 +1,6 @@
 import { expect, spyOn } from "bun:test";
 import * as buildModule from "../../src/build";
-import { getBundledModel, getBundledModels, getBundledProviders, type GeneratedProvider } from "../../src/models";
+import { type GeneratedProvider, getBundledModel, getBundledModels, getBundledProviders } from "../../src/models";
 import MODELS from "../../src/models.json" with { type: "json" };
 
 const buildSpy = spyOn(buildModule, "buildModel");

--- a/packages/catalog/test/models-lazy-provider-cache.test.ts
+++ b/packages/catalog/test/models-lazy-provider-cache.test.ts
@@ -1,44 +1,11 @@
-import { expect, spyOn, test } from "bun:test";
-import * as buildModule from "../src/build";
-import { getBundledModel, getBundledModels, getBundledProviders, type GeneratedProvider } from "../src/models";
-import MODELS from "../src/models.json" with { type: "json" };
+import { expect, test } from "bun:test";
+
+const FIXTURE = `${import.meta.dir}/fixtures/models-lazy-provider-cache.ts`;
 
 test("bundled models are enriched one provider at a time", () => {
-	const buildSpy = spyOn(buildModule, "buildModel");
-	const rawProviders = Object.keys(MODELS) as GeneratedProvider[];
-	const firstProviders = getBundledProviders();
-	const secondProviders = getBundledProviders();
-
-	expect(buildSpy).toHaveBeenCalledTimes(0);
-	expect(firstProviders).toEqual(rawProviders);
-	expect(secondProviders).toEqual(rawProviders);
-	expect(secondProviders).not.toBe(firstProviders);
-
-	const provider = "sakana" satisfies GeneratedProvider;
-	const rawModelIds = Object.keys(MODELS[provider]);
-	const firstModels = getBundledModels(provider);
-
-	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
-	expect(firstModels.map(model => model.id)).toEqual(rawModelIds);
-
-	const secondModels = getBundledModels(provider);
-	expect(secondModels).not.toBe(firstModels);
-	expect(secondModels).toHaveLength(firstModels.length);
-	for (let index = 0; index < firstModels.length; index++) {
-		expect(secondModels[index]).toBe(firstModels[index]);
-	}
-	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
-
-	const firstModelId = rawModelIds[0];
-	if (firstModelId === undefined) throw new Error(`${provider} must have a bundled model`);
-	expect(getBundledModel(provider, firstModelId)).toBe(firstModels[0]);
-	expect(getBundledModel(provider, firstModelId)).toBe(firstModels[0]);
-	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
-
-	const unknownProvider = "not-a-bundled-provider" as GeneratedProvider;
-	expect(getBundledModels(unknownProvider)).toEqual([]);
-	expect(getBundledModel(unknownProvider, "missing-model")).toBeUndefined();
-	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
-
-	buildSpy.mockRestore();
+	const result = Bun.spawnSync({
+		cmd: [process.execPath, FIXTURE],
+		env: process.env,
+	});
+	expect(result.exitCode, result.stderr.toString()).toBe(0);
 });

--- a/packages/catalog/test/models-lazy-provider-cache.test.ts
+++ b/packages/catalog/test/models-lazy-provider-cache.test.ts
@@ -1,0 +1,44 @@
+import { expect, spyOn, test } from "bun:test";
+import * as buildModule from "../src/build";
+import { getBundledModel, getBundledModels, getBundledProviders, type GeneratedProvider } from "../src/models";
+import MODELS from "../src/models.json" with { type: "json" };
+
+test("bundled models are enriched one provider at a time", () => {
+	const buildSpy = spyOn(buildModule, "buildModel");
+	const rawProviders = Object.keys(MODELS) as GeneratedProvider[];
+	const firstProviders = getBundledProviders();
+	const secondProviders = getBundledProviders();
+
+	expect(buildSpy).toHaveBeenCalledTimes(0);
+	expect(firstProviders).toEqual(rawProviders);
+	expect(secondProviders).toEqual(rawProviders);
+	expect(secondProviders).not.toBe(firstProviders);
+
+	const provider = "sakana" satisfies GeneratedProvider;
+	const rawModelIds = Object.keys(MODELS[provider]);
+	const firstModels = getBundledModels(provider);
+
+	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+	expect(firstModels.map(model => model.id)).toEqual(rawModelIds);
+
+	const secondModels = getBundledModels(provider);
+	expect(secondModels).not.toBe(firstModels);
+	expect(secondModels).toHaveLength(firstModels.length);
+	for (let index = 0; index < firstModels.length; index++) {
+		expect(secondModels[index]).toBe(firstModels[index]);
+	}
+	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+
+	const firstModelId = rawModelIds[0];
+	if (firstModelId === undefined) throw new Error(`${provider} must have a bundled model`);
+	expect(getBundledModel(provider, firstModelId)).toBe(firstModels[0]);
+	expect(getBundledModel(provider, firstModelId)).toBe(firstModels[0]);
+	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+
+	const unknownProvider = "not-a-bundled-provider" as GeneratedProvider;
+	expect(getBundledModels(unknownProvider)).toEqual([]);
+	expect(getBundledModel(unknownProvider, "missing-model")).toBeUndefined();
+	expect(buildSpy).toHaveBeenCalledTimes(rawModelIds.length);
+
+	buildSpy.mockRestore();
+});

--- a/packages/catalog/test/provider-cache-id.test.ts
+++ b/packages/catalog/test/provider-cache-id.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { PROVIDER_DESCRIPTORS, resolveModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
+
+test("lightweight cache resolver matches every descriptor default", () => {
+	for (const descriptor of PROVIDER_DESCRIPTORS) {
+		const options = descriptor.createModelManagerOptions({});
+		expect(resolveModelCacheProviderId(descriptor.providerId)).toBe(options.cacheProviderId ?? descriptor.providerId);
+	}
+});
+
+test("lightweight cache resolver matches scoped descriptor inputs", () => {
+	const cases = [
+		{ providerId: "litellm", baseUrl: "http://litellm.example:4100/v1" },
+		{ providerId: "opencode-go", baseUrl: "https://opencode.example/go" },
+		{ providerId: "opencode-zen", baseUrl: "https://opencode.example/zen/v1/" },
+		{ providerId: "vllm", baseUrl: "http://vllm.example:8000/v1" },
+	] as const;
+	for (const { providerId, baseUrl } of cases) {
+		const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === providerId);
+		if (!descriptor) throw new Error(`Missing descriptor for ${providerId}`);
+		const config = { apiKey: "cache-test-key", baseUrl };
+		const options = descriptor.createModelManagerOptions(config);
+		expect(resolveModelCacheProviderId(providerId, config)).toBe(options.cacheProviderId ?? providerId);
+	}
+});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -26,6 +26,7 @@ import {
 	type OpenAICodexAccount,
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
+	resolveModelCacheProviderId,
 } from "@oh-my-pi/pi-catalog/provider-models";
 import {
 	collapseBuiltModelVariants,
@@ -43,18 +44,6 @@ const STARTUP_MODEL_CACHE_PROVIDER_IDS: readonly string[] = [
 	...PROVIDER_DESCRIPTORS.map(descriptor => descriptor.providerId),
 	...SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
 ];
-
-// Cache namespaces whose descriptor defaults intentionally differ from the
-// provider id. Keep startup cache reads lightweight: constructing all provider
-// manager options also constructs their bundled reference maps.
-const DEFAULT_STARTUP_MODEL_CACHE_PROVIDER_IDS: Readonly<Record<string, string>> = {
-	cursor: "cursor:max-mode-v2",
-	litellm: `litellm:rich-v5:${Bun.hash(Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1").toString(36)}`,
-	"opencode-go": `opencode-go:models-v1:${Bun.hash("\u0000https://opencode.ai/zen/go/v1").toString(36)}`,
-	"opencode-zen": `opencode-zen:models-v1:${Bun.hash("\u0000https://opencode.ai/zen/v1").toString(36)}`,
-	openrouter: "openrouter:pseudo-api",
-	vllm: `vllm:${Bun.hash("http://127.0.0.1:8000/v1").toString(36)}`,
-};
 
 // Sentinels for local-only OAuth tokens — declared inline to avoid loading
 // provider modules at startup. Must match packages/ai/src/registry/llama-cpp.ts,
@@ -1231,15 +1220,11 @@ export class ModelRegistry {
 	}
 
 	#resolveStartupModelCacheProviderId(providerId: string): string {
-		const explicitBaseUrl =
-			this.#runtimeProviderOverrides.get(providerId)?.baseUrl ?? this.#providerOverrides.get(providerId)?.baseUrl;
-		if (explicitBaseUrl === undefined && !this.#hasFullSnapshot) {
-			return DEFAULT_STARTUP_MODEL_CACHE_PROVIDER_IDS[providerId] ?? providerId;
-		}
-		const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === providerId);
-		if (!descriptor) return providerId;
-		const baseUrl = explicitBaseUrl ?? this.getProviderBaseUrl(providerId);
-		return descriptor.createModelManagerOptions({ baseUrl, fetch: this.#fetch }).cacheProviderId ?? providerId;
+		const baseUrl =
+			this.#runtimeProviderOverrides.get(providerId)?.baseUrl ??
+			this.#providerOverrides.get(providerId)?.baseUrl ??
+			(this.#hasFullSnapshot ? this.getProviderBaseUrl(providerId) : undefined);
+		return resolveModelCacheProviderId(providerId, { baseUrl });
 	}
 
 	#loadCachedStandardProviderModels(): { models: Model<Api>[]; authoritativeFreshProviders: Set<string> } {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1171,10 +1171,7 @@ export class ModelRegistry {
 
 	/** Load built-in models, applying provider-level overrides only.
 	 *  Per-model overrides are applied later by #applyModelOverrides. */
-	#loadBuiltInModels(
-		overrides: Map<string, ProviderOverride>,
-		providerFilter?: ReadonlySet<string>,
-	): Model<Api>[] {
+	#loadBuiltInModels(overrides: Map<string, ProviderOverride>, providerFilter?: ReadonlySet<string>): Model<Api>[] {
 		return getBundledProviders().flatMap(provider => {
 			if (providerFilter && !providerFilter.has(provider)) return [];
 			const models = getBundledModels(provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[];
@@ -2274,9 +2271,7 @@ export class ModelRegistry {
 	 * the online refresh completes.
 	 */
 	hasProvider(providerId: string): boolean {
-		const providerModels = this.#hasFullSnapshot
-			? this.#models
-			: this.#composeStaticModels(new Set([providerId]));
+		const providerModels = this.#hasFullSnapshot ? this.#models : this.#composeStaticModels(new Set([providerId]));
 		if (providerModels.some(model => model.provider === providerId)) return true;
 		if (getDisabledProviderIdsFromSettings().has(providerId)) return false;
 		return (

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -44,6 +44,18 @@ const STARTUP_MODEL_CACHE_PROVIDER_IDS: readonly string[] = [
 	...SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
 ];
 
+// Cache namespaces whose descriptor defaults intentionally differ from the
+// provider id. Keep startup cache reads lightweight: constructing all provider
+// manager options also constructs their bundled reference maps.
+const DEFAULT_STARTUP_MODEL_CACHE_PROVIDER_IDS: Readonly<Record<string, string>> = {
+	cursor: "cursor:max-mode-v2",
+	litellm: `litellm:rich-v5:${Bun.hash(Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1").toString(36)}`,
+	"opencode-go": `opencode-go:models-v1:${Bun.hash("\u0000https://opencode.ai/zen/go/v1").toString(36)}`,
+	"opencode-zen": `opencode-zen:models-v1:${Bun.hash("\u0000https://opencode.ai/zen/v1").toString(36)}`,
+	openrouter: "openrouter:pseudo-api",
+	vllm: `vllm:${Bun.hash("http://127.0.0.1:8000/v1").toString(36)}`,
+};
+
 // Sentinels for local-only OAuth tokens — declared inline to avoid loading
 // provider modules at startup. Must match packages/ai/src/registry/llama-cpp.ts,
 // packages/ai/src/registry/lm-studio.ts, and packages/ai/src/registry/vllm.ts.
@@ -778,6 +790,12 @@ export type ResolvedRequestAuth =
  */
 export class ModelRegistry {
 	#models: Model<Api>[] = [];
+	#hasFullSnapshot = false;
+	#cachedStandardModels: Model<Api>[] = [];
+	#cachedDiscoverableModels: Model<Api>[] = [];
+	#cachedAuthoritativeProviders: Set<string> = new Set();
+	#internedStaticModels: Map<string, Model<Api>> = new Map();
+	#providerLookupSnapshots: Map<string, Model<Api>[]> = new Map();
 	#customProviderApiKeys: Map<string, string> = new Map();
 	#keylessProviders: Set<string> = new Set();
 	#discoverableProviders: DiscoveryProviderConfig[] = [];
@@ -831,11 +849,11 @@ export class ModelRegistry {
 	/**
 	 * @param authStorage - Auth storage for API key resolution
 	 *
-	 * Sync constructor — eagerly loads bundled + cached models so tests and
-	 * synchronous callers see a fully-populated registry immediately. Production
-	 * boot paths SHOULD prefer {@link ModelRegistry.create} so the YAML/JSONC
-	 * migration step lands off the event loop's hot path before the first
-	 * `tryLoad()` runs.
+	 * Sync constructor — eagerly loads config (including migrations), cache
+	 * metadata, and custom models. Bundled providers are enriched selectively
+	 * when synchronous callers query them. Production boot paths SHOULD prefer
+	 * {@link ModelRegistry.create} so the YAML/JSONC migration step lands off the
+	 * event loop's hot path before the first `tryLoad()` runs.
 	 */
 	constructor(
 		readonly authStorage: AuthStorage,
@@ -865,7 +883,7 @@ export class ModelRegistry {
 			if (!keyConfig) return undefined;
 			return resolveConfigValue(keyConfig);
 		});
-		// Load models synchronously in constructor.
+		// Load config and cache-backed layers synchronously in the constructor.
 		this.#loadModels();
 	}
 
@@ -950,6 +968,7 @@ export class ModelRegistry {
 		if (!isLlamaCppDiscovery) {
 			return model;
 		}
+		this.#ensureFullSnapshot();
 		const runtimeMetadata = await discoverLlamaCppModelRuntimeMetadata(model, this.#nonResolvingDiscoveryContext());
 		if (runtimeMetadata === undefined) {
 			return this.find(model.provider, model.id) ?? model;
@@ -1051,6 +1070,7 @@ export class ModelRegistry {
 	}
 
 	#loadModels() {
+		this.#resetStaticComposition();
 		// Load custom config first (to know which providers to override).
 		const {
 			models: customModels = [],
@@ -1069,47 +1089,94 @@ export class ModelRegistry {
 		this.#modelOverrides = modelOverrides;
 
 		this.#addImplicitDiscoverableProviders(configuredProviders);
-		let builtInModels = this.#applyHardcodedModelPolicies(this.#loadBuiltInModels(overrides));
 		const cachedStandardResult = this.#loadCachedStandardProviderModels();
-		const cachedStandardModels = this.#applyHardcodedModelPolicies(cachedStandardResult.models);
-		const cachedDiscoveries = this.#applyHardcodedModelPolicies(this.#loadCachedDiscoverableModels());
+		this.#cachedStandardModels = this.#applyHardcodedModelPolicies(cachedStandardResult.models);
+		this.#cachedDiscoverableModels = this.#applyHardcodedModelPolicies(this.#loadCachedDiscoverableModels());
 		// Only drop bundled fallback models when the cached project-catalog row is
 		// itself fresh AND authoritative. A stale or non-authoritative snapshot
 		// (e.g. after ADC discovery failure rewrote the row with authoritative=0)
 		// must not strip bundled Vertex Gemini entries — that would leave only the
 		// stale project-scoped rows in API-key-only environments.
-		const cachedAuthoritativeProviders = new Set<string>();
-		for (const provider of providersWithAuthoritativeProjectCatalog(cachedStandardModels)) {
+		this.#cachedAuthoritativeProviders = new Set<string>();
+		for (const provider of providersWithAuthoritativeProjectCatalog(this.#cachedStandardModels)) {
 			if (cachedStandardResult.authoritativeFreshProviders.has(provider)) {
-				cachedAuthoritativeProviders.add(provider);
+				this.#cachedAuthoritativeProviders.add(provider);
 			}
 		}
 		for (const provider of cachedStandardResult.authoritativeFreshProviders) {
 			if (AUTHORITATIVE_RUNTIME_CATALOG_PROVIDERS.has(provider)) {
-				cachedAuthoritativeProviders.add(provider);
+				this.#cachedAuthoritativeProviders.add(provider);
 			}
 		}
-		if (cachedAuthoritativeProviders.size > 0) {
-			builtInModels = dropProviderModels(builtInModels, cachedAuthoritativeProviders);
+		this.#lastStaticLoadMtime = this.#modelsConfigFile.getMtimeMs();
+	}
+
+	#resetStaticComposition(): void {
+		this.#models = [];
+		this.#hasFullSnapshot = false;
+		this.#internedStaticModels.clear();
+		this.#providerLookupSnapshots.clear();
+	}
+
+	#knownStaticProviders(): string[] {
+		const providers = new Set<string>(getBundledProviders());
+		for (const model of this.#cachedStandardModels) providers.add(model.provider);
+		for (const model of this.#cachedDiscoverableModels) providers.add(model.provider);
+		for (const model of this.#customModelOverlays) providers.add(model.provider);
+		for (const model of this.#runtimeModelOverlays) providers.add(model.provider);
+		return [...providers];
+	}
+
+	#internStaticModels(models: Model<Api>[]): Model<Api>[] {
+		return models.map(model => {
+			const key = `${model.provider}\u0000${model.id}`;
+			const interned = this.#internedStaticModels.get(key);
+			if (interned) return interned;
+			this.#internedStaticModels.set(key, model);
+			return model;
+		});
+	}
+
+	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
+		const select = <T extends { provider: string }>(models: readonly T[]): T[] =>
+			providerFilter ? models.filter(model => providerFilter.has(model.provider)) : [...models];
+		let builtInModels = this.#applyHardcodedModelPolicies(
+			this.#loadBuiltInModels(this.#providerOverrides, providerFilter),
+		);
+		if (this.#cachedAuthoritativeProviders.size > 0) {
+			builtInModels = dropProviderModels(builtInModels, this.#cachedAuthoritativeProviders);
 		}
 		const resolvedDefaults = this.#mergeResolvedModels(
-			this.#mergeResolvedModels(builtInModels, cachedStandardModels),
-			cachedDiscoveries,
+			this.#mergeResolvedModels(builtInModels, select(this.#cachedStandardModels)),
+			select(this.#cachedDiscoverableModels),
 		);
-		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, this.#customModelOverlays);
-		// Merge runtime extension models so they survive refresh() cycles
-		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
+		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, select(this.#customModelOverlays));
+		const combined = this.#mergeCustomModels(withConfigModels, select(this.#runtimeModelOverlays));
 		// Custom/config providers bypass the model-manager merge point —
 		// collapse effort-tier variants here so X/X-thinking twins fold.
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		this.#models = this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides));
-		this.#lastStaticLoadMtime = this.#modelsConfigFile.getMtimeMs();
+		return this.#internStaticModels(
+			this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
+		);
+	}
+
+	#ensureFullSnapshot(): Model<Api>[] {
+		if (!this.#hasFullSnapshot) {
+			this.#models = this.#composeStaticModels();
+			this.#hasFullSnapshot = true;
+			this.#providerLookupSnapshots.clear();
+		}
+		return this.#models;
 	}
 
 	/** Load built-in models, applying provider-level overrides only.
 	 *  Per-model overrides are applied later by #applyModelOverrides. */
-	#loadBuiltInModels(overrides: Map<string, ProviderOverride>): Model<Api>[] {
+	#loadBuiltInModels(
+		overrides: Map<string, ProviderOverride>,
+		providerFilter?: ReadonlySet<string>,
+	): Model<Api>[] {
 		return getBundledProviders().flatMap(provider => {
+			if (providerFilter && !providerFilter.has(provider)) return [];
 			const models = getBundledModels(provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[];
 			const providerOverride = overrides.get(provider);
 
@@ -1158,15 +1225,23 @@ export class ModelRegistry {
 		});
 	}
 
-	#resolveStartupModelCacheProviderId(providerId: string): string {
-		const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === providerId);
-		if (!descriptor) {
-			return providerId;
-		}
-		const baseUrl =
+	#descriptorBaseUrl(providerId: string): string | undefined {
+		return (
 			this.#runtimeProviderOverrides.get(providerId)?.baseUrl ??
 			this.#providerOverrides.get(providerId)?.baseUrl ??
-			this.getProviderBaseUrl(providerId);
+			(this.#hasFullSnapshot ? this.getProviderBaseUrl(providerId) : undefined)
+		);
+	}
+
+	#resolveStartupModelCacheProviderId(providerId: string): string {
+		const explicitBaseUrl =
+			this.#runtimeProviderOverrides.get(providerId)?.baseUrl ?? this.#providerOverrides.get(providerId)?.baseUrl;
+		if (explicitBaseUrl === undefined && !this.#hasFullSnapshot) {
+			return DEFAULT_STARTUP_MODEL_CACHE_PROVIDER_IDS[providerId] ?? providerId;
+		}
+		const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === providerId);
+		if (!descriptor) return providerId;
+		const baseUrl = explicitBaseUrl ?? this.getProviderBaseUrl(providerId);
 		return descriptor.createModelManagerOptions({ baseUrl, fetch: this.#fetch }).cacheProviderId ?? providerId;
 	}
 
@@ -1543,6 +1618,7 @@ export class ModelRegistry {
 		if (discovered.length === 0 && builtInDiscovery.authoritativeProviders.size === 0) {
 			return;
 		}
+		this.#ensureFullSnapshot();
 		const discoveredModels = this.#applyHardcodedModelPolicies(
 			discovered.map(model =>
 				mergeDiscoveredModel(
@@ -1797,7 +1873,7 @@ export class ModelRegistry {
 				createOptions: oauthToken =>
 					googleAntigravityModelManagerOptions({
 						oauthToken,
-						endpoint: this.getProviderBaseUrl("google-antigravity"),
+						endpoint: this.#descriptorBaseUrl("google-antigravity"),
 						fetch: this.#fetch,
 					}),
 			},
@@ -1808,7 +1884,7 @@ export class ModelRegistry {
 				createOptions: oauthToken =>
 					googleGeminiCliModelManagerOptions({
 						oauthToken,
-						endpoint: this.getProviderBaseUrl("google-gemini-cli"),
+						endpoint: this.#descriptorBaseUrl("google-gemini-cli"),
 						fetch: this.#fetch,
 					}),
 			},
@@ -1836,13 +1912,7 @@ export class ModelRegistry {
 		});
 		const standardProviderKeys = await Promise.all(
 			standardProviderDescriptors.map(descriptor => {
-				const discoveryBaseUrl =
-					this.#runtimeProviderOverrides.get(descriptor.providerId)?.baseUrl ??
-					this.#providerOverrides.get(descriptor.providerId)?.baseUrl ??
-					this.getProviderBaseUrl(descriptor.providerId);
-				const cacheProviderId =
-					descriptor.createModelManagerOptions({ baseUrl: discoveryBaseUrl, fetch: this.#fetch })
-						.cacheProviderId ?? descriptor.providerId;
+				const cacheProviderId = this.#resolveStartupModelCacheProviderId(descriptor.providerId);
 				return this.#resolveBuiltInDiscoveryApiKey(
 					descriptor.providerId,
 					strategy,
@@ -1871,10 +1941,7 @@ export class ModelRegistry {
 					this.#providerOverrides.has(descriptor.providerId) ||
 					this.#keylessProviders.has(descriptor.providerId));
 			if (isAuthenticated(apiKey) || descriptor.allowUnauthenticated || hasExplicitVllmConfig) {
-				const discoveryBaseUrl =
-					this.#runtimeProviderOverrides.get(descriptor.providerId)?.baseUrl ??
-					this.#providerOverrides.get(descriptor.providerId)?.baseUrl ??
-					this.getProviderBaseUrl(descriptor.providerId);
+				const discoveryBaseUrl = this.#descriptorBaseUrl(descriptor.providerId);
 				options.push(
 					descriptor.createModelManagerOptions({
 						apiKey: isDiscoveryBearerApiKey(apiKey) ? apiKey : undefined,
@@ -2098,12 +2165,26 @@ export class ModelRegistry {
 		return models;
 	}
 
+	#modelsForProviderLookup(provider: string): Model<Api>[] {
+		if (this.#hasFullSnapshot) return this.#models;
+		const normalizedProvider = provider.trim().toLowerCase();
+		if (!normalizedProvider) return [];
+		const cached = this.#providerLookupSnapshots.get(normalizedProvider);
+		if (cached) return cached;
+		const matchingProviders = new Set(
+			this.#knownStaticProviders().filter(candidate => candidate.toLowerCase() === normalizedProvider),
+		);
+		const models = this.#composeStaticModels(matchingProviders);
+		this.#providerLookupSnapshots.set(normalizedProvider, models);
+		return models;
+	}
+
 	/**
 	 * Get all models (built-in + custom).
 	 * If custom config had errors, returns only built-in models.
 	 */
 	getAll(): Model<Api>[] {
-		return this.#models;
+		return this.#ensureFullSnapshot();
 	}
 
 	/**
@@ -2112,16 +2193,16 @@ export class ModelRegistry {
 	 * per provider instead of once per model, which matters when filtering the
 	 * full bundled catalog (thousands of models, ~50 providers).
 	 */
-	#createAvailabilityCheck(): (model: Model<Api>) => boolean {
+	#createProviderAvailabilityCheck(): (provider: string) => boolean {
 		const disabledProviders = getDisabledProviderIdsFromSettings();
 		const byProvider = new Map<string, boolean>();
-		return model => {
-			let available = byProvider.get(model.provider);
+		return provider => {
+			let available = byProvider.get(provider);
 			if (available === undefined) {
 				available =
-					!disabledProviders.has(model.provider) &&
-					(this.#keylessProviders.has(model.provider) || this.authStorage.hasAuth(model.provider));
-				byProvider.set(model.provider, available);
+					!disabledProviders.has(provider) &&
+					(this.#keylessProviders.has(provider) || this.authStorage.hasAuth(provider));
+				byProvider.set(provider, available);
 			}
 			return available;
 		};
@@ -2132,7 +2213,12 @@ export class ModelRegistry {
 	 * This is a fast check that doesn't refresh OAuth tokens.
 	 */
 	getAvailable(): Model<Api>[] {
-		return this.#models.filter(this.#createAvailabilityCheck());
+		const isProviderAvailable = this.#createProviderAvailabilityCheck();
+		if (this.#hasFullSnapshot) {
+			return this.#models.filter(model => isProviderAvailable(model.provider));
+		}
+		const availableProviders = new Set(this.#knownStaticProviders().filter(isProviderAvailable));
+		return this.#composeStaticModels(availableProviders);
 	}
 
 	/**
@@ -2188,7 +2274,10 @@ export class ModelRegistry {
 	 * the online refresh completes.
 	 */
 	hasProvider(providerId: string): boolean {
-		if (this.#models.some(model => model.provider === providerId)) return true;
+		const providerModels = this.#hasFullSnapshot
+			? this.#models
+			: this.#composeStaticModels(new Set([providerId]));
+		if (providerModels.some(model => model.provider === providerId)) return true;
 		if (getDisabledProviderIdsFromSettings().has(providerId)) return false;
 		return (
 			this.#discoverableProviders.some(provider => provider.provider === providerId) ||
@@ -2204,14 +2293,14 @@ export class ModelRegistry {
 	 * Find a model by provider and ID.
 	 */
 	find(provider: string, modelId: string): Model<Api> | undefined {
-		return resolveProviderModelReference(provider, modelId, this.#models);
+		return resolveProviderModelReference(provider, modelId, this.#modelsForProviderLookup(provider));
 	}
 
 	/**
 	 * Get the base URL associated with a provider, if any model defines one.
 	 */
 	getProviderBaseUrl(provider: string): string | undefined {
-		return this.#models.find(m => m.provider === provider && m.baseUrl)?.baseUrl;
+		return this.#modelsForProviderLookup(provider).find(m => m.provider === provider && m.baseUrl)?.baseUrl;
 	}
 	/**
 	 * Get provider-level headers without including per-model overrides.
@@ -2337,6 +2426,7 @@ export class ModelRegistry {
 		if (!sourceProviders || sourceProviders.size === 0) {
 			return;
 		}
+		this.#ensureFullSnapshot();
 		this.#runtimeProvidersBySource.delete(sourceId);
 		for (const providerName of sourceProviders) {
 			if (this.#runtimeProviderSourceByName.get(providerName) !== sourceId) {
@@ -2427,6 +2517,7 @@ export class ModelRegistry {
 			this.#reloadStaticModels();
 		}
 
+		this.#ensureFullSnapshot();
 		if (config.apiKey) {
 			this.#installProviderApiKey(providerName, config.apiKey);
 			// Persist runtime API keys so they survive #reloadStaticModels() cycles

--- a/packages/coding-agent/test/fixtures/model-registry-construction-build-probe.ts
+++ b/packages/coding-agent/test/fixtures/model-registry-construction-build-probe.ts
@@ -1,0 +1,18 @@
+import { spyOn } from "bun:test";
+import * as path from "node:path";
+import * as buildModule from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const tempDir = TempDir.createSync("@model-registry-lazy-probe-");
+const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+const buildSpy = spyOn(buildModule, "buildModel");
+try {
+	new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	process.stdout.write(JSON.stringify({ buildCalls: buildSpy.mock.calls.length }));
+} finally {
+	buildSpy.mockRestore();
+	authStorage.close();
+	await tempDir.remove().catch(() => {});
+}

--- a/packages/coding-agent/test/model-registry-lazy-loading.test.ts
+++ b/packages/coding-agent/test/model-registry-lazy-loading.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const probePath = path.join(import.meta.dir, "fixtures", "model-registry-construction-build-probe.ts");
+
+function modelKeys(models: readonly Model<Api>[]): string[] {
+	return models.map(model => `${model.provider}\0${model.id}`);
+}
+
+function expectSameModelObjects(models: readonly Model<Api>[], allModels: readonly Model<Api>[]): void {
+	const allByKey = new Map(allModels.map(model => [`${model.provider}\0${model.id}`, model]));
+	for (const model of models) {
+		expect(model).toBe(allByKey.get(`${model.provider}\0${model.id}`));
+	}
+}
+
+describe("ModelRegistry lazy bundled composition", () => {
+	const tempDirs: TempDir[] = [];
+	const authStorages: AuthStorage[] = [];
+
+	afterEach(async () => {
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		await Promise.all(tempDirs.splice(0).map(tempDir => tempDir.remove().catch(() => {})));
+	});
+
+	test("construction with empty auth does not enrich bundled models", async () => {
+		const proc = Bun.spawn([process.execPath, probePath], {
+			cwd: path.join(import.meta.dir, "../../.."),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		expect(exitCode, stderr).toBe(0);
+		expect(JSON.parse(stdout)).toEqual({ buildCalls: 0 });
+	});
+
+	test("query order preserves ordering, snapshots, and model identity", async () => {
+		const createRegistry = async (name: string): Promise<ModelRegistry> => {
+			const tempDir = TempDir.createSync(`@model-registry-lazy-${name}-`);
+			tempDirs.push(tempDir);
+			const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+			authStorages.push(authStorage);
+			authStorage.setRuntimeApiKey("anthropic", "test-key");
+			return new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		};
+
+		const findFirstRegistry = await createRegistry("find-first");
+		const foundBeforeAll = findFirstRegistry.find("anthropic", "claude-sonnet-4-5");
+		expect(foundBeforeAll).toBeDefined();
+		const availableBeforeAll = findFirstRegistry.getAvailable();
+		const availableAgain = findFirstRegistry.getAvailable();
+		expect(availableAgain).not.toBe(availableBeforeAll);
+		expect(availableAgain).toEqual(availableBeforeAll);
+		for (let index = 0; index < availableBeforeAll.length; index += 1) {
+			expect(availableAgain[index]).toBe(availableBeforeAll[index]);
+		}
+		const allAfterSelectiveQueries = findFirstRegistry.getAll();
+		expect(findFirstRegistry.getAll()).toBe(allAfterSelectiveQueries);
+		expect(foundBeforeAll).toBe(
+			allAfterSelectiveQueries.find(model => model.provider === "anthropic" && model.id === "claude-sonnet-4-5"),
+		);
+		expect(foundBeforeAll).toBe(
+			availableBeforeAll.find(model => model.provider === "anthropic" && model.id === "claude-sonnet-4-5"),
+		);
+		expectSameModelObjects(availableBeforeAll, allAfterSelectiveQueries);
+
+		const allFirstRegistry = await createRegistry("all-first");
+		const allBeforeSelectiveQueries = allFirstRegistry.getAll();
+		const availableAfterAll = allFirstRegistry.getAvailable();
+		const foundAfterAll = allFirstRegistry.find("anthropic", "claude-sonnet-4-5");
+		expect(allFirstRegistry.getAll()).toBe(allBeforeSelectiveQueries);
+		expect(foundAfterAll).toBe(
+			allBeforeSelectiveQueries.find(model => model.provider === "anthropic" && model.id === "claude-sonnet-4-5"),
+		);
+		expectSameModelObjects(availableAfterAll, allBeforeSelectiveQueries);
+		expect(modelKeys(allBeforeSelectiveQueries)).toEqual(modelKeys(allAfterSelectiveQueries));
+		expect(modelKeys(availableAfterAll)).toEqual(modelKeys(availableBeforeAll));
+	});
+});

--- a/packages/coding-agent/test/model-registry-lazy-loading.test.ts
+++ b/packages/coding-agent/test/model-registry-lazy-loading.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import * as path from "node:path";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { litellmModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -14,7 +17,7 @@ function modelKeys(models: readonly Model<Api>[]): string[] {
 function expectSameModelObjects(models: readonly Model<Api>[], allModels: readonly Model<Api>[]): void {
 	const allByKey = new Map(allModels.map(model => [`${model.provider}\0${model.id}`, model]));
 	for (const model of models) {
-		expect(model).toBe(allByKey.get(`${model.provider}\0${model.id}`));
+		expect(allByKey.get(`${model.provider}\0${model.id}`)).toBe(model);
 	}
 }
 
@@ -40,6 +43,39 @@ describe("ModelRegistry lazy bundled composition", () => {
 		]);
 		expect(exitCode, stderr).toBe(0);
 		expect(JSON.parse(stdout)).toEqual({ buildCalls: 0 });
+	});
+
+	test("loads the default LiteLLM namespaced cache", async () => {
+		const tempDir = TempDir.createSync("@model-registry-lazy-litellm-cache-");
+		tempDirs.push(tempDir);
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorages.push(authStorage);
+		const cacheProviderId = litellmModelManagerOptions().cacheProviderId;
+		if (!cacheProviderId) throw new Error("LiteLLM must define a cache namespace");
+		writeModelCache(
+			cacheProviderId,
+			Date.now(),
+			[
+				buildModel({
+					id: "cached-fixture",
+					name: "Cached Fixture",
+					api: "openai-completions",
+					provider: "litellm",
+					baseUrl: "http://localhost:4000/v1",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 8192,
+					maxTokens: 1024,
+				}),
+			],
+			true,
+			"",
+			path.join(tempDir.path(), "models.db"),
+		);
+
+		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		expect(registry.find("litellm", "cached-fixture")?.name).toBe("Cached Fixture");
 	});
 
 	test("query order preserves ordering, snapshots, and model identity", async () => {


### PR DESCRIPTION
## Purpose

Materialize bundled model enrichment per provider and defer bundled reference indexes until resolution. The model registry now composes only queried or available providers until a caller requests the complete snapshot. Startup cache lookup reuses the catalog's lightweight public cache-ID resolver instead of duplicating provider namespaces or default endpoints.

## Tests

- Red on upstream `main`: a three-model provider query enriched 3,901 bundled models instead of 3; empty-auth registry construction called `buildModel` 3,910 times instead of 0; the current LiteLLM namespaced startup cache was not loaded.
- Cache-parity red/green: the new public parity test initially failed because no lightweight cache-ID resolver was exported; it now verifies all 54 descriptor defaults plus scoped LiteLLM, OpenCode Go/Zen, and vLLM inputs against their factories.
- Resource red/green: the eager parent-equivalent control retained 43,778,048 RSS bytes after manager-option construction, exceeding the 8 MiB guard; treatment retained 0 bytes in the same probe. The committed test observes process RSS only and does not name or mock catalog builders.
- Green: `bun test packages/catalog/test/provider-cache-id.test.ts packages/catalog/test/models-lazy-provider-cache.test.ts packages/catalog/test/bundled-reference-laziness.test.ts packages/coding-agent/test/model-registry-lazy-loading.test.ts` — 8 pass, 0 fail, 324 assertions.
- `bun run --cwd=packages/catalog check:types`
- `bun run --cwd=packages/coding-agent check:types`
- Targeted Biome check for the modified TypeScript files.
- `bun run ci:test:ts:workspace` passed locally; the reported fast-test failure was not reproducible in this exact run.

## Metrics

Startup CPU baseline was 2,340 ms. Treatment measured 1,980 ms, with an independent confirmation at 2,090 ms. Conservatively, this is a 10.7% startup CPU improvement. These samples support the startup CPU claim only; no RSS improvement is attributed to the CPU benchmark. The RSS value above is a structural regression guard, not a general runtime-memory claim.

## Safety

`getAll()` still returns a stable complete snapshot, while targeted lookups and availability filtering preserve ordering and model identity. Public parity coverage keeps lightweight startup cache namespaces aligned with catalog factories for both default and scoped endpoints. Provider overrides, discovery, and public model-resolution behavior remain covered; this change does not include broader registry refactors.