### PR TITLE
feat(update): hardened binary installs and added JSON checks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `omp update --check --json`, returning the current and latest versions plus every non-deprecated stable npm release in between, with publication timestamps and release-note links ([#6766](https://github.com/can1357/oh-my-pi/pull/6766)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added
@@ -200,6 +204,7 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
+### Added
 
 ## [17.1.5] - 2026-07-27
 
@@ -272,7 +277,7 @@
 - Corrected Windows shell resolution errors to identify the active global, project, overlay, or runtime source for `shellPath`, including profile and custom configuration directories, instead of directing every user to the retired `settings.json` file ([#6579](https://github.com/can1357/oh-my-pi/issues/6579)).
 - Fixed `debug` (js-debug/`pwa-node`) stateful commands misrouting after launch: a lazily-attached `[worker N]` child session (or the threadless root launcher) would steal the active-session focus from the stopped script child, so `threads` listed only the worker thread, post-launch breakpoints read back as pending/unbound, and there was no way to step/continue/evaluate the script's thread. Focus now follows stops rather than registrations, and `threads` aggregates every live thread across the session tree ([#6663](https://github.com/can1357/oh-my-pi/issues/6663)).
 - Fixed a turn-ending provider error being truncated to 8 lines in the transcript with no way to reveal the rest: `AssistantMessageComponent` now implements `setExpanded`, so Ctrl+O (tool-output expansion) reveals the full error body and the collapsed view shows a `… +N more lines (Ctrl+O to expand)` hint ([#6555](https://github.com/can1357/oh-my-pi/issues/6555)).
-- Fixed direct binary updates trusting an executable that only reported the expected version. The updater now selects one exact asset from the tagged GitHub release, requires its published SHA-256 digest and size, and verifies both while streaming the download before installation. GitHub release metadata requests use `GITHUB_TOKEN` or `GH_TOKEN` when available, allowing users behind an exhausted anonymous rate limit to authenticate.
+- Fixed direct binary updates trusting an executable that only reported the expected version. The updater now selects one exact asset from the tagged GitHub release, requires its published SHA-256 digest and size, and verifies both while streaming the download before installation. GitHub release metadata requests use `GITHUB_TOKEN` or `GH_TOKEN` when available, allowing users behind an exhausted anonymous rate limit to authenticate ([#6557](https://github.com/can1357/oh-my-pi/pull/6557)).
 - Documented that the non-PTY shell's bundled `jq` command is backed by jaq, including its null-indexing divergence and portable filter syntax ([#6614](https://github.com/can1357/oh-my-pi/issues/6614)).
 - Fixed `omp://tools/task.md` and `omp://tools/eval.md` drifting from the 17.1.3 runtime: `task.md` claimed subagents force-disable `async.enabled`/`bash.autoBackground.enabled` (both are inherited from the parent since 17.1.0) and omitted the `task` tool's `effort` parameter, and `eval.md` omitted the still-working eval `agent(model=…)` per-call model selector ([#6594](https://github.com/can1357/oh-my-pi/issues/6594)).
 - Fixed advisor retry amplification after transient Codex SSE socket closures by limiting each advisor-level try to one provider transport attempt.

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -33,7 +33,9 @@ const MISE_TOOL = "github:can1357/oh-my-pi";
  */
 const NPM_REGISTRY = "https://registry.npmjs.org/";
 const GITHUB_API = "https://api.github.com";
+const RELEASE_NOTES_BASE_URL = `https://github.com/${REPO}/releases/tag`;
 const RELEASE_METADATA_TIMEOUT_MS = 30_000;
+const RELEASE_HISTORY_TIMEOUT_MS = 60_000;
 const BINARY_DOWNLOAD_TIMEOUT_MS = 15 * 60_000;
 
 /**
@@ -66,6 +68,32 @@ function currentNativeTag(): string {
 interface ReleaseInfo {
 	tag: string;
 	version: string;
+}
+
+export interface UpdateCheckRelease {
+	version: string;
+	tag: string;
+	publishedAt: string | null;
+	releaseNotesUrl: string;
+}
+
+export interface UpdateCheckReport {
+	status: "ok";
+	schemaVersion: 1;
+	currentVersion: string;
+	latestVersion: string;
+	updateAvailable: boolean;
+	releases: UpdateCheckRelease[];
+}
+
+export interface UpdateCheckError {
+	status: "error";
+	schemaVersion: 1;
+	error: string;
+}
+
+export function createUpdateCheckError(error: string): UpdateCheckError {
+	return { status: "error", schemaVersion: 1, error };
 }
 
 export interface ReleaseBinaryAsset {
@@ -133,12 +161,20 @@ export function resolveReleaseBinaryAsset(
 	};
 }
 
-async function getReleaseBinaryAsset(
+export interface ReleaseMetadataOptions {
+	fetchImpl?: Fetch;
+	githubToken?: string;
+	timeoutMs?: number;
+}
+
+export async function getReleaseBinaryAsset(
 	expectedVersion: string,
 	binaryName: string,
-	fetchImpl: Fetch = fetch,
-	githubToken: string | undefined = $env.GITHUB_TOKEN || $env.GH_TOKEN,
+	options: ReleaseMetadataOptions = {},
 ): Promise<ReleaseBinaryAsset> {
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const githubToken = options.githubToken ?? ($env.GITHUB_TOKEN || $env.GH_TOKEN);
+	const timeoutMs = options.timeoutMs ?? RELEASE_METADATA_TIMEOUT_MS;
 	const tag = `v${expectedVersion}`;
 	const headers: Record<string, string> = {
 		Accept: "application/vnd.github+json",
@@ -146,28 +182,28 @@ async function getReleaseBinaryAsset(
 	};
 	if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
 
-	let response: Response;
 	try {
-		response = await fetchImpl(`${GITHUB_API}/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
+		const response = await fetchImpl(`${GITHUB_API}/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
 			headers,
-			signal: withTimeoutSignal(RELEASE_METADATA_TIMEOUT_MS),
+			signal: withTimeoutSignal(timeoutMs),
 		});
+		if ((response.status === 403 && !githubToken) || response.status === 429) {
+			throw new Error(
+				"GitHub API rate limit exceeded while fetching release metadata; retry later or set GITHUB_TOKEN or GH_TOKEN",
+			);
+		}
+		if (!response.ok) {
+			throw new Error(`Failed to fetch GitHub release metadata: ${response.statusText}`);
+		}
+		return resolveReleaseBinaryAsset(await response.json(), tag, binaryName);
 	} catch (err) {
 		if (isTimeoutError(err)) {
-			throw new Error("Timed out fetching GitHub release metadata after 30s", { cause: err });
+			throw new Error(`Timed out fetching GitHub release metadata after ${timeoutMs / 1000}s`, {
+				cause: err,
+			});
 		}
 		throw err;
 	}
-	if ((response.status === 403 && !githubToken) || response.status === 429) {
-		throw new Error(
-			"GitHub API rate limit exceeded while fetching release metadata; retry later or set GITHUB_TOKEN or GH_TOKEN",
-		);
-	}
-	if (!response.ok) {
-		throw new Error(`Failed to fetch GitHub release metadata: ${response.statusText}`);
-	}
-
-	return resolveReleaseBinaryAsset(await response.json(), tag, binaryName);
 }
 
 export interface VerifiedBinaryDownloadOptions {
@@ -193,7 +229,9 @@ export async function downloadVerifiedBinary(options: VerifiedBinaryDownloadOpti
 		});
 	} catch (err) {
 		if (isTimeoutError(err)) {
-			throw new Error("Timed out downloading release binary after 15 minutes", { cause: err });
+			throw new Error(`Timed out downloading release binary after ${BINARY_DOWNLOAD_TIMEOUT_MS / 60_000} minutes`, {
+				cause: err,
+			});
 		}
 		throw err;
 	}
@@ -252,22 +290,6 @@ export interface BinaryReplacementOptions {
 	backupPath: string;
 	expectedVersion: string;
 	verifyInstalledVersion: (expectedVersion: string) => Promise<InstalledVersionVerification>;
-}
-
-/**
- * Parse update subcommand arguments.
- * Returns undefined if not an update command.
- */
-export function parseUpdateArgs(args: string[]): { force: boolean; check: boolean; plugins: boolean } | undefined {
-	if (args.length === 0 || args[0] !== "update") {
-		return undefined;
-	}
-
-	return {
-		force: args.includes("--force") || args.includes("-f"),
-		check: args.includes("--check") || args.includes("-c"),
-		plugins: args.includes("--plugins") || args.includes("-l"),
-	};
 }
 
 async function getBunGlobalBinDir(): Promise<string | undefined> {
@@ -472,48 +494,28 @@ async function resolveUpdateTarget(): Promise<UpdateTarget> {
  * Get the latest release info from the npm registry.
  * Uses npm instead of GitHub API to avoid unauthenticated rate limiting.
  */
-async function getLatestRelease(): Promise<ReleaseInfo> {
-	let response: Response;
+async function getLatestRelease(fetchImpl: Fetch = fetch): Promise<ReleaseInfo> {
 	try {
-		response = await fetch(`${NPM_REGISTRY}${PACKAGE}/latest`, {
+		const response = await fetchImpl(`${NPM_REGISTRY}${PACKAGE}/latest`, {
 			signal: withTimeoutSignal(RELEASE_METADATA_TIMEOUT_MS),
 		});
+		if (!response.ok) {
+			throw new Error(`Failed to fetch release info: ${response.statusText}`);
+		}
+
+		const data = await response.json();
+		if (!isRecord(data) || typeof data.version !== "string" || !STABLE_VERSION_PATTERN.test(data.version)) {
+			throw new Error("Invalid npm latest release metadata");
+		}
+		return { tag: `v${data.version}`, version: data.version };
 	} catch (err) {
 		if (isTimeoutError(err)) {
-			throw new Error("Timed out fetching release info after 30s", { cause: err });
+			throw new Error(`Timed out fetching release info after ${RELEASE_METADATA_TIMEOUT_MS / 1000}s`, {
+				cause: err,
+			});
 		}
 		throw err;
 	}
-	if (!response.ok) {
-		throw new Error(`Failed to fetch release info: ${response.statusText}`);
-	}
-
-	const data = (await response.json()) as { version: string };
-	const version = data.version;
-	const tag = `v${version}`;
-
-	return {
-		tag,
-		version,
-	};
-}
-
-/**
- * Compare semver versions. Returns:
- * - negative if a < b
- * - 0 if a == b
- * - positive if a > b
- */
-function compareVersions(a: string, b: string): number {
-	const pa = a.split(".").map(Number);
-	const pb = b.split(".").map(Number);
-
-	for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-		const na = pa[i] || 0;
-		const nb = pb[i] || 0;
-		if (na !== nb) return na - nb;
-	}
-	return 0;
 }
 
 interface BunInstallCachePruneResult {
@@ -532,40 +534,92 @@ function stripBunCacheVersionSuffix(name: string): string {
 	return metadataIndex === -1 ? name : name.slice(0, metadataIndex);
 }
 
-function compareSemverIdentifier(a: string, b: string): number {
-	const aNumber = /^\d+$/.test(a);
-	const bNumber = /^\d+$/.test(b);
-	if (aNumber && bNumber) return Number(a) - Number(b);
-	if (aNumber) return -1;
-	if (bNumber) return 1;
-	return a.localeCompare(b);
+function compareSemverLikeVersions(a: string, b: string): number {
+	return Bun.semver.order(a, b);
 }
 
-function compareSemverLikeVersions(a: string, b: string): number {
-	const [aCoreWithPrerelease] = a.split("+", 1);
-	const [bCoreWithPrerelease] = b.split("+", 1);
-	const [aCore, aPrerelease] = aCoreWithPrerelease.split("-", 2);
-	const [bCore, bPrerelease] = bCoreWithPrerelease.split("-", 2);
-	const aParts = aCore.split(".");
-	const bParts = bCore.split(".");
-	for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-		const diff = Number(aParts[i] ?? 0) - Number(bParts[i] ?? 0);
-		if (diff !== 0 && Number.isFinite(diff)) return diff;
+const SEMVER_VERSION_PATTERN =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function resolveUpdateCheckReport(metadata: unknown, currentVersion: string): UpdateCheckReport {
+	if (!SEMVER_VERSION_PATTERN.test(currentVersion)) throw new Error("Invalid current version metadata");
+	if (!isRecord(metadata)) throw new Error("Invalid npm package metadata");
+	const distTags = metadata["dist-tags"];
+	const versions = metadata.versions;
+	const publicationTimes = metadata.time;
+	if (!isRecord(distTags) || !isRecord(versions)) throw new Error("Invalid npm package metadata");
+
+	const latestVersion = distTags.latest;
+	const latestManifest = typeof latestVersion === "string" ? versions[latestVersion] : undefined;
+	if (
+		typeof latestVersion !== "string" ||
+		!STABLE_VERSION_PATTERN.test(latestVersion) ||
+		!isRecord(latestManifest) ||
+		typeof latestManifest.deprecated === "string"
+	) {
+		throw new Error("Invalid npm latest release metadata");
 	}
-	if (!aPrerelease && !bPrerelease) return 0;
-	if (!aPrerelease) return 1;
-	if (!bPrerelease) return -1;
-	const aPrereleaseParts = aPrerelease.split(".");
-	const bPrereleaseParts = bPrerelease.split(".");
-	for (let i = 0; i < Math.max(aPrereleaseParts.length, bPrereleaseParts.length); i++) {
-		const aPart = aPrereleaseParts[i];
-		const bPart = bPrereleaseParts[i];
-		if (aPart === undefined) return -1;
-		if (bPart === undefined) return 1;
-		const diff = compareSemverIdentifier(aPart, bPart);
-		if (diff !== 0) return diff;
+
+	const times = isRecord(publicationTimes) ? publicationTimes : {};
+	const releases = Object.keys(versions)
+		.filter(version => {
+			const manifest = versions[version];
+			return (
+				STABLE_VERSION_PATTERN.test(version) &&
+				isRecord(manifest) &&
+				typeof manifest.deprecated !== "string" &&
+				compareSemverLikeVersions(version, currentVersion) > 0 &&
+				compareSemverLikeVersions(version, latestVersion) <= 0
+			);
+		})
+		.sort(compareSemverLikeVersions)
+		.map(version => {
+			const tag = `v${version}`;
+			return {
+				version,
+				tag,
+				publishedAt: typeof times[version] === "string" ? times[version] : null,
+				releaseNotesUrl: `${RELEASE_NOTES_BASE_URL}/${tag}`,
+			};
+		});
+
+	return {
+		status: "ok",
+		schemaVersion: 1,
+		currentVersion,
+		latestVersion,
+		updateAvailable: compareSemverLikeVersions(latestVersion, currentVersion) > 0,
+		releases,
+	};
+}
+
+/**
+ * Fetch the full npm packument. The abbreviated install metadata omits
+ * publication times, so this larger and continually growing response has its
+ * own timeout budget.
+ */
+async function getUpdateCheckReport(
+	fetchImpl: Fetch = fetch,
+	timeoutMs: number = RELEASE_HISTORY_TIMEOUT_MS,
+): Promise<UpdateCheckReport> {
+	try {
+		const response = await fetchImpl(`${NPM_REGISTRY}${PACKAGE}`, {
+			headers: { Accept: "application/json" },
+			signal: withTimeoutSignal(timeoutMs),
+		});
+		if (!response.ok) {
+			throw new Error(`Failed to fetch release history: ${response.statusText}`);
+		}
+		return resolveUpdateCheckReport(await response.json(), VERSION);
+	} catch (err) {
+		if (isTimeoutError(err)) {
+			throw new Error(`Timed out fetching release history after ${timeoutMs / 1000}s`, {
+				cause: err,
+			});
+		}
+		throw err;
 	}
-	return 0;
 }
 
 async function readdirIfExists(dir: string): Promise<fs.Dirent[]> {
@@ -1118,7 +1172,10 @@ export async function updateViaBinaryAt(
 	// would force the move-aside rename to overwrite it. pid + timestamp keeps
 	// two forced updates in the same millisecond from colliding.
 	const backupPath = `${targetPath}.${Date.now()}.${process.pid}.bak`;
-	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl, options.githubToken);
+	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, {
+		fetchImpl: options.fetchImpl,
+		githubToken: options.githubToken,
+	});
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
 	await downloadVerifiedBinary({
 		url: asset.url,
@@ -1146,19 +1203,53 @@ export async function updateViaBinaryAt(
 /**
  * Run the update command.
  */
-export async function runUpdateCommand(opts: { force: boolean; check: boolean }): Promise<void> {
+export interface RunUpdateOptions {
+	force: boolean;
+	check: boolean;
+	json: boolean;
+}
+
+export interface RunUpdateDependencies {
+	fetchImpl?: Fetch;
+	releaseHistoryTimeoutMs?: number;
+	writeStdout?: (text: string) => void;
+	setExitCode?: (code: number) => void;
+}
+
+export async function runUpdateCommand(
+	opts: RunUpdateOptions,
+	dependencies: RunUpdateDependencies = {},
+): Promise<void> {
+	if (opts.json) {
+		const writeStdout = dependencies.writeStdout ?? (text => process.stdout.write(text));
+		const setExitCode =
+			dependencies.setExitCode ??
+			(code => {
+				process.exitCode = code;
+			});
+		try {
+			const report = await getUpdateCheckReport(dependencies.fetchImpl, dependencies.releaseHistoryTimeoutMs);
+			writeStdout(`${JSON.stringify(report, null, 2)}\n`);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			writeStdout(`${JSON.stringify(createUpdateCheckError(message), null, 2)}\n`);
+			setExitCode(1);
+		}
+		return;
+	}
+
 	console.log(chalk.dim(`Current version: ${VERSION}`));
 
 	// Check for updates
 	let release: ReleaseInfo;
 	try {
-		release = await getLatestRelease();
+		release = await getLatestRelease(dependencies.fetchImpl);
 	} catch (err) {
 		console.error(chalk.red(`Failed to check for updates: ${err}`));
 		process.exit(1);
 	}
 
-	const comparison = compareVersions(release.version, VERSION);
+	const comparison = compareSemverLikeVersions(release.version, VERSION);
 
 	if (comparison <= 0 && !opts.force) {
 		console.log(chalk.green(`${theme.status.success} Already up to date`));
@@ -1194,26 +1285,4 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
 		console.error(chalk.red(`Update failed: ${err}`));
 		process.exit(1);
 	}
-}
-
-/**
- * Print update command help.
- */
-export function printUpdateHelp(): void {
-	console.log(`${chalk.bold(`${APP_NAME} update`)} - Check for and install updates
-
-${chalk.bold("Usage:")}
-  ${APP_NAME} update [options]
-
-${chalk.bold("Options:")}
-  -c, --check     Check for updates without installing
-  -f, --force     Force reinstall even if up to date
-  -l, --plugins   Update installed plugins
-
-${chalk.bold("Examples:")}
-  ${APP_NAME} update              Update to latest version
-  ${APP_NAME} update --check      Check if updates are available
-  ${APP_NAME} update --force      Force reinstall
-  ${APP_NAME} update -l           Update installed plugins
-`);
 }

--- a/packages/coding-agent/src/commands/update.ts
+++ b/packages/coding-agent/src/commands/update.ts
@@ -13,21 +13,36 @@ export default class Update extends Command {
 		force: Flags.boolean({ char: "f", description: "Force update", default: false }),
 		check: Flags.boolean({ char: "c", description: "Check for updates without installing", default: false }),
 		plugins: Flags.boolean({ char: "l", description: "Update installed plugins", default: false }),
+		json: Flags.boolean({ description: "Output update check as JSON (implies --check)", default: false }),
 	};
 
 	static examples = [
 		"omp update",
+		"omp update --check --json",
 		"omp update --check",
 		"# If GitHub rate-limits release metadata, set GITHUB_TOKEN or GH_TOKEN\n  GITHUB_TOKEN=... omp update",
 	];
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Update);
+		if (flags.json) {
+			const incompatibleFlag = flags.plugins ? "--plugins" : flags.force ? "--force" : undefined;
+			if (incompatibleFlag) {
+				process.stdout.write(
+					`${JSON.stringify(updateCli.createUpdateCheckError(`--json cannot be used with ${incompatibleFlag}`), null, 2)}\n`,
+				);
+				process.exitCode = 1;
+				return;
+			}
+			await updateCli.runUpdateCommand({ force: false, check: true, json: true });
+			return;
+		}
+
 		await initTheme();
 		if (flags.plugins) {
 			await pluginCli.runPluginCommand({ action: "upgrade", args: [], flags: {} });
 		} else {
-			await updateCli.runUpdateCommand({ force: flags.force, check: flags.check });
+			await updateCli.runUpdateCommand({ force: flags.force, check: flags.check, json: false });
 		}
 	}
 }

--- a/packages/coding-agent/test/cli/update-cli.test.ts
+++ b/packages/coding-agent/test/cli/update-cli.test.ts
@@ -21,7 +21,7 @@ describe("runUpdateCommand fetch cancellation", () => {
 		);
 		vi.spyOn(globalThis, "fetch").mockImplementation(fetchStub);
 
-		await runUpdateCommand({ force: false, check: true });
+		await runUpdateCommand({ force: false, check: true, json: false });
 
 		expect(requestSignal).toBeInstanceOf(AbortSignal);
 	});

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -13,17 +13,18 @@ import {
 	buildMiseUpgradeArgs,
 	buildNpmInstallArgs,
 	downloadVerifiedBinary,
-	parseUpdateArgs,
+	getReleaseBinaryAsset,
 	pruneBunInstallCache,
 	replaceBinaryForUpdate,
 	resolveBunGlobalNodeModulesDirFromLocations,
 	resolveReleaseBinaryAsset,
+	resolveUpdateCheckReport,
 	resolveUpdateMethodForTest,
 	sweepStaleBackups,
 	updateViaBinaryAt,
 } from "@oh-my-pi/pi-coding-agent/cli/update-cli";
 import Update from "@oh-my-pi/pi-coding-agent/commands/update";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries, VERSION } from "@oh-my-pi/pi-utils";
 import type { CliConfig } from "@oh-my-pi/pi-utils/cli";
 
 const tempDirs: string[] = [];
@@ -32,6 +33,24 @@ async function makeTempDir(): Promise<string> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-update-test-"));
 	tempDirs.push(dir);
 	return dir;
+}
+
+type FetchInput = string | URL | Request;
+type FetchInit = RequestInit | BunFetchRequestInit;
+
+function createStalledJsonFetch(): (input: FetchInput, init?: FetchInit) => Promise<Response> {
+	return async (_input, init) => {
+		const signal = init?.signal;
+		if (!signal) throw new Error("Expected timeout signal");
+		const body = new ReadableStream({
+			start(controller) {
+				const abort = () => controller.error(signal.reason);
+				if (signal.aborted) abort();
+				else signal.addEventListener("abort", abort, { once: true });
+			},
+		});
+		return new Response(body, { headers: { "Content-Type": "application/json" } });
+	};
 }
 
 afterEach(async () => {
@@ -64,16 +83,232 @@ describe("update command plugin dispatch", () => {
 		const command = new Update(["--check", "--force"], TEST_CONFIG);
 		await command.run();
 
-		expect(updateSpy).toHaveBeenCalledWith({ force: true, check: true });
+		expect(updateSpy).toHaveBeenCalledWith({ force: true, check: true, json: false });
 		expect(pluginSpy).not.toHaveBeenCalled();
+	});
+
+	it("forwards JSON update checks without installing", async () => {
+		const pluginSpy = spyOn(pluginCli, "runPluginCommand").mockResolvedValue(undefined);
+		const updateSpy = spyOn(updateCli, "runUpdateCommand").mockResolvedValue(undefined);
+
+		const command = new Update(["--json"], TEST_CONFIG);
+		await command.run();
+
+		expect(updateSpy).toHaveBeenCalledWith({ force: false, check: true, json: true });
+		expect(pluginSpy).not.toHaveBeenCalled();
+	});
+
+	it("returns versioned JSON errors for incompatible flags", async () => {
+		const pluginSpy = spyOn(pluginCli, "runPluginCommand").mockResolvedValue(undefined);
+		const updateSpy = spyOn(updateCli, "runUpdateCommand").mockResolvedValue(undefined);
+		const output: string[] = [];
+		spyOn(process.stdout, "write").mockImplementation(chunk => {
+			output.push(String(chunk));
+			return true;
+		});
+		const previousExitCode = process.exitCode;
+
+		try {
+			for (const flag of ["--plugins", "--force"]) {
+				output.length = 0;
+				process.exitCode = 0;
+				await new Update(["--json", flag], TEST_CONFIG).run();
+				expect(process.exitCode).toBe(1);
+				expect(JSON.parse(output.join(""))).toEqual({
+					status: "error",
+					schemaVersion: 1,
+					error: `--json cannot be used with ${flag}`,
+				});
+			}
+		} finally {
+			process.exitCode = previousExitCode ?? 0;
+		}
+
+		expect(pluginSpy).not.toHaveBeenCalled();
+		expect(updateSpy).not.toHaveBeenCalled();
 	});
 });
 
-describe("parseUpdateArgs", () => {
-	it("preserves the legacy plugin update shorthand", () => {
-		expect(parseUpdateArgs(["update", "-l"])).toEqual({ force: false, check: false, plugins: true });
+describe("update-cli JSON checks", () => {
+	it("lists stable installable releases between the current and latest versions", () => {
+		const report = resolveUpdateCheckReport(
+			{
+				"dist-tags": { latest: "17.1.2" },
+				versions: {
+					"17.0.8": {},
+					"17.0.9": {},
+					"17.1.0-beta.1": {},
+					"17.1.0": { deprecated: "known regression" },
+					"17.1.2": {},
+					"17.2.0": {},
+				},
+				time: {
+					"17.0.9": "2026-07-23T10:00:00.000Z",
+					"17.1.0": "2026-07-24T02:00:00.000Z",
+				},
+			},
+			"17.0.8",
+		);
+
+		expect(report).toEqual({
+			status: "ok",
+			schemaVersion: 1,
+			currentVersion: "17.0.8",
+			latestVersion: "17.1.2",
+			updateAvailable: true,
+			releases: [
+				{
+					version: "17.0.9",
+					tag: "v17.0.9",
+					publishedAt: "2026-07-23T10:00:00.000Z",
+					releaseNotesUrl: "https://github.com/can1357/oh-my-pi/releases/tag/v17.0.9",
+				},
+				{
+					version: "17.1.2",
+					tag: "v17.1.2",
+					publishedAt: null,
+					releaseNotesUrl: "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.2",
+				},
+			],
+		});
+	});
+
+	it("compares valid prerelease current versions against stable releases", () => {
+		const metadata = {
+			"dist-tags": { latest: "17.1.2" },
+			versions: { "17.1.1": {}, "17.1.2": {} },
+			time: {},
+		};
+
+		expect(resolveUpdateCheckReport(metadata, "17.1.2-dev.1+local")).toMatchObject({
+			status: "ok",
+			updateAvailable: true,
+			releases: [{ version: "17.1.2" }],
+		});
+		expect(resolveUpdateCheckReport(metadata, "17.1.3-dev")).toMatchObject({
+			status: "ok",
+			updateAvailable: false,
+			releases: [],
+		});
+	});
+
+	it("rejects malformed current, package, and latest metadata", () => {
+		const valid = {
+			"dist-tags": { latest: "17.1.2" },
+			versions: { "17.1.2": {} },
+		};
+		const invalid: Array<[unknown, string, string]> = [
+			[valid, "17.1", "Invalid current version metadata"],
+			[valid, "17.1.2-01", "Invalid current version metadata"],
+			[null, "17.1.1", "Invalid npm package metadata"],
+			[{ "dist-tags": {} }, "17.1.1", "Invalid npm package metadata"],
+			[
+				{ "dist-tags": { latest: "17.1.2-rc.1" }, versions: { "17.1.2-rc.1": {} } },
+				"17.1.1",
+				"Invalid npm latest release metadata",
+			],
+			[{ "dist-tags": { latest: "17.1.2" }, versions: {} }, "17.1.1", "Invalid npm latest release metadata"],
+			[
+				{ "dist-tags": { latest: "17.1.2" }, versions: { "17.1.2": null } },
+				"17.1.1",
+				"Invalid npm latest release metadata",
+			],
+			[
+				{ "dist-tags": { latest: "17.1.2" }, versions: { "17.1.2": { deprecated: "withdrawn" } } },
+				"17.1.1",
+				"Invalid npm latest release metadata",
+			],
+		];
+
+		for (const [metadata, currentVersion, message] of invalid) {
+			expect(() => resolveUpdateCheckReport(metadata, currentVersion)).toThrow(message);
+		}
+	});
+
+	it("returns no releases when the current version is up to date", () => {
+		expect(
+			resolveUpdateCheckReport(
+				{
+					"dist-tags": { latest: "17.1.2" },
+					versions: { "17.1.1": {}, "17.1.2": {} },
+					time: {},
+				},
+				"17.1.2",
+			),
+		).toEqual({
+			status: "ok",
+			schemaVersion: 1,
+			currentVersion: "17.1.2",
+			latestVersion: "17.1.2",
+			updateAvailable: false,
+			releases: [],
+		});
+	});
+
+	it("prints only the update report when JSON output is requested", async () => {
+		const [major, minor, patch] = VERSION.split(".").map(Number);
+		const latestVersion = `${major}.${minor}.${patch + 1}`;
+		const output: string[] = [];
+		const fetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					"dist-tags": { latest: latestVersion },
+					versions: { [VERSION]: {}, [latestVersion]: {} },
+					time: { [latestVersion]: "2026-07-27T00:00:00.000Z" },
+				}),
+			);
+
+		await updateCli.runUpdateCommand(
+			{ force: false, check: true, json: true },
+			{ fetchImpl, writeStdout: text => output.push(text) },
+		);
+
+		expect(output).toHaveLength(1);
+		expect(JSON.parse(output[0])).toEqual({
+			status: "ok",
+			schemaVersion: 1,
+			currentVersion: VERSION,
+			latestVersion,
+			updateAvailable: true,
+			releases: [
+				{
+					version: latestVersion,
+					tag: `v${latestVersion}`,
+					publishedAt: "2026-07-27T00:00:00.000Z",
+					releaseNotesUrl: `https://github.com/can1357/oh-my-pi/releases/tag/v${latestVersion}`,
+				},
+			],
+		});
+	});
+
+	it("returns a versioned JSON error when a stalled packument body times out", async () => {
+		const output: string[] = [];
+		let exitCode: number | undefined;
+		const timeoutMs = 25;
+
+		await updateCli.runUpdateCommand(
+			{ force: false, check: true, json: true },
+			{
+				fetchImpl: createStalledJsonFetch(),
+				releaseHistoryTimeoutMs: timeoutMs,
+				writeStdout: text => output.push(text),
+				setExitCode: code => {
+					exitCode = code;
+				},
+			},
+		);
+
+		expect(exitCode).toBe(1);
+		expect(output).toHaveLength(1);
+		expect(output[0]).toEndWith("\n");
+		expect(JSON.parse(output[0])).toEqual({
+			status: "error",
+			schemaVersion: 1,
+			error: `Timed out fetching release history after ${timeoutMs / 1000}s`,
+		});
 	});
 });
+
 describe("update-cli install target detection", () => {
 	it("uses bun update when prioritized omp is inside bun global bin", () => {
 		const method = resolveUpdateMethodForTest("/Users/test/.bun/bin/omp", "/Users/test/.bun/bin");
@@ -389,6 +624,40 @@ describe("update-cli release binary integrity", () => {
 			size: Buffer.byteLength(content),
 			digest,
 		});
+	});
+
+	it("wraps stalled release metadata body timeouts", async () => {
+		const timeoutMs = 25;
+
+		await expect(
+			getReleaseBinaryAsset("17.1.2", binaryName, {
+				fetchImpl: createStalledJsonFetch(),
+				timeoutMs,
+			}),
+		).rejects.toThrow(`Timed out fetching GitHub release metadata after ${timeoutMs / 1000}s`);
+	});
+
+	it("falls back to GH_TOKEN when GITHUB_TOKEN is empty", async () => {
+		const previousGitHubToken = Bun.env.GITHUB_TOKEN;
+		const previousGhToken = Bun.env.GH_TOKEN;
+		const authorizations: Array<string | null> = [];
+		Bun.env.GITHUB_TOKEN = "";
+		Bun.env.GH_TOKEN = "fallback-token";
+
+		try {
+			await getReleaseBinaryAsset("17.1.2", binaryName, {
+				fetchImpl: async (_input, init) => {
+					authorizations.push(new Headers(init?.headers).get("Authorization"));
+					return new Response(JSON.stringify(releaseAsset()));
+				},
+			});
+			expect(authorizations).toEqual(["Bearer fallback-token"]);
+		} finally {
+			if (previousGitHubToken === undefined) delete Bun.env.GITHUB_TOKEN;
+			else Bun.env.GITHUB_TOKEN = previousGitHubToken;
+			if (previousGhToken === undefined) delete Bun.env.GH_TOKEN;
+			else Bun.env.GH_TOKEN = previousGhToken;
+		}
 	});
 
 	it("rejects missing and unsupported release asset digests", () => {


### PR DESCRIPTION
## What

Adds `omp update --check --json` for a machine-readable view of the available update path(s). It returns the current and latest versions, plus each non-deprecated stable release in between with its publication time and GitHub release-notes URL.

The output has a versioned schema, uses stdout for both success and error envelopes, and exits non-zero on failure. `--json` implies `--check` and rejects other combos.

Aside, since a reader might wonder: the full npm packument is currently about 198 KiB compressed and 5.1 MiB decoded, it's got a separate timeout but just for proportionality.

## Why

omp releases quickly and I want an agent to inspect the exact delta, read the release notes, and help me assess an update before anything is installed. I also want to apply my own cooldown period to updates, hence the timestamps being valuable here. 

This follows the updater verification work in #6557.

## Testing

New unit tests

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

<details>
<summary>Example JSON output from my local test run on 17.0.8</summary>

```json
{
 "schemaVersion": 1,
 "currentVersion": "17.0.8",
 "latestVersion": "17.1.5",
 "updateAvailable": true,
 "releases": [
   {
     "version": "17.0.9",
     "tag": "v17.0.9",
     "publishedAt": "2026-07-23T13:09:43.904Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.0.9"
   },
   {
     "version": "17.1.0",
     "tag": "v17.1.0",
     "publishedAt": "2026-07-24T02:07:57.599Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.0"
   },
   {
     "version": "17.1.1",
     "tag": "v17.1.1",
     "publishedAt": "2026-07-24T08:46:38.309Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.1"
   },
   {
     "version": "17.1.2",
     "tag": "v17.1.2",
     "publishedAt": "2026-07-24T15:58:53.993Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.2"
   },
   {
     "version": "17.1.3",
     "tag": "v17.1.3",
     "publishedAt": "2026-07-24T23:55:15.352Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.3"
   },
   {
     "version": "17.1.4",
     "tag": "v17.1.4",
     "publishedAt": "2026-07-26T18:57:42.559Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.4"
   },
   {
     "version": "17.1.5",
     "tag": "v17.1.5",
     "publishedAt": "2026-07-27T04:55:04.579Z",
     "releaseNotesUrl": "https://github.com/can1357/oh-my-pi/releases/tag/v17.1.5"
   }
 ]
}
```
</details>