### PR TITLE
test(coding-agent): decouple changelog bundle probe from native addon resolution

### DIFF
--- a/packages/coding-agent/test/utils/changelog-static-import.test.ts
+++ b/packages/coding-agent/test/utils/changelog-static-import.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { VERSION } from "@oh-my-pi/pi-utils";
+import type { BunPlugin } from "bun";
 import { resolveBundledChangelogPath } from "../../src/utils/changelog";
 
 interface HeapProbeResult {
@@ -32,6 +33,25 @@ async function runProbe(command: string[], cwd?: string): Promise<BundleProbeRes
 	]);
 	expect(exitCode, stderr).toBe(0);
 	return JSON.parse(stdout) as BundleProbeResult;
+}
+
+/**
+ * Swap `@oh-my-pi/pi-utils` and the changelog module's `../config` import for a
+ * dependency-free stub. Both pull the native addon loader into the bundle graph, and
+ * that loader resolves `pi_natives.<platform>.node` relative to the emitted artifact,
+ * so any probe written outside the repo fails to start. The subject under test is
+ * emitted-asset resolution, not native loading.
+ */
+function changelogUtilsStubPlugin(): BunPlugin {
+	return {
+		name: "changelog-utils-stub",
+		setup(build) {
+			build.onResolve({ filter: /^@oh-my-pi\/pi-utils$/ }, () => ({ path: utilsStubPath }));
+			build.onResolve({ filter: /^\.\.\/config$/ }, args =>
+				args.importer.endsWith("/utils/changelog.ts") ? { path: utilsStubPath } : undefined,
+			);
+		},
+	};
 }
 
 describe("bundled changelog asset path resolution", () => {
@@ -77,23 +97,14 @@ describe("changelog static import resources", () => {
 			await fs.mkdir(unrelatedCwd);
 			const sourceResult = await runProbe([process.execPath, bundleProbePath, missingPackageChangelogPath]);
 
-			const buildProc = Bun.spawn(
-				[
-					process.execPath,
-					"build",
-					bundleProbePath,
-					"--target=bun",
-					"--external=omp-legacy-pi-modules",
-					`--outdir=${bundleDir}`,
-				],
-				{ stderr: "pipe", stdout: "pipe" },
-			);
-			const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
-				new Response(buildProc.stdout).text(),
-				new Response(buildProc.stderr).text(),
-				buildProc.exited,
-			]);
-			expect(buildExitCode, buildStdout + buildStderr).toBe(0);
+			const buildOutput = await Bun.build({
+				entrypoints: [bundleProbePath],
+				outdir: bundleDir,
+				target: "bun",
+				external: ["omp-legacy-pi-modules"],
+				plugins: [changelogUtilsStubPlugin()],
+			});
+			expect(buildOutput.success, buildOutput.logs.map(log => log.message).join("\n")).toBe(true);
 
 			const outputs = await fs.readdir(bundleDir);
 			expect(outputs.some(output => output.endsWith(".md"))).toBe(true);
@@ -124,17 +135,7 @@ describe("changelog static import resources", () => {
 				entrypoints: [bundleProbePath],
 				root: repoRoot,
 				external: ["omp-legacy-pi-modules"],
-				plugins: [
-					{
-						name: "changelog-utils-stub",
-						setup(build) {
-							build.onResolve({ filter: /^@oh-my-pi\/pi-utils$/ }, () => ({ path: utilsStubPath }));
-							build.onResolve({ filter: /^\.\.\/config$/ }, args =>
-								args.importer.endsWith("/utils/changelog.ts") ? { path: utilsStubPath } : undefined,
-							);
-						},
-					},
-				],
+				plugins: [changelogUtilsStubPlugin()],
 				compile: {
 					outfile: binaryPath,
 					autoloadBunfig: false,


### PR DESCRIPTION
## What

Build the changelog bundle probe with `Bun.build()` and the same `changelog-utils-stub` plugin the compiled-binary probe in this file already uses, instead of shelling out to the `bun build` CLI. The plugin becomes one helper shared by both probes.

## Why

`test/utils/changelog-static-import.test.ts` → "reads the emitted changelog asset when run outside the bundle directory" fails, which is why `Test coding-agent native/unit` is currently red on open pull requests.

The probe imports `@oh-my-pi/pi-utils`, and `src/utils/changelog.ts` imports `../config`. Both pull the native addon loader into the bundle graph. A CLI `bun build` invocation cannot take a plugin, so neither could be stubbed, and the emitted bundle called `loadNative()` at startup:

```
Cannot find module '<tmp>/native/pi_natives.<platform>.node'
  from '<tmp>/bundle/changelog-bundle-fallback-probe.js'
    at loadNative
```

The loader resolves `pi_natives.<platform>.node` relative to the artifact and to `process.execPath`. This probe is deliberately written to a temp directory and run from an unrelated cwd, so neither location can hold a native. Passing therefore depended on a platform native happening to sit next to the runner, which is why an identical tree is green on a `main` push and red under `pull_request`.

The compiled-binary probe a few lines below already solved exactly this with a stub plugin. The outdir probe never got the same treatment. What this test exists to check is emitted-asset resolution, not native loading.

## Testing

- `bun --cwd=packages/coding-agent test test/utils/changelog-static-import.test.ts`
  - 7 pass, 0 fail (previously 6 pass, 1 fail)
- `bun --cwd=packages/coding-agent test test/utils/`
  - 117 pass, 1 skip, 0 fail
- `bun --cwd=packages/coding-agent run check`
  - passed

Coverage is restored rather than removed. Reverting `resolveBundledChangelogPath` to resolve against cwd instead of the module URL, which is the #1423 shape, fails both the unit assertion and this bundle probe. Before this change the probe died at native load before it could observe that regression.

No changelog entry: test-only change with no user-facing behavior.

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
