### PR TITLE
fix(cli): set kernel process name via prctl on linux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp` showing up as `bun` in `ps`/`pgrep`/`killall`/`top` on Linux: `process.title = "omp"` is a JS-level no-op under Bun (it never calls `prctl(PR_SET_NAME)`), so the kernel `comm` name stayed `bun`. Startup and the daemon broker now set the kernel-visible process name via `bun:ffi` ([#6815](https://github.com/can1357/oh-my-pi/issues/6815)).
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -25,6 +25,7 @@ import {
 	VERSION,
 } from "@oh-my-pi/pi-utils/dirs";
 import { interceptUnhandledRejections } from "@oh-my-pi/pi-utils/postmortem";
+import { setProcessName } from "@oh-my-pi/pi-utils/process-name";
 import { declareWorkerHostEntry, installWorkerInbox, isWorkerHostSelector } from "@oh-my-pi/pi-utils/worker-host";
 import { installProfileAlias, resolveProfileAliasCommandFromProcess } from "./cli/profile-alias";
 import { extractProfileFlags } from "./cli/profile-bootstrap";
@@ -42,7 +43,7 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.exit(1);
 }
 
-process.title = APP_NAME;
+setProcessName(APP_NAME);
 
 // `Bun.build`-API compiled Windows executables report `import.meta.main ===
 // false`: the standalone loader keys the entry module with native backslashes

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -3,7 +3,7 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
-import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText } from "@oh-my-pi/pi-utils";
+import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText, setProcessName } from "@oh-my-pi/pi-utils";
 import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
 import { workerEnvFromParent } from "../subprocess/worker-client";
@@ -1110,7 +1110,7 @@ export async function startDaemonBrokerFromEnvironment(): Promise<void> {
 	await fs.mkdir(runtimeDir, { recursive: true, mode: 0o700 });
 	const lease = await acquireBrokerLease(runtimeDir);
 	if (!lease) return;
-	process.title = "omp daemon broker";
+	setProcessName("omp daemon broker");
 	const token = (await Bun.file(path.join(runtimeDir, TOKEN_FILE)).text()).trim();
 	if (!token) throw new Error("Daemon broker token is empty");
 	const broker = new DaemonBroker(projectDir, runtimeDir, token, idleGraceMs);

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `setProcessName`, which sets the OS-visible process name (`/proc/self/comm`) via `prctl(PR_SET_NAME)` through `bun:ffi` on Linux in addition to `process.title`, since Bun's `process.title` setter never reaches the kernel ([#6815](https://github.com/can1357/oh-my-pi/issues/6815)).
+
 ## [17.1.5] - 2026-07-27
 
 ### Fixed

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,6 +19,7 @@ export * from "./path";
 export * from "./path-tree";
 export * from "./peek-file";
 export * as postmortem from "./postmortem";
+export * from "./process-name";
 export * as procmgr from "./procmgr";
 export * as prompt from "./prompt";
 export * as ptree from "./ptree";

--- a/packages/utils/src/process-name.ts
+++ b/packages/utils/src/process-name.ts
@@ -1,0 +1,53 @@
+/**
+ * Set the OS-visible process name (`/proc/self/comm`) so `omp` shows up as
+ * `omp` — not `bun` — in `ps`, `pgrep`, `killall`, `top`, `htop`, and systemd.
+ *
+ * Bun's `process.title` setter only stores the value on the JS side; unlike
+ * Node/libuv it never calls `prctl(PR_SET_NAME)`, so the kernel's `comm` stays
+ * `bun` and process-name-based tooling can't target omp (and `pkill bun` becomes
+ * a footgun that kills every Bun process on the machine). We keep the
+ * `process.title` assignment (correct getter, future-proof if Bun ever fixes the
+ * setter) and additionally drive `prctl` via `bun:ffi` on Linux, mirroring the
+ * libc-FFI pattern in `ttyid.ts` / `stderr-guard.ts`.
+ *
+ * macOS has no clean userspace equivalent for the shebang-run path, and on
+ * Windows / compiled binaries the kernel derives the name from the exec'd file,
+ * so those paths already report correctly; there we only set `process.title`.
+ */
+import { dlopen, FFIType, ptr } from "bun:ffi";
+import * as os from "node:os";
+
+/** `prctl(2)` option that sets the calling thread's `comm` name. */
+const PR_SET_NAME = 15;
+
+/**
+ * Set both the JS `process.title` and — on Linux — the kernel `comm` name.
+ *
+ * Never throws: `bun:ffi` unavailability or a failed syscall degrades silently
+ * to the `process.title`-only behavior, so it is safe to call at startup.
+ */
+export function setProcessName(name: string): void {
+	try {
+		process.title = name;
+	} catch {}
+
+	if (os.platform() !== "linux") return;
+
+	try {
+		const libc = dlopen("libc.so.6", {
+			prctl: {
+				args: [FFIType.i32, FFIType.ptr, FFIType.u64, FFIType.u64, FFIType.u64],
+				returns: FFIType.i32,
+			},
+		});
+		try {
+			// TASK_COMM_LEN is 16 (name + NUL); the kernel truncates the rest.
+			const buf = Buffer.from(`${name}\0`, "utf8");
+			libc.symbols.prctl(PR_SET_NAME, ptr(buf), 0n, 0n, 0n);
+		} finally {
+			libc.close();
+		}
+	} catch {
+		// bun:ffi unavailable or libc missing; process.title stands alone.
+	}
+}

--- a/packages/utils/test/process-name.test.ts
+++ b/packages/utils/test/process-name.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Contract (issue #6815): `setProcessName` must make the kernel-visible process
+ * name (`/proc/self/comm`) match the requested name on Linux — not leave it as
+ * `bun` the way a bare `process.title` assignment does under Bun.
+ *
+ * Runs in a subprocess so the test suite's own `comm` is never mutated.
+ */
+
+const MODULE = path.resolve(import.meta.dir, "../src/process-name.ts");
+
+describe("setProcessName", () => {
+	it.skipIf(os.platform() !== "linux")("sets /proc/self/comm on Linux", async () => {
+		const probe = [
+			`import { setProcessName } from ${JSON.stringify(MODULE)};`,
+			`import * as fs from "node:fs";`,
+			`setProcessName("omp-probe");`,
+			`const comm = fs.readFileSync("/proc/self/comm", "utf8").trim();`,
+			`process.stdout.write(JSON.stringify({ comm, title: process.title }));`,
+		].join("\n");
+
+		const result = await Bun.$`bun -e ${probe}`.quiet();
+		expect(result.exitCode).toBe(0);
+		const report = JSON.parse(result.stdout.toString()) as { comm: string; title: string };
+		// TASK_COMM_LEN caps comm at 15 chars; "omp-probe" fits whole.
+		expect(report.comm).toBe("omp-probe");
+		expect(report.title).toBe("omp-probe");
+	});
+});


### PR DESCRIPTION
## Repro
Under Bun on Linux, `omp` shows up as `bun` in `ps`/`pgrep`/`killall`/`top`/`htop` because assigning `process.title` never reaches the OS. Reproduced on Bun 1.3.14:

```console
$ bun -e 'process.title = "omp"; const fs=require("fs"); console.log("process.title getter =", JSON.stringify(process.title)); console.log("/proc/self/comm    =", JSON.stringify(fs.readFileSync("/proc/self/comm","utf8").trim()));'
process.title getter = "omp"
/proc/self/comm    = "bun"
```

The JS getter reflects the assignment but `/proc/self/comm` stays `bun`, so `pgrep omp`/`killall omp` miss the process and `pkill bun` becomes a footgun that kills every Bun process.

## Cause
Bun's `process.title` setter only stores the value on the JS side; unlike Node/libuv's `uv_set_process_title` it never calls `prctl(PR_SET_NAME)`. The repo already commits to process naming — `process.title = APP_NAME` in `packages/coding-agent/src/cli.ts` and `process.title = "omp daemon broker"` in `packages/coding-agent/src/launch/broker.ts` — but both are no-ops on the runtime omp ships on.

## Fix
- Add `setProcessName(name)` in `packages/utils/src/process-name.ts`: sets `process.title` and, on Linux, calls `prctl(PR_SET_NAME, name)` through `bun:ffi`, mirroring the existing libc-FFI pattern in `ttyid.ts`/`stderr-guard.ts`. Non-Linux and FFI-unavailable paths degrade silently to `process.title` only.
- Export it from the `@oh-my-pi/pi-utils` barrel.
- Use it at CLI startup (`cli.ts`) and in the daemon broker (`broker.ts`) in place of the bare `process.title` assignments.

## Verification
`bun test test/process-name.test.ts` (packages/utils) passes: a subprocess probe confirms `/proc/self/comm` becomes the requested name on Linux. Manual smoke replicating the cli.ts ordering (`setProcessName(APP_NAME)`) reports `comm = "omp"`. `bun check:types` clean for both `packages/utils` and `packages/coding-agent`.

Fixes #6815