### PR TITLE
feat(commands): /exit alias and user-configurable slash-command priority

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -721,6 +721,25 @@ searxng:
 
 Provider credentials and custom model definitions are configured separately — see [Providers](./providers.md) and [Models](./models.md).
 
+### Slash command priority overrides
+
+When several slash commands share the same prefix, autocomplete ranks them by match quality. You can give specific commands a boost so that short prefixes resolve the way you expect.
+
+```yaml
+commands:
+  priorityOverrides:
+    exit: 10
+    q: 5
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `commands.priorityOverrides` | record | `{ exit: 10 }` | Map of slash-command name or alias to a numeric priority boost. Higher values rank first. Exact matches still win over boosted prefix matches, and ties keep registry order. |
+
+For example, the default `{ exit: 10 }` ensures that typing `/ex` offers `/exit` (an alias of `/quit`) before `/export`. To make `/qu` prefer `/quit` over `/queue` or `/quote`, set `quit: 10` or `q: 10`.
+
+Keys may match either a command's canonical name or any of its aliases; aliases are resolved per-command so an alias override affects that command's ranking, not other commands.
+
 ### Other groups
 
 `omp config list` exposes many more grouped settings, including: `task.*` (subagent concurrency, isolation, model overrides), `skills.*` and `commands.*` (discovery toggles), `mcp.*`, `github.*`, `async.*`, `goal.*`, `loop.*`, `todo.*`, `magicKeywords.*`, `ttsr.*` (time-traveling stream rules), `display.*`, `startup.*`, `share.*`, `collab.*`, `stt.*`/`tts.*`, `memories.*`/`hindsight.*`/`mnemopi.*` (memory backends), and `bashInterceptor.*`. Each follows the same type/default rules shown above.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -45,6 +45,12 @@
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
 
+
+- Added `/exit` as an alias for `/quit` so existing terminal muscle memory works in the TUI.
+- Added `commands.priorityOverrides` setting for user-configurable slash-command autocomplete priority boosts.
+
+### Changed
+
 ## [17.1.5] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4751,13 +4751,13 @@ export const SETTINGS_SCHEMA = {
 
 	"commands.priorityOverrides": {
 		type: "record",
-		default: { exit: 10 } as Record<string, number>,
+		default: {} as Record<string, number>,
 		ui: {
 			tab: "tasks",
 			group: "Commands & Skills",
 			label: "Slash Command Priority Overrides",
 			description:
-				"Numeric priority boosts for slash-command autocomplete. Higher values rank a command before others that share the same prefix. Keys match command names or aliases.",
+				"Numeric priority boosts for slash-command autocomplete (0-99). Higher values rank a command before others that share the same prefix. Keys match command names or aliases.",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4749,6 +4749,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"commands.priorityOverrides": {
+		type: "record",
+		default: { exit: 10 } as Record<string, number>,
+		ui: {
+			tab: "tasks",
+			group: "Commands & Skills",
+			label: "Slash Command Priority Overrides",
+			description:
+				"Numeric priority boosts for slash-command autocomplete. Higher values rank a command before others that share the same prefix. Keys match command names or aliases.",
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Providers
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -553,6 +553,9 @@ export class Settings {
 		if (path === "modelRoles") {
 			modelRolesSignal.fire();
 		}
+		if (path === "commands.priorityOverrides") {
+			commandPriorityOverridesSignal.fire();
+		}
 	}
 
 	/** Set once this instance is discarded; background saves become no-ops. */
@@ -1800,6 +1803,28 @@ export class Settings {
 				: undefined,
 		);
 
+		// Sanitize commands.priorityOverrides: keep only finite numeric values
+		// so malformed user edits can't break autocomplete scoring.
+		const priorityOverrides = raw.commands as Record<string, unknown> | undefined;
+		if (priorityOverrides && isRecord(priorityOverrides.priorityOverrides)) {
+			const sanitized: Record<string, number> = {};
+			for (const [key, value] of Object.entries(priorityOverrides.priorityOverrides)) {
+				if (typeof value === "number" && Number.isFinite(value)) {
+					sanitized[key] = value;
+				}
+			}
+			priorityOverrides.priorityOverrides = sanitized;
+		}
+		if (isRecord(raw["commands.priorityOverrides"])) {
+			const sanitized: Record<string, number> = {};
+			for (const [key, value] of Object.entries(raw["commands.priorityOverrides"])) {
+				if (typeof value === "number" && Number.isFinite(value)) {
+					sanitized[key] = value;
+				}
+			}
+			raw["commands.priorityOverrides"] = sanitized;
+		}
+
 		return raw;
 	}
 
@@ -2228,6 +2253,16 @@ const appendOnlyModeSignal = new SettingSignal<[value: string]>("provider.append
  * can register independently without overwriting each other.
  */
 export const onAppendOnlyModeChanged = (cb: (value: string) => void) => appendOnlyModeSignal.on(cb);
+
+/** Fires when any `commands.priorityOverrides` value changes at runtime. */
+const commandPriorityOverridesSignal = new SettingSignal("command priority overrides");
+
+/**
+ * Subscribe to slash-command priority override changes. The callback receives
+ * no arguments; callers should re-read `settings.get("commands.priorityOverrides")`.
+ * Returns an unsubscribe function.
+ */
+export const onCommandPriorityOverridesChanged = (cb: () => void) => commandPriorityOverridesSignal.on(cb);
 
 /** Fires when any model role changes at runtime. */
 const modelRolesSignal = new SettingSignal("modelRoles");

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -60,6 +60,7 @@ import { formatModelString, type ResolvedModelRoleValue } from "../config/model-
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import {
 	isSettingsInitialized,
+	onCommandPriorityOverridesChanged,
 	onModelRolesChanged,
 	onStatusLineSessionAccentChanged,
 	Settings,
@@ -1097,6 +1098,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			}),
 		);
 		this.#eventBusUnsubscribers.push(
+			onCommandPriorityOverridesChanged(() => {
+				void this.refreshSlashCommandState().catch(error => {
+					logger.warn("Failed to refresh slash commands after priority override change", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+			}),
+		);
+		this.#eventBusUnsubscribers.push(
 			this.session.subscribeCommandMetadataChanged(() => {
 				const retainedCommands = this.#pendingSlashCommands.filter(command => !command.name.startsWith("skill:"));
 				const skillCommands = this.#rebuildSkillCommandsFromSession();
@@ -1183,16 +1193,25 @@ export class InteractiveMode implements InteractiveModeContext {
 		const overrides = settings.get("commands.priorityOverrides");
 		if (!overrides || Object.keys(overrides).length === 0) return commands;
 		return commands.map(cmd => {
-			let override = overrides[cmd.name];
+			let override: number | undefined;
+			const rawOverride = overrides[cmd.name];
+			if (rawOverride !== undefined && typeof rawOverride === "number" && Number.isFinite(rawOverride)) {
+				override = rawOverride;
+			}
 			if (override === undefined) {
 				for (const alias of cmd.aliases ?? []) {
-					if (overrides[alias] !== undefined) {
-						override = overrides[alias];
+					const rawAliasOverride = overrides[alias];
+					if (
+						rawAliasOverride !== undefined &&
+						typeof rawAliasOverride === "number" &&
+						Number.isFinite(rawAliasOverride)
+					) {
+						override = rawAliasOverride;
 						break;
 					}
 				}
 			}
-			return override === undefined ? cmd : { ...cmd, priority: override };
+			return override === undefined ? cmd : { ...cmd, priority: Math.max(0, Math.min(99, override)) };
 		});
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1172,6 +1172,30 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#pendingSlashCommands = [...retainedCommands, ...skillCommands];
 	}
 
+	/**
+	 * Apply user-configured priority overrides to slash commands before they are
+	 * handed to the autocomplete provider. Keys in `commands.priorityOverrides`
+	 * may match either a command name or one of its aliases. Commands without a
+	 * matching override keep any intrinsic priority they already have.
+	 */
+	#applyCommandPriorityOverrides(commands: SlashCommand[]): SlashCommand[] {
+		if (!isSettingsInitialized()) return commands;
+		const overrides = settings.get("commands.priorityOverrides");
+		if (!overrides || Object.keys(overrides).length === 0) return commands;
+		return commands.map(cmd => {
+			let override = overrides[cmd.name];
+			if (override === undefined) {
+				for (const alias of cmd.aliases ?? []) {
+					if (overrides[alias] !== undefined) {
+						override = overrides[alias];
+						break;
+					}
+				}
+			}
+			return override === undefined ? cmd : { ...cmd, priority: override };
+		});
+	}
+
 	/** Reload slash commands and autocomplete for the provided working directory. */
 	async refreshSlashCommandState(cwd?: string): Promise<void> {
 		const basePath = cwd ?? this.sessionManager.getCwd();
@@ -1204,7 +1228,11 @@ export class InteractiveMode implements InteractiveModeContext {
 				description: template.description,
 			}));
 		this.#baseAutocompleteProvider = this.#inputController.createAutocompleteProvider(
-			[...this.#pendingSlashCommands, ...fileSlashCommands, ...promptTemplateCommands],
+			this.#applyCommandPriorityOverrides([
+				...this.#pendingSlashCommands,
+				...fileSlashCommands,
+				...promptTemplateCommands,
+			]),
 			basePath,
 		);
 		this.#applyAutocompleteProvider();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2005,11 +2005,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
-		name: "exit",
-		description: "Exit the application",
-		handleTui: shutdownHandlerTui,
-	},
-	{
 		name: "marketplace",
 		description: "Manage marketplace plugin sources and installed plugins",
 		acpDescription: "Manage plugins from marketplaces",
@@ -2606,7 +2601,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "quit",
-		aliases: ["q"],
+		aliases: ["q","exit"],
 		description: "Quit the application",
 		handleTui: shutdownHandlerTui,
 	},
@@ -2793,6 +2788,7 @@ export const BUILTIN_SLASH_COMMAND_DEFS: ReadonlyArray<BuiltinSlashCommand> = BU
 		aliases: command.aliases,
 		allowArgs: command.allowArgs === true,
 		description: command.description,
+		priority: command.priority,
 		subcommands: command.subcommands,
 		inlineHint: command.inlineHint,
 		getTuiAutocompleteDescription: command.getTuiAutocompleteDescription,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2601,7 +2601,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "quit",
-		aliases: ["q","exit"],
+		aliases: ["q", "exit"],
 		description: "Quit the application",
 		handleTui: shutdownHandlerTui,
 	},

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -18,6 +18,8 @@ export interface BuiltinSlashCommand {
 	description: string;
 	/** Whether the command consumes text after the command name. */
 	allowArgs?: boolean;
+	/** Numeric priority boost for slash-command autocomplete. Higher values rank the command before others that share the same prefix. */
+	priority?: number;
 	/** Subcommands for dropdown completion (e.g. /mcp add, /mcp list). */
 	subcommands?: SubcommandDef[];
 	/** Static inline hint when command takes a simple argument (no subcommands). */

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed the multi-line prompt editor bypassing the keybindings registry for word/line delete and yank: `ctrl+backspace` (a declared default of `tui.editor.deleteWordBackward`) never fired and `keybindings.yml` remaps of `deleteWordBackward`, `deleteWordForward`, `deleteToLineStart`, `deleteToLineEnd`, `yank`, and `yankPop` were ignored, because those actions were matched with hardcoded chords instead of `keybindings.matches(...)` like cursor motion and the single-line `Input` already do ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Restored the Windows Terminal raw `0x08` → `ctrl+backspace` disambiguation (`WT_SESSION` set, `SSH_*` unset) by routing the exported `matchesRawBackspace` helper through the `matchesKey`/`parseKey` seam. Remote SSH/container sessions where terminal identity is unavailable can opt in with `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` ([#6782](https://github.com/can1357/oh-my-pi/issues/6782)).
 - Fixed plain Backspace deleting a whole word inside tmux/GNU screen/Zellij panes launched from Windows Terminal: multiplexers inherit `WT_SESSION` but emit raw `0x08` for plain Backspace, so the automatic raw-backspace → `ctrl+backspace` heuristic misfired. The heuristic now skips multiplexer sessions (`TMUX`/`STY`/`ZELLIJ` or `TERM` starting with `tmux`/`screen`); `PI_TUI_RAW_BACKSPACE_IS_CTRL=1` remains the explicit opt-in everywhere ([#6784](https://github.com/can1357/oh-my-pi/pull/6784)).
+- Added optional `priority` field to `SlashCommand` for configurable autocomplete ranking.
 
 ## [17.1.4] - 2026-07-26
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -184,6 +184,13 @@ export interface SlashCommand {
 	argumentHint?: string;
 	/** Whether the command consumes argument text after the command name. False means the full input stays normal prompt text once args are present. */
 	allowArgs?: boolean;
+	/**
+	 * Optional priority boost used when ranking prefix-matched slash commands.
+	 * Higher values make this command appear before other commands that share
+	 * the same prefix. Exact matches still win; prefix matches with equal score
+	 * keep registry order.
+	 */
+	priority?: number;
 	/** Dynamic display-only description for slash-command autocomplete. Must be synchronous and side-effect free. */
 	getAutocompleteDescription?: () => string | undefined;
 	// Function to get argument completions for this command
@@ -308,6 +315,7 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 				return fullDescMemo;
 			};
 			let best: (AutocompleteItem & { score: number }) | undefined;
+			const priorityBoost = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
 
 			const isSkillCommand = name.startsWith("skill:");
 			const nameScore =
@@ -315,7 +323,7 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 			const lowerDesc = staticDesc.toLowerCase();
 			const descScore =
 				lowerDesc && fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-			const primaryScore = Math.max(nameScore, descScore);
+			const primaryScore = Math.max(nameScore, descScore) + priorityBoost;
 			if (primaryScore > 0) {
 				const fullDesc = resolveFullDesc();
 				best = {
@@ -329,7 +337,7 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 			if (lowerPrefix.length > 0) {
 				for (const alias of getCommandAliases(cmd)) {
 					if (alias === name) continue;
-					const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
+					const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase()) + priorityBoost;
 					if (aliasScore === 0 || (best && aliasScore <= best.score)) continue;
 					const fullDesc = resolveFullDesc();
 					best = {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -315,7 +315,8 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 				return fullDescMemo;
 			};
 			let best: (AutocompleteItem & { score: number }) | undefined;
-			const priorityBoost = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
+			const rawPriorityBoost = "priority" in cmd && typeof cmd.priority === "number" ? cmd.priority : 0;
+			const priorityBoost = Number.isFinite(rawPriorityBoost) ? Math.max(0, Math.min(99, rawPriorityBoost)) : 0;
 
 			const isSkillCommand = name.startsWith("skill:");
 			const nameScore =
@@ -323,7 +324,8 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 			const lowerDesc = staticDesc.toLowerCase();
 			const descScore =
 				lowerDesc && fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-			const primaryScore = Math.max(nameScore, descScore) + priorityBoost;
+			const textualScore = Math.max(nameScore, descScore);
+			const primaryScore = textualScore > 0 ? textualScore + priorityBoost : 0;
 			if (primaryScore > 0) {
 				const fullDesc = resolveFullDesc();
 				best = {
@@ -337,7 +339,8 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 			if (lowerPrefix.length > 0) {
 				for (const alias of getCommandAliases(cmd)) {
 					if (alias === name) continue;
-					const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase()) + priorityBoost;
+					const aliasTextualScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
+					const aliasScore = aliasTextualScore > 0 ? aliasTextualScore + priorityBoost : 0;
 					if (aliasScore === 0 || (best && aliasScore <= best.score)) continue;
 					const fullDesc = resolveFullDesc();
 					best = {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -891,6 +891,49 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items[0]?.value).toBe("q");
 	});
 
+	it("ranks a priority-boosted prefix match above an equal prefix match", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "export", description: "Export session" },
+				{ name: "expand", description: "Expand selection", priority: 10 },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/ex");
+		expect(result).not.toBeNull();
+		expect(result!.items[0]?.value).toBe("expand");
+	});
+
+	it("ranks a priority-boosted alias above a same-prefix command (/ex -> exit, not export)", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "quit", aliases: ["q", "exit"], description: "Quit the application", priority: 10 },
+				{ name: "export", description: "Export session" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/ex");
+		expect(result).not.toBeNull();
+		// The `exit` alias on `quit` carries a priority boost, so /ex should
+		// resolve to exit/quit even though `export` shares the same prefix.
+		expect(result!.items[0]?.value).toBe("exit");
+	});
+
+	it("does not let priority overtake an exact command-name match", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "quote", description: "Insert a quote", priority: 100 },
+				{ name: "quit", description: "Quit the application" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/quit");
+		expect(result).not.toBeNull();
+		// /quit is an exact match for `quit`; even a large priority boost on
+		// `quote` (a mere prefix match) must not overtake it.
+		expect(result!.items[0]?.value).toBe("quit");
+	});
+
 	it("uses aliases when completing slash command arguments", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[


### PR DESCRIPTION
## Summary
- Adds `/exit` as an alias of `/quit` so both commands behave identically.
- Introduces `commands.priorityOverrides`: a user setting that boosts a command's autocomplete ranking by name or alias. The default `{ exit: 10 }` ensures typing `/ex` ranks `/exit` above `/export`.
- Wires the boost through the TUI autocomplete scorer without changing default ordering for non-overridden commands.
- Adds docs in `docs/settings.md` and unit tests in `packages/tui/test/autocomplete.test.ts`.

## Test Plan
- `bun --cwd=packages/tui run check:types` passes.
- `bun --cwd=packages/coding-agent run check:types` passes.
- `bun --cwd=packages/tui test autocomplete.test.ts` passes (62/62).

bun.lock changes were intentionally excluded.