### PR TITLE
feat(coding-agent): add forked task context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,7 +120,7 @@
 
 ### Added
 
-- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, read-only fork execution, safe fresh fallback, and cache-read result metadata.
+- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, read-only fork execution, fresh fallback when parent context is unavailable, and cache-read result metadata. Forked tasks continue with inherited context when child tools differ, accepting a provider cache miss.
 - Added omp cleanse, a new command that automatically detects language-ecosystem checkers, parses diagnostics (such as Cargo Clippy JSON), distributes repair workloads across concurrent subagents, and runs verification checks with a live progress bar.
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,6 +120,7 @@
 
 ### Added
 
+- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, read-only fork execution, safe fresh fallback, and cache-read result metadata.
 - Added omp cleanse, a new command that automatically detects language-ecosystem checkers, parses diagnostics (such as Cargo Clippy JSON), distributes repair workloads across concurrent subagents, and runs verification checks with a live progress bar.
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -125,11 +125,13 @@
 
 ### Changed
 
+- Changed default task subagents without an explicit tool catalog to inherit the parent's active tools.
 - Reworked the /guided-goal command from a modal-based popup flow into a natural, conversational chat interface where the agent asks follow-up questions directly in the session.
 - Reduced startup memory usage by lazy-loading HTML session export assets only on their first use.
 
 ### Fixed
 
+- Fixed completed background task artifact paths being omitted from aggregate task details.
 - Fixed Advisor notes appending stale-review-window warnings when newer primary turns are queued during a review.
 - Fixed layout padding alignment issues in bordered output blocks and web-search result panels.
 - Fixed excluded web search providers remaining visible in the Web Search Provider Order settings list.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,12 +120,12 @@
 
 ### Added
 
-- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, read-only fork execution, fresh fallback when parent context is unavailable, and cache-read result metadata. Forked tasks continue with inherited context when child tools differ, accepting a provider cache miss.
+- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, fresh fallback when parent context is unavailable, and cache-read result metadata. Source selection preserves the selected agent's normal tools, and forked tasks continue with inherited context when child tools differ, accepting a provider cache miss.
 - Added omp cleanse, a new command that automatically detects language-ecosystem checkers, parses diagnostics (such as Cargo Clippy JSON), distributes repair workloads across concurrent subagents, and runs verification checks with a live progress bar.
 
 ### Changed
 
-- Changed default task subagents without an explicit tool catalog to inherit the parent's active tools.
+
 - Reworked the /guided-goal command from a modal-based popup flow into a natural, conversational chat interface where the agent asks follow-up questions directly in the session.
 - Reduced startup memory usage by lazy-loading HTML session export assets only on their first use.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,7 +120,7 @@
 
 ### Added
 
-- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, fresh fallback when parent context is unavailable, and cache-read result metadata. Source selection preserves the selected agent's normal tools, and forked tasks continue with inherited context when child tools differ, accepting a provider cache miss.
+- Added `fresh`, `fork`, and `auto` context sources to the task tool, including completed-parent conversation cloning, prompt-cache lineage inheritance, read-only fork execution, fresh fallback when parent context is unavailable, and cache-read result metadata. Forked tasks continue with inherited context when child tools differ, accepting a provider cache miss.
 - Added omp cleanse, a new command that automatically detects language-ecosystem checkers, parses diagnostics (such as Cargo Clippy JSON), distributes repair workloads across concurrent subagents, and runs verification checks with a live progress bar.
 
 ### Changed

--- a/packages/coding-agent/src/prompts/system/fork-task-context.md
+++ b/packages/coding-agent/src/prompts/system/fork-task-context.md
@@ -1,0 +1,16 @@
+<system-notice cause="task-fork">
+The conversation above is inherited from the parent session. Handle only the immediate delegated assignment that follows this notice.
+
+- Use inherited context to understand prior requirements and decisions.
+- You MAY inspect, audit, and reason about parent-session work when the immediate assignment names or requires it.
+- Do not resume unrelated parent TODOs, plans, or unfinished work.
+- This fork is read-only. Do not edit files or run commands that can mutate the workspace; return findings to the parent.
+{{#if context}}
+Shared batch contract:
+{{context}}
+{{/if}}
+{{#if outputSchema}}
+Return JSON that satisfies this schema:
+{{outputSchema}}
+{{/if}}
+</system-notice>

--- a/packages/coding-agent/src/prompts/system/fork-task-context.md
+++ b/packages/coding-agent/src/prompts/system/fork-task-context.md
@@ -4,7 +4,7 @@ The conversation above is inherited from the parent session. Handle the explicit
 - Use inherited context to understand prior requirements and decisions.
 - You MAY inspect, audit, and reason about parent-session work when the immediate assignment names or requires it.
 - Do not resume unrelated parent TODOs, plans, or unfinished work. Later explicit messages from the parent are valid follow-up assignments.
-- This fork is read-only. Do not edit files or run commands that can mutate the workspace; return findings to the parent.
+
 {{#if context}}
 Shared batch contract:
 {{context}}

--- a/packages/coding-agent/src/prompts/system/fork-task-context.md
+++ b/packages/coding-agent/src/prompts/system/fork-task-context.md
@@ -1,9 +1,9 @@
 <system-notice cause="task-fork">
-The conversation above is inherited from the parent session. Handle only the immediate delegated assignment that follows this notice.
+The conversation above is inherited from the parent session. Handle the explicit delegated assignments you receive after this notice.
 
 - Use inherited context to understand prior requirements and decisions.
 - You MAY inspect, audit, and reason about parent-session work when the immediate assignment names or requires it.
-- Do not resume unrelated parent TODOs, plans, or unfinished work.
+- Do not resume unrelated parent TODOs, plans, or unfinished work. Later explicit messages from the parent are valid follow-up assignments.
 - This fork is read-only. Do not edit files or run commands that can mutate the workspace; return findings to the parent.
 {{#if context}}
 Shared batch contract:

--- a/packages/coding-agent/src/prompts/system/fork-task-context.md
+++ b/packages/coding-agent/src/prompts/system/fork-task-context.md
@@ -4,7 +4,7 @@ The conversation above is inherited from the parent session. Handle the explicit
 - Use inherited context to understand prior requirements and decisions.
 - You MAY inspect, audit, and reason about parent-session work when the immediate assignment names or requires it.
 - Do not resume unrelated parent TODOs, plans, or unfinished work. Later explicit messages from the parent are valid follow-up assignments.
-
+- This fork is read-only. Do not edit files or run commands that can mutate the workspace; return findings to the parent.
 {{#if context}}
 Shared batch contract:
 {{context}}

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -25,7 +25,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-  - `source`: `fresh` starts blank. `fork` inherits the completed parent conversation. `auto` forks when the parent context is available and otherwise starts fresh. Source selection does not change the selected agent's tools. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` when prior conversation context is important and `fresh` for independent work.
+  - `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when the parent context is available and otherwise starts fresh. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
@@ -41,7 +41,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
 - `agent`: The agent type to spawn (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-- `source`: `fresh` starts blank. `fork` inherits the completed parent conversation. `auto` forks when the parent context is available and otherwise starts fresh. Source selection does not change the selected agent's tools. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` when prior conversation context is important and `fresh` for independent work.
+- `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when the parent context is available and otherwise starts fresh. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -25,7 +25,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-  - `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when compatible and otherwise starts fresh. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
+  - `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when the parent context is available and otherwise starts fresh. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
@@ -41,7 +41,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
 - `agent`: The agent type to spawn (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-- `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when compatible and otherwise starts fresh. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
+- `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when the parent context is available and otherwise starts fresh. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -25,7 +25,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-  - `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when the parent context is available and otherwise starts fresh. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
+  - `source`: `fresh` starts blank. `fork` inherits the completed parent conversation. `auto` forks when the parent context is available and otherwise starts fresh. Source selection does not change the selected agent's tools. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` when prior conversation context is important and `fresh` for independent work.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
@@ -41,7 +41,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
 - `agent`: The agent type to spawn (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-- `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when the parent context is available and otherwise starts fresh. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
+- `source`: `fresh` starts blank. `fork` inherits the completed parent conversation. `auto` forks when the parent context is available and otherwise starts fresh. Source selection does not change the selected agent's tools. A fork can miss the provider prompt cache when the child tool catalog differs. Use `fork` when prior conversation context is important and `fresh` for independent work.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -25,6 +25,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
+  - `source`: `fresh` starts blank; `fork` inherits the completed parent conversation; `auto` forks when compatible and otherwise starts fresh. Prefer `fork` for context-heavy continuation and `fresh` for independent review.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
@@ -40,6 +41,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
 - `agent`: The agent type to spawn (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
+- `source`: `fresh` starts blank; `fork` inherits the completed parent conversation; `auto` forks when compatible and otherwise starts fresh. Prefer `fork` for context-heavy continuation and `fresh` for independent review.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
@@ -54,7 +56,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 {{/if}}
 
 # Communication
-Subagents start blank — no conversation history.{{#if ircEnabled}} Parent-to-subagent IRC delivered immediately as steering.{{/if}}
+Fresh subagents start blank. Forked subagents inherit the completed parent conversation, excluding the current task call.{{#if ircEnabled}} Parent-to-subagent IRC delivered immediately as steering.{{/if}}
 Pass large payloads via `local://<path>` URIs, NEVER inline text.
 
 # Format Contracts

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -25,7 +25,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
   - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-  - `source`: `fresh` starts blank; `fork` inherits the completed parent conversation; `auto` forks when compatible and otherwise starts fresh. Prefer `fork` for context-heavy continuation and `fresh` for independent review.
+  - `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when compatible and otherwise starts fresh. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
 {{#if effortEnabled}}  - `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
   - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.
@@ -41,7 +41,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
 - `agent`: The agent type to spawn (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
 - `task`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
-- `source`: `fresh` starts blank; `fork` inherits the completed parent conversation; `auto` forks when compatible and otherwise starts fresh. Prefer `fork` for context-heavy continuation and `fresh` for independent review.
+- `source`: `fresh` starts blank and can use the selected agent's normal tools. `fork` inherits the completed parent conversation but is always read-only. `auto` forks when compatible and otherwise starts fresh. Use `fork` only for context-heavy investigation or review; use `fresh` for implementation, independent review, or isolated worktree tasks.
 {{#if effortEnabled}}- `effort`: Scale w/ complexity of this task: `"lo"`|`"med"`|`"hi"`
 {{/if}}
 - `outputSchema`: Invocation-specific JSON Schema. Overrides the selected agent and parent-session schemas.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1698,11 +1698,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getSystemPrompt: () => session.systemPrompt,
 			getActiveToolNames: () => session.getActiveToolNames(),
 			getConfiguredThinkingLevel: () => session.configuredThinkingLevel(),
-			getPromptCacheKey: () => session.agent.promptCacheKey,
+			getPromptCacheKey: () => session.agent.promptCacheKey ?? providerSessionId,
 			getTaskForkLeafId: () => {
 				const leaf = sessionManager.getBranch().at(-1);
 				return leaf?.type === "message" && leaf.message.role === "assistant" ? leaf.parentId : (leaf?.id ?? null);
 			},
+
 			getEvalKernelOwnerId: () => evalKernelOwnerId,
 			getEvalSessionId: () =>
 				session?.getEvalSessionId() ?? options.parentEvalSessionId ?? defaultEvalSessionId(toolSession),

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1695,6 +1695,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			taskDepth: options.taskDepth ?? 0,
 			getSessionFile: () => sessionManager.getSessionFile() ?? null,
 			sessionManager,
+			getSystemPrompt: () => session.systemPrompt,
+			getActiveToolNames: () => session.getActiveToolNames(),
+			getConfiguredThinkingLevel: () => session.configuredThinkingLevel(),
+			getPromptCacheKey: () => session.agent.promptCacheKey,
+			getTaskForkLeafId: () => {
+				const leaf = sessionManager.getBranch().at(-1);
+				return leaf?.type === "message" && leaf.message.role === "assistant" ? leaf.parentId : (leaf?.id ?? null);
+			},
 			getEvalKernelOwnerId: () => evalKernelOwnerId,
 			getEvalSessionId: () =>
 				session?.getEvalSessionId() ?? options.parentEvalSessionId ?? defaultEvalSessionId(toolSession),

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1698,10 +1698,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getSystemPrompt: () => session.systemPrompt,
 			getActiveToolNames: () => session.getActiveToolNames(),
 			getConfiguredThinkingLevel: () => session.configuredThinkingLevel(),
-			getPromptCacheKey: () => session.agent.promptCacheKey ?? providerSessionId,
+			getPromptCacheKey: () => session.agent.promptCacheKey ?? session.sessionId,
 			getTaskForkLeafId: () => {
-				const leaf = sessionManager.getBranch().at(-1);
-				return leaf?.type === "message" && leaf.message.role === "assistant" ? leaf.parentId : (leaf?.id ?? null);
+				const branch = sessionManager.getBranch();
+				for (let index = branch.length - 1; index >= 0; index--) {
+					const entry = branch[index];
+					if (entry?.type === "message" && entry.message.role === "assistant") return entry.parentId;
+				}
+				return branch.at(-1)?.id ?? null;
 			},
 
 			getEvalKernelOwnerId: () => evalKernelOwnerId,

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2353,7 +2353,7 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { suppressBreadcrumb?: boolean; sessionFile?: string },
+		options?: { suppressBreadcrumb?: boolean; sessionFile?: string; sourceLeafId?: string | null },
 	): Promise<SessionManager> {
 		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
 		const manager = new SessionManager(cwd, dir, true, storage);
@@ -2364,7 +2364,19 @@ export class SessionManager {
 		await resolveBlobRefsInEntries(sourceEntries, manager.#blobs);
 
 		const sourceHeader = sourceEntries.find(entry => entry.type === "session") as SessionHeader | undefined;
-		const history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
+		let history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
+		if (options && "sourceLeafId" in options) {
+			const entriesById = new Map(history.map(entry => [entry.id, entry]));
+			const branch: SessionEntry[] = [];
+			let cursor = options.sourceLeafId ?? null;
+			while (cursor) {
+				const entry = entriesById.get(cursor);
+				if (!entry) throw new Error(`Fork source entry ${cursor} not found`);
+				branch.push(entry);
+				cursor = entry.parentId;
+			}
+			history = branch.reverse();
+		}
 		manager.#resetToNewSession(
 			{
 				parentSession: sourceHeader?.id,

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2353,7 +2353,12 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { suppressBreadcrumb?: boolean; sessionFile?: string; sourceLeafId?: string | null },
+		options?: {
+			suppressBreadcrumb?: boolean;
+			sessionFile?: string;
+			sourceLeafId?: string | null;
+			additionalDirectories?: readonly string[];
+		},
 	): Promise<SessionManager> {
 		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
 		const manager = new SessionManager(cwd, dir, true, storage);
@@ -2386,7 +2391,11 @@ export class SessionManager {
 		);
 		manager.#header.title = sourceHeader?.title;
 		manager.#header.titleSource = sourceHeader?.titleSource;
-		manager.#additionalDirectories = (sourceHeader?.additionalDirectories ?? []).filter(d => d !== path.resolve(cwd));
+		manager.#additionalDirectories = (
+			options?.additionalDirectories ??
+			sourceHeader?.additionalDirectories ??
+			[]
+		).filter(d => d !== path.resolve(cwd));
 		manager.#header.additionalDirectories =
 			manager.#additionalDirectories.length > 0 ? manager.#additionalDirectories : undefined;
 		manager.#sessionName = manager.#header.title;
@@ -2399,6 +2408,27 @@ export class SessionManager {
 		manager.#forceFileCreation = true;
 		await manager.#rewriteAtomically();
 		return manager;
+	}
+
+	/** Clone a completed branch through this manager's configured storage backend. */
+	async forkBranch(options: {
+		cwd: string;
+		sessionDir?: string;
+		sessionFile?: string;
+		sourceLeafId?: string | null;
+		additionalDirectories?: readonly string[];
+		suppressBreadcrumb?: boolean;
+	}): Promise<SessionManager> {
+		if (!this.#sessionFile) throw new Error("Cannot fork a session without a persisted transcript");
+		await this.ensureOnDisk();
+		await this.flush();
+		return SessionManager.forkFrom(this.#sessionFile, options.cwd, options.sessionDir, this.#storage, options);
+	}
+
+	/** Reopen this session through its configured storage backend. */
+	async reopen(options?: { suppressBreadcrumb?: boolean }): Promise<SessionManager> {
+		if (!this.#sessionFile) throw new Error("Cannot reopen a session without a persisted transcript");
+		return SessionManager.open(this.#sessionFile, undefined, this.#storage, options);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2412,6 +2412,7 @@ export class SessionManager {
 
 	/** Clone a completed branch through this manager's configured storage backend. */
 	async forkBranch(options: {
+		sourceFile?: string;
 		cwd: string;
 		sessionDir?: string;
 		sessionFile?: string;
@@ -2419,10 +2420,15 @@ export class SessionManager {
 		additionalDirectories?: readonly string[];
 		suppressBreadcrumb?: boolean;
 	}): Promise<SessionManager> {
-		if (!this.#sessionFile) throw new Error("Cannot fork a session without a persisted transcript");
-		await this.ensureOnDisk();
-		await this.flush();
-		return SessionManager.forkFrom(this.#sessionFile, options.cwd, options.sessionDir, this.#storage, options);
+		const sourceFile = options.sourceFile ?? this.#sessionFile;
+		if (!sourceFile) throw new Error("Cannot fork a session without a persisted transcript");
+		if (sourceFile === this.#sessionFile) {
+			await this.ensureOnDisk();
+			await this.flush();
+		} else {
+			await this.#storage.drain();
+		}
+		return SessionManager.forkFrom(sourceFile, options.cwd, options.sessionDir, this.#storage, options);
 	}
 
 	/** Reopen this session through its configured storage backend. */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2373,8 +2373,11 @@ export class SessionManager {
 		if (options && "sourceLeafId" in options) {
 			const entriesById = new Map(history.map(entry => [entry.id, entry]));
 			const branch: SessionEntry[] = [];
+			const seen = new Set<string>();
 			let cursor = options.sourceLeafId ?? null;
 			while (cursor) {
+				if (seen.has(cursor)) throw new Error(`Fork source contains a parent cycle at entry ${cursor}`);
+				seen.add(cursor);
 				const entry = entriesById.get(cursor);
 				if (!entry) throw new Error(`Fork source entry ${cursor} not found`);
 				branch.push(entry);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -36,6 +36,7 @@ import type { MnemopiSessionState } from "../mnemopi/state";
 import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pending.md" with { type: "text" };
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
+import forkContextSwitchPrompt from "../prompts/system/tan-context-switch.md" with { type: "text" };
 import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-lifecycle";
 import { AgentRegistry } from "../registry/agent-registry";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "../sdk";
@@ -48,6 +49,7 @@ import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import { type ConfiguredThinkingLevel, prewalkWouldBeNoop, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
 import type { ContextFileEntry, ToolSession } from "../tools";
+import { resolveToolTier } from "../tools/approval";
 import { resolveEvalBackends } from "../tools/eval-backends";
 import { isIrcEnabled } from "../tools/hub";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
@@ -71,6 +73,8 @@ import {
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
+	type TaskContextSource,
+	type TaskContextSourceResult,
 	type TaskToolDetails,
 	type YieldItem,
 } from "./types";
@@ -314,6 +318,24 @@ export interface ExecutorOptions {
 	assignment?: string;
 	/** Shared background from the task call (`task.batch`), rendered into the subagent's system prompt. */
 	context?: string;
+	/** Parent-context strategy requested by the task caller. */
+	contextSource?: TaskContextSource;
+	/** Persisted parent session that supplies fork history. */
+	parentSessionFile?: string | null;
+	/** Parent manager used to flush the committed history before cloning. */
+	parentSessionManager?: Pick<SessionManager, "ensureOnDisk" | "flush" | "getCwd">;
+	/** Exact parent model used by fork mode. */
+	parentModel?: Model;
+	/** Exact parent thinking level used by fork mode. */
+	parentThinkingLevel?: ConfiguredThinkingLevel;
+	/** Parent system prompt retained for provider-prefix compatibility. */
+	parentSystemPrompt?: readonly string[];
+	/** Parent tool catalog retained for provider-prefix compatibility. */
+	parentToolNames?: string[];
+	/** Parent provider prompt-cache affinity. */
+	parentPromptCacheKey?: string;
+	/** Last committed parent entry to clone, excluding the in-flight task call. */
+	parentForkLeafId?: string | null;
 	/**
 	 * The session's active overall plan, handed off so subagents spawned during
 	 * plan execution share the same plan context as the main agent. Omitted when
@@ -1794,6 +1816,7 @@ async function driveSessionToYield(
 	session: AgentSession,
 	monitor: SubagentRunMonitor,
 	task: string,
+	requireYield = true,
 ): Promise<DriveOutcome> {
 	const abortSignal = monitor.abortSignal;
 	let exitCode = 0;
@@ -1841,6 +1864,10 @@ async function driveSessionToYield(
 			// failures keep the old path.
 			const recoverableStop = monitor.budgetStopRequested() || monitor.yieldTurnStopRequested();
 			if (!recoverableStop || abortSignal.aborted) throw err;
+		}
+
+		if (!requireYield) {
+			return { exitCode, error, aborted, abortReasonText };
 		}
 
 		const reminderToolChoice = buildNamedToolChoice("yield", session.model);
@@ -2054,6 +2081,7 @@ interface FinalizeRunArgs {
 	detached?: boolean;
 	sessionFile?: string;
 	startTime: number;
+	contextSource?: TaskContextSourceResult;
 }
 
 /**
@@ -2167,6 +2195,8 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		});
 	}
 
+	const usage = monitor.hasUsage() ? monitor.accumulatedUsage : undefined;
+	if (args.contextSource) args.contextSource.cacheReadTokens = usage?.cacheRead ?? 0;
 	return {
 		index,
 		id,
@@ -2192,7 +2222,8 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,
-		usage: monitor.hasUsage() ? monitor.accumulatedUsage : undefined,
+		usage,
+		contextSource: args.contextSource,
 		outputPath,
 		extractedToolData: progress.extractedToolData,
 		retryFailure: progress.retryFailure,
@@ -2406,6 +2437,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		onProgress,
 	} = options;
 	const startTime = Date.now();
+	const requestedContextSource = options.contextSource ?? "fresh";
+	let contextSource: TaskContextSourceResult = {
+		requested: requestedContextSource,
+		used: "fresh",
+		cacheReadTokens: 0,
+	};
 	// Set by the session's onFirstChatDispatch hook the first time the agent
 	// loop dispatches a chat request to the provider — the launch-complete boundary.
 	let firstChatDispatchAt: number | undefined;
@@ -2719,14 +2756,54 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			const effectiveCwd = worktree ?? cwd;
-			const sessionManager = sessionFile
-				? await awaitAbortable(
-						SessionManager.open(sessionFile, undefined, undefined, {
-							initialCwd: effectiveCwd,
+			const forkRequested = requestedContextSource !== "fresh";
+			const forkUnavailableReason =
+				worktree !== undefined
+					? "fork context is incompatible with isolated worktrees"
+					: !sessionFile
+						? "fork context requires a persisted child transcript"
+						: !options.parentSessionFile ||
+								!options.parentSessionManager ||
+								options.parentForkLeafId === undefined
+							? "fork context requires a persisted parent session"
+							: !options.parentModel || !options.parentSystemPrompt || !options.parentToolNames
+								? "fork context requires the active parent request shape"
+								: undefined;
+			if (requestedContextSource === "fork" && forkUnavailableReason) {
+				throw new Error(forkUnavailableReason);
+			}
+			const useFork = forkRequested && forkUnavailableReason === undefined;
+			let sessionManager: SessionManager;
+			if (useFork) {
+				await awaitAbortable(options.parentSessionManager!.ensureOnDisk());
+				await awaitAbortable(options.parentSessionManager!.flush());
+				sessionManager = await awaitAbortable(
+					SessionManager.forkFrom(
+						options.parentSessionFile!,
+						effectiveCwd,
+						path.dirname(sessionFile!),
+						undefined,
+						{
 							suppressBreadcrumb: true,
-						}),
-					)
-				: SessionManager.inMemory(effectiveCwd);
+							sessionFile: sessionFile!,
+							sourceLeafId: options.parentForkLeafId,
+						},
+					),
+				);
+				contextSource = { requested: requestedContextSource, used: "fork", cacheReadTokens: 0 };
+			} else {
+				sessionManager = sessionFile
+					? await awaitAbortable(
+							SessionManager.open(sessionFile, undefined, undefined, {
+								initialCwd: effectiveCwd,
+								suppressBreadcrumb: true,
+							}),
+						)
+					: SessionManager.inMemory(effectiveCwd);
+				if (forkUnavailableReason && requestedContextSource === "auto") {
+					contextSource.downgradeReason = forkUnavailableReason;
+				}
+			}
 			if (options.parentArtifactManager) {
 				sessionManager.adoptArtifactManager(options.parentArtifactManager);
 			}
@@ -2787,21 +2864,23 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				modelRegistry,
 				getApiKey: options.getApiKey,
 				settings: subagentSettings,
-				model,
-				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
+				model: useFork ? options.parentModel : model,
+				modelPattern: useFork || model || modelOverride === undefined ? undefined : modelPatterns,
 				modelPatternAuthFallback:
-					model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
+					useFork || model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
 				modelPatternFallbackRole:
-					model || modelOverride === undefined ? undefined : `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`,
+					useFork || model || modelOverride === undefined
+						? undefined
+						: `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`,
 				modelPatternDefaultFallbackChain:
-					model || modelOverride === undefined ? undefined : defaultRetryFallbackChain,
-				thinkingLevel: effectiveThinkingLevel,
-				thinkingLevelCeiling: spawnEffortCeiling,
-				toolNames,
+					useFork || model || modelOverride === undefined ? undefined : defaultRetryFallbackChain,
+				thinkingLevel: useFork ? options.parentThinkingLevel : effectiveThinkingLevel,
+				thinkingLevelCeiling: useFork ? undefined : spawnEffortCeiling,
+				toolNames: useFork ? options.parentToolNames : toolNames,
 				outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: options.restrictToolNames,
-				requireYieldTool: true,
+				requireYieldTool: !useFork,
 				contextFiles: options.contextFiles,
 				skills: options.skills,
 				promptTemplates: options.promptTemplates,
@@ -2809,22 +2888,26 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				rules: options.rules,
 				preloadedExtensionPaths: restrictToolNames ? [] : options.preloadedExtensionPaths,
 				preloadedCustomToolPaths: restrictToolNames ? [] : options.preloadedCustomToolPaths,
-				systemPrompt: defaultPrompt => {
-					const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
-						agent: agent.systemPrompt,
-						context: options.context?.trim() ?? "",
-						planReference: options.planReference?.content ?? "",
-						planReferencePath: options.planReference?.path ?? "",
-						worktree: worktree ?? "",
-						outputSchema: normalizedOutputSchema,
-						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
-						ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
-						ircSelfId: ircEnabled ? id : "",
-					});
-					return defaultPrompt.length === 0
-						? [subagentPrompt]
-						: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
-				},
+				systemPrompt: useFork
+					? [...options.parentSystemPrompt!]
+					: defaultPrompt => {
+							const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
+								agent: agent.systemPrompt,
+								context: options.context?.trim() ?? "",
+								planReference: options.planReference?.content ?? "",
+								planReferencePath: options.planReference?.path ?? "",
+								worktree: worktree ?? "",
+								outputSchema: normalizedOutputSchema,
+								outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
+								ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
+								ircSelfId: ircEnabled ? id : "",
+							});
+							return defaultPrompt.length === 0
+								? [subagentPrompt]
+								: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
+						},
+				providerSessionId: useFork ? `${sessionManagerForRun.getSessionId()}:fork` : undefined,
+				providerPromptCacheKey: useFork ? options.parentPromptCacheKey : undefined,
 				sessionManager: sessionManagerForRun,
 				hasUI: false,
 				prewalk,
@@ -2865,6 +2948,24 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);
+			if (useFork) {
+				session.setTodoPhases([]);
+				const beforeToolCall = session.agent.beforeToolCall;
+				session.agent.beforeToolCall = async (ctx, toolSignal) => {
+					const inherited = await beforeToolCall?.(ctx, toolSignal);
+					if (inherited?.block || inherited?.args !== undefined) return inherited;
+					if (resolveToolTier(ctx.tool, ctx.args) !== "read") {
+						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
+					}
+					return undefined;
+				};
+				session.agent.appendMessage({
+					role: "developer",
+					content: forkContextSwitchPrompt,
+					attribution: "agent",
+					timestamp: Date.now(),
+				});
+			}
 			installRegistryStatusSync(session);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
@@ -3018,7 +3119,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			readyAt = performance.now();
-			const outcome = await driveSessionToYield(session, monitor, task);
+			const outcome = await driveSessionToYield(session, monitor, task, !useFork);
 			exitCode = outcome.exitCode;
 			error = outcome.error;
 			aborted = outcome.aborted;
@@ -3141,5 +3242,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		detached: options.detached,
 		sessionFile: subtaskSessionFile,
 		startTime,
+		contextSource,
 	});
 }

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -323,7 +323,7 @@ export interface ExecutorOptions {
 	/** Persisted parent session that supplies fork history. */
 	parentSessionFile?: string | null;
 	/** Parent manager used to flush the committed history before cloning. */
-	parentSessionManager?: Pick<SessionManager, "ensureOnDisk" | "flush" | "getCwd">;
+	parentSessionManager?: Pick<SessionManager, "forkBranch" | "getCwd">;
 	/** Exact parent model used by fork mode. */
 	parentModel?: Model;
 	/** Exact parent thinking level used by fork mode. */
@@ -482,7 +482,7 @@ export interface ExecutorOptions {
 /** Immutable parent request shape captured at the task scheduling boundary. */
 export interface ForkContextSnapshot {
 	sessionFile: string | null;
-	sessionManager: Pick<SessionManager, "ensureOnDisk" | "flush" | "getCwd">;
+	sessionManager: Pick<SessionManager, "forkBranch" | "getCwd">;
 	model?: Model;
 	thinkingLevel?: ConfiguredThinkingLevel;
 	systemPrompt?: readonly string[];
@@ -2780,20 +2780,15 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 			let sessionManager: SessionManager;
 			if (useFork) {
-				await awaitAbortable(options.parentSessionManager!.ensureOnDisk());
-				await awaitAbortable(options.parentSessionManager!.flush());
 				sessionManager = await awaitAbortable(
-					SessionManager.forkFrom(
-						options.parentSessionFile!,
-						effectiveCwd,
-						path.dirname(sessionFile!),
-						undefined,
-						{
-							suppressBreadcrumb: true,
-							sessionFile: sessionFile!,
-							sourceLeafId: options.parentForkLeafId,
-						},
-					),
+					options.parentSessionManager!.forkBranch({
+						cwd: effectiveCwd,
+						sessionDir: path.dirname(sessionFile!),
+						suppressBreadcrumb: true,
+						sessionFile: sessionFile!,
+						sourceLeafId: options.parentForkLeafId,
+						additionalDirectories: worktree !== undefined ? [] : undefined,
+					}),
 				);
 			} else {
 				contextSource = { requested: requestedContextSource, used: "fresh", cacheReadTokens: 0 };
@@ -2990,7 +2985,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				// (createAgentSession → agent.replaceMessages). Isolated runs are not
 				// resumable (worktree is merged + cleaned) and never get a reviver.
 				reviveSession = async expectedAgentRef => {
-					const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
+					const reopened = await sessionManager.reopen({
 						suppressBreadcrumb: true,
 					});
 					if (options.parentArtifactManager) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -49,6 +49,7 @@ import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import { type ConfiguredThinkingLevel, prewalkWouldBeNoop, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
 import type { ContextFileEntry, ToolSession } from "../tools";
+import { resolveToolTier } from "../tools/approval";
 import { resolveEvalBackends } from "../tools/eval-backends";
 import { isIrcEnabled } from "../tools/hub";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
@@ -2848,9 +2849,19 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				context: options.context?.trim() ?? "",
 				outputSchema: normalizedOutputSchema ? JSON.stringify(normalizedOutputSchema, null, 2) : "",
 			});
-			const installForkContext = (target: AgentSession, appendNotice: boolean): void => {
+			const installForkRestrictions = (target: AgentSession, appendNotice: boolean): void => {
 				if (!useFork) return;
 				target.setTodoPhases([]);
+				const beforeToolCall = target.agent.beforeToolCall;
+				target.agent.beforeToolCall = async (ctx, toolSignal) => {
+					const inherited = await beforeToolCall?.(ctx, toolSignal);
+					if (inherited?.block) return inherited;
+					const effectiveArgs = inherited?.args ?? ctx.args;
+					if (resolveToolTier(ctx.tool, effectiveArgs) !== "read") {
+						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
+					}
+					return inherited;
+				};
 				const injectNotice = () => {
 					const message = {
 						role: "developer",
@@ -2962,7 +2973,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);
-			installForkContext(session, true);
+			installForkRestrictions(session, true);
 			installRegistryStatusSync(session);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
@@ -2979,7 +2990,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
-					installForkContext(revived, false);
+					installForkRestrictions(revived, false);
 					installRegistryStatusSync(revived);
 					return revived;
 				};

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1828,7 +1828,6 @@ async function driveSessionToYield(
 	session: AgentSession,
 	monitor: SubagentRunMonitor,
 	task: string,
-	requireYield = true,
 ): Promise<DriveOutcome> {
 	const abortSignal = monitor.abortSignal;
 	let exitCode = 0;
@@ -1876,10 +1875,6 @@ async function driveSessionToYield(
 			// failures keep the old path.
 			const recoverableStop = monitor.budgetStopRequested() || monitor.yieldTurnStopRequested();
 			if (!recoverableStop || abortSignal.aborted) throw err;
-		}
-
-		if (!requireYield) {
-			return { exitCode, error, aborted, abortReasonText };
 		}
 
 		const reminderToolChoice = buildNamedToolChoice("yield", session.model);
@@ -2862,12 +2857,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const inherited = await beforeToolCall?.(ctx, toolSignal);
 					if (inherited?.block) return inherited;
 					const effectiveArgs = inherited?.args ?? ctx.args;
-					if (ctx.tool.name === "hub" && isRecord(effectiveArgs) && effectiveArgs.op === "send") {
-						return {
-							block: true,
-							reason: "Forked task agents cannot steer peers; return findings to the parent.",
-						};
-					}
 					if (resolveToolTier(ctx.tool, effectiveArgs) !== "read") {
 						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
 					}
@@ -3139,7 +3128,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			readyAt = performance.now();
-			const outcome = await driveSessionToYield(session, monitor, task, !useFork);
+			const outcome = await driveSessionToYield(session, monitor, task);
 			exitCode = outcome.exitCode;
 			error = outcome.error;
 			aborted = outcome.aborted;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2782,6 +2782,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			if (useFork) {
 				sessionManager = await awaitAbortable(
 					options.parentSessionManager!.forkBranch({
+						sourceFile: options.parentSessionFile!,
 						cwd: effectiveCwd,
 						sessionDir: path.dirname(sessionFile!),
 						suppressBreadcrumb: true,
@@ -2861,6 +2862,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const inherited = await beforeToolCall?.(ctx, toolSignal);
 					if (inherited?.block) return inherited;
 					const effectiveArgs = inherited?.args ?? ctx.args;
+					if (ctx.tool.name === "hub" && isRecord(effectiveArgs) && effectiveArgs.op === "send") {
+						return {
+							block: true,
+							reason: "Forked task agents cannot steer peers; return findings to the parent.",
+						};
+					}
 					if (resolveToolTier(ctx.tool, effectiveArgs) !== "read") {
 						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
 					}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2765,32 +2765,18 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const effectiveCwd = worktree ?? cwd;
 			const forkRequested = requestedContextSource !== "fresh";
-			const forkUnavailableReason =
-				worktree !== undefined
-					? "fork context is incompatible with isolated worktrees"
-					: !sessionFile
-						? "fork context requires a persisted child transcript"
-						: !options.parentSessionFile ||
-								!options.parentSessionManager ||
-								options.parentForkLeafId === undefined
-							? "fork context requires a persisted parent session"
-							: !options.parentModel || !options.parentSystemPrompt || !options.parentToolNames
-								? "fork context requires the active parent request shape"
-								: undefined;
+			const forkUnavailableReason = !sessionFile
+				? "fork context requires a persisted child transcript"
+				: !options.parentSessionFile || !options.parentSessionManager || options.parentForkLeafId === undefined
+					? "fork context requires a persisted parent session"
+					: undefined;
 			if (requestedContextSource === "fork" && forkUnavailableReason) {
 				throw new Error(forkUnavailableReason);
 			}
-			let useFork = forkRequested && forkUnavailableReason === undefined;
-			const runtimeModel = useFork ? options.parentModel : model;
+			const useFork = forkRequested && forkUnavailableReason === undefined;
+			const runtimeModel = model;
 			if (runtimeModel?.contextWindow && runtimeModel.contextWindow > 0) {
 				progress.contextWindow = runtimeModel.contextWindow;
-			}
-			if (useFork && runtimeModel) {
-				const level = options.parentThinkingLevel;
-				progress.resolvedModel =
-					level !== undefined
-						? formatModelSelectorValue(formatModelStringWithRouting(runtimeModel), level)
-						: formatModelStringWithRouting(runtimeModel);
 			}
 			let sessionManager: SessionManager;
 			if (useFork) {
@@ -2915,23 +2901,21 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				modelRegistry,
 				getApiKey: options.getApiKey,
 				settings: subagentSettings,
-				model: useFork ? options.parentModel : model,
-				modelPattern: useFork || model || modelOverride === undefined ? undefined : modelPatterns,
+				model,
+				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
 				modelPatternAuthFallback:
-					useFork || model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
+					model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
 				modelPatternFallbackRole:
-					useFork || model || modelOverride === undefined
-						? undefined
-						: `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`,
+					model || modelOverride === undefined ? undefined : `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`,
 				modelPatternDefaultFallbackChain:
-					useFork || model || modelOverride === undefined ? undefined : defaultRetryFallbackChain,
-				thinkingLevel: useFork ? options.parentThinkingLevel : effectiveThinkingLevel,
-				thinkingLevelCeiling: useFork ? undefined : spawnEffortCeiling,
-				toolNames: useFork ? options.parentToolNames : toolNames,
+					model || modelOverride === undefined ? undefined : defaultRetryFallbackChain,
+				thinkingLevel: effectiveThinkingLevel,
+				thinkingLevelCeiling: spawnEffortCeiling,
+				toolNames,
 				outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: options.restrictToolNames,
-				requireYieldTool: !useFork,
+				requireYieldTool: true,
 				contextFiles: options.contextFiles,
 				skills: options.skills,
 				promptTemplates: options.promptTemplates,
@@ -2939,29 +2923,27 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				rules: options.rules,
 				preloadedExtensionPaths: restrictToolNames ? [] : options.preloadedExtensionPaths,
 				preloadedCustomToolPaths: restrictToolNames ? [] : options.preloadedCustomToolPaths,
-				systemPrompt: useFork
-					? [...options.parentSystemPrompt!]
-					: defaultPrompt => {
-							const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
-								agent: agent.systemPrompt,
-								context: options.context?.trim() ?? "",
-								planReference: options.planReference?.content ?? "",
-								planReferencePath: options.planReference?.path ?? "",
-								worktree: worktree ?? "",
-								outputSchema: normalizedOutputSchema,
-								outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
-								ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
-								ircSelfId: ircEnabled ? id : "",
-							});
-							return defaultPrompt.length === 0
-								? [subagentPrompt]
-								: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
-						},
+				systemPrompt: defaultPrompt => {
+					const subagentPrompt = prompt.render(subagentSystemPromptTemplate, {
+						agent: agent.systemPrompt,
+						context: options.context?.trim() ?? "",
+						planReference: options.planReference?.content ?? "",
+						planReferencePath: options.planReference?.path ?? "",
+						worktree: worktree ?? "",
+						outputSchema: normalizedOutputSchema,
+						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
+						ircPeers: ircEnabled ? renderIrcPeerRoster(id) : "",
+						ircSelfId: ircEnabled ? id : "",
+					});
+					return defaultPrompt.length === 0
+						? [subagentPrompt]
+						: [...defaultPrompt.slice(0, -1), subagentPrompt, defaultPrompt[defaultPrompt.length - 1]];
+				},
 				providerSessionId: useFork ? `${sessionManagerForRun.getSessionId()}:fork` : undefined,
 				providerPromptCacheKey: useFork ? options.parentPromptCacheKey : undefined,
 				sessionManager: sessionManagerForRun,
 				hasUI: false,
-				prewalk: useFork ? undefined : prewalk,
+				prewalk,
 				spawns: spawnsEnv,
 				taskDepth: childDepth,
 				parentHindsightSessionState: options.parentHindsightSessionState,
@@ -2985,7 +2967,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				},
 			});
 
-			let sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
+			const sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
 			let session: AgentSession;
 			try {
 				({ session } = await awaitAbortable(sessionPromise));
@@ -2996,46 +2978,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				void sessionPromise.then(created => created.session.dispose()).catch(() => {});
 				throw err;
 			}
-			if (useFork) {
-				const requestedTools = options.parentToolNames!;
-				const reconstructedTools = session.getActiveToolNames();
-				const sameTools =
-					requestedTools.length === reconstructedTools.length &&
-					requestedTools.every((name, index) => reconstructedTools[index] === name);
-				if (!sameTools) {
-					await session.dispose();
-					const reason = `fork context cannot reconstruct the parent tool catalog (expected: ${requestedTools.join(", ")}; actual: ${reconstructedTools.join(", ")})`;
-					if (requestedContextSource === "fork") throw new Error(reason);
-					if (sessionFile) {
-						await sessionManager.dropSession(sessionFile);
-						sessionManager = await SessionManager.open(sessionFile, undefined, undefined, {
-							initialCwd: effectiveCwd,
-							suppressBreadcrumb: true,
-						});
-					} else {
-						sessionManager = SessionManager.inMemory(effectiveCwd);
-					}
-					if (options.parentArtifactManager) sessionManager.adoptArtifactManager(options.parentArtifactManager);
-					useFork = false;
-					contextSource = {
-						requested: requestedContextSource,
-						used: "fresh",
-						cacheReadTokens: 0,
-						downgradeReason: reason,
-					};
-					if (model?.contextWindow && model.contextWindow > 0) progress.contextWindow = model.contextWindow;
-					if (model) {
-						const displayLevel = effortLevel ?? (explicitThinkingLevel ? resolvedThinkingLevel : undefined);
-						progress.resolvedModel =
-							displayLevel !== undefined
-								? formatModelSelectorValue(formatModelStringWithRouting(model), displayLevel)
-								: formatModelStringWithRouting(model);
-					}
-					sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
-					({ session } = await awaitAbortable(sessionPromise));
-				}
-				if (useFork) contextSource = { requested: requestedContextSource, used: "fork", cacheReadTokens: 0 };
-			}
+			if (useFork) contextSource = { requested: requestedContextSource, used: "fork", cacheReadTokens: 0 };
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -49,7 +49,6 @@ import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import { type ConfiguredThinkingLevel, prewalkWouldBeNoop, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
 import type { ContextFileEntry, ToolSession } from "../tools";
-import { resolveToolTier } from "../tools/approval";
 import { resolveEvalBackends } from "../tools/eval-backends";
 import { isIrcEnabled } from "../tools/hub";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
@@ -2509,17 +2508,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	const atMaxDepth = maxRecursionDepth >= 0 && childDepth >= maxRecursionDepth;
 	const ircEnabled = options.enableIrc !== false && isIrcEnabled(subagentSettings, childDepth);
 
-	// Named agents with an explicit catalog use it. The default agent inherits
-	// the parent's active catalog so spawning does not silently widen access.
+	// Add tools if specified
 	let toolNames: string[] | undefined;
 	if (agent.tools && agent.tools.length > 0) {
-		toolNames = [...agent.tools];
+		toolNames = agent.tools;
 		// Auto-include task tool if spawns defined but task not in tools
 		if (agent.spawns !== undefined && !toolNames.includes("task") && !atMaxDepth) {
 			toolNames = [...toolNames, "task"];
 		}
-	} else if (options.parentToolNames) {
-		toolNames = [...options.parentToolNames];
 	}
 
 	if (atMaxDepth && toolNames?.includes("task")) {
@@ -2852,19 +2848,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				context: options.context?.trim() ?? "",
 				outputSchema: normalizedOutputSchema ? JSON.stringify(normalizedOutputSchema, null, 2) : "",
 			});
-			const installForkRestrictions = (target: AgentSession, appendNotice: boolean): void => {
+			const installForkContext = (target: AgentSession, appendNotice: boolean): void => {
 				if (!useFork) return;
 				target.setTodoPhases([]);
-				const beforeToolCall = target.agent.beforeToolCall;
-				target.agent.beforeToolCall = async (ctx, toolSignal) => {
-					const inherited = await beforeToolCall?.(ctx, toolSignal);
-					if (inherited?.block) return inherited;
-					const effectiveArgs = inherited?.args ?? ctx.args;
-					if (resolveToolTier(ctx.tool, effectiveArgs) !== "read") {
-						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
-					}
-					return inherited;
-				};
 				const injectNotice = () => {
 					const message = {
 						role: "developer",
@@ -2976,7 +2962,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);
-			installForkRestrictions(session, true);
+			installForkContext(session, true);
 			installRegistryStatusSync(session);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
@@ -2993,7 +2979,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
-					installForkRestrictions(revived, false);
+					installForkContext(revived, false);
 					installRegistryStatusSync(revived);
 					return revived;
 				};

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -33,10 +33,10 @@ import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
 import type { MCPManager } from "../mcp/manager";
 import type { MnemopiSessionState } from "../mnemopi/state";
+import forkTaskContextPrompt from "../prompts/system/fork-task-context.md" with { type: "text" };
 import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pending.md" with { type: "text" };
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
-import forkContextSwitchPrompt from "../prompts/system/tan-context-switch.md" with { type: "text" };
 import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-lifecycle";
 import { AgentRegistry } from "../registry/agent-registry";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "../sdk";
@@ -477,6 +477,18 @@ export interface ExecutorOptions {
 	 * set this false so disposal unregisters them instead of leaving idle peers.
 	 */
 	keepAlive?: boolean;
+}
+
+/** Immutable parent request shape captured at the task scheduling boundary. */
+export interface ForkContextSnapshot {
+	sessionFile: string | null;
+	sessionManager: Pick<SessionManager, "ensureOnDisk" | "flush" | "getCwd">;
+	model?: Model;
+	thinkingLevel?: ConfiguredThinkingLevel;
+	systemPrompt?: readonly string[];
+	toolNames?: string[];
+	promptCacheKey?: string;
+	leafId?: string | null;
 }
 
 function parseStringifiedJson(value: unknown): unknown {
@@ -2773,6 +2785,17 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				throw new Error(forkUnavailableReason);
 			}
 			const useFork = forkRequested && forkUnavailableReason === undefined;
+			const runtimeModel = useFork ? options.parentModel : model;
+			if (runtimeModel?.contextWindow && runtimeModel.contextWindow > 0) {
+				progress.contextWindow = runtimeModel.contextWindow;
+			}
+			if (useFork && runtimeModel) {
+				const level = options.parentThinkingLevel;
+				progress.resolvedModel =
+					level !== undefined
+						? formatModelSelectorValue(formatModelStringWithRouting(runtimeModel), level)
+						: formatModelStringWithRouting(runtimeModel);
+			}
 			let sessionManager: SessionManager;
 			if (useFork) {
 				await awaitAbortable(options.parentSessionManager!.ensureOnDisk());
@@ -2849,6 +2872,32 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			const { normalized: normalizedOutputSchema } = normalizeSchema(outputSchema);
+			const forkTaskNotice = prompt.render(forkTaskContextPrompt, {
+				context: options.context?.trim() ?? "",
+				outputSchema: normalizedOutputSchema ? JSON.stringify(normalizedOutputSchema, null, 2) : "",
+			});
+			const installForkRestrictions = (target: AgentSession, appendNotice: boolean): void => {
+				if (!useFork) return;
+				target.setTodoPhases([]);
+				const beforeToolCall = target.agent.beforeToolCall;
+				target.agent.beforeToolCall = async (ctx, toolSignal) => {
+					const inherited = await beforeToolCall?.(ctx, toolSignal);
+					if (inherited?.block) return inherited;
+					const effectiveArgs = inherited?.args ?? ctx.args;
+					if (resolveToolTier(ctx.tool, effectiveArgs) !== "read") {
+						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
+					}
+					return inherited;
+				};
+				if (appendNotice) {
+					target.agent.appendMessage({
+						role: "developer",
+						content: forkTaskNotice,
+						attribution: "agent",
+						timestamp: Date.now(),
+					});
+				}
+			};
 
 			// Captured by the lifecycle reviver: rebuilding an equivalent session from
 			// the same JSONL file re-invokes createAgentSession with the exact options
@@ -2948,24 +2997,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			sessionCreatedAt = performance.now();
 
 			monitor.setActiveSession(session);
-			if (useFork) {
-				session.setTodoPhases([]);
-				const beforeToolCall = session.agent.beforeToolCall;
-				session.agent.beforeToolCall = async (ctx, toolSignal) => {
-					const inherited = await beforeToolCall?.(ctx, toolSignal);
-					if (inherited?.block || inherited?.args !== undefined) return inherited;
-					if (resolveToolTier(ctx.tool, ctx.args) !== "read") {
-						return { block: true, reason: "Forked task agents are read-only; return findings to the parent." };
-					}
-					return undefined;
-				};
-				session.agent.appendMessage({
-					role: "developer",
-					content: forkContextSwitchPrompt,
-					attribution: "agent",
-					timestamp: Date.now(),
-				});
-			}
+			installForkRestrictions(session, true);
 			installRegistryStatusSync(session);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
@@ -2982,6 +3014,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					const { session: revived } = await createAgentSession(
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
+					installForkRestrictions(revived, false);
 					installRegistryStatusSync(revived);
 					return revived;
 				};
@@ -3005,7 +3038,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// Todos are parent-owned bookkeeping and stripped from subagents —
 			// except under prewalk, whose plan nudge + todo gate require the
 			// subagent to commit its own todo list before the hand-off.
-			const isParentOwnedTool = (name: string): boolean => !prewalk && name === "todo";
+			const isParentOwnedTool = (name: string): boolean => !useFork && !prewalk && name === "todo";
 			const subagentToolNames = session.getEnabledToolNames();
 			const filteredSubagentTools = subagentToolNames.filter(name => !isParentOwnedTool(name));
 			if (filteredSubagentTools.length !== subagentToolNames.length) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2509,14 +2509,17 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	const atMaxDepth = maxRecursionDepth >= 0 && childDepth >= maxRecursionDepth;
 	const ircEnabled = options.enableIrc !== false && isIrcEnabled(subagentSettings, childDepth);
 
-	// Add tools if specified
+	// Named agents with an explicit catalog use it. The default agent inherits
+	// the parent's active catalog so spawning does not silently widen access.
 	let toolNames: string[] | undefined;
 	if (agent.tools && agent.tools.length > 0) {
-		toolNames = agent.tools;
+		toolNames = [...agent.tools];
 		// Auto-include task tool if spawns defined but task not in tools
 		if (agent.spawns !== undefined && !toolNames.includes("task") && !atMaxDepth) {
 			toolNames = [...toolNames, "task"];
 		}
+	} else if (options.parentToolNames) {
+		toolNames = [...options.parentToolNames];
 	}
 
 	if (atMaxDepth && toolNames?.includes("task")) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2450,11 +2450,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	} = options;
 	const startTime = Date.now();
 	const requestedContextSource = options.contextSource ?? "fresh";
-	let contextSource: TaskContextSourceResult = {
-		requested: requestedContextSource,
-		used: "fresh",
-		cacheReadTokens: 0,
-	};
+	let contextSource: TaskContextSourceResult | undefined;
 	// Set by the session's onFirstChatDispatch hook the first time the agent
 	// loop dispatches a chat request to the provider — the launch-complete boundary.
 	let firstChatDispatchAt: number | undefined;
@@ -2784,7 +2780,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			if (requestedContextSource === "fork" && forkUnavailableReason) {
 				throw new Error(forkUnavailableReason);
 			}
-			const useFork = forkRequested && forkUnavailableReason === undefined;
+			let useFork = forkRequested && forkUnavailableReason === undefined;
 			const runtimeModel = useFork ? options.parentModel : model;
 			if (runtimeModel?.contextWindow && runtimeModel.contextWindow > 0) {
 				progress.contextWindow = runtimeModel.contextWindow;
@@ -2813,8 +2809,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						},
 					),
 				);
-				contextSource = { requested: requestedContextSource, used: "fork", cacheReadTokens: 0 };
 			} else {
+				contextSource = { requested: requestedContextSource, used: "fresh", cacheReadTokens: 0 };
 				sessionManager = sessionFile
 					? await awaitAbortable(
 							SessionManager.open(sessionFile, undefined, undefined, {
@@ -2889,14 +2885,20 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					}
 					return inherited;
 				};
-				if (appendNotice) {
-					target.agent.appendMessage({
+				const injectNotice = () => {
+					const message = {
 						role: "developer",
 						content: forkTaskNotice,
 						attribution: "agent",
 						timestamp: Date.now(),
-					});
-				}
+					} as const;
+					target.agent.appendMessage(message);
+					target.sessionManager.appendMessage(message);
+				};
+				if (appendNotice) injectNotice();
+				target.subscribe(event => {
+					if (event.type === "auto_compaction_end" && event.result && !event.aborted) injectNotice();
+				});
 			};
 
 			// Captured by the lifecycle reviver: rebuilding an equivalent session from
@@ -2959,7 +2961,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				providerPromptCacheKey: useFork ? options.parentPromptCacheKey : undefined,
 				sessionManager: sessionManagerForRun,
 				hasUI: false,
-				prewalk,
+				prewalk: useFork ? undefined : prewalk,
 				spawns: spawnsEnv,
 				taskDepth: childDepth,
 				parentHindsightSessionState: options.parentHindsightSessionState,
@@ -2983,7 +2985,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				},
 			});
 
-			const sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
+			let sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
 			let session: AgentSession;
 			try {
 				({ session } = await awaitAbortable(sessionPromise));
@@ -2993,6 +2995,46 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				// a cancelled subagent cannot leak them.
 				void sessionPromise.then(created => created.session.dispose()).catch(() => {});
 				throw err;
+			}
+			if (useFork) {
+				const requestedTools = options.parentToolNames!;
+				const reconstructedTools = session.getActiveToolNames();
+				const sameTools =
+					requestedTools.length === reconstructedTools.length &&
+					requestedTools.every((name, index) => reconstructedTools[index] === name);
+				if (!sameTools) {
+					await session.dispose();
+					const reason = `fork context cannot reconstruct the parent tool catalog (expected: ${requestedTools.join(", ")}; actual: ${reconstructedTools.join(", ")})`;
+					if (requestedContextSource === "fork") throw new Error(reason);
+					if (sessionFile) {
+						await sessionManager.dropSession(sessionFile);
+						sessionManager = await SessionManager.open(sessionFile, undefined, undefined, {
+							initialCwd: effectiveCwd,
+							suppressBreadcrumb: true,
+						});
+					} else {
+						sessionManager = SessionManager.inMemory(effectiveCwd);
+					}
+					if (options.parentArtifactManager) sessionManager.adoptArtifactManager(options.parentArtifactManager);
+					useFork = false;
+					contextSource = {
+						requested: requestedContextSource,
+						used: "fresh",
+						cacheReadTokens: 0,
+						downgradeReason: reason,
+					};
+					if (model?.contextWindow && model.contextWindow > 0) progress.contextWindow = model.contextWindow;
+					if (model) {
+						const displayLevel = effortLevel ?? (explicitThinkingLevel ? resolvedThinkingLevel : undefined);
+						progress.resolvedModel =
+							displayLevel !== undefined
+								? formatModelSelectorValue(formatModelStringWithRouting(model), displayLevel)
+								: formatModelStringWithRouting(model);
+					}
+					sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
+					({ session } = await awaitAbortable(sessionPromise));
+				}
+				if (useFork) contextSource = { requested: requestedContextSource, used: "fork", cacheReadTokens: 0 };
 			}
 			sessionCreatedAt = performance.now();
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -34,6 +34,7 @@ import {
 	canSpawnAtDepth,
 	getTaskSchema,
 	type SingleResult,
+	type TaskContextSource,
 	type TaskItem,
 	type TaskParams,
 	type TaskToolDetails,
@@ -259,6 +260,11 @@ function validateEffort(effort: TaskEffort | undefined, label: string): string |
 	return `${label} has an invalid \`effort\` value ${JSON.stringify(effort)}. Use "lo", "med", or "hi".`;
 }
 
+function validateSource(source: TaskContextSource | undefined, label: string): string | undefined {
+	if (source === undefined || source === "fresh" || source === "fork" || source === "auto") return undefined;
+	return `${label} has an invalid \`source\` value ${JSON.stringify(source)}. Use "fresh", "fork", or "auto".`;
+}
+
 function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string | undefined {
 	const hasTask = typeof params.task === "string" && params.task.trim() !== "";
 	const tasks = params.tasks;
@@ -276,6 +282,8 @@ function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string 
 			}
 			const effortError = validateEffort(item.effort, `Task ${i + 1}${item.name ? ` (\`${item.name}\`)` : ""}`);
 			if (effortError) return effortError;
+			const sourceError = validateSource(item.source, `Task ${i + 1}${item.name ? ` (\`${item.name}\`)` : ""}`);
+			if (sourceError) return sourceError;
 		}
 		const seen = new Map<string, string>();
 		for (const item of tasks) {
@@ -298,7 +306,7 @@ function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string 
 			? "Missing `tasks`. Provide a `tasks` array (one subagent per item) with a shared `context`."
 			: "Missing `task`. Provide complete, self-contained instructions for the agent.";
 	}
-	return validateEffort(params.effort, "The call");
+	return validateEffort(params.effort, "The call") ?? validateSource(params.source, "The call");
 }
 
 /**
@@ -891,19 +899,32 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		let syncUsage: Usage | undefined;
 		let syncOutputPaths: string[] | undefined;
 		let syncProjectAgentsDir: string | null = null;
-		const buildAsyncDetails = (): TaskToolDetails => ({
-			projectAgentsDir: syncProjectAgentsDir,
-			results: [...syncResults, ...asyncResults],
-			totalDurationMs: Date.now() - callStartedAt,
-			usage: syncUsage,
-			outputPaths: syncOutputPaths,
-			progress: spawns.map(spawn => ({ ...spawn.progress })),
-			async: {
-				state: settledCount < asyncSpawns.length ? "running" : failedCount > 0 ? "failed" : "completed",
-				jobId: primaryJobId,
-				type: "task",
-			},
-		});
+		const buildAsyncDetails = (): TaskToolDetails => {
+			const usage = createUsageTotals();
+			let hasUsage = false;
+			if (syncUsage) {
+				addUsageTotals(usage, syncUsage);
+				hasUsage = true;
+			}
+			for (const result of asyncResults) {
+				if (!result.usage) continue;
+				addUsageTotals(usage, result.usage);
+				hasUsage = true;
+			}
+			return {
+				projectAgentsDir: syncProjectAgentsDir,
+				results: [...syncResults, ...asyncResults],
+				totalDurationMs: Date.now() - callStartedAt,
+				usage: hasUsage ? usage : undefined,
+				outputPaths: syncOutputPaths,
+				progress: spawns.map(spawn => ({ ...spawn.progress })),
+				async: {
+					state: settledCount < asyncSpawns.length ? "running" : failedCount > 0 ? "failed" : "completed",
+					jobId: primaryJobId,
+					type: "task",
+				},
+			};
+		};
 
 		const started: Array<{ agentId: string; jobId: string }> = [];
 		const failedSchedules: string[] = [];
@@ -923,6 +944,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					onSettled: failed => {
 						settledCount += 1;
 						if (failed) failedCount += 1;
+						const primary = manager.getJob(primaryJobId);
+						if (primary) primary.latestDetails = buildAsyncDetails() as unknown as Record<string, unknown>;
 					},
 					onResult: result => asyncResults.push(result),
 				});

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -45,6 +45,7 @@ import type { AsyncJobManager } from "../async";
 import { hasResolvableTranscript } from "../internal-urls/registry-helpers";
 import { AgentRegistry } from "../registry/agent-registry";
 import { type DiscoveryResult, discoverAgents } from "./discovery";
+import type { ForkContextSnapshot } from "./executor";
 import { generateTaskName } from "./name-generator";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
@@ -56,6 +57,20 @@ function renderSubagentUserPrompt(assignment: string): string {
 	return prompt.render(subagentUserPromptTemplate, {
 		assignment: assignment.trim(),
 	});
+}
+
+function captureForkContext(session: ToolSession, source: TaskParams["source"]): ForkContextSnapshot | undefined {
+	if (source === undefined || source === "fresh" || !session.sessionManager) return undefined;
+	return {
+		sessionFile: session.getSessionFile(),
+		sessionManager: session.sessionManager,
+		model: session.getActiveModel?.(),
+		thinkingLevel: session.getConfiguredThinkingLevel?.(),
+		systemPrompt: session.getSystemPrompt?.(),
+		toolNames: session.getActiveToolNames?.(),
+		promptCacheKey: session.getPromptCacheKey?.(),
+		leafId: session.getTaskForkLeafId?.(),
+	};
 }
 
 function createUsageTotals(): Usage {
@@ -893,10 +908,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const failedSchedules: string[] = [];
 		for (const spawn of asyncSpawns) {
 			try {
+				const spawnParams = spawnParamsFor(params, spawn.item, defaultAgent);
 				const jobId = this.#registerSpawnJob({
 					manager,
 					toolCallId,
-					spawnParams: spawnParamsFor(params, spawn.item, defaultAgent),
+					spawnParams,
+					forkContextSnapshot: captureForkContext(this.session, spawnParams.source),
 					agentId: spawn.agentId,
 					progress: spawn.progress,
 					ircEnabled,
@@ -1056,6 +1073,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		manager: AsyncJobManager;
 		toolCallId: string;
 		spawnParams: TaskParams;
+		forkContextSnapshot?: ForkContextSnapshot;
 		agentId: string;
 		progress: AgentProgress;
 		ircEnabled: boolean;
@@ -1063,8 +1081,18 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>;
 		onSettled?: (failed: boolean) => void;
 	}): string {
-		const { manager, toolCallId, spawnParams, agentId, progress, ircEnabled, buildDetails, onUpdate, onSettled } =
-			options;
+		const {
+			manager,
+			toolCallId,
+			spawnParams,
+			forkContextSnapshot,
+			agentId,
+			progress,
+			ircEnabled,
+			buildDetails,
+			onUpdate,
+			onSettled,
+		} = options;
 		const buildFollowUpHint = async (aborted: boolean): Promise<string> => {
 			if (aborted) {
 				const ref = AgentRegistry.global().get(agentId);
@@ -1157,6 +1185,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						progress.index,
 						true,
 						{ invokedAt: startedAt, acquiredAt },
+						forkContextSnapshot,
 					);
 					const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 					const singleResult = result.details?.results[0];
@@ -1385,8 +1414,19 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		spawnIndex = 0,
 		detached = false,
 		launchTiming?: { invokedAt: number; acquiredAt: number },
+		forkContextSnapshot?: ForkContextSnapshot,
 	): Promise<AgentToolResult<TaskToolDetails>> {
-		return this.#runSpawn(toolCallId, params, signal, onUpdate, preAllocatedId, spawnIndex, detached, launchTiming);
+		return this.#runSpawn(
+			toolCallId,
+			params,
+			signal,
+			onUpdate,
+			preAllocatedId,
+			spawnIndex,
+			detached,
+			launchTiming,
+			forkContextSnapshot,
+		);
 	}
 
 	/** Spawn a fresh subagent and run it to completion. */
@@ -1399,6 +1439,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		spawnIndex = 0,
 		detached = false,
 		launchTiming?: { invokedAt: number; acquiredAt: number },
+		forkContextSnapshot?: ForkContextSnapshot,
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
 		const assignment = (params.task ?? "").trim();
@@ -1411,6 +1452,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				assignment,
 				context,
 				source: params.source,
+				forkContextSnapshot,
 				agent: params.agent,
 				...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 				...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -902,11 +902,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const buildAsyncDetails = (): TaskToolDetails => {
 			const usage = createUsageTotals();
 			let hasUsage = false;
+			const outputPaths = syncOutputPaths ? [...syncOutputPaths] : [];
 			if (syncUsage) {
 				addUsageTotals(usage, syncUsage);
 				hasUsage = true;
 			}
 			for (const result of asyncResults) {
+				if (result.outputPath) outputPaths.push(result.outputPath);
 				if (!result.usage) continue;
 				addUsageTotals(usage, result.usage);
 				hasUsage = true;
@@ -916,7 +918,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				results: [...syncResults, ...asyncResults],
 				totalDurationMs: Date.now() - callStartedAt,
 				usage: hasUsage ? usage : undefined,
-				outputPaths: syncOutputPaths,
+				outputPaths: outputPaths.length > 0 ? outputPaths : undefined,
 				progress: spawns.map(spawn => ({ ...spawn.progress })),
 				async: {
 					state: settledCount < asyncSpawns.length ? "running" : failedCount > 0 ? "failed" : "completed",

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -887,12 +887,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		let failedCount = 0;
 		let primaryJobId = asyncSpawns[0].agentId;
 		const syncResults: SingleResult[] = [];
+		const asyncResults: SingleResult[] = [];
 		let syncUsage: Usage | undefined;
 		let syncOutputPaths: string[] | undefined;
 		let syncProjectAgentsDir: string | null = null;
 		const buildAsyncDetails = (): TaskToolDetails => ({
 			projectAgentsDir: syncProjectAgentsDir,
-			results: [...syncResults],
+			results: [...syncResults, ...asyncResults],
 			totalDurationMs: Date.now() - callStartedAt,
 			usage: syncUsage,
 			outputPaths: syncOutputPaths,
@@ -923,6 +924,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						settledCount += 1;
 						if (failed) failedCount += 1;
 					},
+					onResult: result => asyncResults.push(result),
 				});
 				if (started.length === 0) primaryJobId = jobId;
 				started.push({ agentId: spawn.agentId, jobId });
@@ -1080,6 +1082,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		buildDetails: () => TaskToolDetails;
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>;
 		onSettled?: (failed: boolean) => void;
+		onResult?: (result: SingleResult) => void;
 	}): string {
 		const {
 			manager,
@@ -1092,6 +1095,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			buildDetails,
 			onUpdate,
 			onSettled,
+			onResult,
 		} = options;
 		const buildFollowUpHint = async (aborted: boolean): Promise<string> => {
 			if (aborted) {
@@ -1189,6 +1193,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					);
 					const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 					const singleResult = result.details?.results[0];
+					if (singleResult) onResult?.(singleResult);
 					// A missing result means the sync path failed at the tool level
 					// (results: []) — treat it as a failure, not success.
 					const resultFailed = !singleResult || (singleResult.aborted ?? false) || singleResult.exitCode !== 0;

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -296,7 +296,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
 		return params.tasks;
 	}
-	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task };
+	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task, source: params.source };
 	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
 	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
 	if ("effort" in params) item.effort = params.effort;
@@ -317,6 +317,7 @@ function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string
 	const spawn: TaskParams = { agent: item.agent?.trim() || defaultAgent };
 	if (item.name !== undefined) spawn.name = item.name;
 	if (item.task !== undefined) spawn.task = item.task;
+	if (item.source !== undefined) spawn.source = item.source;
 	if (params.context !== undefined) spawn.context = params.context;
 	if ("outputSchema" in item) spawn.outputSchema = item.outputSchema;
 	if ("schemaMode" in item) spawn.schemaMode = item.schemaMode;
@@ -1409,6 +1410,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				invocationKind: "task",
 				assignment,
 				context,
+				source: params.source,
 				agent: params.agent,
 				...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 				...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -39,6 +39,7 @@ import {
 	canSpawnAtDepth,
 	type SingleResult,
 	type StructuredSubagentOutput,
+	type TaskContextSource,
 } from "./types";
 import { type NestedRepoPatch, parseIsolationMode } from "./worktree";
 
@@ -83,6 +84,8 @@ export interface StructuredSubagentRequest {
 	invocationKind: "task" | "eval";
 	assignment: string;
 	context?: string;
+	/** Parent-context strategy. Fork modes are available only to task invocations. */
+	source?: TaskContextSource;
 	agent?: string;
 	model?: string | string[];
 	/** Presence, rather than truthiness, makes this the highest-priority schema. */
@@ -383,6 +386,15 @@ function buildExecutorOptions(
 		task: renderSubagentPrompt(request.assignment),
 		assignment: request.assignment.trim(),
 		context: request.context?.trim() || undefined,
+		contextSource: request.source,
+		parentSessionFile: request.session.getSessionFile(),
+		parentSessionManager: request.session.sessionManager,
+		parentModel: request.session.getActiveModel?.(),
+		parentThinkingLevel: request.session.getConfiguredThinkingLevel?.(),
+		parentSystemPrompt: request.session.getSystemPrompt?.(),
+		parentToolNames: request.session.getActiveToolNames?.(),
+		parentPromptCacheKey: request.session.getPromptCacheKey?.(),
+		parentForkLeafId: request.session.getTaskForkLeafId?.(),
 		planReference: undefined,
 		description: trimToUndefined(request.identity?.label),
 		index: request.index ?? 0,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -21,7 +21,7 @@ import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
 import { buildOutputValidator } from "../tools/output-schema-validator";
 import { type DiscoveryResult, discoverAgents, getAgent } from "./discovery";
-import { type ExecutorOptions, runSubprocess } from "./executor";
+import { type ExecutorOptions, type ForkContextSnapshot, runSubprocess } from "./executor";
 import {
 	applyEligibleNestedPatches,
 	type IsolationContext,
@@ -86,6 +86,8 @@ export interface StructuredSubagentRequest {
 	context?: string;
 	/** Parent-context strategy. Fork modes are available only to task invocations. */
 	source?: TaskContextSource;
+	/** Parent request boundary captured when an async task is scheduled. */
+	forkContextSnapshot?: ForkContextSnapshot;
 	agent?: string;
 	model?: string | string[];
 	/** Presence, rather than truthiness, makes this the highest-priority schema. */
@@ -378,6 +380,7 @@ function buildExecutorOptions(
 	};
 	const restrictToolNames = policy.planMode || session.restrictToolNames === true;
 	const enableMCP = !restrictToolNames && (session.enableMCP ?? true);
+	const forkContext = request.forkContextSnapshot;
 	return {
 		cwd: session.cwd,
 		additionalDirectories: session.additionalDirectories,
@@ -387,14 +390,14 @@ function buildExecutorOptions(
 		assignment: request.assignment.trim(),
 		context: request.context?.trim() || undefined,
 		contextSource: request.source,
-		parentSessionFile: request.session.getSessionFile(),
-		parentSessionManager: request.session.sessionManager,
-		parentModel: request.session.getActiveModel?.(),
-		parentThinkingLevel: request.session.getConfiguredThinkingLevel?.(),
-		parentSystemPrompt: request.session.getSystemPrompt?.(),
-		parentToolNames: request.session.getActiveToolNames?.(),
-		parentPromptCacheKey: request.session.getPromptCacheKey?.(),
-		parentForkLeafId: request.session.getTaskForkLeafId?.(),
+		parentSessionFile: forkContext?.sessionFile ?? request.session.getSessionFile(),
+		parentSessionManager: forkContext?.sessionManager ?? request.session.sessionManager,
+		parentModel: forkContext?.model ?? request.session.getActiveModel?.(),
+		parentThinkingLevel: forkContext?.thinkingLevel ?? request.session.getConfiguredThinkingLevel?.(),
+		parentSystemPrompt: forkContext?.systemPrompt ?? request.session.getSystemPrompt?.(),
+		parentToolNames: forkContext?.toolNames ?? request.session.getActiveToolNames?.(),
+		parentPromptCacheKey: forkContext?.promptCacheKey ?? request.session.getPromptCacheKey?.(),
+		parentForkLeafId: forkContext ? forkContext.leafId : request.session.getTaskForkLeafId?.(),
 		planReference: undefined,
 		description: trimToUndefined(request.identity?.label),
 		index: request.index ?? 0,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -22,6 +22,17 @@ export type StructuredSubagentSchemaSource = "caller" | "agent" | "session" | "n
 /** Final validation state of a structured subagent invocation. */
 export type StructuredSubagentValidationStatus = "valid" | "invalid" | "unavailable";
 
+/** Parent-context strategy requested for a task spawn. */
+export type TaskContextSource = "fresh" | "fork" | "auto";
+
+/** Actual context strategy and provider cache evidence for a completed spawn. */
+export interface TaskContextSourceResult {
+	requested: TaskContextSource;
+	used: "fresh" | "fork";
+	cacheReadTokens: number;
+	downgradeReason?: string;
+}
+
 /**
  * Parsed structured completion and its schema-validation metadata.
  *
@@ -110,11 +121,13 @@ export const LABEL_MAX = 80;
 const outputSchemaInputSchema = type("object | boolean | string | null");
 // Coarse per-spawn thinking effort; must stay in sync with TASK_EFFORTS in ../thinking.
 const effortRule = '"lo" | "med" | "hi"' as const;
+const sourceRule = '"fresh" | "fork" | "auto"' as const;
 
 export const taskItemSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": sourceRule,
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
@@ -123,6 +136,7 @@ const taskItemSchemaIsolated = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": sourceRule,
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
@@ -137,6 +151,8 @@ export interface TaskItem {
 	agent?: string;
 	/** The work; required by the schema. */
 	task?: string;
+	/** Context source: fresh handoff, full parent-conversation fork, or fork with fresh fallback. */
+	source?: TaskContextSource;
 	/** Per-spawn thinking effort: lowest/middle/highest level the resolved model supports. Overrides the agent's default selector (e.g. `auto`). */
 	effort?: TaskEffort;
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
@@ -151,6 +167,7 @@ export const taskSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": sourceRule,
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
@@ -160,6 +177,7 @@ const taskSchemaNoIsolation = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": sourceRule,
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
@@ -206,6 +224,7 @@ function createTaskSchema(options: {
 				"name?": "string",
 				agent,
 				task: "string",
+				"source?": sourceRule,
 				...effortField,
 				"outputSchema?": outputSchemaInputSchema,
 				"schemaMode?": '"permissive" | "strict"',
@@ -222,6 +241,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
+			"source?": sourceRule,
 			...effortField,
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
@@ -238,6 +258,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
+			"source?": sourceRule,
 			...effortField,
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
@@ -249,6 +270,7 @@ function createTaskSchema(options: {
 		"name?": "string",
 		agent,
 		task: "string",
+		"source?": sourceRule,
 		...effortField,
 		"outputSchema?": outputSchemaInputSchema,
 		"schemaMode?": '"permissive" | "strict"',
@@ -290,6 +312,8 @@ export interface TaskParams {
 	agent?: string;
 	/** The work (flat form). */
 	task?: string;
+	/** Context source (flat form). */
+	source?: TaskContextSource;
 	/** Per-spawn thinking effort (flat form): lowest/middle/highest level the resolved model supports. */
 	effort?: TaskEffort;
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
@@ -504,6 +528,8 @@ export interface SingleResult {
 	abortReason?: string;
 	/** Aggregated usage from the subprocess, accumulated incrementally from message_end events. */
 	usage?: Usage;
+	/** Requested/actual parent-context strategy and measured prompt-cache reuse. */
+	contextSource?: TaskContextSourceResult;
 	/** Output path for the task result */
 	outputPath?: string;
 	/** Patch path for isolated worktree output */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -232,7 +232,7 @@ export interface ToolSession {
 	/** Parent session journal used by tools that persist runtime lifecycle state. */
 	sessionManager?: Pick<
 		SessionManager,
-		"appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries" | "getCwd"
+		"appendCustomEntry" | "ensureOnDisk" | "flush" | "forkBranch" | "getBranch" | "getEntries" | "getCwd"
 	>;
 	/** Active parent system prompt, needed to preserve a fork's provider-visible prefix. */
 	getSystemPrompt?: () => readonly string[];

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -31,6 +31,7 @@ import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
 import type { AgentOutputManager } from "../task/output-manager";
 import { canSpawnAtDepth, type StructuredSubagentSchemaMode } from "../task/types";
+import type { ConfiguredThinkingLevel } from "../thinking";
 import type { EventBus } from "../utils/event-bus";
 import { type InspectImageMode, isInspectImageToolActive } from "../utils/inspect-image-mode";
 import { WebSearchTool } from "../web/search";
@@ -229,7 +230,20 @@ export interface ToolSession {
 	/** Get session file */
 	getSessionFile: () => string | null;
 	/** Parent session journal used by tools that persist runtime lifecycle state. */
-	sessionManager?: Pick<SessionManager, "appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries">;
+	sessionManager?: Pick<
+		SessionManager,
+		"appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries" | "getCwd"
+	>;
+	/** Active parent system prompt, needed to preserve a fork's provider-visible prefix. */
+	getSystemPrompt?: () => readonly string[];
+	/** Active parent tool names, needed to preserve a fork's provider-visible prefix. */
+	getActiveToolNames?: () => string[];
+	/** Parent's configured thinking level for exact-model fork execution. */
+	getConfiguredThinkingLevel?: () => ConfiguredThinkingLevel | undefined;
+	/** Provider prompt-cache affinity inherited across nested forks. */
+	getPromptCacheKey?: () => string | undefined;
+	/** Last committed parent entry included in a task fork. */
+	getTaskForkLeafId?: () => string | null;
 	/** Get eval kernel owner ID for session-scoped retained-kernel cleanup. */
 	getEvalKernelOwnerId?: () => string | null;
 	/** Reject new eval work once session disposal has started. */

--- a/packages/coding-agent/test/session/session-manager-fork.test.ts
+++ b/packages/coding-agent/test/session/session-manager-fork.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { MemorySessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
 import { getAgentDir, getTerminalSessionsDir, removeWithRetries, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
@@ -24,6 +25,31 @@ interface JsonlMessageEntry {
 }
 
 describe("SessionManager.forkFrom", () => {
+	it("forks through the manager storage and can replace inherited workspace roots", async () => {
+		using tempDir = TempDir.createSync("@omp-session-storage-fork-");
+		const storage = new MemorySessionStorage();
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const source = SessionManager.create(cwd, sessionDir, storage);
+		await source.setAdditionalDirectories([path.join(tempDir.path(), "shared")]);
+		source.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+
+		const forked = await source.forkBranch({
+			cwd: path.join(tempDir.path(), "isolated"),
+			sessionDir,
+			sessionFile: path.join(sessionDir, "fork.jsonl"),
+			additionalDirectories: [],
+		});
+		const forkFile = forked.getSessionFile();
+		if (!forkFile) throw new Error("expected forked session file");
+		const entries = await loadEntriesFromFile(forkFile, storage);
+		const header = entries.find((entry): entry is SessionHeader => entry.type === "session");
+
+		expect(header?.additionalDirectories).toBeUndefined();
+		expect(entries.some(entry => entry.type === "message" && entry.message.role === "user")).toBe(true);
+		expect(await Bun.file(forkFile).exists()).toBe(false);
+	});
+
 	it("suppresses terminal breadcrumbs while preserving source history under a new parented session", async () => {
 		using tempDir = TempDir.createSync("@omp-session-fork-");
 		const previousAgentDir = getAgentDir();

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -95,12 +95,6 @@ function createMockSession(
 	} as unknown as AgentSession;
 }
 
-function createRewriteSession() {
-	const session = createMockSession({ activeTools: ["bash", "todo"] });
-	session.agent.beforeToolCall = async () => ({ args: { command: "rewritten" } });
-	return session;
-}
-
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
 	return {
 		session,
@@ -155,7 +149,7 @@ describe("runSubprocess fork context", () => {
 		const options = createSpy.mock.calls[0]?.[0];
 		expect(options?.model).toBeUndefined();
 		expect(options?.systemPrompt).toBeInstanceOf(Function);
-		expect(options?.toolNames).toEqual(["read", "hub"]);
+		expect(options?.toolNames).toBeUndefined();
 		expect(options?.providerPromptCacheKey).toBe("parent-cache");
 	});
 
@@ -183,43 +177,6 @@ describe("runSubprocess fork context", () => {
 			downgradeReason: "fork context requires a persisted child transcript",
 		});
 		expect(typeof createSpy.mock.calls[0]?.[0]?.systemPrompt).toBe("function");
-	});
-
-	it("blocks non-read tools after extension argument rewrites", async () => {
-		const session = createRewriteSession();
-		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
-		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
-
-		await runSubprocess({
-			cwd: "/tmp",
-			agent: AGENT,
-			task: "inspect",
-			index: 0,
-			id: "GuardAgent",
-			artifactsDir: "/tmp",
-			settings: Settings.isolated(),
-			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
-			enableLsp: false,
-			contextSource: "fork",
-			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
-			parentForkLeafId: "completed-assistant",
-			parentModel: MODEL,
-			parentSystemPrompt: ["parent system"],
-			parentToolNames: ["bash", "todo"],
-		});
-
-		const result = await session.agent.beforeToolCall?.(
-			{
-				tool: { name: "bash", approval: { tier: "exec" } },
-				args: { command: "original" },
-			} as never,
-			undefined,
-		);
-		expect(result).toEqual({
-			block: true,
-			reason: "Forked task agents are read-only; return findings to the parent.",
-		});
 	});
 
 	it("preserves parent tools and appends fork-specific invocation contracts", async () => {
@@ -326,6 +283,6 @@ describe("runSubprocess fork context", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.contextSource).toMatchObject({ requested: "fork", used: "fork" });
 		expect(createSpy).toHaveBeenCalledTimes(1);
-		expect(createSpy.mock.calls[0]?.[0]?.toolNames).toEqual(["ask", "hub"]);
+		expect(createSpy.mock.calls[0]?.[0]?.toolNames).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -57,10 +57,20 @@ function createMockSession(
 		prompt: async (_text: string, _options?: PromptOptions) => {
 			for (const listener of listeners) {
 				listener({
+					type: "tool_execution_end",
+					toolCallId: "tool-fork-yield",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: "fork result" },
+					},
+					isError: false,
+				});
+				listener({
 					type: "message_end",
 					message: {
 						role: "assistant",
-						content: [{ type: "text", text: "fork result" }],
+						content: [],
 						api: MODEL.api,
 						provider: MODEL.provider,
 						model: MODEL.id,
@@ -72,7 +82,7 @@ function createMockSession(
 							totalTokens: 23,
 							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 						},
-						stopReason: "stop",
+						stopReason: "toolUse",
 						timestamp: Date.now(),
 					},
 				});
@@ -132,7 +142,7 @@ describe("runSubprocess fork context", () => {
 		});
 
 		expect(result.exitCode).toBe(0);
-		expect(result.output).toBe("fork result");
+		expect(result.output).toBe('"fork result"');
 		expect(result.contextSource).toEqual({ requested: "fork", used: "fork", cacheReadTokens: 21 });
 		expect(forkBranch).toHaveBeenCalledWith({
 			sourceFile: parentFile,
@@ -169,7 +179,7 @@ describe("runSubprocess fork context", () => {
 		expect(result.contextSource).toEqual({
 			requested: "auto",
 			used: "fresh",
-			cacheReadTokens: 84,
+			cacheReadTokens: 21,
 			downgradeReason: "fork context requires a persisted child transcript",
 		});
 		expect(typeof createSpy.mock.calls[0]?.[0]?.systemPrompt).toBe("function");
@@ -209,38 +219,6 @@ describe("runSubprocess fork context", () => {
 		expect(result).toEqual({
 			block: true,
 			reason: "Forked task agents are read-only; return findings to the parent.",
-		});
-	});
-
-	it("blocks forked agents from steering write-capable peers", async () => {
-		const session = createMockSession({ activeTools: ["hub"] });
-		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
-		await runSubprocess({
-			cwd: "/tmp",
-			agent: AGENT,
-			task: "inspect",
-			index: 0,
-			id: "PeerSteeringAgent",
-			artifactsDir: "/tmp",
-			settings: Settings.isolated(),
-			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
-			enableLsp: false,
-			contextSource: "fork",
-			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
-			parentForkLeafId: "completed-assistant",
-		});
-
-		const decision = await session.agent.beforeToolCall?.(
-			{
-				tool: { name: "hub", approval: { tier: "read" } },
-				args: { op: "send", to: "Main", message: "edit the workspace" },
-			} as never,
-			undefined,
-		);
-		expect(decision).toEqual({
-			block: true,
-			reason: "Forked task agents cannot steer peers; return findings to the parent.",
 		});
 	});
 

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -27,8 +27,15 @@ const AGENT: AgentDefinition = {
 	source: "bundled",
 };
 
-function createMockSession(options: { activeTools?: string[]; messages?: unknown[] } = {}): AgentSession {
-	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+function createMockSession(
+	options: {
+		activeTools?: string[];
+		messages?: unknown[];
+		appendMessage?: (message: AgentMessage) => void;
+		listeners?: Array<(event: AgentSessionEvent) => void>;
+	} = {},
+): AgentSession {
+	const listeners = options.listeners ?? [];
 	const activeTools = options.activeTools ?? ["read"];
 	return {
 		agent: {
@@ -38,7 +45,7 @@ function createMockSession(options: { activeTools?: string[]; messages?: unknown
 		},
 		model: MODEL,
 		extensionRunner: undefined,
-		sessionManager: { appendSessionInit: () => {} },
+		sessionManager: { appendSessionInit: () => {}, appendMessage: options.appendMessage ?? (() => {}) },
 		getActiveToolNames: () => activeTools,
 		getEnabledToolNames: () => activeTools,
 		setActiveToolsByName: async () => {},
@@ -79,7 +86,7 @@ function createMockSession(options: { activeTools?: string[]; messages?: unknown
 }
 
 function createRewriteSession() {
-	const session = createMockSession();
+	const session = createMockSession({ activeTools: ["bash", "todo"] });
 	session.agent.beforeToolCall = async () => ({ args: { command: "rewritten" } });
 	return session;
 }
@@ -240,5 +247,110 @@ describe("runSubprocess fork context", () => {
 		expect(JSON.stringify(messages[0])).toContain("Do not change the API contract.");
 		expect(JSON.stringify(messages[0])).toContain("answer");
 		expect(JSON.stringify(messages[0])).not.toContain("NEVER fix, audit, or build on it");
+	});
+
+	it("reinjects and persists the fork contract after compaction", async () => {
+		const messages: unknown[] = [];
+		const listeners: Array<(event: AgentSessionEvent) => void> = [];
+		const appendMessage = vi.fn();
+		const session = createMockSession({ messages, appendMessage, listeners });
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "CompactAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["read"],
+		});
+
+		expect(appendMessage).toHaveBeenCalledTimes(1);
+		for (const listener of listeners) {
+			listener({
+				type: "auto_compaction_end",
+				action: "context-full",
+				result: {} as never,
+				aborted: false,
+				willRetry: true,
+			});
+		}
+		expect(appendMessage).toHaveBeenCalledTimes(2);
+		expect(messages).toHaveLength(2);
+	});
+
+	it("reports no fresh downgrade when an explicit incompatible fork never starts", async () => {
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
+		const createSpy = vi
+			.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValue(createSessionResult(createMockSession({ activeTools: ["read"] })));
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "IncompatibleAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["ask"],
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.contextSource).toBeUndefined();
+		expect(createSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("auto rebuilds a fresh child when the fork tool catalog differs", async () => {
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
+		const incompatible = createMockSession({ activeTools: ["read"] });
+		const fresh = createMockSession({ activeTools: ["read"] });
+		const createSpy = vi
+			.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValueOnce(createSessionResult(incompatible))
+			.mockResolvedValueOnce(createSessionResult(fresh));
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "AutoCatalogAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "auto",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["read", "ask"],
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.contextSource).toMatchObject({ requested: "auto", used: "fresh" });
+		expect(result.contextSource?.downgradeReason).toContain("cannot reconstruct the parent tool catalog");
+		expect(createSpy).toHaveBeenCalledTimes(2);
+		expect(createSpy.mock.calls[1]?.[0]?.systemPrompt).toBeInstanceOf(Function);
 	});
 });

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -135,6 +135,7 @@ describe("runSubprocess fork context", () => {
 		expect(result.output).toBe("fork result");
 		expect(result.contextSource).toEqual({ requested: "fork", used: "fork", cacheReadTokens: 21 });
 		expect(forkBranch).toHaveBeenCalledWith({
+			sourceFile: parentFile,
 			cwd: "/tmp",
 			sessionDir: "/tmp",
 			suppressBreadcrumb: true,
@@ -208,6 +209,38 @@ describe("runSubprocess fork context", () => {
 		expect(result).toEqual({
 			block: true,
 			reason: "Forked task agents are read-only; return findings to the parent.",
+		});
+	});
+
+	it("blocks forked agents from steering write-capable peers", async () => {
+		const session = createMockSession({ activeTools: ["hub"] });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "PeerSteeringAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+		});
+
+		const decision = await session.agent.beforeToolCall?.(
+			{
+				tool: { name: "hub", approval: { tier: "read" } },
+				args: { op: "send", to: "Main", message: "edit the workspace" },
+			} as never,
+			undefined,
+		);
+		expect(decision).toEqual({
+			block: true,
+			reason: "Forked task agents cannot steer peers; return findings to the parent.",
 		});
 	});
 

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -95,6 +95,12 @@ function createMockSession(
 	} as unknown as AgentSession;
 }
 
+function createRewriteSession() {
+	const session = createMockSession({ activeTools: ["bash", "todo"] });
+	session.agent.beforeToolCall = async () => ({ args: { command: "rewritten" } });
+	return session;
+}
+
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
 	return {
 		session,
@@ -177,6 +183,43 @@ describe("runSubprocess fork context", () => {
 			downgradeReason: "fork context requires a persisted child transcript",
 		});
 		expect(typeof createSpy.mock.calls[0]?.[0]?.systemPrompt).toBe("function");
+	});
+
+	it("blocks non-read tools after extension argument rewrites", async () => {
+		const session = createRewriteSession();
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "GuardAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["bash", "todo"],
+		});
+
+		const result = await session.agent.beforeToolCall?.(
+			{
+				tool: { name: "bash", approval: { tier: "exec" } },
+				args: { command: "original" },
+			} as never,
+			undefined,
+		);
+		expect(result).toEqual({
+			block: true,
+			reason: "Forked task agents are read-only; return findings to the parent.",
+		});
 	});
 
 	it("preserves parent tools and appends fork-specific invocation contracts", async () => {

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -143,9 +143,9 @@ describe("runSubprocess fork context", () => {
 			sourceLeafId: "completed-assistant",
 		});
 		const options = createSpy.mock.calls[0]?.[0];
-		expect(options?.model).toBe(MODEL);
-		expect(options?.systemPrompt).toEqual(["parent system"]);
-		expect(options?.toolNames).toEqual(["read"]);
+		expect(options?.model).toBeUndefined();
+		expect(options?.systemPrompt).toBeInstanceOf(Function);
+		expect(options?.toolNames).toBeUndefined();
 		expect(options?.providerPromptCacheKey).toBe("parent-cache");
 		expect(parent.getEntries()).toEqual([]);
 	});
@@ -290,7 +290,7 @@ describe("runSubprocess fork context", () => {
 		expect(messages).toHaveLength(2);
 	});
 
-	it("reports no fresh downgrade when an explicit incompatible fork never starts", async () => {
+	it("keeps fork context when headless construction omits a parent tool", async () => {
 		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
 		const createSpy = vi
 			.spyOn(sdkModule, "createAgentSession")
@@ -314,43 +314,9 @@ describe("runSubprocess fork context", () => {
 			parentToolNames: ["ask"],
 		});
 
-		expect(result.exitCode).toBe(1);
-		expect(result.contextSource).toBeUndefined();
-		expect(createSpy).toHaveBeenCalledTimes(1);
-	});
-
-	it("auto rebuilds a fresh child when the fork tool catalog differs", async () => {
-		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
-		const incompatible = createMockSession({ activeTools: ["read"] });
-		const fresh = createMockSession({ activeTools: ["read"] });
-		const createSpy = vi
-			.spyOn(sdkModule, "createAgentSession")
-			.mockResolvedValueOnce(createSessionResult(incompatible))
-			.mockResolvedValueOnce(createSessionResult(fresh));
-
-		const result = await runSubprocess({
-			cwd: "/tmp",
-			agent: AGENT,
-			task: "inspect",
-			index: 0,
-			id: "AutoCatalogAgent",
-			artifactsDir: "/tmp",
-			settings: Settings.isolated(),
-			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
-			enableLsp: false,
-			contextSource: "auto",
-			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
-			parentForkLeafId: "completed-assistant",
-			parentModel: MODEL,
-			parentSystemPrompt: ["parent system"],
-			parentToolNames: ["read", "ask"],
-		});
-
 		expect(result.exitCode).toBe(0);
-		expect(result.contextSource).toMatchObject({ requested: "auto", used: "fresh" });
-		expect(result.contextSource?.downgradeReason).toContain("cannot reconstruct the parent tool catalog");
-		expect(createSpy).toHaveBeenCalledTimes(2);
-		expect(createSpy.mock.calls[1]?.[0]?.systemPrompt).toBeInstanceOf(Function);
+		expect(result.contextSource).toMatchObject({ requested: "fork", used: "fork" });
+		expect(createSpy).toHaveBeenCalledTimes(1);
+		expect(createSpy.mock.calls[0]?.[0]?.toolNames).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -155,7 +155,7 @@ describe("runSubprocess fork context", () => {
 		const options = createSpy.mock.calls[0]?.[0];
 		expect(options?.model).toBeUndefined();
 		expect(options?.systemPrompt).toBeInstanceOf(Function);
-		expect(options?.toolNames).toBeUndefined();
+		expect(options?.toolNames).toEqual(["read", "hub"]);
 		expect(options?.providerPromptCacheKey).toBe("parent-cache");
 	});
 
@@ -326,6 +326,6 @@ describe("runSubprocess fork context", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.contextSource).toMatchObject({ requested: "fork", used: "fork" });
 		expect(createSpy).toHaveBeenCalledTimes(1);
-		expect(createSpy.mock.calls[0]?.[0]?.toolNames).toBeUndefined();
+		expect(createSpy.mock.calls[0]?.[0]?.toolNames).toEqual(["ask", "hub"]);
 	});
 });

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-catalog";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+const MODEL = {
+	provider: "test",
+	id: "fork-model",
+	api: "openai-completions",
+	contextWindow: 32_000,
+	maxTokens: 4_000,
+} as Model;
+
+const AGENT: AgentDefinition = {
+	name: "task",
+	description: "test",
+	systemPrompt: "fresh prompt",
+	source: "bundled",
+};
+
+function createMockSession(): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	return {
+		agent: {
+			state: { systemPrompt: ["parent system"] },
+			beforeToolCall: undefined,
+			appendMessage: () => {},
+		},
+		model: MODEL,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["read"],
+		getEnabledToolNames: () => ["read"],
+		setActiveToolsByName: async () => {},
+		setTodoPhases: () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {};
+		},
+		prompt: async (_text: string, _options?: PromptOptions) => {
+			for (const listener of listeners) {
+				listener({
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "fork result" }],
+						api: MODEL.api,
+						provider: MODEL.provider,
+						model: MODEL.id,
+						usage: {
+							input: 1,
+							output: 1,
+							cacheRead: 21,
+							cacheWrite: 0,
+							totalTokens: 23,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: Date.now(),
+					},
+				});
+			}
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+	} as unknown as AgentSession;
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: { extensions: [], errors: [], runtime: {} as unknown } as unknown as LoadExtensionsResult,
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	};
+}
+
+describe("runSubprocess fork context", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("clones through the completed boundary and reports measured cache reads", async () => {
+		const parent = SessionManager.inMemory("/tmp");
+		const parentFile = "/tmp/parent.jsonl";
+		const forkManager = SessionManager.inMemory("/tmp");
+		const ensureOnDisk = vi.fn(async () => {});
+		const flush = vi.fn(async () => {});
+		const forkSpy = vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(forkManager);
+		const createSpy = vi
+			.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValue(createSessionResult(createMockSession()));
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect inherited context",
+			index: 0,
+			id: "ForkAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: parentFile,
+			parentSessionManager: { ensureOnDisk, flush, getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["read"],
+			parentPromptCacheKey: "parent-cache",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output).toBe("fork result");
+		expect(result.contextSource).toEqual({ requested: "fork", used: "fork", cacheReadTokens: 21 });
+		expect(forkSpy).toHaveBeenCalledWith(parentFile, "/tmp", "/tmp", undefined, {
+			suppressBreadcrumb: true,
+			sessionFile: "/tmp/ForkAgent.jsonl",
+			sourceLeafId: "completed-assistant",
+		});
+		const options = createSpy.mock.calls[0]?.[0];
+		expect(options?.model).toBe(MODEL);
+		expect(options?.systemPrompt).toEqual(["parent system"]);
+		expect(options?.toolNames).toEqual(["read"]);
+		expect(options?.providerPromptCacheKey).toBe("parent-cache");
+		expect(parent.getEntries()).toEqual([]);
+	});
+
+	it("auto falls back to fresh context when the parent is not persisted", async () => {
+		const createSpy = vi
+			.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValue(createSessionResult(createMockSession()));
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "AutoAgent",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "auto",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.contextSource).toEqual({
+			requested: "auto",
+			used: "fresh",
+			cacheReadTokens: 84,
+			downgradeReason: "fork context requires a persisted child transcript",
+		});
+		expect(typeof createSpy.mock.calls[0]?.[0]?.systemPrompt).toBe("function");
+	});
+});

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -104,12 +104,9 @@ describe("runSubprocess fork context", () => {
 	afterEach(() => vi.restoreAllMocks());
 
 	it("clones through the completed boundary and reports measured cache reads", async () => {
-		const parent = SessionManager.inMemory("/tmp");
 		const parentFile = "/tmp/parent.jsonl";
 		const forkManager = SessionManager.inMemory("/tmp");
-		const ensureOnDisk = vi.fn(async () => {});
-		const flush = vi.fn(async () => {});
-		const forkSpy = vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(forkManager);
+		const forkBranch = vi.fn(async () => forkManager);
 		const createSpy = vi
 			.spyOn(sdkModule, "createAgentSession")
 			.mockResolvedValue(createSessionResult(createMockSession()));
@@ -126,7 +123,7 @@ describe("runSubprocess fork context", () => {
 			enableLsp: false,
 			contextSource: "fork",
 			parentSessionFile: parentFile,
-			parentSessionManager: { ensureOnDisk, flush, getCwd: () => "/tmp" },
+			parentSessionManager: { forkBranch, getCwd: () => "/tmp" },
 			parentForkLeafId: "completed-assistant",
 			parentModel: MODEL,
 			parentSystemPrompt: ["parent system"],
@@ -137,7 +134,9 @@ describe("runSubprocess fork context", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.output).toBe("fork result");
 		expect(result.contextSource).toEqual({ requested: "fork", used: "fork", cacheReadTokens: 21 });
-		expect(forkSpy).toHaveBeenCalledWith(parentFile, "/tmp", "/tmp", undefined, {
+		expect(forkBranch).toHaveBeenCalledWith({
+			cwd: "/tmp",
+			sessionDir: "/tmp",
 			suppressBreadcrumb: true,
 			sessionFile: "/tmp/ForkAgent.jsonl",
 			sourceLeafId: "completed-assistant",
@@ -147,7 +146,6 @@ describe("runSubprocess fork context", () => {
 		expect(options?.systemPrompt).toBeInstanceOf(Function);
 		expect(options?.toolNames).toBeUndefined();
 		expect(options?.providerPromptCacheKey).toBe("parent-cache");
-		expect(parent.getEntries()).toEqual([]);
 	});
 
 	it("auto falls back to fresh context when the parent is not persisted", async () => {
@@ -193,7 +191,7 @@ describe("runSubprocess fork context", () => {
 			enableLsp: false,
 			contextSource: "fork",
 			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
 			parentForkLeafId: "completed-assistant",
 			parentModel: MODEL,
 			parentSystemPrompt: ["parent system"],
@@ -234,7 +232,7 @@ describe("runSubprocess fork context", () => {
 			enableLsp: false,
 			contextSource: "fork",
 			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
 			parentForkLeafId: "completed-assistant",
 			parentModel: MODEL,
 			parentSystemPrompt: ["parent system"],
@@ -269,7 +267,7 @@ describe("runSubprocess fork context", () => {
 			enableLsp: false,
 			contextSource: "fork",
 			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
 			parentForkLeafId: "completed-assistant",
 			parentModel: MODEL,
 			parentSystemPrompt: ["parent system"],
@@ -307,7 +305,7 @@ describe("runSubprocess fork context", () => {
 			enableLsp: false,
 			contextSource: "fork",
 			parentSessionFile: "/tmp/parent.jsonl",
-			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentSessionManager: { forkBranch: async () => SessionManager.inMemory("/tmp"), getCwd: () => "/tmp" },
 			parentForkLeafId: "completed-assistant",
 			parentModel: MODEL,
 			parentSystemPrompt: ["parent system"],

--- a/packages/coding-agent/test/task/executor-fork-context.test.ts
+++ b/packages/coding-agent/test/task/executor-fork-context.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-catalog";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -26,19 +27,20 @@ const AGENT: AgentDefinition = {
 	source: "bundled",
 };
 
-function createMockSession(): AgentSession {
+function createMockSession(options: { activeTools?: string[]; messages?: unknown[] } = {}): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const activeTools = options.activeTools ?? ["read"];
 	return {
 		agent: {
 			state: { systemPrompt: ["parent system"] },
 			beforeToolCall: undefined,
-			appendMessage: () => {},
+			appendMessage: (message: AgentMessage) => options.messages?.push(message),
 		},
 		model: MODEL,
 		extensionRunner: undefined,
 		sessionManager: { appendSessionInit: () => {} },
-		getActiveToolNames: () => ["read"],
-		getEnabledToolNames: () => ["read"],
+		getActiveToolNames: () => activeTools,
+		getEnabledToolNames: () => activeTools,
 		setActiveToolsByName: async () => {},
 		setTodoPhases: () => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
@@ -74,6 +76,12 @@ function createMockSession(): AgentSession {
 		abort: async () => {},
 		dispose: async () => {},
 	} as unknown as AgentSession;
+}
+
+function createRewriteSession() {
+	const session = createMockSession();
+	session.agent.beforeToolCall = async () => ({ args: { command: "rewritten" } });
+	return session;
 }
 
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
@@ -159,5 +167,78 @@ describe("runSubprocess fork context", () => {
 			downgradeReason: "fork context requires a persisted child transcript",
 		});
 		expect(typeof createSpy.mock.calls[0]?.[0]?.systemPrompt).toBe("function");
+	});
+
+	it("blocks non-read tools after extension argument rewrites", async () => {
+		const session = createRewriteSession();
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			index: 0,
+			id: "GuardAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["bash", "todo"],
+		});
+
+		const result = await session.agent.beforeToolCall?.(
+			{
+				tool: { name: "bash", approval: { tier: "exec" } },
+				args: { command: "original" },
+			} as never,
+			undefined,
+		);
+		expect(result).toEqual({
+			block: true,
+			reason: "Forked task agents are read-only; return findings to the parent.",
+		});
+	});
+
+	it("preserves parent tools and appends fork-specific invocation contracts", async () => {
+		const messages: unknown[] = [];
+		const session = createMockSession({ activeTools: ["read", "todo"], messages });
+		const setTools = vi.spyOn(session, "setActiveToolsByName");
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(SessionManager.inMemory("/tmp"));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent: AGENT,
+			task: "inspect",
+			context: "Do not change the API contract.",
+			outputSchema: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] },
+			index: 0,
+			id: "ContractAgent",
+			artifactsDir: "/tmp",
+			settings: Settings.isolated(),
+			modelRegistry: { authStorage: {}, refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			contextSource: "fork",
+			parentSessionFile: "/tmp/parent.jsonl",
+			parentSessionManager: { ensureOnDisk: async () => {}, flush: async () => {}, getCwd: () => "/tmp" },
+			parentForkLeafId: "completed-assistant",
+			parentModel: MODEL,
+			parentSystemPrompt: ["parent system"],
+			parentToolNames: ["read", "todo"],
+		});
+
+		expect(setTools).not.toHaveBeenCalled();
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toMatchObject({ role: "developer" });
+		expect(JSON.stringify(messages[0])).toContain("Do not change the API contract.");
+		expect(JSON.stringify(messages[0])).toContain("answer");
+		expect(JSON.stringify(messages[0])).not.toContain("NEVER fix, audit, or build on it");
 	});
 });

--- a/packages/coding-agent/test/task/spawn-policy.test.ts
+++ b/packages/coding-agent/test/task/spawn-policy.test.ts
@@ -47,6 +47,14 @@ describe("task spawn policy surfaces", () => {
 		expect(parsed).toEqual({ agent: "fact-finder", task: "check" });
 	});
 
+	it("accepts explicit fresh, fork, and auto context sources", () => {
+		const schema = getTaskSchema({ isolationEnabled: false, batchEnabled: false, defaultAgent: "fact-finder" });
+
+		for (const source of ["fresh", "fork", "auto"] as const) {
+			expect(schema({ task: "check", source })).toEqual({ agent: "fact-finder", task: "check", source });
+		}
+	});
+
 	it("filters the agent list to the restricted spawn policy in the description", async () => {
 		vi.spyOn(taskDiscovery, "discoverAgents").mockResolvedValue({
 			agents: [factFinderAgent, oracleAgent],

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -403,6 +403,7 @@ describe("task.batch spawning", () => {
 		vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(
 			makeResult("Forked", {
 				contextSource: { requested: "fork", used: "fork", cacheReadTokens: 17 },
+				outputPath: "/tmp/Forked-output.txt",
 			}),
 		);
 		const manager = createManager();
@@ -418,12 +419,13 @@ describe("task.batch spawning", () => {
 		expect(job).toBeDefined();
 		await job!.promise;
 
-		const details = job?.latestDetails as { results?: SingleResult[] } | undefined;
+		const details = job?.latestDetails as { results?: SingleResult[]; outputPaths?: string[] } | undefined;
 		expect(details?.results?.[0]?.contextSource).toEqual({
 			requested: "fork",
 			used: "fork",
 			cacheReadTokens: 17,
 		});
+		expect(details?.outputPaths).toEqual(["/tmp/Forked-output.txt"]);
 	});
 
 	it("routes each mixed-agent item through its selected definition while preserving caller overrides", async () => {

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -398,6 +398,34 @@ describe("task.batch spawning", () => {
 		for (const spawn of seen) expect(spawn.parentAgentId).toBe("ParentA");
 	});
 
+	it("preserves completed fork metadata in background job details", async () => {
+		mockDiscovery();
+		vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(
+			makeResult("Forked", {
+				contextSource: { requested: "fork", used: "fork", cacheReadTokens: 17 },
+			}),
+		);
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({ manager, settings: { "async.enabled": true, "task.batch": true } }),
+		);
+
+		await tool.execute("tc-fork-background", {
+			context: "Shared context.",
+			tasks: [{ name: "Forked", task: "Inspect inherited context.", source: "fork" }],
+		} as TaskParams);
+		const job = manager.getJob("Forked");
+		expect(job).toBeDefined();
+		await job!.promise;
+
+		const details = job?.latestDetails as { results?: SingleResult[] } | undefined;
+		expect(details?.results?.[0]?.contextSource).toEqual({
+			requested: "fork",
+			used: "fork",
+			cacheReadTokens: 17,
+		});
+	});
+
 	it("routes each mixed-agent item through its selected definition while preserving caller overrides", async () => {
 		const scoutSchema = { type: "object", properties: { findings: { type: "array" } } };
 		const reviewerSchema = { type: "object", properties: { verdict: { type: "string" } } };


### PR DESCRIPTION
## What

- Add per-spawn task context sources: `fresh`, `fork`, and `auto`.
- Clone the parent conversation only through the completed request boundary, excluding the in-flight assistant task call.
- Preserve the parent model, thinking level, system prompt, tool schema, and prompt-cache lineage for forked requests.
- Keep fork execution read-only at the host tool boundary.
- Report requested/actual source mode, downgrade reason, and measured cache-read tokens.
- Retain existing fresh-context behavior as the default.

## Why

Task subagents currently receive only a generated handoff. Context-heavy work can lose prior user intent, constraints, and decisions, while prompt-cache reuse is unavailable. This implements the Phase 1 `fresh | fork | auto` source modes proposed in #6193 without removing clean-room fresh agents.

## Verification

- `bun test test/task/executor-fork-context.test.ts test/task/spawn-policy.test.ts test/task/task-batch.test.ts` — 23 passed
- `bun check` — passed

## Safety

- Forks pin the completed parent boundary instead of cloning the live tool-call leaf.
- Forked tool calls are blocked unless their resolved approval tier is read-only.
- Isolated worktrees are incompatible with fork mode; `fork` fails and `auto` downgrades to fresh with an explicit reason.

Closes #6193