### PR TITLE
fix(live): honor standard proxies for sideband websocket

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `getProxyForUrl()` for transports that need provider-specific and standard proxy environment resolution with `NO_PROXY` support ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -61,7 +61,7 @@ import {
 	getOpenAIStreamIdleTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
-import { getProxyForProvider, shouldBypassProxy } from "../utils/proxy";
+import { getProxyForUrl } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
 import { notifyRawSseEvent } from "../utils/sse-debug";
@@ -3855,15 +3855,7 @@ async function getOrCreateCodexWebSocketConnection(
 	provider: string,
 	signal?: AbortSignal,
 ): Promise<CodexWebSocketConnection> {
-	const targetUrl = new URL(url);
-	const proxy = shouldBypassProxy(targetUrl)
-		? undefined
-		: (getProxyForProvider(provider) ??
-			(targetUrl.protocol === "wss:"
-				? Bun.env.HTTPS_PROXY || Bun.env.https_proxy
-				: Bun.env.HTTP_PROXY || Bun.env.http_proxy) ??
-			Bun.env.ALL_PROXY ??
-			Bun.env.all_proxy);
+	const proxy = getProxyForUrl(provider, new URL(url));
 	const headerRecord = headersToRecord(headers);
 	// Join an in-flight handshake instead of tearing it down: closing a
 	// CONNECTING socket rejects the concurrent caller (prewarm racing the first

--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -129,6 +129,16 @@ export function getProxyForProvider(provider: string): string | undefined {
 	return value;
 }
 
+/** Resolves provider-specific and standard proxy variables for a target URL, honoring NO_PROXY. */
+export function getProxyForUrl(provider: string, url: URL): string | undefined {
+	if (shouldBypassProxy(url)) return undefined;
+	const protocolProxy =
+		url.protocol === "https:" || url.protocol === "wss:"
+			? Bun.env.HTTPS_PROXY || Bun.env.https_proxy
+			: Bun.env.HTTP_PROXY || Bun.env.http_proxy;
+	return getProxyForProvider(provider) || protocolProxy || Bun.env.ALL_PROXY || Bun.env.all_proxy || undefined;
+}
+
 /**
  * Wraps a fetch implementation to inject proxy options for non-local hosts.
  */

--- a/packages/ai/test/proxy.test.ts
+++ b/packages/ai/test/proxy.test.ts
@@ -5,6 +5,7 @@ import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import {
 	connectProxiedSocket,
 	getProxyForProvider,
+	getProxyForUrl,
 	isLocalOrMetadataHost,
 	shouldBypassProxy,
 	wrapFetchForProxy,
@@ -61,12 +62,29 @@ async function waitForSocketClose(socket: net.Socket): Promise<void> {
 	await closed.promise;
 }
 
-const isProxyEnvKey = (k: string): boolean => k.startsWith("PI_PROXY") || k === "NO_PROXY" || k === "no_proxy";
+const isProxyEnvKey = (k: string): boolean =>
+	k.startsWith("PI_PROXY") ||
+	k === "HTTP_PROXY" ||
+	k === "http_proxy" ||
+	k === "HTTPS_PROXY" ||
+	k === "https_proxy" ||
+	k === "ALL_PROXY" ||
+	k === "all_proxy" ||
+	k === "NO_PROXY" ||
+	k === "no_proxy";
 
-// NO_PROXY/no_proxy set at runtime are readable but hidden from Bun.env
-// enumeration (Bun's fetch proxy layer intercepts them), so the sweep must
-// name them explicitly instead of relying on for..in.
-const HIDDEN_PROXY_KEYS = ["NO_PROXY", "no_proxy"];
+// Standard proxy variables set at runtime can be readable but hidden from Bun.env
+// enumeration, so the sweep must name them explicitly instead of relying on for..in.
+const HIDDEN_PROXY_KEYS = [
+	"HTTP_PROXY",
+	"http_proxy",
+	"HTTPS_PROXY",
+	"https_proxy",
+	"ALL_PROXY",
+	"all_proxy",
+	"NO_PROXY",
+	"no_proxy",
+];
 
 function proxyEnvKeys(): Set<string> {
 	const keys = new Set(HIDDEN_PROXY_KEYS);
@@ -121,6 +139,33 @@ describe("getProxyForProvider", () => {
 
 	it("returns undefined when neither var is set", () => {
 		expect(getProxyForProvider("none-prov")).toBeUndefined();
+	});
+});
+
+describe("getProxyForUrl", () => {
+	it("uses protocol-specific standard proxy variables", () => {
+		Bun.env.HTTPS_PROXY = "http://secure-proxy:8080";
+		Bun.env.HTTP_PROXY = "http://plain-proxy:8080";
+
+		expect(getProxyForUrl("standard-secure-proxy", new URL("wss://api.openai.com/v1/live"))).toBe(
+			"http://secure-proxy:8080",
+		);
+		expect(getProxyForUrl("standard-plain-proxy", new URL("ws://api.openai.com/v1/live"))).toBe(
+			"http://plain-proxy:8080",
+		);
+	});
+
+	it("falls back to ALL_PROXY", () => {
+		Bun.env.ALL_PROXY = PROXY;
+
+		expect(getProxyForUrl("standard-all-proxy", new URL("wss://api.openai.com/v1/live"))).toBe(PROXY);
+	});
+
+	it("bypasses configured proxies for NO_PROXY targets", () => {
+		Bun.env.PI_PROXY_NO_PROXY_TEST = PROXY;
+		Bun.env.NO_PROXY = "api.openai.com";
+
+		expect(getProxyForUrl("no-proxy-test", new URL("wss://api.openai.com/v1/live"))).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed DeepSeek V4 Flash and Step 3.7 Flash models using hashline edit mode by default despite repeatedly misreading its range grammar; both now use the simpler replace-mode fallback unless explicitly overridden ([#6671](https://github.com/can1357/oh-my-pi/issues/6671)).
 - Fixed an Ask form appearing while the main prompt contains a draft hiding that text and consuming the next in-flight keystroke. The draft now remains visible and keeps receiving input until it is submitted or cleared; only then do form controls activate ([#6737](https://github.com/can1357/oh-my-pi/issues/6737)).
 - Fixed `glob` rejecting safe `memory://root/<directory>/**` patterns. Memory globs now resolve their directory prefix inside the project memory root while rejecting traversal and percent-encoded path separators across the complete glob path.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Added
@@ -16,7 +20,6 @@
 
 ### Fixed
 
-- Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed DeepSeek V4 Flash and Step 3.7 Flash models using hashline edit mode by default despite repeatedly misreading its range grammar; both now use the simpler replace-mode fallback unless explicitly overridden ([#6671](https://github.com/can1357/oh-my-pi/issues/6671)).
 - Fixed an Ask form appearing while the main prompt contains a draft hiding that text and consuming the next in-flight keystroke. The draft now remains visible and keeps receiving input until it is submitted or cleared; only then do form controls activate ([#6737](https://github.com/can1357/oh-my-pi/issues/6737)).
 - Fixed `glob` rejecting safe `memory://root/<directory>/**` patterns. Memory globs now resolve their directory prefix inside the project memory root while rejecting traversal and percent-encoded path separators across the complete glob path.

--- a/packages/coding-agent/src/live/transport.ts
+++ b/packages/coding-agent/src/live/transport.ts
@@ -1,5 +1,5 @@
 import { type AuthStorage, isAuthRetryableError, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
-import { getProxyForProvider, wrapFetchForProxy } from "@oh-my-pi/pi-ai/utils/proxy";
+import { getProxyForUrl, wrapFetchForProxy } from "@oh-my-pi/pi-ai/utils/proxy";
 import {
 	CODEX_BASE_URL,
 	CODEX_CLIENT_VERSION,
@@ -252,7 +252,7 @@ export class CodexLiveTransport {
 		const url = buildLiveSidebandUrl(callId);
 		const options = {
 			headers: liveSessionHeaders(access, this.#options.sessionId, this.#realtimeSessionId, attestation),
-			proxy: getProxyForProvider(LIVE_PROVIDER),
+			proxy: getProxyForUrl(LIVE_PROVIDER, new URL(url)),
 		} satisfies Bun.WebSocketOptions;
 		const socket: Bun.WebSocket = Reflect.construct(WebSocket, [url, options]);
 		socket.binaryType = "nodebuffer";


### PR DESCRIPTION
## Repro
With `PI_PROXY` unset and `HTTPS_PROXY=http://127.0.0.1:7890`, run `bun -e` against the proxy resolver used by `CodexLiveTransport.#openSideband()` and compare it with `HTTPS_PROXY`; current `main` reports `{"standardProxy":"http://127.0.0.1:7890","liveSidebandProxy":null}` and exits 1.

## Cause
`packages/coding-agent/src/live/transport.ts` passed `getProxyForProvider()` directly to Bun's WebSocket, while the equivalent Codex WebSocket path in `packages/ai/src/providers/openai-codex-responses.ts` separately inlined the standard proxy fallback and `NO_PROXY` check. The live sideband therefore had neither behavior.

## Fix
- Add `getProxyForUrl()` in `packages/ai/src/utils/proxy.ts` to resolve provider overrides, protocol-specific standard variables, `ALL_PROXY`, and `NO_PROXY` in one place.
- Use the shared resolver for both Codex Responses and `/live` sideband WebSockets.
- Cover secure/plain standard variables, `ALL_PROXY`, and `NO_PROXY` in proxy resolver tests.

## Verification
`bun test packages/ai/test/proxy.test.ts` passes 40 tests; `bun test packages/ai/test/openai-codex-stream.test.ts` passes 72 tests; the focused `/live` resolver probe now reports `liveSidebandProxy` as `http://127.0.0.1:7890` and exits 0. `bun check` fails on `main` in the unchanged Rust phase because this runner lacks `cmake` and `libclang`; skipped the pre-publish gate after reproducing both failures from a clean `origin/main` checkout.

Fixes #6770