### PR TITLE
fix(discovery): honor plugin MCP manifest pointers

### DIFF
--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -15,7 +15,7 @@ In the TUI, `/marketplace` with no arguments opens the interactive plugin browse
 
 A **marketplace** is a Git repository (or local directory) containing a catalog file at `.omp-plugin/marketplace.json` (preferred) or `.claude-plugin/marketplace.json` (Claude Code-compatible fallback). The catalog lists available plugins with their sources, descriptions, and metadata.
 
-A **plugin** is a directory containing Claude/OMP plugin content such as skills, commands, agents, hooks, tools, MCP servers, or LSP servers. Extension modules (`package.json` `omp.extensions` entry points) are not loaded from marketplace installs — they only load for npm-installed or `omp plugin link`ed plugins. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
+A **plugin** is a directory containing Claude/OMP plugin content such as skills, commands, agents, hooks, tools, MCP servers, or LSP servers. Marketplace installs also load extension modules declared by `package.json` `omp.extensions`: installation symlinks the cached plugin into the scope's `node_modules` tree and records it in `omp-plugins.lock.json`, the same runtime surfaces used by npm-installed and `omp plugin link`ed plugins. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
 
 **Scopes**: marketplace plugins can be installed at two scopes:
 
@@ -208,6 +208,8 @@ Current installer behavior rejects npm marketplace sources with `npm plugin sour
   marketplaces.json              # Registry of added marketplaces
   plugins/
     installed_plugins.json       # User-scoped marketplace plugins (version: 2)
+    omp-plugins.lock.json         # Runtime enable/feature state
+    node_modules/<package>        # Symlink to the cached plugin
     cache/
       marketplaces/<name>/       # Cached marketplace clone/catalog
       plugins/<marketplace>___<plugin>___<version>/  # Cached plugin directories
@@ -215,6 +217,8 @@ Current installer behavior rejects npm marketplace sources with `npm plugin sour
 <project>/.omp/
   plugins/
     installed_plugins.json       # Project-scoped marketplace plugins (version: 2)
+    omp-plugins.lock.json         # Project runtime enable/feature state
+    node_modules/<package>        # Symlink to the cached plugin
 ```
 
 ## Naming rules

--- a/docs/plugin-manager-installer-plumbing.md
+++ b/docs/plugin-manager-installer-plumbing.md
@@ -1,6 +1,6 @@
 # Plugin manager and installer plumbing
 
-This document describes how `omp plugin` npm/git/link operations mutate plugin state on disk and how installed npm/git/link plugins become runtime capabilities (tools and extensions today, hooks/commands path resolution available). Marketplace installs use separate marketplace registries and cache plumbing; see `docs/marketplace.md`.
+This document describes how `omp plugin` npm/git/link and marketplace operations mutate plugin state on disk and become runtime capabilities. Marketplace installs keep their own registries and cache, then register the cached plugin through the same `node_modules` and `omp-plugins.lock.json` runtime surfaces used by npm/git/link installs; see `docs/marketplace.md`.
 
 ## Scope and architecture
 
@@ -27,8 +27,9 @@ omp plugin <npm/link action> ...
 
 omp plugin install name@marketplace / omp install name@marketplace
   -> MarketplaceManager
-  -> mutate ~/.omp/marketplaces.json, ~/.omp/plugins/installed_plugins.json, cache dirs
-  -> installed marketplace plugin cache is surfaced as plugin roots/capabilities
+  -> mutate marketplace registries and cache
+  -> symlink the cached package into the scope's node_modules and update omp-plugins.lock.json
+  -> plugin-root discovery loads skills/commands/etc.; runtime loaders import tools and extensions
 ```
 
 ### Command entrypoints
@@ -44,8 +45,8 @@ omp plugin install name@marketplace / omp install name@marketplace
 Global plugin state lives under `~/.omp/plugins`:
 
 - `package.json` — dependency manifest used by `bun install`/`bun uninstall` for npm-installed plugins
-- `node_modules/` — installed npm plugin packages or symlinks
-- `omp-plugins.lock.json` — runtime state for npm/link plugins:
+- `node_modules/` — installed npm packages plus link and marketplace-cache symlinks
+- `omp-plugins.lock.json` — runtime state for npm/link/marketplace plugins:
   - enabled/disabled per plugin
   - selected feature set per plugin
   - persisted plugin settings
@@ -56,12 +57,14 @@ Project-local overrides live at:
 
 Overrides are read-only from manager/loader perspective (no write path here) and can disable plugins or override features/settings for this project.
 
-Marketplace registries live separately:
+Marketplace installs add registry and cache state alongside those runtime entries:
 
 - `~/.omp/marketplaces.json` — configured marketplace catalogs
 - `~/.omp/plugins/installed_plugins.json` — user-scoped marketplace installs
 - `<cwd>/.omp/plugins/installed_plugins.json` — project-scoped marketplace installs when available
 - `~/.omp/plugins/cache/{marketplaces,plugins}/` — cached catalogs and plugin directories
+- `<scope>/plugins/node_modules/<package>` — symlink to the cached plugin, allowing its `package.json` `omp.extensions` and tools to load
+- `<scope>/plugins/omp-plugins.lock.json` — enablement and feature state shared with the runtime plugin loader
 
 ## Plugin spec parsing and metadata interpretation
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed marketplace plugin MCP discovery ignoring `mcpServers` file pointers in `.omp-plugin/plugin.json` and `.claude-plugin/plugin.json`; OMP-specific manifests now take precedence before the conventional root `.mcp.json` fallback ([#6871](https://github.com/can1357/oh-my-pi/issues/6871)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed marketplace plugin MCP discovery ignoring `mcpServers` file pointers in `.omp-plugin/plugin.json` and `.claude-plugin/plugin.json`; OMP-specific manifests now take precedence before the conventional root `.mcp.json` fallback ([#6871](https://github.com/can1357/oh-my-pi/issues/6871)).
+- Fixed marketplace plugin MCP discovery ignoring the `mcpServers` manifest field in `.omp-plugin/plugin.json` and `.claude-plugin/plugin.json`; both an inline server-map object and a file-path pointer are now honored (OMP manifest first) before the conventional root `.mcp.json` fallback ([#6871](https://github.com/can1357/oh-my-pi/issues/6871)).
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -42,7 +42,14 @@ interface ResolvedPluginDir {
 }
 
 interface ResolvedMCPConfig {
+	/** On-disk config file to read, or null when servers are inline or nothing applies. */
 	path: string | null;
+	/** Server map declared inline in the plugin manifest, or null when the source is a file. */
+	inlineServers: Record<string, unknown> | null;
+	/** Path recorded as each discovered server's capability source. */
+	sourcePath: string;
+	/** Directory that relative stdio `command`/`cwd` values resolve against. */
+	baseDir: string;
 	warnings: string[];
 }
 
@@ -380,7 +387,30 @@ async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
 // MCP Servers
 // =============================================================================
 
+/**
+ * Unwrap a parsed MCP config file to its server map. Supports the nested
+ * `{ mcpServers: { … } }` project shape and the flat `{ name: cfg, … }`
+ * marketplace-plugin shape. Returns null when a `mcpServers` field is present
+ * but not an object map (malformed) so the caller skips the file.
+ */
+function extractServerMap(obj: Record<string, unknown>): Record<string, unknown> | null {
+	if (isRecord(obj.mcpServers)) return obj.mcpServers;
+	if (!("mcpServers" in obj)) return obj;
+	return null;
+}
+
+/**
+ * Resolve where a plugin's MCP servers come from, honoring the manifest's
+ * `mcpServers` field before the conventional root `.mcp.json`.
+ *
+ * `.omp-plugin/plugin.json` takes precedence over `.claude-plugin/plugin.json`.
+ * The field may be an inline object (the server map itself) or a string path to
+ * a config file within the plugin root; a path escaping the root is rejected
+ * with a warning. When no manifest declares the field, `<root>/.mcp.json` is the
+ * fallback source.
+ */
 async function resolvePluginMCPConfig(root: ClaudePluginRoot): Promise<ResolvedMCPConfig> {
+	const fallback = path.join(root.path, ".mcp.json");
 	for (const manifestDir of [".omp-plugin", ".claude-plugin"]) {
 		const manifestPath = path.join(root.path, manifestDir, "plugin.json");
 		const raw = await readFile(manifestPath);
@@ -392,21 +422,40 @@ async function resolvePluginMCPConfig(root: ClaudePluginRoot): Promise<ResolvedM
 		} catch {
 			continue;
 		}
-		if (!isRecord(parsed) || typeof parsed.mcpServers !== "string") continue;
+		if (!isRecord(parsed)) continue;
+		const pointer = parsed.mcpServers;
 
-		const configured = parsed.mcpServers.trim();
-		if (configured.length === 0) continue;
-		const resolved = path.resolve(root.path, configured);
-		if (!isWithinPluginRoot(root.path, resolved)) {
+		// Inline object form: the manifest value is the server map itself, rooted
+		// at the plugin directory (Claude's ${CLAUDE_PLUGIN_ROOT} base).
+		if (isRecord(pointer)) {
+			return { path: null, inlineServers: pointer, sourcePath: manifestPath, baseDir: root.path, warnings: [] };
+		}
+
+		// File-pointer form: resolve the named config file within the plugin root.
+		if (typeof pointer === "string") {
+			const configured = pointer.trim();
+			if (configured.length === 0) continue;
+			const resolved = path.resolve(root.path, configured);
+			if (!isWithinPluginRoot(root.path, resolved)) {
+				return {
+					path: null,
+					inlineServers: null,
+					sourcePath: manifestPath,
+					baseDir: root.path,
+					warnings: [`[claude-plugins] Ignoring mcpServers path outside plugin root for ${root.id}: ${configured}`],
+				};
+			}
 			return {
-				path: null,
-				warnings: [`[claude-plugins] Ignoring mcpServers path outside plugin root for ${root.id}: ${configured}`],
+				path: resolved,
+				inlineServers: null,
+				sourcePath: resolved,
+				baseDir: path.dirname(resolved),
+				warnings: [],
 			};
 		}
-		return { path: resolved, warnings: [] };
 	}
 
-	return { path: path.join(root.path, ".mcp.json"), warnings: [] };
+	return { path: fallback, inlineServers: null, sourcePath: fallback, baseDir: path.dirname(fallback), warnings: [] };
 }
 
 async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> {
@@ -419,43 +468,35 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 	for (const root of roots) {
 		const resolved = await resolvePluginMCPConfig(root);
 		warnings.push(...resolved.warnings);
-		if (resolved.path === null) continue;
-		const mcpPath = resolved.path;
-		const raw = await readFile(mcpPath);
-		if (raw === null) continue; // file absent — skip silently
 
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(raw);
-		} catch {
-			warnings.push(`[claude-plugins] Invalid JSON in ${mcpPath}`);
-			logger.warn(`[claude-plugins] Invalid JSON in ${mcpPath}`);
-			continue;
-		}
+		let servers: Record<string, unknown> | null;
+		if (resolved.inlineServers) {
+			servers = resolved.inlineServers;
+		} else if (resolved.path !== null) {
+			const raw = await readFile(resolved.path);
+			if (raw === null) continue; // file absent — skip silently
 
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
-		const obj = parsed as Record<string, unknown>;
-
-		// Two shapes are supported:
-		//   nested: { "mcpServers": { name: cfg, ... } }   (OMP/Claude Code project shape)
-		//   flat:   { name: cfg, ... }                      (Claude marketplace plugin shape)
-		// If "mcpServers" is present and an object, treat it as the canonical map.
-		// Otherwise, treat the whole object as the server map.
-		let servers: Record<string, unknown>;
-		if (
-			obj.mcpServers !== undefined &&
-			obj.mcpServers !== null &&
-			typeof obj.mcpServers === "object" &&
-			!Array.isArray(obj.mcpServers)
-		) {
-			servers = obj.mcpServers as Record<string, unknown>;
-		} else if (!("mcpServers" in obj)) {
-			servers = obj;
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				warnings.push(`[claude-plugins] Invalid JSON in ${resolved.path}`);
+				logger.warn(`[claude-plugins] Invalid JSON in ${resolved.path}`);
+				continue;
+			}
+			// Two file shapes are supported:
+			//   nested: { "mcpServers": { name: cfg, ... } }   (OMP/Claude Code project shape)
+			//   flat:   { name: cfg, ... }                      (Claude marketplace plugin shape)
+			if (!isRecord(parsed)) continue;
+			servers = extractServerMap(parsed);
 		} else {
 			continue;
 		}
+		if (servers === null) continue;
 
-		for (const [serverName, serverCfg] of Object.entries(servers)) {
+		const { sourcePath, baseDir } = resolved;
+		for (const serverName in servers) {
+			const serverCfg = servers[serverName];
 			if (!serverCfg || typeof serverCfg !== "object" || Array.isArray(serverCfg)) continue;
 			const raw = serverCfg as {
 				enabled?: boolean;
@@ -474,7 +515,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			// occasionally ship .mcp.json entries with neither, which would register a useless
 			// server and surface as a connection error at runtime.
 			if (typeof raw.command !== "string" && typeof raw.url !== "string") {
-				warnings.push(`[claude-plugins] Skipping MCP server "${serverName}" in ${mcpPath}: missing command or url`);
+				warnings.push(`[claude-plugins] Skipping MCP server "${serverName}" in ${sourcePath}: missing command or url`);
 				continue;
 			}
 			const namespacedName = root.plugin ? `${root.plugin}:${serverName}` : serverName;
@@ -483,10 +524,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			const substitutedCwd = raw.cwd !== undefined ? substitutePluginRoot(raw.cwd, root.path) : undefined;
 			// Root relative command/cwd at the plugin's config directory, not the
 			// session cwd (MCP stdio spawning resolves relative values there).
-			const rooted = resolvePluginStdioPaths(
-				{ command: substitutedCommand, cwd: substitutedCwd },
-				path.dirname(mcpPath),
-			);
+			const rooted = resolvePluginStdioPaths({ command: substitutedCommand, cwd: substitutedCwd }, baseDir);
 			const server: MCPServer = {
 				name: namespacedName,
 				...(raw.enabled !== undefined && { enabled: raw.enabled }),
@@ -500,7 +538,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				...(raw.auth !== undefined && { auth: raw.auth }),
 				...(raw.oauth !== undefined && { oauth: raw.oauth }),
 				...(raw.type !== undefined && { transport: raw.type as MCPServer["transport"] }),
-				_source: createSourceMeta(PROVIDER_ID, mcpPath, root.scope),
+				_source: createSourceMeta(PROVIDER_ID, sourcePath, root.scope),
 			};
 			items.push(server);
 		}

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -41,6 +41,11 @@ interface ResolvedPluginDir {
 	warnings: string[];
 }
 
+interface ResolvedMCPConfig {
+	path: string | null;
+	warnings: string[];
+}
+
 async function readPluginManifest(root: ClaudePluginRoot): Promise<ClaudePluginManifest | null> {
 	const manifestPath = path.join(root.path, ".claude-plugin", "plugin.json");
 	const raw = await readFile(manifestPath);
@@ -375,6 +380,35 @@ async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
 // MCP Servers
 // =============================================================================
 
+async function resolvePluginMCPConfig(root: ClaudePluginRoot): Promise<ResolvedMCPConfig> {
+	for (const manifestDir of [".omp-plugin", ".claude-plugin"]) {
+		const manifestPath = path.join(root.path, manifestDir, "plugin.json");
+		const raw = await readFile(manifestPath);
+		if (raw === null) continue;
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			continue;
+		}
+		if (!isRecord(parsed) || typeof parsed.mcpServers !== "string") continue;
+
+		const configured = parsed.mcpServers.trim();
+		if (configured.length === 0) continue;
+		const resolved = path.resolve(root.path, configured);
+		if (!isWithinPluginRoot(root.path, resolved)) {
+			return {
+				path: null,
+				warnings: [`[claude-plugins] Ignoring mcpServers path outside plugin root for ${root.id}: ${configured}`],
+			};
+		}
+		return { path: resolved, warnings: [] };
+	}
+
+	return { path: path.join(root.path, ".mcp.json"), warnings: [] };
+}
+
 async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> {
 	const items: MCPServer[] = [];
 	const warnings: string[] = [];
@@ -383,7 +417,10 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 	warnings.push(...rootWarnings);
 
 	for (const root of roots) {
-		const mcpPath = path.join(root.path, ".mcp.json");
+		const resolved = await resolvePluginMCPConfig(root);
+		warnings.push(...resolved.warnings);
+		if (resolved.path === null) continue;
+		const mcpPath = resolved.path;
 		const raw = await readFile(mcpPath);
 		if (raw === null) continue; // file absent — skip silently
 
@@ -446,7 +483,10 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			const substitutedCwd = raw.cwd !== undefined ? substitutePluginRoot(raw.cwd, root.path) : undefined;
 			// Root relative command/cwd at the plugin's config directory, not the
 			// session cwd (MCP stdio spawning resolves relative values there).
-			const rooted = resolvePluginStdioPaths({ command: substitutedCommand, cwd: substitutedCwd }, root.path);
+			const rooted = resolvePluginStdioPaths(
+				{ command: substitutedCommand, cwd: substitutedCwd },
+				path.dirname(mcpPath),
+			);
 			const server: MCPServer = {
 				name: namespacedName,
 				...(raw.enabled !== undefined && { enabled: raw.enabled }),

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -565,6 +565,47 @@ describe("listClaudePluginRoots", () => {
 		]);
 	});
 
+	test("loads inline manifest mcpServers object and roots relative stdio at plugin root", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "inline-mcp");
+		await fs.mkdir(pluginsDir, { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".omp-plugin"), { recursive: true });
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"inline-mcp@market": [
+						{
+							scope: "user",
+							installPath: pluginPath,
+							version: "1.0.0",
+							installedAt: "2026-07-28T00:00:00Z",
+							lastUpdated: "2026-07-28T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		// Inline object form: the manifest carries the server map directly, and no
+		// root .mcp.json exists, so the pre-fix fallback would register nothing.
+		await fs.writeFile(
+			path.join(pluginPath, ".omp-plugin", "plugin.json"),
+			JSON.stringify({ mcpServers: { local: { command: "./bin/server", args: ["run"] } } }),
+		);
+
+		const result = await loadCapability<MCPServer>(mcpCapability.id, {
+			cwd: tempDir,
+			providers: ["claude-plugins"],
+		});
+
+		expect(result.warnings).toEqual([]);
+		const server = result.all.find(item => item.name === "inline-mcp:local");
+		expect(server).toBeDefined();
+		expect(server?.command).toBe(path.join(pluginPath, "bin", "server"));
+		expect(server?.args).toEqual(["run"]);
+	});
+
 	test("deduplicates a plugin alias of a directly configured MCP connection", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		const pluginPath = path.join(tempDir, "plugins", "context7");

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -491,6 +491,80 @@ describe("listClaudePluginRoots", () => {
 		}
 	});
 
+	test("uses OMP then Claude manifest mcpServers paths before .mcp.json", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const ompPluginPath = path.join(tempDir, "plugins", "omp-pointer");
+		const claudePluginPath = path.join(tempDir, "plugins", "claude-pointer");
+		await fs.mkdir(pluginsDir, { recursive: true });
+		await Promise.all([
+			fs.mkdir(path.join(ompPluginPath, ".omp-plugin"), { recursive: true }),
+			fs.mkdir(path.join(ompPluginPath, ".claude-plugin"), { recursive: true }),
+			fs.mkdir(path.join(claudePluginPath, ".claude-plugin"), { recursive: true }),
+		]);
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"omp-pointer@market": [
+						{
+							scope: "user",
+							installPath: ompPluginPath,
+							version: "1.0.0",
+							installedAt: "2026-07-28T00:00:00Z",
+							lastUpdated: "2026-07-28T00:00:00Z",
+						},
+					],
+					"claude-pointer@market": [
+						{
+							scope: "user",
+							installPath: claudePluginPath,
+							version: "1.0.0",
+							installedAt: "2026-07-28T00:00:00Z",
+							lastUpdated: "2026-07-28T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await Promise.all([
+			fs.writeFile(
+				path.join(ompPluginPath, ".omp-plugin", "plugin.json"),
+				JSON.stringify({ mcpServers: "./mcp-omp.json" }),
+			),
+			fs.writeFile(
+				path.join(ompPluginPath, ".claude-plugin", "plugin.json"),
+				JSON.stringify({ mcpServers: "./mcp-claude.json" }),
+			),
+			fs.writeFile(path.join(ompPluginPath, "mcp-omp.json"), JSON.stringify({ "from-omp": { command: "omp" } })),
+			fs.writeFile(
+				path.join(ompPluginPath, "mcp-claude.json"),
+				JSON.stringify({ "from-claude": { command: "claude" } }),
+			),
+			fs.writeFile(path.join(ompPluginPath, ".mcp.json"), JSON.stringify({ "from-root": { command: "root" } })),
+			fs.writeFile(
+				path.join(claudePluginPath, ".claude-plugin", "plugin.json"),
+				JSON.stringify({ mcpServers: "./mcp-claude.json" }),
+			),
+			fs.writeFile(
+				path.join(claudePluginPath, "mcp-claude.json"),
+				JSON.stringify({ "from-claude": { command: "claude" } }),
+			),
+			fs.writeFile(path.join(claudePluginPath, ".mcp.json"), JSON.stringify({ "from-root": { command: "root" } })),
+		]);
+
+		const result = await loadCapability<MCPServer>(mcpCapability.id, {
+			cwd: tempDir,
+			providers: ["claude-plugins"],
+		});
+
+		expect(result.warnings).toEqual([]);
+		expect(result.all.map(server => server.name).sort()).toEqual([
+			"claude-pointer:from-claude",
+			"omp-pointer:from-omp",
+		]);
+	});
+
 	test("deduplicates a plugin alias of a directly configured MCP connection", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		const pluginPath = path.join(tempDir, "plugins", "context7");


### PR DESCRIPTION
## Repro
A marketplace fixture with `.omp-plugin/plugin.json` pointing to `./mcp-omp.json`, a `.claude-plugin/plugin.json` fallback pointer, and root `.mcp.json` files reproduced the bug with `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts --test-name-pattern 'uses OMP then Claude manifest mcpServers'`: discovery returned both root `*:from-root` servers instead of the manifest-selected servers.

## Cause
`loadMCPServers` in `packages/coding-agent/src/discovery/claude-plugins.ts` hard-coded `<pluginRoot>/.mcp.json` and never inspected either plugin manifest. Separately, `docs/marketplace.md` and `docs/plugin-manager-installer-plumbing.md` still described marketplace installs from before `MarketplaceManager.installPlugin` registered cached packages through runtime symlinks and `omp-plugins.lock.json`.

## Fix
- Resolve string `mcpServers` pointers from `.omp-plugin/plugin.json`, then `.claude-plugin/plugin.json`, before the conventional root `.mcp.json` fallback.
- Reject pointers outside the plugin root and resolve relative stdio paths against the selected config file's directory.
- Add a precedence/fallback regression test and correct marketplace extension/runtime-layout documentation.
- Record the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` passes: 34 tests, 91 assertions. LSP diagnostics for `claude-plugins.ts` report no errors, and both corrected documentation sections were re-read against `MarketplaceManager.installPlugin` / `#registerRuntimePlugin`. Pre-publish gate skipped: `bun run fix` fails identically on clean `main` because `audiopus_sys` cannot invoke the unavailable `cmake`; the TypeScript formatter completed with no remaining changes.

Fixes #6871