### PR TITLE
fix(tui): bound stdout backlog when the pty consumer stalls

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unbounded memory growth when a PTY consumer stalls without dying: `ProcessTerminal.#safeWrite` handed every frame to `process.stdout.write()` and ignored its backpressure return, so a stalled-but-alive reader (never throws, unlike the terminal-death path in [#5837](https://github.com/can1357/oh-my-pi/pull/5837)) let the writable buffer grow without bound as cosmetic `hub wait` spinner/progress frames piled up — one incident reached ~48 GiB RSS and wedged the host. The write path now caps the pending stdout backlog and treats a consumer that will not drain past the cap as a disconnect, taking the same clean, supervisor-resumable exit as a dead terminal ([#6854](https://github.com/can1357/oh-my-pi/issues/6854)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -141,6 +141,66 @@ export function chunkForConPTY(data: string, maxChunkBytes: number = MAX_CONPTY_
 }
 
 /**
+ * Hard cap on bytes queued to a stalled stdout before its consumer is declared
+ * gone. A live terminal drains within milliseconds, so a backlog this large —
+ * far above any legitimate paint (a full session resume is a few MiB) — means
+ * the PTY reader has stopped consuming entirely. Without the cap, `#safeWrite`
+ * keeps handing cosmetic frames (the `hub wait` spinner, 500 ms progress
+ * snapshots) to a writable buffer that never drains, growing RSS without bound
+ * until the host runs out of memory. See #6854.
+ */
+const MAX_STDOUT_BACKLOG_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Turns an unbounded, never-draining stdout writable buffer into a bounded
+ * disconnect signal.
+ *
+ * `process.stdout.write()` returns `false` once its buffer exceeds the stream
+ * high-water mark; the bytes stay queued and are only freed when the consumer
+ * drains (the `drain` event). While the consumer keeps up, writes are accepted
+ * and nothing accumulates. When it stalls, every subsequent write piles onto
+ * the buffer — a stalled-but-alive PTY reader never throws, so the write path
+ * has no other signal that output is going nowhere. This guard sums the bytes
+ * queued since backpressure began and reports when that backlog crosses the
+ * cap, at which point the caller treats the terminal as disconnected.
+ *
+ * Exported for unit testing; `ProcessTerminal` is the sole production user.
+ */
+export class OutputBacklogGuard {
+	#bytes = 0;
+	#tracking = false;
+
+	constructor(private readonly capBytes: number = MAX_STDOUT_BACKLOG_BYTES) {}
+
+	/** True once a refused write started a backlog that has not yet drained. */
+	get tracking(): boolean {
+		return this.#tracking;
+	}
+
+	/**
+	 * Record one `stdout.write()`: `accepted` is that call's return value and
+	 * `bytes` its encoded size. Returns true when the pending backlog now
+	 * exceeds the cap and the terminal should be treated as disconnected.
+	 */
+	record(accepted: boolean, bytes: number): boolean {
+		if (!this.#tracking) {
+			// Consumer is keeping up; nothing is queued.
+			if (accepted) return false;
+			// First refused write: backpressure has begun.
+			this.#tracking = true;
+		}
+		this.#bytes += bytes;
+		return this.#bytes > this.capBytes;
+	}
+
+	/** Called on the stdout `drain` event: the buffer emptied, backlog cleared. */
+	reset(): void {
+		this.#bytes = 0;
+		this.#tracking = false;
+	}
+}
+
+/**
  * Minimal terminal interface for TUI
  */
 
@@ -494,6 +554,16 @@ export class ProcessTerminal implements Terminal {
 	#stdoutErrorCleanup?: () => void;
 	#stdoutErrorHandler = (err: Error) => {
 		this.#markTerminalDisconnected("stdout failed", err);
+	};
+	// Bounds the stdout writable buffer against a stalled PTY consumer: a
+	// stalled-but-alive reader never throws, so #safeWrite has no error to catch
+	// and the writable buffer grows without bound as cosmetic frames pile up.
+	// See OutputBacklogGuard and #6854.
+	#stdoutBacklog = new OutputBacklogGuard();
+	#stdoutDrainArmed = false;
+	#stdoutDrainHandler = () => {
+		this.#stdoutDrainArmed = false;
+		this.#stdoutBacklog.reset();
 	};
 
 	#windowsVTInputRestore?: () => void;
@@ -1468,6 +1538,11 @@ export class ProcessTerminal implements Terminal {
 			process.stdout.removeListener("resize", this.#stdoutResizeListener);
 			this.#stdoutResizeListener = undefined;
 		}
+		if (this.#stdoutDrainArmed) {
+			process.stdout.removeListener("drain", this.#stdoutDrainHandler);
+			this.#stdoutDrainArmed = false;
+		}
+		this.#stdoutBacklog.reset();
 		this.#resizeHandler = undefined;
 
 		// Pause stdin to prevent any buffered input (e.g., Ctrl+D) from being
@@ -1561,13 +1636,26 @@ export class ProcessTerminal implements Terminal {
 			// `process.stdout.write(string)` UTF-8-encodes before `WriteFile`,
 			// and a code-unit cap would let CJK transcript rows expand past the
 			// threshold. See #2034 and #2095.
-			if (isConPTYHosted() && Buffer.byteLength(data, "utf8") > MAX_CONPTY_WRITE_CHUNK_BYTES) {
+			const bytes = Buffer.byteLength(data, "utf8");
+			let accepted: boolean;
+			if (isConPTYHosted() && bytes > MAX_CONPTY_WRITE_CHUNK_BYTES) {
+				accepted = true;
 				for (const chunk of chunkForConPTY(data, MAX_CONPTY_WRITE_CHUNK_BYTES)) {
 					if (this.#dead) break;
-					process.stdout.write(chunk);
+					accepted = process.stdout.write(chunk);
 				}
 			} else {
-				process.stdout.write(data);
+				accepted = process.stdout.write(data);
+			}
+			// A stalled-but-alive PTY consumer never throws: write() just returns
+			// false and queues the bytes. Bound that never-draining backlog by
+			// declaring the terminal disconnected once it crosses the cap — the
+			// same clean-exit path a dead terminal takes (#6854).
+			if (this.#stdoutBacklog.record(accepted, bytes)) {
+				this.#markTerminalDisconnected("stdout backlog exceeded cap; PTY consumer stalled");
+			} else if (this.#stdoutBacklog.tracking && !this.#stdoutDrainArmed) {
+				this.#stdoutDrainArmed = true;
+				process.stdout.once("drain", this.#stdoutDrainHandler);
 			}
 		} catch (err) {
 			this.#markTerminalDisconnected("stdout failed", err);

--- a/packages/tui/test/output-backlog-guard.test.ts
+++ b/packages/tui/test/output-backlog-guard.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { OutputBacklogGuard } from "@oh-my-pi/pi-tui/terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/6854
+//
+// A stalled-but-alive PTY consumer never throws, so ProcessTerminal.#safeWrite
+// has no error to catch: process.stdout.write() just returns false and queues
+// the bytes. OutputBacklogGuard turns that never-draining backlog into a bounded
+// disconnect signal. These tests pin the accounting contract #safeWrite relies
+// on to decide when to declare the terminal disconnected.
+describe("issue #6854: OutputBacklogGuard bounds a stalled stdout", () => {
+	it("never trips while the consumer keeps up (writes accepted)", () => {
+		const guard = new OutputBacklogGuard(1024);
+		for (let i = 0; i < 10_000; i++) {
+			expect(guard.record(true, 4096)).toBe(false);
+		}
+		expect(guard.tracking).toBe(false);
+	});
+
+	it("starts tracking on the first refused write and accumulates the backlog", () => {
+		const guard = new OutputBacklogGuard(1024);
+		// First refusal: backpressure begins.
+		expect(guard.record(false, 256)).toBe(false);
+		expect(guard.tracking).toBe(true);
+		// Bytes keep accumulating up to — but not past — the cap.
+		expect(guard.record(false, 256)).toBe(false);
+		expect(guard.record(false, 256)).toBe(false);
+		expect(guard.record(false, 256)).toBe(false); // total 1024 == cap, not over
+		// One more byte crosses the cap and signals disconnect.
+		expect(guard.record(false, 1)).toBe(true);
+	});
+
+	it("keeps counting bytes while tracking even when a later write is accepted", () => {
+		const guard = new OutputBacklogGuard(1024);
+		// Backpressure began: the buffer is not empty until a drain resets us,
+		// so a transient write() === true still adds to the pending backlog.
+		expect(guard.record(false, 512)).toBe(false);
+		expect(guard.tracking).toBe(true);
+		expect(guard.record(true, 512)).toBe(false); // total 1024
+		expect(guard.record(true, 1)).toBe(true); // crosses cap
+	});
+
+	it("clears the backlog on reset (drain) and starts fresh afterward", () => {
+		const guard = new OutputBacklogGuard(1024);
+		expect(guard.record(false, 1025)).toBe(true);
+		guard.reset();
+		expect(guard.tracking).toBe(false);
+		// After a drain, accepted writes are healthy again and never trip.
+		expect(guard.record(true, 100_000)).toBe(false);
+		expect(guard.tracking).toBe(false);
+		// A fresh stall restarts accounting from zero.
+		expect(guard.record(false, 1024)).toBe(false);
+		expect(guard.record(false, 1)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
A TUI-on-PTY session whose consumer stalls but does not die grows RSS without bound. During a `hub wait` the only output produced is cosmetic (the spinner + 500 ms progress snapshots), yet every frame is handed to `process.stdout.write()` with its backpressure return value dropped, so a non-draining but alive PTY reader lets the writable buffer accumulate forever — one incident reached ~48 GiB RSS, entered D-state, and wedged the host VM (#6854). Modelling the write path against a stalled consumer reproduces the mechanism:

```
$ bun repro.mjs   # 100k ~16 KiB frames into a 64 KiB-HWM Writable with no reader
frames written        : 100000
writes refused (false): 99994   (backpressure signal omp ignores)
buffered in stdout     : 1562.5 MiB
process RSS growth     : 1605.3 MiB
```

The buffer scales linearly with frames emitted and is never freed while the consumer stays stalled.

## Cause
`ProcessTerminal.#safeWrite` (`packages/tui/src/terminal.ts`) writes each frame via `process.stdout.write(data)` and ignores the `false` return that signals the writable buffer is over its high-water mark. A stalled-but-alive consumer never throws (unlike terminal *death*, where `write()` throws EPIPE and `#markTerminalDisconnected` → SIGHUP handles it, [#5837](https://github.com/can1357/oh-my-pi/pull/5837)), so the write path had no signal that output was going nowhere and kept queueing bytes indefinitely.

## Fix
- Add `OutputBacklogGuard` (exported from `terminal.ts`): sums the bytes queued to stdout since backpressure began (first refused `write()`) and reports when that pending backlog crosses a 64 MiB cap. A drain resets it; while the consumer keeps up nothing accumulates.
- `#safeWrite` now captures each `write()` return, feeds it to the guard, and on cap-crossing calls `#markTerminalDisconnected("stdout backlog exceeded cap; PTY consumer stalled")` — the same clean, supervisor-resumable SIGHUP exit a dead terminal already takes — instead of unbounded growth. A one-shot `drain` listener resets the backlog when the consumer catches up; `stop()` tears the listener down.
- The 64 MiB cap sits far above any legitimate paint (a full session resume is a few MiB) so a live-but-slow terminal never trips it; only a consumer that accepts nothing reaches it.

## Verification
`bun test test/output-backlog-guard.test.ts` (4 pass) covers the accounting contract: healthy accepted writes never trip, the first refused write starts tracking and accumulates to the cap, transient accepted writes still count while a backlog is pending, and `reset()` clears state for a fresh stall. Terminal-path regressions stay green: `bun test test/issue-2034-repro.test.ts test/cursor-visibility-dedupe.test.ts test/emergency-restore-altscreen.test.ts` (24 pass). `bun check` passes in `packages/tui`. Fixes #6854