### PR TITLE
fix(natives): surface exit code and stdout in napi build error

### DIFF
--- a/packages/natives/scripts/build-bindings.ts
+++ b/packages/natives/scripts/build-bindings.ts
@@ -171,14 +171,30 @@ const napiArgs = [
 	"local",
 ];
 
+// napi-rs / cargo route much failure detail to stdout (e.g. `cargo metadata`
+// errors), so a stderr-only error collapses real failures to a bare message.
+const BUILD_LOG_TAIL_LINES = 40;
+
+/** Tail-cap captured build output into a labeled section for the failure report. */
+function tailSection(label: string, text: string): string {
+	const trimmed = text.trimEnd();
+	if (!trimmed) return "";
+	const lines = trimmed.split("\n");
+	const capped = lines.length > BUILD_LOG_TAIL_LINES;
+	const shown = capped ? lines.slice(-BUILD_LOG_TAIL_LINES) : lines;
+	return `\n--- ${label}${capped ? ` (last ${BUILD_LOG_TAIL_LINES} lines)` : ""} ---\n${shown.join("\n")}`;
+}
+
 try {
 	// The package declares Bun as its build runtime. Invoke napi's JavaScript
 	// entry through this Bun process instead of its `#!/usr/bin/env node` shim so
 	// an old host Node installation cannot make an otherwise supported Bun build fail.
 	const buildResult = await $`${process.execPath} ${napiBin} ${napiArgs}`.nothrow();
 	if (buildResult.exitCode !== 0) {
+		const stdout = buildResult.stdout?.toString("utf-8") ?? "";
 		const stderr = buildResult.stderr?.toString("utf-8") ?? "";
-		throw new Error(`napi build failed${stderr ? `:\n${stderr}` : ""}`);
+		const detail = `${tailSection("stdout", stdout)}${tailSection("stderr", stderr)}`;
+		throw new Error(`napi build failed (exit ${buildResult.exitCode})${detail}`);
 	}
 
 	const builtAddonPath = await resolveBuiltAddonPath(buildOutputDir, canonicalAddonFilename);


### PR DESCRIPTION
## Repro
Running the dev bindings build against a broken toolchain surfaces nothing but a bare error. `RUSTFLAGS="--definitely-not-a-flag" bun --cwd=packages/natives run build:bindings` fails because napi-rs's `cargo metadata` step errors out; napi prints the real cause (`Internal Error: cargo metadata exited with code 101 ... error: Unrecognized option: 'definitely-not-a-flag'`) to **stdout**, yet the propagated `Error` collapses to `napi build failed` with no detail.

## Cause
In `packages/natives/scripts/build-bindings.ts`, the non-zero-exit path built the thrown error from captured **stderr only**:
```ts
const stderr = buildResult.stderr?.toString("utf-8") ?? "";
throw new Error(`napi build failed${stderr ? `:\n${stderr}` : ""}`);
```
napi-rs/cargo route much of the failure detail to stdout, so when stderr is empty the error object carries nothing actionable — the cause survives only if it happens to be echoed to a live terminal, and is lost in CI/captured contexts.

## Fix
- Add a `tailSection` helper that tail-caps captured output to its last 40 lines (matching the `STDERR_TAIL_LINES` convention in `scripts/bazel-natives.ts`) into a labeled section, returning empty for empty streams.
- Rebuild the thrown error as `napi build failed (exit <code>)` followed by `--- stdout ---` and `--- stderr ---` sections, so the real cause is attached to the `Error` regardless of which stream napi used.

## Verification
`cd packages/natives && RUSTFLAGS="--definitely-not-a-flag" bun run build:bindings 1>/dev/null` now prints:
```
error: napi build failed (exit 1)
--- stdout ---
Internal Error: cargo metadata exited with code 101 and error message:
... error: Unrecognized option: 'definitely-not-a-flag'
```
The actionable detail is now part of the thrown error. `bunx biome check scripts/build-bindings.ts` passes.

Fixes #6796