### PR TITLE
fix(ai): preserve reasoning IDs for computer replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stateless OpenAI Responses history after an interrupted native Computer Use turn: replay now keeps the reasoning item ID paired with a retained `computer_call` ID, while continuing to strip IDs from unrelated reasoning. The next prompt no longer fails with HTTP 400 for a missing `rs_*` item.
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -51,6 +51,7 @@ import {
 	normalizeSystemPrompts,
 	sanitizeOpenAIResponsesAssistantFallbackItemsForReplay,
 	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
+	stripOpenAIResponsesComputerLinkedReasoningIdsForReplay,
 } from "../utils";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
@@ -1172,8 +1173,9 @@ export function normalizeCodexToolChoice(
 	return undefined;
 }
 function unrollCodexComputerItems(items: ResponseInput, supportsImageDetailOriginal: boolean): ResponseInput {
+	const replayItems = stripOpenAIResponsesComputerLinkedReasoningIdsForReplay(items);
 	const unrolled: ResponseInput = [];
-	for (const item of items) {
+	for (const item of replayItems) {
 		if (item.type === "computer_call") {
 			const actions = item.actions ?? (item.action ? [item.action] : []);
 			unrolled.push({

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -69,6 +69,7 @@ import {
 	sanitizeOpenAIResponsesAssistantFallbackItemsForReplay,
 	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 	sanitizeOpenAIResponsesHistoryItemsForReplay,
+	stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay,
 } from "../utils";
 import {
 	clearStreamingPartialJson,
@@ -1759,7 +1760,8 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 	}
 
 	const withRepairedOutputs = options.repairOrphanOutputs ? repairOrphanResponsesToolOutputs(messages) : messages;
-	return repairOrphanResponsesToolCalls(withRepairedOutputs);
+	const withRepairedCalls = repairOrphanResponsesToolCalls(withRepairedOutputs);
+	return stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay(withRepairedCalls);
 }
 
 type ResponsesReplayAssistantMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1646,6 +1646,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 			if (historyItems && shouldReplayPayloadItems) {
 				const sanitizedItems = sanitizeOpenAIResponsesHistoryItemsForReplay(filterReasoning(historyItems), {
 					supportsImageDetailOriginal,
+					supportsComputerUse: options.model.supportsComputerUse === true,
 				});
 				messages.push(
 					...adaptResponsesReplayItemsForModel(
@@ -1694,7 +1695,10 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 			if (historyItems) {
 				const rawSanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
 					filterReasoning(historyItems),
-					{ supportsImageDetailOriginal },
+					{
+						supportsImageDetailOriginal,
+						supportsComputerUse: options.model.supportsComputerUse === true,
+					},
 				);
 				const sanitizedHistoryItems = rawSanitizedHistoryItems
 					? adaptResponsesReplayItemsForModel(

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -106,11 +106,25 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 ): ResponseInput {
 	const normalizedCallIds = new Map<string, string>();
 	const supportsImageDetailOriginal = options.supportsImageDetailOriginal !== false;
+	// Stateless native computer history is an atomic Responses chain: replaying
+	// a `computer_call` ID requires the reasoning item IDs from that response.
+	const computerLinkedReasoningItems = new Set<Record<string, unknown>>();
+	const responseReasoningItems: Array<Record<string, unknown>> = [];
+	for (const item of items) {
+		if (item.type === "message") {
+			responseReasoningItems.length = 0;
+		} else if (item.type === "reasoning") {
+			responseReasoningItems.push(item);
+		} else if (item.type === "computer_call" && typeof item.id === "string") {
+			for (const reasoningItem of responseReasoningItems) computerLinkedReasoningItems.add(reasoningItem);
+		}
+	}
 	return items.flatMap(item => {
 		const sanitized = sanitizeOpenAIResponsesHistoryItemForReplay(
 			item,
 			normalizedCallIds,
 			supportsImageDetailOriginal,
+			computerLinkedReasoningItems.has(item),
 		);
 		return sanitized ? [sanitized] : [];
 	});
@@ -198,11 +212,13 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	item: Record<string, unknown>,
 	normalizedCallIds: Map<string, string>,
 	supportsImageDetailOriginal: boolean,
+	preserveReasoningItemIds: boolean,
 ): OpenAIResponsesReplayItem | undefined {
 	if (item.type === "item_reference") return undefined;
 	if (item.type === "image_generation_call") return sanitizeOpenAIResponsesImageGenerationCallForReplay(item);
-	if (item.type === "reasoning") return sanitizeOpenAIResponsesReasoningItemForReplay(item);
-
+	if (item.type === "reasoning") {
+		return sanitizeOpenAIResponsesReasoningItemForReplay(item, preserveReasoningItemIds);
+	}
 	// Strip status only from item types whose replay input rejects output
 	// lifecycle metadata. Hosted built-in tool items require status for replay.
 	const { id: _id, ...sanitizedItem } = item;
@@ -220,8 +236,12 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	) as unknown as OpenAIResponsesReplayItem;
 }
 
-function sanitizeOpenAIResponsesReasoningItemForReplay(item: Record<string, unknown>): OpenAIResponsesReplayItem {
+function sanitizeOpenAIResponsesReasoningItemForReplay(
+	item: Record<string, unknown>,
+	preserveItemId: boolean,
+): OpenAIResponsesReplayItem {
 	const sanitizedItem: Record<string, unknown> = { type: "reasoning" };
+	if (preserveItemId && typeof item.id === "string") sanitizedItem.id = item.id;
 	if (Array.isArray(item.summary)) sanitizedItem.summary = item.summary;
 	if (Array.isArray(item.content)) sanitizedItem.content = item.content;
 	if (typeof item.encrypted_content === "string" || item.encrypted_content === null) {

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -125,50 +125,100 @@ function isOpenAIResponsesClientInputBoundary(item: Record<string, unknown>): bo
 	}
 }
 
+function collectOpenAIResponsesComputerLinkedReasoningItems(
+	items: Array<Record<string, unknown>>,
+	requireLaterOutput: boolean,
+): Set<Record<string, unknown>> {
+	let computerCallsWithLaterOutputs: Set<Record<string, unknown>> | undefined;
+	if (requireLaterOutput) {
+		computerCallsWithLaterOutputs = new Set();
+		const laterComputerOutputCallIds = new Set<string>();
+		for (let index = items.length - 1; index >= 0; index--) {
+			const item = items[index]!;
+			if (item.type === "computer_call_output" && typeof item.call_id === "string") {
+				laterComputerOutputCallIds.add(item.call_id);
+			} else if (
+				item.type === "computer_call" &&
+				typeof item.id === "string" &&
+				typeof item.call_id === "string" &&
+				laterComputerOutputCallIds.has(item.call_id)
+			) {
+				computerCallsWithLaterOutputs.add(item);
+			}
+		}
+	}
+
+	const computerLinkedReasoningItems = new Set<Record<string, unknown>>();
+	const responseReasoningItems: Array<Record<string, unknown>> = [];
+	for (const item of items) {
+		if (isOpenAIResponsesClientInputBoundary(item)) {
+			responseReasoningItems.length = 0;
+		} else if (item.type === "reasoning") {
+			responseReasoningItems.push(item);
+		} else if (
+			item.type === "computer_call" &&
+			typeof item.id === "string" &&
+			(!computerCallsWithLaterOutputs || computerCallsWithLaterOutputs.has(item))
+		) {
+			for (const reasoningItem of responseReasoningItems) computerLinkedReasoningItems.add(reasoningItem);
+		}
+	}
+	return computerLinkedReasoningItems;
+}
+
+const provisionalOpenAIResponsesComputerReasoningItems = new WeakSet<object>();
+
 export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	items: Array<Record<string, unknown>>,
 	options: OpenAIResponsesReplaySanitizeOptions = {},
 ): ResponseInput {
 	const normalizedCallIds = new Map<string, string>();
 	const supportsImageDetailOriginal = options.supportsImageDetailOriginal !== false;
-	const supportsComputerUse = options.supportsComputerUse !== false;
-	// Stateless native computer history is an atomic Responses chain: replaying
-	// a `computer_call` ID requires the reasoning item IDs from that response.
-	const computerLinkedReasoningItems = new Set<Record<string, unknown>>();
-	const responseReasoningItems: Array<Record<string, unknown>> = [];
-	const computerCallsWithLaterOutputs = new Set<Record<string, unknown>>();
-	const laterComputerOutputCallIds = new Set<string>();
-	for (let index = items.length - 1; index >= 0; index--) {
-		const item = items[index]!;
-		if (item.type === "computer_call_output" && typeof item.call_id === "string") {
-			laterComputerOutputCallIds.add(item.call_id);
-		} else if (
-			item.type === "computer_call" &&
-			typeof item.id === "string" &&
-			typeof item.call_id === "string" &&
-			laterComputerOutputCallIds.has(item.call_id)
-		) {
-			computerCallsWithLaterOutputs.add(item);
-		}
-	}
-	for (const item of items) {
-		if (isOpenAIResponsesClientInputBoundary(item)) {
-			responseReasoningItems.length = 0;
-		} else if (item.type === "reasoning") {
-			responseReasoningItems.push(item);
-		} else if (supportsComputerUse && computerCallsWithLaterOutputs.has(item)) {
-			for (const reasoningItem of responseReasoningItems) computerLinkedReasoningItems.add(reasoningItem);
-		}
-	}
+	const computerLinkedReasoningItems =
+		options.supportsComputerUse === false
+			? undefined
+			: collectOpenAIResponsesComputerLinkedReasoningItems(items, false);
 	return items.flatMap(item => {
+		const preserveForComputer = computerLinkedReasoningItems?.has(item) === true;
 		const sanitized = sanitizeOpenAIResponsesHistoryItemForReplay(
 			item,
 			normalizedCallIds,
 			supportsImageDetailOriginal,
-			computerLinkedReasoningItems.has(item),
+			preserveForComputer,
 		);
+		if (preserveForComputer && sanitized?.type === "reasoning") {
+			provisionalOpenAIResponsesComputerReasoningItems.add(sanitized);
+		}
 		return sanitized ? [sanitized] : [];
 	});
+}
+
+/**
+ * Finalize provisional native-computer reasoning IDs after the complete
+ * Responses input has been rebuilt, model-adapted, and orphan-repaired.
+ */
+export function stripUnpairedOpenAIResponsesComputerReasoningIdsForReplay(items: ResponseInput): ResponseInput {
+	const records = items as unknown as Array<Record<string, unknown>>;
+	const linkedReasoningItems = collectOpenAIResponsesComputerLinkedReasoningItems(records, true);
+	let sanitized: ResponseInput | undefined;
+
+	for (let index = 0; index < items.length; index++) {
+		const item = items[index]!;
+		const record = records[index]!;
+		if (
+			item.type !== "reasoning" ||
+			!provisionalOpenAIResponsesComputerReasoningItems.has(item) ||
+			typeof record.id !== "string" ||
+			linkedReasoningItems.has(record)
+		) {
+			sanitized?.push(item);
+			continue;
+		}
+		if (!sanitized) sanitized = items.slice(0, index);
+		const { id: _id, ...withoutId } = record;
+		sanitized.push(withoutId as unknown as ResponseInput[number]);
+	}
+	return sanitized ?? items;
 }
 
 /**

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -111,7 +111,12 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	const computerLinkedReasoningItems = new Set<Record<string, unknown>>();
 	const responseReasoningItems: Array<Record<string, unknown>> = [];
 	for (const item of items) {
-		if (item.type === "message") {
+		const startsNewResponse =
+			(item.type === "message" && item.role !== "assistant") ||
+			item.type === "function_call_output" ||
+			item.type === "custom_tool_call_output" ||
+			item.type === "computer_call_output";
+		if (startsNewResponse) {
 			responseReasoningItems.length = 0;
 		} else if (item.type === "reasoning") {
 			responseReasoningItems.push(item);

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -70,6 +70,7 @@ export function truncateResponseItemId(id: string, prefix: string): string {
 
 interface OpenAIResponsesReplaySanitizeOptions {
 	supportsImageDetailOriginal?: boolean;
+	supportsComputerUse?: boolean;
 }
 
 /**
@@ -100,27 +101,47 @@ function clampReplayItemImageDetail(
 	return changed ? { ...item, content } : item;
 }
 
+function isOpenAIResponsesClientInputBoundary(item: Record<string, unknown>): boolean {
+	if (item.type === "message") return item.role !== "assistant";
+	if (item.type === undefined && typeof item.role === "string") return item.role !== "assistant";
+
+	switch (item.type) {
+		case "function_call_output":
+		case "custom_tool_call_output":
+		case "computer_call_output":
+		case "local_shell_call_output":
+		case "shell_call_output":
+		case "apply_patch_call_output":
+		case "mcp_approval_response":
+		case "compaction_trigger":
+		case "item_reference":
+			return true;
+		case "additional_tools":
+			return item.role !== "assistant";
+		case "tool_search_output":
+			return item.execution !== "server";
+		default:
+			return false;
+	}
+}
+
 export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	items: Array<Record<string, unknown>>,
 	options: OpenAIResponsesReplaySanitizeOptions = {},
 ): ResponseInput {
 	const normalizedCallIds = new Map<string, string>();
 	const supportsImageDetailOriginal = options.supportsImageDetailOriginal !== false;
+	const supportsComputerUse = options.supportsComputerUse !== false;
 	// Stateless native computer history is an atomic Responses chain: replaying
 	// a `computer_call` ID requires the reasoning item IDs from that response.
 	const computerLinkedReasoningItems = new Set<Record<string, unknown>>();
 	const responseReasoningItems: Array<Record<string, unknown>> = [];
 	for (const item of items) {
-		const startsNewResponse =
-			(item.type === "message" && item.role !== "assistant") ||
-			item.type === "function_call_output" ||
-			item.type === "custom_tool_call_output" ||
-			item.type === "computer_call_output";
-		if (startsNewResponse) {
+		if (isOpenAIResponsesClientInputBoundary(item)) {
 			responseReasoningItems.length = 0;
 		} else if (item.type === "reasoning") {
 			responseReasoningItems.push(item);
-		} else if (item.type === "computer_call" && typeof item.id === "string") {
+		} else if (supportsComputerUse && item.type === "computer_call" && typeof item.id === "string") {
 			for (const reasoningItem of responseReasoningItems) computerLinkedReasoningItems.add(reasoningItem);
 		}
 	}

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -193,6 +193,26 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	});
 }
 
+/** Strip only reasoning IDs whose native computer calls will be demoted. */
+export function stripOpenAIResponsesComputerLinkedReasoningIdsForReplay(items: ResponseInput): ResponseInput {
+	const records = items as unknown as Array<Record<string, unknown>>;
+	const linkedReasoningItems = collectOpenAIResponsesComputerLinkedReasoningItems(records, false);
+	let sanitized: ResponseInput | undefined;
+
+	for (let index = 0; index < items.length; index++) {
+		const item = items[index]!;
+		const record = records[index]!;
+		if (item.type !== "reasoning" || typeof record.id !== "string" || !linkedReasoningItems.has(record)) {
+			sanitized?.push(item);
+			continue;
+		}
+		if (!sanitized) sanitized = items.slice(0, index);
+		const { id: _id, ...withoutId } = record;
+		sanitized.push(withoutId as unknown as ResponseInput[number]);
+	}
+	return sanitized ?? items;
+}
+
 /**
  * Finalize provisional native-computer reasoning IDs after the complete
  * Responses input has been rebuilt, model-adapted, and orphan-repaired.

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -106,6 +106,10 @@ function isOpenAIResponsesClientInputBoundary(item: Record<string, unknown>): bo
 	if (item.type === undefined && typeof item.role === "string") return item.role !== "assistant";
 
 	switch (item.type) {
+		case "input_text":
+		case "input_image":
+		case "input_file":
+		case "input_audio":
 		case "function_call_output":
 		case "custom_tool_call_output":
 		case "computer_call_output":
@@ -113,6 +117,8 @@ function isOpenAIResponsesClientInputBoundary(item: Record<string, unknown>): bo
 		case "shell_call_output":
 		case "apply_patch_call_output":
 		case "mcp_approval_response":
+		case "compaction":
+		case "compaction_summary":
 		case "compaction_trigger":
 		case "item_reference":
 			return true;

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -136,12 +136,27 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	// a `computer_call` ID requires the reasoning item IDs from that response.
 	const computerLinkedReasoningItems = new Set<Record<string, unknown>>();
 	const responseReasoningItems: Array<Record<string, unknown>> = [];
+	const computerCallsWithLaterOutputs = new Set<Record<string, unknown>>();
+	const laterComputerOutputCallIds = new Set<string>();
+	for (let index = items.length - 1; index >= 0; index--) {
+		const item = items[index]!;
+		if (item.type === "computer_call_output" && typeof item.call_id === "string") {
+			laterComputerOutputCallIds.add(item.call_id);
+		} else if (
+			item.type === "computer_call" &&
+			typeof item.id === "string" &&
+			typeof item.call_id === "string" &&
+			laterComputerOutputCallIds.has(item.call_id)
+		) {
+			computerCallsWithLaterOutputs.add(item);
+		}
+	}
 	for (const item of items) {
 		if (isOpenAIResponsesClientInputBoundary(item)) {
 			responseReasoningItems.length = 0;
 		} else if (item.type === "reasoning") {
 			responseReasoningItems.push(item);
-		} else if (supportsComputerUse && item.type === "computer_call" && typeof item.id === "string") {
+		} else if (supportsComputerUse && computerCallsWithLaterOutputs.has(item)) {
 			for (const reasoningItem of responseReasoningItems) computerLinkedReasoningItems.add(reasoningItem);
 		}
 	}

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -199,16 +199,49 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	});
 }
 
-/** Strip only reasoning IDs whose native computer calls will be demoted. */
+function collectOpenAIResponsesReasoningItemsWithSurvivingOutputIds(
+	items: Array<Record<string, unknown>>,
+): Set<Record<string, unknown>> {
+	const retainedReasoningItems = new Set<Record<string, unknown>>();
+	let responseReasoningItems: Array<Record<string, unknown>> = [];
+	let hasSurvivingOutputId = false;
+	const finishResponse = (): void => {
+		if (hasSurvivingOutputId) {
+			for (const reasoningItem of responseReasoningItems) retainedReasoningItems.add(reasoningItem);
+		}
+		responseReasoningItems = [];
+		hasSurvivingOutputId = false;
+	};
+
+	for (const item of items) {
+		if (isOpenAIResponsesClientInputBoundary(item)) {
+			finishResponse();
+		} else if (item.type === "reasoning") {
+			responseReasoningItems.push(item);
+		} else if (item.type !== "computer_call" && typeof item.id === "string") {
+			hasSurvivingOutputId = true;
+		}
+	}
+	finishResponse();
+	return retainedReasoningItems;
+}
+
+/** Strip reasoning IDs whose only linked native output is a computer call that will be demoted. */
 export function stripOpenAIResponsesComputerLinkedReasoningIdsForReplay(items: ResponseInput): ResponseInput {
 	const records = items as unknown as Array<Record<string, unknown>>;
 	const linkedReasoningItems = collectOpenAIResponsesComputerLinkedReasoningItems(records, false);
+	const retainedReasoningItems = collectOpenAIResponsesReasoningItemsWithSurvivingOutputIds(records);
 	let sanitized: ResponseInput | undefined;
 
 	for (let index = 0; index < items.length; index++) {
 		const item = items[index]!;
 		const record = records[index]!;
-		if (item.type !== "reasoning" || typeof record.id !== "string" || !linkedReasoningItems.has(record)) {
+		if (
+			item.type !== "reasoning" ||
+			typeof record.id !== "string" ||
+			!linkedReasoningItems.has(record) ||
+			retainedReasoningItems.has(record)
+		) {
 			sanitized?.push(item);
 			continue;
 		}

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -401,73 +401,39 @@ describe("OpenAI GA computer contract", () => {
 		}
 	});
 
-	test("preserves linked reasoning and computer item IDs for stateless replay", () => {
+	test("keeps earlier tool-response reasoning IDs stripped in mixed computer history", () => {
 		const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay([
 			{
 				type: "reasoning",
-				id: "rs_interrupted_turn",
-				summary: [],
-				encrypted_content: "encrypted-reasoning",
-			},
-			{
-				type: "computer_call",
-				id: "cu_interrupted_turn",
-				call_id: "call_interrupted_turn",
-				action: { type: "screenshot" },
-				pending_safety_checks: [],
-				status: "completed",
-			},
-			{
-				type: "computer_call_output",
-				call_id: "call_interrupted_turn",
-				output: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
-			},
-		]);
-
-		expect(sanitized).toEqual([
-			{
-				type: "reasoning",
-				id: "rs_interrupted_turn",
-				summary: [],
-				encrypted_content: "encrypted-reasoning",
-			},
-			{
-				type: "computer_call",
-				id: "cu_interrupted_turn",
-				call_id: "call_interrupted_turn",
-				action: { type: "screenshot" },
-				pending_safety_checks: [],
-				status: "completed",
-			},
-			{
-				type: "computer_call_output",
-				call_id: "call_interrupted_turn",
-				output: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
-			},
-		]);
-	});
-
-	test("keeps unrelated reasoning item IDs stripped in mixed computer history", () => {
-		const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay([
-			{
-				type: "reasoning",
-				id: "rs_unrelated_turn",
+				id: "rs_unrelated_tool_turn",
 				summary: [],
 				encrypted_content: "unrelated-reasoning",
 			},
 			{
-				type: "message",
-				id: "msg_unrelated_turn",
-				role: "assistant",
+				type: "function_call",
+				id: "fc_unrelated_tool_turn",
+				call_id: "call_unrelated_tool_turn",
+				name: "read",
+				arguments: "{}",
 				status: "completed",
-				content: [{ type: "output_text", text: "Earlier answer", annotations: [] }],
 			},
-			{ type: "message", role: "user", content: [{ type: "input_text", text: "Use the computer" }] },
+			{
+				type: "function_call_output",
+				call_id: "call_unrelated_tool_turn",
+				output: "earlier tool result",
+			},
 			{
 				type: "reasoning",
 				id: "rs_computer_turn",
 				summary: [],
 				encrypted_content: "computer-reasoning",
+			},
+			{
+				type: "message",
+				id: "msg_computer_turn",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "I will inspect the screen.", annotations: [] }],
 			},
 			{
 				type: "computer_call",
@@ -485,6 +451,7 @@ describe("OpenAI GA computer contract", () => {
 			encrypted_content: "unrelated-reasoning",
 		});
 		expect(sanitized[3]!).toMatchObject({ type: "reasoning", id: "rs_computer_turn" });
+		expect(sanitized[5]!).toMatchObject({ type: "computer_call", id: "cu_computer_turn" });
 	});
 
 	test("turns a failed computer call without a screenshot into valid recovery history", () => {

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -404,6 +404,10 @@ describe("OpenAI GA computer contract", () => {
 	test("clears reasoning candidates at every client continuation boundary", () => {
 		const boundaries: Array<[string, Record<string, unknown>]> = [
 			["input message", { role: "user", content: "next turn" }],
+			["input text", { type: "input_text", text: "next turn" }],
+			["input image", { type: "input_image", file_id: "file_input_image" }],
+			["input file", { type: "input_file", file_id: "file_input_file" }],
+			["input audio", { type: "input_audio", input_audio: { data: "base64", format: "wav" } }],
 			["function output", { type: "function_call_output", call_id: "call_function", output: "done" }],
 			["custom output", { type: "custom_tool_call_output", call_id: "call_custom", output: "done" }],
 			[
@@ -420,6 +424,8 @@ describe("OpenAI GA computer contract", () => {
 			["MCP approval", { type: "mcp_approval_response", approval_request_id: "approval_1", approve: true }],
 			["client tool search output", { type: "tool_search_output", execution: "client", tools: [] }],
 			["additional tools", { type: "additional_tools", role: "developer", tools: [] }],
+			["compaction", { type: "compaction", encrypted_content: "compacted-context" }],
+			["legacy compaction summary", { type: "compaction_summary", summary: "compacted context" }],
 			["compaction trigger", { type: "compaction_trigger" }],
 			["item reference", { type: "item_reference", id: "item_reference_1" }],
 		];

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -401,6 +401,92 @@ describe("OpenAI GA computer contract", () => {
 		}
 	});
 
+	test("preserves linked reasoning and computer item IDs for stateless replay", () => {
+		const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay([
+			{
+				type: "reasoning",
+				id: "rs_interrupted_turn",
+				summary: [],
+				encrypted_content: "encrypted-reasoning",
+			},
+			{
+				type: "computer_call",
+				id: "cu_interrupted_turn",
+				call_id: "call_interrupted_turn",
+				action: { type: "screenshot" },
+				pending_safety_checks: [],
+				status: "completed",
+			},
+			{
+				type: "computer_call_output",
+				call_id: "call_interrupted_turn",
+				output: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
+			},
+		]);
+
+		expect(sanitized).toEqual([
+			{
+				type: "reasoning",
+				id: "rs_interrupted_turn",
+				summary: [],
+				encrypted_content: "encrypted-reasoning",
+			},
+			{
+				type: "computer_call",
+				id: "cu_interrupted_turn",
+				call_id: "call_interrupted_turn",
+				action: { type: "screenshot" },
+				pending_safety_checks: [],
+				status: "completed",
+			},
+			{
+				type: "computer_call_output",
+				call_id: "call_interrupted_turn",
+				output: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
+			},
+		]);
+	});
+
+	test("keeps unrelated reasoning item IDs stripped in mixed computer history", () => {
+		const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay([
+			{
+				type: "reasoning",
+				id: "rs_unrelated_turn",
+				summary: [],
+				encrypted_content: "unrelated-reasoning",
+			},
+			{
+				type: "message",
+				id: "msg_unrelated_turn",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "Earlier answer", annotations: [] }],
+			},
+			{ type: "message", role: "user", content: [{ type: "input_text", text: "Use the computer" }] },
+			{
+				type: "reasoning",
+				id: "rs_computer_turn",
+				summary: [],
+				encrypted_content: "computer-reasoning",
+			},
+			{
+				type: "computer_call",
+				id: "cu_computer_turn",
+				call_id: "call_computer_turn",
+				action: { type: "screenshot" },
+				pending_safety_checks: [],
+				status: "completed",
+			},
+		]);
+
+		expect(sanitized[0] as unknown).toEqual({
+			type: "reasoning",
+			summary: [],
+			encrypted_content: "unrelated-reasoning",
+		});
+		expect(sanitized[3]!).toMatchObject({ type: "reasoning", id: "rs_computer_turn" });
+	});
+
 	test("turns a failed computer call without a screenshot into valid recovery history", () => {
 		const context = {
 			messages: [

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -683,6 +683,12 @@ describe("OpenAI GA computer contract", () => {
 				dt: true,
 				items: [
 					{
+						type: "reasoning",
+						id: "rs_codex_computer",
+						summary: [],
+						encrypted_content: "encrypted-codex-computer-reasoning",
+					},
+					{
 						type: "computer_call",
 						id: "item_codex_computer",
 						call_id: "call_codex_computer",
@@ -700,6 +706,8 @@ describe("OpenAI GA computer contract", () => {
 			},
 		};
 		const replay = convertCodexResponsesMessages(codex, { messages: [previous] });
+		const reasoning = replay.find(item => item.type === "reasoning") as { id?: string } | undefined;
+		expect(reasoning?.id).toBeUndefined();
 		expect(replay.some(item => item.type === "computer_call" || item.type === "computer_call_output")).toBe(false);
 		const call = replay.find(item => item.type === "function_call" && item.call_id === "call_codex_computer");
 		expect(call).toMatchObject({ type: "function_call", name: "computer" });

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -461,6 +461,11 @@ describe("OpenAI GA computer contract", () => {
 					pending_safety_checks: [],
 					status: "completed",
 				},
+				{
+					type: "computer_call_output",
+					call_id: "call_computer_turn",
+					output: { type: "computer_screenshot", file_id: "file_computer_turn" },
+				},
 			]);
 			const reasoningIds = sanitized
 				.filter(replayItem => replayItem.type === "reasoning")
@@ -470,6 +475,44 @@ describe("OpenAI GA computer contract", () => {
 				reasoningIds: [undefined, "rs_computer_turn"],
 			});
 		}
+	});
+
+	test("strips reasoning identity when an orphan native computer call is demoted", () => {
+		const supported = model("openai-responses");
+		const previous = {
+			...assistant([]),
+			providerPayload: {
+				type: "openaiResponsesHistory" as const,
+				provider: "openai" as const,
+				dt: true,
+				items: [
+					{
+						type: "reasoning",
+						id: "rs_orphan_computer",
+						summary: [],
+						encrypted_content: "orphan-computer-reasoning",
+					},
+					{
+						type: "computer_call",
+						id: "cu_orphan_computer",
+						call_id: "call_orphan_computer",
+						actions: [{ type: "screenshot" }],
+						pending_safety_checks: [],
+						status: "completed",
+					},
+				],
+			},
+		};
+		const replay = buildResponsesInput({
+			model: supported,
+			context: { messages: [previous] },
+			strictResponsesPairing: false,
+			supportsImageDetailOriginal: true,
+			nativeHistory: { replay: true, filterReasoning: false },
+		});
+		expect(replay.some(item => item.type === "computer_call" || item.type === "computer_call_output")).toBe(false);
+		expect(JSON.stringify(replay)).toContain("interrupted before a screenshot was recorded");
+		expect(JSON.stringify(replay)).not.toContain("rs_orphan_computer");
 	});
 
 	test("turns a failed computer call without a screenshot into valid recovery history", () => {

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -401,57 +401,75 @@ describe("OpenAI GA computer contract", () => {
 		}
 	});
 
-	test("keeps earlier tool-response reasoning IDs stripped in mixed computer history", () => {
-		const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay([
-			{
-				type: "reasoning",
-				id: "rs_unrelated_tool_turn",
-				summary: [],
-				encrypted_content: "unrelated-reasoning",
-			},
-			{
-				type: "function_call",
-				id: "fc_unrelated_tool_turn",
-				call_id: "call_unrelated_tool_turn",
-				name: "read",
-				arguments: "{}",
-				status: "completed",
-			},
-			{
-				type: "function_call_output",
-				call_id: "call_unrelated_tool_turn",
-				output: "earlier tool result",
-			},
-			{
-				type: "reasoning",
-				id: "rs_computer_turn",
-				summary: [],
-				encrypted_content: "computer-reasoning",
-			},
-			{
-				type: "message",
-				id: "msg_computer_turn",
-				role: "assistant",
-				status: "completed",
-				content: [{ type: "output_text", text: "I will inspect the screen.", annotations: [] }],
-			},
-			{
-				type: "computer_call",
-				id: "cu_computer_turn",
-				call_id: "call_computer_turn",
-				action: { type: "screenshot" },
-				pending_safety_checks: [],
-				status: "completed",
-			},
-		]);
+	test("clears reasoning candidates at every client continuation boundary", () => {
+		const boundaries: Array<[string, Record<string, unknown>]> = [
+			["input message", { role: "user", content: "next turn" }],
+			["function output", { type: "function_call_output", call_id: "call_function", output: "done" }],
+			["custom output", { type: "custom_tool_call_output", call_id: "call_custom", output: "done" }],
+			[
+				"computer output",
+				{
+					type: "computer_call_output",
+					call_id: "call_computer_output",
+					output: { type: "computer_screenshot", file_id: "file_computer_output" },
+				},
+			],
+			["local shell output", { type: "local_shell_call_output", id: "call_local_shell", output: "done" }],
+			["shell output", { type: "shell_call_output", call_id: "call_shell", output: [], status: "completed" }],
+			["apply patch output", { type: "apply_patch_call_output", call_id: "call_patch", status: "completed" }],
+			["MCP approval", { type: "mcp_approval_response", approval_request_id: "approval_1", approve: true }],
+			["client tool search output", { type: "tool_search_output", execution: "client", tools: [] }],
+			["additional tools", { type: "additional_tools", role: "developer", tools: [] }],
+			["compaction trigger", { type: "compaction_trigger" }],
+			["item reference", { type: "item_reference", id: "item_reference_1" }],
+		];
 
-		expect(sanitized[0] as unknown).toEqual({
-			type: "reasoning",
-			summary: [],
-			encrypted_content: "unrelated-reasoning",
-		});
-		expect(sanitized[3]!).toMatchObject({ type: "reasoning", id: "rs_computer_turn" });
-		expect(sanitized[5]!).toMatchObject({ type: "computer_call", id: "cu_computer_turn" });
+		for (const [boundary, item] of boundaries) {
+			const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay([
+				{
+					type: "reasoning",
+					id: "rs_unrelated_turn",
+					summary: [],
+					encrypted_content: "unrelated-reasoning",
+				},
+				item,
+				{
+					type: "reasoning",
+					id: "rs_computer_turn",
+					summary: [],
+					encrypted_content: "computer-reasoning",
+				},
+				{
+					type: "message",
+					id: "msg_computer_turn",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "I will inspect the screen.", annotations: [] }],
+				},
+				{
+					type: "tool_search_output",
+					id: "tool_search_server_1",
+					execution: "server",
+					status: "completed",
+					tools: [],
+				},
+				{
+					type: "computer_call",
+					id: "cu_computer_turn",
+					call_id: "call_computer_turn",
+					action: { type: "screenshot" },
+					pending_safety_checks: [],
+					status: "completed",
+				},
+			]);
+			const reasoningIds = sanitized
+				.filter(replayItem => replayItem.type === "reasoning")
+				.map(replayItem => (replayItem as { id?: string }).id);
+			expect({ boundary, reasoningIds }).toEqual({
+				boundary,
+				reasoningIds: [undefined, "rs_computer_turn"],
+			});
+		}
 	});
 
 	test("turns a failed computer call without a screenshot into valid recovery history", () => {
@@ -494,6 +512,12 @@ describe("OpenAI GA computer contract", () => {
 
 	test("demotes native computer history when replaying to an unsupported model", () => {
 		const unsupported = model("openai-responses", "gpt-5.3");
+		const reasoning = {
+			type: "reasoning",
+			id: "rs_native_1",
+			summary: [],
+			encrypted_content: "native-computer-reasoning",
+		};
 		const call = {
 			type: "computer_call",
 			id: "item_native_1",
@@ -515,7 +539,7 @@ describe("OpenAI GA computer contract", () => {
 				type: "openaiResponsesHistory" as const,
 				provider: "openai" as const,
 				dt: true,
-				items: [call, output],
+				items: [reasoning, call, output],
 			},
 		};
 		const replay = buildResponsesInput({
@@ -528,6 +552,7 @@ describe("OpenAI GA computer contract", () => {
 		expect(replay.some(item => item.type === "computer_call" || item.type === "computer_call_output")).toBe(false);
 		expect(JSON.stringify(replay)).toContain("call_native_1");
 		expect(JSON.stringify(replay)).toContain("file_native_1");
+		expect(JSON.stringify(replay)).not.toContain("rs_native_1");
 	});
 
 	test("full native history replacement clears stale computer call pairing state", () => {

--- a/packages/ai/test/openai-computer-contract.test.ts
+++ b/packages/ai/test/openai-computer-contract.test.ts
@@ -725,6 +725,62 @@ describe("OpenAI GA computer contract", () => {
 		expect(JSON.stringify(replay)).toContain("file_codex_computer");
 	});
 
+	test("retains Codex reasoning identity when computer demotion leaves native response IDs", () => {
+		const codex = model("openai-codex-responses");
+		const compacted = {
+			role: "user" as const,
+			content: "compacted history",
+			providerPayload: {
+				type: "openaiResponsesHistory" as const,
+				provider: "openai-codex",
+				items: [
+					{
+						type: "reasoning",
+						id: "rs_codex_mixed",
+						summary: [],
+						encrypted_content: "encrypted-codex-mixed-reasoning",
+					},
+					{
+						type: "message",
+						id: "msg_codex_mixed",
+						role: "assistant",
+						status: "completed",
+						content: [{ type: "output_text", text: "Inspecting the screen." }],
+					},
+					{
+						type: "function_call",
+						id: "fc_codex_mixed",
+						call_id: "call_codex_mixed_tool",
+						name: "inspect",
+						arguments: "{}",
+						status: "completed",
+					},
+					{
+						type: "computer_call",
+						id: "item_codex_mixed_computer",
+						call_id: "call_codex_mixed_computer",
+						actions: [{ type: "screenshot" }],
+						pending_safety_checks: [],
+						status: "completed",
+					},
+					{
+						type: "computer_call_output",
+						call_id: "call_codex_mixed_computer",
+						output: { type: "computer_screenshot", file_id: "file_codex_mixed_computer" },
+						acknowledged_safety_checks: [],
+					},
+				],
+			},
+			timestamp: Date.now(),
+		};
+
+		const replay = convertCodexResponsesMessages(codex, { messages: [compacted] });
+		expect(replay).toContainEqual(expect.objectContaining({ type: "reasoning", id: "rs_codex_mixed" }));
+		expect(replay).toContainEqual(expect.objectContaining({ type: "message", id: "msg_codex_mixed" }));
+		expect(replay).toContainEqual(expect.objectContaining({ type: "function_call", id: "fc_codex_mixed" }));
+		expect(replay.some(item => item.type === "computer_call" || item.type === "computer_call_output")).toBe(false);
+	});
+
 	test("unrolls internal computer calls and screenshot results for Codex replay", () => {
 		const codex = model("openai-codex-responses");
 		const call = {

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1277,6 +1277,77 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
+	it("preserves linked reasoning when the screenshot is a later tool result", async () => {
+		const context: Context = {
+			messages: [
+				{
+					...makeAssistantMessage(
+						[
+							{
+								type: "reasoning",
+								id: "rs_split_computer_turn",
+								summary: [],
+								encrypted_content: "encrypted-split-computer-reasoning",
+								status: "completed",
+							},
+							{
+								type: "computer_call",
+								id: "cu_split_computer_turn",
+								call_id: "call_split_computer_turn",
+								action: { type: "screenshot" },
+								pending_safety_checks: [],
+								status: "completed",
+							},
+						],
+						true,
+						"openai",
+						"gpt-5.4",
+					),
+					content: [
+						{
+							type: "toolCall" as const,
+							id: "call_split_computer_turn|cu_split_computer_turn",
+							name: "computer",
+							arguments: { actions: [{ type: "screenshot" }] },
+							providerMetadata: {
+								type: "computer" as const,
+								providerItemId: "cu_split_computer_turn",
+								actions: [{ type: "screenshot" as const }],
+								pendingSafetyChecks: [],
+							},
+						},
+					],
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_split_computer_turn|cu_split_computer_turn",
+					toolName: "computer",
+					content: [{ type: "image", data: "AAEC", mimeType: "image/png" }],
+					isError: false,
+					timestamp: Date.now(),
+					providerMetadata: {
+						type: "computer",
+						screenshot: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
+						acknowledgedSafetyChecks: [],
+					},
+				},
+				{ role: "user", content: "continue after split persistence", timestamp: Date.now() },
+			],
+		};
+
+		const model = getOpenAIReasoningModel("openai", "gpt-5.4");
+		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+
+		expect(findResponsesInputItem(payload.input, "reasoning")?.id).toBe("rs_split_computer_turn");
+		expect(findResponsesInputItem(payload.input, "computer_call")).toMatchObject({
+			id: "cu_split_computer_turn",
+			call_id: "call_split_computer_turn",
+		});
+		expect(findResponsesInputItem(payload.input, "computer_call_output")).toMatchObject({
+			call_id: "call_split_computer_turn",
+		});
+	});
+
 	it("backward compat: old full-snapshot payloads still replace history for legacy same-provider assistant turns", async () => {
 		const fullSnapshotItems = [
 			{ type: "message", role: "user", content: [{ type: "input_text", text: "Canonical user" }] },

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1220,6 +1220,63 @@ describe("OpenAI responses history payload", () => {
 		expect(replayHistoryItems[6]?.id).toBe(opaqueMessageId);
 	});
 
+	it("preserves the reasoning ID linked to a native computer call in the next request", async () => {
+		const nativeComputerHistory = [
+			{
+				type: "reasoning",
+				id: "rs_interrupted_computer_turn",
+				summary: [],
+				encrypted_content: "encrypted-computer-reasoning",
+				status: "completed",
+			},
+			{
+				type: "computer_call",
+				id: "cu_interrupted_computer_turn",
+				call_id: "call_interrupted_computer_turn",
+				action: { type: "screenshot" },
+				pending_safety_checks: [],
+				status: "completed",
+			},
+			{
+				type: "computer_call_output",
+				call_id: "call_interrupted_computer_turn",
+				output: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
+			},
+		];
+		const context: Context = {
+			messages: [
+				makeAssistantMessage(nativeComputerHistory, false, "openai", "gpt-5.4"),
+				{ role: "user", content: "continue after interrupt", timestamp: Date.now() },
+			],
+		};
+
+		const model = getOpenAIReasoningModel("openai", "gpt-5.4");
+		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+
+		expect(payload.input).toEqual([
+			{
+				type: "reasoning",
+				id: "rs_interrupted_computer_turn",
+				summary: [],
+				encrypted_content: "encrypted-computer-reasoning",
+			},
+			{
+				type: "computer_call",
+				id: "cu_interrupted_computer_turn",
+				call_id: "call_interrupted_computer_turn",
+				action: { type: "screenshot" },
+				pending_safety_checks: [],
+				status: "completed",
+			},
+			{
+				type: "computer_call_output",
+				call_id: "call_interrupted_computer_turn",
+				output: { type: "computer_screenshot", image_url: "data:image/png;base64,AAEC" },
+			},
+			{ role: "user", content: [{ type: "input_text", text: "continue after interrupt" }] },
+		]);
+	});
+
 	it("backward compat: old full-snapshot payloads still replace history for legacy same-provider assistant turns", async () => {
 		const fullSnapshotItems = [
 			{ type: "message", role: "user", content: [{ type: "input_text", text: "Canonical user" }] },


### PR DESCRIPTION
## What

- Provisionally preserve a Responses reasoning item ID when its assistant response segment contains a native `computer_call`.
- Reset candidate reasoning at every client continuation boundary, while allowing assistant output and server-executed tool-search output inside one response chain.
- After the complete input is rebuilt, model-adapted, and orphan-repaired, keep that provisional ID only when a matching `computer_call_output` remains later in the final input.
- Strip linked reasoning IDs when the target model cannot retain native Computer Use, including the separate Codex subscription unroll path, or when orphan repair demotes an interrupted call without a screenshot.
- Keep unrelated and legacy reasoning-ID behavior unchanged.
- Add full-snapshot, split-persistence, boundary, unsupported-target, Codex-demotion, and orphan-call regressions.

## Why

With `store: false`, OMP replays prior Responses output items. After an interrupted native Computer Use turn, replay kept the `cu_*` computer-call ID but stripped its required preceding `rs_*` reasoning ID. The next request then failed with HTTP 400 because the referenced reasoning item was missing.

Normal persistence can store the assistant reasoning/call payload separately from the later screenshot `ToolResultMessage`, so final pairing must use the fully reconstructed request rather than only one provider payload. The sanitizer now carries the ID provisionally through reconstruction, then drops it unless the final wire input still contains the complete native computer pair that needs it. Paths that intentionally demote native computer calls strip only the reasoning IDs linked to those calls.

OpenAI reference: https://developers.openai.com/api/docs/guides/tools-programmatic-tool-calling#continue-after-client-owned-function-calls

## Testing

- `bun test packages/ai/test/openai-computer-contract.test.ts packages/ai/test/openai-responses-history-payload.test.ts` — 51 pass, 0 fail, 247 expectations
- `bun check`
- Independent isolated-diff, boundary/demotion, orphan-repair, finalization, Codex-demotion, and mixed-output Codex-demotion reviews: clean
- Re-tested the original interrupted Computer Use flow locally; the next prompt remains usable

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)