### PR TITLE
feat(commands): add /worktree command and /cd alias of /move

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- Extracted the managed-worktree scanner and free-path resolution out of the `omp worktree` CLI into a shared `utils/managed-worktrees.ts` module, now consumed by the CLI, the `github` tool's PR checkout, and the new `/worktree` command.
+- Extracted the managed-worktree scanner, worktree naming (`managedWorktreeName`), and free-path resolution out of the `omp worktree` CLI into a shared `utils/managed-worktrees.ts` module, now consumed by the CLI, the `github` tool's PR checkout, and the new `/worktree` command.
 
 ## [17.1.6] - 2026-07-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `/worktree` slash command managing agent-managed git worktrees under `~/.omp/wt`: `list` shows live worktrees of the current repo (`--all` widens to every repo and orphaned leftovers), `create <branch> [base]` checks a branch out into a new `<branch-slug>-<repo-hash>` worktree in the managed dir (creating the branch from `base` when needed), and `remove <path|branch> [--force]` deletes a managed worktree with dirty-tree and current-session guards.
+- Added `/cd` as an alias of `/move`.
+
+### Changed
+
+- Extracted the managed-worktree scanner and free-path resolution out of the `omp worktree` CLI into a shared `utils/managed-worktrees.ts` module, now consumed by the CLI, the `github` tool's PR checkout, and the new `/worktree` command.
+
 ## [17.1.6] - 2026-07-27
 
 ### Added

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -1,41 +1,16 @@
 /**
  * CLI handler for `omp worktree` — list and clean up agent-managed worktrees.
- *
- * Layout under `~/.omp/wt/`:
- *
- *   - **PR-checkout worktrees** (`tools/gh.ts`): a regular git worktree dir
- *     containing a `.git` *file* that points back at
- *     `<parent-repo>/.git/worktrees/<name>/`.
- *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
- *     compact `m` subdir mounted/cloned by `natives.isoStart`. Legacy `merged`
- *     subdirs are still recognized. These are ephemeral; `ensureIsolation`
- *     removes the base before re-creating it, so leftovers are crashed runs.
- *
- * Legacy entries from before the encoding change keep working because git still
- * tracks them by branch name. This command exists to GC them on demand.
+ * Scanning/classification lives in `utils/managed-worktrees.ts`; this file
+ * owns console output (chalk) and removal logic.
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getWorktreesDir, isEnoent } from "@oh-my-pi/pi-utils";
+import { getWorktreesDir } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import * as git from "../utils/git";
+import { scanWorktrees, type WorktreeEntry } from "../utils/managed-worktrees";
 
-type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
-
-const TASK_ISOLATION_MOUNT_DIRS = ["m", "merged"] as const;
-
-export interface WorktreeEntry {
-	/** Absolute path to the worktree dir (or stray container) under `~/.omp/wt/`. */
-	path: string;
-	/** Classification of what we found on disk. */
-	kind: WorktreeKind;
-	/** Parent repo root, when this is a registered git worktree. */
-	parentRepo?: string;
-	/** Branch name extracted from the parent's tracking file, when available. */
-	branch?: string;
-	/** When set, the entry is unhealthy and `omp worktree clear` will remove it. */
-	orphanReason?: string;
-}
+export type { WorktreeEntry } from "../utils/managed-worktrees";
 
 export interface ListWorktreesOptions {
 	json: boolean;
@@ -148,132 +123,6 @@ export async function clearWorktrees(options: ClearWorktreesOptions): Promise<vo
 	}
 	console.log(chalk.dim(`\n${succeeded} removed${failed > 0 ? ` · ${chalk.red(`${failed} failed`)}` : ""}`));
 	if (failed > 0) process.exitCode = 1;
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// Scanner
-// ───────────────────────────────────────────────────────────────────────────
-
-async function scanWorktrees(): Promise<WorktreeEntry[]> {
-	const root = getWorktreesDir();
-	let topLevel: string[];
-	try {
-		topLevel = await fs.readdir(root);
-	} catch (err) {
-		if (isEnoent(err)) return [];
-		throw err;
-	}
-
-	const entries: WorktreeEntry[] = [];
-	for (const name of topLevel) {
-		const dir = path.join(root, name);
-		const stat = await fs.stat(dir).catch(() => null);
-		if (!stat?.isDirectory()) continue;
-
-		const direct = await classifyDir(dir);
-		if (direct) {
-			entries.push(direct);
-			continue;
-		}
-
-		// Legacy nesting: ~/.omp/wt/<encoded-project>/<branch-or-id>
-		let children: string[];
-		try {
-			children = await fs.readdir(dir);
-		} catch {
-			continue;
-		}
-		let nested = 0;
-		for (const child of children) {
-			const childDir = path.join(dir, child);
-			const childStat = await fs.stat(childDir).catch(() => null);
-			if (!childStat?.isDirectory()) continue;
-			const childClassified = await classifyDir(childDir);
-			if (childClassified) {
-				entries.push(childClassified);
-				nested += 1;
-			}
-		}
-		if (nested === 0) {
-			entries.push({
-				path: dir,
-				kind: children.length === 0 ? "empty" : "stray",
-				orphanReason: children.length === 0 ? "empty directory" : "no recognizable worktree contents",
-			});
-		}
-	}
-	return entries;
-}
-
-async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
-	const gitEntry = path.join(dir, ".git");
-	const gitStat = await fs.stat(gitEntry).catch(() => null);
-	if (gitStat?.isFile()) {
-		return classifyPrCheckout(dir, gitEntry);
-	}
-	for (const mountDir of TASK_ISOLATION_MOUNT_DIRS) {
-		const mountStat = await fs.stat(path.join(dir, mountDir)).catch(() => null);
-		if (!mountStat?.isDirectory()) continue;
-		return {
-			path: dir,
-			kind: "task-isolation",
-			orphanReason: "task-isolation leftover (no live task owns it)",
-		};
-	}
-	return null;
-}
-
-async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
-	let contents: string;
-	try {
-		contents = await fs.readFile(gitEntry, "utf8");
-	} catch (err) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			orphanReason: `cannot read .git file: ${err instanceof Error ? err.message : String(err)}`,
-		};
-	}
-	const match = /^gitdir:\s*(.+?)\s*$/m.exec(contents);
-	const parentGitDir = match?.[1];
-	if (!parentGitDir) {
-		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
-	}
-	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
-	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
-	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
-
-	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
-	if (!parentDirStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo no longer tracks this worktree",
-		};
-	}
-	const parentRepoStat = await fs.stat(parentRepo).catch(() => null);
-	if (!parentRepoStat?.isDirectory()) {
-		return {
-			path: dir,
-			kind: "pr-checkout",
-			parentRepo,
-			branch,
-			orphanReason: "parent repo missing",
-		};
-	}
-	return { path: dir, kind: "pr-checkout", parentRepo, branch };
-}
-
-async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
-	try {
-		const head = (await fs.readFile(headFile, "utf8")).trim();
-		const refMatch = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
-		return refMatch?.[1];
-	} catch {
-		return undefined;
-	}
 }
 
 function formatEntryDetail(entry: WorktreeEntry): string {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -65,6 +65,7 @@ import { handleSshAcp } from "./helpers/ssh";
 import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-dashboard";
 import { handleTodoAcp } from "./helpers/todo";
 import { buildUsageReportText } from "./helpers/usage-report";
+import { handleWorktreeAcp } from "./helpers/worktree";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
 import type {
 	BuiltinSlashCommand,
@@ -1893,6 +1894,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "move",
+		aliases: ["cd"],
 		description: "Move the current session to a different directory",
 		acpDescription: "Move the current session to a different directory",
 		inlineHint: "[<path>]",
@@ -1935,6 +1937,23 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			runtime.ctx.editor.setText("");
 			await runtime.ctx.handleMoveCommand(command.args || undefined);
 		},
+	},
+	{
+		name: "worktree",
+		description: "List, create, and remove agent-managed git worktrees",
+		acpDescription: "Manage agent-managed git worktrees",
+		inlineHint: "[<subcommand>]",
+		subcommands: [
+			{ name: "list", description: "List live managed worktrees of the current repo", usage: "[--all]" },
+			{ name: "create", description: "Check a branch out into a new managed worktree", usage: "<branch> [base]" },
+			{
+				name: "remove",
+				description: "Remove a managed worktree by path or branch",
+				usage: "<path|branch> [--force]",
+			},
+		],
+		allowArgs: true,
+		handle: handleWorktreeAcp,
 	},
 	{
 		name: "add-dir",

--- a/packages/coding-agent/src/slash-commands/helpers/worktree.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/worktree.ts
@@ -1,0 +1,175 @@
+/**
+ * `/worktree` handler — list, create, and remove agent-managed git worktrees
+ * under `~/.omp/wt` (see `utils/managed-worktrees.ts`). One body serves both
+ * dispatchers: the TUI adapts `runtime.output` to `ctx.showStatus`, ACP routes
+ * it to `sessionUpdate`. Cleanup of orphaned entries stays with the
+ * `omp worktree clear` CLI (`cli/worktree-cli.ts`).
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getWorktreeDir, getWorktreesDir, hashPath } from "@oh-my-pi/pi-utils";
+import { resolveToCwd } from "../../tools/path-utils";
+import * as git from "../../utils/git";
+import {
+	resolveManagedWorktreePath,
+	scanWorktrees,
+	slugifyBranch,
+	type WorktreeEntry,
+} from "../../utils/managed-worktrees";
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
+import { commandConsumed, errorMessage, parseSubcommand, usage } from "./parse";
+
+const WORKTREE_USAGE = "Usage: /worktree [list [--all] | create <branch> [base] | remove <path|branch> [--force]]";
+
+/** `/worktree` entry point shared by the TUI and ACP dispatchers via the spec. */
+export async function handleWorktreeAcp(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const { verb, rest } = parseSubcommand(command.args);
+	switch (verb) {
+		case "":
+		case "list":
+			return handleList(rest, runtime);
+		case "create":
+			return handleCreate(rest, runtime);
+		case "remove":
+		case "rm":
+			return handleRemove(rest, runtime);
+		default:
+			return usage(WORKTREE_USAGE, runtime);
+	}
+}
+
+async function handleList(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
+	const tokens = rest.split(/\s+/).filter(Boolean);
+	if (tokens.some(token => token !== "--all")) return usage("Usage: /worktree list [--all]", runtime);
+	const all = tokens.length > 0;
+
+	const entries = await scanWorktrees();
+	const primaryRoot = await git.repo.primaryRoot(runtime.cwd);
+	const visible = entries.filter(entry => {
+		if (all) return true;
+		if (entry.kind !== "pr-checkout" || entry.orphanReason !== undefined) return false;
+		// Outside a repo there is no "current repo" to filter by — show everything.
+		if (!primaryRoot || !entry.parentRepo) return true;
+		return path.resolve(entry.parentRepo) === path.resolve(primaryRoot);
+	});
+	if (visible.length === 0) {
+		const scope = all ? getWorktreesDir() : `the current repo under ${getWorktreesDir()}`;
+		return usage(`No agent-managed worktrees found for ${scope}.`, runtime);
+	}
+	const lines = visible.map(entry => {
+		const suffix = entry.orphanReason ? ` — orphaned (${entry.orphanReason})` : "";
+		return `${entry.path} — ${entry.branch ?? "unknown branch"}${suffix}`;
+	});
+	if (all && visible.some(entry => entry.orphanReason !== undefined)) {
+		lines.push("Clean up orphaned entries with `omp worktree clear`.");
+	}
+	await runtime.output(lines.join("\n"));
+	return commandConsumed();
+}
+
+async function handleCreate(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
+	const tokens = rest.split(/\s+/).filter(Boolean);
+	const [branch, base] = tokens;
+	if (!branch || branch.startsWith("-") || tokens.length > 2) {
+		return usage("Usage: /worktree create <branch> [base]", runtime);
+	}
+	const repoRoot = await git.repo.root(runtime.cwd);
+	if (!repoRoot) return usage(`Not a git repository: ${runtime.cwd}`, runtime);
+	const primaryRoot = (await git.repo.primaryRoot(runtime.cwd)) ?? repoRoot;
+	const branchRef = `refs/heads/${branch}`;
+
+	const existing = await git.worktree.list(primaryRoot);
+	const checkedOut = existing.find(entry => entry.branch === branchRef);
+	if (checkedOut) return usage(`Branch ${branch} is already checked out at ${checkedOut.path}.`, runtime);
+
+	const branchExists = await git.ref.exists(primaryRoot, branchRef);
+	const worktreePath = await resolveManagedWorktreePath(
+		getWorktreeDir(`${slugifyBranch(branch)}-${hashPath(primaryRoot)}`),
+		existing.map(entry => entry.path),
+	);
+
+	try {
+		// Serialize against other git mutations on this repo (see gh.ts pr_checkout).
+		await git.withRepoLock(primaryRoot, async () => {
+			await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+			if (branchExists) {
+				await git.worktree.add(primaryRoot, worktreePath, branch);
+			} else {
+				await git.worktree.add(primaryRoot, worktreePath, base ?? "HEAD", { newBranch: branch });
+			}
+		});
+	} catch (err) {
+		return usage(`Create failed: ${errorMessage(err)}`, runtime);
+	}
+	await runtime.output(
+		[
+			`Created worktree: ${worktreePath}`,
+			`Branch: ${branch}${branchExists ? " (existing)" : ` (new, from ${base ?? "HEAD"})`}`,
+			"Move the session into it with /move (alias /cd).",
+		].join("\n"),
+	);
+	return commandConsumed();
+}
+
+async function handleRemove(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
+	const tokens = rest.split(/\s+/).filter(Boolean);
+	const force = tokens.includes("--force");
+	const selector = tokens.find(token => token !== "--force");
+	if (!selector || tokens.some(token => token !== "--force" && token !== selector)) {
+		return usage("Usage: /worktree remove <path|branch> [--force]", runtime);
+	}
+
+	const target = await resolveRemovalTarget(selector, runtime.cwd);
+	if ("error" in target) return usage(target.error, runtime);
+	const { entry } = target;
+
+	const sessionRoot = await git.repo.root(runtime.cwd);
+	if (sessionRoot && path.resolve(sessionRoot) === path.resolve(entry.path)) {
+		return usage("Refusing to remove the worktree the session is running in.", runtime);
+	}
+	const parentRepo = entry.parentRepo!;
+	try {
+		await git.worktree.remove(parentRepo, entry.path, { force });
+	} catch (err) {
+		const message = errorMessage(err);
+		if (!force && /dirty|modified|untracked|not clean/i.test(message)) {
+			return usage(`Worktree has uncommitted changes; pass --force to discard them. (${message})`, runtime);
+		}
+		return usage(message, runtime);
+	}
+	await git.worktree.prune(parentRepo).catch(() => {});
+	await runtime.output(`Removed worktree: ${entry.path}${entry.branch ? ` (${entry.branch})` : ""}`);
+	return commandConsumed();
+}
+
+type RemovalTarget = { entry: WorktreeEntry } | { error: string };
+
+/**
+ * Match a `<path|branch>` selector against the live managed worktrees of the
+ * current repo. Path equality wins over branch equality so a selector that is
+ * both stays deterministic.
+ */
+async function resolveRemovalTarget(selector: string, cwd: string): Promise<RemovalTarget> {
+	const entries = await scanWorktrees();
+	const primaryRoot = await git.repo.primaryRoot(cwd);
+	const candidates = entries.filter(entry => {
+		if (entry.kind !== "pr-checkout" || entry.orphanReason !== undefined || !entry.parentRepo) return false;
+		if (!primaryRoot) return true;
+		return path.resolve(entry.parentRepo) === path.resolve(primaryRoot);
+	});
+	const resolvedSelector = path.resolve(resolveToCwd(selector, cwd));
+	const byPath = candidates.filter(entry => path.resolve(entry.path) === resolvedSelector);
+	const matches = byPath.length > 0 ? byPath : candidates.filter(entry => entry.branch === selector);
+	if (matches.length === 0) {
+		return {
+			error: `No live managed worktree of the current repo matches ${selector}. Use /worktree list to see candidates.`,
+		};
+	}
+	if (matches.length > 1) {
+		return { error: `Ambiguous selector: ${matches.map(entry => entry.path).join(", ")}` };
+	}
+	return { entry: matches[0]! };
+}

--- a/packages/coding-agent/src/slash-commands/helpers/worktree.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/worktree.ts
@@ -7,13 +7,13 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getWorktreeDir, getWorktreesDir, hashPath } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, getWorktreesDir } from "@oh-my-pi/pi-utils";
 import { resolveToCwd } from "../../tools/path-utils";
 import * as git from "../../utils/git";
 import {
+	managedWorktreeName,
 	resolveManagedWorktreePath,
 	scanWorktrees,
-	slugifyBranch,
 	type WorktreeEntry,
 } from "../../utils/managed-worktrees";
 import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
@@ -86,8 +86,12 @@ async function handleCreate(rest: string, runtime: SlashCommandRuntime): Promise
 	if (checkedOut) return usage(`Branch ${branch} is already checked out at ${checkedOut.path}.`, runtime);
 
 	const branchExists = await git.ref.exists(primaryRoot, branchRef);
+	// Default base: the session checkout's HEAD, resolved to a SHA. Inside a
+	// linked worktree, `git worktree add … HEAD` run from primaryRoot would
+	// fork from the *primary* checkout's commit, not the caller's.
+	const startPoint = base ?? (await git.head.sha(runtime.cwd)) ?? "HEAD";
 	const worktreePath = await resolveManagedWorktreePath(
-		getWorktreeDir(`${slugifyBranch(branch)}-${hashPath(primaryRoot)}`),
+		getWorktreeDir(managedWorktreeName(branch, primaryRoot)),
 		existing.map(entry => entry.path),
 	);
 
@@ -98,7 +102,7 @@ async function handleCreate(rest: string, runtime: SlashCommandRuntime): Promise
 			if (branchExists) {
 				await git.worktree.add(primaryRoot, worktreePath, branch);
 			} else {
-				await git.worktree.add(primaryRoot, worktreePath, base ?? "HEAD", { newBranch: branch });
+				await git.worktree.add(primaryRoot, worktreePath, startPoint, { newBranch: branch });
 			}
 		});
 	} catch (err) {

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -10,11 +10,12 @@ import type {
 	ToolApprovalDecision,
 } from "@oh-my-pi/pi-agent-core";
 
-import { getWorktreeDir, hashPath, isEnoent, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, hashPath, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import type { Settings } from "../config/settings";
 import githubDescription from "../prompts/tools/github.md" with { type: "text" };
 import * as git from "../utils/git";
+import { resolveManagedWorktreePath } from "../utils/managed-worktrees";
 import type { ToolSession } from ".";
 import { formatShortSha } from "./gh-format";
 import { type CacheStatus, getOrFetchView, invalidateAllForNumber, resolveGithubCacheAuthKey } from "./github-cache";
@@ -915,9 +916,6 @@ function sanitizeRemoteName(value: string): string {
 	return sanitized.length > 0 ? `fork-${sanitized}` : "fork";
 }
 
-/** Maximum disambiguation suffixes we try before giving up on a worktree path. */
-const WORKTREE_PATH_MAX_SUFFIX = 100;
-
 function toLocalBranchRef(value: string): string {
 	return `refs/heads/${value}`;
 }
@@ -959,37 +957,22 @@ async function requireCurrentGitHead(cwd: string, signal?: AbortSignal): Promise
 }
 
 /**
- * Resolve a worktree path that is free of conflicts.
- *
- * Given a `basePath`, return either `basePath` itself or `${basePath}-2`,
- * `${basePath}-3`, … up to {@link WORKTREE_PATH_MAX_SUFFIX} — whichever is the
- * first variant that is **not** registered with git as another worktree and
- * **not** present on disk. The numeric tail salvages two rare cases that
- * would otherwise abort a checkout: stale leftover dirs from an interrupted
- * `git worktree add`, and the (vanishingly unlikely) `hashPath` collision
- * between two repos that happen to produce the same 7-hex digest.
+ * Return the first free worktree path for a PR checkout. Thin wrapper over
+ * the shared resolver: git-registered paths plus on-disk leftovers are both
+ * skipped via `-2`, `-3`, … suffixes.
  */
 async function resolveAvailableWorktreePath(
 	basePath: string,
 	existingWorktrees: git.GitWorktreeEntry[],
 ): Promise<string> {
-	const registered = new Set(existingWorktrees.map(entry => path.resolve(entry.path)));
-	for (let attempt = 0; attempt < WORKTREE_PATH_MAX_SUFFIX; attempt += 1) {
-		const candidate = attempt === 0 ? basePath : `${basePath}-${attempt + 1}`;
-		const normalized = path.resolve(candidate);
-		if (registered.has(normalized)) continue;
-		try {
-			await fs.stat(normalized);
-		} catch (error) {
-			if (isEnoent(error)) {
-				return candidate;
-			}
-			throw error;
-		}
+	try {
+		return await resolveManagedWorktreePath(
+			basePath,
+			existingWorktrees.map(entry => entry.path),
+		);
+	} catch (error) {
+		throw new ToolError(error instanceof Error ? error.message : String(error));
 	}
-	throw new ToolError(
-		`could not find an unused worktree path under ${basePath} (tried ${WORKTREE_PATH_MAX_SUFFIX} suffixes)`,
-	);
 }
 
 function selectPrCloneUrl(originUrl: string | undefined, repo: Pick<GhRepoViewData, "url" | "sshUrl">): string {

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -10,12 +10,12 @@ import type {
 	ToolApprovalDecision,
 } from "@oh-my-pi/pi-agent-core";
 
-import { getWorktreeDir, hashPath, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import type { Settings } from "../config/settings";
 import githubDescription from "../prompts/tools/github.md" with { type: "text" };
 import * as git from "../utils/git";
-import { resolveManagedWorktreePath } from "../utils/managed-worktrees";
+import { managedWorktreeName, resolveManagedWorktreePath } from "../utils/managed-worktrees";
 import type { ToolSession } from ".";
 import { formatShortSha } from "./gh-format";
 import { type CacheStatus, getOrFetchView, invalidateAllForNumber, resolveGithubCacheAuthKey } from "./github-cache";
@@ -3278,7 +3278,7 @@ async function checkoutPullRequest(
 	const repoRoot = await requireGitRepoRoot(session.cwd, signal);
 	const primaryRepoRoot = await requirePrimaryGitRepoRoot(repoRoot, signal);
 	const localBranch = `pr-${prNumber}`;
-	const worktreePath = getWorktreeDir(`${prNumber}-${hashPath(primaryRepoRoot)}`);
+	const worktreePath = getWorktreeDir(managedWorktreeName(String(prNumber), primaryRepoRoot));
 
 	// Every git mutation against `repoRoot` from here on must run under the
 	// per-repo lock. Worktrees of the same primary repo share `.git/config`,

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1867,10 +1867,11 @@ export const worktree = {
 		cwd: string,
 		worktreePath: string,
 		refName: string,
-		options: { detach?: boolean; signal?: AbortSignal } = {},
+		options: { detach?: boolean; newBranch?: string; signal?: AbortSignal } = {},
 	): Promise<void> {
 		const args = ["worktree", "add"];
 		if (options.detach) args.push("--detach");
+		if (options.newBranch) args.push("-b", options.newBranch);
 		args.push(worktreePath, refName);
 		await runEffect(cwd, args, { signal: options.signal });
 	},

--- a/packages/coding-agent/src/utils/managed-worktrees.ts
+++ b/packages/coding-agent/src/utils/managed-worktrees.ts
@@ -17,7 +17,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getWorktreesDir, isEnoent } from "@oh-my-pi/pi-utils";
+import { getWorktreesDir, hashPath, isEnoent } from "@oh-my-pi/pi-utils";
 
 export type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
 
@@ -120,6 +120,15 @@ export async function resolveManagedWorktreePath(basePath: string, registeredPat
 	throw new Error(
 		`could not find an unused worktree path under ${basePath} (tried ${WORKTREE_PATH_MAX_SUFFIX} suffixes)`,
 	);
+}
+
+/**
+ * Directory name for a managed worktree: `<branch-slug>-<repo-hash>`. The
+ * hash scopes the name to its primary repo so identical branch (or PR-number)
+ * segments from different repos never collide under the managed root.
+ */
+export function managedWorktreeName(branch: string, primaryRoot: string): string {
+	return `${slugifyBranch(branch)}-${hashPath(primaryRoot)}`;
 }
 
 /** Convert a branch name into a filesystem-safe worktree path segment. */

--- a/packages/coding-agent/src/utils/managed-worktrees.ts
+++ b/packages/coding-agent/src/utils/managed-worktrees.ts
@@ -1,0 +1,205 @@
+/**
+ * Managed-worktree registry: scan and classify agent-managed worktrees under
+ * `~/.omp/wt/` (see {@link getWorktreesDir}).
+ *
+ * Layout under the managed root:
+ *
+ *   - **PR-checkout / agent-created worktrees** (`tools/gh.ts`,
+ *     `slash-commands/helpers/worktree.ts`): a regular git worktree dir containing a `.git`
+ *     *file* that points back at `<parent-repo>/.git/worktrees/<name>/`.
+ *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
+ *     compact `m` subdir mounted/cloned by `natives.isoStart`. Legacy `merged`
+ *     subdirs are still recognized. These are ephemeral; `ensureIsolation`
+ *     removes the base before re-creating it, so leftovers are crashed runs.
+ *
+ * Shared by the `omp worktree` CLI (`cli/worktree-cli.ts`) and the `/worktree`
+ * slash command (`slash-commands/helpers/worktree.ts`).
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getWorktreesDir, isEnoent } from "@oh-my-pi/pi-utils";
+
+export type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
+
+const TASK_ISOLATION_MOUNT_DIRS = ["m", "merged"] as const;
+
+/** Cap on `-2`, `-3`, … path suffixes tried when a worktree path is occupied. */
+export const WORKTREE_PATH_MAX_SUFFIX = 100;
+
+export interface WorktreeEntry {
+	/** Absolute path to the worktree dir (or stray container) under `~/.omp/wt/`. */
+	path: string;
+	/** Classification of what we found on disk. */
+	kind: WorktreeKind;
+	/** Parent repo root, when this is a registered git worktree. */
+	parentRepo?: string;
+	/** Branch name extracted from the parent's tracking file, when available. */
+	branch?: string;
+	/** When set, the entry is unhealthy and `omp worktree clear` will remove it. */
+	orphanReason?: string;
+}
+
+/** Scan the managed worktrees directory and classify every entry found. */
+export async function scanWorktrees(): Promise<WorktreeEntry[]> {
+	const root = getWorktreesDir();
+	let topLevel: string[];
+	try {
+		topLevel = await fs.readdir(root);
+	} catch (err) {
+		if (isEnoent(err)) return [];
+		throw err;
+	}
+
+	const entries: WorktreeEntry[] = [];
+	for (const name of topLevel) {
+		const dir = path.join(root, name);
+		const stat = await fs.stat(dir).catch(() => null);
+		if (!stat?.isDirectory()) continue;
+
+		const direct = await classifyDir(dir);
+		if (direct) {
+			entries.push(direct);
+			continue;
+		}
+
+		// Legacy nesting: ~/.omp/wt/<encoded-project>/<branch-or-id>
+		let children: string[];
+		try {
+			children = await fs.readdir(dir);
+		} catch {
+			continue;
+		}
+		let nested = 0;
+		for (const child of children) {
+			const childDir = path.join(dir, child);
+			const childStat = await fs.stat(childDir).catch(() => null);
+			if (!childStat?.isDirectory()) continue;
+			const childClassified = await classifyDir(childDir);
+			if (childClassified) {
+				entries.push(childClassified);
+				nested += 1;
+			}
+		}
+		if (nested === 0) {
+			entries.push({
+				path: dir,
+				kind: children.length === 0 ? "empty" : "stray",
+				orphanReason: children.length === 0 ? "empty directory" : "no recognizable worktree contents",
+			});
+		}
+	}
+	return entries;
+}
+
+/**
+ * Resolve a worktree path that is free of conflicts.
+ *
+ * Return either `basePath` itself or `${basePath}-2`,
+ * `${basePath}-3`, … up to {@link WORKTREE_PATH_MAX_SUFFIX} — whichever is the
+ * first variant that is **not** registered with git as another worktree and
+ * **not** present on disk. The numeric tail salvages two rare cases that
+ * would otherwise abort a checkout: stale leftover dirs from an interrupted
+ * `git worktree add`, and the (vanishingly unlikely) `hashPath` collision
+ * between two repos that happen to produce the same 7-hex digest.
+ */
+export async function resolveManagedWorktreePath(basePath: string, registeredPaths: Iterable<string>): Promise<string> {
+	const registered = new Set([...registeredPaths].map(entry => path.resolve(entry)));
+	for (let attempt = 0; attempt < WORKTREE_PATH_MAX_SUFFIX; attempt += 1) {
+		const candidate = attempt === 0 ? basePath : `${basePath}-${attempt + 1}`;
+		const normalized = path.resolve(candidate);
+		if (registered.has(normalized)) continue;
+		try {
+			await fs.stat(normalized);
+		} catch (error) {
+			if (isEnoent(error)) {
+				return candidate;
+			}
+			throw error;
+		}
+	}
+	throw new Error(
+		`could not find an unused worktree path under ${basePath} (tried ${WORKTREE_PATH_MAX_SUFFIX} suffixes)`,
+	);
+}
+
+/** Convert a branch name into a filesystem-safe worktree path segment. */
+export function slugifyBranch(branch: string): string {
+	const slug = branch
+		.trim()
+		.replace(/[/\\\s]+/g, "-")
+		.replace(/[^A-Za-z0-9._-]+/g, "-")
+		.replace(/-{2,}/g, "-")
+		.replace(/^[-.]+|[-.]+$/g, "");
+	return slug || "worktree";
+}
+
+async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
+	const gitEntry = path.join(dir, ".git");
+	const gitStat = await fs.stat(gitEntry).catch(() => null);
+	if (gitStat?.isFile()) {
+		return classifyPrCheckout(dir, gitEntry);
+	}
+	for (const mountDir of TASK_ISOLATION_MOUNT_DIRS) {
+		const mountStat = await fs.stat(path.join(dir, mountDir)).catch(() => null);
+		if (!mountStat?.isDirectory()) continue;
+		return {
+			path: dir,
+			kind: "task-isolation",
+			orphanReason: "task-isolation leftover (no live task owns it)",
+		};
+	}
+	return null;
+}
+
+async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
+	let contents: string;
+	try {
+		contents = await fs.readFile(gitEntry, "utf8");
+	} catch (err) {
+		return {
+			path: dir,
+			kind: "pr-checkout",
+			orphanReason: `cannot read .git file: ${err instanceof Error ? err.message : String(err)}`,
+		};
+	}
+	const match = /^gitdir:\s*(.+?)\s*$/m.exec(contents);
+	const parentGitDir = match?.[1];
+	if (!parentGitDir) {
+		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
+	}
+	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
+	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
+	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
+
+	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
+	if (!parentDirStat?.isDirectory()) {
+		return {
+			path: dir,
+			kind: "pr-checkout",
+			parentRepo,
+			branch,
+			orphanReason: "parent repo no longer tracks this worktree",
+		};
+	}
+	const parentRepoStat = await fs.stat(parentRepo).catch(() => null);
+	if (!parentRepoStat?.isDirectory()) {
+		return {
+			path: dir,
+			kind: "pr-checkout",
+			parentRepo,
+			branch,
+			orphanReason: "parent repo missing",
+		};
+	}
+	return { path: dir, kind: "pr-checkout", parentRepo, branch };
+}
+
+async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
+	try {
+		const head = (await fs.readFile(headFile, "utf8")).trim();
+		const refMatch = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
+		return refMatch?.[1];
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/coding-agent/test/slash-commands/move.test.ts
+++ b/packages/coding-agent/test/slash-commands/move.test.ts
@@ -43,4 +43,13 @@ describe("/move slash command", () => {
 		expect(harness.setText).toHaveBeenCalledWith("");
 		expect(harness.handleMoveCommand).toHaveBeenCalledWith(undefined);
 	});
+
+	it("routes /cd to the same move handler", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/cd /tmp/project", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.handleMoveCommand).toHaveBeenCalledWith("/tmp/project");
+	});
 });

--- a/packages/coding-agent/test/slash-commands/worktree.test.ts
+++ b/packages/coding-agent/test/slash-commands/worktree.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { handleWorktreeAcp } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/worktree";
+import type { ParsedSlashCommand, SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import { hashPath } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+
+const ENV_KEY = "OMP_WORKTREE_DIR";
+
+let tmpRoot: string;
+let managedDir: string;
+let repoDir: string;
+let savedEnv: string | undefined;
+let outputs: string[];
+
+function runtime(cwd: string): SlashCommandRuntime {
+	return {
+		cwd,
+		output: (text: string) => {
+			outputs.push(text);
+		},
+	} as unknown as SlashCommandRuntime;
+}
+
+/** Invoke `/worktree <args>` against a stub runtime and capture its output. */
+async function run(args: string, cwd: string = repoDir): Promise<string> {
+	outputs = [];
+	const command: ParsedSlashCommand = { name: "worktree", args, text: `/worktree ${args}` };
+	await handleWorktreeAcp(command, runtime(cwd));
+	return outputs.join("\n");
+}
+
+async function initRepo(dir: string): Promise<void> {
+	await fs.mkdir(dir, { recursive: true });
+	await $`git init -b main ${dir}`.quiet();
+	await fs.writeFile(path.join(dir, "file.txt"), "hello\n");
+	await $`git -C ${dir} add file.txt`.quiet();
+	await $`git -C ${dir} -c user.email=t@t.t -c user.name=t commit -m init`.quiet();
+}
+
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-wt-cmd-"));
+	managedDir = path.join(tmpRoot, "wt");
+	repoDir = path.join(tmpRoot, "repo");
+	await initRepo(repoDir);
+	savedEnv = process.env[ENV_KEY];
+	process.env[ENV_KEY] = managedDir;
+});
+
+afterEach(async () => {
+	if (savedEnv === undefined) {
+		delete process.env[ENV_KEY];
+	} else {
+		process.env[ENV_KEY] = savedEnv;
+	}
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("/worktree command", () => {
+	it("create makes a new-branch worktree under the managed dir", async () => {
+		const out = await run("create feat/thing");
+		const expected = path.join(managedDir, `feat-thing-${hashPath(repoDir)}`);
+		expect(out).toContain(`Created worktree: ${expected}`);
+		expect(out).toContain("Branch: feat/thing (new, from HEAD)");
+		const branch = await $`git -C ${expected} branch --show-current`.text();
+		expect(branch.trim()).toBe("feat/thing");
+	});
+
+	it("create checks out an existing branch as-is", async () => {
+		await $`git -C ${repoDir} branch existing`.quiet();
+		const out = await run("create existing");
+		expect(out).toContain("Branch: existing (existing)");
+	});
+
+	it("create refuses a branch already checked out in a worktree", async () => {
+		await run("create dup");
+		const out = await run("create dup");
+		expect(out).toContain("already checked out");
+	});
+
+	it("list defaults to the current repo; --all includes other repos", async () => {
+		await run("create mine");
+		const otherRepo = path.join(tmpRoot, "other");
+		await initRepo(otherRepo);
+		await run("create theirs", otherRepo);
+
+		const scoped = await run("list");
+		expect(scoped).toContain(`mine-${hashPath(repoDir)}`);
+		expect(scoped).not.toContain("theirs");
+
+		const all = await run("list --all");
+		expect(all).toContain(`mine-${hashPath(repoDir)}`);
+		expect(all).toContain(`theirs-${hashPath(otherRepo)}`);
+	});
+
+	it("remove deletes by branch; dirty trees need --force", async () => {
+		await run("create doomed");
+		const wtPath = path.join(managedDir, `doomed-${hashPath(repoDir)}`);
+		await fs.writeFile(path.join(wtPath, "dirty.txt"), "x");
+
+		const refused = await run("remove doomed");
+		expect(refused).toContain("--force");
+		const removed = await run("remove doomed --force");
+		expect(removed).toContain(`Removed worktree: ${wtPath}`);
+		const stat = await fs.stat(wtPath).catch(() => null);
+		expect(stat).toBeNull();
+	});
+
+	it("remove refuses the worktree the session is running in", async () => {
+		await run("create home");
+		const wtPath = path.join(managedDir, `home-${hashPath(repoDir)}`);
+		const out = await run(`remove ${wtPath} --force`, wtPath);
+		expect(out).toContain("session is running in");
+	});
+});

--- a/packages/coding-agent/test/slash-commands/worktree.test.ts
+++ b/packages/coding-agent/test/slash-commands/worktree.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { handleWorktreeAcp } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/worktree";
 import type { ParsedSlashCommand, SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
-import { hashPath } from "@oh-my-pi/pi-utils";
+import { managedWorktreeName } from "@oh-my-pi/pi-coding-agent/utils/managed-worktrees";
 import { $ } from "bun";
 
 const ENV_KEY = "OMP_WORKTREE_DIR";
@@ -61,7 +61,7 @@ afterEach(async () => {
 describe("/worktree command", () => {
 	it("create makes a new-branch worktree under the managed dir", async () => {
 		const out = await run("create feat/thing");
-		const expected = path.join(managedDir, `feat-thing-${hashPath(repoDir)}`);
+		const expected = path.join(managedDir, managedWorktreeName("feat/thing", repoDir));
 		expect(out).toContain(`Created worktree: ${expected}`);
 		expect(out).toContain("Branch: feat/thing (new, from HEAD)");
 		const branch = await $`git -C ${expected} branch --show-current`.text();
@@ -87,17 +87,34 @@ describe("/worktree command", () => {
 		await run("create theirs", otherRepo);
 
 		const scoped = await run("list");
-		expect(scoped).toContain(`mine-${hashPath(repoDir)}`);
+		expect(scoped).toContain(managedWorktreeName("mine", repoDir));
 		expect(scoped).not.toContain("theirs");
 
 		const all = await run("list --all");
-		expect(all).toContain(`mine-${hashPath(repoDir)}`);
-		expect(all).toContain(`theirs-${hashPath(otherRepo)}`);
+		expect(all).toContain(managedWorktreeName("mine", repoDir));
+		expect(all).toContain(managedWorktreeName("theirs", otherRepo));
+	});
+
+	it("create from a linked worktree bases the new branch on that worktree's HEAD", async () => {
+		await run("create first");
+		const firstPath = path.join(managedDir, managedWorktreeName("first", repoDir));
+		// Advance the linked worktree beyond the primary checkout.
+		await fs.writeFile(path.join(firstPath, "extra.txt"), "x");
+		await $`git -C ${firstPath} add extra.txt`.quiet();
+		await $`git -C ${firstPath} -c user.email=t@t.t -c user.name=t commit -m advance`.quiet();
+		const firstHead = (await $`git -C ${firstPath} rev-parse HEAD`.text()).trim();
+		const primaryHead = (await $`git -C ${repoDir} rev-parse HEAD`.text()).trim();
+		expect(firstHead).not.toBe(primaryHead);
+
+		await run("create second", firstPath);
+		const secondPath = path.join(managedDir, managedWorktreeName("second", repoDir));
+		const secondHead = (await $`git -C ${secondPath} rev-parse HEAD`.text()).trim();
+		expect(secondHead).toBe(firstHead);
 	});
 
 	it("remove deletes by branch; dirty trees need --force", async () => {
 		await run("create doomed");
-		const wtPath = path.join(managedDir, `doomed-${hashPath(repoDir)}`);
+		const wtPath = path.join(managedDir, managedWorktreeName("doomed", repoDir));
 		await fs.writeFile(path.join(wtPath, "dirty.txt"), "x");
 
 		const refused = await run("remove doomed");
@@ -110,7 +127,7 @@ describe("/worktree command", () => {
 
 	it("remove refuses the worktree the session is running in", async () => {
 		await run("create home");
-		const wtPath = path.join(managedDir, `home-${hashPath(repoDir)}`);
+		const wtPath = path.join(managedDir, managedWorktreeName("home", repoDir));
 		const out = await run(`remove ${wtPath} --force`, wtPath);
 		expect(out).toContain("session is running in");
 	});


### PR DESCRIPTION
## Why

Agent-managed worktrees under `~/.omp/wt` are invisible in session. The only creation path (`github` `pr_checkout`) hands the path back in a tool result, and past that conversation nothing can enumerate, create, or enter those worktrees — "spawn a new worktree" requests fall back to ad-hoc `git worktree add` outside the managed dir, and `omp worktree` cleanup never sees them.

Earlier revisions of this PR exposed dedicated `worktree` and `cd` agent tools. They were scrapped: every command-as-tool forks behavior, prompts, docs, and settings surface, and the deferred-`cd` plumbing was bespoke. Interactive slash commands already implement exactly these operations, so the PR now exposes them to the user instead; giving the *agent* access to commands generically is tracked as a `command://` URI design in #6954.

## What

**New `/worktree` slash command** (`list` default, works in TUI and ACP via a single `handle` body):
- `list [--all]` — live worktrees of the *current* repo (matched on `git.repo.primaryRoot`); `--all` widens to every repo + orphaned leftovers, with an `omp worktree clear` hint
- `create <branch> [base]` — checks a branch out into `~/.omp/wt/<branch-slug>-<repoHash>`, creating the branch from `base` (default `HEAD`) when needed; serialized via `git.withRepoLock`; refuses branches already checked out elsewhere; output points at `/move`
- `remove <path|branch> [--force]` — refuses dirty trees without `--force`, always refuses the worktree the session runs in

**New `/cd`**: alias of `/move` (registry-level `aliases`, so dispatch, autocomplete, ACP reservation, and directory argument completion all apply).

**Reverted**: the `worktree`/`cd` agent tools and their wiring (`worktree.enabled`/`cd.enabled` settings, `requestCwdChange` deferred-move plumbing in `AgentSession`/SDK/interactive mode, prompts, docs, tests).

**Kept refactor**: the managed-worktree scanner and free-path resolution live in shared `utils/managed-worktrees.ts`, consumed by the `omp worktree` CLI, the `github` tool's PR checkout (behavior preserved), and the new command. `git.worktree.add` gains a `newBranch` option.

## Test plan

- 6 contract tests in `test/slash-commands/worktree.test.ts` (create new/existing/duplicate branch, repo-scoped vs `--all` listing, dirty/force/self-removal guards) — all pass
- `/cd` routing covered in `test/slash-commands/move.test.ts`; `gh` `pr_checkout` suite still green over the shared path resolver
- `bun run check:ts` (tsgo + biome) clean
