### PR TITLE
fix(cli): stop forwarding project dotenv to shells

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed agent shell commands inheriting variables silently loaded from the launch directory's `.env`; OMP can still use project dotenv values for its own configuration, while commands receive only the parent environment and explicit tool overrides ([#6813](https://github.com/can1357/oh-my-pi/issues/6813)).
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -61,9 +61,10 @@ describe("buildNonInteractiveEnv", () => {
 	});
 });
 
-it("keeps launch .env.local values out of child shell config", async () => {
-	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-env-local-"));
+it("keeps launch dotenv values out of child shell config", async () => {
+	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-env-"));
 	try {
+		await Bun.write(path.join(tmp, ".env"), "TEST_ENV_FROM_DOTENV=loaded-by-omp\n");
 		await Bun.write(
 			path.join(tmp, ".env.local"),
 			"CONVEX_DEPLOYMENT=anonymous:root-local\nCONVEX_URL=http://127.0.0.1:3210\n",
@@ -73,6 +74,7 @@ it("keeps launch .env.local values out of child shell config", async () => {
 			`import { getShellConfig } from ${JSON.stringify(procmgrPath)};`,
 			"const env = getShellConfig().env;",
 			"console.log(JSON.stringify({",
+			"	project: env.TEST_ENV_FROM_DOTENV ?? null,",
 			"	deployment: env.CONVEX_DEPLOYMENT ?? null,",
 			"	url: env.CONVEX_URL ?? null,",
 			"	inherited: env.OMP_TEST_INHERITED_MARKER ?? null,",
@@ -98,11 +100,13 @@ it("keeps launch .env.local values out of child shell config", async () => {
 		expect(stderr).toBe("");
 		expect(exitCode).toBe(0);
 		const payload: {
+			project: string | null;
 			deployment: string | null;
 			url: string | null;
 			inherited: string | null;
 		} = JSON.parse(stdout);
 		expect(payload).toEqual({
+			project: null,
 			deployment: null,
 			url: null,
 			inherited: "keep-me",

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -66,7 +66,14 @@ it("filters expanded dotenv values while preserving matching launcher values", a
 	try {
 		await Bun.write(
 			path.join(tmp, ".env"),
-			"BASE=loaded-by-omp\nTEST_ENV_FROM_DOTENV=$BASE-suffix\nNODE_ENV=development\n",
+			[
+				"BASE=loaded-by-omp",
+				"TEST_ENV_FROM_DOTENV=$BASE-suffix",
+				"NODE_ENV=development",
+				"export EXPORTED_SECRET=exported",
+				"COMMENTED_SECRET=secret # trailing comment",
+				"",
+			].join("\n"),
 		);
 		await Bun.write(
 			path.join(tmp, ".env.local"),
@@ -82,6 +89,8 @@ it("filters expanded dotenv values while preserving matching launcher values", a
 			"	url: env.CONVEX_URL ?? null,",
 			"	inherited: env.OMP_TEST_INHERITED_MARKER ?? null,",
 			"	matching: env.NODE_ENV ?? null,",
+			"	exported: env.EXPORTED_SECRET ?? null,",
+			"	commented: env.COMMENTED_SECRET ?? null,",
 			"}));",
 		].join("\n");
 		const bunArgSets = process.platform === "linux" ? [[], ["--no-env-file"]] : [["--no-env-file"]];
@@ -112,6 +121,8 @@ it("filters expanded dotenv values while preserving matching launcher values", a
 				url: string | null;
 				inherited: string | null;
 				matching: string | null;
+				exported: string | null;
+				commented: string | null;
 			} = JSON.parse(stdout);
 			expect(payload).toEqual({
 				project: null,
@@ -119,6 +130,8 @@ it("filters expanded dotenv values while preserving matching launcher values", a
 				url: null,
 				inherited: "keep-me",
 				matching: "development",
+				exported: null,
+				commented: null,
 			});
 		}
 	} finally {

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -61,10 +61,13 @@ describe("buildNonInteractiveEnv", () => {
 	});
 });
 
-it("keeps expanded launch dotenv values out of child shell config", async () => {
+it("filters expanded dotenv values while preserving matching launcher values", async () => {
 	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-env-"));
 	try {
-		await Bun.write(path.join(tmp, ".env"), "BASE=loaded-by-omp\nTEST_ENV_FROM_DOTENV=$BASE-suffix\n");
+		await Bun.write(
+			path.join(tmp, ".env"),
+			"BASE=loaded-by-omp\nTEST_ENV_FROM_DOTENV=$BASE-suffix\nNODE_ENV=development\n",
+		);
 		await Bun.write(
 			path.join(tmp, ".env.local"),
 			"CONVEX_DEPLOYMENT=anonymous:root-local\nCONVEX_URL=http://127.0.0.1:3210\n",
@@ -78,14 +81,17 @@ it("keeps expanded launch dotenv values out of child shell config", async () => 
 			"	deployment: env.CONVEX_DEPLOYMENT ?? null,",
 			"	url: env.CONVEX_URL ?? null,",
 			"	inherited: env.OMP_TEST_INHERITED_MARKER ?? null,",
+			"	matching: env.NODE_ENV ?? null,",
 			"}));",
 		].join("\n");
-		for (const bunArgs of [[], ["--no-env-file"]]) {
+		const bunArgSets = process.platform === "linux" ? [[], ["--no-env-file"]] : [["--no-env-file"]];
+		for (const bunArgs of bunArgSets) {
 			const proc = Bun.spawn([process.execPath, ...bunArgs, "--no-install", "--eval", script], {
 				cwd: tmp,
 				env: {
 					HOME: process.env.HOME ?? "",
 					OMP_TEST_INHERITED_MARKER: "keep-me",
+					NODE_ENV: "development",
 					PATH: process.env.PATH ?? "",
 					SHELL: process.env.SHELL ?? "/bin/bash",
 				},
@@ -105,12 +111,14 @@ it("keeps expanded launch dotenv values out of child shell config", async () => 
 				deployment: string | null;
 				url: string | null;
 				inherited: string | null;
+				matching: string | null;
 			} = JSON.parse(stdout);
 			expect(payload).toEqual({
 				project: null,
 				deployment: null,
 				url: null,
 				inherited: "keep-me",
+				matching: "development",
 			});
 		}
 	} finally {

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -61,10 +61,10 @@ describe("buildNonInteractiveEnv", () => {
 	});
 });
 
-it("keeps launch dotenv values out of child shell config", async () => {
+it("keeps expanded launch dotenv values out of child shell config", async () => {
 	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-env-"));
 	try {
-		await Bun.write(path.join(tmp, ".env"), "TEST_ENV_FROM_DOTENV=loaded-by-omp\n");
+		await Bun.write(path.join(tmp, ".env"), "BASE=loaded-by-omp\nTEST_ENV_FROM_DOTENV=$BASE-suffix\n");
 		await Bun.write(
 			path.join(tmp, ".env.local"),
 			"CONVEX_DEPLOYMENT=anonymous:root-local\nCONVEX_URL=http://127.0.0.1:3210\n",
@@ -80,37 +80,39 @@ it("keeps launch dotenv values out of child shell config", async () => {
 			"	inherited: env.OMP_TEST_INHERITED_MARKER ?? null,",
 			"}));",
 		].join("\n");
-		const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
-			cwd: tmp,
-			env: {
-				HOME: process.env.HOME ?? "",
-				OMP_TEST_INHERITED_MARKER: "keep-me",
-				PATH: process.env.PATH ?? "",
-				SHELL: process.env.SHELL ?? "/bin/bash",
-			},
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		const [stdout, stderr, exitCode] = await Promise.all([
-			new Response(proc.stdout).text(),
-			new Response(proc.stderr).text(),
-			proc.exited,
-		]);
+		for (const bunArgs of [[], ["--no-env-file"]]) {
+			const proc = Bun.spawn([process.execPath, ...bunArgs, "--no-install", "--eval", script], {
+				cwd: tmp,
+				env: {
+					HOME: process.env.HOME ?? "",
+					OMP_TEST_INHERITED_MARKER: "keep-me",
+					PATH: process.env.PATH ?? "",
+					SHELL: process.env.SHELL ?? "/bin/bash",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
 
-		expect(stderr).toBe("");
-		expect(exitCode).toBe(0);
-		const payload: {
-			project: string | null;
-			deployment: string | null;
-			url: string | null;
-			inherited: string | null;
-		} = JSON.parse(stdout);
-		expect(payload).toEqual({
-			project: null,
-			deployment: null,
-			url: null,
-			inherited: "keep-me",
-		});
+			expect(stderr).toBe("");
+			expect(exitCode).toBe(0);
+			const payload: {
+				project: string | null;
+				deployment: string | null;
+				url: string | null;
+				inherited: string | null;
+			} = JSON.parse(stdout);
+			expect(payload).toEqual({
+				project: null,
+				deployment: null,
+				url: null,
+				inherited: "keep-me",
+			});
+		}
 	} finally {
 		await fs.rm(tmp, { recursive: true, force: true });
 	}

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed child shell environment filtering to drop launch-directory `.env` values in addition to Bun-autoloaded `.env.local` values ([#6813](https://github.com/can1357/oh-my-pi/issues/6813)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Fixed

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -52,6 +52,28 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 	}
 	return result;
 }
+// Bun can mutate `process.env` from project dotenv files before user code runs.
+// Linux retains the original exec environment in procfs; compiled and explicit
+// `--no-env-file` launches can safely snapshot `Bun.env` before OMP loads files.
+function readLaunchEnvNames(): ReadonlySet<string> | undefined {
+	if (process.platform === "linux") {
+		try {
+			const names = new Set<string>();
+			for (const entry of fs.readFileSync("/proc/self/environ", "utf8").split("\0")) {
+				const separator = entry.indexOf("=");
+				if (separator > 0) names.add(entry.slice(0, separator));
+			}
+			return names;
+		} catch {}
+	}
+	if (!process.execArgv.includes("--no-env-file") && !isCompiledBinary()) return undefined;
+	const names = new Set<string>();
+	for (const key in Bun.env) names.add(key);
+	return names;
+}
+
+const launchEnvNames = readLaunchEnvNames();
+const projectEnvNamesLoadedByOmp = new Set<string>();
 
 function expandDotenvValues(values: Record<string, string>, env: Record<string, string>): Record<string, string> {
 	const expanded: Record<string, string> = {};
@@ -83,7 +105,14 @@ export function filterChildShellEnv(
 		...expandDotenvValues(localEnv, result),
 	};
 	for (const key in launchEnv) {
-		if (result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key]) delete result[key];
+		if (projectEnvNamesLoadedByOmp.has(key)) {
+			delete result[key];
+		} else if (
+			!launchEnvNames?.has(key) &&
+			(result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key])
+		) {
+			delete result[key];
+		}
 	}
 	return result;
 }
@@ -150,6 +179,7 @@ for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
 	for (const key in file) {
 		if (!isMacosMallocStackLoggingEnvName(key) && !Bun.env[key]) {
 			Bun.env[key] = file[key];
+			if (file === projectEnv) projectEnvNamesLoadedByOmp.add(key);
 		}
 	}
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -105,12 +105,16 @@ export function filterChildShellEnv(
 		...expandDotenvValues(localEnv, result),
 	};
 	for (const key in launchEnv) {
-		if (projectEnvNamesLoadedByOmp.has(key)) {
+		// Launcher-owned names always survive with the launcher's own value.
+		if (launchEnvNames?.has(key)) continue;
+		if (launchEnvNames || projectEnvNamesLoadedByOmp.has(key)) {
+			// Strong provenance: the launch environment is known and this name is
+			// absent from it, or OMP itself injected the value — either way it came
+			// from a project dotenv file, not the parent shell.
 			delete result[key];
-		} else if (
-			!launchEnvNames?.has(key) &&
-			(result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key])
-		) {
+		} else if (result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key]) {
+			// No launch-env snapshot (non-Linux source install without
+			// `--no-env-file`): best-effort value match against the Bun-parsed dotenv.
 			delete result[key];
 		}
 	}
@@ -118,35 +122,43 @@ export function filterChildShellEnv(
 }
 
 /**
- * Parses a .env file synchronously and extracts key-value string pairs.
- * Ignores lines that are empty or start with '#'. Trims whitespace.
- * Allows values to be quoted with single or double quotes.
- * Returns an object of key-value pairs.
+ * Parse one dotenv line with Bun-compatible semantics: an optional `export`
+ * prefix, full-line `#` comments, inline `#` comments after whitespace on
+ * unquoted values, and single/double/backtick quoting (a `#` inside quotes
+ * stays literal). Returns undefined for blank lines, comments, and malformed
+ * names.
+ */
+function parseEnvLine(line: string): { key: string; value: string } | undefined {
+	const trimmed = line.trim();
+	if (!trimmed || trimmed.startsWith("#")) return undefined;
+	const eqIndex = trimmed.indexOf("=");
+	if (eqIndex === -1) return undefined;
+	let key = trimmed.slice(0, eqIndex).trim();
+	const exported = key.match(/^export[ \t]+(.*)$/);
+	if (exported) key = exported[1].trim();
+	if (!isValidEnvName(key)) return undefined;
+	const raw = trimmed.slice(eqIndex + 1).replace(/^[ \t]+/, "");
+	const quote = raw[0];
+	if (quote === '"' || quote === "'" || quote === "`") {
+		const close = raw.indexOf(quote, 1);
+		return { key, value: close === -1 ? raw.slice(1) : raw.slice(1, close) };
+	}
+	const commentIndex = raw.search(/[ \t]#/);
+	return { key, value: (commentIndex === -1 ? raw : raw.slice(0, commentIndex)).trimEnd() };
+}
+
+/**
+ * Parses a .env file synchronously into key-value string pairs using
+ * {@link parseEnvLine} for Bun-compatible line semantics, then mirrors valid
+ * `OMP_` variables to their `PI_` aliases.
  */
 export function parseEnvFile(filePath: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	try {
 		const content = fs.readFileSync(filePath, "utf-8");
 		for (const line of content.split("\n")) {
-			const trimmed = line.trim();
-			// Skip comments and blank lines
-			if (!trimmed || trimmed.startsWith("#")) continue;
-
-			const eqIndex = trimmed.indexOf("=");
-			if (eqIndex === -1) continue;
-
-			const key = trimmed.slice(0, eqIndex).trim();
-			if (!isValidEnvName(key)) continue;
-
-			let value = trimmed.slice(eqIndex + 1).trim();
-
-			// Remove surrounding quotes (" or ')
-			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-				value = value.slice(1, -1);
-			}
-			if (!isSafeEnvValue(value)) continue;
-
-			result[key] = value;
+			const parsed = parseEnvLine(line);
+			if (parsed && isSafeEnvValue(parsed.value)) result[parsed.key] = parsed.value;
 		}
 	} catch {
 		// File doesn't exist or can't be read - return empty result

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -53,18 +53,37 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 	return result;
 }
 
+function expandDotenvValues(values: Record<string, string>, env: Record<string, string>): Record<string, string> {
+	const expanded: Record<string, string> = {};
+	for (const key in values) {
+		expanded[key] = values[key].replace(
+			/(\\)?\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+			(match, escaped: string | undefined, braced: string | undefined, bare: string | undefined) => {
+				if (escaped) return match.slice(1);
+				const name = braced ?? bare;
+				if (!name) return match;
+				return env[name] ?? expanded[name] ?? "";
+			},
+		);
+	}
+	return expanded;
+}
+
 /** Filters process env for child shells without launch-cwd dotenv values. */
 export function filterChildShellEnv(
 	env: Record<string, string | undefined>,
 	cwd: string = process.cwd(),
 ): Record<string, string> {
 	const result = filterProcessEnv(env);
-	const launchEnv = {
-		...parseEnvFile(path.join(cwd, ".env")),
-		...parseEnvFile(path.join(cwd, ".env.local")),
+	const projectEnv = parseEnvFile(path.join(cwd, ".env"));
+	const localEnv = parseEnvFile(path.join(cwd, ".env.local"));
+	const launchEnv = { ...projectEnv, ...localEnv };
+	const expandedLaunchEnv = {
+		...expandDotenvValues(projectEnv, result),
+		...expandDotenvValues(localEnv, result),
 	};
 	for (const key in launchEnv) {
-		if (result[key] === launchEnv[key]) delete result[key];
+		if (result[key] === launchEnv[key] || result[key] === expandedLaunchEnv[key]) delete result[key];
 	}
 	return result;
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -53,15 +53,18 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 	return result;
 }
 
-/** Filters process env for child shells without launch-cwd `.env.local` values. */
+/** Filters process env for child shells without launch-cwd dotenv values. */
 export function filterChildShellEnv(
 	env: Record<string, string | undefined>,
 	cwd: string = process.cwd(),
 ): Record<string, string> {
 	const result = filterProcessEnv(env);
-	const launchLocalEnv = parseEnvFile(path.join(cwd, ".env.local"));
-	for (const key in launchLocalEnv) {
-		if (result[key] === launchLocalEnv[key]) delete result[key];
+	const launchEnv = {
+		...parseEnvFile(path.join(cwd, ".env")),
+		...parseEnvFile(path.join(cwd, ".env.local")),
+	};
+	for (const key in launchEnv) {
+		if (result[key] === launchEnv[key]) delete result[key];
 	}
 	return result;
 }

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -49,6 +49,24 @@ describe("parseEnvFile", () => {
 			PI_FEATURE: "enabled",
 		});
 	});
+
+	it("matches Bun dotenv syntax for export prefixes and inline comments", () => {
+		const filePath = writeTempEnv(
+			[
+				"export EXPORTED=value",
+				"COMMENTED=secret # trailing comment",
+				'QUOTED_HASH="keep # this"',
+				"NO_SPACE=http://host/path#frag",
+			].join("\n"),
+		);
+
+		expect(parseEnvFile(filePath)).toEqual({
+			EXPORTED: "value",
+			COMMENTED: "secret",
+			QUOTED_HASH: "keep # this",
+			NO_SPACE: "http://host/path#frag",
+		});
+	});
 });
 
 describe("filterProcessEnv", () => {


### PR DESCRIPTION
## Repro
From a temporary project containing `.env` with `TEST_ENV_FROM_DOTENV=loaded-by-omp`, run the coding-agent bash executor with `printf '%s' "$TEST_ENV_FROM_DOTENV"`; current `main` returns `loaded-by-omp` with exit code 0 even when the launch environment did not define the variable.

## Cause
`packages/utils/src/env.ts` eagerly merges the launch directory's `.env` into `Bun.env` for OMP configuration. `buildSpawnEnv()` in `packages/utils/src/procmgr.ts` copied that mutated environment into every command shell; its existing `filterChildShellEnv()` removed matching `.env.local` values but not `.env` values.

## Fix
- Filter matching launch-directory `.env` and `.env.local` entries from the base child-shell environment.
- Preserve explicit bash-tool `env` overrides, which are layered after the filtered base environment.
- Extend the shell-environment regression test to cover both dotenv files while retaining ordinary inherited values.

## Verification
`bun test packages/coding-agent/test/non-interactive-env.test.ts packages/utils/test/env.test.ts` passed: 13 tests, 0 failures. The manual reproduction changed from `loaded-by-omp` to an empty value, while an explicit tool override returned `explicit-tool-value`; the pre-publish `bun check` gate also passed. Fixes #6813