### PR TITLE
fix(tools): refuse write targets shaped as a read-selector list

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed Python cell errors (`$` commands and the eval tool) leaking runner-internal traceback frames. Cell syntax errors now render as the bare caret display with a `<cell>` filename instead of a `_handle_request_async`/`ast.parse` stack dump, and runtime tracebacks start at user code, matching the Ruby runner's user-frame filtering.
 - Dropped unavailable forced tool choices through the queue rejection lifecycle and discarded their remaining sequence yields so a skipped force cannot disable tools on the next request ([#6543](https://github.com/can1357/oh-my-pi/pull/6543) by [@paralin](https://github.com/paralin)).
+- Fixed the `write` tool treating a semicolon-joined list of read selectors (e.g. `a.txt:1-2;b/c.txt:3-4`) as a filesystem path, silently creating a nested directory tree when a read-only step mis-dispatched a multi-file `read` as `write`. Such targets are now refused regardless of `content`, since no real write targets a `;`-list whose every segment carries a read selector ([#6809](https://github.com/can1357/oh-my-pi/issues/6809)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -153,7 +153,38 @@ function throwReadSelectorMisfire(target: string, sel: string): never {
 	);
 }
 
+/**
+ * Recognize a semicolon-joined list of read-tool selectors mis-dispatched as a
+ * single write target — the multi-file read expression the scout emitted in
+ * issue #6809 (`a.txt:1-2;b/c.txt:3-4`). Every `;`-segment must be non-empty and
+ * carry its own read selector ({@link splitPathAndSel} peels a `:N-M`, `:raw`,
+ * or `:conflicts` tail). No real call targets such a list: `read` accepts one
+ * path, `write` writes one file. Unlike {@link readSelectorForEmptyWrite} this
+ * fires regardless of `content` — the non-empty-content escape hatch exists for
+ * a lone selector-shaped *filename*, never a `;`-list, and honoring it here
+ * silently creates a nested directory tree (`a.txt:1-2;b/`) in the workspace.
+ */
+function readSelectorListMisfire(target: string): number | undefined {
+	if (!target.includes(";")) return undefined;
+	const segments = target.split(";");
+	if (segments.length < 2) return undefined;
+	for (const segment of segments) {
+		const trimmed = segment.trim();
+		if (trimmed.length === 0 || splitPathAndSel(trimmed).sel === undefined) return undefined;
+	}
+	return segments.length;
+}
+
+function throwReadSelectorListMisfire(target: string, count: number): never {
+	throw new ToolError(
+		`write target '${target}' is a semicolon-joined list of ${count} read-tool selectors, not a filesystem path — refusing to create it. ` +
+			`write creates a single file; issue one read() per path to read these ranges (e.g. read({ path: "<one path>:<range>" })).`,
+	);
+}
+
 async function assertNotReadSelectorMisfire(target: string, content: string, cwd: string): Promise<void> {
+	const listCount = readSelectorListMisfire(target);
+	if (listCount !== undefined) throwReadSelectorListMisfire(target, listCount);
 	const sel = readSelectorForEmptyWrite(target, content);
 	if (sel === undefined) return;
 	if ((await probeLiteralPathExists(target, cwd)) !== "missing") return;

--- a/packages/coding-agent/test/write-read-selector-misfire.test.ts
+++ b/packages/coding-agent/test/write-read-selector-misfire.test.ts
@@ -103,4 +103,27 @@ describe("write refuses read-selector misfires", () => {
 		expect(entries.get(member)).toEqual(new Uint8Array());
 		await fs.rm(dir, { recursive: true, force: true });
 	});
+
+	it("rejects a semicolon-joined selector list with non-empty content and creates nothing", async () => {
+		const dir = await makeWorkspace();
+		const write = new WriteTool(session(dir));
+		const target = "a.txt:1-2;b/c.txt:3-4";
+		await expect(write.execute("c", { path: target, content: "{}" })).rejects.toThrow(
+			/semicolon-joined list of 2 read-tool selectors/,
+		);
+		expect(await Bun.file(path.join(dir, target)).exists()).toBe(false);
+		expect(await Bun.file(path.join(dir, "a.txt:1-2;b/c.txt:3-4")).exists()).toBe(false);
+		expect(await fs.readdir(dir)).toEqual(["src"]);
+		await fs.rm(dir, { recursive: true, force: true });
+	});
+
+	it("still writes a real path that merely contains a semicolon (no per-segment selectors)", async () => {
+		const dir = await makeWorkspace();
+		const write = new WriteTool(session(dir));
+		const target = "notes;draft.txt";
+		const res = await write.execute("c", { path: target, content: "hi" });
+		expect(res.isError).toBeUndefined();
+		expect(await Bun.file(path.join(dir, target)).text()).toBe("hi");
+		await fs.rm(dir, { recursive: true, force: true });
+	});
 });


### PR DESCRIPTION
## Repro
A read-only step that mis-dispatches a multi-file `read` as `write` passes the full expression as the target. Driving `WriteTool.execute` in an isolated tmp workspace with `write({ path: "a.txt:1-2;b/c.txt:3-4", content: "{}" })` reports success and silently creates the nested tree `a.txt:1-2;b/c.txt:3-4` (leaf 2 bytes), dirtying the checkout.

## Cause
The read-selector-misfire guard `assertNotReadSelectorMisfire` in `packages/coding-agent/src/tools/write.ts` (added for #6123/#6387) short-circuits via `readSelectorForEmptyWrite` whenever `content` is non-empty, so a semicolon-joined list of read selectors is never inspected and falls through to ordinary filesystem creation. Because the target embeds `/`, `Bun.write` builds the nested directory tree. `read` accepts no such `;`-list, so the shape is unambiguously a mis-dispatched multi-file read.

## Fix
- Add `readSelectorListMisfire`: recognizes a target that splits on `;` into 2+ non-empty segments, each carrying its own read selector (`splitPathAndSel().sel`).
- Wire it into `assertNotReadSelectorMisfire` to throw before the content check, so `;`-lists are refused regardless of `content` — the non-empty-content escape hatch remains for a lone selector-shaped filename, never a `;`-list.
- Add `throwReadSelectorListMisfire` with a message pointing at one `read()` per path.
- Regression tests in `write-read-selector-misfire.test.ts`: `;`-list with content is refused and creates nothing; a real path merely containing a `;` (no per-segment selectors) still writes.
- Changelog entry under `[Unreleased] > Fixed`.

## Verification
`bun test test/write-read-selector-misfire.test.ts` → 8 pass, 0 fail. Manual: the original repro call now throws `write target '...' is a semicolon-joined list of 2 read-tool selectors ...` and creates no files (workspace dir left with only `src`). Fixes #6809