### PR TITLE
fix(catalog): price cache writes by ttl breakdown

### DIFF
--- a/packages/ai/test/models-cost.test.ts
+++ b/packages/ai/test/models-cost.test.ts
@@ -103,6 +103,60 @@ describe("calculateCost", () => {
 		expect(usage.cost.total).toBeCloseTo(0.2805, 8);
 	});
 
+	it("prices 1h cache writes at the 1h rate via the cttl breakdown (issue #6876)", () => {
+		const model = getBundledModel("anthropic", "claude-opus-5");
+		const usage: Usage = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 344139,
+			cttl: { ephemeral1h: 344139 },
+			totalTokens: 344139,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		calculateCost(model, usage);
+
+		// 1h write bills at 2x base input ($5/MTok -> $10/MTok), not the 5m
+		// scalar cost.cacheWrite ($6.25/MTok) which would give $2.15086875.
+		expect(usage.cost.cacheWrite).toBeCloseTo(3.44139, 8);
+		expect(usage.cost.total).toBeCloseTo(3.44139, 8);
+	});
+
+	it("prices a mixed 5m/1h cache write per component", () => {
+		const model = getBundledModel("anthropic", "claude-opus-5");
+		const usage: Usage = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 300,
+			cttl: { ephemeral5m: 100, ephemeral1h: 200 },
+			totalTokens: 300,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		calculateCost(model, usage);
+
+		// 100 * $6.25/MTok (5m) + 200 * $10/MTok (1h).
+		expect(usage.cost.cacheWrite).toBeCloseTo((6.25 * 100 + 10 * 200) / 1e6, 12);
+	});
+
+	it("keeps the flat 5m rate for cache writes without a cttl breakdown", () => {
+		const model = getBundledModel("anthropic", "claude-opus-5");
+		const usage: Usage = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 1000,
+			totalTokens: 1000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		calculateCost(model, usage);
+
+		expect(usage.cost.cacheWrite).toBeCloseTo((6.25 * 1000) / 1e6, 12);
+	});
+
 	it("prices OpenAI Codex GPT models from the matching OpenAI catalog entry", () => {
 		const openAIModel = getBundledModel("openai", "gpt-5.4");
 		const codexModel = getBundledModel("openai-codex", "gpt-5.4");

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `calculateCost` under-reporting cache-write cost by a factor of 1.6 on the default first-party Anthropic path: writes were priced at the catalog's 5-minute rate (`cost.cacheWrite`, 1.25x base input) even though omp defaults to 1-hour retention, which Anthropic bills at 2x base input. The already-parsed `usage.cttl` breakdown is now honored — 5m tokens price at `cost.cacheWrite`, 1h tokens at `input * 2`, mixed writes per component — while providers that report no `cttl` keep the flat-rate calculation ([#6876](https://github.com/can1357/oh-my-pi/issues/6876)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Added

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -48,10 +48,30 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
 	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0));
 	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0));
 	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0));
-	usage.cost.cacheWrite = (model.cost.cacheWrite / 1000000) * usage.cacheWrite;
+	usage.cost.cacheWrite = cacheWriteCost(model, usage);
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
 }
+
+/**
+ * Price cache-write tokens, honoring the TTL breakdown when the provider reports one.
+ *
+ * `model.cost.cacheWrite` is the 5-minute write rate (Anthropic bills 5m writes at
+ * 1.25x base input). When `usage.cttl` is present the write mixes 5m and 1h
+ * breakpoints — omp defaults to 1h retention on first-party Anthropic, and 1h writes
+ * bill at 2x base input — so each component is priced at its own rate instead of the
+ * flat 5m rate. Deriving 1h from `input * 2` (Anthropic's published multiplier) is
+ * model-independent and stays correct even for legacy entries whose stored
+ * `cacheWrite` scalar drifts from 1.25x input. Providers that omit `cttl`
+ * (everyone but Anthropic) keep the flat-rate calculation.
+ */
+function cacheWriteCost<TApi extends Api>(model: Model<TApi>, usage: Usage): number {
+	const cttl = usage.cttl;
+	if (!cttl) return (model.cost.cacheWrite / 1000000) * usage.cacheWrite;
+	const rate1h = model.cost.input * 2;
+	return (model.cost.cacheWrite / 1000000) * (cttl.ephemeral5m ?? 0) + (rate1h / 1000000) * (cttl.ephemeral1h ?? 0);
+}
+
 /**
  * Check if two models are equal by comparing both their id and provider.
  * Returns false if either model is null or undefined.


### PR DESCRIPTION
## Repro
Running an agent session on `claude-opus-5` against the first-party Anthropic API (OAuth or API key, both default to 1h retention) and triggering a cache write produces a `usage` whose declared write is 1-hour but whose cost is computed at the 5-minute rate. Minimal repro against `main`:

```
calculateCost(getBundledModel("anthropic", "claude-opus-5"), { cacheWrite: 344139, cttl: { ephemeral1h: 344139 }, cost: { ... } })
// cost.cacheWrite = 2.15086875   (344139 x $6.25/MTok, the 5m rate)
// correct 1h cost = 3.44139       (344139 x $10/MTok)
```

Every cache-write cost on the default path is understated by a factor of 1.6.

## Cause
`calculateCost` in `packages/catalog/src/models.ts` priced every write token with the scalar `model.cost.cacheWrite`, which the catalog populates with Anthropic's 5-minute rate (1.25x base input — verified: `claude-opus-5` 6.25, `claude-sonnet-5` 2.5, `claude-haiku-4-5` 1.25). omp defaults to 1-hour retention on first-party Anthropic (`getCacheControl` in `packages/ai/src/providers/anthropic.ts` resolves OAuth and long-supporting API keys to `retention: "long"` -> `ttl: "1h"`; `compat.supportsLongCacheRetention: official`), and Anthropic bills 1h writes at 2x base input. The `usage.cttl` breakdown that distinguishes the two was already parsed and stored (`anthropic.ts:1618`) and documented to sum to `cacheWrite` (`types.ts:127-131`), but `calculateCost` never read it.

## Fix
- Extract `cacheWriteCost(model, usage)` in `packages/catalog/src/models.ts`.
- When `usage.cttl` is present, price `ephemeral5m` at `model.cost.cacheWrite` and `ephemeral1h` at `model.cost.input * 2` (Anthropic's published, model-independent 1h multiplier — robust even for legacy entries whose stored `cacheWrite` scalar has drifted from 1.25x input), summing both components for mixed writes.
- When `cttl` is absent (every non-Anthropic provider), keep the existing flat-rate calculation unchanged.
- Add regression tests covering the 1h case (issue #6876), a mixed 5m/1h write, and the flat no-`cttl` path.

## Verification
`bun test packages/ai/test/models-cost.test.ts` -> 7 pass / 0 fail. Direct reruns confirm: 1h 344139 -> $3.44139, 5m 344139 -> $2.15086875 (unchanged), mixed 100x5m+200x1h -> $0.002625, no-cttl 1000 -> $0.00625. Pre-publish `bun run fix` + `bun check` passed via the gate.

Fixes #6876