### PR TITLE
fix(git): force stable locale for non-interactive commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,12 +36,14 @@
 - Fixed omp worktree clear prematurely deleting active task-isolation sandboxes owned by running subagents.
 - Fixed /vibe mode preventing the director from completing parent tasks after verifying worker results by keeping the built-in todo tool active.
 - Fixed numeric GitHub issue and pull request autocomplete being suppressed inside skill slash-command arguments.
+### Fixed
+
+- Force Git subprocesses to use the stable `C` message locale for predictable non-interactive command output.
 
 ## [17.1.7] - 2026-07-27
 
 ### Fixed
 
-- Force Git subprocesses to use the stable `C` locale for predictable non-interactive command output.
 - Restoring a prompt with image attachments via esc-esc branch or `/tree` now re-attaches the images to the composer draft: previously only the text (with its `[Image #N]` markers) was restored, so resubmitting sent the literal marker with no image.
 - Fixed large bash/eval/ssh output citing two different artifact ids in one result — the truncation notice said `Read artifact://N for full output` while the footer said `Artifact: N+1`. The streaming sink's head and tail windows each had a full budget, so a middle-elided inline body could reach `headBytes + spillThreshold` and always re-tripped the final-defense inline byte cap, which truncated a second time (two elision markers), saved a duplicate already-truncated artifact, and left the notice's line ranges stale. The head and tail windows now share the spill-threshold budget (head clamped to half), the cap budget derives from the configured threshold plus notice slack, and when the cap does fire on a sink-spilled result it references the existing raw artifact instead of saving a copy.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Fixed
 
+- Force Git subprocesses to use the stable `C` locale for predictable non-interactive command output.
 - Restoring a prompt with image attachments via esc-esc branch or `/tree` now re-attaches the images to the composer draft: previously only the text (with its `[Image #N]` markers) was restored, so resubmitting sent the literal marker with no image.
 - Fixed large bash/eval/ssh output citing two different artifact ids in one result — the truncation notice said `Read artifact://N for full output` while the footer said `Artifact: N+1`. The streaming sink's head and tail windows each had a full budget, so a middle-elided inline body could reach `headBytes + spillThreshold` and always re-tripped the final-defense inline byte cap, which truncated a second time (two elision markers), saved a duplicate already-truncated artifact, and left the notice's line ranges stale. The head and tail windows now share the spill-threshold budget (head clamped to half), the cap budget derives from the configured threshold plus notice slack, and when the cap does fire on a sink-spilled result it references the existing raw artifact instead of saving a copy.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Force Git subprocesses to use the stable `C` message locale for predictable non-interactive command output.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes
@@ -36,9 +40,6 @@
 - Fixed omp worktree clear prematurely deleting active task-isolation sandboxes owned by running subagents.
 - Fixed /vibe mode preventing the director from completing parent tasks after verifying worker results by keeping the built-in todo tool active.
 - Fixed numeric GitHub issue and pull request autocomplete being suppressed inside skill slash-command arguments.
-### Fixed
-
-- Force Git subprocesses to use the stable `C` message locale for predictable non-interactive command output.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -197,13 +197,14 @@ const GIT_NON_INTERACTIVE_ENV = {
 	GIT_ASKPASS: "true",
 	GIT_EDITOR: "true",
 	GIT_TERMINAL_PROMPT: "0",
-	LC_ALL: "C",
+	LC_ALL: undefined,
+	LC_MESSAGES: "C",
 	SSH_ASKPASS: "/usr/bin/false",
-} satisfies Record<string, string>;
+} satisfies Record<string, string | undefined>;
 const GH_NON_INTERACTIVE_ENV = {
 	...GIT_NON_INTERACTIVE_ENV,
 	GH_PROMPT_DISABLED: "1",
-} satisfies Record<string, string>;
+} satisfies Record<string, string | undefined>;
 
 /** Default deadline for git and gh subprocesses spawned by the coding agent. */
 export const GIT_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -381,11 +381,19 @@ function normalizeStdin(input: CommandOptions["stdin"]): "ignore" | Uint8Array {
 }
 
 function buildGitEnv(overrides?: Record<string, string | undefined>): Record<string, string | undefined> {
-	return {
+	const env: Record<string, string | undefined> = {
 		...process.env,
 		GIT_OPTIONAL_LOCKS: "0",
 		...AMBIENT_GIT_ENV,
 		...overrides,
+	};
+	const preservedCharacterLocale =
+		env.LC_CTYPE === undefined && env.LC_ALL !== undefined && /(?:^|[._-])utf-?8(?:$|[.@_-])/i.test(env.LC_ALL)
+			? env.LC_ALL
+			: undefined;
+	return {
+		...env,
+		...(preservedCharacterLocale === undefined ? {} : { LC_CTYPE: preservedCharacterLocale }),
 		...GIT_NON_INTERACTIVE_ENV,
 	};
 }

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -197,6 +197,7 @@ const GIT_NON_INTERACTIVE_ENV = {
 	GIT_ASKPASS: "true",
 	GIT_EDITOR: "true",
 	GIT_TERMINAL_PROMPT: "0",
+	LC_ALL: "C",
 	SSH_ASKPASS: "/usr/bin/false",
 } satisfies Record<string, string>;
 const GH_NON_INTERACTIVE_ENV = {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -388,7 +388,9 @@ function buildGitEnv(overrides?: Record<string, string | undefined>): Record<str
 		...overrides,
 	};
 	const preservedCharacterLocale =
-		env.LC_CTYPE === undefined && env.LC_ALL !== undefined && /(?:^|[._-])utf-?8(?:$|[.@_-])/i.test(env.LC_ALL)
+		(env.LC_CTYPE === undefined || env.LC_CTYPE === "") &&
+		env.LC_ALL !== undefined &&
+		/(?:^|[._-])utf-?8(?:$|[.@_-])/i.test(env.LC_ALL)
 			? env.LC_ALL
 			: undefined;
 	return {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -380,13 +380,10 @@ function normalizeStdin(input: CommandOptions["stdin"]): "ignore" | Uint8Array {
 	return new Uint8Array(input);
 }
 
-function buildGitEnv(overrides?: Record<string, string | undefined>): Record<string, string | undefined> {
-	const env: Record<string, string | undefined> = {
-		...process.env,
-		GIT_OPTIONAL_LOCKS: "0",
-		...AMBIENT_GIT_ENV,
-		...overrides,
-	};
+function buildNonInteractiveEnv(
+	env: Record<string, string | undefined>,
+	pinnedEnv: Record<string, string | undefined>,
+): Record<string, string | undefined> {
 	const preservedCharacterLocale =
 		(env.LC_CTYPE === undefined || env.LC_CTYPE === "") &&
 		env.LC_ALL !== undefined &&
@@ -396,8 +393,24 @@ function buildGitEnv(overrides?: Record<string, string | undefined>): Record<str
 	return {
 		...env,
 		...(preservedCharacterLocale === undefined ? {} : { LC_CTYPE: preservedCharacterLocale }),
-		...GIT_NON_INTERACTIVE_ENV,
+		...pinnedEnv,
 	};
+}
+
+function buildGitEnv(overrides?: Record<string, string | undefined>): Record<string, string | undefined> {
+	return buildNonInteractiveEnv(
+		{
+			...process.env,
+			GIT_OPTIONAL_LOCKS: "0",
+			...AMBIENT_GIT_ENV,
+			...overrides,
+		},
+		GIT_NON_INTERACTIVE_ENV,
+	);
+}
+
+function buildGhEnv(): Record<string, string | undefined> {
+	return buildNonInteractiveEnv({ ...process.env }, GH_NON_INTERACTIVE_ENV);
 }
 
 function ensureAvailable(): void {
@@ -2386,10 +2399,7 @@ export const github = {
 		try {
 			const child = Bun.spawn(["gh", ...args], {
 				cwd,
-				env: {
-					...process.env,
-					...GH_NON_INTERACTIVE_ENV,
-				},
+				env: buildGhEnv(),
 				stdin: "ignore",
 				stdout: "pipe",
 				stderr: "pipe",

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -16,7 +16,7 @@ import {
 	resolveDefaultRepoMemoized,
 } from "@oh-my-pi/pi-coding-agent/tools/gh";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
-import { getAgentDir, hashPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import { $which, getAgentDir, hashPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 // Isolate every `git` invocation in this file from the developer's host
 // configuration. The fixture spawns dozens of git subprocesses against tiny
@@ -1085,32 +1085,33 @@ exec ${JSON.stringify(realGit)} "$@"
 			}
 		});
 
-		it("pins Git message locale without clobbering LC_CTYPE", async () => {
-			// The shim is a bash script resolved via `which`; neither exists on Windows.
+		it("pins Git messages while preserving UTF-8 character locale", async () => {
 			if (process.platform === "win32") return;
 			const originalPath = process.env.PATH;
 			const originalLocale = {
+				EXPECTED_LC_CTYPE: process.env.EXPECTED_LC_CTYPE,
+				LANG: process.env.LANG,
 				LC_ALL: process.env.LC_ALL,
 				LC_CTYPE: process.env.LC_CTYPE,
 				LC_MESSAGES: process.env.LC_MESSAGES,
 			};
 			const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), "omp-fake-git-locale-"));
-			const realGitResult = Bun.spawnSync(["which", "git"], { stdout: "pipe", stderr: "pipe" });
-			expect(realGitResult.exitCode).toBe(0);
-			const realGit = new TextDecoder().decode(realGitResult.stdout).trim();
+			const realGit = $which("git");
+			expect(realGit).not.toBeNull();
+			if (realGit === null) return;
 			const fakeGit = path.join(fakeBin, "git");
 			await fs.writeFile(
 				fakeGit,
-				`#!/usr/bin/env bash
-if [[ "\${LC_MESSAGES-}" != "C" ]]; then
+				`#!/bin/sh
+if [ "\${LC_MESSAGES-}" != "C" ]; then
 	echo "LC_MESSAGES was \${LC_MESSAGES-<unset>}" >&2
 	exit 41
 fi
-if [[ "\${LC_CTYPE-}" != "UTF-8-SENTINEL" ]]; then
-	echo "LC_CTYPE was \${LC_CTYPE-<unset>}" >&2
+if [ "\${LC_CTYPE-}" != "\${EXPECTED_LC_CTYPE-}" ]; then
+	echo "LC_CTYPE was \${LC_CTYPE-<unset>}, expected \${EXPECTED_LC_CTYPE-<unset>}" >&2
 	exit 42
 fi
-if [[ "\${LC_ALL+x}" == "x" ]]; then
+if [ "\${LC_ALL+x}" = "x" ]; then
 	echo "LC_ALL leaked: \${LC_ALL}" >&2
 	exit 43
 fi
@@ -1120,12 +1121,19 @@ exec ${JSON.stringify(realGit)} "$@"
 			await fs.chmod(fakeGit, 0o755);
 
 			try {
-				process.env.PATH = `${fakeBin}${path.delimiter}${originalPath ?? ""}`;
+				process.env.PATH = fakeBin;
+				process.env.EXPECTED_LC_CTYPE = "C.UTF-8";
+				process.env.LC_ALL = "C.UTF-8";
+				delete process.env.LANG;
+				delete process.env.LC_CTYPE;
+				delete process.env.LC_MESSAGES;
+				await git.diff(remoteFixture.repoRoot, { env: { LC_MESSAGES: undefined } });
+
+				process.env.EXPECTED_LC_CTYPE = "UTF-8-SENTINEL";
 				process.env.LC_ALL = "fr_FR.UTF-8";
 				process.env.LC_CTYPE = "UTF-8-SENTINEL";
 				process.env.LC_MESSAGES = "fr_FR.UTF-8";
-
-				await git.diff(remoteFixture.repoRoot, { env: { LC_ALL: "fr_FR.UTF-8", LC_MESSAGES: undefined } });
+				await git.diff(remoteFixture.repoRoot, { env: { LC_ALL: "C", LC_MESSAGES: undefined } });
 			} finally {
 				if (originalPath === undefined) {
 					delete process.env.PATH;

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1125,7 +1125,7 @@ exec ${JSON.stringify(realGit)} "$@"
 				process.env.EXPECTED_LC_CTYPE = "C.UTF-8";
 				process.env.LC_ALL = "C.UTF-8";
 				delete process.env.LANG;
-				delete process.env.LC_CTYPE;
+				process.env.LC_CTYPE = "";
 				delete process.env.LC_MESSAGES;
 				await git.diff(remoteFixture.repoRoot, { env: { LC_MESSAGES: undefined } });
 

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1084,6 +1084,64 @@ exec ${JSON.stringify(realGit)} "$@"
 				await removeWithRetries(fakeBin);
 			}
 		});
+
+		it("pins Git message locale without clobbering LC_CTYPE", async () => {
+			// The shim is a bash script resolved via `which`; neither exists on Windows.
+			if (process.platform === "win32") return;
+			const originalPath = process.env.PATH;
+			const originalLocale = {
+				LC_ALL: process.env.LC_ALL,
+				LC_CTYPE: process.env.LC_CTYPE,
+				LC_MESSAGES: process.env.LC_MESSAGES,
+			};
+			const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), "omp-fake-git-locale-"));
+			const realGitResult = Bun.spawnSync(["which", "git"], { stdout: "pipe", stderr: "pipe" });
+			expect(realGitResult.exitCode).toBe(0);
+			const realGit = new TextDecoder().decode(realGitResult.stdout).trim();
+			const fakeGit = path.join(fakeBin, "git");
+			await fs.writeFile(
+				fakeGit,
+				`#!/usr/bin/env bash
+if [[ "\${LC_MESSAGES-}" != "C" ]]; then
+	echo "LC_MESSAGES was \${LC_MESSAGES-<unset>}" >&2
+	exit 41
+fi
+if [[ "\${LC_CTYPE-}" != "UTF-8-SENTINEL" ]]; then
+	echo "LC_CTYPE was \${LC_CTYPE-<unset>}" >&2
+	exit 42
+fi
+if [[ "\${LC_ALL+x}" == "x" ]]; then
+	echo "LC_ALL leaked: \${LC_ALL}" >&2
+	exit 43
+fi
+exec ${JSON.stringify(realGit)} "$@"
+`,
+			);
+			await fs.chmod(fakeGit, 0o755);
+
+			try {
+				process.env.PATH = `${fakeBin}${path.delimiter}${originalPath ?? ""}`;
+				process.env.LC_ALL = "fr_FR.UTF-8";
+				process.env.LC_CTYPE = "UTF-8-SENTINEL";
+				process.env.LC_MESSAGES = "fr_FR.UTF-8";
+
+				await git.diff(remoteFixture.repoRoot, { env: { LC_ALL: "fr_FR.UTF-8", LC_MESSAGES: undefined } });
+			} finally {
+				if (originalPath === undefined) {
+					delete process.env.PATH;
+				} else {
+					process.env.PATH = originalPath;
+				}
+				for (const [key, value] of Object.entries(originalLocale)) {
+					if (value === undefined) {
+						delete process.env[key];
+					} else {
+						process.env[key] = value;
+					}
+				}
+				await removeWithRetries(fakeBin);
+			}
+		});
 	});
 
 	it("serializes concurrent git mutations through withRepoLock so callers don't race git's internal locks", async () => {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1152,6 +1152,69 @@ exec ${JSON.stringify(realGit)} "$@"
 		});
 	});
 
+	it("pins gh messages while preserving UTF-8 character locale", async () => {
+		if (process.platform === "win32") return;
+		const originalPath = process.env.PATH;
+		const originalLocale = {
+			EXPECTED_LC_CTYPE: process.env.EXPECTED_LC_CTYPE,
+			LANG: process.env.LANG,
+			LC_ALL: process.env.LC_ALL,
+			LC_CTYPE: process.env.LC_CTYPE,
+			LC_MESSAGES: process.env.LC_MESSAGES,
+		};
+		const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), "omp-fake-gh-locale-"));
+		const fakeGh = path.join(fakeBin, "gh");
+		await fs.writeFile(
+			fakeGh,
+			`#!/bin/sh
+if [ "\${LC_MESSAGES-}" != "C" ]; then
+	echo "LC_MESSAGES was \${LC_MESSAGES-<unset>}" >&2
+	exit 41
+fi
+if [ "\${LC_CTYPE-}" != "\${EXPECTED_LC_CTYPE-}" ]; then
+	echo "LC_CTYPE was \${LC_CTYPE-<unset>}, expected \${EXPECTED_LC_CTYPE-<unset>}" >&2
+	exit 42
+fi
+if [ "\${LC_ALL+x}" = "x" ]; then
+	echo "LC_ALL leaked: \${LC_ALL}" >&2
+	exit 43
+fi
+echo ok
+`,
+		);
+		await fs.chmod(fakeGh, 0o755);
+
+		try {
+			process.env.PATH = fakeBin;
+			for (const lcCtype of [undefined, ""] as const) {
+				process.env.EXPECTED_LC_CTYPE = "C.UTF-8";
+				process.env.LC_ALL = "C.UTF-8";
+				delete process.env.LANG;
+				delete process.env.LC_MESSAGES;
+				if (lcCtype === undefined) {
+					delete process.env.LC_CTYPE;
+				} else {
+					process.env.LC_CTYPE = lcCtype;
+				}
+				await expect(git.github.run(process.cwd(), ["--version"])).resolves.toMatchObject({ stdout: "ok" });
+			}
+		} finally {
+			if (originalPath === undefined) {
+				delete process.env.PATH;
+			} else {
+				process.env.PATH = originalPath;
+			}
+			for (const [key, value] of Object.entries(originalLocale)) {
+				if (value === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = value;
+				}
+			}
+			await removeWithRetries(fakeBin);
+		}
+	});
+
 	it("serializes concurrent git mutations through withRepoLock so callers don't race git's internal locks", async () => {
 		// withRepoLock only needs a real `.git/config` to serialize against, so a
 		// bare `git init` repo is enough — no fixture clone, remotes, or commits.

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -16,7 +16,8 @@ import {
 	resolveDefaultRepoMemoized,
 } from "@oh-my-pi/pi-coding-agent/tools/gh";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
-import { $which, getAgentDir, hashPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import { $which, getAgentDir, hashPath, removeWithRetries, setAgentDir, WhichCachePolicy } from "@oh-my-pi/pi-utils";
 
 // Isolate every `git` invocation in this file from the developer's host
 // configuration. The fixture spawns dozens of git subprocesses against tiny
@@ -1182,6 +1183,17 @@ fi
 echo ok
 `,
 		);
+		const realWhich = $which;
+		process.env.PATH = "";
+		expect(realWhich("gh", { cache: WhichCachePolicy.Bypass, PATH: "" })).toBeNull();
+		const whichSpy = vi
+			.spyOn(piUtils, "$which")
+			.mockImplementation((command, options) =>
+				command === "gh"
+					? realWhich(command, { ...options, cache: WhichCachePolicy.Bypass })
+					: realWhich(command, options),
+			);
+
 		await fs.chmod(fakeGh, 0o755);
 
 		try {
@@ -1199,6 +1211,7 @@ echo ok
 				await expect(git.github.run(process.cwd(), ["--version"])).resolves.toMatchObject({ stdout: "ok" });
 			}
 		} finally {
+			whichSpy.mockRestore();
 			if (originalPath === undefined) {
 				delete process.env.PATH;
 			} else {


### PR DESCRIPTION
## Summary

Stabilize non-interactive Git diagnostics without forcing Git hooks or child processes into the ASCII `C` character locale.

## Changes

- Pin `LC_MESSAGES=C` for predictable Git diagnostic output.
- Remove `LC_ALL` before spawning Git so it cannot override locale categories.
- Preserve a sole inherited UTF-8 `LC_ALL` as `LC_CTYPE`.
- Treat `LC_CTYPE=""` as unset when preserving the inherited UTF-8 locale.
- Preserve an explicitly configured non-empty `LC_CTYPE`.
- Use `$which("git")` from `@oh-my-pi/pi-utils` in the regression test.
- Add the required changelog entry under `Unreleased` → `Fixed`.

## Validation

- `bun test --parallel=1 test/tools/gh.test.ts`: 47 pass, 0 fail
- `bun run check`: PASS
- `git diff --check`: PASS
- Working tree clean