### PR TITLE
perf(utils): avoid Winston runtime dispatch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -440,7 +440,7 @@
     "vite": "^8.1.4",
     "vite-plugin-solid": "^2.11.12",
     "winston": "^3.19.0",
-    "winston-daily-rotate-file": "^5.0.0",
+    "winston-daily-rotate-file": "5.0.0",
     "zod": "^4",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
       "vite": "^8.1.4",
       "vite-plugin-solid": "^2.11.12",
       "winston": "^3.19.0",
-      "winston-daily-rotate-file": "^5.0.0",
+      "winston-daily-rotate-file": "5.0.0",
       "zod": "^4"
     }
   },

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced the central logger's Winston dispatch with a byte-compatible local dispatcher while retaining the existing `winston-daily-rotate-file` rotation and retention behavior.
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -17,6 +17,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { isPromise } from "node:util/types";
 import type DailyRotateFile from "winston-daily-rotate-file";
+// Import the implementation directly because the package index imports and mutates
+// Winston. The exact workspace catalog pin protects this internal entrypoint.
 import DailyRotateFileImplementation from "winston-daily-rotate-file/daily-rotate-file.js";
 import { getLogsDir } from "./dirs";
 import { drainModuleLoadEvents } from "./timing-buffer";

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,3 +1,5 @@
+/// <reference path="./winston-daily-rotate-file.d.ts" />
+
 /**
  * Centralized logger for omp.
  *
@@ -11,10 +13,11 @@
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { isPromise } from "node:util/types";
-import winston from "winston";
-import DailyRotateFile from "winston-daily-rotate-file";
+import type DailyRotateFile from "winston-daily-rotate-file";
+import DailyRotateFileImplementation from "winston-daily-rotate-file/daily-rotate-file.js";
 import { getLogsDir } from "./dirs";
 import { drainModuleLoadEvents } from "./timing-buffer";
 /** Severity names accepted by the centralized logger. */
@@ -143,36 +146,68 @@ function jsonReplacer(_key: string, value: unknown): unknown {
 	return value;
 }
 
-/** Custom format that includes pid and flattens metadata; built on first use. */
-let logFormat: winston.Logform.Format | undefined;
-
-function getLogFormat(): winston.Logform.Format {
-	logFormat ??= winston.format.combine(
-		winston.format.timestamp({ format: "YYYY-MM-DDTHH:mm:ss.SSSZ" }),
-		winston.format.printf(({ timestamp, level, message, ...meta }) => {
-			const entry: Record<string, unknown> = {
-				timestamp,
-				level,
-				pid: process.pid,
-				message,
-			};
-			// Flatten metadata into entry
-			for (const [key, value] of Object.entries(meta)) {
-				if (key !== "level" && key !== "timestamp" && key !== "message") {
-					entry[key] = value;
-				}
-			}
-			return JSON.stringify(entry, jsonReplacer);
-		}),
-	);
-	return logFormat;
+interface NormalizedLogInfo extends Record<string, unknown> {
+	level: LogLevel;
+	message: unknown;
 }
 
+function padTimestampPart(value: number, width = 2): string {
+	return String(value).padStart(width, "0");
+}
+
+function formatLocalTimestamp(date: Date): string {
+	const offsetMinutes = -date.getTimezoneOffset();
+	const absoluteOffset = Math.abs(offsetMinutes);
+	const offsetSign = offsetMinutes >= 0 ? "+" : "-";
+	return (
+		`${padTimestampPart(date.getFullYear(), 4)}-${padTimestampPart(date.getMonth() + 1)}-${padTimestampPart(date.getDate())}` +
+		`T${padTimestampPart(date.getHours())}:${padTimestampPart(date.getMinutes())}:${padTimestampPart(date.getSeconds())}` +
+		`.${padTimestampPart(date.getMilliseconds(), 3)}${offsetSign}${padTimestampPart(Math.floor(absoluteOffset / 60))}` +
+		`:${padTimestampPart(absoluteOffset % 60)}`
+	);
+}
+
+const FORMAT_TOKEN_PATTERN = /%[scdjifoO%]/;
+
+function normalizeLogInfo(
+	level: LogLevel,
+	message: string,
+	context: Record<string, unknown> | undefined,
+): NormalizedLogInfo {
+	const metadata =
+		!FORMAT_TOKEN_PATTERN.test(message) && context !== null && typeof context === "object" ? context : undefined;
+	const info = Object.assign({}, metadata, { level, message }) as NormalizedLogInfo;
+	if (metadata?.message) info.message = `${message} ${metadata.message}`;
+	if (metadata?.stack) info.stack = metadata.stack;
+	if (metadata?.cause) info.cause = metadata.cause;
+	return info;
+}
+
+function formatLogInfo(info: NormalizedLogInfo): string {
+	const timestamp = formatLocalTimestamp(new Date());
+	info.timestamp = timestamp;
+	const entry: Record<string, unknown> = {
+		timestamp,
+		level: info.level,
+		pid: process.pid,
+		message: info.message,
+	};
+	for (const [key, value] of Object.entries(info)) {
+		if (key !== "level" && key !== "timestamp" && key !== "message") entry[key] = value;
+	}
+	return JSON.stringify(entry, jsonReplacer) as string;
+}
+
+type FileTransport = DailyRotateFile & {
+	log(info: Record<symbol, string>, callback: () => void): void;
+	close(): void;
+};
+
 /** Build a rotating file transport with process-local rotation and shared retention. */
-function makeFileTransport(dir?: string): winston.transport {
+function makeFileTransport(dir?: string): FileTransport {
 	const logsDir = ensureDir(dir ?? getLogsDir());
 	pruneStaleProcessLogs(logsDir);
-	return new DailyRotateFile({
+	return new DailyRotateFileImplementation({
 		dirname: logsDir,
 		filename: `omp.%DATE%.${process.pid}.log`,
 		datePattern: "YYYY-MM-DD",
@@ -180,45 +215,48 @@ function makeFileTransport(dir?: string): winston.transport {
 		maxFiles: 5,
 		zippedArchive: false,
 		auditFile: path.join(logsDir, `.omp.${process.pid}-audit.json`),
-	});
-}
-
-function makeConsoleTransport(): winston.transport {
-	return new winston.transports.Console({ format: getLogFormat() });
+	}) as FileTransport;
 }
 
 /**
- * Desired transport configuration, applied when the winston logger is built.
+ * Desired transport configuration, applied when local logging is initialized.
  * Default: file ON (TUI-safe), console OFF.
  */
 let transportOpts: { console?: boolean; file?: boolean | string } = { file: true };
 
-/** The winston logger instance, created lazily on first log emission. */
-let winstonLogger: winston.Logger | undefined;
-
-function buildTransports(opts: { console?: boolean; file?: boolean | string }): winston.transport[] {
-	const transports: winston.transport[] = [];
-	if (opts.file) transports.push(makeFileTransport(typeof opts.file === "string" ? opts.file : undefined));
-	if (opts.console) transports.push(makeConsoleTransport());
-	return transports;
+interface LocalTransports {
+	readonly file: FileTransport | undefined;
+	readonly console: boolean;
 }
 
-function getWinstonLogger(): winston.Logger {
-	if (!winstonLogger) {
-		const transports = buildTransports(transportOpts);
-		winstonLogger = winston.createLogger({
-			level: "debug",
-			format: getLogFormat(),
-			transports,
-			// A transport-less winston logger console.warns "Attempt to write logs
-			// with no transports" on every emit; mark it silent instead so disabling
-			// all transports is a clean no-op.
-			silent: transports.length === 0,
-			// Don't exit on error - logging failures shouldn't crash the app
-			exitOnError: false,
-		});
-	}
-	return winstonLogger;
+/** Local transports, constructed lazily on first log emission. */
+let activeTransports: LocalTransports | undefined;
+
+const TRANSPORT_MESSAGE = Symbol.for("message");
+const onTransportLogged = (): void => {};
+
+function buildTransports(opts: { console?: boolean; file?: boolean | string }): LocalTransports {
+	return {
+		file: opts.file ? makeFileTransport(typeof opts.file === "string" ? opts.file : undefined) : undefined,
+		console: opts.console === true,
+	};
+}
+
+function getLocalTransports(): LocalTransports {
+	activeTransports ??= buildTransports(transportOpts);
+	return activeTransports;
+}
+
+function emitLocally(level: LogLevel, message: string, context: Record<string, unknown> | undefined): void {
+	const transports = getLocalTransports();
+	const info = normalizeLogInfo(level, message, context);
+	if (!transports.file && !transports.console) return;
+
+	// Winston applied the shared format before dispatch, then the same format a
+	// second time inside Console. Keep those evaluation and timestamp semantics.
+	const line = formatLogInfo(info);
+	if (transports.file) transports.file.log({ [TRANSPORT_MESSAGE]: line }, onTransportLogged);
+	if (transports.console) process.stdout.write(`${formatLogInfo(info)}${os.EOL}`);
 }
 
 /**
@@ -228,12 +266,11 @@ function getWinstonLogger(): winston.Logger {
  */
 export function setTransports(opts: { console?: boolean; file?: boolean | string }): void {
 	transportOpts = opts;
-	if (!winstonLogger) return; // applied lazily when the logger is first built
-	winstonLogger.clear();
-	const transports = buildTransports(opts);
-	for (const transport of transports) winstonLogger.add(transport);
-	// Keep the logger silent when nothing is attached so winston doesn't warn on emit.
-	winstonLogger.silent = transports.length === 0;
+	if (!activeTransports) return; // applied lazily when local logging is first initialized
+	const previousTransports = activeTransports;
+	activeTransports = { file: undefined, console: false };
+	previousTransports.file?.close();
+	activeTransports = buildTransports(opts);
 }
 
 /**
@@ -243,7 +280,7 @@ export function setTransports(opts: { console?: boolean; file?: boolean | string
  */
 export function error(message: string, context?: Record<string, unknown>): void {
 	try {
-		getWinstonLogger().error(message, context);
+		emitLocally("error", message, context);
 	} catch {
 		// Silently ignore logging failures
 	}
@@ -257,7 +294,7 @@ export function error(message: string, context?: Record<string, unknown>): void 
  */
 export function warn(message: string, context?: Record<string, unknown>): void {
 	try {
-		getWinstonLogger().warn(message, context);
+		emitLocally("warn", message, context);
 	} catch {
 		// Silently ignore logging failures
 	}
@@ -271,7 +308,7 @@ export function warn(message: string, context?: Record<string, unknown>): void {
  */
 export function info(message: string, context?: Record<string, unknown>): void {
 	try {
-		getWinstonLogger().info(message, context);
+		emitLocally("info", message, context);
 	} catch {
 		// Silently ignore logging failures
 	}
@@ -285,7 +322,7 @@ export function info(message: string, context?: Record<string, unknown>): void {
  */
 export function debug(message: string, context?: Record<string, unknown>): void {
 	try {
-		getWinstonLogger().debug(message, context);
+		emitLocally("debug", message, context);
 	} catch {
 		// Silently ignore logging failures
 	}

--- a/packages/utils/src/winston-daily-rotate-file.d.ts
+++ b/packages/utils/src/winston-daily-rotate-file.d.ts
@@ -1,0 +1,6 @@
+declare module "winston-daily-rotate-file/daily-rotate-file.js" {
+	import type DailyRotateFile from "winston-daily-rotate-file";
+
+	const DailyRotateFileImplementation: typeof DailyRotateFile;
+	export default DailyRotateFileImplementation;
+}

--- a/packages/utils/test/fixtures/logger-api-probe.ts
+++ b/packages/utils/test/fixtures/logger-api-probe.ts
@@ -1,0 +1,15 @@
+import * as fs from "node:fs";
+import { logger as rootLogger } from "../../src/index";
+import * as directLogger from "../../src/logger";
+
+const outputPath = process.argv[2];
+if (!outputPath) throw new Error("expected output path");
+
+const keys = Object.keys(directLogger).sort();
+const identities = keys.every(key => {
+	const direct = directLogger as Record<string, unknown>;
+	const root = rootLogger as Record<string, unknown>;
+	return direct[key] === root[key];
+});
+
+fs.writeFileSync(outputPath, JSON.stringify({ identities, keys }));

--- a/packages/utils/test/fixtures/logger-cache-positive-control.ts
+++ b/packages/utils/test/fixtures/logger-cache-positive-control.ts
@@ -1,0 +1,9 @@
+import * as fs from "node:fs";
+import * as winston from "winston";
+import { snapshotLoggerRuntime } from "./logger-cache-snapshot";
+
+const outputPath = process.argv[2];
+if (!outputPath) throw new Error("expected output path");
+
+void winston;
+fs.writeFileSync(outputPath, JSON.stringify(snapshotLoggerRuntime()));

--- a/packages/utils/test/fixtures/logger-cache-probe.ts
+++ b/packages/utils/test/fixtures/logger-cache-probe.ts
@@ -1,0 +1,29 @@
+import * as fs from "node:fs";
+import * as logger from "../../src/logger";
+import { snapshotLoggerRuntime } from "./logger-cache-snapshot";
+
+const scenario = process.argv[2];
+const outputPath = process.argv[3];
+const logsDir = process.argv[4];
+
+if (!scenario || !outputPath) throw new Error("expected scenario and output path");
+
+switch (scenario) {
+	case "import":
+		break;
+	case "console":
+		logger.setTransports({ console: true, file: false });
+		logger.info("logger-cache-console");
+		logger.setTransports({ console: false, file: false });
+		break;
+	case "file":
+		if (!logsDir) throw new Error("file scenario requires logs directory");
+		logger.setTransports({ console: false, file: logsDir });
+		logger.info("logger-cache-file");
+		logger.setTransports({ console: false, file: false });
+		break;
+	default:
+		throw new Error(`unknown scenario: ${scenario}`);
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(snapshotLoggerRuntime()));

--- a/packages/utils/test/fixtures/logger-cache-snapshot.ts
+++ b/packages/utils/test/fixtures/logger-cache-snapshot.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs";
+import * as nodeModule from "node:module";
+
+interface ModuleConstructorWithCache {
+	readonly _cache: Record<string, object>;
+}
+
+export interface CacheFamily {
+	readonly modules: number;
+	readonly bytes: number;
+	readonly paths: string[];
+}
+
+export interface LoggerCacheSnapshot {
+	readonly winston: CacheFamily;
+	readonly fileStreamRotator: CacheFamily;
+	readonly moment: CacheFamily;
+}
+
+const moduleCache = (nodeModule.Module as unknown as ModuleConstructorWithCache)._cache;
+
+function snapshotFamily(segment: string): CacheFamily {
+	const paths = Object.keys(moduleCache)
+		.filter(modulePath => modulePath.replaceAll("\\", "/").includes(segment))
+		.sort();
+	return {
+		modules: paths.length,
+		bytes: paths.reduce((total, modulePath) => total + fs.statSync(modulePath).size, 0),
+		paths,
+	};
+}
+
+export function snapshotLoggerRuntime(): LoggerCacheSnapshot {
+	return {
+		winston: snapshotFamily("/node_modules/winston/"),
+		fileStreamRotator: snapshotFamily("/node_modules/file-stream-rotator/"),
+		moment: snapshotFamily("/node_modules/moment/"),
+	};
+}

--- a/packages/utils/test/fixtures/logger-contract-probe.ts
+++ b/packages/utils/test/fixtures/logger-contract-probe.ts
@@ -1,0 +1,226 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as logger from "../../src/logger";
+
+const scenario = process.argv[2];
+const primaryDir = process.argv[3];
+const secondaryDir = process.argv[4];
+const resultPath = process.argv[5];
+
+if (!scenario || !primaryDir || !secondaryDir || !resultPath) {
+	throw new Error("expected scenario, primary directory, secondary directory, and result path");
+}
+
+function disableTransports(): void {
+	logger.setTransports({ console: false, file: false });
+}
+
+function writeResult(value: unknown): void {
+	fs.writeFileSync(resultPath, JSON.stringify(value));
+}
+
+switch (scenario) {
+	case "matrix": {
+		logger.setTransports({ console: false, file: primaryDir });
+		logger.error("level-error", { ordinal: 1 });
+		logger.warn("level-warn", { ordinal: 2 });
+		logger.info("level-info", { ordinal: 3 });
+		logger.debug("level-debug", { ordinal: 4 });
+
+		const hidden = Symbol("hidden");
+		const context: Record<string, unknown> & { [hidden]?: unknown } = {
+			stringValue: "text",
+			numberValue: 7,
+			booleanValue: false,
+			nullValue: null,
+			nested: { alpha: "a", values: [1, undefined, () => "omitted", Number.NaN] },
+			undefinedValue: undefined,
+			functionValue: () => "omitted",
+			infinity: Number.POSITIVE_INFINITY,
+			nan: Number.NaN,
+		};
+		context[hidden] = "omitted";
+		logger.info("context-matrix", context);
+		logger.warn("reserved-primary", {
+			before: "first",
+			message: "metadata-message",
+			level: "context-level",
+			timestamp: "context-timestamp",
+			after: "last",
+		});
+		logger.debug("reserved-falsy", { message: "", after: true });
+
+		const cause = new Error("downstream");
+		cause.stack = "CAUSE_STACK";
+		const error = new Error("upstream", { cause }) as Error & { code: string; detail: { retry: boolean } };
+		error.name = "CustomError";
+		error.stack = "OUTER_STACK";
+		error.code = "E_FIXTURE";
+		error.detail = { retry: false };
+		logger.error("error-matrix", { error });
+		disableTransports();
+		break;
+	}
+	case "format-tokens": {
+		logger.setTransports({ console: false, file: primaryDir });
+		for (const token of ["s", "c", "d", "j", "i", "f", "o", "O", "%"]) {
+			logger.info(`token-%${token}`, { value: 7 });
+		}
+		logger.info("non-token-%q", { value: 7 });
+		interface TokenCircularContext extends Record<string, unknown> {
+			self?: TokenCircularContext;
+		}
+		const circular: TokenCircularContext = { kind: "circular" };
+		circular.self = circular;
+		logger.info("circular-%s", circular);
+		logger.info("bigint-%d", { value: 1n });
+		disableTransports();
+		break;
+	}
+	case "serialization-failures": {
+		logger.setTransports({ console: false, file: primaryDir });
+		interface CircularContext extends Record<string, unknown> {
+			self?: CircularContext;
+		}
+		const circular: CircularContext = { kind: "circular" };
+		circular.self = circular;
+		const bigintContext: Record<string, unknown> = { value: 1n };
+		const expectedContexts: Record<string, unknown>[] = [circular, bigintContext];
+		const events: Array<{ level: logger.LogLevel; message: string; sameContext: boolean; timestamp: string }> = [];
+		const dispose = logger.registerLogSink(event => {
+			const expected = expectedContexts[events.length];
+			events.push({
+				level: event.level,
+				message: event.message,
+				sameContext: event.context === expected,
+				timestamp: event.timestamp.toISOString(),
+			});
+		});
+		logger.info("circular-drop", circular);
+		logger.error("bigint-drop", bigintContext);
+		dispose();
+		disableTransports();
+		writeResult({ events });
+		break;
+	}
+	case "default-file":
+		logger.info("mode-default", { mode: "default" });
+		disableTransports();
+		break;
+	case "file-only":
+		logger.setTransports({ console: false, file: primaryDir });
+		logger.info("mode-file", { mode: "file" });
+		disableTransports();
+		break;
+	case "console-only":
+		logger.setTransports({ console: true, file: false });
+		logger.info("mode-console", { mode: "console" });
+		disableTransports();
+		break;
+	case "both":
+		logger.setTransports({ console: true, file: primaryDir });
+		logger.info("mode-both", { mode: "both" });
+		disableTransports();
+		break;
+	case "disabled-reenable": {
+		const contexts: Record<string, unknown>[] = [];
+		const disabledContext = { mode: "disabled" };
+		const dispose = logger.registerLogSink(event => {
+			if (event.context) contexts.push(event.context);
+		});
+		const setReturn = logger.setTransports({ console: false, file: false });
+		const logReturn = logger.warn("mode-disabled", disabledContext);
+		logger.setTransports({ console: false, file: primaryDir });
+		logger.warn("mode-reenabled", { mode: "file" });
+		const disposeReturn = dispose();
+		disableTransports();
+		writeResult({
+			disabledSinkSameContext: contexts[0] === disabledContext,
+			sinkCount: contexts.length,
+			returnsUndefined: setReturn === undefined && logReturn === undefined && disposeReturn === undefined,
+		});
+		break;
+	}
+	case "reconfigure":
+		logger.setTransports({ console: false, file: primaryDir });
+		logger.info("directory-a", { destination: "a" });
+		logger.setTransports({ console: false, file: secondaryDir });
+		logger.info("directory-b", { destination: "b" });
+		disableTransports();
+		break;
+	case "reconfigure-failure": {
+		logger.setTransports({ console: false, file: primaryDir });
+		logger.info("before-failed-reconfigure");
+		const blockerPath = path.join(secondaryDir, "not-a-directory");
+		fs.writeFileSync(blockerPath, "blocked");
+		let reconfigureThrew = false;
+		try {
+			logger.setTransports({ console: false, file: path.join(blockerPath, "child") });
+		} catch {
+			reconfigureThrew = true;
+		}
+		const sinkContext = { after: "failure" };
+		let sinkSameContext = false;
+		let sinkCount = 0;
+		const dispose = logger.registerLogSink(event => {
+			sinkCount++;
+			sinkSameContext = event.context === sinkContext;
+		});
+		logger.info("after-failed-reconfigure", sinkContext);
+		dispose();
+		await Bun.sleep(20);
+		writeResult({ reconfigureThrew, sinkCount, sinkSameContext });
+		break;
+	}
+	case "burst-close":
+		logger.setTransports({ console: false, file: primaryDir });
+		for (let index = 0; index < 1_000; index++) logger.info("burst-close", { index });
+		disableTransports();
+		break;
+	case "burst-natural":
+		logger.setTransports({ console: false, file: primaryDir });
+		for (let index = 0; index < 1_000; index++) logger.info("burst-natural", { index });
+		break;
+	case "sink-order": {
+		logger.setTransports({ console: true, file: false });
+		const sinkContext = { identity: "same" };
+		const dispose = logger.registerLogSink(event => {
+			process.stdout.write(`SINK:${event.context === sinkContext}\n`);
+			throw new Error("sink failure must be isolated");
+		});
+		logger.info("sink-first", sinkContext);
+		dispose();
+		logger.info("sink-disposed");
+		disableTransports();
+		break;
+	}
+	case "date-retention": {
+		const dates = [
+			"2026-01-02T03:04:05.006Z",
+			"2026-01-03T03:04:05.006Z",
+			"2026-01-04T03:04:05.006Z",
+			"2026-01-05T03:04:05.006Z",
+			"2026-01-06T03:04:05.006Z",
+			"2026-01-07T03:04:05.006Z",
+		];
+		process.env.OMP_LOGGER_TEST_NOW = dates[0];
+		logger.setTransports({ console: false, file: primaryDir });
+		for (const [index, date] of dates.entries()) {
+			process.env.OMP_LOGGER_TEST_NOW = date;
+			logger.info(`date-${index + 1}`);
+			await Bun.sleep(10);
+		}
+		disableTransports();
+		break;
+	}
+	case "size-rotation":
+		logger.setTransports({ console: false, file: primaryDir });
+		logger.info("size-nine-mib", { payload: "x".repeat(9 * 1024 * 1024) });
+		logger.info("size-half-mib", { payload: "y".repeat(512 * 1024) });
+		logger.info("size-crosses-ten-mib", { payload: "z".repeat(1024 * 1024) });
+		logger.info("rotation-trigger");
+		disableTransports();
+		break;
+	default:
+		throw new Error(`unknown scenario: ${scenario}`);
+}

--- a/packages/utils/test/fixtures/logger-fixed-date-preload.ts
+++ b/packages/utils/test/fixtures/logger-fixed-date-preload.ts
@@ -1,0 +1,21 @@
+const NativeDate = globalThis.Date;
+
+function fixtureNow(): number {
+	const value = process.env.OMP_LOGGER_TEST_NOW;
+	if (!value) throw new Error("OMP_LOGGER_TEST_NOW is required");
+	const parsed = NativeDate.parse(value);
+	if (!Number.isFinite(parsed)) throw new Error(`invalid OMP_LOGGER_TEST_NOW: ${value}`);
+	return parsed;
+}
+
+class FixedDate extends NativeDate {
+	constructor(value?: string | number) {
+		super(value === undefined ? fixtureNow() : value);
+	}
+
+	static now(): number {
+		return fixtureNow();
+	}
+}
+
+globalThis.Date = FixedDate as DateConstructor;

--- a/packages/utils/test/logger-contract.test.ts
+++ b/packages/utils/test/logger-contract.test.ts
@@ -70,7 +70,9 @@ async function runScenario(scenario: string): Promise<ScenarioResult> {
 }
 
 async function logFileNames(directory: string): Promise<string[]> {
-	return (await fs.readdir(directory)).filter(name => /^omp\.\d{4}-\d{2}-\d{2}\.\d+\.log(?:\.\d+)?$/.test(name)).sort();
+	return (await fs.readdir(directory))
+		.filter(name => /^omp\.\d{4}-\d{2}-\d{2}\.\d+\.log(?:\.\d+)?$/.test(name))
+		.sort();
 }
 
 async function readSingleLog(directory: string): Promise<{ name: string; text: string }> {
@@ -134,7 +136,17 @@ describe("central logger byte contract", () => {
 		const result = await runScenario("format-tokens");
 		expect(result.stdout).toBe("");
 		expect(result.stderr).toBe("");
-		const tokenMessages = ["token-%s", "token-%c", "token-%d", "token-%j", "token-%i", "token-%f", "token-%o", "token-%O", "token-%%"];
+		const tokenMessages = [
+			"token-%s",
+			"token-%c",
+			"token-%d",
+			"token-%j",
+			"token-%i",
+			"token-%f",
+			"token-%o",
+			"token-%O",
+			"token-%%",
+		];
 		const expected = [
 			...tokenMessages.map(message => expectedLine(result.pid, "info", message)),
 			expectedLine(result.pid, "info", "non-token-%q", { value: 7 }),
@@ -297,7 +309,8 @@ describe("DailyRotateFile option and retention contract", () => {
 		const basePath = path.join(result.primaryDir, baseName);
 		const baseStat = await fs.stat(basePath);
 		const recordSize = (message: string, payloadSize: number): number =>
-			`{"timestamp":"${fixedTimestamp}","level":"info","pid":${result.pid},"message":"${message}","payload":"`.length +
+			`{"timestamp":"${fixedTimestamp}","level":"info","pid":${result.pid},"message":"${message}","payload":"`
+				.length +
 			payloadSize +
 			`"}${os.EOL}`.length;
 		const expectedBytes =

--- a/packages/utils/test/logger-contract.test.ts
+++ b/packages/utils/test/logger-contract.test.ts
@@ -1,0 +1,358 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const fixtureDir = path.join(import.meta.dir, "fixtures");
+const probePath = path.join(fixtureDir, "logger-contract-probe.ts");
+const preloadPath = path.join(fixtureDir, "logger-fixed-date-preload.ts");
+const apiProbePath = path.join(fixtureDir, "logger-api-probe.ts");
+const fixedNow = "2026-01-02T03:04:05.006Z";
+const fixedTimestamp = "2026-01-01T22:04:05.006-05:00";
+const roots: string[] = [];
+
+interface ScenarioResult {
+	readonly pid: number;
+	readonly root: string;
+	readonly primaryDir: string;
+	readonly secondaryDir: string;
+	readonly resultPath: string;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+interface AuditFile {
+	readonly keep: { readonly days: boolean; readonly amount: number };
+	readonly auditLog: string;
+	readonly files: Array<{ readonly date: number; readonly name: string; readonly hash: string }>;
+	readonly hashType: string;
+}
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function runScenario(scenario: string): Promise<ScenarioResult> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-logger-contract-"));
+	roots.push(root);
+	const primaryDir = path.join(root, "primary");
+	const secondaryDir = path.join(root, "secondary");
+	const resultPath = path.join(root, "result.json");
+	await Promise.all([fs.mkdir(primaryDir), fs.mkdir(secondaryDir)]);
+	const proc = Bun.spawn(
+		[process.execPath, "--preload", preloadPath, probePath, scenario, primaryDir, secondaryDir, resultPath],
+		{
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			env: {
+				...process.env,
+				HOME: primaryDir,
+				PI_CONFIG_DIR: ".omp",
+				OMP_PROFILE: "",
+				PI_PROFILE: "",
+				XDG_DATA_HOME: "",
+				XDG_STATE_HOME: "",
+				XDG_CACHE_HOME: "",
+				OMP_LOGGER_TEST_NOW: fixedNow,
+				TZ: "Etc/GMT+5",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return { pid: proc.pid, root, primaryDir, secondaryDir, resultPath, stdout, stderr };
+}
+
+async function logFileNames(directory: string): Promise<string[]> {
+	return (await fs.readdir(directory)).filter(name => /^omp\.\d{4}-\d{2}-\d{2}\.\d+\.log(?:\.\d+)?$/.test(name)).sort();
+}
+
+async function readSingleLog(directory: string): Promise<{ name: string; text: string }> {
+	const names = await logFileNames(directory);
+	expect(names).toHaveLength(1);
+	const name = names[0];
+	if (!name) throw new Error("expected one log file");
+	return { name, text: await fs.readFile(path.join(directory, name), "utf8") };
+}
+
+function expectedLine(
+	pid: number,
+	level: "error" | "warn" | "info" | "debug",
+	message: string,
+	context: Record<string, unknown> = {},
+	timestamp = fixedTimestamp,
+): string {
+	return `${JSON.stringify({ timestamp, level, pid, message, ...context })}${os.EOL}`;
+}
+
+describe("central logger byte contract", () => {
+	test("pins levels, metadata normalization, key order, timestamp, errors, pid, and EOL", async () => {
+		const result = await runScenario("matrix");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		const log = await readSingleLog(result.primaryDir);
+		expect(log.name).toBe(`omp.2026-01-01.${result.pid}.log`);
+		const expected = [
+			expectedLine(result.pid, "error", "level-error", { ordinal: 1 }),
+			expectedLine(result.pid, "warn", "level-warn", { ordinal: 2 }),
+			expectedLine(result.pid, "info", "level-info", { ordinal: 3 }),
+			expectedLine(result.pid, "debug", "level-debug", { ordinal: 4 }),
+			expectedLine(result.pid, "info", "context-matrix", {
+				stringValue: "text",
+				numberValue: 7,
+				booleanValue: false,
+				nullValue: null,
+				nested: { alpha: "a", values: [1, null, null, null] },
+				infinity: null,
+				nan: null,
+			}),
+			expectedLine(result.pid, "warn", "reserved-primary metadata-message", { before: "first", after: "last" }),
+			expectedLine(result.pid, "debug", "reserved-falsy", { after: true }),
+			expectedLine(result.pid, "error", "error-matrix", {
+				error: {
+					name: "CustomError",
+					message: "upstream",
+					stack: "OUTER_STACK",
+					code: "E_FIXTURE",
+					detail: { retry: false },
+					cause: { name: "Error", message: "downstream", stack: "CAUSE_STACK" },
+				},
+			}),
+		].join("");
+		expect(log.text).toBe(expected);
+		expect(log.text.endsWith(os.EOL)).toBe(true);
+		expect(await fs.readFile(path.join(result.primaryDir, `.omp.${result.pid}-audit.json`), "utf8")).not.toBe("");
+	});
+
+	test("treats Winston format tokens as a splat branch and omits context", async () => {
+		const result = await runScenario("format-tokens");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		const tokenMessages = ["token-%s", "token-%c", "token-%d", "token-%j", "token-%i", "token-%f", "token-%o", "token-%O", "token-%%"];
+		const expected = [
+			...tokenMessages.map(message => expectedLine(result.pid, "info", message)),
+			expectedLine(result.pid, "info", "non-token-%q", { value: 7 }),
+			expectedLine(result.pid, "info", "circular-%s"),
+			expectedLine(result.pid, "info", "bigint-%d"),
+		].join("");
+		expect((await readSingleLog(result.primaryDir)).text).toBe(expected);
+	});
+
+	test("drops native JSON failures locally but sends original contexts to sinks", async () => {
+		const result = await runScenario("serialization-failures");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		const log = await readSingleLog(result.primaryDir);
+		expect(log.text).toBe("");
+		const payload = JSON.parse(await fs.readFile(result.resultPath, "utf8")) as {
+			events: Array<{ level: string; message: string; sameContext: boolean; timestamp: string }>;
+		};
+		expect(payload.events).toEqual([
+			{ level: "info", message: "circular-drop", sameContext: true, timestamp: fixedNow },
+			{ level: "error", message: "bigint-drop", sameContext: true, timestamp: fixedNow },
+		]);
+	});
+});
+
+describe("central logger transport lifecycle", () => {
+	test("defaults to file-only without touching stdout or stderr", async () => {
+		const result = await runScenario("default-file");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		const defaultLogsDir = path.join(result.primaryDir, ".omp", "logs");
+		const log = await readSingleLog(defaultLogsDir);
+		expect(log.text).toBe(expectedLine(result.pid, "info", "mode-default", { mode: "default" }));
+	});
+
+	test("emits file-only, console-only, and dual modes exactly once", async () => {
+		const fileOnly = await runScenario("file-only");
+		const fileLine = expectedLine(fileOnly.pid, "info", "mode-file", { mode: "file" });
+		expect(fileOnly.stdout).toBe("");
+		expect(fileOnly.stderr).toBe("");
+		expect((await readSingleLog(fileOnly.primaryDir)).text).toBe(fileLine);
+
+		const consoleOnly = await runScenario("console-only");
+		const consoleLine = expectedLine(consoleOnly.pid, "info", "mode-console", { mode: "console" });
+		expect(consoleOnly.stdout).toBe(consoleLine);
+		expect(consoleOnly.stderr).toBe("");
+		expect(await logFileNames(consoleOnly.primaryDir)).toEqual([]);
+
+		const both = await runScenario("both");
+		const bothLine = expectedLine(both.pid, "info", "mode-both", { mode: "both" });
+		expect(both.stdout).toBe(bothLine);
+		expect(both.stderr).toBe("");
+		expect((await readSingleLog(both.primaryDir)).text).toBe(bothLine);
+	});
+
+	test("keeps disabled mode silent, sends sinks, preserves void returns, and re-enables", async () => {
+		const result = await runScenario("disabled-reenable");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		expect((await readSingleLog(result.primaryDir)).text).toBe(
+			expectedLine(result.pid, "warn", "mode-reenabled", { mode: "file" }),
+		);
+		const payload = JSON.parse(await fs.readFile(result.resultPath, "utf8")) as {
+			disabledSinkSameContext: boolean;
+			sinkCount: number;
+			returnsUndefined: boolean;
+		};
+		expect(payload).toEqual({ disabledSinkSameContext: true, sinkCount: 2, returnsUndefined: true });
+	});
+
+	test("closes A before reconfiguring to B and never cross-writes", async () => {
+		const result = await runScenario("reconfigure");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		expect((await readSingleLog(result.primaryDir)).text).toBe(
+			expectedLine(result.pid, "info", "directory-a", { destination: "a" }),
+		);
+		expect((await readSingleLog(result.secondaryDir)).text).toBe(
+			expectedLine(result.pid, "info", "directory-b", { destination: "b" }),
+		);
+	});
+
+	test("invalidates closed transports when warm replacement construction fails", async () => {
+		const result = await runScenario("reconfigure-failure");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		expect((await readSingleLog(result.primaryDir)).text).toBe(
+			expectedLine(result.pid, "info", "before-failed-reconfigure"),
+		);
+		expect(await logFileNames(result.secondaryDir)).toEqual([]);
+		const payload = JSON.parse(await fs.readFile(result.resultPath, "utf8")) as {
+			reconfigureThrew: boolean;
+			sinkCount: number;
+			sinkSameContext: boolean;
+		};
+		expect(payload).toEqual({ reconfigureThrew: true, sinkCount: 1, sinkSameContext: true });
+	});
+
+	test("preserves burst order and drains on close and natural child exit", async () => {
+		for (const scenario of ["burst-close", "burst-natural"] as const) {
+			const result = await runScenario(scenario);
+			expect(result.stdout).toBe("");
+			expect(result.stderr).toBe("");
+			const text = (await readSingleLog(result.primaryDir)).text;
+			expect(text.endsWith(os.EOL)).toBe(true);
+			const lines = text.split(os.EOL);
+			expect(lines.pop()).toBe("");
+			expect(lines).toHaveLength(1_000);
+			for (const [index, line] of lines.entries()) {
+				const entry = JSON.parse(line) as { message: string; index: number };
+				expect(entry).toMatchObject({ message: scenario, index });
+			}
+		}
+	});
+
+	test("runs local console output before sinks and isolates throwing or disposed sinks", async () => {
+		const result = await runScenario("sink-order");
+		const first = expectedLine(result.pid, "info", "sink-first", { identity: "same" });
+		const second = expectedLine(result.pid, "info", "sink-disposed");
+		expect(result.stdout).toBe(`${first}SINK:true\n${second}`);
+		expect(result.stderr).toBe("");
+	});
+});
+
+describe("DailyRotateFile option and retention contract", () => {
+	test("uses local-day names, a PID audit, SHA-256, and retains exactly five rotations", async () => {
+		const result = await runScenario("date-retention");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		const expectedNames = [2, 3, 4, 5, 6].map(day => `omp.2026-01-0${day}.${result.pid}.log`);
+		expect(await logFileNames(result.primaryDir)).toEqual(expectedNames);
+		for (const [offset, name] of expectedNames.entries()) {
+			const day = offset + 2;
+			const timestamp = `2026-01-0${day}T22:04:05.006-05:00`;
+			expect(await fs.readFile(path.join(result.primaryDir, name), "utf8")).toBe(
+				expectedLine(result.pid, "info", `date-${day}`, {}, timestamp),
+			);
+		}
+
+		const auditPath = path.join(result.primaryDir, `.omp.${result.pid}-audit.json`);
+		const audit = JSON.parse(await fs.readFile(auditPath, "utf8")) as AuditFile;
+		expect(audit.keep).toEqual({ days: false, amount: 5 });
+		expect(audit.auditLog).toBe(auditPath);
+		expect(audit.hashType).toBe("sha256");
+		expect(audit.files.map(file => file.name)).toEqual(expectedNames.map(name => path.join(result.primaryDir, name)));
+		for (const file of audit.files) {
+			const hash = crypto.createHash("sha256").update(`${file.name}LOG_FILE${file.date}`).digest("hex");
+			expect(file.hash).toBe(hash);
+			expect(file.hash).toMatch(/^[0-9a-f]{64}$/);
+		}
+	});
+
+	test("crosses 10 MiB before rolling the following record to suffix .1", async () => {
+		const result = await runScenario("size-rotation");
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
+		const baseName = `omp.2026-01-01.${result.pid}.log`;
+		const rotatedName = `${baseName}.1`;
+		expect(await logFileNames(result.primaryDir)).toEqual([baseName, rotatedName]);
+		const basePath = path.join(result.primaryDir, baseName);
+		const baseStat = await fs.stat(basePath);
+		const recordSize = (message: string, payloadSize: number): number =>
+			`{"timestamp":"${fixedTimestamp}","level":"info","pid":${result.pid},"message":"${message}","payload":"`.length +
+			payloadSize +
+			`"}${os.EOL}`.length;
+		const expectedBytes =
+			recordSize("size-nine-mib", 9 * 1024 * 1024) +
+			recordSize("size-half-mib", 512 * 1024) +
+			recordSize("size-crosses-ten-mib", 1024 * 1024);
+		expect(baseStat.size).toBe(expectedBytes);
+		expect(baseStat.size).toBeGreaterThan(10 * 1024 * 1024);
+		expect(await fs.readFile(path.join(result.primaryDir, rotatedName), "utf8")).toBe(
+			expectedLine(result.pid, "info", "rotation-trigger"),
+		);
+		const audit = JSON.parse(
+			await fs.readFile(path.join(result.primaryDir, `.omp.${result.pid}-audit.json`), "utf8"),
+		) as AuditFile;
+		expect(audit.keep).toEqual({ days: false, amount: 5 });
+		expect(audit.files.map(file => path.basename(file.name))).toEqual([baseName, rotatedName]);
+	});
+});
+
+test("root and direct source entry points expose identical public logger functions", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-logger-api-"));
+	roots.push(root);
+	const outputPath = path.join(root, "result.json");
+	const proc = Bun.spawn([process.execPath, apiProbePath, outputPath], {
+		cwd: path.resolve(import.meta.dir, "../../.."),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	expect(stdout).toBe("");
+	expect(stderr).toBe("");
+	const payload = JSON.parse(await fs.readFile(outputPath, "utf8")) as { identities: boolean; keys: string[] };
+	expect(payload).toEqual({
+		identities: true,
+		keys: [
+			"debug",
+			"endTiming",
+			"error",
+			"info",
+			"openSpanPath",
+			"printTimings",
+			"recordModuleLoadSpan",
+			"registerLogSink",
+			"setTransports",
+			"shouldExitAfterTimings",
+			"startTiming",
+			"startupMarker",
+			"time",
+			"timingModeIncludes",
+			"warn",
+		],
+	});
+});

--- a/packages/utils/test/logger-runtime-closure.test.ts
+++ b/packages/utils/test/logger-runtime-closure.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { LoggerCacheSnapshot } from "./fixtures/logger-cache-snapshot";
+
+const fixtureDir = path.join(import.meta.dir, "fixtures");
+const probePath = path.join(fixtureDir, "logger-cache-probe.ts");
+const positiveControlPath = path.join(fixtureDir, "logger-cache-positive-control.ts");
+const roots: string[] = [];
+
+interface ProbeResult {
+	readonly snapshot: LoggerCacheSnapshot;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function makeRoot(prefix: string): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	roots.push(root);
+	return root;
+}
+
+async function runProbe(scenario: "import" | "console" | "file"): Promise<ProbeResult> {
+	const root = await makeRoot("omp-logger-cache-");
+	const outputPath = path.join(root, "result.json");
+	const logsDir = path.join(root, "logs");
+	await fs.mkdir(logsDir);
+	const proc = Bun.spawn([process.execPath, probePath, scenario, outputPath, logsDir], {
+		cwd: path.resolve(import.meta.dir, "../../.."),
+		env: { ...process.env, TZ: "Etc/GMT+5" },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return {
+		snapshot: JSON.parse(await fs.readFile(outputPath, "utf8")) as LoggerCacheSnapshot,
+		stdout,
+		stderr,
+	};
+}
+
+async function runPositiveControl(): Promise<LoggerCacheSnapshot> {
+	const root = await makeRoot("omp-logger-cache-control-");
+	const outputPath = path.join(root, "result.json");
+	const proc = Bun.spawn([process.execPath, positiveControlPath, outputPath], {
+		cwd: path.resolve(import.meta.dir, "../../.."),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stderr = new Response(proc.stderr).text();
+	expect(await proc.exited, await stderr).toBe(0);
+	return JSON.parse(await fs.readFile(outputPath, "utf8")) as LoggerCacheSnapshot;
+}
+
+describe("central logger runtime closure", () => {
+	test("detector observes the direct Winston positive control", async () => {
+		const { winston } = await runPositiveControl();
+		expect(winston.modules, JSON.stringify(winston)).toBeGreaterThan(0);
+		expect(winston.bytes, JSON.stringify(winston)).toBeGreaterThan(0);
+	});
+
+	for (const scenario of ["import", "console", "file"] as const) {
+		test(`${scenario} evaluates zero Winston runtime modules`, async () => {
+			const { snapshot } = await runProbe(scenario);
+			expect(
+				{ modules: snapshot.winston.modules, bytes: snapshot.winston.bytes },
+				JSON.stringify(snapshot.winston),
+			).toEqual({ modules: 0, bytes: 0 });
+		});
+	}
+
+	test("rotation engine stays lazy until a file transport is constructed", async () => {
+		const imported = await runProbe("import");
+		const consoled = await runProbe("console");
+		for (const result of [imported, consoled]) {
+			expect(result.snapshot.fileStreamRotator.modules, JSON.stringify(result.snapshot)).toBe(0);
+			expect(result.snapshot.moment.modules, JSON.stringify(result.snapshot)).toBe(0);
+		}
+		expect(imported.stdout).toBe("");
+		expect(imported.stderr).toBe("");
+		expect(consoled.stdout.endsWith(`${os.EOL}`)).toBe(true);
+		expect(consoled.stderr).toBe("");
+
+		const filed = await runProbe("file");
+		expect(filed.snapshot.fileStreamRotator.modules, JSON.stringify(filed.snapshot)).toBeGreaterThan(0);
+		expect(filed.snapshot.moment.modules, JSON.stringify(filed.snapshot)).toBeGreaterThan(0);
+		expect(filed.stdout).toBe("");
+		expect(filed.stderr).toBe("");
+	});
+});

--- a/packages/utils/test/logger-runtime-closure.test.ts
+++ b/packages/utils/test/logger-runtime-closure.test.ts
@@ -97,4 +97,13 @@ describe("central logger runtime closure", () => {
 		expect(filed.stdout).toBe("");
 		expect(filed.stderr).toBe("");
 	});
+	test("pins the deep rotation entrypoint to the reviewed package layout", async () => {
+		const rootPackage = JSON.parse(
+			await fs.readFile(path.resolve(import.meta.dir, "../../..", "package.json"), "utf8"),
+		) as { workspaces?: { catalog?: Record<string, string> } };
+		expect(rootPackage.workspaces?.catalog?.["winston-daily-rotate-file"]).toBe("5.0.0");
+		expect(Bun.resolveSync("winston-daily-rotate-file/daily-rotate-file.js", import.meta.dir)).toEndWith(
+			"/winston-daily-rotate-file/daily-rotate-file.js",
+		);
+	});
 });


### PR DESCRIPTION
## Problem

`packages/utils/src/logger.ts` imports the Winston runtime in every process even though OMP only needs four level methods, its existing JSON-line format, console routing, and the existing DailyRotateFile transport. Current `main` evaluates 13 Winston modules (54,252 source bytes) for import/file paths and 14 modules (58,094 bytes) for console logging.

Related discussion: #3767. This deliberately does **not** replace the rotation engine: the issue feedback correctly called out local-day naming, 10 MiB size rotation, five-file retention, append behavior, and multi-process isolation as compatibility requirements.

## Change

- Dispatch the existing `error` / `warn` / `info` / `debug` API locally.
- Preserve byte-for-byte JSON lines, local-offset timestamps, PID fields, metadata/error normalization, format-token behavior, and sink ordering.
- Keep `winston-daily-rotate-file` / FileStreamRotator for the existing local-day, 10 MiB, five-file, PID-audit behavior.
- Keep the rotation closure lazy until a file transport is actually created.
- Disable local output after a failed warm transport replacement instead of leaving Winston's cleared logger to emit its no-transport warning.

## Before / after

A regression committed before the implementation fails on current `main`:

- import: 13 Winston modules / 54,252 bytes
- console: 14 Winston modules / 58,094 bytes
- file: 13 Winston modules / 54,252 bytes
- failed warm reconfiguration emits Winston's no-transport warning

With this change:

- import, console, and file: 0 Winston runtime modules / 0 bytes
- FileStreamRotator and Moment remain unloaded for import/console and load only for file transport
- all byte, rotation, retention, lifecycle, and public-export contracts pass

Three matched forced-GC pairs against the byte-identical parent/treatment measured median selected heap self-size reductions of 1,009,257 bytes on import and 1,083,033 bytes after first console logging. No CPU improvement is claimed; CPU samples became invalid under host pressure.

## Verification

- Focused RED on current main: 13 pass, 5 fail; the three runtime-closure cases and failed-reconfiguration contract fail as intended (one additional environment-only failure was a missing local native addon).
- Focused GREEN: 30 pass, 0 fail, 2,163 assertions.
- Full `packages/utils`: 496 pass, 0 fail, 3,314 assertions.
- `packages/utils` type check: pass.
- Changed-file Biome check: pass.
- Source, Bun bundle, and compiled Linux x64 smoke each emitted the same pinned console JSON line.

## Compatibility and scope

- Public logger exports and call signatures are unchanged.
- Log paths, JSON shape, local timestamps, 10 MiB rotation, five-file retention, PID audit files, and stdout routing are unchanged.
- `winston-daily-rotate-file` remains the rotation implementation and its Winston peer remains installed; this PR claims runtime-closure/heap reduction, not dependency-install reduction.
- No provider, credential, network, session, or telemetry data path changes.