### PR TITLE
fix(coding-agent): preserve extension providers for plan subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan-mode task subagents unregistering extension-provided models, credentials, managers, and custom APIs from the shared parent `ModelRegistry` when restricted sessions intentionally skip extension loading ([#6783](https://github.com/can1357/oh-my-pi/issues/6783)).
+
+
 ## [17.1.5] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1985,10 +1985,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Process provider registrations queued during extension loading.
 		// This must happen before the runner is created so that models registered by
 		// extensions are available for model selection on session resume / fallback.
-		const activeExtensionSources = extensionsResult.extensions.map(extension => extension.path);
-		modelRegistry.syncExtensionSources(activeExtensionSources);
-		for (const sourceId of new Set(activeExtensionSources)) {
-			modelRegistry.clearSourceRegistrations(sourceId);
+		if (!restrictToolNames) {
+			const activeExtensionSources = extensionsResult.extensions.map(extension => extension.path);
+			modelRegistry.syncExtensionSources(activeExtensionSources);
+			for (const sourceId of new Set(activeExtensionSources)) {
+				modelRegistry.clearSourceRegistrations(sourceId);
+			}
 		}
 		if (extensionsResult.runtime.pendingProviderRegistrations.length > 0) {
 			for (const { name, config, sourceId } of extensionsResult.runtime.pendingProviderRegistrations) {

--- a/packages/coding-agent/test/sdk-restricted-extension-provider.test.ts
+++ b/packages/coding-agent/test/sdk-restricted-extension-provider.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createAssistantMessageEventStream, getCustomApi } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	type CreateAgentSessionOptions,
+	createAgentSession,
+	type ExtensionFactory,
+} from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+const providerName = "restricted-session-provider";
+const modelId = "restricted-session-model";
+const apiId = "restricted-session-api";
+const sourceId = "<inline-0>";
+
+describe("restricted sessions sharing extension providers", () => {
+	let tempDir: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let settings: Settings;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-sdk-restricted-provider-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		settings = Settings.isolated();
+		settings.setModelRole("default", `${providerName}/${modelId}`);
+	});
+
+	afterEach(() => {
+		modelRegistry.clearSourceRegistrations(sourceId);
+		authStorage.close();
+		removeSyncWithRetries(tempDir);
+	});
+
+	const providerExtension: ExtensionFactory = pi => {
+		pi.registerProvider(providerName, {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "RUNTIME_KEY",
+			api: apiId,
+			streamSimple: () => createAssistantMessageEventStream(),
+			models: [
+				{
+					id: modelId,
+					name: "Restricted Session Model",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 8192,
+				},
+			],
+		});
+	};
+
+	function createOptions(): CreateAgentSessionOptions {
+		return {
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		};
+	}
+
+	test("does not unregister the parent's provider when extension loading is restricted", async () => {
+		const { session: parent } = await createAgentSession({
+			...createOptions(),
+			extensions: [providerExtension],
+		});
+
+		try {
+			expect(parent.model?.provider).toBe(providerName);
+			expect(modelRegistry.authStorage.hasAuth(providerName)).toBe(true);
+			expect(getCustomApi(apiId)).toBeDefined();
+
+			const { session: child } = await createAgentSession({
+				...createOptions(),
+				model: parent.model,
+				restrictToolNames: true,
+				toolNames: ["read"],
+			});
+
+			try {
+				expect(child.model?.provider).toBe(providerName);
+				expect(modelRegistry.find(providerName, modelId)).toBeDefined();
+				expect(modelRegistry.authStorage.hasAuth(providerName)).toBe(true);
+				expect(getCustomApi(apiId)).toBeDefined();
+			} finally {
+				await child.dispose();
+			}
+		} finally {
+			await parent.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A parent session registers a model, credential, and custom API through an inline extension, then creates a restricted child with the same `ModelRegistry`. `cd packages/coding-agent && bun test test/sdk-restricted-extension-provider.test.ts` failed because `modelRegistry.find("restricted-session-provider", "restricted-session-model")` returned `undefined` after child creation.

## Cause
`createAgentSession` in `packages/coding-agent/src/sdk.ts` always passed the loaded extension paths to `ModelRegistry.syncExtensionSources`. Restricted plan-mode sessions intentionally call `loadExtensions([])`, so the shared registry interpreted their empty session-local result as an authoritative empty process-wide source set and cleared the parent provider through `clearSourceRegistrations`.

## Fix
- Skip extension-source reconciliation when `restrictToolNames` deliberately suppresses extension loading.
- Add a shared-registry regression covering retention of the provider model, credential, and custom API across restricted child creation.
- Record the fix in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/sdk-restricted-extension-provider.test.ts test/sdk-default-role-extension-provider.test.ts test/model-registry-runtime-cleanup.test.ts test/task/structured-subagent.test.ts` passes: 21 tests, 77 assertions. Skipped the pre-publish gate because `bun check` fails identically on a clean `origin/main` archive due to existing rustfmt differences in `crates/vendor/uu-sort/src/ext_sort/threaded.rs`; the TypeScript check completed successfully on this branch.

Fixes #6783