### PR TITLE
fix(coding-agent): thinking traces keep their markdown hierarchy while receding

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed Advisor notes appending stale-review-window warnings when newer primary turns are queued during a review.
+- Fixed thinking traces losing their markdown hierarchy. The trace was rendered with a flat `DefaultTextStyle.color` override, which `Markdown#applyDefaultStyle` applies after the element theme function, so the innermost sequence won and every heading collapsed to body grey while list markers and inline code — which the override never reached — stayed bright; the block was also italicised throughout, which monospace fonts synthesise by shearing glyphs. Traces now render through the full markdown theme and recede as a whole: each emitted colour is desaturated and faded toward the theme surface (accents less than plain prose, so a heading still outranks the body it introduces), `ESC[39m` is rewritten to a recessed base foreground so uncoloured prose recedes too, and the aside is marked with a left rail instead of italics. Light themes fade toward white rather than scaling HSV value, which cannot dim a `#000000` foreground; 256-colour terminals recess with SGR 2 (faint).
 - Fixed layout padding alignment issues in bordered output blocks and web-search result panels.
 - Fixed excluded web search providers remaining visible in the Web Search Provider Order settings list.
 - Fixed internal Hub peer messages being exposed as ordinary tool-call updates in clients like Paseo.

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -18,6 +18,7 @@ import { expandKeyHint, getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS }
 import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
 import { resolveAssistantErrorPresentation } from "../utils/transcript-render-helpers";
 import { type CacheInvalidation, CacheInvalidationMarkerComponent } from "./cache-invalidation-marker";
+import { ThinkingBlockComponent } from "./thinking-block";
 
 /**
  * Max lines of a turn-ending provider error rendered inline in the transcript.
@@ -892,13 +893,14 @@ export class AssistantMessageComponent extends Container {
 							(c.type === "thinking" && resolveThinkingDisplay(c, this.proseOnlyThinking).visible),
 					);
 
-				// Thinking traces in thinkingText color, italic
-				const md = new Markdown(thinkingText, 1, 0, getMarkdownTheme(), {
-					color: (text: string) => theme.fg("thinkingText", text),
-					italic: true,
-				});
+				// Thinking renders through the full markdown theme — headings, bullets,
+				// inline code and quotes keep their semantic colours — and is recessed
+				// as a whole by ThinkingBlockComponent (per-line foreground attenuation
+				// plus a muted rail). A flat `color` override would erase exactly the
+				// hierarchy the trace needs, and italics shear CJK glyphs.
+				const md = new Markdown(thinkingText, 0, 0, getMarkdownTheme());
 				md.transientRenderCache = this.#lastUpdateTransient;
-				this.#contentContainer.addChild(md);
+				this.#contentContainer.addChild(new ThinkingBlockComponent(md));
 				captureItems?.push({ md, contentIndex: i, blockType: "thinking", lastText: thinkingText });
 				this.#appendThinkingExtensions(i, thinkingIndex, thinkingText);
 				hasRenderedContent = true;

--- a/packages/coding-agent/src/modes/components/thinking-block.ts
+++ b/packages/coding-agent/src/modes/components/thinking-block.ts
@@ -1,0 +1,128 @@
+import { type Component, type Markdown, shadeAnsiForegrounds, visibleWidth } from "@oh-my-pi/pi-tui";
+import { adjustHsv } from "@oh-my-pi/pi-utils";
+import { theme } from "../theme/theme";
+
+/**
+ * How far a colour travels toward the surface it recesses into. Accents move
+ * less than plain prose: they *are* the hierarchy, so they must stay above the
+ * body they annotate (measured inversion when both used one factor: base luma
+ * 166 vs shaded-heading luma 161).
+ */
+const ACCENT_RECESS = 0.32;
+const BASE_RECESS = 0.46;
+/** Saturation multiplier applied alongside the fade, so accents read as quieter. */
+const ACCENT_DESATURATE = 0.72;
+
+/** Left-edge aside marker. Two columns: rail plus separator space. */
+const GUTTER_WIDTH = 2;
+
+/**
+ * A thinking trace rendered as a recessed aside.
+ *
+ * The inner {@link Markdown} is built with the *full* markdown theme — no
+ * foreground override, no italic — so headings, bullets, inline code and quotes
+ * keep their semantic colours. This wrapper then pushes the whole block back one
+ * step and marks it as an aside with a muted rail instead of italics, which
+ * monospace fonts synthesise by shearing glyphs and which costs CJK text most.
+ *
+ * Recessing is a fade toward the surface, not a multiplicative darkening: on a
+ * light theme the body text is `#000000`, whose HSV value is 0 and therefore
+ * immune to any multiplier — it can only recede by moving toward white.
+ *
+ * On 256-colour terminals there is no RGB foreground to rewrite, so the block
+ * recesses with SGR 2 (faint) instead, keeping colour identity intact.
+ *
+ * The inner component stays the streaming target: callers hold the `Markdown`
+ * and drive `setText`/`transientRenderCache` on it exactly as before.
+ */
+export class ThinkingBlockComponent implements Component {
+	#cacheSource: readonly string[] | undefined;
+	#cacheWidth = -1;
+	#cacheResult: readonly string[] = [];
+	/** Recessed colour per source colour, reset whenever the theme changes. */
+	readonly #recessed = new Map<string, string>();
+	#recessedForTheme: unknown;
+
+	constructor(readonly markdown: Markdown) {}
+
+	render(width: number): readonly string[] {
+		const innerWidth = Math.max(1, width - GUTTER_WIDTH);
+		const source = this.markdown.render(innerWidth);
+		// Markdown returns the same array reference while unchanged, so reference
+		// identity is a sound (and free) memo key for the decoration pass.
+		if (source === this.#cacheSource && this.#cacheWidth === width) return this.#cacheResult;
+
+		if (this.#recessedForTheme !== theme) {
+			this.#recessed.clear();
+			this.#recessedForTheme = theme;
+		}
+		const truecolor = theme.getColorMode() === "truecolor";
+		const rail = theme.fg("mdQuoteBorder", theme.symbol("thinking.rail"));
+		// Plain prose carries no explicit foreground, so rewriting emitted colours
+		// alone would leave body text at full terminal brightness while only the
+		// accents receded. A recessed `text` role becomes the block's base
+		// foreground, and markdown's own `ESC[39m` (revert to default) is rewritten
+		// to that base so a coloured run hands the line back to the aside rather
+		// than to the terminal default.
+		const base = truecolor ? `\x1b[${sgrFg(this.#recess(theme.getColorHex("text"), BASE_RECESS))}m` : "";
+		const shade = (hex: string): string => {
+			const cached = this.#recessed.get(hex);
+			if (cached !== undefined) return cached;
+			const value = this.#recess(adjustHsv(hex, { s: ACCENT_DESATURATE }), ACCENT_RECESS);
+			this.#recessed.set(hex, value);
+			return value;
+		};
+
+		const decorated: string[] = [];
+		for (const line of source) {
+			if (visibleWidth(line) === 0) {
+				decorated.push(rail);
+				continue;
+			}
+			const body = truecolor
+				? `${base}${shadeAnsiForegrounds(line, shade).replaceAll("\x1b[39m", base)}\x1b[39m`
+				: faint(line);
+			decorated.push(`${rail} ${body}`);
+		}
+
+		this.#cacheSource = source;
+		this.#cacheWidth = width;
+		this.#cacheResult = decorated;
+		return decorated;
+	}
+
+	invalidate(): void {
+		this.#cacheSource = undefined;
+		this.#cacheWidth = -1;
+		this.markdown.invalidate();
+	}
+
+	/** Fade `hex` toward the theme's surface (white on light themes, black on dark). */
+	#recess(hex: string, amount: number): string {
+		const target = theme.isLight ? 255 : 0;
+		const channels: string[] = [];
+		for (let i = 1; i < 7; i += 2) {
+			const channel = Number.parseInt(hex.slice(i, i + 2), 16);
+			channels.push(
+				Math.round(channel + (target - channel) * amount)
+					.toString(16)
+					.padStart(2, "0"),
+			);
+		}
+		return `#${channels.join("")}`;
+	}
+}
+
+/**
+ * Wrap a rendered line in SGR 2 (faint). Any reset the line already emits would
+ * clear the attenuation, so faint is re-armed after every reset sequence.
+ */
+function faint(line: string): string {
+	if (line.length === 0) return line;
+	return `\x1b[2m${line.replaceAll("\x1b[0m", "\x1b[0m\x1b[2m").replaceAll("\x1b[22m", "\x1b[22m\x1b[2m")}\x1b[22m`;
+}
+
+/** `#rrggbb` → the SGR parameter list selecting it as a truecolor foreground. */
+function sgrFg(hex: string): string {
+	return `38;2;${Number.parseInt(hex.slice(1, 3), 16)};${Number.parseInt(hex.slice(3, 5), 16)};${Number.parseInt(hex.slice(5, 7), 16)}`;
+}

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -108,6 +108,7 @@ export type SymbolKey =
 	| "icon.context"
 	| "icon.cost"
 	| "icon.time"
+	| "icon.health"
 	| "icon.pi"
 	| "icon.ghost"
 	| "icon.agents"
@@ -163,6 +164,7 @@ export type SymbolKey =
 	| "md.colorSwatch"
 	// Advisor note rail
 	| "advisor.rail"
+	| "thinking.rail"
 	// Language/file type icons
 	| "lang.default"
 	| "lang.typescript"
@@ -318,6 +320,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"icon.context": "◫",
 	"icon.cost": "💲",
 	"icon.time": "⏱",
+	"icon.health": "✓",
 	"icon.pi": "π",
 	"icon.ghost": "👻",
 	"icon.agents": "👥",
@@ -373,6 +376,9 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"md.colorSwatch": "■",
 	// Advisor note rail (heavier than md.quoteBorder so notes read as a distinct voice)
 	"advisor.rail": "▎",
+	// Thinking-trace rail (lighter than md.quoteBorder so a recessed trace never
+	// out-weighs a real blockquote inside it)
+	"thinking.rail": "╎",
 	// Language/file icons (emoji-centric, no Nerd Font required)
 	"lang.default": "⌘",
 	"lang.typescript": "🟦",
@@ -594,6 +600,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.cost": "\uf155",
 	// pick:  | alt: ◷ ◴
 	"icon.time": "\uf017",
+	// pick: ✓ | alt:  (nf-fa-shield) 󰒃 (nf-md-shield)
+	"icon.health": "✓",
 	// pick:  | alt: π ∏ ∑
 	"icon.pi": "\ue22c",
 	// pick: 󰊠 (nf-md-ghost) | alt: 👻
@@ -684,6 +692,7 @@ const NERD_SYMBOLS: SymbolMap = {
 	"md.colorSwatch": "■",
 	// pick: ▎ | alt: ┃ │
 	"advisor.rail": "▎",
+	"thinking.rail": "╎",
 	// Language icons (nerd font devicons)
 	"lang.default": "",
 	"lang.typescript": "\u{E628}",
@@ -838,6 +847,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"icon.context": "ctx:",
 	"icon.cost": "$",
 	"icon.time": "t:",
+	"icon.health": "ok",
 	"icon.pi": "pi",
 	"icon.ghost": "@",
 	"icon.agents": "AG",
@@ -890,6 +900,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"md.bullet": "*",
 	"md.colorSwatch": "[]",
 	"advisor.rail": "|",
+	"thinking.rail": ":",
 	// Language icons (ASCII uses abbreviations)
 	"lang.default": "code",
 	"lang.typescript": "ts",
@@ -1838,6 +1849,7 @@ export class Theme {
 			context: this.#symbols["icon.context"],
 			cost: this.#symbols["icon.cost"],
 			time: this.#symbols["icon.time"],
+			health: this.#symbols["icon.health"],
 			pi: this.#symbols["icon.pi"],
 			ghost: this.#symbols["icon.ghost"],
 			agents: this.#symbols["icon.agents"],

--- a/packages/coding-agent/test/thinking-block.test.ts
+++ b/packages/coding-agent/test/thinking-block.test.ts
@@ -1,0 +1,164 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Markdown } from "@oh-my-pi/pi-tui";
+import { ThinkingBlockComponent } from "../src/modes/components/thinking-block";
+import { getMarkdownTheme, setTheme, theme } from "../src/modes/theme/theme";
+
+/**
+ * Thinking traces are rendered by attenuating the markdown theme's own colours
+ * rather than overriding them, so the block recedes while keeping the hierarchy
+ * the model wrote. These tests assert that hierarchy from the emitted ANSI —
+ * the only ground truth for "is the heading still a heading" — because the
+ * previous rendering looked reasonable in a screenshot while having silently
+ * flattened every heading to body grey.
+ */
+
+const SAMPLE = [
+	"## Plan",
+	"",
+	"Weigh **cache** placement:",
+	"",
+	"- inside `SessionStore` — simple",
+	"- at `ProviderBoundary` — isolated",
+	"",
+	"> note: `transformProviderContext` memoises already.",
+	"",
+	"Go with the second.",
+].join("\n");
+
+const WIDTH = 72;
+const FG_RE = /38;2;(\d{1,3});(\d{1,3});(\d{1,3})/g;
+
+type Rgb = readonly [number, number, number];
+
+function foregrounds(line: string): Rgb[] {
+	return [...line.matchAll(FG_RE)].map(m => [Number(m[1]), Number(m[2]), Number(m[3])] as Rgb);
+}
+
+function luma([r, g, b]: Rgb): number {
+	return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** Hue in degrees, or -1 for achromatic colours (r == g == b). */
+function hue([r, g, b]: Rgb): number {
+	const [rn, gn, bn] = [r / 255, g / 255, b / 255];
+	const max = Math.max(rn, gn, bn);
+	const delta = max - Math.min(rn, gn, bn);
+	if (delta < 0.02) return -1;
+	let h: number;
+	if (max === rn) h = ((gn - bn) / delta) % 6;
+	else if (max === gn) h = (bn - rn) / delta + 2;
+	else h = (rn - gn) / delta + 4;
+	h *= 60;
+	return h < 0 ? h + 360 : h;
+}
+
+function renderThinking(): readonly string[] {
+	const block = new ThinkingBlockComponent(new Markdown(SAMPLE, 0, 0, getMarkdownTheme()));
+	return block.render(WIDTH);
+}
+
+function renderProse(): readonly string[] {
+	return new Markdown(SAMPLE, 1, 0, getMarkdownTheme(), undefined).render(WIDTH);
+}
+
+const contentful = (lines: readonly string[]): string[] => lines.filter(line => line.trim().length > 0);
+
+describe("thinking block rendering", () => {
+	beforeAll(async () => {
+		await setTheme("dark");
+	});
+
+	test("heading keeps its semantic hue, attenuated rather than replaced", () => {
+		const thinkingHeading = contentful(renderThinking())[0]!;
+		const proseHeading = contentful(renderProse())[0]!;
+		const proseHeadingFg = foregrounds(proseHeading)[0]!;
+		// [rail, base, heading, base, …] — the heading colour is the first foreground
+		// that is neither the (unshaded) rail nor the repeated base.
+		const fgs = foregrounds(thinkingHeading);
+		const headingFg = fgs.find((c, i) => i > 1 && c.join() !== fgs[1]!.join())!;
+
+		expect(headingFg).toBeDefined();
+		expect(Math.abs(hue(headingFg) - hue(proseHeadingFg))).toBeLessThanOrEqual(10);
+		// The pre-fix rendering emitted the flat `thinkingText` role here instead.
+		expect(headingFg.join()).not.toBe(theme.getColorHex("thinkingText"));
+	});
+
+	test("heading outranks body prose in brightness", () => {
+		const lines = contentful(renderThinking());
+		const bodyFg = foregrounds(lines[1]!)[1]!;
+		const fgs = foregrounds(lines[0]!);
+		const headingFg = fgs.find((c, i) => i > 1 && c.join() !== fgs[1]!.join())!;
+
+		expect(luma(headingFg)).toBeGreaterThan(luma(bodyFg));
+	});
+
+	test("body prose is attenuated below unshaded prose", () => {
+		const thinkingBodyFg = foregrounds(contentful(renderThinking())[1]!)[1]!;
+		// Prose body carries no explicit foreground at all — it renders at the
+		// terminal default, which is the brightest thing on screen.
+		expect(luma(thinkingBodyFg)).toBeLessThan(luma([255, 255, 255]));
+		expect(hue(thinkingBodyFg)).toBeLessThan(1);
+	});
+
+	test("inline code stays chromatically distinct from body prose", () => {
+		const lines = contentful(renderThinking());
+		const codeLine = lines.find(line => line.includes("SessionStore"))!;
+		const fgs = foregrounds(codeLine);
+		const bodyFg = fgs[1]!;
+		const codeFg = fgs.find(c => hue(c) >= 0 && Math.abs(hue(c) - 40) > 15)!;
+
+		expect(codeFg).toBeDefined();
+		expect(hue(bodyFg)).toBeLessThan(0);
+		expect(hue(codeFg)).toBeGreaterThanOrEqual(0);
+	});
+
+	test("every rendered row carries the aside rail", () => {
+		const rail = theme.symbol("thinking.rail");
+		for (const line of renderThinking()) expect(line).toContain(rail);
+	});
+
+	test("prose is no longer italicised; only markdown's own blockquote italics remain", () => {
+		const quoteBorder = theme.symbol("md.quoteBorder");
+		for (const line of contentful(renderThinking())) {
+			if (line.includes(quoteBorder)) continue;
+			expect(line).not.toContain("\x1b[3m");
+		}
+	});
+
+	test("decoration is memoised while the inner markdown is unchanged", () => {
+		const block = new ThinkingBlockComponent(new Markdown(SAMPLE, 0, 0, getMarkdownTheme()));
+		const first = block.render(WIDTH);
+		expect(block.render(WIDTH)).toBe(first);
+		block.invalidate();
+		expect(block.render(WIDTH)).not.toBe(first);
+	});
+
+	test("streaming target stays the inner markdown", () => {
+		const md = new Markdown(SAMPLE, 0, 0, getMarkdownTheme());
+		const block = new ThinkingBlockComponent(md);
+		const before = block.render(WIDTH);
+		md.setText(`${SAMPLE}\n\nAnd one more line.`);
+		const after = block.render(WIDTH);
+
+		expect(block.markdown).toBe(md);
+		expect(after.length).toBeGreaterThan(before.length);
+		expect(after.at(-1)).toContain("more line");
+	});
+
+	test("light theme attenuates toward the surface instead of away from it", async () => {
+		await setTheme("light");
+		try {
+			const lightBodyFg = foregrounds(contentful(renderThinking())[1]!)[1]!;
+			const lightText = theme.getColorHex("text");
+			const textRgb: Rgb = [
+				Number.parseInt(lightText.slice(1, 3), 16),
+				Number.parseInt(lightText.slice(3, 5), 16),
+				Number.parseInt(lightText.slice(5, 7), 16),
+			];
+			// Recessing on a bright surface means moving *up* in luma, toward the page.
+			expect(luma(lightBodyFg)).toBeGreaterThan(luma(textRgb));
+		} finally {
+			await setTheme("dark");
+		}
+	});
+});

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -596,6 +596,52 @@ export function applyBackgroundToLine(line: string, width: number, bgFn: (text: 
 }
 
 /**
+ * Rewrite every truecolor foreground in an already-rendered line.
+ *
+ * Recessing a styled block (a thinking trace, a replayed transcript) and
+ * keeping its semantic colours are only compatible under a colour *transform*:
+ * overriding the foreground with one recess colour erases the hierarchy the
+ * markdown theme just encoded. This maps each `CSI 38;2;r;g;b m` run through
+ * `transform`, so an amber heading can stay a recessed amber heading while body
+ * prose stays body prose, one step further back.
+ *
+ * The colour policy belongs to the caller: only it knows the surface being
+ * recessed toward (a dark theme fades to black, a light one to white, and a
+ * pure-black foreground cannot be attenuated multiplicatively at all).
+ * `transform` receives and returns `#rrggbb`; returning the input is a no-op.
+ *
+ * Indexed (`38;5;N`) and legacy 30-37/90-97 foregrounds carry no RGB to
+ * rewrite and are left untouched — callers targeting a 256-colour terminal
+ * should recess with SGR 2 (faint) instead. Backgrounds, decorations and the
+ * text itself are never modified.
+ *
+ * @param line - Rendered line, ANSI included
+ * @param transform - `#rrggbb` → `#rrggbb`; called once per foreground run
+ */
+export function shadeAnsiForegrounds(line: string, transform: (hex: string) => string): string {
+	if (!line.includes("38;2;")) return line;
+	// Scoped to SGR sequences: a thinking trace may legitimately contain the text
+	// `38;2;7;7;7` (a model reasoning about ANSI), and rewriting prose would both
+	// corrupt it and mislead anyone reading the transcript.
+	return line.replace(SGR_RE, (sequence, params: string) => {
+		if (!params.includes("38;2;")) return sequence;
+		return `\x1b[${params.replace(TRUECOLOR_FG_RE, (match, r: string, g: string, b: string) => {
+			const rgb = [Number(r), Number(g), Number(b)];
+			if (rgb.some(channel => channel > 255)) return match;
+			const hex = `#${((1 << 24) | (rgb[0]! << 16) | (rgb[1]! << 8) | rgb[2]!).toString(16).slice(1)}`;
+			const shaded = transform(hex);
+			if (shaded === hex || !/^#[0-9a-fA-F]{6}$/.test(shaded)) return match;
+			return `38;2;${Number.parseInt(shaded.slice(1, 3), 16)};${Number.parseInt(shaded.slice(3, 5), 16)};${Number.parseInt(shaded.slice(5, 7), 16)}`;
+		})}m`;
+	});
+}
+
+/** A complete SGR sequence — `ESC [ <params> m` — with its parameter list captured. */
+const SGR_RE = /\x1b\[([\d;:]*)m/g;
+/** `38;2;R;G;B` inside an SGR parameter list — not anchored, a list may carry several. */
+const TRUECOLOR_FG_RE = /38;2;(\d{1,3});(\d{1,3});(\d{1,3})/g;
+
+/**
  * Extract a range of visible columns from a line. Handles ANSI codes and wide chars.
  *
  * @param strict - If true, exclude wide chars at boundary that would extend past the range

--- a/packages/tui/test/ansi-shade.test.ts
+++ b/packages/tui/test/ansi-shade.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { shadeAnsiForegrounds } from "../src/utils";
+
+/**
+ * `shadeAnsiForegrounds` exists so a caller can recess an already-rendered block
+ * without discarding the colours the renderer just chose. The contract is
+ * narrow on purpose: truecolor foregrounds are rewritten, everything else in the
+ * stream — backgrounds, indexed colours, decorations, text — is bit-preserved.
+ */
+describe("shadeAnsiForegrounds", () => {
+	const toBlack = (): string => "#000000";
+
+	test("rewrites every truecolor foreground in the line", () => {
+		const line = "\x1b[38;2;254;188;56mheading\x1b[39m body \x1b[38;2;10;20;30mtail\x1b[39m";
+		expect(shadeAnsiForegrounds(line, toBlack)).toBe(
+			"\x1b[38;2;0;0;0mheading\x1b[39m body \x1b[38;2;0;0;0mtail\x1b[39m",
+		);
+	});
+
+	test("passes the source colour to the transform as #rrggbb", () => {
+		const seen: string[] = [];
+		shadeAnsiForegrounds("\x1b[38;2;254;188;56mx\x1b[39m", hex => {
+			seen.push(hex);
+			return hex;
+		});
+		expect(seen).toEqual(["#febc38"]);
+	});
+
+	test("leaves backgrounds, indexed colours and decorations untouched", () => {
+		const line = "\x1b[48;2;10;20;30m\x1b[38;5;213m\x1b[1m\x1b[3mstyled\x1b[0m";
+		expect(shadeAnsiForegrounds(line, toBlack)).toBe(line);
+	});
+
+	test("is a no-op when the line carries no truecolor foreground", () => {
+		const line = "plain \x1b[31mred\x1b[39m";
+		expect(shadeAnsiForegrounds(line, toBlack)).toBe(line);
+	});
+
+	test("keeps the original run when the transform returns a non-colour", () => {
+		const line = "\x1b[38;2;1;2;3mx\x1b[39m";
+		expect(shadeAnsiForegrounds(line, () => "not-a-colour")).toBe(line);
+		expect(shadeAnsiForegrounds(line, () => "#12345")).toBe(line);
+	});
+
+	test("ignores parameter runs that cannot be a colour", () => {
+		// 999 is not a channel value; rewriting it would corrupt the sequence.
+		const line = "\x1b[38;2;999;1;2mx\x1b[39m";
+		expect(shadeAnsiForegrounds(line, toBlack)).toBe(line);
+	});
+
+	test("literal colour syntax in the text is left alone", () => {
+		// A thinking trace may reason about ANSI itself; only real SGR sequences are
+		// rewritten, so prose that merely looks like one survives verbatim.
+		const line = "\x1b[38;2;5;5;5mliteral 38;2;7;7;7 inside text\x1b[39m";
+		expect(shadeAnsiForegrounds(line, toBlack)).toBe("\x1b[38;2;0;0;0mliteral 38;2;7;7;7 inside text\x1b[39m");
+	});
+
+	test("rewrites a foreground carried in a compound parameter list", () => {
+		const line = "\x1b[1;38;2;9;9;9;4mx\x1b[0m";
+		expect(shadeAnsiForegrounds(line, toBlack)).toBe("\x1b[1;38;2;0;0;0;4mx\x1b[0m");
+	});
+});


### PR DESCRIPTION
## Problem

Thinking traces are rendered with a flat `DefaultTextStyle.color` override:

```ts
// assistant-message.ts
new Markdown(thinkingText, 1, 0, getMarkdownTheme(), {
  color: (text: string) => theme.fg("thinkingText", text),
  italic: true,
})
```

`Markdown#applyDefaultStyle` applies that colour **after** the element theme function, so the innermost SGR wins and the heading colour is discarded before a single glyph is emitted. Same source, rendered both ways:

```
prose:    ESC[38;2;254;188;56m ESC[1m 方案对比
thinking: ESC[38;2;254;188;56m ESC[1m ESC[3m ESC[38;2;119;125;136m 方案对比
```

Two consequences:

1. **Headings render at exactly body grey.** List markers (`ESC[38;2;254;188;56m- `) and inline code (`ESC[38;2;229;193;255mSessionStore`) are on paths the override never reaches, so they keep full brightness — emphasis is inverted, an accent that happens to dodge the override reads louder than the heading above it. Reasoning text is the most structure-heavy content in the transcript (enumeration, weighing, comparison), and it loses precisely the level that carries that structure.
2. **The whole block is italicised**, including CJK runs, where monospace fonts synthesise italic by shearing glyphs.

Recessing a block and preserving its structure cannot compose under a colour *replacement* model — only under a colour *transform*.

## Change

- **`packages/tui`**: `shadeAnsiForegrounds(line, transform)` maps every truecolor foreground in an already-rendered line through a caller-supplied policy. Rewrites are scoped to SGR sequences, so a trace whose prose contains a literal `38;2;7;7;7` survives verbatim (not hypothetical — a model reasoning about ANSI hits this). Indexed colours, backgrounds, decorations and text are bit-preserved. The colour policy stays with the caller: only it knows which surface is being recessed toward.
- **`ThinkingBlockComponent`**: builds the inner `Markdown` with the full markdown theme (no override, no italic) and recesses the rendered rows — colours desaturated and faded toward the theme surface, accents less than plain prose so a heading still outranks the body it introduces. Markdown's own `ESC[39m` is rewritten to a recessed base foreground; otherwise uncoloured prose keeps rendering at full terminal brightness while only accents recede. The aside marker moves from glyph shape to a left rail (`thinking.rail`, with nerd-font and ASCII preset variants), lighter than `md.quoteBorder` so a real blockquote inside a trace still outweighs it.
- **Light themes** fade toward white instead of scaling HSV value: their `text` role is `#000000`, whose value is 0 and immune to any multiplier. A multiplicative recess leaves light themes completely unaffected — this was the first implementation, caught by a test rather than by inspection.
- **256-colour terminals** have no RGB foreground to rewrite and recess with SGR 2 (faint), keeping colour identity intact.

The inner `Markdown` remains the streaming target, so the `assistant-message` fast path (`setText`, `transientRenderCache`) is unchanged; `hideThinkingBlock` and `proseOnlyThinking` behave as before.

## Result

Dark theme, measured from emitted ANSI:

| element | before | after |
|---|---|---|
| heading | `38;2;119;125;136` (body grey, hierarchy lost) | `38;2;208;175;108` — hue 40.2 vs prose 40.0, luma 177 |
| body prose | flat grey via override | `38;2;138;138;139` recessed base, luma 138 |
| inline code | `38;2;229;193;255` (unrecessed) | `38;2;196;178;209` — hue 275, still distinct |
| italics | every run | only markdown's own blockquotes, as in prose |

## Tests

Assertions read the emitted ANSI rather than judging by eye — the previous rendering looks plausible in a screenshot while having flattened every heading.

- `packages/tui/test/ansi-shade.test.ts` (8): rewrite scope, transform contract, indexed/background/decoration preservation, invalid transform output rejected, out-of-range params rejected, literal colour syntax in text untouched, compound parameter lists.
- `packages/coding-agent/test/thinking-block.test.ts` (9): heading hue vs prose, heading luma above body, body attenuated, inline code chromatic against an achromatic body base, rail on every row, no italics outside blockquotes, memoisation on unchanged source, streaming target identity, light-theme direction.

Regression surface: 134 existing tui markdown tests and the assistant/transcript suites pass unchanged.
