### PR TITLE
feat(coding-agent): tools.xdevTopLevelDevices glob allowlist to pin hot devices top-level

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `tools.xdevTopLevelDevices`, a glob allowlist that keeps matching discoverable tools (built-in, MCP, or extension) mounted top-level instead of behind `xd://` dispatch, trading prompt tokens for zero docs-read/write round-trips on hot devices.
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4238,6 +4238,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tools.xdevTopLevelDevices": {
+		type: "array",
+		default: EMPTY_STRING_ARRAY,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "xd:// Top-Level Devices",
+			description:
+				"Keep discoverable tools whose names match these glob patterns top-level (schema shipped with every request, called directly) instead of mounting them behind xd:// dispatch. Spends prompt tokens to remove the docs-read/write round-trip for hot devices (for example lsp or mcp__linear_*).",
+		},
+	},
+
 	// MCP
 	"mcp.enableProjectConfig": {
 		type: "boolean",

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -177,6 +177,7 @@ import {
 import {
 	BashTool,
 	BUILTIN_TOOLS,
+	compileXdevDeviceGlobs,
 	createTools,
 	createVibeTools,
 	type DeferredDiagnosticsEntry,
@@ -2853,10 +2854,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (toolSession.xdev) {
 			const topLevelToolNames: string[] = [];
 			const mountedNames: string[] = [];
+			const pinnedTopLevelGlobs = compileXdevDeviceGlobs(settings.get("tools.xdevTopLevelDevices"));
 			for (const name of initialToolNames) {
 				const tool = toolRegistry.get(name);
 				const explicitlyRequested = explicitlyRequestedToolNameSet?.has(name) === true;
-				if (tool && xdevReadAvailable && !explicitlyRequested && isMountableUnderXdev(tool))
+				if (tool && xdevReadAvailable && !explicitlyRequested && isMountableUnderXdev(tool, pinnedTopLevelGlobs))
 					mountedNames.push(name);
 				else topLevelToolNames.push(name);
 			}

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -21,7 +21,14 @@ import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
 import { computerExposureMode } from "../tools/computer/exposure";
 import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
-import { isMountableUnderXdev, listXdevTools, type XdevState, xdevDocsFor, xdevEntries } from "../tools/xdev";
+import {
+	compileXdevDeviceGlobs,
+	isMountableUnderXdev,
+	listXdevTools,
+	type XdevState,
+	xdevDocsFor,
+	xdevEntries,
+} from "../tools/xdev";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { type InspectImageMode, isInspectImageToolActive } from "../utils/inspect-image-mode";
 import { formatLocalCalendarDate } from "../utils/local-date";
@@ -550,9 +557,13 @@ export class SessionTools {
 		const xdevReadAvailable = this.#builtInToolNames.has("read") && selectedTools.some(({ name }) => name === "read");
 		const isPresentationPinned = (name: string): boolean =>
 			this.#presentationPinnedToolNames?.has(name) === true || this.#runtimeSelectedToolNames?.has(name) === true;
+		const pinnedTopLevelGlobs = compileXdevDeviceGlobs(this.#host.settings.get("tools.xdevTopLevelDevices"));
 		const mountCandidates = selectedTools.filter(
 			({ name, tool }) =>
-				this.#xdev !== undefined && xdevReadAvailable && !isPresentationPinned(name) && isMountableUnderXdev(tool),
+				this.#xdev !== undefined &&
+				xdevReadAvailable &&
+				!isPresentationPinned(name) &&
+				isMountableUnderXdev(tool, pinnedTopLevelGlobs),
 		);
 
 		let builtInWriteAvailable = this.#builtInToolNames.has("write");

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -62,7 +62,7 @@ import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
 import { type TodoPhase, TodoTool } from "./todo";
 import { WriteTool } from "./write";
-import { isMountableUnderXdev, type XdevState } from "./xdev";
+import { compileXdevDeviceGlobs, isMountableUnderXdev, type XdevState } from "./xdev";
 import { YieldTool } from "./yield";
 
 export * from "../edit";
@@ -632,8 +632,10 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	if (xdevEnabled) {
 		const mountedNames = new Set<string>();
 		const kept: Tool[] = [];
+		const pinnedTopLevelGlobs = compileXdevDeviceGlobs(session.settings.get("tools.xdevTopLevelDevices"));
 		for (const tool of tools) {
-			const mountable = mountBuiltinTools && isMountableUnderXdev(tool) && tool.name in BUILTIN_TOOLS;
+			const mountable =
+				mountBuiltinTools && isMountableUnderXdev(tool, pinnedTopLevelGlobs) && tool.name in BUILTIN_TOOLS;
 			if (mountable) mountedNames.add(tool.name);
 			else kept.push(tool);
 		}

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -72,12 +72,17 @@ export type XdevDocsMode = "inline" | "builtins" | "catalog";
 /**
  * Whether an enabled tool is presented under `xd://` (rather than top-level)
  * while the `xd://` transport is active. Discoverable tools mount unless they
- * are pinned top-level by {@link XDEV_KEEP_TOP_LEVEL} or carry the transport
- * itself ({@link XDEV_TRANSPORT_TOOLS}); essential tools never do. The caller
- * gates this on the transport being active.
+ * are pinned top-level by {@link XDEV_KEEP_TOP_LEVEL}, carry the transport
+ * itself ({@link XDEV_TRANSPORT_TOOLS}), or match a user pin from
+ * `tools.xdevTopLevelDevices`; essential tools never do. The caller gates
+ * this on the transport being active.
  */
-export function isMountableUnderXdev(tool: { name: string; loadMode?: ToolLoadMode }): boolean {
+export function isMountableUnderXdev(
+	tool: { name: string; loadMode?: ToolLoadMode },
+	pinnedTopLevelGlobs?: readonly Bun.Glob[],
+): boolean {
 	if (tool.name in XDEV_TRANSPORT_TOOLS || tool.name in XDEV_KEEP_TOP_LEVEL) return false;
+	if (pinnedTopLevelGlobs?.some(glob => glob.match(tool.name))) return false;
 	return tool.loadMode === "discoverable";
 }
 
@@ -188,9 +193,10 @@ function promptCatalogSummary(inst: Tool, maxLength?: number): string {
 	return `${summary.slice(0, maxLength).trimEnd()}…`;
 }
 
-/** Compile the `tools.xdevInlineDevices` allowlist once per render, dropping
- *  non-string entries so malformed user config cannot break prompt builds. */
-function compileInlineGlobs(patterns: readonly string[]): Bun.Glob[] {
+/** Compile a device-name glob list (`tools.xdevInlineDevices`,
+ *  `tools.xdevTopLevelDevices`) once per use, dropping non-string entries so
+ *  malformed user config cannot break prompt builds or tool partitioning. */
+export function compileXdevDeviceGlobs(patterns: readonly string[]): Bun.Glob[] {
 	if (!Array.isArray(patterns)) return [];
 	const globs: Bun.Glob[] = [];
 	for (const pattern of patterns) {
@@ -292,7 +298,7 @@ export function xdevDocsAll(
 ): string {
 	const sections: string[] = [];
 	const overflow: Tool[] = [];
-	const inlineGlobs = compileInlineGlobs(inlinePatterns);
+	const inlineGlobs = compileXdevDeviceGlobs(inlinePatterns);
 	let used = 0;
 	for (const tool of listXdevTools(state)) {
 		if (!shouldInlineXdevTool(state, tool, mode, inlineGlobs)) {
@@ -332,7 +338,7 @@ export function xdevDocsFor(
 	inlinePatterns: readonly string[] = [],
 ): string {
 	const sections: string[] = [];
-	const inlineGlobs = compileInlineGlobs(inlinePatterns);
+	const inlineGlobs = compileXdevDeviceGlobs(inlinePatterns);
 	let used = 0;
 	for (const name of names) {
 		const tool = resolveMountedXdevTool(state, name);

--- a/packages/coding-agent/test/xdev-top-level-pins.test.ts
+++ b/packages/coding-agent/test/xdev-top-level-pins.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Contract for `tools.xdevTopLevelDevices`: a discoverable tool whose name
+ * matches a configured glob must stay top-level (skipping xd:// dispatch
+ * round-trips) while non-matching tools still mount; transport tools and
+ * essential tools are never affected by pins; malformed config entries are
+ * dropped instead of breaking partitioning.
+ */
+import { describe, expect, it } from "bun:test";
+import { compileXdevDeviceGlobs, isMountableUnderXdev } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+
+describe("tools.xdevTopLevelDevices pins", () => {
+	it("keeps a matching discoverable tool top-level and mounts the rest", () => {
+		const pins = compileXdevDeviceGlobs(["lsp", "mcp__linear_*"]);
+		expect(isMountableUnderXdev({ name: "lsp", loadMode: "discoverable" }, pins)).toBe(false);
+		expect(isMountableUnderXdev({ name: "mcp__linear_create_issue", loadMode: "discoverable" }, pins)).toBe(false);
+		expect(isMountableUnderXdev({ name: "browser", loadMode: "discoverable" }, pins)).toBe(true);
+	});
+
+	it("never promotes transport tools or demotes essentials via pins", () => {
+		const pins = compileXdevDeviceGlobs(["*"]);
+		// A '*' pin keeps every discoverable tool top-level…
+		expect(isMountableUnderXdev({ name: "lsp", loadMode: "discoverable" }, pins)).toBe(false);
+		// …and essential tools were never mountable to begin with.
+		expect(isMountableUnderXdev({ name: "edit", loadMode: "essential" }, pins)).toBe(false);
+	});
+
+	it("drops malformed glob config entries instead of breaking partitioning", () => {
+		const pins = compileXdevDeviceGlobs([42, null, "lsp"] as unknown as string[]);
+		expect(isMountableUnderXdev({ name: "lsp", loadMode: "discoverable" }, pins)).toBe(false);
+		expect(isMountableUnderXdev({ name: "debug", loadMode: "discoverable" }, pins)).toBe(true);
+	});
+});


### PR DESCRIPTION
Adds `tools.xdevTopLevelDevices` (default `[]`): a glob allowlist that keeps matching discoverable tools — built-in, MCP, or extension — mounted top-level instead of behind `xd://` dispatch.

### Why

`xd://` mounting is the right default for the long tail, but a hot device pays the docs-read → write round-trip on every use. When you know a device is hot (say `lsp`, or one MCP server your workflow leans on), pinning it top-level ships its schema with each request and lets the model call it directly — one setting, per-user tradeoff of prompt tokens vs round-trips. Complements `tools.xdevInlineDevices`, which inlines docs but keeps dispatch.

### Implementation

- `isMountableUnderXdev(tool, pinnedTopLevelGlobs?)` — a matching pin returns false; transport carriers (`read`/`write`) and `XDEV_KEEP_TOP_LEVEL` semantics unchanged; essential tools were never mountable.
- `compileXdevDeviceGlobs` (exported rename of the former private `compileInlineGlobs`, shared with the inline-docs path) drops malformed entries so bad config cannot break partitioning.
- Wired at all three partition sites: SDK initial partition, `applyActiveToolsByName` repartition, and `createTools` built-in mounting.

### Tests

`test/xdev-top-level-pins.test.ts`: pin matching (exact + glob), `*`-pin vs transport/essential invariants, malformed config entries. Existing `issue-5764-registertool-loadmode` suite untouched and green. `bun run check:ts` clean on top of the xdev state refactor.

(Split out of the closed #6793, whose MCP-dedupe half was superseded by #6787.)
