### PR TITLE
fix(natives): stopped sort panicking on disconnected receiver

### DIFF
--- a/crates/vendor/uu-sort/src/chunks.rs
+++ b/crates/vendor/uu-sort/src/chunks.rs
@@ -245,7 +245,14 @@ pub fn read<T: Read>(
 			);
 			Ok(ChunkContents { lines, line_data, token_buffer, line_count_hint })
 		});
-		sender.send(payload?).unwrap();
+		// pi-uutils: diverge from upstream, which unwraps the send here and panics
+		// with `SendError(..)` when the receiver has disconnected (issue #6736).
+		// The receiver goes away when the consumer thread (sorter, merger, or
+		// checker) stops early after hitting an error or a closed output. Stop
+		// reading gracefully; the real error is reported by that other thread.
+		if sender.send(payload?).is_err() {
+			return Ok(false);
+		}
 	}
 	Ok(should_continue)
 }
@@ -451,4 +458,39 @@ pub fn parse_into_chunk<'a>(
 		settings,
 	);
 	ChunkContents { lines, line_data, token_buffer, line_count_hint }
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter;
+
+	use super::*;
+
+	/// Regression test for issue #6736: when the receiving end of the chunk
+	/// channel has disconnected (the consumer thread stopped early), `read`
+	/// must stop gracefully and report end-of-input instead of panicking on
+	/// `SendError`.
+	#[test]
+	fn read_stops_gracefully_when_receiver_disconnected() {
+		let (sender, receiver) = flume::bounded::<Chunk>(1);
+		drop(receiver);
+
+		let settings = GlobalSettings::default();
+		let mut carry_over = Vec::new();
+		let mut input: &[u8] = b"c\na\nb\n";
+
+		let should_continue = read(
+			&sender,
+			RecycledChunk::new(64 * 1024),
+			None,
+			&mut carry_over,
+			&mut input,
+			&mut iter::empty::<UResult<&[u8]>>(),
+			b'\n',
+			&settings,
+		)
+		.expect("read must not error on a disconnected receiver");
+
+		assert!(!should_continue);
+	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the native `sort` builtin panicking with `SendError(..)` at `chunks.rs:248` when the chunk-channel receiver disconnected early (e.g. a consumer thread stopping after an error or closed output); the reader now stops gracefully instead of unwrapping the failed send ([#6736](https://github.com/can1357/oh-my-pi/issues/6736)).
+
 ## [17.1.4] - 2026-07-26
 
 ### Added


### PR DESCRIPTION
## Repro

With the upstream `sender.send(payload?).unwrap()` restored at `crates/vendor/uu-sort/src/chunks.rs:248`, run `cargo test -p uu_sort --lib chunks::tests`; the regression test drives `chunks::read` against a dropped receiver and fails with the reported `called Result::unwrap() on an Err value: "SendError(..)"` panic at line 248.

## Cause

`chunks::read` unconditionally unwrapped the chunk-channel send. When a sorter, merger, or checker consumer stopped early after an error or closed output, its receiver disconnected and the reader thread panicked instead of shutting down; `crates/vendor/uu-sort/src/ext_sort/threaded.rs` already treats the same disconnection as normal early shutdown.

## Fix

- Stop chunk reading gracefully with `Ok(false)` when the receiver has disconnected instead of unwrapping the failed send.
- Add a regression test covering a dropped chunk receiver.
- Document the native `sort` crash fix in the natives changelog.

## Verification

`cargo test -p uu_sort` — 29 passed, 0 failed. The regression test fails with the exact reported panic against the old code and passes with this change.

Fixes #6736