### PR TITLE
fix(acp): sync model status when the agent switches models internally

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed ACP clients (e.g. Zed) not learning about a model change that happens from inside the agent loop — prewalk hand-offs, retry-fallback, model cycling — so the client's model picker/status bar kept showing the session's starting model even though the active model had actually switched. `AgentSession` now emits a `model_changed` event from its single model-mutation choke point, and the ACP surface's lifetime subscription re-pushes `config_option_update` on it.
+- Fixed ACP clients (e.g. Zed) not learning about a model change that happens from inside the agent loop — prewalk hand-offs, retry-fallback, model cycling — so the client's model picker/status bar kept showing the session's starting model even though the active model had actually switched. `AgentSession` now emits a `model_changed` event from its single model-mutation choke point, and the ACP surface's lifetime subscription re-pushes `config_option_update` on it. The same event now also keeps the TUI status line and collab guests' footer state in sync, and a failed session switch that rolls back to the previous model emits a corrective event so subscribers don't keep advertising the never-committed target.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP clients (e.g. Zed) not learning about a model change that happens from inside the agent loop — prewalk hand-offs, retry-fallback, model cycling — so the client's model picker/status bar kept showing the session's starting model even though the active model had actually switched. `AgentSession` now emits a `model_changed` event from its single model-mutation choke point, and the ACP surface's lifetime subscription re-pushes `config_option_update` on it.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -53,6 +53,7 @@ const STATE_TRIGGER_EVENTS: Record<string, true> = {
 	message_end: true,
 	tool_execution_end: true,
 	thinking_level_changed: true,
+	model_changed: true,
 	auto_compaction_end: true,
 };
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -651,12 +651,17 @@ export class AcpAgent implements Agent {
 			});
 		}
 
-		// For `thinking` the lifetime subscription pushes post-bootstrap; only
-		// push here when it's not yet installed so pre-bootstrap callers still
-		// see the change without a post-bootstrap duplicate.
-		const thinkingHandledBySubscription =
-			params.configId === THINKING_CONFIG_ID && record.lifetimeUnsubscribe !== undefined;
-		if (!thinkingHandledBySubscription) {
+		// For `model`/`thinking`, `#setModelById`/`#setThinkingLevelById` change
+		// the session model/thinking level through AgentSession, which now emits
+		// a lifetime event (`model_changed`/`thinking_level_changed`) that
+		// `#handleLifetimeEvent` turns into a push once the subscription is
+		// installed. Only push here when that subscription is not yet
+		// installed, so pre-bootstrap callers still see the change without a
+		// post-bootstrap duplicate.
+		const handledBySubscription =
+			(params.configId === THINKING_CONFIG_ID || params.configId === MODEL_CONFIG_ID) &&
+			record.lifetimeUnsubscribe !== undefined;
+		if (!handledBySubscription) {
 			await this.#pushConfigOptionUpdate(record);
 		}
 		return { configOptions: this.#buildConfigOptions(record.session) };
@@ -1150,14 +1155,15 @@ export class AcpAgent implements Agent {
 	}
 
 	async #handleLifetimeEvent(record: ManagedSessionRecord, event: AgentSessionEvent): Promise<void> {
-		if (event.type !== "thinking_level_changed") {
+		if (event.type !== "thinking_level_changed" && event.type !== "model_changed") {
 			return;
 		}
 		try {
 			await this.#pushConfigOptionUpdate(record);
 		} catch (error) {
-			logger.warn("Failed to push thinking-level config_option_update", {
+			logger.warn("Failed to push config_option_update after a lifetime event", {
 				sessionId: record.session.sessionId,
+				eventType: event.type,
 				error,
 			});
 		}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -195,6 +195,7 @@ export class EventController {
 			notice: e => this.#handleNotice(e),
 			model_changed: async () => {
 				this.ctx.statusLine.invalidate();
+				this.ctx.ui.requestRender();
 			},
 			thinking_level_changed: async () => {
 				this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -193,6 +193,9 @@ export class EventController {
 			todo_auto_clear: e => this.#handleTodoAutoClear(e),
 			irc_message: e => this.#handleIrcMessage(e),
 			notice: e => this.#handleNotice(e),
+			model_changed: async () => {
+				this.ctx.statusLine.invalidate();
+			},
 			thinking_level_changed: async () => {
 				this.ctx.statusLine.invalidate();
 				this.ctx.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -128,6 +128,7 @@ const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
 	"irc_message",
 	"notice",
 	"thinking_level_changed",
+	"model_changed",
 	"goal_updated",
 ]);
 

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -47,6 +47,7 @@ export type AgentSessionEvent =
 	  }
 	| { type: "retry_fallback_applied"; from: string; to: string; role: string }
 	| { type: "retry_fallback_succeeded"; model: string; role: string }
+	| { type: "model_changed" }
 	| { type: "ttsr_triggered"; rules: Rule[] }
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }
 	| { type: "todo_auto_clear" }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7219,21 +7219,29 @@ export class AgentSession {
 			this.#pendingRewindReport = previousPendingRewindReport;
 			this.#lastCompletedRewind = previousLastCompletedRewind;
 			this.#rewoundToolResultIds = previousRewoundToolResultIds;
+			// The try block may have already reached #setModelWithProviderSessionReset
+			// for the target session's model, which emits `model_changed` for it.
+			// Restoring here bypasses that method (it also resets provider-session
+			// state we're already unwinding above), so if the rollback actually
+			// changes the model back, emit the corrective event ourselves —
+			// otherwise ACP/RPC/TUI keep advertising the never-committed target.
+			// Deferred until after restoreThinkingSnapshot below: #emit's listeners
+			// (ACP's #handleLifetimeEvent -> #pushConfigOptionUpdate) read
+			// session state synchronously before their first await, so emitting
+			// here — before the target session's thinking level is unwound —
+			// would push a { previousModel, target-session-thinking } config that
+			// was never a real session state.
+			let modelRolledBack = false;
 			if (previousModel) {
-				// The try block may have already reached #setModelWithProviderSessionReset
-				// for the target session's model, which emits `model_changed` for it.
-				// Restoring here bypasses that method (it also resets provider-session
-				// state we're already unwinding above), so if the rollback actually
-				// changes the model back, emit the corrective event ourselves —
-				// otherwise ACP/RPC/TUI keep advertising the never-committed target.
 				const rolledBackModel = this.model;
 				this.agent.setModel(previousModel);
-				if (!modelsAreEqual(rolledBackModel, previousModel)) {
-					this.#emit({ type: "model_changed" });
-				}
+				modelRolledBack = !modelsAreEqual(rolledBackModel, previousModel);
 			}
 			this.#models.restoreThinkingSnapshot(previousThinkingLevel, previousAutoThinking, previousAutoResolvedLevel);
 			this.#models.restoreServiceTiers(previousServiceTierByFamily);
+			if (modelRolledBack) {
+				this.#emit({ type: "model_changed" });
+			}
 			this.#todo.syncFromBranch();
 			this.#advisors.resetAllRuntimes();
 			this.#reconnectToAgent();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6527,13 +6527,21 @@ export class AgentSession {
 			}
 		}
 		this.agent.setModel(model);
-		// Every internal model mutation funnels through this method (explicit
-		// /model, prewalk hand-offs, retry-fallback, model cycling), so this is
-		// the single point that notifies subscribers (ACP config sync, RPC,
-		// TUI status line) — callers that bypass ModelControls never need to
-		// remember to notify separately.
+		// Model mutations driven through ModelControls (explicit /model, prewalk
+		// hand-offs, retry-fallback, model cycling) funnel through this method,
+		// so this is the single point that notifies subscribers (ACP config
+		// sync, RPC, TUI status line) — callers that bypass ModelControls never
+		// need to remember to notify separately. `switchSession`'s rollback
+		// restores via `agent.setModel` directly and emits its own corrective
+		// event.
+		//
+		// Fan-out uses the synchronous `#emit`, matching `thinking_level_changed`:
+		// `model_changed` has no extension-facing hook (`#emitExtensionEvent`
+		// never maps it), so routing it through `#emitSessionEvent` would only
+		// add an extension-delivery await inside every model switch — including
+		// retry-fallback on the error path.
 		if (isChanging) {
-			await this.#emitSessionEvent({ type: "model_changed" });
+			this.#emit({ type: "model_changed" });
 		}
 
 		// Re-evaluate append-only context mode — provider or setting may have changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6519,13 +6519,22 @@ export class AgentSession {
 
 	async #setModelWithProviderSessionReset(model: Model): Promise<void> {
 		const currentModel = this.model;
+		const isChanging = !currentModel || !modelsAreEqual(currentModel, model);
 		if (currentModel) {
 			this.#closeProviderSessionsForModelSwitch(currentModel, model);
-			if (!modelsAreEqual(currentModel, model)) {
+			if (isChanging) {
 				this.#clearInheritedProviderPromptCacheKey();
 			}
 		}
 		this.agent.setModel(model);
+		// Every internal model mutation funnels through this method (explicit
+		// /model, prewalk hand-offs, retry-fallback, model cycling), so this is
+		// the single point that notifies subscribers (ACP config sync, RPC,
+		// TUI status line) — callers that bypass ModelControls never need to
+		// remember to notify separately.
+		if (isChanging) {
+			await this.#emitSessionEvent({ type: "model_changed" });
+		}
 
 		// Re-evaluate append-only context mode — provider or setting may have changed
 		this.#syncAppendOnlyContext(model);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7220,7 +7220,17 @@ export class AgentSession {
 			this.#lastCompletedRewind = previousLastCompletedRewind;
 			this.#rewoundToolResultIds = previousRewoundToolResultIds;
 			if (previousModel) {
+				// The try block may have already reached #setModelWithProviderSessionReset
+				// for the target session's model, which emits `model_changed` for it.
+				// Restoring here bypasses that method (it also resets provider-session
+				// state we're already unwinding above), so if the rollback actually
+				// changes the model back, emit the corrective event ourselves —
+				// otherwise ACP/RPC/TUI keep advertising the never-committed target.
+				const rolledBackModel = this.model;
 				this.agent.setModel(previousModel);
+				if (!modelsAreEqual(rolledBackModel, previousModel)) {
+					this.#emit({ type: "model_changed" });
+				}
 			}
 			this.#models.restoreThinkingSnapshot(previousThinkingLevel, previousAutoThinking, previousAutoResolvedLevel);
 			this.#models.restoreServiceTiers(previousServiceTierByFamily);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -199,7 +199,13 @@ class FakeAgentSession {
 	}
 
 	async setModel(model: Model): Promise<void> {
+		const isChanging = this.model?.provider !== model.provider || this.model?.id !== model.id;
 		this.model = model;
+		if (isChanging) {
+			for (const listener of this.#listeners) {
+				listener({ type: "model_changed" } as AgentSessionEvent);
+			}
+		}
 	}
 
 	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
@@ -895,6 +901,83 @@ describe("ACP agent", () => {
 			| { currentValue?: unknown }
 			| undefined;
 		expect(thinkingOption?.currentValue).toBe("high");
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("pushes config_option_update when the model changes internally", async () => {
+		// Internal callers (prewalk hand-offs, retry-fallback, model cycling)
+		// change AgentSession's model directly without going through the ACP
+		// setSessionConfigOption surface. Once the session-lifetime subscription
+		// is installed, those changes must surface to clients as
+		// `config_option_update` — otherwise a client's model indicator (e.g.
+		// Zed's status bar) goes stale the moment prewalk hands off to a
+		// cheaper model mid-session.
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		await waitForBootstrapGuard();
+
+		const updatesBefore = harness.updates.length;
+		await session.setModel(TEST_MODELS[1]!);
+
+		const pushedAfter = harness.updates.slice(updatesBefore);
+		const configUpdates = pushedAfter.filter(
+			notification =>
+				notification.sessionId === created.sessionId &&
+				notification.update.sessionUpdate === "config_option_update",
+		);
+		expect(configUpdates.length).toBeGreaterThanOrEqual(1);
+		expectAcpNotifications(configUpdates);
+		const firstUpdate = configUpdates[0]!.update;
+		if (firstUpdate.sessionUpdate !== "config_option_update") {
+			throw new Error("expected config_option_update");
+		}
+		const modelConfig = firstUpdate.configOptions.find(option => option.id === "model") as
+			| { currentValue?: unknown }
+			| undefined;
+		expect(modelConfig?.currentValue).toBe(`${TEST_MODELS[1]!.provider}/${TEST_MODELS[1]!.id}`);
+
+		// Setting to the same model must not produce a redundant notification.
+		const updatesBeforeRedundant = harness.updates.length;
+		await session.setModel(TEST_MODELS[1]!);
+		expect(harness.updates.length).toBe(updatesBeforeRedundant);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("emits a single config_option_update per setSessionConfigOption(model) call", async () => {
+		// Client-initiated model changes flow through #setModelById, which now
+		// changes the session model and fires `model_changed`, letting the
+		// lifetime subscription push the notification. The ACP surface must not
+		// also push a duplicate `config_option_update` of its own.
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		await waitForBootstrapGuard();
+
+		const updatesBefore = harness.updates.length;
+		const response = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "model",
+			value: `${TEST_MODELS[1]!.provider}/${TEST_MODELS[1]!.id}`,
+		});
+
+		const configUpdates = harness.updates
+			.slice(updatesBefore)
+			.filter(
+				notification =>
+					notification.sessionId === created.sessionId &&
+					notification.update.sessionUpdate === "config_option_update",
+			);
+		expect(configUpdates.length).toBe(1);
+		expectAcpNotifications(configUpdates);
+
+		const modelOption = response.configOptions.find(option => option.id === "model") as
+			| { currentValue?: unknown }
+			| undefined;
+		expect(modelOption?.currentValue).toBe(`${TEST_MODELS[1]!.provider}/${TEST_MODELS[1]!.id}`);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);


### PR DESCRIPTION
## Problem

ACP clients (e.g. Zed) never learned about a model switch that happened from inside the agent loop — prewalk hand-offs, retry-fallback, model cycling. The active model did switch correctly for subsequent requests, but the client's model picker/status bar kept showing the session's starting model, because `#pushConfigOptionUpdate` was only wired to client-initiated `setSessionConfigOption`/`setSessionMode` RPCs and to the `thinking_level_changed` lifetime event.

## Fix

- `AgentSession#setModelWithProviderSessionReset` is the single choke point every model mutation runs through (explicit `/model`, prewalk hand-offs, retry-fallback, model cycling). It now emits a `model_changed` `AgentSessionEvent` whenever the model actually changes, wired into every exhaustive consumer of `AgentSessionEvent` (TUI event controller invalidates the status line; RPC client's forwarded-event allowlist).
- The ACP surface's `#handleLifetimeEvent` now also reacts to `model_changed` and re-pushes `config_option_update`. The existing thinking-only subscription dedupe in `setSessionConfigOption` is extended to cover the model config id too, so a client-initiated model change still produces exactly one notification once the lifetime subscription is installed.

## Verification

Manually confirmed with a prewalk run switching to a cheaper model mid-session: Zed's model selector now updates to reflect the switched model instead of showing the session's original model.

## Commits

- `feat(session): emit model_changed event on every internal model switch`
- `fix(acp): sync model config option on internal model changes`
- `docs(coding-agent): note ACP model status-sync fix in changelog`
