### PR TITLE
fix(acp): hide internal Hub messages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed internal Hub peer messages being emitted over ACP as ordinary tool-call updates, which exposed inter-agent coordination text in clients such as Paseo ([#6872](https://github.com/can1357/oh-my-pi/issues/6872)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -82,7 +82,6 @@ import {
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { createAcpClientBridge } from "./acp-client-bridge";
 import {
-	buildToolCallStartUpdate,
 	extractAssistantMessageText,
 	mapAgentSessionEventToAcpSessionUpdates,
 	normalizeReplayToolArguments,
@@ -2158,14 +2157,18 @@ export class AcpAgent implements Agent {
 					typeof toolItem.name === "string"
 				) {
 					const args = this.#buildReplayAssistantToolArgs(toolItem);
-					const update = buildToolCallStartUpdate({
-						toolCallId: toolItem.id,
-						toolName: toolItem.name,
-						args,
-						status: "completed",
-						cwd,
-					});
-					notifications.push({ sessionId, update });
+					notifications.push(
+						...mapAgentSessionEventToAcpSessionUpdates(
+							{
+								type: "tool_execution_start",
+								toolCallId: toolItem.id,
+								toolName: toolItem.name,
+								args,
+							},
+							sessionId,
+							{ cwd },
+						),
+					);
 					replayedToolCallIds.add(toolItem.id);
 					replayedToolCallArgs.set(toolItem.id, args);
 				}

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -141,6 +141,36 @@ function xdevDispatchDevice(toolName: string, args: unknown): string | undefined
 	return parseXdUrl(path)?.name ?? undefined;
 }
 
+/** Whether a Hub call carries peer-to-peer coordination rather than process control. */
+function isInternalHubMessageTool(toolName: string, args: unknown): boolean {
+	let hubArgs = args;
+	if (toolName !== "hub") {
+		if (xdevDispatchDevice(toolName, args) !== "hub" || typeof args !== "object" || args === null) {
+			return false;
+		}
+		const content = Reflect.get(args, "content");
+		if (typeof content !== "string") return false;
+		try {
+			hubArgs = JSON.parse(content);
+		} catch {
+			return false;
+		}
+	}
+	if (typeof hubArgs !== "object" || hubArgs === null) return false;
+	const op = Reflect.get(hubArgs, "op");
+	switch (op) {
+		case "list":
+		case "inbox":
+			return true;
+		case "send":
+			return typeof Reflect.get(hubArgs, "to") === "string";
+		case "wait":
+			return typeof Reflect.get(hubArgs, "name") !== "string";
+		default:
+			return false;
+	}
+}
+
 export function mapToolKind(toolName: string, args?: unknown): ToolKind {
 	// An xd:// device write executes the mounted tool — "edit" would make ACP
 	// clients render it as a file modification to a nonexistent path (and
@@ -186,6 +216,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 		case "message_end":
 			return mapAssistantMessageEnd(event, sessionId, options);
 		case "tool_execution_start": {
+			if (isInternalHubMessageTool(event.toolName, event.args)) return [];
 			const update = buildToolCallStartUpdate({
 				toolCallId: event.toolCallId,
 				toolName: event.toolName,
@@ -196,6 +227,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_update": {
+			if (isInternalHubMessageTool(event.toolName, event.args)) return [];
 			const content = mergeToolUpdateContent(
 				buildToolStartContent(event.toolName, event.args),
 				extractToolCallContent(event.partialResult, options),
@@ -216,14 +248,13 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_end": {
+			const args = getToolExecutionEndArgs(event, options);
+			if (isInternalHubMessageTool(event.toolName, args)) return [];
 			const resultContent = [
 				...extractDiffToolCallContent(event.result),
 				...extractToolCallContent(event.result, options),
 			];
-			const content = mergeToolUpdateContent(
-				buildToolStartContent(event.toolName, getToolExecutionEndArgs(event, options)),
-				resultContent,
-			);
+			const content = mergeToolUpdateContent(buildToolStartContent(event.toolName, args), resultContent);
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
 				toolCallId: event.toolCallId,

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -165,7 +165,10 @@ function isInternalHubMessageTool(toolName: string, args: unknown): boolean {
 		case "send":
 			return typeof Reflect.get(hubArgs, "to") === "string";
 		case "wait":
-			return typeof Reflect.get(hubArgs, "name") !== "string";
+			// A bare wait or an `ids` wait settles on background-job delivery,
+			// whose snapshot IS the job result (hub.md) — keep those visible.
+			// Only a peer-scoped wait (`from`, no jobs) is internal messaging.
+			return typeof Reflect.get(hubArgs, "from") === "string" && Reflect.get(hubArgs, "ids") === undefined;
 		default:
 			return false;
 	}

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1306,6 +1306,49 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("does not replay internal Hub messages to ACP clients", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		stored.sessionManager.appendMessage({ role: "user", content: "Delegate this task", timestamp: Date.now() });
+		stored.sessionManager.appendMessage({
+			...makeAssistantMessage(""),
+			content: [
+				{
+					type: "toolCall",
+					id: "toolu_hub_replay",
+					name: "hub",
+					arguments: { op: "send", to: "Scout", message: "Private coordination" },
+				},
+			],
+			stopReason: "toolUse",
+		});
+		stored.sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "toolu_hub_replay",
+			toolName: "hub",
+			content: [{ type: "text", text: "Private reply" }],
+			isError: false,
+			timestamp: Date.now(),
+		});
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		await harness.agent.loadSession({
+			sessionId: stored.sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+
+		const hubUpdates = harness.updates
+			.filter(update => update.sessionId === stored.sessionId)
+			.map(notification => notification.update)
+			.filter(update => "toolCallId" in update && update.toolCallId === "toolu_hub_replay");
+		expect(hubUpdates).toEqual([]);
+
+		harness.abortController.abort();
+	});
+
 	it("preserves tool_use input payloads when replaying assistant tool calls", async () => {
 		const harness = await createHarness();
 		const stored = new FakeAgentSession(harness.cwdA);

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -302,6 +302,61 @@ describe("ACP event mapper", () => {
 		);
 	});
 
+	it("keeps background job-wait results visible over ACP", () => {
+		const events = [
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-hub-job-wait",
+				toolName: "hub",
+				args: { op: "wait", ids: ["bash_a1b2c3"] },
+			},
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-hub-job-wait",
+				toolName: "hub",
+				isError: false,
+				result: { content: [{ type: "text", text: "job output" }] },
+			},
+		] satisfies AgentSessionEvent[];
+
+		const updates = events.flatMap(event =>
+			mapAgentSessionEventToAcpSessionUpdates(event, "session-1", {
+				getToolArgs: () => ({ op: "wait", ids: ["bash_a1b2c3"] }),
+			}),
+		);
+
+		expect(updates.map(update => update.update.sessionUpdate)).toEqual(["tool_call", "tool_call_update"]);
+	});
+
+	it("keeps a bare Hub wait visible so job deliveries reach ACP", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-hub-bare-wait",
+				toolName: "hub",
+				args: { op: "wait" },
+			},
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expect(updates[0]?.update.sessionUpdate).toBe("tool_call");
+	});
+
+	it("hides a peer-scoped Hub wait from ACP", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-hub-peer-wait",
+				toolName: "hub",
+				args: { op: "wait", from: "Scout" },
+			},
+			"session-1",
+		);
+
+		expect(updates).toEqual([]);
+	});
+
 	it("uses command text for a new command tool even when intent is generic", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -219,6 +219,89 @@ describe("ACP event mapper", () => {
 		expect(update.content).toContainEqual({ type: "content", content: { type: "text", text: "$ npm run check" } });
 	});
 
+	it("keeps internal Hub traffic off the ACP session stream", () => {
+		const events: AgentSessionEvent[] = [
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-hub-send",
+				toolName: "hub",
+				args: { op: "send", to: "Scout", message: "Private coordination" },
+			},
+			{
+				type: "tool_execution_update",
+				toolCallId: "tc-hub-send",
+				toolName: "hub",
+				args: { op: "send", to: "Scout", message: "Private coordination" },
+				partialResult: { content: [{ type: "text", text: "delivering" }] },
+			},
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-hub-send",
+				toolName: "hub",
+				isError: false,
+				result: { content: [{ type: "text", text: "delivered" }] },
+			},
+		] satisfies AgentSessionEvent[];
+
+		const updates = events.flatMap(event =>
+			mapAgentSessionEventToAcpSessionUpdates(event, "session-1", {
+				getToolArgs: () => ({ op: "send", to: "Scout", message: "Private coordination" }),
+			}),
+		);
+
+		expect(updates).toEqual([]);
+	});
+
+	it("keeps xd-routed Hub traffic off the ACP session stream", () => {
+		const args = {
+			path: "xd://hub",
+			content: JSON.stringify({ op: "inbox", from: "Scout" }),
+		};
+		const events = [
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-xd-hub-inbox",
+				toolName: "write",
+				args,
+			},
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-xd-hub-inbox",
+				toolName: "write",
+				isError: false,
+				result: { content: [{ type: "text", text: "Private reply" }] },
+			},
+		] satisfies AgentSessionEvent[];
+
+		const updates = events.flatMap(event =>
+			mapAgentSessionEventToAcpSessionUpdates(event, "session-1", {
+				getToolArgs: () => args,
+			}),
+		);
+
+		expect(updates).toEqual([]);
+	});
+
+	it("keeps Hub process control visible over ACP", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-hub-process-send",
+				toolName: "hub",
+				args: { op: "send", name: "server", text: "ping" },
+			},
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expect(updates[0]?.update).toEqual(
+			expect.objectContaining({
+				sessionUpdate: "tool_call",
+				rawInput: { op: "send", name: "server", text: "ping" },
+			}),
+		);
+	});
+
 	it("uses command text for a new command tool even when intent is generic", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{


### PR DESCRIPTION
## Repro
A delegated agent can issue an internal `hub send` while an ACP client is attached. `bun test packages/coding-agent/test/acp-event-mapper.test.ts -t "keeps internal Hub traffic off the ACP session stream"` previously failed because ACP received the private `rawInput.message` plus in-progress and completed tool-result updates.

## Cause
`mapAgentSessionEventToAcpSessionUpdates` in `packages/coding-agent/src/modes/acp/acp-event-mapper.ts` mapped every Hub tool event as an ordinary ACP tool call, and `AcpAgent.#replayAssistantMessage` in `packages/coding-agent/src/modes/acp/acp-agent.ts` bypassed that mapper for persisted assistant tool calls. Neither path distinguished peer messaging from user-visible Hub process control.

## Fix
- Filter Hub peer `send`, `list`, `inbox`, and non-process `wait` events from live ACP notifications, including `write xd://hub` dispatches.
- Route replayed assistant tool calls through the same mapper so resumed sessions enforce the same filter.
- Preserve user-visible Hub process-control calls and cover live, xd-routed, and replayed behavior with regression tests.

## Verification
`bun test packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/acp-agent.test.ts` passed: 92 tests, 0 failures. `bun run check:ts` passed. Skipped the full pre-publish gate because `bun run fix` fails identically on clean `origin/main`: `audiopus_sys` cannot invoke unavailable `cmake`; TypeScript formatting completed successfully before that unrelated Rust failure.

Fixes #6872