### PR TITLE
fix(coding-agent): clear advisor cost when a handoff opens the replacement session

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1379,6 +1379,7 @@ export class AgentSession {
 			resetTodoCycle: () => this.#todo.resetCycle(),
 			buildDisplaySessionContext: () => this.buildDisplaySessionContext(),
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
+			clearAdvisorCost: () => this.#advisors.clearCost(),
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
 		};
 		this.#handoff = new SessionHandoff(handoffHost);

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -65,6 +65,7 @@ export interface SessionHandoffHost {
 	resetTodoCycle(): void;
 	buildDisplaySessionContext(): SessionContext;
 	resetAdvisorRuntimes(): void;
+	clearAdvisorCost(): void;
 	syncTodoPhasesFromBranch(): void;
 }
 
@@ -232,6 +233,10 @@ export class SessionHandoff {
 					previousSessionFile ? { parentSession: previousSessionFile } : undefined,
 				);
 				this.#host.markBashSessionTransition(bashTransition);
+				// The handoff opens a fresh conversation, so the spend of the one it
+				// summarizes stays with it. Clearing here, at the commit point, keeps the
+				// status line honest even if a later step throws.
+				this.#host.clearAdvisorCost();
 				sessionTransitioned = true;
 			} finally {
 				this.#host.finishBashSessionTransition(bashTransition, sessionTransitioned);

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { Model } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
@@ -417,6 +418,61 @@ describe("AgentSession advisor toggle", () => {
 		await session.newSession();
 
 		expect(session.getAdvisorCost()).toBe(0);
+	});
+	it("keeps advisor cost across a fork of the same conversation", async () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.toggleAdvisorEnabled();
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent to exist");
+		sessionManager.appendMessage({ role: "user", content: "keep me", timestamp: 1 });
+		appendAdvisorCost(advisor, 0.5, 1);
+		const previousSessionFile = sessionManager.getSessionFile();
+
+		expect(await session.fork()).toBe(true);
+
+		// A fork copies the entries and artifacts and keeps the messages, so the
+		// conversation continues under a new file and its spend continues with it.
+		expect(sessionManager.getSessionFile()).not.toBe(previousSessionFile);
+		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
+	});
+	it("clears advisor cost when a handoff opens the replacement session", async () => {
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockResolvedValue("## Goal\nContinue from here");
+		try {
+			session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+			session.toggleAdvisorEnabled();
+			const advisor = session.getAdvisorAgent();
+			if (!advisor) throw new Error("Expected advisor agent to exist");
+			sessionManager.appendMessage({ role: "user", content: "work to hand off", timestamp: 1 });
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "done" }],
+				api: "anthropic-messages",
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 2,
+			});
+			session.agent.replaceMessages(sessionManager.buildSessionContext().messages);
+			appendAdvisorCost(advisor, 0.5, 1);
+			const previousSessionFile = session.sessionFile;
+
+			await session.handoff();
+
+			// The handoff hands the work over to a fresh conversation, so the spend of
+			// the one it summarizes must not follow it.
+			expect(session.sessionFile).not.toBe(previousSessionFile);
+			expect(session.getAdvisorCost()).toBe(0);
+		} finally {
+			vi.restoreAllMocks();
+		}
 	});
 	it("clears advisor cost when a branch skips conversation restore", async () => {
 		const extensionRunner = {


### PR DESCRIPTION
## What

The status-line change from this PR is already on `main` (`9d240ea0a`), so after a rebase this branch carries only the remaining follow-up: the session-handoff path.

`SessionHandoff.handoff()` commits a brand-new session through `sessionManager.newSession()`, but afterwards it only calls `resetAdvisorRuntimes()`, which re-primes the advisors without touching the cost ledger. The replacement session therefore kept reporting the Advisor spend of the conversation it had just handed off, unlike every other new-conversation path.

The ledger is now cleared at the handoff commit point, right after `markBashSessionTransition()`, through a `clearAdvisorCost()` capability on the handoff host. Clearing at the commit point rather than later also keeps the status line honest if a subsequent step throws while the new session is already active.

While fixing this I audited every caller that starts a session:

| Path | Ledger | Why |
| --- | --- | --- |
| `newSession()` | cleared | the conversation is replaced |
| `branch()` | cleared | the conversation is replaced |
| `branchFromBtw()` | cleared | the conversation is replaced |
| `handoff()` | cleared | hands the work to a fresh conversation |
| `fork()` | **kept** | copies entries and artifacts and preserves the messages, so the same conversation continues under a new file |
| `switchSession()` | cleared on commit | this path can still roll back to the original session |

`fork()` was the one case where clearing would have been wrong, so it now has a test pinning the behaviour as intentional.

## Testing

- `bun run check` passes.
- `bun test test/modes/components/status-line/component.test.ts test/advisor*.test.ts test/advisor/*.test.ts test/agent-session-handoff.test.ts test/agent-session-btw-branch.test.ts` passes: 283 tests, 0 failures, 1076 assertions.
- Added two regressions:
  - a handoff clears the retained Advisor cost in the replacement session; it fails without the fix by carrying the previous conversation's spend across;
  - a fork keeps it, because the conversation continues.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — the entry for this feature already landed with `9d240ea0a`
