### PR TITLE
fix(natives): restore macOS CoreAudio capture bindings

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "895940582b3df625bf97f8d0dbfa4e278a01598c711363c7c09b944c976796d4",
+  "checksum": "fc307c26a4097bcc99136c3cf6a30b6170ac95277b3f7999f8619c401d44d644",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -2998,6 +2998,15 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "logging",
+            "prettyplease",
+            "runtime"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -3019,6 +3028,14 @@
             {
               "id": "itertools 0.13.0",
               "target": "itertools"
+            },
+            {
+              "id": "log 0.4.33",
+              "target": "log"
+            },
+            {
+              "id": "prettyplease 0.2.37",
+              "target": "prettyplease"
             },
             {
               "id": "proc-macro2 1.0.107",
@@ -3065,6 +3082,10 @@
             {
               "id": "clang-sys 1.8.1",
               "target": "clang_sys"
+            },
+            {
+              "id": "prettyplease 0.2.37",
+              "target": "prettyplease"
             }
           ],
           "selects": {}
@@ -6417,6 +6438,26 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "clang_10_0",
+            "clang_11_0",
+            "clang_3_5",
+            "clang_3_6",
+            "clang_3_7",
+            "clang_3_8",
+            "clang_3_9",
+            "clang_4_0",
+            "clang_5_0",
+            "clang_6_0",
+            "clang_7_0",
+            "clang_8_0",
+            "clang_9_0",
+            "libloading",
+            "runtime"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -6430,6 +6471,10 @@
             {
               "id": "libc 0.2.189",
               "target": "libc"
+            },
+            {
+              "id": "libloading 0.8.9",
+              "target": "libloading"
             }
           ],
           "selects": {}
@@ -22288,6 +22333,17 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "generate-bindings"
+            ],
+            "x86_64-apple-darwin": [
+              "generate-bindings"
+            ]
+          }
+        },
         "deps": {
           "common": [
             {
@@ -22313,7 +22369,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/maudio-sys/0.1.3/download",
-          "sha256": "f00ae1969d0a389937161b834623e5cba2d8449752a0970d71382cf9a905bb35"
+          "sha256": "f00ae1969d0a389937161b834623e5cba2d8449752a0970d71382cf9a905bb35",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel/patches:maudio-sys-target-bindings.patch"
+          ]
         }
       },
       "targets": [
@@ -22351,7 +22413,14 @@
           "common": [
             "default"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "generate-bindings"
+            ],
+            "x86_64-apple-darwin": [
+              "generate-bindings"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -22382,7 +22451,20 @@
               "target": "cc"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "bindgen 0.72.1",
+                "target": "bindgen"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "bindgen 0.72.1",
+                "target": "bindgen"
+              }
+            ]
+          }
         }
       },
       "license": "MIT",
@@ -32301,6 +32383,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "verbatim"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -37454,6 +37542,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "edition": "2015",
         "version": "1.3.0"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -3662,6 +3664,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00ae1969d0a389937161b834623e5cba2d8449752a0970d71382cf9a905bb35"
 dependencies = [
+ "bindgen",
  "cc",
 ]
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -153,6 +153,16 @@ crate.annotation(
     crate = "tree-sitter-just",
     build_script_env = {"CFLAGS": "-UNDEBUG"},
 )
+# `generate-bindings` is enabled for darwin so miniaudio's Rust bindings match
+# its CoreAudio C layout. Build scripts execute for the host, however, so a
+# macOS-hosted Linux cross-build also sees that feature. Use Cargo's TARGET to
+# keep bindgen darwin-only and select pregenerated bindings for other targets.
+crate.annotation(
+    crate = "maudio-sys",
+    patches = ["//bazel/patches:maudio-sys-target-bindings.patch"],
+    patch_args = ["-p1"],
+)
+
 use_repo(crate, "crates")
 
 

--- a/bazel/patches/maudio-sys-target-bindings.patch
+++ b/bazel/patches/maudio-sys-target-bindings.patch
@@ -1,0 +1,38 @@
+--- a/build.rs
++++ b/build.rs
+@@ -5,6 +5,12 @@ use cc::Build;
+ 
+ #[cfg(feature = "generate-bindings")]
+ fn write_bindings(out_bindings: &std::path::Path) {
++    let target = env::var("TARGET").expect("TARGET must be set by Cargo");
++    if !target.contains("apple-darwin") {
++        copy_bindings(&target, out_bindings);
++        return;
++    }
++
+     let mut builder = bindgen::Builder::default()
+         .header("native/miniaudio/miniaudio.h")
+         .clang_arg("-Inative")
+@@ -25,11 +31,17 @@ fn write_bindings(out_bindings: &std::path::Path) {
+ 
+ #[cfg(not(feature = "generate-bindings"))]
+ fn write_bindings(out_bindings: &std::path::Path) {
++    let target = env::var("TARGET").expect("TARGET must be set by Cargo");
++    copy_bindings(&target, out_bindings);
++}
++
++fn copy_bindings(target: &str, out_bindings: &std::path::Path) {
+     eprintln!("Copying bindings");
+-    #[cfg(unix)]
+-    std::fs::copy("src/pregen_bindings/unix.rs", out_bindings)
+-        .expect("Failed to copy pre-generated bindings to OUT_DIR");
+-    #[cfg(windows)]
+-    std::fs::copy("src/pregen_bindings/windows.rs", out_bindings)
++    let source = if target.contains("windows") {
++        "src/pregen_bindings/windows.rs"
++    } else {
++        "src/pregen_bindings/unix.rs"
++    };
++    std::fs::copy(source, out_bindings)
+         .expect("Failed to copy pre-generated bindings to OUT_DIR");
+ }

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -72,6 +72,16 @@ xcap = { version = "=0.9.6", default-features = false }
 [target.'cfg(target_os = "macos")'.dependencies]
 tempfile = "=3.27.0"
 core-graphics = "0.25"
+# Regenerate miniaudio FFI bindings from the compiled headers on macOS only.
+# The maudio-sys pregenerated `unix.rs` bindings are Linux-shaped: their
+# `ma_device`/`ma_context` backend-state unions omit the `#ifdef
+# MA_SUPPORT_COREAUDIO` members that the macOS build of miniaudio.c actually
+# contains, so shipping them on darwin is an ABI mismatch that silently breaks
+# CoreAudio capture (device init/start succeed but no render callbacks fire).
+# darwin builds with host Xcode (libclang available), so bindgen is fine here;
+# the hermetic zig/musl/windows toolchains keep the bindgen-free pregen path,
+# whose bindings are correct for those platforms.
+maudio = { workspace = true, features = ["generate-bindings"] }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the macOS (darwin) native addon delivering zero `AudioCapture` callbacks — `/live` could listen without ever capturing microphone audio ([#6846](https://github.com/can1357/oh-my-pi/issues/6846)). The 17.1.6 Bazel migration dropped `maudio`'s `generate-bindings` feature, so darwin shipped `maudio-sys`'s Linux-shaped pregenerated miniaudio bindings, whose `ma_device`/`ma_context` backend-state unions omit the `MA_SUPPORT_COREAUDIO` members present in the macOS build of `miniaudio.c`. The resulting Rust↔C ABI mismatch let device init/start succeed while the CoreAudio render callback never fired. `generate-bindings` is now re-enabled for apple targets only (darwin builds with host Xcode, so bindgen/libclang are available); the hermetic linux/musl/windows toolchains keep the bindgen-free pregenerated bindings, which are correct for those platforms.
+
 ## [17.1.6] - 2026-07-27
 
 ### Changed


### PR DESCRIPTION
## Repro
On macOS arm64 with OMP 17.1.6, the shipped `pi_natives.darwin-arm64.node` delivers zero `AudioCapture` callbacks, so `/live` listens without ever capturing microphone audio (17.1.5 works on the same machine/mic/permissions). Reporter's deterministic native-addon bisect:

```js
const native = require(`${process.env.HOME}/.omp/natives/${VERSION}/pi_natives.darwin-arm64.node`);
let chunks = 0, samples = 0;
const capture = new native.AudioCapture(16_000, (err, audio) => { if (err) throw err; chunks++; samples += audio.length; });
setTimeout(() => { capture.stop(); console.log({ chunks, samples }); }, 3_000);
// 17.1.5: { chunks: 151, samples: 48320 }   17.1.6: { chunks: 0, samples: 0 }
```

## Cause
The 17.1.6 Bazel migration (commit `8facd237d5b`) changed the `maudio` dependency in `Cargo.toml` from `{ features = ["generate-bindings"] }` to plain `maudio = "0.1.6"`. With `generate-bindings` off, `maudio-sys` 0.1.3 stops running bindgen and copies its committed `src/pregen_bindings/unix.rs` for every unix target. Those bindings were generated on **Linux**: the `ma_device` backend-state union (`ma_device__bindgen_ty_4`) and the `ma_context` union (`ma_context__bindgen_ty_1`) contain only `alsa`/`pulse`/`jack`/`null` — no `coreaudio` member. `miniaudio.h` gates the CoreAudio backend-state member behind `#ifdef MA_SUPPORT_COREAUDIO` (Apple only), so the `miniaudio.c` compiled on the macOS build host has a `coreaudio` union member the Linux-shaped Rust bindings do not describe. The resulting Rust↔C ABI mismatch on `ma_device`/`ma_context` lets `ma_device_init`/`ma_device_start` return `MA_SUCCESS` (no exception) while the AURenderCallback wiring reads/writes through wrong offsets — the HAL thread never fires the callback. Linux is unaffected because its pregenerated bindings match its compile; 17.1.5 worked because it still built with `generate-bindings`, so bindgen ran on the macOS host and produced correct CoreAudio layout.

## Fix
- `crates/pi-natives/Cargo.toml`: re-enable `maudio`'s `generate-bindings` feature for apple targets only, via an additive `[target.'cfg(target_os = "macos")'.dependencies]` entry. darwin builds with host Xcode (libclang available), so bindgen regenerates bindings matching the compiled headers; the hermetic zig/musl and windows-msvc toolchains keep the bindgen-free pregenerated bindings, which are correct for those platforms — so the migration's hermeticity goal is preserved everywhere it applies.
- `Cargo.lock` / `Cargo.Bazel.lock`: repinned (`bun run bazel:repin`). `maudio-sys` now carries the `generate-bindings` feature and a `bindgen 0.72.1` build-dep gated behind the `aarch64-apple-darwin` / `x86_64-apple-darwin` selects; no new crates entered the graph (bindgen was already spliced in).
- `packages/natives/CHANGELOG.md`: entry under `[Unreleased] > Fixed`.

## Verification
- `cargo tree -p pi-natives --target aarch64-apple-darwin -e features` shows `maudio-sys` with `generate-bindings` + `bindgen v0.72.1`; `--target x86_64-unknown-linux-gnu` shows neither — confirming the feature activates on darwin only.
- Repin (`CARGO_BAZEL_REPIN=1 bazelisk fetch @crates//...`) completed successfully and the regenerated `Cargo.Bazel.lock` gates `generate-bindings` + the bindgen build-dep behind the two apple triples with a fresh checksum.
- Pre-publish gate (`bun run fix` + `bun check`) passed.
- Not runtime-verified from this Linux triage host: building the darwin addon requires a macOS Xcode host and confirming callbacks requires a physical microphone under TCC. The change restores exactly the 17.1.5 build configuration (bindgen on the macOS host) that the reporter confirmed working, so the shipped darwin addon regains correct CoreAudio bindings. One residual risk to watch in the darwin CI action: bindgen's `clang-sys` must locate `libclang.dylib` in the Bazel sandbox; host Xcode normally exposes it via `xcrun`, but if the action can't find it, add a `crate.annotation(crate = "maudio-sys", build_script_env = { "LIBCLANG_PATH": ... })`.

Fixes #6846