### PR TITLE
feat(coding-agent): select thinking after models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -174,6 +174,9 @@
 - Fixed Assistant-mode TTS playback aborting prematurely when an agent continued after a tool call.
 - Fixed absolute usage amounts rendering inconsistently across CLI, TUI, and ACP output surfaces.
 - Fixed MCP sessions dropping tools from servers that finished connecting after the initial startup window.
+### Added
+
+- Added explicit model-aware thinking-level selection to `/switch` and `/models` fallback assignments, with visible sequential-step controls and persisted fallback effort suffixes.
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added explicit model-aware thinking-level selection to `/switch` and `/models` fallback assignments, with visible sequential-step controls and persisted fallback effort suffixes.
+
 ## [17.1.4] - 2026-07-26
 
 ### Added
@@ -174,9 +178,6 @@
 - Fixed Assistant-mode TTS playback aborting prematurely when an agent continued after a tool call.
 - Fixed absolute usage amounts rendering inconsistently across CLI, TUI, and ACP output surfaces.
 - Fixed MCP sessions dropping tools from servers that finished connecting after the initial startup window.
-### Added
-
-- Added explicit model-aware thinking-level selection to `/switch` and `/models` fallback assignments, with visible sequential-step controls and persisted fallback effort suffixes.
 
 ## [17.0.9] - 2026-07-23
 

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -30,12 +30,12 @@ import type { ModelRegistry } from "../../config/model-registry";
 import {
 	formatModelSelectorValue,
 	type ModelRoleLookup,
-	parseModelString,
 	type ResolvedModelRoleValue,
 	resolveModelRoleValue,
 } from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
+import { parseRetryFallbackSelector, type RetryFallbackSelector } from "../../session/retry-fallback-chains";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -887,12 +887,14 @@ export class ModelHubComponent implements Component {
 		fallbackTarget?: { role: string; index: number | null },
 	): void {
 		const options = fallbackTarget
-			? this.#thinkingOptionsFor(item.model).filter(
-					level =>
-						level !== AUTO_THINKING &&
-						(level === ThinkingLevel.Inherit ||
-							!this.#hasLiteralFallbackSelector(formatModelSelectorValue(item.selector, level))),
-				)
+			? this.#thinkingOptionsFor(item.model).filter(level => {
+					if (level === AUTO_THINKING) return false;
+					if (level === ThinkingLevel.Inherit) return true;
+					return (
+						this.#parseFallbackSelector(formatModelSelectorValue(item.selector, level))?.thinkingLevel !==
+						undefined
+					);
+				})
 			: this.#thinkingOptionsFor(item.model);
 		let current: ConfiguredThinkingLevel;
 		if (fallbackTarget) {
@@ -1016,30 +1018,11 @@ export class ModelHubComponent implements Component {
 		}
 	}
 
-	#hasLiteralFallbackSelector(selector: string): boolean {
-		const normalized = selector.trim();
-		const slashIndex = normalized.indexOf("/");
-		if (slashIndex <= 0) return false;
-		const provider = normalized.slice(0, slashIndex);
-		const id = normalized.slice(slashIndex + 1);
-		return (
-			this.#availableItems.some(item => item.model.provider === provider && item.model.id === id) ||
-			this.#registry.getAll().some(model => model.provider === provider && model.id === id)
-		);
-	}
-
-	#parseFallbackSelector(
-		selector: string,
-	): { provider: string; id: string; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
-		const normalized = selector.trim();
-		if (this.#hasLiteralFallbackSelector(normalized)) {
-			const slashIndex = normalized.indexOf("/");
-			return { provider: normalized.slice(0, slashIndex), id: normalized.slice(slashIndex + 1) };
-		}
-		return parseModelString(normalized, {
-			allowMaxSuffix: true,
-			allowAutoAlias: true,
-			isLiteralModelId: (provider, id) => this.#hasLiteralFallbackSelector(`${provider}/${id}`),
+	#parseFallbackSelector(selector: string): RetryFallbackSelector | undefined {
+		return parseRetryFallbackSelector(selector, {
+			find: (provider, id) =>
+				this.#availableItems.find(item => item.model.provider === provider && item.model.id === id)?.model ??
+				this.#registry.getAll().find(model => model.provider === provider && model.id === id),
 		});
 	}
 

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -12,7 +12,6 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
-import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getCatalogProviderEntry } from "@oh-my-pi/pi-catalog/provider-models";
 import {
 	type Component,
@@ -28,10 +27,21 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
-import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValue } from "../../config/model-resolver";
+import {
+	formatModelSelectorValue,
+	type ModelRoleLookup,
+	parseModelString,
+	type ResolvedModelRoleValue,
+	resolveModelRoleValue,
+} from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
-import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	getConfiguredThinkingLevelMetadata,
+	getConfiguredThinkingLevelsForModel,
+} from "../../thinking";
 import { theme } from "../theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import {
@@ -135,6 +145,7 @@ type StripState =
 			index: number;
 			/** Where to land when a scope or thinking strip closes. */
 			returnToRoles: boolean;
+			fallbackTarget?: { role: string; index: number | null };
 	  }
 	| {
 			/** Footer text input naming a new custom role. */
@@ -754,7 +765,7 @@ export class ModelHubComponent implements Component {
 			} else if (target.kind === "fallbackKey") {
 				this.#openFallbackKeyStrip(item);
 			} else {
-				this.#commitFallback(item, target);
+				this.#openThinkingStrip(item, target.role, true, undefined, target);
 			}
 			return;
 		}
@@ -814,7 +825,7 @@ export class ModelHubComponent implements Component {
 	}
 
 	#thinkingOptionsFor(model: Model): ConfiguredThinkingLevel[] {
-		return [ThinkingLevel.Inherit, ThinkingLevel.Off, AUTO_THINKING, ...getSupportedEfforts(model)];
+		return getConfiguredThinkingLevelsForModel(model);
 	}
 
 	#openRoleStrip(item: ModelBrowserItem): void {
@@ -873,12 +884,31 @@ export class ModelHubComponent implements Component {
 		role: string,
 		returnToRoles: boolean,
 		scope?: ModelRoleSelectionScope,
+		fallbackTarget?: { role: string; index: number | null },
 	): void {
-		const options = this.#thinkingOptionsFor(item.model);
-		const current =
-			this.#settings.get("modelRoleStorage") === "project" && scope !== undefined
-				? this.#thinkingLevelForScope(role, scope)
-				: (this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit);
+		const options = fallbackTarget
+			? this.#thinkingOptionsFor(item.model).filter(
+					level =>
+						level !== AUTO_THINKING &&
+						(level === ThinkingLevel.Inherit ||
+							!this.#hasLiteralFallbackSelector(formatModelSelectorValue(item.selector, level))),
+				)
+			: this.#thinkingOptionsFor(item.model);
+		let current: ConfiguredThinkingLevel;
+		if (fallbackTarget) {
+			const selector =
+				fallbackTarget.index === null
+					? undefined
+					: this.#fallbackChains()[fallbackTarget.role]?.[fallbackTarget.index];
+			current = selector
+				? (this.#parseFallbackSelector(selector)?.thinkingLevel ?? ThinkingLevel.Inherit)
+				: ThinkingLevel.Inherit;
+		} else {
+			current =
+				this.#settings.get("modelRoleStorage") === "project" && scope !== undefined
+					? this.#thinkingLevelForScope(role, scope)
+					: (this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit);
+		}
 		const chips: StripChip[] = options.map(level => {
 			const label = getConfiguredThinkingLevelMetadata(level).label;
 			const glyph = thinkingLevelGlyph(level);
@@ -898,6 +928,7 @@ export class ModelHubComponent implements Component {
 			chips,
 			index: preselect >= 0 ? preselect : 0,
 			returnToRoles,
+			fallbackTarget,
 		};
 	}
 
@@ -935,8 +966,8 @@ export class ModelHubComponent implements Component {
 				this.#closeStrip();
 				return;
 			case "fallback":
-				this.#appendFallback(strip.item, "default");
-				this.#closeStrip();
+				this.#strip = null;
+				this.#openThinkingStrip(strip.item, "default", true, undefined, { role: "default", index: null });
 				return;
 			case "fallbackModel":
 				this.#closeStrip();
@@ -953,15 +984,19 @@ export class ModelHubComponent implements Component {
 				}
 				return;
 			case "thinking":
-				if (strip.role && chip.thinkingLevel !== undefined) {
-					this.#callbacks.onAssign(
-						strip.item.model,
-						strip.role,
-						chip.thinkingLevel,
-						strip.item.selector,
-						strip.scope,
-					);
-					this.#refreshAfterMutation();
+				if (chip.thinkingLevel !== undefined) {
+					if (strip.fallbackTarget) {
+						this.#commitFallback(strip.item, strip.fallbackTarget, chip.thinkingLevel);
+					} else if (strip.role) {
+						this.#callbacks.onAssign(
+							strip.item.model,
+							strip.role,
+							chip.thinkingLevel,
+							strip.item.selector,
+							strip.scope,
+						);
+						this.#refreshAfterMutation();
+					}
 				}
 				this.#closeStrip();
 				return;
@@ -981,6 +1016,33 @@ export class ModelHubComponent implements Component {
 		}
 	}
 
+	#hasLiteralFallbackSelector(selector: string): boolean {
+		const normalized = selector.trim();
+		const slashIndex = normalized.indexOf("/");
+		if (slashIndex <= 0) return false;
+		const provider = normalized.slice(0, slashIndex);
+		const id = normalized.slice(slashIndex + 1);
+		return (
+			this.#availableItems.some(item => item.model.provider === provider && item.model.id === id) ||
+			this.#registry.getAll().some(model => model.provider === provider && model.id === id)
+		);
+	}
+
+	#parseFallbackSelector(
+		selector: string,
+	): { provider: string; id: string; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
+		const normalized = selector.trim();
+		if (this.#hasLiteralFallbackSelector(normalized)) {
+			const slashIndex = normalized.indexOf("/");
+			return { provider: normalized.slice(0, slashIndex), id: normalized.slice(slashIndex + 1) };
+		}
+		return parseModelString(normalized, {
+			allowMaxSuffix: true,
+			allowAutoAlias: true,
+			isLiteralModelId: (provider, id) => this.#hasLiteralFallbackSelector(`${provider}/${id}`),
+		});
+	}
+
 	/** Browse the catalog to fill a fallback-chain slot: `index` replaces an entry, `null` appends. */
 	#startAssignFallback(role: string, index: number | null): void {
 		this.#assigning = { kind: "fallback", role, index };
@@ -990,7 +1052,10 @@ export class ModelHubComponent implements Component {
 		this.#browser.setQuery("");
 		if (index !== null) {
 			const selector = this.#fallbackChains()[role]?.[index];
-			if (selector) this.#browser.selectSelector(selector);
+			if (selector) {
+				const parsed = this.#parseFallbackSelector(selector);
+				this.#browser.selectSelector(parsed ? `${parsed.provider}/${parsed.id}` : selector);
+			}
 		}
 	}
 
@@ -1020,17 +1085,33 @@ export class ModelHubComponent implements Component {
 		this.#strip = { kind: "role", item, chips, index: 0, returnToRoles: false };
 	}
 
-	/** Write the picked model into the target chain slot, dedupe, and land back on its Roles row. */
-	#commitFallback(item: ModelBrowserItem, target: { role: string; index: number | null }): void {
+	/** Write the picked model and thinking level into the target chain slot, dedupe, and land back on its Roles row. */
+	#commitFallback(
+		item: ModelBrowserItem,
+		target: { role: string; index: number | null },
+		thinkingLevel: ConfiguredThinkingLevel,
+	): void {
 		const chain = [...(this.#fallbackChains()[target.role] ?? [])];
-		const selector = item.selector;
+		const selector = formatModelSelectorValue(item.selector, thinkingLevel);
+		const matchesItem = (entry: string): boolean => {
+			const parsed = this.#parseFallbackSelector(entry);
+			return parsed?.provider === item.model.provider && parsed.id === item.model.id;
+		};
 		if (target.index !== null && target.index < chain.length) {
 			chain[target.index] = selector;
 			for (let i = chain.length - 1; i >= 0; i--) {
-				if (i !== target.index && chain[i] === selector) chain.splice(i, 1);
+				if (i !== target.index && matchesItem(chain[i] ?? "")) chain.splice(i, 1);
 			}
-		} else if (!chain.includes(selector)) {
-			chain.push(selector);
+		} else {
+			const existingIndex = chain.findIndex(matchesItem);
+			if (existingIndex >= 0) {
+				chain[existingIndex] = selector;
+				for (let i = chain.length - 1; i >= 0; i--) {
+					if (i !== existingIndex && matchesItem(chain[i] ?? "")) chain.splice(i, 1);
+				}
+			} else {
+				chain.push(selector);
+			}
 		}
 		this.#setFallbackChain(target.role, chain);
 		this.#browser.setQuery("");
@@ -1046,14 +1127,6 @@ export class ModelHubComponent implements Component {
 	#setFallbackChain(role: string, chain: string[]): void {
 		this.#callbacks.onFallbackChainChange?.(role, chain);
 		this.#refreshAfterMutation();
-	}
-
-	/** Append `item` to `role`'s fallback chain (no-op when already present). */
-	#appendFallback(item: ModelBrowserItem, role: string): void {
-		const chain = [...(this.#fallbackChains()[role] ?? [])];
-		if (chain.includes(item.selector)) return;
-		chain.push(item.selector);
-		this.#setFallbackChain(role, chain);
 	}
 
 	/** Remove one chain entry; the cursor stays on the nearest surviving row. */
@@ -1636,6 +1709,20 @@ export class ModelHubComponent implements Component {
 	}
 
 	#statusRow(width: number): string {
+		const thinkingStrip = this.#strip?.kind === "thinking" ? this.#strip : undefined;
+		if (thinkingStrip) {
+			let subject: string;
+			if (thinkingStrip.fallbackTarget) {
+				subject = `fallback · ${thinkingStrip.item.id}`;
+			} else {
+				const role = getRoleInfo(thinkingStrip.role ?? "", this.#settings);
+				subject = `${theme.bold(role.tag ?? role.name ?? thinkingStrip.role ?? "")} · ${thinkingStrip.item.id}`;
+			}
+			return truncateToWidth(
+				theme.fg("accent", ` Final step · ↑/↓ choose · Enter apply · Esc back · ${subject}`),
+				width,
+			);
+		}
 		if (this.#assigning !== null) {
 			if (this.#assigning.kind === "fallbackKey") {
 				return truncateToWidth(
@@ -1920,7 +2007,7 @@ export class ModelHubComponent implements Component {
 			return truncateToWidth(`${label} ${inputLine} ${theme.fg("dim", "(letters, digits, - and _)")}`, width);
 		}
 
-		const prefix =
+		const rawPrefix =
 			strip.kind === "role"
 				? `${theme.fg("accent", strip.item.id)}${theme.fg("dim", " →")} `
 				: `${theme.fg(getRoleInfo(strip.role ?? "", this.#settings).color ?? "muted", (getRoleInfo(strip.role ?? "", this.#settings).tag ?? strip.role ?? "").toLowerCase())}${theme.fg("dim", ` · ${strip.item.id} →`)} `;
@@ -1928,11 +2015,13 @@ export class ModelHubComponent implements Component {
 		// Horizontal window: once the strip overflows, drop leading chips behind
 		// a dim ellipsis so the selected chip (plus one chip of lookahead when it
 		// fits) stays visible while cycling right.
-		const prefixWidth = visibleWidth(prefix);
-		const available = Math.max(1, width - prefixWidth);
 		const chipWidths = strip.chips.map(
 			(chip, i) => visibleWidth(` ${chip.styled} `) + (i === strip.index ? 2 : 0) + 1,
 		);
+		const selectedChipWidth = chipWidths[strip.index] ?? 1;
+		const prefix = truncateToWidth(rawPrefix, Math.max(0, width - selectedChipWidth - (strip.index > 0 ? 2 : 0)));
+		const prefixWidth = visibleWidth(prefix);
+		const available = Math.max(1, width - prefixWidth);
 		// Smallest start index whose window [start..target] (with its "… " lead-in
 		// when start > 0) fits in the available width; `target` itself may still
 		// overflow when a single chip is wider than the row.

--- a/packages/coding-agent/src/modes/components/model-picker.ts
+++ b/packages/coding-agent/src/modes/components/model-picker.ts
@@ -6,6 +6,7 @@
  */
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
+import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { type Component, matchesKey, type TUI, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
@@ -126,6 +127,10 @@ export class ModelPickerComponent implements Component {
 			const levels = getConfiguredThinkingLevelsForModel(item.model);
 			const current = options.thinkingLevelForModel?.(item.model) ?? ThinkingLevel.Inherit;
 			const currentIndex = levels.indexOf(current);
+			if (getSupportedEfforts(item.model).length === 0) {
+				callbacks.onPick(item.model, item.selector, currentIndex >= 0 ? current : ThinkingLevel.Inherit);
+				return;
+			}
 			this.#pendingPick = { item, levels, index: currentIndex >= 0 ? currentIndex : 0 };
 			this.#tui.requestRender();
 		};

--- a/packages/coding-agent/src/modes/components/model-picker.ts
+++ b/packages/coding-agent/src/modes/components/model-picker.ts
@@ -4,11 +4,17 @@
  * Model entries switch the current session only; a search beginning with `@`
  * exposes the configured ctrl+p quick roles.
  */
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
-import type { Component, TUI } from "@oh-my-pi/pi-tui";
+import { type Component, matchesKey, type TUI, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
 import type { ResolvedRoleModel } from "../../session/agent-session";
+import {
+	type ConfiguredThinkingLevel,
+	getConfiguredThinkingLevelMetadata,
+	getConfiguredThinkingLevelsForModel,
+} from "../../thinking";
 import { theme } from "../theme/theme";
 import {
 	buildBrowserItems,
@@ -22,8 +28,8 @@ import { bottomBorder, row, topBorder } from "./overlay-box";
 import { resolveSegmentPalette } from "./segment-track";
 
 export interface ModelPickerCallbacks {
-	/** A model was chosen for a session-only switch. `selector` is `provider/id`. */
-	onPick: (model: Model, selector: string) => void;
+	/** A model and thinking level were chosen for a session-only switch. `selector` is `provider/id`. */
+	onPick: (model: Model, selector: string, thinkingLevel: ConfiguredThinkingLevel) => void;
 	/** A configured ctrl+p quick role was chosen. */
 	onPickRole?: (entry: ResolvedRoleModel) => void;
 	/** The picker was dismissed. */
@@ -41,6 +47,8 @@ export interface ModelPickerOptions {
 	quickRoleOrder?: ReadonlyArray<string>;
 	/** Active quick role, highlighted when the search begins with `@`. */
 	currentQuickRole?: string;
+	/** Resolve the thinking level to preselect for a candidate model. */
+	thinkingLevelForModel?: (model: Model) => ConfiguredThinkingLevel | undefined;
 }
 
 /** Fixed chrome rows: top border, status row, footer, bottom border. */
@@ -52,9 +60,9 @@ const MIN_VISIBLE = 5;
 /** Fraction of the terminal height the floating overlay occupies. */
 const HEIGHT_FRACTION = 0.4;
 
-const STATUS_HINT = "Session-only switch — role models stay unchanged";
+const STATUS_HINT = "Step 1 of 2 · Choose a session model — role models stay unchanged";
 const QUICK_ROLE_STATUS_HINT = "Quick role switch — applies its model and thinking for this session";
-const FOOTER_HINT = "↑/↓ models · Enter use for this session · type to search · @ quick roles · Esc close";
+const FOOTER_HINT = "↑/↓ models · Enter choose thinking · type to search · @ quick roles · Esc close";
 const QUICK_ROLE_FOOTER_HINT = "↑/↓ roles · Enter apply role model · type to search · Esc close";
 
 /**
@@ -68,6 +76,7 @@ export class ModelPickerComponent implements Component {
 	#registry: ModelRegistry;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#browser: ModelBrowser;
+	#callbacks: ModelPickerCallbacks;
 	#configError: string | undefined;
 	#currentSelector: string | undefined;
 	#currentQuickRoleSelector: string | undefined;
@@ -75,6 +84,13 @@ export class ModelPickerComponent implements Component {
 	#quickRoleItems: ModelBrowserItem[] = [];
 	#quickRoles = new Map<string, ResolvedRoleModel>();
 	#roleMode = false;
+	#pendingPick:
+		| {
+				item: ModelBrowserItem;
+				levels: ConfiguredThinkingLevel[];
+				index: number;
+		  }
+		| undefined;
 
 	constructor(
 		tui: TUI,
@@ -88,6 +104,7 @@ export class ModelPickerComponent implements Component {
 		this.#settings = settings;
 		this.#registry = registry;
 		this.#scopedModels = scopedModels;
+		this.#callbacks = callbacks;
 		this.#currentSelector = options.currentSelector;
 		this.#currentQuickRoleSelector = options.currentQuickRole ? `@${options.currentQuickRole}` : undefined;
 		this.#quickRoleItems = this.#buildQuickRoleItems(
@@ -106,7 +123,11 @@ export class ModelPickerComponent implements Component {
 				callbacks.onPickRole?.(quickRole);
 				return;
 			}
-			callbacks.onPick(item.model, item.selector);
+			const levels = getConfiguredThinkingLevelsForModel(item.model);
+			const current = options.thinkingLevelForModel?.(item.model) ?? ThinkingLevel.Inherit;
+			const currentIndex = levels.indexOf(current);
+			this.#pendingPick = { item, levels, index: currentIndex >= 0 ? currentIndex : 0 };
+			this.#tui.requestRender();
 		};
 		this.#browser.onCancel = () => callbacks.onCancel();
 		this.#browser.onQueryChange = query => this.#syncItemsForQuery(query);
@@ -207,18 +228,80 @@ export class ModelPickerComponent implements Component {
 		// Mouse tracking is off outside fullscreen overlays; drop any stray SGR
 		// reports instead of feeding them to the search input.
 		if (data.startsWith("\x1b[<")) return;
-		this.#browser.handleInput(data);
+		const pending = this.#pendingPick;
+		if (!pending) {
+			this.#browser.handleInput(data);
+			return;
+		}
+		if (matchesKey(data, "escape")) {
+			this.#pendingPick = undefined;
+			this.#tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, "left") || matchesKey(data, "up") || matchesKey(data, "shift+tab")) {
+			pending.index = (pending.index - 1 + pending.levels.length) % pending.levels.length;
+			this.#tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, "right") || matchesKey(data, "down") || matchesKey(data, "tab")) {
+			pending.index = (pending.index + 1) % pending.levels.length;
+			this.#tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			const level = pending.levels[pending.index];
+			if (level !== undefined) this.#callbacks.onPick(pending.item.model, pending.item.selector, level);
+		}
+	}
+
+	#renderThinkingFooter(width: number): string {
+		const pending = this.#pendingPick;
+		if (!pending) return "";
+		const labels = pending.levels.map(level => getConfiguredThinkingLevelMetadata(level).label);
+		const selectedLabel = labels[pending.index] ?? "";
+		const selectedChoiceWidth = visibleWidth(` [ ${selectedLabel} ] `);
+		const maxPrefixWidth = Math.max(0, width - selectedChoiceWidth - 3);
+		const prefix = truncateToWidth(`${theme.fg("accent", pending.item.id)}${theme.fg("dim", " →")} `, maxPrefixWidth);
+		const prefixWidth = visibleWidth(prefix);
+		const available = Math.max(1, width - prefixWidth);
+		const choiceWidths = labels.map(
+			(label, index) => visibleWidth(` ${label} `) + (index === pending.index ? 2 : 0) + 1,
+		);
+		let start = 0;
+		while (start < pending.index) {
+			let used = start > 0 ? 2 : 0;
+			for (let index = start; index <= pending.index; index++) used += choiceWidths[index] ?? 0;
+			if (used <= available) break;
+			start++;
+		}
+		let line = prefix;
+		if (start > 0) line += theme.fg("dim", "… ");
+		for (let index = start; index < labels.length; index++) {
+			const label = labels[index];
+			if (!label) continue;
+			const body = ` ${label} `;
+			line +=
+				index === pending.index
+					? theme.bg("selectedBg", `${theme.fg("accent", "[")}${body}${theme.fg("accent", "]")}`)
+					: body;
+			line += " ";
+		}
+		return truncateToWidth(line, width);
 	}
 
 	render(width: number): string[] {
 		const termRows = Math.max(16, this.#tui.terminal?.rows || process.stdout.rows || 40);
 		const listBudget = Math.floor(termRows * HEIGHT_FRACTION) - CHROME_ROWS - BROWSER_FRAME_ROWS;
 		this.#browser.setMaxVisible(Math.max(MIN_VISIBLE, listBudget));
+		this.#browser.setFocused(this.#pendingPick === undefined);
 
 		const inner = Math.max(1, width - 4);
+		const pending = this.#pendingPick;
 		const status = this.#configError
 			? theme.fg("error", ` ${this.#configError}`)
-			: theme.fg("muted", ` ${this.#roleMode ? QUICK_ROLE_STATUS_HINT : STATUS_HINT}`);
+			: pending
+				? theme.fg("muted", ` 2/2 · ↑/↓ · Enter apply · Esc back · ${pending.item.id}`)
+				: theme.fg("muted", ` ${this.#roleMode ? QUICK_ROLE_STATUS_HINT : STATUS_HINT}`);
 
 		const out: string[] = [];
 		out.push(topBorder(width, "Switch Model"));
@@ -226,7 +309,14 @@ export class ModelPickerComponent implements Component {
 		for (const line of this.#browser.render(inner)) {
 			out.push(row(line, width));
 		}
-		out.push(row(theme.fg("dim", this.#roleMode ? QUICK_ROLE_FOOTER_HINT : FOOTER_HINT), width));
+		out.push(
+			row(
+				pending
+					? this.#renderThinkingFooter(inner)
+					: theme.fg("dim", this.#roleMode ? QUICK_ROLE_FOOTER_HINT : FOOTER_HINT),
+				width,
+			),
+		);
 		out.push(bottomBorder(width));
 		return out;
 	}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -687,10 +687,7 @@ export class SelectorController {
 				onPick: async (model, selector, thinkingLevel) => {
 					try {
 						// Session-only: update agent state but don't persist the model to settings.
-						await this.ctx.session.setModelTemporary(
-							model,
-							thinkingLevel === ThinkingLevel.Inherit ? undefined : thinkingLevel,
-						);
+						await this.ctx.session.setModelTemporary(model, thinkingLevel);
 						this.ctx.statusLine.invalidate();
 						this.ctx.updateEditorBorderColor();
 						const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -684,11 +684,13 @@ export class SelectorController {
 			this.ctx.session.modelRegistry,
 			this.ctx.session.scopedModels,
 			{
-				onPick: async (model, selector) => {
+				onPick: async (model, selector, thinkingLevel) => {
 					try {
 						// Session-only: update agent state but don't persist the model to settings.
-						const roleThinkingLevel = this.ctx.session.resolveTemporaryModelThinkingLevel(model);
-						await this.ctx.session.setModelTemporary(model, roleThinkingLevel);
+						await this.ctx.session.setModelTemporary(
+							model,
+							thinkingLevel === ThinkingLevel.Inherit ? undefined : thinkingLevel,
+						);
 						this.ctx.statusLine.invalidate();
 						this.ctx.updateEditorBorderColor();
 						const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
@@ -722,6 +724,7 @@ export class SelectorController {
 				quickRoles: quickRoleCycle?.models,
 				quickRoleOrder,
 				currentQuickRole: quickRoleCycle?.models[quickRoleCycle.currentIndex]?.role,
+				thinkingLevelForModel: model => this.ctx.session.resolveTemporaryModelThinkingLevel(model),
 			},
 		);
 		overlayHandle = this.ctx.ui.showOverlay(picker, {

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -69,6 +69,14 @@ export function parseRetryFallbackSelector(
 ): RetryFallbackSelector | undefined {
 	const trimmed = selector.trim();
 	if (!trimmed) return undefined;
+	const slashIndex = trimmed.indexOf("/");
+	if (slashIndex > 0) {
+		const provider = trimmed.slice(0, slashIndex);
+		const id = trimmed.slice(slashIndex + 1);
+		if (modelLookup?.find(provider, id)) {
+			return { raw: trimmed, provider, id, thinkingLevel: undefined };
+		}
+	}
 	const parsed = parseModelString(trimmed, {
 		allowMaxSuffix: true,
 		allowAutoAlias: true,

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -209,6 +209,11 @@ export function getConfiguredThinkingLevelMetadata(level: ConfiguredThinkingLeve
 	return level === AUTO_THINKING ? AUTO_THINKING_METADATA : getThinkingLevelMetadata(level);
 }
 
+/** Thinking choices shown after selecting a model, ordered from inherited policy to explicit effort. */
+export function getConfiguredThinkingLevelsForModel(model: Model): ConfiguredThinkingLevel[] {
+	return [ThinkingLevel.Inherit, ThinkingLevel.Off, AUTO_THINKING, ...getSupportedEfforts(model)];
+}
+
 /**
  * Thinking selectors accepted by the `--thinking` CLI flag, in display order:
  * `off`, every concrete effort (`minimal`..`max`), then `auto`. Single source

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -485,6 +485,42 @@ describe("AgentSession retry fallback", () => {
 		expect(requestedModels).toEqual([]);
 	});
 
+	it("preserves inherited thinking for a fallback whose literal model id ends in an effort suffix", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const literalFallback = getBundledModel("nanogpt", "nanogpt/coding-router:low");
+		if (!primaryModel || !literalFallback) {
+			throw new Error("Expected bundled primary and literal suffixed fallback models");
+		}
+		authStorage.setRuntimeApiKey("nanogpt", "nanogpt-test-key");
+		const requestedModels: string[] = [];
+		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": {
+				default: [`${literalFallback.provider}/${literalFallback.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			thinkingLevel: Effort.High,
+		});
+
+		await session.prompt("Recover on the literal suffixed fallback");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${literalFallback.provider}/${literalFallback.id}`,
+		]);
+		expect(session.model?.id).toBe(literalFallback.id);
+		expect(session.thinkingLevel).toBe(Effort.High);
+	});
+
 	it("continues a startup-owned role fallback chain from the active fallback", async () => {
 		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
 		const secondFallback = getBundledModel("openai", "gpt-4o");

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -382,6 +382,7 @@ describe("ModelHub", () => {
 			expect(thinking).toContain("inherit");
 			expect(thinking).toContain("xhigh");
 			expect(thinking).not.toContain("max");
+			expect(normalize(hub.render(80))).toContain("↑/↓ choose · Enter apply · Esc back");
 		});
 		test("project storage exposes project and global role actions with callback scopes", () => {
 			const model = makeModel("test", "scoped-role-model");
@@ -592,7 +593,7 @@ describe("ModelHub", () => {
 			expect(footerLine(hub.render(220))).not.toContain("inherit");
 		});
 
-		test("retry-fallback chip appends the model to the default chain without a thinking strip", () => {
+		test("retry-fallback chip appends the model with an explicit thinking level", () => {
 			const model = makeModel("test", "retry-fallback-model");
 			const { hub, onAssign, onFallbackChainChange } = createHub({ models: [model], scoped: true });
 			installTestTheme();
@@ -601,15 +602,20 @@ describe("ModelHub", () => {
 			hub.handleInput(LEFT); // wraps to the trailing retry-fallback chip
 			hub.handleInput("\n");
 
-			expect(onFallbackChainChange).toHaveBeenCalledWith("default", ["test/retry-fallback-model"]);
-			expect(onAssign).not.toHaveBeenCalled();
-			expect(footerLine(hub.render(220))).not.toContain("inherit");
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+			const thinking = normalize(hub.render(220));
+			expect(thinking).toContain("Final step");
+			expect(thinking).toContain("fallback · retry-fallback-model");
+			expect(footerLine(hub.render(220))).toContain("inherit");
+			expect(footerLine(hub.render(220))).toContain("off");
+			expect(footerLine(hub.render(220))).not.toContain("auto");
+			expect(footerLine(hub.render(50))).toContain("[ inherit ]");
 
-			// A second registration of the same model is a no-op, not a duplicate.
+			hub.handleInput(DOWN); // inherit → off
 			hub.handleInput("\n");
-			hub.handleInput(LEFT);
-			hub.handleInput("\n");
-			expect(onFallbackChainChange).toHaveBeenCalledTimes(1);
+			expect(onFallbackChainChange).toHaveBeenCalledWith("default", ["test/retry-fallback-model:off"]);
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(normalize(hub.render(220))).toContain("↳ test/retry-fallback-model:off");
 		});
 
 		test("overflowing role strip scrolls left so the selected chip stays visible", () => {
@@ -655,7 +661,7 @@ describe("ModelHub", () => {
 			expect(rendered).toContain("↳ test/model-b");
 		});
 
-		test("f on a role opens fallback assignment and Enter appends the picked model", () => {
+		test("f on a role selects fallback thinking before appending the model", () => {
 			const a = makeModel("test", "model-a");
 			const settings = Settings.isolated({});
 			const { hub, onFallbackChainChange, onAssign } = createHub({ models: [a], scoped: true, settings });
@@ -665,8 +671,11 @@ describe("ModelHub", () => {
 			expect(normalize(hub.render(220))).toContain("Adding fallback for");
 
 			hub.handleInput("\n"); // pick the only model
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+			expect(normalize(hub.render(220))).toContain("Final step");
+			hub.handleInput("\n"); // inherit preserves the primary thinking level
 			expect(onFallbackChainChange).toHaveBeenCalledWith("default", ["test/model-a"]);
-			expect(onAssign).not.toHaveBeenCalled(); // no role assignment, no thinking strip
+			expect(onAssign).not.toHaveBeenCalled();
 			expect(normalize(hub.render(220))).toContain("↳ test/model-a");
 		});
 
@@ -684,11 +693,95 @@ describe("ModelHub", () => {
 			expect(normalize(hub.render(220))).toContain("Replacing fallback of");
 			for (const ch of "model-b") hub.handleInput(ch); // search: arrows hop scopes in assign mode
 			hub.handleInput("\n");
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+			hub.handleInput("\n"); // preserve thinking for the replacement
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-b"]);
 
 			hub.handleInput("x"); // cursor landed on the replaced entry — remove it
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", []);
 			expect(normalize(hub.render(220))).not.toContain("↳");
+		});
+
+		test("editing a fallback preselects and preserves its configured thinking level", () => {
+			const model = makeModel("test", "model-a");
+			const settings = Settings.isolated({
+				"retry.fallbackChains": { default: ["test/model-a:off"] },
+			});
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → model-a:off
+			hub.handleInput("\n"); // replace this entry
+			hub.handleInput("\n"); // pick the preselected model
+			expect(footerLine(hub.render(220))).toContain("[ ⦸ off ]");
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a:off"]);
+		});
+
+		test("appending removes every duplicate of the same fallback model regardless of thinking suffix", () => {
+			const model = makeModel("test", "model-a");
+			const settings = Settings.isolated({
+				"retry.fallbackChains": { default: ["test/model-a:off", "test/model-a:high"] },
+			});
+			const { hub, onFallbackChainChange } = createHub({ models: [model], scoped: true, settings });
+
+			hub.handleInput("\n");
+			hub.handleInput(LEFT); // retry-fallback
+			hub.handleInput("\n");
+			hub.handleInput(DOWN); // inherit → off
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a:off"]);
+		});
+
+		test("omits ambiguous effort choices that collide with a literal model id in the full registry", () => {
+			const base = buildModel({
+				id: "router",
+				name: "router",
+				api: "ollama-chat",
+				provider: "test",
+				baseUrl: "https://example.com",
+				reasoning: true,
+				thinking: { mode: "effort", efforts: [ThinkingLevel.Low, ThinkingLevel.High] },
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 1024,
+			});
+			const literal = makeModel("test", "router:low");
+			const { hub, onFallbackChainChange } = createHub({
+				models: [base],
+				scoped: true,
+				registry: { getAll: () => [base, literal] },
+			});
+
+			hub.handleInput("\n");
+			hub.handleInput(LEFT);
+			hub.handleInput("\n");
+			const footer = footerLine(hub.render(220));
+			expect(footer).not.toContain("◔ low");
+			expect(footer).toContain("◒ high");
+			hub.handleInput(DOWN); // inherit → off
+			hub.handleInput(DOWN); // off → high (low is omitted)
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/router:high"]);
+		});
+
+		test("editing an exact literal suffixed model id does not reinterpret it as fallback thinking", () => {
+			const base = makeModel("test", "router");
+			const literal = makeModel("test", "router:low");
+			const settings = Settings.isolated({
+				"retry.fallbackChains": { default: ["test/router:low"] },
+			});
+			const { hub, onFallbackChainChange } = createHub({ models: [base, literal], scoped: true, settings });
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // default → literal router:low fallback
+			hub.handleInput("\n");
+			hub.handleInput("\n"); // pick the exact preselected literal model
+			expect(normalize(hub.render(220))).toContain("fallback · router:low");
+			expect(footerLine(hub.render(220))).toContain("[ inherit ]");
+			hub.handleInput("\n");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/router:low"]);
 		});
 
 		test("] moves a chain entry later and the cursor follows it", () => {
@@ -740,6 +833,7 @@ describe("ModelHub", () => {
 
 			for (const ch of "model-b") hub.handleInput(ch);
 			hub.handleInput("\n");
+			hub.handleInput("\n"); // preserve thinking for the fallback
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("test/model-a", ["test/model-b"]);
 			const rendered = normalize(hub.render(220));
 			expect(rendered).toContain("test/model-a");
@@ -760,6 +854,7 @@ describe("ModelHub", () => {
 
 			for (const ch of "model-b") hub.handleInput(ch);
 			hub.handleInput("\n");
+			hub.handleInput("\n"); // preserve thinking for the fallback
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("test/*", ["test/model-b"]);
 		});
 
@@ -783,6 +878,7 @@ describe("ModelHub", () => {
 			expect(normalize(hub.render(220))).toContain("Adding fallback for test/model-a");
 			for (const ch of "model-b") hub.handleInput(ch);
 			hub.handleInput("\n");
+			hub.handleInput("\n"); // preserve thinking for the fallback
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("test/model-a", ["test/model-b"]);
 		});
 

--- a/packages/coding-agent/test/model-picker.test.ts
+++ b/packages/coding-agent/test/model-picker.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, type Mock, test, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -44,7 +45,7 @@ interface RegistryOverrides {
 
 interface PickerHarness {
 	picker: ModelPickerComponent;
-	onPick: Mock<(model: Model, selector: string) => void>;
+	onPick: Mock<(model: Model, selector: string, thinkingLevel: ThinkingLevel) => void>;
 	onPickRole: Mock<(entry: ResolvedRoleModel) => void>;
 	onCancel: Mock<() => void>;
 }
@@ -103,8 +104,10 @@ describe("ModelPicker", () => {
 		const rendered = normalize(picker.render(220));
 		expect(rendered).toContain("a-small");
 		expect(rendered).toContain("context>4.1k");
-		expect(rendered).toContain("Session-only switch");
+		expect(rendered).toContain("Step 1 of 2");
 
+		picker.handleInput("\n");
+		expect(onPick).not.toHaveBeenCalled();
 		picker.handleInput("\n");
 		expect(onPick).toHaveBeenCalledTimes(1);
 		expect(onPick.mock.calls[0]?.[0]).toBe(large);
@@ -119,6 +122,8 @@ describe("ModelPicker", () => {
 			registry: { refresh },
 		});
 
+		picker.handleInput("\n");
+		expect(onPick).not.toHaveBeenCalled();
 		picker.handleInput("\n");
 		expect(onPick).toHaveBeenCalledTimes(1);
 		expect(onPick.mock.calls[0]?.[0]).toBe(cached);
@@ -144,6 +149,7 @@ describe("ModelPicker", () => {
 		// refresh().then(...) continuation chain deterministically.
 		await Bun.sleep(0);
 		picker.handleInput("\n");
+		picker.handleInput("\n");
 		expect(onPick.mock.calls[0]?.[0]?.id).toBe("cc-model");
 	});
 
@@ -158,9 +164,41 @@ describe("ModelPicker", () => {
 		// The detail block tags the selected (= current) model.
 		expect(normalize(picker.render(220))).toContain("current");
 
-		// Enter without navigation picks the preselected current model.
+		// Enter opens thinking selection without losing the preselected current model.
+		picker.handleInput("\n");
+		expect(onPick).not.toHaveBeenCalled();
+		expect(normalize(picker.render(220))).toContain("2/2 · ↑/↓ · Enter apply · Esc back · bb-model");
 		picker.handleInput("\n");
 		expect(onPick.mock.calls[0]?.[0]?.id).toBe("bb-model");
+	});
+
+	test("selects thinking immediately after the model and Esc returns to models", () => {
+		const model = makeModel("test", "thinking-model");
+		const { picker, onPick } = createPicker({ models: [model], scoped: true });
+
+		picker.handleInput("\n");
+		expect(normalize(picker.render(220))).toContain("[ inherit ] off auto");
+		picker.handleInput(DOWN);
+		picker.handleInput("\n");
+		expect(onPick).toHaveBeenCalledWith(model, "test/thinking-model", ThinkingLevel.Off);
+
+		const second = createPicker({ models: [model], scoped: true });
+		second.picker.handleInput("\n");
+		second.picker.handleInput(ESC);
+		expect(second.onPick).not.toHaveBeenCalled();
+		expect(second.onCancel).not.toHaveBeenCalled();
+		expect(normalize(second.picker.render(220))).toContain("Step 1 of 2");
+	});
+
+	test("keeps the selected thinking choice visible beside a long model id on narrow terminals", () => {
+		const model = makeModel("test", "a-very-long-model-id-that-fills-the-picker-footer");
+		const { picker } = createPicker({ models: [model], scoped: true });
+
+		picker.handleInput("\n");
+		picker.handleInput(DOWN);
+		const rendered = normalize(picker.render(50));
+		expect(rendered).toContain("2/2 · ↑/↓ · Enter apply · Esc back");
+		expect(rendered).toContain("[ off ]");
 	});
 
 	test("shows and applies ctrl+p quick roles when search starts with @", () => {

--- a/packages/coding-agent/test/model-picker.test.ts
+++ b/packages/coding-agent/test/model-picker.test.ts
@@ -30,6 +30,14 @@ function makeModel(provider: string, id: string, contextWindow = 128_000): Model
 	});
 }
 
+function makeReasoningModel(provider: string, id: string, contextWindow = 128_000): Model {
+	return {
+		...makeModel(provider, id, contextWindow),
+		reasoning: true,
+		thinking: { mode: "effort", efforts: [ThinkingLevel.Low, ThinkingLevel.High] },
+	};
+}
+
 let testTheme = await getThemeByName("dark");
 
 function installTestTheme(): void {
@@ -107,8 +115,6 @@ describe("ModelPicker", () => {
 		expect(rendered).toContain("Step 1 of 2");
 
 		picker.handleInput("\n");
-		expect(onPick).not.toHaveBeenCalled();
-		picker.handleInput("\n");
 		expect(onPick).toHaveBeenCalledTimes(1);
 		expect(onPick.mock.calls[0]?.[0]).toBe(large);
 	});
@@ -122,8 +128,6 @@ describe("ModelPicker", () => {
 			registry: { refresh },
 		});
 
-		picker.handleInput("\n");
-		expect(onPick).not.toHaveBeenCalled();
 		picker.handleInput("\n");
 		expect(onPick).toHaveBeenCalledTimes(1);
 		expect(onPick.mock.calls[0]?.[0]).toBe(cached);
@@ -149,12 +153,15 @@ describe("ModelPicker", () => {
 		// refresh().then(...) continuation chain deterministically.
 		await Bun.sleep(0);
 		picker.handleInput("\n");
-		picker.handleInput("\n");
 		expect(onPick.mock.calls[0]?.[0]?.id).toBe("cc-model");
 	});
 
 	test("highlights and preselects the session's current model", () => {
-		const models = [makeModel("test", "aa-model"), makeModel("test", "bb-model"), makeModel("test", "cc-model")];
+		const models = [
+			makeReasoningModel("test", "aa-model"),
+			makeReasoningModel("test", "bb-model"),
+			makeReasoningModel("test", "cc-model"),
+		];
 		const { picker, onPick } = createPicker({
 			models,
 			scoped: true,
@@ -173,7 +180,7 @@ describe("ModelPicker", () => {
 	});
 
 	test("selects thinking immediately after the model and Esc returns to models", () => {
-		const model = makeModel("test", "thinking-model");
+		const model = makeReasoningModel("test", "thinking-model");
 		const { picker, onPick } = createPicker({ models: [model], scoped: true });
 
 		picker.handleInput("\n");
@@ -190,8 +197,18 @@ describe("ModelPicker", () => {
 		expect(normalize(second.picker.render(220))).toContain("Step 1 of 2");
 	});
 
+	test("applies a non-reasoning model without opening an empty thinking step", () => {
+		const model = makeModel("test", "non-reasoning-model");
+		const { picker, onPick } = createPicker({ models: [model], scoped: true });
+
+		picker.handleInput("\n");
+
+		expect(onPick).toHaveBeenCalledWith(model, "test/non-reasoning-model", ThinkingLevel.Inherit);
+		expect(normalize(picker.render(220))).not.toContain("2/2");
+	});
+
 	test("keeps the selected thinking choice visible beside a long model id on narrow terminals", () => {
-		const model = makeModel("test", "a-very-long-model-id-that-fills-the-picker-footer");
+		const model = makeReasoningModel("test", "a-very-long-model-id-that-fills-the-picker-footer");
 		const { picker } = createPicker({ models: [model], scoped: true });
 
 		picker.handleInput("\n");

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -853,6 +853,7 @@ describe("selector setting side effects", () => {
 			expect(frame).toContain("retry-fallback");
 			hub.handleInput("\x1b[D");
 			hub.handleInput("\n");
+			hub.handleInput("\n"); // apply the preselected inherit fallback thinking level
 			await Promise.resolve();
 
 			expect(showError).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -864,7 +864,7 @@ describe("selector setting side effects", () => {
 		}
 	});
 
-	it("applies an @ quick role through the role-switch session API", async () => {
+	it("routes quick roles and explicit inherit through their session APIs", async () => {
 		const testTheme = await getThemeByName("dark");
 		if (!testTheme) throw new Error("Failed to load dark theme for quick-role picker test");
 		setThemeInstance(testTheme);
@@ -927,6 +927,7 @@ describe("selector setting side effects", () => {
 				scopedModels: [{ model: smol }, { model: slow }],
 				getContextUsage: () => undefined,
 				getRoleModelCycle: () => ({ models: quickRoles, currentIndex: 1 }),
+				resolveTemporaryModelThinkingLevel: () => ThinkingLevel.Inherit,
 				applyRoleModel,
 				setModelTemporary,
 			},
@@ -947,6 +948,13 @@ describe("selector setting side effects", () => {
 		expect(setModelTemporary).not.toHaveBeenCalled();
 		expect(showModelCycleTrack).toHaveBeenCalledTimes(1);
 		expect(showError).not.toHaveBeenCalled();
+
+		controller.showModelSelector({ temporaryOnly: true });
+		if (!picker) throw new Error("Expected temporary model picker overlay");
+		picker.handleInput("\n");
+		await Promise.resolve();
+
+		expect(setModelTemporary).toHaveBeenCalledWith(slow, ThinkingLevel.Inherit);
 	});
 
 	it("switches the live session to the global default when the project default is unassigned", async () => {


### PR DESCRIPTION
## Problem

Selecting a model through `/switch` applied it immediately, so changing its thinking level required reopening the picker. `/models` exposed thinking through a dense role strip, and retry fallback assignments could not persist a model-aware thinking choice.

## Change

- Make `/switch` a sequential model → thinking → apply flow.
- Reuse the same model-aware final thinking step for `/models` role assignments.
- Add thinking selection when adding or replacing retry fallbacks and persist the selected suffix.
- Preserve `inherit`/automatic thinking semantics instead of converting them to `off`.
- Preserve literal model IDs ending in effort-like suffixes at edit time and runtime.
- Deduplicate fallback chains by base model identity.
- Keep the selected thinking chip and keyboard controls visible on narrow terminals.

## Screenshots

### `/switch`: model selected, then thinking

![Switch model thinking step](https://raw.githubusercontent.com/eggpeat/oh-my-pi/pr-assets/sequential-model-thinking/.github/pr-assets/sequential-model-thinking/e2e-switch-thinking.png)

### `/models`: role assignment thinking step

![Models role thinking step](https://raw.githubusercontent.com/eggpeat/oh-my-pi/pr-assets/sequential-model-thinking/.github/pr-assets/sequential-model-thinking/e2e-models-thinking.png)

### `/models`: fallback thinking selection

![Fallback thinking selection](https://raw.githubusercontent.com/eggpeat/oh-my-pi/pr-assets/sequential-model-thinking/.github/pr-assets/sequential-model-thinking/e2e-fallback-thinking.png)

### Persisted fallback suffix

![Persisted fallback thinking suffix](https://raw.githubusercontent.com/eggpeat/oh-my-pi/pr-assets/sequential-model-thinking/.github/pr-assets/sequential-model-thinking/e2e-fallback-persisted.png)

## Verification

- `bun test packages/coding-agent/test/model-hub.test.ts packages/coding-agent/test/model-picker.test.ts packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/selector-settings-side-effects.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts` — 268 passed, 0 failed.
- `bun run check:ts` — passed across all packages.
- Actual isolated 120×36 terminal flows exercised for `/switch`, `/models` role assignment, and `/models` fallback assignment.
- OMP-native autoreview clean: no actionable findings.
- GitHub Actions CI — all required jobs passed, including lint/type check, install smoke, CLI smoke, workspace, native/integration, UI/TUI, native/unit, runtime/session, and singleton/global-state lanes.

