### PR TITLE
feat(coding-agent): expose owner-scoped async jobs to plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an owner-scoped background-job API to custom-tool and extension contexts, allowing plugin-defined job kinds to participate safely in Hub listing, waiting, cancellation, rendering, and completion delivery ([#6909](https://github.com/can1357/oh-my-pi/pull/6909) by [@incloon](https://github.com/incloon)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -5,6 +5,13 @@ const DELIVERY_RETRY_MAX_MS = 30_000;
 const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
+const ASYNC_JOB_KIND_PATTERN = /^[a-z0-9][a-z0-9._:-]{0,63}$/;
+const ASYNC_JOB_KIND_ERROR =
+	"Background job kind must be 1-64 lowercase ASCII letters, digits, dots, underscores, colons, or hyphens.";
+
+function assertValidAsyncJobKind(kind: string): void {
+	if (!ASYNC_JOB_KIND_PATTERN.test(kind)) throw new Error(ASYNC_JOB_KIND_ERROR);
+}
 
 /**
  * Adaptive ("smart") `hub` poll-wait ladder (ms). A tight poll loop climbs
@@ -29,7 +36,7 @@ interface PollEscalationState {
 
 export interface AsyncJob {
 	id: string;
-	type: "bash" | "task";
+	type: string;
 	status: "running" | "completed" | "failed" | "cancelled";
 	startTime: number;
 	label: string;
@@ -105,6 +112,31 @@ export interface AsyncJobRegisterOptions {
 	queued?: boolean;
 }
 
+export interface AsyncJobRunContext {
+	jobId: string;
+	signal: AbortSignal;
+	reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
+	/** Clear the queued flag once the job actually starts executing. */
+	markRunning: () => void;
+}
+
+export type ScopedAsyncJobRegisterOptions = Omit<AsyncJobRegisterOptions, "ownerId" | "agentId">;
+
+/**
+ * Owner-bound background-job surface exposed to plugins and custom tools.
+ * The caller cannot override ownership, so hub visibility, cancellation, and
+ * completion delivery remain isolated to the session's agent.
+ */
+export interface ScopedAsyncJobs {
+	register(
+		/** Stable display identifier; lowercase ASCII letters, digits, `.`, `_`, `:`, or `-`, up to 64 characters. */
+		kind: string,
+		label: string,
+		run: (ctx: AsyncJobRunContext) => Promise<string>,
+		options?: ScopedAsyncJobRegisterOptions,
+	): string;
+}
+
 /**
  * Filter applied to job query/cancel APIs. With `ownerId`, results are
  * restricted to jobs registered by that agent (registry id from
@@ -148,7 +180,7 @@ export class AsyncJobManager {
 
 	#filterJobs(jobs: Iterable<AsyncJob>, filter?: AsyncJobFilter): AsyncJob[] {
 		const ownerId = filter?.ownerId;
-		if (!ownerId) return Array.from(jobs);
+		if (ownerId === undefined) return Array.from(jobs);
 		const out: AsyncJob[] = [];
 		for (const job of jobs) {
 			if (job.ownerId === ownerId) out.push(job);
@@ -174,20 +206,15 @@ export class AsyncJobManager {
 	}
 
 	register(
-		type: "bash" | "task",
+		kind: string,
 		label: string,
-		run: (ctx: {
-			jobId: string;
-			signal: AbortSignal;
-			reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
-			/** Clear the queued flag once the job actually starts executing. */
-			markRunning: () => void;
-		}) => Promise<string>,
+		run: (ctx: AsyncJobRunContext) => Promise<string>,
 		options?: AsyncJobRegisterOptions,
 	): string {
 		if (this.#disposed) {
 			throw new Error("Async job manager is disposed");
 		}
+		assertValidAsyncJobKind(kind);
 		// Queued jobs hold no execution slot yet — only count jobs that are
 		// actually running so a large parked batch cannot starve registration.
 		let activeCount = 0;
@@ -207,7 +234,7 @@ export class AsyncJobManager {
 
 		const job: AsyncJob = {
 			id,
-			type,
+			type: kind,
 			status: "running",
 			startTime,
 			label,
@@ -275,7 +302,7 @@ export class AsyncJobManager {
 	cancel(id: string, filter?: AsyncJobFilter): boolean {
 		const job = this.#jobs.get(id);
 		if (!job) return false;
-		if (filter?.ownerId && job.ownerId !== filter.ownerId) return false;
+		if (filter?.ownerId !== undefined && job.ownerId !== filter.ownerId) return false;
 		if (job.status !== "running") return false;
 		job.status = "cancelled";
 		job.abortController.abort();
@@ -818,4 +845,15 @@ export class AsyncJobManager {
 		const jitterMs = Math.floor(Math.random() * DELIVERY_RETRY_JITTER_MS);
 		return Math.min(DELIVERY_RETRY_MAX_MS, backoffMs + jitterMs);
 	}
+}
+
+/** Bind an async manager to one immutable owner identity. */
+export function createScopedAsyncJobs(manager: AsyncJobManager, ownerId: string): ScopedAsyncJobs {
+	return {
+		register: (kind, label, run, options) =>
+			manager.register(kind, label, run, {
+				...options,
+				ownerId,
+			}),
+	};
 }

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -18,6 +18,7 @@ import type { Component } from "@oh-my-pi/pi-tui";
 import type { logger as PiLogger } from "@oh-my-pi/pi-utils";
 import type { type as ArkType } from "arktype";
 import type * as zod from "zod/v4";
+import type { ScopedAsyncJobs } from "../../async";
 import type { Rule } from "../../capability/rule";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
@@ -86,6 +87,8 @@ export interface CustomToolContext {
 	sessionManager: ReadonlySessionManager;
 	/** Model registry - use for API key resolution and model retrieval */
 	modelRegistry: ModelRegistry;
+	/** Owner-scoped background jobs surfaced through hub jobs/wait/cancel. */
+	asyncJobs?: ScopedAsyncJobs;
 	/** Current model (may be undefined if no model is selected yet) */
 	model: Model | undefined;
 	/** Whether the agent is idle (not streaming) */

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -5,6 +5,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
+import type { ScopedAsyncJobs } from "../../async";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
 import type { LocalProtocolOptions } from "../../internal-urls/local-protocol";
@@ -392,6 +393,7 @@ export class ExtensionRunner {
 		getMemory?: () => MemoryRuntimeContext | undefined,
 		private readonly settings?: Settings,
 		private readonly localProtocolOptions?: LocalProtocolOptions,
+		private readonly asyncJobs?: ScopedAsyncJobs,
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
@@ -663,6 +665,7 @@ export class ExtensionRunner {
 	createContext(model?: Model): ExtensionContext {
 		const getModel = model ? () => model : this.#getModel;
 		return {
+			asyncJobs: this.asyncJobs,
 			ui: this.#uiContext,
 			getContextUsage: () => this.#getContextUsageFn(),
 			compact: instructionsOrOptions => this.#compactFn(instructionsOrOptions),

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -38,6 +38,7 @@ import type { AutocompleteItem, AutocompleteProvider, Component, EditorTheme, Ke
 import type { logger as PiLogger } from "@oh-my-pi/pi-utils";
 import type { Type as arktype } from "arktype";
 import type * as zod from "zod/v4";
+import type { ScopedAsyncJobs } from "../../async";
 import type { KeybindingsManager } from "../../config/keybindings";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { EditToolDetails } from "../../edit";
@@ -411,6 +412,8 @@ export interface ExtensionModelQuery {
 }
 
 export interface ExtensionContext {
+	/** Owner-scoped background jobs surfaced through hub jobs/wait/cancel. */
+	asyncJobs?: ScopedAsyncJobs;
 	/** UI methods for user interaction */
 	ui: ExtensionUIContext;
 	/** Get current context usage for the active model. */

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -23,18 +23,18 @@ type CustomOrHookMessage = Extract<AgentMessage, { role: "custom" | "hookMessage
 type AssistantAgentMessage = Extract<AgentMessage, { role: "assistant" }>;
 
 /**
- * Render an `async-result` custom message (a completed background bash/task job,
- * or a batch of them) as a transcript block of one "Background job completed"
+ * Render an `async-result` custom message (a completed background core or
+ * plugin-defined job, or a batch) as one "Background job completed"
  * row per job.
  */
 export function buildAsyncResultBlock(message: CustomOrHookMessage): TranscriptBlock {
 	const details = (
 		message as CustomMessage<{
 			jobId?: string;
-			type?: "bash" | "task";
+			type?: string;
 			label?: string;
 			durationMs?: number;
-			jobs?: Array<{ jobId?: string; type?: "bash" | "task"; label?: string; durationMs?: number }>;
+			jobs?: Array<{ jobId?: string; type?: string; label?: string; durationMs?: number }>;
 		}>
 	).details;
 	const jobs =

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -34,7 +34,7 @@ import {
 	formatActiveRepoWatchdogPrompt,
 	formatAdvisorContextPrompt,
 } from "./advisor";
-import { AsyncJobManager } from "./async";
+import { AsyncJobManager, createScopedAsyncJobs } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
 import { createAutoresearchExtension } from "./autoresearch";
 import { loadCapability } from "./capability";
@@ -847,6 +847,7 @@ function createCustomToolContext(ctx: ExtensionContext): CustomToolContext {
 	return {
 		sessionManager: ctx.sessionManager,
 		modelRegistry: ctx.modelRegistry,
+		asyncJobs: ctx.asyncJobs,
 		model: ctx.model,
 		isIdle: ctx.isIdle,
 		hasQueuedMessages: ctx.hasPendingMessages,
@@ -2504,6 +2505,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// (The builtin autoresearch extension is unconditionally loaded above, so this scenario
 		// is unreachable; unconditional runner construction keeps that invariant explicit and
 		// prevents future optional extensions from silently re-opening the hole.)
+		const asyncJobs = scopedAsyncJobManager
+			? createScopedAsyncJobs(scopedAsyncJobManager, resolvedAgentId)
+			: undefined;
 		const extensionRunner: ExtensionRunner = new ExtensionRunner(
 			extensionsResult.extensions,
 			extensionsResult.runtime,
@@ -2513,6 +2517,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			() => (hasSession ? createSessionMemoryRuntimeContext(session, agentDir, cwd) : undefined),
 			settings,
 			localProtocolOptions,
+			asyncJobs,
 		);
 
 		credentialDisabledTarget = extensionRunner;
@@ -2524,6 +2529,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const getSessionContext = () => ({
 			sessionManager,
 			modelRegistry,
+			asyncJobs,
 			model: agent.state.model,
 			isIdle: () => !session.isStreaming,
 			hasQueuedMessages: () => session.queuedMessageCount > 0,

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -41,7 +41,7 @@ export interface AsyncResultEntry {
 
 type AsyncResultJobDetails = {
 	jobId: string;
-	type?: "bash" | "task";
+	type?: string;
 	label?: string;
 	durationMs?: number;
 };

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -73,7 +73,7 @@ export function visibleJobs(manager: AsyncJobManager, ids: string[], ownerId: st
 	for (const id of ids) {
 		const job = manager.getJob(id);
 		if (!job) continue;
-		if (ownerId && job.ownerId !== ownerId) continue;
+		if (ownerId !== undefined && job.ownerId !== ownerId) continue;
 		out.push(job);
 	}
 	return out;
@@ -132,7 +132,7 @@ function describeAgents(agents: AgentActivitySnapshot[]): string[] {
 
 interface TrackedJobLike {
 	id: string;
-	type: "bash" | "task";
+	type: string;
 	status: string;
 	label: string;
 	startTime: number;

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -42,7 +42,7 @@ export interface HubPeerInfo {
 /** Background-job row surfaced by `wait`/`cancel`/`jobs` results. */
 export interface JobSnapshot {
 	id: string;
-	type: "bash" | "task";
+	type: string;
 	status: "running" | "completed" | "failed" | "cancelled";
 	label: string;
 	durationMs: number;

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { AsyncJobManager, createScopedAsyncJobs } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 
 describe("AsyncJobManager", () => {
 	test("forwards progress updates and delivers completion", async () => {
@@ -428,6 +428,49 @@ describe("AsyncJobManager", () => {
 		manager.cancelAll();
 		await manager.waitForAll();
 		expect(manager.getJob(parentJobId)?.status).toBe("cancelled");
+	});
+
+	test("scoped plugin jobs preserve type and enforce immutable ownership", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const release = Promise.withResolvers<void>();
+		const mainJobs = createScopedAsyncJobs(manager, "Main");
+		const jobId = mainJobs.register("plugin:custom", "plugin job", async ({ signal }) => {
+			const aborted = Promise.withResolvers<void>();
+			signal.addEventListener("abort", () => aborted.resolve(), { once: true });
+			await Promise.race([release.promise, aborted.promise]);
+			return "done";
+		});
+
+		expect(manager.getAllJobs({ ownerId: "Main" }).map(job => job.type)).toEqual(["plugin:custom"]);
+		expect(manager.getAllJobs({ ownerId: "OtherAgent" })).toEqual([]);
+		expect(manager.cancel(jobId, { ownerId: "OtherAgent" })).toBe(false);
+		expect(manager.cancel(jobId, { ownerId: "Main" })).toBe(true);
+
+		release.resolve();
+		await manager.waitForAll();
+		expect(manager.getJob(jobId)?.status).toBe("cancelled");
+	});
+
+	test("rejects unsafe plugin job kinds before registration", () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const jobs = createScopedAsyncJobs(manager, "Main");
+		const run = async () => "done";
+		const invalidKinds = [
+			"",
+			"Plugin",
+			"video generation",
+			"video\tgeneration",
+			"video\ngeneration",
+			"\x1b[2Jvideo",
+			"a".repeat(65),
+		];
+
+		for (const kind of invalidKinds) {
+			expect(() => jobs.register(kind, "plugin job", run)).toThrow(
+				"Background job kind must be 1-64 lowercase ASCII letters, digits, dots, underscores, colons, or hyphens.",
+			);
+		}
+		expect(manager.getAllJobs()).toEqual([]);
 	});
 
 	test("routes owned deliveries to the owner's registered sink only", async () => {

--- a/packages/coding-agent/test/async-yield-queue.test.ts
+++ b/packages/coding-agent/test/async-yield-queue.test.ts
@@ -16,7 +16,7 @@ type AsyncEntry = {
 type AsyncDetails = {
 	jobs: Array<{
 		jobId: string;
-		type?: "bash" | "task";
+		type?: string;
 		label?: string;
 		durationMs?: number;
 	}>;


### PR DESCRIPTION
## Motivation

Oh My Pi already manages built-in background work such as asynchronous Bash commands and Task subagents through `AsyncJobManager`. That integration gives those jobs a complete lifecycle: they are visible through Hub, can be waited on or cancelled, receive abort signals, report progress, and deliver their final result back to the owning agent.

Custom tools and extensions currently have no supported way to participate in that lifecycle. A plugin that performs long-running work must either:

- block the original tool call until the operation finishes;
- detach a promise that Hub cannot list, wait for, or cancel, and whose result is not delivered through the normal session flow; or
- depend on the process-global `AsyncJobManager`, which would expose cross-agent state and allow callers to override ownership metadata.

This becomes particularly important for plugin-defined workflows that submit remote operations and poll them in the background, but the API is intentionally generic rather than tied to any one plugin or workload.

## What changed

- Added `ScopedAsyncJobs`, an owner-bound background-job registration surface.
- Exposed it as `CustomToolContext.asyncJobs` and `ExtensionContext.asyncJobs`.
- Added `createScopedAsyncJobs()` to bind registrations to the current agent before the context is handed to plugin code.
- Generalized job-kind metadata from the built-in `"bash" | "task"` union to plugin-defined identifiers across Hub snapshots, transcript rendering, and async-result delivery.
- Validated job kinds centrally as bounded lowercase ASCII identifiers before registration, keeping every current and future display path safe without duplicating renderer-specific sanitization.
- Tightened owner filtering to distinguish an absent owner filter from an explicitly supplied value.

The plugin-facing registration shape is:

```ts
ctx.asyncJobs?.register(kind, label, async ({ jobId, signal, reportProgress, markRunning }) => {
  // Long-running plugin work.
  return "final result";
});
```

`kind` is descriptive metadata used in Hub and transcript output. It does not select an executor or grant TaskTool/subagent behavior. Built-in `bash` and `task` jobs keep their existing implementations and semantics. Because the value is an identifier rather than free-form display text, registration accepts 1-64 lowercase ASCII letters, digits, dots, underscores, colons, or hyphens and rejects unsafe values before creating a job.

## Ownership and isolation

Plugins receive a capability scoped to the current agent, not the underlying manager:

- `ownerId` is fixed when `ScopedAsyncJobs` is created.
- Plugin options omit both `ownerId` and `agentId`, so a plugin cannot impersonate another agent or claim a subagent relationship.
- Hub list, wait, and cancel operations continue to filter by exact owner identity.
- Completion delivery is routed only to the owning agent's registered sink.
- Session transitions can cancel and evict only that session owner's jobs.

This preserves the existing process-wide manager while avoiding a second plugin-specific scheduler and without exposing cross-session control.

## Why this API shape

The surface is deliberately registration-only. Plugins need a safe way to place work into the existing lifecycle; listing, waiting, and cancellation already belong to Hub. Keeping those control operations out of the plugin context avoids duplicating Hub and keeps the capability small.

The public parameter is named `kind` rather than `type` because the value is a display/classification identifier, not an execution mode. Registering a job with kind `task` does not create a coding subagent; actual TaskTool behavior still comes from TaskTool's runner, AgentRegistry integration, queueing, and progress details. Validating this identifier at the registration boundary establishes one invariant for transcript, Hub, and slash-command renderers instead of requiring every display path to sanitize the same value independently.

`asyncJobs` remains optional because SDK sessions may be constructed without an async job manager. Existing custom tools and extensions therefore remain source-compatible.

## Non-goals

- This PR does not add a new executor or scheduling policy.
- It does not give plugins direct access to `AsyncJobManager`.
- It does not turn plugin jobs into TaskTool subagents.
- It does not persist jobs across process restarts.
- It does not include the video-generation plugin that motivated the initial use case; that remains a separate change.

## Testing

- `bun test test/async-job-manager.test.ts test/tools/hub-wait.test.ts test/async-yield-queue.test.ts`
  - 29 tests passed
- `bun run check` in `packages/coding-agent`
- Verified that the interface-only patch applies cleanly to the current `origin/main`

The added regression coverage verifies that valid plugin-defined kinds are retained, unsafe or overlong kinds are rejected before registration, ownership is immutable from the scoped API, cross-owner listing and cancellation are rejected, and owned job cleanup remains isolated.
