### PR TITLE
fix(cli): preserve live task-isolation sandboxes on worktree clear

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp worktree clear` (without `--all`) deleting task-isolation sandboxes owned by subagents that are still running, discarding their uncaptured work; the `no live task owns it` reason was set from the mere presence of the `m` mount dir with no ownership check. `ensureIsolation` now writes a pid-stamped ownership marker into each sandbox and `worktree list`/`clear` report a sandbox as `live` (never removed without `--all`) while its owning process is alive, reclaiming only crashed leftovers ([#6761](https://github.com/can1357/oh-my-pi/issues/6761)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `omp worktree clear` (without `--all`) deleting task-isolation sandboxes owned by subagents that are still running, discarding their uncaptured work; the `no live task owns it` reason was set from the mere presence of the `m` mount dir with no ownership check. `ensureIsolation` now writes a pid-stamped ownership marker into each sandbox and `worktree list`/`clear` report a sandbox as `live` (never removed without `--all`) while its owning process is alive, reclaiming only crashed leftovers ([#6761](https://github.com/can1357/oh-my-pi/issues/6761)).
+- Fixed `omp worktree clear` (without `--all`) deleting task-isolation sandboxes owned by subagents that are still running, discarding their uncaptured work; the `no live task owns it` reason was set from the mere presence of the `m` mount dir with no ownership check. `ensureIsolation` now writes an ownership marker (pid plus a process start-time token that survives pid reuse) into each sandbox, and `worktree list`/`clear` report a sandbox as `live` (never removed without `--all`) while its owning process is alive, reclaiming only crashed leftovers ([#6761](https://github.com/can1357/oh-my-pi/issues/6761)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -8,8 +8,10 @@
  *     `<parent-repo>/.git/worktrees/<name>/`.
  *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
  *     compact `m` subdir mounted/cloned by `natives.isoStart`. Legacy `merged`
- *     subdirs are still recognized. These are ephemeral; `ensureIsolation`
- *     removes the base before re-creating it, so leftovers are crashed runs.
+ *     subdirs are still recognized. `ensureIsolation` writes an ownership
+ *     marker naming the live omp process; a
+ *     sandbox whose owner is still running is reported `live` and never
+ *     removed without `--all`, so `clear` reclaims only crashed leftovers.
  *
  * Legacy entries from before the encoding change keep working because git still
  * tracks them by branch name. This command exists to GC them on demand.
@@ -18,6 +20,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getWorktreesDir, isEnoent } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
+import { hasLiveIsolationOwner } from "../task/isolation-ownership";
 import * as git from "../utils/git";
 
 type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
@@ -214,10 +217,13 @@ async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
 	for (const mountDir of TASK_ISOLATION_MOUNT_DIRS) {
 		const mountStat = await fs.stat(path.join(dir, mountDir)).catch(() => null);
 		if (!mountStat?.isDirectory()) continue;
+		const live = await hasLiveIsolationOwner(dir);
 		return {
 			path: dir,
 			kind: "task-isolation",
-			orphanReason: "task-isolation leftover (no live task owns it)",
+			// Only after confirming no live owner is the "no live task" claim true.
+			// A running subagent's sandbox stays live so `clear` won't delete it.
+			orphanReason: live ? undefined : "task-isolation leftover (no live task owns it)",
 		};
 	}
 	return null;

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -20,7 +20,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getWorktreesDir, isEnoent } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
-import { hasLiveIsolationOwner } from "../task/isolation-ownership";
+import { hasLiveIsolationOwner, ISOLATION_OWNER_FILE } from "../task/isolation-ownership";
 import * as git from "../utils/git";
 
 type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
@@ -214,19 +214,30 @@ async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
 	if (gitStat?.isFile()) {
 		return classifyPrCheckout(dir, gitEntry);
 	}
-	for (const mountDir of TASK_ISOLATION_MOUNT_DIRS) {
-		const mountStat = await fs.stat(path.join(dir, mountDir)).catch(() => null);
-		if (!mountStat?.isDirectory()) continue;
-		const live = await hasLiveIsolationOwner(dir);
-		return {
-			path: dir,
-			kind: "task-isolation",
-			// Only after confirming no live owner is the "no live task" claim true.
-			// A running subagent's sandbox stays live so `clear` won't delete it.
-			orphanReason: live ? undefined : "task-isolation leftover (no live task owns it)",
-		};
+	// A task-isolation sandbox is identified by its ownership marker — written
+	// before the backend materialises the mount — or by the `m`/`merged` mount
+	// dir itself (legacy dirs and crashed pre-marker runs). Recognizing the
+	// marker alone keeps an in-progress sandbox from being mistaken for a stray
+	// during the window between marker creation and mount materialisation.
+	let isIsolation = await Bun.file(path.join(dir, ISOLATION_OWNER_FILE)).exists();
+	if (!isIsolation) {
+		for (const mountDir of TASK_ISOLATION_MOUNT_DIRS) {
+			const mountStat = await fs.stat(path.join(dir, mountDir)).catch(() => null);
+			if (mountStat?.isDirectory()) {
+				isIsolation = true;
+				break;
+			}
+		}
 	}
-	return null;
+	if (!isIsolation) return null;
+	const live = await hasLiveIsolationOwner(dir);
+	return {
+		path: dir,
+		kind: "task-isolation",
+		// Only after confirming no live owner is the "no live task" claim true.
+		// A running subagent's sandbox stays live so `clear` won't delete it.
+		orphanReason: live ? undefined : "task-isolation leftover (no live task owns it)",
+	};
 }
 
 async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {

--- a/packages/coding-agent/src/task/isolation-ownership.ts
+++ b/packages/coding-agent/src/task/isolation-ownership.ts
@@ -7,6 +7,7 @@
  * subagent's sandbox from a crashed run's leftover instead of deleting both.
  */
 import * as path from "node:path";
+import { $ } from "bun";
 
 /** Marker file written into a task-isolation base dir identifying its owner. */
 export const ISOLATION_OWNER_FILE = ".omp-isolation-owner.json";
@@ -17,6 +18,43 @@ export interface IsolationOwner {
 	pid: number;
 	/** Task id the sandbox was materialised for. */
 	id: string;
+	/**
+	 * Process-instance start-time token for {@link pid}, when the OS can report
+	 * it. Distinguishes the owning process from an unrelated process that later
+	 * inherits a recycled pid, so a crashed sandbox is never pinned live.
+	 */
+	startToken?: string;
+}
+
+/**
+ * Boot-stable start-time token for `pid`, or `null` when the process is gone or
+ * the platform cannot report it. Read from the same source on write and
+ * validate so an exact string compare rejects a recycled pid.
+ *
+ * Linux reads `/proc/<pid>/stat` field 22 (start time in clock ticks since
+ * boot); other Unixes shell out to `ps -o lstart`. Platforms that report
+ * neither (e.g. Windows) yield `null`, degrading to a pid-only liveness check.
+ */
+async function processStartToken(pid: number): Promise<string | null> {
+	if (process.platform === "linux") {
+		let stat: string;
+		try {
+			stat = await Bun.file(`/proc/${pid}/stat`).text();
+		} catch {
+			return null;
+		}
+		// The comm field (2) may embed spaces and parens, so parse the numeric
+		// fields after the final ')'. `starttime` is field 22 overall, i.e. the
+		// 20th token once `pid` and `(comm)` are dropped.
+		const commEnd = stat.lastIndexOf(")");
+		if (commEnd < 0) return null;
+		const starttime = stat.slice(commEnd + 2).split(" ")[19];
+		return starttime && starttime.length > 0 ? starttime : null;
+	}
+	const res = await $`ps -o lstart= -p ${pid}`.quiet().nothrow();
+	if (res.exitCode !== 0) return null;
+	const started = res.text().trim();
+	return started.length > 0 ? started : null;
 }
 
 /**
@@ -26,7 +64,8 @@ export interface IsolationOwner {
  * `omp worktree clear` never sees an owner-less sandbox mid-creation.
  */
 export async function writeIsolationOwner(baseDir: string, id: string): Promise<void> {
-	const owner: IsolationOwner = { pid: process.pid, id };
+	const startToken = await processStartToken(process.pid);
+	const owner: IsolationOwner = { pid: process.pid, id, ...(startToken ? { startToken } : {}) };
 	await Bun.write(path.join(baseDir, ISOLATION_OWNER_FILE), JSON.stringify(owner));
 }
 
@@ -37,7 +76,9 @@ export async function writeIsolationOwner(baseDir: string, id: string): Promise<
  * sandbox from before markers existed, both safe to reclaim. `process.kill(pid,
  * 0)` can fail with `EPERM` even when the process is alive, so only an explicit
  * `ESRCH` ("no such process") counts as dead; any other error is treated as
- * alive to avoid deleting a sandbox that is actually in use.
+ * alive to avoid deleting a sandbox that is actually in use. When the marker
+ * carries a {@link IsolationOwner.startToken}, a live pid whose current token no
+ * longer matches is a recycled pid — a different process — and counts as dead.
  */
 export async function hasLiveIsolationOwner(baseDir: string): Promise<boolean> {
 	let decoded: unknown;
@@ -51,8 +92,15 @@ export async function hasLiveIsolationOwner(baseDir: string): Promise<boolean> {
 	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
 	try {
 		process.kill(pid, 0);
-		return true;
 	} catch (err) {
-		return (err as NodeJS.ErrnoException).code !== "ESRCH";
+		if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
 	}
+	// The pid is live (or unknowable via EPERM). Reject a recycled pid: if the
+	// marker pinned the owner's start-time token, the process wearing that pid
+	// now must still present the same token.
+	if ("startToken" in decoded && typeof decoded.startToken === "string" && decoded.startToken.length > 0) {
+		const current = await processStartToken(pid);
+		if (current !== null && current !== decoded.startToken) return false;
+	}
+	return true;
 }

--- a/packages/coding-agent/src/task/isolation-ownership.ts
+++ b/packages/coding-agent/src/task/isolation-ownership.ts
@@ -1,0 +1,58 @@
+/**
+ * Ownership marker for task-isolation sandboxes under `~/.omp/wt/`.
+ *
+ * Each isolation base dir (`ensureIsolation` in {@link ./worktree}) holds a
+ * compact `m` mount plus this marker file naming the omp process that created
+ * it. `omp worktree clear` consults the marker so it can distinguish a live
+ * subagent's sandbox from a crashed run's leftover instead of deleting both.
+ */
+import * as path from "node:path";
+
+/** Marker file written into a task-isolation base dir identifying its owner. */
+export const ISOLATION_OWNER_FILE = ".omp-isolation-owner.json";
+
+/** Recorded owner of a task-isolation sandbox. */
+export interface IsolationOwner {
+	/** PID of the omp process that created and owns the sandbox. */
+	pid: number;
+	/** Task id the sandbox was materialised for. */
+	id: string;
+}
+
+/**
+ * Record the current process as owner of the sandbox rooted at `baseDir`.
+ *
+ * Written before the isolation backend materialises `m` so a concurrent
+ * `omp worktree clear` never sees an owner-less sandbox mid-creation.
+ */
+export async function writeIsolationOwner(baseDir: string, id: string): Promise<void> {
+	const owner: IsolationOwner = { pid: process.pid, id };
+	await Bun.write(path.join(baseDir, ISOLATION_OWNER_FILE), JSON.stringify(owner));
+}
+
+/**
+ * Whether a live omp process still owns the sandbox at `baseDir`.
+ *
+ * A missing or malformed marker means no verifiable owner — a crashed run or a
+ * sandbox from before markers existed, both safe to reclaim. `process.kill(pid,
+ * 0)` can fail with `EPERM` even when the process is alive, so only an explicit
+ * `ESRCH` ("no such process") counts as dead; any other error is treated as
+ * alive to avoid deleting a sandbox that is actually in use.
+ */
+export async function hasLiveIsolationOwner(baseDir: string): Promise<boolean> {
+	let decoded: unknown;
+	try {
+		decoded = await Bun.file(path.join(baseDir, ISOLATION_OWNER_FILE)).json();
+	} catch {
+		return false;
+	}
+	if (typeof decoded !== "object" || decoded === null || !("pid" in decoded)) return false;
+	const pid = decoded.pid;
+	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code !== "ESRCH";
+	}
+}

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -6,6 +6,7 @@ import * as natives from "@oh-my-pi/pi-natives";
 import { getWorktreeDir, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import * as git from "../utils/git";
 import * as jj from "../utils/jj";
+import { writeIsolationOwner } from "./isolation-ownership";
 import { mapWithConcurrencyLimit } from "./parallel";
 
 const { IsoBackendKind } = natives;
@@ -434,6 +435,13 @@ export async function ensureIsolation(
 
 	for (const candidate of candidates) {
 		await fs.rm(baseDir, { recursive: true, force: true });
+		// Claim ownership before the backend materialises `m`. Backends only
+		// create/replace `mergedDir` (and overlay upper/work), never the base
+		// dir, so the marker survives `isoStart` — and a concurrent
+		// `omp worktree clear` never sees this sandbox without a live owner,
+		// even while a large clone is still in progress.
+		await fs.mkdir(baseDir, { recursive: true });
+		await writeIsolationOwner(baseDir, id);
 		try {
 			await natives.isoStart(candidate, repoRoot, mergedDir);
 			// Sever the isolation's git metadata from the source checkout. Copy

--- a/packages/coding-agent/test/cli/worktree-clear-isolation.test.ts
+++ b/packages/coding-agent/test/cli/worktree-clear-isolation.test.ts
@@ -57,6 +57,12 @@ describe("worktree clear task-isolation ownership", () => {
 		const corrupt = await makeSandbox("tbad00004");
 		await Bun.write(path.join(corrupt, ISOLATION_OWNER_FILE), "{ not json");
 
+		// Setup race: marker written before the backend materialises `m`. The
+		// dir holds only the live-owner marker and no mount yet.
+		const pending = path.join(base, "tpend0005");
+		await fs.mkdir(pending, { recursive: true });
+		await writeIsolationOwner(pending, "pend0005");
+
 		await clearWorktrees({ all: false, dryRun: false, json: true });
 
 		const exists = async (p: string): Promise<boolean> =>
@@ -68,5 +74,6 @@ describe("worktree clear task-isolation ownership", () => {
 		expect(await exists(dead)).toBe(false);
 		expect(await exists(orphan)).toBe(false);
 		expect(await exists(corrupt)).toBe(false);
+		expect(await exists(pending)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/cli/worktree-clear-isolation.test.ts
+++ b/packages/coding-agent/test/cli/worktree-clear-isolation.test.ts
@@ -63,6 +63,14 @@ describe("worktree clear task-isolation ownership", () => {
 		await fs.mkdir(pending, { recursive: true });
 		await writeIsolationOwner(pending, "pend0005");
 
+		// Recycled pid: the crashed owner's pid was reassigned to this live test
+		// process, but the recorded start-time token no longer matches.
+		const recycled = await makeSandbox("trecyc06");
+		await Bun.write(
+			path.join(recycled, ISOLATION_OWNER_FILE),
+			JSON.stringify({ pid: process.pid, id: "recyc06", startToken: "not-the-current-token" }),
+		);
+
 		await clearWorktrees({ all: false, dryRun: false, json: true });
 
 		const exists = async (p: string): Promise<boolean> =>
@@ -75,5 +83,6 @@ describe("worktree clear task-isolation ownership", () => {
 		expect(await exists(orphan)).toBe(false);
 		expect(await exists(corrupt)).toBe(false);
 		expect(await exists(pending)).toBe(true);
+		expect(await exists(recycled)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/cli/worktree-clear-isolation.test.ts
+++ b/packages/coding-agent/test/cli/worktree-clear-isolation.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearWorktrees } from "@oh-my-pi/pi-coding-agent/cli/worktree-cli";
+import { ISOLATION_OWNER_FILE, writeIsolationOwner } from "@oh-my-pi/pi-coding-agent/task/isolation-ownership";
+import { setWorktreesDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression for #6761: `omp worktree clear` (no `--all`) must delete only
+ * task-isolation sandboxes whose owner process is gone. A sandbox owned by a
+ * live omp process holds a running subagent's uncaptured work and must survive.
+ */
+describe("worktree clear task-isolation ownership", () => {
+	let base: string;
+	let savedEnv: string | undefined;
+
+	beforeEach(async () => {
+		base = await fs.mkdtemp(path.join(os.tmpdir(), "omp-wt-clear-"));
+		savedEnv = process.env.OMP_WORKTREE_DIR;
+		delete process.env.OMP_WORKTREE_DIR;
+		setWorktreesDir(base);
+		vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(async () => {
+		setWorktreesDir(undefined);
+		if (savedEnv === undefined) delete process.env.OMP_WORKTREE_DIR;
+		else process.env.OMP_WORKTREE_DIR = savedEnv;
+		vi.restoreAllMocks();
+		await fs.rm(base, { recursive: true, force: true });
+	});
+
+	async function makeSandbox(name: string): Promise<string> {
+		const dir = path.join(base, name);
+		await fs.mkdir(path.join(dir, "m"), { recursive: true });
+		await Bun.write(path.join(dir, "m", "work.txt"), "uncaptured\n");
+		return dir;
+	}
+
+	/** A pid that has been spawned and reaped, so `kill(pid, 0)` reports ESRCH. */
+	async function deadPid(): Promise<number> {
+		const proc = Bun.spawn(["true"], { stdout: "ignore", stderr: "ignore" });
+		await proc.exited;
+		return proc.pid;
+	}
+
+	it("keeps live-owned sandboxes and reclaims dead/markerless/corrupt ones", async () => {
+		const live = await makeSandbox("tlive0001");
+		await writeIsolationOwner(live, "live0001"); // marker names this test process
+
+		const dead = await makeSandbox("tdead0002");
+		await Bun.write(path.join(dead, ISOLATION_OWNER_FILE), JSON.stringify({ pid: await deadPid(), id: "dead0002" }));
+
+		const orphan = await makeSandbox("tnone0003"); // no marker at all (crashed pre-marker run)
+
+		const corrupt = await makeSandbox("tbad00004");
+		await Bun.write(path.join(corrupt, ISOLATION_OWNER_FILE), "{ not json");
+
+		await clearWorktrees({ all: false, dryRun: false, json: true });
+
+		const exists = async (p: string): Promise<boolean> =>
+			await fs.stat(p).then(
+				() => true,
+				() => false,
+			);
+		expect(await Bun.file(path.join(live, "m", "work.txt")).exists()).toBe(true);
+		expect(await exists(dead)).toBe(false);
+		expect(await exists(orphan)).toBe(false);
+		expect(await exists(corrupt)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
`omp worktree clear` without `--all` is advertised as removing only orphaned entries, but it deletes every task-isolation dir under the worktree base — including sandboxes owned by subagents running right now. Driving `listWorktrees` + `clearWorktrees({all:false})` against a base holding `tdeadbeef1/m/agent-work-in-progress.txt` classifies the dir `orphaned  task-isolation leftover (no live task owns it)` and removes it, destroying the file, even though nothing checked for a live owner.

## Cause
`classifyDir` in `packages/coding-agent/src/cli/worktree-cli.ts` set `orphanReason` from the mere presence of the `m`/`merged` mount dir — no pid, lock, or registry was consulted, so the "no live task owns it" string was never true. `clearWorktrees` removes anything with an `orphanReason` even without `--all`, making the default invocation destructive for in-flight isolated tasks (in patch-merge mode the delta is captured only at the end, so everything since the baseline is lost).

## Fix
- Add `packages/coding-agent/src/task/isolation-ownership.ts`: an ownership marker (`.omp-isolation-owner.json`, pid + task id) with `writeIsolationOwner` and a `hasLiveIsolationOwner` probe that treats only `ESRCH` as dead (an `EPERM` from `process.kill(pid, 0)` still counts as alive, so a sandbox in use is never reaped).
- `ensureIsolation` (`task/worktree.ts`) writes the marker into the base dir *before* `isoStart` materialises `m`. Backends only create/replace `merged` (and overlay upper/work), never the base dir, so the marker survives the clone and closes the setup-race window.
- `classifyDir` now only marks a task-isolation dir orphaned after `hasLiveIsolationOwner` confirms no live owner; live sandboxes report `live` and are never removed without `--all`. Module doc corrected accordingly.

## Verification
`bun test packages/coding-agent/test/cli/worktree-clear-isolation.test.ts packages/coding-agent/test/task/worktree.test.ts` → 41 pass. The new test creates live-owner, dead-owner (spawned-and-reaped pid), markerless, and corrupt-marker sandboxes and asserts `clear` keeps only the live one. Manually re-ran the original repro: the live-owner sandbox and its uncaptured file survive `clear` while the dead-owner leftover is still reclaimed. Pre-publish `bun check` passed.

Fixes #6761