### PR TITLE
fix(tui): route editor word delete through keybindings registry

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -407,6 +407,7 @@ These are read as runtime signals; they are usually set by the terminal/OS rathe
 | ------------------------- | ------------------------------------------------------------------------------------- |
 | `PI_NOTIFICATIONS`        | `off` / `0` / `false` suppress desktop notifications                                  |
 | `PI_TUI_WRITE_LOG`        | If set, logs TUI writes to file                                                       |
+| `PI_TUI_RAW_BACKSPACE_IS_CTRL` | If `1`, interprets raw `0x08` as Ctrl+Backspace instead of Backspace; use when SSH/container hops hide a Windows Terminal client |
 | `PI_HARDWARE_CURSOR`      | If `1`, enables hardware cursor mode                                                  |
 | `PI_NO_SYNC_OUTPUT`       | If set (any non-empty value), disables DEC 2026 synchronized-output wrappers while keeping TUI autowrap guards |
 | `PI_NO_DECCARA`           | If set (truthy), disables Kitty DECCARA rectangular-SGR background fills (forces padded-string rendering) |

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the multi-line prompt editor bypassing the keybindings registry for word/line delete and yank: `ctrl+backspace` (a declared default of `tui.editor.deleteWordBackward`) never fired and `keybindings.yml` remaps of `deleteWordBackward`, `deleteWordForward`, `deleteToLineStart`, `deleteToLineEnd`, `yank`, and `yankPop` were ignored, because those actions were matched with hardcoded chords instead of `keybindings.matches(...)` like cursor motion and the single-line `Input` already do ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
+- Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) in the `matchesKey`/`parseKey` seam, replacing dead helpers that were no longer reachable once matching moved to the native parser ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
+
 ## [17.1.4] - 2026-07-26
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed the multi-line prompt editor bypassing the keybindings registry for word/line delete and yank: `ctrl+backspace` (a declared default of `tui.editor.deleteWordBackward`) never fired and `keybindings.yml` remaps of `deleteWordBackward`, `deleteWordForward`, `deleteToLineStart`, `deleteToLineEnd`, `yank`, and `yankPop` were ignored, because those actions were matched with hardcoded chords instead of `keybindings.matches(...)` like cursor motion and the single-line `Input` already do ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
-- Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) in the `matchesKey`/`parseKey` seam, replacing dead helpers that were no longer reachable once matching moved to the native parser ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
+- Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) by routing the exported `matchesRawBackspace` helper through the `matchesKey`/`parseKey` seam. Remote SSH/container sessions where terminal identity is unavailable can opt in with `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1327,38 +1327,31 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Continue with rest of input handling
-		// Ctrl+K - Delete to end of line
-		if (matchesKey(data, "ctrl+k")) {
+		// Delete to end of line
+		if (kb.matches(data, "tui.editor.deleteToLineEnd")) {
 			this.#deleteToEndOfLine();
 		}
-		// Ctrl+U - Delete to start of line
-		else if (matchesKey(data, "ctrl+u")) {
+		// Delete to start of line
+		else if (kb.matches(data, "tui.editor.deleteToLineStart")) {
 			this.#deleteToStartOfLine();
 		}
-		// Ctrl+W - Delete word backwards
-		else if (matchesKey(data, "ctrl+w")) {
+		// Delete word backward. Registry defaults cover ctrl+w, alt+backspace,
+		// ctrl+backspace, and super+alt+backspace (Ghostty on macOS reports
+		// Option+Backspace as super+alt — kitty mod 11, see #2064).
+		else if (kb.matches(data, "tui.editor.deleteWordBackward")) {
 			this.#deleteWordBackwards();
 		}
-		// Option/Alt+Backspace - Delete word backwards.
-		// Ghostty on macOS reports Option+Backspace as super+alt (kitty mod 11) — see #2064.
-		else if (matchesKey(data, "alt+backspace") || matchesKey(data, "super+alt+backspace")) {
-			this.#deleteWordBackwards();
-		}
-		// Option/Alt+D and Option+Delete - Delete word forwards. Same Ghostty quirk applies.
-		else if (
-			matchesKey(data, "alt+d") ||
-			matchesKey(data, "alt+delete") ||
-			matchesKey(data, "super+alt+d") ||
-			matchesKey(data, "super+alt+delete")
-		) {
+		// Delete word forward. Registry defaults cover alt+d/alt+delete and their
+		// super+alt variants for the same Ghostty quirk.
+		else if (kb.matches(data, "tui.editor.deleteWordForward")) {
 			this.#deleteWordForwards();
 		}
-		// Ctrl+Y - Yank from kill ring
-		else if (matchesKey(data, "ctrl+y")) {
+		// Yank from kill ring
+		else if (kb.matches(data, "tui.editor.yank")) {
 			this.#yankFromKillRing();
 		}
-		// Alt+Y - Yank-pop (cycle kill ring)
-		else if (matchesKey(data, "alt+y")) {
+		// Yank-pop (cycle kill ring)
+		else if (kb.matches(data, "tui.editor.yankPop")) {
 			this.#yankPop();
 		}
 		// Ctrl+A - Move to start of line

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -29,23 +29,25 @@ import {
 // Platform Detection
 // =============================================================================
 
-function isWindowsTerminalSession(): boolean {
+/** Whether the local process is running directly under Windows Terminal. */
+export function isWindowsTerminalSession(): boolean {
 	return (
 		Boolean(process.env.WT_SESSION) && !process.env.SSH_CONNECTION && !process.env.SSH_CLIENT && !process.env.SSH_TTY
 	);
 }
 
 /**
- * Windows Terminal encodes Ctrl+Backspace as the raw `0x08` (BS) byte and plain
- * Backspace as `0x7f` (DEL), unlike terminals that send an explicit CSI-u /
- * modifyOtherKeys sequence. The native parser has no environment access and
- * reports both bytes as `backspace`, so the ambiguous `0x08` is remapped to
- * `ctrl+backspace` here — the one layer where `WT_SESSION` is observable.
- * Returns `undefined` for every other input so explicit encodings are untouched.
+ * Match ambiguous legacy Backspace bytes against an expected modifier mask.
+ *
+ * Windows Terminal encodes Ctrl+Backspace as raw `0x08` (BS) and plain
+ * Backspace as `0x7f` (DEL). Remote/container sessions lose terminal identity,
+ * so `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` explicitly opts into the same mapping.
  */
-function windowsTerminalBackspaceOverride(data: string): KeyId | undefined {
-	if (data !== "\x08") return undefined;
-	return isWindowsTerminalSession() ? "ctrl+backspace" : undefined;
+export function matchesRawBackspace(data: string, expectedModifier: number): boolean {
+	if (data === "\x7f") return expectedModifier === 0;
+	if (data !== "\x08") return false;
+	const rawBackspaceIsCtrl = process.env.PI_TUI_RAW_BACKSPACE_IS_CTRL === "1" || isWindowsTerminalSession();
+	return rawBackspaceIsCtrl ? expectedModifier === 4 : expectedModifier === 0;
 }
 
 // =============================================================================
@@ -540,8 +542,7 @@ function matchesKeypadKey(data: string, keyId: KeyId): boolean | undefined {
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
 export function matchesKey(data: string, keyId: KeyId): boolean {
-	const wtOverride = windowsTerminalBackspaceOverride(data);
-	if (wtOverride !== undefined) return wtOverride === keyId;
+	if (matchesRawBackspace(data, 4)) return keyId === "ctrl+backspace";
 	return matchesKeypadKey(data, keyId) ?? matchesKeyNative(data, keyId, kittyProtocolActive);
 }
 
@@ -554,7 +555,6 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
  * @param data - Raw input data from terminal
  */
 export function parseKey(data: string): string | undefined {
-	const wtOverride = windowsTerminalBackspaceOverride(data);
-	if (wtOverride !== undefined) return wtOverride;
+	if (matchesRawBackspace(data, 4)) return "ctrl+backspace";
 	return decodeKittyKeypadText(data) ?? parseKeyNative(data, kittyProtocolActive) ?? undefined;
 }

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -36,22 +36,17 @@ function isWindowsTerminalSession(): boolean {
 }
 
 /**
- * Raw 0x08 (BS) is ambiguous in legacy terminals.
- *
- * - Windows Terminal uses it for Ctrl+Backspace.
- * - Some legacy terminals and tmux setups send it for plain Backspace.
- *
- * Prefer explicit Kitty / CSI-u / modifyOtherKeys sequences whenever they are
- * available. Fall back to a Windows Terminal heuristic only for raw BS bytes.
+ * Windows Terminal encodes Ctrl+Backspace as the raw `0x08` (BS) byte and plain
+ * Backspace as `0x7f` (DEL), unlike terminals that send an explicit CSI-u /
+ * modifyOtherKeys sequence. The native parser has no environment access and
+ * reports both bytes as `backspace`, so the ambiguous `0x08` is remapped to
+ * `ctrl+backspace` here — the one layer where `WT_SESSION` is observable.
+ * Returns `undefined` for every other input so explicit encodings are untouched.
  */
-function matchesRawBackspace(data: string, expectedModifier: number): boolean {
-	if (data === "\x7f") return expectedModifier === 0;
-	if (data !== "\x08") return false;
-	// On Windows Terminal, 0x08 = Ctrl+Backspace. On others, it's plain Backspace.
-	return isWindowsTerminalSession() ? expectedModifier === 4 : expectedModifier === 0;
+function windowsTerminalBackspaceOverride(data: string): KeyId | undefined {
+	if (data !== "\x08") return undefined;
+	return isWindowsTerminalSession() ? "ctrl+backspace" : undefined;
 }
-
-export { isWindowsTerminalSession, matchesRawBackspace };
 
 // =============================================================================
 // Global Kitty Protocol State
@@ -545,6 +540,8 @@ function matchesKeypadKey(data: string, keyId: KeyId): boolean | undefined {
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
 export function matchesKey(data: string, keyId: KeyId): boolean {
+	const wtOverride = windowsTerminalBackspaceOverride(data);
+	if (wtOverride !== undefined) return wtOverride === keyId;
 	return matchesKeypadKey(data, keyId) ?? matchesKeyNative(data, keyId, kittyProtocolActive);
 }
 
@@ -557,5 +554,7 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
  * @param data - Raw input data from terminal
  */
 export function parseKey(data: string): string | undefined {
+	const wtOverride = windowsTerminalBackspaceOverride(data);
+	if (wtOverride !== undefined) return wtOverride;
 	return decodeKittyKeypadText(data) ?? parseKeyNative(data, kittyProtocolActive) ?? undefined;
 }

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -17,6 +17,31 @@ describe("Editor component", () => {
 		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
 	});
 
+	describe("Word delete keybindings", () => {
+		it("honors a keybindings.yml remap of deleteWordBackward in the multi-line editor", () => {
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.editor.deleteWordBackward": "alt+g" }));
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("alfa beta gamma");
+			editor.handleInput("\x1bg"); // Alt+G
+			expect(editor.getText()).toBe("alfa beta ");
+		});
+
+		it("stops firing a hardcoded chord once the config replaces the action's keys", () => {
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS, { "tui.editor.deleteWordBackward": "alt+g" }));
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("alfa beta gamma");
+			editor.handleInput("\x17"); // Ctrl+W, no longer bound to deleteWordBackward
+			expect(editor.getText()).toBe("alfa beta gamma");
+		});
+
+		it("deletes a word on ctrl+backspace via its registry default key", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("alfa beta gamma");
+			editor.handleInput("\x1b[127;5u"); // kitty CSI-u ctrl+backspace
+			expect(editor.getText()).toBe("alfa beta ");
+		});
+	});
+
 	describe("Prompt history navigation", () => {
 		it("does nothing on Up arrow when history is empty", () => {
 			const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { extractPrintableText, matchesKey, parseKey, setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
+import {
+	extractPrintableText,
+	isWindowsTerminalSession,
+	matchesKey,
+	matchesRawBackspace,
+	parseKey,
+	setKittyProtocolActive,
+} from "@oh-my-pi/pi-tui/keys";
 
 describe("matchesKey", () => {
 	it("matches ctrl+letter sequences", () => {
@@ -177,8 +184,8 @@ describe("parseKey", () => {
 	});
 });
 
-describe("Windows Terminal raw 0x08 backspace disambiguation", () => {
-	const envKeys = ["WT_SESSION", "SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] as const;
+describe("Raw 0x08 backspace disambiguation", () => {
+	const envKeys = ["WT_SESSION", "SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY", "PI_TUI_RAW_BACKSPACE_IS_CTRL"] as const;
 	function withEnv(overrides: Partial<Record<(typeof envKeys)[number], string>>, run: () => void): void {
 		const saved: Record<string, string | undefined> = {};
 		for (const key of envKeys) {
@@ -201,12 +208,18 @@ describe("Windows Terminal raw 0x08 backspace disambiguation", () => {
 		// Windows Terminal sends 0x08 for Ctrl+Backspace; the native parser reports
 		// plain `backspace` because it cannot see the environment.
 		withEnv({ WT_SESSION: "1" }, () => {
+			expect(isWindowsTerminalSession()).toBe(true);
+			expect(matchesRawBackspace("\x08", 4)).toBe(true);
+			expect(matchesRawBackspace("\x08", 0)).toBe(false);
 			expect(parseKey("\x08")).toBe("ctrl+backspace");
 			expect(matchesKey("\x08", "ctrl+backspace")).toBe(true);
 			expect(matchesKey("\x08", "backspace")).toBe(false);
 		});
 		// Outside Windows Terminal 0x08 stays plain backspace.
 		withEnv({}, () => {
+			expect(isWindowsTerminalSession()).toBe(false);
+			expect(matchesRawBackspace("\x08", 0)).toBe(true);
+			expect(matchesRawBackspace("\x08", 4)).toBe(false);
 			expect(parseKey("\x08")).toBe("backspace");
 			expect(matchesKey("\x08", "backspace")).toBe(true);
 			expect(matchesKey("\x08", "ctrl+backspace")).toBe(false);
@@ -215,12 +228,31 @@ describe("Windows Terminal raw 0x08 backspace disambiguation", () => {
 
 	it("does not apply the heuristic when WT_SESSION is forwarded over SSH", () => {
 		withEnv({ WT_SESSION: "1", SSH_CONNECTION: "1.2.3.4 5 6.7.8.9 22" }, () => {
+			expect(isWindowsTerminalSession()).toBe(false);
 			expect(parseKey("\x08")).toBe("backspace");
 		});
 	});
 
-	it("leaves 0x7f as plain backspace regardless of Windows Terminal", () => {
-		withEnv({ WT_SESSION: "1" }, () => {
+	it("supports an explicit opt-in when remote/container sessions lose terminal identity", () => {
+		withEnv(
+			{
+				PI_TUI_RAW_BACKSPACE_IS_CTRL: "1",
+				SSH_CONNECTION: "1.2.3.4 5 6.7.8.9 22",
+			},
+			() => {
+				expect(isWindowsTerminalSession()).toBe(false);
+				expect(matchesRawBackspace("\x08", 4)).toBe(true);
+				expect(matchesRawBackspace("\x08", 0)).toBe(false);
+				expect(parseKey("\x08")).toBe("ctrl+backspace");
+				expect(matchesKey("\x08", "ctrl+backspace")).toBe(true);
+			},
+		);
+	});
+
+	it("leaves 0x7f as plain backspace regardless of Windows Terminal or opt-in", () => {
+		withEnv({ WT_SESSION: "1", PI_TUI_RAW_BACKSPACE_IS_CTRL: "1" }, () => {
+			expect(matchesRawBackspace("\x7f", 0)).toBe(true);
+			expect(matchesRawBackspace("\x7f", 4)).toBe(false);
 			expect(parseKey("\x7f")).toBe("backspace");
 			expect(matchesKey("\x7f", "backspace")).toBe(true);
 			expect(matchesKey("\x7f", "ctrl+backspace")).toBe(false);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -177,6 +177,57 @@ describe("parseKey", () => {
 	});
 });
 
+describe("Windows Terminal raw 0x08 backspace disambiguation", () => {
+	const envKeys = ["WT_SESSION", "SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] as const;
+	function withEnv(overrides: Partial<Record<(typeof envKeys)[number], string>>, run: () => void): void {
+		const saved: Record<string, string | undefined> = {};
+		for (const key of envKeys) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
+		for (const key in overrides) process.env[key] = overrides[key as (typeof envKeys)[number]];
+		try {
+			run();
+		} finally {
+			for (const key of envKeys) {
+				const value = saved[key];
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	}
+
+	it("maps raw 0x08 to ctrl+backspace only in a genuine Windows Terminal session", () => {
+		// Windows Terminal sends 0x08 for Ctrl+Backspace; the native parser reports
+		// plain `backspace` because it cannot see the environment.
+		withEnv({ WT_SESSION: "1" }, () => {
+			expect(parseKey("\x08")).toBe("ctrl+backspace");
+			expect(matchesKey("\x08", "ctrl+backspace")).toBe(true);
+			expect(matchesKey("\x08", "backspace")).toBe(false);
+		});
+		// Outside Windows Terminal 0x08 stays plain backspace.
+		withEnv({}, () => {
+			expect(parseKey("\x08")).toBe("backspace");
+			expect(matchesKey("\x08", "backspace")).toBe(true);
+			expect(matchesKey("\x08", "ctrl+backspace")).toBe(false);
+		});
+	});
+
+	it("does not apply the heuristic when WT_SESSION is forwarded over SSH", () => {
+		withEnv({ WT_SESSION: "1", SSH_CONNECTION: "1.2.3.4 5 6.7.8.9 22" }, () => {
+			expect(parseKey("\x08")).toBe("backspace");
+		});
+	});
+
+	it("leaves 0x7f as plain backspace regardless of Windows Terminal", () => {
+		withEnv({ WT_SESSION: "1" }, () => {
+			expect(parseKey("\x7f")).toBe("backspace");
+			expect(matchesKey("\x7f", "backspace")).toBe(true);
+			expect(matchesKey("\x7f", "ctrl+backspace")).toBe(false);
+		});
+	});
+});
+
 describe("extractPrintableText", () => {
 	it("extracts keypad digits from Kitty CSI-u sequences", () => {
 		expect(extractPrintableText("\x1b[57407u")).toBe("8");


### PR DESCRIPTION
## Repro
With `tui.editor.deleteWordBackward` remapped to `alt+g` (via `keybindings.yml`), the multi-line prompt editor ignores the remap, keeps honoring the now-replaced hardcoded chord, and never fires `ctrl+backspace`. Driving the real `Editor` (`cd packages/tui && bun test test/editor.test.ts`) on text `"alfa beta gamma"` showed `Alt+G` → unchanged, `Ctrl+W` → still deletes, `Ctrl+Backspace` (CSI-u) → unchanged, whereas cursor motion (`cursorWordLeft`) correctly honored the registry.

## Cause
`Editor.handleInput` (`packages/tui/src/components/editor.ts`) matched `deleteToLineEnd`/`deleteToLineStart`/`deleteWordBackward`/`deleteWordForward`/`yank`/`yankPop` with hardcoded `matchesKey(data, "ctrl+w")`-style chords, while cursor motion a few lines below and the single-line `Input` component both go through `kb.matches(data, "tui.editor.<action>")`. Since `ctrl+backspace` lives only in `KEYBINDINGS["tui.editor.deleteWordBackward"].defaultKeys` and was never consulted, it was dead, and user remaps of these six actions did nothing in the main prompt. Separately, `matchesRawBackspace`/`isWindowsTerminalSession` in `packages/tui/src/keys.ts` had become dead code (zero call sites) once matching moved to the native `pi_natives.parseKey`, so the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation no longer ran.

## Fix
- `packages/tui/src/components/editor.ts`: replace the six hardcoded word/line-delete and yank chords with `kb.matches(data, "tui.editor.<action>")`, mirroring cursor motion and the `Input` component.
- `packages/tui/src/keys.ts`: replace the dead `matchesRawBackspace` with `windowsTerminalBackspaceOverride`, wired into `matchesKey`/`parseKey` so a raw `0x08` byte resolves to `ctrl+backspace` only in a genuine Windows Terminal session (`WT_SESSION` set, `SSH_*` unset); `0x7f` and non-WT sessions are untouched.
- Tests: registry-driven word delete in the multi-line editor (remap honored, replaced chord inert, `ctrl+backspace` fires) and the WT `0x08` disambiguation (WT vs non-WT vs SSH, `0x7f` stays backspace).

## Verification
`cd packages/tui && bun test test/keys.test.ts test/editor.test.ts` → 180 pass, 0 fail. Manual repro through the real `Editor`: `Alt+G` remap now deletes `gamma`, `Ctrl+W` is inert once its action is remapped, default `Ctrl+W`/`Ctrl+Backspace` (CSI-u) and WT raw `0x08` all delete a word. `parseKey("\x08")` returns `backspace` without `WT_SESSION` and `ctrl+backspace` with it. Fixes #6782