### PR TITLE
fix(settings): hide excluded web search providers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed excluded web search providers remaining visible in the `Web Search Provider Order` settings list ([#6860](https://github.com/can1357/oh-my-pi/issues/6860)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1169,6 +1169,14 @@ export class SettingsSelectorComponent implements Component {
 	}
 
 	#createMultiSelect(def: SettingDef & { type: "multiselect" }, done: (value?: string) => void): Container {
+		let options = def.options;
+		if (def.path === "providers.webSearchOrder") {
+			const excluded: unknown = settings.get("providers.webSearchExclude");
+			if (Array.isArray(excluded)) {
+				options = options.filter(option => !excluded.includes(option.value));
+			}
+		}
+
 		const current: unknown = settings.get(def.path);
 		const initial = Array.isArray(current)
 			? current.filter((entry): entry is string => typeof entry === "string")
@@ -1176,7 +1184,7 @@ export class SettingsSelectorComponent implements Component {
 		return new MultiSelectSubmenu(
 			def.label,
 			def.description,
-			def.options,
+			options,
 			initial,
 			def.ordered,
 			value => {

--- a/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
@@ -85,6 +85,17 @@ describe("multiselect settings (array-of-enum)", () => {
 		expect(comp.render(120).join("\n")).toContain(firstChoice!.label);
 	});
 
+	it("hides excluded providers from the web search order list", () => {
+		const comp = createSelector();
+		settings.set("providers.webSearchExclude", [firstChoice!.value]);
+		for (const ch of "web search provider order") comp.handleInput(ch);
+		comp.handleInput("\n");
+
+		const menu = comp.render(120).join("\n");
+		expect(menu).not.toContain(firstChoice!.label);
+		expect(menu).toContain(secondChoice!.label);
+	});
+
 	it("splices the hovered option into the pressed digit's position", () => {
 		const [a, b, c] = SEARCH_PROVIDER_CHOICES;
 		const comp = createSelector();


### PR DESCRIPTION
## Repro
Set `providers.webSearchExclude` to include `perplexity`, then open `/settings` → Providers → Web Search Provider Order; `Perplexity` still appears. `bun test packages/coding-agent/test/modes/components/settings-multiselect.test.ts` reproduced the failure before the fix.

## Cause
`SettingsSelectorComponent.#createMultiSelect` in `packages/coding-agent/src/modes/components/settings-selector.ts` passed every schema option to `MultiSelectSubmenu` without applying `providers.webSearchExclude` when constructing the provider-order editor.

## Fix
- Filter the web search order submenu options against the current exclusion setting.
- Add a rendered-component regression test proving excluded providers are absent while available providers remain visible.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/components/settings-multiselect.test.ts` passes: 4 tests, 0 failures. The pre-publish `bun check` gate also passed.

Fixes #6860