### PR TITLE
feat(undo): snapshot-based /undo [n] with snapshots.enabled setting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -721,6 +721,14 @@ searxng:
 
 Provider credentials and custom model definitions are configured separately — see [Providers](./providers.md) and [Models](./models.md).
 
+### Undo
+
+`/undo [n]` rolls back the last `n` user→assistant turns, restoring workspace files and branching the session so the reverted user message is ready to edit and resend. Snapshots are captured automatically at the start of each user turn in a hidden git repository under the agent data directory, keeping the user's project history untouched. Undo only restores files that actually changed, requires confirmation before destructive restore, and is disabled when git is unavailable or the project directory does not exist. Toggle snapshots with `snapshots.enabled`.
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `snapshots.enabled` | boolean | `true` | Capture per-turn workspace snapshots and enable `/undo`. Set to `false` to disable snapshotting entirely. |
+
 ### Other groups
 
 `omp config list` exposes many more grouped settings, including: `task.*` (subagent concurrency, isolation, model overrides), `skills.*` and `commands.*` (discovery toggles), `mcp.*`, `github.*`, `async.*`, `goal.*`, `loop.*`, `todo.*`, `magicKeywords.*`, `ttsr.*` (time-traveling stream rules), `display.*`, `startup.*`, `share.*`, `collab.*`, `stt.*`/`tts.*`, `memories.*`/`hindsight.*`/`mnemopi.*` (memory backends), and `bashInterceptor.*`. Each follows the same type/default rules shown above.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -124,6 +124,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 	model: ["Thinking", "Sampling", "Prompt", "Retry & Fallback", "Advisor", "Prewalk", "Vision"],
 	interaction: [
 		"Input",
+		"Undo",
 		"Approvals",
 		"Notifications",
 		"Speech",
@@ -4720,6 +4721,21 @@ export const SETTINGS_SCHEMA = {
 			group: "Commands & Skills",
 			label: "OpenCode Project Commands",
 			description: "Load commands from .opencode/commands/",
+		},
+	},
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Snapshots
+	// ────────────────────────────────────────────────────────────────────────
+
+	"snapshots.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Undo",
+			label: "Enable per-turn snapshots",
+			description: "Capture workspace state before each assistant turn so /undo can restore files",
 		},
 	},
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1416,6 +1416,63 @@ export class CommandController {
 		}
 		this.ctx.ui.requestRender(true, { clearScrollback: true });
 	}
+
+	async handleUndoCommand(howMuchRaw?: string): Promise<void> {
+		if (this.ctx.session.isStreaming) {
+			this.ctx.showWarning("Wait for the current response to finish or abort it before undoing.");
+			return;
+		}
+
+		const tracker = this.ctx.session.getUndoTracker();
+		const supported = await tracker.isSupported();
+		if (!supported) {
+			this.ctx.showError("Undo is not available (no git or unsupported project).");
+			return;
+		}
+
+		const boundaries = tracker.resolveUndo(howMuchRaw);
+		if (!boundaries) {
+			this.ctx.showError("Nothing to undo.");
+			return;
+		}
+
+		const howMuch = Math.max(1, parseInt(howMuchRaw ?? "1", 10));
+		const confirmed = await this.ctx.showHookConfirm(
+			"Undo?",
+			`Revert ${howMuch === 1 ? "the last turn" : `${howMuch} turns`} and restore ${boundaries.filesToRestore.length} file(s)?`,
+		);
+		if (!confirmed) {
+			this.ctx.showStatus("Undo cancelled.");
+			return;
+		}
+
+		const loader = new Loader(
+			this.ctx.ui,
+			spinner => theme.fg("accent", spinner),
+			text => theme.fg("muted", text),
+			"Reverting…",
+			getSymbolTheme().spinnerFrames,
+		);
+		this.ctx.statusContainer.addChild(loader);
+		this.ctx.ui.requestRender();
+
+		try {
+			await tracker.restoreFiles(boundaries);
+			this.ctx.sessionManager.branch(boundaries.targetUserEntryId);
+			this.ctx.editor.setText(boundaries.userMessageText);
+			this.ctx.clearTransientSessionUi();
+			this.ctx.renderInitialMessages();
+			this.ctx.statusLine.invalidate();
+			this.ctx.ui.requestRender(true, { clearScrollback: true });
+			this.ctx.showStatus(`Undid ${howMuch === 1 ? "1 turn" : `${howMuch} turns`}. Edit and resend your message.`);
+		} catch (error) {
+			this.ctx.showError(`Undo failed: ${error instanceof Error ? error.message : String(error)}`);
+		} finally {
+			loader.stop();
+			this.ctx.statusContainer.disposeChildren();
+			this.ctx.ui.requestRender();
+		}
+	}
 }
 
 const BAR_WIDTH_MAX = 24;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4498,6 +4498,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleMemoryCommand(text);
 	}
 
+	async handleUndoCommand(howMuchRaw?: string): Promise<void> {
+		await this.#commandController.handleUndoCommand(howMuchRaw);
+	}
+
 	async handleSTTToggle(): Promise<void> {
 		if (this.#liveCommandController.active) {
 			this.showWarning("End live mode before using push-to-talk speech input.");

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -360,6 +360,7 @@ export interface InteractiveModeContext {
 	handleMoveCommand(targetPath?: string): Promise<void>;
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;
+	handleUndoCommand(howMuchRaw?: string): Promise<void>;
 	handleSTTToggle(): Promise<void>;
 	/** Start or stop the Codex-backed realtime voice session. */
 	handleLiveCommand(): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -99,7 +99,8 @@ export interface AgentSessionConfig {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settings: Settings;
-	/** Whether the caller explicitly requested yolo/auto-approve behavior for this session. */
+	/** Whether per-turn workspace snapshots and `/undo` are enabled. Defaults to true when supported. */
+	undoEnabled?: boolean;
 	autoApprove?: boolean;
 	/** Models to cycle through with Ctrl+P (from --models flag). */
 	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -310,6 +310,7 @@ import type { ShakeMode, ShakeResult } from "./shake-types";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { planTurnPersistence, sameMessageContent, sessionMessagePersistenceKey } from "./turn-persistence";
 import { TurnRecovery, type TurnRecoveryHost } from "./turn-recovery";
+import { UndoTracker } from "./undo-tracker";
 import { YieldQueue } from "./yield-queue";
 
 export * from "./agent-session-events";
@@ -560,6 +561,7 @@ export class AgentSession {
 	#pendingRewindReport: string | undefined = undefined;
 	#lastCompletedRewind: CompletedRewindState | undefined = undefined;
 	#rewoundToolResultIds = new Set<string>();
+	readonly #undoTracker: UndoTracker;
 	#lastSuccessfulYieldToolCallId: string | undefined = undefined;
 	/**
 	 * Sticky across an in-flight prompt run: a successful `yield` makes the run
@@ -777,6 +779,10 @@ export class AgentSession {
 		this.#prewalk.arm(target, thinkingLevel);
 	}
 
+	getUndoTracker(): UndoTracker {
+		return this.#undoTracker;
+	}
+
 	/** Validate the active plan artifact and shape an `xd://propose` result for review-mode hosts. */
 	async preparePlanForReview(title: string): Promise<AgentToolResult<PlanApprovalDetails>> {
 		const state = this.getPlanModeState();
@@ -813,6 +819,11 @@ export class AgentSession {
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
 		this.#modelRegistry = config.modelRegistry;
+		this.#undoTracker = new UndoTracker({
+			sessionManager: this.sessionManager,
+			projectRoot: this.sessionManager.getCwd(),
+			enabled: config.undoEnabled ?? this.settings.get("snapshots.enabled"),
+		});
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
@@ -2718,6 +2729,7 @@ export class AgentSession {
 				return;
 			}
 			const sessionStopWillContinue = await this.#emitSessionStopEvent(activeMessages, msg);
+			await this.#undoTracker.onAssistantTurnEnd();
 			await emitAgentEndNotification(sessionStopWillContinue ? { willContinue: true } : undefined);
 		}
 	};
@@ -4986,6 +4998,7 @@ export class AgentSession {
 				this.#planReferenceSent = true;
 			}
 			try {
+				await this.#undoTracker.onUserTurnStart();
 				await this.#recovery.promptAgentWithIdleRetry(messages, agentPromptOptions);
 			} finally {
 				this.#stats.setPendingSnapshot(undefined);

--- a/packages/coding-agent/src/session/undo-tracker.ts
+++ b/packages/coding-agent/src/session/undo-tracker.ts
@@ -1,0 +1,160 @@
+import type { UserMessage } from "@oh-my-pi/pi-ai";
+import { getAgentDir } from "@oh-my-pi/pi-utils";
+import {
+	HiddenWorkspaceSnapshotService,
+	type WorkspaceSnapshotData,
+	type WorkspaceSnapshotService,
+} from "../workspace-snapshot";
+import { UNDO_SNAPSHOT_CUSTOM_TYPE } from "../workspace-snapshot/service";
+import type { SessionManager } from "./session-manager";
+
+export interface UndoTurnBoundaries {
+	/** User message entry before which the session leaf should be reparented. */
+	targetUserEntryId: string;
+	/** Snapshot captured before the first assistant turn being undone. */
+	restoreSnapshotId: string;
+	/** Union of all files changed by the assistant turns being undone. */
+	filesToRestore: string[];
+	/** Original user message text to re-inject into the editor. */
+	userMessageText: string;
+}
+
+export interface UndoTrackerOptions {
+	sessionManager: SessionManager;
+	projectRoot?: string;
+	agentDataDir?: string;
+	/** If false, snapshot capture is skipped entirely. */
+	enabled?: boolean;
+}
+
+/**
+ * Tracks per-turn workspace snapshots and resolves `/undo` operations.
+ *
+ * Snapshot metadata is stored as a parallel `custom` entry (Option B) so the
+ * message schema stays untouched and future redo/branch features can build on
+ * the same data.
+ */
+export class UndoTracker {
+	readonly #sessionManager: SessionManager;
+	readonly #projectRoot: string;
+	readonly #snapshotService: WorkspaceSnapshotService;
+	readonly #enabled: boolean;
+	#pendingStartSnapshot: string | undefined;
+
+	constructor(options: UndoTrackerOptions) {
+		this.#sessionManager = options.sessionManager;
+		this.#projectRoot = options.projectRoot ?? options.sessionManager.getCwd();
+		this.#enabled = options.enabled ?? true;
+		this.#snapshotService = new HiddenWorkspaceSnapshotService({
+			projectRoot: this.#projectRoot,
+			agentDataDir: options.agentDataDir ?? getAgentDir(),
+		});
+	}
+
+	async isSupported(): Promise<boolean> {
+		if (!this.#enabled) return false;
+		return this.#snapshotService.isSupported();
+	}
+
+	/**
+	 * Call before running the assistant for a user message. Captures the
+	 * workspace state that will be restored if this turn is undone.
+	 */
+	async onUserTurnStart(): Promise<void> {
+		if (!this.#enabled) return;
+		this.#pendingStartSnapshot = await this.#snapshotService.capture();
+	}
+
+	/**
+	 * Call after the assistant turn ends and its messages are persisted. Records
+	 * which files changed and closes out the snapshot metadata entry.
+	 */
+	async onAssistantTurnEnd(): Promise<void> {
+		if (!this.#enabled) return;
+		const startSnapshot = this.#pendingStartSnapshot;
+		this.#pendingStartSnapshot = undefined;
+		if (!startSnapshot) return;
+		const endSnapshot = await this.#snapshotService.capture();
+		if (!endSnapshot) return;
+		const changedFiles = await this.#snapshotService.listChangedFiles(startSnapshot, endSnapshot);
+		if (changedFiles.length === 0) return;
+		const targetUserEntryId = findLastUserEntryId(this.#sessionManager);
+		if (!targetUserEntryId) return;
+		const data: WorkspaceSnapshotData = {
+			refEntryId: targetUserEntryId,
+			startSnapshot,
+			endSnapshot,
+			changedFiles,
+		};
+		this.#sessionManager.appendCustomEntry(UNDO_SNAPSHOT_CUSTOM_TYPE, data);
+	}
+
+	/**
+	 * Resolve `/undo [howMuch]` to concrete boundaries.
+	 *
+	 * `howMuch` is the number of user/assistant turn pairs to roll back.
+	 * Defaults to 1. Returns undefined when there is nothing to undo or the
+	 * snapshot metadata is missing.
+	 */
+	resolveUndo(howMuchRaw?: string): UndoTurnBoundaries | undefined {
+		const howMuch = Math.max(1, parseInt(howMuchRaw ?? "1", 10));
+		const branch = this.#sessionManager.getBranch();
+		let remaining = howMuch;
+		let targetUserEntryId: string | undefined;
+		let restoreSnapshotId: string | undefined;
+		let filesToRestore: string[] | undefined;
+		let userMessageText = "";
+		for (let i = branch.length - 1; i >= 0; i--) {
+			const entry = branch[i];
+			if (entry.type === "custom" && entry.customType === UNDO_SNAPSHOT_CUSTOM_TYPE) {
+				const data = entry.data as WorkspaceSnapshotData | undefined;
+				if (!data) continue;
+				if (remaining === howMuch) {
+					filesToRestore = [...data.changedFiles];
+				} else {
+					filesToRestore?.push(...data.changedFiles);
+				}
+				restoreSnapshotId = data.startSnapshot;
+				if (--remaining === 0) {
+					targetUserEntryId = data.refEntryId;
+					break;
+				}
+			}
+		}
+		if (!targetUserEntryId || !restoreSnapshotId || !filesToRestore) return undefined;
+		const userEntry = this.#sessionManager.getEntry(targetUserEntryId);
+		if (userEntry?.type === "message" && userEntry.message.role === "user") {
+			userMessageText = extractUserMessageText(userEntry.message);
+		}
+		return {
+			targetUserEntryId,
+			restoreSnapshotId,
+			filesToRestore: [...new Set(filesToRestore)],
+			userMessageText,
+		};
+	}
+
+	async restoreFiles(boundaries: UndoTurnBoundaries): Promise<void> {
+		await this.#snapshotService.restore(boundaries.restoreSnapshotId, boundaries.filesToRestore);
+	}
+
+	getProjectRoot(): string {
+		return this.#projectRoot;
+	}
+}
+
+function findLastUserEntryId(sessionManager: SessionManager): string | undefined {
+	const branch = sessionManager.getBranch();
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i];
+		if (entry.type === "message" && entry.message.role === "user") {
+			return entry.id;
+		}
+	}
+	return undefined;
+}
+
+function extractUserMessageText(message: UserMessage): string {
+	if (typeof message.content === "string") return message.content;
+	return message.content.map(part => (part.type === "text" ? part.text : "")).join("");
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1457,6 +1457,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "undo",
+		description: "Revert the last assistant turn and restore files",
+		inlineHint: "[n]",
+		allowArgs: true,
+		handleTui: (command, runtime) => {
+			runtime.ctx.editor.setText("");
+			void runtime.ctx.handleUndoCommand(command.args?.trim());
+		},
+	},
+	{
 		name: "login",
 		description: "Login with OAuth provider",
 		inlineHint: "[provider|redirect URL]",

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1180,7 +1180,24 @@ function parseStatusPorcelain(text: string): GitStatusSummary {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// API: diff
+// Low-level plumbing runner exposed for callers that need custom args/env.
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run an arbitrary git command and return the raw result. Prefer the typed
+ * helpers in this module; this escape hatch is for custom plumbing that needs
+ * control over arguments and environment (e.g. a snapshot repo with a separate
+ * GIT_DIR and GIT_INDEX_FILE).
+ */
+export async function run(
+	cwd: string,
+	args: readonly string[],
+	options: CommandOptions = {},
+): Promise<GitCommandResult> {
+	ensureAvailable();
+	return git(cwd, args, options);
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 
 /** Run `git diff` with the given options. Returns raw diff text. */

--- a/packages/coding-agent/src/workspace-snapshot/index.ts
+++ b/packages/coding-agent/src/workspace-snapshot/index.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./types";

--- a/packages/coding-agent/src/workspace-snapshot/service.ts
+++ b/packages/coding-agent/src/workspace-snapshot/service.ts
@@ -1,0 +1,284 @@
+import { createHash } from "node:crypto";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as git from "../utils/git";
+import type { WorkspaceSnapshotData, WorkspaceSnapshotOptions, WorkspaceSnapshotService } from "./types";
+
+export const UNDO_SNAPSHOT_CUSTOM_TYPE = "undo-snapshot";
+export type { WorkspaceSnapshotData, WorkspaceSnapshotOptions, WorkspaceSnapshotService };
+
+const SNAPSHOT_GIT_DIR = "git";
+const MAX_UNTRACKED_FILE_BYTES_DEFAULT = 2 * 1024 * 1024;
+
+interface GitDirs {
+	worktree: string;
+	gitDir: string;
+}
+
+export class HiddenWorkspaceSnapshotService implements WorkspaceSnapshotService {
+	readonly #projectRoot: string;
+	readonly #agentDataDir: string;
+	readonly #maxUntrackedFileBytes: number;
+	#dirs: GitDirs | undefined | null = undefined;
+
+	constructor(options: WorkspaceSnapshotOptions) {
+		this.#projectRoot = path.resolve(options.projectRoot);
+		this.#agentDataDir = options.agentDataDir;
+		this.#maxUntrackedFileBytes = options.maxUntrackedFileBytes ?? MAX_UNTRACKED_FILE_BYTES_DEFAULT;
+	}
+
+	async isSupported(): Promise<boolean> {
+		const dirs = await this.#resolveDirs();
+		return dirs !== null;
+	}
+
+	async capture(): Promise<string | undefined> {
+		const dirs = await this.#resolveDirs();
+		if (!dirs) return undefined;
+		const env = this.#gitEnv(dirs.gitDir);
+		const files = await this.#listFilesToStage(dirs);
+		if (files.length > 0) {
+			await git.run(
+				dirs.worktree,
+				["--git-dir", dirs.gitDir, "--work-tree", dirs.worktree, "add", "--force", "--", ...files],
+				{
+					env,
+				},
+			);
+		}
+		const result = await git.run(
+			dirs.worktree,
+			["--git-dir", dirs.gitDir, "--work-tree", dirs.worktree, "write-tree"],
+			{ env },
+		);
+		return result.stdout.trim() || undefined;
+	}
+
+	async restore(snapshotId: string, files: readonly string[]): Promise<void> {
+		const dirs = await this.#resolveDirs();
+		if (!dirs) throw new Error("Snapshot repository not available");
+		if (files.length === 0) return;
+		for (const file of files) {
+			const absolute = path.resolve(dirs.worktree, file);
+			if (!isWithin(dirs.worktree, absolute)) {
+				throw new Error(`Refusing to restore path outside project: ${file}`);
+			}
+		}
+		const env = this.#gitEnv(dirs.gitDir);
+		const tmpIndex = path.join(dirs.gitDir, `restore-index-${Date.now()}-${process.hrtime.bigint().toString(36)}`);
+		try {
+			// Build a temporary index containing the target tree.
+			await git.run(
+				dirs.worktree,
+				["--git-dir", dirs.gitDir, "--work-tree", dirs.worktree, "read-tree", snapshotId],
+				{ env: { ...env, GIT_INDEX_FILE: tmpIndex } },
+			);
+			// Check out the requested paths from that temporary index.
+			await git.run(
+				dirs.worktree,
+				["--git-dir", dirs.gitDir, "--work-tree", dirs.worktree, "checkout-index", "--force", "--", ...files],
+				{ env: { ...env, GIT_INDEX_FILE: tmpIndex } },
+			);
+			// Delete paths that were requested but do not exist in the target tree.
+			const present = new Set(await this.#listTreePaths(dirs, snapshotId, files, env));
+			for (const file of files) {
+				if (!present.has(file)) {
+					try {
+						await fs.rm(path.join(dirs.worktree, file), { force: true, recursive: true });
+					} catch {
+						// Best-effort removal.
+					}
+				}
+			}
+		} finally {
+			try {
+				await fs.unlink(tmpIndex);
+			} catch {
+				// Ignore cleanup errors.
+			}
+		}
+	}
+
+	async listChangedFiles(fromSnapshotId: string, toSnapshotId: string): Promise<string[]> {
+		const dirs = await this.#resolveDirs();
+		if (!dirs) return [];
+		const env = this.#gitEnv(dirs.gitDir);
+		const result = await git.run(
+			dirs.worktree,
+			[
+				"--git-dir",
+				dirs.gitDir,
+				"--work-tree",
+				dirs.worktree,
+				"diff-tree",
+				"-r",
+				"--name-only",
+				fromSnapshotId,
+				toSnapshotId,
+			],
+			{ env },
+		);
+		return result.stdout
+			.split("\n")
+			.map(line => line.trim())
+			.filter(Boolean);
+	}
+
+	async #resolveDirs(): Promise<GitDirs | null> {
+		if (this.#dirs === undefined) {
+			this.#dirs = await this.#initDirs();
+		}
+		return this.#dirs;
+	}
+
+	async #initDirs(): Promise<GitDirs | null> {
+		if (!(await isGitAvailable())) return null;
+		const worktree = this.#projectRoot;
+		let statOk = false;
+		try {
+			const stat = await fs.stat(worktree);
+			statOk = stat.isDirectory();
+		} catch {}
+		if (!statOk) return null;
+		const projectId = hashPath(worktree);
+		const gitDir = path.join(this.#agentDataDir, "snapshots", projectId, SNAPSHOT_GIT_DIR);
+		await fs.mkdir(gitDir, { recursive: true });
+		const hasHead = await fs.access(path.join(gitDir, "HEAD")).then(
+			() => true,
+			() => false,
+		);
+		if (!hasHead) {
+			const result = await git.run(worktree, ["init", "--bare", gitDir]);
+			if (result.exitCode !== 0) return null;
+			await fs.writeFile(path.join(gitDir, "config"), `[core]\n	worktree = ${worktree.replace(/\\\\/g, "/")}\n`, {
+				flag: "a",
+			});
+		}
+		return { worktree, gitDir };
+	}
+
+	async #listFilesToStage(dirs: GitDirs): Promise<string[]> {
+		const userGitDir = await discoverUserGitDir(dirs.worktree);
+		const tracked = userGitDir ? await git.ls.files(dirs.worktree) : [];
+		const untracked = userGitDir
+			? await git.ls.untracked(dirs.worktree)
+			: await manualWalk(dirs.worktree, this.#maxUntrackedFileBytes);
+		const selected = new Set<string>();
+		for (const file of tracked) selected.add(normalizeSep(file));
+		for (const file of untracked) {
+			const normalized = normalizeSep(file);
+			if (selected.has(normalized)) continue;
+			const absolute = path.join(dirs.worktree, normalized);
+			if (await exceedsSize(absolute, this.#maxUntrackedFileBytes)) continue;
+			selected.add(normalized);
+		}
+		return Array.from(selected);
+	}
+
+	async #listTreePaths(
+		dirs: GitDirs,
+		tree: string,
+		files: readonly string[],
+		env: Record<string, string>,
+	): Promise<string[]> {
+		const result = await git.run(
+			dirs.worktree,
+			[
+				"--git-dir",
+				dirs.gitDir,
+				"--work-tree",
+				dirs.worktree,
+				"ls-tree",
+				"--name-only",
+				"-r",
+				"-z",
+				tree,
+				"--",
+				...files,
+			],
+			{ env },
+		);
+		return result.stdout.split("\0").filter(Boolean);
+	}
+
+	#gitEnv(gitDir: string): Record<string, string> {
+		return {
+			...process.env,
+			GIT_INDEX_FILE: path.join(gitDir, "index"),
+		};
+	}
+}
+
+async function isGitAvailable(): Promise<boolean> {
+	try {
+		const result = await git.run(os.homedir(), ["--version"]);
+		return result.exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+async function discoverUserGitDir(worktree: string): Promise<string | undefined> {
+	try {
+		const result = await git.run(worktree, ["rev-parse", "--git-dir"]);
+		if (result.exitCode !== 0) return undefined;
+		const raw = result.stdout.trim();
+		if (!raw) return undefined;
+		return path.isAbsolute(raw) ? raw : path.resolve(worktree, raw);
+	} catch {
+		return undefined;
+	}
+}
+
+function hashPath(p: string): string {
+	return createHash("sha256").update(path.resolve(p)).digest("hex").slice(0, 16);
+}
+
+function normalizeSep(p: string): string {
+	return p.replace(/\\/g, "/");
+}
+
+function isWithin(root: string, target: string): boolean {
+	const rel = path.relative(root, target);
+	return !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+async function exceedsSize(filePath: string, maxBytes: number): Promise<boolean> {
+	try {
+		const stat = await fs.stat(filePath);
+		return stat.isFile() && stat.size > maxBytes;
+	} catch {
+		return true;
+	}
+}
+
+async function manualWalk(root: string, maxBytes: number): Promise<string[]> {
+	const results: string[] = [];
+	const skip = new Set([".git", ".omp", "node_modules", ".next", ".dist", "dist", "build"]);
+	const queue: string[] = [""];
+	while (queue.length > 0) {
+		const relative = queue.shift()!;
+		const absolute = path.join(root, relative);
+		let entries: Dirent[];
+		try {
+			entries = await fs.readdir(absolute, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			const entryRel = relative ? `${relative}/${entry.name}` : entry.name;
+			if (skip.has(entry.name)) continue;
+			if (entry.isDirectory()) {
+				queue.push(entryRel);
+			} else if (entry.isFile()) {
+				const full = path.join(root, entryRel);
+				if (!(await exceedsSize(full, maxBytes))) {
+					results.push(entryRel);
+				}
+			}
+		}
+	}
+	return results;
+}

--- a/packages/coding-agent/src/workspace-snapshot/types.ts
+++ b/packages/coding-agent/src/workspace-snapshot/types.ts
@@ -1,0 +1,41 @@
+export interface WorkspaceSnapshotService {
+	/**
+	 * Whether snapshots can be captured for this project. Returns false when git
+	 * is unavailable, the project path is invalid, or snapshots are disabled.
+	 */
+	isSupported(): Promise<boolean>;
+
+	/**
+	 * Capture the current filesystem state as a content-addressed git tree.
+	 * Returns the tree SHA, or undefined if snapshots are disabled/unsupported.
+	 */
+	capture(): Promise<string | undefined>;
+
+	/**
+	 * Restore the given project-relative paths to the state in `snapshotId`.
+	 * Files that did not exist in the snapshot are deleted. Paths outside the
+	 * project root are rejected.
+	 */
+	restore(snapshotId: string, files: readonly string[]): Promise<void>;
+
+	/**
+	 * List project-relative paths that differ between two captured snapshots.
+	 */
+	listChangedFiles(fromSnapshotId: string, toSnapshotId: string): Promise<string[]>;
+}
+
+export interface WorkspaceSnapshotOptions {
+	/** Root directory that owns the snapshot repo. */
+	projectRoot: string;
+	/** Base agent data directory; snapshots live under `<agentDataDir>/snapshots/`. */
+	agentDataDir: string;
+	/** Skip untracked files larger than this many bytes. Tracked files are always captured. */
+	maxUntrackedFileBytes?: number;
+}
+
+export interface WorkspaceSnapshotData {
+	refEntryId: string;
+	startSnapshot: string;
+	endSnapshot: string;
+	changedFiles: string[];
+}

--- a/packages/coding-agent/test/session/undo-tracker.test.ts
+++ b/packages/coding-agent/test/session/undo-tracker.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { UndoTracker } from "@oh-my-pi/pi-coding-agent/session/undo-tracker";
+
+async function runGit(cwd: string, ...args: string[]): Promise<string> {
+	const proc = await Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const out = await new Response(proc.stdout).text();
+	const err = await new Response(proc.stderr).text();
+	if ((proc.exitCode ?? 0) !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${err || out}`);
+	}
+	return out;
+}
+
+function makeUserMessage(text: string) {
+	return { role: "user" as const, content: text, timestamp: Date.now() };
+}
+
+function makeAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+		api: "test",
+		provider: "test",
+		model: "test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+describe("UndoTracker", () => {
+	let tmpDir: string;
+	let projectDir: string;
+	let agentDir: string;
+	let sessionManager: SessionManager;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-undo-tracker-test-"));
+		projectDir = path.join(tmpDir, "project");
+		agentDir = path.join(tmpDir, "agent");
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+		await runGit(projectDir, "init");
+		await runGit(projectDir, "config", "user.email", "test@example.com");
+		await runGit(projectDir, "config", "user.name", "Test");
+		await fs.writeFile(path.join(projectDir, "file.txt"), "v1");
+		await runGit(projectDir, "add", "file.txt");
+		await runGit(projectDir, "commit", "-m", "initial");
+		sessionManager = SessionManager.inMemory(projectDir);
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("records a snapshot entry after a turn with file changes", async () => {
+		const tracker = new UndoTracker({
+			sessionManager,
+			projectRoot: projectDir,
+			agentDataDir: agentDir,
+			enabled: true,
+		});
+		expect(await tracker.isSupported()).toBe(true);
+
+		await tracker.onUserTurnStart();
+		const userId = sessionManager.appendMessage(makeUserMessage("change it"));
+		await fs.writeFile(path.join(projectDir, "file.txt"), "v2");
+		await fs.writeFile(path.join(projectDir, "new.txt"), "fresh");
+		sessionManager.appendMessage(makeAssistantMessage("done"));
+		await tracker.onAssistantTurnEnd();
+
+		const entries = sessionManager.getEntries();
+		const undoEntry = entries.find(e => e.type === "custom" && e.customType === "undo-snapshot");
+		expect(undoEntry).toBeTruthy();
+		const data = (undoEntry as { data?: Record<string, unknown> }).data ?? {};
+		expect(data.refEntryId).toBe(userId);
+		expect((data.changedFiles as string[]).sort()).toEqual(["file.txt", "new.txt"]);
+	});
+
+	it("resolves undo boundaries across one turn", async () => {
+		const tracker = new UndoTracker({
+			sessionManager,
+			projectRoot: projectDir,
+			agentDataDir: agentDir,
+			enabled: true,
+		});
+		await tracker.onUserTurnStart();
+		const userId = sessionManager.appendMessage(makeUserMessage("change it"));
+		await fs.writeFile(path.join(projectDir, "file.txt"), "v2");
+		sessionManager.appendMessage(makeAssistantMessage("done"));
+		await tracker.onAssistantTurnEnd();
+
+		const boundaries = tracker.resolveUndo("1");
+		expect(boundaries).toBeTruthy();
+		expect(boundaries!.targetUserEntryId).toBe(userId);
+		expect(boundaries!.filesToRestore).toContain("file.txt");
+		expect(boundaries!.userMessageText).toBe("change it");
+	});
+
+	it("restores files to the pre-turn snapshot", async () => {
+		const tracker = new UndoTracker({
+			sessionManager,
+			projectRoot: projectDir,
+			agentDataDir: agentDir,
+			enabled: true,
+		});
+		await tracker.onUserTurnStart();
+		sessionManager.appendMessage(makeUserMessage("change it"));
+		await fs.writeFile(path.join(projectDir, "file.txt"), "v2");
+		sessionManager.appendMessage(makeAssistantMessage("done"));
+		await tracker.onAssistantTurnEnd();
+
+		const boundaries = tracker.resolveUndo("1")!;
+		await tracker.restoreFiles(boundaries);
+		expect(await fs.readFile(path.join(projectDir, "file.txt"), "utf8")).toBe("v1");
+	});
+
+	it("skips capture when disabled", async () => {
+		const tracker = new UndoTracker({
+			sessionManager,
+			projectRoot: projectDir,
+			agentDataDir: agentDir,
+			enabled: false,
+		});
+		expect(await tracker.isSupported()).toBe(false);
+		await tracker.onUserTurnStart();
+		sessionManager.appendMessage(makeUserMessage("hi"));
+		await fs.writeFile(path.join(projectDir, "x.txt"), "x");
+		sessionManager.appendMessage(makeAssistantMessage("ok"));
+		await tracker.onAssistantTurnEnd();
+		expect(sessionManager.getEntries().some(e => e.type === "custom" && e.customType === "undo-snapshot")).toBe(
+			false,
+		);
+	});
+
+	it("resolves undo boundaries across multiple turns", async () => {
+		const tracker = new UndoTracker({
+			sessionManager,
+			projectRoot: projectDir,
+			agentDataDir: agentDir,
+			enabled: true,
+		});
+
+		await tracker.onUserTurnStart();
+		const firstUserId = sessionManager.appendMessage(makeUserMessage("first"));
+		await fs.writeFile(path.join(projectDir, "file.txt"), "v2");
+		sessionManager.appendMessage(makeAssistantMessage("done1"));
+		await tracker.onAssistantTurnEnd();
+
+		await tracker.onUserTurnStart();
+		sessionManager.appendMessage(makeUserMessage("second"));
+		await fs.writeFile(path.join(projectDir, "file.txt"), "v3");
+		await fs.writeFile(path.join(projectDir, "new.txt"), "created");
+		sessionManager.appendMessage(makeAssistantMessage("done2"));
+		await tracker.onAssistantTurnEnd();
+
+		const boundaries = tracker.resolveUndo("2");
+		expect(boundaries).toBeTruthy();
+		expect(boundaries!.targetUserEntryId).toBe(firstUserId);
+		expect(boundaries!.filesToRestore.sort()).toEqual(["file.txt", "new.txt"]);
+		expect(boundaries!.userMessageText).toBe("first");
+
+		await tracker.restoreFiles(boundaries!);
+		expect(await fs.readFile(path.join(projectDir, "file.txt"), "utf8")).toBe("v1");
+		expect(await fileExists(path.join(projectDir, "new.txt"))).toBe(false);
+	});
+});
+
+async function fileExists(p: string): Promise<boolean> {
+	try {
+		await fs.access(p);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/coding-agent/test/workspace-snapshot.test.ts
+++ b/packages/coding-agent/test/workspace-snapshot.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { HiddenWorkspaceSnapshotService } from "../src/workspace-snapshot/service";
+
+async function run(cwd: string, ...args: string[]): Promise<string> {
+	const proc = await Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const out = await new Response(proc.stdout).text();
+	const err = await new Response(proc.stderr).text();
+	if ((proc.exitCode ?? 0) !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${err || out}`);
+	}
+	return out;
+}
+
+describe("HiddenWorkspaceSnapshotService", () => {
+	let tmpDir: string;
+	let projectDir: string;
+	let agentDir: string;
+	let svc: HiddenWorkspaceSnapshotService;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-snapshot-test-"));
+		projectDir = path.join(tmpDir, "project");
+		agentDir = path.join(tmpDir, "agent-data");
+		await fs.mkdir(projectDir, { recursive: true });
+		await fs.mkdir(agentDir, { recursive: true });
+		await run(projectDir, "init");
+		await run(projectDir, "config", "user.email", "test@example.com");
+		await run(projectDir, "config", "user.name", "Test");
+		await fs.writeFile(path.join(projectDir, "tracked.txt"), "tracked v1");
+		await run(projectDir, "add", "tracked.txt");
+		await run(projectDir, "commit", "-m", "initial");
+		svc = new HiddenWorkspaceSnapshotService({ projectRoot: projectDir, agentDataDir: agentDir });
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("reports supported for git projects", async () => {
+		expect(await svc.isSupported()).toBe(true);
+	});
+
+	it("captures a snapshot and computes changed files", async () => {
+		const before = await svc.capture();
+		expect(before).toBeTruthy();
+		await fs.writeFile(path.join(projectDir, "tracked.txt"), "tracked v2");
+		await fs.writeFile(path.join(projectDir, "new.txt"), "new file");
+		const after = await svc.capture();
+		expect(after).toBeTruthy();
+		const changed = await svc.listChangedFiles(before!, after!);
+		expect(changed.sort()).toEqual(["new.txt", "tracked.txt"]);
+	});
+
+	it("restores selected files to an earlier snapshot", async () => {
+		const before = await svc.capture();
+		await fs.writeFile(path.join(projectDir, "tracked.txt"), "tracked v2");
+		await fs.writeFile(path.join(projectDir, "new.txt"), "new file");
+		await svc.capture();
+		await svc.restore(before!, ["tracked.txt"]);
+		expect(await fs.readFile(path.join(projectDir, "tracked.txt"), "utf8")).toBe("tracked v1");
+		expect(await fileExists(path.join(projectDir, "new.txt"))).toBe(true);
+	});
+
+	it("deletes files that did not exist in the snapshot", async () => {
+		const before = await svc.capture();
+		await fs.writeFile(path.join(projectDir, "new.txt"), "new file");
+		await svc.capture();
+		await svc.restore(before!, ["new.txt"]);
+		expect(await fileExists(path.join(projectDir, "new.txt"))).toBe(false);
+	});
+
+	it("returns undefined when the project directory does not exist", async () => {
+		const bad = new HiddenWorkspaceSnapshotService({
+			projectRoot: path.join(tmpDir, "missing"),
+			agentDataDir: agentDir,
+		});
+		expect(await bad.capture()).toBeUndefined();
+	});
+});
+
+async function fileExists(p: string): Promise<boolean> {
+	try {
+		await fs.access(p);
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `/undo [n]` to roll back the last `n` user→assistant turns, restoring workspace files and branching the session so the reverted user message is ready to edit and resend.
- HiddenWorkspaceSnapshotService captures per-turn workspace state in a project-scoped hidden git repository under the agent data directory, keeping the user's project history untouched.
- UndoTracker stores snapshot metadata as parallel custom session entries (`customType: undo-snapshot`) for clean long-term extensibility.
- AgentSession hooks snapshot capture around each assistant turn (before prompt, after `agent_end`).
- Confirmation is required before destructive file restore; only files that actually changed are restored; paths outside the project root are rejected.
- Adds a user-facing `snapshots.enabled` setting (default `true`) to toggle snapshotting.
- /redo is intentionally omitted until full re-apply support is implemented.

## Test Plan
- `bun --cwd=packages/coding-agent run check` passes.
- `bun --cwd=packages/coding-agent run lint` passes.
- `bun --cwd=packages/coding-agent test test/workspace-snapshot.test.ts test/session/undo-tracker.test.ts` passes (10/10).

bun.lock changes were intentionally excluded.