### PR TITLE
perf(coding-agent): load changelog asset on demand

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced startup CPU and memory by loading the bundled changelog only when needed, while preserving source, npm bundle, standalone binary, and native absolute-path fallback resolution.
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -106,6 +106,7 @@
   "files": [
     "src",
     "dist/cli.js",
+    "dist/CHANGELOG-*.md",
     "dist/*.node",
     "scripts",
     "examples",

--- a/packages/coding-agent/scripts/bundle-dist.ts
+++ b/packages/coding-agent/scripts/bundle-dist.ts
@@ -64,8 +64,8 @@ function formatBytes(bytes: number): string {
 }
 
 async function cleanBundleOutputs(): Promise<void> {
-	// dist/ is shared with the dev binary (dist/omp); only remove this
-	// script's own outputs (entry bundle + copied native assets).
+	// dist/ is shared with the dev binary (dist/omp); only remove assets
+	// emitted by this script.
 	let entries: string[];
 	try {
 		entries = await fs.readdir(outDir);
@@ -75,7 +75,13 @@ async function cleanBundleOutputs(): Promise<void> {
 	}
 	await Promise.all(
 		entries
-			.filter(entry => entry === "cli.js" || entry.endsWith(".node") || entry.endsWith(".js.map"))
+			.filter(
+				entry =>
+					entry === "cli.js" ||
+					entry.endsWith(".node") ||
+					entry.endsWith(".js.map") ||
+					(entry.startsWith("CHANGELOG-") && entry.endsWith(".md")),
+			)
 			.map(entry => fs.rm(path.join(outDir, entry), { force: true })),
 	);
 }

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,5 +1,6 @@
+import * as path from "node:path";
 import { getLastChangelogVersionPath, isEnoent, logger } from "@oh-my-pi/pi-utils";
-import bundledChangelog from "../../CHANGELOG.md" with { type: "text" };
+import bundledChangelogPath from "../../CHANGELOG.md" with { type: "file" };
 
 export interface ChangelogEntry {
 	major: number;
@@ -36,8 +37,13 @@ export interface StartupChangelogSelection {
  * The embedded fallback keeps standalone binaries self-contained without
  * resolving relative to the host project's cwd, which caused issue #1423.
  */
+export function resolveBundledChangelogPath(assetPath: string, moduleUrl: string | URL): string | URL {
+	if (path.isAbsolute(assetPath) || path.win32.isAbsolute(assetPath)) return assetPath;
+	return new URL(assetPath, moduleUrl);
+}
+
 export async function parseChangelog(changelogPath: string | undefined): Promise<ChangelogEntry[]> {
-	let content = bundledChangelog;
+	let content: string | undefined;
 	if (changelogPath) {
 		try {
 			content = await Bun.file(changelogPath).text();
@@ -47,6 +53,7 @@ export async function parseChangelog(changelogPath: string | undefined): Promise
 			}
 		}
 	}
+	content ??= await Bun.file(resolveBundledChangelogPath(bundledChangelogPath, import.meta.url)).text();
 
 	return parseChangelogContent(content);
 }

--- a/packages/coding-agent/test/fixtures/changelog-bundle-fallback-probe.ts
+++ b/packages/coding-agent/test/fixtures/changelog-bundle-fallback-probe.ts
@@ -1,0 +1,16 @@
+import { VERSION } from "@oh-my-pi/pi-utils";
+import { parseChangelog } from "../../src/utils/changelog";
+
+const missingPackageChangelogPath = process.argv[2];
+if (!missingPackageChangelogPath) {
+	throw new Error("Expected a missing package changelog path argument");
+}
+
+const entries = await parseChangelog(missingPackageChangelogPath);
+const latest = entries[0];
+const version = latest ? `${latest.major}.${latest.minor}.${latest.patch}` : undefined;
+if (version !== VERSION || !latest?.content.startsWith(`## [${VERSION}]`)) {
+	throw new Error(`Unexpected latest changelog release: ${JSON.stringify({ version, expected: VERSION })}`);
+}
+
+process.stdout.write(JSON.stringify({ version, entries: entries.length }));

--- a/packages/coding-agent/test/fixtures/changelog-static-import-heap-probe.ts
+++ b/packages/coding-agent/test/fixtures/changelog-static-import-heap-probe.ts
@@ -1,0 +1,37 @@
+import "../../src/utils/changelog";
+
+interface V8HeapSnapshot {
+	snapshot: {
+		meta: {
+			node_fields: string[];
+			node_types: Array<string | string[]>;
+		};
+	};
+	nodes: number[];
+	strings: string[];
+}
+
+const LARGE_STRING_MIN_SIZE = 1024 * 1024;
+
+Bun.gc(true);
+const heap = JSON.parse(Bun.generateHeapSnapshot("v8")) as V8HeapSnapshot;
+const { node_fields: nodeFields, node_types: nodeTypes } = heap.snapshot.meta;
+const typeOffset = nodeFields.indexOf("type");
+const nameOffset = nodeFields.indexOf("name");
+const sizeOffset = nodeFields.indexOf("self_size");
+const typeNames = nodeTypes[typeOffset];
+if (typeOffset < 0 || nameOffset < 0 || sizeOffset < 0 || !Array.isArray(typeNames)) {
+	throw new Error("Unexpected V8 heap snapshot schema");
+}
+
+let retainedChangelogStrings = 0;
+for (let nodeOffset = 0; nodeOffset < heap.nodes.length; nodeOffset += nodeFields.length) {
+	if (typeNames[heap.nodes[nodeOffset + typeOffset]!] !== "string") continue;
+	const value = heap.strings[heap.nodes[nodeOffset + nameOffset]!];
+	const selfSize = heap.nodes[nodeOffset + sizeOffset]!;
+	if (value !== undefined && selfSize > LARGE_STRING_MIN_SIZE && value.startsWith("# Changelog")) {
+		retainedChangelogStrings++;
+	}
+}
+
+process.stdout.write(JSON.stringify({ retainedChangelogStrings }));

--- a/packages/coding-agent/test/fixtures/changelog-utils-stub.ts
+++ b/packages/coding-agent/test/fixtures/changelog-utils-stub.ts
@@ -1,0 +1,8 @@
+import packageJson from "../../package.json" with { type: "json" };
+
+export const VERSION = packageJson.version;
+export const getLastChangelogVersionPath = (): string => "";
+export const getChangelogPath = (): string | undefined => undefined;
+export const isEnoent = (error: unknown): boolean =>
+	typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+export const logger = { error: () => {}, warn: () => {} };

--- a/packages/coding-agent/test/utils/changelog-static-import.test.ts
+++ b/packages/coding-agent/test/utils/changelog-static-import.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { VERSION } from "@oh-my-pi/pi-utils";
+import { resolveBundledChangelogPath } from "../../src/utils/changelog";
+
+interface HeapProbeResult {
+	retainedChangelogStrings: number;
+}
+
+interface BundleProbeResult {
+	version: string;
+	entries: number;
+}
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const heapProbePath = path.resolve(import.meta.dir, "..", "fixtures", "changelog-static-import-heap-probe.ts");
+const bundleProbePath = path.resolve(import.meta.dir, "..", "fixtures", "changelog-bundle-fallback-probe.ts");
+const utilsStubPath = path.resolve(import.meta.dir, "..", "fixtures", "changelog-utils-stub.ts");
+
+async function runProbe(command: string[], cwd?: string): Promise<BundleProbeResult> {
+	const proc = Bun.spawn(command, {
+		cwd,
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return JSON.parse(stdout) as BundleProbeResult;
+}
+
+describe("bundled changelog asset path resolution", () => {
+	const moduleUrl = new URL("file:///opt/omp/dist/cli.js");
+
+	test.each([
+		["Windows drive-letter", String.raw`C:\omp\dist\CHANGELOG.md`],
+		["Windows UNC", String.raw`\\server\share\omp\CHANGELOG.md`],
+		["POSIX", "/opt/omp/dist/CHANGELOG.md"],
+	])("preserves an absolute %s path", (_kind, nativePath) => {
+		expect(resolveBundledChangelogPath(nativePath, moduleUrl)).toBe(nativePath);
+	});
+
+	test("resolves a relative emitted asset against the module", () => {
+		expect(resolveBundledChangelogPath("./CHANGELOG-hash.md", moduleUrl)).toEqual(
+			new URL("./CHANGELOG-hash.md", moduleUrl),
+		);
+	});
+});
+
+describe("changelog static import resources", () => {
+	test("does not retain the multi-megabyte changelog text before parsing", async () => {
+		const proc = Bun.spawn([process.execPath, heapProbePath], {
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(JSON.parse(stdout) as HeapProbeResult).toEqual({ retainedChangelogStrings: 0 });
+	}, 30_000);
+
+	test("reads the emitted changelog asset when run outside the bundle directory", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-changelog-bundle-"));
+		try {
+			const bundleDir = path.join(tempDir, "bundle");
+			const unrelatedCwd = path.join(tempDir, "cwd");
+			const missingPackageChangelogPath = path.join(tempDir, "missing-package", "CHANGELOG.md");
+			await fs.mkdir(unrelatedCwd);
+			const sourceResult = await runProbe([process.execPath, bundleProbePath, missingPackageChangelogPath]);
+
+			const buildProc = Bun.spawn(
+				[
+					process.execPath,
+					"build",
+					bundleProbePath,
+					"--target=bun",
+					"--external=omp-legacy-pi-modules",
+					`--outdir=${bundleDir}`,
+				],
+				{ stderr: "pipe", stdout: "pipe" },
+			);
+			const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+				new Response(buildProc.stdout).text(),
+				new Response(buildProc.stderr).text(),
+				buildProc.exited,
+			]);
+			expect(buildExitCode, buildStdout + buildStderr).toBe(0);
+
+			const outputs = await fs.readdir(bundleDir);
+			expect(outputs.some(output => output.endsWith(".md"))).toBe(true);
+			const bundleFilename = outputs.find(output => output.endsWith(".js"));
+			if (!bundleFilename) throw new Error("Changelog bundle build did not emit an entrypoint");
+			const result = await runProbe(
+				[process.execPath, path.join(bundleDir, bundleFilename), missingPackageChangelogPath],
+				unrelatedCwd,
+			);
+
+			expect(result.version).toBe(VERSION);
+			expect(result.entries).toBe(sourceResult.entries);
+		} finally {
+			await fs.rm(tempDir, { force: true, recursive: true });
+		}
+	}, 30_000);
+
+	test("reads the emitted changelog asset from a compiled binary", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-changelog-compiled-"));
+		try {
+			const binaryPath = path.join(tempDir, "changelog-probe");
+			const unrelatedCwd = path.join(tempDir, "cwd");
+			const missingPackageChangelogPath = path.join(tempDir, "missing-package", "CHANGELOG.md");
+			await fs.mkdir(unrelatedCwd);
+			const sourceResult = await runProbe([process.execPath, bundleProbePath, missingPackageChangelogPath]);
+
+			const buildOutput = await Bun.build({
+				entrypoints: [bundleProbePath],
+				root: repoRoot,
+				external: ["omp-legacy-pi-modules"],
+				plugins: [
+					{
+						name: "changelog-utils-stub",
+						setup(build) {
+							build.onResolve({ filter: /^@oh-my-pi\/pi-utils$/ }, () => ({ path: utilsStubPath }));
+							build.onResolve({ filter: /^\.\.\/config$/ }, args =>
+								args.importer.endsWith("/utils/changelog.ts") ? { path: utilsStubPath } : undefined,
+							);
+						},
+					},
+				],
+				compile: {
+					outfile: binaryPath,
+					autoloadBunfig: false,
+					autoloadDotenv: false,
+					autoloadTsconfig: false,
+					autoloadPackageJson: false,
+				},
+			});
+			expect(buildOutput.success, buildOutput.logs.map(log => log.message).join("\n")).toBe(true);
+
+			const result = await runProbe([binaryPath, missingPackageChangelogPath], unrelatedCwd);
+			expect(result.version).toBe(VERSION);
+			expect(result.entries).toBe(sourceResult.entries);
+		} finally {
+			await fs.rm(tempDir, { force: true, recursive: true });
+		}
+	}, 30_000);
+});

--- a/packages/coding-agent/test/utils/changelog.test.ts
+++ b/packages/coding-agent/test/utils/changelog.test.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import { removeWithRetries, VERSION } from "@oh-my-pi/pi-utils";
 import {
 	type ChangelogEntry,
+	getNewEntries,
 	parseChangelog,
 	RECENT_CHANGELOG_ENTRY_LIMIT,
 	readLastChangelogVersion,
@@ -153,12 +154,17 @@ describe("selectStartupChangelog", () => {
 });
 
 describe("parseChangelog", () => {
-	test("reads the embedded release history when no package path is available", async () => {
+	test("reads current source release data and filters versions newer than the previous release", async () => {
 		const entries = await parseChangelog(undefined);
 		const latest = entries[0];
+		const previous = entries[1];
 
 		expect(`${latest?.major}.${latest?.minor}.${latest?.patch}`).toBe(VERSION);
 		expect(latest?.content).toContain(`## [${VERSION}]`);
+		expect(previous).toBeDefined();
+
+		const previousVersion = `${previous?.major}.${previous?.minor}.${previous?.patch}`;
+		expect(getNewEntries(entries, previousVersion)).toEqual([latest]);
 	});
 });
 


### PR DESCRIPTION
## Purpose

Load the bundled coding-agent changelog only when `parseChangelog` needs its fallback, and resolve emitted relative assets against the module while preserving native absolute paths on every platform.

## Tests

- Current-upstream RED: the static-import heap probe retained 1 changelog string larger than 1 MiB (expected 0), the normal bundle emitted no Markdown asset, and native absolute paths were converted to URL objects instead of remaining native strings.
- GREEN: `bun test packages/coding-agent/test/utils/changelog.test.ts packages/coding-agent/test/utils/changelog-static-import.test.ts` — 16 passed, 0 failed, covering Windows drive-letter, Windows UNC, POSIX absolute, and module-relative paths.
- Source, unrelated-working-directory bundle, and compiled fallback probes all returned version 17.1.4 with the same 658 parsed entries.
- `bun run ci:check:full` passed. A fresh npm bundle emitted its hashed changelog sibling, and `bun pm pack --dry-run` included that asset in the package.

## Metrics

- Startup harness medians (three samples per revision, immediate accepted parent versus treatment): CPU 1,880 ms to 1,800 ms, -80 ms (-4.3%); RSS 303,996 KiB to 299,604 KiB, -4,392 KiB (-1.44%).
- The static-import heap count for retained `# Changelog` strings larger than 1 MiB changed from 1 to 0.
- These measurements are bounded to that parent/treatment startup comparison. The module-relative and native-path fallback repairs claim correctness only and no additional performance.

## Safety

Released changelog history and parsing semantics are unchanged; the Unreleased section documents this performance change. An available package changelog remains preferred, and only the missing-path fallback reads the bundled asset. Native absolute paths remain strings for `Bun.file`; relative bundle locators resolve against the module. Source, normal-bundle, compiled-binary, and npm-package coverage verifies matching release data and distribution of the emitted fallback.