### PR TITLE
feat(coding-agent/rpc): expose /vibe over ACP/RPC and surface vibeMode in get_state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Populated `previousTools` in the shared `VibeModeState` from the TUI enter path (previously only the ACP/RPC path set it), so the `?? []` fallback on exit can never wipe a legitimately active toolset.
 - Vibe workers are killed on session dispose: `disposeActiveVibe()` runs from `#doDispose` before the async-job manager is torn down, so no runtime (TUI quit, ACP close, RPC shutdown) leaves background workers running. Previously the old scope's workers survived every session dispose.
 - ACP/RPC install a headless vibe session-switch reconciler that detaches the previous scope's workers (suspend-based, not kill) and clears vibe state only AFTER a `switchSession()`/`branch()` commits — a switch that fails and rolls back leaves the original session's vibe mode, workers, and restricted toolset untouched. `branch()` now participates in switch reconciliation (previously it did not).
-- Removed the redundant RPC JSON-command vibe guard: the commit-phase reconciler covers all callers, including extension actions calling `switchSession()`/`branch()` directly, so the explicit guard was no longer needed.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Exposed `/vibe` over ACP/RPC: the builtin slash command now carries a `handle` that activates vibe (director) mode programmatically — building the `VibeParentSession` adapter inline, restricting the toolset to read + vibe tools, recording a mode-change entry, and returning any inline directive as a residual prompt — so an RPC/ACP host toggles director mode instead of the command being forwarded to the model as plain text. `get_state` now reports `vibeMode` so hosts can introspect whether director mode is active, and `VibeModeState` gained an optional `previousTools` so the ACP path can restore the pre-vibe toolset on exit.
 
+### Fixed
+
+- Forwarded `streamingBehavior` on the RPC builtin residual-prompt path (e.g. `/vibe <directive>`), matching the normal fallthrough: `AgentSession.prompt()` throws `AgentBusyError` when streaming with no behavior, so the directive was rejected instead of queued during an active turn.
+- Blocked RPC `new_session`/`switch_session`/`branch` while vibe mode is active: RPC has no session-switch reconciler (unlike the TUI), so these transitions previously leaked the old scope's workers and carried the restricted tool snapshot into the new session.
+- Populated `previousTools` in the shared `VibeModeState` from the TUI enter path (previously only the ACP/RPC path set it), so the `?? []` fallback on exit can never wipe a legitimately active toolset.
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,11 +9,10 @@
 ### Fixed
 
 - Forwarded `streamingBehavior` on the RPC builtin residual-prompt path (e.g. `/vibe <directive>`), matching the normal fallthrough: `AgentSession.prompt()` throws `AgentBusyError` when streaming with no behavior, so the directive was rejected instead of queued during an active turn.
-- Blocked RPC `switch_session`/`branch` while vibe mode is active: these lack the internal vibe guard that `newSession` has (`#assertVibeSessionTransitionAllowed`), and RPC installs no session-switch reconciler (unlike the TUI), so they previously leaked the old scope's workers and carried the restricted tool snapshot into the new session. `new_session` already hard-throws at the `AgentSession` boundary and surfaces a clean RPC error, so it is left untouched.
 - Populated `previousTools` in the shared `VibeModeState` from the TUI enter path (previously only the ACP/RPC path set it), so the `?? []` fallback on exit can never wipe a legitimately active toolset.
-- Vibe workers torn down on session dispose: `disposeActiveVibe()` is called from `#doDispose` before the async-job manager is disposed, so no runtime (TUI quit, ACP close, RPC shutdown) leaks background workers. Previously the registry's old scope lived through every session dispose.
-- ACP/RPC install a headless vibe session-switch reconciler: programmatic `switchSession()`/`branch()` during vibe now tears down the old scope instead of leaking workers into another transcript; `branch()` now invokes the before-switch reconciler (previously it did not).
-- Removed the redundant RPC JSON-command vibe guard: the session-switch reconciler covers all callers, including extension actions calling `switchSession()`/`branch()` directly, so the explicit `vibe_mode` JSON guard was no longer needed.
+- Vibe workers are killed on session dispose: `disposeActiveVibe()` runs from `#doDispose` before the async-job manager is torn down, so no runtime (TUI quit, ACP close, RPC shutdown) leaves background workers running. Previously the old scope's workers survived every session dispose.
+- ACP/RPC install a headless vibe session-switch reconciler that detaches the previous scope's workers (suspend-based, not kill) and clears vibe state only AFTER a `switchSession()`/`branch()` commits — a switch that fails and rolls back leaves the original session's vibe mode, workers, and restricted toolset untouched. `branch()` now participates in switch reconciliation (previously it did not).
+- Removed the redundant RPC JSON-command vibe guard: the commit-phase reconciler covers all callers, including extension actions calling `switchSession()`/`branch()` directly, so the explicit guard was no longer needed.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Forwarded `streamingBehavior` on the RPC builtin residual-prompt path (e.g. `/vibe <directive>`), matching the normal fallthrough: `AgentSession.prompt()` throws `AgentBusyError` when streaming with no behavior, so the directive was rejected instead of queued during an active turn.
 - Blocked RPC `switch_session`/`branch` while vibe mode is active: these lack the internal vibe guard that `newSession` has (`#assertVibeSessionTransitionAllowed`), and RPC installs no session-switch reconciler (unlike the TUI), so they previously leaked the old scope's workers and carried the restricted tool snapshot into the new session. `new_session` already hard-throws at the `AgentSession` boundary and surfaces a clean RPC error, so it is left untouched.
 - Populated `previousTools` in the shared `VibeModeState` from the TUI enter path (previously only the ACP/RPC path set it), so the `?? []` fallback on exit can never wipe a legitimately active toolset.
+- Vibe workers torn down on session dispose: `disposeActiveVibe()` is called from `#doDispose` before the async-job manager is disposed, so no runtime (TUI quit, ACP close, RPC shutdown) leaks background workers. Previously the registry's old scope lived through every session dispose.
+- ACP/RPC install a headless vibe session-switch reconciler: programmatic `switchSession()`/`branch()` during vibe now tears down the old scope instead of leaking workers into another transcript; `branch()` now invokes the before-switch reconciler (previously it did not).
+- Removed the redundant RPC JSON-command vibe guard: the session-switch reconciler covers all callers, including extension actions calling `switchSession()`/`branch()` directly, so the explicit `vibe_mode` JSON guard was no longer needed.
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `/vibe` over ACP/RPC: the builtin slash command now carries a `handle` that activates vibe (director) mode programmatically — building the `VibeParentSession` adapter inline, restricting the toolset to read + vibe tools, recording a mode-change entry, and returning any inline directive as a residual prompt — so an RPC/ACP host toggles director mode instead of the command being forwarded to the model as plain text. `get_state` now reports `vibeMode` so hosts can introspect whether director mode is active, and `VibeModeState` gained an optional `previousTools` so the ACP path can restore the pre-vibe toolset on exit.
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Forwarded `streamingBehavior` on the RPC builtin residual-prompt path (e.g. `/vibe <directive>`), matching the normal fallthrough: `AgentSession.prompt()` throws `AgentBusyError` when streaming with no behavior, so the directive was rejected instead of queued during an active turn.
-- Blocked RPC `new_session`/`switch_session`/`branch` while vibe mode is active: RPC has no session-switch reconciler (unlike the TUI), so these transitions previously leaked the old scope's workers and carried the restricted tool snapshot into the new session.
+- Blocked RPC `switch_session`/`branch` while vibe mode is active: these lack the internal vibe guard that `newSession` has (`#assertVibeSessionTransitionAllowed`), and RPC installs no session-switch reconciler (unlike the TUI), so they previously leaked the old scope's workers and carried the restricted tool snapshot into the new session. `new_session` already hard-throws at the `AgentSession` boundary and surfaces a clean RPC error, so it is left untouched.
 - Populated `previousTools` in the shared `VibeModeState` from the TUI enter path (previously only the ACP/RPC path set it), so the `?? []` fallback on exit can never wipe a legitimately active toolset.
 
 ## [17.1.7] - 2026-07-27

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Populated `previousTools` in the shared `VibeModeState` from the TUI enter path (previously only the ACP/RPC path set it), so the `?? []` fallback on exit can never wipe a legitimately active toolset.
 - Vibe workers are killed on session dispose: `disposeActiveVibe()` runs from `#doDispose` before the async-job manager is torn down, so no runtime (TUI quit, ACP close, RPC shutdown) leaves background workers running. Previously the old scope's workers survived every session dispose.
 - ACP/RPC install a headless vibe session-switch reconciler that detaches the previous scope's workers (suspend-based, not kill) and clears vibe state only AFTER a `switchSession()`/`branch()` commits — a switch that fails and rolls back leaves the original session's vibe mode, workers, and restricted toolset untouched. `branch()` now participates in switch reconciliation (previously it did not).
+- Branching from the TUI while vibe mode is active now runs the after-switch reconciler, so vibe state is correctly reconciled for the branched session (previously the before-switch quiesce suspended workers but the matching rehydrate never fired, leaving InteractiveMode with a stale owner scope and no workers).
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1119,11 +1119,11 @@ export class AcpAgent implements Agent {
 	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
-		// Headless vibe reconciliation: kill the old scope on session switch/branch
-		// (ACP has no InteractiveMode to suspend/rehydrate). Mirrors rpc-mode.ts.
-		session.setSessionBeforeSwitchReconciler(async () => {
-			await session.disposeActiveVibe();
-		});
+		// Headless vibe reconciliation: detach the old scope's workers only after a
+		// session switch/branch commits (ACP has no InteractiveMode to
+		// suspend/rehydrate), so a failed switch never strips the original session.
+		// Mirrors rpc-mode.ts.
+		session.setSessionAfterSwitchReconciler?.(vibeScope => session.detachVibeAfterSessionSwitch(vibeScope));
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
 		try {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1119,6 +1119,11 @@ export class AcpAgent implements Agent {
 	async #registerPreparedSession(session: AgentSession, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
+		// Headless vibe reconciliation: kill the old scope on session switch/branch
+		// (ACP has no InteractiveMode to suspend/rehydrate). Mirrors rpc-mode.ts.
+		session.setSessionBeforeSwitchReconciler(async () => {
+			await session.disposeActiveVibe();
+		});
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
 		try {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3324,7 +3324,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Suppress cache-miss marker on the next turn: vibe mode changes the
 		// injected context, which predictably invalidates the cache.
 		this.lastAssistantUsage = undefined;
-		this.session.setVibeModeState({ enabled: true });
+		this.session.setVibeModeState({ enabled: true, previousTools });
 		if (this.session.isStreaming) {
 			await this.session.sendVibeModeContext({ deliverAs: "steer" });
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1009,7 +1009,11 @@ export async function runRpcMode(
 					if ("prompt" in builtinResult) {
 						watchAndReportLocalOnlyPromptResult({
 							id,
-							startPrompt: () => session.prompt(builtinResult.prompt, { images: command.images }),
+							startPrompt: () =>
+								session.prompt(builtinResult.prompt, {
+									images: command.images,
+									streamingBehavior: command.streamingBehavior,
+								}),
 							output,
 							onError: promptError => output(error(id, "prompt", promptError.message)),
 							extensionUserMessageTracker,
@@ -1062,6 +1066,18 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
+				// The TUI installs session-switch reconcilers that suspend and
+				// rehydrate vibe workers; RPC has no such reconciler, so a
+				// session change here would leak the old scope's workers and
+				// carry the restricted tool snapshot into the new session. Block
+				// the transition with a clear error instead.
+				if (session.getVibeModeState()?.enabled) {
+					return error(
+						id,
+						command.type,
+						"Cannot change the active session while vibe mode is active. Exit vibe mode first.",
+					);
+				}
 				const result = await handleRpcSessionChange(session, command, subagentRegistry);
 				if (!result.data.cancelled) await emitAvailableCommandsUpdate();
 				return success(id, result.type, result.data);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1084,6 +1084,7 @@ export async function runRpcMode(
 					sessionId: session.sessionId,
 					sessionName: session.sessionName,
 					autoCompactionEnabled: session.autoCompactionEnabled,
+					vibeMode: session.getVibeModeState()?.enabled ?? false,
 					messageCount: session.messages.length,
 					queuedMessageCount: session.queuedMessageCount,
 					todoPhases: session.getTodoPhases(),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1066,12 +1066,13 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
-				// The TUI installs session-switch reconcilers that suspend and
-				// rehydrate vibe workers; RPC has no such reconciler, so a
-				// session change here would leak the old scope's workers and
-				// carry the restricted tool snapshot into the new session. Block
-				// the transition with a clear error instead.
-				if (session.getVibeModeState()?.enabled) {
+				// switch_session and branch have no vibe guard inside AgentSession
+				// (unlike newSession, which hard-throws via
+				// #assertVibeSessionTransitionAllowed and surfaces a clean RPC
+				// error). The TUI reconciles vibe on session switch via a
+				// reconciler RPC never installs, so block these two here to
+				// avoid leaking workers / carrying the tool snapshot.
+				if (command.type !== "new_session" && session.getVibeModeState()?.enabled) {
 					return error(
 						id,
 						command.type,

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -670,6 +670,14 @@ export async function runRpcMode(
 	// breaks JSON.parse. In RPC mode stdout is the JSON protocol channel — nothing else
 	// may write there.
 	process.env.PI_NOTIFICATIONS = "off";
+	// Headless runtimes have no InteractiveMode to suspend/rehydrate vibe
+	// workers across a session switch; reconcile by tearing down the old scope
+	// (AgentSession.disposeActiveVibe) so a programmatic switch/branch never
+	// leaks workers into another transcript. switchSession()/branch() invoke this
+	// hook before changing the session identity; newSession() self-throws.
+	session.setSessionBeforeSwitchReconciler(async () => {
+		await session.disposeActiveVibe();
+	});
 
 	const frameEncoder = new RpcFrameEncoder();
 	// Ordered stdout writer honoring backpressure: chunked v2 frames are produced
@@ -1066,19 +1074,6 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
-				// switch_session and branch have no vibe guard inside AgentSession
-				// (unlike newSession, which hard-throws via
-				// #assertVibeSessionTransitionAllowed and surfaces a clean RPC
-				// error). The TUI reconciles vibe on session switch via a
-				// reconciler RPC never installs, so block these two here to
-				// avoid leaking workers / carrying the tool snapshot.
-				if (command.type !== "new_session" && session.getVibeModeState()?.enabled) {
-					return error(
-						id,
-						command.type,
-						"Cannot change the active session while vibe mode is active. Exit vibe mode first.",
-					);
-				}
 				const result = await handleRpcSessionChange(session, command, subagentRegistry);
 				if (!result.data.cancelled) await emitAvailableCommandsUpdate();
 				return success(id, result.type, result.data);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -670,14 +670,12 @@ export async function runRpcMode(
 	// breaks JSON.parse. In RPC mode stdout is the JSON protocol channel — nothing else
 	// may write there.
 	process.env.PI_NOTIFICATIONS = "off";
-	// Headless runtimes have no InteractiveMode to suspend/rehydrate vibe
-	// workers across a session switch; reconcile by tearing down the old scope
-	// (AgentSession.disposeActiveVibe) so a programmatic switch/branch never
-	// leaks workers into another transcript. switchSession()/branch() invoke this
-	// hook before changing the session identity; newSession() self-throws.
-	session.setSessionBeforeSwitchReconciler(async () => {
-		await session.disposeActiveVibe();
-	});
+	// Headless runtimes have no InteractiveMode to suspend/rehydrate vibe workers
+	// across a session switch. The after-switch reconciler tears down the previous
+	// scope's workers only after the switch commits, so a switch that fails and
+	// rolls back never strips the original session of its workers. newSession()
+	// self-throws during vibe (it cannot be rolled back).
+	session.setSessionAfterSwitchReconciler?.(vibeScope => session.detachVibeAfterSessionSwitch(vibeScope));
 
 	const frameEncoder = new RpcFrameEncoder();
 	// Ordered stdout writer honoring backpressure: chunked v2 frames are produced

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -100,6 +100,8 @@ export interface RpcSessionState {
 	thinkingLevel: ThinkingLevel | undefined;
 	isStreaming: boolean;
 	isCompacting: boolean;
+	/** Whether vibe (director) mode is active — toolset is restricted to read + vibe tools. */
+	vibeMode: boolean;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
 	interruptMode: "immediate" | "wait";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7372,6 +7372,12 @@ export class AgentSession {
 			this.#closeCodexProviderSessionsForHistoryRewrite();
 		}
 
+		try {
+			await this.#sessionSwitchReconciler?.();
+		} catch (error) {
+			logger.warn("Failed to reconcile session mode after branch", { error: String(error) });
+		}
+
 		if (frozenVibeScope) {
 			try {
 				await this.#sessionAfterSwitchReconciler?.(frozenVibeScope);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -204,6 +204,7 @@ import { normalizeModelContextImages } from "../utils/image-loading";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
 import { generateSessionTitle } from "../utils/title-generator";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
+import { type VibeParentSession, VibeSessionRegistry } from "../vibe/runtime";
 import type { VibeModeState } from "../vibe/state";
 import type { AgentSessionEvent, AgentSessionEventListener } from "./agent-session-events";
 import type {
@@ -3552,6 +3553,15 @@ export class AgentSession {
 		}
 		await this.#drainAutolearnCapture();
 		await this.#memory.transition;
+		// Tear down any active vibe workers before the async-job manager is
+		// disposed: killAll drives #killRecord through session.asyncJobManager,
+		// which #disposeOwnedAsyncJobs (below) tears down. No runtime should
+		// leave its own background workers running after disposal.
+		try {
+			await this.disposeActiveVibe();
+		} catch (error) {
+			logger.warn("Failed to tear down active vibe workers during dispose", { error: String(error) });
+		}
 
 		const hindsightState = this.getHindsightSessionState();
 		const mnemopiState = setMnemopiSessionState(this, undefined);
@@ -4276,6 +4286,31 @@ export class AgentSession {
 		if (this.#vibeModeState?.enabled) {
 			throw new Error(`Cannot ${action} while vibe mode is active. Exit vibe mode first.`);
 		}
+	}
+
+	/**
+	 * Kill this session's vibe workers, restore the pre-vibe toolset, and clear
+	 * vibe state. Called from {@link #doDispose} (no runtime should leave its own
+	 * background workers running after disposal) and from the headless
+	 * session-switch reconciler installed by ACP/RPC — the TUI instead suspends
+	 * and rehydrates via its own reconciler. A no-op returning 0 when vibe is
+	 * inactive, so callers need not pre-check.
+	 */
+	async disposeActiveVibe(): Promise<number> {
+		const vibeState = this.#vibeModeState;
+		if (!vibeState?.enabled) return 0;
+		const parent: VibeParentSession = {
+			getAgentId: () => this.getAgentId() ?? null,
+			getSessionId: () => this.sessionManager.getSessionId(),
+			getSessionFile: () => this.sessionManager.getSessionFile() ?? null,
+			sessionManager: this.sessionManager,
+			asyncJobManager: this.#asyncJobManager,
+			settings: this.settings,
+		};
+		const killed = await VibeSessionRegistry.global().killAll(parent);
+		await this.deactivateVibeTools(vibeState.previousTools ?? []);
+		this.#vibeModeState = undefined;
+		return killed;
 	}
 
 	get goalRuntime(): GoalRuntime {
@@ -7242,6 +7277,8 @@ export class AgentSession {
 		// Clear pending messages (bound to old session state)
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
+
+		await this.#sessionBeforeSwitchReconciler?.();
 
 		await this.#bash.flushPending();
 		// Flush pending writes before branching

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -204,7 +204,7 @@ import { normalizeModelContextImages } from "../utils/image-loading";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
 import { generateSessionTitle } from "../utils/title-generator";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
-import { type VibeParentSession, VibeSessionRegistry } from "../vibe/runtime";
+import { type VibeOwnerScope, type VibeParentSession, VibeSessionRegistry } from "../vibe/runtime";
 import type { VibeModeState } from "../vibe/state";
 import type { AgentSessionEvent, AgentSessionEventListener } from "./agent-session-events";
 import type {
@@ -1525,6 +1525,12 @@ export class AgentSession {
 
 	setSessionSwitchReconciler(reconciler: (() => Promise<void>) | null): void {
 		this.#sessionSwitchReconciler = reconciler ?? undefined;
+	}
+
+	#sessionAfterSwitchReconciler: ((vibeScope: VibeOwnerScope) => Promise<void>) | undefined;
+
+	setSessionAfterSwitchReconciler(reconciler: ((vibeScope: VibeOwnerScope) => Promise<void>) | null): void {
+		this.#sessionAfterSwitchReconciler = reconciler ?? undefined;
 	}
 
 	/** Provider-scoped mutable state store for transport/session caches. */
@@ -4288,18 +4294,8 @@ export class AgentSession {
 		}
 	}
 
-	/**
-	 * Kill this session's vibe workers, restore the pre-vibe toolset, and clear
-	 * vibe state. Called from {@link #doDispose} (no runtime should leave its own
-	 * background workers running after disposal) and from the headless
-	 * session-switch reconciler installed by ACP/RPC — the TUI instead suspends
-	 * and rehydrates via its own reconciler. A no-op returning 0 when vibe is
-	 * inactive, so callers need not pre-check.
-	 */
-	async disposeActiveVibe(): Promise<number> {
-		const vibeState = this.#vibeModeState;
-		if (!vibeState?.enabled) return 0;
-		const parent: VibeParentSession = {
+	#vibeParentAdapter(): VibeParentSession {
+		return {
 			getAgentId: () => this.getAgentId() ?? null,
 			getSessionId: () => this.sessionManager.getSessionId(),
 			getSessionFile: () => this.sessionManager.getSessionFile() ?? null,
@@ -4307,10 +4303,45 @@ export class AgentSession {
 			asyncJobManager: this.#asyncJobManager,
 			settings: this.settings,
 		};
-		const killed = await VibeSessionRegistry.global().killAll(parent);
+	}
+
+	/** Frozen vibe owner scope for the current session, or undefined when vibe is off. */
+	#captureVibeOwnerScope(): VibeOwnerScope | undefined {
+		if (!this.#vibeModeState?.enabled) return undefined;
+		return VibeSessionRegistry.global().ownerScope(this.#vibeParentAdapter());
+	}
+
+	/**
+	 * Kill this session's vibe workers, restore the pre-vibe toolset, and clear
+	 * vibe state. Called from {@link #doDispose} so no runtime (TUI quit, ACP
+	 * close, RPC shutdown) leaves its own background workers running after
+	 * disposal. A no-op returning 0 when vibe is inactive, so callers need not
+	 * pre-check. NOT used for session switches — those run teardown only after
+	 * the switch commits via {@link detachVibeAfterSessionSwitch}.
+	 */
+	async disposeActiveVibe(): Promise<number> {
+		const vibeState = this.#vibeModeState;
+		if (!vibeState?.enabled) return 0;
+		const killed = await VibeSessionRegistry.global().killAll(this.#vibeParentAdapter());
 		await this.deactivateVibeTools(vibeState.previousTools ?? []);
 		this.#vibeModeState = undefined;
 		return killed;
+	}
+
+	/**
+	 * Commit-phase vibe teardown for a headless session switch/branch: detach the
+	 * previous scope's workers (suspendScope — no tombstone, since the session
+	 * manager has already moved off the source), strip the transient vibe tools
+	 * without clobbering the target's active set, and clear vibe state. Invoked
+	 * only after the switch/branch commits (via the after-switch reconciler), so
+	 * a failed switch that rolls back leaves the original session's vibe mode
+	 * untouched. Uses suspendScope rather than killAll: killAll validates the
+	 * scope against the now-target session manager and would throw.
+	 */
+	async detachVibeAfterSessionSwitch(vibeScope: VibeOwnerScope): Promise<void> {
+		await VibeSessionRegistry.global().suspendScope(vibeScope, this.#asyncJobManager);
+		await this.removeVibeToolsPreservingActive();
+		this.#vibeModeState = undefined;
 	}
 
 	get goalRuntime(): GoalRuntime {
@@ -7010,6 +7041,7 @@ export class AgentSession {
 		await this.#bash.flushPending();
 		// Flush pending writes before switching so restore snapshots reflect committed state.
 		await this.sessionManager.flush();
+		const frozenVibeScope = this.#captureVibeOwnerScope();
 		const previousSessionState = this.sessionManager.captureState();
 		const bashTransition = this.#bash.beginSessionTransition();
 		// Only same-session reloads compare against the prior context to detect
@@ -7190,6 +7222,18 @@ export class AgentSession {
 					error: String(refreshErr),
 				});
 			}
+			// Commit-phase vibe teardown (headless): detach the previous scope's
+			// workers and clear vibe state AFTER the switch commits, so a switch
+			// that fails and rolls back leaves the original session's vibe mode
+			// intact. Skipped on same-session reload — the scope is unchanged, so
+			// detaching would drop the session's own live workers.
+			if (frozenVibeScope && switchingToDifferentSession) {
+				try {
+					await this.#sessionAfterSwitchReconciler?.(frozenVibeScope);
+				} catch (vibeError) {
+					logger.warn("Failed to reconcile vibe after session switch", { error: String(vibeError) });
+				}
+			}
 			// Only a committed switch retires the previous conversation's advisor spend:
 			// an earlier clear would be lost work if any step above rolled the switch back.
 			if (switchingToDifferentSession) this.#advisors.clearCost();
@@ -7278,6 +7322,7 @@ export class AgentSession {
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 
+		const frozenVibeScope = this.#captureVibeOwnerScope();
 		await this.#sessionBeforeSwitchReconciler?.();
 
 		await this.#bash.flushPending();
@@ -7327,6 +7372,13 @@ export class AgentSession {
 			this.#closeCodexProviderSessionsForHistoryRewrite();
 		}
 
+		if (frozenVibeScope) {
+			try {
+				await this.#sessionAfterSwitchReconciler?.(frozenVibeScope);
+			} catch (vibeError) {
+				logger.warn("Failed to reconcile vibe after session branch", { error: String(vibeError) });
+			}
+		}
 		return { selectedText, selectedImages, cancelled: false };
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -443,21 +443,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		handle: async (command, runtime) => {
 			const { session, sessionManager } = runtime;
 			const vibeState = session.getVibeModeState();
-			// The ACP handler has no InteractiveModeContext, so build the
-			// VibeParentSession adapter inline and reuse it on both paths.
-			const parent: VibeParentSession = {
-				getAgentId: () => session.getAgentId() ?? null,
-				getSessionId: () => sessionManager.getSessionId(),
-				getSessionFile: () => sessionManager.getSessionFile() ?? null,
-				sessionManager,
-				asyncJobManager: session.asyncJobManager,
-				settings: session.settings,
-				getActiveModelString: () => (session.model ? formatModelString(session.model) : undefined),
-			};
+
 			if (vibeState?.enabled) {
-				const killed = await VibeSessionRegistry.global().killAll(parent);
-				await session.deactivateVibeTools(vibeState.previousTools ?? []);
-				session.setVibeModeState(undefined);
+				const killed = await session.disposeActiveVibe();
 				await runtime.output(
 					killed > 0
 						? `Vibe mode disabled. Killed ${killed} worker session${killed === 1 ? "" : "s"}.`
@@ -471,6 +459,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			if (session.getGoalModeState()?.enabled) {
 				return usage("Exit goal mode first.", runtime);
 			}
+			const parent: VibeParentSession = {
+				getAgentId: () => session.getAgentId() ?? null,
+				getSessionId: () => sessionManager.getSessionId(),
+				getSessionFile: () => sessionManager.getSessionFile() ?? null,
+				sessionManager,
+				asyncJobManager: session.asyncJobManager,
+				settings: session.settings,
+				getActiveModelString: () => (session.model ? formatModelString(session.model) : undefined),
+			};
 			const registry = VibeSessionRegistry.global();
 			registry.activateScope(registry.ownerScope(parent));
 			const previousTools = session.getEnabledToolNames();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -54,6 +54,7 @@ import {
 } from "../utils/changelog";
 import { copyToClipboard } from "../utils/clipboard";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
+import { type VibeParentSession, VibeSessionRegistry } from "../vibe/runtime";
 import { CollabQrCodeComponent } from "./helpers/collab-qrcode";
 import { buildContextReportText } from "./helpers/context-report";
 import { formatDuration } from "./helpers/format";
@@ -431,11 +432,57 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		description: "Toggle vibe mode (direct persistent fast/good worker sessions; read-only toolset)",
 		inlineHint: "[prompt]",
 		allowArgs: true,
+		acpDescription: "Toggle vibe mode",
+		acpInputHint: "[prompt]",
 		getTuiAutocompleteDescription: runtime => {
 			if (runtime.ctx.vibeModeEnabled) return "Vibe: on";
 			if (runtime.ctx.planModeEnabled) return "Vibe: blocked by plan mode";
 			if (runtime.ctx.goalModeEnabled) return "Vibe: blocked by goal mode";
 			return "Vibe: off";
+		},
+		handle: async (command, runtime) => {
+			const { session, sessionManager } = runtime;
+			const vibeState = session.getVibeModeState();
+			// The ACP handler has no InteractiveModeContext, so build the
+			// VibeParentSession adapter inline and reuse it on both paths.
+			const parent: VibeParentSession = {
+				getAgentId: () => session.getAgentId() ?? null,
+				getSessionId: () => sessionManager.getSessionId(),
+				getSessionFile: () => sessionManager.getSessionFile() ?? null,
+				sessionManager,
+				asyncJobManager: session.asyncJobManager,
+				settings: session.settings,
+				getActiveModelString: () => (session.model ? formatModelString(session.model) : undefined),
+			};
+			if (vibeState?.enabled) {
+				const killed = await VibeSessionRegistry.global().killAll(parent);
+				await session.deactivateVibeTools(vibeState.previousTools ?? []);
+				session.setVibeModeState(undefined);
+				await runtime.output(
+					killed > 0
+						? `Vibe mode disabled. Killed ${killed} worker session${killed === 1 ? "" : "s"}.`
+						: "Vibe mode disabled.",
+				);
+				return commandConsumed();
+			}
+			if (session.getPlanModeState()?.enabled) {
+				return usage("Exit plan mode first.", runtime);
+			}
+			if (session.getGoalModeState()?.enabled) {
+				return usage("Exit goal mode first.", runtime);
+			}
+			const registry = VibeSessionRegistry.global();
+			registry.activateScope(registry.ownerScope(parent));
+			const previousTools = session.getEnabledToolNames();
+			await session.activateVibeTools(["read"]);
+			session.setVibeModeState({ enabled: true, previousTools });
+			if (session.isStreaming) {
+				await session.sendVibeModeContext({ deliverAs: "steer" });
+			}
+			sessionManager.appendModeChange("vibe");
+			await runtime.output("Vibe mode enabled. You direct fast/good worker sessions; toolset is read + vibe tools.");
+			const prompt = command.args.trim();
+			return prompt ? { prompt } : commandConsumed();
 		},
 		handleTui: async (command, runtime) => {
 			await runtime.ctx.handleVibeModeCommand(command.args || undefined);

--- a/packages/coding-agent/src/vibe/state.ts
+++ b/packages/coding-agent/src/vibe/state.ts
@@ -1,4 +1,11 @@
 /** Vibe mode session-level state, mirroring {@link ../plan-mode/state.ts}. */
 export interface VibeModeState {
 	enabled: boolean;
+	/**
+	 * Pre-vibe enabled toolset captured on enter so it can be restored on exit.
+	 * Set by the ACP/RPC `/vibe` handler (which lacks the TUI's private
+	 * `#vibeModePreviousTools` field); the TUI path keeps using its own field
+	 * and leaves this undefined.
+	 */
+	previousTools?: string[];
 }

--- a/packages/coding-agent/src/vibe/state.ts
+++ b/packages/coding-agent/src/vibe/state.ts
@@ -3,9 +3,10 @@ export interface VibeModeState {
 	enabled: boolean;
 	/**
 	 * Pre-vibe enabled toolset captured on enter so it can be restored on exit.
-	 * Set by the ACP/RPC `/vibe` handler (which lacks the TUI's private
-	 * `#vibeModePreviousTools` field); the TUI path keeps using its own field
-	 * and leaves this undefined.
+	 * Both the ACP/RPC `/vibe` handler and the TUI path populate this from
+	 * `session.getEnabledToolNames()`, so the exit path's `?? []` fallback is
+	 * purely defensive. The TUI also mirrors the value in its private
+	 * `#vibeModePreviousTools` field for session-switch reconciliation.
 	 */
 	previousTools?: string[];
 }

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -103,6 +103,7 @@ class ReplayTestSession {
 	}
 
 	async refreshMCPTools(_tools: unknown): Promise<void> {}
+	setSessionBeforeSwitchReconciler(_reconciler: (() => Promise<void>) | null): void {}
 }
 
 describe("ACP event mapper", () => {

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -137,7 +137,7 @@ class LazyFakeSession {
 	async fork(): Promise<boolean> {
 		return false;
 	}
-	setSessionBeforeSwitchReconciler(_reconciler: (() => Promise<void>) | null): void {}
+	setSessionAfterSwitchReconciler(_vibeScope: unknown): void {}
 }
 
 /**

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -137,6 +137,7 @@ class LazyFakeSession {
 	async fork(): Promise<boolean> {
 		return false;
 	}
+	setSessionBeforeSwitchReconciler(_reconciler: (() => Promise<void>) | null): void {}
 }
 
 /**

--- a/packages/coding-agent/test/acp-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/acp-vibe-toggle.test.ts
@@ -15,6 +15,12 @@
  *    the registry's workers.
  * 4. While plan mode is active, `/vibe` is consumed with a usage message and
  *    vibe stays disabled (the guard works).
+ * 5. Disposing a vibe-active session tears down its workers and clears vibe
+ *    state — no runtime (TUI quit, ACP close, RPC shutdown) leaks background
+ *    workers.
+ * 6. A headless `switchSession()` during vibe triggers the before-switch
+ *    reconciler (kill, not suspend/rehydrate), preventing workers from leaking
+ *    into another transcript.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
@@ -153,6 +159,47 @@ describe("ACP /vibe handle", () => {
 		// Consumed (not forwarded to the model), but vibe must stay off.
 		expect(result).toEqual({ consumed: true });
 		expect(output.some(line => line.includes("Exit plan mode first"))).toBe(true);
+		expect(session.getVibeModeState()).toBeUndefined();
+	});
+	it("kills active vibe workers and clears vibe state when the session is disposed", async () => {
+		await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+		const killAll = vi.spyOn(VibeSessionRegistry.global(), "killAll");
+
+		await session.dispose();
+
+		// Disposing a vibe-active session must tear down its workers so no runtime
+		// (TUI quit, ACP close, RPC shutdown) leaves background workers running.
+		expect(killAll).toHaveBeenCalledTimes(1);
+		expect(session.getVibeModeState()).toBeUndefined();
+	});
+
+	it("reconciles vibe on a headless session switch instead of leaking workers", async () => {
+		await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+		await session.sessionManager.ensureOnDisk();
+		// Headless runtimes (ACP/RPC) install this reconciler; the TUI installs its
+		// own suspend/rehydrate variant. Mirrors runRpcMode / #registerPreparedSession.
+		session.setSessionBeforeSwitchReconciler(async () => {
+			await session.disposeActiveVibe();
+		});
+
+		const target = SessionManager.create(tempDir.path(), tempDir.path());
+		target.appendModeChange("none");
+		await target.ensureOnDisk();
+		const targetFile = target.getSessionFile();
+		if (!targetFile) throw new Error("Expected target session file");
+		await target.close();
+
+		const killAll = vi.spyOn(VibeSessionRegistry.global(), "killAll");
+		const suspend = vi.spyOn(VibeSessionRegistry.global(), "suspendScope");
+
+		expect(await session.switchSession(targetFile)).toBe(true);
+
+		// The headless reconciler kills the old scope (a programmatic switch has no
+		// expectation vibe survives it) and clears vibe state — not suspend/rehydrate.
+		expect(killAll).toHaveBeenCalledTimes(1);
+		expect(suspend).not.toHaveBeenCalled();
 		expect(session.getVibeModeState()).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/acp-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/acp-vibe-toggle.test.ts
@@ -18,11 +18,14 @@
  * 5. Disposing a vibe-active session tears down its workers and clears vibe
  *    state — no runtime (TUI quit, ACP close, RPC shutdown) leaks background
  *    workers.
- * 6. A headless `switchSession()` during vibe triggers the before-switch
- *    reconciler (kill, not suspend/rehydrate), preventing workers from leaking
- *    into another transcript.
+ * 6. A headless `switchSession()`/`branch()` during vibe detaches the previous
+ *    scope's workers only after the switch commits (commit-phase reconciler),
+ *    clearing vibe state without clobbering the target's tools.
+ * 7. A headless switch that fails and rolls back leaves the original session's
+ *    vibe mode, workers, and restricted toolset untouched.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -178,11 +181,11 @@ describe("ACP /vibe handle", () => {
 		await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
 		expect(session.getVibeModeState()?.enabled).toBe(true);
 		await session.sessionManager.ensureOnDisk();
-		// Headless runtimes (ACP/RPC) install this reconciler; the TUI installs its
-		// own suspend/rehydrate variant. Mirrors runRpcMode / #registerPreparedSession.
-		session.setSessionBeforeSwitchReconciler(async () => {
-			await session.disposeActiveVibe();
-		});
+		const sourceSessionId = session.sessionManager.getSessionId();
+		// Headless runtimes (ACP/RPC) install the commit-phase reconciler; the TUI
+		// installs its own suspend/rehydrate variant. Mirrors runRpcMode /
+		// #registerPreparedSession — teardown runs AFTER the switch commits.
+		session.setSessionAfterSwitchReconciler(vibeScope => session.detachVibeAfterSessionSwitch(vibeScope));
 
 		const target = SessionManager.create(tempDir.path(), tempDir.path());
 		target.appendModeChange("none");
@@ -196,10 +199,38 @@ describe("ACP /vibe handle", () => {
 
 		expect(await session.switchSession(targetFile)).toBe(true);
 
-		// The headless reconciler kills the old scope (a programmatic switch has no
-		// expectation vibe survives it) and clears vibe state — not suspend/rehydrate.
-		expect(killAll).toHaveBeenCalledTimes(1);
-		expect(suspend).not.toHaveBeenCalled();
+		// The commit-phase reconciler detaches the SOURCE scope (frozen before the
+		// switch, so it is NOT the target's id) and clears vibe state — without
+		// persisting tombstones (suspend, not kill) or clobbering the target tools.
+		expect(suspend).toHaveBeenCalledTimes(1);
+		expect(suspend.mock.calls[0]?.[0]).toMatchObject({ parentSessionId: sourceSessionId });
+		expect(killAll).not.toHaveBeenCalled();
 		expect(session.getVibeModeState()).toBeUndefined();
+	});
+
+	it("leaves vibe mode intact when a headless session switch fails and rolls back", async () => {
+		await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+		await session.sessionManager.ensureOnDisk();
+		const sourceSessionId = session.sessionManager.getSessionId();
+		const vibeToolCount = session.getActiveToolNames().length;
+		session.setSessionAfterSwitchReconciler(vibeScope => session.detachVibeAfterSessionSwitch(vibeScope));
+
+		// A directory path throws EISDIR (not ENOENT) inside setSessionFile,
+		// forcing the switch to fail inside the try and roll back.
+		const dirPath = path.join(tempDir.path(), "not-a-file.jsonl");
+		await fs.mkdir(dirPath);
+		const suspend = vi.spyOn(VibeSessionRegistry.global(), "suspendScope");
+		const killAll = vi.spyOn(VibeSessionRegistry.global(), "killAll");
+
+		await expect(session.switchSession(dirPath)).rejects.toThrow();
+
+		// The commit-phase reconciler must NOT have run: vibe mode, the worker
+		// scope, and the restricted toolset survive the rollback exactly as before.
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+		expect(session.sessionManager.getSessionId()).toBe(sourceSessionId);
+		expect(session.getActiveToolNames().length).toBe(vibeToolCount);
+		expect(suspend).not.toHaveBeenCalled();
+		expect(killAll).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/acp-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/acp-vibe-toggle.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Contracts: the text-mode (ACP/RPC) `/vibe` builtin handle exposed via
+ * `executeAcpBuiltinSlashCommand`.
+ *
+ * Mirrors the real-AgentSession harness from `interactive-mode-vibe-toggle.test.ts`
+ * (real SessionManager + temp-dir storage + `VibeSessionRegistry.resetGlobalForTests`
+ * in setup/teardown) so the process-global registry is exercised safely.
+ *
+ * 1. `/vibe` on an idle session with vibe off returns `{ consumed: true }` (not
+ *    `false`, i.e. not forwarded to the model), enables vibe, and restricts the
+ *    toolset to `read` plus the vibe tools.
+ * 2. `/vibe <directive>` returns the residual-prompt `{ prompt }` shape this PR
+ *    adds, while still enabling vibe.
+ * 3. A second `/vibe` disables vibe, restores the pre-vibe toolset, and kills
+ *    the registry's workers.
+ * 4. While plan mode is active, `/vibe` is consumed with a usage message and
+ *    vibe stays disabled (the guard works).
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { VIBE_TOOL_NAMES } from "@oh-my-pi/pi-coding-agent/tools/vibe";
+import { VibeSessionRegistry } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+function stubTool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `${name} tool`,
+		parameters: type({ value: "string" }),
+		strict: true,
+		async execute() {
+			return { content: [{ type: "text", text: `${name} executed` }] };
+		},
+	};
+}
+
+describe("ACP /vibe handle", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let output: string[];
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		VibeSessionRegistry.resetGlobalForTests();
+		tempDir = TempDir.createSync("@pi-acp-vibe-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+
+		const registryTools = [stubTool("read")];
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({}),
+			modelRegistry,
+			toolRegistry: new Map(registryTools.map(tool => [tool.name, tool])),
+			createVibeTools: () => VIBE_TOOL_NAMES.map(stubTool),
+		});
+		output = [];
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		VibeSessionRegistry.resetGlobalForTests();
+		authStorage?.close();
+		tempDir?.removeSync();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	function buildRuntime() {
+		return {
+			session,
+			sessionManager: session.sessionManager,
+			settings: session.settings,
+			cwd: session.sessionManager.getCwd(),
+			output: (text: string) => {
+				output.push(text);
+			},
+			refreshCommands: () => {},
+			reloadPlugins: async () => {},
+			notifyTitleChanged: undefined as (() => Promise<void> | void) | undefined,
+			notifyConfigChanged: undefined as (() => Promise<void> | void) | undefined,
+		};
+	}
+
+	it("enables vibe and restricts the toolset when toggled on an idle session", async () => {
+		expect(session.getVibeModeState()).toBeUndefined();
+		// Not forwarded to the model: returns { consumed: true }, not false.
+		const result = await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		expect(result).toEqual({ consumed: true });
+
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+		const active = session.getActiveToolNames();
+		expect(active).toContain("read");
+		for (const name of VIBE_TOOL_NAMES) {
+			expect(active).toContain(name);
+		}
+	});
+
+	it("returns the residual prompt for /vibe <directive>", async () => {
+		const result = await executeAcpBuiltinSlashCommand("/vibe focus on test coverage", buildRuntime());
+		expect(result).toEqual({ prompt: "focus on test coverage" });
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+	});
+
+	it("disables vibe, restores the pre-vibe toolset, and kills workers on a second toggle", async () => {
+		await session.setActiveToolsByName(["read"]);
+		const preVibe = session.getActiveToolNames();
+		expect(preVibe).toEqual(["read"]);
+
+		await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		expect(session.getVibeModeState()?.enabled).toBe(true);
+		// Vibe tools are now mounted alongside read.
+		expect(session.getActiveToolNames().length).toBeGreaterThan(preVibe.length);
+
+		const killAll = vi.spyOn(VibeSessionRegistry.global(), "killAll");
+		const result = await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		expect(result).toEqual({ consumed: true });
+		expect(session.getVibeModeState()).toBeUndefined();
+		// The pre-vibe active set is restored exactly; vibe tools are gone.
+		expect(session.getActiveToolNames()).toEqual(preVibe);
+		expect(killAll).toHaveBeenCalledTimes(1);
+	});
+
+	it("blocks vibe entry with a usage message while plan mode is active", async () => {
+		session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+		const result = await executeAcpBuiltinSlashCommand("/vibe", buildRuntime());
+		// Consumed (not forwarded to the model), but vibe must stay off.
+		expect(result).toEqual({ consumed: true });
+		expect(output.some(line => line.includes("Exit plan mode first"))).toBe(true);
+		expect(session.getVibeModeState()).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -309,4 +309,35 @@ describe("InteractiveMode vibe mode toggle", () => {
 		await mode.handleVibeModeCommand();
 		expect(mode.vibeModeEnabled).toBe(false);
 	});
+
+	it("reconciles TUI vibe state after branching while vibe is active", async () => {
+		await mode.init({ suppressWelcomeIntro: true });
+		await mode.handleVibeModeCommand();
+		expect(mode.vibeModeEnabled).toBe(true);
+		await session.sessionManager.ensureOnDisk();
+		// A user message after entering vibe gives branch() a branchable entry;
+		// the branched session inherits the vibe mode_change entry, so the
+		// after-switch reconciler must rehydrate vibe for the new session.
+		session.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "branch from here" }],
+			timestamp: Date.now(),
+		});
+		const branchable = session.getUserMessagesForBranching();
+		const target = branchable.find(m => m.text === "branch from here");
+		if (!target) throw new Error("Expected a branchable user message");
+
+		const registry = VibeSessionRegistry.global();
+		const rehydrate = vi.spyOn(registry, "rehydrate").mockImplementation(async () => 0);
+
+		const result = await session.branch(target.entryId);
+		expect(result.cancelled).toBe(false);
+
+		// #reconcileModeFromSession (the TUI's sessionSwitchReconciler) must have
+		// fired after the branch, rehydrating the vibe registry for the new
+		// session instead of leaving a suspended scope with no workers.
+		expect(rehydrate).toHaveBeenCalled();
+		expect(mode.vibeModeEnabled).toBe(true);
+		expect(vibeModeEntryCount(session.sessionManager)).toBe(1);
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -302,7 +302,7 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(String(exitError)).toContain("journal atomic publish failed");
 
 		expect(mode.vibeModeEnabled).toBe(true);
-		expect(session.getVibeModeState()).toEqual({ enabled: true });
+		expect(session.getVibeModeState()).toEqual({ enabled: true, previousTools: [] });
 		expect(session.getActiveToolNames()).toEqual(activeTools);
 		expect(vibeModeEntryCount(session.sessionManager)).toBe(1);
 

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -319,6 +319,7 @@ describe("RpcInputDispatcher", () => {
 						thinkingLevel: undefined,
 						isStreaming: false,
 						isCompacting: false,
+						vibeMode: false,
 						steeringMode: "all",
 						followUpMode: "all",
 						interruptMode: "immediate",


### PR DESCRIPTION
## Summary

The `/vibe` slash command toggles "vibe (director) mode" — the session drives persistent fast/good worker sub-sessions instead of editing code itself. Over ACP/RPC this command was a no-op: `executeAcpBuiltinSlashCommand` returns `false` when a builtin lacks a `handle`, so `/vibe` was forwarded to the model as plain text instead of activating director mode.

## Changes

### Core feature

- **`/vibe` builtin gains a `handle`** (`builtin-registry.ts`): builds the `VibeParentSession` adapter inline (the ACP/RPC runtime has no `InteractiveModeContext`), calls the same session methods the TUI path uses (`activateVibeTools`/`deactivateVibeTools`/`setVibeModeState`/`sendVibeModeContext`), kills all worker sessions on exit, and guards against plan/goal mode mutual exclusion. An inline directive (`/vibe <prompt>`) is returned as a residual prompt.
- **`VibeModeState.previousTools`** (`vibe/state.ts`): lets the ACP/RPC path capture and restore the pre-vibe toolset on exit.
- **`get_state` reports `vibeMode`** (`rpc-types.ts` + `rpc-mode.ts`): a required boolean so RPC hosts (e.g. agor) can introspect whether director mode is active.

### Review follow-ups

- **Forward `streamingBehavior` on the builtin residual-prompt path** (`rpc-mode.ts`): the builtin branch called `session.prompt(prompt, { images })` while the normal fallthrough in the same handler passed `streamingBehavior`. Because `AgentSession.prompt()` throws `AgentBusyError` when `isStreaming` and no behavior is supplied, `/vibe <directive>` sent mid-turn enabled the mode but silently rejected the directive instead of queuing it as a steer/follow-up. ACP was checked and deliberately left unchanged — it never plumbs `streamingBehavior` on any path, so it is internally consistent; only RPC was inconsistent with itself.
- **Guard `switch_session`/`branch` while vibe is active** (`rpc-mode.ts`): these two lack `#assertVibeSessionTransitionAllowed`, and RPC never installs the TUI's session-switch reconciler, so a transition would leak the old scope's workers and carry the restricted tool snapshot into the new session. `new_session` is intentionally excluded — it already hard-throws inside `AgentSession` and surfaces a clean RPC error, matching TUI behavior.
- **Populate `previousTools` from the TUI path too** (`interactive-mode.ts`): both paths now write it, so the exit-path `?? []` fallback is purely defensive rather than load-bearing in a mixed TUI+RPC session.
- **Test coverage** (`acp-vibe-toggle.test.ts`, new).

## Why a handle, not a new RPC command

`/vibe` already flows through the RPC `prompt` handler via `executeAcpBuiltinSlashCommand`. The missing piece was the `handle` field that makes dispatch actually run the activation logic. This keeps the single slash-command entrypoint consistent across TUI, ACP, and RPC — no parallel protocol surface to maintain.

## Verification

- `bun check` passes. The untracked `profiles.ts` WIP in the working tree is unrelated to this PR and is not staged.
- Tests: 99 pass / 0 fail across `acp-builtins`, `interactive-mode-vibe-toggle`, `rpc-input-frame`, and the new `acp-vibe-toggle`.
- `acp-vibe-toggle.test.ts` mirrors the real-`AgentSession` harness from `interactive-mode-vibe-toggle.test.ts` and defends four contracts: enable returns `{consumed:true}` (not `false`, i.e. not forwarded to the model) and restricts the toolset to read + vibe tools; `/vibe <directive>` returns `{prompt}`; a second toggle disables, restores `previousTools`, and kills workers; plan mode active blocks entry with a usage message.
- RPC smoke probe against `bun packages/coding-agent/src/cli.ts --mode rpc`:
  - `/vibe` → `command_output "Vibe mode enabled…"` + `agentInvoked:false` (mode activated, NOT forwarded to the model)
  - `get_state` after enable → `vibeMode:true`; before any `/vibe` → `vibeMode:false`
  - second `/vibe` → `command_output "Vibe mode disabled."`
  - `available_commands_update` advertises `{name:"vibe", description:"Toggle vibe mode", input:{hint:"[prompt]"}}`