### PR TITLE
perf(launch): isolate PTY replay in broker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Moved PTY log replay into the shared project launch broker, so normal CLI and Hub startup no longer load the xterm runtime while launch logs return validated rendered terminal rows.
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/src/launch/broker-output-snapshot.test.ts
+++ b/packages/coding-agent/src/launch/broker-output-snapshot.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { startDaemonBrokerFromEnvironment } from "./broker";
+import { createDaemonBrokerClient } from "./client";
+import {
+	DAEMON_IDLE_GRACE_ENV,
+	DAEMON_PROJECT_DIR_ENV,
+	DAEMON_RUNTIME_DIR_ENV,
+	type DaemonOperation,
+} from "./protocol";
+import * as terminalOutput from "./terminal-output";
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}
+
+describe("daemon broker log snapshots", () => {
+	it("returns the cursor captured with the PTY bytes rendered in the response", async () => {
+		using tempDir = TempDir.createSync("@omp-launch-cursor-");
+		const projectDir = path.join(tempDir.path(), "project");
+		const runtimeDir = path.join(tempDir.path(), "runtime");
+		await fs.mkdir(projectDir);
+		const scriptPath = path.join(projectDir, "service.ts");
+		await Bun.write(
+			scriptPath,
+			`process.stdin.setEncoding("utf8");
+process.stdin.resume();
+process.stdout.write("READY\\n");
+process.stdin.on("data", () => process.stdout.write("AFTER-SNAPSHOT\\n"));
+`,
+		);
+
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const renderStarted = Promise.withResolvers<void>();
+		const releaseRender = Promise.withResolvers<void>();
+		const renderTerminalOutput = terminalOutput.renderTerminalOutput;
+		vi.spyOn(terminalOutput, "renderTerminalOutput").mockImplementation(async (output, options) => {
+			renderStarted.resolve();
+			await releaseRender.promise;
+			return renderTerminalOutput(output, options);
+		});
+
+		const previousProjectDir = process.env[DAEMON_PROJECT_DIR_ENV];
+		const previousRuntimeDir = process.env[DAEMON_RUNTIME_DIR_ENV];
+		const previousGrace = process.env[DAEMON_IDLE_GRACE_ENV];
+		const previousTitle = process.title;
+		process.env[DAEMON_PROJECT_DIR_ENV] = projectDir;
+		process.env[DAEMON_RUNTIME_DIR_ENV] = runtimeDir;
+		process.env[DAEMON_IDLE_GRACE_ENV] = "5000";
+		const broker = startDaemonBrokerFromEnvironment();
+		restoreEnv(DAEMON_PROJECT_DIR_ENV, previousProjectDir);
+		restoreEnv(DAEMON_RUNTIME_DIR_ENV, previousRuntimeDir);
+		restoreEnv(DAEMON_IDLE_GRACE_ENV, previousGrace);
+
+		try {
+			const started = await client.request({
+				op: "start",
+				spec: {
+					name: "cursor",
+					application: process.execPath,
+					args: [scriptPath],
+					env: {},
+					cwd: projectDir,
+					pty: true,
+					ready: { log: "READY", timeoutMs: 5_000 },
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+			});
+			if (started.op !== "start") throw new Error("unexpected start result");
+			expect(started.readyTimedOut).toBeFalse();
+
+			const snapshotPromise = client.request({
+				op: "logs",
+				name: "cursor",
+				lines: 20,
+				head: false,
+				follow: false,
+				timeoutMs: 1_000,
+				renderTerminalRows: true,
+			} as DaemonOperation);
+			await renderStarted.promise;
+			await client.request({ op: "send", name: "cursor", data: "race\r" });
+			const observed = await client.request({
+				op: "wait",
+				name: "cursor",
+				for: "exit",
+				pattern: "AFTER-SNAPSHOT",
+				timeoutMs: 1_000,
+			});
+			if (observed.op !== "wait") throw new Error("unexpected wait result");
+			expect(observed.timedOut).toBeFalse();
+			releaseRender.resolve();
+
+			const snapshot = await snapshotPromise;
+			if (snapshot.op !== "logs") throw new Error("unexpected logs result");
+			expect(snapshot.terminalRows?.join("\n")).not.toContain("AFTER-SNAPSHOT");
+
+			const followed = await client.request({
+				op: "logs",
+				name: "cursor",
+				lines: 20,
+				head: false,
+				follow: true,
+				cursor: snapshot.cursor,
+				timeoutMs: 1_000,
+				renderTerminalRows: true,
+			} as DaemonOperation);
+			if (followed.op !== "logs") throw new Error("unexpected follow result");
+			expect(followed.timedOut).toBeFalse();
+			expect(followed.text).toContain("AFTER-SNAPSHOT");
+		} finally {
+			releaseRender.resolve();
+			await client.request({ op: "stop", name: "cursor", timeoutMs: 2_000 }).catch(() => undefined);
+			await client.request({ op: "shutdown" }).catch(() => undefined);
+			client.close();
+			await broker;
+			process.title = previousTitle;
+			vi.restoreAllMocks();
+		}
+	}, 20_000);
+});

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -26,6 +26,7 @@ import {
 	parseDaemonWireRequest,
 } from "./protocol";
 import { resolveDaemonSpawnOptions } from "./spawn-options";
+import { renderTerminalOutput } from "./terminal-output";
 
 const DEFAULT_IDLE_GRACE_MS = 3_000;
 const MAX_REQUEST_BYTES = 1024 * 1024;
@@ -90,7 +91,8 @@ interface BrokerLease {
 
 interface DaemonLogRead {
 	text: string;
-	terminalText: string;
+	terminalOutput: string;
+	cursor: number;
 }
 
 function quoteShellArg(value: string): string {
@@ -204,10 +206,15 @@ class DaemonLog {
 		return text;
 	}
 
-	async read(head: boolean, lines: number, grep?: string): Promise<DaemonLogRead> {
-		await this.#queue;
-		await this.#writer.flush();
-		return DaemonLog.readFiles(this.#path, this.#previousPath, head, lines, grep);
+	read(head: boolean, lines: number, cursor: number, grep?: string): Promise<DaemonLogRead> {
+		const snapshot = this.#queue.then(async () => {
+			await this.#writer.flush();
+			return DaemonLog.readFiles(this.#path, this.#previousPath, head, lines, cursor, grep);
+		});
+		// Appends that arrive after this call queue behind the file snapshot, so its
+		// cursor can never include bytes that its terminal replay did not read.
+		this.#queue = snapshot.then(() => undefined);
+		return snapshot;
 	}
 
 	async close(): Promise<void> {
@@ -222,14 +229,15 @@ class DaemonLog {
 		previousPath: string,
 		head: boolean,
 		lines: number,
+		cursor: number,
 		grep?: string,
 	): Promise<DaemonLogRead> {
 		const [previous, current] = await Promise.all([fileTextSlice(previousPath, head), fileTextSlice(logPath, head)]);
 		const combined = `${previous}${previous && current && !previous.endsWith("\n") ? "\n" : ""}${current}`;
-		const terminalText = head
+		const terminalOutput = head
 			? truncateHeadBytes(combined, LOG_READ_BYTES).text
 			: truncateTailBytes(combined, LOG_READ_BYTES).text;
-		let text = sanitizeText(terminalText);
+		let text = sanitizeText(terminalOutput);
 		if (grep) {
 			let pattern: RegExp;
 			try {
@@ -245,7 +253,8 @@ class DaemonLog {
 		const options = { maxLines: lines, maxBytes: 256 * 1024 };
 		return {
 			text: head ? truncateHead(text, options).content : truncateTail(text, options).content,
-			terminalText,
+			terminalOutput,
+			cursor,
 		};
 	}
 
@@ -834,20 +843,30 @@ class DaemonBroker {
 		}
 		const lines = Math.max(1, Math.min(1_000, Math.floor(operation.lines)));
 		const output = record.log
-			? await record.log.read(operation.head, lines, operation.grep)
+			? await record.log.read(operation.head, lines, record.snapshot.outputBytes, operation.grep)
 			: await DaemonLog.readFiles(
 					path.join(record.dir, LOG_FILE),
 					path.join(record.dir, PREVIOUS_LOG_FILE),
 					operation.head,
 					lines,
+					record.snapshot.outputBytes,
 					operation.grep,
 				);
+		const terminalOutput = record.spec.pty && operation.grep === undefined ? output.terminalOutput : undefined;
+		const terminalRows =
+			terminalOutput !== undefined && operation.renderTerminalRows === true
+				? await renderTerminalOutput(terminalOutput, { head: operation.head, maxRows: lines })
+				: undefined;
 		return {
 			op: "logs",
 			name: record.snapshot.name,
 			text: output.text,
-			terminalText: record.spec.pty && operation.grep === undefined ? output.terminalText : undefined,
-			cursor: record.snapshot.outputBytes,
+			terminalRows,
+			terminalText:
+				terminalOutput !== undefined && (operation.renderTerminalRows !== true || terminalRows === undefined)
+					? terminalOutput
+					: undefined,
+			cursor: output.cursor,
 			timedOut,
 			state: record.snapshot.state,
 		};

--- a/packages/coding-agent/src/launch/protocol.test.ts
+++ b/packages/coding-agent/src/launch/protocol.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { type DaemonOperation, parseDaemonRpcResult, parseDaemonWireRequest } from "./protocol";
+
+const operation: Extract<DaemonOperation, { op: "logs" }> = {
+	op: "logs",
+	name: "web",
+	lines: 20,
+	head: false,
+	follow: false,
+	timeoutMs: 1_000,
+};
+
+const baseResult = {
+	name: "web",
+	text: "ready",
+	cursor: 42,
+	timedOut: false,
+	state: "running" as const,
+};
+
+describe("launch logs protocol", () => {
+	it("decodes terminal rows without changing their bytes", () => {
+		const terminalRows = ["\x1b[0m\x1b[1;38;5;2mready", "", "界e\u0301"];
+		expect(parseDaemonRpcResult(operation, { ...baseResult, terminalRows })).toEqual({
+			op: "logs",
+			...baseResult,
+			terminalRows,
+		});
+	});
+
+	it("rejects a non-array terminal row payload", () => {
+		expect(() => parseDaemonRpcResult(operation, { ...baseResult, terminalRows: "ready" })).toThrow(
+			"result.terminalRows must be an array of strings",
+		);
+	});
+
+	it("rejects non-string terminal row entries", () => {
+		expect(() => parseDaemonRpcResult(operation, { ...baseResult, terminalRows: ["ready", 7] })).toThrow(
+			"result.terminalRows item must be a string",
+		);
+	});
+});
+
+describe("launch logs compatibility", () => {
+	it("preserves the rendered-row request for upgraded brokers", () => {
+		const request = parseDaemonWireRequest({
+			id: "request-1",
+			token: "token-1",
+			operation: { ...operation, renderTerminalRows: true },
+		});
+		expect(request.operation).toMatchObject({ ...operation, renderTerminalRows: true });
+	});
+
+	it("decodes raw terminal text from an already-running legacy broker", () => {
+		const result = parseDaemonRpcResult(operation, { ...baseResult, terminalText: "progress\rready" });
+		if (result.op !== "logs") throw new Error("unexpected result");
+		expect("terminalText" in result ? result.terminalText : undefined).toBe("progress\rready");
+	});
+});

--- a/packages/coding-agent/src/launch/protocol.ts
+++ b/packages/coding-agent/src/launch/protocol.ts
@@ -83,6 +83,8 @@ export type DaemonOperation =
 			grep?: string;
 			follow: boolean;
 			cursor?: number;
+			/** Ask an upgraded broker to replay PTY output; absent preserves legacy raw-text responses. */
+			renderTerminalRows?: boolean;
 			timeoutMs: number;
 	  }
 	| { op: "wait"; name: string; for: "ready" | "exit"; pattern?: string; timeoutMs: number }
@@ -101,7 +103,9 @@ export type DaemonRpcResult =
 			op: "logs";
 			name: string;
 			text: string;
-			/** Raw PTY byte stream used only to reconstruct the terminal screen. */
+			/** Virtual PTY rows reconstructed by the broker for terminal display. */
+			terminalRows?: string[];
+			/** Raw PTY bytes returned by legacy brokers and to clients that did not request rendered rows. */
 			terminalText?: string;
 			cursor: number;
 			timedOut: boolean;
@@ -300,6 +304,10 @@ function parseDaemonOperation(value: unknown): DaemonOperation {
 				grep: optionalString(source.grep, "operation.grep"),
 				follow: booleanValue(source.follow, "operation.follow"),
 				cursor: optionalNumber(source.cursor, "operation.cursor"),
+				renderTerminalRows:
+					source.renderTerminalRows === undefined
+						? undefined
+						: booleanValue(source.renderTerminalRows, "operation.renderTerminalRows"),
 				timeoutMs: numberValue(source.timeoutMs, "operation.timeoutMs"),
 			};
 		case "wait": {
@@ -355,6 +363,8 @@ export function parseDaemonRpcResult(operation: DaemonOperation, value: unknown)
 				op: "logs",
 				name: stringValue(source.name, "result.name"),
 				text: typeof source.text === "string" ? source.text : "",
+				terminalRows:
+					source.terminalRows === undefined ? undefined : stringArray(source.terminalRows, "result.terminalRows"),
 				terminalText:
 					source.terminalText === undefined ? undefined : rawString(source.terminalText, "result.terminalText"),
 				cursor: numberValue(source.cursor, "result.cursor"),

--- a/packages/coding-agent/src/launch/terminal-output.test.ts
+++ b/packages/coding-agent/src/launch/terminal-output.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { renderTerminalOutput } from "./terminal-output";
+
+const RESET = "\x1b[0m";
+
+interface TerminalCase {
+	name: string;
+	input: string;
+	expected: string[];
+}
+
+const cases: TerminalCase[] = [
+	{
+		name: "overwrites the current row after carriage return",
+		input: "progress 10%\rDONE",
+		expected: [`${RESET}DONEress 10%`],
+	},
+	{
+		name: "honors absolute and relative horizontal cursor movement",
+		input: "abcdef\x1b[3GZ\x1b[2CX",
+		expected: [`${RESET}abZdeX`],
+	},
+	{
+		name: "honors absolute and relative vertical cursor movement",
+		input: "one\r\ntwo\r\nthree\x1b[2A\x1b[1GONE\x1b[1B\x1b[2D]",
+		expected: [`${RESET}ONE`, `${RESET}t]o`, `${RESET}three`],
+	},
+	{
+		name: "honors absolute cursor positioning",
+		input: "abc\r\ndef\x1b[1;2HZ",
+		expected: [`${RESET}aZc`, `${RESET}def`],
+	},
+	{
+		name: "erases from the cursor through the row",
+		input: "abcdef\r\x1b[3C\x1b[K",
+		expected: [`${RESET}abc`],
+	},
+	{
+		name: "inserts characters without losing shifted content",
+		input: "abcdef\r\x1b[3C\x1b[2@XY",
+		expected: [`${RESET}abcXYdef`],
+	},
+	{
+		name: "deletes characters and closes the gap",
+		input: "abcdef\r\x1b[2C\x1b[2P",
+		expected: [`${RESET}abef`],
+	},
+	{
+		name: "inserts a terminal row",
+		input: "one\r\ntwo\r\nthree\x1b[2;1H\x1b[Linserted",
+		expected: [`${RESET}one`, `${RESET}inserted`, `${RESET}two`, `${RESET}three`],
+	},
+	{
+		name: "deletes a terminal row",
+		input: "one\r\ntwo\r\nthree\x1b[2;1H\x1b[M",
+		expected: [`${RESET}one`, `${RESET}three`],
+	},
+	{
+		name: "wraps at the fixed 120-column PTY width",
+		input: `${"a".repeat(120)}b`,
+		expected: [`${RESET}${"a".repeat(120)}`, `${RESET}b`],
+	},
+	{
+		name: "preserves wide and combining characters",
+		input: "A界e\u0301B",
+		expected: [`${RESET}A界e\u0301B`],
+	},
+	{
+		name: "canonicalizes color, reset, and text decorations",
+		input: "\x1b[1;2;3;4;7;9;53;38;2;1;2;3;48;5;17mX\x1b[0mY",
+		expected: [`${RESET}\x1b[1;2;3;4;7;9;53;38;2;1;2;3;48;5;17mX${RESET}Y`],
+	},
+	{
+		name: "restores the normal buffer after alternate-buffer output",
+		input: "main\x1b[?1049hALT\x1b[?1049l",
+		expected: [`${RESET}main`],
+	},
+	{
+		name: "keeps internal blank rows while trimming blank rows and spaces at the end",
+		input: "alpha   \r\n\r\nomega   \r\n\r\n",
+		expected: [`${RESET}alpha`, "", `${RESET}omega`],
+	},
+];
+
+describe("renderTerminalOutput", () => {
+	for (const testCase of cases) {
+		it(testCase.name, async () => {
+			expect(await renderTerminalOutput(testCase.input, { head: false, maxRows: 100 })).toEqual(testCase.expected);
+		});
+	}
+
+	it("returns an empty row set for empty output", async () => {
+		expect(await renderTerminalOutput("", { head: false, maxRows: 100 })).toEqual([]);
+	});
+
+	it("applies head and tail row limits after replaying scrollback", async () => {
+		const output = Array.from({ length: 4_200 }, (_, index) => `row-${index}`).join("\r\n");
+		expect(await renderTerminalOutput(output, { head: true, maxRows: 2 })).toEqual([
+			`${RESET}row-64`,
+			`${RESET}row-65`,
+		]);
+		expect(await renderTerminalOutput(output, { head: false, maxRows: 2 })).toEqual([
+			`${RESET}row-4198`,
+			`${RESET}row-4199`,
+		]);
+	});
+});

--- a/packages/coding-agent/src/tools/hub/launch-compat.test.ts
+++ b/packages/coding-agent/src/tools/hub/launch-compat.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { DaemonBrokerClient } from "../../launch/client";
+import * as daemonClient from "../../launch/client";
+import type { DaemonRpcResult } from "../../launch/protocol";
+import type { ToolSession } from "..";
+import { executeLaunch } from "./launch";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("launch broker protocol compatibility", () => {
+	it("replays raw terminal text returned by an already-running legacy broker", async () => {
+		const projectDir = process.cwd();
+		const legacyResult = {
+			op: "logs",
+			name: "web",
+			text: "ready",
+			terminalText: "old\r\x1b[2K\x1b[1;32mready\x1b[0m",
+			cursor: 42,
+			timedOut: false,
+			state: "running",
+		} as unknown as DaemonRpcResult;
+		const client = {
+			projectDir,
+			request: async () => legacyResult,
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		const result = await executeLaunch({ cwd: projectDir } as ToolSession, {
+			op: "logs",
+			name: "web",
+			lines: 10,
+			head: false,
+		});
+
+		expect(result.details?.terminalRows).toEqual(["\x1b[0m\x1b[1;38;5;2mready"]);
+	});
+});

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -12,7 +12,7 @@ import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { daemonClientForProject } from "../../launch/client";
 import type { DaemonOperation, DaemonRpcResult, DaemonSnapshot, DaemonSpec, DaemonState } from "../../launch/protocol";
-import { renderTerminalOutput } from "../../launch/terminal-output";
+import type { TerminalOutputOptions } from "../../launch/terminal-output";
 import type { Theme, ThemeColor } from "../../modes/theme/theme";
 import { framedBlock, outputBlockContentWidth, renderStatusLine } from "../../tui";
 import type { ToolSession } from "..";
@@ -161,6 +161,7 @@ function operationFor(params: LaunchParams, session: ToolSession): DaemonOperati
 				grep: params.grep,
 				follow: params.follow ?? false,
 				cursor: params.cursor,
+				renderTerminalRows: true,
 				timeoutMs: timeoutMs(params.timeout, 30),
 			};
 		case "wait":
@@ -270,28 +271,38 @@ function toolContent(result: DaemonRpcResult, params: LaunchParams): string {
 	}
 }
 
+interface TerminalOutputRuntime {
+	renderTerminalOutput(output: string, options: TerminalOutputOptions): Promise<string[] | undefined>;
+}
+
+async function renderLegacyTerminalOutput(terminalText: string, params: LaunchParams): Promise<string[] | undefined> {
+	// `require` keeps xterm out of normal main/Hub startup while retaining display
+	// compatibility with a legacy broker that was already running during upgrade.
+	const runtime = require("../../launch/terminal-output") as TerminalOutputRuntime;
+	return runtime.renderTerminalOutput(terminalText, {
+		head: params.head ?? false,
+		maxRows: Math.min(1_000, Math.floor(params.lines ?? 100)),
+	});
+}
+
 async function toolDetails(result: DaemonRpcResult, params: LaunchParams): Promise<LaunchToolDetails> {
 	switch (result.op) {
 		case "start":
 			return { op: "start", daemon: result.daemon, timedOut: result.readyTimedOut };
 		case "list":
 			return { op: "list", daemons: result.daemons };
-		case "logs": {
-			const terminalRows =
-				result.terminalText === undefined
-					? undefined
-					: await renderTerminalOutput(result.terminalText, {
-							head: params.head ?? false,
-							maxRows: Math.min(1_000, Math.floor(params.lines ?? 100)),
-						});
+		case "logs":
 			return {
 				op: "logs",
 				cursor: result.cursor,
 				timedOut: result.timedOut,
 				state: result.state,
-				terminalRows,
+				terminalRows:
+					result.terminalRows ??
+					(result.terminalText === undefined
+						? undefined
+						: await renderLegacyTerminalOutput(result.terminalText, params)),
 			};
-		}
 		case "wait":
 			return { op: "wait", daemon: result.daemon, timedOut: result.timedOut, matched: result.matched };
 		case "send":

--- a/packages/coding-agent/test/fixtures/xterm-cache-broker-probe.ts
+++ b/packages/coding-agent/test/fixtures/xterm-cache-broker-probe.ts
@@ -1,0 +1,11 @@
+import { statSync } from "node:fs";
+import "../../src/launch/broker";
+
+const paths = Object.keys(require.cache)
+	.filter(modulePath => modulePath.replaceAll("\\", "/").includes("/node_modules/@xterm/headless/"))
+	.sort();
+const bytes = paths.reduce((total, modulePath) => total + statSync(modulePath).size, 0);
+const memory = process.memoryUsage();
+process.stdout.write(
+	JSON.stringify({ modules: paths.length, bytes, rss: memory.rss, heapUsed: memory.heapUsed, paths }),
+);

--- a/packages/coding-agent/test/fixtures/xterm-cache-hub-probe.ts
+++ b/packages/coding-agent/test/fixtures/xterm-cache-hub-probe.ts
@@ -1,0 +1,11 @@
+import { statSync } from "node:fs";
+import "../../src/tools/hub/index";
+
+const paths = Object.keys(require.cache)
+	.filter(modulePath => modulePath.replaceAll("\\", "/").includes("/node_modules/@xterm/headless/"))
+	.sort();
+const bytes = paths.reduce((total, modulePath) => total + statSync(modulePath).size, 0);
+const memory = process.memoryUsage();
+process.stdout.write(
+	JSON.stringify({ modules: paths.length, bytes, rss: memory.rss, heapUsed: memory.heapUsed, paths }),
+);

--- a/packages/coding-agent/test/fixtures/xterm-cache-main-probe.ts
+++ b/packages/coding-agent/test/fixtures/xterm-cache-main-probe.ts
@@ -1,0 +1,11 @@
+import { statSync } from "node:fs";
+import "../../src/main";
+
+const paths = Object.keys(require.cache)
+	.filter(modulePath => modulePath.replaceAll("\\", "/").includes("/node_modules/@xterm/headless/"))
+	.sort();
+const bytes = paths.reduce((total, modulePath) => total + statSync(modulePath).size, 0);
+const memory = process.memoryUsage();
+process.stdout.write(
+	JSON.stringify({ modules: paths.length, bytes, rss: memory.rss, heapUsed: memory.heapUsed, paths }),
+);

--- a/packages/coding-agent/test/fixtures/xterm-cache-positive-control.ts
+++ b/packages/coding-agent/test/fixtures/xterm-cache-positive-control.ts
@@ -1,0 +1,11 @@
+import { statSync } from "node:fs";
+import "@xterm/headless";
+
+const paths = Object.keys(require.cache)
+	.filter(modulePath => modulePath.replaceAll("\\", "/").includes("/node_modules/@xterm/headless/"))
+	.sort();
+const bytes = paths.reduce((total, modulePath) => total + statSync(modulePath).size, 0);
+const memory = process.memoryUsage();
+process.stdout.write(
+	JSON.stringify({ modules: paths.length, bytes, rss: memory.rss, heapUsed: memory.heapUsed, paths }),
+);

--- a/packages/coding-agent/test/tools/launch.test.ts
+++ b/packages/coding-agent/test/tools/launch.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createDaemonBrokerClient, type DaemonBrokerClient } from "../../src/launch/client";
 import { registerDaemonProjectPresence } from "../../src/launch/presence";
-import type { DaemonSpec } from "../../src/launch/protocol";
+import type { DaemonOperation, DaemonSpec } from "../../src/launch/protocol";
 
 const cleanupDirs: string[] = [];
 
@@ -192,16 +192,45 @@ setInterval(() => {}, 1000);
 				head: false,
 				follow: false,
 				timeoutMs: 1_000,
-			});
+				renderTerminalRows: true,
+			} as DaemonOperation);
 			expect(logs.op).toBe("logs");
 			if (logs.op !== "logs") throw new Error("unexpected logs result");
 			expect(logs.text).toContain("READY");
 			expect(logs.text).not.toContain("\x1b");
 			expect(logs.text).not.toContain("BOOT:0");
 			expect(logs.text).toContain('INPUT:"run\\r"');
-			expect(logs.terminalText).toContain("\x1b[2J\x1b[H");
-			expect(logs.terminalText).toContain("\x1b[1;32mREADY\x1b[0m");
-			expect(logs.terminalText).toContain("BOOT:0");
+			const expectedTerminalRows = [
+				...Array.from({ length: 18 }, (_, index) => `\x1b[0mBOOT:${index + 7}`),
+				"\x1b[0m\x1b[1;38;5;2mREADY",
+				'\x1b[0mINPUT:"run\\r"',
+			];
+			expect(logs.terminalRows).toEqual(expectedTerminalRows);
+
+			const legacyLogs = await second.request({
+				op: "logs",
+				name: "debugger",
+				lines: 20,
+				head: false,
+				follow: false,
+				timeoutMs: 1_000,
+			});
+			if (legacyLogs.op !== "logs") throw new Error("unexpected legacy logs result");
+			expect("terminalText" in legacyLogs ? legacyLogs.terminalText : undefined).toContain("BOOT:0");
+			expect(legacyLogs.terminalRows).toBeUndefined();
+
+			const grepped = await second.request({
+				op: "logs",
+				name: "debugger",
+				lines: 20,
+				head: false,
+				grep: "READY",
+				follow: false,
+				timeoutMs: 1_000,
+			});
+			if (grepped.op !== "logs") throw new Error("unexpected grep logs result");
+			expect(grepped.text).toContain("READY");
+			expect(grepped.terminalRows).toBeUndefined();
 
 			const stopped = await first.request({ op: "stop", name: "debugger", timeoutMs: 2_000 });
 			expect(stopped.op).toBe("stop");
@@ -210,6 +239,47 @@ setInterval(() => {}, 1000);
 		} finally {
 			await shutdown(first);
 			second.close();
+		}
+	}, 20_000);
+
+	it("omits terminal rows for non-PTY logs", async () => {
+		const projectDir = await tempDir("omp-daemon-plain-project-");
+		const runtimeDir = await tempDir("omp-daemon-plain-runtime-");
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		try {
+			const started = await client.request({
+				op: "start",
+				spec: {
+					name: "plain",
+					application: process.execPath,
+					args: ["-e", 'process.stdout.write("\\x1b[31mPLAIN\\x1b[0m\\n"); process.stdin.resume();'],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					ready: { log: "PLAIN", timeoutMs: 5_000 },
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+			});
+			if (started.op !== "start") throw new Error("unexpected start result");
+			expect(started.readyTimedOut).toBeFalse();
+
+			const logs = await client.request({
+				op: "logs",
+				name: "plain",
+				lines: 20,
+				head: false,
+				follow: false,
+				timeoutMs: 1_000,
+			});
+			if (logs.op !== "logs") throw new Error("unexpected logs result");
+			expect(logs.text).toBe("PLAIN\n");
+			expect(logs.terminalRows).toBeUndefined();
+
+			await client.request({ op: "stop", name: "plain", timeoutMs: 2_000 });
+		} finally {
+			await shutdown(client);
 		}
 	}, 20_000);
 

--- a/packages/coding-agent/test/xterm-runtime-ownership.test.ts
+++ b/packages/coding-agent/test/xterm-runtime-ownership.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+interface CacheProbeResult {
+	modules: number;
+	bytes: number;
+	rss: number;
+	heapUsed: number;
+	paths: string[];
+}
+
+const fixture = (name: string): string => path.resolve(import.meta.dir, "fixtures", name);
+
+async function runProbe(childPath: string): Promise<CacheProbeResult> {
+	const proc = Bun.spawn([process.execPath, childPath], {
+		cwd: path.resolve(import.meta.dir, "../.."),
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return JSON.parse(stdout) as CacheProbeResult;
+}
+
+describe("launch xterm runtime ownership", () => {
+	test("cache detector observes the direct xterm positive control", async () => {
+		const result = await runProbe(fixture("xterm-cache-positive-control.ts"));
+		expect(result.modules, JSON.stringify(result)).toBe(1);
+		expect(result.bytes, JSON.stringify(result)).toBeGreaterThan(0);
+	});
+
+	test("normal main startup evaluates no xterm CommonJS module", async () => {
+		const result = await runProbe(fixture("xterm-cache-main-probe.ts"));
+		expect(result.modules, JSON.stringify(result)).toBe(0);
+	});
+
+	test("static Hub import evaluates no xterm CommonJS module", async () => {
+		const result = await runProbe(fixture("xterm-cache-hub-probe.ts"));
+		expect(result.modules, JSON.stringify(result)).toBe(0);
+	});
+
+	test("broker import owns exactly one xterm CommonJS module", async () => {
+		const result = await runProbe(fixture("xterm-cache-broker-probe.ts"));
+		expect(result.modules, JSON.stringify(result)).toBe(1);
+	});
+});


### PR DESCRIPTION
## Purpose

Move PTY replay into the existing isolated project launch broker. Upgraded clients request validated rendered rows; the negotiated fallback preserves styled PTY logs across already-running old/new broker boundaries without loading xterm during normal main/Hub startup.

## Tests

- Current-base red: protocol decoding ignored `terminalRows`; normal main and Hub each loaded one xterm module while the broker loaded none.
- Review red: legacy `terminalText` was discarded in the upgraded client, an upgraded broker did not preserve raw output for legacy clients, and output arriving during replay advanced the returned cursor past unseen bytes.
- Green: `bun test packages/coding-agent/src/launch/protocol.test.ts packages/coding-agent/src/tools/hub/launch-compat.test.ts packages/coding-agent/src/launch/broker-output-snapshot.test.ts packages/coding-agent/src/launch/terminal-output.test.ts packages/coding-agent/test/tools/launch.test.ts packages/coding-agent/test/xterm-runtime-ownership.test.ts` (38 tests, 107 assertions).
- Focused Biome check and `bun --cwd=packages/coding-agent run check:types`.
- Source, npm-bundle, and compiled `--smoke-test` broker startup/RPC checks.

## Metrics

Isolated import probes moved xterm cache ownership as intended: normal main and Hub each went from 1 entry / 182,672 bytes to 0 / 0 (delta: -1 entry / -182,672 bytes each), while the isolated broker went from 0 / 0 to 1 entry / 182,672 bytes (delta: +1 entry / +182,672 bytes).

In bounded startup samples, CPU median moved from 1,825 ms (four accepted-parent samples: 1,770/1,640/1,930/1,880 ms) to 1,620 ms (three treatment samples: 1,620/1,620/1,580 ms), a 205 ms or about 11.2% reduction. This is startup evidence for this measured environment, not a general throughput claim. Root RSS remained approximately 288–290 MiB; no RSS improvement is claimed.

## Safety

PTY rendering semantics and fixed terminal dimensions are unchanged. A capability bit selects rendered rows for upgraded peers; absent capability preserves the legacy raw-text response, and upgraded clients lazily replay raw responses from an already-running legacy broker. Non-PTY and grep responses omit both PTY payloads. Both payload shapes are validated. Log reads serialize a cursor with the exact queued file snapshot before replay, so output arriving during replay remains visible to the next follow request. No broader broker protocol redesign is included.