### PR TITLE
feat(tui): add opt-in Vim prompt editing mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -50,6 +50,10 @@
 - Fixed image paste failing on Wayland-only Linux sessions by reading PNG clipboard payloads through `wl-paste` before falling back to the native bridge ([#7316](https://github.com/can1357/oh-my-pi/issues/7316)).
 - Fixed prewalk switching to the fast model during read-only investigation: `xd://` devices are dispatched through the `write` tool, so a read-only call such as an `lsp` navigation counted as the first edit/write and armed the one-way hand-off mid-planning. Device dispatches now carry the wrapped tool's approval tier and only trigger the switch at a `write`/`exec` tier — read-only `lsp`, `debug` inspection, and internal-URL `ast_edit` calls no longer downgrade the model ([#7312](https://github.com/can1357/oh-my-pi/issues/7312)).
 
+### Added
+
+- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels, Vim normal-mode Ctrl-R redo, and safe interaction with autocomplete, paste, voice input, app shortcuts, and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added
@@ -90,10 +94,6 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
-
-### Added
-
-- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels, Vim normal-mode Ctrl-R redo, and safe interaction with autocomplete, paste, voice input, app shortcuts, and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -351,6 +351,10 @@
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
 
+### Added
+
+- Added an `inputMode: vim` setting for modal prompt editing, including a visible mode label and safe interaction with autocomplete, paste, voice input, app shortcuts, and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -91,6 +91,10 @@
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
 
+### Added
+
+- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels, Vim normal-mode Ctrl-R redo, and safe interaction with autocomplete, paste, voice input, app shortcuts, and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed
@@ -262,10 +266,6 @@
 
 - Removed the dangling `MCPManager.setOnNotification` single-slot setter, which had no callers in the runtime. Replaced by `MCPManager.addNotificationListener` — multi-listener, per-listener error isolation, returns an unsubscribe function.
 
-### Added
-
-- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels, Vim normal-mode Ctrl-R redo, and safe interaction with app shortcuts and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
-
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes
@@ -354,10 +354,6 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
-
-### Added
-
-- Added an `inputMode: vim` setting for modal prompt editing, including a visible mode label and safe interaction with autocomplete, paste, voice input, app shortcuts, and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -264,11 +264,7 @@
 
 ### Added
 
-- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels and safe interaction with app shortcuts and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
-
-### Fixed
-
-- Kept Ctrl-R available for redo in Vim normal mode instead of opening prompt history search.
+- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels, Vim normal-mode Ctrl-R redo, and safe interaction with app shortcuts and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -262,6 +262,14 @@
 
 - Removed the dangling `MCPManager.setOnNotification` single-slot setter, which had no callers in the runtime. Replaced by `MCPManager.addNotificationListener` — multi-listener, per-listener error isolation, returns an unsubscribe function.
 
+### Added
+
+- Added a configurable `inputMode: vim` setting for modal prompt editing, including visible mode labels and safe interaction with app shortcuts and editor replacement ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
+### Fixed
+
+- Kept Ctrl-R available for redo in Vim normal mode instead of opening prompt history search.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1688,6 +1688,22 @@ export const SETTINGS_SCHEMA = {
 	},
 
 	// Input and startup
+	inputMode: {
+		type: "enum",
+		values: ["default", "vim"] as const,
+		default: "default",
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Input Mode",
+			description: "Prompt editor keymap",
+			options: [
+				{ value: "default", label: "Default", description: "Use the standard prompt editor keybindings" },
+				{ value: "vim", label: "Vim", description: "Use Vim-style normal and insert modes" },
+			],
+		},
+	},
+
 	doubleEscapeAction: {
 		type: "enum",
 		values: ["branch", "tree", "none"] as const,

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -847,9 +847,13 @@ export class CustomEditor extends Editor {
 			const imagePaths = extractImagePastePathsFromText(content);
 			if (imagePaths && this.onPasteImagePath) {
 				this.prepareVimInsertMutation();
+				const pasteSignal = this.getAsyncPasteSignal();
 				void this.trackAsyncPaste(
 					(async () => {
-						for (const p of imagePaths) await this.onPasteImagePath?.(p);
+						for (const p of imagePaths) {
+							if (pasteSignal.aborted) return;
+							await this.onPasteImagePath?.(p);
+						}
 					})(),
 				);
 				return;

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -810,7 +810,8 @@ export class CustomEditor extends Editor {
 			// Enter that the user pressed right after Cmd+V) so they only fire *after* the paste
 			// completes — fixes the race where submit runs against an empty `pendingImages`.
 			if (remaining.length > 0) this.#pendingInput.push(remaining);
-			if (this.getVimMode() === "normal") {
+			const pasteVimMode = this.getVimMode();
+			if (pasteVimMode !== undefined && pasteVimMode !== "insert") {
 				const drained = this.#pendingInput.splice(0);
 				for (const chunk of drained) this.handleInput(chunk);
 				return;

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -838,6 +838,12 @@ export class CustomEditor extends Editor {
 		const parsedKey = parseKey(data);
 		const canonical = parsedKey !== undefined ? canonicalKeyId(parsedKey) : undefined;
 
+		// Vim owns Ctrl-R in normal mode; history search remains available in insert mode.
+		if (canonical === "ctrl+r" && this.getVimMode() === "normal") {
+			super.handleInput(data);
+			return;
+		}
+
 		// Left-arrow on an empty editor: surface for the agent-hub double-tap
 		// gesture. Plain "left" only — modified arrows and any in-text cursor
 		// movement fall through to normal handling.

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -812,6 +812,7 @@ export class CustomEditor extends Editor {
 			if (remaining.length > 0) this.#pendingInput.push(remaining);
 			const pasteVimMode = this.getVimMode();
 			if (pasteVimMode !== undefined && pasteVimMode !== "insert") {
+				this.pasteText(content);
 				const drained = this.#pendingInput.splice(0);
 				for (const chunk of drained) this.handleInput(chunk);
 				return;
@@ -850,6 +851,7 @@ export class CustomEditor extends Editor {
 		// gesture. Plain "left" only — modified arrows and any in-text cursor
 		// movement fall through to normal handling.
 		if (canonical === "left" && this.onLeftAtStart && this.getText().trim() === "") {
+			if (vimMode !== undefined && vimMode !== "insert") this.clearVimPendingCommand();
 			this.onLeftAtStart();
 			return;
 		}
@@ -864,6 +866,7 @@ export class CustomEditor extends Editor {
 			canonical !== undefined &&
 			(this.#actionMatchKeyUnion.has(canonical) || this.#customMatchKeys.has(canonical))
 		) {
+			if (!acceptsTextEntry) this.clearVimPendingCommand();
 			// Intercept configured image paste (async - fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
 				void this.onPasteImage();

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -39,6 +39,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.pasteTextRaw"
 	| "app.clipboard.copyPrompt"
+	| "app.stt.toggle"
 >;
 
 const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
@@ -61,6 +62,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],
 	"app.clipboard.copyPrompt": ["alt+shift+c"],
+	"app.stt.toggle": [],
 };
 
 function buildMatchKeys(keys: readonly KeyId[]): Set<string> {
@@ -567,6 +569,8 @@ export class CustomEditor extends Editor {
 	onDequeue?: () => void;
 	/** Called when the configured retry shortcut is pressed. */
 	onRetry?: () => void;
+	/** Called when the configured speech-to-text toggle is pressed. */
+	onSTTToggle?: () => void;
 	/** Called when Caps Lock is pressed. */
 	onCapsLock?: () => void;
 	/** Called when left-arrow is pressed while the editor is empty (cursor necessarily at start). */
@@ -869,6 +873,11 @@ export class CustomEditor extends Editor {
 			(this.#actionMatchKeyUnion.has(canonical) || this.#customMatchKeys.has(canonical))
 		) {
 			if (!acceptsTextEntry) this.clearVimPendingCommand();
+			if (acceptsTextEntry && this.#matchesAction(canonical, "app.stt.toggle") && this.onSTTToggle) {
+				this.onSTTToggle();
+				return;
+			}
+
 			// Intercept configured image paste (async - fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
 				this.prepareVimPaste();

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -565,7 +565,7 @@ export class CustomEditor extends Editor {
 	/** Called when a bracketed paste contains one or more image-file paths. */
 	onPasteImagePath?: (path: string) => void | Promise<void>;
 	/** Called when the configured raw text-paste shortcut is pressed. */
-	onPasteTextRaw?: () => void;
+	onPasteTextRaw?: () => void | Promise<void>;
 	/** Called when the configured dequeue shortcut is pressed. */
 	onDequeue?: () => void;
 	/** Called when the configured retry shortcut is pressed. */
@@ -894,10 +894,10 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured raw text paste (fires and handles result)
+			// Intercept configured raw text paste and serialize follow-up input until it settles.
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") && this.onPasteTextRaw) {
 				this.prepareVimInsertMutation();
-				this.onPasteTextRaw();
+				this.#trackAsyncPaste(Promise.resolve(this.onPasteTextRaw()));
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -852,8 +852,10 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
-		// Space-hold push-to-talk: a sustained space bar starts/stops STT instead of typing spaces.
-		if (this.getVimMode() !== "normal" && this.#handleSpaceHold(data, canonical)) return;
+		// Space-hold push-to-talk is text-entry behavior: visual and normal modes must not mutate the prompt.
+		const vimMode = this.getVimMode();
+		const acceptsTextEntry = vimMode === undefined || vimMode === "insert";
+		if (acceptsTextEntry && this.#handleSpaceHold(data, canonical)) return;
 
 		// One union probe decides whether any per-action interception below can
 		// match — plain typing then skips the ~20 per-action set lookups per key.
@@ -861,21 +863,14 @@ export class CustomEditor extends Editor {
 			canonical !== undefined &&
 			(this.#actionMatchKeyUnion.has(canonical) || this.#customMatchKeys.has(canonical))
 		) {
-			const vimMode = this.getVimMode();
-			const acceptsClipboardPaste = vimMode === undefined || vimMode === "insert";
-
 			// Intercept configured image paste (async - fires and handles result)
-			if (acceptsClipboardPaste && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
+			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
 				void this.onPasteImage();
 				return;
 			}
 
 			// Intercept configured raw text paste (fires and handles result)
-			if (
-				acceptsClipboardPaste &&
-				this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") &&
-				this.onPasteTextRaw
-			) {
+			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") && this.onPasteTextRaw) {
 				this.onPasteTextRaw();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -818,11 +818,13 @@ export class CustomEditor extends Editor {
 				return;
 			}
 			if (content.length === 0 && this.onPasteImage) {
+				this.prepareVimPaste();
 				this.#trackAsyncPaste(Promise.resolve(this.onPasteImage()));
 				return;
 			}
 			const imagePaths = extractImagePastePathsFromText(content);
 			if (imagePaths && this.onPasteImagePath) {
+				this.prepareVimPaste();
 				this.#trackAsyncPaste(
 					(async () => {
 						for (const p of imagePaths) await this.onPasteImagePath?.(p);
@@ -869,12 +871,14 @@ export class CustomEditor extends Editor {
 			if (!acceptsTextEntry) this.clearVimPendingCommand();
 			// Intercept configured image paste (async - fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
+				this.prepareVimPaste();
 				void this.onPasteImage();
 				return;
 			}
 
 			// Intercept configured raw text paste (fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") && this.onPasteTextRaw) {
+				this.prepareVimPaste();
 				this.onPasteTextRaw();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -839,8 +839,9 @@ export class CustomEditor extends Editor {
 		const parsedKey = parseKey(data);
 		const canonical = parsedKey !== undefined ? canonicalKeyId(parsedKey) : undefined;
 
-		// Vim owns Ctrl-R in normal mode; history search remains available in insert mode.
-		if (canonical === "ctrl+r" && this.getVimMode() === "normal") {
+		const vimMode = this.getVimMode();
+		// Vim owns Ctrl-R outside insert mode; history search remains available while editing text.
+		if (canonical === "ctrl+r" && vimMode !== undefined && vimMode !== "insert") {
 			super.handleInput(data);
 			return;
 		}
@@ -854,7 +855,6 @@ export class CustomEditor extends Editor {
 		}
 
 		// Space-hold push-to-talk is text-entry behavior: visual and normal modes must not mutate the prompt.
-		const vimMode = this.getVimMode();
 		const acceptsTextEntry = vimMode === undefined || vimMode === "insert";
 		if (acceptsTextEntry && this.#handleSpaceHold(data, canonical)) return;
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -765,7 +765,7 @@ export class CustomEditor extends Editor {
 		this.#spaceHoldTimer.unref?.();
 	}
 
-	#endSpaceHold(): void {
+	cancelSpaceHold(): void {
 		if (!this.#spaceHoldActive) return;
 		this.#spaceHoldActive = false;
 		this.#resetSpaceRun();
@@ -773,6 +773,11 @@ export class CustomEditor extends Editor {
 			clearTimeout(this.#spaceHoldTimer);
 			this.#spaceHoldTimer = undefined;
 		}
+	}
+
+	#endSpaceHold(): void {
+		if (!this.#spaceHoldActive) return;
+		this.cancelSpaceHold();
 		this.onSpaceHoldEnd?.();
 	}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -941,13 +941,13 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Escape leaves Vim insert mode before it can act as the app interrupt.
+			// Escape leaves Vim insert or visual mode before it can act as the app interrupt.
 			// Autocomplete still closes on the same key in the base editor.
 			if (
 				this.#matchesAction(canonical, "app.interrupt") &&
 				this.onEscape &&
 				!this.isShowingAutocomplete() &&
-				!this.isVimInsertEscape(data)
+				!this.isVimModeEscape(data)
 			) {
 				this.onEscape();
 				return;

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -417,6 +417,23 @@ export class CustomEditor extends Editor {
 	constructor(...args: readonly unknown[]) {
 		super(pickEditorTheme(args));
 		if (args[0] instanceof TUI) this.tui = args[0];
+		this.undoStateHooks = {
+			capture: () => ({
+				imageLinks: this.imageLinks,
+				pendingImages: this.pendingImages,
+				pendingImageLinks: this.pendingImageLinks,
+			}),
+			restore: state => {
+				const draft = state as {
+					imageLinks: (string | undefined)[] | undefined;
+					pendingImages: ImageContent[];
+					pendingImageLinks: (string | undefined)[];
+				};
+				this.imageLinks = draft.imageLinks;
+				this.pendingImages = draft.pendingImages;
+				this.pendingImageLinks = draft.pendingImageLinks;
+			},
+		};
 	}
 
 	/** Clear the composer draft: optionally commit `historyText` to history, then

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -822,13 +822,13 @@ export class CustomEditor extends Editor {
 				return;
 			}
 			if (content.length === 0 && this.onPasteImage) {
-				this.prepareVimPaste();
+				this.prepareVimInsertMutation();
 				this.#trackAsyncPaste(Promise.resolve(this.onPasteImage()));
 				return;
 			}
 			const imagePaths = extractImagePastePathsFromText(content);
 			if (imagePaths && this.onPasteImagePath) {
-				this.prepareVimPaste();
+				this.prepareVimInsertMutation();
 				this.#trackAsyncPaste(
 					(async () => {
 						for (const p of imagePaths) await this.onPasteImagePath?.(p);
@@ -874,20 +874,21 @@ export class CustomEditor extends Editor {
 		) {
 			if (!acceptsTextEntry) this.clearVimPendingCommand();
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.stt.toggle") && this.onSTTToggle) {
+				this.prepareVimInsertMutation();
 				this.onSTTToggle();
 				return;
 			}
 
 			// Intercept configured image paste (async - fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
-				this.prepareVimPaste();
+				this.prepareVimInsertMutation();
 				void this.onPasteImage();
 				return;
 			}
 
 			// Intercept configured raw text paste (fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") && this.onPasteTextRaw) {
-				this.prepareVimPaste();
+				this.prepareVimInsertMutation();
 				this.onPasteTextRaw();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -810,6 +810,11 @@ export class CustomEditor extends Editor {
 			// Enter that the user pressed right after Cmd+V) so they only fire *after* the paste
 			// completes — fixes the race where submit runs against an empty `pendingImages`.
 			if (remaining.length > 0) this.#pendingInput.push(remaining);
+			if (this.getVimMode() === "normal") {
+				const drained = this.#pendingInput.splice(0);
+				for (const chunk of drained) this.handleInput(chunk);
+				return;
+			}
 			if (content.length === 0 && this.onPasteImage) {
 				this.#trackAsyncPaste(Promise.resolve(this.onPasteImage()));
 				return;
@@ -842,7 +847,7 @@ export class CustomEditor extends Editor {
 		}
 
 		// Space-hold push-to-talk: a sustained space bar starts/stops STT instead of typing spaces.
-		if (this.#handleSpaceHold(data, canonical)) return;
+		if (this.getVimMode() !== "normal" && this.#handleSpaceHold(data, canonical)) return;
 
 		// One union probe decides whether any per-action interception below can
 		// match — plain typing then skips the ~20 per-action set lookups per key.
@@ -851,13 +856,21 @@ export class CustomEditor extends Editor {
 			(this.#actionMatchKeyUnion.has(canonical) || this.#customMatchKeys.has(canonical))
 		) {
 			// Intercept configured image paste (async - fires and handles result)
-			if (this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
+			if (
+				this.getVimMode() !== "normal" &&
+				this.#matchesAction(canonical, "app.clipboard.pasteImage") &&
+				this.onPasteImage
+			) {
 				void this.onPasteImage();
 				return;
 			}
 
 			// Intercept configured raw text paste (fires and handles result)
-			if (this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") && this.onPasteTextRaw) {
+			if (
+				this.getVimMode() !== "normal" &&
+				this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") &&
+				this.onPasteTextRaw
+			) {
 				this.onPasteTextRaw();
 				return;
 			}
@@ -928,14 +941,14 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured interrupt shortcut.
-			// When the autocomplete popup is visible, ESC's first job is to dismiss
-			// the popup — let super.handleInput() route it to #cancelAutocomplete().
-			// The user can press ESC again afterward to fire the global interrupt
-			// handler. This matches the standard TUI/IDE pattern and prevents a
-			// single ESC from both closing an @ completion and aborting an active
-			// agent run (#1655).
-			if (this.#matchesAction(canonical, "app.interrupt") && this.onEscape && !this.isShowingAutocomplete()) {
+			// Escape leaves Vim insert mode before it can act as the app interrupt.
+			// Autocomplete still closes on the same key in the base editor.
+			if (
+				this.#matchesAction(canonical, "app.interrupt") &&
+				this.onEscape &&
+				!this.isShowingAutocomplete() &&
+				!this.isVimInsertEscape(data)
+			) {
 				this.onEscape();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -6,6 +6,7 @@ import {
 	Editor,
 	type EditorTheme,
 	type KeyId,
+	matchesKey,
 	parseKey,
 	parseKittySequence,
 	TUI,
@@ -779,8 +780,15 @@ export class CustomEditor extends Editor {
 	handleInput(data: string): void {
 		// Serialize behind any in-flight async paste so a trailing Enter / follow-up key can't
 		// submit before the clipboard image reaches `pendingImages` (Codex PR #3602 review).
+		// Escape remains immediate in Vim insert mode: it cancels queued input, switches to normal,
+		// and lets the commit-time mode guard discard the eventual paste result.
 		if (this.#pasteInFlight > 0) {
-			this.#pendingInput.push(data);
+			if (this.getVimMode() === "insert" && matchesKey(data, "escape")) {
+				this.#pendingInput.length = 0;
+				super.handleInput(data);
+			} else {
+				this.#pendingInput.push(data);
+			}
 			return;
 		}
 		// textEquals avoids getText()'s O(buffer) join on every keystroke; kitty
@@ -882,7 +890,7 @@ export class CustomEditor extends Editor {
 			// Intercept configured image paste (async - fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
 				this.prepareVimInsertMutation();
-				void this.onPasteImage();
+				this.#trackAsyncPaste(Promise.resolve(this.onPasteImage()));
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -947,8 +947,14 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Escape leaves Vim insert or visual mode before it can act as the app interrupt.
-			// Autocomplete still closes on the same key in the base editor.
+			// Intercept configured interrupt shortcut.
+			// When the autocomplete popup is visible, ESC's first job is to dismiss
+			// the popup — let super.handleInput() route it to #cancelAutocomplete().
+			// The user can press ESC again afterward to fire the global interrupt
+			// handler. This matches the standard TUI/IDE pattern and prevents a
+			// single ESC from both closing an @ completion and aborting an active
+			// agent run (#1655). In Vim insert or visual mode, ESC first returns to
+			// normal mode before it can act as the app interrupt.
 			if (
 				this.#matchesAction(canonical, "app.interrupt") &&
 				this.onEscape &&

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -767,14 +767,11 @@ export class CustomEditor extends Editor {
 		for (const chunk of drained) this.handleInput(chunk);
 	};
 
-	/** Track `promise` as an in-flight paste so subsequent `handleInput` calls queue behind it,
-	 *  then drain the queue once it settles. Codex PR #3602 review: without this, a trailing
-	 *  keystroke (Enter most painfully) in the same stdin read processes synchronously while the
-	 *  clipboard read is still pending — submit fires with the text but `pendingImages` is still
-	 *  empty and the image lands on the *next* draft instead. */
-	#trackAsyncPaste(promise: Promise<unknown>): void {
+	/** Track an in-flight paste so subsequent input cannot overtake its editor mutation. */
+	trackAsyncPaste<T>(promise: Promise<T>): Promise<T> {
 		this.#pasteInFlight++;
 		void promise.then(this.#onPasteSettled, this.#onPasteSettled);
+		return promise;
 	}
 
 	handleInput(data: string): void {
@@ -831,13 +828,13 @@ export class CustomEditor extends Editor {
 			}
 			if (content.length === 0 && this.onPasteImage) {
 				this.prepareVimInsertMutation();
-				this.#trackAsyncPaste(Promise.resolve(this.onPasteImage()));
+				void this.trackAsyncPaste(Promise.resolve(this.onPasteImage()));
 				return;
 			}
 			const imagePaths = extractImagePastePathsFromText(content);
 			if (imagePaths && this.onPasteImagePath) {
 				this.prepareVimInsertMutation();
-				this.#trackAsyncPaste(
+				void this.trackAsyncPaste(
 					(async () => {
 						for (const p of imagePaths) await this.onPasteImagePath?.(p);
 					})(),
@@ -890,14 +887,14 @@ export class CustomEditor extends Editor {
 			// Intercept configured image paste (async - fires and handles result)
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
 				this.prepareVimInsertMutation();
-				this.#trackAsyncPaste(Promise.resolve(this.onPasteImage()));
+				void this.trackAsyncPaste(Promise.resolve(this.onPasteImage()));
 				return;
 			}
 
 			// Intercept configured raw text paste and serialize follow-up input until it settles.
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") && this.onPasteTextRaw) {
 				this.prepareVimInsertMutation();
-				this.#trackAsyncPaste(Promise.resolve(this.onPasteTextRaw()));
+				void this.trackAsyncPaste(Promise.resolve(this.onPasteTextRaw()));
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -861,19 +861,18 @@ export class CustomEditor extends Editor {
 			canonical !== undefined &&
 			(this.#actionMatchKeyUnion.has(canonical) || this.#customMatchKeys.has(canonical))
 		) {
+			const vimMode = this.getVimMode();
+			const acceptsClipboardPaste = vimMode === undefined || vimMode === "insert";
+
 			// Intercept configured image paste (async - fires and handles result)
-			if (
-				this.getVimMode() !== "normal" &&
-				this.#matchesAction(canonical, "app.clipboard.pasteImage") &&
-				this.onPasteImage
-			) {
+			if (acceptsClipboardPaste && this.#matchesAction(canonical, "app.clipboard.pasteImage") && this.onPasteImage) {
 				void this.onPasteImage();
 				return;
 			}
 
 			// Intercept configured raw text paste (fires and handles result)
 			if (
-				this.getVimMode() !== "normal" &&
+				acceptsClipboardPaste &&
 				this.#matchesAction(canonical, "app.clipboard.pasteTextRaw") &&
 				this.onPasteTextRaw
 			) {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -600,6 +600,9 @@ export class CustomEditor extends Editor {
 	 *  dispatching them so a trailing `Enter` after `Cmd+V` can't submit before the image lands on
 	 *  `pendingImages` (Codex PR #3602 review). */
 	#pasteInFlight = 0;
+	/** Aborted when Vim Escape releases the current async-paste gate. Async producers capture
+	 *  the signal before their first await so a later insert session cannot accept stale results. */
+	#asyncPasteAbort = new AbortController();
 	/** Input chunks deferred behind an in-flight paste, drained in FIFO order once the paste
 	 *  count returns to zero. */
 	#pendingInput: string[] = [];
@@ -756,32 +759,42 @@ export class CustomEditor extends Editor {
 		this.onSpaceHoldEnd?.();
 	}
 
-	/** Decrement {@link #pasteInFlight} once an async paste settles and, when the count returns
-	 *  to zero, drain {@link #pendingInput} through `handleInput` so requeueing still works if a
-	 *  drained chunk triggers another async paste. Bound member so it can be passed straight to
-	 *  `Promise.then(callback, callback)`. */
-	#onPasteSettled = (): void => {
+	/** Signal scoped to the current async-paste generation. Producers must check it before
+	 *  committing an awaited result to the editor. */
+	getAsyncPasteSignal(): AbortSignal {
+		return this.#asyncPasteAbort.signal;
+	}
+
+	/** Decrement {@link #pasteInFlight} once a non-canceled async paste settles and, when the
+	 *  count returns to zero, drain {@link #pendingInput} through `handleInput`. */
+	#onPasteSettled(signal: AbortSignal): void {
+		if (signal.aborted) return;
 		this.#pasteInFlight--;
 		if (this.#pasteInFlight > 0) return;
 		const drained = this.#pendingInput.splice(0);
 		for (const chunk of drained) this.handleInput(chunk);
-	};
+	}
 
 	/** Track an in-flight paste so subsequent input cannot overtake its editor mutation. */
 	trackAsyncPaste<T>(promise: Promise<T>): Promise<T> {
+		const signal = this.#asyncPasteAbort.signal;
 		this.#pasteInFlight++;
-		void promise.then(this.#onPasteSettled, this.#onPasteSettled);
+		const onSettled = (): void => this.#onPasteSettled(signal);
+		void promise.then(onSettled, onSettled);
 		return promise;
 	}
 
 	handleInput(data: string): void {
 		// Serialize behind any in-flight async paste so a trailing Enter / follow-up key can't
 		// submit before the clipboard image reaches `pendingImages` (Codex PR #3602 review).
-		// Escape remains immediate in Vim insert mode: it cancels queued input, switches to normal,
-		// and lets the commit-time mode guard discard the eventual paste result.
+		// Vim Escape cancels this paste generation and releases queued input immediately; async
+		// producers use getAsyncPasteSignal() to discard any result that finishes after canceling.
 		if (this.#pasteInFlight > 0) {
 			if (this.getVimMode() === "insert" && matchesKey(data, "escape")) {
 				this.#pendingInput.length = 0;
+				this.#asyncPasteAbort.abort();
+				this.#asyncPasteAbort = new AbortController();
+				this.#pasteInFlight = 0;
 				super.handleInput(data);
 			} else {
 				this.#pendingInput.push(data);

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -877,7 +877,11 @@ export class CustomEditor extends Editor {
 			canonical !== undefined &&
 			(this.#actionMatchKeyUnion.has(canonical) || this.#customMatchKeys.has(canonical))
 		) {
-			if (!acceptsTextEntry) this.clearVimPendingCommand();
+			const clearedVimPending = !acceptsTextEntry && this.clearVimPendingCommand();
+			if (clearedVimPending && (matchesKey(data, "escape") || matchesKey(data, "esc"))) {
+				super.handleInput(data);
+				return;
+			}
 			if (acceptsTextEntry && this.#matchesAction(canonical, "app.stt.toggle") && this.onSTTToggle) {
 				this.prepareVimInsertMutation();
 				this.onSTTToggle();

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -617,8 +617,8 @@ export class CustomEditor extends Editor {
 	 *  dispatching them so a trailing `Enter` after `Cmd+V` can't submit before the image lands on
 	 *  `pendingImages` (Codex PR #3602 review). */
 	#pasteInFlight = 0;
-	/** Aborted when Vim Escape releases the current async-paste gate. Async producers capture
-	 *  the signal before their first await so a later insert session cannot accept stale results. */
+	/** Aborted when an editor cancellation shortcut releases the current async-paste gate. Async
+	 *  producers capture the signal before their first await so canceled results cannot commit. */
 	#asyncPasteAbort = new AbortController();
 	/** Input chunks deferred behind an in-flight paste, drained in FIFO order once the paste
 	 *  count returns to zero. */
@@ -809,19 +809,24 @@ export class CustomEditor extends Editor {
 	handleInput(data: string): void {
 		// Serialize behind any in-flight async paste so a trailing Enter / follow-up key can't
 		// submit before the clipboard image reaches `pendingImages` (Codex PR #3602 review).
-		// Vim Escape cancels this paste generation and releases queued input immediately; async
-		// producers use getAsyncPasteSignal() to discard any result that finishes after canceling.
+		// Cancellation shortcuts abort this paste generation, discard queued input, and continue
+		// through normal routing immediately; async producers discard any later result.
 		if (this.#pasteInFlight > 0) {
-			if (this.getVimMode() === "insert" && matchesKey(data, "escape")) {
-				this.#pendingInput.length = 0;
-				this.#asyncPasteAbort.abort();
-				this.#asyncPasteAbort = new AbortController();
-				this.#pasteInFlight = 0;
-				super.handleInput(data);
-			} else {
+			const parsed = parseKey(data);
+			const canonical = parsed !== undefined ? canonicalKeyId(parsed) : undefined;
+			const cancelsPaste =
+				(this.getVimMode() === "insert" && matchesKey(data, "escape")) ||
+				this.#matchesAction(canonical, "app.interrupt") ||
+				this.#matchesAction(canonical, "app.clear") ||
+				this.#matchesAction(canonical, "app.exit");
+			if (!cancelsPaste) {
 				this.#pendingInput.push(data);
+				return;
 			}
-			return;
+			this.#pendingInput.length = 0;
+			this.#asyncPasteAbort.abort();
+			this.#asyncPasteAbort = new AbortController();
+			this.#pasteInFlight = 0;
 		}
 		// textEquals avoids getText()'s O(buffer) join on every keystroke; kitty
 		// sequences always start with ESC, so plain bytes skip the native parse.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1647,6 +1647,8 @@ export class InputController {
 	async handleClipboardTextRawPaste(): Promise<void> {
 		try {
 			const text = await this.clipboard.readText();
+			const vimMode = this.ctx.editor.getVimMode();
+			if (vimMode !== undefined && vimMode !== "insert") return;
 			if (text) {
 				this.ctx.editor.insertText(text);
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1427,6 +1427,9 @@ export class InputController {
 				this.ctx.sessionManager.putBlob.bind(this.ctx.sessionManager),
 			)
 		)?.[0];
+		const dims = await this.#imageDimensions(imageData);
+		const vimMode = this.ctx.editor.getVimMode?.();
+		if (vimMode !== undefined && vimMode !== "insert") return;
 		this.ctx.editor.pendingImages.push({
 			type: "image",
 			data: imageData.data,
@@ -1435,7 +1438,6 @@ export class InputController {
 		this.ctx.editor.pendingImageLinks.push(imageLink);
 		this.ctx.editor.imageLinks = this.ctx.editor.pendingImageLinks;
 		const imageNum = this.ctx.editor.pendingImages.length;
-		const dims = await this.#imageDimensions(imageData);
 		const label = dims ? `[Image #${imageNum}, ${dims.width}x${dims.height}]` : `[Image #${imageNum}]`;
 		this.ctx.editor.insertText(`${label} `);
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1539,6 +1539,7 @@ export class InputController {
 				// Path resolved but is not a readable image (e.g. a zero-byte or
 				// locked transient screenshot file). Prefer the clipboard bytes.
 				if (await this.#tryPasteClipboardImage(pasteSignal)) return;
+				if (pasteSignal.aborted) return;
 				this.ctx.editor.pasteText(path);
 				this.ctx.ui.requestRender();
 				this.ctx.showStatus("Pasted path is not a supported image");
@@ -1562,6 +1563,7 @@ export class InputController {
 				// path on the *local* filesystem. The bytes may still be on the
 				// clipboard (Win+Shift+S), so try those before giving up.
 				if (await this.#tryPasteClipboardImage(pasteSignal)) return;
+				if (pasteSignal.aborted) return;
 				// Over SSH the clipboard lives on the remote host, so the path is
 				// genuinely unreachable; pasting it as text would look like the
 				// image was attached when nothing was sent. Surface an SSH-aware
@@ -1586,6 +1588,7 @@ export class InputController {
 				return;
 			}
 			if (await this.#tryPasteClipboardImage(pasteSignal)) return;
+			if (pasteSignal.aborted) return;
 			this.ctx.editor.pasteText(path);
 			this.ctx.ui.requestRender();
 			this.ctx.showStatus("Failed to read pasted image path");

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -459,6 +459,8 @@ export class InputController {
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 		this.ctx.editor.setActionKeys("app.retry", this.ctx.keybindings.getKeys("app.retry"));
 		this.ctx.editor.onRetry = () => void this.handleRetry();
+		this.ctx.editor.setActionKeys("app.stt.toggle", this.ctx.keybindings.getKeys("app.stt.toggle"));
+		this.ctx.editor.onSTTToggle = () => void this.ctx.handleSTTToggle();
 		this.ctx.editor.clearCustomKeyHandlers();
 		// Wire up extension shortcuts
 		this.registerExtensionShortcuts();
@@ -481,9 +483,6 @@ export class InputController {
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.message.followUp")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.handleFollowUp());
-		}
-		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
 		for (const key of this.ctx.keybindings.getKeys("app.live.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleLiveCommand());

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -585,7 +585,7 @@ export class InputController {
 				target.pasteText(text);
 				this.ctx.ui.requestRender();
 			},
-			pasteImage: async image => {
+			pasteImage: image => {
 				// Images can only land in the main editor — when a modal Input is
 				// focused, refuse rather than dump the binary blob in a hidden buffer.
 				const focused = this.ctx.ui.getFocused();
@@ -593,7 +593,11 @@ export class InputController {
 					this.ctx.showStatus("Image paste is not supported in this prompt");
 					return;
 				}
-				await this.#normalizeAndInsertPastedImage(image, `Unsupported pasted image format: ${image.mimeType}`);
+				return this.ctx.editor
+					.trackAsyncPaste(
+						this.#normalizeAndInsertPastedImage(image, `Unsupported pasted image format: ${image.mimeType}`),
+					)
+					.then(() => {});
 			},
 			showStatus: message => this.ctx.showStatus(message),
 		});

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -587,10 +587,6 @@ export class InputController {
 			},
 			pasteImage: image => {
 				const vimMode = this.ctx.editor.getVimMode();
-				if (vimMode !== undefined && vimMode !== "insert") {
-					this.ctx.editor.clearVimPendingCommand();
-					return;
-				}
 				// Images can only land in the main editor — when a modal Input is
 				// focused, refuse rather than dump the binary blob in a hidden buffer.
 				const focused = this.ctx.ui.getFocused();
@@ -598,10 +594,19 @@ export class InputController {
 					this.ctx.showStatus("Image paste is not supported in this prompt");
 					return;
 				}
+				if (vimMode !== undefined && vimMode !== "insert") {
+					this.ctx.editor.clearVimPendingCommand();
+					return;
+				}
+				const pasteSignal = this.ctx.editor.getAsyncPasteSignal();
 				if (vimMode === "insert") this.ctx.editor.prepareVimInsertMutation();
 				return this.ctx.editor
 					.trackAsyncPaste(
-						this.#normalizeAndInsertPastedImage(image, `Unsupported pasted image format: ${image.mimeType}`),
+						this.#normalizeAndInsertPastedImage(
+							image,
+							`Unsupported pasted image format: ${image.mimeType}`,
+							pasteSignal,
+						),
 					)
 					.then(() => {});
 			},
@@ -1424,7 +1429,7 @@ export class InputController {
 		return allQueued.length;
 	}
 
-	async #insertPendingImage(imageData: ImageContent): Promise<void> {
+	async #insertPendingImage(imageData: ImageContent, pasteSignal: AbortSignal): Promise<void> {
 		const imageLink = (
 			await materializeImageReferenceLinks(
 				[
@@ -1439,7 +1444,7 @@ export class InputController {
 		)?.[0];
 		const dims = await this.#imageDimensions(imageData);
 		const vimMode = this.ctx.editor.getVimMode?.();
-		if (vimMode !== undefined && vimMode !== "insert") return;
+		if (pasteSignal.aborted || (vimMode !== undefined && vimMode !== "insert")) return;
 		this.ctx.editor.pendingImages.push({
 			type: "image",
 			data: imageData.data,
@@ -1465,8 +1470,13 @@ export class InputController {
 		return undefined;
 	}
 
-	async #normalizeAndInsertPastedImage(image: ImageContent, unsupportedMessage: string): Promise<boolean> {
+	async #normalizeAndInsertPastedImage(
+		image: ImageContent,
+		unsupportedMessage: string,
+		pasteSignal: AbortSignal,
+	): Promise<boolean> {
 		let imageData = await ensureSupportedImageInput(image);
+		if (pasteSignal.aborted) return false;
 		if (!imageData) {
 			this.ctx.showStatus(unsupportedMessage);
 			return false;
@@ -1483,7 +1493,7 @@ export class InputController {
 				// Keep the normalized image when resize fails.
 			}
 		}
-		await this.#insertPendingImage(imageData);
+		await this.#insertPendingImage(imageData, pasteSignal);
 		return true;
 	}
 
@@ -1500,15 +1510,16 @@ export class InputController {
 	 * the outcome (image attached, or an unsupported-format status surfaced), so
 	 * the caller stops without emitting its own degraded diagnostic.
 	 */
-	async #tryPasteClipboardImage(): Promise<boolean> {
+	async #tryPasteClipboardImage(pasteSignal: AbortSignal): Promise<boolean> {
 		const env = process.env;
 		if (env.SSH_CONNECTION || env.SSH_TTY || env.SSH_CLIENT) return false;
 		try {
 			const image = await this.clipboard.readImage();
-			if (!image) return false;
+			if (pasteSignal.aborted || !image) return false;
 			await this.#normalizeAndInsertPastedImage(
 				{ type: "image", data: image.data.toBase64(), mimeType: image.mimeType },
 				`Unsupported clipboard image format: ${image.mimeType}`,
+				pasteSignal,
 			);
 			return true;
 		} catch {
@@ -1516,17 +1527,18 @@ export class InputController {
 		}
 	}
 
-	async handleImagePathPaste(path: string): Promise<void> {
+	async handleImagePathPaste(path: string, pasteSignal = this.ctx.editor.getAsyncPasteSignal()): Promise<void> {
 		try {
 			const image = await loadImageInput({
 				path,
 				cwd: this.ctx.sessionManager.getCwd(),
 				autoResize: false,
 			});
+			if (pasteSignal.aborted) return;
 			if (!image) {
 				// Path resolved but is not a readable image (e.g. a zero-byte or
 				// locked transient screenshot file). Prefer the clipboard bytes.
-				if (await this.#tryPasteClipboardImage()) return;
+				if (await this.#tryPasteClipboardImage(pasteSignal)) return;
 				this.ctx.editor.pasteText(path);
 				this.ctx.ui.requestRender();
 				this.ctx.showStatus("Pasted path is not a supported image");
@@ -1535,8 +1547,10 @@ export class InputController {
 			await this.#normalizeAndInsertPastedImage(
 				{ type: "image", data: image.data, mimeType: image.mimeType },
 				`Unsupported pasted image format: ${image.mimeType}`,
+				pasteSignal,
 			);
 		} catch (error) {
+			if (pasteSignal.aborted) return;
 			if (error instanceof ImageInputTooLargeError) {
 				this.ctx.editor.pasteText(path);
 				this.ctx.ui.requestRender();
@@ -1547,7 +1561,7 @@ export class InputController {
 				// #2375: the bracketed paste forwarded by a local terminal carries a
 				// path on the *local* filesystem. The bytes may still be on the
 				// clipboard (Win+Shift+S), so try those before giving up.
-				if (await this.#tryPasteClipboardImage()) return;
+				if (await this.#tryPasteClipboardImage(pasteSignal)) return;
 				// Over SSH the clipboard lives on the remote host, so the path is
 				// genuinely unreachable; pasting it as text would look like the
 				// image was attached when nothing was sent. Surface an SSH-aware
@@ -1571,7 +1585,7 @@ export class InputController {
 				);
 				return;
 			}
-			if (await this.#tryPasteClipboardImage()) return;
+			if (await this.#tryPasteClipboardImage(pasteSignal)) return;
 			this.ctx.editor.pasteText(path);
 			this.ctx.ui.requestRender();
 			this.ctx.showStatus("Failed to read pasted image path");
@@ -1579,6 +1593,7 @@ export class InputController {
 	}
 
 	async handleImagePaste(): Promise<boolean> {
+		const pasteSignal = this.ctx.editor.getAsyncPasteSignal();
 		try {
 			// When a modal paste-capable prompt (login/API-key Input) owns focus,
 			// only clipboard text may land there. Image payloads must not mutate
@@ -1588,6 +1603,7 @@ export class InputController {
 			const promptTarget =
 				focusedNow && focusedNow !== this.ctx.editor && hasPasteText(focusedNow) ? focusedNow : null;
 			const image = await this.clipboard.readImage();
+			if (pasteSignal.aborted) return false;
 			if (image) {
 				if (promptTarget) {
 					this.ctx.showStatus("Image paste is not supported in this prompt");
@@ -1600,6 +1616,7 @@ export class InputController {
 						mimeType: image.mimeType,
 					},
 					`Unsupported clipboard image format: ${image.mimeType}`,
+					pasteSignal,
 				);
 			}
 			// #3506: macOS Finder `Cmd+C` puts only a `public.file-url`
@@ -1615,11 +1632,12 @@ export class InputController {
 			// `readMacFileUrls` returns an empty list off Darwin, so the
 			// check is free on every other platform.
 			const fileUrls = promptTarget ? [] : ((await this.clipboard.readMacFileUrls?.()) ?? []);
+			if (pasteSignal.aborted) return false;
 			let attachedFromFileUrls = false;
 			for (const url of fileUrls) {
 				const candidate = extractImagePathFromText(url);
 				if (!candidate) continue;
-				await this.handleImagePathPaste(candidate);
+				await this.handleImagePathPaste(candidate, pasteSignal);
 				attachedFromFileUrls = true;
 			}
 			if (attachedFromFileUrls) return true;
@@ -1629,6 +1647,7 @@ export class InputController {
 			// integrated terminal, Win+V clipboard history) deliver only
 			// this keypress, so a miss here must not dead-end.
 			const text = await this.clipboard.readText();
+			if (pasteSignal.aborted) return false;
 			if (!text) {
 				this.ctx.showStatus("Clipboard is empty");
 				return false;
@@ -1641,7 +1660,7 @@ export class InputController {
 			// terminals do this for image clipboards).
 			const imagePath = promptTarget ? null : extractImagePathFromText(text);
 			if (imagePath) {
-				await this.handleImagePathPaste(imagePath);
+				await this.handleImagePathPaste(imagePath, pasteSignal);
 				return true;
 			}
 			// Route to the focused component when it accepts pastes (modal
@@ -1651,16 +1670,18 @@ export class InputController {
 			this.ctx.ui.requestRender();
 			return true;
 		} catch {
+			if (pasteSignal.aborted) return false;
 			this.ctx.showStatus("Failed to read clipboard");
 			return false;
 		}
 	}
 
 	async handleClipboardTextRawPaste(): Promise<void> {
+		const pasteSignal = this.ctx.editor.getAsyncPasteSignal();
 		try {
 			const text = await this.clipboard.readText();
 			const vimMode = this.ctx.editor.getVimMode();
-			if (vimMode !== undefined && vimMode !== "insert") return;
+			if (pasteSignal.aborted || (vimMode !== undefined && vimMode !== "insert")) return;
 			if (text) {
 				this.ctx.editor.insertText(text);
 				this.ctx.ui.requestRender();
@@ -1668,6 +1689,7 @@ export class InputController {
 				this.ctx.showStatus("No text in clipboard to paste raw");
 			}
 		} catch {
+			if (pasteSignal.aborted) return;
 			this.ctx.showStatus("Failed to paste raw text from clipboard");
 		}
 	}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -11,7 +11,12 @@ import { extractImagePathFromText } from "../../modes/components/custom-editor";
 import { renderSegmentTrack } from "../../modes/components/segment-track";
 import { TinyTitleDownloadProgressComponent } from "../../modes/components/tiny-title-download-progress";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
-import { materializeImageReferenceLinks, shiftImageMarkers } from "../../modes/image-references";
+import {
+	materializeImageReferenceLinks,
+	type ReconciledImageReferences,
+	reconcileImageReferences,
+	shiftImageMarkers,
+} from "../../modes/image-references";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { parseQueueShorthand, splitQueuedMessages } from "../../modes/queue-input";
 import { invokeSkillCommandFromText, isKnownSkillCommand } from "../../modes/skill-command";
@@ -616,10 +621,23 @@ export class InputController {
 		this.ctx.ui.addStartListener(() => this.#enhancedPaste?.enable());
 	}
 
+	#reconcileEditorImageReferences(text: string): ReconciledImageReferences {
+		const reconciled = reconcileImageReferences(
+			text,
+			this.ctx.editor.pendingImages,
+			this.ctx.editor.pendingImageLinks,
+		);
+		this.ctx.editor.pendingImages = reconciled.images;
+		this.ctx.editor.pendingImageLinks = reconciled.imageLinks;
+		this.ctx.editor.imageLinks = reconciled.images.length > 0 ? reconciled.imageLinks : undefined;
+		return reconciled;
+	}
+
 	setupEditorSubmitHandler(): void {
 		this.ctx.editor.onSubmit = async (text: string) => {
-			text = text.trim();
-			const hasPendingImages = this.ctx.editor.pendingImages.length > 0;
+			const editorInput = this.#reconcileEditorImageReferences(text.trim());
+			text = editorInput.text;
+			const hasPendingImages = editorInput.images.length > 0;
 			if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
 
 			// Focused subagent session: the editor is a plain chat box for it.
@@ -1157,10 +1175,10 @@ export class InputController {
 
 	/** Queue `/queue` input behind an active turn, or start it immediately when idle. */
 	async handleQueueCommand(text: string): Promise<void> {
-		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
-		const imageLinks =
-			images && this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
-		await this.#queueForYield(text, { images, imageLinks });
+		const input = this.#reconcileEditorImageReferences(text);
+		const images = input.images.length > 0 ? [...input.images] : undefined;
+		const imageLinks = images ? [...input.imageLinks] : undefined;
+		await this.#queueForYield(input.text, { images, imageLinks });
 	}
 
 	async #queueForYield(
@@ -1278,9 +1296,10 @@ export class InputController {
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
 		let text = this.ctx.editor.getExpandedText().trim();
-		const images = this.ctx.editor.pendingImages.length > 0 ? [...this.ctx.editor.pendingImages] : undefined;
-		const imageLinks =
-			images && this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
+		const input = this.#reconcileEditorImageReferences(text);
+		text = input.text;
+		const images = input.images.length > 0 ? [...input.images] : undefined;
+		const imageLinks = images ? [...input.imageLinks] : undefined;
 		if (!text && !images) return;
 
 		// Focused subagent session: follow-ups go to it; non-chat input is gated.

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -586,6 +586,7 @@ export class InputController {
 				this.ctx.ui.requestRender();
 			},
 			pasteImage: image => {
+				if (this.ctx.editor.getVimMode() !== "insert") this.ctx.editor.clearVimPendingCommand();
 				// Images can only land in the main editor — when a modal Input is
 				// focused, refuse rather than dump the binary blob in a hidden buffer.
 				const focused = this.ctx.ui.getFocused();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -586,7 +586,8 @@ export class InputController {
 				this.ctx.ui.requestRender();
 			},
 			pasteImage: image => {
-				if (this.ctx.editor.getVimMode() !== "insert") this.ctx.editor.clearVimPendingCommand();
+				const vimMode = this.ctx.editor.getVimMode();
+				if (vimMode !== "insert") this.ctx.editor.clearVimPendingCommand();
 				// Images can only land in the main editor — when a modal Input is
 				// focused, refuse rather than dump the binary blob in a hidden buffer.
 				const focused = this.ctx.ui.getFocused();
@@ -594,6 +595,7 @@ export class InputController {
 					this.ctx.showStatus("Image paste is not supported in this prompt");
 					return;
 				}
+				if (vimMode === "insert") this.ctx.editor.prepareVimInsertMutation();
 				return this.ctx.editor
 					.trackAsyncPaste(
 						this.#normalizeAndInsertPastedImage(image, `Unsupported pasted image format: ${image.mimeType}`),

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -446,7 +446,7 @@ export class InputController {
 			"app.clipboard.pasteTextRaw",
 			this.ctx.keybindings.getKeys("app.clipboard.pasteTextRaw"),
 		);
-		this.ctx.editor.onPasteTextRaw = () => void this.handleClipboardTextRawPaste();
+		this.ctx.editor.onPasteTextRaw = () => this.handleClipboardTextRawPaste();
 		this.ctx.editor.onLargePaste = (text, lineCount) => this.handleLargePaste(text, lineCount);
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.copyPrompt",

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -587,7 +587,10 @@ export class InputController {
 			},
 			pasteImage: image => {
 				const vimMode = this.ctx.editor.getVimMode();
-				if (vimMode !== "insert") this.ctx.editor.clearVimPendingCommand();
+				if (vimMode !== undefined && vimMode !== "insert") {
+					this.ctx.editor.clearVimPendingCommand();
+					return;
+				}
 				// Images can only land in the main editor — when a modal Input is
 				// focused, refuse rather than dump the binary blob in a hidden buffer.
 				const focused = this.ctx.ui.getFocused();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1698,12 +1698,13 @@ export class InputController {
 	 * Editor `onLargePaste` hook: gate a marker-sized paste behind the large-paste menu. Returns
 	 * `true` to intercept (the editor skips its default `[Paste]` marker) once the paste reaches the
 	 * configured `paste.largeMenuThreshold` line count; otherwise `false` for default collapse-to-marker
-	 * behavior. The async menu is fired and forgotten — the editor only needs the synchronous verdict.
+	 * behavior. The intercepted promise is tracked so Vim Escape can cancel its generation and
+	 * subsequent input cannot overtake the deferred menu/file commit.
 	 */
 	handleLargePaste(text: string, lineCount: number): boolean {
 		const threshold = this.ctx.settings.get("paste.largeMenuThreshold");
 		if (!(threshold > 0) || lineCount < threshold) return false;
-		void this.presentLargePasteMenu(text, lineCount);
+		void this.ctx.editor.trackAsyncPaste(this.presentLargePasteMenu(text, lineCount));
 		return true;
 	}
 
@@ -1714,6 +1715,7 @@ export class InputController {
 	 * inline paste marker, so the pasted content is never lost.
 	 */
 	async presentLargePasteMenu(text: string, lineCount: number): Promise<void> {
+		const pasteSignal = this.ctx.editor.getAsyncPasteSignal();
 		const WRAPPED_BLOCK = "Attach as a wrapped block";
 		const LOCAL_FILE = "Attach as local file";
 		const INLINE = "Paste inline";
@@ -1733,13 +1735,14 @@ export class InputController {
 			logger.warn("large-paste menu failed", { error: error instanceof Error ? error.message : String(error) });
 			choice = undefined;
 		}
+		if (pasteSignal.aborted) return;
 
 		switch (choice) {
 			case WRAPPED_BLOCK:
 				this.ctx.editor.insertPaste(wrapPasteInAttachmentBlock(text));
 				break;
 			case LOCAL_FILE:
-				await this.#attachPasteAsFile(text, lineCount);
+				await this.#attachPasteAsFile(text, lineCount, pasteSignal);
 				break;
 			case INLINE:
 				this.ctx.editor.insertPaste(text);
@@ -1749,6 +1752,7 @@ export class InputController {
 				this.ctx.editor.insertPaste(text);
 				break;
 		}
+		if (pasteSignal.aborted) return;
 		this.ctx.ui.requestRender();
 	}
 
@@ -1758,8 +1762,9 @@ export class InputController {
 	 * leaking a raw temp path. Falls back to an inline paste marker when the write fails, so the
 	 * content is never lost.
 	 */
-	async #attachPasteAsFile(text: string, lineCount: number): Promise<void> {
+	async #attachPasteAsFile(text: string, lineCount: number, pasteSignal: AbortSignal): Promise<void> {
 		try {
+			if (pasteSignal.aborted) return;
 			// Mirror the exact mapping the read tool's local:// resolver uses so a later
 			// `read local://paste-N.md` lands on the file written here.
 			const localRoot = resolveLocalRoot({
@@ -1773,10 +1778,13 @@ export class InputController {
 				name = `paste-${this.#pasteCounter}.md`;
 				filePath = path.join(localRoot, name);
 			} while (await Bun.file(filePath).exists());
+			if (pasteSignal.aborted) return;
 			await Bun.write(filePath, text);
+			if (pasteSignal.aborted) return;
 			this.ctx.editor.insertText(`local://${name} `);
 			this.ctx.showStatus(`Saved ${lineCount} pasted lines to local://${name}`);
 		} catch (error) {
+			if (pasteSignal.aborted) return;
 			logger.warn("failed to save large paste to file", {
 				error: error instanceof Error ? error.message : String(error),
 			});

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -469,6 +469,10 @@ export class SelectorController {
 				});
 				break;
 
+			case "inputMode":
+				this.ctx.editor.setInputMode(value === "vim" ? "vim" : "default");
+				break;
+
 			case "autocompleteMaxVisible":
 				this.ctx.editor.setAutocompleteMaxVisible(typeof value === "number" ? value : Number(value));
 				break;

--- a/packages/coding-agent/src/modes/image-references.ts
+++ b/packages/coding-agent/src/modes/image-references.ts
@@ -28,6 +28,38 @@ export function shiftImageMarkers(text: string, offset: number): string {
 	);
 }
 
+export interface ReconciledImageReferences {
+	text: string;
+	images: ImageContent[];
+	imageLinks: (string | undefined)[];
+}
+
+/** Keep only image sidecars referenced by `text` and compact their marker indices
+ * in first-appearance order. Invalid marker indices remain ordinary text. */
+export function reconcileImageReferences(
+	text: string,
+	images: readonly ImageContent[],
+	imageLinks: readonly (string | undefined)[],
+): ReconciledImageReferences {
+	const reconciledImages: ImageContent[] = [];
+	const reconciledLinks: (string | undefined)[] = [];
+	const remappedIndices = new Map<number, number>();
+	const reconciledText = text.replace(IMAGE_MARKER_REGEX, (marker, indexText: string, tail: string) => {
+		const sourceIndex = Number(indexText) - 1;
+		const image = images[sourceIndex];
+		if (image === undefined) return marker;
+		let targetIndex = remappedIndices.get(sourceIndex);
+		if (targetIndex === undefined) {
+			reconciledImages.push(image);
+			reconciledLinks.push(imageLinks[sourceIndex]);
+			targetIndex = reconciledImages.length;
+			remappedIndices.set(sourceIndex, targetIndex);
+		}
+		return `[Image #${targetIndex}${tail}]`;
+	});
+	return { text: reconciledText, images: reconciledImages, imageLinks: reconciledLinks };
+}
+
 type ImageBlobWriter = (data: Buffer, options?: { extension?: string }) => Promise<BlobPutResult>;
 type ImageBlobWriterSync = (data: Buffer, options?: { extension?: string }) => BlobPutResult;
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -733,6 +733,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setImeSafeCursorLayout(settings.get("tui.imeSafeCursor"));
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
+		this.editor.setInputMode(settings.get("inputMode"));
 		this.editor.onAutocompleteCancel = () => {
 			this.ui.requestRender(true);
 		};
@@ -776,7 +777,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		// (#4145). The TUI throttles renders at ~30fps, so a long-running eval
 		// spraying events no longer runs `getTopBorder` synchronously in the
 		// hot path where the render never gets to paint the result.
-		this.editor.setTopBorderProvider(availableWidth => this.statusLine.getTopBorder(availableWidth));
+		this.editor.onInputModeChange = () => this.ui.requestComponentRender(this.editor);
+		this.editor.setTopBorderProvider(availableWidth => this.#getEditorTopBorder(this.editor, availableWidth));
 
 		this.hideThinkingBlock = settings.get("hideThinkingBlock");
 		this.proseOnlyThinking = settings.get("proseOnlyThinking");
@@ -4086,6 +4088,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#extensionUiController.initializeHookRunner(uiContext, hasUI);
 	}
 
+	#getEditorTopBorder(editor: CustomEditor, availableWidth: number): { content: string; width: number } {
+		const mode = editor.getVimMode();
+		if (!mode) return this.statusLine.getTopBorder(availableWidth);
+		const label = theme.bold(theme.fg(mode === "normal" ? "accent" : "muted", ` ${mode.toUpperCase()} `));
+		const labelWidth = visibleWidth(label);
+		const status = this.statusLine.getTopBorder(Math.max(0, availableWidth - labelWidth));
+		return { content: label + status.content, width: labelWidth + status.width };
+	}
+
 	setEditorComponent(
 		factory: ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => CustomEditor) | undefined,
 	): void {
@@ -4099,14 +4110,16 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		nextEditor.setImeSafeCursorLayout(this.settings.get("tui.imeSafeCursor"));
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
+		nextEditor.setInputMode(this.settings.get("inputMode"));
 		nextEditor.onAutocompleteCancel = () => {
 			this.ui.requestRender(true);
 		};
 		nextEditor.onAutocompleteUpdate = () => {
 			this.ui.requestRender();
 		};
+		nextEditor.onInputModeChange = () => this.ui.requestComponentRender(nextEditor);
 		nextEditor.setShimmerRepaintHandler(() => this.ui.requestComponentRender(this.editor));
-		nextEditor.setTopBorderProvider(availableWidth => this.statusLine.getTopBorder(availableWidth));
+		nextEditor.setTopBorderProvider(availableWidth => this.#getEditorTopBorder(nextEditor, availableWidth));
 		nextEditor.setMaxHeight(this.#computeEditorMaxHeight());
 		if (this.historyStorage) {
 			nextEditor.setHistoryStorage(this.historyStorage);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -777,7 +777,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		// (#4145). The TUI throttles renders at ~30fps, so a long-running eval
 		// spraying events no longer runs `getTopBorder` synchronously in the
 		// hot path where the render never gets to paint the result.
-		this.editor.onInputModeChange = () => this.ui.requestComponentRender(this.editor);
+		this.editor.onInputModeChange = mode => {
+			if (mode !== undefined && mode !== "insert") this.#sttController?.cancel();
+			this.ui.requestComponentRender(this.editor);
+		};
 		this.editor.setTopBorderProvider(availableWidth => this.#getEditorTopBorder(this.editor, availableWidth));
 
 		this.hideThinkingBlock = settings.get("hideThinkingBlock");
@@ -4117,7 +4120,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		nextEditor.onAutocompleteUpdate = () => {
 			this.ui.requestRender();
 		};
-		nextEditor.onInputModeChange = () => this.ui.requestComponentRender(nextEditor);
+		nextEditor.onInputModeChange = mode => {
+			if (mode !== undefined && mode !== "insert") this.#sttController?.cancel();
+			this.ui.requestComponentRender(nextEditor);
+		};
 		nextEditor.setShimmerRepaintHandler(() => this.ui.requestComponentRender(this.editor));
 		nextEditor.setTopBorderProvider(availableWidth => this.#getEditorTopBorder(nextEditor, availableWidth));
 		nextEditor.setMaxHeight(this.#computeEditorMaxHeight());

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -733,7 +733,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setImeSafeCursorLayout(settings.get("tui.imeSafeCursor"));
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
-		this.editor.setInputMode(settings.get("inputMode"));
+		this.editor.setInputMode(this.settings.get("inputMode"));
 		this.editor.onAutocompleteCancel = () => {
 			this.ui.requestRender(true);
 		};

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4124,7 +4124,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.requestRender();
 		};
 		nextEditor.onInputModeChange = mode => {
-			if (mode !== undefined && mode !== "insert") this.#sttController?.cancel();
+			if (mode !== undefined && mode !== "insert") {
+				nextEditor.cancelSpaceHold();
+				this.#sttController?.cancel();
+			}
 			this.ui.requestComponentRender(nextEditor);
 		};
 		nextEditor.setShimmerRepaintHandler(() => this.ui.requestComponentRender(this.editor));

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -778,7 +778,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		// spraying events no longer runs `getTopBorder` synchronously in the
 		// hot path where the render never gets to paint the result.
 		this.editor.onInputModeChange = mode => {
-			if (mode !== undefined && mode !== "insert") this.#sttController?.cancel();
+			if (mode !== undefined && mode !== "insert") {
+				this.editor.cancelSpaceHold();
+				this.#sttController?.cancel();
+			}
 			this.ui.requestComponentRender(this.editor);
 		};
 		this.editor.setTopBorderProvider(availableWidth => this.#getEditorTopBorder(this.editor, availableWidth));

--- a/packages/coding-agent/src/stt/stt-controller.ts
+++ b/packages/coding-agent/src/stt/stt-controller.ts
@@ -261,6 +261,7 @@ export class STTController {
 		try {
 			finalText = (await stream.stop()).trim();
 		} catch (err) {
+			if (this.#stream !== stream) return;
 			failed = true;
 			if (!this.#disposed) {
 				const msg = err instanceof Error ? err.message : "Transcription failed";
@@ -268,6 +269,7 @@ export class STTController {
 				logger.error("STT live transcription failed", { error: msg });
 			}
 		}
+		if (this.#stream !== stream) return;
 		if (this.#disposed) {
 			this.#cleanupStream();
 			return;

--- a/packages/coding-agent/src/stt/stt-controller.ts
+++ b/packages/coding-agent/src/stt/stt-controller.ts
@@ -176,17 +176,18 @@ export class STTController {
 		this.#streamEditor = editor;
 		this.#streamCommitted = false;
 		this.#streamUtterance = "";
-		this.#streamAbort = new AbortController();
+		const streamAbort = new AbortController();
+		this.#streamAbort = streamAbort;
 		const stream = sttClient.startStream(modelKey, {
 			language: language || undefined,
-			signal: this.#streamAbort.signal,
+			signal: streamAbort.signal,
 			onPartial: text => {
-				if (this.#disposed || this.#state !== "recording") return;
+				if (this.#disposed || this.#streamAbort !== streamAbort || this.#state !== "recording") return;
 				this.#streamEditor?.setVolatileText(this.#prefixed(text));
 				options.requestRender?.();
 			},
 			onSegment: text => {
-				if (this.#disposed) return;
+				if (this.#disposed || this.#streamAbort !== streamAbort) return;
 				const prefixed = this.#prefixed(text);
 				if (prefixed) {
 					this.#streamEditor?.commitVolatileText(prefixed);

--- a/packages/coding-agent/src/stt/stt-controller.ts
+++ b/packages/coding-agent/src/stt/stt-controller.ts
@@ -40,6 +40,7 @@ export class STTController {
 	#stopAfterStart = false;
 	#cancelRequested = false;
 	#activeOptions: ToggleOptions | null = null;
+	#preflightStatusActive = false;
 	#disposed = false;
 	readonly #createCapture: CaptureFactory;
 
@@ -108,7 +109,9 @@ export class STTController {
 			// cached-model fast path emits nothing.
 			let wroteStatus = false;
 			const status = (msg: string): void => {
+				if (this.#cancelRequested || this.#disposed) return;
 				wroteStatus = true;
+				this.#preflightStatusActive = true;
 				options.showStatus(msg);
 			};
 			// Loading the multi-hundred-MB speech model into the worker is what made
@@ -123,10 +126,13 @@ export class STTController {
 			} else {
 				await downloadSttModel(modelKey, p => status(`Downloading speech model ${p.label} (${p.percent}%)`));
 			}
-			if (wroteStatus) options.showStatus("");
+			if (wroteStatus && !this.#cancelRequested && !this.#disposed) options.showStatus("");
+			this.#preflightStatusActive = false;
 			this.#resolvedModelKey = modelKey;
 			return true;
 		} catch (err) {
+			this.#preflightStatusActive = false;
+			if (this.#cancelRequested || this.#disposed) return false;
 			const msg = err instanceof Error ? err.message : "Failed to setup STT dependencies";
 			options.showWarning(msg);
 			logger.error("STT dependency setup failed", { error: msg });
@@ -314,6 +320,11 @@ export class STTController {
 		this.#cancelRequested = true;
 		if (this.#state === "idle" && !this.#toggling) return;
 
+		const options = this.#activeOptions;
+		if (this.#preflightStatusActive) {
+			options?.showStatus("");
+			this.#preflightStatusActive = false;
+		}
 		this.#streamAbort?.abort();
 		this.#stream?.cancel();
 		try {
@@ -323,7 +334,6 @@ export class STTController {
 		}
 		this.#streamEditor?.clearVolatileText();
 		this.#cleanupStream();
-		const options = this.#activeOptions;
 		if (options) {
 			this.#setState("idle", options);
 			options.requestRender?.();
@@ -346,6 +356,7 @@ export class STTController {
 			// best effort cleanup
 		}
 		this.#cleanupStream();
+		this.#preflightStatusActive = false;
 		this.#state = "idle";
 		this.#resolvedModelKey = null;
 	}

--- a/packages/coding-agent/src/stt/stt-controller.ts
+++ b/packages/coding-agent/src/stt/stt-controller.ts
@@ -38,6 +38,8 @@ export class STTController {
 	#resolvedModelKey: string | null = null;
 	#toggling = false;
 	#stopAfterStart = false;
+	#cancelRequested = false;
+	#activeOptions: ToggleOptions | null = null;
 	#disposed = false;
 	readonly #createCapture: CaptureFactory;
 
@@ -68,6 +70,8 @@ export class STTController {
 			if (this.#state === "idle" || this.#state === "recording") this.#stopAfterStart = true;
 			return;
 		}
+		this.#cancelRequested = false;
+		this.#activeOptions = options;
 		this.#toggling = true;
 		try {
 			switch (this.#state) {
@@ -89,6 +93,7 @@ export class STTController {
 			}
 		} finally {
 			this.#toggling = false;
+			if (this.#state === "idle") this.#activeOptions = null;
 		}
 	}
 
@@ -147,6 +152,7 @@ export class STTController {
 
 	async #start(editor: Editor, options: ToggleOptions): Promise<void> {
 		if (!(await this.#ensureDeps(options))) return;
+		if (this.#cancelRequested) return;
 		await this.#startStreaming(editor, options);
 	}
 
@@ -299,6 +305,29 @@ export class STTController {
 		this.#streamCommitted = false;
 		this.#streamAbort = null;
 		this.#streamUtterance = "";
+	}
+
+	cancel(): void {
+		this.#cancelRequested = true;
+		if (this.#state === "idle" && !this.#toggling) return;
+
+		this.#streamAbort?.abort();
+		this.#stream?.cancel();
+		try {
+			this.#streamRecorder?.stop();
+		} catch {
+			// best effort cleanup
+		}
+		this.#streamEditor?.clearVolatileText();
+		this.#cleanupStream();
+		const options = this.#activeOptions;
+		if (options) {
+			this.#setState("idle", options);
+			options.requestRender?.();
+		} else {
+			this.#state = "idle";
+		}
+		this.#activeOptions = null;
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -139,6 +139,31 @@ describe("CustomEditor keybindings", () => {
 		expect(onSpaceHoldStart).not.toHaveBeenCalled();
 	});
 
+	it("allows configured STT toggles only from Vim insert mode", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onSTTToggle = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.stt.toggle", ["alt+s"]);
+		editor.onSTTToggle = onSTTToggle;
+		editor.setText("one two");
+
+		editor.handleInput("0");
+		editor.handleInput("d");
+		editor.handleInput("\x1bs");
+		editor.handleInput("w");
+		expect(onSTTToggle).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("one two");
+
+		editor.handleInput("v");
+		editor.handleInput("\x1bs");
+		expect(onSTTToggle).not.toHaveBeenCalled();
+		editor.handleInput("\x1b");
+
+		editor.handleInput("i");
+		editor.handleInput("\x1bs");
+		expect(onSTTToggle).toHaveBeenCalledTimes(1);
+	});
+
 	it("allows clipboard image paste only from Vim insert mode", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onPasteImage = vi.fn(async () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -96,6 +96,25 @@ describe("CustomEditor keybindings", () => {
 		expect(onEscape).toHaveBeenCalledTimes(1);
 	});
 
+	it("keeps Ctrl-R for Vim redo instead of opening history search", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onHistorySearch = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.history.search", ["ctrl+r"]);
+		editor.onHistorySearch = onHistorySearch;
+
+		editor.handleInput("i");
+		for (const char of "hello") editor.handleInput(char);
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+
+		editor.handleInput("\x12");
+
+		expect(editor.getText()).toBe("hello");
+		expect(onHistorySearch).not.toHaveBeenCalled();
+	});
+
 	it("does not start push-to-talk from Vim normal-mode spaces", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onSpaceHoldStart = vi.fn();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -113,6 +113,17 @@ describe("CustomEditor keybindings", () => {
 
 		expect(editor.getText()).toBe("hello");
 		expect(onHistorySearch).not.toHaveBeenCalled();
+
+		editor.handleInput("v");
+		editor.handleInput("\x12");
+		expect(editor.getVimMode()).toBe("visual");
+		expect(onHistorySearch).not.toHaveBeenCalled();
+
+		editor.handleInput("\x1b");
+		editor.handleInput("i");
+		editor.handleInput("\x12");
+		expect(editor.getVimMode()).toBe("insert");
+		expect(onHistorySearch).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not start push-to-talk from Vim normal-mode spaces", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -141,7 +141,7 @@ describe("CustomEditor keybindings", () => {
 
 	it("allows configured STT toggles only from Vim insert mode", () => {
 		const editor = new CustomEditor(getEditorTheme());
-		const onSTTToggle = vi.fn();
+		const onSTTToggle = vi.fn(() => editor.insertText("transcript"));
 		editor.setInputMode("vim");
 		editor.setActionKeys("app.stt.toggle", ["alt+s"]);
 		editor.onSTTToggle = onSTTToggle;
@@ -162,6 +162,10 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("i");
 		editor.handleInput("\x1bs");
 		expect(onSTTToggle).toHaveBeenCalledTimes(1);
+		editor.handleInput("!");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("one two");
 	});
 
 	it("allows clipboard image paste only from Vim insert mode", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -302,7 +302,7 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("");
 	});
 
-	it("allows configured raw-text paste only from Vim insert mode", () => {
+	it("allows configured raw-text paste only from Vim insert mode", async () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onPasteTextRaw = vi.fn(() => editor.insertText("pasted"));
 		editor.setInputMode("vim");
@@ -322,10 +322,39 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("i");
 		editor.handleInput("\x1bt");
 		expect(onPasteTextRaw).toHaveBeenCalledTimes(1);
+		await Promise.resolve();
+		await Promise.resolve();
 		editor.handleInput("!");
 		editor.handleInput("\x1b");
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("text");
+	});
+
+	it("queues Vim submit until a configured raw paste settles", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const clipboard = Promise.withResolvers<void>();
+		const onSubmit = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteTextRaw", ["alt+t"]);
+		editor.onPasteTextRaw = async () => {
+			await clipboard.promise;
+			editor.insertText("pasted");
+		};
+		editor.onSubmit = onSubmit;
+		editor.handleInput("i");
+
+		editor.handleInput("\x1bt");
+		editor.handleInput("\r");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getVimMode()).toBe("insert");
+
+		clipboard.resolve();
+		await clipboard.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onSubmit).toHaveBeenCalledWith("pasted");
+		expect(editor.getVimMode()).toBe("normal");
 	});
 });
 

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -96,6 +96,24 @@ describe("CustomEditor keybindings", () => {
 		expect(onEscape).toHaveBeenCalledTimes(1);
 	});
 
+	it("lets Escape cancel a pending Vim command before interrupting the app", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onEscape = vi.fn();
+		editor.setInputMode("vim");
+		editor.setText("abc");
+		editor.onEscape = onEscape;
+		editor.handleInput("d");
+
+		editor.handleInput("\x1b");
+
+		expect(editor.getVimMode()).toBe("normal");
+		expect(editor.getText()).toBe("abc");
+		expect(onEscape).not.toHaveBeenCalled();
+
+		editor.handleInput("\x1b");
+		expect(onEscape).toHaveBeenCalledTimes(1);
+	});
+
 	it("keeps Ctrl-R for Vim redo instead of opening history search", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onHistorySearch = vi.fn();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -141,7 +141,10 @@ describe("CustomEditor keybindings", () => {
 
 	it("allows clipboard image paste only from Vim insert mode", () => {
 		const editor = new CustomEditor(getEditorTheme());
-		const onPasteImage = vi.fn();
+		const onPasteImage = vi.fn(async () => {
+			editor.insertText("[Image] ");
+			return true;
+		});
 		editor.setInputMode("vim");
 		editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
 		editor.onPasteImage = onPasteImage;
@@ -159,6 +162,10 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("i");
 		editor.handleInput("\x1bp");
 		expect(onPasteImage).toHaveBeenCalledTimes(1);
+		editor.handleInput("!");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("text");
 	});
 	it("keeps configured app shortcuts reachable from Vim normal mode", () => {
 		const editor = new CustomEditor(getEditorTheme());
@@ -209,7 +216,7 @@ describe("CustomEditor keybindings", () => {
 
 	it("allows configured raw-text paste only from Vim insert mode", () => {
 		const editor = new CustomEditor(getEditorTheme());
-		const onPasteTextRaw = vi.fn();
+		const onPasteTextRaw = vi.fn(() => editor.insertText("pasted"));
 		editor.setInputMode("vim");
 		editor.setActionKeys("app.clipboard.pasteTextRaw", ["alt+t"]);
 		editor.onPasteTextRaw = onPasteTextRaw;
@@ -227,6 +234,10 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("i");
 		editor.handleInput("\x1bt");
 		expect(onPasteTextRaw).toHaveBeenCalledTimes(1);
+		editor.handleInput("!");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("text");
 	});
 });
 

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -378,6 +378,31 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("undoes and redoes pasted image sidecars with their Vim marker", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const image = { type: "image" as const, mimeType: "image/png", data: "aW1hZ2U=" };
+		editor.setInputMode("vim");
+		editor.handleInput("i");
+		editor.prepareVimInsertMutation();
+		editor.pendingImages.push(image);
+		editor.pendingImageLinks.push("local://draft.png");
+		editor.imageLinks = editor.pendingImageLinks;
+		editor.insertText("[Image #1] ");
+		editor.handleInput("\x1b");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+		expect(editor.pendingImages).toEqual([]);
+		expect(editor.pendingImageLinks).toEqual([]);
+		expect(editor.imageLinks).toBeUndefined();
+
+		editor.handleInput("\x12");
+		expect(editor.getText()).toBe("[Image #1] ");
+		expect(editor.pendingImages).toEqual([image]);
+		expect(editor.pendingImageLinks).toEqual(["local://draft.png"]);
+		expect(editor.imageLinks).toEqual(["local://draft.png"]);
+	});
+
 	it("stops a multi-image path paste after Vim Escape cancels its generation", async () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const firstImage = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -138,6 +138,13 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("\x1bp");
 		expect(onPasteImage).not.toHaveBeenCalled();
 
+		editor.setText("text");
+		editor.handleInput("v");
+		expect(editor.getVimMode()).toBe("visual");
+		editor.handleInput("\x1bp");
+		expect(onPasteImage).not.toHaveBeenCalled();
+		editor.handleInput("\x1b");
+
 		editor.handleInput("i");
 		editor.handleInput("\x1bp");
 		expect(onPasteImage).toHaveBeenCalledTimes(1);
@@ -186,6 +193,13 @@ describe("CustomEditor keybindings", () => {
 
 		editor.handleInput("\x1bt");
 		expect(onPasteTextRaw).not.toHaveBeenCalled();
+
+		editor.setText("text");
+		editor.handleInput("v");
+		expect(editor.getVimMode()).toBe("visual");
+		editor.handleInput("\x1bt");
+		expect(onPasteTextRaw).not.toHaveBeenCalled();
+		editor.handleInput("\x1b");
 
 		editor.handleInput("i");
 		editor.handleInput("\x1bt");

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -274,6 +274,60 @@ describe("CustomEditor keybindings", () => {
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 
+	it("lets default-mode cancellation shortcuts bypass a configured image paste", async () => {
+		const cases = [
+			{
+				name: "interrupt",
+				action: "app.interrupt",
+				key: "escape",
+				input: "\x1b",
+				wire: (editor: CustomEditor, callback: () => void) => {
+					editor.onEscape = callback;
+				},
+			},
+			{
+				name: "clear",
+				action: "app.clear",
+				key: "ctrl+c",
+				input: "\x03",
+				wire: (editor: CustomEditor, callback: () => void) => {
+					editor.onClear = callback;
+				},
+			},
+			{
+				name: "exit",
+				action: "app.exit",
+				key: "ctrl+d",
+				input: "\x04",
+				wire: (editor: CustomEditor, callback: () => void) => {
+					editor.onExit = callback;
+				},
+			},
+		] as const;
+
+		for (const testCase of cases) {
+			const editor = new CustomEditor(getEditorTheme());
+			const image = Promise.withResolvers<void>();
+			const onCancel = vi.fn();
+			editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
+			editor.setActionKeys(testCase.action, [testCase.key]);
+			editor.onPasteImage = () => image.promise.then(() => true);
+			testCase.wire(editor, onCancel);
+
+			editor.handleInput("\x1bp");
+			editor.handleInput("queued");
+			editor.handleInput(testCase.input);
+
+			expect(onCancel, testCase.name).toHaveBeenCalledTimes(1);
+			expect(editor.getText(), testCase.name).toBe("");
+
+			image.resolve();
+			await image.promise;
+			await Promise.resolve();
+			expect(editor.getText(), testCase.name).toBe("");
+		}
+	});
+
 	it("releases the async paste gate when Vim Escape cancels", async () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const image = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -378,6 +378,33 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("stops a multi-image path paste after Vim Escape cancels its generation", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const firstImage = Promise.withResolvers<void>();
+		const onPasteImagePath = vi.fn(async () => {
+			if (onPasteImagePath.mock.calls.length === 1) await firstImage.promise;
+			else editor.insertText("[stale image] ");
+		});
+		editor.setInputMode("vim");
+		editor.onPasteImagePath = onPasteImagePath;
+		editor.setText("draft");
+		editor.handleInput("i");
+
+		editor.handleInput("\x1b[200~/tmp/first.png\n/tmp/second.png\x1b[201~");
+		expect(onPasteImagePath).toHaveBeenCalledTimes(1);
+		editor.handleInput("\x1b");
+		editor.handleInput("i");
+		editor.handleInput("!");
+		firstImage.resolve();
+		await firstImage.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPasteImagePath).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).not.toContain("[stale image]");
+		expect(editor.getVimMode()).toBe("insert");
+	});
+
 	it("allows configured raw-text paste only from Vim insert mode", async () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onPasteTextRaw = vi.fn(() => editor.insertText("pasted"));

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -62,6 +62,49 @@ describe("CustomEditor keybindings", () => {
 		expect(onDisplayReset).toHaveBeenCalledTimes(1);
 		expect(onLiveToggle).toHaveBeenCalledTimes(1);
 	});
+
+	it("lets Escape leave Vim insert mode before interrupting the app", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onEscape = vi.fn();
+		editor.setInputMode("vim");
+		editor.onEscape = onEscape;
+
+		editor.handleInput("i");
+		editor.handleInput("\x1b");
+
+		expect(editor.getVimMode()).toBe("normal");
+		expect(onEscape).not.toHaveBeenCalled();
+
+		editor.handleInput("\x1b");
+		expect(onEscape).toHaveBeenCalledTimes(1);
+	});
+	it("does not start push-to-talk from Vim normal-mode spaces", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onSpaceHoldStart = vi.fn();
+		editor.setInputMode("vim");
+		editor.onSpaceHoldStart = onSpaceHoldStart;
+		editor.sttHoldEnabled = () => true;
+
+		for (let i = 0; i < 10; i++) editor.handleInput(" ");
+
+		expect(editor.getText()).toBe("");
+		expect(onSpaceHoldStart).not.toHaveBeenCalled();
+	});
+
+	it("allows clipboard image paste only from Vim insert mode", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onPasteImage = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
+		editor.onPasteImage = onPasteImage;
+
+		editor.handleInput("\x1bp");
+		expect(onPasteImage).not.toHaveBeenCalled();
+
+		editor.handleInput("i");
+		editor.handleInput("\x1bp");
+		expect(onPasteImage).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("shipped dequeue defaults", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -78,6 +78,24 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("\x1b");
 		expect(onEscape).toHaveBeenCalledTimes(1);
 	});
+	it("lets Escape leave Vim visual mode before interrupting the app", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onEscape = vi.fn();
+		editor.setInputMode("vim");
+		editor.setText("one\ntwo");
+		editor.onEscape = onEscape;
+
+		editor.handleInput("V");
+		expect(editor.getVimMode()).toBe("visual");
+
+		editor.handleInput("\x1b");
+		expect(editor.getVimMode()).toBe("normal");
+		expect(onEscape).not.toHaveBeenCalled();
+
+		editor.handleInput("\x1b");
+		expect(onEscape).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not start push-to-talk from Vim normal-mode spaces", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onSpaceHoldStart = vi.fn();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -168,7 +168,7 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("one two");
 	});
 
-	it("allows clipboard image paste only from Vim insert mode", () => {
+	it("allows clipboard image paste only from Vim insert mode", async () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onPasteImage = vi.fn(async () => {
 			editor.insertText("[Image] ");
@@ -191,10 +191,69 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("i");
 		editor.handleInput("\x1bp");
 		expect(onPasteImage).toHaveBeenCalledTimes(1);
+		await Promise.resolve();
+		await Promise.resolve();
 		editor.handleInput("!");
 		editor.handleInput("\x1b");
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("text");
+	});
+
+	it("queues Vim submit until a configured image paste settles", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const image = Promise.withResolvers<void>();
+		const onSubmit = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
+		editor.onPasteImage = async () => {
+			await image.promise;
+			editor.insertText("[Image] ");
+			return true;
+		};
+		editor.onSubmit = onSubmit;
+		editor.handleInput("i");
+
+		editor.handleInput("\x1bp");
+		editor.handleInput("\r");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getVimMode()).toBe("insert");
+
+		image.resolve();
+		await image.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onSubmit).toHaveBeenCalledWith("[Image]");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("lets Vim escape cancel queued input during a configured image paste", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const image = Promise.withResolvers<void>();
+		const onSubmit = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
+		editor.onPasteImage = async () => {
+			await image.promise;
+			if (editor.getVimMode() === "insert") editor.insertText("[Image] ");
+			return true;
+		};
+		editor.onSubmit = onSubmit;
+		editor.setText("draft");
+		editor.handleInput("i");
+
+		editor.handleInput("\x1bp");
+		editor.handleInput("\r");
+		editor.handleInput("\x1b");
+		expect(editor.getVimMode()).toBe("normal");
+
+		image.resolve();
+		await image.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(editor.getText()).toBe("draft");
+		expect(onSubmit).not.toHaveBeenCalled();
 	});
 	it("keeps configured app shortcuts reachable from Vim normal mode", () => {
 		const editor = new CustomEditor(getEditorTheme());

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -273,6 +273,64 @@ describe("CustomEditor keybindings", () => {
 		expect(editor.getText()).toBe("draft");
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
+
+	it("releases the async paste gate when Vim Escape cancels", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const image = Promise.withResolvers<void>();
+		const onEscape = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
+		editor.onPasteImage = () => image.promise.then(() => true);
+		editor.onEscape = onEscape;
+		editor.setText("draft");
+		editor.handleInput("i");
+
+		editor.handleInput("\x1bp");
+		editor.handleInput("\r");
+		editor.handleInput("\x1b");
+		expect(editor.getVimMode()).toBe("normal");
+
+		editor.handleInput("\x1b");
+		expect(onEscape).toHaveBeenCalledTimes(1);
+		editor.handleInput("i");
+		editor.handleInput("!");
+		expect(editor.getText()).toBe("draf!t");
+
+		image.resolve();
+		await image.promise;
+		await Promise.resolve();
+		expect(editor.getText()).toBe("draf!t");
+	});
+
+	it("does not let a canceled paste settlement release a newer paste gate", async () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const first = Promise.withResolvers<void>();
+		const second = Promise.withResolvers<void>();
+		const onSubmit = vi.fn();
+		let pasteNumber = 0;
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteImage", ["alt+p"]);
+		editor.onPasteImage = () => (++pasteNumber === 1 ? first.promise : second.promise).then(() => true);
+		editor.onSubmit = onSubmit;
+		editor.handleInput("i");
+
+		editor.handleInput("\x1bp");
+		editor.handleInput("\x1b");
+		editor.handleInput("i");
+		editor.handleInput("\x1bp");
+		editor.handleInput("\r");
+
+		first.resolve();
+		await first.promise;
+		await Promise.resolve();
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		second.resolve();
+		await second.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+	});
 	it("keeps configured app shortcuts reachable from Vim normal mode", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onRetry = vi.fn();

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -166,11 +166,15 @@ describe("CustomEditor keybindings", () => {
 		editor.setInputMode("vim");
 		editor.setActionKeys("app.retry", ["alt+r"]);
 		editor.onRetry = onRetry;
+		editor.setText("one two");
+		editor.handleInput("0");
+		editor.handleInput("d");
 
 		editor.handleInput("\x1br");
+		editor.handleInput("w");
 
 		expect(onRetry).toHaveBeenCalledTimes(1);
-		expect(editor.getText()).toBe("");
+		expect(editor.getText()).toBe("one two");
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
@@ -182,6 +186,14 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("ignored");
 		editor.handleInput("\x1b[201~");
 		expect(editor.getText()).toBe("");
+
+		editor.setText("one two");
+		editor.handleInput("0");
+		editor.handleInput("d");
+		editor.handleInput("\x1b[200~ignored\x1b[201~");
+		editor.handleInput("w");
+		expect(editor.getText()).toBe("one two");
+		editor.setText("");
 
 		editor.handleInput("i");
 		editor.handleInput("\x1b[200~");

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -105,6 +105,55 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("\x1bp");
 		expect(onPasteImage).toHaveBeenCalledTimes(1);
 	});
+	it("keeps configured app shortcuts reachable from Vim normal mode", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onRetry = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.retry", ["alt+r"]);
+		editor.onRetry = onRetry;
+
+		editor.handleInput("\x1br");
+
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("routes fragmented bracketed paste through Vim insert-mode undo", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setInputMode("vim");
+
+		editor.handleInput("\x1b[200~");
+		editor.handleInput("ignored");
+		editor.handleInput("\x1b[201~");
+		expect(editor.getText()).toBe("");
+
+		editor.handleInput("i");
+		editor.handleInput("\x1b[200~");
+		editor.handleInput("pasted");
+		editor.handleInput("\x1b[201~");
+		editor.handleInput("!");
+		editor.handleInput("\x1b");
+		expect(editor.getText()).toBe("pasted!");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("allows configured raw-text paste only from Vim insert mode", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onPasteTextRaw = vi.fn();
+		editor.setInputMode("vim");
+		editor.setActionKeys("app.clipboard.pasteTextRaw", ["alt+t"]);
+		editor.onPasteTextRaw = onPasteTextRaw;
+
+		editor.handleInput("\x1bt");
+		expect(onPasteTextRaw).not.toHaveBeenCalled();
+
+		editor.handleInput("i");
+		editor.handleInput("\x1bt");
+		expect(onPasteTextRaw).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("shipped dequeue defaults", () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -39,6 +39,7 @@ type FakeEditor = {
 	trackAsyncPaste(promise: Promise<unknown>): Promise<unknown>;
 	getVimMode(): "insert" | "normal" | "visual" | undefined;
 	clearVimPendingCommand(): void;
+	prepareVimInsertMutation(): void;
 	imageLinks?: (string | undefined)[];
 	pendingImages: ImageContent[];
 	pendingImageLinks: (string | undefined)[];
@@ -87,6 +88,7 @@ async function createContext() {
 	});
 	const getVimMode = vi.fn<() => "insert" | "normal" | "visual" | undefined>(() => undefined);
 	const clearVimPendingCommand = vi.fn();
+	const prepareVimInsertMutation = vi.fn();
 	const showError = vi.fn();
 	let focused: unknown;
 	const addInputListener = vi.fn((listener: InputListener) => {
@@ -139,6 +141,7 @@ async function createContext() {
 		trackAsyncPaste,
 		getVimMode,
 		clearVimPendingCommand,
+		prepareVimInsertMutation,
 		setActionKeys,
 		setCustomKeyHandler,
 		clearCustomKeyHandlers,
@@ -260,6 +263,7 @@ async function createContext() {
 			trackAsyncPaste,
 			getVimMode,
 			clearVimPendingCommand,
+			prepareVimInsertMutation,
 			showError,
 		},
 	};
@@ -455,12 +459,15 @@ describe("InputController keybinding setup", () => {
 		expect(spies.handleBtwBranchKey).not.toHaveBeenCalled();
 	});
 
-	it("tracks enhanced image paste before accepting follow-up input", async () => {
+	it.each([
+		{ name: "clears pending Vim state in normal mode", mode: "normal" as const, clearCalls: 1, prepareCalls: 0 },
+		{ name: "prepares Vim insert undo", mode: "insert" as const, clearCalls: 0, prepareCalls: 1 },
+	])("$name before tracking an enhanced image paste", async ({ mode, clearCalls, prepareCalls }) => {
 		await Settings.init({ inMemory: true });
 		try {
 			const { InputController, ctx, spies } = await createContext();
 			const controller = new InputController(ctx);
-			spies.getVimMode.mockReturnValue("normal");
+			spies.getVimMode.mockReturnValue(mode);
 			controller.setupKeyHandlers();
 			const packet = (metadata: string, payload?: string) =>
 				`\x1b]5522;${metadata}${payload === undefined ? "" : `;${payload}`}\x1b\\`;
@@ -478,7 +485,8 @@ describe("InputController keybinding setup", () => {
 			dispatchInput(listeners, packet("type=read:status=DONE"));
 
 			expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(1);
-			expect(spies.clearVimPendingCommand).toHaveBeenCalledTimes(1);
+			expect(spies.clearVimPendingCommand).toHaveBeenCalledTimes(clearCalls);
+			expect(spies.prepareVimInsertMutation).toHaveBeenCalledTimes(prepareCalls);
 			await spies.trackAsyncPaste.mock.calls[0]?.[0];
 		} finally {
 			resetSettingsForTest();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -23,6 +23,7 @@ type FakeEditor = {
 	onToggleThinking?: () => void;
 	onExternalEditor?: () => void;
 	onRetry?: () => void;
+	onSTTToggle?: () => void;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => Promise<void>;
 	setText(text: string): void;
@@ -62,6 +63,7 @@ async function createContext() {
 		"app.model.select": ["alt+m"],
 		"app.retry": ["alt+r"],
 		"app.clipboard.pasteImage": ["ctrl+v"],
+		"app.stt.toggle": ["alt+s"],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -262,6 +264,17 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplayAfterAppearanceRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers STT as a text-entry editor action", async () => {
+		const { InputController, ctx, editor, customHandlers, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.stt.toggle", ["alt+s"]);
+		expect(editor.onSTTToggle).toBeDefined();
+		expect(customHandlers.has("alt+s")).toBe(false);
 	});
 
 	it("does not mark pasted shell prompts as Python mode while editing", async () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -711,6 +711,44 @@ describe("InputController keybinding setup", () => {
 		expect(ctx.locallySubmittedUserSignatures.has("queued during stream\u00000")).toBe(false);
 	});
 
+	it("drops image sidecars whose markers were deleted before submit", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		editor.pendingImages = [{ type: "image", mimeType: "image/png", data: "deleted" }];
+		editor.pendingImageLinks = ["local://deleted.png"];
+		editor.imageLinks = editor.pendingImageLinks;
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("");
+
+		expect(spies.prompt).not.toHaveBeenCalled();
+		expect(editor.pendingImages).toEqual([]);
+		expect(editor.pendingImageLinks).toEqual([]);
+		expect(editor.imageLinks).toBeUndefined();
+	});
+
+	it("compacts surviving image markers and sidecars before submit", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const session = ctx.session as unknown as { isStreaming: boolean };
+		session.isStreaming = true;
+		const deleted = { type: "image" as const, mimeType: "image/png", data: "deleted" };
+		const kept = { type: "image" as const, mimeType: "image/png", data: "kept" };
+		editor.pendingImages = [deleted, kept];
+		editor.pendingImageLinks = ["local://deleted.png", "local://kept.png"];
+		editor.imageLinks = editor.pendingImageLinks;
+		const controller = new InputController(ctx);
+
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("[Image #2]");
+
+		expect(spies.prompt).toHaveBeenCalledWith("[Image #1]", {
+			streamingBehavior: "steer",
+			images: [kept],
+		});
+	});
+
 	it("continue shortcuts submit a hidden synthetic developer directive", async () => {
 		for (const shortcut of [".", "c"]) {
 			const { InputController, ctx, editor } = await createContext();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -37,6 +37,8 @@ type FakeEditor = {
 	pasteText(text: string): void;
 	insertText(text: string): void;
 	trackAsyncPaste(promise: Promise<unknown>): Promise<unknown>;
+	getVimMode(): "insert" | "normal" | "visual" | undefined;
+	clearVimPendingCommand(): void;
 	imageLinks?: (string | undefined)[];
 	pendingImages: ImageContent[];
 	pendingImageLinks: (string | undefined)[];
@@ -83,6 +85,8 @@ async function createContext() {
 		void promise.catch(() => {});
 		return promise;
 	});
+	const getVimMode = vi.fn<() => "insert" | "normal" | "visual" | undefined>(() => undefined);
+	const clearVimPendingCommand = vi.fn();
 	const showError = vi.fn();
 	let focused: unknown;
 	const addInputListener = vi.fn((listener: InputListener) => {
@@ -133,6 +137,8 @@ async function createContext() {
 			editorText += text;
 		},
 		trackAsyncPaste,
+		getVimMode,
+		clearVimPendingCommand,
 		setActionKeys,
 		setCustomKeyHandler,
 		clearCustomKeyHandlers,
@@ -252,6 +258,8 @@ async function createContext() {
 			handleBtwCopyKey,
 			canCopyBtw,
 			trackAsyncPaste,
+			getVimMode,
+			clearVimPendingCommand,
 			showError,
 		},
 	};
@@ -452,6 +460,7 @@ describe("InputController keybinding setup", () => {
 		try {
 			const { InputController, ctx, spies } = await createContext();
 			const controller = new InputController(ctx);
+			spies.getVimMode.mockReturnValue("normal");
 			controller.setupKeyHandlers();
 			const packet = (metadata: string, payload?: string) =>
 				`\x1b]5522;${metadata}${payload === undefined ? "" : `;${payload}`}\x1b\\`;
@@ -469,6 +478,7 @@ describe("InputController keybinding setup", () => {
 			dispatchInput(listeners, packet("type=read:status=DONE"));
 
 			expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(1);
+			expect(spies.clearVimPendingCommand).toHaveBeenCalledTimes(1);
 			await spies.trackAsyncPaste.mock.calls[0]?.[0];
 		} finally {
 			resetSettingsForTest();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -37,6 +37,7 @@ type FakeEditor = {
 	pasteText(text: string): void;
 	insertText(text: string): void;
 	trackAsyncPaste(promise: Promise<unknown>): Promise<unknown>;
+	getAsyncPasteSignal(): AbortSignal;
 	getVimMode(): "insert" | "normal" | "visual" | undefined;
 	clearVimPendingCommand(): void;
 	prepareVimInsertMutation(): void;
@@ -89,6 +90,7 @@ async function createContext() {
 	const getVimMode = vi.fn<() => "insert" | "normal" | "visual" | undefined>(() => undefined);
 	const clearVimPendingCommand = vi.fn();
 	const prepareVimInsertMutation = vi.fn();
+	const asyncPasteSignal = new AbortController().signal;
 	const showError = vi.fn();
 	let focused: unknown;
 	const addInputListener = vi.fn((listener: InputListener) => {
@@ -139,6 +141,7 @@ async function createContext() {
 			editorText += text;
 		},
 		trackAsyncPaste,
+		getAsyncPasteSignal: () => asyncPasteSignal,
 		getVimMode,
 		clearVimPendingCommand,
 		prepareVimInsertMutation,
@@ -463,54 +466,74 @@ describe("InputController keybinding setup", () => {
 		{
 			name: "drops the paste and clears pending Vim state in normal mode",
 			mode: "normal" as const,
+			focusedPrompt: false,
 			trackCalls: 0,
 			clearCalls: 1,
 			prepareCalls: 0,
+			statusCalls: 0,
 		},
 		{
 			name: "prepares Vim insert undo",
 			mode: "insert" as const,
+			focusedPrompt: false,
 			trackCalls: 1,
 			clearCalls: 0,
 			prepareCalls: 1,
+			statusCalls: 0,
 		},
 		{
 			name: "tracks the paste in default input mode",
 			mode: undefined,
+			focusedPrompt: false,
 			trackCalls: 1,
 			clearCalls: 0,
 			prepareCalls: 0,
+			statusCalls: 0,
 		},
-	])("$name for an enhanced image paste", async ({ mode, trackCalls, clearCalls, prepareCalls }) => {
-		await Settings.init({ inMemory: true });
-		try {
-			const { InputController, ctx, spies } = await createContext();
-			const controller = new InputController(ctx);
-			spies.getVimMode.mockReturnValue(mode);
-			controller.setupKeyHandlers();
-			const packet = (metadata: string, payload?: string) =>
-				`\x1b]5522;${metadata}${payload === undefined ? "" : `;${payload}`}\x1b\\`;
-			const listeners = registeredInputListeners(spies.addInputListener);
-			const imageMime = Buffer.from("image/png", "utf8").toString("base64");
+		{
+			name: "reports an unsupported paste to a focused prompt before the Vim mode guard",
+			mode: "normal" as const,
+			focusedPrompt: true,
+			trackCalls: 0,
+			clearCalls: 0,
+			prepareCalls: 0,
+			statusCalls: 1,
+		},
+	])(
+		"$name for an enhanced image paste",
+		async ({ mode, focusedPrompt, trackCalls, clearCalls, prepareCalls, statusCalls }) => {
+			await Settings.init({ inMemory: true });
+			try {
+				const { InputController, ctx, setFocused, spies } = await createContext();
+				const controller = new InputController(ctx);
+				spies.getVimMode.mockReturnValue(mode);
+				if (focusedPrompt) setFocused({ pasteText: vi.fn() });
+				controller.setupKeyHandlers();
+				const packet = (metadata: string, payload?: string) =>
+					`\x1b]5522;${metadata}${payload === undefined ? "" : `;${payload}`}\x1b\\`;
+				const listeners = registeredInputListeners(spies.addInputListener);
+				const imageMime = Buffer.from("image/png", "utf8").toString("base64");
 
-			dispatchInput(listeners, packet("type=read:status=OK:pw=c2VjcmV0"));
-			dispatchInput(listeners, packet(`type=read:status=DATA:mime=${imageMime}`));
-			dispatchInput(listeners, packet("type=read:status=DONE"));
-			dispatchInput(listeners, packet("type=read:status=OK"));
-			dispatchInput(
-				listeners,
-				packet(`type=read:status=DATA:mime=${imageMime}`, Buffer.from("image-bytes").toString("base64")),
-			);
-			dispatchInput(listeners, packet("type=read:status=DONE"));
+				dispatchInput(listeners, packet("type=read:status=OK:pw=c2VjcmV0"));
+				dispatchInput(listeners, packet(`type=read:status=DATA:mime=${imageMime}`));
+				dispatchInput(listeners, packet("type=read:status=DONE"));
+				dispatchInput(listeners, packet("type=read:status=OK"));
+				dispatchInput(
+					listeners,
+					packet(`type=read:status=DATA:mime=${imageMime}`, Buffer.from("image-bytes").toString("base64")),
+				);
+				dispatchInput(listeners, packet("type=read:status=DONE"));
 
-			expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(trackCalls);
-			expect(spies.clearVimPendingCommand).toHaveBeenCalledTimes(clearCalls);
-			expect(spies.prepareVimInsertMutation).toHaveBeenCalledTimes(prepareCalls);
-			await spies.trackAsyncPaste.mock.calls[0]?.[0];
-		} finally {
-			resetSettingsForTest();
-		}
-	});
+				expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(trackCalls);
+				expect(spies.clearVimPendingCommand).toHaveBeenCalledTimes(clearCalls);
+				expect(spies.prepareVimInsertMutation).toHaveBeenCalledTimes(prepareCalls);
+				expect(ctx.showStatus).toHaveBeenCalledTimes(statusCalls);
+				await spies.trackAsyncPaste.mock.calls[0]?.[0];
+			} finally {
+				resetSettingsForTest();
+			}
+		},
+	);
 
 	it("routes the smart-paste shortcut to a focused login input", async () => {
 		const { promise: pasted, resolve: resolvePaste } = Promise.withResolvers<string>();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, type Mock, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { type KeyId, matchesKey } from "@oh-my-pi/pi-tui";
@@ -34,6 +35,8 @@ type FakeEditor = {
 	setCustomKeyHandler(key: string, handler: () => void): void;
 	clearCustomKeyHandlers(): void;
 	pasteText(text: string): void;
+	insertText(text: string): void;
+	trackAsyncPaste(promise: Promise<unknown>): Promise<unknown>;
 	imageLinks?: (string | undefined)[];
 	pendingImages: ImageContent[];
 	pendingImageLinks: (string | undefined)[];
@@ -76,6 +79,10 @@ async function createContext() {
 	const resetDisplay = vi.fn();
 	const showModelSelector = vi.fn();
 	const requestRender = vi.fn();
+	const trackAsyncPaste = vi.fn((promise: Promise<unknown>) => {
+		void promise.catch(() => {});
+		return promise;
+	});
 	const showError = vi.fn();
 	let focused: unknown;
 	const addInputListener = vi.fn((listener: InputListener) => {
@@ -122,6 +129,10 @@ async function createContext() {
 		pasteText(text: string) {
 			editorText += text;
 		},
+		insertText(text: string) {
+			editorText += text;
+		},
+		trackAsyncPaste,
 		setActionKeys,
 		setCustomKeyHandler,
 		clearCustomKeyHandlers,
@@ -152,6 +163,9 @@ async function createContext() {
 		retryLoader: undefined,
 		autoCompactionEscapeHandler: undefined,
 		retryEscapeHandler: undefined,
+		sessionManager: {
+			putBlob: vi.fn(async () => ({ displayPath: "blob:image" })),
+		},
 		session: session as unknown as InteractiveModeContext["session"],
 		viewSession: session as unknown as InteractiveModeContext["viewSession"],
 		keybindings: {
@@ -237,6 +251,7 @@ async function createContext() {
 			canBranchBtw,
 			handleBtwCopyKey,
 			canCopyBtw,
+			trackAsyncPaste,
 			showError,
 		},
 	};
@@ -430,6 +445,34 @@ describe("InputController keybinding setup", () => {
 
 		expect(result).toBeUndefined();
 		expect(spies.handleBtwBranchKey).not.toHaveBeenCalled();
+	});
+
+	it("tracks enhanced image paste before accepting follow-up input", async () => {
+		await Settings.init({ inMemory: true });
+		try {
+			const { InputController, ctx, spies } = await createContext();
+			const controller = new InputController(ctx);
+			controller.setupKeyHandlers();
+			const packet = (metadata: string, payload?: string) =>
+				`\x1b]5522;${metadata}${payload === undefined ? "" : `;${payload}`}\x1b\\`;
+			const listeners = registeredInputListeners(spies.addInputListener);
+			const imageMime = Buffer.from("image/png", "utf8").toString("base64");
+
+			dispatchInput(listeners, packet("type=read:status=OK:pw=c2VjcmV0"));
+			dispatchInput(listeners, packet(`type=read:status=DATA:mime=${imageMime}`));
+			dispatchInput(listeners, packet("type=read:status=DONE"));
+			dispatchInput(listeners, packet("type=read:status=OK"));
+			dispatchInput(
+				listeners,
+				packet(`type=read:status=DATA:mime=${imageMime}`, Buffer.from("image-bytes").toString("base64")),
+			);
+			dispatchInput(listeners, packet("type=read:status=DONE"));
+
+			expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(1);
+			await spies.trackAsyncPaste.mock.calls[0]?.[0];
+		} finally {
+			resetSettingsForTest();
+		}
 	});
 
 	it("routes the smart-paste shortcut to a focused login input", async () => {

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -460,9 +460,28 @@ describe("InputController keybinding setup", () => {
 	});
 
 	it.each([
-		{ name: "clears pending Vim state in normal mode", mode: "normal" as const, clearCalls: 1, prepareCalls: 0 },
-		{ name: "prepares Vim insert undo", mode: "insert" as const, clearCalls: 0, prepareCalls: 1 },
-	])("$name before tracking an enhanced image paste", async ({ mode, clearCalls, prepareCalls }) => {
+		{
+			name: "drops the paste and clears pending Vim state in normal mode",
+			mode: "normal" as const,
+			trackCalls: 0,
+			clearCalls: 1,
+			prepareCalls: 0,
+		},
+		{
+			name: "prepares Vim insert undo",
+			mode: "insert" as const,
+			trackCalls: 1,
+			clearCalls: 0,
+			prepareCalls: 1,
+		},
+		{
+			name: "tracks the paste in default input mode",
+			mode: undefined,
+			trackCalls: 1,
+			clearCalls: 0,
+			prepareCalls: 0,
+		},
+	])("$name for an enhanced image paste", async ({ mode, trackCalls, clearCalls, prepareCalls }) => {
 		await Settings.init({ inMemory: true });
 		try {
 			const { InputController, ctx, spies } = await createContext();
@@ -484,7 +503,7 @@ describe("InputController keybinding setup", () => {
 			);
 			dispatchInput(listeners, packet("type=read:status=DONE"));
 
-			expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(1);
+			expect(spies.trackAsyncPaste).toHaveBeenCalledTimes(trackCalls);
 			expect(spies.clearVimPendingCommand).toHaveBeenCalledTimes(clearCalls);
 			expect(spies.prepareVimInsertMutation).toHaveBeenCalledTimes(prepareCalls);
 			await spies.trackAsyncPaste.mock.calls[0]?.[0];

--- a/packages/coding-agent/test/input-controller-large-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-large-paste.test.ts
@@ -13,16 +13,29 @@ import * as path from "node:path";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 
-function createContext(options?: { threshold?: number; choice?: string; artifactsDir?: string }) {
+function createContext(options?: {
+	threshold?: number;
+	choice?: string | Promise<string | undefined>;
+	artifactsDir?: string;
+	pasteSignal?: AbortSignal;
+}) {
 	const insertPaste = vi.fn();
 	const insertText = vi.fn();
 	const pasteText = vi.fn();
 	const requestRender = vi.fn();
 	const showStatus = vi.fn();
 	const showError = vi.fn();
+	const pasteSignal = options?.pasteSignal ?? new AbortController().signal;
+	const trackAsyncPaste = vi.fn(<T>(promise: Promise<T>) => promise);
 	const showHookSelector = vi.fn(async (_title: string, _options: unknown, _dialog?: unknown) => options?.choice);
 	const ctx = {
-		editor: { insertPaste, insertText, pasteText } as unknown as InteractiveModeContext["editor"],
+		editor: {
+			insertPaste,
+			insertText,
+			pasteText,
+			getAsyncPasteSignal: () => pasteSignal,
+			trackAsyncPaste,
+		} as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
 		settings: { get: () => options?.threshold ?? 100 } as unknown as InteractiveModeContext["settings"],
 		sessionManager: {
@@ -37,7 +50,16 @@ function createContext(options?: { threshold?: number; choice?: string; artifact
 	const controller = new InputController(ctx);
 	return {
 		controller,
-		spies: { insertPaste, insertText, pasteText, requestRender, showStatus, showError, showHookSelector },
+		spies: {
+			insertPaste,
+			insertText,
+			pasteText,
+			requestRender,
+			showStatus,
+			showError,
+			showHookSelector,
+			trackAsyncPaste,
+		},
 	};
 }
 
@@ -68,6 +90,16 @@ describe("InputController.handleLargePaste gate", () => {
 
 		expect(controller.handleLargePaste("payload", 100)).toBe(true);
 		expect(menu).toHaveBeenCalledWith("payload", 100);
+	});
+
+	it("tracks the deferred menu promise", () => {
+		const menu = Promise.withResolvers<void>();
+		const { controller, spies } = createContext({ threshold: 100 });
+		vi.spyOn(controller, "presentLargePasteMenu").mockReturnValue(menu.promise);
+
+		expect(controller.handleLargePaste("payload", 100)).toBe(true);
+		expect(spies.trackAsyncPaste).toHaveBeenCalledWith(menu.promise);
+		menu.resolve();
 	});
 });
 
@@ -116,6 +148,24 @@ describe("InputController.presentLargePasteMenu actions", () => {
 
 		expect(spies.showHookSelector.mock.calls[0][0]).toBe("Pasted 123 lines");
 	});
+
+	it("drops the deferred menu choice after its paste generation is canceled", async () => {
+		const choice = Promise.withResolvers<string | undefined>();
+		const pasteAbort = new AbortController();
+		const { controller, spies } = createContext({
+			choice: choice.promise,
+			pasteSignal: pasteAbort.signal,
+		});
+
+		expect(controller.handleLargePaste("payload", 100)).toBe(true);
+		pasteAbort.abort();
+		choice.resolve("Paste inline");
+		await spies.trackAsyncPaste.mock.calls[0]?.[0];
+
+		expect(spies.insertPaste).not.toHaveBeenCalled();
+		expect(spies.insertText).not.toHaveBeenCalled();
+		expect(spies.requestRender).not.toHaveBeenCalled();
+	});
 });
 
 describe("InputController.presentLargePasteMenu file attachment", () => {
@@ -149,5 +199,33 @@ describe("InputController.presentLargePasteMenu file attachment", () => {
 		expect(spies.insertText).toHaveBeenCalledWith("local://paste-2.md ");
 		expect(await Bun.file(path.join(dir, "local", "paste-1.md")).text()).toBe("previous");
 		expect(await Bun.file(path.join(dir, "local", "paste-2.md")).text()).toBe("fresh");
+	});
+
+	it("does not commit a local-file reference after Vim cancels the pending write", async () => {
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-paste-test-"));
+		const pasteAbort = new AbortController();
+		const writeStarted = Promise.withResolvers<void>();
+		const releaseWrite = Promise.withResolvers<void>();
+		vi.spyOn(Bun, "write").mockImplementation(async () => {
+			writeStarted.resolve();
+			await releaseWrite.promise;
+			return 7;
+		});
+		const { controller, spies } = createContext({
+			choice: "Attach as local file",
+			artifactsDir: dir,
+			pasteSignal: pasteAbort.signal,
+		});
+
+		expect(controller.handleLargePaste("payload", 100)).toBe(true);
+		await writeStarted.promise;
+		pasteAbort.abort();
+		releaseWrite.resolve();
+		await spies.trackAsyncPaste.mock.calls[0]?.[0];
+
+		expect(spies.insertText).not.toHaveBeenCalled();
+		expect(spies.insertPaste).not.toHaveBeenCalled();
+		expect(spies.showStatus).not.toHaveBeenCalled();
+		expect(spies.requestRender).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/input-controller-smart-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-smart-paste.test.ts
@@ -13,16 +13,19 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 function createContext(options?: {
 	focused?: { pasteText(text: string): void };
 	getVimMode?: () => "insert" | "normal" | "visual" | undefined;
+	pasteSignal?: AbortSignal;
 }) {
 	const pasteText = vi.fn();
 	const insertText = vi.fn();
 	const requestRender = vi.fn();
 	const showStatus = vi.fn();
+	const asyncPasteSignal = options?.pasteSignal ?? new AbortController().signal;
 	const ctx = {
 		editor: {
 			pasteText,
 			insertText,
 			getVimMode: options?.getVimMode ?? (() => undefined),
+			getAsyncPasteSignal: () => asyncPasteSignal,
 		} as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender, getFocused: () => options?.focused ?? null } as unknown as InteractiveModeContext["ui"],
 		showStatus,
@@ -137,6 +140,27 @@ describe("InputController.handleClipboardTextRawPaste", () => {
 		const paste = controller.handleClipboardTextRawPaste();
 		vimMode = "normal";
 		request.resolve("late paste");
+		await paste;
+
+		expect(spies.insertText).not.toHaveBeenCalled();
+		expect(spies.requestRender).not.toHaveBeenCalled();
+	});
+
+	it("drops a canceled raw paste after Vim re-enters insert mode", async () => {
+		const request = Promise.withResolvers<string>();
+		const pasteAbort = new AbortController();
+		const { ctx, spies } = createContext({
+			getVimMode: () => "insert",
+			pasteSignal: pasteAbort.signal,
+		});
+		const controller = new InputController(ctx, {
+			readImage: async () => null,
+			readText: () => request.promise,
+		});
+
+		const paste = controller.handleClipboardTextRawPaste();
+		pasteAbort.abort();
+		request.resolve("stale paste");
 		await paste;
 
 		expect(spies.insertText).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/input-controller-smart-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-smart-paste.test.ts
@@ -10,13 +10,20 @@ import { describe, expect, it, vi } from "bun:test";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 
-function createContext(options?: { focused?: { pasteText(text: string): void } }) {
+function createContext(options?: {
+	focused?: { pasteText(text: string): void };
+	getVimMode?: () => "insert" | "normal" | "visual" | undefined;
+}) {
 	const pasteText = vi.fn();
 	const insertText = vi.fn();
 	const requestRender = vi.fn();
 	const showStatus = vi.fn();
 	const ctx = {
-		editor: { pasteText, insertText } as unknown as InteractiveModeContext["editor"],
+		editor: {
+			pasteText,
+			insertText,
+			getVimMode: options?.getVimMode ?? (() => undefined),
+		} as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender, getFocused: () => options?.focused ?? null } as unknown as InteractiveModeContext["ui"],
 		showStatus,
 	} as unknown as InteractiveModeContext;
@@ -116,6 +123,24 @@ describe("InputController.handleClipboardTextRawPaste", () => {
 
 		expect(spies.insertText).toHaveBeenCalledWith("raw $TEXT");
 		expect(spies.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("drops a pending raw paste after Vim leaves insert mode", async () => {
+		let vimMode: "insert" | "normal" = "insert";
+		const request = Promise.withResolvers<string>();
+		const { ctx, spies } = createContext({ getVimMode: () => vimMode });
+		const controller = new InputController(ctx, {
+			readImage: async () => null,
+			readText: () => request.promise,
+		});
+
+		const paste = controller.handleClipboardTextRawPaste();
+		vimMode = "normal";
+		request.resolve("late paste");
+		await paste;
+
+		expect(spies.insertText).not.toHaveBeenCalled();
+		expect(spies.requestRender).not.toHaveBeenCalled();
 	});
 
 	it("shows the empty-clipboard status only when there is no text", async () => {

--- a/packages/coding-agent/test/input-mode.test.ts
+++ b/packages/coding-agent/test/input-mode.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+
+describe("inputMode setting", () => {
+	it("defaults to the standard editor and accepts Vim mode", () => {
+		expect(Settings.isolated().get("inputMode")).toBe("default");
+		expect(Settings.isolated({ inputMode: "vim" }).get("inputMode")).toBe("vim");
+	});
+
+	it("updates the live editor", () => {
+		const setInputMode = vi.fn();
+		const controller = new SelectorController({
+			editor: { setInputMode },
+		} as unknown as ConstructorParameters<typeof SelectorController>[0]);
+
+		controller.handleSettingChange("inputMode", "vim");
+
+		expect(setInputMode).toHaveBeenCalledWith("vim");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -44,7 +45,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 				},
 			}),
 			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
-			settings: Settings.isolated(),
+			settings: Settings.isolated({ inputMode: "vim" }),
 			modelRegistry,
 		});
 		mode = new InteractiveMode(session, "test");
@@ -67,10 +68,23 @@ describe("InteractiveMode.setEditorComponent", () => {
 		mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
 
 		expect(mode.editor).toBeInstanceOf(TestModalEditor);
+		expect(mode.editor.getVimMode()).toBe("normal");
+		expect(stripVTControlCharacters(mode.editor.render(80).join("\n"))).toContain("NORMAL");
 		expect(mode.editor).not.toBe(previousEditor);
 		expect(mode.editor.getText()).toBe("draft prompt");
 		expect(mode.editor.onSubmit).toBeDefined();
 		expect(mode.editor.onEscape).toBeDefined();
 		expect(refreshSpy).toHaveBeenCalled();
+	});
+	it("renders live Vim mode transitions in the editor border", () => {
+		const normal = stripVTControlCharacters(mode.editor.render(80).join("\n"));
+		expect(normal).toContain("NORMAL");
+		expect(normal).not.toContain("INSERT");
+
+		mode.editor.handleInput("i");
+
+		const insert = stripVTControlCharacters(mode.editor.render(80).join("\n"));
+		expect(insert).toContain("INSERT");
+		expect(insert).not.toContain("NORMAL");
 	});
 });

--- a/packages/coding-agent/test/issue-2375-repro.test.ts
+++ b/packages/coding-agent/test/issue-2375-repro.test.ts
@@ -41,11 +41,13 @@ function createContext(getVimMode: () => "insert" | "normal" | "visual" | undefi
 	const insertText = vi.fn();
 	const requestRender = vi.fn();
 	const showStatus = vi.fn();
+	const asyncPasteSignal = new AbortController().signal;
 	const ctx = {
 		editor: {
 			pasteText,
 			insertText,
 			getVimMode,
+			getAsyncPasteSignal: () => asyncPasteSignal,
 			imageLinks: undefined,
 			pendingImages: [] as ImageContent[],
 			pendingImageLinks: [] as (string | undefined)[],

--- a/packages/coding-agent/test/issue-2375-repro.test.ts
+++ b/packages/coding-agent/test/issue-2375-repro.test.ts
@@ -36,7 +36,7 @@ const ONE_PX_PNG = Buffer.from(
 	"base64",
 );
 
-function createContext() {
+function createContext(getVimMode: () => "insert" | "normal" | "visual" | undefined = () => undefined) {
 	const pasteText = vi.fn();
 	const insertText = vi.fn();
 	const requestRender = vi.fn();
@@ -45,6 +45,7 @@ function createContext() {
 		editor: {
 			pasteText,
 			insertText,
+			getVimMode,
 			imageLinks: undefined,
 			pendingImages: [] as ImageContent[],
 			pendingImageLinks: [] as (string | undefined)[],
@@ -157,6 +158,25 @@ describe("InputController.handleImagePathPaste (issue #2375)", () => {
 		expect(spies.showStatus).not.toHaveBeenCalled();
 		expect(ctx.editor.pendingImages.length).toBe(1);
 		expect(ctx.editor.pendingImages[0]?.mimeType).toBe("image/png");
+	});
+
+	it("drops a pending clipboard image after Vim leaves insert mode", async () => {
+		let vimMode: "insert" | "normal" = "insert";
+		const image = Promise.withResolvers<{ data: Buffer; mimeType: string } | null>();
+		const { ctx, spies } = createContext(() => vimMode);
+		const controller = new InputController(ctx, {
+			readImage: () => image.promise,
+			readText: async () => "",
+		});
+
+		const paste = controller.handleImagePaste();
+		vimMode = "normal";
+		image.resolve({ data: ONE_PX_PNG, mimeType: "image/png" });
+		await paste;
+
+		expect(ctx.editor.pendingImages).toHaveLength(0);
+		expect(spies.insertText).not.toHaveBeenCalled();
+		expect(spies.requestRender).not.toHaveBeenCalled();
 	});
 
 	it("locally: attaches the clipboard image when the pasted path resolves to a non-image file", async () => {

--- a/packages/coding-agent/test/issue-2375-repro.test.ts
+++ b/packages/coding-agent/test/issue-2375-repro.test.ts
@@ -181,6 +181,33 @@ describe("InputController.handleImagePathPaste (issue #2375)", () => {
 		expect(spies.requestRender).not.toHaveBeenCalled();
 	});
 
+	it("drops a canceled image-path fallback after the clipboard read", async () => {
+		const clipboardRead = Promise.withResolvers<{ data: Buffer; mimeType: string } | null>();
+		const readStarted = Promise.withResolvers<void>();
+		const { ctx, spies } = createContext();
+		const controller = new InputController(ctx, {
+			readImage: () => {
+				readStarted.resolve();
+				return clipboardRead.promise;
+			},
+			readText: async () => "",
+		});
+		const pasteController = new AbortController();
+		const paste = controller.handleImagePathPaste(
+			"/tmp/definitely-does-not-exist-canceled-image-path.png",
+			pasteController.signal,
+		);
+		await readStarted.promise;
+
+		pasteController.abort();
+		clipboardRead.resolve(null);
+		await paste;
+
+		expect(spies.pasteText).not.toHaveBeenCalled();
+		expect(spies.showStatus).not.toHaveBeenCalled();
+		expect(spies.requestRender).not.toHaveBeenCalled();
+	});
+
 	it("locally: attaches the clipboard image when the pasted path resolves to a non-image file", async () => {
 		// The bracketed paste can resolve to an existing file that is not a
 		// decodable image (zero-byte/locked transient snip), which surfaces as a

--- a/packages/coding-agent/test/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor.test.ts
@@ -259,6 +259,24 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(editor.getText()).toBe("text");
 	});
 
+	it("groups bracketed image insertion with Vim insert undo", async () => {
+		const { editor } = makeEditor();
+		editor.onPasteImagePath = () => {
+			editor.insertText("[Image] ");
+		};
+		editor.setInputMode("vim");
+		editor.handleInput("i");
+
+		editor.handleInput(bracketedPaste("/tmp/image.png"));
+		await Promise.resolve();
+		await Promise.resolve();
+		editor.handleInput("!");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("");
+	});
+
 	it("keeps a two-file drag with unescaped spaces as text instead of attaching one fused path", () => {
 		// PR #6582 review: selecting two screenshots and dropping them together
 		// emits a single space-separated payload the splitter also refuses

--- a/packages/coding-agent/test/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor.test.ts
@@ -589,6 +589,17 @@ describe("CustomEditor space-hold push-to-talk", () => {
 		expect(events).toEqual([]);
 	});
 
+	it("cancels an active hold without firing its release callback", () => {
+		const { editor, events } = makeEditor();
+		feedSpaces(editor, SPACE_HOLD_MECHANICAL_RUN + 2, REPEAT_GAP_MS);
+		expect(events).toEqual(["start"]);
+
+		editor.cancelSpaceHold();
+		vi.advanceTimersByTime(SPACE_HOLD_RELEASE_MS + 1);
+
+		expect(events).toEqual(["start"]);
+	});
+
 	it("leaves the space bar typing normally when the gesture is disabled", () => {
 		const { editor, events } = makeEditor();
 		editor.sttHoldEnabled = () => false;

--- a/packages/coding-agent/test/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor.test.ts
@@ -229,6 +229,36 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("does not attach an empty bracketed image paste in Vim visual mode", () => {
+		const { editor } = makeEditor();
+		const onPasteImage = vi.fn();
+		editor.onPasteImage = onPasteImage;
+		editor.setInputMode("vim");
+		editor.setText("text");
+		editor.handleInput("v");
+		expect(editor.getVimMode()).toBe("visual");
+
+		editor.handleInput(bracketedPaste(""));
+
+		expect(onPasteImage).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("text");
+	});
+
+	it("does not attach bracketed image paths in Vim visual mode", () => {
+		const { editor } = makeEditor();
+		const onPasteImagePath = vi.fn();
+		editor.onPasteImagePath = onPasteImagePath;
+		editor.setInputMode("vim");
+		editor.setText("text");
+		editor.handleInput("v");
+		expect(editor.getVimMode()).toBe("visual");
+
+		editor.handleInput(bracketedPaste("/tmp/image.png"));
+
+		expect(onPasteImagePath).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("text");
+	});
+
 	it("keeps a two-file drag with unescaped spaces as text instead of attaching one fused path", () => {
 		// PR #6582 review: selecting two screenshots and dropping them together
 		// emits a single space-separated payload the splitter also refuses

--- a/packages/coding-agent/test/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor.test.ts
@@ -500,6 +500,19 @@ describe("CustomEditor space-hold push-to-talk", () => {
 		expect(events).toEqual(["start", "end"]);
 	});
 
+	it("leaves visual selections untouched by space-hold push-to-talk", () => {
+		const { editor, events } = makeEditor();
+		editor.setInputMode("vim");
+		editor.setText("hello");
+		editor.handleInput("v");
+		expect(editor.getVimMode()).toBe("visual");
+
+		feedSpaces(editor, SPACE_HOLD_MECHANICAL_RUN + 2, REPEAT_GAP_MS);
+
+		expect(editor.getText()).toBe("hello");
+		expect(events).toEqual([]);
+	});
+
 	it("does not trigger when the space bar is smashed at an irregular cadence", () => {
 		const { editor, events } = makeEditor();
 		// Fast but jittery, the way a human mashes — not the metronomic delta of OS auto-repeat.

--- a/packages/coding-agent/test/stt-preflight.test.ts
+++ b/packages/coding-agent/test/stt-preflight.test.ts
@@ -205,6 +205,38 @@ describe("STTController preflight", () => {
 		expect(options.onStateChange).toHaveBeenLastCalledWith("idle");
 	});
 
+	it("ignores canceled stream callbacks after a new recording starts", async () => {
+		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(true);
+		vi.spyOn(downloader, "downloadSttModel").mockResolvedValue(undefined);
+		let firstPartial: ((text: string) => void) | undefined;
+		let firstSegment: ((text: string, index: number) => void) | undefined;
+		let starts = 0;
+		vi.spyOn(asrClient.sttClient, "startStream").mockImplementation((_model, callbacks) => {
+			if (starts++ === 0) {
+				firstPartial = callbacks?.onPartial;
+				firstSegment = callbacks?.onSegment;
+			}
+			return {
+				pushAudio: vi.fn(),
+				stop: vi.fn().mockResolvedValue(""),
+				cancel: vi.fn(),
+			};
+		});
+		const editor = makeEditor();
+		const options = makeOptions();
+		controller = new STTController(() => ({ stop: vi.fn() }));
+		await controller.toggle(editor, options);
+		controller.cancel();
+		await controller.toggle(editor, options);
+
+		firstPartial?.("stale partial");
+		firstSegment?.("stale segment", 0);
+
+		expect(controller.state).toBe("recording");
+		expect(editor.setVolatileText).not.toHaveBeenCalled();
+		expect(editor.commitVolatileText).not.toHaveBeenCalled();
+	});
+
 	it("ignores a final STT flush after cancellation", async () => {
 		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(true);
 		vi.spyOn(downloader, "downloadSttModel").mockResolvedValue(undefined);

--- a/packages/coding-agent/test/stt-preflight.test.ts
+++ b/packages/coding-agent/test/stt-preflight.test.ts
@@ -174,6 +174,56 @@ describe("STTController preflight", () => {
 		// Preflight ran again for the new tier rather than short-circuiting.
 		expect(isCached).toHaveBeenLastCalledWith("turbo");
 	});
+
+	it("cancels an active stream without allowing later editor mutations", async () => {
+		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(true);
+		vi.spyOn(downloader, "downloadSttModel").mockResolvedValue(undefined);
+		const cancelStream = vi.fn();
+		let onSegment: ((text: string, index: number) => void) | undefined;
+		vi.spyOn(asrClient.sttClient, "startStream").mockImplementation((_model, callbacks) => {
+			onSegment = callbacks?.onSegment;
+			return {
+				pushAudio: vi.fn(),
+				stop: vi.fn().mockResolvedValue(""),
+				cancel: cancelStream,
+			};
+		});
+		const stopCapture = vi.fn();
+		const editor = makeEditor();
+		const options = makeOptions();
+		controller = new STTController(() => ({ stop: stopCapture }));
+		await controller.toggle(editor, options);
+
+		controller.cancel();
+		onSegment?.("late transcript", 0);
+
+		expect(controller.state).toBe("idle");
+		expect(stopCapture).toHaveBeenCalledTimes(1);
+		expect(cancelStream).toHaveBeenCalledTimes(1);
+		expect(editor.clearVolatileText).toHaveBeenCalledTimes(1);
+		expect(editor.commitVolatileText).not.toHaveBeenCalled();
+		expect(options.onStateChange).toHaveBeenLastCalledWith("idle");
+	});
+
+	it("cancels a pending preflight before microphone capture starts", async () => {
+		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(false);
+		const download = Promise.withResolvers<void>();
+		vi.spyOn(downloader, "downloadSttModel").mockReturnValue(download.promise);
+		const createCapture = vi.fn(() => ({ stop: vi.fn() }));
+		const options = makeOptions();
+		controller = new STTController(createCapture);
+
+		const start = controller.toggle(makeEditor(), options);
+		await Promise.resolve();
+		controller.cancel();
+		download.resolve();
+		await start;
+
+		expect(controller.state).toBe("idle");
+		expect(createCapture).not.toHaveBeenCalled();
+		expect(asrClient.sttClient.startStream).not.toHaveBeenCalled();
+	});
+
 	it("stops recording and surfaces asynchronous microphone failures", async () => {
 		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(true);
 		vi.spyOn(downloader, "downloadSttModel").mockReturnValue(new Promise<void>(() => {}));

--- a/packages/coding-agent/test/stt-preflight.test.ts
+++ b/packages/coding-agent/test/stt-preflight.test.ts
@@ -282,6 +282,38 @@ describe("STTController preflight", () => {
 		expect(asrClient.sttClient.startStream).not.toHaveBeenCalled();
 	});
 
+	it("suppresses late preflight progress and failure UI after cancellation", async () => {
+		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(false);
+		const download = Promise.withResolvers<void>();
+		let reportProgress: Parameters<typeof downloader.downloadSttModel>[1];
+		vi.spyOn(downloader, "downloadSttModel").mockImplementation((_key, onProgress) => {
+			reportProgress = onProgress;
+			return download.promise;
+		});
+		const options = makeOptions();
+		controller = new STTController(() => ({ stop: vi.fn() }));
+
+		const progress = {
+			status: "progress" as const,
+			percent: 42,
+			loaded: 1,
+			total: 2,
+			repo: WHISPER_BASE_REPO,
+			label: "Whisper base",
+		};
+		const start = controller.toggle(makeEditor(), options);
+		await Promise.resolve();
+		reportProgress?.(progress);
+		controller.cancel();
+		reportProgress?.(progress);
+		download.reject(new Error("stale preflight failure"));
+		await start;
+
+		expect(controller.state).toBe("idle");
+		expect(options.showStatus.mock.calls).toEqual([["Downloading speech model Whisper base (42%)"], [""]]);
+		expect(options.showWarning).not.toHaveBeenCalled();
+	});
+
 	it("stops recording and surfaces asynchronous microphone failures", async () => {
 		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(true);
 		vi.spyOn(downloader, "downloadSttModel").mockReturnValue(new Promise<void>(() => {}));

--- a/packages/coding-agent/test/stt-preflight.test.ts
+++ b/packages/coding-agent/test/stt-preflight.test.ts
@@ -205,6 +205,32 @@ describe("STTController preflight", () => {
 		expect(options.onStateChange).toHaveBeenLastCalledWith("idle");
 	});
 
+	it("ignores a final STT flush after cancellation", async () => {
+		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(true);
+		vi.spyOn(downloader, "downloadSttModel").mockResolvedValue(undefined);
+		const stopped = Promise.withResolvers<string>();
+		const cancelStream = vi.fn(() => stopped.resolve(""));
+		vi.spyOn(asrClient.sttClient, "startStream").mockReturnValue({
+			pushAudio: vi.fn(),
+			stop: vi.fn(() => stopped.promise),
+			cancel: cancelStream,
+		});
+		const editor = makeEditor();
+		const options = makeOptions();
+		controller = new STTController(() => ({ stop: vi.fn() }));
+		await controller.toggle(editor, options);
+
+		const stopping = controller.toggle(editor, options);
+		expect(controller.state).toBe("transcribing");
+		controller.cancel();
+		await stopping;
+
+		expect(controller.state).toBe("idle");
+		expect(options.onStateChange).toHaveBeenCalledTimes(3);
+		expect(options.showStatus).not.toHaveBeenCalledWith("No speech detected.");
+		expect(cancelStream).toHaveBeenCalledTimes(1);
+	});
+
 	it("cancels a pending preflight before microphone capture starts", async () => {
 		vi.spyOn(downloader, "isSttModelCached").mockResolvedValue(false);
 		const download = Promise.withResolvers<void>();

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,16 +6,16 @@
 
 - Fixed Kitty/Ghostty shortcuts on non-Latin keyboard layouts by requesting base-layout key reporting from the terminal ([#7320](https://github.com/can1357/oh-my-pi/issues/7320)).
 
+### Added
+
+- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, visual deletion and change, grapheme-safe motions and edits, bounded command counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Fixed
 
 - Fixed animated Loader paints saturating a CPU core on slow WSL/ConPTY terminals by applying cost-aware cadence backpressure while preserving 30fps on cheap frames ([#7290](https://github.com/can1357/oh-my-pi/issues/7290)).
 - Fixed interactive terminals suppressing all output and input when the host project sets `NODE_ENV=test` or `BUN_ENV=test` ([#7261](https://github.com/can1357/oh-my-pi/issues/7261)).
-
-### Added
-
-- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, visual deletion and change, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Added
 
-- Added an opt-in Vim input mode to the editor with normal/insert state, grapheme-safe motions and edits, counts, operators, and shared undo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+- Added an opt-in Vim input mode to the editor with normal/insert/visual states, highlighted line selection, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Fixed animated Loader paints saturating a CPU core on slow WSL/ConPTY terminals by applying cost-aware cadence backpressure while preserving 30fps on cheap frames ([#7290](https://github.com/can1357/oh-my-pi/issues/7290)).
 - Fixed interactive terminals suppressing all output and input when the host project sets `NODE_ENV=test` or `BUN_ENV=test` ([#7261](https://github.com/can1357/oh-my-pi/issues/7261)).
 
+### Added
+
+- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, visual deletion and change, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added
@@ -36,10 +40,6 @@
 - Fixed high CPU usage in the Loader spinner during idle waits by optimizing text wrapping and caching during frame updates.
 - Fixed hash-prefixed UUIDs in prose being misclassified as 8-digit CSS colors and receiving spurious swatches.
 - Fixed unbounded memory growth and potential host freezes when a PTY consumer stalls by capping the pending stdout backlog and treating undrained consumers as a disconnect.
-
-### Added
-
-- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, visual deletion and change, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -67,6 +67,10 @@
 - Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) by routing the exported `matchesRawBackspace` helper through the `matchesKey`/`parseKey` seam. Remote SSH/container sessions where terminal identity is unavailable can opt in with `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Fixed plain Backspace deleting a whole word inside tmux/GNU screen/Zellij panes launched from Windows Terminal: multiplexers inherit `WT_SESSION` but emit raw `0x08` for plain Backspace, so the automatic raw-backspace → `ctrl+backspace` heuristic misfired. The heuristic now skips multiplexer sessions (`TMUX`/`STY`/`ZELLIJ` or `TERM` starting with `tmux`/`screen`); `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` remains the explicit opt-in everywhere ([#6784](https://github.com/can1357/oh-my-pi/pull/6784)).
 
+### Added
+
+- Added an opt-in Vim input mode to the editor with normal/insert state, grapheme-safe motions and edits, counts, operators, and shared undo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.1.4] - 2026-07-26
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -37,6 +37,10 @@
 - Fixed hash-prefixed UUIDs in prose being misclassified as 8-digit CSS colors and receiving spurious swatches.
 - Fixed unbounded memory growth and potential host freezes when a PTY consumer stalls by capping the pending stdout backlog and treating undrained consumers as a disconnect.
 
+### Added
+
+- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, visual deletion and change, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed
@@ -66,10 +70,6 @@
 - Fixed the multi-line prompt editor bypassing the keybindings registry for word/line delete and yank: `ctrl+backspace` (a declared default of `tui.editor.deleteWordBackward`) never fired and `keybindings.yml` remaps of `deleteWordBackward`, `deleteWordForward`, `deleteToLineStart`, `deleteToLineEnd`, `yank`, and `yankPop` were ignored, because those actions were matched with hardcoded chords instead of `keybindings.matches(...)` like cursor motion and the single-line `Input` already do ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) by routing the exported `matchesRawBackspace` helper through the `matchesKey`/`parseKey` seam. Remote SSH/container sessions where terminal identity is unavailable can opt in with `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Fixed plain Backspace deleting a whole word inside tmux/GNU screen/Zellij panes launched from Windows Terminal: multiplexers inherit `WT_SESSION` but emit raw `0x08` for plain Backspace, so the automatic raw-backspace → `ctrl+backspace` heuristic misfired. The heuristic now skips multiplexer sessions (`TMUX`/`STY`/`ZELLIJ` or `TERM` starting with `tmux`/`screen`); `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` remains the explicit opt-in everywhere ([#6784](https://github.com/can1357/oh-my-pi/pull/6784)).
-
-### Added
-
-- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Added
 
-- Added an opt-in Vim input mode to the editor with normal/insert/visual states, highlighted line selection, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
+- Added an opt-in Vim input mode to the editor with normal/insert/visual states, characterwise and highlighted line selection, grapheme-safe motions and edits, counts, inner/around word and paragraph text objects, and shared undo/redo history ([#1834](https://github.com/can1357/oh-my-pi/issues/1834)).
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3872,7 +3872,8 @@ export class Editor implements Component, Focusable {
 		this.#resetKillSequence();
 		this.#recordUndoState();
 		const deleted = this.#state.lines.slice(startLine, startLine + deleteCount).join("\n");
-		this.#state.lines.splice(startLine, deleteCount);
+		if (enterInsert) this.#state.lines.splice(startLine, deleteCount, "");
+		else this.#state.lines.splice(startLine, deleteCount);
 		if (this.#state.lines.length === 0) this.#state.lines.push("");
 		this.#state.cursorLine = Math.min(startLine, this.#state.lines.length - 1);
 		this.#setCursorCol(0);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1858,6 +1858,7 @@ export class Editor implements Component, Focusable {
 	 * Used for command-like autocomplete actions whose typed trigger should not count as the edit being undone.
 	 */
 	undoPastTransientText(transientText: string): void {
+		if (this.#inputMode === "vim") this.#vim.finishInsertUndo();
 		if (transientText.length === 0) {
 			this.#applyUndo();
 			return;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3450,7 +3450,7 @@ export class Editor implements Component, Focusable {
 		this.#state.cursorLine = Math.min(boundedStart, this.#state.lines.length - 1);
 		this.#setCursorCol(0);
 		this.#recordKill(deleted, "forward");
-		this.#notifyVimMutation();
+		this.#notifyVimMutation(enterInsert);
 	}
 
 	#openVimLines(line: number, count: number): void {
@@ -3461,7 +3461,7 @@ export class Editor implements Component, Focusable {
 		this.#state.lines.splice(targetLine, 0, ...Array.from({ length: count }, () => ""));
 		this.#state.cursorLine = targetLine + count - 1;
 		this.#setCursorCol(0);
-		this.#notifyVimMutation();
+		this.#notifyVimMutation(true);
 	}
 
 	#deleteVimRange(start: number, end: number, enterInsert: boolean): void {
@@ -3485,7 +3485,7 @@ export class Editor implements Component, Focusable {
 		if (this.#state.lines.length === 0) this.#state.lines = [""];
 		this.#setVimAbsoluteCursor(from, enterInsert);
 		this.#recordKill(deleted, start <= end ? "forward" : "backward");
-		this.#notifyVimMutation();
+		this.#notifyVimMutation(enterInsert);
 	}
 
 	#vimGraphemeStartAtOrBefore(text: string, col: number): number {
@@ -3538,10 +3538,10 @@ export class Editor implements Component, Focusable {
 		return { start: expandedStart, end: expandedEnd };
 	}
 
-	#notifyVimMutation(): void {
+	#notifyVimMutation(retriggerAutocomplete: boolean): void {
 		this.#preferredVisualCol = null;
 		this.onChange?.(this.getText());
-		this.#retriggerAutocompleteAtCursor();
+		if (retriggerAutocomplete) this.#retriggerAutocompleteAtCursor();
 	}
 
 	/**

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1275,14 +1275,21 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Bulk printable fast path: a multi-scalar run of plain text (paste
-		// remainder, batched stdin) parses to no key, so no binding probe or
-		// special-key branch below can consume it — it always falls through to
-		// one #insertCharacter call. Take that path directly and skip the
-		// dispatch cascade. Runs containing ESC or control bytes (including
-		// \r/\n) keep the full path: those bytes carry key semantics.
+		// remainder, batched stdin) parses to no key. Vim must see each grapheme
+		// while outside insert mode because one command can change how the
+		// remainder is interpreted, such as `ihello` or `dd`.
 		if (canonical === undefined && data.length > 1 && isPlainTextRun(data)) {
-			this.#insertCharacter(data);
-			return;
+			if (this.#inputMode === "vim" && this.#vim.mode !== "insert") {
+				const graphemes = [...segmenter.segment(data)];
+				if (graphemes.length > 1) {
+					for (const { segment } of graphemes) this.#handleInputChunk(segment);
+					return;
+				}
+			} else {
+				if (this.#inputMode === "vim") this.#vim.prepareInsertInput(data, kb);
+				this.#insertCharacter(data);
+				return;
+			}
 		}
 
 		// Handle special key combinations first

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1247,6 +1247,20 @@ export class Editor implements Component, Focusable {
 
 	/** Process one input chunk. Returns the unconsumed tail of a completed paste, if any. */
 	#handleInputChunk(data: string): string | undefined {
+		// Paste buffering owns every byte from its start marker through its end
+		// marker. Process it before Vim commands so pasted control bytes cannot
+		// change editor mode between fragmented stdin chunks.
+		const paste = this.#pasteHandler.process(data);
+		if (paste.handled) {
+			if (paste.pasteContent !== undefined) {
+				this.pasteText(paste.pasteContent);
+				if (paste.remaining.length > 0) {
+					return paste.remaining;
+				}
+			}
+			return;
+		}
+
 		const kb = getKeybindings();
 		// Parse the sequence once; every binding probe below is then a set
 		// lookup instead of re-parsing `data` per probe (~35 probes per key).
@@ -1281,18 +1295,6 @@ export class Editor implements Component, Focusable {
 
 			// Control character - cancel and fall through to normal handling
 			this.#jumpMode = null;
-		}
-
-		// Handle bracketed paste mode
-		const paste = this.#pasteHandler.process(data);
-		if (paste.handled) {
-			if (paste.pasteContent !== undefined) {
-				this.pasteText(paste.pasteContent);
-				if (paste.remaining.length > 0) {
-					return paste.remaining;
-				}
-			}
-			return;
 		}
 
 		// Bulk printable fast path: a multi-scalar run of plain text (paste

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1245,6 +1245,7 @@ export class Editor implements Component, Focusable {
 
 		if (this.isVimModeEscape(data)) {
 			if (this.#autocompleteState) this.#cancelAutocomplete(true);
+			this.#jumpMode = null;
 			this.#vim.enterNormalMode();
 			return;
 		}
@@ -1308,6 +1309,7 @@ export class Editor implements Component, Focusable {
 		// Do not consume arbitrary user-bound "copy" keys here, since the editor
 		// has no copy implementation and would make those keys disappear.
 		if (matchesKey(data, "ctrl+c")) {
+			if (this.#inputMode === "vim") this.#vim.clearPendingCommand();
 			return;
 		}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -365,6 +365,7 @@ interface EditorState {
 interface LayoutLine {
 	text: string;
 	sourceLine: number;
+	sourceStart: number;
 	/** Exact `visibleWidth(text)` carried from wrap/layout, never re-derived. */
 	width: number;
 	hasCursor: boolean;
@@ -412,6 +413,10 @@ type VimPendingCommand =
 	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
 	| { kind: "g"; count: number | undefined }
 	| { kind: "visualTextObject"; textObject: "inner" | "around"; count: number };
+
+type VimVisualSelection =
+	| { kind: "line"; anchorLine: number; startLine: number; endLine: number }
+	| { kind: "character"; anchor: number; start: number; end: number };
 
 export class Editor implements Component, Focusable {
 	#state: EditorState = {
@@ -508,8 +513,7 @@ export class Editor implements Component, Focusable {
 	#vimPending: VimPendingCommand | undefined;
 	#vimCount = "";
 	#vimInsertUndoActive = false;
-	#vimVisualAnchorLine = 0;
-	#vimVisualLineRange: { startLine: number; endLine: number } | undefined;
+	#vimVisualSelection: VimVisualSelection | undefined;
 
 	// Debounce timer for autocomplete updates
 	#autocompleteTimeout?: NodeJS.Timeout;
@@ -547,7 +551,7 @@ export class Editor implements Component, Focusable {
 		this.#inputMode = mode;
 		this.#vimPending = undefined;
 		this.#vimCount = "";
-		this.#vimVisualLineRange = undefined;
+		this.#vimVisualSelection = undefined;
 		if (mode === "vim") {
 			this.#vimMode = "normal";
 			this.#clampVimNormalCursor();
@@ -565,8 +569,8 @@ export class Editor implements Component, Focusable {
 		return this.#inputMode === "vim" ? this.#vimMode : undefined;
 	}
 
-	isVimInsertEscape(data: string): boolean {
-		return this.#inputMode === "vim" && this.#vimMode === "insert" && this.#isVimEscape(data);
+	isVimModeEscape(data: string): boolean {
+		return this.#inputMode === "vim" && this.#vimMode !== "normal" && this.#isVimEscape(data);
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -982,11 +986,21 @@ export class Editor implements Component, Focusable {
 			let displayText = layoutLine.text;
 			let displayWidth = layoutLine.width;
 			let cursorPaddingOverflow = 0;
-			const visualSelected =
-				this.#vimMode === "visual" &&
-				this.#vimVisualLineRange !== undefined &&
-				layoutLine.sourceLine >= this.#vimVisualLineRange.startLine &&
-				layoutLine.sourceLine < this.#vimVisualLineRange.endLine;
+			const visualSelection = this.#vimMode === "visual" ? this.#vimVisualSelection : undefined;
+			const visualLineSelected =
+				visualSelection?.kind === "line" &&
+				layoutLine.sourceLine >= visualSelection.startLine &&
+				layoutLine.sourceLine < visualSelection.endLine;
+			const visualCharacterStart =
+				visualSelection?.kind === "character"
+					? Math.max(0, Math.min(displayText.length, visualSelection.start - layoutLine.sourceStart))
+					: 0;
+			const visualCharacterEnd =
+				visualSelection?.kind === "character"
+					? Math.max(0, Math.min(displayText.length, visualSelection.end - layoutLine.sourceStart))
+					: 0;
+			const visualCharacterSelected = visualCharacterStart < visualCharacterEnd;
+			const visualSelected = visualLineSelected || visualCharacterSelected;
 			let decorated = false;
 			let imeSafeCursorTail = false;
 			const showPromptGutter = promptGutter !== undefined && visibleIndex === 0;
@@ -1124,8 +1138,14 @@ export class Editor implements Component, Focusable {
 				}
 			}
 
-			if (visualSelected) {
+			if (visualLineSelected) {
 				displayText = `\x1b[7m${displayText}\x1b[0m`;
+				decorated = true;
+			} else if (visualCharacterSelected) {
+				const before = displayText.slice(0, visualCharacterStart);
+				const selected = displayText.slice(visualCharacterStart, visualCharacterEnd);
+				const after = displayText.slice(visualCharacterEnd);
+				displayText = `${this.#decorate(before)}\x1b[7m${selected}\x1b[0m${this.#decorate(after)}`;
 				decorated = true;
 			}
 
@@ -1212,7 +1232,7 @@ export class Editor implements Component, Focusable {
 		const parsedKey = parseKey(data);
 		const canonical = parsedKey === undefined ? undefined : canonicalKeyId(parsedKey);
 
-		if (this.isVimInsertEscape(data)) {
+		if (this.isVimModeEscape(data)) {
 			if (this.#autocompleteState) this.#cancelAutocomplete(true);
 			this.#enterVimNormalMode();
 			return;
@@ -1655,6 +1675,7 @@ export class Editor implements Component, Focusable {
 			layoutLines.push({
 				text: "",
 				sourceLine: 0,
+				sourceStart: 0,
 				width: 0,
 				hasCursor: true,
 				cursorPos: 0,
@@ -1663,6 +1684,7 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Process each logical line
+		let sourceLineStart = 0;
 		for (let i = 0; i < this.#state.lines.length; i++) {
 			const line = this.#state.lines[i] || "";
 			const isCurrentLine = i === this.#state.cursorLine;
@@ -1674,6 +1696,7 @@ export class Editor implements Component, Focusable {
 					layoutLines.push({
 						text: line,
 						sourceLine: i,
+						sourceStart: sourceLineStart,
 						width: lineVisibleWidth,
 						hasCursor: true,
 						cursorPos: this.#state.cursorCol,
@@ -1682,6 +1705,7 @@ export class Editor implements Component, Focusable {
 					layoutLines.push({
 						text: line,
 						sourceLine: i,
+						sourceStart: sourceLineStart,
 						width: lineVisibleWidth,
 						hasCursor: false,
 					});
@@ -1724,6 +1748,7 @@ export class Editor implements Component, Focusable {
 						layoutLines.push({
 							text: chunk.text,
 							sourceLine: i,
+							sourceStart: sourceLineStart + chunk.startIndex,
 							width: chunk.width,
 							hasCursor: true,
 							cursorPos: adjustedCursorPos,
@@ -1732,12 +1757,14 @@ export class Editor implements Component, Focusable {
 						layoutLines.push({
 							text: chunk.text,
 							sourceLine: i,
+							sourceStart: sourceLineStart + chunk.startIndex,
 							width: chunk.width,
 							hasCursor: false,
 						});
 					}
 				}
 			}
+			sourceLineStart += line.length + 1;
 		}
 
 		return layoutLines;
@@ -3390,7 +3417,7 @@ export class Editor implements Component, Focusable {
 	#enterVimNormalMode(): void {
 		this.#finishVimInsertUndo();
 		this.#vimPending = undefined;
-		this.#vimVisualLineRange = undefined;
+		this.#vimVisualSelection = undefined;
 		this.#vimCount = "";
 		const changed = this.#vimMode !== "normal";
 		this.#vimMode = "normal";
@@ -3402,7 +3429,7 @@ export class Editor implements Component, Focusable {
 		if (col !== undefined) this.#setCursorCol(col);
 		this.#vimPending = undefined;
 		this.#vimCount = "";
-		this.#vimVisualLineRange = undefined;
+		this.#vimVisualSelection = undefined;
 		if (existingUndo) {
 			this.#vimInsertUndoActive = true;
 			this.#suspendUndo = true;
@@ -3411,12 +3438,29 @@ export class Editor implements Component, Focusable {
 		this.#vimMode = "insert";
 		if (changed) this.onInputModeChange?.("insert");
 	}
+	#enterVimVisualCharacterMode(): void {
+		this.#finishVimInsertUndo();
+		this.#vimPending = undefined;
+		this.#vimCount = "";
+		const anchor = this.#vimAbsoluteCursor();
+		this.#vimVisualSelection = {
+			kind: "character",
+			anchor,
+			start: anchor,
+			end: this.#vimGraphemeEndAt(this.getText(), anchor),
+		};
+		const changed = this.#vimMode !== "visual";
+		this.#vimMode = "visual";
+		if (changed) this.onInputModeChange?.("visual");
+	}
+
 	#enterVimVisualLineMode(): void {
 		this.#finishVimInsertUndo();
 		this.#vimPending = undefined;
 		this.#vimCount = "";
-		this.#vimVisualAnchorLine = this.#state.cursorLine;
-		this.#vimVisualLineRange = {
+		this.#vimVisualSelection = {
+			kind: "line",
+			anchorLine: this.#state.cursorLine,
 			startLine: this.#state.cursorLine,
 			endLine: this.#state.cursorLine + 1,
 		};
@@ -3425,11 +3469,23 @@ export class Editor implements Component, Focusable {
 		if (changed) this.onInputModeChange?.("visual");
 	}
 
-	#updateVimVisualLineRange(): void {
-		this.#vimVisualLineRange = {
-			startLine: Math.min(this.#vimVisualAnchorLine, this.#state.cursorLine),
-			endLine: Math.max(this.#vimVisualAnchorLine, this.#state.cursorLine) + 1,
-		};
+	#updateVimVisualSelection(): void {
+		const selection = this.#vimVisualSelection;
+		if (selection?.kind === "line") {
+			this.#vimVisualSelection = {
+				...selection,
+				startLine: Math.min(selection.anchorLine, this.#state.cursorLine),
+				endLine: Math.max(selection.anchorLine, this.#state.cursorLine) + 1,
+			};
+		} else if (selection?.kind === "character") {
+			const text = this.getText();
+			const cursor = this.#vimAbsoluteCursor();
+			this.#vimVisualSelection = {
+				...selection,
+				start: Math.min(selection.anchor, cursor),
+				end: Math.max(this.#vimGraphemeEndAt(text, selection.anchor), this.#vimGraphemeEndAt(text, cursor)),
+			};
+		}
 	}
 
 	#prepareVimInsertInput(data: string, kb: KeybindingsManager): void {
@@ -3593,6 +3649,8 @@ export class Editor implements Component, Focusable {
 				this.#vimPending = { kind: "g", count: this.#takeOptionalVimCount() };
 				return true;
 			case "v":
+				this.#enterVimVisualCharacterMode();
+				return true;
 			case "V":
 				this.#enterVimVisualLineMode();
 				return true;
@@ -3648,9 +3706,25 @@ export class Editor implements Component, Focusable {
 			this.#vimPending = undefined;
 			if (char === "p") {
 				const range = this.#vimParagraphLineRange(pending.count, pending.textObject === "around");
-				this.#vimVisualAnchorLine = range.startLine;
-				this.#vimVisualLineRange = range;
+				this.#vimVisualSelection = {
+					kind: "line",
+					anchorLine: range.startLine,
+					...range,
+				};
 				this.#setVimCursor(range.endLine - 1, 0);
+			} else if (char === "w" || char === "W") {
+				const range = this.#vimWordTextObjectRange(
+					this.#vimAbsoluteCursor(),
+					pending.count,
+					char === "W",
+					pending.textObject === "around",
+				);
+				this.#vimVisualSelection = {
+					kind: "character",
+					anchor: range.start,
+					...range,
+				};
+				this.#setVimAbsoluteCursor(this.#vimPreviousGraphemeStart(this.getText(), range.end));
 			}
 			return true;
 		}
@@ -3669,21 +3743,42 @@ export class Editor implements Component, Focusable {
 					count: this.#takeVimCount(),
 				};
 				return true;
+			case "h":
+				this.#moveVimHorizontal(-1, this.#takeVimCount());
+				this.#updateVimVisualSelection();
+				return true;
 			case "j":
 				this.#moveVimVertical(1, this.#takeVimCount());
-				this.#updateVimVisualLineRange();
+				this.#updateVimVisualSelection();
 				return true;
 			case "k":
 				this.#moveVimVertical(-1, this.#takeVimCount());
-				this.#updateVimVisualLineRange();
+				this.#updateVimVisualSelection();
+				return true;
+			case "l":
+				this.#moveVimHorizontal(1, this.#takeVimCount());
+				this.#updateVimVisualSelection();
+				return true;
+			case "v":
+				if (this.#vimVisualSelection?.kind === "character") this.#enterVimNormalMode();
+				else this.#enterVimVisualCharacterMode();
+				return true;
+			case "V":
+				if (this.#vimVisualSelection?.kind === "line") this.#enterVimNormalMode();
+				else this.#enterVimVisualLineMode();
 				return true;
 			case "d": {
-				const range = this.#vimVisualLineRange;
-				if (!range) return true;
-				this.#state.cursorLine = range.startLine;
-				this.#setCursorCol(0);
-				this.#enterVimNormalMode();
-				this.#deleteVimLines(range.endLine - range.startLine, false);
+				const selection = this.#vimVisualSelection;
+				if (!selection) return true;
+				if (selection.kind === "line") {
+					this.#state.cursorLine = selection.startLine;
+					this.#setCursorCol(0);
+					this.#enterVimNormalMode();
+					this.#deleteVimLines(selection.endLine - selection.startLine, false);
+				} else {
+					this.#enterVimNormalMode();
+					this.#deleteVimRange(selection.start, selection.end, false);
+				}
 				return true;
 			}
 			default:

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1303,7 +1303,10 @@ export class Editor implements Component, Focusable {
 
 		// Undo
 		if (kb.matchesCanonical(canonical, "tui.editor.undo")) {
-			if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.finishInsertUndo();
+			if (this.#inputMode === "vim") {
+				if (this.#vim.mode === "insert") this.#vim.finishInsertUndo();
+				else if (this.#vim.mode === "visual") this.#vim.enterNormalMode();
+			}
 			this.#applyUndo();
 			return;
 		}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -364,6 +364,7 @@ interface EditorState {
 
 interface LayoutLine {
 	text: string;
+	sourceLine: number;
 	/** Exact `visibleWidth(text)` carried from wrap/layout, never re-derived. */
 	width: number;
 	hasCursor: boolean;
@@ -405,11 +406,12 @@ interface HistoryStorage {
 type HistoryCursorAnchor = "start" | "end";
 
 export type EditorInputMode = "default" | "vim";
-export type VimEditorMode = "normal" | "insert";
+export type VimEditorMode = "normal" | "insert" | "visual";
 
 type VimPendingCommand =
-	| { kind: "operator"; operator: "d" | "c"; prefixCount: number }
-	| { kind: "g"; count: number | undefined };
+	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
+	| { kind: "g"; count: number | undefined }
+	| { kind: "visualTextObject"; textObject: "inner" | "around"; count: number };
 
 export class Editor implements Component, Focusable {
 	#state: EditorState = {
@@ -498,6 +500,7 @@ export class Editor implements Component, Focusable {
 
 	// Undo stack for editor state changes
 	#undoStack: EditorState[] = [];
+	#redoStack: EditorState[] = [];
 	#suspendUndo = false;
 
 	#inputMode: EditorInputMode = "default";
@@ -505,6 +508,8 @@ export class Editor implements Component, Focusable {
 	#vimPending: VimPendingCommand | undefined;
 	#vimCount = "";
 	#vimInsertUndoActive = false;
+	#vimVisualAnchorLine = 0;
+	#vimVisualLineRange: { startLine: number; endLine: number } | undefined;
 
 	// Debounce timer for autocomplete updates
 	#autocompleteTimeout?: NodeJS.Timeout;
@@ -542,6 +547,7 @@ export class Editor implements Component, Focusable {
 		this.#inputMode = mode;
 		this.#vimPending = undefined;
 		this.#vimCount = "";
+		this.#vimVisualLineRange = undefined;
 		if (mode === "vim") {
 			this.#vimMode = "normal";
 			this.#clampVimNormalCursor();
@@ -720,6 +726,7 @@ export class Editor implements Component, Focusable {
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
 		this.#undoStack.length = 0;
+		this.#redoStack.length = 0;
 		const lines = sanitizeLoadedText(text).split("\n");
 		this.#state.lines = lines.length === 0 ? [""] : lines;
 		if (cursorAnchor === "start") {
@@ -975,6 +982,11 @@ export class Editor implements Component, Focusable {
 			let displayText = layoutLine.text;
 			let displayWidth = layoutLine.width;
 			let cursorPaddingOverflow = 0;
+			const visualSelected =
+				this.#vimMode === "visual" &&
+				this.#vimVisualLineRange !== undefined &&
+				layoutLine.sourceLine >= this.#vimVisualLineRange.startLine &&
+				layoutLine.sourceLine < this.#vimVisualLineRange.endLine;
 			let decorated = false;
 			let imeSafeCursorTail = false;
 			const showPromptGutter = promptGutter !== undefined && visibleIndex === 0;
@@ -982,7 +994,7 @@ export class Editor implements Component, Focusable {
 				promptGutter === undefined ? "" : showPromptGutter ? promptGutter.firstLine : promptGutter.continuation;
 
 			// Add cursor if this line has it
-			const hasCursor = layoutLine.hasCursor && layoutLine.cursorPos !== undefined;
+			const hasCursor = !visualSelected && layoutLine.hasCursor && layoutLine.cursorPos !== undefined;
 			const marker = emitCursorMarker ? CURSOR_MARKER : "";
 
 			if (!borderVisible && displayWidth > lineContentWidth) {
@@ -1110,6 +1122,11 @@ export class Editor implements Component, Focusable {
 						cursorPaddingOverflow = displayWidth - lineContentWidth;
 					}
 				}
+			}
+
+			if (visualSelected) {
+				displayText = `\x1b[7m${displayText}\x1b[0m`;
+				decorated = true;
 			}
 
 			// No cursor on this line, or a branch that left the user text intact: decorate
@@ -1408,7 +1425,7 @@ export class Editor implements Component, Focusable {
 			// Let them fall through to normal character handling
 		}
 
-		if (this.#inputMode === "vim" && this.#vimMode === "normal" && this.#handleVimNormalInput(data, kb)) {
+		if (this.#inputMode === "vim" && this.#vimMode !== "insert" && this.#handleVimNormalInput(data, kb)) {
 			return;
 		}
 		if (this.#inputMode === "vim" && this.#vimMode === "insert") {
@@ -1637,6 +1654,7 @@ export class Editor implements Component, Focusable {
 			// Empty editor
 			layoutLines.push({
 				text: "",
+				sourceLine: 0,
 				width: 0,
 				hasCursor: true,
 				cursorPos: 0,
@@ -1655,6 +1673,7 @@ export class Editor implements Component, Focusable {
 				if (isCurrentLine) {
 					layoutLines.push({
 						text: line,
+						sourceLine: i,
 						width: lineVisibleWidth,
 						hasCursor: true,
 						cursorPos: this.#state.cursorCol,
@@ -1662,6 +1681,7 @@ export class Editor implements Component, Focusable {
 				} else {
 					layoutLines.push({
 						text: line,
+						sourceLine: i,
 						width: lineVisibleWidth,
 						hasCursor: false,
 					});
@@ -1703,6 +1723,7 @@ export class Editor implements Component, Focusable {
 					if (hasCursorInChunk) {
 						layoutLines.push({
 							text: chunk.text,
+							sourceLine: i,
 							width: chunk.width,
 							hasCursor: true,
 							cursorPos: adjustedCursorPos,
@@ -1710,6 +1731,7 @@ export class Editor implements Component, Focusable {
 					} else {
 						layoutLines.push({
 							text: chunk.text,
+							sourceLine: i,
 							width: chunk.width,
 							hasCursor: false,
 						});
@@ -1937,7 +1959,7 @@ export class Editor implements Component, Focusable {
 
 	/** Apply terminal paste semantics to text from non-bracketed paste transports. */
 	pasteText(text: string): void {
-		if (this.#inputMode === "vim" && this.#vimMode === "normal") return;
+		if (this.#inputMode === "vim" && this.#vimMode !== "insert") return;
 		if (this.#inputMode === "vim" && !this.#vimInsertUndoActive) {
 			this.#recordUndoState();
 			this.#vimInsertUndoActive = true;
@@ -2207,6 +2229,7 @@ export class Editor implements Component, Focusable {
 		this.#historyIndex = -1;
 		this.#scrollOffset = 0;
 		this.#undoStack.length = 0;
+		this.#redoStack.length = 0;
 
 		if (this.onChange) this.onChange("");
 		if (this.onSubmit) this.onSubmit(result);
@@ -2472,6 +2495,7 @@ export class Editor implements Component, Focusable {
 
 	#recordUndoState(): void {
 		if (this.#suspendUndo) return;
+		this.#redoStack.length = 0;
 		this.#undoStack.push(structuredClone(this.#state));
 		if (this.#undoStack.length > MAX_UNDO_STACK) {
 			this.#undoStack.shift();
@@ -2481,7 +2505,20 @@ export class Editor implements Component, Focusable {
 	#applyUndo(): void {
 		const snapshot = this.#undoStack.pop();
 		if (!snapshot) return;
+		this.#redoStack.push(structuredClone(this.#state));
+		if (this.#redoStack.length > MAX_UNDO_STACK) this.#redoStack.shift();
+		this.#restoreUndoState(snapshot);
+	}
+	#applyRedo(): void {
+		const snapshot = this.#redoStack.pop();
+		if (!snapshot) return;
 
+		this.#undoStack.push(structuredClone(this.#state));
+		if (this.#undoStack.length > MAX_UNDO_STACK) this.#undoStack.shift();
+		this.#restoreUndoState(snapshot);
+	}
+
+	#restoreUndoState(snapshot: EditorState): void {
 		this.#historyIndex = -1;
 		this.#resetKillSequence();
 		this.#preferredVisualCol = null;
@@ -3353,6 +3390,7 @@ export class Editor implements Component, Focusable {
 	#enterVimNormalMode(): void {
 		this.#finishVimInsertUndo();
 		this.#vimPending = undefined;
+		this.#vimVisualLineRange = undefined;
 		this.#vimCount = "";
 		const changed = this.#vimMode !== "normal";
 		this.#vimMode = "normal";
@@ -3364,6 +3402,7 @@ export class Editor implements Component, Focusable {
 		if (col !== undefined) this.#setCursorCol(col);
 		this.#vimPending = undefined;
 		this.#vimCount = "";
+		this.#vimVisualLineRange = undefined;
 		if (existingUndo) {
 			this.#vimInsertUndoActive = true;
 			this.#suspendUndo = true;
@@ -3371,6 +3410,26 @@ export class Editor implements Component, Focusable {
 		const changed = this.#vimMode !== "insert";
 		this.#vimMode = "insert";
 		if (changed) this.onInputModeChange?.("insert");
+	}
+	#enterVimVisualLineMode(): void {
+		this.#finishVimInsertUndo();
+		this.#vimPending = undefined;
+		this.#vimCount = "";
+		this.#vimVisualAnchorLine = this.#state.cursorLine;
+		this.#vimVisualLineRange = {
+			startLine: this.#state.cursorLine,
+			endLine: this.#state.cursorLine + 1,
+		};
+		const changed = this.#vimMode !== "visual";
+		this.#vimMode = "visual";
+		if (changed) this.onInputModeChange?.("visual");
+	}
+
+	#updateVimVisualLineRange(): void {
+		this.#vimVisualLineRange = {
+			startLine: Math.min(this.#vimVisualAnchorLine, this.#state.cursorLine),
+			endLine: Math.max(this.#vimVisualAnchorLine, this.#state.cursorLine) + 1,
+		};
 	}
 
 	#prepareVimInsertInput(data: string, kb: KeybindingsManager): void {
@@ -3408,12 +3467,21 @@ export class Editor implements Component, Focusable {
 
 	#handleVimNormalInput(data: string, kb: KeybindingsManager): boolean {
 		if (this.#isVimEscape(data)) {
-			this.#vimPending = undefined;
-			this.#vimCount = "";
+			if (this.#vimMode === "visual") this.#enterVimNormalMode();
+			else {
+				this.#vimPending = undefined;
+				this.#vimCount = "";
+			}
 			return true;
 		}
 		if (data === "\n") return true;
 		if (matchesKey(data, "enter") || matchesKey(data, "return")) return false;
+		if (matchesKey(data, "ctrl+r")) {
+			const count = this.#takeVimCount();
+			for (let i = 0; i < count; i++) this.#applyRedo();
+			this.#clampVimNormalCursor();
+			return true;
+		}
 		if (
 			kb.matches(data, "tui.input.tab") ||
 			kb.matches(data, "tui.input.newLine") ||
@@ -3440,6 +3508,7 @@ export class Editor implements Component, Focusable {
 		if (graphemes.length !== 1) return printable !== undefined;
 		const char = graphemes[0]?.segment;
 		if (!char) return false;
+		if (this.#vimMode === "visual") return this.#handleVimVisualInput(char);
 
 		if (this.#vimPending?.kind === "operator") return this.#handleVimOperatorInput(char);
 		if (this.#vimPending?.kind === "g") {
@@ -3523,6 +3592,10 @@ export class Editor implements Component, Focusable {
 			case "g":
 				this.#vimPending = { kind: "g", count: this.#takeOptionalVimCount() };
 				return true;
+			case "v":
+			case "V":
+				this.#enterVimVisualLineMode();
+				return true;
 			case "i":
 				this.#vimCount = "";
 				this.#enterVimInsertMode();
@@ -3569,6 +3642,56 @@ export class Editor implements Component, Focusable {
 				return true;
 		}
 	}
+	#handleVimVisualInput(char: string): boolean {
+		const pending = this.#vimPending;
+		if (pending?.kind === "visualTextObject") {
+			this.#vimPending = undefined;
+			if (char === "p") {
+				const range = this.#vimParagraphLineRange(pending.count, pending.textObject === "around");
+				this.#vimVisualAnchorLine = range.startLine;
+				this.#vimVisualLineRange = range;
+				this.#setVimCursor(range.endLine - 1, 0);
+			}
+			return true;
+		}
+
+		if (/[1-9]/u.test(char) || (char === "0" && this.#vimCount.length > 0)) {
+			this.#vimCount += char;
+			return true;
+		}
+
+		switch (char) {
+			case "i":
+			case "a":
+				this.#vimPending = {
+					kind: "visualTextObject",
+					textObject: char === "i" ? "inner" : "around",
+					count: this.#takeVimCount(),
+				};
+				return true;
+			case "j":
+				this.#moveVimVertical(1, this.#takeVimCount());
+				this.#updateVimVisualLineRange();
+				return true;
+			case "k":
+				this.#moveVimVertical(-1, this.#takeVimCount());
+				this.#updateVimVisualLineRange();
+				return true;
+			case "d": {
+				const range = this.#vimVisualLineRange;
+				if (!range) return true;
+				this.#state.cursorLine = range.startLine;
+				this.#setCursorCol(0);
+				this.#enterVimNormalMode();
+				this.#deleteVimLines(range.endLine - range.startLine, false);
+				return true;
+			}
+			default:
+				this.#vimPending = undefined;
+				this.#vimCount = "";
+				return true;
+		}
+	}
 
 	#handleVimOperatorInput(char: string): boolean {
 		const pending = this.#vimPending;
@@ -3579,9 +3702,29 @@ export class Editor implements Component, Focusable {
 			return true;
 		}
 
+		if ((char === "i" || char === "a") && pending.textObject === undefined) {
+			this.#vimPending = { ...pending, textObject: char === "i" ? "inner" : "around" };
+			return true;
+		}
+
 		this.#vimPending = undefined;
 		const count = pending.prefixCount * this.#takeVimCount();
 		const enterInsert = pending.operator === "c";
+		if (pending.textObject !== undefined) {
+			if (char === "w" || char === "W") {
+				const range = this.#vimWordTextObjectRange(
+					this.#vimAbsoluteCursor(),
+					count,
+					char === "W",
+					pending.textObject === "around",
+				);
+				this.#deleteVimRange(range.start, range.end, enterInsert);
+			} else if (char === "p" && pending.textObject === "around") {
+				this.#deleteVimParagraphs(count, enterInsert);
+			}
+			return true;
+		}
+
 		if (char === pending.operator) {
 			this.#deleteVimLines(count, enterInsert);
 			return true;
@@ -3795,6 +3938,44 @@ export class Editor implements Component, Focusable {
 		}
 		return segments.length;
 	}
+	#vimWordTextObjectRange(
+		start: number,
+		count: number,
+		bigWord: boolean,
+		around: boolean,
+	): { start: number; end: number } {
+		const text = this.getText();
+		const segments = this.#vimSegments(text, bigWord);
+		let first = this.#vimSegmentIndexAt(segments, start);
+		if (first >= segments.length) return { start, end: start };
+
+		const firstKind = segments[first]?.kind;
+		while (first > 0 && segments[first - 1]?.kind === firstKind) first--;
+
+		let end = first;
+		const consumeGroup = (): void => {
+			const kind = segments[end]?.kind;
+			while (end < segments.length && segments[end]?.kind === kind) end++;
+		};
+		consumeGroup();
+		for (let step = 1; step < count && end < segments.length; step++) {
+			while (end < segments.length && segments[end]?.kind === "whitespace") end++;
+			if (end < segments.length) consumeGroup();
+		}
+
+		if (around) {
+			const innerEnd = end;
+			while (end < segments.length && segments[end]?.kind === "whitespace") end++;
+			if (end === innerEnd) {
+				while (first > 0 && segments[first - 1]?.kind === "whitespace") first--;
+			}
+		}
+
+		return {
+			start: segments[first]?.index ?? start,
+			end: segments[end]?.index ?? text.length,
+		};
+	}
 
 	#vimWordForwardPosition(start: number, count: number, bigWord: boolean): number {
 		const text = this.getText();
@@ -3872,6 +4053,57 @@ export class Editor implements Component, Focusable {
 		this.#resetKillSequence();
 		this.#recordUndoState();
 		const deleted = this.#state.lines.slice(startLine, startLine + deleteCount).join("\n");
+		if (enterInsert) this.#state.lines.splice(startLine, deleteCount, "");
+		else this.#state.lines.splice(startLine, deleteCount);
+		if (this.#state.lines.length === 0) this.#state.lines.push("");
+		this.#state.cursorLine = Math.min(startLine, this.#state.lines.length - 1);
+		this.#setCursorCol(0);
+		this.#recordKill(deleted, "forward");
+		this.#notifyVimMutation();
+		if (enterInsert) this.#enterVimInsertMode(true, 0);
+		else this.#clampVimNormalCursor();
+	}
+	#vimParagraphLineRange(count: number, around: boolean): { startLine: number; endLine: number } {
+		const isBlank = (line: string): boolean => line.trim().length === 0;
+		let paragraphLine = this.#state.cursorLine;
+		if (isBlank(this.#state.lines[paragraphLine] ?? "")) {
+			while (paragraphLine < this.#state.lines.length && isBlank(this.#state.lines[paragraphLine] ?? "")) {
+				paragraphLine++;
+			}
+			if (paragraphLine >= this.#state.lines.length) {
+				paragraphLine = this.#state.cursorLine;
+				while (paragraphLine > 0 && isBlank(this.#state.lines[paragraphLine] ?? "")) paragraphLine--;
+			}
+		}
+
+		let startLine = paragraphLine;
+		while (startLine > 0 && !isBlank(this.#state.lines[startLine - 1] ?? "")) startLine--;
+		let endLine = paragraphLine + 1;
+		while (endLine < this.#state.lines.length && !isBlank(this.#state.lines[endLine] ?? "")) endLine++;
+
+		for (let step = 1; step < count; step++) {
+			while (endLine < this.#state.lines.length && isBlank(this.#state.lines[endLine] ?? "")) endLine++;
+			while (endLine < this.#state.lines.length && !isBlank(this.#state.lines[endLine] ?? "")) endLine++;
+		}
+
+		if (around) {
+			const paragraphEnd = endLine;
+			while (endLine < this.#state.lines.length && isBlank(this.#state.lines[endLine] ?? "")) endLine++;
+			if (endLine === paragraphEnd) {
+				while (startLine > 0 && isBlank(this.#state.lines[startLine - 1] ?? "")) startLine--;
+			}
+		}
+		return { startLine, endLine };
+	}
+
+	#deleteVimParagraphs(count: number, enterInsert: boolean): void {
+		const { startLine, endLine } = this.#vimParagraphLineRange(count, true);
+
+		const deleteCount = Math.max(1, endLine - startLine);
+		this.#historyIndex = -1;
+		this.#resetKillSequence();
+		this.#recordUndoState();
+		const deleted = this.#state.lines.slice(startLine, endLine).join("\n");
 		if (enterInsert) this.#state.lines.splice(startLine, deleteCount, "");
 		else this.#state.lines.splice(startLine, deleteCount);
 		if (this.#state.lines.length === 0) this.#state.lines.push("");

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -576,8 +576,8 @@ export class Editor implements Component, Focusable {
 		if (this.#inputMode === "vim") this.#vim.clearPendingCommand();
 	}
 
-	prepareVimPaste(): void {
-		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.preparePaste();
+	prepareVimInsertMutation(): void {
+		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.prepareInsertMutation();
 	}
 
 	isVimModeEscape(data: string): boolean {
@@ -2020,7 +2020,7 @@ export class Editor implements Component, Focusable {
 			this.#vim.clearPendingCommand();
 			return;
 		}
-		this.prepareVimPaste();
+		this.prepareVimInsertMutation();
 		this.#handlePaste(text);
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1321,6 +1321,7 @@ export class Editor implements Component, Focusable {
 				else this.#vim.clearPendingCommand();
 			}
 			this.#applyUndo();
+			if (this.#inputMode === "vim") this.#vim.clampNormalCursor();
 			return;
 		}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -740,6 +740,7 @@ export class Editor implements Component, Focusable {
 	}
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
+		this.#vim.finishInsertUndo();
 		this.#undoStack.length = 0;
 		this.#redoStack.length = 0;
 		const lines = sanitizeLoadedText(text).split("\n");

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -409,6 +409,11 @@ interface HistoryStorage {
 
 type HistoryCursorAnchor = "start" | "end";
 
+export interface EditorUndoStateHooks {
+	capture: () => unknown;
+	restore: (state: unknown) => void;
+}
+
 export type EditorInputMode = "default" | "vim";
 
 export class Editor implements Component, Focusable {
@@ -500,6 +505,7 @@ export class Editor implements Component, Focusable {
 	#undoStack: EditorState[] = [];
 	#redoStack: EditorState[] = [];
 	#suspendUndo = false;
+	#auxiliaryUndoStates = new WeakMap<EditorState, unknown>();
 
 	#inputMode: EditorInputMode = "default";
 	#vim: VimEditorController;
@@ -511,6 +517,8 @@ export class Editor implements Component, Focusable {
 	onAltEnter?: (text: string) => void;
 	onChange?: (text: string) => void;
 	onInputModeChange?: (mode: VimEditorMode | undefined) => void;
+	/** Optional host state captured and restored atomically with editor text undo/redo snapshots. */
+	undoStateHooks: EditorUndoStateHooks | undefined;
 	/** Called for a "marker-sized" paste — the point where the editor would otherwise collapse it
 	 *  into a `[Paste #N]` token (> 10 lines or > 1000 characters). Return `true` to intercept:
 	 *  the editor inserts nothing and records no undo state, leaving insertion to the host (e.g. a
@@ -2559,16 +2567,23 @@ export class Editor implements Component, Focusable {
 	#recordUndoState(): void {
 		if (this.#suspendUndo) return;
 		this.#redoStack.length = 0;
-		this.#undoStack.push(structuredClone(this.#state));
+		this.#undoStack.push(this.#snapshotUndoState());
 		if (this.#undoStack.length > MAX_UNDO_STACK) {
 			this.#undoStack.shift();
 		}
 	}
 
+	#snapshotUndoState(): EditorState {
+		const snapshot = structuredClone(this.#state);
+		const hooks = this.undoStateHooks;
+		if (hooks) this.#auxiliaryUndoStates.set(snapshot, structuredClone(hooks.capture()));
+		return snapshot;
+	}
+
 	#applyUndo(): boolean {
 		const snapshot = this.#undoStack.pop();
 		if (!snapshot) return false;
-		this.#redoStack.push(structuredClone(this.#state));
+		this.#redoStack.push(this.#snapshotUndoState());
 		if (this.#redoStack.length > MAX_UNDO_STACK) this.#redoStack.shift();
 		this.#restoreUndoState(snapshot);
 		return true;
@@ -2577,7 +2592,7 @@ export class Editor implements Component, Focusable {
 		const snapshot = this.#redoStack.pop();
 		if (!snapshot) return false;
 
-		this.#undoStack.push(structuredClone(this.#state));
+		this.#undoStack.push(this.#snapshotUndoState());
 		if (this.#undoStack.length > MAX_UNDO_STACK) this.#undoStack.shift();
 		this.#restoreUndoState(snapshot);
 		return true;
@@ -2588,6 +2603,10 @@ export class Editor implements Component, Focusable {
 		this.#resetKillSequence();
 		this.#preferredVisualCol = null;
 		Object.assign(this.#state, snapshot);
+		const hooks = this.undoStateHooks;
+		if (hooks && this.#auxiliaryUndoStates.has(snapshot)) {
+			hooks.restore(structuredClone(this.#auxiliaryUndoStates.get(snapshot)));
+		}
 
 		if (this.onChange) {
 			this.onChange(this.getText());

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3464,7 +3464,10 @@ export class Editor implements Component, Focusable {
 		const text = this.getText();
 		let from = Math.max(0, Math.min(start, end));
 		let to = Math.max(from, Math.min(text.length, Math.max(start, end)));
-		if (from === to) return;
+		if (from === to) {
+			if (enterInsert) this.#recordUndoState();
+			return;
+		}
 
 		const expanded = this.#expandVimRangeOverAtomicTokens(from, to);
 		from = expanded.start;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -404,6 +404,13 @@ interface HistoryStorage {
 
 type HistoryCursorAnchor = "start" | "end";
 
+export type EditorInputMode = "default" | "vim";
+export type VimEditorMode = "normal" | "insert";
+
+type VimPendingCommand =
+	| { kind: "operator"; operator: "d" | "c"; prefixCount: number }
+	| { kind: "g"; count: number | undefined };
+
 export class Editor implements Component, Focusable {
 	#state: EditorState = {
 		lines: [""],
@@ -493,12 +500,19 @@ export class Editor implements Component, Focusable {
 	#undoStack: EditorState[] = [];
 	#suspendUndo = false;
 
+	#inputMode: EditorInputMode = "default";
+	#vimMode: VimEditorMode = "insert";
+	#vimPending: VimPendingCommand | undefined;
+	#vimCount = "";
+	#vimInsertUndoActive = false;
+
 	// Debounce timer for autocomplete updates
 	#autocompleteTimeout?: NodeJS.Timeout;
 
 	onSubmit?: (text: string) => void | Promise<void>;
 	onAltEnter?: (text: string) => void;
 	onChange?: (text: string) => void;
+	onInputModeChange?: (mode: VimEditorMode | undefined) => void;
 	/** Called for a "marker-sized" paste — the point where the editor would otherwise collapse it
 	 *  into a `[Paste #N]` token (> 10 lines or > 1000 characters). Return `true` to intercept:
 	 *  the editor inserts nothing and records no undo state, leaving insertion to the host (e.g. a
@@ -520,6 +534,33 @@ export class Editor implements Component, Focusable {
 	constructor(theme: EditorTheme) {
 		this.#theme = theme;
 		this.borderColor = theme.borderColor;
+	}
+
+	setInputMode(mode: EditorInputMode): void {
+		if (this.#inputMode === mode) return;
+		this.#finishVimInsertUndo();
+		this.#inputMode = mode;
+		this.#vimPending = undefined;
+		this.#vimCount = "";
+		if (mode === "vim") {
+			this.#vimMode = "normal";
+			this.#clampVimNormalCursor();
+		} else {
+			this.#vimMode = "insert";
+		}
+		this.onInputModeChange?.(this.getVimMode());
+	}
+
+	getInputMode(): EditorInputMode {
+		return this.#inputMode;
+	}
+
+	getVimMode(): VimEditorMode | undefined {
+		return this.#inputMode === "vim" ? this.#vimMode : undefined;
+	}
+
+	isVimInsertEscape(data: string): boolean {
+		return this.#inputMode === "vim" && this.#vimMode === "insert" && this.#isVimEscape(data);
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -1154,6 +1195,12 @@ export class Editor implements Component, Focusable {
 		const parsedKey = parseKey(data);
 		const canonical = parsedKey === undefined ? undefined : canonicalKeyId(parsedKey);
 
+		if (this.isVimInsertEscape(data)) {
+			if (this.#autocompleteState) this.#cancelAutocomplete(true);
+			this.#enterVimNormalMode();
+			return;
+		}
+
 		// Handle character jump mode (awaiting next character to jump to)
 		if (this.#jumpMode !== null) {
 			// Cancel if the hotkey is pressed again
@@ -1181,7 +1228,7 @@ export class Editor implements Component, Focusable {
 		const paste = this.#pasteHandler.process(data);
 		if (paste.handled) {
 			if (paste.pasteContent !== undefined) {
-				this.#handlePaste(paste.pasteContent);
+				this.pasteText(paste.pasteContent);
 				if (paste.remaining.length > 0) {
 					return paste.remaining;
 				}
@@ -1211,6 +1258,7 @@ export class Editor implements Component, Focusable {
 
 		// Undo
 		if (kb.matchesCanonical(canonical, "tui.editor.undo")) {
+			if (this.#inputMode === "vim" && this.#vimMode === "insert") this.#finishVimInsertUndo();
 			this.#applyUndo();
 			return;
 		}
@@ -1358,6 +1406,13 @@ export class Editor implements Component, Focusable {
 			}
 			// For other keys (like regular typing), DON'T return here
 			// Let them fall through to normal character handling
+		}
+
+		if (this.#inputMode === "vim" && this.#vimMode === "normal" && this.#handleVimNormalInput(data, kb)) {
+			return;
+		}
+		if (this.#inputMode === "vim" && this.#vimMode === "insert") {
+			this.#prepareVimInsertInput(data, kb);
 		}
 
 		// Tab key - context-aware completion (but not when already autocompleting)
@@ -1773,9 +1828,12 @@ export class Editor implements Component, Focusable {
 	}
 
 	setText(text: string): void {
+		this.#finishVimInsertUndo();
+		if (this.#inputMode === "vim") this.#enterVimNormalMode();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#setTextInternal(text);
+		this.#clampVimNormalCursor();
 	}
 	submit(): void {
 		if (this.disableSubmit) return;
@@ -1879,6 +1937,12 @@ export class Editor implements Component, Focusable {
 
 	/** Apply terminal paste semantics to text from non-bracketed paste transports. */
 	pasteText(text: string): void {
+		if (this.#inputMode === "vim" && this.#vimMode === "normal") return;
+		if (this.#inputMode === "vim" && !this.#vimInsertUndoActive) {
+			this.#recordUndoState();
+			this.#vimInsertUndoActive = true;
+			this.#suspendUndo = true;
+		}
 		this.#handlePaste(text);
 	}
 
@@ -3274,6 +3338,608 @@ export class Editor implements Component, Focusable {
 			clearTimeout(this.#autocompleteTimeout);
 			this.#autocompleteTimeout = undefined;
 		}
+	}
+
+	#isVimEscape(data: string): boolean {
+		return matchesKey(data, "escape") || matchesKey(data, "esc");
+	}
+
+	#finishVimInsertUndo(): void {
+		if (!this.#vimInsertUndoActive) return;
+		this.#vimInsertUndoActive = false;
+		this.#suspendUndo = false;
+	}
+
+	#enterVimNormalMode(): void {
+		this.#finishVimInsertUndo();
+		this.#vimPending = undefined;
+		this.#vimCount = "";
+		const changed = this.#vimMode !== "normal";
+		this.#vimMode = "normal";
+		this.#clampVimNormalCursor();
+		if (changed) this.onInputModeChange?.("normal");
+	}
+
+	#enterVimInsertMode(existingUndo = false, col?: number): void {
+		if (col !== undefined) this.#setCursorCol(col);
+		this.#vimPending = undefined;
+		this.#vimCount = "";
+		if (existingUndo) {
+			this.#vimInsertUndoActive = true;
+			this.#suspendUndo = true;
+		}
+		const changed = this.#vimMode !== "insert";
+		this.#vimMode = "insert";
+		if (changed) this.onInputModeChange?.("insert");
+	}
+
+	#prepareVimInsertInput(data: string, kb: KeybindingsManager): void {
+		if (!this.#autocompleteState && data !== "\n" && kb.matches(data, "tui.input.submit")) {
+			this.#enterVimNormalMode();
+			return;
+		}
+		if (this.#vimInsertUndoActive) return;
+
+		const mutates =
+			extractPrintableText(data) !== undefined ||
+			kb.matches(data, "tui.input.newLine") ||
+			kb.matches(data, "tui.editor.deleteCharBackward") ||
+			kb.matches(data, "tui.editor.deleteCharForward") ||
+			matchesKey(data, "shift+backspace") ||
+			matchesKey(data, "shift+delete") ||
+			matchesKey(data, "ctrl+k") ||
+			matchesKey(data, "ctrl+u") ||
+			matchesKey(data, "ctrl+w") ||
+			matchesKey(data, "alt+backspace") ||
+			matchesKey(data, "super+alt+backspace") ||
+			matchesKey(data, "alt+d") ||
+			matchesKey(data, "alt+delete") ||
+			matchesKey(data, "super+alt+d") ||
+			matchesKey(data, "super+alt+delete") ||
+			matchesKey(data, "ctrl+y") ||
+			data === "\n" ||
+			(data.length > 1 && data.includes("\r"));
+		if (!mutates) return;
+
+		this.#recordUndoState();
+		this.#vimInsertUndoActive = true;
+		this.#suspendUndo = true;
+	}
+
+	#handleVimNormalInput(data: string, kb: KeybindingsManager): boolean {
+		if (this.#isVimEscape(data)) {
+			this.#vimPending = undefined;
+			this.#vimCount = "";
+			return true;
+		}
+		if (data === "\n") return true;
+		if (matchesKey(data, "enter") || matchesKey(data, "return")) return false;
+		if (
+			kb.matches(data, "tui.input.tab") ||
+			kb.matches(data, "tui.input.newLine") ||
+			kb.matches(data, "tui.editor.deleteCharBackward") ||
+			kb.matches(data, "tui.editor.deleteCharForward") ||
+			matchesKey(data, "shift+backspace") ||
+			matchesKey(data, "shift+delete") ||
+			matchesKey(data, "ctrl+k") ||
+			matchesKey(data, "ctrl+u") ||
+			matchesKey(data, "ctrl+w") ||
+			matchesKey(data, "alt+backspace") ||
+			matchesKey(data, "super+alt+backspace") ||
+			matchesKey(data, "alt+d") ||
+			matchesKey(data, "alt+delete") ||
+			matchesKey(data, "super+alt+d") ||
+			matchesKey(data, "super+alt+delete") ||
+			matchesKey(data, "ctrl+y") ||
+			matchesKey(data, "alt+y")
+		) {
+			return true;
+		}
+		const printable = extractPrintableText(data);
+		const graphemes = printable ? [...segmenter.segment(printable)] : [];
+		if (graphemes.length !== 1) return printable !== undefined;
+		const char = graphemes[0]?.segment;
+		if (!char) return false;
+
+		if (this.#vimPending?.kind === "operator") return this.#handleVimOperatorInput(char);
+		if (this.#vimPending?.kind === "g") {
+			const pending = this.#vimPending;
+			this.#vimPending = undefined;
+			this.#vimCount = "";
+			if (char === "g") {
+				this.#setVimCursor(pending.count === undefined ? 0 : pending.count - 1, 0);
+			}
+			return true;
+		}
+
+		if (/[1-9]/u.test(char) || (char === "0" && this.#vimCount.length > 0)) {
+			this.#vimCount += char;
+			return true;
+		}
+
+		switch (char) {
+			case "h":
+				this.#moveVimHorizontal(-1, this.#takeVimCount());
+				return true;
+			case "j":
+				this.#moveVimVertical(1, this.#takeVimCount());
+				return true;
+			case "k":
+				this.#moveVimVertical(-1, this.#takeVimCount());
+				return true;
+			case "l":
+				this.#moveVimHorizontal(1, this.#takeVimCount());
+				return true;
+			case "w":
+				this.#setVimAbsoluteCursor(
+					this.#vimWordForwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), false),
+				);
+				return true;
+			case "W":
+				this.#setVimAbsoluteCursor(
+					this.#vimWordForwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), true),
+				);
+				return true;
+			case "b":
+				this.#setVimAbsoluteCursor(
+					this.#vimWordBackwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), false),
+				);
+				return true;
+			case "B":
+				this.#setVimAbsoluteCursor(
+					this.#vimWordBackwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), true),
+				);
+				return true;
+			case "e":
+				this.#setVimAbsoluteCursor(
+					this.#vimWordEndPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), false),
+				);
+				return true;
+			case "E":
+				this.#setVimAbsoluteCursor(this.#vimWordEndPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), true));
+				return true;
+			case "0":
+				this.#vimCount = "";
+				this.#setVimCursor(this.#state.cursorLine, 0);
+				return true;
+			case "^":
+				this.#vimCount = "";
+				this.#setVimCursor(this.#state.cursorLine, this.#vimFirstNonBlankCol(this.#currentLine()));
+				return true;
+			case "$": {
+				const targetLine = Math.min(
+					this.#state.lines.length - 1,
+					this.#state.cursorLine + this.#takeVimCount() - 1,
+				);
+				this.#setVimCursor(targetLine, this.#vimLineLastCol(this.#state.lines[targetLine] ?? ""));
+				return true;
+			}
+			case "G": {
+				const count = this.#takeOptionalVimCount();
+				const targetLine = count === undefined ? this.#state.lines.length - 1 : count - 1;
+				this.#setVimCursor(targetLine, this.#vimFirstNonBlankCol(this.#state.lines[targetLine] ?? ""));
+				return true;
+			}
+			case "g":
+				this.#vimPending = { kind: "g", count: this.#takeOptionalVimCount() };
+				return true;
+			case "i":
+				this.#vimCount = "";
+				this.#enterVimInsertMode();
+				return true;
+			case "a":
+				this.#vimCount = "";
+				this.#enterVimInsertMode(false, this.#vimGraphemeEndAt(this.#currentLine(), this.#state.cursorCol));
+				return true;
+			case "I":
+				this.#vimCount = "";
+				this.#enterVimInsertMode(false, this.#vimFirstNonBlankCol(this.#currentLine()));
+				return true;
+			case "A":
+				this.#vimCount = "";
+				this.#enterVimInsertMode(false, this.#currentLine().length);
+				return true;
+			case "o":
+				this.#openVimLines(1, this.#takeVimCount());
+				return true;
+			case "O":
+				this.#openVimLines(0, this.#takeVimCount());
+				return true;
+			case "x":
+				this.#deleteVimCharacters(this.#takeVimCount());
+				return true;
+			case "D":
+				this.#deleteVimToLineEnd(this.#takeVimCount(), false);
+				return true;
+			case "C":
+				this.#deleteVimToLineEnd(this.#takeVimCount(), true);
+				return true;
+			case "d":
+			case "c":
+				this.#vimPending = { kind: "operator", operator: char, prefixCount: this.#takeVimCount() };
+				return true;
+			case "u": {
+				const count = this.#takeVimCount();
+				for (let i = 0; i < count; i++) this.#applyUndo();
+				this.#clampVimNormalCursor();
+				return true;
+			}
+			default:
+				this.#vimCount = "";
+				return true;
+		}
+	}
+
+	#handleVimOperatorInput(char: string): boolean {
+		const pending = this.#vimPending;
+		if (pending?.kind !== "operator") return false;
+
+		if (/[1-9]/u.test(char) || (char === "0" && this.#vimCount.length > 0)) {
+			this.#vimCount += char;
+			return true;
+		}
+
+		this.#vimPending = undefined;
+		const count = pending.prefixCount * this.#takeVimCount();
+		const enterInsert = pending.operator === "c";
+		if (char === pending.operator) {
+			this.#deleteVimLines(count, enterInsert);
+			return true;
+		}
+
+		const start = this.#vimAbsoluteCursor();
+		let endpoint: number | undefined;
+		switch (char) {
+			case "w":
+			case "W": {
+				const bigWord = char === "W";
+				endpoint =
+					enterInsert && this.#vimClassAt(start, bigWord) !== "whitespace"
+						? this.#vimGraphemeEndAt(this.getText(), this.#vimWordEndPosition(start, count, bigWord))
+						: this.#vimWordForwardPosition(start, count, bigWord);
+				break;
+			}
+			case "b":
+				endpoint = this.#vimWordBackwardPosition(start, count, false);
+				break;
+			case "B":
+				endpoint = this.#vimWordBackwardPosition(start, count, true);
+				break;
+			case "e":
+				endpoint = this.#vimGraphemeEndAt(this.getText(), this.#vimWordEndPosition(start, count, false));
+				break;
+			case "E":
+				endpoint = this.#vimGraphemeEndAt(this.getText(), this.#vimWordEndPosition(start, count, true));
+				break;
+			case "h":
+				endpoint = this.#vimAbsoluteLineStart(this.#state.cursorLine) + this.#vimMoveCol(-1, count);
+				break;
+			case "l":
+				endpoint =
+					this.#vimAbsoluteLineStart(this.#state.cursorLine) +
+					this.#vimGraphemeEndAt(this.#currentLine(), this.#vimMoveCol(1, count));
+				break;
+			case "0":
+				endpoint = this.#vimAbsoluteLineStart(this.#state.cursorLine);
+				break;
+			case "$":
+				endpoint = this.#vimLineEndAbsolute(
+					Math.min(this.#state.lines.length - 1, this.#state.cursorLine + count - 1),
+				);
+				break;
+			default:
+				return true;
+		}
+
+		this.#deleteVimRange(start, endpoint, enterInsert);
+		return true;
+	}
+
+	#takeVimCount(): number {
+		const count = this.#vimCount.length === 0 ? 1 : Number(this.#vimCount);
+		this.#vimCount = "";
+		return Number.isSafeInteger(count) && count > 0 ? count : 1;
+	}
+
+	#takeOptionalVimCount(): number | undefined {
+		if (this.#vimCount.length === 0) return undefined;
+		return this.#takeVimCount();
+	}
+
+	#currentLine(): string {
+		return this.#state.lines[this.#state.cursorLine] ?? "";
+	}
+
+	#vimFirstNonBlankCol(line: string): number {
+		const index = line.search(/\S/u);
+		return index < 0 ? 0 : this.#vimGraphemeStartAtOrBefore(line, index);
+	}
+
+	#vimLineLastCol(line: string): number {
+		let last = 0;
+		for (const grapheme of segmenter.segment(line)) last = grapheme.index;
+		return last;
+	}
+
+	#vimGraphemeStartAtOrBefore(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		let last = 0;
+		for (const grapheme of segmenter.segment(text)) {
+			const end = grapheme.index + grapheme.segment.length;
+			if (bounded < end) return grapheme.index;
+			last = grapheme.index;
+		}
+		return last;
+	}
+
+	#vimGraphemeEndAt(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		for (const grapheme of segmenter.segment(text)) {
+			const end = grapheme.index + grapheme.segment.length;
+			if (bounded <= grapheme.index || bounded < end) return end;
+		}
+		return text.length;
+	}
+
+	#vimPreviousGraphemeStart(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		let previous = 0;
+		for (const grapheme of segmenter.segment(text)) {
+			if (grapheme.index >= bounded) return previous;
+			previous = grapheme.index;
+		}
+		return previous;
+	}
+
+	#vimNextGraphemeStart(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		for (const grapheme of segmenter.segment(text)) {
+			if (grapheme.index > bounded) return grapheme.index;
+		}
+		return text.length;
+	}
+
+	#setVimCursor(line: number, col: number): void {
+		const targetLine = Math.max(0, Math.min(this.#state.lines.length - 1, Math.trunc(line)));
+		const text = this.#state.lines[targetLine] ?? "";
+		this.#state.cursorLine = targetLine;
+		this.#setCursorCol(this.#vimGraphemeStartAtOrBefore(text, col));
+	}
+
+	#clampVimNormalCursor(): void {
+		if (this.#inputMode !== "vim" || this.#vimMode !== "normal") return;
+		this.#setVimCursor(this.#state.cursorLine, this.#state.cursorCol);
+	}
+
+	#vimMoveCol(direction: -1 | 1, count: number): number {
+		const line = this.#currentLine();
+		let col = this.#state.cursorCol;
+		for (let i = 0; i < count; i++) {
+			const next = direction < 0 ? this.#vimPreviousGraphemeStart(line, col) : this.#vimNextGraphemeStart(line, col);
+			if (next >= line.length || next === col) break;
+			col = next;
+		}
+		return col;
+	}
+
+	#moveVimHorizontal(direction: -1 | 1, count: number): void {
+		this.#setVimCursor(this.#state.cursorLine, this.#vimMoveCol(direction, count));
+	}
+
+	#moveVimVertical(direction: -1 | 1, count: number): void {
+		const targetLine = Math.max(
+			0,
+			Math.min(this.#state.lines.length - 1, this.#state.cursorLine + direction * count),
+		);
+		this.#setVimCursor(targetLine, this.#state.cursorCol);
+	}
+
+	#vimAbsoluteLineStart(line: number): number {
+		let offset = 0;
+		for (let i = 0; i < line; i++) offset += (this.#state.lines[i] ?? "").length + 1;
+		return offset;
+	}
+
+	#vimLineEndAbsolute(line: number): number {
+		return this.#vimAbsoluteLineStart(line) + (this.#state.lines[line] ?? "").length;
+	}
+
+	#vimAbsoluteCursor(): number {
+		return this.#vimAbsoluteLineStart(this.#state.cursorLine) + this.#state.cursorCol;
+	}
+
+	#setVimAbsoluteCursor(pos: number, allowLineEnd = false): void {
+		let remaining = Math.max(0, Math.min(this.getText().length, Math.trunc(pos)));
+		for (let line = 0; line < this.#state.lines.length; line++) {
+			const text = this.#state.lines[line] ?? "";
+			if (remaining <= text.length || line === this.#state.lines.length - 1) {
+				this.#state.cursorLine = line;
+				const col =
+					allowLineEnd && remaining >= text.length
+						? text.length
+						: this.#vimGraphemeStartAtOrBefore(text, remaining);
+				this.#setCursorCol(col);
+				return;
+			}
+			remaining -= text.length + 1;
+		}
+	}
+
+	#vimSegments(text: string, bigWord: boolean): Array<{ index: number; segment: string; kind: string }> {
+		return [...segmenter.segment(text)].map(grapheme => ({
+			index: grapheme.index,
+			segment: grapheme.segment,
+			kind: this.#vimWordKind(grapheme.segment, bigWord),
+		}));
+	}
+
+	#vimWordKind(grapheme: string, bigWord: boolean): string {
+		const kind = getWordNavKind(grapheme);
+		if (kind === "whitespace") return "whitespace";
+		if (bigWord) return "word";
+		return kind === "word" || kind === "cjk" ? "word" : "delimiter";
+	}
+
+	#vimClassAt(pos: number, bigWord: boolean): string {
+		const text = this.getText();
+		for (const grapheme of segmenter.segment(text)) {
+			if (pos < grapheme.index + grapheme.segment.length) return this.#vimWordKind(grapheme.segment, bigWord);
+		}
+		return "whitespace";
+	}
+
+	#vimSegmentIndexAt(segments: Array<{ index: number; segment: string; kind: string }>, pos: number): number {
+		for (let i = 0; i < segments.length; i++) {
+			const grapheme = segments[i];
+			if (grapheme && pos < grapheme.index + grapheme.segment.length) return i;
+		}
+		return segments.length;
+	}
+
+	#vimWordForwardPosition(start: number, count: number, bigWord: boolean): number {
+		const text = this.getText();
+		const segments = this.#vimSegments(text, bigWord);
+		let pos = start;
+		for (let step = 0; step < count; step++) {
+			let index = this.#vimSegmentIndexAt(segments, pos);
+			if (index >= segments.length) return text.length;
+			const kind = segments[index]?.kind;
+			if (kind !== "whitespace") {
+				while (index < segments.length && segments[index]?.kind === kind) index++;
+			}
+			while (index < segments.length && segments[index]?.kind === "whitespace") index++;
+			pos = segments[index]?.index ?? text.length;
+		}
+		return pos;
+	}
+
+	#vimWordBackwardPosition(start: number, count: number, bigWord: boolean): number {
+		const segments = this.#vimSegments(this.getText(), bigWord);
+		let pos = start;
+		for (let step = 0; step < count; step++) {
+			let index = this.#vimSegmentIndexAt(segments, pos);
+			if (index >= segments.length || segments[index]?.index === pos) index--;
+			while (index >= 0 && segments[index]?.kind === "whitespace") index--;
+			if (index < 0) return 0;
+			const kind = segments[index]?.kind;
+			while (index > 0 && segments[index - 1]?.kind === kind) index--;
+			pos = segments[index]?.index ?? 0;
+		}
+		return pos;
+	}
+
+	#vimWordEndPosition(start: number, count: number, bigWord: boolean): number {
+		const text = this.getText();
+		const segments = this.#vimSegments(text, bigWord);
+		let pos = start;
+		for (let step = 0; step < count; step++) {
+			let index = this.#vimSegmentIndexAt(segments, pos);
+			if (index >= segments.length) return this.#vimPreviousGraphemeStart(text, text.length);
+			const kind = segments[index]?.kind;
+			if (kind !== "whitespace" && index + 1 < segments.length && segments[index + 1]?.kind === kind) {
+				while (index + 1 < segments.length && segments[index + 1]?.kind === kind) index++;
+			} else {
+				index++;
+				while (index < segments.length && segments[index]?.kind === "whitespace") index++;
+				const nextKind = segments[index]?.kind;
+				while (index + 1 < segments.length && segments[index + 1]?.kind === nextKind) index++;
+			}
+			pos = segments[index]?.index ?? this.#vimPreviousGraphemeStart(text, text.length);
+		}
+		return pos;
+	}
+
+	#deleteVimCharacters(count: number): void {
+		const start = this.#vimAbsoluteCursor();
+		let endCol = this.#state.cursorCol;
+		for (let i = 0; i < count; i++) {
+			const next = this.#vimGraphemeEndAt(this.#currentLine(), endCol);
+			if (next === endCol) break;
+			endCol = next;
+		}
+		this.#deleteVimRange(start, this.#vimAbsoluteLineStart(this.#state.cursorLine) + endCol, false);
+	}
+
+	#deleteVimToLineEnd(count: number, enterInsert: boolean): void {
+		const targetLine = Math.min(this.#state.lines.length - 1, this.#state.cursorLine + count - 1);
+		this.#deleteVimRange(this.#vimAbsoluteCursor(), this.#vimLineEndAbsolute(targetLine), enterInsert);
+	}
+
+	#deleteVimLines(count: number, enterInsert: boolean): void {
+		const startLine = this.#state.cursorLine;
+		const deleteCount = Math.max(1, Math.min(count, this.#state.lines.length - startLine));
+		this.#historyIndex = -1;
+		this.#resetKillSequence();
+		this.#recordUndoState();
+		const deleted = this.#state.lines.slice(startLine, startLine + deleteCount).join("\n");
+		this.#state.lines.splice(startLine, deleteCount);
+		if (this.#state.lines.length === 0) this.#state.lines.push("");
+		this.#state.cursorLine = Math.min(startLine, this.#state.lines.length - 1);
+		this.#setCursorCol(0);
+		this.#recordKill(deleted, "forward");
+		this.#notifyVimMutation();
+		if (enterInsert) this.#enterVimInsertMode(true, 0);
+		else this.#clampVimNormalCursor();
+	}
+
+	#openVimLines(offset: 0 | 1, count: number): void {
+		this.#historyIndex = -1;
+		this.#resetKillSequence();
+		this.#recordUndoState();
+		const line = this.#state.cursorLine + offset;
+		this.#state.lines.splice(line, 0, ...Array.from({ length: count }, () => ""));
+		this.#state.cursorLine = line + count - 1;
+		this.#setCursorCol(0);
+		this.#notifyVimMutation();
+		this.#enterVimInsertMode(true, 0);
+	}
+
+	#deleteVimRange(start: number, end: number, enterInsert: boolean): void {
+		const text = this.getText();
+		let from = Math.max(0, Math.min(start, end));
+		let to = Math.max(from, Math.min(text.length, Math.max(start, end)));
+		if (from === to) {
+			if (enterInsert) this.#enterVimInsertMode();
+			return;
+		}
+
+		const expanded = this.#expandVimRangeOverAtomicTokens(from, to);
+		from = expanded.start;
+		to = expanded.end;
+		this.#historyIndex = -1;
+		this.#resetKillSequence();
+		this.#recordUndoState();
+		const deleted = text.slice(from, to);
+		const nextText = text.slice(0, from) + text.slice(to);
+		this.#state.lines = nextText.split("\n");
+		if (this.#state.lines.length === 0) this.#state.lines = [""];
+		this.#setVimAbsoluteCursor(from, enterInsert);
+		this.#recordKill(deleted, start <= end ? "forward" : "backward");
+		this.#notifyVimMutation();
+		if (enterInsert) this.#enterVimInsertMode(true, this.#state.cursorCol);
+		else this.#clampVimNormalCursor();
+	}
+
+	#expandVimRangeOverAtomicTokens(start: number, end: number): { start: number; end: number } {
+		let expandedStart = start;
+		let expandedEnd = end;
+		for (let line = 0; line < this.#state.lines.length; line++) {
+			const lineText = this.#state.lines[line] ?? "";
+			const lineStart = this.#vimAbsoluteLineStart(line);
+			const localStart = Math.max(0, start - lineStart);
+			const localEnd = Math.min(lineText.length, end - lineStart);
+			if (localStart >= localEnd) continue;
+			const expanded = this.#expandRangeOverAtomicTokens(lineText, localStart, localEnd);
+			expandedStart = Math.min(expandedStart, lineStart + expanded.start);
+			expandedEnd = Math.max(expandedEnd, lineStart + expanded.end);
+		}
+		return { start: expandedStart, end: expandedEnd };
+	}
+
+	#notifyVimMutation(): void {
+		this.#preferredVisualCol = null;
+		this.onChange?.(this.getText());
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	/**

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -576,6 +576,10 @@ export class Editor implements Component, Focusable {
 		if (this.#inputMode === "vim") this.#vim.clearPendingCommand();
 	}
 
+	prepareVimPaste(): void {
+		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.preparePaste();
+	}
+
 	isVimModeEscape(data: string): boolean {
 		return this.#inputMode === "vim" && this.#vim.isModeEscape(data);
 	}
@@ -2016,7 +2020,7 @@ export class Editor implements Component, Focusable {
 			this.#vim.clearPendingCommand();
 			return;
 		}
-		if (this.#inputMode === "vim") this.#vim.preparePaste();
+		this.prepareVimPaste();
 		this.#handlePaste(text);
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1916,8 +1916,6 @@ export class Editor implements Component, Focusable {
 	}
 	submit(): void {
 		if (this.disableSubmit) return;
-		this.#cancelAutocomplete(true);
-		this.#jumpMode = null;
 		this.#submitValue();
 	}
 
@@ -2277,6 +2275,8 @@ export class Editor implements Component, Focusable {
 	}
 
 	#submitValue(): void {
+		this.#cancelAutocomplete(true);
+		this.#jumpMode = null;
 		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.enterNormalMode();
 		this.#resetKillSequence();
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3767,17 +3767,19 @@ export class Editor implements Component, Focusable {
 				if (this.#vimVisualSelection?.kind === "line") this.#enterVimNormalMode();
 				else this.#enterVimVisualLineMode();
 				return true;
-			case "d": {
+			case "d":
+			case "c": {
 				const selection = this.#vimVisualSelection;
 				if (!selection) return true;
+				const enterInsert = char === "c";
 				if (selection.kind === "line") {
 					this.#state.cursorLine = selection.startLine;
 					this.#setCursorCol(0);
 					this.#enterVimNormalMode();
-					this.#deleteVimLines(selection.endLine - selection.startLine, false);
+					this.#deleteVimLines(selection.endLine - selection.startLine, enterInsert);
 				} else {
 					this.#enterVimNormalMode();
-					this.#deleteVimRange(selection.start, selection.end, false);
+					this.#deleteVimRange(selection.start, selection.end, enterInsert);
 				}
 				return true;
 			}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -572,6 +572,10 @@ export class Editor implements Component, Focusable {
 		return this.#inputMode === "vim" ? this.#vim.mode : undefined;
 	}
 
+	clearVimPendingCommand(): void {
+		if (this.#inputMode === "vim") this.#vim.clearPendingCommand();
+	}
+
 	isVimModeEscape(data: string): boolean {
 		return this.#inputMode === "vim" && this.#vim.isModeEscape(data);
 	}
@@ -1308,6 +1312,7 @@ export class Editor implements Component, Focusable {
 			if (this.#inputMode === "vim") {
 				if (this.#vim.mode === "insert") this.#vim.finishInsertUndo();
 				else if (this.#vim.mode === "visual") this.#vim.enterNormalMode();
+				else this.#vim.clearPendingCommand();
 			}
 			this.#applyUndo();
 			return;
@@ -1356,6 +1361,7 @@ export class Editor implements Component, Focusable {
 					}
 					if (selected && this.#autocompleteProvider) {
 						const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
+						if (this.#inputMode === "vim") this.#vim.prepareCompletion();
 						const result = this.#autocompleteProvider.applyCompletion(
 							this.#state.lines,
 							this.#state.cursorLine,
@@ -1401,6 +1407,7 @@ export class Editor implements Component, Focusable {
 						this.#cancelAutocomplete();
 					} else {
 						if (selected && this.#autocompleteProvider) {
+							if (this.#inputMode === "vim") this.#vim.prepareCompletion();
 							const result = this.#autocompleteProvider.applyCompletion(
 								this.#state.lines,
 								this.#state.cursorLine,
@@ -1429,6 +1436,7 @@ export class Editor implements Component, Focusable {
 						this.#cancelAutocomplete();
 					} else {
 						if (selected && this.#autocompleteProvider) {
+							if (this.#inputMode === "vim") this.#vim.prepareCompletion();
 							const result = this.#autocompleteProvider.applyCompletion(
 								this.#state.lines,
 								this.#state.cursorLine,
@@ -2004,7 +2012,10 @@ export class Editor implements Component, Focusable {
 
 	/** Apply terminal paste semantics to text from non-bracketed paste transports. */
 	pasteText(text: string): void {
-		if (this.#inputMode === "vim" && this.#vim.mode !== "insert") return;
+		if (this.#inputMode === "vim" && this.#vim.mode !== "insert") {
+			this.#vim.clearPendingCommand();
+			return;
+		}
 		if (this.#inputMode === "vim") this.#vim.preparePaste();
 		this.#handlePaste(text);
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2589,21 +2589,11 @@ export class Editor implements Component, Focusable {
 			this.onChange(this.getText());
 		}
 
-		if (this.#autocompleteState) {
-			this.#debouncedUpdateAutocomplete();
-		} else {
-			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
-			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			if (this.#isInSlashAutocompleteContext()) {
-				this.#tryTriggerAutocomplete();
-			} else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
-				this.#tryTriggerAutocomplete();
-			} else if (textBeforeCursor.match(/#[^\s#]*$/)) {
-				this.#tryTriggerAutocomplete();
-			} else if (this.#textTriggersUrlAutocomplete(textBeforeCursor)) {
-				this.#tryTriggerAutocomplete();
-			}
+		if (this.#inputMode === "vim" && this.#vim.mode !== "insert") {
+			this.#cancelAutocomplete(true);
+			return;
 		}
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	#matchesTransientUndoSnapshot(

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -24,6 +24,9 @@ import {
 	visibleWidth,
 } from "../utils";
 import { type SelectItem, SelectList, type SelectListLayoutOptions, type SelectListTheme } from "./select-list";
+import { VimEditorController, type VimEditorMode } from "./vim-editor-controller";
+
+export type { VimEditorMode } from "./vim-editor-controller";
 
 const AUTOCOMPLETE_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 	overflowSearch: false,
@@ -407,16 +410,6 @@ interface HistoryStorage {
 type HistoryCursorAnchor = "start" | "end";
 
 export type EditorInputMode = "default" | "vim";
-export type VimEditorMode = "normal" | "insert" | "visual";
-
-type VimPendingCommand =
-	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
-	| { kind: "g"; count: number | undefined }
-	| { kind: "visualTextObject"; textObject: "inner" | "around"; count: number };
-
-type VimVisualSelection =
-	| { kind: "line"; anchorLine: number; startLine: number; endLine: number }
-	| { kind: "character"; anchor: number; start: number; end: number };
 
 export class Editor implements Component, Focusable {
 	#state: EditorState = {
@@ -509,11 +502,7 @@ export class Editor implements Component, Focusable {
 	#suspendUndo = false;
 
 	#inputMode: EditorInputMode = "default";
-	#vimMode: VimEditorMode = "insert";
-	#vimPending: VimPendingCommand | undefined;
-	#vimCount = "";
-	#vimInsertUndoActive = false;
-	#vimVisualSelection: VimVisualSelection | undefined;
+	#vim: VimEditorController;
 
 	// Debounce timer for autocomplete updates
 	#autocompleteTimeout?: NodeJS.Timeout;
@@ -543,21 +532,33 @@ export class Editor implements Component, Focusable {
 	constructor(theme: EditorTheme) {
 		this.#theme = theme;
 		this.borderColor = theme.borderColor;
+		this.#vim = new VimEditorController({
+			getText: () => this.getText(),
+			getLines: () => this.#state.lines,
+			getCursor: () => ({ line: this.#state.cursorLine, col: this.#state.cursorCol }),
+			setCursor: (line, col) => {
+				this.#state.cursorLine = line;
+				this.#setCursorCol(col);
+			},
+			isShowingAutocomplete: () => this.#autocompleteState !== null,
+			recordUndoState: () => this.#recordUndoState(),
+			setUndoSuspended: suspended => {
+				this.#suspendUndo = suspended;
+			},
+			applyUndo: () => this.#applyUndo(),
+			applyRedo: () => this.#applyRedo(),
+			deleteRange: (start, end, enterInsert) => this.#deleteVimRange(start, end, enterInsert),
+			deleteLineRange: (startLine, endLine, enterInsert) =>
+				this.#deleteVimLineRange(startLine, endLine, enterInsert),
+			openLines: (line, count) => this.#openVimLines(line, count),
+			onModeChange: mode => this.onInputModeChange?.(mode),
+		});
 	}
 
 	setInputMode(mode: EditorInputMode): void {
 		if (this.#inputMode === mode) return;
-		this.#finishVimInsertUndo();
 		this.#inputMode = mode;
-		this.#vimPending = undefined;
-		this.#vimCount = "";
-		this.#vimVisualSelection = undefined;
-		if (mode === "vim") {
-			this.#vimMode = "normal";
-			this.#clampVimNormalCursor();
-		} else {
-			this.#vimMode = "insert";
-		}
+		this.#vim.setEnabled(mode === "vim");
 		this.onInputModeChange?.(this.getVimMode());
 	}
 
@@ -566,11 +567,11 @@ export class Editor implements Component, Focusable {
 	}
 
 	getVimMode(): VimEditorMode | undefined {
-		return this.#inputMode === "vim" ? this.#vimMode : undefined;
+		return this.#inputMode === "vim" ? this.#vim.mode : undefined;
 	}
 
 	isVimModeEscape(data: string): boolean {
-		return this.#inputMode === "vim" && this.#vimMode !== "normal" && this.#isVimEscape(data);
+		return this.#inputMode === "vim" && this.#vim.isModeEscape(data);
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -986,7 +987,7 @@ export class Editor implements Component, Focusable {
 			let displayText = layoutLine.text;
 			let displayWidth = layoutLine.width;
 			let cursorPaddingOverflow = 0;
-			const visualSelection = this.#vimMode === "visual" ? this.#vimVisualSelection : undefined;
+			const visualSelection = this.#vim.mode === "visual" ? this.#vim.visualSelection : undefined;
 			const visualLineSelected =
 				visualSelection?.kind === "line" &&
 				layoutLine.sourceLine >= visualSelection.startLine &&
@@ -1234,7 +1235,7 @@ export class Editor implements Component, Focusable {
 
 		if (this.isVimModeEscape(data)) {
 			if (this.#autocompleteState) this.#cancelAutocomplete(true);
-			this.#enterVimNormalMode();
+			this.#vim.enterNormalMode();
 			return;
 		}
 
@@ -1295,7 +1296,7 @@ export class Editor implements Component, Focusable {
 
 		// Undo
 		if (kb.matchesCanonical(canonical, "tui.editor.undo")) {
-			if (this.#inputMode === "vim" && this.#vimMode === "insert") this.#finishVimInsertUndo();
+			if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.finishInsertUndo();
 			this.#applyUndo();
 			return;
 		}
@@ -1445,11 +1446,11 @@ export class Editor implements Component, Focusable {
 			// Let them fall through to normal character handling
 		}
 
-		if (this.#inputMode === "vim" && this.#vimMode !== "insert" && this.#handleVimNormalInput(data, kb)) {
+		if (this.#inputMode === "vim" && this.#vim.mode !== "insert" && this.#vim.handleNormalInput(data, kb)) {
 			return;
 		}
-		if (this.#inputMode === "vim" && this.#vimMode === "insert") {
-			this.#prepareVimInsertInput(data, kb);
+		if (this.#inputMode === "vim" && this.#vim.mode === "insert") {
+			this.#vim.prepareInsertInput(data, kb);
 		}
 
 		// Tab key - context-aware completion (but not when already autocompleting)
@@ -1877,12 +1878,12 @@ export class Editor implements Component, Focusable {
 	}
 
 	setText(text: string): void {
-		this.#finishVimInsertUndo();
-		if (this.#inputMode === "vim") this.#enterVimNormalMode();
+		this.#vim.finishInsertUndo();
+		if (this.#inputMode === "vim") this.#vim.enterNormalMode();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#setTextInternal(text);
-		this.#clampVimNormalCursor();
+		this.#vim.clampNormalCursor();
 	}
 	submit(): void {
 		if (this.disableSubmit) return;
@@ -1986,12 +1987,8 @@ export class Editor implements Component, Focusable {
 
 	/** Apply terminal paste semantics to text from non-bracketed paste transports. */
 	pasteText(text: string): void {
-		if (this.#inputMode === "vim" && this.#vimMode !== "insert") return;
-		if (this.#inputMode === "vim" && !this.#vimInsertUndoActive) {
-			this.#recordUndoState();
-			this.#vimInsertUndoActive = true;
-			this.#suspendUndo = true;
-		}
+		if (this.#inputMode === "vim" && this.#vim.mode !== "insert") return;
+		if (this.#inputMode === "vim") this.#vim.preparePaste();
 		this.#handlePaste(text);
 	}
 
@@ -3404,834 +3401,39 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
-	#isVimEscape(data: string): boolean {
-		return matchesKey(data, "escape") || matchesKey(data, "esc");
-	}
-
-	#finishVimInsertUndo(): void {
-		if (!this.#vimInsertUndoActive) return;
-		this.#vimInsertUndoActive = false;
-		this.#suspendUndo = false;
-	}
-
-	#enterVimNormalMode(): void {
-		this.#finishVimInsertUndo();
-		this.#vimPending = undefined;
-		this.#vimVisualSelection = undefined;
-		this.#vimCount = "";
-		const changed = this.#vimMode !== "normal";
-		this.#vimMode = "normal";
-		this.#clampVimNormalCursor();
-		if (changed) this.onInputModeChange?.("normal");
-	}
-
-	#enterVimInsertMode(existingUndo = false, col?: number): void {
-		if (col !== undefined) this.#setCursorCol(col);
-		this.#vimPending = undefined;
-		this.#vimCount = "";
-		this.#vimVisualSelection = undefined;
-		if (existingUndo) {
-			this.#vimInsertUndoActive = true;
-			this.#suspendUndo = true;
-		}
-		const changed = this.#vimMode !== "insert";
-		this.#vimMode = "insert";
-		if (changed) this.onInputModeChange?.("insert");
-	}
-	#enterVimVisualCharacterMode(): void {
-		this.#finishVimInsertUndo();
-		this.#vimPending = undefined;
-		this.#vimCount = "";
-		const anchor = this.#vimAbsoluteCursor();
-		this.#vimVisualSelection = {
-			kind: "character",
-			anchor,
-			start: anchor,
-			end: this.#vimGraphemeEndAt(this.getText(), anchor),
-		};
-		const changed = this.#vimMode !== "visual";
-		this.#vimMode = "visual";
-		if (changed) this.onInputModeChange?.("visual");
-	}
-
-	#enterVimVisualLineMode(): void {
-		this.#finishVimInsertUndo();
-		this.#vimPending = undefined;
-		this.#vimCount = "";
-		this.#vimVisualSelection = {
-			kind: "line",
-			anchorLine: this.#state.cursorLine,
-			startLine: this.#state.cursorLine,
-			endLine: this.#state.cursorLine + 1,
-		};
-		const changed = this.#vimMode !== "visual";
-		this.#vimMode = "visual";
-		if (changed) this.onInputModeChange?.("visual");
-	}
-
-	#updateVimVisualSelection(): void {
-		const selection = this.#vimVisualSelection;
-		if (selection?.kind === "line") {
-			this.#vimVisualSelection = {
-				...selection,
-				startLine: Math.min(selection.anchorLine, this.#state.cursorLine),
-				endLine: Math.max(selection.anchorLine, this.#state.cursorLine) + 1,
-			};
-		} else if (selection?.kind === "character") {
-			const text = this.getText();
-			const cursor = this.#vimAbsoluteCursor();
-			this.#vimVisualSelection = {
-				...selection,
-				start: Math.min(selection.anchor, cursor),
-				end: Math.max(this.#vimGraphemeEndAt(text, selection.anchor), this.#vimGraphemeEndAt(text, cursor)),
-			};
-		}
-	}
-
-	#prepareVimInsertInput(data: string, kb: KeybindingsManager): void {
-		if (!this.#autocompleteState && data !== "\n" && kb.matches(data, "tui.input.submit")) {
-			this.#enterVimNormalMode();
-			return;
-		}
-		if (this.#vimInsertUndoActive) return;
-
-		const mutates =
-			extractPrintableText(data) !== undefined ||
-			kb.matches(data, "tui.input.newLine") ||
-			kb.matches(data, "tui.editor.deleteCharBackward") ||
-			kb.matches(data, "tui.editor.deleteCharForward") ||
-			matchesKey(data, "shift+backspace") ||
-			matchesKey(data, "shift+delete") ||
-			matchesKey(data, "ctrl+k") ||
-			matchesKey(data, "ctrl+u") ||
-			matchesKey(data, "ctrl+w") ||
-			matchesKey(data, "alt+backspace") ||
-			matchesKey(data, "super+alt+backspace") ||
-			matchesKey(data, "alt+d") ||
-			matchesKey(data, "alt+delete") ||
-			matchesKey(data, "super+alt+d") ||
-			matchesKey(data, "super+alt+delete") ||
-			matchesKey(data, "ctrl+y") ||
-			data === "\n" ||
-			(data.length > 1 && data.includes("\r"));
-		if (!mutates) return;
-
-		this.#recordUndoState();
-		this.#vimInsertUndoActive = true;
-		this.#suspendUndo = true;
-	}
-
-	#handleVimNormalInput(data: string, kb: KeybindingsManager): boolean {
-		if (this.#isVimEscape(data)) {
-			if (this.#vimMode === "visual") this.#enterVimNormalMode();
-			else {
-				this.#vimPending = undefined;
-				this.#vimCount = "";
-			}
-			return true;
-		}
-		if (data === "\n") return true;
-		if (matchesKey(data, "enter") || matchesKey(data, "return")) return false;
-		if (matchesKey(data, "ctrl+r")) {
-			const count = this.#takeVimCount();
-			for (let i = 0; i < count; i++) this.#applyRedo();
-			this.#clampVimNormalCursor();
-			return true;
-		}
-		if (
-			kb.matches(data, "tui.input.tab") ||
-			kb.matches(data, "tui.input.newLine") ||
-			kb.matches(data, "tui.editor.deleteCharBackward") ||
-			kb.matches(data, "tui.editor.deleteCharForward") ||
-			matchesKey(data, "shift+backspace") ||
-			matchesKey(data, "shift+delete") ||
-			matchesKey(data, "ctrl+k") ||
-			matchesKey(data, "ctrl+u") ||
-			matchesKey(data, "ctrl+w") ||
-			matchesKey(data, "alt+backspace") ||
-			matchesKey(data, "super+alt+backspace") ||
-			matchesKey(data, "alt+d") ||
-			matchesKey(data, "alt+delete") ||
-			matchesKey(data, "super+alt+d") ||
-			matchesKey(data, "super+alt+delete") ||
-			matchesKey(data, "ctrl+y") ||
-			matchesKey(data, "alt+y")
-		) {
-			return true;
-		}
-		const printable = extractPrintableText(data);
-		const graphemes = printable ? [...segmenter.segment(printable)] : [];
-		if (graphemes.length !== 1) return printable !== undefined;
-		const char = graphemes[0]?.segment;
-		if (!char) return false;
-		if (this.#vimMode === "visual") return this.#handleVimVisualInput(char);
-
-		if (this.#vimPending?.kind === "operator") return this.#handleVimOperatorInput(char);
-		if (this.#vimPending?.kind === "g") {
-			const pending = this.#vimPending;
-			this.#vimPending = undefined;
-			this.#vimCount = "";
-			if (char === "g") {
-				this.#setVimCursor(pending.count === undefined ? 0 : pending.count - 1, 0);
-			}
-			return true;
-		}
-
-		if (/[1-9]/u.test(char) || (char === "0" && this.#vimCount.length > 0)) {
-			this.#vimCount += char;
-			return true;
-		}
-
-		switch (char) {
-			case "h":
-				this.#moveVimHorizontal(-1, this.#takeVimCount());
-				return true;
-			case "j":
-				this.#moveVimVertical(1, this.#takeVimCount());
-				return true;
-			case "k":
-				this.#moveVimVertical(-1, this.#takeVimCount());
-				return true;
-			case "l":
-				this.#moveVimHorizontal(1, this.#takeVimCount());
-				return true;
-			case "w":
-				this.#setVimAbsoluteCursor(
-					this.#vimWordForwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), false),
-				);
-				return true;
-			case "W":
-				this.#setVimAbsoluteCursor(
-					this.#vimWordForwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), true),
-				);
-				return true;
-			case "b":
-				this.#setVimAbsoluteCursor(
-					this.#vimWordBackwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), false),
-				);
-				return true;
-			case "B":
-				this.#setVimAbsoluteCursor(
-					this.#vimWordBackwardPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), true),
-				);
-				return true;
-			case "e":
-				this.#setVimAbsoluteCursor(
-					this.#vimWordEndPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), false),
-				);
-				return true;
-			case "E":
-				this.#setVimAbsoluteCursor(this.#vimWordEndPosition(this.#vimAbsoluteCursor(), this.#takeVimCount(), true));
-				return true;
-			case "0":
-				this.#vimCount = "";
-				this.#setVimCursor(this.#state.cursorLine, 0);
-				return true;
-			case "^":
-				this.#vimCount = "";
-				this.#setVimCursor(this.#state.cursorLine, this.#vimFirstNonBlankCol(this.#currentLine()));
-				return true;
-			case "$": {
-				const targetLine = Math.min(
-					this.#state.lines.length - 1,
-					this.#state.cursorLine + this.#takeVimCount() - 1,
-				);
-				this.#setVimCursor(targetLine, this.#vimLineLastCol(this.#state.lines[targetLine] ?? ""));
-				return true;
-			}
-			case "G": {
-				const count = this.#takeOptionalVimCount();
-				const targetLine = count === undefined ? this.#state.lines.length - 1 : count - 1;
-				this.#setVimCursor(targetLine, this.#vimFirstNonBlankCol(this.#state.lines[targetLine] ?? ""));
-				return true;
-			}
-			case "g":
-				this.#vimPending = { kind: "g", count: this.#takeOptionalVimCount() };
-				return true;
-			case "v":
-				this.#enterVimVisualCharacterMode();
-				return true;
-			case "V":
-				this.#enterVimVisualLineMode();
-				return true;
-			case "i":
-				this.#vimCount = "";
-				this.#enterVimInsertMode();
-				return true;
-			case "a":
-				this.#vimCount = "";
-				this.#enterVimInsertMode(false, this.#vimGraphemeEndAt(this.#currentLine(), this.#state.cursorCol));
-				return true;
-			case "I":
-				this.#vimCount = "";
-				this.#enterVimInsertMode(false, this.#vimFirstNonBlankCol(this.#currentLine()));
-				return true;
-			case "A":
-				this.#vimCount = "";
-				this.#enterVimInsertMode(false, this.#currentLine().length);
-				return true;
-			case "o":
-				this.#openVimLines(1, this.#takeVimCount());
-				return true;
-			case "O":
-				this.#openVimLines(0, this.#takeVimCount());
-				return true;
-			case "x":
-				this.#deleteVimCharacters(this.#takeVimCount());
-				return true;
-			case "D":
-				this.#deleteVimToLineEnd(this.#takeVimCount(), false);
-				return true;
-			case "C":
-				this.#deleteVimToLineEnd(this.#takeVimCount(), true);
-				return true;
-			case "d":
-			case "c":
-				this.#vimPending = { kind: "operator", operator: char, prefixCount: this.#takeVimCount() };
-				return true;
-			case "u": {
-				const count = this.#takeVimCount();
-				for (let i = 0; i < count; i++) this.#applyUndo();
-				this.#clampVimNormalCursor();
-				return true;
-			}
-			default:
-				this.#vimCount = "";
-				return true;
-		}
-	}
-	#handleVimVisualInput(char: string): boolean {
-		const pending = this.#vimPending;
-		if (pending?.kind === "visualTextObject") {
-			this.#vimPending = undefined;
-			if (char === "p") {
-				const range = this.#vimParagraphLineRange(pending.count, pending.textObject === "around");
-				this.#vimVisualSelection = {
-					kind: "line",
-					anchorLine: range.startLine,
-					...range,
-				};
-				this.#setVimCursor(range.endLine - 1, 0);
-			} else if (char === "w" || char === "W") {
-				const range = this.#vimWordTextObjectRange(
-					this.#vimAbsoluteCursor(),
-					pending.count,
-					char === "W",
-					pending.textObject === "around",
-				);
-				this.#vimVisualSelection = {
-					kind: "character",
-					anchor: range.start,
-					...range,
-				};
-				this.#setVimAbsoluteCursor(this.#vimPreviousGraphemeStart(this.getText(), range.end));
-			}
-			return true;
-		}
-
-		if (/[1-9]/u.test(char) || (char === "0" && this.#vimCount.length > 0)) {
-			this.#vimCount += char;
-			return true;
-		}
-
-		switch (char) {
-			case "i":
-			case "a":
-				this.#vimPending = {
-					kind: "visualTextObject",
-					textObject: char === "i" ? "inner" : "around",
-					count: this.#takeVimCount(),
-				};
-				return true;
-			case "h":
-				this.#moveVimHorizontal(-1, this.#takeVimCount());
-				this.#updateVimVisualSelection();
-				return true;
-			case "j":
-				this.#moveVimVertical(1, this.#takeVimCount());
-				this.#updateVimVisualSelection();
-				return true;
-			case "k":
-				this.#moveVimVertical(-1, this.#takeVimCount());
-				this.#updateVimVisualSelection();
-				return true;
-			case "l":
-				this.#moveVimHorizontal(1, this.#takeVimCount());
-				this.#updateVimVisualSelection();
-				return true;
-			case "v":
-				if (this.#vimVisualSelection?.kind === "character") this.#enterVimNormalMode();
-				else this.#enterVimVisualCharacterMode();
-				return true;
-			case "V":
-				if (this.#vimVisualSelection?.kind === "line") this.#enterVimNormalMode();
-				else this.#enterVimVisualLineMode();
-				return true;
-			case "d":
-			case "c": {
-				const selection = this.#vimVisualSelection;
-				if (!selection) return true;
-				const enterInsert = char === "c";
-				if (selection.kind === "line") {
-					this.#state.cursorLine = selection.startLine;
-					this.#setCursorCol(0);
-					this.#enterVimNormalMode();
-					this.#deleteVimLines(selection.endLine - selection.startLine, enterInsert);
-				} else {
-					this.#enterVimNormalMode();
-					this.#deleteVimRange(selection.start, selection.end, enterInsert);
-				}
-				return true;
-			}
-			default:
-				this.#vimPending = undefined;
-				this.#vimCount = "";
-				return true;
-		}
-	}
-
-	#handleVimOperatorInput(char: string): boolean {
-		const pending = this.#vimPending;
-		if (pending?.kind !== "operator") return false;
-
-		if (/[1-9]/u.test(char) || (char === "0" && this.#vimCount.length > 0)) {
-			this.#vimCount += char;
-			return true;
-		}
-
-		if ((char === "i" || char === "a") && pending.textObject === undefined) {
-			this.#vimPending = { ...pending, textObject: char === "i" ? "inner" : "around" };
-			return true;
-		}
-
-		this.#vimPending = undefined;
-		const count = pending.prefixCount * this.#takeVimCount();
-		const enterInsert = pending.operator === "c";
-		if (pending.textObject !== undefined) {
-			if (char === "w" || char === "W") {
-				const range = this.#vimWordTextObjectRange(
-					this.#vimAbsoluteCursor(),
-					count,
-					char === "W",
-					pending.textObject === "around",
-				);
-				this.#deleteVimRange(range.start, range.end, enterInsert);
-			} else if (char === "p" && pending.textObject === "around") {
-				this.#deleteVimParagraphs(count, enterInsert);
-			}
-			return true;
-		}
-
-		if (char === pending.operator) {
-			this.#deleteVimLines(count, enterInsert);
-			return true;
-		}
-
-		const start = this.#vimAbsoluteCursor();
-		let endpoint: number | undefined;
-		switch (char) {
-			case "w":
-			case "W": {
-				const bigWord = char === "W";
-				endpoint =
-					enterInsert && this.#vimClassAt(start, bigWord) !== "whitespace"
-						? this.#vimGraphemeEndAt(this.getText(), this.#vimWordEndPosition(start, count, bigWord))
-						: this.#vimWordForwardPosition(start, count, bigWord);
-				break;
-			}
-			case "b":
-				endpoint = this.#vimWordBackwardPosition(start, count, false);
-				break;
-			case "B":
-				endpoint = this.#vimWordBackwardPosition(start, count, true);
-				break;
-			case "e":
-				endpoint = this.#vimGraphemeEndAt(this.getText(), this.#vimWordEndPosition(start, count, false));
-				break;
-			case "E":
-				endpoint = this.#vimGraphemeEndAt(this.getText(), this.#vimWordEndPosition(start, count, true));
-				break;
-			case "h":
-				endpoint = this.#vimAbsoluteLineStart(this.#state.cursorLine) + this.#vimMoveCol(-1, count);
-				break;
-			case "l":
-				endpoint =
-					this.#vimAbsoluteLineStart(this.#state.cursorLine) +
-					this.#vimGraphemeEndAt(this.#currentLine(), this.#vimMoveCol(1, count));
-				break;
-			case "0":
-				endpoint = this.#vimAbsoluteLineStart(this.#state.cursorLine);
-				break;
-			case "$":
-				endpoint = this.#vimLineEndAbsolute(
-					Math.min(this.#state.lines.length - 1, this.#state.cursorLine + count - 1),
-				);
-				break;
-			default:
-				return true;
-		}
-
-		this.#deleteVimRange(start, endpoint, enterInsert);
-		return true;
-	}
-
-	#takeVimCount(): number {
-		const count = this.#vimCount.length === 0 ? 1 : Number(this.#vimCount);
-		this.#vimCount = "";
-		return Number.isSafeInteger(count) && count > 0 ? count : 1;
-	}
-
-	#takeOptionalVimCount(): number | undefined {
-		if (this.#vimCount.length === 0) return undefined;
-		return this.#takeVimCount();
-	}
-
-	#currentLine(): string {
-		return this.#state.lines[this.#state.cursorLine] ?? "";
-	}
-
-	#vimFirstNonBlankCol(line: string): number {
-		const index = line.search(/\S/u);
-		return index < 0 ? 0 : this.#vimGraphemeStartAtOrBefore(line, index);
-	}
-
-	#vimLineLastCol(line: string): number {
-		let last = 0;
-		for (const grapheme of segmenter.segment(line)) last = grapheme.index;
-		return last;
-	}
-
-	#vimGraphemeStartAtOrBefore(text: string, col: number): number {
-		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
-		let last = 0;
-		for (const grapheme of segmenter.segment(text)) {
-			const end = grapheme.index + grapheme.segment.length;
-			if (bounded < end) return grapheme.index;
-			last = grapheme.index;
-		}
-		return last;
-	}
-
-	#vimGraphemeEndAt(text: string, col: number): number {
-		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
-		for (const grapheme of segmenter.segment(text)) {
-			const end = grapheme.index + grapheme.segment.length;
-			if (bounded <= grapheme.index || bounded < end) return end;
-		}
-		return text.length;
-	}
-
-	#vimPreviousGraphemeStart(text: string, col: number): number {
-		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
-		let previous = 0;
-		for (const grapheme of segmenter.segment(text)) {
-			if (grapheme.index >= bounded) return previous;
-			previous = grapheme.index;
-		}
-		return previous;
-	}
-
-	#vimNextGraphemeStart(text: string, col: number): number {
-		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
-		for (const grapheme of segmenter.segment(text)) {
-			if (grapheme.index > bounded) return grapheme.index;
-		}
-		return text.length;
-	}
-
-	#setVimCursor(line: number, col: number): void {
-		const targetLine = Math.max(0, Math.min(this.#state.lines.length - 1, Math.trunc(line)));
-		const text = this.#state.lines[targetLine] ?? "";
-		this.#state.cursorLine = targetLine;
-		this.#setCursorCol(this.#vimGraphemeStartAtOrBefore(text, col));
-	}
-
-	#clampVimNormalCursor(): void {
-		if (this.#inputMode !== "vim" || this.#vimMode !== "normal") return;
-		this.#setVimCursor(this.#state.cursorLine, this.#state.cursorCol);
-	}
-
-	#vimMoveCol(direction: -1 | 1, count: number): number {
-		const line = this.#currentLine();
-		let col = this.#state.cursorCol;
-		for (let i = 0; i < count; i++) {
-			const next = direction < 0 ? this.#vimPreviousGraphemeStart(line, col) : this.#vimNextGraphemeStart(line, col);
-			if (next >= line.length || next === col) break;
-			col = next;
-		}
-		return col;
-	}
-
-	#moveVimHorizontal(direction: -1 | 1, count: number): void {
-		this.#setVimCursor(this.#state.cursorLine, this.#vimMoveCol(direction, count));
-	}
-
-	#moveVimVertical(direction: -1 | 1, count: number): void {
-		const targetLine = Math.max(
-			0,
-			Math.min(this.#state.lines.length - 1, this.#state.cursorLine + direction * count),
-		);
-		this.#setVimCursor(targetLine, this.#state.cursorCol);
-	}
-
-	#vimAbsoluteLineStart(line: number): number {
-		let offset = 0;
-		for (let i = 0; i < line; i++) offset += (this.#state.lines[i] ?? "").length + 1;
-		return offset;
-	}
-
-	#vimLineEndAbsolute(line: number): number {
-		return this.#vimAbsoluteLineStart(line) + (this.#state.lines[line] ?? "").length;
-	}
-
-	#vimAbsoluteCursor(): number {
-		return this.#vimAbsoluteLineStart(this.#state.cursorLine) + this.#state.cursorCol;
-	}
-
-	#setVimAbsoluteCursor(pos: number, allowLineEnd = false): void {
-		let remaining = Math.max(0, Math.min(this.getText().length, Math.trunc(pos)));
-		for (let line = 0; line < this.#state.lines.length; line++) {
-			const text = this.#state.lines[line] ?? "";
-			if (remaining <= text.length || line === this.#state.lines.length - 1) {
-				this.#state.cursorLine = line;
-				const col =
-					allowLineEnd && remaining >= text.length
-						? text.length
-						: this.#vimGraphemeStartAtOrBefore(text, remaining);
-				this.#setCursorCol(col);
-				return;
-			}
-			remaining -= text.length + 1;
-		}
-	}
-
-	#vimSegments(text: string, bigWord: boolean): Array<{ index: number; segment: string; kind: string }> {
-		return [...segmenter.segment(text)].map(grapheme => ({
-			index: grapheme.index,
-			segment: grapheme.segment,
-			kind: this.#vimWordKind(grapheme.segment, bigWord),
-		}));
-	}
-
-	#vimWordKind(grapheme: string, bigWord: boolean): string {
-		const kind = getWordNavKind(grapheme);
-		if (kind === "whitespace") return "whitespace";
-		if (bigWord) return "word";
-		return kind === "word" || kind === "cjk" ? "word" : "delimiter";
-	}
-
-	#vimClassAt(pos: number, bigWord: boolean): string {
-		const text = this.getText();
-		for (const grapheme of segmenter.segment(text)) {
-			if (pos < grapheme.index + grapheme.segment.length) return this.#vimWordKind(grapheme.segment, bigWord);
-		}
-		return "whitespace";
-	}
-
-	#vimSegmentIndexAt(segments: Array<{ index: number; segment: string; kind: string }>, pos: number): number {
-		for (let i = 0; i < segments.length; i++) {
-			const grapheme = segments[i];
-			if (grapheme && pos < grapheme.index + grapheme.segment.length) return i;
-		}
-		return segments.length;
-	}
-	#vimWordTextObjectRange(
-		start: number,
-		count: number,
-		bigWord: boolean,
-		around: boolean,
-	): { start: number; end: number } {
-		const text = this.getText();
-		const segments = this.#vimSegments(text, bigWord);
-		let first = this.#vimSegmentIndexAt(segments, start);
-		if (first >= segments.length) return { start, end: start };
-
-		const firstKind = segments[first]?.kind;
-		while (first > 0 && segments[first - 1]?.kind === firstKind) first--;
-
-		let end = first;
-		const consumeGroup = (): void => {
-			const kind = segments[end]?.kind;
-			while (end < segments.length && segments[end]?.kind === kind) end++;
-		};
-		consumeGroup();
-		for (let step = 1; step < count && end < segments.length; step++) {
-			while (end < segments.length && segments[end]?.kind === "whitespace") end++;
-			if (end < segments.length) consumeGroup();
-		}
-
-		if (around) {
-			const innerEnd = end;
-			while (end < segments.length && segments[end]?.kind === "whitespace") end++;
-			if (end === innerEnd) {
-				while (first > 0 && segments[first - 1]?.kind === "whitespace") first--;
-			}
-		}
-
-		return {
-			start: segments[first]?.index ?? start,
-			end: segments[end]?.index ?? text.length,
-		};
-	}
-
-	#vimWordForwardPosition(start: number, count: number, bigWord: boolean): number {
-		const text = this.getText();
-		const segments = this.#vimSegments(text, bigWord);
-		let pos = start;
-		for (let step = 0; step < count; step++) {
-			let index = this.#vimSegmentIndexAt(segments, pos);
-			if (index >= segments.length) return text.length;
-			const kind = segments[index]?.kind;
-			if (kind !== "whitespace") {
-				while (index < segments.length && segments[index]?.kind === kind) index++;
-			}
-			while (index < segments.length && segments[index]?.kind === "whitespace") index++;
-			pos = segments[index]?.index ?? text.length;
-		}
-		return pos;
-	}
-
-	#vimWordBackwardPosition(start: number, count: number, bigWord: boolean): number {
-		const segments = this.#vimSegments(this.getText(), bigWord);
-		let pos = start;
-		for (let step = 0; step < count; step++) {
-			let index = this.#vimSegmentIndexAt(segments, pos);
-			if (index >= segments.length || segments[index]?.index === pos) index--;
-			while (index >= 0 && segments[index]?.kind === "whitespace") index--;
-			if (index < 0) return 0;
-			const kind = segments[index]?.kind;
-			while (index > 0 && segments[index - 1]?.kind === kind) index--;
-			pos = segments[index]?.index ?? 0;
-		}
-		return pos;
-	}
-
-	#vimWordEndPosition(start: number, count: number, bigWord: boolean): number {
-		const text = this.getText();
-		const segments = this.#vimSegments(text, bigWord);
-		let pos = start;
-		for (let step = 0; step < count; step++) {
-			let index = this.#vimSegmentIndexAt(segments, pos);
-			if (index >= segments.length) return this.#vimPreviousGraphemeStart(text, text.length);
-			const kind = segments[index]?.kind;
-			if (kind !== "whitespace" && index + 1 < segments.length && segments[index + 1]?.kind === kind) {
-				while (index + 1 < segments.length && segments[index + 1]?.kind === kind) index++;
-			} else {
-				index++;
-				while (index < segments.length && segments[index]?.kind === "whitespace") index++;
-				const nextKind = segments[index]?.kind;
-				while (index + 1 < segments.length && segments[index + 1]?.kind === nextKind) index++;
-			}
-			pos = segments[index]?.index ?? this.#vimPreviousGraphemeStart(text, text.length);
-		}
-		return pos;
-	}
-
-	#deleteVimCharacters(count: number): void {
-		const start = this.#vimAbsoluteCursor();
-		let endCol = this.#state.cursorCol;
-		for (let i = 0; i < count; i++) {
-			const next = this.#vimGraphemeEndAt(this.#currentLine(), endCol);
-			if (next === endCol) break;
-			endCol = next;
-		}
-		this.#deleteVimRange(start, this.#vimAbsoluteLineStart(this.#state.cursorLine) + endCol, false);
-	}
-
-	#deleteVimToLineEnd(count: number, enterInsert: boolean): void {
-		const targetLine = Math.min(this.#state.lines.length - 1, this.#state.cursorLine + count - 1);
-		this.#deleteVimRange(this.#vimAbsoluteCursor(), this.#vimLineEndAbsolute(targetLine), enterInsert);
-	}
-
-	#deleteVimLines(count: number, enterInsert: boolean): void {
-		const startLine = this.#state.cursorLine;
-		const deleteCount = Math.max(1, Math.min(count, this.#state.lines.length - startLine));
+	#deleteVimLineRange(startLine: number, endLine: number, enterInsert: boolean): void {
+		const boundedStart = Math.max(0, Math.min(this.#state.lines.length - 1, Math.trunc(startLine)));
+		const boundedEnd = Math.max(boundedStart + 1, Math.min(this.#state.lines.length, Math.trunc(endLine)));
+		const deleteCount = boundedEnd - boundedStart;
 		this.#historyIndex = -1;
 		this.#resetKillSequence();
 		this.#recordUndoState();
-		const deleted = this.#state.lines.slice(startLine, startLine + deleteCount).join("\n");
-		if (enterInsert) this.#state.lines.splice(startLine, deleteCount, "");
-		else this.#state.lines.splice(startLine, deleteCount);
+		const deleted = this.#state.lines.slice(boundedStart, boundedEnd).join("\n");
+		if (enterInsert) this.#state.lines.splice(boundedStart, deleteCount, "");
+		else this.#state.lines.splice(boundedStart, deleteCount);
 		if (this.#state.lines.length === 0) this.#state.lines.push("");
-		this.#state.cursorLine = Math.min(startLine, this.#state.lines.length - 1);
+		this.#state.cursorLine = Math.min(boundedStart, this.#state.lines.length - 1);
 		this.#setCursorCol(0);
 		this.#recordKill(deleted, "forward");
 		this.#notifyVimMutation();
-		if (enterInsert) this.#enterVimInsertMode(true, 0);
-		else this.#clampVimNormalCursor();
-	}
-	#vimParagraphLineRange(count: number, around: boolean): { startLine: number; endLine: number } {
-		const isBlank = (line: string): boolean => line.trim().length === 0;
-		let paragraphLine = this.#state.cursorLine;
-		if (isBlank(this.#state.lines[paragraphLine] ?? "")) {
-			while (paragraphLine < this.#state.lines.length && isBlank(this.#state.lines[paragraphLine] ?? "")) {
-				paragraphLine++;
-			}
-			if (paragraphLine >= this.#state.lines.length) {
-				paragraphLine = this.#state.cursorLine;
-				while (paragraphLine > 0 && isBlank(this.#state.lines[paragraphLine] ?? "")) paragraphLine--;
-			}
-		}
-
-		let startLine = paragraphLine;
-		while (startLine > 0 && !isBlank(this.#state.lines[startLine - 1] ?? "")) startLine--;
-		let endLine = paragraphLine + 1;
-		while (endLine < this.#state.lines.length && !isBlank(this.#state.lines[endLine] ?? "")) endLine++;
-
-		for (let step = 1; step < count; step++) {
-			while (endLine < this.#state.lines.length && isBlank(this.#state.lines[endLine] ?? "")) endLine++;
-			while (endLine < this.#state.lines.length && !isBlank(this.#state.lines[endLine] ?? "")) endLine++;
-		}
-
-		if (around) {
-			const paragraphEnd = endLine;
-			while (endLine < this.#state.lines.length && isBlank(this.#state.lines[endLine] ?? "")) endLine++;
-			if (endLine === paragraphEnd) {
-				while (startLine > 0 && isBlank(this.#state.lines[startLine - 1] ?? "")) startLine--;
-			}
-		}
-		return { startLine, endLine };
 	}
 
-	#deleteVimParagraphs(count: number, enterInsert: boolean): void {
-		const { startLine, endLine } = this.#vimParagraphLineRange(count, true);
-
-		const deleteCount = Math.max(1, endLine - startLine);
+	#openVimLines(line: number, count: number): void {
 		this.#historyIndex = -1;
 		this.#resetKillSequence();
 		this.#recordUndoState();
-		const deleted = this.#state.lines.slice(startLine, endLine).join("\n");
-		if (enterInsert) this.#state.lines.splice(startLine, deleteCount, "");
-		else this.#state.lines.splice(startLine, deleteCount);
-		if (this.#state.lines.length === 0) this.#state.lines.push("");
-		this.#state.cursorLine = Math.min(startLine, this.#state.lines.length - 1);
-		this.#setCursorCol(0);
-		this.#recordKill(deleted, "forward");
-		this.#notifyVimMutation();
-		if (enterInsert) this.#enterVimInsertMode(true, 0);
-		else this.#clampVimNormalCursor();
-	}
-
-	#openVimLines(offset: 0 | 1, count: number): void {
-		this.#historyIndex = -1;
-		this.#resetKillSequence();
-		this.#recordUndoState();
-		const line = this.#state.cursorLine + offset;
-		this.#state.lines.splice(line, 0, ...Array.from({ length: count }, () => ""));
-		this.#state.cursorLine = line + count - 1;
+		const targetLine = Math.max(0, Math.min(this.#state.lines.length, Math.trunc(line)));
+		this.#state.lines.splice(targetLine, 0, ...Array.from({ length: count }, () => ""));
+		this.#state.cursorLine = targetLine + count - 1;
 		this.#setCursorCol(0);
 		this.#notifyVimMutation();
-		this.#enterVimInsertMode(true, 0);
 	}
 
 	#deleteVimRange(start: number, end: number, enterInsert: boolean): void {
 		const text = this.getText();
 		let from = Math.max(0, Math.min(start, end));
 		let to = Math.max(from, Math.min(text.length, Math.max(start, end)));
-		if (from === to) {
-			if (enterInsert) this.#enterVimInsertMode();
-			return;
-		}
+		if (from === to) return;
 
 		const expanded = this.#expandVimRangeOverAtomicTokens(from, to);
 		from = expanded.start;
@@ -4246,8 +3448,40 @@ export class Editor implements Component, Focusable {
 		this.#setVimAbsoluteCursor(from, enterInsert);
 		this.#recordKill(deleted, start <= end ? "forward" : "backward");
 		this.#notifyVimMutation();
-		if (enterInsert) this.#enterVimInsertMode(true, this.#state.cursorCol);
-		else this.#clampVimNormalCursor();
+	}
+
+	#vimGraphemeStartAtOrBefore(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		let last = 0;
+		for (const grapheme of segmenter.segment(text)) {
+			const end = grapheme.index + grapheme.segment.length;
+			if (bounded < end) return grapheme.index;
+			last = grapheme.index;
+		}
+		return last;
+	}
+
+	#vimAbsoluteLineStart(line: number): number {
+		let offset = 0;
+		for (let i = 0; i < line; i++) offset += (this.#state.lines[i] ?? "").length + 1;
+		return offset;
+	}
+
+	#setVimAbsoluteCursor(pos: number, allowLineEnd: boolean): void {
+		let remaining = Math.max(0, Math.min(this.getText().length, Math.trunc(pos)));
+		for (let line = 0; line < this.#state.lines.length; line++) {
+			const text = this.#state.lines[line] ?? "";
+			if (remaining <= text.length || line === this.#state.lines.length - 1) {
+				this.#state.cursorLine = line;
+				const col =
+					allowLineEnd && remaining >= text.length
+						? text.length
+						: this.#vimGraphemeStartAtOrBefore(text, remaining);
+				this.#setCursorCol(col);
+				return;
+			}
+			remaining -= text.length + 1;
+		}
 	}
 
 	#expandVimRangeOverAtomicTokens(start: number, end: number): { start: number; end: number } {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1902,7 +1902,6 @@ export class Editor implements Component, Focusable {
 	}
 	submit(): void {
 		if (this.disableSubmit) return;
-		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.enterNormalMode();
 		this.#cancelAutocomplete(true);
 		this.#jumpMode = null;
 		this.#submitValue();
@@ -2261,6 +2260,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#submitValue(): void {
+		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.enterNormalMode();
 		this.#resetKillSequence();
 
 		const result = this.#expandPasteMarkers(this.#state.lines.join("\n")).trim();

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -557,6 +557,8 @@ export class Editor implements Component, Focusable {
 
 	setInputMode(mode: EditorInputMode): void {
 		if (this.#inputMode === mode) return;
+		this.#jumpMode = null;
+		if (mode === "vim") this.#cancelAutocomplete(true);
 		this.#inputMode = mode;
 		this.#vim.setEnabled(mode === "vim");
 		this.onInputModeChange?.(this.getVimMode());
@@ -1888,6 +1890,8 @@ export class Editor implements Component, Focusable {
 	}
 
 	setText(text: string): void {
+		this.#cancelAutocomplete(true);
+		this.#jumpMode = null;
 		this.#vim.finishInsertUndo();
 		if (this.#inputMode === "vim") this.#vim.enterNormalMode();
 		this.#historyIndex = -1; // Exit history browsing mode

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -558,6 +558,7 @@ export class Editor implements Component, Focusable {
 	setInputMode(mode: EditorInputMode): void {
 		if (this.#inputMode === mode) return;
 		this.#jumpMode = null;
+		this.#lastAction = null;
 		if (mode === "vim") this.#cancelAutocomplete(true);
 		this.#inputMode = mode;
 		this.#vim.setEnabled(mode === "vim");

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1244,7 +1244,7 @@ export class Editor implements Component, Focusable {
 		const canonical = parsedKey === undefined ? undefined : canonicalKeyId(parsedKey);
 
 		if (this.isVimModeEscape(data)) {
-			if (this.#autocompleteState) this.#cancelAutocomplete(true);
+			this.#cancelAutocomplete(true);
 			this.#jumpMode = null;
 			this.#vim.enterNormalMode();
 			return;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1653,6 +1653,7 @@ export class Editor implements Component, Focusable {
 				this.#insertCharacter(printableText);
 			}
 		}
+		if (this.#inputMode === "vim" && this.#vim.mode === "normal") this.#vim.clampNormalCursor();
 	}
 
 	/** Cached per-line measurement: exact visible width now, wrap chunks on demand. */
@@ -1901,6 +1902,9 @@ export class Editor implements Component, Focusable {
 	}
 	submit(): void {
 		if (this.disableSubmit) return;
+		if (this.#inputMode === "vim" && this.#vim.mode === "insert") this.#vim.enterNormalMode();
+		this.#cancelAutocomplete(true);
+		this.#jumpMode = null;
 		this.#submitValue();
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2526,20 +2526,22 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
-	#applyUndo(): void {
+	#applyUndo(): boolean {
 		const snapshot = this.#undoStack.pop();
-		if (!snapshot) return;
+		if (!snapshot) return false;
 		this.#redoStack.push(structuredClone(this.#state));
 		if (this.#redoStack.length > MAX_UNDO_STACK) this.#redoStack.shift();
 		this.#restoreUndoState(snapshot);
+		return true;
 	}
-	#applyRedo(): void {
+	#applyRedo(): boolean {
 		const snapshot = this.#redoStack.pop();
-		if (!snapshot) return;
+		if (!snapshot) return false;
 
 		this.#undoStack.push(structuredClone(this.#state));
 		if (this.#undoStack.length > MAX_UNDO_STACK) this.#undoStack.shift();
 		this.#restoreUndoState(snapshot);
+		return true;
 	}
 
 	#restoreUndoState(snapshot: EditorState): void {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -572,8 +572,8 @@ export class Editor implements Component, Focusable {
 		return this.#inputMode === "vim" ? this.#vim.mode : undefined;
 	}
 
-	clearVimPendingCommand(): void {
-		if (this.#inputMode === "vim") this.#vim.clearPendingCommand();
+	clearVimPendingCommand(): boolean {
+		return this.#inputMode === "vim" && this.#vim.clearPendingCommand();
 	}
 
 	prepareVimInsertMutation(): void {

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -98,10 +98,6 @@ export class VimEditorController {
 	}
 
 	prepareInsertInput(data: string, kb: KeybindingsManager): void {
-		if (!this.#adapter.isShowingAutocomplete() && data !== "\n" && kb.matches(data, "tui.input.submit")) {
-			this.enterNormalMode();
-			return;
-		}
 		if (this.#insertUndoActive) return;
 
 		const mutates =

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -147,13 +147,25 @@ export class VimEditorController {
 			return true;
 		}
 		if (this.#mode === "visual" && this.#handleVisualNavigation(data, kb)) return true;
+		const matchesBaseMutation =
+			kb.matches(data, "tui.input.newLine") ||
+			kb.matches(data, "tui.editor.deleteCharBackward") ||
+			kb.matches(data, "tui.editor.deleteCharForward") ||
+			matchesKey(data, "shift+backspace") ||
+			matchesKey(data, "shift+delete") ||
+			kb.matches(data, "tui.editor.deleteToLineEnd") ||
+			kb.matches(data, "tui.editor.deleteToLineStart") ||
+			kb.matches(data, "tui.editor.deleteWordBackward") ||
+			kb.matches(data, "tui.editor.deleteWordForward") ||
+			kb.matches(data, "tui.editor.yank") ||
+			kb.matches(data, "tui.editor.yankPop");
 		if (data === "\n") {
 			this.clearPendingCommand();
 			return true;
 		}
 		if (matchesKey(data, "enter") || matchesKey(data, "return")) {
 			this.clearPendingCommand();
-			return this.#mode === "visual";
+			return this.#mode === "visual" || matchesBaseMutation;
 		}
 		if (matchesKey(data, "ctrl+r")) {
 			if (this.#mode === "visual") {
@@ -171,21 +183,11 @@ export class VimEditorController {
 		if (
 			kb.matches(data, "tui.input.submit") ||
 			kb.matches(data, "tui.input.tab") ||
-			kb.matches(data, "tui.input.newLine") ||
 			matchesKey(data, "alt+enter") ||
 			matchesKey(data, "ctrl+enter") ||
 			data === "\x1b[13;2~" ||
 			(data.length > 1 && (data.charCodeAt(0) === 10 || data.includes("\r"))) ||
-			kb.matches(data, "tui.editor.deleteCharBackward") ||
-			kb.matches(data, "tui.editor.deleteCharForward") ||
-			matchesKey(data, "shift+backspace") ||
-			matchesKey(data, "shift+delete") ||
-			kb.matches(data, "tui.editor.deleteToLineEnd") ||
-			kb.matches(data, "tui.editor.deleteToLineStart") ||
-			kb.matches(data, "tui.editor.deleteWordBackward") ||
-			kb.matches(data, "tui.editor.deleteWordForward") ||
-			kb.matches(data, "tui.editor.yank") ||
-			kb.matches(data, "tui.editor.yankPop")
+			matchesBaseMutation
 		) {
 			this.clearPendingCommand();
 			return true;

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -325,7 +325,12 @@ export class VimEditorController {
 		} else if (kb.matches(data, "tui.editor.cursorLineEnd") || matchesKey(data, "ctrl+e")) {
 			this.#count = "";
 			this.#setCursor(this.#cursor().line, this.#lineLastCol(this.#currentLine()));
-		} else if (kb.matches(data, "tui.editor.jumpForward") || kb.matches(data, "tui.editor.jumpBackward")) {
+		} else if (
+			kb.matches(data, "tui.editor.pageUp") ||
+			kb.matches(data, "tui.editor.pageDown") ||
+			kb.matches(data, "tui.editor.jumpForward") ||
+			kb.matches(data, "tui.editor.jumpBackward")
+		) {
 			this.#count = "";
 			return true;
 		} else {

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -135,9 +135,14 @@ export class VimEditorController {
 			}
 			return true;
 		}
+		if (this.#mode === "visual" && this.#handleVisualNavigation(data, kb)) return true;
 		if (data === "\n") return true;
-		if (matchesKey(data, "enter") || matchesKey(data, "return")) return false;
+		if (matchesKey(data, "enter") || matchesKey(data, "return")) return this.#mode === "visual";
 		if (matchesKey(data, "ctrl+r")) {
+			if (this.#mode === "visual") {
+				this.#count = "";
+				return true;
+			}
 			const count = this.#takeCount();
 			for (let i = 0; i < count; i++) {
 				if (!this.#adapter.applyRedo()) break;
@@ -148,6 +153,10 @@ export class VimEditorController {
 		if (
 			kb.matches(data, "tui.input.tab") ||
 			kb.matches(data, "tui.input.newLine") ||
+			matchesKey(data, "alt+enter") ||
+			matchesKey(data, "ctrl+enter") ||
+			data === "\x1b[13;2~" ||
+			(data.length > 1 && (data.charCodeAt(0) === 10 || data.includes("\r"))) ||
 			kb.matches(data, "tui.editor.deleteCharBackward") ||
 			kb.matches(data, "tui.editor.deleteCharForward") ||
 			matchesKey(data, "shift+backspace") ||
@@ -295,6 +304,35 @@ export class VimEditorController {
 				this.#count = "";
 				return true;
 		}
+	}
+
+	#handleVisualNavigation(data: string, kb: KeybindingsManager): boolean {
+		if (kb.matches(data, "tui.editor.cursorLeft")) {
+			this.#moveHorizontal(-1, this.#takeCount());
+		} else if (kb.matches(data, "tui.editor.cursorRight")) {
+			this.#moveHorizontal(1, this.#takeCount());
+		} else if (kb.matches(data, "tui.editor.cursorUp")) {
+			this.#moveVertical(-1, this.#takeCount());
+		} else if (kb.matches(data, "tui.editor.cursorDown")) {
+			this.#moveVertical(1, this.#takeCount());
+		} else if (kb.matches(data, "tui.editor.cursorWordLeft")) {
+			this.#setAbsoluteCursor(this.#wordBackwardPosition(this.#absoluteCursor(), this.#takeCount(), false));
+		} else if (kb.matches(data, "tui.editor.cursorWordRight")) {
+			this.#setAbsoluteCursor(this.#wordForwardPosition(this.#absoluteCursor(), this.#takeCount(), false));
+		} else if (kb.matches(data, "tui.editor.cursorLineStart") || matchesKey(data, "ctrl+a")) {
+			this.#count = "";
+			this.#setCursor(this.#cursor().line, 0);
+		} else if (kb.matches(data, "tui.editor.cursorLineEnd") || matchesKey(data, "ctrl+e")) {
+			this.#count = "";
+			this.#setCursor(this.#cursor().line, this.#lineLastCol(this.#currentLine()));
+		} else if (kb.matches(data, "tui.editor.jumpForward") || kb.matches(data, "tui.editor.jumpBackward")) {
+			this.#count = "";
+			return true;
+		} else {
+			return false;
+		}
+		this.#updateVisualSelection();
+		return true;
 	}
 
 	clampNormalCursor(): void {

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -128,7 +128,7 @@ export class VimEditorController {
 		this.#beginInsertUndo();
 	}
 
-	preparePaste(): void {
+	prepareInsertMutation(): void {
 		if (!this.#insertUndoActive) this.#beginInsertUndo();
 	}
 

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -667,11 +667,12 @@ export class VimEditorController {
 			case "h":
 				endpoint = this.#absoluteLineStart(this.#cursor().line) + this.#moveCol(-1, count);
 				break;
-			case "l":
+			case "l": {
+				const targetCol = count === 1 ? this.#cursor().col : this.#moveCol(1, count - 1);
 				endpoint =
-					this.#absoluteLineStart(this.#cursor().line) +
-					this.#graphemeEndAt(this.#currentLine(), this.#moveCol(1, count));
+					this.#absoluteLineStart(this.#cursor().line) + this.#graphemeEndAt(this.#currentLine(), targetCol);
 				break;
+			}
 			case "0":
 				endpoint = this.#absoluteLineStart(this.#cursor().line);
 				break;

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -6,7 +6,13 @@ const segmenter = getSegmenter();
 const MAX_VIM_COUNT = 1000;
 
 type VimPendingCommand =
-	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
+	| {
+			kind: "operator";
+			operator: "d" | "c";
+			prefixCount: number | undefined;
+			textObject?: "inner" | "around";
+			motion?: "g";
+	  }
 	| { kind: "g"; count: number | undefined }
 	| { kind: "visualTextObject"; textObject: "inner" | "around"; count: number };
 
@@ -313,7 +319,7 @@ export class VimEditorController {
 				return true;
 			case "d":
 			case "c":
-				this.#pending = { kind: "operator", operator: char, prefixCount: this.#takeCount() };
+				this.#pending = { kind: "operator", operator: char, prefixCount: this.#takeOptionalCount() };
 				return true;
 			case "u": {
 				const count = this.#takeCount();
@@ -583,14 +589,29 @@ export class VimEditorController {
 			return true;
 		}
 
-		if ((char === "i" || char === "a") && pending.textObject === undefined) {
+		if ((char === "i" || char === "a") && pending.textObject === undefined && pending.motion === undefined) {
 			this.#pending = { ...pending, textObject: char === "i" ? "inner" : "around" };
+			return true;
+		}
+		if (char === "g" && pending.textObject === undefined && pending.motion === undefined) {
+			this.#pending = { ...pending, motion: "g" };
 			return true;
 		}
 
 		this.#pending = undefined;
-		const count = Math.min(MAX_VIM_COUNT, pending.prefixCount * this.#takeCount());
+		const suffixCount = this.#takeOptionalCount();
+		const hasCount = pending.prefixCount !== undefined || suffixCount !== undefined;
+		const count = Math.min(MAX_VIM_COUNT, (pending.prefixCount ?? 1) * (suffixCount ?? 1));
 		const enterInsert = pending.operator === "c";
+		if (pending.motion === "g") {
+			if (char === "g") {
+				const startLine = this.#cursor().line;
+				const targetLine = Math.min(this.#lines().length - 1, count - 1);
+				this.#deleteLineRange(Math.min(startLine, targetLine), Math.max(startLine, targetLine) + 1, enterInsert);
+			}
+			return true;
+		}
+
 		if (pending.textObject !== undefined) {
 			if (char === "w" || char === "W") {
 				const range = this.#wordTextObjectRange(
@@ -609,6 +630,13 @@ export class VimEditorController {
 		if (char === pending.operator) {
 			const startLine = this.#cursor().line;
 			this.#deleteLineRange(startLine, startLine + count, enterInsert);
+			return true;
+		}
+
+		if (char === "G") {
+			const startLine = this.#cursor().line;
+			const targetLine = hasCount ? Math.min(this.#lines().length - 1, count - 1) : this.#lines().length - 1;
+			this.#deleteLineRange(Math.min(startLine, targetLine), Math.max(startLine, targetLine) + 1, enterInsert);
 			return true;
 		}
 

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -354,10 +354,12 @@ export class VimEditorController {
 			kb.matches(data, "tui.editor.jumpBackward")
 		) {
 			this.#count = "";
+			this.clearPendingCommand();
 			return true;
 		} else {
 			return false;
 		}
+		this.clearPendingCommand();
 		this.#updateVisualSelection();
 		return true;
 	}

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -212,7 +212,14 @@ export class VimEditorController {
 			const pending = this.#pending;
 			this.#pending = undefined;
 			this.#count = "";
-			if (char === "g") this.#setCursor(pending.count === undefined ? 0 : pending.count - 1, 0);
+			if (char === "g") {
+				const lines = this.#lines();
+				const targetLine = Math.max(
+					0,
+					Math.min(lines.length - 1, pending.count === undefined ? 0 : pending.count - 1),
+				);
+				this.#setCursor(targetLine, this.#firstNonBlankCol(lines[targetLine] ?? ""));
+			}
 			return true;
 		}
 
@@ -454,7 +461,12 @@ export class VimEditorController {
 			this.#pending = undefined;
 			this.#count = "";
 			if (char === "g") {
-				this.#setCursor(pending.count === undefined ? 0 : pending.count - 1, 0);
+				const lines = this.#lines();
+				const targetLine = Math.max(
+					0,
+					Math.min(lines.length - 1, pending.count === undefined ? 0 : pending.count - 1),
+				);
+				this.#setCursor(targetLine, this.#firstNonBlankCol(lines[targetLine] ?? ""));
 				this.#updateVisualSelection();
 			}
 			return true;

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -126,6 +126,15 @@ export class VimEditorController {
 		if (!this.#insertUndoActive) this.#beginInsertUndo();
 	}
 
+	prepareCompletion(): void {
+		if (this.#mode === "insert" && !this.#insertUndoActive) this.#beginInsertUndo();
+	}
+
+	clearPendingCommand(): void {
+		this.#pending = undefined;
+		this.#count = "";
+	}
+
 	handleNormalInput(data: string, kb: KeybindingsManager): boolean {
 		if (this.#isEscape(data)) {
 			if (this.#mode === "visual") this.enterNormalMode();
@@ -136,8 +145,14 @@ export class VimEditorController {
 			return true;
 		}
 		if (this.#mode === "visual" && this.#handleVisualNavigation(data, kb)) return true;
-		if (data === "\n") return true;
-		if (matchesKey(data, "enter") || matchesKey(data, "return")) return this.#mode === "visual";
+		if (data === "\n") {
+			this.clearPendingCommand();
+			return true;
+		}
+		if (matchesKey(data, "enter") || matchesKey(data, "return")) {
+			this.clearPendingCommand();
+			return this.#mode === "visual";
+		}
 		if (matchesKey(data, "ctrl+r")) {
 			if (this.#mode === "visual") {
 				this.#count = "";
@@ -173,6 +188,7 @@ export class VimEditorController {
 			matchesKey(data, "ctrl+y") ||
 			matchesKey(data, "alt+y")
 		) {
+			this.clearPendingCommand();
 			return true;
 		}
 		const printable = extractPrintableText(data);

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -111,16 +111,12 @@ export class VimEditorController {
 			kb.matches(data, "tui.editor.deleteCharForward") ||
 			matchesKey(data, "shift+backspace") ||
 			matchesKey(data, "shift+delete") ||
-			matchesKey(data, "ctrl+k") ||
-			matchesKey(data, "ctrl+u") ||
-			matchesKey(data, "ctrl+w") ||
-			matchesKey(data, "alt+backspace") ||
-			matchesKey(data, "super+alt+backspace") ||
-			matchesKey(data, "alt+d") ||
-			matchesKey(data, "alt+delete") ||
-			matchesKey(data, "super+alt+d") ||
-			matchesKey(data, "super+alt+delete") ||
-			matchesKey(data, "ctrl+y") ||
+			kb.matches(data, "tui.editor.deleteToLineEnd") ||
+			kb.matches(data, "tui.editor.deleteToLineStart") ||
+			kb.matches(data, "tui.editor.deleteWordBackward") ||
+			kb.matches(data, "tui.editor.deleteWordForward") ||
+			kb.matches(data, "tui.editor.yank") ||
+			kb.matches(data, "tui.editor.yankPop") ||
 			data === "\n" ||
 			(data.length > 1 && data.includes("\r"));
 		if (!mutates) return;
@@ -183,17 +179,12 @@ export class VimEditorController {
 			kb.matches(data, "tui.editor.deleteCharForward") ||
 			matchesKey(data, "shift+backspace") ||
 			matchesKey(data, "shift+delete") ||
-			matchesKey(data, "ctrl+k") ||
-			matchesKey(data, "ctrl+u") ||
-			matchesKey(data, "ctrl+w") ||
-			matchesKey(data, "alt+backspace") ||
-			matchesKey(data, "super+alt+backspace") ||
-			matchesKey(data, "alt+d") ||
-			matchesKey(data, "alt+delete") ||
-			matchesKey(data, "super+alt+d") ||
-			matchesKey(data, "super+alt+delete") ||
-			matchesKey(data, "ctrl+y") ||
-			matchesKey(data, "alt+y")
+			kb.matches(data, "tui.editor.deleteToLineEnd") ||
+			kb.matches(data, "tui.editor.deleteToLineStart") ||
+			kb.matches(data, "tui.editor.deleteWordBackward") ||
+			kb.matches(data, "tui.editor.deleteWordForward") ||
+			kb.matches(data, "tui.editor.yank") ||
+			kb.matches(data, "tui.editor.yankPop")
 		) {
 			this.clearPendingCommand();
 			return true;

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -177,7 +177,13 @@ export class VimEditorController {
 		}
 		const printable = extractPrintableText(data);
 		const graphemes = printable ? [...segmenter.segment(printable)] : [];
-		if (graphemes.length !== 1) return printable !== undefined;
+		if (graphemes.length !== 1) {
+			if (printable === undefined) {
+				this.#pending = undefined;
+				this.#count = "";
+			}
+			return printable !== undefined;
+		}
 		const char = graphemes[0]?.segment;
 		if (!char) return false;
 		if (this.#mode === "visual") return this.#handleVisualInput(char);

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -3,6 +3,7 @@ import { extractPrintableText, matchesKey } from "../keys";
 import { getSegmenter, getWordNavKind } from "../utils";
 
 const segmenter = getSegmenter();
+const MAX_VIM_OPEN_LINES = 1000;
 
 type VimPendingCommand =
 	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
@@ -28,8 +29,8 @@ export interface VimEditorAdapter {
 	isShowingAutocomplete(): boolean;
 	recordUndoState(): void;
 	setUndoSuspended(suspended: boolean): void;
-	applyUndo(): void;
-	applyRedo(): void;
+	applyUndo(): boolean;
+	applyRedo(): boolean;
 	deleteRange(start: number, end: number, enterInsert: boolean): void;
 	deleteLineRange(startLine: number, endLine: number, enterInsert: boolean): void;
 	openLines(line: number, count: number): void;
@@ -138,7 +139,9 @@ export class VimEditorController {
 		if (matchesKey(data, "enter") || matchesKey(data, "return")) return false;
 		if (matchesKey(data, "ctrl+r")) {
 			const count = this.#takeCount();
-			for (let i = 0; i < count; i++) this.#adapter.applyRedo();
+			for (let i = 0; i < count; i++) {
+				if (!this.#adapter.applyRedo()) break;
+			}
 			this.clampNormalCursor();
 			return true;
 		}
@@ -282,7 +285,9 @@ export class VimEditorController {
 				return true;
 			case "u": {
 				const count = this.#takeCount();
-				for (let i = 0; i < count; i++) this.#adapter.applyUndo();
+				for (let i = 0; i < count; i++) {
+					if (!this.#adapter.applyUndo()) break;
+				}
 				this.clampNormalCursor();
 				return true;
 			}
@@ -850,7 +855,8 @@ export class VimEditorController {
 	}
 
 	#openLines(offset: 0 | 1, count: number): void {
-		this.#adapter.openLines(this.#cursor().line + offset, count);
+		const boundedCount = Math.min(count, MAX_VIM_OPEN_LINES);
+		this.#adapter.openLines(this.#cursor().line + offset, boundedCount);
 		this.#enterInsertMode(true, 0);
 	}
 }

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -1,0 +1,856 @@
+import type { KeybindingsManager } from "../keybindings";
+import { extractPrintableText, matchesKey } from "../keys";
+import { getSegmenter, getWordNavKind } from "../utils";
+
+const segmenter = getSegmenter();
+
+type VimPendingCommand =
+	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
+	| { kind: "g"; count: number | undefined }
+	| { kind: "visualTextObject"; textObject: "inner" | "around"; count: number };
+
+export type VimEditorMode = "normal" | "insert" | "visual";
+
+export type VimVisualSelection =
+	| { kind: "line"; anchorLine: number; startLine: number; endLine: number }
+	| { kind: "character"; anchor: number; start: number; end: number };
+
+interface VimEditorCursor {
+	line: number;
+	col: number;
+}
+
+export interface VimEditorAdapter {
+	getText(): string;
+	getLines(): readonly string[];
+	getCursor(): VimEditorCursor;
+	setCursor(line: number, col: number): void;
+	isShowingAutocomplete(): boolean;
+	recordUndoState(): void;
+	setUndoSuspended(suspended: boolean): void;
+	applyUndo(): void;
+	applyRedo(): void;
+	deleteRange(start: number, end: number, enterInsert: boolean): void;
+	deleteLineRange(startLine: number, endLine: number, enterInsert: boolean): void;
+	openLines(line: number, count: number): void;
+	onModeChange(mode: VimEditorMode): void;
+}
+
+export class VimEditorController {
+	readonly #adapter: VimEditorAdapter;
+	#pending: VimPendingCommand | undefined;
+	#count = "";
+	#insertUndoActive = false;
+	#mode: VimEditorMode = "insert";
+	#visualSelection: VimVisualSelection | undefined;
+
+	constructor(adapter: VimEditorAdapter) {
+		this.#adapter = adapter;
+	}
+
+	get mode(): VimEditorMode {
+		return this.#mode;
+	}
+
+	get visualSelection(): VimVisualSelection | undefined {
+		return this.#visualSelection;
+	}
+
+	get insertUndoActive(): boolean {
+		return this.#insertUndoActive;
+	}
+
+	setEnabled(enabled: boolean): void {
+		this.finishInsertUndo();
+		this.#pending = undefined;
+		this.#count = "";
+		this.#visualSelection = undefined;
+		this.#mode = enabled ? "normal" : "insert";
+		if (enabled) this.clampNormalCursor();
+	}
+
+	isModeEscape(data: string): boolean {
+		return this.#mode !== "normal" && this.#isEscape(data);
+	}
+
+	finishInsertUndo(): void {
+		if (!this.#insertUndoActive) return;
+		this.#insertUndoActive = false;
+		this.#adapter.setUndoSuspended(false);
+	}
+
+	enterNormalMode(): void {
+		this.finishInsertUndo();
+		this.#pending = undefined;
+		this.#visualSelection = undefined;
+		this.#count = "";
+		const changed = this.#mode !== "normal";
+		this.#mode = "normal";
+		this.clampNormalCursor();
+		if (changed) this.#adapter.onModeChange("normal");
+	}
+
+	prepareInsertInput(data: string, kb: KeybindingsManager): void {
+		if (!this.#adapter.isShowingAutocomplete() && data !== "\n" && kb.matches(data, "tui.input.submit")) {
+			this.enterNormalMode();
+			return;
+		}
+		if (this.#insertUndoActive) return;
+
+		const mutates =
+			extractPrintableText(data) !== undefined ||
+			kb.matches(data, "tui.input.newLine") ||
+			kb.matches(data, "tui.editor.deleteCharBackward") ||
+			kb.matches(data, "tui.editor.deleteCharForward") ||
+			matchesKey(data, "shift+backspace") ||
+			matchesKey(data, "shift+delete") ||
+			matchesKey(data, "ctrl+k") ||
+			matchesKey(data, "ctrl+u") ||
+			matchesKey(data, "ctrl+w") ||
+			matchesKey(data, "alt+backspace") ||
+			matchesKey(data, "super+alt+backspace") ||
+			matchesKey(data, "alt+d") ||
+			matchesKey(data, "alt+delete") ||
+			matchesKey(data, "super+alt+d") ||
+			matchesKey(data, "super+alt+delete") ||
+			matchesKey(data, "ctrl+y") ||
+			data === "\n" ||
+			(data.length > 1 && data.includes("\r"));
+		if (!mutates) return;
+
+		this.#beginInsertUndo();
+	}
+
+	preparePaste(): void {
+		if (!this.#insertUndoActive) this.#beginInsertUndo();
+	}
+
+	handleNormalInput(data: string, kb: KeybindingsManager): boolean {
+		if (this.#isEscape(data)) {
+			if (this.#mode === "visual") this.enterNormalMode();
+			else {
+				this.#pending = undefined;
+				this.#count = "";
+			}
+			return true;
+		}
+		if (data === "\n") return true;
+		if (matchesKey(data, "enter") || matchesKey(data, "return")) return false;
+		if (matchesKey(data, "ctrl+r")) {
+			const count = this.#takeCount();
+			for (let i = 0; i < count; i++) this.#adapter.applyRedo();
+			this.clampNormalCursor();
+			return true;
+		}
+		if (
+			kb.matches(data, "tui.input.tab") ||
+			kb.matches(data, "tui.input.newLine") ||
+			kb.matches(data, "tui.editor.deleteCharBackward") ||
+			kb.matches(data, "tui.editor.deleteCharForward") ||
+			matchesKey(data, "shift+backspace") ||
+			matchesKey(data, "shift+delete") ||
+			matchesKey(data, "ctrl+k") ||
+			matchesKey(data, "ctrl+u") ||
+			matchesKey(data, "ctrl+w") ||
+			matchesKey(data, "alt+backspace") ||
+			matchesKey(data, "super+alt+backspace") ||
+			matchesKey(data, "alt+d") ||
+			matchesKey(data, "alt+delete") ||
+			matchesKey(data, "super+alt+d") ||
+			matchesKey(data, "super+alt+delete") ||
+			matchesKey(data, "ctrl+y") ||
+			matchesKey(data, "alt+y")
+		) {
+			return true;
+		}
+		const printable = extractPrintableText(data);
+		const graphemes = printable ? [...segmenter.segment(printable)] : [];
+		if (graphemes.length !== 1) return printable !== undefined;
+		const char = graphemes[0]?.segment;
+		if (!char) return false;
+		if (this.#mode === "visual") return this.#handleVisualInput(char);
+
+		if (this.#pending?.kind === "operator") return this.#handleOperatorInput(char);
+		if (this.#pending?.kind === "g") {
+			const pending = this.#pending;
+			this.#pending = undefined;
+			this.#count = "";
+			if (char === "g") this.#setCursor(pending.count === undefined ? 0 : pending.count - 1, 0);
+			return true;
+		}
+
+		if (/[1-9]/u.test(char) || (char === "0" && this.#count.length > 0)) {
+			this.#count += char;
+			return true;
+		}
+
+		switch (char) {
+			case "h":
+				this.#moveHorizontal(-1, this.#takeCount());
+				return true;
+			case "j":
+				this.#moveVertical(1, this.#takeCount());
+				return true;
+			case "k":
+				this.#moveVertical(-1, this.#takeCount());
+				return true;
+			case "l":
+				this.#moveHorizontal(1, this.#takeCount());
+				return true;
+			case "w":
+				this.#setAbsoluteCursor(this.#wordForwardPosition(this.#absoluteCursor(), this.#takeCount(), false));
+				return true;
+			case "W":
+				this.#setAbsoluteCursor(this.#wordForwardPosition(this.#absoluteCursor(), this.#takeCount(), true));
+				return true;
+			case "b":
+				this.#setAbsoluteCursor(this.#wordBackwardPosition(this.#absoluteCursor(), this.#takeCount(), false));
+				return true;
+			case "B":
+				this.#setAbsoluteCursor(this.#wordBackwardPosition(this.#absoluteCursor(), this.#takeCount(), true));
+				return true;
+			case "e":
+				this.#setAbsoluteCursor(this.#wordEndPosition(this.#absoluteCursor(), this.#takeCount(), false));
+				return true;
+			case "E":
+				this.#setAbsoluteCursor(this.#wordEndPosition(this.#absoluteCursor(), this.#takeCount(), true));
+				return true;
+			case "0":
+				this.#count = "";
+				this.#setCursor(this.#cursor().line, 0);
+				return true;
+			case "^":
+				this.#count = "";
+				this.#setCursor(this.#cursor().line, this.#firstNonBlankCol(this.#currentLine()));
+				return true;
+			case "$": {
+				const lines = this.#lines();
+				const targetLine = Math.min(lines.length - 1, this.#cursor().line + this.#takeCount() - 1);
+				this.#setCursor(targetLine, this.#lineLastCol(lines[targetLine] ?? ""));
+				return true;
+			}
+			case "G": {
+				const lines = this.#lines();
+				const count = this.#takeOptionalCount();
+				const targetLine = count === undefined ? lines.length - 1 : count - 1;
+				this.#setCursor(targetLine, this.#firstNonBlankCol(lines[targetLine] ?? ""));
+				return true;
+			}
+			case "g":
+				this.#pending = { kind: "g", count: this.#takeOptionalCount() };
+				return true;
+			case "v":
+				this.#enterVisualCharacterMode();
+				return true;
+			case "V":
+				this.#enterVisualLineMode();
+				return true;
+			case "i":
+				this.#count = "";
+				this.#enterInsertMode();
+				return true;
+			case "a":
+				this.#count = "";
+				this.#enterInsertMode(false, this.#graphemeEndAt(this.#currentLine(), this.#cursor().col));
+				return true;
+			case "I":
+				this.#count = "";
+				this.#enterInsertMode(false, this.#firstNonBlankCol(this.#currentLine()));
+				return true;
+			case "A":
+				this.#count = "";
+				this.#enterInsertMode(false, this.#currentLine().length);
+				return true;
+			case "o":
+				this.#openLines(1, this.#takeCount());
+				return true;
+			case "O":
+				this.#openLines(0, this.#takeCount());
+				return true;
+			case "x":
+				this.#deleteCharacters(this.#takeCount());
+				return true;
+			case "D":
+				this.#deleteToLineEnd(this.#takeCount(), false);
+				return true;
+			case "C":
+				this.#deleteToLineEnd(this.#takeCount(), true);
+				return true;
+			case "d":
+			case "c":
+				this.#pending = { kind: "operator", operator: char, prefixCount: this.#takeCount() };
+				return true;
+			case "u": {
+				const count = this.#takeCount();
+				for (let i = 0; i < count; i++) this.#adapter.applyUndo();
+				this.clampNormalCursor();
+				return true;
+			}
+			default:
+				this.#count = "";
+				return true;
+		}
+	}
+
+	clampNormalCursor(): void {
+		if (this.#mode !== "normal") return;
+		const cursor = this.#cursor();
+		this.#setCursor(cursor.line, cursor.col);
+	}
+
+	#beginInsertUndo(): void {
+		this.#adapter.recordUndoState();
+		this.#insertUndoActive = true;
+		this.#adapter.setUndoSuspended(true);
+	}
+
+	#isEscape(data: string): boolean {
+		return matchesKey(data, "escape") || matchesKey(data, "esc");
+	}
+
+	#enterInsertMode(existingUndo = false, col?: number): void {
+		if (col !== undefined) this.#adapter.setCursor(this.#cursor().line, col);
+		this.#pending = undefined;
+		this.#count = "";
+		this.#visualSelection = undefined;
+		if (existingUndo) {
+			this.#insertUndoActive = true;
+			this.#adapter.setUndoSuspended(true);
+		}
+		const changed = this.#mode !== "insert";
+		this.#mode = "insert";
+		if (changed) this.#adapter.onModeChange("insert");
+	}
+
+	#enterVisualCharacterMode(): void {
+		this.finishInsertUndo();
+		this.#pending = undefined;
+		this.#count = "";
+		const anchor = this.#absoluteCursor();
+		this.#visualSelection = {
+			kind: "character",
+			anchor,
+			start: anchor,
+			end: this.#graphemeEndAt(this.#adapter.getText(), anchor),
+		};
+		const changed = this.#mode !== "visual";
+		this.#mode = "visual";
+		if (changed) this.#adapter.onModeChange("visual");
+	}
+
+	#enterVisualLineMode(): void {
+		this.finishInsertUndo();
+		this.#pending = undefined;
+		this.#count = "";
+		const line = this.#cursor().line;
+		this.#visualSelection = { kind: "line", anchorLine: line, startLine: line, endLine: line + 1 };
+		const changed = this.#mode !== "visual";
+		this.#mode = "visual";
+		if (changed) this.#adapter.onModeChange("visual");
+	}
+
+	#updateVisualSelection(): void {
+		const selection = this.#visualSelection;
+		if (selection?.kind === "line") {
+			const line = this.#cursor().line;
+			this.#visualSelection = {
+				...selection,
+				startLine: Math.min(selection.anchorLine, line),
+				endLine: Math.max(selection.anchorLine, line) + 1,
+			};
+		} else if (selection?.kind === "character") {
+			const text = this.#adapter.getText();
+			const cursor = this.#absoluteCursor();
+			this.#visualSelection = {
+				...selection,
+				start: Math.min(selection.anchor, cursor),
+				end: Math.max(this.#graphemeEndAt(text, selection.anchor), this.#graphemeEndAt(text, cursor)),
+			};
+		}
+	}
+
+	#handleVisualInput(char: string): boolean {
+		const pending = this.#pending;
+		if (pending?.kind === "visualTextObject") {
+			this.#pending = undefined;
+			if (char === "p") {
+				const range = this.#paragraphLineRange(pending.count, pending.textObject === "around");
+				this.#visualSelection = { kind: "line", anchorLine: range.startLine, ...range };
+				this.#setCursor(range.endLine - 1, 0);
+			} else if (char === "w" || char === "W") {
+				const range = this.#wordTextObjectRange(
+					this.#absoluteCursor(),
+					pending.count,
+					char === "W",
+					pending.textObject === "around",
+				);
+				this.#visualSelection = { kind: "character", anchor: range.start, ...range };
+				this.#setAbsoluteCursor(this.#previousGraphemeStart(this.#adapter.getText(), range.end));
+			}
+			return true;
+		}
+
+		if (/[1-9]/u.test(char) || (char === "0" && this.#count.length > 0)) {
+			this.#count += char;
+			return true;
+		}
+
+		switch (char) {
+			case "i":
+			case "a":
+				this.#pending = {
+					kind: "visualTextObject",
+					textObject: char === "i" ? "inner" : "around",
+					count: this.#takeCount(),
+				};
+				return true;
+			case "h":
+				this.#moveHorizontal(-1, this.#takeCount());
+				this.#updateVisualSelection();
+				return true;
+			case "j":
+				this.#moveVertical(1, this.#takeCount());
+				this.#updateVisualSelection();
+				return true;
+			case "k":
+				this.#moveVertical(-1, this.#takeCount());
+				this.#updateVisualSelection();
+				return true;
+			case "l":
+				this.#moveHorizontal(1, this.#takeCount());
+				this.#updateVisualSelection();
+				return true;
+			case "v":
+				if (this.#visualSelection?.kind === "character") this.enterNormalMode();
+				else this.#enterVisualCharacterMode();
+				return true;
+			case "V":
+				if (this.#visualSelection?.kind === "line") this.enterNormalMode();
+				else this.#enterVisualLineMode();
+				return true;
+			case "d":
+			case "c": {
+				const selection = this.#visualSelection;
+				if (!selection) return true;
+				const enterInsert = char === "c";
+				if (selection.kind === "line") {
+					this.enterNormalMode();
+					this.#deleteLineRange(selection.startLine, selection.endLine, enterInsert);
+				} else {
+					this.enterNormalMode();
+					this.#deleteRange(selection.start, selection.end, enterInsert);
+				}
+				return true;
+			}
+			default:
+				this.#pending = undefined;
+				this.#count = "";
+				return true;
+		}
+	}
+
+	#handleOperatorInput(char: string): boolean {
+		const pending = this.#pending;
+		if (pending?.kind !== "operator") return false;
+
+		if (/[1-9]/u.test(char) || (char === "0" && this.#count.length > 0)) {
+			this.#count += char;
+			return true;
+		}
+
+		if ((char === "i" || char === "a") && pending.textObject === undefined) {
+			this.#pending = { ...pending, textObject: char === "i" ? "inner" : "around" };
+			return true;
+		}
+
+		this.#pending = undefined;
+		const count = pending.prefixCount * this.#takeCount();
+		const enterInsert = pending.operator === "c";
+		if (pending.textObject !== undefined) {
+			if (char === "w" || char === "W") {
+				const range = this.#wordTextObjectRange(
+					this.#absoluteCursor(),
+					count,
+					char === "W",
+					pending.textObject === "around",
+				);
+				this.#deleteRange(range.start, range.end, enterInsert);
+			} else if (char === "p" && pending.textObject === "around") {
+				this.#deleteParagraphs(count, enterInsert);
+			}
+			return true;
+		}
+
+		if (char === pending.operator) {
+			const startLine = this.#cursor().line;
+			this.#deleteLineRange(startLine, startLine + count, enterInsert);
+			return true;
+		}
+
+		const start = this.#absoluteCursor();
+		let endpoint: number | undefined;
+		switch (char) {
+			case "w":
+			case "W": {
+				const bigWord = char === "W";
+				endpoint =
+					enterInsert && this.#classAt(start, bigWord) !== "whitespace"
+						? this.#graphemeEndAt(this.#adapter.getText(), this.#wordEndPosition(start, count, bigWord))
+						: this.#wordForwardPosition(start, count, bigWord);
+				break;
+			}
+			case "b":
+				endpoint = this.#wordBackwardPosition(start, count, false);
+				break;
+			case "B":
+				endpoint = this.#wordBackwardPosition(start, count, true);
+				break;
+			case "e":
+				endpoint = this.#graphemeEndAt(this.#adapter.getText(), this.#wordEndPosition(start, count, false));
+				break;
+			case "E":
+				endpoint = this.#graphemeEndAt(this.#adapter.getText(), this.#wordEndPosition(start, count, true));
+				break;
+			case "h":
+				endpoint = this.#absoluteLineStart(this.#cursor().line) + this.#moveCol(-1, count);
+				break;
+			case "l":
+				endpoint =
+					this.#absoluteLineStart(this.#cursor().line) +
+					this.#graphemeEndAt(this.#currentLine(), this.#moveCol(1, count));
+				break;
+			case "0":
+				endpoint = this.#absoluteLineStart(this.#cursor().line);
+				break;
+			case "$":
+				endpoint = this.#lineEndAbsolute(Math.min(this.#lines().length - 1, this.#cursor().line + count - 1));
+				break;
+			default:
+				return true;
+		}
+
+		this.#deleteRange(start, endpoint, enterInsert);
+		return true;
+	}
+
+	#takeCount(): number {
+		const count = this.#count.length === 0 ? 1 : Number(this.#count);
+		this.#count = "";
+		return Number.isSafeInteger(count) && count > 0 ? count : 1;
+	}
+
+	#takeOptionalCount(): number | undefined {
+		if (this.#count.length === 0) return undefined;
+		return this.#takeCount();
+	}
+
+	#lines(): readonly string[] {
+		return this.#adapter.getLines();
+	}
+
+	#cursor(): VimEditorCursor {
+		return this.#adapter.getCursor();
+	}
+
+	#currentLine(): string {
+		const cursor = this.#cursor();
+		return this.#lines()[cursor.line] ?? "";
+	}
+
+	#firstNonBlankCol(line: string): number {
+		const index = line.search(/\S/u);
+		return index < 0 ? 0 : this.#graphemeStartAtOrBefore(line, index);
+	}
+
+	#lineLastCol(line: string): number {
+		let last = 0;
+		for (const grapheme of segmenter.segment(line)) last = grapheme.index;
+		return last;
+	}
+
+	#graphemeStartAtOrBefore(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		let last = 0;
+		for (const grapheme of segmenter.segment(text)) {
+			const end = grapheme.index + grapheme.segment.length;
+			if (bounded < end) return grapheme.index;
+			last = grapheme.index;
+		}
+		return last;
+	}
+
+	#graphemeEndAt(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		for (const grapheme of segmenter.segment(text)) {
+			const end = grapheme.index + grapheme.segment.length;
+			if (bounded <= grapheme.index || bounded < end) return end;
+		}
+		return text.length;
+	}
+
+	#previousGraphemeStart(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		let previous = 0;
+		for (const grapheme of segmenter.segment(text)) {
+			if (grapheme.index >= bounded) return previous;
+			previous = grapheme.index;
+		}
+		return previous;
+	}
+
+	#nextGraphemeStart(text: string, col: number): number {
+		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
+		for (const grapheme of segmenter.segment(text)) {
+			if (grapheme.index > bounded) return grapheme.index;
+		}
+		return text.length;
+	}
+
+	#setCursor(line: number, col: number): void {
+		const lines = this.#lines();
+		const targetLine = Math.max(0, Math.min(lines.length - 1, Math.trunc(line)));
+		const text = lines[targetLine] ?? "";
+		this.#adapter.setCursor(targetLine, this.#graphemeStartAtOrBefore(text, col));
+	}
+
+	#moveCol(direction: -1 | 1, count: number): number {
+		const line = this.#currentLine();
+		let col = this.#cursor().col;
+		for (let i = 0; i < count; i++) {
+			const next = direction < 0 ? this.#previousGraphemeStart(line, col) : this.#nextGraphemeStart(line, col);
+			if (next >= line.length || next === col) break;
+			col = next;
+		}
+		return col;
+	}
+
+	#moveHorizontal(direction: -1 | 1, count: number): void {
+		this.#setCursor(this.#cursor().line, this.#moveCol(direction, count));
+	}
+
+	#moveVertical(direction: -1 | 1, count: number): void {
+		const cursor = this.#cursor();
+		const targetLine = Math.max(0, Math.min(this.#lines().length - 1, cursor.line + direction * count));
+		this.#setCursor(targetLine, cursor.col);
+	}
+
+	#absoluteLineStart(line: number): number {
+		let offset = 0;
+		for (let i = 0; i < line; i++) offset += (this.#lines()[i] ?? "").length + 1;
+		return offset;
+	}
+
+	#lineEndAbsolute(line: number): number {
+		return this.#absoluteLineStart(line) + (this.#lines()[line] ?? "").length;
+	}
+
+	#absoluteCursor(): number {
+		const cursor = this.#cursor();
+		return this.#absoluteLineStart(cursor.line) + cursor.col;
+	}
+
+	#setAbsoluteCursor(pos: number, allowLineEnd = false): void {
+		let remaining = Math.max(0, Math.min(this.#adapter.getText().length, Math.trunc(pos)));
+		const lines = this.#lines();
+		for (let line = 0; line < lines.length; line++) {
+			const text = lines[line] ?? "";
+			if (remaining <= text.length || line === lines.length - 1) {
+				const col =
+					allowLineEnd && remaining >= text.length ? text.length : this.#graphemeStartAtOrBefore(text, remaining);
+				this.#adapter.setCursor(line, col);
+				return;
+			}
+			remaining -= text.length + 1;
+		}
+	}
+
+	#segments(text: string, bigWord: boolean): Array<{ index: number; segment: string; kind: string }> {
+		return [...segmenter.segment(text)].map(grapheme => ({
+			index: grapheme.index,
+			segment: grapheme.segment,
+			kind: this.#wordKind(grapheme.segment, bigWord),
+		}));
+	}
+
+	#wordKind(grapheme: string, bigWord: boolean): string {
+		const kind = getWordNavKind(grapheme);
+		if (kind === "whitespace") return "whitespace";
+		if (bigWord) return "word";
+		return kind === "word" || kind === "cjk" ? "word" : "delimiter";
+	}
+
+	#classAt(pos: number, bigWord: boolean): string {
+		const text = this.#adapter.getText();
+		for (const grapheme of segmenter.segment(text)) {
+			if (pos < grapheme.index + grapheme.segment.length) return this.#wordKind(grapheme.segment, bigWord);
+		}
+		return "whitespace";
+	}
+
+	#segmentIndexAt(segments: Array<{ index: number; segment: string; kind: string }>, pos: number): number {
+		for (let i = 0; i < segments.length; i++) {
+			const grapheme = segments[i];
+			if (grapheme && pos < grapheme.index + grapheme.segment.length) return i;
+		}
+		return segments.length;
+	}
+
+	#wordTextObjectRange(
+		start: number,
+		count: number,
+		bigWord: boolean,
+		around: boolean,
+	): { start: number; end: number } {
+		const text = this.#adapter.getText();
+		const segments = this.#segments(text, bigWord);
+		let first = this.#segmentIndexAt(segments, start);
+		if (first >= segments.length) return { start, end: start };
+
+		const firstKind = segments[first]?.kind;
+		while (first > 0 && segments[first - 1]?.kind === firstKind) first--;
+
+		let end = first;
+		const consumeGroup = (): void => {
+			const kind = segments[end]?.kind;
+			while (end < segments.length && segments[end]?.kind === kind) end++;
+		};
+		consumeGroup();
+		for (let step = 1; step < count && end < segments.length; step++) {
+			while (end < segments.length && segments[end]?.kind === "whitespace") end++;
+			if (end < segments.length) consumeGroup();
+		}
+
+		if (around) {
+			const innerEnd = end;
+			while (end < segments.length && segments[end]?.kind === "whitespace") end++;
+			if (end === innerEnd) {
+				while (first > 0 && segments[first - 1]?.kind === "whitespace") first--;
+			}
+		}
+
+		return { start: segments[first]?.index ?? start, end: segments[end]?.index ?? text.length };
+	}
+
+	#wordForwardPosition(start: number, count: number, bigWord: boolean): number {
+		const text = this.#adapter.getText();
+		const segments = this.#segments(text, bigWord);
+		let pos = start;
+		for (let step = 0; step < count; step++) {
+			let index = this.#segmentIndexAt(segments, pos);
+			if (index >= segments.length) return text.length;
+			const kind = segments[index]?.kind;
+			if (kind !== "whitespace") {
+				while (index < segments.length && segments[index]?.kind === kind) index++;
+			}
+			while (index < segments.length && segments[index]?.kind === "whitespace") index++;
+			pos = segments[index]?.index ?? text.length;
+		}
+		return pos;
+	}
+
+	#wordBackwardPosition(start: number, count: number, bigWord: boolean): number {
+		const segments = this.#segments(this.#adapter.getText(), bigWord);
+		let pos = start;
+		for (let step = 0; step < count; step++) {
+			let index = this.#segmentIndexAt(segments, pos);
+			if (index >= segments.length || segments[index]?.index === pos) index--;
+			while (index >= 0 && segments[index]?.kind === "whitespace") index--;
+			if (index < 0) return 0;
+			const kind = segments[index]?.kind;
+			while (index > 0 && segments[index - 1]?.kind === kind) index--;
+			pos = segments[index]?.index ?? 0;
+		}
+		return pos;
+	}
+
+	#wordEndPosition(start: number, count: number, bigWord: boolean): number {
+		const text = this.#adapter.getText();
+		const segments = this.#segments(text, bigWord);
+		let pos = start;
+		for (let step = 0; step < count; step++) {
+			let index = this.#segmentIndexAt(segments, pos);
+			if (index >= segments.length) return this.#previousGraphemeStart(text, text.length);
+			const kind = segments[index]?.kind;
+			if (kind !== "whitespace" && index + 1 < segments.length && segments[index + 1]?.kind === kind) {
+				while (index + 1 < segments.length && segments[index + 1]?.kind === kind) index++;
+			} else {
+				index++;
+				while (index < segments.length && segments[index]?.kind === "whitespace") index++;
+				const nextKind = segments[index]?.kind;
+				while (index + 1 < segments.length && segments[index + 1]?.kind === nextKind) index++;
+			}
+			pos = segments[index]?.index ?? this.#previousGraphemeStart(text, text.length);
+		}
+		return pos;
+	}
+
+	#paragraphLineRange(count: number, around: boolean): { startLine: number; endLine: number } {
+		const lines = this.#lines();
+		const isBlank = (line: string): boolean => line.trim().length === 0;
+		let paragraphLine = this.#cursor().line;
+		if (isBlank(lines[paragraphLine] ?? "")) {
+			while (paragraphLine < lines.length && isBlank(lines[paragraphLine] ?? "")) paragraphLine++;
+			if (paragraphLine >= lines.length) {
+				paragraphLine = this.#cursor().line;
+				while (paragraphLine > 0 && isBlank(lines[paragraphLine] ?? "")) paragraphLine--;
+			}
+		}
+
+		let startLine = paragraphLine;
+		while (startLine > 0 && !isBlank(lines[startLine - 1] ?? "")) startLine--;
+		let endLine = paragraphLine + 1;
+		while (endLine < lines.length && !isBlank(lines[endLine] ?? "")) endLine++;
+
+		for (let step = 1; step < count; step++) {
+			while (endLine < lines.length && isBlank(lines[endLine] ?? "")) endLine++;
+			while (endLine < lines.length && !isBlank(lines[endLine] ?? "")) endLine++;
+		}
+
+		if (around) {
+			const paragraphEnd = endLine;
+			while (endLine < lines.length && isBlank(lines[endLine] ?? "")) endLine++;
+			if (endLine === paragraphEnd) {
+				while (startLine > 0 && isBlank(lines[startLine - 1] ?? "")) startLine--;
+			}
+		}
+		return { startLine, endLine };
+	}
+
+	#deleteCharacters(count: number): void {
+		const start = this.#absoluteCursor();
+		let endCol = this.#cursor().col;
+		for (let i = 0; i < count; i++) {
+			const next = this.#graphemeEndAt(this.#currentLine(), endCol);
+			if (next === endCol) break;
+			endCol = next;
+		}
+		this.#deleteRange(start, this.#absoluteLineStart(this.#cursor().line) + endCol, false);
+	}
+
+	#deleteToLineEnd(count: number, enterInsert: boolean): void {
+		const targetLine = Math.min(this.#lines().length - 1, this.#cursor().line + count - 1);
+		this.#deleteRange(this.#absoluteCursor(), this.#lineEndAbsolute(targetLine), enterInsert);
+	}
+
+	#deleteParagraphs(count: number, enterInsert: boolean): void {
+		const range = this.#paragraphLineRange(count, true);
+		this.#deleteLineRange(range.startLine, range.endLine, enterInsert);
+	}
+
+	#deleteRange(start: number, end: number, enterInsert: boolean): void {
+		this.#adapter.deleteRange(start, end, enterInsert);
+		if (enterInsert) this.#enterInsertMode(true, this.#cursor().col);
+		else this.clampNormalCursor();
+	}
+
+	#deleteLineRange(startLine: number, endLine: number, enterInsert: boolean): void {
+		this.#adapter.deleteLineRange(startLine, endLine, enterInsert);
+		if (enterInsert) this.#enterInsertMode(true, 0);
+		else this.clampNormalCursor();
+	}
+
+	#openLines(offset: 0 | 1, count: number): void {
+		this.#adapter.openLines(this.#cursor().line + offset, count);
+		this.#enterInsertMode(true, 0);
+	}
+}

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -359,9 +359,7 @@ export class VimEditorController {
 		} else {
 			return false;
 		}
-		this.clearPendingCommand();
-		this.#updateVisualSelection();
-		return true;
+		return this.#finishVisualMotion();
 	}
 
 	clampNormalCursor(): void {
@@ -441,8 +439,24 @@ export class VimEditorController {
 		}
 	}
 
+	#finishVisualMotion(): boolean {
+		this.clearPendingCommand();
+		this.#updateVisualSelection();
+		return true;
+	}
+
 	#handleVisualInput(char: string): boolean {
 		const pending = this.#pending;
+		if (pending?.kind === "g") {
+			this.#pending = undefined;
+			this.#count = "";
+			if (char === "g") {
+				this.#setCursor(pending.count === undefined ? 0 : pending.count - 1, 0);
+				this.#updateVisualSelection();
+			}
+			return true;
+		}
+
 		if (pending?.kind === "visualTextObject") {
 			this.#pending = undefined;
 			if (char === "p") {
@@ -478,19 +492,57 @@ export class VimEditorController {
 				return true;
 			case "h":
 				this.#moveHorizontal(-1, this.#takeCount());
-				this.#updateVisualSelection();
-				return true;
+				return this.#finishVisualMotion();
 			case "j":
 				this.#moveVertical(1, this.#takeCount());
-				this.#updateVisualSelection();
-				return true;
+				return this.#finishVisualMotion();
 			case "k":
 				this.#moveVertical(-1, this.#takeCount());
-				this.#updateVisualSelection();
-				return true;
+				return this.#finishVisualMotion();
 			case "l":
 				this.#moveHorizontal(1, this.#takeCount());
-				this.#updateVisualSelection();
+				return this.#finishVisualMotion();
+			case "w":
+				this.#setAbsoluteCursor(this.#wordForwardPosition(this.#absoluteCursor(), this.#takeCount(), false));
+				return this.#finishVisualMotion();
+			case "W":
+				this.#setAbsoluteCursor(this.#wordForwardPosition(this.#absoluteCursor(), this.#takeCount(), true));
+				return this.#finishVisualMotion();
+			case "b":
+				this.#setAbsoluteCursor(this.#wordBackwardPosition(this.#absoluteCursor(), this.#takeCount(), false));
+				return this.#finishVisualMotion();
+			case "B":
+				this.#setAbsoluteCursor(this.#wordBackwardPosition(this.#absoluteCursor(), this.#takeCount(), true));
+				return this.#finishVisualMotion();
+			case "e":
+				this.#setAbsoluteCursor(this.#wordEndPosition(this.#absoluteCursor(), this.#takeCount(), false));
+				return this.#finishVisualMotion();
+			case "E":
+				this.#setAbsoluteCursor(this.#wordEndPosition(this.#absoluteCursor(), this.#takeCount(), true));
+				return this.#finishVisualMotion();
+			case "0":
+				this.#count = "";
+				this.#setCursor(this.#cursor().line, 0);
+				return this.#finishVisualMotion();
+			case "^":
+				this.#count = "";
+				this.#setCursor(this.#cursor().line, this.#firstNonBlankCol(this.#currentLine()));
+				return this.#finishVisualMotion();
+			case "$": {
+				const lines = this.#lines();
+				const targetLine = Math.min(lines.length - 1, this.#cursor().line + this.#takeCount() - 1);
+				this.#setCursor(targetLine, this.#lineLastCol(lines[targetLine] ?? ""));
+				return this.#finishVisualMotion();
+			}
+			case "G": {
+				const lines = this.#lines();
+				const count = this.#takeOptionalCount();
+				const targetLine = count === undefined ? lines.length - 1 : count - 1;
+				this.#setCursor(targetLine, this.#firstNonBlankCol(lines[targetLine] ?? ""));
+				return this.#finishVisualMotion();
+			}
+			case "g":
+				this.#pending = { kind: "g", count: this.#takeOptionalCount() };
 				return true;
 			case "v":
 				if (this.#visualSelection?.kind === "character") this.enterNormalMode();

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -155,9 +155,10 @@ export class VimEditorController {
 		}
 		if (matchesKey(data, "ctrl+r")) {
 			if (this.#mode === "visual") {
-				this.#count = "";
+				this.clearPendingCommand();
 				return true;
 			}
+			if (this.#pending !== undefined) this.clearPendingCommand();
 			const count = this.#takeCount();
 			for (let i = 0; i < count; i++) {
 				if (!this.#adapter.applyRedo()) break;

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -165,6 +165,7 @@ export class VimEditorController {
 			return true;
 		}
 		if (
+			kb.matches(data, "tui.input.submit") ||
 			kb.matches(data, "tui.input.tab") ||
 			kb.matches(data, "tui.input.newLine") ||
 			matchesKey(data, "alt+enter") ||

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -103,6 +103,10 @@ export class VimEditorController {
 		const mutates =
 			extractPrintableText(data) !== undefined ||
 			kb.matches(data, "tui.input.newLine") ||
+			matchesKey(data, "alt+enter") ||
+			(data.charCodeAt(0) === 10 && data.length > 1) ||
+			matchesKey(data, "ctrl+enter") ||
+			data === "\x1b[13;2~" ||
 			kb.matches(data, "tui.editor.deleteCharBackward") ||
 			kb.matches(data, "tui.editor.deleteCharForward") ||
 			matchesKey(data, "shift+backspace") ||

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -269,7 +269,7 @@ export class VimEditorController {
 			case "G": {
 				const lines = this.#lines();
 				const count = this.#takeOptionalCount();
-				const targetLine = count === undefined ? lines.length - 1 : count - 1;
+				const targetLine = count === undefined ? lines.length - 1 : Math.min(lines.length - 1, count - 1);
 				this.#setCursor(targetLine, this.#firstNonBlankCol(lines[targetLine] ?? ""));
 				return true;
 			}
@@ -540,7 +540,7 @@ export class VimEditorController {
 			case "G": {
 				const lines = this.#lines();
 				const count = this.#takeOptionalCount();
-				const targetLine = count === undefined ? lines.length - 1 : count - 1;
+				const targetLine = count === undefined ? lines.length - 1 : Math.min(lines.length - 1, count - 1);
 				this.#setCursor(targetLine, this.#firstNonBlankCol(lines[targetLine] ?? ""));
 				return this.#finishVisualMotion();
 			}

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -3,7 +3,7 @@ import { extractPrintableText, matchesKey } from "../keys";
 import { getSegmenter, getWordNavKind } from "../utils";
 
 const segmenter = getSegmenter();
-const MAX_VIM_OPEN_LINES = 1000;
+const MAX_VIM_COUNT = 1000;
 
 type VimPendingCommand =
 	| { kind: "operator"; operator: "d" | "c"; prefixCount: number; textObject?: "inner" | "around" }
@@ -192,7 +192,7 @@ export class VimEditorController {
 		}
 
 		if (/[1-9]/u.test(char) || (char === "0" && this.#count.length > 0)) {
-			this.#count += char;
+			this.#appendCountDigit(char);
 			return true;
 		}
 
@@ -439,7 +439,7 @@ export class VimEditorController {
 		}
 
 		if (/[1-9]/u.test(char) || (char === "0" && this.#count.length > 0)) {
-			this.#count += char;
+			this.#appendCountDigit(char);
 			return true;
 		}
 
@@ -502,7 +502,7 @@ export class VimEditorController {
 		if (pending?.kind !== "operator") return false;
 
 		if (/[1-9]/u.test(char) || (char === "0" && this.#count.length > 0)) {
-			this.#count += char;
+			this.#appendCountDigit(char);
 			return true;
 		}
 
@@ -512,7 +512,7 @@ export class VimEditorController {
 		}
 
 		this.#pending = undefined;
-		const count = pending.prefixCount * this.#takeCount();
+		const count = Math.min(MAX_VIM_COUNT, pending.prefixCount * this.#takeCount());
 		const enterInsert = pending.operator === "c";
 		if (pending.textObject !== undefined) {
 			if (char === "w" || char === "W") {
@@ -581,10 +581,15 @@ export class VimEditorController {
 		return true;
 	}
 
+	#appendCountDigit(digit: string): void {
+		const current = this.#count.length === 0 ? 0 : Number(this.#count);
+		this.#count = String(Math.min(MAX_VIM_COUNT, current * 10 + Number(digit)));
+	}
+
 	#takeCount(): number {
 		const count = this.#count.length === 0 ? 1 : Number(this.#count);
 		this.#count = "";
-		return Number.isSafeInteger(count) && count > 0 ? count : 1;
+		return Number.isSafeInteger(count) && count > 0 ? Math.min(count, MAX_VIM_COUNT) : 1;
 	}
 
 	#takeOptionalCount(): number | undefined {
@@ -646,14 +651,6 @@ export class VimEditorController {
 		return previous;
 	}
 
-	#nextGraphemeStart(text: string, col: number): number {
-		const bounded = Math.max(0, Math.min(text.length, Math.trunc(col)));
-		for (const grapheme of segmenter.segment(text)) {
-			if (grapheme.index > bounded) return grapheme.index;
-		}
-		return text.length;
-	}
-
 	#setCursor(line: number, col: number): void {
 		const lines = this.#lines();
 		const targetLine = Math.max(0, Math.min(lines.length - 1, Math.trunc(line)));
@@ -663,13 +660,27 @@ export class VimEditorController {
 
 	#moveCol(direction: -1 | 1, count: number): number {
 		const line = this.#currentLine();
-		let col = this.#cursor().col;
-		for (let i = 0; i < count; i++) {
-			const next = direction < 0 ? this.#previousGraphemeStart(line, col) : this.#nextGraphemeStart(line, col);
-			if (next >= line.length || next === col) break;
-			col = next;
+		const col = this.#cursor().col;
+		if (direction > 0) {
+			let remaining = count;
+			let target = col;
+			for (const grapheme of segmenter.segment(line)) {
+				if (grapheme.index <= col) continue;
+				target = grapheme.index;
+				if (--remaining === 0) break;
+			}
+			return target;
 		}
-		return col;
+
+		const priorStarts = new Array<number>(count);
+		let seen = 0;
+		for (const grapheme of segmenter.segment(line)) {
+			if (grapheme.index >= col) break;
+			priorStarts[seen % count] = grapheme.index;
+			seen++;
+		}
+		if (seen === 0) return col;
+		return priorStarts[seen <= count ? 0 : (seen - count) % count] ?? 0;
 	}
 
 	#moveHorizontal(direction: -1 | 1, count: number): void {
@@ -783,8 +794,8 @@ export class VimEditorController {
 		const text = this.#adapter.getText();
 		const segments = this.#segments(text, bigWord);
 		let pos = start;
+		let index = this.#segmentIndexAt(segments, pos);
 		for (let step = 0; step < count; step++) {
-			let index = this.#segmentIndexAt(segments, pos);
 			if (index >= segments.length) return text.length;
 			const kind = segments[index]?.kind;
 			if (kind !== "whitespace") {
@@ -799,8 +810,8 @@ export class VimEditorController {
 	#wordBackwardPosition(start: number, count: number, bigWord: boolean): number {
 		const segments = this.#segments(this.#adapter.getText(), bigWord);
 		let pos = start;
+		let index = this.#segmentIndexAt(segments, pos);
 		for (let step = 0; step < count; step++) {
-			let index = this.#segmentIndexAt(segments, pos);
 			if (index >= segments.length || segments[index]?.index === pos) index--;
 			while (index >= 0 && segments[index]?.kind === "whitespace") index--;
 			if (index < 0) return 0;
@@ -815,8 +826,8 @@ export class VimEditorController {
 		const text = this.#adapter.getText();
 		const segments = this.#segments(text, bigWord);
 		let pos = start;
+		let index = this.#segmentIndexAt(segments, pos);
 		for (let step = 0; step < count; step++) {
-			let index = this.#segmentIndexAt(segments, pos);
 			if (index >= segments.length) return this.#previousGraphemeStart(text, text.length);
 			const kind = segments[index]?.kind;
 			if (kind !== "whitespace" && index + 1 < segments.length && segments[index + 1]?.kind === kind) {
@@ -827,7 +838,9 @@ export class VimEditorController {
 				const nextKind = segments[index]?.kind;
 				while (index + 1 < segments.length && segments[index + 1]?.kind === nextKind) index++;
 			}
-			pos = segments[index]?.index ?? this.#previousGraphemeStart(text, text.length);
+			const next = segments[index]?.index ?? this.#previousGraphemeStart(text, text.length);
+			if (next === pos) return pos;
+			pos = next;
 		}
 		return pos;
 	}
@@ -850,6 +863,7 @@ export class VimEditorController {
 		while (endLine < lines.length && !isBlank(lines[endLine] ?? "")) endLine++;
 
 		for (let step = 1; step < count; step++) {
+			if (endLine >= lines.length) break;
 			while (endLine < lines.length && isBlank(lines[endLine] ?? "")) endLine++;
 			while (endLine < lines.length && !isBlank(lines[endLine] ?? "")) endLine++;
 		}
@@ -866,11 +880,13 @@ export class VimEditorController {
 
 	#deleteCharacters(count: number): void {
 		const start = this.#absoluteCursor();
-		let endCol = this.#cursor().col;
-		for (let i = 0; i < count; i++) {
-			const next = this.#graphemeEndAt(this.#currentLine(), endCol);
-			if (next === endCol) break;
-			endCol = next;
+		const startCol = this.#cursor().col;
+		let endCol = startCol;
+		let remaining = count;
+		for (const grapheme of segmenter.segment(this.#currentLine())) {
+			if (grapheme.index < startCol) continue;
+			endCol = grapheme.index + grapheme.segment.length;
+			if (--remaining === 0) break;
 		}
 		this.#deleteRange(start, this.#absoluteLineStart(this.#cursor().line) + endCol, false);
 	}
@@ -898,8 +914,7 @@ export class VimEditorController {
 	}
 
 	#openLines(offset: 0 | 1, count: number): void {
-		const boundedCount = Math.min(count, MAX_VIM_OPEN_LINES);
-		this.#adapter.openLines(this.#cursor().line + offset, boundedCount);
+		this.#adapter.openLines(this.#cursor().line + offset, Math.min(count, MAX_VIM_COUNT));
 		this.#enterInsertMode(true, 0);
 	}
 }

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -523,8 +523,8 @@ export class VimEditorController {
 					pending.textObject === "around",
 				);
 				this.#deleteRange(range.start, range.end, enterInsert);
-			} else if (char === "p" && pending.textObject === "around") {
-				this.#deleteParagraphs(count, enterInsert);
+			} else if (char === "p") {
+				this.#deleteParagraphs(count, enterInsert, pending.textObject === "around");
 			}
 			return true;
 		}
@@ -896,8 +896,8 @@ export class VimEditorController {
 		this.#deleteRange(this.#absoluteCursor(), this.#lineEndAbsolute(targetLine), enterInsert);
 	}
 
-	#deleteParagraphs(count: number, enterInsert: boolean): void {
-		const range = this.#paragraphLineRange(count, true);
+	#deleteParagraphs(count: number, enterInsert: boolean, around: boolean): void {
+		const range = this.#paragraphLineRange(count, around);
 		this.#deleteLineRange(range.startLine, range.endLine, enterInsert);
 	}
 

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -632,6 +632,15 @@ export class VimEditorController {
 			return true;
 		}
 
+		if (char === "j" || char === "k") {
+			const lines = this.#lines();
+			const startLine = this.#cursor().line;
+			const delta = char === "j" ? count : -count;
+			const targetLine = Math.max(0, Math.min(lines.length - 1, startLine + delta));
+			this.#deleteLineRange(Math.min(startLine, targetLine), Math.max(startLine, targetLine) + 1, enterInsert);
+			return true;
+		}
+
 		const start = this.#absoluteCursor();
 		let endpoint: number | undefined;
 		switch (char) {
@@ -667,6 +676,9 @@ export class VimEditorController {
 			}
 			case "0":
 				endpoint = this.#absoluteLineStart(this.#cursor().line);
+				break;
+			case "^":
+				endpoint = this.#absoluteLineStart(this.#cursor().line) + this.#firstNonBlankCol(this.#currentLine());
 				break;
 			case "$":
 				endpoint = this.#lineEndAbsolute(Math.min(this.#lines().length - 1, this.#cursor().line + count - 1));

--- a/packages/tui/src/components/vim-editor-controller.ts
+++ b/packages/tui/src/components/vim-editor-controller.ts
@@ -132,9 +132,11 @@ export class VimEditorController {
 		if (this.#mode === "insert" && !this.#insertUndoActive) this.#beginInsertUndo();
 	}
 
-	clearPendingCommand(): void {
+	clearPendingCommand(): boolean {
+		const hadPending = this.#pending !== undefined || this.#count.length > 0;
 		this.#pending = undefined;
 		this.#count = "";
+		return hadPending;
 	}
 
 	handleNormalInput(data: string, kb: KeybindingsManager): boolean {
@@ -164,8 +166,8 @@ export class VimEditorController {
 			return true;
 		}
 		if (matchesKey(data, "enter") || matchesKey(data, "return")) {
-			this.clearPendingCommand();
-			return this.#mode === "visual" || matchesBaseMutation;
+			const hadPending = this.clearPendingCommand();
+			return this.#mode === "visual" || matchesBaseMutation || hadPending;
 		}
 		if (matchesKey(data, "ctrl+r")) {
 			if (this.#mode === "visual") {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -219,6 +219,23 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("changes a viw selection and groups replacement undo", () => {
+		const editor = createVimEditor();
+		editor.setText("one two");
+
+		typeText(editor, "0viwc");
+
+		expect(editor.getText()).toBe(" two");
+		expect(editor.getVimMode()).toBe("insert");
+
+		typeText(editor, "changed");
+		editor.handleInput("\u001b");
+		expect(editor.getText()).toBe("changed two");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("one two");
+	});
+
 	it("selects and highlights lines with Shift-V", () => {
 		const editor = createVimEditor();
 		editor.setText("one\ntwo\nthree");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -954,6 +954,35 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("invalidates pending autocomplete before submitting from Vim insert mode", async () => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		const request = Promise.withResolvers<{
+			items: Array<{ label: string; value: string }>;
+			prefix: string;
+		}>();
+		editor.onSubmit = onSubmit;
+		editor.setAutocompleteProvider({
+			getSuggestions() {
+				return request.promise;
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		typeText(editor, "i@");
+
+		editor.handleInput("\r");
+		request.resolve({ items: [{ label: "@file", value: "@file" }], prefix: "@" });
+		await request.promise;
+		await Promise.resolve();
+
+		expect(onSubmit).toHaveBeenCalledWith("@");
+		expect(editor.getText()).toBe("");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("keeps Vim normal-mode undo and redo from reopening autocomplete", async () => {
 		const editor = createVimEditor();
 		const getSuggestions = vi.fn(async () => ({

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -723,6 +723,25 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("stays in insert mode when submit is disabled", () => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.onSubmit = onSubmit;
+		editor.disableSubmit = true;
+		editor.handleInput("i");
+		typeText(editor, "wait");
+
+		editor.handleInput("\r");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("wait");
+		expect(editor.getVimMode()).toBe("insert");
+
+		editor.disableSubmit = false;
+		editor.handleInput("\r");
+		expect(onSubmit).toHaveBeenCalledWith("wait");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("finishes the insert session before a direct submit", () => {
 		const editor = createVimEditor();
 		const onSubmit = vi.fn();

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -102,6 +102,20 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("stops huge undo and redo counts when history is exhausted", () => {
+		const editor = createVimEditor();
+		typeText(editor, "ia\u001bab\u001b");
+		expect(editor.getText()).toBe("ab");
+
+		typeText(editor, "999999999999u");
+		expect(editor.getText()).toBe("");
+
+		typeText(editor, "999999999999");
+		editor.handleInput("\u0012");
+		expect(editor.getText()).toBe("ab");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("keeps change-word whitespace and folds replacement text into one undo", () => {
 		const editor = createVimEditor();
 		editor.setText("one two");
@@ -502,6 +516,20 @@ describe("Editor Vim input mode", () => {
 		typeText(above, "top");
 		above.handleInput("\x1b");
 		expect(above.getText()).toBe("top\none\ntwo");
+	});
+
+	it.each(["o", "O"] as const)("limits huge %s counts to 1,000 new lines", command => {
+		const editor = createVimEditor();
+		editor.setText("seed");
+
+		typeText(editor, `999999999999${command}`);
+
+		expect(editor.getVimMode()).toBe("insert");
+		expect(editor.getLines()).toHaveLength(1001);
+
+		editor.handleInput("\u001b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("seed");
 	});
 
 	it("applies first-nonblank and counted line-end motions", () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -118,6 +118,22 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("starts a new insert undo group after loading history", () => {
+		const editor = createVimEditor();
+		editor.addToHistory("history");
+		editor.handleInput("i");
+		editor.handleInput("x");
+		editor.handleInput("\x7f");
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("history");
+
+		editor.handleInput("!");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("history");
+	});
+
 	it("undoes replacement text after changing an empty range", () => {
 		const editor = createVimEditor();
 

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -681,6 +681,18 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("groups modified Enter with the surrounding insert session", () => {
+		const editor = createVimEditor();
+		editor.handleInput("i");
+		editor.handleInput("\x1b[13;5u");
+		editor.handleInput("x");
+		editor.handleInput("\x1b");
+
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("");
+	});
+
 	it.each([
 		{ mode: "normal", enterMode: "" },
 

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -928,6 +928,32 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("/");
 	});
 
+	it("invalidates pending autocomplete before leaving Vim insert mode", async () => {
+		const editor = createVimEditor();
+		const request = Promise.withResolvers<{
+			items: Array<{ label: string; value: string }>;
+			prefix: string;
+		}>();
+		editor.setAutocompleteProvider({
+			getSuggestions() {
+				return request.promise;
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		typeText(editor, "i/");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+
+		editor.handleInput("\x1b");
+		request.resolve({ items: [{ label: "/help", value: "/help" }], prefix: "/" });
+		await request.promise;
+		await Promise.resolve();
+
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("keeps Vim normal-mode undo and redo from reopening autocomplete", async () => {
 		const editor = createVimEditor();
 		const getSuggestions = vi.fn(async () => ({

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Editor } from "@oh-my-pi/pi-tui/components/editor";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui/keybindings";
 import { defaultEditorTheme } from "./test-themes";
+
+afterEach(() => {
+	setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+});
 
 function createVimEditor(): Editor {
 	const editor = new Editor(defaultEditorTheme);
@@ -455,6 +460,31 @@ describe("Editor Vim input mode", () => {
 		editor.handleInput("x");
 
 		expect(editor.getText()).toBe("ab");
+	});
+
+	it("blocks remapped base mutations in Vim normal mode", () => {
+		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.editor.deleteToLineEnd": "alt+g" }));
+		const editor = createVimEditor();
+		editor.setText("abc");
+		editor.handleInput("0");
+
+		editor.handleInput("\x1bg");
+
+		expect(editor.getText()).toBe("abc");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("groups remapped base mutations into the Vim insert undo session", () => {
+		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.editor.deleteToLineEnd": "alt+g" }));
+		const editor = createVimEditor();
+		editor.setText("abc");
+		typeText(editor, "0i");
+
+		editor.handleInput("\x1bg");
+		typeText(editor, "X\u001bu");
+
+		expect(editor.getText()).toBe("abc");
+		expect(editor.getVimMode()).toBe("normal");
 	});
 
 	it("clears pending counts and operators before non-command keys", () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -445,6 +445,28 @@ describe("Editor Vim input mode", () => {
 		undone.handleInput("w");
 		expect(undone.getText()).toBe("one two");
 		expect(undone.getCursor()).toEqual({ line: 0, col: 4 });
+
+		const redone = createVimEditor();
+		redone.setText("one two");
+		typeText(redone, "0d");
+		redone.handleInput("\x12");
+		redone.handleInput("w");
+		expect(redone.getText()).toBe("one two");
+		expect(redone.getCursor()).toEqual({ line: 0, col: 4 });
+
+		const jumped = createVimEditor();
+		jumped.setText("abc");
+		jumped.handleInput("g");
+		jumped.handleInput("\x12");
+		jumped.handleInput("x");
+		expect(jumped.getText()).toBe("ab");
+
+		const visual = createVimEditor();
+		visual.setText("abc");
+		typeText(visual, "0vi");
+		visual.handleInput("\x12");
+		visual.handleInput("d");
+		expect(visual.getText()).toBe("bc");
 	});
 
 	it.each([

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1022,6 +1022,35 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("abcQx");
 	});
 
+	it("cancels an insert-mode character jump when Escape enters normal mode", () => {
+		const editor = createVimEditor();
+		editor.setText("abxc");
+		typeText(editor, "0i");
+		editor.handleInput("\x1d");
+
+		editor.handleInput("\x1b");
+		editor.handleInput("x");
+
+		expect(editor.getText()).toBe("bxc");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+	});
+
+	it.each([
+		{ pending: "d", key: "w", expected: "one two", cursor: { line: 0, col: 4 } },
+		{ pending: "3", key: "x", expected: "ne two", cursor: { line: 0, col: 0 } },
+	])("clears pending '$pending' before reserved Ctrl-C", ({ pending, key, expected, cursor }) => {
+		const editor = createVimEditor();
+		editor.setText("one two");
+		editor.handleInput("0");
+		editor.handleInput(pending);
+
+		editor.handleInput("\x03");
+		editor.handleInput(key);
+
+		expect(editor.getText()).toBe(expected);
+		expect(editor.getCursor()).toEqual(cursor);
+	});
+
 	it("cleanly switches back to default editing behavior", () => {
 		const editor = createVimEditor();
 		editor.setText("ab");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1326,6 +1326,18 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("aXb");
 	});
 
+	it("starts a new undo unit when switching from Vim insert to default mode", () => {
+		const editor = createVimEditor();
+		typeText(editor, "iabc");
+
+		editor.setInputMode("default");
+		editor.handleInput("d");
+		expect(editor.getText()).toBe("abcd");
+
+		editor.handleInput("\x1f");
+		expect(editor.getText()).toBe("abc");
+	});
+
 	it("expands operator ranges over host-owned atomic placeholders", () => {
 		const editor = createVimEditor();
 		editor.atomicTokenPattern = /\[Image #[^\]]+\]/g;

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -484,6 +484,29 @@ describe("Editor Vim input mode", () => {
 	});
 
 	it.each([
+		{ name: "line start", text: "abc", start: "$", motion: "0", expected: "" },
+		{ name: "line end", text: "abc", start: "0", motion: "$", expected: "" },
+		{ name: "first non-blank", text: "  abc", start: "$", motion: "^", expected: "  " },
+		{ name: "next word", text: "one two", start: "0", motion: "w", expected: "wo" },
+		{ name: "previous word", text: "one two", start: "$", motion: "b", expected: "one " },
+		{ name: "word end", text: "one two", start: "0", motion: "e", expected: " two" },
+		{ name: "last line", text: "one\ntwo\nthree", start: "gg", motion: "G", expected: "hree" },
+		{ name: "first line", text: "one\ntwo\nthree", start: "G", motion: "gg", expected: "hree" },
+		{ name: "counted words", text: "one two three", start: "0", motion: "2w", expected: "hree" },
+	])("extends visual selections to $name with printable motions", ({ text, start, motion, expected }) => {
+		const editor = createVimEditor();
+		editor.setText(text);
+		typeText(editor, start);
+		editor.handleInput("v");
+
+		typeText(editor, motion);
+		editor.handleInput("d");
+
+		expect(editor.getText()).toBe(expected);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it.each([
 		{ name: "Down Arrow", start: "gg", key: "\x1b[B", expected: "three" },
 		{ name: "Up Arrow", start: "G", key: "\x1b[A", expected: "one" },
 	])("extends linewise visual selections with $name", ({ start, key, expected }) => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -226,6 +226,20 @@ describe("Editor Vim input mode", () => {
 		expect(last.getText()).toBe("one\ntwo");
 	});
 
+	it("deletes and changes inner paragraphs without consuming surrounding blank lines", () => {
+		const deleted = createVimEditor();
+		deleted.setText("one\ntwo\n\nthree");
+		typeText(deleted, "ggdip");
+		expect(deleted.getText()).toBe("\nthree");
+
+		const changed = createVimEditor();
+		changed.setText("one\ntwo\n\nthree");
+		typeText(changed, "ggcipreplacement\u001b");
+		expect(changed.getText()).toBe("replacement\n\nthree");
+		changed.handleInput("u");
+		expect(changed.getText()).toBe("one\ntwo\n\nthree");
+	});
+
 	it("changes a paragraph linewise and groups replacement undo", () => {
 		const editor = createVimEditor();
 		editor.setText("one\n\ntwo\n\nthree");
@@ -377,6 +391,21 @@ describe("Editor Vim input mode", () => {
 	});
 
 	it.each([
+		{ name: "Right Arrow", key: "\x1b[C" },
+		{ name: "End", key: "\x1b[F" },
+		{ name: "Ctrl-E", key: "\x05" },
+	])("keeps the normal cursor on a grapheme after $name fallback", ({ key }) => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+		editor.handleInput("$");
+
+		editor.handleInput(key);
+		editor.handleInput("x");
+
+		expect(editor.getText()).toBe("ab");
+	});
+
+	it.each([
 		{ name: "Right Arrow", text: "abc", start: "0", key: "\x1b[C", expected: "c" },
 		{ name: "Left Arrow", text: "abc", start: "$", key: "\x1b[D", expected: "a" },
 		{ name: "Down Arrow", text: "a\nb", start: "gg", key: "\x1b[B", expected: "" },
@@ -521,6 +550,21 @@ describe("Editor Vim input mode", () => {
 		expect(onSubmit).toHaveBeenCalledWith("ship it");
 		expect(editor.getText()).toBe("");
 		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("finishes the insert session before a direct submit", () => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.onSubmit = onSubmit;
+		typeText(editor, "ifirst");
+
+		editor.submit();
+
+		expect(onSubmit).toHaveBeenCalledWith("first");
+		expect(editor.getVimMode()).toBe("normal");
+		typeText(editor, "inext\u001b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
 	});
 
 	it("accepts bracketed paste only in insert mode and groups it with insert undo", () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -405,7 +405,7 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("ab");
 	});
 
-	it("clears pending counts and operators before fallback navigation", () => {
+	it("clears pending counts and operators before non-command keys", () => {
 		const counted = createVimEditor();
 		counted.setText("abcde");
 		typeText(counted, "03");
@@ -420,6 +420,21 @@ describe("Editor Vim input mode", () => {
 		operated.handleInput("w");
 		expect(operated.getText()).toBe("one two");
 		expect(operated.getCursor()).toEqual({ line: 0, col: 4 });
+
+		const blocked = createVimEditor();
+		blocked.setText("abcde");
+		typeText(blocked, "03");
+		blocked.handleInput("\t");
+		blocked.handleInput("x");
+		expect(blocked.getText()).toBe("bcde");
+
+		const undone = createVimEditor();
+		undone.setText("one two");
+		typeText(undone, "0xd");
+		undone.handleInput("\x1f");
+		undone.handleInput("w");
+		expect(undone.getText()).toBe("one two");
+		expect(undone.getCursor()).toEqual({ line: 0, col: 4 });
 	});
 
 	it.each([
@@ -946,6 +961,32 @@ describe("Editor Vim input mode", () => {
 		editor.handleInput("\x1b");
 		expect(editor.getText()).toBe("/help");
 
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("undoes a forced completion accepted before typing in insert mode", async () => {
+		const editor = createVimEditor();
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return null;
+			},
+			async getForceFileSuggestions() {
+				return { items: [{ label: "file.txt", value: "file.txt" }], prefix: "" };
+			},
+			applyCompletion() {
+				return { lines: ["file.txt"], cursorLine: 0, cursorCol: 8 };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+		editor.handleInput("i");
+		editor.handleInput("\t");
+		await promise;
+
+		editor.handleInput("\t");
+		editor.handleInput("\x1b");
+		expect(editor.getText()).toBe("file.txt");
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("");
 	});

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -11,6 +11,51 @@ function createVimEditor(): Editor {
 function typeText(editor: Editor, text: string): void {
 	for (const char of text) editor.handleInput(char);
 }
+const VIM_TERMINAL_ENV_KEYS = ["TERM", "TMUX", "SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT"] as const;
+
+const VIM_TERMINAL_ENVIRONMENTS: ReadonlyArray<{
+	name: string;
+	env: Partial<Record<(typeof VIM_TERMINAL_ENV_KEYS)[number], string>>;
+}> = [
+	{
+		name: "tmux",
+		env: { TERM: "tmux-256color", TMUX: "/tmp/tmux-1000/default,1234,0" },
+	},
+	{
+		name: "SSH",
+		env: {
+			TERM: "xterm-256color",
+			SSH_CONNECTION: "192.0.2.10 54321 192.0.2.20 22",
+			SSH_TTY: "/dev/pts/7",
+			SSH_CLIENT: "192.0.2.10 54321 22",
+		},
+	},
+	{
+		name: "tmux over SSH",
+		env: {
+			TERM: "tmux-256color",
+			TMUX: "/tmp/tmux-1000/default,1234,0",
+			SSH_CONNECTION: "192.0.2.10 54321 192.0.2.20 22",
+			SSH_TTY: "/dev/pts/7",
+			SSH_CLIENT: "192.0.2.10 54321 22",
+		},
+	},
+];
+
+function withVimTerminalEnvironment(env: (typeof VIM_TERMINAL_ENVIRONMENTS)[number]["env"], run: () => void): void {
+	const saved = Object.fromEntries(VIM_TERMINAL_ENV_KEYS.map(key => [key, process.env[key]]));
+	try {
+		for (const key of VIM_TERMINAL_ENV_KEYS) delete process.env[key];
+		for (const [key, value] of Object.entries(env)) process.env[key] = value;
+		run();
+	} finally {
+		for (const key of VIM_TERMINAL_ENV_KEYS) {
+			const value = saved[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
+}
 
 describe("Editor Vim input mode", () => {
 	it("leaves default input behavior unchanged", () => {
@@ -46,6 +91,16 @@ describe("Editor Vim input mode", () => {
 
 		expect(editor.getText()).toBe("");
 	});
+	it("redoes an undone change with Ctrl-R in normal mode", () => {
+		const editor = createVimEditor();
+
+		typeText(editor, "ihello world\u001bu");
+		expect(editor.getText()).toBe("");
+
+		editor.handleInput("\u0012");
+		expect(editor.getText()).toBe("hello world");
+		expect(editor.getVimMode()).toBe("normal");
+	});
 
 	it("keeps change-word whitespace and folds replacement text into one undo", () => {
 		const editor = createVimEditor();
@@ -61,6 +116,100 @@ describe("Editor Vim input mode", () => {
 
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("one two");
+	});
+
+	it("changes the inner word under the cursor and groups replacement undo", () => {
+		const editor = createVimEditor();
+		editor.setText("one target two");
+
+		typeText(editor, "0wllciw");
+		expect(editor.getText()).toBe("one  two");
+		expect(editor.getVimMode()).toBe("insert");
+
+		typeText(editor, "replacement\u001b");
+		expect(editor.getText()).toBe("one replacement two");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("one target two");
+	});
+
+	it("deletes the inner word under the cursor", () => {
+		const editor = createVimEditor();
+		editor.setText("one target two");
+
+		typeText(editor, "0wlldiw");
+
+		expect(editor.getText()).toBe("one  two");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("deletes a word together with its trailing whitespace", () => {
+		const editor = createVimEditor();
+		editor.setText("one target two");
+
+		typeText(editor, "0wlldaw");
+
+		expect(editor.getText()).toBe("one two");
+	});
+
+	it("deletes paragraphs at the start, middle, and end of the prompt", () => {
+		const first = createVimEditor();
+		first.setText("one\ntwo\n\nthree\nfour");
+		typeText(first, "ggdap");
+		expect(first.getText()).toBe("three\nfour");
+
+		const middle = createVimEditor();
+		middle.setText("one\n\ntwo\n\nthree");
+		typeText(middle, "gg2jdap");
+		expect(middle.getText()).toBe("one\n\nthree");
+
+		const last = createVimEditor();
+		last.setText("one\ntwo\n\nthree\nfour");
+		typeText(last, "Gdap");
+		expect(last.getText()).toBe("one\ntwo");
+	});
+
+	it("changes a paragraph linewise and groups replacement undo", () => {
+		const editor = createVimEditor();
+		editor.setText("one\n\ntwo\n\nthree");
+
+		typeText(editor, "gg2jcap");
+		expect(editor.getVimMode()).toBe("insert");
+		typeText(editor, "replacement\u001b");
+		expect(editor.getText()).toBe("one\n\nreplacement\nthree");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("one\n\ntwo\n\nthree");
+	});
+	it("selects the inner paragraph with vip", () => {
+		const editor = createVimEditor();
+		editor.setText("one\n\ntwo\nthree\n\nfour");
+
+		typeText(editor, "gg2jvip");
+
+		expect(editor.getVimMode()).toBe("visual");
+		const rendered = editor.render(40).join("\n");
+		expect(rendered).toContain("\u001b[7mtwo\u001b[0m");
+		expect(rendered).toContain("\u001b[7mthree\u001b[0m");
+
+		editor.handleInput("\u001b");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+	it("selects and highlights lines with Shift-V", () => {
+		const editor = createVimEditor();
+		editor.setText("one\ntwo\nthree");
+
+		typeText(editor, "ggVj");
+
+		expect(editor.getVimMode()).toBe("visual");
+		const rendered = editor.render(40).join("\n");
+		expect(rendered).toContain("\u001b[7mone\u001b[0m");
+		expect(rendered).toContain("\u001b[7mtwo\u001b[0m");
+		expect(rendered).not.toContain("\u001b[7mthree\u001b[0m");
+
+		editor.handleInput("d");
+		expect(editor.getText()).toBe("three");
+		expect(editor.getVimMode()).toBe("normal");
 	});
 
 	it("treats punctuation as a small-word motion target", () => {
@@ -445,4 +594,50 @@ describe("Editor Vim input mode", () => {
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("");
 	});
+	for (const fixture of VIM_TERMINAL_ENVIRONMENTS) {
+		it(`preserves Vim text objects, redo, and visual selections under ${fixture.name}`, () => {
+			withVimTerminalEnvironment(fixture.env, () => {
+				const changedWord = createVimEditor();
+				changedWord.setText("one target two");
+				typeText(changedWord, "0wllciwreplacement\u001bu\u0012");
+				expect(changedWord.getText()).toBe("one replacement two");
+
+				const innerWord = createVimEditor();
+				innerWord.setText("one target two");
+				typeText(innerWord, "0wlldiw");
+				expect(innerWord.getText()).toBe("one  two");
+
+				const aroundWord = createVimEditor();
+				aroundWord.setText("one target two");
+				typeText(aroundWord, "0wlldaw");
+				expect(aroundWord.getText()).toBe("one two");
+
+				const deletedParagraph = createVimEditor();
+				deletedParagraph.setText("one\n\ntwo\n\nthree");
+				typeText(deletedParagraph, "gg2jdap");
+				expect(deletedParagraph.getText()).toBe("one\n\nthree");
+
+				const changedParagraph = createVimEditor();
+				changedParagraph.setText("one\n\ntwo\n\nthree");
+				typeText(changedParagraph, "gg2jcapreplacement\u001b");
+				expect(changedParagraph.getText()).toBe("one\n\nreplacement\nthree");
+
+				const innerParagraph = createVimEditor();
+				innerParagraph.setText("one\n\ntwo\nthree\n\nfour");
+				typeText(innerParagraph, "gg2jvip");
+				const paragraphRender = innerParagraph.render(40).join("\n");
+				expect(paragraphRender).toContain("\u001b[7mtwo\u001b[0m");
+				expect(paragraphRender).toContain("\u001b[7mthree\u001b[0m");
+
+				const visualLines = createVimEditor();
+				visualLines.setText("one\ntwo\nthree");
+				typeText(visualLines, "ggVj");
+				const visualRender = visualLines.render(40).join("\n");
+				expect(visualRender).toContain("\u001b[7mone\u001b[0m");
+				expect(visualRender).toContain("\u001b[7mtwo\u001b[0m");
+				visualLines.handleInput("d");
+				expect(visualLines.getText()).toBe("three");
+			});
+		});
+	}
 });

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -474,6 +474,25 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("blocks remapped submit keys outside Vim insert mode", () => {
+		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.input.submit": "ctrl+s" }));
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.setText("send");
+		editor.onSubmit = onSubmit;
+
+		editor.handleInput("\x13");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("send");
+		expect(editor.getVimMode()).toBe("normal");
+
+		typeText(editor, "0v");
+		editor.handleInput("\x13");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("send");
+		expect(editor.getVimMode()).toBe("visual");
+	});
+
 	it("groups remapped base mutations into the Vim insert undo session", () => {
 		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.editor.deleteToLineEnd": "alt+g" }));
 		const editor = createVimEditor();

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -378,6 +378,35 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("four");
 	});
 
+	it("applies G and gg as linewise operator motions", () => {
+		const toEnd = createVimEditor();
+		toEnd.setText("one\ntwo\nthree");
+		typeText(toEnd, "ggdG");
+		expect(toEnd.getText()).toBe("");
+
+		const toStart = createVimEditor();
+		toStart.setText("one\ntwo\nthree");
+		typeText(toStart, "Gdgg");
+		expect(toStart.getText()).toBe("");
+
+		const countedEnd = createVimEditor();
+		countedEnd.setText("one\ntwo\nthree\nfour");
+		typeText(countedEnd, "ggd2G");
+		expect(countedEnd.getText()).toBe("three\nfour");
+
+		const countedStart = createVimEditor();
+		countedStart.setText("one\ntwo\nthree\nfour");
+		typeText(countedStart, "G2dgg");
+		expect(countedStart.getText()).toBe("one");
+
+		const changed = createVimEditor();
+		changed.setText("one\ntwo\nthree");
+		typeText(changed, "Gcggreplacement\u001b");
+		expect(changed.getText()).toBe("replacement");
+		changed.handleInput("u");
+		expect(changed.getText()).toBe("one\ntwo\nthree");
+	});
+
 	it("does not wrap h and l across logical lines", () => {
 		const editor = createVimEditor();
 		editor.setText("a\nb");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -195,6 +195,30 @@ describe("Editor Vim input mode", () => {
 		editor.handleInput("\u001b");
 		expect(editor.getVimMode()).toBe("normal");
 	});
+	it("keeps v characterwise while viw selects only the current word", () => {
+		const editor = createVimEditor();
+		editor.setText("one two");
+
+		typeText(editor, "0v");
+		expect(editor.getVimMode()).toBe("visual");
+		const characterRender = editor.render(40).join("\n");
+		expect(characterRender).toContain("\u001b[7mo\u001b[0mne two");
+		expect(characterRender).not.toContain("\u001b[7mone\u001b[0m");
+
+		editor.handleInput("d");
+		expect(editor.getText()).toBe("ne two");
+		expect(editor.getVimMode()).toBe("normal");
+
+		editor.setText("one two");
+		typeText(editor, "0viw");
+		const wordRender = editor.render(40).join("\n");
+		expect(wordRender).toContain("\u001b[7mone\u001b[0m two");
+
+		editor.handleInput("d");
+		expect(editor.getText()).toBe(" two");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("selects and highlights lines with Shift-V", () => {
 		const editor = createVimEditor();
 		editor.setText("one\ntwo\nthree");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -507,6 +507,20 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("blocks Enter remapped to a base mutation in Vim normal mode", () => {
+		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.input.newLine": "enter" }));
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.setText("abc");
+		editor.onSubmit = onSubmit;
+
+		editor.handleInput("\r");
+
+		expect(editor.getText()).toBe("abc");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("blocks remapped submit keys outside Vim insert mode", () => {
 		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.input.submit": "ctrl+s" }));
 		const editor = createVimEditor();

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -354,6 +354,74 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
 	});
 
+	it.each([
+		{ name: "Right Arrow", text: "abc", start: "0", key: "\x1b[C", expected: "c" },
+		{ name: "Left Arrow", text: "abc", start: "$", key: "\x1b[D", expected: "a" },
+		{ name: "Down Arrow", text: "a\nb", start: "gg", key: "\x1b[B", expected: "" },
+		{ name: "Up Arrow", text: "a\nb", start: "G", key: "\x1b[A", expected: "" },
+		{ name: "End", text: "abc", start: "0", key: "\x1b[F", expected: "" },
+		{ name: "Ctrl-E", text: "abc", start: "0", key: "\x05", expected: "" },
+		{ name: "Home", text: "abc", start: "$", key: "\x1b[H", expected: "" },
+		{ name: "Ctrl-A", text: "abc", start: "$", key: "\x01", expected: "" },
+		{ name: "Alt-Right", text: "one two", start: "0", key: "\x1bf", expected: "wo" },
+		{ name: "Alt-Left", text: "one two", start: "$", key: "\x1bb", expected: "one " },
+	])("extends visual selections with $name", ({ text, start, key, expected }) => {
+		const editor = createVimEditor();
+		editor.setText(text);
+		typeText(editor, start);
+		editor.handleInput("v");
+
+		editor.handleInput(key);
+		editor.handleInput("d");
+
+		expect(editor.getText()).toBe(expected);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it.each([
+		{ name: "Down Arrow", start: "gg", key: "\x1b[B", expected: "three" },
+		{ name: "Up Arrow", start: "G", key: "\x1b[A", expected: "one" },
+	])("extends linewise visual selections with $name", ({ start, key, expected }) => {
+		const editor = createVimEditor();
+		editor.setText("one\ntwo\nthree");
+		typeText(editor, start);
+		editor.handleInput("V");
+
+		editor.handleInput(key);
+		editor.handleInput("d");
+
+		expect(editor.getText()).toBe(expected);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it.each([
+		{ mode: "normal", enterMode: "" },
+
+		{ mode: "visual", enterMode: "0v" },
+	])("blocks modified newlines in $mode mode", ({ enterMode }) => {
+		for (const key of ["\x1b\r", "\x1b[13;2~"]) {
+			const editor = createVimEditor();
+			editor.setText("abc");
+			typeText(editor, enterMode);
+
+			editor.handleInput(key);
+
+			expect(editor.getText()).toBe("abc");
+		}
+	});
+
+	it("leaves visual mode before applying a base-editor undo", () => {
+		const editor = createVimEditor();
+		typeText(editor, "iabc");
+		editor.handleInput("\x1b");
+		typeText(editor, "0v");
+
+		editor.handleInput("\x1f");
+
+		expect(editor.getText()).toBe("");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("blocks default editing shortcuts in normal mode", () => {
 		const editor = createVimEditor();
 		editor.setText("abc");
@@ -660,6 +728,20 @@ describe("Editor Vim input mode", () => {
 		expect(onSubmit).toHaveBeenCalledWith("send");
 		expect(editor.getText()).toBe("");
 		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("does not submit while a visual selection is active", () => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.setText("send");
+		editor.onSubmit = onSubmit;
+		typeText(editor, "0v");
+
+		editor.handleInput("\r");
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("send");
+		expect(editor.getVimMode()).toBe("visual");
 	});
 
 	it("applies autocomplete in insert mode and undoes it with the typed prefix", async () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -471,6 +471,18 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("clears pending visual text objects before navigation", () => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+		typeText(editor, "0vi");
+
+		editor.handleInput("\x1b[C");
+		editor.handleInput("d");
+
+		expect(editor.getText()).toBe("c");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it.each([
 		{ name: "Down Arrow", start: "gg", key: "\x1b[B", expected: "three" },
 		{ name: "Up Arrow", start: "G", key: "\x1b[A", expected: "one" },

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -405,6 +405,23 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("ab");
 	});
 
+	it("clears pending counts and operators before fallback navigation", () => {
+		const counted = createVimEditor();
+		counted.setText("abcde");
+		typeText(counted, "03");
+		counted.handleInput("\x1b[C");
+		counted.handleInput("x");
+		expect(counted.getText()).toBe("acde");
+
+		const operated = createVimEditor();
+		operated.setText("one two");
+		typeText(operated, "0d");
+		operated.handleInput("\x1b[C");
+		operated.handleInput("w");
+		expect(operated.getText()).toBe("one two");
+		expect(operated.getCursor()).toEqual({ line: 0, col: 4 });
+	});
+
 	it.each([
 		{ name: "Right Arrow", text: "abc", start: "0", key: "\x1b[C", expected: "c" },
 		{ name: "Left Arrow", text: "abc", start: "$", key: "\x1b[D", expected: "a" },
@@ -932,6 +949,7 @@ describe("Editor Vim input mode", () => {
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("");
 	});
+
 	for (const fixture of VIM_TERMINAL_ENVIRONMENTS) {
 		it(`preserves Vim text objects, redo, and visual selections under ${fixture.name}`, () => {
 			withVimTerminalEnvironment(fixture.env, () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1290,6 +1290,41 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("starts a new insert undo group after a prompt-action undo completion", async () => {
+		const editor = createVimEditor();
+		const ready = Promise.withResolvers<void>();
+		editor.setText("base");
+		editor.setAutocompleteProvider({
+			async getSuggestions(lines, cursorLine, cursorCol) {
+				if (!lines[cursorLine]?.slice(0, cursorCol).endsWith("#undo")) return null;
+				ready.resolve();
+				return { items: [{ label: "Undo", value: "Undo" }], prefix: "#undo" };
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return {
+					lines,
+					cursorLine,
+					cursorCol,
+					onApplied: () => editor.undoPastTransientText("#undo"),
+				};
+			},
+		});
+		editor.handleInput("A");
+		typeText(editor, " prior");
+		editor.handleInput("\x1b");
+		editor.handleInput("A");
+		typeText(editor, "#undo");
+		await ready.promise;
+
+		editor.handleInput("\t");
+		expect(editor.getText()).toBe("base");
+		typeText(editor, " next");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("base");
+	});
+
 	it("undoes a forced completion accepted before typing in insert mode", async () => {
 		const editor = createVimEditor();
 		const { promise, resolve } = Promise.withResolvers<void>();

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -393,6 +393,19 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getCursor().line).toBe(2);
 	});
 
+	it("clamps oversized counted G before choosing the target column", () => {
+		const normal = createVimEditor();
+		normal.setText("one\n   final");
+		typeText(normal, "999G");
+		expect(normal.getCursor()).toEqual({ line: 1, col: 3 });
+
+		const visual = createVimEditor();
+		visual.setText("one\n   final");
+		typeText(visual, "v999G");
+		expect(visual.getCursor()).toEqual({ line: 1, col: 3 });
+		expect(visual.getVimMode()).toBe("visual");
+	});
+
 	it("supports counts after an operator", () => {
 		const editor = createVimEditor();
 		editor.setText("one two three");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1059,6 +1059,22 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("clamps a newer history recall before the next normal command", () => {
+		const editor = createVimEditor();
+		editor.addToHistory("older");
+		editor.addToHistory("newer");
+		editor.setText("");
+
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[B");
+		expect(editor.getText()).toBe("newer");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 4 });
+
+		editor.handleInput("x");
+		expect(editor.getText()).toBe("newe");
+	});
+
 	it("cancels autocomplete before leaving Vim insert mode", async () => {
 		const editor = createVimEditor();
 		const { promise, resolve } = Promise.withResolvers<void>();

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -217,4 +217,232 @@ describe("Editor Vim input mode", () => {
 		expect(onInputModeChange).toHaveBeenNthCalledWith(1, "insert");
 		expect(onInputModeChange).toHaveBeenNthCalledWith(2, "normal");
 	});
+	it("distinguishes small-word and WORD motions", () => {
+		const editor = createVimEditor();
+		editor.setText("foo.bar baz");
+
+		typeText(editor, "0e");
+		expect(editor.getCursor().col).toBe(2);
+		editor.handleInput("e");
+		expect(editor.getCursor().col).toBe(3);
+
+		editor.handleInput("0");
+		editor.handleInput("E");
+		expect(editor.getCursor().col).toBe(6);
+		editor.handleInput("W");
+		expect(editor.getCursor().col).toBe(8);
+		editor.handleInput("B");
+		expect(editor.getCursor().col).toBe(0);
+	});
+
+	it("supports backward, inclusive-end, line-start, and line-end delete motions", () => {
+		const backward = createVimEditor();
+		backward.setText("one two");
+		typeText(backward, "0wdb");
+		expect(backward.getText()).toBe("two");
+
+		const inclusiveEnd = createVimEditor();
+		inclusiveEnd.setText("one two");
+		typeText(inclusiveEnd, "0de");
+		expect(inclusiveEnd.getText()).toBe(" two");
+
+		const lineStart = createVimEditor();
+		lineStart.setText("one two");
+		typeText(lineStart, "0wd0");
+		expect(lineStart.getText()).toBe("two");
+
+		const lineEnd = createVimEditor();
+		lineEnd.setText("one two");
+		typeText(lineEnd, "0wd$");
+		expect(lineEnd.getText()).toBe("one ");
+	});
+
+	it("multiplies counts before and after operators", () => {
+		const editor = createVimEditor();
+		editor.setText("one two three four five six");
+
+		typeText(editor, "02d2w");
+
+		expect(editor.getText()).toBe("five six");
+	});
+
+	it("changes whole lines without joining the following line", () => {
+		const editor = createVimEditor();
+		editor.setText("one\ntwo\nthree");
+
+		typeText(editor, "ggcc");
+		typeText(editor, "replacement");
+		editor.handleInput("\x1b");
+
+		expect(editor.getText()).toBe("replacement\ntwo\nthree");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("one\ntwo\nthree");
+	});
+
+	it("supports insert-at-cursor, first-nonblank, and line-end entry points", () => {
+		const afterCursor = createVimEditor();
+		afterCursor.setText("one");
+		typeText(afterCursor, "0aX\u001b");
+		expect(afterCursor.getText()).toBe("oXne");
+
+		const firstNonBlank = createVimEditor();
+		firstNonBlank.setText("  one");
+		typeText(firstNonBlank, "IX\u001b");
+		expect(firstNonBlank.getText()).toBe("  Xone");
+
+		const lineEnd = createVimEditor();
+		lineEnd.setText("one");
+		typeText(lineEnd, "AX\u001b");
+		expect(lineEnd.getText()).toBe("oneX");
+	});
+
+	it("opens lines above and below and undoes each insert session atomically", () => {
+		const below = createVimEditor();
+		below.setText("one\ntwo");
+		typeText(below, "ggo");
+		typeText(below, "middle");
+		below.handleInput("\x1b");
+		expect(below.getText()).toBe("one\nmiddle\ntwo");
+		below.handleInput("u");
+		expect(below.getText()).toBe("one\ntwo");
+
+		const above = createVimEditor();
+		above.setText("one\ntwo");
+		typeText(above, "ggO");
+		typeText(above, "top");
+		above.handleInput("\x1b");
+		expect(above.getText()).toBe("top\none\ntwo");
+	});
+
+	it("applies first-nonblank and counted line-end motions", () => {
+		const editor = createVimEditor();
+		editor.setText("  one\n x");
+
+		typeText(editor, "gg^");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 2 });
+
+		typeText(editor, "2$");
+		expect(editor.getCursor()).toEqual({ line: 1, col: 1 });
+	});
+
+	it("undoes direct normal-mode edits through the shared undo stack", () => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+
+		typeText(editor, "0x");
+		expect(editor.getText()).toBe("bc");
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("abc");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("keeps history navigation usable from normal mode", () => {
+		const editor = createVimEditor();
+		editor.addToHistory("recalled");
+		editor.setText("");
+
+		editor.handleInput("\x1b[A");
+		expect(editor.getText()).toBe("recalled");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+		editor.handleInput("x");
+
+		expect(editor.getText()).toBe("ecalled");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("cancels autocomplete before leaving Vim insert mode", async () => {
+		const editor = createVimEditor();
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return { items: [{ label: "/help", value: "/help" }], prefix: "/" };
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+
+		typeText(editor, "i/");
+		await promise;
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("\x1b");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
+		expect(editor.getText()).toBe("/");
+	});
+
+	it("cleanly switches back to default editing behavior", () => {
+		const editor = createVimEditor();
+		editor.setText("ab");
+
+		editor.setInputMode("default");
+		editor.handleInput("X");
+
+		expect(editor.getVimMode()).toBeUndefined();
+		expect(editor.getText()).toBe("aXb");
+	});
+
+	it("expands operator ranges over host-owned atomic placeholders", () => {
+		const editor = createVimEditor();
+		editor.atomicTokenPattern = /\[Image #[^\]]+\]/g;
+		editor.setText("[Image #1] rest");
+
+		typeText(editor, "0dw");
+
+		expect(editor.getText()).toBe(" rest");
+	});
+	it("supports counted D and C across logical lines", () => {
+		const deleted = createVimEditor();
+		deleted.setText("abc\ndef\nghi");
+		typeText(deleted, "ggl2D");
+		expect(deleted.getText()).toBe("a\nghi");
+
+		const changed = createVimEditor();
+		changed.setText("abc\ndef\nghi");
+		typeText(changed, "ggl2C");
+		typeText(changed, "X");
+		changed.handleInput("\x1b");
+		expect(changed.getText()).toBe("aX\nghi");
+		changed.handleInput("u");
+		expect(changed.getText()).toBe("abc\ndef\nghi");
+	});
+
+	it("submits unchanged drafts directly from normal mode", () => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.setText("send");
+		editor.onSubmit = onSubmit;
+
+		editor.handleInput("\r");
+
+		expect(onSubmit).toHaveBeenCalledWith("send");
+		expect(editor.getText()).toBe("");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("applies autocomplete in insert mode and undoes it with the typed prefix", async () => {
+		const editor = createVimEditor();
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return { items: [{ label: "/help", value: "/help" }], prefix: "/" };
+			},
+			applyCompletion() {
+				return { lines: ["/help"], cursorLine: 0, cursorCol: 5 };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+
+		typeText(editor, "i/");
+		await promise;
+		editor.handleInput("\t");
+		editor.handleInput("\x1b");
+		expect(editor.getText()).toBe("/help");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+	});
 });

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -81,6 +81,27 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("dispatches batched printable input through Vim modes", () => {
+		const inserted = createVimEditor();
+		inserted.handleInput("ihello");
+		expect(inserted.getText()).toBe("hello");
+		expect(inserted.getVimMode()).toBe("insert");
+
+		inserted.handleInput("\x1b");
+		inserted.handleInput("u");
+		expect(inserted.getText()).toBe("");
+
+		const deleted = createVimEditor();
+		deleted.setText("one\ntwo");
+		deleted.handleInput("ggdd");
+		expect(deleted.getText()).toBe("two");
+		expect(deleted.getVimMode()).toBe("normal");
+
+		const grapheme = createVimEditor();
+		grapheme.handleInput("e\u0301");
+		expect(grapheme.getText()).toBe("");
+	});
+
 	it("undoes an insert session as one change", () => {
 		const editor = createVimEditor();
 

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -950,6 +950,53 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("replacement");
 	});
 
+	it("does not retrigger autocomplete after a normal-mode mutation", async () => {
+		const editor = createVimEditor();
+		const getSuggestions = vi.fn(async () => ({
+			items: [{ label: "/help", value: "/help" }],
+			prefix: "/",
+		}));
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			getSuggestions,
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+		typeText(editor, "i/he");
+		await promise;
+		editor.handleInput("\x1b");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		const callsBeforeMutation = getSuggestions.mock.calls.length;
+
+		editor.handleInput("x");
+
+		expect(getSuggestions).toHaveBeenCalledTimes(callsBeforeMutation);
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("retriggers autocomplete after a Vim change enters insert mode", () => {
+		const editor = createVimEditor();
+		const getSuggestions = vi.fn(async () => ({
+			items: [{ label: "/help", value: "/help" }],
+			prefix: "/h",
+		}));
+		editor.setAutocompleteProvider({
+			getSuggestions,
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		editor.setText("/he");
+
+		editor.handleInput("C");
+
+		expect(getSuggestions).toHaveBeenCalledTimes(1);
+		expect(editor.getVimMode()).toBe("insert");
+	});
+
 	it("cancels a pending character jump when enabling Vim mode", () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setText("abcx");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -879,6 +879,21 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getText()).toBe("");
 	});
 
+	it("keeps fragmented pasted escape bytes inside the paste buffer", () => {
+		const editor = createVimEditor();
+		editor.handleInput("i");
+
+		editor.handleInput("\x1b[200~before");
+		editor.handleInput("\x1b");
+		editor.handleInput("after\x1b[201~");
+
+		expect(editor.getVimMode()).toBe("insert");
+		expect(editor.getText()).toBe("beforeafter");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+	});
+
 	it("resets externally supplied text to an editable normal-mode cursor", () => {
 		const editor = createVimEditor();
 		editor.handleInput("i");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "bun:test";
+import { Editor } from "@oh-my-pi/pi-tui/components/editor";
+import { defaultEditorTheme } from "./test-themes";
+
+function createVimEditor(): Editor {
+	const editor = new Editor(defaultEditorTheme);
+	editor.setInputMode("vim");
+	return editor;
+}
+
+function typeText(editor: Editor, text: string): void {
+	for (const char of text) editor.handleInput(char);
+}
+
+describe("Editor Vim input mode", () => {
+	it("leaves default input behavior unchanged", () => {
+		const editor = new Editor(defaultEditorTheme);
+
+		typeText(editor, "hello");
+
+		expect(editor.getText()).toBe("hello");
+		expect(editor.getVimMode()).toBeUndefined();
+	});
+
+	it("starts in normal mode and enters text only from insert mode", () => {
+		const editor = createVimEditor();
+
+		typeText(editor, "zzz");
+		expect(editor.getText()).toBe("");
+
+		editor.handleInput("i");
+		typeText(editor, "hello");
+		expect(editor.getText()).toBe("hello");
+
+		editor.handleInput("\x1b");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("undoes an insert session as one change", () => {
+		const editor = createVimEditor();
+
+		editor.handleInput("i");
+		typeText(editor, "hello world");
+		editor.handleInput("\x1b");
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("");
+	});
+
+	it("keeps change-word whitespace and folds replacement text into one undo", () => {
+		const editor = createVimEditor();
+		editor.setText("one two");
+
+		editor.handleInput("0");
+		editor.handleInput("c");
+		editor.handleInput("w");
+		typeText(editor, "X");
+		editor.handleInput("\x1b");
+
+		expect(editor.getText()).toBe("X two");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("one two");
+	});
+
+	it("treats punctuation as a small-word motion target", () => {
+		const editor = createVimEditor();
+		editor.setText("foo.bar baz");
+
+		editor.handleInput("0");
+		editor.handleInput("w");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 3 });
+
+		editor.handleInput("x");
+		expect(editor.getText()).toBe("foobar baz");
+	});
+
+	it("supports zero-containing counts and counted gg", () => {
+		const editor = createVimEditor();
+		editor.setText(Array.from({ length: 12 }, (_, index) => String(index + 1)).join("\n"));
+
+		editor.handleInput("g");
+		editor.handleInput("g");
+		typeText(editor, "10j");
+		expect(editor.getCursor().line).toBe(10);
+
+		typeText(editor, "3gg");
+		expect(editor.getCursor().line).toBe(2);
+	});
+
+	it("supports counts after an operator", () => {
+		const editor = createVimEditor();
+		editor.setText("one two three");
+
+		editor.handleInput("0");
+		typeText(editor, "d2w");
+
+		expect(editor.getText()).toBe("three");
+	});
+
+	it("applies counts to linewise deletes", () => {
+		const editor = createVimEditor();
+		editor.setText("one\ntwo\nthree\nfour");
+
+		typeText(editor, "gg3dd");
+
+		expect(editor.getText()).toBe("four");
+	});
+
+	it("does not wrap h and l across logical lines", () => {
+		const editor = createVimEditor();
+		editor.setText("a\nb");
+
+		typeText(editor, "ggl");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+
+		editor.handleInput("G");
+		editor.handleInput("h");
+		expect(editor.getCursor()).toEqual({ line: 1, col: 0 });
+	});
+
+	it("leaves arrow-key navigation available in normal mode", () => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+
+		editor.handleInput("0");
+		editor.handleInput("\x1b[C");
+
+		expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+	});
+
+	it("blocks default editing shortcuts in normal mode", () => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+
+		editor.handleInput("\x7f");
+		editor.handleInput("\x1b[3~");
+		editor.handleInput("\x15");
+		editor.handleInput("\x0b");
+		editor.handleInput("\n");
+
+		expect(editor.getText()).toBe("abc");
+	});
+
+	it("deletes emoji and combining graphemes atomically", () => {
+		const emoji = createVimEditor();
+		emoji.setText("😀a");
+		typeText(emoji, "0x");
+		expect(emoji.getText()).toBe("a");
+
+		const combining = createVimEditor();
+		combining.setText("e\u0301x");
+		typeText(combining, "0x");
+		expect(combining.getText()).toBe("x");
+	});
+
+	it("preserves atomic placeholder invariants", () => {
+		const editor = createVimEditor();
+		editor.atomicTokenPattern = /\[Image #[^\]]+\]/g;
+		editor.setText("[Image #1] x");
+
+		typeText(editor, "0x");
+
+		expect(editor.getText()).toBe(" x");
+	});
+
+	it("returns to normal mode after submitting from insert mode", () => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.onSubmit = onSubmit;
+
+		editor.handleInput("i");
+		typeText(editor, "ship it");
+		editor.handleInput("\r");
+
+		expect(onSubmit).toHaveBeenCalledWith("ship it");
+		expect(editor.getText()).toBe("");
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("accepts bracketed paste only in insert mode and groups it with insert undo", () => {
+		const editor = createVimEditor();
+		const paste = "\x1b[200~pasted text\x1b[201~";
+
+		editor.handleInput(paste);
+		expect(editor.getText()).toBe("");
+
+		editor.handleInput("i");
+		editor.handleInput(paste);
+		typeText(editor, "!");
+		editor.handleInput("\x1b");
+		expect(editor.getText()).toBe("pasted text!");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("resets externally supplied text to an editable normal-mode cursor", () => {
+		const editor = createVimEditor();
+		editor.handleInput("i");
+
+		editor.setText("abc");
+		editor.handleInput("x");
+
+		expect(editor.getVimMode()).toBe("normal");
+		expect(editor.getText()).toBe("ab");
+	});
+
+	it("reports mode transitions for host status rendering", () => {
+		const editor = createVimEditor();
+		const onInputModeChange = vi.fn();
+		editor.onInputModeChange = onInputModeChange;
+
+		editor.handleInput("i");
+		editor.handleInput("\x1b");
+
+		expect(onInputModeChange).toHaveBeenNthCalledWith(1, "insert");
+		expect(onInputModeChange).toHaveBeenNthCalledWith(2, "normal");
+	});
+});

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -395,6 +395,36 @@ describe("Editor Vim input mode", () => {
 	});
 
 	it.each([
+		{
+			name: "PageDown",
+			start: "gg",
+			key: "\x1b[6~",
+			cursor: { line: 0, col: 0 },
+			expected: "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9",
+		},
+		{
+			name: "PageUp",
+			start: "G",
+			key: "\x1b[5~",
+			cursor: { line: 9, col: 0 },
+			expected: "l0\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8",
+		},
+	])("keeps $name from bypassing visual selection tracking", ({ start, key, cursor, expected }) => {
+		const editor = createVimEditor();
+		editor.setMaxHeight(6);
+		editor.setText("l0\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9");
+		typeText(editor, start);
+		editor.handleInput("V");
+
+		editor.handleInput(key);
+		expect(editor.getCursor()).toEqual(cursor);
+		editor.handleInput("d");
+
+		expect(editor.getText()).toBe(expected);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it.each([
 		{ mode: "normal", enterMode: "" },
 
 		{ mode: "visual", enterMode: "0v" },

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -774,6 +774,29 @@ describe("Editor Vim input mode", () => {
 		expect(lineEnd.getText()).toBe("one ");
 	});
 
+	it.each([
+		{ command: "dl", expected: "bc", mode: "normal" },
+		{ command: "d2l", expected: "c", mode: "normal" },
+		{ command: "clX\u001b", expected: "Xbc", mode: "normal" },
+		{ command: "c2lX\u001b", expected: "Xc", mode: "normal" },
+	])("applies $command to exactly its rightward character count", ({ command, expected, mode }) => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+		typeText(editor, `0${command}`);
+
+		expect(editor.getText()).toBe(expected);
+		expect(editor.getVimMode()).toBe(mode);
+	});
+
+	it("counts graphemes in rightward operator motions", () => {
+		const editor = createVimEditor();
+		editor.setText("ae\u0301c");
+
+		typeText(editor, "0d2l");
+
+		expect(editor.getText()).toBe("c");
+	});
+
 	it("multiplies counts before and after operators", () => {
 		const editor = createVimEditor();
 		editor.setText("one two three four five six");
@@ -903,6 +926,38 @@ describe("Editor Vim input mode", () => {
 		expect(editor.isShowingAutocomplete()).toBe(false);
 		expect(editor.getVimMode()).toBe("normal");
 		expect(editor.getText()).toBe("/");
+	});
+
+	it("keeps Vim normal-mode undo and redo from reopening autocomplete", async () => {
+		const editor = createVimEditor();
+		const getSuggestions = vi.fn(async () => ({
+			items: [{ label: "/help", value: "/help" }],
+			prefix: "/",
+		}));
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			getSuggestions,
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+		typeText(editor, "i/");
+		await promise;
+		editor.handleInput("\x1b");
+		const callsBeforeRestore = getSuggestions.mock.calls.length;
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+		editor.handleInput("\x12");
+		expect(editor.getText()).toBe("/");
+		editor.handleInput("x");
+		editor.handleInput("u");
+
+		expect(editor.getText()).toBe("/");
+		expect(getSuggestions).toHaveBeenCalledTimes(callsBeforeRestore);
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
 	});
 
 	it("cancels active autocomplete when enabling Vim mode", async () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -112,6 +112,16 @@ describe("Editor Vim input mode", () => {
 
 		expect(editor.getText()).toBe("");
 	});
+
+	it("undoes replacement text after changing an empty range", () => {
+		const editor = createVimEditor();
+
+		typeText(editor, "Creplacement\u001b");
+		expect(editor.getText()).toBe("replacement");
+
+		editor.handleInput("u");
+		expect(editor.getText()).toBe("");
+	});
 	it("redoes an undone change with Ctrl-R in normal mode", () => {
 		const editor = createVimEditor();
 

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -122,6 +122,19 @@ describe("Editor Vim input mode", () => {
 		editor.handleInput("u");
 		expect(editor.getText()).toBe("");
 	});
+
+	it("clamps the normal cursor after the configured base undo", () => {
+		const editor = createVimEditor();
+		editor.setText("abc");
+		typeText(editor, "A!\u001b");
+
+		editor.handleInput("\x1f");
+		editor.handleInput("x");
+
+		expect(editor.getText()).toBe("ab");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+	});
+
 	it("redoes an undone change with Ctrl-R in normal mode", () => {
 		const editor = createVimEditor();
 

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -521,6 +521,20 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it.each(["d", "3"])("consumes Enter while %s is pending", pending => {
+		const editor = createVimEditor();
+		const onSubmit = vi.fn();
+		editor.setText("abc");
+		editor.onSubmit = onSubmit;
+		editor.handleInput(pending);
+
+		editor.handleInput("\r");
+
+		expect(editor.getText()).toBe("abc");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
 	it("blocks remapped submit keys outside Vim insert mode", () => {
 		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.input.submit": "ctrl+s" }));
 		const editor = createVimEditor();

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -441,6 +441,23 @@ describe("Editor Vim input mode", () => {
 		expect(changed.getText()).toBe("one\ntwo\nthree");
 	});
 
+	it("applies vertical and caret motions to pending operators", () => {
+		const down = createVimEditor();
+		down.setText("one\ntwo\nthree\nfour");
+		typeText(down, "ggd2j");
+		expect(down.getText()).toBe("four");
+
+		const up = createVimEditor();
+		up.setText("one\ntwo\nthree\nfour");
+		typeText(up, "Gdk");
+		expect(up.getText()).toBe("one\ntwo");
+
+		const caret = createVimEditor();
+		caret.setText("  alpha beta");
+		typeText(caret, "0wwd^");
+		expect(caret.getText()).toBe("  beta");
+	});
+
 	it("does not wrap h and l across logical lines", () => {
 		const editor = createVimEditor();
 		editor.setText("a\nb");

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -137,6 +137,28 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getVimMode()).toBe("normal");
 	});
 
+	it("caps huge word and paragraph counts without spinning at buffer boundaries", () => {
+		const word = createVimEditor();
+		word.setText("one");
+		typeText(word, "999999999999e");
+		expect(word.getCursor()).toEqual({ line: 0, col: 2 });
+
+		const paragraph = createVimEditor();
+		paragraph.setText("one\n\ntwo");
+		typeText(paragraph, "gg999999999999dap");
+		expect(paragraph.getText()).toBe("");
+		expect(paragraph.getVimMode()).toBe("normal");
+	});
+
+	it("caps multiplied operator counts before applying them", () => {
+		const editor = createVimEditor();
+		editor.setText(Array.from({ length: 1100 }, (_, index) => `line ${index}`).join("\n"));
+		typeText(editor, "gg2d600d");
+
+		expect(editor.getLines()).toHaveLength(100);
+		expect(editor.getLines()[0]).toBe("line 1000");
+	});
+
 	it("keeps change-word whitespace and folds replacement text into one undo", () => {
 		const editor = createVimEditor();
 		editor.setText("one two");
@@ -709,6 +731,76 @@ describe("Editor Vim input mode", () => {
 		expect(editor.isShowingAutocomplete()).toBe(false);
 		expect(editor.getVimMode()).toBe("normal");
 		expect(editor.getText()).toBe("/");
+	});
+
+	it("cancels active autocomplete when enabling Vim mode", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return { items: [{ label: "/help", value: "/help" }], prefix: "/" };
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+		editor.handleInput("/");
+		await promise;
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.setInputMode("vim");
+
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
+	});
+
+	it("cancels autocomplete when replacing a Vim draft", async () => {
+		const editor = createVimEditor();
+		const { promise, resolve } = Promise.withResolvers<void>();
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return { items: [{ label: "/help", value: "/help" }], prefix: "/" };
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+		editor.onAutocompleteUpdate = resolve;
+		typeText(editor, "i/");
+		await promise;
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.setText("replacement");
+
+		expect(editor.isShowingAutocomplete()).toBe(false);
+		expect(editor.getVimMode()).toBe("normal");
+		expect(editor.getText()).toBe("replacement");
+	});
+
+	it("cancels a pending character jump when enabling Vim mode", () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setText("abcx");
+		editor.handleInput("\x1b[H");
+		editor.handleInput("\x1d");
+
+		editor.setInputMode("vim");
+		editor.handleInput("x");
+
+		expect(editor.getText()).toBe("bcx");
+		expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+	});
+
+	it("cancels a pending character jump when replacing a Vim draft", () => {
+		const editor = createVimEditor();
+		editor.handleInput("i");
+		editor.handleInput("\x1d");
+
+		editor.setText("abcx");
+		editor.setInputMode("default");
+		editor.handleInput("Q");
+
+		expect(editor.getText()).toBe("abcQx");
 	});
 
 	it("cleanly switches back to default editing behavior", () => {

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -393,6 +393,21 @@ describe("Editor Vim input mode", () => {
 		expect(editor.getCursor().line).toBe(2);
 	});
 
+	it("moves gg to the target line's first nonblank column", () => {
+		const normal = createVimEditor();
+		normal.setText("  first\nplain\n   third");
+		typeText(normal, "gg");
+		expect(normal.getCursor()).toEqual({ line: 0, col: 2 });
+		typeText(normal, "3gg");
+		expect(normal.getCursor()).toEqual({ line: 2, col: 3 });
+
+		const visual = createVimEditor();
+		visual.setText("  first\nplain\n   third");
+		typeText(visual, "3Gvgg");
+		expect(visual.getCursor()).toEqual({ line: 0, col: 2 });
+		expect(visual.getVimMode()).toBe("visual");
+	});
+
 	it("clamps oversized counted G before choosing the target column", () => {
 		const normal = createVimEditor();
 		normal.setText("one\n   final");


### PR DESCRIPTION
Adds optional "vim mode" for editing text. I added the keystrokes that I personally use. I may have missed some.

At least on my machine, it feels pretty snappy and good to use.

## Summary

- add opt-in `inputMode: vim` prompt editing at the shared TUI `Editor` layer
- implement modal `NORMAL`, `INSERT`, and `VISUAL` states with visible status labels
- support `h/j/k/l`, `w/W/b/B/e/E`, `0/^/$`, `gg/G`, `i/a/I/A/o/O`, `x`, `d/c` motions, `dd/cc`, `D/C`, counts, `u`, and Ctrl-R redo
- add essential word and paragraph text objects: `ciw`, `diw`, `daw`, `dap`, and `cap`
- support characterwise `v` selection, `viw` word selection, `vip` paragraph selection, and Shift-V line selection with reverse-video highlighting, `d` deletion, and `c` change into insert mode (`viwc` included)
- keep Escape inside Vim until insert or visual mode has returned to normal mode; app interruption remains available from normal mode, while autocomplete still consumes its first Escape without aborting the run
- reserve Ctrl-R for redo in Vim normal mode while preserving prompt history search in insert/default modes
- keep graphemes and host atomic placeholders indivisible, with Vim edits sharing the editor's undo, redo, and kill history
- preserve host behavior for submission, autocomplete, bracketed/clipboard paste, prompt history, editor replacement, app shortcuts, and push-to-talk voice input

## Verification

- focused Vim/host/STT regression suites: 342 pass, 0 fail, 1,009 assertions
- complete TUI suite after rebasing onto current upstream `main`: 1,530 pass, 3 skip, 0 fail, 16,893 assertions
- parameterized Vim contract coverage under tmux, SSH, and tmux-over-SSH fixtures
- `bun run check:ts`
- `bun run lint:ts`
- `bun run ci:test:smoke`

The complete TUI run used an isolated terminal environment, while dedicated fixture tests re-enable tmux, SSH, and combined tmux-over-SSH environments and assert text objects, undo/redo, paragraph operations, characterwise and linewise visual highlighting, visual deletion and change, Escape routing, and host shortcut precedence.

Closes #1834