### PR TITLE
fix(session): attribute user bang executions in advisor transcripts

### DIFF
--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -218,7 +218,10 @@ function toolCallLine(
 	return base;
 }
 
-/** One line for a user-initiated `!`/`$` execution. */
+/** One line for a user-initiated `!`/`$` execution. Always attributed to the
+ *  user: these roles never carry agent-run commands (the model's bash goes
+ *  through `toolCall`), so the `user-` prefix makes provenance explicit for the
+ *  advisor and history readers regardless of render mode. */
 function executionLine(
 	kind: "bash" | "python",
 	source: string,
@@ -231,7 +234,7 @@ function executionLine(
 			: "ok";
 	const lines = lineCount(msg.output);
 	const sourcePreview = formatExecutionSourcePreview(source);
-	return `→ ${kind}! ${sourcePreview} ⇒ ${status} · ${lines} ${lines === 1 ? "line" : "lines"}`;
+	return `→ user-${kind}! ${sourcePreview} ⇒ ${status} · ${lines} ${lines === 1 ? "line" : "lines"}`;
 }
 
 /**
@@ -311,6 +314,18 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 	// every call repeats `**agent**:`). Cleared whenever a
 	// non-role-labeled line is emitted so the next turn re-labels.
 	let lastWatchedLabel: string | undefined;
+	// Emit a watched-mode role label, collapsing consecutive same-role turns
+	// under one label (matching the user/assistant paths). Used for the
+	// user-attributed `!`/`$` execution lines so the advisor never reads them
+	// as agent actions.
+	const pushWatchedRole = (label: string, body: string): void => {
+		if (lastWatchedLabel === label) {
+			lines.push(body, "");
+		} else {
+			lines.push(label, body, "");
+			lastWatchedLabel = label;
+		}
+	};
 
 	for (const msg of typed) {
 		switch (msg.role) {
@@ -372,15 +387,25 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 			case "bashExecution": {
 				const bashMsg = msg as BashExecutionMessage;
 				if (bashMsg.excludeFromContext) break;
-				lines.push(executionLine("bash", bashMsg.command, bashMsg), "");
-				lastWatchedLabel = undefined;
+				const bashLine = executionLine("bash", bashMsg.command, bashMsg);
+				if (opts?.watchedRoles) {
+					pushWatchedRole("**user**:", bashLine);
+				} else {
+					lines.push(bashLine, "");
+					lastWatchedLabel = undefined;
+				}
 				break;
 			}
 			case "pythonExecution": {
 				const pythonMsg = msg as PythonExecutionMessage;
 				if (pythonMsg.excludeFromContext) break;
-				lines.push(executionLine("python", pythonMsg.code, pythonMsg), "");
-				lastWatchedLabel = undefined;
+				const pythonLine = executionLine("python", pythonMsg.code, pythonMsg);
+				if (opts?.watchedRoles) {
+					pushWatchedRole("**user**:", pythonLine);
+				} else {
+					lines.push(pythonLine, "");
+					lastWatchedLabel = undefined;
+				}
 				break;
 			}
 			case "custom":

--- a/packages/coding-agent/test/session/session-history-format.test.ts
+++ b/packages/coding-agent/test/session/session-history-format.test.ts
@@ -310,4 +310,58 @@ describe("formatSessionHistoryMarkdown", () => {
 		expect(output).toContain("→ advise(concern: Avoid shadowing the outer variable.) ⇒ ok · 1 line");
 		expect(output).not.toContain("Recorded.");
 	});
+
+	it("attributes a user bang command to the user, not the preceding agent turn", () => {
+		const delta = [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "It's safe to remove it. I'd run `rm -rf .wt/foo` but will stop here." }],
+				stopReason: "endTurn",
+				timestamp: 1,
+			},
+			{
+				role: "bashExecution",
+				command: "rm -rf .wt/foo",
+				output: "",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+				excludeFromContext: false,
+				timestamp: 2,
+			},
+			{ role: "user", content: "Done!", timestamp: 3 },
+		];
+
+		const output = formatSessionHistoryMarkdown(delta, { watchedRoles: true });
+
+		// The execution line is prefixed `user-bash!` and sits under a `**user**:`
+		// label, not trailing the `**agent**:` block, so the advisor cannot read
+		// the user-run command as an agent action.
+		expect(output).toContain("→ user-bash! rm -rf .wt/foo ⇒ ok · 0 lines");
+		const agentIdx = output.indexOf("**agent**:");
+		const userIdx = output.indexOf("**user**:");
+		const execIdx = output.indexOf("→ user-bash!");
+		expect(agentIdx).toBeGreaterThanOrEqual(0);
+		expect(userIdx).toBeGreaterThan(agentIdx);
+		expect(execIdx).toBeGreaterThan(userIdx);
+	});
+
+	it("prefixes a user python bang execution with user-python in watched mode", () => {
+		const output = formatSessionHistoryMarkdown(
+			[
+				{
+					role: "pythonExecution",
+					code: "print(1)",
+					output: "1",
+					exitCode: 0,
+					cancelled: false,
+					truncated: false,
+					timestamp: 1,
+				},
+			],
+			{ watchedRoles: true },
+		);
+		expect(output).toContain("**user**:");
+		expect(output).toContain("→ user-python! print(1) ⇒ ok · 1 line");
+	});
 });


### PR DESCRIPTION
## Repro
With the advisor enabled, an agent recommends but does not run a cleanup command, the user runs it themselves via the bang surface (`!rm -rf .wt/foo`), then sends a short confirmation. Rendering that session delta with the advisor render options (`watchedRoles: true`) yields:

```text
**agent**:
It looks safe to remove the worktree. I'd run `rm -rf .wt/foo` but I'll stop here per your request.

→ bash! rm -rf .wt/foo ⇒ ok · 0 lines

**user**:
Done!
```

The `→ bash! …` line trails the `**agent**:` block with no user attribution, so the advisor reads the user-run command as an agent action and raises a false blocker.

## Cause
`bashExecution`/`pythonExecution` roles are always user-initiated — user bang `!`/`$` commands and RPC `bash` route through `AgentSession.executeBash()` / `eval-runner`, while the model's bash goes through `toolCall`. The role already carries provenance (`session/messages.ts` sets `attribution: "user"` on LLM conversion), but `session/session-history-format.ts` never surfaced it: the `bashExecution`/`pythonExecution` cases pushed a bare `executionLine` and cleared `lastWatchedLabel`, so no `**user**:` label was emitted in watched (advisor) mode.

## Fix
- `executionLine` now prefixes the line `→ user-bash!` / `→ user-python!`, making provenance explicit in every render path (advisor watched mode and `history://` dumps).
- In `formatSessionHistoryMarkdown`, the `bashExecution`/`pythonExecution` cases emit the line under a `**user**:` label in watched mode (via a `pushWatchedRole` helper that collapses consecutive same-role turns, matching the user/assistant paths), so the advisor attributes the command to the user; non-watched dumps keep the bare line, now `user-`prefixed.

## Verification
`bun test test/session/session-history-format.test.ts` → 12 pass / 0 fail, including two new regression tests: one asserting a user bang command after an agent turn renders under `**user**:` as `→ user-bash!` (ordering after the `**agent**:` label), one asserting `→ user-python!` for a `$` execution. Manually re-ran the repro delta and confirmed the command now renders under `**user**:`. (The 6 failures in `test/advisor` are a pre-existing missing generated module `src/export/html/tool-views.generated.js`, unrelated to this diff.)

Fixes #6837