### PR TITLE
fix(cli): wrap streaming-phase download timeout with friendly message

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp update` surfacing a raw `TimeoutError: The operation timed out.` when the 15-minute download deadline fired while streaming the binary body rather than during the initial `fetch()`. The streaming-phase catch now emits the same friendly `Timed out downloading release binary after 15 minutes` message as the connection phase ([#6822](https://github.com/can1357/oh-my-pi/issues/6822)).
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -231,6 +231,9 @@ export async function downloadVerifiedBinary(options: VerifiedBinaryDownloadOpti
 		await fs.promises.chmod(options.targetPath, 0o755);
 	} catch (err) {
 		await unlinkIfExists(options.targetPath);
+		if (isTimeoutError(err)) {
+			throw new Error("Timed out downloading release binary after 15 minutes", { cause: err });
+		}
 		throw err;
 	}
 }

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -465,6 +465,31 @@ describe("update-cli release binary integrity", () => {
 		expect(await Bun.file(targetPath).exists()).toBe(false);
 	});
 
+	it("wraps a timeout during body streaming with a friendly message", async () => {
+		const dir = await makeTempDir();
+		const targetPath = path.join(dir, binaryName);
+		const body = new ReadableStream<Uint8Array>(
+			{
+				pull(controller) {
+					controller.enqueue(new Uint8Array(1));
+					controller.error(new DOMException("The operation timed out.", "TimeoutError"));
+				},
+			},
+			{ highWaterMark: 0 },
+		);
+
+		await expect(
+			downloadVerifiedBinary({
+				url,
+				targetPath,
+				expectedSize: Buffer.byteLength(content),
+				expectedDigest: digest,
+				fetchImpl: async () => new Response(body),
+			}),
+		).rejects.toThrow("Timed out downloading release binary after 15 minutes");
+		expect(await Bun.file(targetPath).exists()).toBe(false);
+	});
+
 	it("removes downloads whose size or digest does not match", async () => {
 		const dir = await makeTempDir();
 		const targetPath = path.join(dir, binaryName);


### PR DESCRIPTION
## Repro
On a slow connection `omp update` prints `Update failed: TimeoutError: The operation timed out.` when the 15-minute `AbortSignal.timeout()` fires while the binary body is streaming (HTTP headers arrive fast, body transfer stalls). Reproduced in-process by feeding `downloadVerifiedBinary` a body `ReadableStream` that errors with a `TimeoutError` mid-stream:

```
CAUGHT: TimeoutError - The operation timed out.
```

## Cause
`downloadVerifiedBinary` in `packages/coding-agent/src/cli/update-cli.ts` wraps `isTimeoutError` with a friendly message only in the `fetch()` catch (lines ~194-199). The `pipeline(response.body, …)` catch (lines ~232-235) cleaned up the partial file and re-threw the raw error, so a timeout in the streaming phase bypassed the friendly-message path.

## Fix
- Add an `isTimeoutError` check to the `pipeline()` catch after `unlinkIfExists`, re-throwing `"Timed out downloading release binary after 15 minutes"` to match the connection-phase message.
- Add a regression test asserting a mid-stream `TimeoutError` surfaces the friendly message and removes the partial file.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/update-cli.test.ts` → 38 pass / 0 fail (includes the new streaming-timeout test). Fixes #6822