### PR TITLE
fix: google-vertex support multi-region endpoints

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Google Vertex AI multi-region locations `eu` and `us` building invalid hosts (`eu-aiplatform.googleapis.com` / `us-aiplatform.googleapis.com`) that 404. Both Gemini GenerateContent and Claude/OpenAI-compat Vertex routes now resolve the REP endpoints (`aiplatform.eu.rep.googleapis.com` / `aiplatform.us.rep.googleapis.com`).
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -1,4 +1,5 @@
 import { $env } from "@oh-my-pi/pi-utils";
+import { resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
 import * as AIError from "../error";
 import type { Context, Model, StreamFunction } from "../types";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
@@ -69,7 +70,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 				// global-only request.
 				const explicitLocation = options?.location;
 				const location = explicitLocation ?? resolveAmbientLocation() ?? "global";
-				const host = resolveEndpointHost(location);
+				const host = resolveVertexEndpointHost(location);
 				const path = `${API_VERSION}/publishers/google/models/${model.id}:streamGenerateContent?alt=sse`;
 				const useGlobalFallback = !explicitLocation && host !== "aiplatform.googleapis.com";
 				return {
@@ -87,7 +88,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 			const project = resolveProject(options);
 			const location = resolveLocation(options);
 			const accessToken = await getVertexAccessToken({ signal: options?.signal, fetch: options?.fetch });
-			const host = resolveEndpointHost(location);
+			const host = resolveVertexEndpointHost(location);
 			const url = `https://${host}/${API_VERSION}/projects/${project}/locations/${location}/publishers/google/models/${model.id}:streamGenerateContent?alt=sse`;
 			return {
 				params,
@@ -117,9 +118,6 @@ function resolveProject(options?: GoogleVertexOptions): string {
 	return project;
 }
 
-function resolveEndpointHost(location: string): string {
-	return location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`;
-}
 function resolveAmbientLocation(): string | undefined {
 	return $env.GOOGLE_VERTEX_LOCATION || $env.GOOGLE_CLOUD_LOCATION || $env.VERTEX_LOCATION || undefined;
 }

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -1,5 +1,5 @@
-import { $env } from "@oh-my-pi/pi-utils";
 import { resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
+import { $env } from "@oh-my-pi/pi-utils";
 import * as AIError from "../error";
 import type { Context, Model, StreamFunction } from "../types";
 import type { AssistantMessageEventStream } from "../utils/event-stream";

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
-import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl } from "@oh-my-pi/pi-catalog/hosts";
+import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl, resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
 import {
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
@@ -662,7 +662,7 @@ function resolveVertexRequest(input: string | URL | Request): string | URL | Req
 			url.includes("{location}") ||
 			url.includes("%7Bproject%7D") ||
 			url.includes("%7Blocation%7D");
-		const host = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`;
+		const host = resolveVertexEndpointHost(location);
 		const rewritten = hasPlaceholder
 			? url
 					.replace("https://{location}-aiplatform.googleapis.com", `https://${host}`)

--- a/packages/ai/test/issue-1270-repro.test.ts
+++ b/packages/ai/test/issue-1270-repro.test.ts
@@ -62,4 +62,42 @@ describe("issue #1270: Vertex AI global endpoint", () => {
 			"https://aiplatform.googleapis.com/v1/projects/vertex-project/locations/global/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
 		);
 	});
+
+	it.each([
+		{
+			location: "eu",
+			host: "aiplatform.eu.rep.googleapis.com",
+		},
+		{
+			location: "us",
+			host: "aiplatform.us.rep.googleapis.com",
+		},
+		{
+			location: "europe-west4",
+			host: "europe-west4-aiplatform.googleapis.com",
+		},
+	] as const)("uses the $host host for location $location", async ({ location, host }) => {
+		delete Bun.env.GOOGLE_CLOUD_API_KEY;
+		delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+		const urls: string[] = [];
+		const stream = streamGoogleVertex(model, context, {
+			project: "vertex-project",
+			location,
+			fetch: async input => {
+				const url = input instanceof Request ? input.url : input.toString();
+				urls.push(url);
+				if (url === METADATA_TOKEN_URL || url === OAUTH_TOKEN_URL) {
+					return new Response(JSON.stringify({ access_token: "token", expires_in: 3600 }));
+				}
+				return new Response('{"error":{"message":"stop after capture"}}', { status: 400 });
+			},
+		});
+
+		await stream.result();
+
+		expect(urls).toContain(
+			`https://${host}/v1/projects/vertex-project/locations/${location}/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse`,
+		);
+	});
 });

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -552,118 +552,131 @@ describe("Generate E2E Tests", () => {
 			}
 		});
 
-		it("routes Vertex Claude models through Anthropic rawPredict with ADC auth", async () => {
-			const originalProject = Bun.env.GOOGLE_CLOUD_PROJECT;
-			const originalGcpProject = Bun.env.GCP_PROJECT;
-			const originalGcloudProject = Bun.env.GCLOUD_PROJECT;
-			const originalVertexLocation = Bun.env.GOOGLE_VERTEX_LOCATION;
-			const originalCloudLocation = Bun.env.GOOGLE_CLOUD_LOCATION;
-			const originalLocation = Bun.env.VERTEX_LOCATION;
-			const originalApiKey = Bun.env.GOOGLE_CLOUD_API_KEY;
-			const originalGac = Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
-			// Force the GCE/Cloud Run metadata-server token path: neutralize any host
-			// ADC so resolveAccessTokenUncached() falls through to fetchMetadataToken().
-			// Without this the test reads ~/.config/gcloud/application_default_credentials.json
-			// when present and hangs on the OAuth exchange (form body, not JSON).
-			const homedirSpy = spyOn(os, "homedir").mockReturnValue(
-				path.join(os.tmpdir(), `vertex-adc-absent-${Date.now()}`),
-			);
-			const model: Model<"anthropic-messages"> = buildModel({
-				id: "claude-sonnet-4@20250514",
-				name: "Claude Sonnet 4",
-				api: "anthropic-messages",
-				provider: "google-vertex",
-				baseUrl:
-					"https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/anthropic/models/claude-sonnet-4@20250514:streamRawPredict",
-				reasoning: true,
-				input: ["text", "image"],
-				cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-				contextWindow: 200_000,
-				maxTokens: 64_000,
-			});
-			const captured = Promise.withResolvers<{
-				url: string;
-				authorization: string | null;
-				betaHeader: string | null;
-				body: unknown;
-			}>();
-
-			try {
-				__resetVertexTokenCache();
-				Bun.env.GOOGLE_CLOUD_PROJECT = "vertex-project";
-				Bun.env.GOOGLE_VERTEX_LOCATION = "global";
-				delete Bun.env.GCP_PROJECT;
-				delete Bun.env.GCLOUD_PROJECT;
-				delete Bun.env.GOOGLE_CLOUD_LOCATION;
-				delete Bun.env.VERTEX_LOCATION;
-				delete Bun.env.GOOGLE_CLOUD_API_KEY;
-				delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
-
-				const events = stream(
-					model,
-					{ messages: [{ role: "user", content: "Hello", timestamp: Date.now() }] },
-					{
-						apiKey: "<authenticated>",
-						thinkingEnabled: true,
-						fetch: async (input, init) => {
-							const url = input instanceof Request ? input.url : input.toString();
-							if (
-								url ===
-								"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-							) {
-								return new Response(JSON.stringify({ access_token: "vertex-token", expires_in: 3600 }));
-							}
-							const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
-							const bodyText = input instanceof Request ? await input.clone().text() : String(init?.body ?? "");
-							captured.resolve({
-								url,
-								authorization: headers.get("authorization"),
-								betaHeader: headers.get("anthropic-beta"),
-								body: JSON.parse(bodyText),
-							});
-							return new Response(JSON.stringify({ error: { message: "stop after capture" } }), { status: 400 });
-						},
-					},
+		it.each([
+			{ location: "global", host: "aiplatform.googleapis.com" },
+			{ location: "eu", host: "aiplatform.eu.rep.googleapis.com" },
+			{ location: "us", host: "aiplatform.us.rep.googleapis.com" },
+		] as const)(
+			"routes Vertex Claude rawPredict to $host for location $location",
+			async ({ location, host }) => {
+				const originalProject = Bun.env.GOOGLE_CLOUD_PROJECT;
+				const originalGcpProject = Bun.env.GCP_PROJECT;
+				const originalGcloudProject = Bun.env.GCLOUD_PROJECT;
+				const originalVertexLocation = Bun.env.GOOGLE_VERTEX_LOCATION;
+				const originalCloudLocation = Bun.env.GOOGLE_CLOUD_LOCATION;
+				const originalLocation = Bun.env.VERTEX_LOCATION;
+				const originalApiKey = Bun.env.GOOGLE_CLOUD_API_KEY;
+				const originalGac = Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+				// Force the GCE/Cloud Run metadata-server token path: neutralize any host
+				// ADC so resolveAccessTokenUncached() falls through to fetchMetadataToken().
+				// Without this the test reads ~/.config/gcloud/application_default_credentials.json
+				// when present and hangs on the OAuth exchange (form body, not JSON).
+				const homedirSpy = spyOn(os, "homedir").mockReturnValue(
+					path.join(os.tmpdir(), `vertex-adc-absent-${location}-${Date.now()}`),
 				);
-
-				for await (const _event of events) {
-				}
-
-				const request = await captured.promise;
-				expect(request.url).toBe(
-					"https://aiplatform.googleapis.com/v1/projects/vertex-project/locations/global/publishers/anthropic/models/claude-sonnet-4@20250514:streamRawPredict",
-				);
-				expect(request.authorization).toBe("Bearer vertex-token");
-				expect(request.body).toMatchObject({
-					anthropic_version: "vertex-2023-10-16",
-					messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
-					stream: true,
+				const model: Model<"anthropic-messages"> = buildModel({
+					id: "claude-sonnet-4@20250514",
+					name: "Claude Sonnet 4",
+					api: "anthropic-messages",
+					provider: "google-vertex",
+					baseUrl:
+						"https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/anthropic/models/claude-sonnet-4@20250514:streamRawPredict",
+					reasoning: true,
+					input: ["text", "image"],
+					cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+					contextWindow: 200_000,
+					maxTokens: 64_000,
 				});
-				expect((request.body as Record<string, unknown>).model).toBeUndefined();
-				expect((request.body as Record<string, { type?: string }>).thinking?.type).toBe("enabled");
-				expect((request.body as Record<string, unknown>).context_management).toBeUndefined();
-				expect(request.betaHeader ?? "").not.toContain("context-management-2025-06-27");
-			} finally {
-				__resetVertexTokenCache();
-				homedirSpy.mockRestore();
-				if (originalProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
-				else Bun.env.GOOGLE_CLOUD_PROJECT = originalProject;
-				if (originalGcpProject === undefined) delete Bun.env.GCP_PROJECT;
-				else Bun.env.GCP_PROJECT = originalGcpProject;
-				if (originalGcloudProject === undefined) delete Bun.env.GCLOUD_PROJECT;
-				else Bun.env.GCLOUD_PROJECT = originalGcloudProject;
-				if (originalVertexLocation === undefined) delete Bun.env.GOOGLE_VERTEX_LOCATION;
-				else Bun.env.GOOGLE_VERTEX_LOCATION = originalVertexLocation;
-				if (originalCloudLocation === undefined) delete Bun.env.GOOGLE_CLOUD_LOCATION;
-				else Bun.env.GOOGLE_CLOUD_LOCATION = originalCloudLocation;
-				if (originalLocation === undefined) delete Bun.env.VERTEX_LOCATION;
-				else Bun.env.VERTEX_LOCATION = originalLocation;
-				if (originalApiKey === undefined) delete Bun.env.GOOGLE_CLOUD_API_KEY;
-				else Bun.env.GOOGLE_CLOUD_API_KEY = originalApiKey;
-				if (originalGac === undefined) delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
-				else Bun.env.GOOGLE_APPLICATION_CREDENTIALS = originalGac;
-			}
-		});
+				const captured = Promise.withResolvers<{
+					url: string;
+					authorization: string | null;
+					betaHeader: string | null;
+					body: unknown;
+				}>();
+
+				try {
+					__resetVertexTokenCache();
+					Bun.env.GOOGLE_CLOUD_PROJECT = "vertex-project";
+					Bun.env.GOOGLE_VERTEX_LOCATION = location;
+					delete Bun.env.GCP_PROJECT;
+					delete Bun.env.GCLOUD_PROJECT;
+					delete Bun.env.GOOGLE_CLOUD_LOCATION;
+					delete Bun.env.VERTEX_LOCATION;
+					delete Bun.env.GOOGLE_CLOUD_API_KEY;
+					delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+					const events = stream(
+						model,
+						{ messages: [{ role: "user", content: "Hello", timestamp: Date.now() }] },
+						{
+							apiKey: "<authenticated>",
+							thinkingEnabled: true,
+							fetch: async (input, init) => {
+								const url = input instanceof Request ? input.url : input.toString();
+								if (
+									url ===
+									"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+								) {
+									return new Response(JSON.stringify({ access_token: "vertex-token", expires_in: 3600 }));
+								}
+								const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
+								const bodyText =
+									input instanceof Request ? await input.clone().text() : String(init?.body ?? "");
+								captured.resolve({
+									url,
+									authorization: headers.get("authorization"),
+									betaHeader: headers.get("anthropic-beta"),
+									body: JSON.parse(bodyText),
+								});
+								return new Response(JSON.stringify({ error: { message: "stop after capture" } }), {
+									status: 400,
+								});
+							},
+						},
+					);
+
+					for await (const _event of events) {
+					}
+
+					const request = await captured.promise;
+					// Placeholder baseUrl + GOOGLE_VERTEX_LOCATION must rewrite through
+					// resolveVertexRequest: multi-region eu/us hit REP hosts, not the
+					// invalid {location}-aiplatform.googleapis.com regional pattern.
+					expect(request.url).toBe(
+						`https://${host}/v1/projects/vertex-project/locations/${location}/publishers/anthropic/models/claude-sonnet-4@20250514:streamRawPredict`,
+					);
+					expect(request.authorization).toBe("Bearer vertex-token");
+					expect(request.body).toMatchObject({
+						anthropic_version: "vertex-2023-10-16",
+						messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+						stream: true,
+					});
+					expect((request.body as Record<string, unknown>).model).toBeUndefined();
+					expect((request.body as Record<string, { type?: string }>).thinking?.type).toBe("enabled");
+					expect((request.body as Record<string, unknown>).context_management).toBeUndefined();
+					expect(request.betaHeader ?? "").not.toContain("context-management-2025-06-27");
+				} finally {
+					__resetVertexTokenCache();
+					homedirSpy.mockRestore();
+					if (originalProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
+					else Bun.env.GOOGLE_CLOUD_PROJECT = originalProject;
+					if (originalGcpProject === undefined) delete Bun.env.GCP_PROJECT;
+					else Bun.env.GCP_PROJECT = originalGcpProject;
+					if (originalGcloudProject === undefined) delete Bun.env.GCLOUD_PROJECT;
+					else Bun.env.GCLOUD_PROJECT = originalGcloudProject;
+					if (originalVertexLocation === undefined) delete Bun.env.GOOGLE_VERTEX_LOCATION;
+					else Bun.env.GOOGLE_VERTEX_LOCATION = originalVertexLocation;
+					if (originalCloudLocation === undefined) delete Bun.env.GOOGLE_CLOUD_LOCATION;
+					else Bun.env.GOOGLE_CLOUD_LOCATION = originalCloudLocation;
+					if (originalLocation === undefined) delete Bun.env.VERTEX_LOCATION;
+					else Bun.env.VERTEX_LOCATION = originalLocation;
+					if (originalApiKey === undefined) delete Bun.env.GOOGLE_CLOUD_API_KEY;
+					else Bun.env.GOOGLE_CLOUD_API_KEY = originalApiKey;
+					if (originalGac === undefined) delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+					else Bun.env.GOOGLE_APPLICATION_CREDENTIALS = originalGac;
+				}
+			},
+		);
 
 		it("routes impersonated_service_account ADC through IAM to the Vertex request", async () => {
 			const originalProject = Bun.env.GOOGLE_CLOUD_PROJECT;

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `resolveVertexEndpointHost(location)` for Vertex AI hostname selection: `global` → `aiplatform.googleapis.com`, multi-region `eu`/`us` → `aiplatform.{eu|us}.rep.googleapis.com`, and regional locations → `{location}-aiplatform.googleapis.com`.
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -111,6 +111,24 @@ function includesAsciiCaseInsensitive(value: string, lowerNeedle: string): boole
 
 // --- Endpoint-shape predicates (URL path/verb shapes, not vendor hosts) ---
 
+/**
+ * Hostname for a Vertex AI GenerateContent / rawPredict / OpenAI-compat
+ * request for the given location.
+ *
+ * - `global` → global endpoint (`aiplatform.googleapis.com`)
+ * - `eu` / `us` multi-regions → REP endpoints (`aiplatform.{eu|us}.rep.googleapis.com`)
+ * - every other location → regional (`{location}-aiplatform.googleapis.com`)
+ *
+ * Multi-region codes do NOT follow the regional `{location}-aiplatform` pattern;
+ * interpolating them that way yields hosts like `eu-aiplatform.googleapis.com`
+ * that 404.
+ */
+export function resolveVertexEndpointHost(location: string): string {
+	if (location === "global") return "aiplatform.googleapis.com";
+	if (location === "eu" || location === "us") return `aiplatform.${location}.rep.googleapis.com`;
+	return `${location}-aiplatform.googleapis.com`;
+}
+
 /** Vertex AI express-mode OpenAI-compatible endpoint (`…/endpoints/openapi`). */
 export function isVertexExpressOpenAIUrl(baseUrl: string): boolean {
 	return baseUrl.includes("/endpoints/openapi");

--- a/packages/catalog/test/hosts.test.ts
+++ b/packages/catalog/test/hosts.test.ts
@@ -5,6 +5,7 @@ import {
 	isVertexExpressOpenAIUrl,
 	isVertexRawPredictUrl,
 	modelMatchesHost,
+	resolveVertexEndpointHost,
 } from "@oh-my-pi/pi-catalog/hosts";
 
 describe("hostMatchesUrl", () => {
@@ -64,6 +65,14 @@ describe("endpoint shape predicates", () => {
 				"https://aiplatform.googleapis.com/v1/projects/p/locations/us/publishers/anthropic/models/claude:streamRawPredict",
 			),
 		).toBe(true);
+	});
+
+	test("resolves Vertex endpoint hosts for global, multi-region, and regional locations", () => {
+		expect(resolveVertexEndpointHost("global")).toBe("aiplatform.googleapis.com");
+		expect(resolveVertexEndpointHost("eu")).toBe("aiplatform.eu.rep.googleapis.com");
+		expect(resolveVertexEndpointHost("us")).toBe("aiplatform.us.rep.googleapis.com");
+		expect(resolveVertexEndpointHost("europe-west4")).toBe("europe-west4-aiplatform.googleapis.com");
+		expect(resolveVertexEndpointHost("us-central1")).toBe("us-central1-aiplatform.googleapis.com");
 	});
 
 	test("requires all DashScope compatible-mode URL markers", () => {


### PR DESCRIPTION
## What

Hello i ran into an issue using the multi-region endpoints on vertex https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations#multi-region_endpoints after a bit of debugging it appears this was not yet implemented in oh my pi  me and my intern (claude) have implemented support for multi region endpoints.


## Why
In the EU vertex only supports sonnet-5 on a multi-region endpoint.
I only got 404 errors when trying with `GOOGLE_CLOUD_LOCATION=eu`
for some reason google decided to give the multi-region api a different domain name structure.
In this pr support is added for `eu` and `us` multiregion endpoints (those are the only ones on the google docs page).


## Testing

ran it locally with these changes 

<img width="1195" height="552" alt="image" src="https://github.com/user-attachments/assets/bb5a31c1-590f-46d1-ade3-d17ba86e5546" />

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
