### PR TITLE
fix(tui): don't crash on teardown when the pty is already gone

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed omp dying with an uncaught `setRawMode failed with errno: 2` instead of exiting 129 when the terminal disconnects. A recycled terminal pane revokes the pty, so the raw-mode restore in `stop()` hit an fd that is no longer a tty; the throw escaped `#markTerminalDisconnected()` and preempted its own SIGHUP. Terminal teardown on the disconnect path is now best-effort, matching `emergencyTerminalRestore()`, so the exit added in [#5837](https://github.com/can1357/oh-my-pi/pull/5837) always runs.
+
 ## [17.1.4] - 2026-07-26
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1462,10 +1462,12 @@ export class ProcessTerminal implements Terminal {
 		// where Ctrl+D could close the parent shell over SSH.
 		process.stdin.pause();
 
-		// Restore raw mode state
-		if (process.stdin.setRawMode) {
-			process.stdin.setRawMode(this.#wasRaw);
-		}
+		// Restore raw mode state, best-effort: a revoked pty (pane recycled, ssh
+		// dropped) is no longer a tty and Bun's node:tty shim throws ENOENT. There
+		// is nothing left to restore, and throwing here would abort the caller.
+		try {
+			process.stdin.setRawMode?.(this.#wasRaw);
+		} catch {}
 		this.#stdoutErrorCleanup?.();
 		this.#stdoutErrorCleanup = undefined;
 	}
@@ -1482,7 +1484,14 @@ export class ProcessTerminal implements Terminal {
 		const disconnectHandler = this.#disconnectHandler;
 		this.#disconnectHandler = undefined;
 		if (!disconnectHandler) return;
-		disconnectHandler();
+		// The handler tears the TUI down against a terminal that is already gone,
+		// so any step in it can fail. Swallow that: the exit below is the whole
+		// point of this method and must not be preempted by teardown noise.
+		try {
+			disconnectHandler();
+		} catch (handlerErr) {
+			logger.error("Terminal disconnect handler failed; exiting anyway", { err: handlerErr });
+		}
 
 		if (process.platform === "win32") {
 			void postmortem.quit(129);

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1462,12 +1462,16 @@ export class ProcessTerminal implements Terminal {
 		// where Ctrl+D could close the parent shell over SSH.
 		process.stdin.pause();
 
-		// Restore raw mode state, best-effort: a revoked pty (pane recycled, ssh
-		// dropped) is no longer a tty and Bun's node:tty shim throws ENOENT. There
-		// is nothing left to restore, and throwing here would abort the caller.
+		// Restore raw mode state. On a disconnected terminal (pane recycled, ssh
+		// dropped) the fd is no longer a tty and Bun's node:tty shim throws; there
+		// is nothing left to restore, and throwing would abort the caller. On a
+		// live terminal the failure still surfaces - swallowing it would silently
+		// leave stdin in raw mode.
 		try {
 			process.stdin.setRawMode?.(this.#wasRaw);
-		} catch {}
+		} catch (err) {
+			if (!this.#dead) throw err;
+		}
 		this.#stdoutErrorCleanup?.();
 		this.#stdoutErrorCleanup = undefined;
 	}

--- a/packages/tui/test/terminal-disconnect-raw-mode-throw.test.ts
+++ b/packages/tui/test/terminal-disconnect-raw-mode-throw.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
+import { setTerminalHeadless } from "@oh-my-pi/pi-utils";
+
+// Regression: a recycled terminal pane (Muxy's "terminal offline" sweep, a
+// dropped ssh session) revokes the pty. stdin EOFs, the disconnect path runs,
+// and stop() restores raw mode on an fd that is no longer a tty, so Bun's
+// node:tty shim throws ENOENT. That throw escaped stop() and
+// #markTerminalDisconnected(), preempting its own process.kill(SIGHUP), and the
+// process died with an uncaught exception instead of exiting 129. Teardown
+// against a dead terminal is best-effort; the exit must still happen.
+
+/** The error Bun's node:tty shim raises for an ioctl on a revoked pty. */
+const REVOKED_PTY = "setRawMode failed with errno: 2";
+
+const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
+
+function restoreProperty(target: object, key: string, descriptor: PropertyDescriptor | undefined): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+		return;
+	}
+	delete (target as Record<string, unknown>)[key];
+}
+
+describe("ProcessTerminal disconnect with a revoked pty", () => {
+	let previousHeadless: boolean;
+	let signals: string[];
+
+	beforeEach(() => {
+		signals = [];
+		previousHeadless = setTerminalHeadless(false);
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		vi.spyOn(process, "kill").mockImplementation(((_pid: number, signal: string) => {
+			signals.push(signal);
+			return true;
+		}) as unknown as typeof process.kill);
+		vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
+		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
+		setTerminalHeadless(previousHeadless);
+	});
+
+	it("still signals SIGHUP when restoring raw mode throws on a revoked fd", () => {
+		// Raw mode goes on during start(); the pty is revoked after that, so the
+		// restore call inside stop() is the one that fails.
+		let started = false;
+		Object.defineProperty(process.stdin, "setRawMode", {
+			value: () => {
+				if (started) throw new Error(REVOKED_PTY);
+				started = true;
+				return process.stdin;
+			},
+			configurable: true,
+		});
+
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			() => {},
+			() => {},
+			() => terminal.stop(), // what the app wires as onDisconnect
+		);
+
+		expect(() => process.stdin.emit("end")).not.toThrow();
+		expect(signals).toContain("SIGHUP");
+	});
+
+	it("still signals SIGHUP when the disconnect handler itself throws", () => {
+		Object.defineProperty(process.stdin, "setRawMode", { value: () => process.stdin, configurable: true });
+
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			() => {},
+			() => {},
+			() => {
+				throw new Error("teardown blew up");
+			},
+		);
+
+		expect(() => process.stdin.emit("end")).not.toThrow();
+		expect(signals).toContain("SIGHUP");
+		terminal.stop();
+	});
+});

--- a/packages/tui/test/terminal-disconnect-raw-mode-throw.test.ts
+++ b/packages/tui/test/terminal-disconnect-raw-mode-throw.test.ts
@@ -76,6 +76,27 @@ describe("ProcessTerminal disconnect with a revoked pty", () => {
 		expect(signals).toContain("SIGHUP");
 	});
 
+	it("propagates a raw-mode restore failure while the terminal is still live", () => {
+		let started = false;
+		Object.defineProperty(process.stdin, "setRawMode", {
+			value: () => {
+				if (started) throw new Error(REVOKED_PTY);
+				started = true;
+				return process.stdin;
+			},
+			configurable: true,
+		});
+
+		const terminal = new ProcessTerminal();
+		terminal.start(
+			() => {},
+			() => {},
+			() => {},
+		);
+
+		expect(() => terminal.stop()).toThrow(REVOKED_PTY);
+	});
+
 	it("still signals SIGHUP when the disconnect handler itself throws", () => {
 		Object.defineProperty(process.stdin, "setRawMode", { value: () => process.stdin, configurable: true });
 


### PR DESCRIPTION
I'm using Muxy and keeping coding CLIs in tabs. CC, Codex, Opencode etc. work fine this way. But I've found OhMyPi killing itself multiple times when in idle tab - and started investigating.

Turns out Muxy has a "terminal offline" feature that reaps panes after 5 min invisible and revokes the pty (their bug, filing separately — omp exiting on terminal death is correct per #5837). But omp should exit 129, not die like this:

```
warn   terminal disconnected; stopping interactive rendering   reason: "stdin ended"
error  Uncaught exception  Error: setRawMode failed with errno: 2
```

`stop()` checks `process.stdin.setRawMode` exists, but on a revoked pty the fd isn't a tty anymore, the ioctl fails, Bun's `node:tty` shim throws — and the throw unwinds out of `#markTerminalDisconnected()` before its own SIGHUP. So the intended clean exit becomes a fatal uncaught exception.

Fix makes disconnect teardown best-effort, same as `emergencyTerminalRestore()` already is: raw-mode restore in try/catch, and the disconnect handler wrapped + logged so the exit runs no matter what fails in teardown.

Validation:

- `bun run check` + `bun run test` pass (1357/0). New regression test: 2 failures on main (`setRawMode failed with errno: 2`), green with patch.
- Live A/B: one Muxy sweep hit patched and stock omp in the same second — patched exited `sighup`/`signal`, stock 17.1.5 died `uncaught_exception`.

Re #6098: that was closed asking for "a concrete case where `setRawMode` throws independent of a misbehaving child" — this is that case, ENOENT from a revoked pty, no children involved.
