### PR TITLE
fix(session): preserve auto-thinking level on classifier failure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved the active auto-thinking effort when per-turn classification fails, avoiding an unnecessary full prompt-cache invalidation from reverting to the model's provisional default ([#6877](https://github.com/can1357/oh-my-pi/issues/6877)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -581,9 +581,9 @@ export class ModelControls {
 
 	/**
 	 * Classify the current user turn and set the effective thinking level for it.
-	 * Bounded by a timeout + abort; on any failure (no smol model, timeout, parse
-	 * error) it falls back to the provisional concrete level and continues. Never
-	 * throws into the turn, and never clears `#autoThinking` (auto stays active).
+	 * Bounded by a timeout + abort; on failure it preserves the last classified
+	 * level, or uses the provisional concrete level before the first resolution.
+	 * Never throws into the turn, and never clears `#autoThinking`.
 	 */
 	async applyAutoThinkingLevel(promptText: string, generation: number): Promise<void> {
 		const model = this.#model;
@@ -625,7 +625,7 @@ export class ModelControls {
 
 		const effort = clampThinkingLevelToCeiling(
 			model,
-			resolved ?? resolveProvisionalAutoLevel(model),
+			resolved ?? this.#autoResolvedLevel ?? resolveProvisionalAutoLevel(model),
 			this.#thinkingLevelCeiling,
 		);
 		if (effort === undefined) return;

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -541,6 +541,34 @@ describe("AgentSession role model thinking behavior", () => {
 		);
 	});
 
+	it("preserves the resolved auto level when a later classification fails", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		await createSession({
+			initialModelId: model.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: { default: `${model.provider}/${model.id}` },
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		vi.spyOn(autoThinkingClassifier, "classifyDifficulty")
+			.mockResolvedValueOnce(Effort.Low)
+			.mockRejectedValueOnce(new Error("classifier down"));
+
+		session.setThinkingLevel(AUTO_THINKING);
+		await session.prompt("Handle a straightforward update");
+		const receiptCount = session.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "thinking_level_change").length;
+		await session.prompt("Investigate another update");
+
+		expect(session.configuredThinkingLevel()).toBe(AUTO_THINKING);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Low);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.Low);
+		expect(session.sessionManager.getEntries().filter(entry => entry.type === "thinking_level_change")).toHaveLength(
+			receiptCount,
+		);
+	});
+
 	it("skips classification for synthetic turns", async () => {
 		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		await createSession({


### PR DESCRIPTION
## Repro
With auto thinking active, resolve one user turn to `low`, reject the next classifier call, and run `bun test packages/coding-agent/test/agent-session-role-thinking.test.ts --test-name-pattern "preserves the resolved auto level when a later classification fails"`; before the fix the assertion receives the model's provisional `high` level instead of `low`.

## Cause
`ModelControls.applyAutoThinkingLevel` in `packages/coding-agent/src/session/model-controls.ts` used `resolved ?? resolveProvisionalAutoLevel(model)` for every classifier failure, ignoring `#autoResolvedLevel` and reverting an established session effort to the model-derived provisional default.

## Fix
- Reuse the last successfully classified effort when classification fails.
- Retain the provisional model-derived fallback only before the first successful classification.
- Cover a successful `low` classification followed by a rejected classification without another thinking-level receipt.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-role-thinking.test.ts` passes: 21 tests, 120 assertions. `bun run check:types` passes for `packages/coding-agent`. The pre-publish `bun check` gate also passes.

Fixes #6877