### PR TITLE
fix(mcp): deduplicate aliased server connections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed identical MCP server connections discovered under direct and marketplace-plugin names spawning twice and duplicating mounted tool routes; distinct tools whose server names sanitize to the same route now keep the first registration and log both origins ([#6786](https://github.com/can1357/oh-my-pi/issues/6786)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -164,21 +164,26 @@ async function loadImpl<T>(
 		}
 	}
 
-	// Deduplicate by key (first wins = highest priority)
-	const seen = new Map<string, number>();
+	// Deduplicate by key or semantic equivalence (first wins = highest priority)
+	const seen = new Set<string>();
 	const deduped: Array<T & { _source: SourceMeta }> = [];
+	const equivalent = capability.equivalent;
 
-	for (let i = 0; i < allItems.length; i++) {
-		const item = allItems[i];
+	for (const item of allItems) {
 		const key = capability.key(item);
 
 		if (key === undefined) {
 			deduped.push(item);
-		} else if (!seen.has(key)) {
-			seen.set(key, i);
-			deduped.push(item);
-		} else {
+			continue;
+		}
+
+		const keySeen = seen.has(key);
+		seen.add(key);
+		const aliasSeen = !keySeen && equivalent !== undefined && deduped.some(existing => equivalent(existing, item));
+		if (keySeen || aliasSeen) {
 			item._shadowed = true;
+		} else {
+			deduped.push(item);
 		}
 	}
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -102,7 +102,7 @@ async function loadImpl<T>(
 	capability: Capability<T>,
 	providers: Provider<T>[],
 	ctx: LoadContext,
-	options: LoadOptions,
+	options: LoadOptions<T>,
 ): Promise<CapabilityResult<T>> {
 	const allItems: Array<T & { _source: SourceMeta; _shadowed?: boolean }> = [];
 	const allWarnings: string[] = [];
@@ -216,7 +216,7 @@ async function loadImpl<T>(
 /**
  * Filter providers based on options and disabled state.
  */
-function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Provider<T>[] {
+function filterProviders<T>(capability: Capability<T>, options: LoadOptions<T>): Provider<T>[] {
 	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledProviders.has(p.id));
 
 	if (options.providers) {
@@ -234,7 +234,10 @@ function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Pr
 /**
  * Load a capability by ID.
  */
-export async function loadCapability<T>(capabilityId: string, options: LoadOptions = {}): Promise<CapabilityResult<T>> {
+export async function loadCapability<T>(
+	capabilityId: string,
+	options: LoadOptions<T> = {},
+): Promise<CapabilityResult<T>> {
 	const capability = capabilities.get(capabilityId) as Capability<T> | undefined;
 	if (!capability) {
 		throw new Error(`Unknown capability: "${capabilityId}"`);

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -154,6 +154,10 @@ async function loadImpl<T>(
 				continue;
 			}
 
+			if (options.filter && !options.filter(itemWithSource)) {
+				continue;
+			}
+
 			itemWithSource._source.providerName = provider.displayName;
 			allItems.push(itemWithSource as T & { _source: SourceMeta; _shadowed?: boolean });
 			contributedItemCount += 1;

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -53,11 +53,32 @@ export interface MCPServer {
 	_source: SourceMeta;
 }
 
+/** Compare the transport inputs that determine which MCP endpoint gets connected. */
+function isSameMCPConnection(left: MCPServer, right: MCPServer): boolean {
+	if (!Bun.deepEquals(left.auth, right.auth) || !Bun.deepEquals(left.oauth, right.oauth)) return false;
+
+	const leftTransport = left.transport ?? (left.command ? "stdio" : left.url ? "http" : "stdio");
+	const rightTransport = right.transport ?? (right.command ? "stdio" : right.url ? "http" : "stdio");
+	if (leftTransport !== rightTransport) return false;
+
+	if (leftTransport === "stdio") {
+		return (
+			left.command === right.command &&
+			Bun.deepEquals(left.args, right.args) &&
+			Bun.deepEquals(left.env, right.env) &&
+			left.cwd === right.cwd
+		);
+	}
+
+	return left.url === right.url && Bun.deepEquals(left.headers, right.headers);
+}
+
 export const mcpCapability = defineCapability<MCPServer>({
 	id: "mcps",
 	displayName: "MCP Servers",
 	description: "Model Context Protocol server configurations for external tool integrations",
 	key: server => server.name,
+	equivalent: isSameMCPConnection,
 	toExtensionId: server => `mcp:${server.name}`,
 	validate: server => {
 		if (!server.name) return "Missing server name";

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -122,6 +122,9 @@ export interface Capability<T> {
 	 */
 	key(item: T): string | undefined;
 
+	/** Treat items with different keys as aliases; the first equivalent item wins. */
+	equivalent?(left: T, right: T): boolean;
+
 	/**
 	 * Optional validation. Return error message if invalid, undefined if valid.
 	 */

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -59,7 +59,7 @@ export interface Provider<T> {
 /**
  * Options for loading a capability.
  */
-export interface LoadOptions {
+export interface LoadOptions<T = unknown> {
 	/** Only use these providers (by ID). Default: all registered */
 	providers?: string[];
 	/** Exclude these providers (by ID). Default: none */
@@ -73,11 +73,12 @@ export interface LoadOptions {
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];
 	/**
-	 * Drop items before deduplication. Use when a downstream scope filter must
+	 * Drop items before deduplication. Use when a per-name or scope filter must
 	 * precede equivalence collapse, so a to-be-filtered item cannot shadow a
-	 * differently-keyed but equivalent survivor. Receives the item's `_source`.
+	 * differently-keyed but equivalent survivor and then be removed downstream,
+	 * leaving none. Receives the item with its attached `_source`.
 	 */
-	filter?(item: { _source: SourceMeta }): boolean;
+	filter?(item: T & { _source: SourceMeta }): boolean;
 }
 
 /**

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -72,6 +72,12 @@ export interface LoadOptions {
 	includeDisabled?: boolean;
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];
+	/**
+	 * Drop items before deduplication. Use when a downstream scope filter must
+	 * precede equivalence collapse, so a to-be-filtered item cannot shadow a
+	 * differently-keyed but equivalent survivor. Receives the item's `_source`.
+	 */
+	filter?(item: { _source: SourceMeta }): boolean;
 }
 
 /**

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -97,15 +97,6 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	const filterExa = options?.filterExa ?? true;
 	const filterBrowser = options?.filterBrowser ?? false;
 
-	// Filter project-scoped entries BEFORE the capability layer's equivalence
-	// deduplication so a project server cannot shadow a differently-named but
-	// connection-equivalent user server and then be dropped here, leaving none.
-	const result = await loadCapability<MCPServer>(mcpCapability.id, {
-		cwd,
-		...(enableProjectConfig ? {} : { filter: server => server._source.level !== "project" }),
-	});
-	const servers = result.items;
-
 	// Load user-level disable/force-enable lists. The denylist always wins; the
 	// allowlist overrides a non-writable source config's `enabled: false`.
 	const userPath = getMCPConfigPath("user", cwd);
@@ -113,14 +104,25 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 		readDisabledServers(userPath).then(list => new Set(list)),
 		readEnabledServers(userPath).then(list => new Set(list)),
 	]);
-	// Convert to legacy format and preserve source metadata
+
+	// Apply every per-name and per-scope exclusion BEFORE the capability layer's
+	// equivalence deduplication. Otherwise a disabled or out-of-scope server can
+	// shadow a differently-named but connection-equivalent enabled server during
+	// dedup and then be removed here, leaving no connection at all.
+	const includeServer = (server: MCPServer & { _source: SourceMeta }): boolean => {
+		if (!enableProjectConfig && server._source.level === "project") return false;
+		if (disabledServers.has(server.name)) return false;
+		if (server.enabled === false && !forcedEnabled.has(server.name)) return false;
+		return true;
+	};
+
+	const result = await loadCapability<MCPServer>(mcpCapability.id, { cwd, filter: includeServer });
+
+	// Convert to legacy format and preserve source metadata.
 	let configs: Record<string, MCPServerConfig> = {};
 	let sources: Record<string, SourceMeta> = {};
-	for (const server of servers) {
-		const config = convertToLegacyConfig(server);
-		if (disabledServers.has(server.name)) continue;
-		if (config.enabled === false && !forcedEnabled.has(server.name)) continue;
-		configs[server.name] = config;
+	for (const server of result.items) {
+		configs[server.name] = convertToLegacyConfig(server);
 		sources[server.name] = server._source;
 	}
 

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -97,13 +97,14 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	const filterExa = options?.filterExa ?? true;
 	const filterBrowser = options?.filterBrowser ?? false;
 
-	// Load MCP servers via capability system
-	const result = await loadCapability<MCPServer>(mcpCapability.id, { cwd });
-
-	// Filter out project-level configs if disabled
-	const servers = enableProjectConfig
-		? result.items
-		: result.items.filter(server => server._source.level !== "project");
+	// Filter project-scoped entries BEFORE the capability layer's equivalence
+	// deduplication so a project server cannot shadow a differently-named but
+	// connection-equivalent user server and then be dropped here, leaving none.
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd,
+		...(enableProjectConfig ? {} : { filter: server => server._source.level !== "project" }),
+	});
+	const servers = result.items;
 
 	// Load user-level disable/force-enable lists. The denylist always wins; the
 	// allowlist overrides a non-writable source config's `enabled: false`.

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -6,7 +6,7 @@
 import type { AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { TSchema } from "@oh-my-pi/pi-ai";
 import { normalizeSchemaForMCP } from "@oh-my-pi/pi-ai/utils/schema";
-import { untilAborted } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import type { SourceMeta } from "../capability/types";
 import type {
@@ -355,6 +355,43 @@ export function createMCPToolName(serverName: string, toolName: string): string 
 	}
 
 	return `mcp__${sanitizedServerName}_${normalizedToolName}`;
+}
+
+/**
+ * Keeps the first MCP tool for each minted name and logs collisions between
+ * distinct MCP origins. Non-MCP tools pass through unchanged.
+ */
+export function deduplicateMCPToolsByName<T extends { name: string; mcpServerName?: unknown; mcpToolName?: unknown }>(
+	tools: readonly T[],
+): T[] {
+	const deduplicated: T[] = [];
+	const registered = new Map<string, T>();
+
+	for (const tool of tools) {
+		if (typeof tool.mcpServerName !== "string" || typeof tool.mcpToolName !== "string") {
+			deduplicated.push(tool);
+			continue;
+		}
+
+		const existing = registered.get(tool.name);
+		if (!existing) {
+			registered.set(tool.name, tool);
+			deduplicated.push(tool);
+			continue;
+		}
+
+		if (existing.mcpServerName !== tool.mcpServerName || existing.mcpToolName !== tool.mcpToolName) {
+			logger.warn("MCP tool name collision; keeping first registration", {
+				name: tool.name,
+				keptServer: existing.mcpServerName,
+				keptTool: existing.mcpToolName,
+				ignoredServer: tool.mcpServerName,
+				ignoredTool: tool.mcpToolName,
+			});
+		}
+	}
+
+	return deduplicated;
 }
 
 /**

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -98,6 +98,7 @@ import type { HindsightSessionState } from "./hindsight/state";
 import { LocalProtocolHandler, type LocalProtocolOptions } from "./internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-events";
 import {
+	deduplicateMCPToolsByName,
 	discoverAndLoadMCPTools,
 	type MCPLoadResult,
 	MCPManager,
@@ -924,13 +925,14 @@ export function customToolToDefinition(tool: CustomTool): ToolDefinition {
 }
 
 function createCustomToolsExtension(tools: CustomTool[]): ExtensionFactory {
+	const uniqueTools = deduplicateMCPToolsByName(tools);
 	return api => {
-		for (const tool of tools) {
+		for (const tool of uniqueTools) {
 			api.registerTool(customToolToDefinition(tool));
 		}
 
 		const runOnSession = async (event: CustomToolSessionEvent, ctx: ExtensionContext) => {
-			for (const tool of tools) {
+			for (const tool of uniqueTools) {
 				if (!tool.onSession) continue;
 				try {
 					await tool.onSession(event, createCustomToolContext(ctx));
@@ -2537,8 +2539,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Built-in tools get it in `createTools`; extension, SDK-custom, image-gen,
 		// TTS, and startup (non-deferred) MCP tools all funnel through here, so apply
 		// it once at this adapter boundary (idempotent — a no-op if already wrapped).
-		const wrappedExtensionTools: Tool[] = wrapRegisteredTools(allCustomTools, extensionRunner).map(
-			wrapToolWithMetaNotice,
+		const wrappedExtensionTools: Tool[] = deduplicateMCPToolsByName(
+			wrapRegisteredTools(allCustomTools, extensionRunner).map(wrapToolWithMetaNotice),
 		);
 
 		// All built-in tools are active (conditional tools like git/ask return null from factory if disabled)

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -11,6 +11,7 @@ import type { ExtensionRunner } from "../extensibility/extensions";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "../extensibility/skills";
 import { type LocalProtocolOptions, XD_URL_PREFIX } from "../internal-urls";
+import { deduplicateMCPToolsByName } from "../mcp/tool-bridge";
 import { resolveMemoryBackend } from "../memory-backend/resolve";
 import { MEMORY_BACKEND_TOOL_NAMES } from "../memory-backend/tool-names";
 import type { MemoryBackendStartOptions } from "../memory-backend/types";
@@ -1040,25 +1041,8 @@ export class SessionTools {
 		});
 
 		const extensionRunner = this.#host.extensionRunner();
-		const registeredMcpTools = new Map<string, CustomTool>();
-		for (const customTool of mcpTools) {
-			const existing = registeredMcpTools.get(customTool.name);
-			if (existing) {
-				if (
-					existing.mcpServerName !== customTool.mcpServerName ||
-					existing.mcpToolName !== customTool.mcpToolName
-				) {
-					logger.warn("MCP tool name collision; keeping first registration", {
-						name: customTool.name,
-						keptServer: existing.mcpServerName,
-						keptTool: existing.mcpToolName,
-						ignoredServer: customTool.mcpServerName,
-						ignoredTool: customTool.mcpToolName,
-					});
-				}
-				continue;
-			}
-			registeredMcpTools.set(customTool.name, customTool);
+		const uniqueMcpTools = deduplicateMCPToolsByName(mcpTools);
+		for (const customTool of uniqueMcpTools) {
 			const wrapped = wrapToolWithMetaNotice(CustomToolAdapter.wrap(customTool, getCustomToolContext) as AgentTool);
 			const finalTool = (
 				extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped
@@ -1068,7 +1052,7 @@ export class SessionTools {
 
 		// Every connected MCP tool is selected; centralized repartitioning owns
 		// presentation pins and write-transport activation/removal.
-		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)])];
+		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...uniqueMcpTools.map(tool => tool.name)])];
 		try {
 			await this.applyActiveToolsByName(nextActive);
 			if (this.#host.isDisposed()) restorePreviousMcpTools();

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1040,7 +1040,25 @@ export class SessionTools {
 		});
 
 		const extensionRunner = this.#host.extensionRunner();
+		const registeredMcpTools = new Map<string, CustomTool>();
 		for (const customTool of mcpTools) {
+			const existing = registeredMcpTools.get(customTool.name);
+			if (existing) {
+				if (
+					existing.mcpServerName !== customTool.mcpServerName ||
+					existing.mcpToolName !== customTool.mcpToolName
+				) {
+					logger.warn("MCP tool name collision; keeping first registration", {
+						name: customTool.name,
+						keptServer: existing.mcpServerName,
+						keptTool: existing.mcpToolName,
+						ignoredServer: customTool.mcpServerName,
+						ignoredTool: customTool.mcpToolName,
+					});
+				}
+				continue;
+			}
+			registeredMcpTools.set(customTool.name, customTool);
 			const wrapped = wrapToolWithMetaNotice(CustomToolAdapter.wrap(customTool, getCustomToolContext) as AgentTool);
 			const finalTool = (
 				extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Message, Model } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponseSource } from "@oh-my-pi/pi-ai/providers/mock";
@@ -13,6 +13,7 @@ import {
 	projectMountedMCPXdevGuidance,
 } from "@oh-my-pi/pi-coding-agent/session/session-tools";
 import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { logger } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 
 // Cache-stability invariant: when MCP servers reconnect with byte-identical tool
@@ -82,6 +83,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		for (const session of sessions.splice(0)) {
 			await session.dispose();
 		}
+		vi.restoreAllMocks();
 	});
 
 	interface NewSessionOptions {
@@ -179,6 +181,24 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 		await session.refreshMCPTools([initialMcp]);
 		expect(rebuildCount).toBe(1);
+	});
+
+	it("warns and keeps the first tool when distinct MCP tools mint the same name", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const { session, toolRegistry } = newSession(async toolNames => `tools:${toolNames.join(",")}`);
+		const dotted = createMcpCustomTool("mcp__foo_bar_lookup", "foo.bar", "lookup", "Lookup from dotted");
+		const underscored = createMcpCustomTool("mcp__foo_bar_lookup", "foo_bar", "lookup", "Lookup from underscored");
+
+		await session.refreshMCPTools([dotted, underscored]);
+
+		expect(toolRegistry.get("mcp__foo_bar_lookup")?.label).toBe("foo.bar/lookup");
+		expect(warn).toHaveBeenCalledWith("MCP tool name collision; keeping first registration", {
+			name: "mcp__foo_bar_lookup",
+			keptServer: "foo.bar",
+			keptTool: "lookup",
+			ignoredServer: "foo_bar",
+			ignoredTool: "lookup",
+		});
 	});
 
 	it("serializes concurrent MCP refreshes before committing rebuilt prompts", async () => {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -491,6 +491,53 @@ describe("listClaudePluginRoots", () => {
 		}
 	});
 
+	test("deduplicates a plugin alias of a directly configured MCP connection", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "context7");
+		const directConfigPath = path.join(tempDir, ".omp", "mcp.json");
+		const connection = {
+			type: "http",
+			url: "https://mcp.context7.example/mcp",
+			headers: { CONTEXT7_API_KEY: "ctx7sk-test-key" },
+		};
+		await fs.mkdir(pluginsDir, { recursive: true });
+		await fs.mkdir(pluginPath, { recursive: true });
+		await fs.mkdir(path.dirname(directConfigPath), { recursive: true });
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"context7@claude-plugins-official": [
+						{
+							scope: "user",
+							installPath: pluginPath,
+							version: "1.0.0",
+							installedAt: "2026-06-01T00:00:00Z",
+							lastUpdated: "2026-06-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(path.join(pluginPath, ".mcp.json"), JSON.stringify({ context7: connection }));
+		await fs.writeFile(
+			directConfigPath,
+			JSON.stringify({
+				mcpServers: { context7: connection },
+			}),
+		);
+
+		const result = await loadCapability<MCPServer>(mcpCapability.id, {
+			cwd: tempDir,
+			providers: ["native", "claude-plugins"],
+		});
+
+		expect(result.items.map(server => server.name)).toEqual(["context7"]);
+		expect(result.items[0]?._source.provider).toBe("native");
+		expect(result.all.find(server => server.name === "context7:context7")?._shadowed).toBe(true);
+	});
+
 	test("resolves relative path-like command and cwd against the plugin config directory", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		const pluginPath = path.join(tempDir, "plugins", "computer-use");

--- a/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
+++ b/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression: project-scope filtering must run BEFORE MCP connection-equivalence
+ * deduplication. The native provider orders project entries before user entries,
+ * so a project server can shadow a differently-named but connection-equivalent
+ * user server during dedup. When `enableProjectConfig` is false the project entry
+ * is then removed, and without pre-dedup scope filtering no server would survive.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { loadAllMCPConfigs } from "@oh-my-pi/pi-coding-agent/mcp/config";
+import { getConfigRootDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import "@oh-my-pi/pi-coding-agent/discovery/builtin";
+
+const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+const CONNECTION = { type: "http", url: "https://mcp.example/mcp" } as const;
+
+async function writeMcpJson(dir: string, servers: Record<string, unknown>): Promise<void> {
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(path.join(dir, "mcp.json"), JSON.stringify({ mcpServers: servers }, null, 2));
+}
+
+describe("MCP scope filtering precedes connection-equivalence deduplication", () => {
+	let tempHome = "";
+	let projectDir = "";
+	let userAgentDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(async () => {
+		originalHome = process.env.HOME;
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-scope-home-"));
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-scope-project-"));
+		userAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-scope-agent-"));
+		process.env.HOME = tempHome;
+		vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+		setAgentDir(userAgentDir);
+		clearFsCache();
+		// Same connection identity under two distinct names, one per scope.
+		await writeMcpJson(path.join(projectDir, ".omp"), { projcontext: CONNECTION });
+		await writeMcpJson(userAgentDir, { usercontext: CONNECTION });
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		clearFsCache();
+		if (originalAgentDirEnv) {
+			setAgentDir(originalAgentDirEnv);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		await removeWithRetries(tempHome);
+		await removeWithRetries(projectDir);
+		await removeWithRetries(userAgentDir);
+	});
+
+	test("keeps the user server when project config is disabled", async () => {
+		const result = await loadAllMCPConfigs(projectDir, { enableProjectConfig: false, filterExa: false });
+		expect(Object.keys(result.configs)).toEqual(["usercontext"]);
+		expect(result.sources.usercontext?.level).toBe("user");
+	});
+
+	test("collapses the equivalent alias to the higher-priority project name when enabled", async () => {
+		const result = await loadAllMCPConfigs(projectDir, { enableProjectConfig: true, filterExa: false });
+		expect(Object.keys(result.configs)).toEqual(["projcontext"]);
+		expect(result.sources.projcontext?.level).toBe("project");
+	});
+});

--- a/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
+++ b/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
@@ -70,4 +70,13 @@ describe("MCP scope filtering precedes connection-equivalence deduplication", ()
 		expect(Object.keys(result.configs)).toEqual(["projcontext"]);
 		expect(result.sources.projcontext?.level).toBe("project");
 	});
+
+	test("keeps the enabled alias when an equivalent higher-priority server is disabled", async () => {
+		// Higher-priority project server disabled via `enabled: false`; a differently
+		// named but connection-equivalent user server stays enabled and must survive.
+		await writeMcpJson(path.join(projectDir, ".omp"), { projcontext: { ...CONNECTION, enabled: false } });
+		const result = await loadAllMCPConfigs(projectDir, { enableProjectConfig: true, filterExa: false });
+		expect(Object.keys(result.configs)).toEqual(["usercontext"]);
+		expect(result.sources.usercontext?.level).toBe("user");
+	});
 });

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -15,7 +15,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { VIBE_TOOL_NAMES } from "@oh-my-pi/pi-coding-agent/tools/vibe";
-import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 
 const toolActivationExtension: ExtensionFactory = pi => {
@@ -360,6 +360,40 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			// tts is a discoverable custom tool → mounted as an xd:// device, not top-level.
 			expect(session.getXdevToolEntries().map(entry => entry.name)).toContain("tts");
 			expect(session.getActiveToolNames()).not.toContain("tts");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("keeps the first MCP tool-name collision during SDK startup and warns", async () => {
+		const tempDir = makeTempDir();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const createMcpTool = (serverName: string, label: string): CustomTool => ({
+			name: "mcp__foo_bar_lookup",
+			label,
+			description: `Lookup from ${serverName}`,
+			parameters: type({}),
+			mcpServerName: serverName,
+			mcpToolName: "lookup",
+			async execute() {
+				return { content: [{ type: "text", text: serverName }] };
+			},
+		});
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			customTools: [createMcpTool("foo.bar", "foo.bar/lookup"), createMcpTool("foo_bar", "foo_bar/lookup")],
+		});
+
+		try {
+			expect(session.getToolByName("mcp__foo_bar_lookup")?.label).toBe("foo.bar/lookup");
+			expect(warn).toHaveBeenCalledWith("MCP tool name collision; keeping first registration", {
+				name: "mcp__foo_bar_lookup",
+				keptServer: "foo.bar",
+				keptTool: "lookup",
+				ignoredServer: "foo_bar",
+				ignoredTool: "lookup",
+			});
 		} finally {
 			await session.dispose();
 		}


### PR DESCRIPTION
## Repro

A fixture with identical Context7 HTTP configs in `.omp/mcp.json` and a marketplace plugin `.mcp.json` reproduced the issue with `HOME=/tmp/issue-6786-home bun .tmp-issue-6786-repro.ts`: `loadCapability("mcps")` returned both `context7` and `context7:context7`, minting `mcp__context_query_docs` and `mcp__context_context_query_docs`. The committed regression is runnable with `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts --test-name-pattern 'deduplicates a plugin alias'`.

## Cause

`packages/coding-agent/src/capability/index.ts` deduplicated capabilities only through `Capability.key`, while `mcpCapability` keyed servers solely by `server.name`; `packages/coding-agent/src/discovery/claude-plugins.ts` deliberately namespaces plugin servers, so identical endpoints under a direct name and plugin alias both reached the MCP manager. Separately, `SessionTools.#applyMCPToolRefresh` inserted each minted name into its registry without checking whether a different MCP origin already owned that name.

## Fix

- Extended capability deduplication with optional semantic equivalence while preserving first/highest-priority key ownership.
- Defined MCP connection equivalence across normalized transport, command/args/env/cwd, URL/headers, and authentication inputs, so the higher-priority direct config keeps the canonical name.
- Kept the first tool registration when distinct MCP origins mint the same name and logged both the kept and ignored origins.
- Added discovery and session-registry regressions plus the coding-agent changelog entry.

## Verification

`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts` passed: 60 tests, 218 assertions. `bun run check:ts` passed across the workspace. Re-running the temporary end-to-end fixture returned only `context7` and `mcp__context_query_docs`. Skipped the full pre-publish gate: `bun run fix` fails identically on a clean `main` archive because this workstation lacks CMake/Opus and libclang required by `audiopus_sys` and `maudio-sys`; its TypeScript formatter/check path passed.

Fixes #6786