### PR TITLE
fix(cli): purge completed async jobs on /new

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/new` retaining completed async jobs from the prior session in `hub jobs` until the five-minute retention window expired ([#6828](https://github.com/can1357/oh-my-pi/issues/6828)).
+- Fixed `/new` retaining completed or failed async jobs from the prior session in `hub jobs` until the five-minute retention window expired ([#6828](https://github.com/can1357/oh-my-pi/issues/6828)).
 
 ## [17.1.6] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/new` retaining completed async jobs from the prior session in `hub jobs` until the five-minute retention window expired ([#6828](https://github.com/can1357/oh-my-pi/issues/6828)).
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -417,12 +417,22 @@ export class AsyncJobManager {
 		}
 	}
 
-	/** Immediately evict completed and failed jobs matching the filter instead of waiting for retention expiry. */
+	/**
+	 * Immediately evict completed and failed jobs matching the filter instead of
+	 * waiting for retention expiry, dropping every queued/in-flight delivery and
+	 * keeping the delivery suppressed so a prior session's result can never be
+	 * injected into a later transcript. Returns the number of jobs evicted.
+	 */
 	evictCompletedJobs(filter?: AsyncJobFilter): number {
 		let evicted = 0;
 		for (const job of this.#filterJobs(this.#jobs.values(), filter)) {
 			if (job.status !== "completed" && job.status !== "failed") continue;
-			if (this.#evictJob(job.id)) evicted += 1;
+			// Suppress + drop any queued delivery. The suppression marker persists
+			// past row removal (register() clears it on id reuse) so a sink call
+			// already in flight when this runs still voids its yield-queue follow-up
+			// via the `async-result` dispatcher's isStale check.
+			this.acknowledgeDeliveries([job.id]);
+			if (this.#removeJobRow(job.id)) evicted += 1;
 		}
 		return evicted;
 	}
@@ -590,9 +600,13 @@ export class AsyncJobManager {
 	}
 
 	#evictJob(jobId: string): boolean {
+		this.#suppressedDeliveries.delete(jobId);
+		return this.#removeJobRow(jobId);
+	}
+
+	#removeJobRow(jobId: string): boolean {
 		clearTimeout(this.#evictionTimers.get(jobId));
 		this.#evictionTimers.delete(jobId);
-		this.#suppressedDeliveries.delete(jobId);
 		this.#watchedJobs.delete(jobId);
 		return this.#jobs.delete(jobId);
 	}

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -419,20 +419,20 @@ export class AsyncJobManager {
 
 	/**
 	 * Immediately evict completed and failed jobs matching the filter instead of
-	 * waiting for retention expiry, dropping every queued/in-flight delivery and
-	 * keeping the delivery suppressed so a prior session's result can never be
-	 * injected into a later transcript. Returns the number of jobs evicted.
+	 * waiting for retention expiry, dropping every queued delivery so a prior
+	 * session's result can never be injected into a later transcript. Returns the
+	 * number of jobs evicted.
+	 *
+	 * A delivery whose sink call is already in flight (or drained onto a caller's
+	 * yield queue) is guarded by the owner's delivery generation, not the per-id
+	 * suppression marker — that marker is cleared when the id is reused.
 	 */
 	evictCompletedJobs(filter?: AsyncJobFilter): number {
 		let evicted = 0;
 		for (const job of this.#filterJobs(this.#jobs.values(), filter)) {
 			if (job.status !== "completed" && job.status !== "failed") continue;
-			// Suppress + drop any queued delivery. The suppression marker persists
-			// past row removal (register() clears it on id reuse) so a sink call
-			// already in flight when this runs still voids its yield-queue follow-up
-			// via the `async-result` dispatcher's isStale check.
 			this.acknowledgeDeliveries([job.id]);
-			if (this.#removeJobRow(job.id)) evicted += 1;
+			if (this.#evictJob(job.id)) evicted += 1;
 		}
 		return evicted;
 	}
@@ -600,13 +600,9 @@ export class AsyncJobManager {
 	}
 
 	#evictJob(jobId: string): boolean {
-		this.#suppressedDeliveries.delete(jobId);
-		return this.#removeJobRow(jobId);
-	}
-
-	#removeJobRow(jobId: string): boolean {
 		clearTimeout(this.#evictionTimers.get(jobId));
 		this.#evictionTimers.delete(jobId);
+		this.#suppressedDeliveries.delete(jobId);
 		this.#watchedJobs.delete(jobId);
 		return this.#jobs.delete(jobId);
 	}

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -417,6 +417,16 @@ export class AsyncJobManager {
 		}
 	}
 
+	/** Immediately evict completed jobs matching the filter instead of waiting for retention expiry. */
+	evictCompletedJobs(filter?: AsyncJobFilter): number {
+		let evicted = 0;
+		for (const job of this.#filterJobs(this.#jobs.values(), filter)) {
+			if (job.status !== "completed") continue;
+			if (this.#evictJob(job.id)) evicted += 1;
+		}
+		return evicted;
+	}
+
 	async waitForAll(): Promise<void> {
 		await Promise.all(Array.from(this.#jobs.values()).map(job => job.promise));
 	}
@@ -579,12 +589,18 @@ export class AsyncJobManager {
 		return candidate;
 	}
 
+	#evictJob(jobId: string): boolean {
+		clearTimeout(this.#evictionTimers.get(jobId));
+		this.#evictionTimers.delete(jobId);
+		this.#suppressedDeliveries.delete(jobId);
+		this.#watchedJobs.delete(jobId);
+		return this.#jobs.delete(jobId);
+	}
+
 	#scheduleEviction(jobId: string): void {
 		if (this.#disposed) return;
 		if (this.#retentionMs <= 0) {
-			this.#jobs.delete(jobId);
-			this.#suppressedDeliveries.delete(jobId);
-			this.#watchedJobs.delete(jobId);
+			this.#evictJob(jobId);
 			return;
 		}
 		const existing = this.#evictionTimers.get(jobId);
@@ -592,10 +608,7 @@ export class AsyncJobManager {
 			clearTimeout(existing);
 		}
 		const timer = setTimeout(() => {
-			this.#evictionTimers.delete(jobId);
-			this.#jobs.delete(jobId);
-			this.#suppressedDeliveries.delete(jobId);
-			this.#watchedJobs.delete(jobId);
+			this.#evictJob(jobId);
 		}, this.#retentionMs);
 		timer.unref();
 		this.#evictionTimers.set(jobId, timer);

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -417,11 +417,11 @@ export class AsyncJobManager {
 		}
 	}
 
-	/** Immediately evict completed jobs matching the filter instead of waiting for retention expiry. */
+	/** Immediately evict completed and failed jobs matching the filter instead of waiting for retention expiry. */
 	evictCompletedJobs(filter?: AsyncJobFilter): number {
 		let evicted = 0;
 		for (const job of this.#filterJobs(this.#jobs.values(), filter)) {
-			if (job.status !== "completed") continue;
+			if (job.status !== "completed" && job.status !== "failed") continue;
 			if (this.#evictJob(job.id)) evicted += 1;
 		}
 		return evicted;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1597,7 +1597,7 @@ export class AgentSession {
 	 * cleans up its own background work without touching its parent's jobs.
 	 *
 	 * Cleanup runs against this session's scoped manager: running jobs are
-	 * cancelled and completed rows are evicted immediately. Subagents have
+	 * cancelled and finished rows are evicted immediately. Subagents have
 	 * unique agent ids and inherit the parent's manager to clean up their own
 	 * jobs. A secondary in-process top-level session gets no scoped manager,
 	 * because it defaults to `MAIN_AGENT_ID`; reaching through the global

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -479,6 +479,13 @@ export class AgentSession {
 	readonly #asyncJobManager: AsyncJobManager | undefined;
 	/** Clears this session's owner delivery sink registration; set when a manager + agent id exist. */
 	#unregisterAsyncDeliverySink: (() => void) | undefined;
+	/**
+	 * Async-delivery generation, bumped on every session transition that evicts
+	 * this owner's jobs (see {@link AgentSession.#cancelOwnAsyncJobs}). Stamped
+	 * onto each queued async-result follow-up so a delivery formatted or drained
+	 * across a `/new` is dropped regardless of job-id reuse.
+	 */
+	#asyncDeliveryEpoch = 0;
 
 	readonly #irc: IrcBridge;
 	// Agent identity (registry id) used for IRC routing and job ownership.
@@ -1161,7 +1168,7 @@ export class AgentSession {
 				this.#deliverAsyncJobResult(manager, jobId, text, job),
 			);
 			this.yieldQueue.register<AsyncResultEntry>("async-result", {
-				isStale: entry => manager.isDeliverySuppressed(entry.jobId),
+				isStale: entry => entry.epoch !== this.#asyncDeliveryEpoch || manager.isDeliverySuppressed(entry.jobId),
 				build: buildAsyncResultBatchMessage,
 			});
 		}
@@ -1612,8 +1619,10 @@ export class AgentSession {
 		const manager = this.#asyncJobManager;
 		manager?.cancelAll({ ownerId: this.#agentId });
 		manager?.evictCompletedJobs({ ownerId: this.#agentId });
-		// Drop any async-result follow-up already delivered onto the yield queue so
-		// a prior session's background result cannot inject into the next transcript.
+		// Invalidate this owner's in-flight/drained deliveries against the new
+		// generation, then drop any async-result follow-up already queued, so a
+		// prior session's background result cannot inject into the next transcript.
+		this.#asyncDeliveryEpoch += 1;
 		this.yieldQueue.clear("async-result");
 	}
 
@@ -1680,10 +1689,17 @@ export class AgentSession {
 	async #deliverAsyncJobResult(manager: AsyncJobManager, jobId: string, text: string, job?: AsyncJob): Promise<void> {
 		if (this.#isDisposed) return;
 		if (manager.isDeliverySuppressed(jobId)) return;
+		// Snapshot the generation before the async format step: a `/new` during it
+		// bumps the epoch, so this delivery belongs to the replaced session and
+		// must not enqueue — the suppression marker alone is unreliable because
+		// job-id reuse clears it.
+		const epoch = this.#asyncDeliveryEpoch;
 		const formatted = await this.#formatAsyncResultForFollowUp(text);
+		if (this.#isDisposed) return;
+		if (epoch !== this.#asyncDeliveryEpoch) return;
 		if (manager.isDeliverySuppressed(jobId)) return;
 		const durationMs = job ? Math.max(0, Date.now() - job.startTime) : undefined;
-		this.yieldQueue.enqueue<AsyncResultEntry>("async-result", { jobId, result: formatted, job, durationMs });
+		this.yieldQueue.enqueue<AsyncResultEntry>("async-result", { jobId, result: formatted, job, durationMs, epoch });
 	}
 
 	async #formatAsyncResultForFollowUp(result: string): Promise<string> {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1597,7 +1597,8 @@ export class AgentSession {
 	 * cleans up its own background work without touching its parent's jobs.
 	 *
 	 * Cleanup runs against this session's scoped manager: running jobs are
-	 * cancelled and finished rows are evicted immediately. Subagents have
+	 * cancelled, finished rows are evicted with their pending deliveries, and any
+	 * async-result follow-up already queued for injection is dropped. Subagents have
 	 * unique agent ids and inherit the parent's manager to clean up their own
 	 * jobs. A secondary in-process top-level session gets no scoped manager,
 	 * because it defaults to `MAIN_AGENT_ID`; reaching through the global
@@ -1611,6 +1612,9 @@ export class AgentSession {
 		const manager = this.#asyncJobManager;
 		manager?.cancelAll({ ownerId: this.#agentId });
 		manager?.evictCompletedJobs({ ownerId: this.#agentId });
+		// Drop any async-result follow-up already delivered onto the yield queue so
+		// a prior session's background result cannot inject into the next transcript.
+		this.yieldQueue.clear("async-result");
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1596,7 +1596,8 @@ export class AgentSession {
 	 * transitions (newSession, switchSession, handoff, dispose) so a subagent
 	 * cleans up its own background work without touching its parent's jobs.
 	 *
-	 * Cancellation runs against this session's scoped manager. Subagents have
+	 * Cleanup runs against this session's scoped manager: running jobs are
+	 * cancelled and completed rows are evicted immediately. Subagents have
 	 * unique agent ids and inherit the parent's manager to clean up their own
 	 * jobs. A secondary in-process top-level session gets no scoped manager,
 	 * because it defaults to `MAIN_AGENT_ID`; reaching through the global
@@ -1609,6 +1610,7 @@ export class AgentSession {
 		if (!this.#agentId) return;
 		const manager = this.#asyncJobManager;
 		manager?.cancelAll({ ownerId: this.#agentId });
+		manager?.evictCompletedJobs({ ownerId: this.#agentId });
 	}
 
 	/**

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -29,6 +29,14 @@ export interface AsyncResultEntry {
 	result: string;
 	job: AsyncJob | undefined;
 	durationMs: number | undefined;
+	/**
+	 * Owning session's async-delivery generation at enqueue time. A session
+	 * transition (`/new`, switch, handoff) bumps the generation, so an entry
+	 * whose generation no longer matches belongs to a replaced transcript and
+	 * is dropped at flush — even after its job id has been reused, which clears
+	 * the manager's per-id suppression marker.
+	 */
+	epoch: number;
 }
 
 type AsyncResultJobDetails = {

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -148,6 +148,58 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(manager.getJob(otherOwnerJobId)?.status).toBe("completed");
 	});
 
+	it("does not inject a prior session's pending async result after a new session", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({ retentionMs: 60_000 });
+		AsyncJobManager.setInstance(manager);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+			ownedAsyncJobManager: manager,
+		});
+
+		// Complete a job and push its result all the way onto the yield queue, so a
+		// follow-up turn is pending injection into the (soon-to-be-replaced) session.
+		manager.register("task", "prior session", async () => "STALE ASYNC RESULT", {
+			id: "prior-session-job",
+			ownerId: "Main",
+		});
+		await manager.waitForOwnerJobs("Main");
+		await manager.drainDeliveries({ filter: { ownerId: "Main" } });
+		expect(session.hasPendingAsyncWork()).toBe(true);
+
+		expect(await session.newSession()).toBe(true);
+		expect(session.hasPendingAsyncWork()).toBe(false);
+
+		// A fresh turn in the replacement session must not carry the prior result.
+		const callsBefore = mock.calls.length;
+		await session.sendUserMessage("fresh turn");
+		const leaked = mock.calls.slice(callsBefore).some(call =>
+			call.context.messages.some(message => {
+				if (typeof message.content === "string") return message.content.includes("STALE ASYNC RESULT");
+				return (
+					Array.isArray(message.content) &&
+					message.content.some(content => content.type === "text" && content.text.includes("STALE ASYNC RESULT"))
+				);
+			}),
+		);
+		expect(leaked).toBe(false);
+	});
+
 	it("still reports pending async work while a delivered result awaits injection", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -94,6 +94,47 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(sawResult).toBe(true);
 	});
 
+	it("purges completed owned jobs when starting a new session", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({ retentionMs: 60_000 });
+		AsyncJobManager.setInstance(manager);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+			ownedAsyncJobManager: manager,
+		});
+
+		const completedJobId = manager.register("task", "prior session", async () => "done", {
+			id: "prior-session-job",
+			ownerId: "Main",
+		});
+		const otherOwnerJobId = manager.register("task", "other session", async () => "done", {
+			id: "other-session-job",
+			ownerId: "Other",
+		});
+		manager.watchJobs([completedJobId, otherOwnerJobId]);
+		await manager.waitForAll();
+
+		expect(manager.getJob(completedJobId)?.status).toBe("completed");
+		expect(await session.newSession()).toBe(true);
+		expect(manager.getJob(completedJobId)).toBeUndefined();
+		expect(manager.getJob(otherOwnerJobId)?.status).toBe("completed");
+	});
+
 	it("still reports pending async work while a delivered result awaits injection", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -94,7 +94,7 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(sawResult).toBe(true);
 	});
 
-	it("purges completed owned jobs when starting a new session", async () => {
+	it("purges finished owned jobs when starting a new session", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
 		const agent = new Agent({
@@ -122,16 +122,29 @@ describe("AgentSession owner-routed async delivery", () => {
 			id: "prior-session-job",
 			ownerId: "Main",
 		});
+		const failedJobId = manager.register(
+			"task",
+			"failed prior session",
+			async () => {
+				throw new Error("prior session failure");
+			},
+			{
+				id: "failed-prior-session-job",
+				ownerId: "Main",
+			},
+		);
 		const otherOwnerJobId = manager.register("task", "other session", async () => "done", {
 			id: "other-session-job",
 			ownerId: "Other",
 		});
-		manager.watchJobs([completedJobId, otherOwnerJobId]);
+		manager.watchJobs([completedJobId, failedJobId, otherOwnerJobId]);
 		await manager.waitForAll();
 
 		expect(manager.getJob(completedJobId)?.status).toBe("completed");
+		expect(manager.getJob(failedJobId)?.status).toBe("failed");
 		expect(await session.newSession()).toBe(true);
 		expect(manager.getJob(completedJobId)).toBeUndefined();
+		expect(manager.getJob(failedJobId)).toBeUndefined();
 		expect(manager.getJob(otherOwnerJobId)?.status).toBe("completed");
 	});
 

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -16,6 +16,7 @@ import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AsyncResultEntry } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -198,6 +199,63 @@ describe("AgentSession owner-routed async delivery", () => {
 			}),
 		);
 		expect(leaked).toBe(false);
+	});
+
+	it("drops a prior session's late delivery even after its job id is reused", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({ retentionMs: 60_000 });
+		AsyncJobManager.setInstance(manager);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+			ownedAsyncJobManager: manager,
+		});
+
+		// The delivery generation starts at 0; a new session bumps it to 1.
+		expect(await session.newSession()).toBe(true);
+
+		// Simulate a delivery that finished formatting in the prior session (epoch
+		// 0) but only reaches the yield queue after the transition — the exact
+		// window a reused job id would reopen by clearing the manager's per-id
+		// suppression marker. It must not inject into the replacement transcript.
+		session.yieldQueue.enqueue<AsyncResultEntry>("async-result", {
+			jobId: "bg_1",
+			result: "STALE ASYNC RESULT",
+			job: undefined,
+			durationMs: 0,
+			epoch: 0,
+		});
+
+		const callsBefore = mock.calls.length;
+		await session.sendUserMessage("fresh turn");
+		await session.settleAsyncWork();
+		const leaked = mock.calls.slice(callsBefore).some(call =>
+			call.context.messages.some(message => {
+				if (typeof message.content === "string") return message.content.includes("STALE ASYNC RESULT");
+				return (
+					Array.isArray(message.content) &&
+					message.content.some(content => content.type === "text" && content.text.includes("STALE ASYNC RESULT"))
+				);
+			}),
+		);
+		expect(leaked).toBe(false);
+		// The stale entry was consumed by the run's aside/flush path and dropped,
+		// not left lingering as pending work.
+		expect(session.hasPendingAsyncWork()).toBe(false);
 	});
 
 	it("still reports pending async work while a delivered result awaits injection", async () => {


### PR DESCRIPTION
## Repro
On current `main`, run `bun -e "import { AsyncJobManager } from './packages/coding-agent/src/async/job-manager.ts'; const manager = new AsyncJobManager({ retentionMs: 300_000 }); manager.register('task', 'prior session job', async () => 'done', { id: 'old-job', ownerId: 'Main' }); await manager.waitForOwnerJobs('Main'); manager.cancelAll({ ownerId: 'Main' }); console.log(JSON.stringify(manager.getAllJobs({ ownerId: 'Main' }).map(({ id, status }) => ({ id, status })))); await manager.dispose();"`; it prints `[{"id":"old-job","status":"completed"}]`, matching the stale row `/new` left visible.

## Cause
`AgentSession.#cancelOwnAsyncJobs()` in `packages/coding-agent/src/session/agent-session.ts` called only `AsyncJobManager.cancelAll()`, while `cancelAll()` intentionally touches running jobs only; completed rows in `packages/coding-agent/src/async/job-manager.ts` therefore remained available to `hub jobs` until retention eviction.

## Fix
- Add owner-filtered `AsyncJobManager.evictCompletedJobs()` using the manager's shared eviction cleanup.
- Evict completed rows immediately after `/new` cancels the prior owner's running jobs.
- Cover fresh-session cleanup and verify another owner's completed row remains intact.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-async-delivery.test.ts` passes: 3 tests, 0 failures. The post-fix reproduction prints `[]`. The pre-publish `bun check` gate passed.

Fixes #6828