### PR TITLE
fix(coding-agent): retract superseded turn's tool cards to stop double render

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed two remaining tool-card double renders: a failed/aborted assistant attempt now retracts never-run cards before a retry or TTSR rewind re-streams them, and a successful read whose persisted result wins a transcript-rebuild race no longer creates a fallback read group when its delayed live completion arrives ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
+- Fixed two remaining tool-card double renders: a superseded assistant turn no longer leaves its never-run cards above the re-run's fresh cards (a TTSR rewind retracts them immediately; an auto-retry removes the synthetic-settled failure cards when it supersedes the turn — while a genuinely terminal failure keeps its card visible), and a successful read whose persisted result wins a transcript-rebuild race no longer creates a fallback read group when its delayed live completion arrives ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
 - Fixed a tool card rendering twice when the provider rewrites a streamed tool call's id mid-stream — GitHub Copilot's `call_id|id` transport, or any stream that delivers the tool name/arguments before the id — so the block appears first with an empty or partial id and is populated in a later delta. The transcript keyed the live card by that mutable id, so the changed id spawned a second card: the old-id card orphaned as a blue pending preview while the new-id card took the result. Streamed tool cards are now re-keyed in place when their id changes, using the block's position in the streaming message as a stable identity ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
 
 ## [17.1.7] - 2026-07-27

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a tool card rendering twice after an assistant turn that streamed the call ended with `error`/`aborted` and was retried or rewound (a provider blip that auto-retries, a TTSR rewind). The failed attempt's never-run cards were only sealed in place, so the retry's fresh cards rendered each call a second time; they are now retracted from the live region (and forgotten) at `message_end`, with a card already committed to native scrollback sealed in place as before ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
+
 ## [17.1.7] - 2026-07-27
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a tool card rendering twice after an assistant turn that streamed the call ended with `error`/`aborted` and was retried or rewound (a provider blip that auto-retries, a TTSR rewind). The failed attempt's never-run cards were only sealed in place, so the retry's fresh cards rendered each call a second time; they are now retracted from the live region (and forgotten) at `message_end`, with a card already committed to native scrollback sealed in place as before ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
+- Fixed two remaining tool-card double renders: a failed/aborted assistant attempt now retracts never-run cards before a retry or TTSR rewind re-streams them, and a successful read whose persisted result wins a transcript-rebuild race no longer creates a fallback read group when its delayed live completion arrives ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed two remaining tool-card double renders: a failed/aborted assistant attempt now retracts never-run cards before a retry or TTSR rewind re-streams them, and a successful read whose persisted result wins a transcript-rebuild race no longer creates a fallback read group when its delayed live completion arrives ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
+- Fixed a tool card rendering twice when the provider rewrites a streamed tool call's id mid-stream — GitHub Copilot's `call_id|id` transport, or any stream that delivers the tool name/arguments before the id — so the block appears first with an empty or partial id and is populated in a later delta. The transcript keyed the live card by that mutable id, so the changed id spawned a second card: the old-id card orphaned as a blue pending preview while the new-id card took the result. Streamed tool cards are now re-keyed in place when their id changes, using the block's position in the streaming message as a stable identity ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
 
 ## [17.1.7] - 2026-07-27
 

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -357,6 +357,26 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
+	/**
+	 * Re-key an entry whose streamed tool-call id changed mid-stream (a provider
+	 * rewriting the id across deltas; see EventController's
+	 * `#streamedToolCallIdByIndex`). Preserves row order so a sibling read run is
+	 * not visibly reshuffled, and no-ops when the rename would collide.
+	 */
+	renameEntry(oldId: string, newId: string): void {
+		if (!oldId || oldId === newId) return;
+		const entry = this.#entries.get(oldId);
+		if (!entry || this.#entries.has(newId)) return;
+		entry.toolCallId = newId;
+		const reordered = [...this.#entries].map(([key, value]): [string, ReadEntry] => [
+			key === oldId ? newId : key,
+			value,
+		]);
+		this.#entries.clear();
+		for (const [key, value] of reordered) this.#entries.set(key, value);
+		this.#updateDisplay();
+	}
+
 	updateResult(
 		result: { content: Array<{ type: string; text?: string }>; details?: unknown; isError?: boolean },
 		isPartial = false,

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -101,12 +101,18 @@ export class EventController {
 	// preview while the new-id card takes the result (#6879). Reset per assistant
 	// message (indices are per-message).
 	#streamedToolCallIdByIndex = new Map<number, string>();
-	// An error/aborted assistant turn is followed by synthetic start/end events
-	// for every tool call the provider emitted but the agent never executed.
-	// Its uncommitted cards are retracted at message_end; retain their ids until
-	// those synthetic completions arrive so the normal no-pending path cannot
-	// recreate failed-attempt cards below the transcript (#6879).
+	// A TTSR rewind retracts its uncommitted never-run cards at message_end;
+	// retain their ids until agent-loop's synthetic tool_execution_start/end for
+	// those calls arrive so the normal no-pending path cannot recreate the
+	// retracted card below the rewind's fresh blocks (#6879).
 	#retractedToolCallIds = new Set<string>();
+	// Cards settled by a synthetic aborted/error `tool_execution_end` (agent-loop
+	// emits one per never-run call on a terminal error/abort). They stay visible
+	// for a genuinely terminal failure, but if an auto-retry then supersedes the
+	// turn (`auto_retry_start`, decided AFTER message_end) they must be removed so
+	// the retry's fresh cards do not render the same call twice (Codex review on
+	// #6881). Keyed by call id; reset per turn.
+	#syntheticFailureCards = new Map<string, ToolExecutionHandle>();
 	// Completions that arrived before any component existed for their call id.
 	// Cursor's server-resolved tools (todo) emit `tool_execution_end` through a
 	// synchronous callback fired mid-parse, while the `toolcall_start` for the
@@ -324,6 +330,18 @@ export class EventController {
 		// A collapsed read renders into a shared group keyed by id; rename its
 		// entry so the row isn't duplicated under the new id.
 		if (pending instanceof ReadToolGroupComponent) pending.renameEntry(oldId, newId);
+		// A server-resolved completion (Cursor/todo) can land under `newId` while
+		// the card was still keyed by `oldId`, so it was parked in
+		// `#orphanedToolCompletions` instead of settling. Now that the card owns
+		// `newId`, apply the held result — the normal creation path that consumes
+		// held completions is skipped on a re-key (Codex review on #6881).
+		if (pending) {
+			const orphan = this.#orphanedToolCompletions.get(newId);
+			if (orphan) {
+				this.#orphanedToolCompletions.delete(newId);
+				this.#settleHeldCompletion(pending, orphan);
+			}
+		}
 	}
 
 	#inlineReadToolImages(
@@ -404,6 +422,8 @@ export class EventController {
 		this.#lastIntent = undefined;
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
+		this.#retractedToolCallIds.clear();
+		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#backgroundTaskCallIds.clear();
@@ -494,6 +514,8 @@ export class EventController {
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
+		this.#retractedToolCallIds.clear();
+		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#lastIntent = undefined;
@@ -992,37 +1014,45 @@ export class EventController {
 					component.setArgsComplete(toolCallId);
 				}
 			} else {
-				// The turn ended without running these calls (abort/error/TTSR rewind),
-				// so they will never produce a result AND their assistant turn is
-				// dropped from the active context when a retry/rewind supersedes it.
-				// The retry then streams fresh tool blocks below these, so any left on
-				// screen render the same call twice (#6879, the parallel-probe screenshots
-				// on #6516's follow-up). Retract the ones still in the live region — they
-				// never reached native scrollback, so they are removable — and forget
-				// them (`pendingTools` + timeline) so a same-id retry rebuilds a fresh
-				// card instead of routing its deltas into the detached one. A block
-				// already committed to the scrollback tape cannot be retracted; seal it
-				// in place as history so it at least stops animating. Background task
-				// calls keep updating across the boundary, so preserve them.
-				for (const [toolCallId, component] of Array.from(this.ctx.pendingTools.entries())) {
-					if (this.#backgroundTaskCallIds.has(toolCallId)) continue;
-					if (!(component instanceof ToolExecutionComponent) && !(component instanceof ReadToolGroupComponent)) {
-						continue;
-					}
-					if (this.ctx.chatContainer.isBlockUncommitted(component)) {
-						component.seal();
-						if (component === this.#lastReadGroup) this.#resetReadGroup();
-						this.ctx.chatContainer.removeChild(component);
-						this.#retractedToolCallIds.add(toolCallId);
-						this.ctx.pendingTools.delete(toolCallId);
-						this.#toolTimelineComponents.delete(toolCallId);
-						this.#clearReadToolCall(toolCallId);
-					} else {
-						component.seal();
+				// The turn ended without running these calls. What happens next
+				// decides whether their cards should vanish or stay:
+				//   • TTSR rewind — known NOW via `isTtsrAbortPending` — re-runs the
+				//     turn and re-streams fresh cards, so retract the uncommitted
+				//     never-run cards here and swallow the synthetic completions
+				//     agent-loop emits for them, else the call renders twice (#6879).
+				//   • A plain terminal error/abort, or an auto-retry (whose
+				//     supersession is only known later at `auto_retry_start`), must
+				//     NOT be retracted here: agent-loop emits a synthetic
+				//     `tool_execution_end` right after this that settles each card
+				//     into a visible aborted/error result. Leave them so the terminal
+				//     failure stays visible; `#handleAutoRetryStart` removes them only
+				//     if a retry actually supersedes them (Codex review on #6881).
+				const supersededByRewind =
+					this.ctx.streamingMessage.stopReason === "aborted" && this.ctx.viewSession.isTtsrAbortPending;
+				if (supersededByRewind) {
+					for (const [toolCallId, component] of Array.from(this.ctx.pendingTools.entries())) {
+						if (this.#backgroundTaskCallIds.has(toolCallId)) continue;
+						if (
+							!(component instanceof ToolExecutionComponent) &&
+							!(component instanceof ReadToolGroupComponent)
+						) {
+							continue;
+						}
+						if (this.ctx.chatContainer.isBlockUncommitted(component)) {
+							component.seal();
+							if (component === this.#lastReadGroup) this.#resetReadGroup();
+							this.ctx.chatContainer.removeChild(component);
+							this.#retractedToolCallIds.add(toolCallId);
+							this.ctx.pendingTools.delete(toolCallId);
+							this.#toolTimelineComponents.delete(toolCallId);
+							this.#clearReadToolCall(toolCallId);
+						} else {
+							component.seal();
+						}
 					}
 				}
-				// These calls will never produce a result either, so the tracked
-				// waiting poll cannot be displaced anymore — freeze it in place.
+				// These calls will never run this attempt, so the tracked waiting
+				// poll cannot be displaced anymore — freeze it in place.
 				this.#resolveDisplaceablePoll();
 			}
 			// Surface a prompt-cache invalidation: if the previous turn cached a
@@ -1230,6 +1260,19 @@ export class EventController {
 		// assistant message. The matching card was deliberately retracted at
 		// message_end; consume the completion instead of recreating/updating UI.
 		if (this.#retractedToolCallIds.delete(event.toolCallId)) return;
+		// A synthetic aborted/error completion (agent-loop's placeholder for a
+		// never-run call on a terminal error/abort) settles the card in place so a
+		// terminal failure stays visible. Remember it so `#handleAutoRetryStart`
+		// can remove it if an auto-retry then supersedes the turn (Codex review on
+		// #6881). Capture the live component now — the settle path below drops it
+		// from `pendingTools` but leaves it in the transcript.
+		const syntheticFailureDetails = event.result.details as { __synthetic?: boolean; source?: string } | undefined;
+		const syntheticFailureCard =
+			syntheticFailureDetails?.__synthetic === true &&
+			(syntheticFailureDetails.source === "assistant_stop_error" ||
+				syntheticFailureDetails.source === "assistant_stop_aborted")
+				? this.ctx.pendingTools.get(event.toolCallId)
+				: undefined;
 		// A transient overlay (auto-compaction / auto-retry / handoff) that ran
 		// between this tool's start and end could have detached the working
 		// loader. `tool_execution_update` already reconciles this so the spinner
@@ -1327,6 +1370,7 @@ export class EventController {
 				this.#orphanedToolCompletions.set(event.toolCallId, event);
 			}
 		}
+		if (syntheticFailureCard) this.#syntheticFailureCards.set(event.toolCallId, syntheticFailureCard);
 		// Update todo display when todo tool completes
 		if (event.toolName === "todo" && !event.isError) {
 			const details = event.result.details as { phases?: TodoPhase[] } | undefined;
@@ -1434,6 +1478,8 @@ export class EventController {
 		this.#readToolCallAssistantComponents.clear();
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
+		this.#retractedToolCallIds.clear();
+		this.#syntheticFailureCards.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#resetReadGroup();
@@ -1607,6 +1653,21 @@ export class EventController {
 	async #handleAutoRetryStart(event: Extract<AgentSessionEvent, { type: "auto_retry_start" }>): Promise<void> {
 		this.#retryPending = true;
 		this.#trackRetrySupersededAssistantComponent(this.#lastAssistantComponent);
+		// A retry supersedes the just-failed turn: its assistant + tool calls are
+		// pruned from context and re-streamed. Remove the cards that a synthetic
+		// aborted/error completion settled in place at message_end so the retry's
+		// fresh cards don't render the same call twice (#6879). Only uncommitted
+		// cards are removable; one already on the scrollback tape stays as history.
+		for (const [toolCallId, component] of this.#syntheticFailureCards) {
+			if (this.ctx.chatContainer.isBlockUncommitted(component)) {
+				if (component === this.#lastReadGroup) this.#resetReadGroup();
+				this.ctx.chatContainer.removeChild(component);
+				this.ctx.pendingTools.delete(toolCallId);
+				this.#toolTimelineComponents.delete(toolCallId);
+				this.#clearReadToolCall(toolCallId);
+			}
+		}
+		this.#syntheticFailureCards.clear();
 		this.#stopWorkingLoader();
 		this.ctx.statusContainer.disposeChildren();
 		if (AIError.is(event.errorId, AIError.Flag.ThinkingLoop)) {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1196,6 +1196,17 @@ export class EventController {
 			} else {
 				let component = this.ctx.pendingTools.get(event.toolCallId);
 				if (!component) {
+					// A persisted result can win a mid-stream transcript rebuild
+					// before this live completion handler runs. Rebuild removes the
+					// pending handle and replay owns the completed card, but the
+					// original timeline entry remains as proof that a card already
+					// existed. Do not create a fallback read group beside replay
+					// (#6879); the fallback is only for a completion that genuinely
+					// outran every streamed card.
+					if (this.#toolTimelineComponents.has(event.toolCallId)) {
+						this.#clearReadToolCall(event.toolCallId);
+						return;
+					}
 					const group = this.#getReadGroup();
 					const args = this.#readToolCallArgs.get(event.toolCallId);
 					if (args) {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -923,11 +923,27 @@ export class EventController {
 				}
 			} else {
 				// The turn ended without running these calls (abort/error/TTSR rewind),
-				// so they will never produce a result. Seal them so they stop animating
-				// and freeze instead of pinning the transcript live region while a retry
-				// streams fresh blocks below them. Background task calls keep updating.
-				for (const [toolCallId, component] of this.ctx.pendingTools.entries()) {
-					if (!this.#backgroundTaskCallIds.has(toolCallId) && component instanceof ToolExecutionComponent) {
+				// so they will never produce a result AND their assistant turn is
+				// dropped from the active context when a retry/rewind supersedes it.
+				// The retry then streams fresh tool blocks below these, so any left on
+				// screen render the same call twice (#6879, the parallel-probe screenshots
+				// on #6516's follow-up). Retract the ones still in the live region — they
+				// never reached native scrollback, so they are removable — and forget
+				// them (`pendingTools` + timeline) so a same-id retry rebuilds a fresh
+				// card instead of routing its deltas into the detached one. A block
+				// already committed to the scrollback tape cannot be retracted; seal it
+				// in place as history so it at least stops animating. Background task
+				// calls keep updating across the boundary, so preserve them.
+				for (const [toolCallId, component] of Array.from(this.ctx.pendingTools.entries())) {
+					if (this.#backgroundTaskCallIds.has(toolCallId)) continue;
+					if (!(component instanceof ToolExecutionComponent) && !(component instanceof ReadToolGroupComponent)) {
+						continue;
+					}
+					if (this.ctx.chatContainer.isBlockUncommitted(component)) {
+						this.ctx.chatContainer.removeChild(component);
+						this.ctx.pendingTools.delete(toolCallId);
+						this.#toolTimelineComponents.delete(toolCallId);
+					} else {
 						component.seal();
 					}
 				}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -89,6 +89,12 @@ export class EventController {
 	#readToolCallArgs = new Map<string, Record<string, unknown>>();
 	#readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
 	#toolTimelineComponents = new Map<string, Component>();
+	// An error/aborted assistant turn is followed by synthetic start/end events
+	// for every tool call the provider emitted but the agent never executed.
+	// Its uncommitted cards are retracted at message_end; retain their ids until
+	// those synthetic completions arrive so the normal no-pending path cannot
+	// recreate failed-attempt cards below the transcript (#6879).
+	#retractedToolCallIds = new Set<string>();
 	// Completions that arrived before any component existed for their call id.
 	// Cursor's server-resolved tools (todo) emit `tool_execution_end` through a
 	// synchronous callback fired mid-parse, while the `toolcall_start` for the
@@ -943,6 +949,7 @@ export class EventController {
 						component.seal();
 						if (component === this.#lastReadGroup) this.#resetReadGroup();
 						this.ctx.chatContainer.removeChild(component);
+						this.#retractedToolCallIds.add(toolCallId);
 						this.ctx.pendingTools.delete(toolCallId);
 						this.#toolTimelineComponents.delete(toolCallId);
 						this.#clearReadToolCall(toolCallId);
@@ -1003,6 +1010,7 @@ export class EventController {
 	}
 
 	async #handleToolExecutionStart(event: Extract<AgentSessionEvent, { type: "tool_execution_start" }>): Promise<void> {
+		if (this.#retractedToolCallIds.has(event.toolCallId)) return;
 		this.#ensureWorkingLoaderWhileStreaming();
 		this.#updateWorkingMessageFromIntent(event.intent);
 		if (event.toolName === "ask" || this.#toolWillPromptForApproval(event.toolName, event.args)) {
@@ -1154,6 +1162,10 @@ export class EventController {
 	}
 
 	async #handleToolExecutionEnd(event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>): Promise<void> {
+		// `createAbortedToolResult` emits start/end after an error/aborted
+		// assistant message. The matching card was deliberately retracted at
+		// message_end; consume the completion instead of recreating/updating UI.
+		if (this.#retractedToolCallIds.delete(event.toolCallId)) return;
 		// A transient overlay (auto-compaction / auto-retry / handoff) that ran
 		// between this tool's start and end could have detached the working
 		// loader. `tool_execution_update` already reconciles this so the spinner

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -940,6 +940,7 @@ export class EventController {
 						continue;
 					}
 					if (this.ctx.chatContainer.isBlockUncommitted(component)) {
+						component.seal();
 						if (component === this.#lastReadGroup) this.#resetReadGroup();
 						this.ctx.chatContainer.removeChild(component);
 						this.ctx.pendingTools.delete(toolCallId);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -940,9 +940,11 @@ export class EventController {
 						continue;
 					}
 					if (this.ctx.chatContainer.isBlockUncommitted(component)) {
+						if (component === this.#lastReadGroup) this.#resetReadGroup();
 						this.ctx.chatContainer.removeChild(component);
 						this.ctx.pendingTools.delete(toolCallId);
 						this.#toolTimelineComponents.delete(toolCallId);
+						this.#clearReadToolCall(toolCallId);
 					} else {
 						component.seal();
 					}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -89,6 +89,18 @@ export class EventController {
 	#readToolCallArgs = new Map<string, Record<string, unknown>>();
 	#readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
 	#toolTimelineComponents = new Map<string, Component>();
+	// Stable identity for a streamed tool call while its assistant message is
+	// live: maps the tool-call block's position in the streaming message to the
+	// id last seen at that position. A streamed id can CHANGE across cumulative
+	// `message_update`s — some providers (GitHub Copilot's `call_id|id`
+	// transport, any stream that delivers name/args before the id) emit the
+	// block with an empty or partial id first and rewrite it in a later delta
+	// (openai-completions sets `id: toolCall.id || ""` then overwrites on the
+	// next chunk). Keyed only by id, the changed id reads as a brand-new call
+	// and a second card is created — the old-id card orphans as a pending
+	// preview while the new-id card takes the result (#6879). Reset per assistant
+	// message (indices are per-message).
+	#streamedToolCallIdByIndex = new Map<number, string>();
 	// An error/aborted assistant turn is followed by synthetic start/end events
 	// for every tool call the provider emitted but the agent never executed.
 	// Its uncommitted cards are retracted at message_end; retain their ids until
@@ -274,6 +286,46 @@ export class EventController {
 		this.#readToolCallAssistantComponents.delete(toolCallId);
 	}
 
+	/**
+	 * Re-key a live streamed tool card whose id changed mid-stream (see
+	 * {@link #streamedToolCallIdByIndex}). Moves every id-keyed tracker from the
+	 * old id to the new one so the next cumulative `message_update` reuses the
+	 * existing card instead of creating a duplicate (#6879). The card component
+	 * itself is id-agnostic (routing is via `pendingTools`), so only the maps and
+	 * the shared read group's entry need re-keying.
+	 */
+	#migrateStreamedToolCallId(oldId: string, newId: string): void {
+		// `oldId` may be "" (the block streamed before its id): that empty key still
+		// owns a live card and must migrate. Skip only a no-op or an empty target.
+		if (oldId === newId || !newId) return;
+		const pending = this.ctx.pendingTools.get(oldId);
+		if (pending && !this.ctx.pendingTools.has(newId)) {
+			this.ctx.pendingTools.delete(oldId);
+			this.ctx.pendingTools.set(newId, pending);
+		}
+		const timeline = this.#toolTimelineComponents.get(oldId);
+		if (timeline && !this.#toolTimelineComponents.has(newId)) {
+			this.#toolTimelineComponents.delete(oldId);
+			this.#toolTimelineComponents.set(newId, timeline);
+		}
+		// The reveal controller is id-keyed; drop the stale target so the loop's
+		// setTarget/bind under the new id owns the paced reveal.
+		this.#toolArgsReveal.finish(oldId);
+		const readArgs = this.#readToolCallArgs.get(oldId);
+		if (readArgs !== undefined) {
+			this.#readToolCallArgs.delete(oldId);
+			this.#readToolCallArgs.set(newId, readArgs);
+		}
+		const readAssistant = this.#readToolCallAssistantComponents.get(oldId);
+		if (readAssistant !== undefined) {
+			this.#readToolCallAssistantComponents.delete(oldId);
+			this.#readToolCallAssistantComponents.set(newId, readAssistant);
+		}
+		// A collapsed read renders into a shared group keyed by id; rename its
+		// entry so the row isn't duplicated under the new id.
+		if (pending instanceof ReadToolGroupComponent) pending.renameEntry(oldId, newId);
+	}
+
 	#inlineReadToolImages(
 		toolCallId: string,
 		result: { content: Array<{ type: string; data?: string; mimeType?: string }> },
@@ -351,6 +403,7 @@ export class EventController {
 		this.#renderedCustomMessages.clear();
 		this.#lastIntent = undefined;
 		this.#toolTimelineComponents.clear();
+		this.#streamedToolCallIdByIndex.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#backgroundTaskCallIds.clear();
@@ -440,6 +493,7 @@ export class EventController {
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
 		this.#toolTimelineComponents.clear();
+		this.#streamedToolCallIdByIndex.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#lastIntent = undefined;
@@ -539,6 +593,7 @@ export class EventController {
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "assistant") {
 			this.#lastVisibleBlockCount = 0;
+			this.#streamedToolCallIdByIndex.clear();
 			this.ctx.streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingMessage = event.message;
 			this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
@@ -750,8 +805,17 @@ export class EventController {
 			if (this.ctx.streamingMessage.content.some(content => content.type === "toolCall")) {
 				this.ctx.streamingComponent.markTranscriptBlockFinalized();
 			}
-			for (const content of this.ctx.streamingMessage.content) {
+			for (let contentIndex = 0; contentIndex < this.ctx.streamingMessage.content.length; contentIndex++) {
+				const content = this.ctx.streamingMessage.content[contentIndex]!;
 				if (content.type !== "toolCall") continue;
+				// Re-key the live card when a provider rewrites this block's id
+				// across deltas, so the changed id reuses the existing card
+				// instead of spawning a duplicate (#6879).
+				const priorId = this.#streamedToolCallIdByIndex.get(contentIndex);
+				if (priorId !== undefined && priorId !== content.id) {
+					this.#migrateStreamedToolCallId(priorId, content.id);
+				}
+				this.#streamedToolCallIdByIndex.set(contentIndex, content.id);
 				if (content.name === "read") {
 					if (!readArgsHaveTarget(content.arguments)) {
 						// Args still streaming — defer until path is parseable so we can route to the
@@ -1369,6 +1433,7 @@ export class EventController {
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
 		this.#toolTimelineComponents.clear();
+		this.#streamedToolCallIdByIndex.clear();
 		this.#orphanedToolCompletions.clear();
 		this.#postToolAssistantComponents.clear();
 		this.#resetReadGroup();

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -413,4 +413,80 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 
 		expect(countCommand(mode)).toBe(1);
 	});
+
+	it("re-keys a streamed tool card when its id is populated after the block appears", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+		await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		// Provider (e.g. GitHub Copilot) streams the tool block before its id: the
+		// first delta carries an empty id, a later delta populates it.
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([bashToolCall("")], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				partial: assistantMessage([bashToolCall("")], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		expect(countCommand(mode)).toBe(1);
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([bashToolCall("call-real")], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: "{}",
+				partial: assistantMessage([bashToolCall("call-real")], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		// The populated id must reuse the existing card, not spawn a second one.
+		expect(countCommand(mode)).toBe(1);
+		await ec.handleEvent({
+			type: "message_end",
+			message: assistantMessage([bashToolCall("call-real")], "toolUse"),
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+		await runToolCallToCompletion("call-real");
+		expect(countCommand(mode)).toBe(1);
+		// The result routes into the surviving card (no orphaned pending preview).
+		expect(Bun.stripANSI(mode.chatContainer.render(120).join("\n"))).toContain("(no output)");
+	});
+
+	it("re-keys a streamed tool card when its id grows across deltas (piped copilot id)", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+		await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([bashToolCall("call-x")], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				partial: assistantMessage([bashToolCall("call-x")], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([bashToolCall("call-x|abc123==")], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: "{}",
+				partial: assistantMessage([bashToolCall("call-x|abc123==")], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		expect(countCommand(mode)).toBe(1);
+		await ec.handleEvent({
+			type: "message_end",
+			message: assistantMessage([bashToolCall("call-x|abc123==")], "toolUse"),
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+		await runToolCallToCompletion("call-x|abc123==");
+		expect(countCommand(mode)).toBe(1);
+	});
 });

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -187,6 +187,25 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 
 		// Attempt 1: the tool call streams a card, then the turn errors out.
 		await streamToolCall("call-attempt-1", "error");
+		// agent-loop now pairs the failed assistant toolCall with a synthetic
+		// start/end event sequence. It must be absorbed rather than recreating
+		// the card that message_end just retracted.
+		await ec.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: "call-attempt-1",
+			toolName: "bash",
+			args: { command: CMD },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		await ec.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "call-attempt-1",
+			toolName: "bash",
+			result: {
+				content: [{ type: "text", text: "Tool call was not executed because the provider stream ended" }],
+				details: { __synthetic: true, source: "assistant_stop_error", executed: false },
+			},
+			isError: true,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
 		// The failed card is retracted immediately (never committed to scrollback),
 		// not left frozen on screen.
 		expect(countCommand(mode)).toBe(0);

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, ToolCall } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression for issue #6879 — a tool call renders twice (follow-up to #6516).
+ *
+ * When an assistant turn streams tool calls and then ends with `error` /
+ * `aborted` (a provider blip that auto-retries, a TTSR rewind), the streamed
+ * tool cards never execute and the whole turn is dropped from the active
+ * context. The retry then re-streams fresh cards. The failed attempt's cards
+ * were only *sealed* in place, so they lingered above the retry's copies and
+ * rendered each call twice — exactly the parallel-probe screenshots in #6879.
+ */
+const CMD = "which psql";
+
+const usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function bashToolCall(id: string): ToolCall {
+	return { type: "toolCall", id, name: "bash", arguments: { command: CMD } };
+}
+
+function assistantMessage(content: AssistantMessage["content"], stopReason: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage,
+		stopReason,
+		timestamp: 2,
+	} as unknown as AssistantMessage;
+}
+
+function countCommand(mode: InteractiveMode): number {
+	const rendered = Bun.stripANSI(mode.chatContainer.render(120).join("\n"));
+	let count = 0;
+	let index = 0;
+	while (true) {
+		const found = rendered.indexOf(`$ ${CMD}`, index);
+		if (found === -1) return count;
+		count++;
+		index = found + CMD.length;
+	}
+}
+
+describe("issue #6879 — tool output appears twice after a superseded turn", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "pause").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockReturnValue(process.stdin);
+		if (typeof process.stdin.setRawMode === "function") {
+			vi.spyOn(process.stdin, "setRawMode").mockReturnValue(process.stdin);
+		}
+
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-6879-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	async function streamToolCall(id: string, stopReason: string): Promise<void> {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([bashToolCall(id)], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall: bashToolCall(id),
+				partial: assistantMessage([bashToolCall(id)], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		await ec.handleEvent({
+			type: "message_end",
+			message: assistantMessage([bashToolCall(id)], stopReason),
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+	}
+
+	async function runToolCallToCompletion(id: string): Promise<void> {
+		const ec = mode.eventController;
+		await ec.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: id,
+			toolName: "bash",
+			args: { command: CMD },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		await ec.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: id,
+			toolName: "bash",
+			result: { content: [{ type: "text", text: "(no output)" }] },
+			isError: true,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+		await ec.handleEvent({ type: "message_end", message: assistantMessage([bashToolCall(id)], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+	}
+
+	it("retracts a superseded turn's never-run tool card so an auto-retry renders it once", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+
+		// Attempt 1: the tool call streams a card, then the turn errors out.
+		await streamToolCall("call-attempt-1", "error");
+		// The failed card is retracted immediately (never committed to scrollback),
+		// not left frozen on screen.
+		expect(countCommand(mode)).toBe(0);
+
+		await ec.handleEvent({
+			type: "auto_retry_start",
+			attempt: 1,
+			maxAttempts: 3,
+			delayMs: 0,
+			errorMessage: "overloaded",
+		} as Extract<AgentSessionEvent, { type: "auto_retry_start" }>);
+		await ec.handleEvent({ type: "auto_retry_end", success: true, attempt: 1 } as Extract<
+			AgentSessionEvent,
+			{ type: "auto_retry_end" }
+		>);
+
+		// Attempt 2 (retry) regenerates the call with a fresh id and runs it.
+		await streamToolCall("call-attempt-2", "toolUse");
+		await runToolCallToCompletion("call-attempt-2");
+
+		expect(countCommand(mode)).toBe(1);
+	});
+
+	it("retracts a TTSR-rewound turn's tool card so the re-run renders it once", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+
+		// Attempt 1: card streams, turn is aborted (rewind) before executing.
+		await streamToolCall("call-rewound", "aborted");
+		expect(countCommand(mode)).toBe(0);
+
+		// Fresh turn re-issues and completes the call.
+		await streamToolCall("call-rerun", "toolUse");
+		await runToolCallToCompletion("call-rerun");
+
+		expect(countCommand(mode)).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -23,6 +23,7 @@ import { TempDir } from "@oh-my-pi/pi-utils";
  * rendered each call twice — exactly the parallel-probe screenshots in #6879.
  */
 const CMD = "which psql";
+const READ_PATH = "src/index.ts";
 
 const usage = {
 	input: 1,
@@ -131,6 +132,34 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		} as Extract<AgentSessionEvent, { type: "message_end" }>);
 	}
 
+	async function streamReadToolCall(id: string, stopReason: string): Promise<void> {
+		const readCall: ToolCall = {
+			type: "toolCall",
+			id,
+			name: "read",
+			arguments: { path: READ_PATH, i: "Inspect entrypoint" },
+		};
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([readCall], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall: readCall,
+				partial: assistantMessage([readCall], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		await ec.handleEvent({
+			type: "message_end",
+			message: assistantMessage([readCall], stopReason),
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+	}
+
 	async function runToolCallToCompletion(id: string): Promise<void> {
 		const ec = mode.eventController;
 		await ec.handleEvent({
@@ -179,6 +208,36 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		await runToolCallToCompletion("call-attempt-2");
 
 		expect(countCommand(mode)).toBe(1);
+	});
+
+	it("resets a detached read group so the retry's grouped read stays visible", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+
+		await streamReadToolCall("read-rewound", "aborted");
+		expect(mode.pendingTools.has("read-rewound")).toBeFalse();
+
+		await streamReadToolCall("read-rerun", "toolUse");
+		const retryGroup = mode.pendingTools.get("read-rerun");
+		if (!retryGroup) throw new Error("Expected retry read group");
+		expect(mode.chatContainer.children).toContain(retryGroup);
+
+		await ec.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: "read-rerun",
+			toolName: "read",
+			args: { path: READ_PATH, i: "Inspect entrypoint" },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		await ec.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "read-rerun",
+			toolName: "read",
+			result: { content: [{ type: "text", text: "entrypoint contents" }] },
+			isError: false,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+
+		const rendered = Bun.stripANSI(mode.chatContainer.render(120).join("\n"));
+		expect(rendered).toContain(READ_PATH);
 	});
 
 	it("retracts a TTSR-rewound turn's tool card so the re-run renders it once", async () => {

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -9,18 +9,19 @@ import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 /**
  * Regression for issue #6879 — a tool call renders twice (follow-up to #6516).
  *
- * When an assistant turn streams tool calls and then ends with `error` /
- * `aborted` (a provider blip that auto-retries, a TTSR rewind), the streamed
- * tool cards never execute and the whole turn is dropped from the active
- * context. The retry then re-streams fresh cards. The failed attempt's cards
- * were only *sealed* in place, so they lingered above the retry's copies and
- * rendered each call twice — exactly the parallel-probe screenshots in #6879.
+ * Failed/aborted assistant attempts used to leave never-run cards above a
+ * retry's fresh copies. Separately, when a successful read's persisted result
+ * won a transcript-rebuild race, replay rendered the completed card before the
+ * live `tool_execution_end`; its no-pending fallback then added another read
+ * group. Both paths rendered one logical call more than once.
  */
 const CMD = "which psql";
 const READ_PATH = "src/index.ts";
@@ -303,6 +304,99 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 
 		const rendered = Bun.stripANSI(mode.chatContainer.render(120).join("\n"));
 		expect(rendered).toContain(READ_PATH);
+	});
+
+	it("keeps a successful internal read single when replay beats its live completion", async () => {
+		const ec = mode.eventController;
+		const memoryPath = "memory://root/rollout_summaries/successful-read";
+		const readCall: ToolCall = {
+			type: "toolCall",
+			id: "read-success",
+			name: "read",
+			arguments: { path: memoryPath, i: "Read successful memory" },
+		};
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+		await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([readCall], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall: readCall,
+				partial: assistantMessage([readCall], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		await ec.handleEvent({
+			type: "message_end",
+			message: assistantMessage([readCall], "toolUse"),
+		} as Extract<AgentSessionEvent, { type: "message_end" }>);
+		await ec.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: readCall.id,
+			toolName: readCall.name,
+			args: readCall.arguments,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "user-success",
+				parentId: null,
+				timestamp: Date.now(),
+				message: { role: "user", content: [{ type: "text", text: "read memory" }], timestamp: 1 },
+			},
+			{
+				type: "message",
+				id: "assistant-success",
+				parentId: "user-success",
+				timestamp: Date.now(),
+				message: assistantMessage([readCall], "toolUse"),
+			},
+			{
+				type: "message",
+				id: "result-success",
+				parentId: "assistant-success",
+				timestamp: Date.now(),
+				message: {
+					role: "toolResult",
+					toolCallId: readCall.id,
+					toolName: readCall.name,
+					content: [{ type: "text", text: "successful memory contents" }],
+					isError: false,
+					timestamp: 3,
+				},
+			},
+		] as unknown as SessionEntry[];
+		vi.spyOn(session, "buildTranscriptSessionContext").mockReturnValue(
+			buildSessionContext(entries, undefined, undefined, { transcript: true }),
+		);
+		mode.rebuildChatFromMessages();
+
+		const replayCards = mode.chatContainer.children.filter(child =>
+			Bun.stripANSI(child.render(120).join("\n")).includes(memoryPath),
+		);
+		expect(replayCards).toHaveLength(1);
+		const replayChildCount = mode.chatContainer.children.length;
+
+		// Persistence/replay won the race; the delayed live completion must not
+		// create a fallback read group beside the completed replay card.
+		await ec.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: readCall.id,
+			toolName: readCall.name,
+			result: { content: [{ type: "text", text: "successful memory contents" }] },
+			isError: false,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+
+		const matchingCards = mode.chatContainer.children.filter(child =>
+			Bun.stripANSI(child.render(120).join("\n")).includes(memoryPath),
+		);
+		expect(matchingCards).toHaveLength(1);
+		expect(mode.chatContainer.children).toHaveLength(replayChildCount);
 	});
 
 	it("retracts a TTSR-rewound turn's tool card so the re-run renders it once", async () => {

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -210,6 +210,52 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		expect(countCommand(mode)).toBe(1);
 	});
 
+	it("stops an animated tool card before retracting it", async () => {
+		vi.useFakeTimers();
+		try {
+			const ec = mode.eventController;
+			const requestComponentRender = vi.spyOn(mode.ui, "requestComponentRender");
+			const writeCall: ToolCall = {
+				type: "toolCall",
+				id: "write-rewound",
+				name: "write",
+				arguments: { path: "out.txt", content: "pending content", i: "Write output" },
+			};
+			await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+			await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+				AgentSessionEvent,
+				{ type: "message_start" }
+			>);
+			await ec.handleEvent({
+				type: "message_update",
+				message: assistantMessage([writeCall], "toolUse"),
+				assistantMessageEvent: {
+					type: "toolcall_end",
+					contentIndex: 0,
+					toolCall: writeCall,
+					partial: assistantMessage([writeCall], "toolUse"),
+				},
+			} as Extract<AgentSessionEvent, { type: "message_update" }>);
+			const writeComponent = mode.pendingTools.get(writeCall.id);
+			if (!writeComponent) throw new Error("Expected animated write component");
+
+			vi.advanceTimersByTime(500);
+			expect(requestComponentRender.mock.calls.some(call => call[0] === writeComponent)).toBeTrue();
+			requestComponentRender.mockClear();
+
+			await ec.handleEvent({
+				type: "message_end",
+				message: assistantMessage([writeCall], "aborted"),
+			} as Extract<AgentSessionEvent, { type: "message_end" }>);
+			expect(mode.pendingTools.has(writeCall.id)).toBeFalse();
+
+			vi.advanceTimersByTime(1_000);
+			expect(requestComponentRender.mock.calls.some(call => call[0] === writeComponent)).toBeFalse();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("resets a detached read group so the retry's grouped read stays visible", async () => {
 		const ec = mode.eventController;
 		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);

--- a/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
+++ b/packages/coding-agent/test/repro-issue-6879-tool-double-render-retry.test.ts
@@ -182,35 +182,54 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		>);
 	}
 
-	it("retracts a superseded turn's never-run tool card so an auto-retry renders it once", async () => {
-		const ec = mode.eventController;
-		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+	function enableTtsrRewind(pending: boolean): void {
+		Object.defineProperty(session, "isTtsrAbortPending", { configurable: true, get: () => pending });
+	}
 
-		// Attempt 1: the tool call streams a card, then the turn errors out.
-		await streamToolCall("call-attempt-1", "error");
-		// agent-loop now pairs the failed assistant toolCall with a synthetic
-		// start/end event sequence. It must be absorbed rather than recreating
-		// the card that message_end just retracted.
+	async function emitSyntheticAbort(id: string, source: string): Promise<void> {
+		const ec = mode.eventController;
 		await ec.handleEvent({
 			type: "tool_execution_start",
-			toolCallId: "call-attempt-1",
+			toolCallId: id,
 			toolName: "bash",
 			args: { command: CMD },
 		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
 		await ec.handleEvent({
 			type: "tool_execution_end",
-			toolCallId: "call-attempt-1",
+			toolCallId: id,
 			toolName: "bash",
 			result: {
-				content: [{ type: "text", text: "Tool call was not executed because the provider stream ended" }],
-				details: { __synthetic: true, source: "assistant_stop_error", executed: false },
+				content: [{ type: "text", text: "Tool execution was aborted." }],
+				details: { __synthetic: true, source, executed: false },
 			},
 			isError: true,
 		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
-		// The failed card is retracted immediately (never committed to scrollback),
-		// not left frozen on screen.
-		expect(countCommand(mode)).toBe(0);
+	}
 
+	it("keeps a terminally failed turn's tool card visible via its synthetic result", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+
+		// The turn errors after streaming the call; agent-loop then emits a
+		// synthetic aborted result for the never-run call. No retry follows.
+		await streamToolCall("call-terminal", "error");
+		await emitSyntheticAbort("call-terminal", "assistant_stop_error");
+
+		// The card stays visible (settled with the failure) instead of vanishing.
+		expect(countCommand(mode)).toBe(1);
+	});
+
+	it("removes a synthetic-settled failed card when an auto-retry supersedes the turn", async () => {
+		const ec = mode.eventController;
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+
+		// Attempt 1 errors; the synthetic result settles the card in place.
+		await streamToolCall("call-attempt-1", "error");
+		await emitSyntheticAbort("call-attempt-1", "assistant_stop_error");
+		expect(countCommand(mode)).toBe(1);
+
+		// The retry supersedes the turn: the settled failed card is removed so the
+		// retry's fresh card does not render the call twice.
 		await ec.handleEvent({
 			type: "auto_retry_start",
 			attempt: 1,
@@ -218,21 +237,21 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 			delayMs: 0,
 			errorMessage: "overloaded",
 		} as Extract<AgentSessionEvent, { type: "auto_retry_start" }>);
+		expect(countCommand(mode)).toBe(0);
 		await ec.handleEvent({ type: "auto_retry_end", success: true, attempt: 1 } as Extract<
 			AgentSessionEvent,
 			{ type: "auto_retry_end" }
 		>);
 
-		// Attempt 2 (retry) regenerates the call with a fresh id and runs it.
 		await streamToolCall("call-attempt-2", "toolUse");
 		await runToolCallToCompletion("call-attempt-2");
-
 		expect(countCommand(mode)).toBe(1);
 	});
 
-	it("stops an animated tool card before retracting it", async () => {
+	it("stops and retracts an animated tool card on a TTSR rewind", async () => {
 		vi.useFakeTimers();
 		try {
+			enableTtsrRewind(true);
 			const ec = mode.eventController;
 			const requestComponentRender = vi.spyOn(mode.ui, "requestComponentRender");
 			const writeCall: ToolCall = {
@@ -263,6 +282,7 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 			expect(requestComponentRender.mock.calls.some(call => call[0] === writeComponent)).toBeTrue();
 			requestComponentRender.mockClear();
 
+			// TTSR rewind is known at message_end (isTtsrAbortPending): retract now.
 			await ec.handleEvent({
 				type: "message_end",
 				message: assistantMessage([writeCall], "aborted"),
@@ -276,13 +296,15 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		}
 	});
 
-	it("resets a detached read group so the retry's grouped read stays visible", async () => {
+	it("resets a detached read group on a TTSR rewind so the re-run stays visible", async () => {
 		const ec = mode.eventController;
 		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
 
+		enableTtsrRewind(true);
 		await streamReadToolCall("read-rewound", "aborted");
 		expect(mode.pendingTools.has("read-rewound")).toBeFalse();
 
+		enableTtsrRewind(false);
 		await streamReadToolCall("read-rerun", "toolUse");
 		const retryGroup = mode.pendingTools.get("read-rerun");
 		if (!retryGroup) throw new Error("Expected retry read group");
@@ -403,11 +425,13 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		const ec = mode.eventController;
 		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
 
-		// Attempt 1: card streams, turn is aborted (rewind) before executing.
+		// Attempt 1: card streams, turn is aborted for a TTSR rewind.
+		enableTtsrRewind(true);
 		await streamToolCall("call-rewound", "aborted");
 		expect(countCommand(mode)).toBe(0);
 
 		// Fresh turn re-issues and completes the call.
+		enableTtsrRewind(false);
 		await streamToolCall("call-rerun", "toolUse");
 		await runToolCallToCompletion("call-rerun");
 
@@ -488,5 +512,50 @@ describe("issue #6879 — tool output appears twice after a superseded turn", ()
 		} as Extract<AgentSessionEvent, { type: "message_end" }>);
 		await runToolCallToCompletion("call-x|abc123==");
 		expect(countCommand(mode)).toBe(1);
+	});
+
+	it("settles a held server-resolved completion after the tool-call id is re-keyed", async () => {
+		const ec = mode.eventController;
+		const todoAt = (id: string): ToolCall => ({ type: "toolCall", id, name: "todo", arguments: {} });
+		await ec.handleEvent({ type: "agent_start" } as Extract<AgentSessionEvent, { type: "agent_start" }>);
+		await ec.handleEvent({ type: "message_start", message: assistantMessage([], "toolUse") } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		// The todo block streams before its id (placeholder empty id).
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([todoAt("")], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				partial: assistantMessage([todoAt("")], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		// A server-resolved completion (Cursor todo) arrives under the REAL id
+		// before the id delta — no card is keyed by it yet, so it is held.
+		await ec.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: "todo-real",
+			toolName: "todo",
+			result: { content: [{ type: "text", text: "todo done" }], details: { phases: [] } },
+			isError: false,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+		expect(mode.pendingTools.has("todo-real")).toBeFalse();
+
+		// A later delta fills the real id: the re-key must consume the held
+		// completion and settle the migrated card, not leave it pending.
+		await ec.handleEvent({
+			type: "message_update",
+			message: assistantMessage([todoAt("todo-real")], "toolUse"),
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: "{}",
+				partial: assistantMessage([todoAt("todo-real")], "toolUse"),
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		expect(mode.pendingTools.has("todo-real")).toBeFalse();
+		expect(mode.pendingTools.has("")).toBeFalse();
 	});
 });


### PR DESCRIPTION
## Repro
When an assistant turn streams tool calls and then ends with `error`/`aborted` — a provider blip that auto-retries, or a TTSR rewind — the streamed tool cards never execute and the whole turn is dropped from the active context. The retry re-streams fresh cards, so each call renders twice, matching the reporter's screenshots (parallel `which …` probes and parallel `memory://` reads, every one duplicated). Driving `EventController` through that sequence (`message_update` streams a bash card → `message_end(error)` → `auto_retry_*` → retry re-streams with a new id → `tool_execution_end`) rendered `$ which psql` twice. Test: `bun test test/repro-issue-6879-tool-double-render-retry.test.ts`.

## Cause
`EventController#handleMessageEnd` (`packages/coding-agent/src/modes/controllers/event-controller.ts`), in the `aborted`/`error` branch, only *sealed* (froze) the turn's still-pending foreground tool cards in place. Those cards never produced a result and their assistant turn is pruned from context on retry/rewind (`#removeAssistantMessageFromActiveContext`), but the sealed UI components lingered in `chatContainer` above the retry's fresh cards — so the same call rendered twice. This is a distinct path from the mid-stream rebuild dedup fixed for #6516 (#6519).

## Fix
- In the `aborted`/`error` branch of `#handleMessageEnd`, retract each never-run pending tool card (`ToolExecutionComponent` or `ReadToolGroupComponent`) that is still in the live region — `chatContainer.isBlockUncommitted(component)` confirms none of its rows reached native scrollback, so it is safely removable — via `removeChild`, and forget it from `pendingTools` and `#toolTimelineComponents` so a same-id retry rebuilds a fresh card instead of routing into the detached one.
- A card already committed to the scrollback tape cannot be retracted, so it is still `seal()`-ed in place as before. Background task calls are preserved (they keep updating across the boundary).

## Verification
- `bun test test/repro-issue-6879-tool-double-render-retry.test.ts` — 2 pass (auto-retry after `error`; TTSR rewind after `aborted`); each asserts the failed card is retracted (count 0) and the re-run renders the tool exactly once (count 1). Pre-fix the same probe rendered it twice.
- Regression: `bun test test/repro-issue-6516-tool-double-render.test.ts test/event-controller-mixed-assistant-render.test.ts test/event-controller-abort-render.test.ts test/event-controller-error-banner.test.ts test/event-controller-cursor-todo.test.ts test/compaction-lifecycle.test.ts` — 35 pass.

Fixes #6879