### PR TITLE
fix: forward parseArgs and CONFIG_DIR_NAME from the legacy pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy pi extensions importing `parseArgs` or `CONFIG_DIR_NAME` from the `@earendil-works/pi-coding-agent` package root failing Bun's static export check during validation, which blocked installs such as `omp install npm:pi-cursor-sdk` ([#6907](https://github.com/can1357/oh-my-pi/pull/6907) by [@Gy-Hu](https://github.com/Gy-Hu)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1378,6 +1378,14 @@ export function getPackageDir(): string {
 // check during validation (issue #6583).
 export { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 
+// Same barrel gap for two more legacy package-root exports: pi re-exported the
+// `CONFIG_DIR_NAME` constant and the CLI parser `parseArgs`. In omp
+// `CONFIG_DIR_NAME` lives in `@oh-my-pi/pi-utils` and `parseArgs` in
+// `../cli/args`, neither of which the barrel below forwards, so legacy
+// extensions importing either fail Bun's static export check during validation.
+export { CONFIG_DIR_NAME } from "@oh-my-pi/pi-utils";
+export { parseArgs } from "../cli/args";
+
 export * from "../index";
 export { formatBytes as formatSize } from "../tools/render-utils";
 export { copyToClipboard } from "../utils/clipboard";


### PR DESCRIPTION
I hit this installing pi-cursor-sdk on 17.1.7 and confirmed the two missing re-exports are the only blocker; I reviewed the diff and re-ran the install before and after.

## Problem

Installing any legacy pi extension that imports `parseArgs` or `CONFIG_DIR_NAME` from the `@earendil-works/pi-coding-agent` package root fails validation:

```
$ omp install npm:pi-cursor-sdk
✘ Failed to install npm:pi-cursor-sdk: Error: Plugin pi-cursor-sdk extension validation failed:
.../plugins/node_modules/pi-cursor-sdk/src/index.ts: Export named 'parseArgs' not found in
module '.../src/extensibility/legacy-pi-coding-agent-shim.ts'.
```

`pi-cursor-sdk@0.1.61` is a real-world case: `src/cursor-session-scope.ts` imports `parseArgs` and `src/cursor-config.ts` imports `CONFIG_DIR_NAME`.

## Root cause

Legacy pi re-exported both symbols from its package root. In omp, `parseArgs` lives in `packages/coding-agent/src/cli/args.ts` and `CONFIG_DIR_NAME` in `packages/utils/src/dirs.ts` (`@oh-my-pi/pi-utils`). The shim's `export * from "../index"` does not forward `cli/args`, and `CONFIG_DIR_NAME` is not in that barrel either, so Bun's static export check rejects the module graph before the extension ever runs.

This is the same class of barrel gap already patched for `getProjectDir` / `getPackageDir` (#5968) and `estimateTokens` (#6583); this change follows those two precedents exactly, including the export ordering biome's `organizeImports` expects.

## Verification

Reproduced against a throwaway `HOME` so nothing touched my real config, using the dev entrypoint at this branch:

| | `bun --cwd=packages/coding-agent src/cli.ts plugin install npm:pi-cursor-sdk` |
| --- | --- |
| before (patch stashed) | `✘ Export named 'parseArgs' not found in module .../legacy-pi-coding-agent-shim.ts` |
| after | `✔ Installed pi-cursor-sdk@0.1.61` |

A direct import of both symbols from the shim also fails with `SyntaxError: Export named 'CONFIG_DIR_NAME' not found` before the change and resolves after it.

- `bun run check` — passes
- `bun test test/extensibility/legacy-pi-path-helpers.test.ts test/extensibility/legacy-pi-override-fallback.test.ts test/pi-scope-aliases.test.ts test/issue-6449-legacy-pi-cjs-double-instance.test.ts` — 15 pass, 0 fail

## Notes

No issue was filed for this, per CONTRIBUTING ("Do not open an issue for work you are about to submit").

Out of scope: `pi-cursor-sdk` also reads `parseArgs(...).projectTrustOverride`, which omp's `Args` does not define. That resolves to `undefined`, so the check evaluates false — a safe degrade, and the extension's concern rather than this barrel fix.
