### PR TITLE
fix(launch): treat restarting daemon as settled in broker #settle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Daemon broker: a detached `restart:"always"` daemon in the `restarting` backoff window is no longer re-settled by routine ops (`list`/`logs`/`stop`/`describe`). Previously each op ran `#refreshDetached` → a re-entrant `#settle` that incremented `restartCount` and overwrote the armed `restartTimer`, orphaning the old timer; `stop` cleared only the last timer, so an orphaned timer later fired `#launch` and resurrected the daemon (`stop` reported success but the daemon kept looping). `#settle` now treats `restarting` as already-settled ([#6852](https://github.com/can1357/oh-my-pi/issues/6852)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -103,6 +103,10 @@ function terminalState(state: DaemonSnapshot["state"]): boolean {
 	return state === "exited" || state === "failed";
 }
 
+function settledState(state: DaemonSnapshot["state"]): boolean {
+	return terminalState(state) || state === "restarting";
+}
+
 /**
  * Order daemons for the `list` response: non-terminal (active) daemons first,
  * oldest to newest, so the process the user is acting on is immediately visible
@@ -754,7 +758,7 @@ class DaemonBroker {
 	}
 
 	async #refreshDetached(record: ManagedDaemon): Promise<void> {
-		if (!record.spec.detached || terminalState(record.snapshot.state)) return;
+		if (!record.spec.detached || settledState(record.snapshot.state)) return;
 		const generation = record.generation;
 		await this.#readDetachedOutput(record, generation);
 		if (generation !== record.generation || record.process) return;
@@ -795,13 +799,10 @@ class DaemonBroker {
 		// runs #refreshDetached on such a record must not re-settle it: re-entry double-counts
 		// restartCount and overwrites record.restartTimer, orphaning the armed timer so it fires
 		// after stop() and resurrects the daemon (issue #6852).
-		if (
-			generation !== record.generation ||
-			terminalState(record.snapshot.state) ||
-			record.snapshot.state === "restarting"
-		)
-			return;
+		if (generation !== record.generation || settledState(record.snapshot.state)) return;
 		await this.#readDetachedOutput(record, generation);
+		// The output read yields, so a concurrent refresh may settle this generation first.
+		if (generation !== record.generation || settledState(record.snapshot.state)) return;
 		record.process = undefined;
 		record.input = undefined;
 		record.pty = undefined;

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -791,7 +791,16 @@ class DaemonBroker {
 	}
 
 	async #settle(record: ManagedDaemon, generation: number, exitCode?: number, error?: string): Promise<void> {
-		if (generation !== record.generation || terminalState(record.snapshot.state)) return;
+		// `restarting` is a settled state (child exited, relaunch timer armed). Any op that
+		// runs #refreshDetached on such a record must not re-settle it: re-entry double-counts
+		// restartCount and overwrites record.restartTimer, orphaning the armed timer so it fires
+		// after stop() and resurrects the daemon (issue #6852).
+		if (
+			generation !== record.generation ||
+			terminalState(record.snapshot.state) ||
+			record.snapshot.state === "restarting"
+		)
+			return;
 		await this.#readDetachedOutput(record, generation);
 		record.process = undefined;
 		record.input = undefined;

--- a/packages/coding-agent/test/launch/broker-restarting-settle.test.ts
+++ b/packages/coding-agent/test/launch/broker-restarting-settle.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { Process } from "@oh-my-pi/pi-natives";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { startDaemonBrokerFromEnvironment } from "../../src/launch/broker";
 import { createDaemonBrokerClient, type DaemonBrokerClient } from "../../src/launch/client";
@@ -19,6 +20,20 @@ import {
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) delete process.env[name];
 	else process.env[name] = value;
+}
+
+function startBroker(projectDir: string, runtimeDir: string): Promise<void> {
+	const previousProjectDir = process.env[DAEMON_PROJECT_DIR_ENV];
+	const previousRuntimeDir = process.env[DAEMON_RUNTIME_DIR_ENV];
+	const previousGrace = process.env[DAEMON_IDLE_GRACE_ENV];
+	process.env[DAEMON_PROJECT_DIR_ENV] = projectDir;
+	process.env[DAEMON_RUNTIME_DIR_ENV] = runtimeDir;
+	process.env[DAEMON_IDLE_GRACE_ENV] = "5000";
+	const broker = startDaemonBrokerFromEnvironment();
+	restoreEnv(DAEMON_PROJECT_DIR_ENV, previousProjectDir);
+	restoreEnv(DAEMON_RUNTIME_DIR_ENV, previousRuntimeDir);
+	restoreEnv(DAEMON_IDLE_GRACE_ENV, previousGrace);
+	return broker;
 }
 
 async function snapshotOf(client: DaemonBrokerClient, name: string): Promise<DaemonSnapshot> {
@@ -51,18 +66,10 @@ describe("daemon broker restart settling", () => {
 		const runtimeDir = path.join(tempDir.path(), "runtime");
 		await fs.mkdir(projectDir);
 
+		const previousTitle = process.title;
 		// Create the client (writes broker.token) before starting the broker, which reads that token.
 		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
-		const previousProjectDir = process.env[DAEMON_PROJECT_DIR_ENV];
-		const previousRuntimeDir = process.env[DAEMON_RUNTIME_DIR_ENV];
-		const previousGrace = process.env[DAEMON_IDLE_GRACE_ENV];
-		process.env[DAEMON_PROJECT_DIR_ENV] = projectDir;
-		process.env[DAEMON_RUNTIME_DIR_ENV] = runtimeDir;
-		process.env[DAEMON_IDLE_GRACE_ENV] = "5000";
-		const broker = startDaemonBrokerFromEnvironment();
-		restoreEnv(DAEMON_PROJECT_DIR_ENV, previousProjectDir);
-		restoreEnv(DAEMON_RUNTIME_DIR_ENV, previousRuntimeDir);
-		restoreEnv(DAEMON_IDLE_GRACE_ENV, previousGrace);
+		const broker = startBroker(projectDir, runtimeDir);
 		const name = "crash-loop";
 		try {
 			const started = await client.request({
@@ -110,6 +117,79 @@ describe("daemon broker restart settling", () => {
 			await client.request({ op: "shutdown" }).catch(() => undefined);
 			client.close();
 			await broker;
+			process.title = previousTitle;
+		}
+	}, 20_000);
+
+	it("settles a recovered detached daemon once across concurrent refreshes", async () => {
+		using tempDir = TempDir.createSync("@omp-launch-recovered-restart-");
+		const projectDir = path.join(tempDir.path(), "project");
+		const runtimeDir = path.join(tempDir.path(), "runtime");
+		await fs.mkdir(projectDir);
+
+		const previousTitle = process.title;
+		const name = "recovered-crash";
+		let pid: number | undefined;
+
+		const firstClient = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const firstBroker = startBroker(projectDir, runtimeDir);
+		try {
+			const started = await firstClient.request({
+				op: "start",
+				spec: {
+					name,
+					application: process.execPath,
+					args: ["-e", 'Bun.serve({ port: 0, fetch() { return new Response("ok"); } })'],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "always",
+					persist: true,
+					detached: true,
+				},
+			});
+			if (started.op !== "start") throw new Error(`unexpected result: ${started.op}`);
+			pid = started.daemon.pid;
+			if (pid === undefined) throw new Error("detached daemon has no pid");
+		} finally {
+			await firstClient.request({ op: "shutdown" }).catch(() => undefined);
+			firstClient.close();
+			await firstBroker;
+		}
+
+		const secondClient = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const secondBroker = startBroker(projectDir, runtimeDir);
+		try {
+			const recovered = await snapshotOf(secondClient, name);
+			expect(recovered.state).toBe("running");
+			expect(recovered.pid).toBe(pid);
+
+			const processRef = Process.fromPid(pid);
+			if (!processRef) throw new Error(`recovered daemon process ${pid} is unavailable`);
+			await processRef.terminate({ group: true, gracefulMs: 0, timeoutMs: 2_000 });
+
+			// Both requests enter #settle before its detached-output read completes. The
+			// post-read guard must let only one continuation settle this generation.
+			const concurrentLists = await Promise.all([
+				secondClient.request({ op: "list" }),
+				secondClient.request({ op: "list" }),
+			]);
+			for (const listed of concurrentLists) {
+				if (listed.op !== "list") throw new Error(`unexpected result: ${listed.op}`);
+				const daemon = listed.daemons.find(entry => entry.name === name);
+				expect(daemon?.state).toBe("restarting");
+				expect(daemon?.restartCount).toBe(1);
+			}
+		} finally {
+			await secondClient.request({ op: "stop", name, timeoutMs: 2_000 }).catch(() => undefined);
+			await secondClient.request({ op: "shutdown" }).catch(() => undefined);
+			secondClient.close();
+			await secondBroker;
+			const processRef = pid === undefined ? null : Process.fromPid(pid);
+			if (processRef?.status() === "running") {
+				await processRef.terminate({ group: true, gracefulMs: 0, timeoutMs: 2_000 });
+			}
+			process.title = previousTitle;
 		}
 	}, 20_000);
 });

--- a/packages/coding-agent/test/launch/broker-restarting-settle.test.ts
+++ b/packages/coding-agent/test/launch/broker-restarting-settle.test.ts
@@ -1,0 +1,115 @@
+// Integration test — real timers are required (ts-no-test-timers exception): this spawns the
+// actual cross-process daemon broker driving real child processes, and the bug is a leaked real
+// `setTimeout` in #settle that resurrects a stopped daemon. Fake timers cannot control the OS
+// process-exit promise or the unix-socket RPC the broker relies on, and proving the *absence* of a
+// resurrection means waiting past the real backoff window (no signal exists to await).
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { startDaemonBrokerFromEnvironment } from "../../src/launch/broker";
+import { createDaemonBrokerClient, type DaemonBrokerClient } from "../../src/launch/client";
+import {
+	DAEMON_IDLE_GRACE_ENV,
+	DAEMON_PROJECT_DIR_ENV,
+	DAEMON_RUNTIME_DIR_ENV,
+	type DaemonSnapshot,
+} from "../../src/launch/protocol";
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}
+
+async function snapshotOf(client: DaemonBrokerClient, name: string): Promise<DaemonSnapshot> {
+	const listed = await client.request({ op: "list" });
+	if (listed.op !== "list") throw new Error(`unexpected result: ${listed.op}`);
+	const daemon = listed.daemons.find(entry => entry.name === name);
+	if (!daemon) throw new Error(`daemon ${name} not listed`);
+	return daemon;
+}
+
+async function waitForState(
+	client: DaemonBrokerClient,
+	name: string,
+	state: DaemonSnapshot["state"],
+	deadlineMs: number,
+): Promise<DaemonSnapshot> {
+	const deadline = Date.now() + deadlineMs;
+	while (Date.now() < deadline) {
+		const daemon = await snapshotOf(client, name);
+		if (daemon.state === state) return daemon;
+		await Bun.sleep(25);
+	}
+	throw new Error(`daemon ${name} never reached state ${state}`);
+}
+
+describe("daemon broker restart settling", () => {
+	it("does not re-settle a restarting detached daemon on ops, keeping stop authoritative", async () => {
+		using tempDir = TempDir.createSync("@omp-launch-restart-");
+		const projectDir = path.join(tempDir.path(), "project");
+		const runtimeDir = path.join(tempDir.path(), "runtime");
+		await fs.mkdir(projectDir);
+
+		// Create the client (writes broker.token) before starting the broker, which reads that token.
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const previousProjectDir = process.env[DAEMON_PROJECT_DIR_ENV];
+		const previousRuntimeDir = process.env[DAEMON_RUNTIME_DIR_ENV];
+		const previousGrace = process.env[DAEMON_IDLE_GRACE_ENV];
+		process.env[DAEMON_PROJECT_DIR_ENV] = projectDir;
+		process.env[DAEMON_RUNTIME_DIR_ENV] = runtimeDir;
+		process.env[DAEMON_IDLE_GRACE_ENV] = "5000";
+		const broker = startDaemonBrokerFromEnvironment();
+		restoreEnv(DAEMON_PROJECT_DIR_ENV, previousProjectDir);
+		restoreEnv(DAEMON_RUNTIME_DIR_ENV, previousRuntimeDir);
+		restoreEnv(DAEMON_IDLE_GRACE_ENV, previousGrace);
+		const name = "crash-loop";
+		try {
+			const started = await client.request({
+				op: "start",
+				spec: {
+					name,
+					// Fast-exit child: exits 0 immediately, so restart:"always" parks it in `restarting`.
+					application: process.execPath,
+					args: ["-e", "process.exit(0)"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "always",
+					persist: false,
+					detached: true,
+				},
+			});
+			expect(started.op).toBe("start");
+
+			// Enter the restarting backoff window and record the restart count.
+			const restarting = await waitForState(client, name, "restarting", 5_000);
+			const baseline = restarting.restartCount;
+
+			// Poll while restarting. Each op runs #refreshDetached; a re-entrant #settle would
+			// phantom-increment restartCount and leak an armed timer (issue #6852).
+			for (let i = 0; i < 3; i++) {
+				const seen = await snapshotOf(client, name);
+				expect(seen.state).toBe("restarting");
+				expect(seen.restartCount).toBe(baseline);
+			}
+
+			// Stop must be authoritative: clears the single armed timer, no orphaned timer resurrects.
+			const stopped = await client.request({ op: "stop", name, timeoutMs: 2_000 });
+			if (stopped.op !== "stop") throw new Error(`unexpected result: ${stopped.op}`);
+			expect(stopped.daemon.state).toBe("exited");
+
+			// Wait past the initial backoff (2s) where a leaked timer would have fired #launch.
+			await Bun.sleep(2_600);
+			const afterStop = await snapshotOf(client, name);
+			expect(afterStop.state).toBe("exited");
+			expect(afterStop.pid).toBeUndefined();
+			expect(afterStop.restartCount).toBe(baseline);
+		} finally {
+			await client.request({ op: "stop", name, timeoutMs: 2_000 }).catch(() => undefined);
+			await client.request({ op: "shutdown" }).catch(() => undefined);
+			client.close();
+			await broker;
+		}
+	}, 20_000);
+});


### PR DESCRIPTION
## Repro
A detached daemon with `restart:"always"` whose child exits quickly (crash/fast-exit loop) enters the broker's `restarting` state with `process`/`pid` cleared and a `restartTimer` armed. Every routine op (`list`/`logs`/`stop`/`describe`) then re-settles it. Reproduced with an integration test that spawns the real cross-process broker: `bun test packages/coding-agent/test/launch/broker-restarting-settle.test.ts`. Against the unpatched broker, `restartCount` climbs by one on every `list` (`Expected 2, Received 3`), and after `stop` an orphaned timer resurrects the daemon.

## Cause
In `packages/coding-agent/src/launch/broker.ts`, `#refreshDetached` only short-circuits terminal states, so a `restarting` record with `process`/`pid` undefined falls through to `#settle`. `#settle`'s entry guard checked only `generation` and `terminalState(...)`, so the re-entry proceeded: `record.snapshot.restartCount++` and `record.restartTimer = setTimeout(...)` overwrote the field without clearing the previously armed timer, orphaning it. `#stopRecord` clears only the last `restartTimer`; an orphaned timer later fires `#launch`, whose first action resets `record.stopRequested = false`, respawning the process after a successful-looking `stop`.

## Fix
- Add `record.snapshot.state === "restarting"` to `#settle`'s entry guard: `restarting` is a settled state (child exited, relaunch timer pending) and no legitimate caller settles while in it (only `#settle` produces it, and `#launch` moves it to `starting`/`running` before any exit can settle again). This closes both the timer leak and the phantom `restartCount` inflation at the single choke point every op funnels through.
- Add `packages/coding-agent/test/launch/broker-restarting-settle.test.ts`: drives the real broker, asserts `restartCount` stays constant across `list` polls while `restarting`, and that after `stop` the daemon stays `exited` past the backoff window (no orphaned-timer resurrection).

## Verification
`bun test packages/coding-agent/test/launch/` — 27 pass, 0 fail. The new test fails on the unpatched broker (`restartCount` inflates `2`→`3`) and passes with the guard. Fixes #6852