### PR TITLE
fix(coding-agent): surface MCP resource templates in resource summary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the assistant-facing available-resource summary omitting parameterized MCP resource templates, so a failed `mcp://` read now lists templates alongside concrete resources ([#6911](https://github.com/can1357/oh-my-pi/issues/6911)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -97,7 +97,10 @@ function formatAvailableResources(mcpManager: MCPManager): string {
 		.getConnectedServers()
 		.flatMap(name => {
 			const serverResources = mcpManager.getServerResources(name);
-			return (serverResources?.resources ?? []).map(r => `  ${r.uri} (${name})`);
+			if (!serverResources) return [];
+			const concrete = serverResources.resources.map(r => `  ${r.uri} (${name})`);
+			const templates = serverResources.templates.map(t => `  ${t.uriTemplate} (${name}, template)`);
+			return [...concrete, ...templates];
 		})
 		.join("\n");
 	return available || "  (none)";

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -73,6 +73,20 @@ describe("McpProtocolHandler", () => {
 		await expect(router.resolve("mcp://test://missing")).rejects.toThrow("server-a");
 	});
 
+	it("lists resource templates alongside concrete resources when no server matches", async () => {
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("server-a", {
+			resources: [{ uri: "example://items/open", name: "open-item" }],
+			templates: [{ uriTemplate: "example://items/{id}", name: "item-template" }],
+		});
+		const manager = createMockManager({ servers: ["server-a"], resources });
+		MCPManager.setInstance(manager);
+		const router = InternalUrlRouter.instance();
+
+		await expect(router.resolve("mcp://example://missing")).rejects.toThrow("example://items/open");
+		await expect(router.resolve("mcp://example://missing")).rejects.toThrow("example://items/{id}");
+	});
+
 	it("reads resource by exact URI match", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("my-server", {


### PR DESCRIPTION
## Repro
Connect an MCP server exposing a concrete resource (`example://items/open`) and a parameterized template (`example://items/{id}`), then read a non-matching `mcp://` URI so the available-resource summary is shown. Only the concrete resource is listed; the template is missing, even though `example://items/2` reads fine. Reproduced with `bun test test/internal-urls/mcp-protocol.test.ts -t "lists resource templates alongside"` — the summary was `Available resources:\n  example://items/open (server-a)`.

## Cause
`formatAvailableResources` in `packages/coding-agent/src/internal-urls/mcp-protocol.ts` built the summary from `serverResources.resources` only and ignored `serverResources.templates`. The routing path (`resolveTargetServer`) and the `/mcp resources` slash command (`mcp-command-controller.ts`) already handle templates, so the assistant-facing discovery summary was the sole path that understated the server's contract.

## Fix
- `formatAvailableResources` now maps over `serverResources.templates` as well, appending each `uriTemplate` marked `(<server>, template)` after the concrete resources.
- Guard when `getServerResources` returns undefined.
- Added a regression test in `test/internal-urls/mcp-protocol.test.ts` asserting the summary lists both the concrete resource and the template.

## Verification
`bun test test/internal-urls/mcp-protocol.test.ts` → 24 pass; `bun test test/client-resources.test.ts test/mcp-resource-templates-missing.test.ts` → 19 pass.

Fixes #6911