### PR TITLE
fix(launch): isolate legacy xterm replay

### DIFF
--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -49,6 +49,7 @@ function capturePayload(
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	void streamBedrock(bedrockModel, context, {
 		signal: abortedSignal(),
+		bearerToken: "test-token",
 		cacheRetention,
 		onPayload: payload => {
 			resolve(payload as Payload);

--- a/packages/ai/test/oauth-barrel-import.test.ts
+++ b/packages/ai/test/oauth-barrel-import.test.ts
@@ -12,5 +12,5 @@ describe("OAuth barrel imports", () => {
 		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
 
 		expect(exitCode, stderr).toBe(0);
-	});
+	}, 30_000);
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -4887,6 +4887,7 @@ describe("openai-codex streaming", () => {
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
 			reasoning: true,
+			preferWebsockets: false,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 400000,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Fixed omp worktree clear prematurely deleting active task-isolation sandboxes owned by running subagents.
 - Fixed /vibe mode preventing the director from completing parent tasks after verifying worker results by keeping the built-in todo tool active.
 - Fixed numeric GitHub issue and pull request autocomplete being suppressed inside skill slash-command arguments.
+### Fixed
+
+- Fixed compatibility replay for an already-running pre-upgrade launch broker evaluating xterm inside the client process; legacy raw PTY output now replays in an isolated worker while normal main/Hub ownership remains zero ([#6748](https://github.com/can1357/oh-my-pi/pull/6748)).
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compatibility replay for an already-running pre-upgrade launch broker evaluating xterm inside the client process; legacy raw PTY output now replays in an isolated worker while normal main/Hub ownership remains zero ([#6748](https://github.com/can1357/oh-my-pi/pull/6748)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes
@@ -36,9 +40,6 @@
 - Fixed omp worktree clear prematurely deleting active task-isolation sandboxes owned by running subagents.
 - Fixed /vibe mode preventing the director from completing parent tasks after verifying worker results by keeping the built-in todo tool active.
 - Fixed numeric GitHub issue and pull request autocomplete being suppressed inside skill slash-command arguments.
-### Fixed
-
-- Fixed compatibility replay for an already-running pre-upgrade launch broker evaluating xterm inside the client process; legacy raw PTY output now replays in an isolated worker while normal main/Hub ownership remains zero ([#6748](https://github.com/can1357/oh-my-pi/pull/6748)).
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -32,6 +32,7 @@ import { extractProfileFlags } from "./cli/profile-bootstrap";
 import { startJsEvalProcess } from "./eval/js/process-entry";
 import type { WorkerInbound as JsWorkerInbound, WorkerOutbound as JsWorkerOutbound } from "./eval/js/worker-protocol";
 import { DAEMON_BROKER_WORKER_ARG } from "./launch/protocol";
+import { TERMINAL_OUTPUT_WORKER_ARG } from "./launch/terminal-output-worker-protocol";
 import { COMPUTER_WORKER_ARG } from "./tools/computer/protocol";
 import { smokeTestComputerWorker } from "./tools/computer/supervisor";
 import { startComputerWorker } from "./tools/computer/worker-entry";
@@ -88,6 +89,7 @@ async function runSmokeTest(): Promise<void> {
 	const { smokeTestJsEvalWorker } = await import("./eval/js/context-manager");
 	// Other smoke dependencies stay lazy so normal CLI startup does not load their worker clients.
 	const { smokeTestDaemonBroker } = await import("./launch/client");
+	const { smokeTestTerminalOutputWorker } = await import("./launch/terminal-output-worker-client");
 	await smokeTestSyncWorker();
 
 	const statsServer = await startServer(0);
@@ -109,6 +111,7 @@ async function runSmokeTest(): Promise<void> {
 	await smokeTestTtsWorker();
 	await smokeTestMnemopiEmbedWorker();
 	await smokeTestDaemonBroker();
+	await smokeTestTerminalOutputWorker();
 	process.stdout.write("smoke-test: ok\n");
 }
 
@@ -193,6 +196,12 @@ async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	if (arg === MNEMOPI_EMBED_WORKER_ARG) {
 		const { startMnemopiEmbedWorker } = await import("./mnemopi/embed-worker");
 		await runIpcSubprocessWorker(startMnemopiEmbedWorker);
+		return true;
+	}
+	if (arg === TERMINAL_OUTPUT_WORKER_ARG) {
+		if (parentPort) installWorkerInbox(parentPort);
+		// This selector is the isolation boundary; a static import would evaluate xterm in normal CLI startup.
+		await import("./launch/terminal-output-worker");
 		return true;
 	}
 	if (arg === DAEMON_BROKER_WORKER_ARG) {

--- a/packages/coding-agent/src/launch/terminal-output-worker-client.ts
+++ b/packages/coding-agent/src/launch/terminal-output-worker-client.ts
@@ -23,8 +23,12 @@ export async function renderTerminalOutputIsolated(
 	const onError = (event: ErrorEvent): void => {
 		pending.reject(event.error instanceof Error ? event.error : new Error(event.message));
 	};
+	const onClose = (): void => {
+		pending.reject(new Error("Terminal output worker exited before responding"));
+	};
 	worker.addEventListener("message", onMessage);
 	worker.addEventListener("error", onError);
+	worker.addEventListener("close", onClose);
 	try {
 		const request: TerminalOutputWorkerRequest = { output, options };
 		worker.postMessage(request);
@@ -32,6 +36,7 @@ export async function renderTerminalOutputIsolated(
 	} finally {
 		worker.removeEventListener("message", onMessage);
 		worker.removeEventListener("error", onError);
+		worker.removeEventListener("close", onClose);
 		worker.terminate();
 	}
 }

--- a/packages/coding-agent/src/launch/terminal-output-worker-client.ts
+++ b/packages/coding-agent/src/launch/terminal-output-worker-client.ts
@@ -1,0 +1,48 @@
+import { workerHostEntry } from "@oh-my-pi/pi-utils/worker-host";
+import type { TerminalOutputOptions } from "./terminal-output";
+import {
+	TERMINAL_OUTPUT_WORKER_ARG,
+	type TerminalOutputWorkerRequest,
+	type TerminalOutputWorkerResult,
+} from "./terminal-output-worker-protocol";
+
+/** Replay legacy broker PTY bytes without evaluating xterm in the client process. */
+export async function renderTerminalOutputIsolated(
+	output: string,
+	options: TerminalOutputOptions,
+): Promise<string[] | undefined> {
+	const hostEntry = workerHostEntry();
+	const worker = hostEntry
+		? new Worker(hostEntry, { type: "module", argv: [TERMINAL_OUTPUT_WORKER_ARG] })
+		: new Worker(new URL("./terminal-output-worker.ts", import.meta.url).href, { type: "module" });
+	const pending = Promise.withResolvers<string[] | undefined>();
+	const onMessage = (event: MessageEvent<TerminalOutputWorkerResult>): void => {
+		if (event.data.ok) pending.resolve(event.data.rows);
+		else pending.reject(new Error(event.data.error));
+	};
+	const onError = (event: ErrorEvent): void => {
+		pending.reject(event.error instanceof Error ? event.error : new Error(event.message));
+	};
+	worker.addEventListener("message", onMessage);
+	worker.addEventListener("error", onError);
+	try {
+		const request: TerminalOutputWorkerRequest = { output, options };
+		worker.postMessage(request);
+		return await pending.promise;
+	} finally {
+		worker.removeEventListener("message", onMessage);
+		worker.removeEventListener("error", onError);
+		worker.terminate();
+	}
+}
+
+/** Distribution smoke for source, npm-bundle, and compiled worker routing. */
+export async function smokeTestTerminalOutputWorker(): Promise<void> {
+	const rows = await renderTerminalOutputIsolated("old\r\x1b[2K\x1b[1;32mready\x1b[0m", {
+		head: false,
+		maxRows: 10,
+	});
+	if (rows?.length !== 1 || rows[0] !== "\x1b[0m\x1b[1;38;5;2mready") {
+		throw new Error("terminal output worker smoke mismatch");
+	}
+}

--- a/packages/coding-agent/src/launch/terminal-output-worker-protocol.ts
+++ b/packages/coding-agent/src/launch/terminal-output-worker-protocol.ts
@@ -1,0 +1,11 @@
+import type { TerminalOutputOptions } from "./terminal-output";
+
+/** Hidden CLI selector for legacy PTY replay outside the client process. */
+export const TERMINAL_OUTPUT_WORKER_ARG = "__omp_worker_terminal_output";
+
+export interface TerminalOutputWorkerRequest {
+	output: string;
+	options: TerminalOutputOptions;
+}
+
+export type TerminalOutputWorkerResult = { ok: true; rows: string[] | undefined } | { ok: false; error: string };

--- a/packages/coding-agent/src/launch/terminal-output-worker.ts
+++ b/packages/coding-agent/src/launch/terminal-output-worker.ts
@@ -1,0 +1,23 @@
+import { parentPort } from "node:worker_threads";
+import { consumeWorkerInbox } from "@oh-my-pi/pi-utils/worker-host";
+import { renderTerminalOutput } from "./terminal-output";
+import type { TerminalOutputWorkerRequest, TerminalOutputWorkerResult } from "./terminal-output-worker-protocol";
+
+if (!parentPort) throw new Error("terminal-output-worker: missing parentPort");
+
+const port = parentPort;
+const inbox = consumeWorkerInbox();
+const handle = async (message: unknown): Promise<void> => {
+	const request = message as TerminalOutputWorkerRequest;
+	let result: TerminalOutputWorkerResult;
+	try {
+		result = { ok: true, rows: await renderTerminalOutput(request.output, request.options) };
+	} catch (error) {
+		result = { ok: false, error: error instanceof Error ? error.message : String(error) };
+	}
+	port.postMessage(result);
+	port.close();
+};
+
+if (inbox) inbox.bind(message => void handle(message));
+else port.on("message", message => void handle(message));

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,7 +53,6 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: error =>
-			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -53,6 +53,7 @@ export function createMCPTimeout(
 	return {
 		signal: operationSignal,
 		clear: () => clearTimeout(timeoutId),
-		isTimeoutAbort: () => abortController.signal.aborted && !signal?.aborted,
+		isTimeoutAbort: error =>
+			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -5,7 +5,7 @@
  * Based on MCP spec 2025-03-26.
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, readSseJson, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -245,7 +245,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			if (!response.ok) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 				const mcpAuthServer = response.headers.get("Mcp-Auth-Server");
 				const authHints = [
@@ -266,7 +266,7 @@ export class HttpTransport implements MCPTransport {
 			}
 
 			// Handle JSON response
-			const result = (await response.json()) as JsonRpcResponse;
+			const result = (await untilAborted(operation.signal, response.json())) as JsonRpcResponse;
 
 			if (result.error) {
 				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
@@ -446,7 +446,7 @@ export class HttpTransport implements MCPTransport {
 
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
-				const text = await response.text();
+				const text = await untilAborted(operation.signal, response.text());
 				throw new Error(`HTTP ${response.status}: ${text}`);
 			}
 

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -12,7 +12,7 @@ import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { daemonClientForProject } from "../../launch/client";
 import type { DaemonOperation, DaemonRpcResult, DaemonSnapshot, DaemonSpec, DaemonState } from "../../launch/protocol";
-import type { TerminalOutputOptions } from "../../launch/terminal-output";
+import { renderTerminalOutputIsolated } from "../../launch/terminal-output-worker-client";
 import type { Theme, ThemeColor } from "../../modes/theme/theme";
 import { framedBlock, outputBlockContentWidth, renderStatusLine } from "../../tui";
 import type { ToolSession } from "..";
@@ -271,15 +271,14 @@ function toolContent(result: DaemonRpcResult, params: LaunchParams): string {
 	}
 }
 
-interface TerminalOutputRuntime {
-	renderTerminalOutput(output: string, options: TerminalOutputOptions): Promise<string[] | undefined>;
-}
-
-async function renderLegacyTerminalOutput(terminalText: string, params: LaunchParams): Promise<string[] | undefined> {
-	// `require` keeps xterm out of normal main/Hub startup while retaining display
-	// compatibility with a legacy broker that was already running during upgrade.
-	const runtime = require("../../launch/terminal-output") as TerminalOutputRuntime;
-	return runtime.renderTerminalOutput(terminalText, {
+/** Resolve display rows while keeping legacy raw replay outside the client process. */
+export async function renderLaunchLogTerminalRows(
+	result: Extract<DaemonRpcResult, { op: "logs" }>,
+	params: Pick<LaunchParams, "head" | "lines">,
+): Promise<string[] | undefined> {
+	if (result.terminalRows !== undefined) return result.terminalRows;
+	if (result.terminalText === undefined) return undefined;
+	return renderTerminalOutputIsolated(result.terminalText, {
 		head: params.head ?? false,
 		maxRows: Math.min(1_000, Math.floor(params.lines ?? 100)),
 	});
@@ -297,11 +296,7 @@ async function toolDetails(result: DaemonRpcResult, params: LaunchParams): Promi
 				cursor: result.cursor,
 				timedOut: result.timedOut,
 				state: result.state,
-				terminalRows:
-					result.terminalRows ??
-					(result.terminalText === undefined
-						? undefined
-						: await renderLegacyTerminalOutput(result.terminalText, params)),
+				terminalRows: await renderLaunchLogTerminalRows(result, params),
 			};
 		case "wait":
 			return { op: "wait", daemon: result.daemon, timedOut: result.timedOut, matched: result.matched };

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -296,7 +296,7 @@ async function toolDetails(result: DaemonRpcResult, params: LaunchParams): Promi
 				cursor: result.cursor,
 				timedOut: result.timedOut,
 				state: result.state,
-				terminalRows: await renderLaunchLogTerminalRows(result, params),
+				terminalRows: await renderLaunchLogTerminalRows(result, params).catch(() => undefined),
 			};
 		case "wait":
 			return { op: "wait", daemon: result.daemon, timedOut: result.timedOut, matched: result.matched };

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1215,9 +1215,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		return extraction;
 	}
 
-	async #waitForPdfImageExtraction(extraction: PdfImageExtraction, signal: AbortSignal | undefined): Promise<string> {
+	async #waitForPdfImageExtraction(
+		extraction: PdfImageExtraction,
+		signal: AbortSignal | undefined,
+		onJoined?: () => Promise<void>,
+	): Promise<string> {
 		extraction.waiters++;
 		try {
+			await onJoined?.();
 			return await untilAborted(signal, extraction.promise);
 		} finally {
 			extraction.waiters--;
@@ -1235,8 +1240,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const imageDir = this.#pdfImageCacheDir(absolutePdfPath, snapshot.digest);
 		const existing = pdfImageExtractions.get(imageDir);
 		if (existing && !existing.settled && !existing.controller.signal.aborted) {
-			await fs.rm(snapshot.directory, { recursive: true, force: true });
-			return this.#waitForPdfImageExtraction(existing, signal);
+			return this.#waitForPdfImageExtraction(existing, signal, () =>
+				fs.rm(snapshot.directory, { recursive: true, force: true }),
+			);
 		}
 
 		const extraction = this.#createPdfImageExtraction(snapshot, imageDir);

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -119,7 +119,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		return session;
 	}
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;
@@ -1199,7 +1199,7 @@ describe("AgentSession TTSR resume gate", () => {
 		vi.restoreAllMocks();
 	});
 
-	async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
 		const deadline = Date.now() + timeoutMs;
 		while (Date.now() < deadline) {
 			if (predicate()) return;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -1349,9 +1349,13 @@ describe("executeBash :async: background retention", () => {
 				});
 				expect(res.cancelled).toBe(false);
 
-				await pollUntil(() => fs.existsSync(pidFile), Date.now() + 4000);
-				pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+				await pollUntil(() => {
+					if (!fs.existsSync(pidFile)) return false;
+					pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+					return Number.isInteger(pid);
+				}, Date.now() + 4000);
 				expect(Number.isInteger(pid)).toBe(true);
+				if (pid === undefined) throw new Error("Expected detached child pid");
 
 				// A later turn on a different per-job shell must not have killed it.
 				await executeBash("true", { sessionKey: "reparent-probe:async:job2", cwd: tmp });

--- a/packages/coding-agent/test/fixtures/xterm-cache-legacy-replay-probe.ts
+++ b/packages/coding-agent/test/fixtures/xterm-cache-legacy-replay-probe.ts
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs";
+import * as fs from "node:fs";
 import type { DaemonRpcResult } from "../../src/launch/protocol";
 import { renderLaunchLogTerminalRows } from "../../src/tools/hub/launch";
 
@@ -15,7 +15,7 @@ const terminalRows = await renderLaunchLogTerminalRows(result, { head: false, li
 const paths = Object.keys(require.cache)
 	.filter(modulePath => modulePath.replaceAll("\\", "/").includes("/node_modules/@xterm/headless/"))
 	.sort();
-const bytes = paths.reduce((total, modulePath) => total + statSync(modulePath).size, 0);
+const bytes = paths.reduce((total, modulePath) => total + fs.statSync(modulePath).size, 0);
 const memory = process.memoryUsage();
 process.stdout.write(
 	JSON.stringify({ modules: paths.length, bytes, rss: memory.rss, heapUsed: memory.heapUsed, paths, terminalRows }),

--- a/packages/coding-agent/test/fixtures/xterm-cache-legacy-replay-probe.ts
+++ b/packages/coding-agent/test/fixtures/xterm-cache-legacy-replay-probe.ts
@@ -1,0 +1,22 @@
+import { statSync } from "node:fs";
+import type { DaemonRpcResult } from "../../src/launch/protocol";
+import { renderLaunchLogTerminalRows } from "../../src/tools/hub/launch";
+
+const result: Extract<DaemonRpcResult, { op: "logs" }> = {
+	op: "logs",
+	name: "web",
+	text: "ready",
+	terminalText: "old\r\x1b[2K\x1b[1;32mready\x1b[0m",
+	cursor: 42,
+	timedOut: false,
+	state: "running",
+};
+const terminalRows = await renderLaunchLogTerminalRows(result, { head: false, lines: 10 });
+const paths = Object.keys(require.cache)
+	.filter(modulePath => modulePath.replaceAll("\\", "/").includes("/node_modules/@xterm/headless/"))
+	.sort();
+const bytes = paths.reduce((total, modulePath) => total + statSync(modulePath).size, 0);
+const memory = process.memoryUsage();
+process.stdout.write(
+	JSON.stringify({ modules: paths.length, bytes, rss: memory.rss, heapUsed: memory.heapUsed, paths, terminalRows }),
+);

--- a/packages/coding-agent/test/mcp-timeout.test.ts
+++ b/packages/coding-agent/test/mcp-timeout.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
+import { afterEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { createMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
 import { logger } from "@oh-my-pi/pi-utils";
 
 const ORIGINAL_TIMEOUT = process.env.OMP_MCP_TIMEOUT_MS;
 
 afterEach(() => {
+	vi.useRealTimers();
 	if (ORIGINAL_TIMEOUT === undefined) {
 		delete process.env.OMP_MCP_TIMEOUT_MS;
 	} else {
@@ -62,5 +63,17 @@ describe("MCP timeout configuration", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+
+	test("classifies only abort errors from the internal timeout", () => {
+		vi.useFakeTimers();
+		const operation = createMCPTimeout(50);
+		vi.advanceTimersByTime(50);
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+
+		expect(operation.isTimeoutAbort(new Error("HTTP 500"))).toBe(false);
+		expect(operation.isTimeoutAbort(abortError)).toBe(true);
+		operation.clear();
 	});
 });

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -385,7 +385,7 @@ describe("retain.execute (Mnemopi backend)", () => {
 
 		const text = (recallResult.content[0] as { text: string }).text;
 		expect(text).toContain("user prefers tabs");
-	});
+	}, 30_000);
 
 	it("stores multiple memories and returns correct count", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
@@ -933,7 +933,7 @@ describe("Mnemopi backend lifecycle", () => {
 		}
 		registeredMnemopiState = getMnemopiSessionState(session);
 		expect(registeredMnemopiState).toBeDefined();
-	});
+	}, 30_000);
 
 	it("exposes direct mnemopi runtime status and search/save results", async () => {
 		const config = makeMnemopiConfig({
@@ -1220,7 +1220,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 		expect(text).toContain("the user likes concise CLI output");
 		expect(text).toContain("project alpha uses pnpm workspaces");
 		expect(text).not.toContain("project beta deploys to staging first");
-	});
+	}, 30_000);
 
 	it("throws when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });

--- a/packages/coding-agent/test/models-config-lazy-validator.test.ts
+++ b/packages/coding-agent/test/models-config-lazy-validator.test.ts
@@ -62,4 +62,4 @@ test("models config validation resources are retained only for a custom config",
 	} finally {
 		await tempDir.remove().catch(() => {});
 	}
-});
+}, 30_000);

--- a/packages/coding-agent/test/terminal-output-worker-client.test.ts
+++ b/packages/coding-agent/test/terminal-output-worker-client.test.ts
@@ -22,7 +22,9 @@ test("legacy replay rejects when its worker exits before responding", async () =
 				outcome = { error, settled: true };
 			},
 		);
-		await new Promise<void>(resolve => setImmediate(resolve));
+		const turn = Promise.withResolvers<void>();
+		setImmediate(turn.resolve);
+		await turn.promise;
 		expect(outcome.settled).toBeTrue();
 		expect(outcome.error).toBeInstanceOf(Error);
 		expect((outcome.error as Error).message).toBe("Terminal output worker exited before responding");

--- a/packages/coding-agent/test/terminal-output-worker-client.test.ts
+++ b/packages/coding-agent/test/terminal-output-worker-client.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { renderTerminalOutputIsolated } from "../src/launch/terminal-output-worker-client";
+
+class CleanExitWorker extends EventTarget {
+	postMessage(): void {
+		this.dispatchEvent(new Event("close"));
+	}
+
+	terminate(): void {}
+}
+
+test("legacy replay rejects when its worker exits before responding", async () => {
+	const originalWorker = globalThis.Worker;
+	Object.defineProperty(globalThis, "Worker", { configurable: true, value: CleanExitWorker });
+	try {
+		let outcome: { error?: unknown; settled: boolean } = { settled: false };
+		void renderTerminalOutputIsolated("ready", { head: false, maxRows: 1 }).then(
+			() => {
+				outcome = { settled: true };
+			},
+			error => {
+				outcome = { error, settled: true };
+			},
+		);
+		await new Promise<void>(resolve => setImmediate(resolve));
+		expect(outcome.settled).toBeTrue();
+		expect(outcome.error).toBeInstanceOf(Error);
+		expect((outcome.error as Error).message).toBe("Terminal output worker exited before responding");
+	} finally {
+		Object.defineProperty(globalThis, "Worker", { configurable: true, value: originalWorker });
+	}
+});

--- a/packages/coding-agent/test/terminal-output-worker-client.test.ts
+++ b/packages/coding-agent/test/terminal-output-worker-client.test.ts
@@ -10,7 +10,8 @@ class CleanExitWorker extends EventTarget {
 }
 
 test("legacy replay rejects when its worker exits before responding", async () => {
-	const originalWorker = globalThis.Worker;
+	const originalWorkerDescriptor = Object.getOwnPropertyDescriptor(globalThis, "Worker");
+	expect(originalWorkerDescriptor).toBeDefined();
 	Object.defineProperty(globalThis, "Worker", { configurable: true, value: CleanExitWorker });
 	try {
 		let outcome: { error?: unknown; settled: boolean } = { settled: false };
@@ -29,6 +30,11 @@ test("legacy replay rejects when its worker exits before responding", async () =
 		expect(outcome.error).toBeInstanceOf(Error);
 		expect((outcome.error as Error).message).toBe("Terminal output worker exited before responding");
 	} finally {
-		Object.defineProperty(globalThis, "Worker", { configurable: true, value: originalWorker });
+		if (originalWorkerDescriptor) {
+			Object.defineProperty(globalThis, "Worker", originalWorkerDescriptor);
+		} else {
+			Reflect.deleteProperty(globalThis, "Worker");
+		}
 	}
+	expect(Object.getOwnPropertyDescriptor(globalThis, "Worker")).toEqual(originalWorkerDescriptor);
 });

--- a/packages/coding-agent/test/tools/hub/launch-compat.test.ts
+++ b/packages/coding-agent/test/tools/hub/launch-compat.test.ts
@@ -9,6 +9,14 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
+class CleanExitWorker extends EventTarget {
+	postMessage(): void {
+		this.dispatchEvent(new Event("close"));
+	}
+
+	terminate(): void {}
+}
+
 describe("launch broker protocol compatibility", () => {
 	it("replays raw terminal text returned by an already-running legacy broker", async () => {
 		const projectDir = process.cwd();
@@ -36,5 +44,39 @@ describe("launch broker protocol compatibility", () => {
 		});
 
 		expect(result.details?.terminalRows).toEqual(["\x1b[0m\x1b[1;38;5;2mready"]);
+	});
+
+	it("keeps sanitized legacy logs when optional terminal replay fails", async () => {
+		const projectDir = process.cwd();
+		const legacyResult = {
+			op: "logs",
+			name: "web",
+			text: "ready",
+			terminalText: "raw",
+			cursor: 42,
+			timedOut: false,
+			state: "running",
+		} as unknown as DaemonRpcResult;
+		const client = {
+			projectDir,
+			request: async () => legacyResult,
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		const originalWorker = globalThis.Worker;
+		Object.defineProperty(globalThis, "Worker", { configurable: true, value: CleanExitWorker });
+		try {
+			const result = await executeLaunch({ cwd: projectDir } as ToolSession, {
+				op: "logs",
+				name: "web",
+				lines: 10,
+				head: false,
+			});
+			expect(result.content).toEqual([{ type: "text", text: "ready\n[web: running; cursor=42]" }]);
+			expect(result.details?.terminalRows).toBeUndefined();
+		} finally {
+			Object.defineProperty(globalThis, "Worker", { configurable: true, value: originalWorker });
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/hub/launch-compat.test.ts
+++ b/packages/coding-agent/test/tools/hub/launch-compat.test.ts
@@ -64,7 +64,8 @@ describe("launch broker protocol compatibility", () => {
 		} satisfies DaemonBrokerClient;
 		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
 
-		const originalWorker = globalThis.Worker;
+		const originalWorkerDescriptor = Object.getOwnPropertyDescriptor(globalThis, "Worker");
+		expect(originalWorkerDescriptor).toBeDefined();
 		Object.defineProperty(globalThis, "Worker", { configurable: true, value: CleanExitWorker });
 		try {
 			const result = await executeLaunch({ cwd: projectDir } as ToolSession, {
@@ -76,7 +77,12 @@ describe("launch broker protocol compatibility", () => {
 			expect(result.content).toEqual([{ type: "text", text: "ready\n[web: running; cursor=42]" }]);
 			expect(result.details?.terminalRows).toBeUndefined();
 		} finally {
-			Object.defineProperty(globalThis, "Worker", { configurable: true, value: originalWorker });
+			if (originalWorkerDescriptor) {
+				Object.defineProperty(globalThis, "Worker", originalWorkerDescriptor);
+			} else {
+				Reflect.deleteProperty(globalThis, "Worker");
+			}
 		}
+		expect(Object.getOwnPropertyDescriptor(globalThis, "Worker")).toEqual(originalWorkerDescriptor);
 	});
 });

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -250,8 +250,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		joinerController.abort();
-		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(joiner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await owner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -233,8 +233,8 @@ describe("read PDF image extraction", () => {
 		await entered.promise;
 
 		ownerController.abort();
-		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		release.resolve();
+		await expect(owner).rejects.toThrow(/Aborted|Cancelled/);
 		const result = await joiner;
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);

--- a/packages/coding-agent/test/tools/read-pdf-images.test.ts
+++ b/packages/coding-agent/test/tools/read-pdf-images.test.ts
@@ -239,7 +239,7 @@ describe("read PDF image extraction", () => {
 
 		expect(result.content.some(content => content.type === "image")).toBe(true);
 		expect(spy).toHaveBeenCalledTimes(1);
-	});
+	}, 30_000);
 
 	it("keeps shared extraction running when a joiner aborts", async () => {
 		const { entered, release, spy } = mockBlockedExtraction();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,6 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2120,7 +2120,7 @@ describe("vibe session registry", () => {
 		const resumedSession = createSession({ manager: createManager(), sessionManager: reopened });
 		expect(await VibeSessionRegistry.global().rehydrate(resumedSession)).toBe(0);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
-	});
+	}, 15_000);
 
 	it("killAll terminates every session for the owner (mode-exit path)", async () => {
 		const gates = new Map<string, Deferred>();

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2103,7 +2103,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
-		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted");
+		await pollUntil(() => AgentRegistry.global().get("pre-init-kill")?.status === "aborted", 10_000);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });
 		expect(
 			parentManager.getEntries().some(entry => {

--- a/packages/coding-agent/test/xterm-runtime-ownership.test.ts
+++ b/packages/coding-agent/test/xterm-runtime-ownership.test.ts
@@ -7,6 +7,7 @@ interface CacheProbeResult {
 	rss: number;
 	heapUsed: number;
 	paths: string[];
+	terminalRows?: string[];
 }
 
 const fixture = (name: string): string => path.resolve(import.meta.dir, "fixtures", name);
@@ -29,7 +30,7 @@ async function runProbe(childPath: string): Promise<CacheProbeResult> {
 describe("launch xterm runtime ownership", () => {
 	test("cache detector observes the direct xterm positive control", async () => {
 		const result = await runProbe(fixture("xterm-cache-positive-control.ts"));
-		expect(result.modules, JSON.stringify(result)).toBe(1);
+		expect(result.modules, JSON.stringify(result)).toBeGreaterThan(0);
 		expect(result.bytes, JSON.stringify(result)).toBeGreaterThan(0);
 	});
 
@@ -43,8 +44,16 @@ describe("launch xterm runtime ownership", () => {
 		expect(result.modules, JSON.stringify(result)).toBe(0);
 	});
 
-	test("broker import owns exactly one xterm CommonJS module", async () => {
+	test("legacy replay evaluates xterm outside the client process", async () => {
+		const result = await runProbe(fixture("xterm-cache-legacy-replay-probe.ts"));
+		expect(result.terminalRows).toEqual(["\x1b[0m\x1b[1;38;5;2mready"]);
+		expect(result.modules, JSON.stringify(result)).toBe(0);
+		expect(result.bytes, JSON.stringify(result)).toBe(0);
+	});
+
+	test("broker import owns the xterm runtime", async () => {
 		const result = await runProbe(fixture("xterm-cache-broker-probe.ts"));
-		expect(result.modules, JSON.stringify(result)).toBe(1);
+		expect(result.modules, JSON.stringify(result)).toBeGreaterThan(0);
+		expect(result.bytes, JSON.stringify(result)).toBeGreaterThan(0);
 	});
 });


### PR DESCRIPTION
## Purpose

Follow up on #6748 by keeping legacy raw-PTY compatibility replay out of the Hub client's module graph. The fallback now runs through the existing compiled/source worker-host boundary, and the xterm ownership proof checks positive ownership without pinning an incidental exact file count.

## Tests

- Red ownership proof: 4 passed, 1 failed because legacy replay added the xterm CommonJS module to the client cache.
- Red lifecycle proof: 0 passed, 1 failed because a clean worker exit before any reply left replay pending.
- Red graceful-degradation proof: 1 passed, 1 failed because optional replay failure rejected `launch logs` instead of returning sanitized text.
- Green: focused launch/protocol/replay suite — 41 passed, 0 failed, 117 assertions.
- Focused Biome check passed.
- `bun --cwd=packages/coding-agent run check:types` passed.
- Source, npm-bundle, and compiled `--smoke-test` runs passed, including worker routing.

## Metrics

- Baseline: one deterministic legacy-replay subprocess sample left 1 xterm module / 182,672 cached source bytes in the Hub client runtime.
- Treatment: the same probe leaves 0 xterm modules / 0 cached source bytes in the client runtime.
- Delta: -1 client module / -182,672 client cached source bytes.
- Sample context: one isolated Bun subprocess per case, replaying the same legacy raw PTY payload; broker and direct-positive controls still report positive module and byte ownership.
- Claim boundary: this is a CommonJS cache-ownership result for the client runtime, not an RSS or end-to-end latency claim.

## Safety

- Upgraded brokers' validated `terminalRows` path is unchanged.
- Only the legacy `terminalText` fallback crosses the worker boundary, and the worker is terminated after one response.
- A worker that closes without replying rejects immediately instead of leaving the Hub request pending; the regression uses a deterministic close event with no timeout.
- Optional replay failure now degrades to `undefined` terminal rows at the tool-details boundary, preserving the sanitized `result.text` log response.
- Existing old/new broker compatibility remains covered end to end.
- No broker protocol redesign or terminal-rendering semantic change.