### PR TITLE
fix(lsp): honor custom server language ids

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed custom LSP servers sending `languageId: "plaintext"` for extensions outside the built-in language map by honoring an optional per-server `languageId` in `lsp.json` for disk and in-memory document opens ([#6800](https://github.com/can1357/oh-my-pi/issues/6800)).
+
 - Fixed Python cell errors (`$` commands and the eval tool) leaking runner-internal traceback frames. Cell syntax errors now render as the bare caret display with a `<cell>` filename instead of a `_handle_request_async`/`ast.parse` stack dump, and runtime tracebacks start at user code, matching the Ruby runner's user-frame filtering.
 
 ## [17.1.5] - 2026-07-27

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -918,7 +918,7 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
 			if (isEnoent(err)) return;
 			throw err;
 		}
-		const languageId = detectLanguageId(filePath);
+		const languageId = client.config.languageId ?? detectLanguageId(filePath);
 		throwIfAborted(signal);
 
 		await sendNotification(
@@ -992,7 +992,7 @@ export async function syncContent(
 
 		if (!info) {
 			// Open file with provided content instead of reading from disk
-			const languageId = detectLanguageId(filePath);
+			const languageId = client.config.languageId ?? detectLanguageId(filePath);
 			throwIfAborted(signal);
 			await sendNotification(
 				client,

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -74,6 +74,8 @@ function normalizeServerConfig(name: string, config: RawServerConfig): ServerCon
 	const fileTypes =
 		normalizeStringArray(config.fileTypes) ?? normalizeExtensionToFileTypes(config.extensionToLanguage);
 	const rootMarkers = normalizeStringArray(config.rootMarkers) ?? (config.extensionToLanguage ? ["."] : null);
+	const languageId =
+		typeof config.languageId === "string" && config.languageId.length > 0 ? config.languageId : undefined;
 
 	if (!command || !fileTypes || !rootMarkers) {
 		logger.warn("Ignoring invalid LSP server config (missing required fields).", { name });
@@ -95,6 +97,7 @@ function normalizeServerConfig(name: string, config: RawServerConfig): ServerCon
 		args,
 		fileTypes,
 		rootMarkers,
+		languageId,
 		...(initOptions ? { initOptions } : {}),
 	};
 }
@@ -423,6 +426,7 @@ function getConfigSources(cwd: string): ConfigSource[] {
  *       "command": "/path/to/server",
  *       "args": ["--stdio"],
  *       "fileTypes": [".xyz"],
+ *       "languageId": "xyz",
  *       "rootMarkers": [".xyz-project"]
  *     }
  *   }

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -340,6 +340,8 @@ export interface ServerConfig {
 	command: string;
 	args?: string[];
 	fileTypes: string[];
+	/** LSP language identifier sent in didOpen; inferred from the file path when omitted. */
+	languageId?: string;
 	rootMarkers: string[];
 	initOptions?: Record<string, unknown>;
 	settings?: Record<string, unknown>;

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -278,6 +278,56 @@ describe("lsp regressions", () => {
 		});
 	});
 
+	it("uses a custom server languageId for disk and in-memory document opens", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-language-id-");
+		const filePath = path.join(tempDir.path(), "foo.gd");
+		const syncedFilePath = path.join(tempDir.path(), "unsaved.gd");
+		try {
+			await Bun.write(
+				path.join(tempDir.path(), ".omp", "lsp.json"),
+				JSON.stringify({
+					servers: {
+						"fake-gd": {
+							command: process.execPath,
+							fileTypes: [".gd"],
+							languageId: "gdscript",
+							rootMarkers: [".omp"],
+						},
+					},
+				}),
+			);
+			await Bun.write(filePath, "extends Node\n");
+
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			const config = loadConfig(tempDir.path());
+			const serverConfig = getServersForFile(config, filePath)[0]?.[1];
+			expect(serverConfig).toBeDefined();
+			if (!serverConfig) throw new Error("Custom GDScript server was not loaded");
+
+			const client = await lspClient.getOrCreateClient(serverConfig, tempDir.path(), 1_000);
+			await lspClient.ensureFileOpen(client, filePath);
+			const diskOpen = await server.waitFor(message => message.method === "textDocument/didOpen");
+			expect(diskOpen.params).toMatchObject({ textDocument: { languageId: "gdscript" } });
+
+			await lspClient.syncContent(client, syncedFilePath, "extends Resource\n");
+			const syncedOpen = await server.waitFor(
+				message => message.method === "textDocument/didOpen" && message !== diskOpen,
+			);
+			expect(syncedOpen.params).toMatchObject({ textDocument: { languageId: "gdscript" } });
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("sends the LSP exit notification after shutdown completes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-shutdown-");
 		try {


### PR DESCRIPTION
## Repro
A custom server loaded from `.omp/lsp.json` with `fileTypes: [".gd"]` is selected for `foo.gd`, but `ensureFileOpen` sends `languageId: "plaintext"`; the regression is exercised with `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts --test-name-pattern "custom server languageId"` (the new assertion fails against the old client implementation).

## Cause
`packages/coding-agent/src/lsp/client.ts` called `detectLanguageId(filePath)` directly in both `ensureFileOpen` and the unopened-file branch of `syncContent`, while `ServerConfig` and `normalizeServerConfig` in `packages/coding-agent/src/lsp/` exposed no per-server override for extensions outside the built-in map.

## Fix
- Add an optional `languageId` to custom server configuration and normalize it from `lsp.json`.
- Prefer the configured identifier in both disk-backed and in-memory `textDocument/didOpen` notifications while retaining built-in detection as the default.
- Cover config loading and both document-open paths with a fake GDScript server.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` passed: 72 tests, 0 failures. A process-backed smoke run loaded a `.gd` custom server with `languageId: "gdscript"` and observed that exact identifier in `didOpen`. The publish gate also completed `bun run fix` and `bun check` before push.

Fixes #6800