### PR TITLE
fix(cli): resume cross-directory sessions in place

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp --resume <id>` prompting to fork sessions from another existing directory instead of switching the process and cwd-scoped settings into the resumed session's recorded directory ([#6752](https://github.com/can1357/oh-my-pi/issues/6752)).
+
 ## [17.1.4] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -620,6 +620,10 @@ async function switchToResumedProject(
 	clearPluginRootsAndCaches();
 	resetCapabilities();
 	const cwd = getProjectDir();
+	// clearPluginRootsAndCaches only kicks off an unawaited re-warm; await a fresh
+	// destination preload so sync consumers (plugin-provided LSP/DAP config) never
+	// read the launch project's stale/empty roots during session creation.
+	await preloadPluginRoots(os.homedir(), cwd);
 	await activeSettings.reloadForCwd(cwd);
 	return cwd;
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1310,6 +1310,9 @@ export async function runRootCommand(
 		const previousCwd = cwd;
 		cwd = await switchToResumedProject(sessionManager.getCwd(), settingsInstance, pluginPreloadPromise);
 		if (cwd !== previousCwd) {
+			// applyStartupCwd persists an explicit --cwd in parsedArgs; once resume
+			// switches projects, keep session construction on the destination too.
+			parsedArgs.cwd = cwd;
 			// Destination project may scope a different `enabledModels`; re-resolve
 			// so the model UI and session options reflect it (explicit `--models`
 			// stays fixed inside resolveScopedModels).
@@ -1363,6 +1366,7 @@ export async function runRootCommand(
 		const previousCwd = cwd;
 		cwd = await switchToResumedProject(selected.cwd, settingsInstance, pluginPreloadPromise);
 		if (cwd !== previousCwd) {
+			parsedArgs.cwd = cwd;
 			scopedModels = await resolveScopedModels(parsedArgs, modelRegistry, settingsInstance);
 		}
 		sessionManager = await SessionManager.open(selected.path);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -624,6 +624,29 @@ async function switchToResumedProject(
 	return cwd;
 }
 
+/**
+ * Resolve the effective model allow-list from an explicit `--models` scope or,
+ * failing that, the active project's `enabledModels`. Re-run after a resume
+ * switches projects so the destination project's settings-derived scope wins
+ * over the launch directory's.
+ */
+async function resolveScopedModels(
+	parsed: Args,
+	modelRegistry: ModelRegistry,
+	activeSettings: Settings,
+): Promise<ScopedModel[]> {
+	const modelPatterns = parsed.models ?? activeSettings.get("enabledModels");
+	if (!modelPatterns || modelPatterns.length === 0) {
+		return [];
+	}
+	return await resolveModelScope(
+		modelPatterns,
+		modelRegistry,
+		getModelMatchPreferences(activeSettings),
+		activeSettings,
+	);
+}
+
 async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
 	if (parsed.continue || parsed.resume) {
 		return undefined;
@@ -1242,19 +1265,13 @@ export async function runRootCommand(
 		settingsInstance.get("theme.light"),
 	);
 
-	let scopedModels: ScopedModel[] = [];
-	const modelPatterns = parsedArgs.models ?? settingsInstance.get("enabledModels");
-	const modelMatchPreferences = getModelMatchPreferences(settingsInstance);
-	if (modelPatterns && modelPatterns.length > 0) {
-		scopedModels = await logger.time(
-			"resolveModelScope",
-			resolveModelScope,
-			modelPatterns,
-			modelRegistry,
-			modelMatchPreferences,
-			settingsInstance,
-		);
-	}
+	let scopedModels = await logger.time(
+		"resolveModelScope",
+		resolveScopedModels,
+		parsedArgs,
+		modelRegistry,
+		settingsInstance,
+	);
 
 	// Resolve an explicit `--continue <id>` before extension flags are loaded.
 	// Reading the token immediately after `--continue` distinguishes the session
@@ -1286,7 +1303,14 @@ export async function runRootCommand(
 	}
 
 	if (typeof parsedArgs.resume === "string" && sessionManager) {
+		const previousCwd = cwd;
 		cwd = await switchToResumedProject(sessionManager.getCwd(), settingsInstance, pluginPreloadPromise);
+		if (cwd !== previousCwd) {
+			// Destination project may scope a different `enabledModels`; re-resolve
+			// so the model UI and session options reflect it (explicit `--models`
+			// stays fixed inside resolveScopedModels).
+			scopedModels = await resolveScopedModels(parsedArgs, modelRegistry, settingsInstance);
+		}
 	}
 
 	// User declined the missing-directory move prompt — exit cleanly instead of
@@ -1332,7 +1356,11 @@ export async function runRootCommand(
 			process.exit(0);
 		}
 		// Re-scope every cwd-derived input before building the resumed session.
+		const previousCwd = cwd;
 		cwd = await switchToResumedProject(selected.cwd, settingsInstance, pluginPreloadPromise);
+		if (cwd !== previousCwd) {
+			scopedModels = await resolveScopedModels(parsedArgs, modelRegistry, settingsInstance);
+		}
 		sessionManager = await SessionManager.open(selected.path);
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -533,22 +533,6 @@ type SessionPromptResult = "accepted" | "declined" | "unavailable";
 
 type SessionPrompt = (session: SessionInfo) => Promise<SessionPromptResult>;
 
-async function promptForkSession(session: SessionInfo): Promise<SessionPromptResult> {
-	if (!process.stdin.isTTY) {
-		return "unavailable";
-	}
-	const message = `Session found in different project: ${session.cwd}. Fork into current directory? [y/N] `;
-	pauseStartupWatchdog();
-	const rl = createInterface({ input: process.stdin, output: process.stdout });
-	try {
-		const answer = (await rl.question(message)).trim().toLowerCase();
-		return answer === "y" || answer === "yes" ? "accepted" : "declined";
-	} finally {
-		rl.close();
-		resumeStartupWatchdog();
-	}
-}
-
 async function promptMoveSession(session: SessionInfo): Promise<SessionPromptResult> {
 	if (!process.stdin.isTTY) {
 		return "unavailable";
@@ -567,9 +551,9 @@ async function promptMoveSession(session: SessionInfo): Promise<SessionPromptRes
 
 /**
  * Friendly CLI failure raised by {@link createSessionManager} when the user's
- * session-resolution flags (`--resume`/`--fork`/cross-project prompts) cannot
- * be satisfied. {@link runRootCommand} catches it and prints a clean stderr
- * message instead of letting it surface as `[Uncaught Exception]`
+ * session-resolution flags (`--resume`/`--fork`/missing-directory move prompts)
+ * cannot be satisfied. {@link runRootCommand} catches it and prints a clean
+ * stderr message instead of letting it surface as `[Uncaught Exception]`
  * (see issue #2084).
  */
 export class SessionResolutionError extends Error {
@@ -615,6 +599,29 @@ async function moveMissingCwdSessionIfNeeded(
 	const manager = await SessionManager.open(session.path, sessionDir, undefined, { initialCwd: sourceCwd });
 	await manager.moveTo(cwd, sessionDir);
 	return { status: "moved", manager };
+}
+
+async function switchToResumedProject(
+	resumedCwd: string | undefined,
+	activeSettings: Settings,
+	pluginPreloadPromise: Promise<unknown>,
+): Promise<string> {
+	if (
+		!resumedCwd ||
+		normalizePathForComparison(resumedCwd) === normalizePathForComparison(getProjectDir()) ||
+		!(await directoryExists(resumedCwd))
+	) {
+		return getProjectDir();
+	}
+
+	// Let the launch-cwd preload settle before clearing and re-warming its caches.
+	await pluginPreloadPromise.catch(() => {});
+	setProjectDir(resumedCwd);
+	clearPluginRootsAndCaches();
+	resetCapabilities();
+	const cwd = getProjectDir();
+	await activeSettings.reloadForCwd(cwd);
+	return cwd;
 }
 
 async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
@@ -672,7 +679,6 @@ export async function createSessionManager(
 	parsed: Args,
 	cwd: string,
 	activeSettings: Settings = settings,
-	askToForkSession: SessionPrompt = promptForkSession,
 	askToMoveSession: SessionPrompt = promptMoveSession,
 ): Promise<SessionManager | undefined> {
 	if (parsed.fork) {
@@ -726,35 +732,18 @@ export async function createSessionManager(
 			}
 		}
 		if (match.scope === "global") {
-			const normalizedCwd = normalizePathForComparison(cwd);
-			const normalizedMatchCwd = normalizePathForComparison(match.session.cwd || cwd);
-			if (normalizedCwd !== normalizedMatchCwd) {
-				const moveResult = await moveMissingCwdSessionIfNeeded(
-					sessionArg,
-					match.session,
-					cwd,
-					parsed.sessionDir,
-					askToMoveSession,
-				);
-				if (moveResult.status === "moved") {
-					return moveResult.manager;
-				}
-				if (moveResult.status === "declined") {
-					return undefined;
-				}
-				const forkPromptResult = await askToForkSession(match.session);
-				if (forkPromptResult === "unavailable") {
-					throw new SessionResolutionError(
-						`Session "${sessionArg}" is in another project (${match.session.cwd}); run interactively to fork it into the current project.`,
-					);
-				}
-				if (forkPromptResult === "declined") {
-					// User declined the cross-project fork prompt. Caller distinguishes
-					// this cancellation from the "default new session" undefined return
-					// by checking `typeof parsed.resume === "string"`.
-					return undefined;
-				}
-				return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
+			const moveResult = await moveMissingCwdSessionIfNeeded(
+				sessionArg,
+				match.session,
+				cwd,
+				parsed.sessionDir,
+				askToMoveSession,
+			);
+			if (moveResult.status === "moved") {
+				return moveResult.manager;
+			}
+			if (moveResult.status === "declined") {
+				return undefined;
 			}
 		}
 		return await SessionManager.open(match.session.path, parsed.sessionDir);
@@ -1296,11 +1285,14 @@ export async function runRootCommand(
 		throw error;
 	}
 
-	// User declined the cross-project fork prompt — exit cleanly with a friendly
-	// message rather than letting the decline bubble up as an uncaught exception
-	// (see issue #1668).
+	if (typeof parsedArgs.resume === "string" && sessionManager) {
+		cwd = await switchToResumedProject(sessionManager.getCwd(), settingsInstance, pluginPreloadPromise);
+	}
+
+	// User declined the missing-directory move prompt — exit cleanly instead of
+	// letting the cancellation fall through to a new session.
 	if (typeof parsedArgs.resume === "string" && !sessionManager) {
-		writeStartupNotice(parsedArgs, `${chalk.dim("Resume cancelled: session is in another project.")}\n`);
+		writeStartupNotice(parsedArgs, `${chalk.dim("Resume cancelled: session was not moved.")}\n`);
 		stopStartupWatchdog();
 		process.exit(0);
 	}
@@ -1339,28 +1331,8 @@ export async function runRootCommand(
 			stopStartupWatchdog();
 			process.exit(0);
 		}
-		// Resuming a session from another project: switch the process into that
-		// project's directory and refresh cwd-derived caches before the session is
-		// built, so settings discovery, plugins, and capabilities all scope to it.
-		// Skip the chdir when the recorded project directory is gone: `setProjectDir`
-		// would throw on the missing path. `SessionManager.open` then falls back to
-		// the launch cwd, so the resumed session simply stays where the user is.
-		if (
-			selected.cwd &&
-			normalizePathForComparison(selected.cwd) !== normalizePathForComparison(getProjectDir()) &&
-			(await directoryExists(selected.cwd))
-		) {
-			// Let the original (launch-cwd) plugin-root preload settle first so its
-			// late resolution can't clobber the re-warm we trigger below.
-			await pluginPreloadPromise.catch(() => {});
-			setProjectDir(selected.cwd);
-			clearPluginRootsAndCaches();
-			resetCapabilities();
-			cwd = getProjectDir();
-			// Re-scope project settings (.claude/settings.yml etc.) to the resumed
-			// project in place so the session is built with its configuration.
-			await settingsInstance.reloadForCwd(cwd);
-		}
+		// Re-scope every cwd-derived input before building the resumed session.
+		cwd = await switchToResumedProject(selected.cwd, settingsInstance, pluginPreloadPromise);
 		sessionManager = await SessionManager.open(selected.path);
 	}
 

--- a/packages/coding-agent/test/main-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-project-resume.test.ts
@@ -126,7 +126,7 @@ describe("runRootCommand — cross-project --resume", () => {
 		await fsp.rm(root, { recursive: true, force: true });
 	});
 
-	it("preloads the destination plugin roots and re-scopes before session creation", async () => {
+	it("uses the destination cwd and preloads its plugin roots before session creation", async () => {
 		const match = buildGlobalMatch(resumedProject);
 		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(match);
 		const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
@@ -139,7 +139,8 @@ describe("runRootCommand — cross-project --resume", () => {
 			preloadedCwds.push(cwd);
 		});
 		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
-		const parsed = parseArgs(["--resume", "019e84ed", "--print"]);
+		const rawArgs = ["--cwd", launchProject, "--resume", "019e84ed", "--print"];
+		const parsed = parseArgs(rawArgs);
 		parsed.noExtensions = true;
 		parsed.noSkills = true;
 		parsed.noRules = true;
@@ -147,14 +148,16 @@ describe("runRootCommand — cross-project --resume", () => {
 		parsed.noLsp = true;
 		let resumedManager: SessionManager | undefined;
 		let preloadedDestinationAtCreation = false;
+		let sessionOptionsCwd: string | undefined;
 
 		try {
-			await runRootCommand(parsed, ["--resume", "019e84ed", "--print"], {
+			await runRootCommand(parsed, rawArgs, {
 				discoverAuthStorage: async () => authStorage,
 				settings,
 				createAgentSession: async options => {
 					if (!options) throw new Error("Expected session options");
 					resumedManager = options.sessionManager;
+					sessionOptionsCwd = options.cwd;
 					// Awaited during the switch, so by session creation the destination
 					// preload has already been requested for the resumed project.
 					preloadedDestinationAtCreation = preloadedCwds.includes(resumedProject);
@@ -172,6 +175,8 @@ describe("runRootCommand — cross-project --resume", () => {
 		expect(process.cwd()).toBe(resumedProject);
 		expect(reloadForCwd).toHaveBeenCalledWith(resumedProject);
 		expect(resumedManager?.getCwd()).toBe(resumedProject);
+		expect(parsed.cwd).toBe(resumedProject);
+		expect(sessionOptionsCwd).toBe(resumedProject);
 		expect(preloadedDestinationAtCreation).toBe(true);
 	}, 15_000);
 

--- a/packages/coding-agent/test/main-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-project-resume.test.ts
@@ -12,6 +12,7 @@ import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type Args, parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import * as modelResolverModule from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createSessionManager, runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -162,6 +163,49 @@ describe("runRootCommand — cross-project --resume", () => {
 		expect(process.cwd()).toBe(resumedProject);
 		expect(reloadForCwd).toHaveBeenCalledWith(resumedProject);
 		expect(resumedManager?.getCwd()).toBe(resumedProject);
+	}, 15_000);
+
+	it("re-resolves the model scope from the resumed project's enabledModels after the switch", async () => {
+		const match = buildGlobalMatch(resumedProject);
+		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(match);
+		// enabledModels scoped only to the resumed project: the launch scope
+		// yields no patterns, so any resolveModelScope call proves the recompute
+		// ran against the destination settings rather than the launch directory.
+		const settings = Settings.isolated({
+			"marketplace.autoUpdate": "off",
+			enabledModels: [{ paths: [resumedProject], models: ["model-resumed"] }],
+		});
+		const resolveModelScope = vi.spyOn(modelResolverModule, "resolveModelScope").mockResolvedValue([]);
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		const parsed = parseArgs(["--resume", "019e84ed", "--print"]);
+		parsed.noExtensions = true;
+		parsed.noSkills = true;
+		parsed.noRules = true;
+		parsed.noTools = true;
+		parsed.noLsp = true;
+		let resumedManager: SessionManager | undefined;
+
+		try {
+			await runRootCommand(parsed, ["--resume", "019e84ed", "--print"], {
+				discoverAuthStorage: async () => authStorage,
+				settings,
+				createAgentSession: async options => {
+					if (!options) throw new Error("Expected session options");
+					resumedManager = options.sessionManager;
+					throw new Error("stop after session options");
+				},
+			});
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== "stop after session options") throw error;
+		} finally {
+			authStorage.close();
+			await resumedManager?.close();
+		}
+
+		// Launch scope had no patterns, so the only resolution is the post-switch
+		// one; the pre-fix code never recomputed and would not call it at all.
+		expect(resolveModelScope).toHaveBeenCalledTimes(1);
+		expect(resolveModelScope.mock.calls[0]?.[0]).toEqual(["model-resumed"]);
 	}, 15_000);
 });
 

--- a/packages/coding-agent/test/main-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-project-resume.test.ts
@@ -1,25 +1,26 @@
 /**
- * Regression: declining the cross-project fork prompt during `--resume <id>`
- * must exit cleanly, while non-interactive resume still fails instead of
- * silently succeeding. See #1668.
+ * Regression: `--resume <id>` must open a cross-project session in its recorded
+ * cwd instead of prompting to fork it into the launch directory.
  *
  * Also covers the moved/renamed-worktree path: when the matched session's
  * recorded directory no longer exists, `--resume <id>` offers to *move*
- * (re-root) the session rather than fork a duplicate.
+ * (re-root) the session rather than opening against a missing directory.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Args } from "@oh-my-pi/pi-coding-agent/cli/args";
-import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createSessionManager } from "@oh-my-pi/pi-coding-agent/main";
+import { type Args, parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createSessionManager, runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { SessionHeader } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import type { SessionInfo } from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import * as sessionListingModule from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 
 function buildArgs(resume: string, sessionDir?: string): Args {
 	return {
@@ -52,13 +53,21 @@ function buildGlobalMatch(cwd: string): { session: SessionInfo; scope: "global" 
 
 const stubSettings = { get: () => undefined } as unknown as Settings;
 
-describe("createSessionManager — cross-project --resume cancellation (#1668)", () => {
-	// An existing directory so the match is treated as a genuinely different
-	// project (fork path), not a moved/renamed worktree (move path).
+describe("createSessionManager — cross-project --resume", () => {
 	let existingProject: string;
 
 	beforeEach(async () => {
 		existingProject = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-xproj-"));
+		const match = buildGlobalMatch(existingProject);
+		await Bun.write(
+			match.session.path,
+			`${JSON.stringify({
+				type: "session",
+				id: match.session.id,
+				cwd: existingProject,
+				timestamp: new Date(0).toISOString(),
+			})}\n`,
+		);
 	});
 
 	afterEach(async () => {
@@ -66,32 +75,94 @@ describe("createSessionManager — cross-project --resume cancellation (#1668)",
 		await fsp.rm(existingProject, { recursive: true, force: true });
 	});
 
-	it("returns undefined when an interactive user declines the fork prompt instead of throwing", async () => {
-		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(buildGlobalMatch(existingProject));
+	it("opens the existing journal in its recorded cwd without a relocation prompt", async () => {
+		const match = buildGlobalMatch(existingProject);
+		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(match);
+		const movePrompt = vi.fn(async () => "declined" as const);
 
-		const result = await createSessionManager(
-			buildArgs("019e84ed"),
-			"/current/project",
-			stubSettings,
-			async () => "declined" as const,
-		);
+		const result = await createSessionManager(buildArgs("019e84ed"), "/current/project", stubSettings, movePrompt);
 
-		expect(result).toBeUndefined();
-	});
-
-	it("throws when the cross-project fork prompt is unavailable in non-interactive mode", async () => {
-		const originalIsTTY = process.stdin.isTTY;
-		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+		if (!result) throw new Error("Expected resumed session manager");
 		try {
-			vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(buildGlobalMatch(existingProject));
-
-			await expect(createSessionManager(buildArgs("019e84ed"), "/current/project", stubSettings)).rejects.toThrow(
-				`Session "019e84ed" is in another project (${existingProject}); run interactively to fork it into the current project.`,
-			);
+			expect(result.getSessionFile()).toBe(match.session.path);
+			expect(result.getCwd()).toBe(existingProject);
 		} finally {
-			Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+			await result.close();
 		}
+		expect(movePrompt).not.toHaveBeenCalled();
 	});
+});
+
+describe("runRootCommand — cross-project --resume", () => {
+	let root: string;
+	let launchProject: string;
+	let resumedProject: string;
+	let originalProject: string;
+
+	beforeEach(async () => {
+		originalProject = getProjectDir();
+		root = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-xproj-root-"));
+		launchProject = path.join(root, "launch");
+		resumedProject = path.join(root, "resumed");
+		await Promise.all([fsp.mkdir(launchProject), fsp.mkdir(resumedProject)]);
+		const match = buildGlobalMatch(resumedProject);
+		await Bun.write(
+			match.session.path,
+			`${JSON.stringify({
+				type: "session",
+				id: match.session.id,
+				cwd: resumedProject,
+				timestamp: new Date(0).toISOString(),
+			})}\n`,
+		);
+		setProjectDir(launchProject);
+	});
+
+	afterEach(async () => {
+		setProjectDir(originalProject);
+		vi.restoreAllMocks();
+		await fsp.rm(root, { recursive: true, force: true });
+	});
+
+	it("switches process and settings scope to the resumed session before session creation", async () => {
+		const match = buildGlobalMatch(resumedProject);
+		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(match);
+		const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+		const reloadForCwd = vi.spyOn(settings, "reloadForCwd");
+		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+		const parsed = parseArgs(["--resume", "019e84ed", "--print"]);
+		parsed.noExtensions = true;
+		parsed.noSkills = true;
+		parsed.noRules = true;
+		parsed.noTools = true;
+		parsed.noLsp = true;
+		let resumedManager: SessionManager | undefined;
+		let reachedSessionCreation = false;
+
+		try {
+			await runRootCommand(parsed, ["--resume", "019e84ed", "--print"], {
+				discoverAuthStorage: async () => authStorage,
+				settings,
+				createAgentSession: async options => {
+					if (!options) throw new Error("Expected session options");
+					resumedManager = options.sessionManager;
+					reachedSessionCreation = true;
+					throw new Error("stop after session options");
+				},
+			});
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== "stop after session options") throw error;
+		} finally {
+			authStorage.close();
+			await resumedManager?.close();
+		}
+
+		expect(reachedSessionCreation).toBe(true);
+		expect(getProjectDir()).toBe(resumedProject);
+		expect(process.cwd()).toBe(resumedProject);
+		expect(reloadForCwd).toHaveBeenCalledWith(resumedProject);
+		expect(resumedManager?.getCwd()).toBe(resumedProject);
+	}, 15_000);
 });
 
 describe("createSessionManager — cross-project --resume relocation (moved worktree)", () => {
@@ -112,18 +183,14 @@ describe("createSessionManager — cross-project --resume relocation (moved work
 		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(buildGlobalMatch(missingProject));
 		expect(fs.existsSync(missingProject)).toBe(false);
 
-		const forkPrompt = vi.fn(async () => "accepted" as const);
 		const result = await createSessionManager(
 			buildArgs("019e84ed"),
 			"/current/project",
 			stubSettings,
-			forkPrompt,
 			async () => "declined" as const,
 		);
 
 		expect(result).toBeUndefined();
-		// The fork prompt must NOT be used for a relocated (gone-dir) session.
-		expect(forkPrompt).not.toHaveBeenCalled();
 	});
 
 	it("throws the move-specific error when unavailable in non-interactive mode", async () => {
@@ -170,13 +237,11 @@ describe("createSessionManager — cross-project --resume relocation (moved work
 			session: sessionInfo,
 		});
 
-		const forkPrompt = vi.fn(async () => "accepted" as const);
 		const movePrompt = vi.fn(async () => "accepted" as const);
 		const result = await createSessionManager(
 			buildArgs(resumePrefix, explicitSessionDir),
 			currentProject,
 			stubSettings,
-			forkPrompt,
 			movePrompt,
 		);
 
@@ -196,7 +261,6 @@ describe("createSessionManager — cross-project --resume relocation (moved work
 		} finally {
 			await result.close();
 		}
-		expect(forkPrompt).not.toHaveBeenCalled();
 		expect(movePrompt).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/main-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-project-resume.test.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import { type Args, parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
 import * as modelResolverModule from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as pluginHelpers from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { createSessionManager, runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { SessionHeader } from "@oh-my-pi/pi-coding-agent/session/session-entries";
@@ -125,11 +126,18 @@ describe("runRootCommand — cross-project --resume", () => {
 		await fsp.rm(root, { recursive: true, force: true });
 	});
 
-	it("switches process and settings scope to the resumed session before session creation", async () => {
+	it("preloads the destination plugin roots and re-scopes before session creation", async () => {
 		const match = buildGlobalMatch(resumedProject);
 		vi.spyOn(sessionListingModule, "resolveResumableSession").mockResolvedValue(match);
 		const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
 		const reloadForCwd = vi.spyOn(settings, "reloadForCwd");
+		// The switch must warm the destination roots via the shared preload helper
+		// (clearPluginRootsAndCaches only fires an unawaited re-warm), so record the
+		// cwds it is invoked with.
+		const preloadedCwds: (string | undefined)[] = [];
+		vi.spyOn(pluginHelpers, "preloadPluginRoots").mockImplementation(async (_home, cwd) => {
+			preloadedCwds.push(cwd);
+		});
 		const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
 		const parsed = parseArgs(["--resume", "019e84ed", "--print"]);
 		parsed.noExtensions = true;
@@ -138,7 +146,7 @@ describe("runRootCommand — cross-project --resume", () => {
 		parsed.noTools = true;
 		parsed.noLsp = true;
 		let resumedManager: SessionManager | undefined;
-		let reachedSessionCreation = false;
+		let preloadedDestinationAtCreation = false;
 
 		try {
 			await runRootCommand(parsed, ["--resume", "019e84ed", "--print"], {
@@ -147,7 +155,9 @@ describe("runRootCommand — cross-project --resume", () => {
 				createAgentSession: async options => {
 					if (!options) throw new Error("Expected session options");
 					resumedManager = options.sessionManager;
-					reachedSessionCreation = true;
+					// Awaited during the switch, so by session creation the destination
+					// preload has already been requested for the resumed project.
+					preloadedDestinationAtCreation = preloadedCwds.includes(resumedProject);
 					throw new Error("stop after session options");
 				},
 			});
@@ -158,11 +168,11 @@ describe("runRootCommand — cross-project --resume", () => {
 			await resumedManager?.close();
 		}
 
-		expect(reachedSessionCreation).toBe(true);
 		expect(getProjectDir()).toBe(resumedProject);
 		expect(process.cwd()).toBe(resumedProject);
 		expect(reloadForCwd).toHaveBeenCalledWith(resumedProject);
 		expect(resumedManager?.getCwd()).toBe(resumedProject);
+		expect(preloadedDestinationAtCreation).toBe(true);
 	}, 15_000);
 
 	it("re-resolves the model scope from the resumed project's enabledModels after the switch", async () => {


### PR DESCRIPTION
## Repro
From a different cwd than an existing session, `omp --resume <id>` entered the cross-project fork/cancel branch while bare `omp --resume` resumed the same journal in place. The focused reproduction is `cd packages/coding-agent && bun test test/main-cross-project-resume.test.ts --test-name-pattern 'cross-project --resume cancellation'`.

## Cause
`createSessionManager` in `packages/coding-agent/src/main.ts` treated global id matches with an existing, different recorded cwd as implicit fork requests. Unlike the startup picker, that branch never switched `getProjectDir()`, plugin/capability caches, or `Settings` into the session's cwd before `SessionManager.open`.

## Fix
- Remove the implicit fork/cancel branch for explicit session-id resumes and open the matched journal directly.
- Share the startup cwd/settings/plugin/capability re-scope path between explicit-id resumes and picker resumes.
- Preserve the missing-recorded-directory move prompt and update regression coverage for both existing and missing cwd cases.
- Record the fix under the coding-agent changelog's Unreleased section.

## Verification
`cd packages/coding-agent && bun test test/main-cross-project-resume.test.ts test/main-session-resolution-error.test.ts test/main-resume-cancel-exit.test.ts` — 13 passed, 0 failed. `cd packages/coding-agent && bun run check:types` and `bun x biome check src/main.ts test/main-cross-project-resume.test.ts` both passed.

Fixes #6752