### PR TITLE
fix(natives): surface cargo/napi failure output in build error

### DIFF
--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -416,6 +416,16 @@ if (!napiBin) {
 	throw new Error("Could not locate @napi-rs/cli `napi` binary in node_modules/.bin");
 }
 
+/** Last `maxLines` lines of a stream capture, so failure output stays readable
+ *  without dropping the cause (cargo/napi put the error at the end). */
+function tailLines(text: string, maxLines = 60): string {
+	const trimmed = text.trim();
+	if (!trimmed) return "";
+	const lines = trimmed.split("\n");
+	if (lines.length <= maxLines) return trimmed;
+	return `[… ${lines.length - maxLines} earlier lines omitted]\n${lines.slice(-maxLines).join("\n")}`;
+}
+
 // The package declares Bun as its build runtime. Invoke napi's JavaScript entry
 // through this Bun process instead of its `#!/usr/bin/env node` shim so an old
 // host Node installation cannot make an otherwise supported Bun build fail.
@@ -445,7 +455,16 @@ async function runNapiBuildWithSccacheFallback() {
 try {
 	const { buildResult, stderr } = await runNapiBuildWithSccacheFallback();
 	if (buildResult.exitCode !== 0) {
-		throw new Error(`napi build failed${stderr ? `:\n${stderr}` : ""}`);
+		// napi/cargo report most failures on stdout; stderr alone is often empty,
+		// which used to reduce this error to a bare "napi build failed".
+		const stdout = buildResult.stdout?.toString("utf-8") ?? "";
+		const detail = [
+			stderr.trim() && `--- stderr ---\n${tailLines(stderr)}`,
+			stdout.trim() && `--- stdout ---\n${tailLines(stdout)}`,
+		]
+			.filter(Boolean)
+			.join("\n");
+		throw new Error(`napi build failed (exit code ${buildResult.exitCode})${detail ? `:\n${detail}` : ""}`);
 	}
 
 	const builtAddonPath = await resolveBuiltAddonPath(buildOutputDir, canonicalAddonFilename);


### PR DESCRIPTION
Fixes #6796.

A failed napi build often reported only `napi build failed` with no cause: the error path attached captured stderr, but napi-rs and cargo route most failure detail (including `cargo metadata` errors) to stdout, which was discarded.

The thrown error now carries the exit code plus tail-capped (last 60 lines) `--- stderr ---` / `--- stdout ---` sections, so the cause survives without dumping megabytes of compile progress.

Verified both ways on macOS arm64:
- forced failure `RUSTFLAGS="--definitely-not-a-flag" bun --cwd=packages/natives run build` now surfaces `Internal Error: cargo metadata exited with code 101 … --definitely-not-a-flag …`
- clean build still ends with `Build complete.`
