### PR TITLE
fix(ai): finalize all prepared statements in SqliteAuthCredentialStore.close()

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `SqliteAuthCredentialStore.close()` leaking eight prepared statements (`updateIfMatches`, `updateIfMatchesWithLease`, `deleteIfMatchesWithLease`, `deleteCachePrefix`, and the four credential-refresh-lease statements), which kept the SQLite connection alive after `close()`. On Windows the auth DB and its `-wal`/`-shm` files stayed locked, so temp-dir cleanup intermittently failed with `EBUSY`; on POSIX the handle leaked silently.
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -7923,6 +7923,14 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#updateUsageHistoryStmt.finalize();
 		this.#insertUsageCostStmt.finalize();
 		this.#listUsageCostsStmt.finalize();
+		this.#updateIfMatchesStmt.finalize();
+		this.#updateIfMatchesWithLeaseStmt.finalize();
+		this.#deleteIfMatchesWithLeaseStmt.finalize();
+		this.#deleteCachePrefixStmt.finalize();
+		this.#acquireCredentialRefreshLeaseStmt.finalize();
+		this.#getCredentialRefreshLeaseStmt.finalize();
+		this.#renewCredentialRefreshLeaseStmt.finalize();
+		this.#releaseCredentialRefreshLeaseStmt.finalize();
 		this.#db.close();
 	}
 }


### PR DESCRIPTION
Fixed a sneaky leakage in auth DB. 

## What changed

`SqliteAuthCredentialStore.close()` finalized 26 of its 34 cached prepared statements. Eight were never finalized:

- `#updateIfMatchesStmt`
- `#updateIfMatchesWithLeaseStmt`
- `#deleteIfMatchesWithLeaseStmt`
- `#deleteCachePrefixStmt`
- `#acquireCredentialRefreshLeaseStmt`
- `#getCredentialRefreshLeaseStmt`
- `#renewCredentialRefreshLeaseStmt`
- `#releaseCredentialRefreshLeaseStmt`

An unfinalized statement holds the SQLite connection open, so `this.#db.close()` did not release the underlying file handles. This adds the eight missing `finalize()` calls.

On Windows the auth DB and its `-wal`/`-shm` sidecars stayed locked after `close()`, so `removeWithRetries()` (`packages/utils/src/temp.ts`, 40 × 50 ms = 2 s budget) exhausted its retries and temp-dir cleanup failed with `EBUSY`. On POSIX the same leak is silent, because open files can be unlinked — which is why CI (`ubuntu-22.04` / `macos-14`) never surfaced it.

This is the same class of bug as 14252e71c ("SQLite handle leaks"), which fixed the one-off inline `this.#db.prepare()` sites but not these cached fields.

## Reproduction

Standalone script, no test harness:

```ts
import * as fs from "node:fs/promises";
import * as os from "node:os";
import * as path from "node:path";
import { SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";

for (let run = 0; run < 8; run++) {
	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-lock-"));
	const store = await SqliteAuthCredentialStore.open(path.join(dir, "agent.db"));
	store.close();

	const start = Date.now();
	let released = false;
	for (let i = 0; i < 40; i++) {
		// 40 x 50ms = 2s, matching removeWithRetries() in packages/utils/src/temp.ts
		try {
			await fs.rm(dir, { recursive: true, force: true });
			released = true;
			break;
		} catch {
			await Bun.sleep(50);
		}
	}
	const held = `${Date.now() - start}ms`;
	if (released) console.log(`run ${run}: released after ${held}`);
	else console.log(`run ${run}: STILL LOCKED after ${held}; left behind ${JSON.stringify(await fs.readdir(dir))}`);
}
```

On pristine `upstream/main` (`403931b96`), Windows 10 19045, Bun 1.3.14 — the leak is intermittent, not deterministic:

```
run 0: released after 340ms
run 1: released after 321ms
run 2: STILL LOCKED after 2475ms; left behind ["agent.db","agent.db-shm","agent.db-wal"]
run 3: released after 187ms
run 4: released after 382ms
run 5: STILL LOCKED after 2475ms; left behind ["agent.db","agent.db-shm","agent.db-wal"]
run 6: released after 193ms
run 7: STILL LOCKED after 2649ms; left behind ["agent.db","agent.db-shm","agent.db-wal"]
```

With this commit, same machine, same script:

```
run 0: released after 1ms
run 1: released after 1ms
run 2: released after 1ms
run 3: released after 0ms
run 4: released after 1ms
run 5: released after 1ms
run 6: released after 0ms
run 7: released after 1ms
```

Lingering `-wal`/`-shm` after `close()` is the signature of an unreleased connection. Note also that even the "released" runs took 187–382 ms before the fix versus ~1 ms after, so the handle was being dropped late by GC rather than by `close()`.

The runtime itself is not at fault — raw `bun:sqlite` releases immediately in every configuration:

```
no-WAL:                      released after 4ms
WAL, plain close:            released after 0ms
WAL, checkpoint + close(true): released after 2ms
```

## Verification

Measured on this branch, reverting/restoring only `packages/ai/src/auth-storage.ts`:

| `packages/ai` tests | before | after |
|---|---|---|
| `remote-auth-store` + `auth-broker-wire` + `auth-storage-sqlite-busy` | 40 fail | **0 fail** (45 pass) |

Every one of those 40 failures was in `afterEach` teardown, masking assertions that already passed. Wall time for those three files drops from ~111 s (mostly retry backoff) to ~4 s.

`cd packages/ai && bun run check` (biome + tsgo) passes.

Ran on Windows only — I do not have a Linux or macOS box to hand, so the POSIX side of this is reasoned from the diff rather than measured. CI covers it.
