### PR TITLE
fix(ai): escape harmony control tokens in codex request input

### DIFF
--- a/packages/agent/src/compaction/utils.ts
+++ b/packages/agent/src/compaction/utils.ts
@@ -4,6 +4,7 @@
 
 import type { Message, ToolCall } from "@oh-my-pi/pi-ai";
 import { type Dialect, getDialectDefinition } from "@oh-my-pi/pi-ai/dialect";
+import { escapeHarmonyControlTokens } from "@oh-my-pi/pi-ai/utils/harmony-leak";
 import { formatGroupedPaths, prompt, stringifyJson } from "@oh-my-pi/pi-utils";
 import type { AgentMessage } from "../types";
 import fileOperationsTemplate from "./prompts/file-operations.md" with { type: "text" };
@@ -207,15 +208,13 @@ export function truncateToolResultForSummary(text: string): string {
 	return `${text.slice(0, TOOL_RESULT_MAX_CHARS)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
-const HARMONY_CONTROL_TOKEN_RE = /<\|(start|end|message|channel|constrain|return|call)\|>/g;
-
 /**
  * Serialize LLM messages as plain summary input without provider control tokens.
  */
 export function serializeConversationForSummary(messages: Message[], dialect?: Dialect): string {
 	const conversation = serializeConversation(messages, dialect);
 	if (dialect !== "harmony") return conversation;
-	return conversation.replace(HARMONY_CONTROL_TOKEN_RE, "<\\|$1\\|>");
+	return escapeHarmonyControlTokens(conversation);
 }
 
 /**

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI Responses requests for Harmony-dialect models (gpt-5.x / openai-codex) now escape reserved Harmony control-token spellings (e.g. `<|channel|>analysis`) in untrusted user and tool-result text before serialization, so ordinary data — documentation, code, logs, or `omp://` grep results — can no longer trip the provider's `invalid_prompt` / "Request blocked" validator and permanently poison the session. Only the transport copy is escaped; the persisted transcript is byte-for-byte unchanged, and non-Harmony models are untouched. Extends the existing compaction-payload escaping to the live agent-loop request boundary ([#6913](https://github.com/can1357/oh-my-pi/issues/6913)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1,6 +1,5 @@
 import * as os from "node:os";
 import { scheduler } from "node:timers/promises";
-import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import {
 	CODEX_BASE_URL,
@@ -56,7 +55,7 @@ import {
 } from "../utils";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { escapeHarmonyControlTokens } from "../utils/harmony-leak";
+import { escapeHarmonyControlTokens, isHarmonyDialectModel } from "../utils/harmony-leak";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import {
 	armPreResponseTimeout,
@@ -106,6 +105,7 @@ import {
 	createSequentialCutoffSummaryState,
 	encodeResponsesToolCallId,
 	encodeTextSignatureV1,
+	escapeReplayedClientText,
 	finalizeCustomToolCallInputDone,
 	finalizeMessageText,
 	finalizePendingResponsesToolCalls,
@@ -4157,7 +4157,7 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 						knownCallIds.add(item.call_id);
 					}
 				}
-				messages.push(...replayItems);
+				messages.push(...(isHarmonyDialectModel(model) ? escapeReplayedClientText(replayItems) : replayItems));
 				msgIndex += 1;
 				continue;
 			}
@@ -4257,7 +4257,7 @@ function normalizeInputMessageContent(
 	// gpt-5.x codex rejects reserved Harmony control-token spellings in input
 	// data; escape the transport copy of untrusted user text so ordinary docs or
 	// grep results cannot poison the session (#6913). History is left untouched.
-	const escapeControlTokens = preferredDialect(model.id) === "harmony";
+	const escapeControlTokens = isHarmonyDialectModel(model);
 	if (typeof content === "string") {
 		if (!content || content.trim() === "") return [];
 		const text = content.toWellFormed();

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1,5 +1,6 @@
 import * as os from "node:os";
 import { scheduler } from "node:timers/promises";
+import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import {
 	CODEX_BASE_URL,
@@ -55,6 +56,7 @@ import {
 } from "../utils";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
+import { escapeHarmonyControlTokens } from "../utils/harmony-leak";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import {
 	armPreResponseTimeout,
@@ -4252,14 +4254,23 @@ function normalizeInputMessageContent(
 	model: Model<"openai-codex-responses">,
 	content: string | Array<{ type: "text"; text: string } | { type: "image"; mimeType: string; data: string }>,
 ): ResponseInputContent[] {
+	// gpt-5.x codex rejects reserved Harmony control-token spellings in input
+	// data; escape the transport copy of untrusted user text so ordinary docs or
+	// grep results cannot poison the session (#6913). History is left untouched.
+	const escapeControlTokens = preferredDialect(model.id) === "harmony";
 	if (typeof content === "string") {
 		if (!content || content.trim() === "") return [];
-		return [{ type: "input_text", text: content.toWellFormed() }];
+		const text = content.toWellFormed();
+		return [{ type: "input_text", text: escapeControlTokens ? escapeHarmonyControlTokens(text) : text }];
 	}
 
 	return (
-		convertResponsesInputContent(content, model.input.includes("image"), model.compat.supportsImageDetailOriginal) ??
-		[]
+		convertResponsesInputContent(
+			content,
+			model.input.includes("image"),
+			model.compat.supportsImageDetailOriginal,
+			escapeControlTokens,
+		) ?? []
 	);
 }
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1,6 +1,6 @@
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { toFirepassWireModelId, toFireworksWireModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
-import { isGlm52ReasoningEffortModelId, isKimiK3ModelId, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
+import { isGlm52ReasoningEffortModelId, isKimiK3ModelId } from "@oh-my-pi/pi-catalog/identity";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import type {
@@ -78,7 +78,7 @@ import {
 	kStreamingPartialJson,
 } from "../utils/block-symbols";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
-import { escapeHarmonyControlTokens } from "../utils/harmony-leak";
+import { escapeHarmonyControlTokens, isHarmonyDialectModel } from "../utils/harmony-leak";
 import type { CapturedHttpErrorResponse } from "../utils/http-inspector";
 import { getOpenRouterHeaders } from "../utils/openrouter-headers";
 import { isForcedToolChoice } from "../utils/tool-choice";
@@ -1610,6 +1610,37 @@ export interface BuildResponsesInputOptions<TApi extends Api> {
 	preserveAssistantMessageIds?: boolean;
 }
 
+/**
+ * Escape reserved Harmony control tokens in the client-boundary text of
+ * replayed Responses input items — user/developer/system message text and
+ * tool-result output. Model-owned items (assistant output, reasoning, tool-call
+ * arguments) carry no client data and are returned untouched.
+ *
+ * Native history replay pushes stored `providerPayload` items straight onto the
+ * wire, bypassing {@link convertResponsesInputContent}; without this a stored
+ * `input_text` carrying `<|channel|>analysis` still reaches gpt-5.x raw (#6913).
+ * Callers gate on {@link isHarmonyDialectModel}. Items are copied, not mutated.
+ */
+export function escapeReplayedClientText(items: ResponseInput): ResponseInput {
+	return items.map(item => {
+		if (item.type === "function_call_output" || item.type === "custom_tool_call_output") {
+			return typeof item.output === "string" ? { ...item, output: escapeHarmonyControlTokens(item.output) } : item;
+		}
+		if (item.type === "message" && (item.role === "user" || item.role === "developer" || item.role === "system")) {
+			if (typeof item.content === "string") {
+				return { ...item, content: escapeHarmonyControlTokens(item.content) };
+			}
+			return {
+				...item,
+				content: item.content.map(part =>
+					part.type === "input_text" ? { ...part, text: escapeHarmonyControlTokens(part.text) } : part,
+				),
+			};
+		}
+		return item;
+	});
+}
+
 export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInputOptions<TApi>): ResponseInput {
 	const messages: ResponseInput = [];
 	const systemPrompts = options.systemRole ? normalizeSystemPrompts(options.context.systemPrompt) : [];
@@ -1641,7 +1672,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 	// reserved control-token spellings; escape the transport copy of untrusted
 	// user/tool text so ordinary docs, code, or grep results cannot poison the
 	// session (#6913). The persisted transcript is never touched.
-	const escapeControlTokens = preferredDialect(options.model.id) === "harmony";
+	const escapeControlTokens = isHarmonyDialectModel(options.model);
 
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
@@ -1663,14 +1694,13 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 					supportsImageDetailOriginal,
 					supportsComputerUse: options.model.supportsComputerUse === true,
 				});
-				messages.push(
-					...adaptResponsesReplayItemsForModel(
-						sanitizedItems,
-						supportsCustomToolCalls,
-						customToolWireNameMap,
-						options.model.supportsComputerUse === true,
-					),
+				const replayItems = adaptResponsesReplayItemsForModel(
+					sanitizedItems,
+					supportsCustomToolCalls,
+					customToolWireNameMap,
+					options.model.supportsComputerUse === true,
 				);
+				messages.push(...(escapeControlTokens ? escapeReplayedClientText(replayItems) : replayItems));
 				knownCallIds = collectKnownCallIds(messages);
 				for (const id of collectCustomCallIds(messages)) customCallIds.add(id);
 				for (const id of collectComputerCallIds(messages)) computerCallIds.add(id);
@@ -1984,7 +2014,7 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 	// Harmony-server models reject reserved control-token spellings even as tool
 	// data; escape the transport copy so a grep/read result cannot poison the
 	// session (#6913). Covers every downstream branch that consumes `output`.
-	const output = preferredDialect(model.id) === "harmony" ? escapeHarmonyControlTokens(rawOutput) : rawOutput;
+	const output = isHarmonyDialectModel(model) ? escapeHarmonyControlTokens(rawOutput) : rawOutput;
 	if (toolResult.providerMetadata?.type === "computer" && model.supportsComputerUse !== true) {
 		messages.push({
 			type: "message",

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1,6 +1,6 @@
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { toFirepassWireModelId, toFireworksWireModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
-import { isGlm52ReasoningEffortModelId, isKimiK3ModelId } from "@oh-my-pi/pi-catalog/identity";
+import { isGlm52ReasoningEffortModelId, isKimiK3ModelId, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import type {
@@ -78,6 +78,7 @@ import {
 	kStreamingPartialJson,
 } from "../utils/block-symbols";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
+import { escapeHarmonyControlTokens } from "../utils/harmony-leak";
 import type { CapturedHttpErrorResponse } from "../utils/http-inspector";
 import { getOpenRouterHeaders } from "../utils/openrouter-headers";
 import { isForcedToolChoice } from "../utils/tool-choice";
@@ -1482,16 +1483,24 @@ export function convertResponsesInputContent(
 	content: string | Array<TextContent | ImageContent>,
 	supportsImages: boolean,
 	supportsImageDetailOriginal: boolean,
+	escapeControlTokens = false,
 ): ResponseInputContent[] | undefined {
 	if (typeof content === "string") {
 		if (content.trim().length === 0) return undefined;
-		return [{ type: "input_text", text: content.toWellFormed() } satisfies ResponseInputText];
+		const text = content.toWellFormed();
+		return [
+			{
+				type: "input_text",
+				text: escapeControlTokens ? escapeHarmonyControlTokens(text) : text,
+			} satisfies ResponseInputText,
+		];
 	}
 
 	const { textBlocks, imageBlocks, omittedImages } = partitionVisionContent(content, supportsImages);
 	const normalizedContent: ResponseInputContent[] = [];
 	for (const item of textBlocks) {
-		const text = item.text.toWellFormed();
+		const raw = item.text.toWellFormed();
+		const text = escapeControlTokens ? escapeHarmonyControlTokens(raw) : raw;
 		if (text.trim().length === 0) continue;
 		normalizedContent.push({
 			type: "input_text",
@@ -1628,6 +1637,11 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 	const filterReasoning = <T extends { type?: string }>(items: T[]): T[] =>
 		options.nativeHistory?.filterReasoning ? items.filter(item => item?.type !== "reasoning") : items;
 	const includeThinkingSignatures = options.includeThinkingSignatures ?? options.nativeHistory?.replay ?? true;
+	// Harmony-server models (gpt-5.x) reject requests whose input data reproduces
+	// reserved control-token spellings; escape the transport copy of untrusted
+	// user/tool text so ordinary docs, code, or grep results cannot poison the
+	// session (#6913). The persisted transcript is never touched.
+	const escapeControlTokens = preferredDialect(options.model.id) === "harmony";
 
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
@@ -1667,13 +1681,20 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 				msg.content,
 				options.model.input.includes("image"),
 				supportsImageDetailOriginal,
+				escapeControlTokens,
 			);
 			if (!content) continue;
+			const developerText =
+				options.developerStringContent && msg.role === "developer" && typeof msg.content === "string"
+					? msg.content.toWellFormed()
+					: undefined;
 			messages.push({
 				role: "user",
 				content:
-					options.developerStringContent && msg.role === "developer" && typeof msg.content === "string"
-						? msg.content.toWellFormed()
+					developerText !== undefined
+						? escapeControlTokens
+							? escapeHarmonyControlTokens(developerText)
+							: developerText
 						: content,
 			});
 		} else if (msg.role === "assistant") {
@@ -1951,7 +1972,7 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 	// genuinely empty text result (empty file read, silent tool) must stay
 	// empty — the placeholder sent models chasing an attachment that never
 	// existed.
-	const output = (
+	const rawOutput = (
 		omittedImages
 			? joinTextWithImagePlaceholder(textResult, true)
 			: textResult.length > 0
@@ -1960,6 +1981,10 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 					? "(see attached image)"
 					: ""
 	).toWellFormed();
+	// Harmony-server models reject reserved control-token spellings even as tool
+	// data; escape the transport copy so a grep/read result cannot poison the
+	// session (#6913). Covers every downstream branch that consumes `output`.
+	const output = preferredDialect(model.id) === "harmony" ? escapeHarmonyControlTokens(rawOutput) : rawOutput;
 	if (toolResult.providerMetadata?.type === "computer" && model.supportsComputerUse !== true) {
 		messages.push({
 			type: "message",

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1626,16 +1626,24 @@ export function escapeReplayedClientText(items: ResponseInput): ResponseInput {
 		if (item.type === "function_call_output" || item.type === "custom_tool_call_output") {
 			return typeof item.output === "string" ? { ...item, output: escapeHarmonyControlTokens(item.output) } : item;
 		}
-		if (item.type === "message" && (item.role === "user" || item.role === "developer" || item.role === "system")) {
-			if (typeof item.content === "string") {
-				return { ...item, content: escapeHarmonyControlTokens(item.content) };
+		// EasyInputMessage may omit `type` (`{ role, content }`); the responses
+		// server persists it verbatim, so treat missing type as a message too.
+		const isTypedMessage = item.type === "message" || item.type === undefined;
+		if (isTypedMessage && "role" in item && "content" in item) {
+			const role = item.role;
+			if (role !== "user" && role !== "developer" && role !== "system") return item;
+			const content = item.content;
+			if (typeof content === "string") {
+				return { ...item, content: escapeHarmonyControlTokens(content) };
 			}
-			return {
-				...item,
-				content: item.content.map(part =>
-					part.type === "input_text" ? { ...part, text: escapeHarmonyControlTokens(part.text) } : part,
-				),
-			};
+			if (Array.isArray(content)) {
+				return {
+					...item,
+					content: content.map(part =>
+						part.type === "input_text" ? { ...part, text: escapeHarmonyControlTokens(part.text) } : part,
+					),
+				};
+			}
 		}
 		return item;
 	});

--- a/packages/ai/src/utils/harmony-leak.ts
+++ b/packages/ai/src/utils/harmony-leak.ts
@@ -14,6 +14,26 @@ import type { AssistantMessage, Model, ToolCall } from "../types";
 const MARKER_RE = /\bto=functions\.[A-Za-z_]\w*/g;
 const HARMONY_RE = /<\|(start|end|channel|message|call|return)\|>/g;
 
+// Reserved Harmony control-token spellings. Escaping these to their inert
+// backslash form lets untrusted data (user text, tool results) reach
+// harmony-server models (gpt-5.x) without the provider's prompt validator
+// rejecting the whole request (invalid_prompt / "Request blocked"). `constrain`
+// is escaped too — it is a real control token even though it is not a leak
+// signal on its own.
+const HARMONY_CONTROL_TOKEN_ESCAPE_RE = /<\|(start|end|message|channel|constrain|return|call)\|>/g;
+
+/**
+ * Escape reserved Harmony control tokens in arbitrary text so it can be
+ * transported as data to a harmony-dialect model. Returns the input unchanged
+ * when it carries no reserved spelling.
+ *
+ * Callers MUST gate on a harmony target and escape only the transport copy —
+ * the persisted transcript keeps the byte-for-byte original.
+ */
+export function escapeHarmonyControlTokens(text: string): string {
+	return text.replace(HARMONY_CONTROL_TOKEN_ESCAPE_RE, "<\\|$1\\|>");
+}
+
 // Channel-word adjacency (`C`): channel/role name appearing immediately before the marker.
 const CHANNEL_WORD_RE = /\b(?:analysis|commentary|assistant|user|system|developer|tool)\s+to=functions\./;
 

--- a/packages/ai/src/utils/harmony-leak.ts
+++ b/packages/ai/src/utils/harmony-leak.ts
@@ -7,6 +7,7 @@
  * hashline DSL form. Other tools and surfaces fall through to
  * abort-and-retry handled by the agent loop.
  */
+import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import type { AssistantMessage, Model, ToolCall } from "../types";
 
 // Single source of truth for the marker pattern. `M` in the errata.
@@ -32,6 +33,17 @@ const HARMONY_CONTROL_TOKEN_ESCAPE_RE = /<\|(start|end|message|channel|constrain
  */
 export function escapeHarmonyControlTokens(text: string): string {
 	return text.replace(HARMONY_CONTROL_TOKEN_ESCAPE_RE, "<\\|$1\\|>");
+}
+
+/**
+ * Whether requests to `model` are served by a Harmony-dialect backend
+ * (gpt-5.x / gpt-oss), which rejects reserved control-token spellings appearing
+ * as data in the request. Resolves the wire model id (`requestModelId ?? id`)
+ * so deployment/catalog aliases — e.g. an Azure alias whose `requestModelId` is
+ * `gpt-5.4` — are detected even when the local id is opaque.
+ */
+export function isHarmonyDialectModel(model: Model): boolean {
+	return preferredDialect(model.requestModelId ?? model.id) === "harmony";
 }
 
 // Channel-word adjacency (`C`): channel/role name appearing immediately before the marker.

--- a/packages/ai/test/issue-6913-harmony-marker-escaping.test.ts
+++ b/packages/ai/test/issue-6913-harmony-marker-escaping.test.ts
@@ -192,4 +192,42 @@ describe("issue #6913: Harmony control-token escaping at the request boundary", 
 		expect(wire).toContain(ESCAPED);
 		expect(wire).not.toContain(MARKER);
 	});
+
+	it("escapes replayed EasyInputMessage items that omit the type field", () => {
+		const model = buildModel({
+			id: "gpt-5.6",
+			name: "gpt-5.6",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		});
+		// Documented EasyInputMessage shape: `{ role, content }` with no `type`.
+		// The responses server persists it verbatim into providerPayload.
+		const user: UserMessage = {
+			role: "user",
+			timestamp: 0,
+			content: "continue",
+			providerPayload: createOpenAIResponsesHistoryPayload("openai", [
+				{ role: "user", content: [{ type: "input_text", text: `typeless ${MARKER} turn` }] },
+			]),
+		};
+
+		const wire = collectWireText(
+			buildResponsesInput({
+				model,
+				context: { messages: [user] },
+				strictResponsesPairing: false,
+				supportsImageDetailOriginal: false,
+				nativeHistory: { replay: true, filterReasoning: false },
+			}),
+		);
+
+		expect(wire).toContain(ESCAPED);
+		expect(wire).not.toContain(MARKER);
+	});
 });

--- a/packages/ai/test/issue-6913-harmony-marker-escaping.test.ts
+++ b/packages/ai/test/issue-6913-harmony-marker-escaping.test.ts
@@ -3,6 +3,7 @@ import { convertCodexResponsesMessages } from "@oh-my-pi/pi-ai/providers/openai-
 import type { ResponseInput } from "@oh-my-pi/pi-ai/providers/openai-responses-wire";
 import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import type { AssistantMessage, Context, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai/types";
+import { createOpenAIResponsesHistoryPayload } from "@oh-my-pi/pi-ai/utils";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { createCodexModel } from "./helpers";
 
@@ -125,5 +126,70 @@ describe("issue #6913: Harmony control-token escaping at the request boundary", 
 		);
 
 		expect(wire).toContain(MARKER);
+	});
+
+	it("detects Harmony via the wire model id for deployment/catalog aliases", () => {
+		// Opaque local id, gpt-5.4 on the wire (Azure-style alias). The gate must
+		// resolve `requestModelId`, not the non-Harmony local id.
+		const model = buildModel({
+			id: "my-azure-deployment",
+			requestModelId: "gpt-5.4",
+			name: "my-azure-deployment",
+			api: "openai-responses",
+			provider: "azure",
+			baseUrl: "https://example.openai.azure.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		});
+		const { context } = harmonyPoisonedContext();
+
+		const wire = collectWireText(
+			buildResponsesInput({ model, context, strictResponsesPairing: false, supportsImageDetailOriginal: false }),
+		);
+
+		expect(wire).toContain(ESCAPED);
+		expect(wire).not.toContain(MARKER);
+	});
+
+	it("escapes replayed native-history input items carrying a raw marker", () => {
+		const model = buildModel({
+			id: "gpt-5.6",
+			name: "gpt-5.6",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		});
+		// A stored client turn replayed verbatim via providerPayload — the branch
+		// that bypasses convertResponsesInputContent entirely.
+		const user: UserMessage = {
+			role: "user",
+			timestamp: 0,
+			content: "continue",
+			providerPayload: createOpenAIResponsesHistoryPayload("openai", [
+				{ type: "message", role: "user", content: [{ type: "input_text", text: `stored ${MARKER} turn` }] },
+				{ type: "function_call_output", call_id: "call_x", output: `tool said ${MARKER}` },
+			]),
+		};
+
+		const wire = collectWireText(
+			buildResponsesInput({
+				model,
+				context: { messages: [user] },
+				strictResponsesPairing: false,
+				supportsImageDetailOriginal: false,
+				nativeHistory: { replay: true, filterReasoning: false },
+			}),
+		);
+
+		expect(wire).toContain(ESCAPED);
+		expect(wire).not.toContain(MARKER);
 	});
 });

--- a/packages/ai/test/issue-6913-harmony-marker-escaping.test.ts
+++ b/packages/ai/test/issue-6913-harmony-marker-escaping.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { convertCodexResponsesMessages } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import type { ResponseInput } from "@oh-my-pi/pi-ai/providers/openai-responses-wire";
+import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { AssistantMessage, Context, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { createCodexModel } from "./helpers";
+
+// Literal Harmony analysis-channel marker. openai-codex/gpt-5.x reject any
+// request whose input carries this reserved control-token spelling as data
+// (invalid_prompt / "Request blocked"), permanently poisoning the session.
+const MARKER = "<|channel|>analysis";
+const ESCAPED = "<\\|channel\\|>analysis";
+
+function harmonyPoisonedContext(): { context: Context; user: UserMessage; toolResult: ToolResultMessage } {
+	const user: UserMessage = {
+		role: "user",
+		timestamp: 0,
+		content: `please summarize ${MARKER} marker`,
+	};
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "call_1", name: "grep", arguments: { pattern: "channel" } }],
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		model: "gpt-5.6-sol",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+	const toolResult: ToolResultMessage = {
+		role: "toolResult",
+		toolCallId: "call_1",
+		toolName: "grep",
+		isError: false,
+		content: [{ type: "text", text: `omp://toolconv/harmony.md: ${MARKER}\nmore docs` }],
+		timestamp: 0,
+	};
+	return { context: { messages: [user, assistant, toolResult] }, user, toolResult };
+}
+
+/** Flatten every free-text field an openai-responses input item can carry. */
+function collectWireText(items: ResponseInput): string {
+	const parts: string[] = [];
+	for (const item of items) {
+		if ("output" in item && typeof item.output === "string") parts.push(item.output);
+		if ("content" in item) {
+			const content = item.content;
+			if (typeof content === "string") {
+				parts.push(content);
+			} else if (Array.isArray(content)) {
+				for (const part of content) {
+					if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+						parts.push(part.text);
+					}
+				}
+			}
+		}
+	}
+	return parts.join("\n");
+}
+
+describe("issue #6913: Harmony control-token escaping at the request boundary", () => {
+	it("escapes markers in codex user text and tool results without mutating persisted history", () => {
+		const model = createCodexModel("gpt-5.6-sol");
+		const { context, user, toolResult } = harmonyPoisonedContext();
+
+		const wire = collectWireText(convertCodexResponsesMessages(model, context));
+
+		expect(wire).toContain(ESCAPED);
+		expect(wire).not.toContain(MARKER);
+
+		// Persisted messages must stay byte-for-byte identical.
+		expect(user.content).toBe(`please summarize ${MARKER} marker`);
+		expect(toolResult.content[0]).toMatchObject({ type: "text", text: expect.stringContaining(MARKER) });
+	});
+
+	it("escapes markers on the shared openai-responses builder for harmony models", () => {
+		const model = buildModel({
+			id: "gpt-5.6",
+			name: "gpt-5.6",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		});
+		const { context } = harmonyPoisonedContext();
+
+		const wire = collectWireText(
+			buildResponsesInput({ model, context, strictResponsesPairing: false, supportsImageDetailOriginal: false }),
+		);
+
+		expect(wire).toContain(ESCAPED);
+		expect(wire).not.toContain(MARKER);
+	});
+
+	it("leaves non-harmony models (anthropic family) untouched", () => {
+		const model = buildModel({
+			id: "claude-sonnet-4",
+			name: "claude-sonnet-4",
+			api: "openai-responses",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 64000,
+		});
+		const { context } = harmonyPoisonedContext();
+
+		const wire = collectWireText(
+			buildResponsesInput({ model, context, strictResponsesPairing: false, supportsImageDetailOriginal: false }),
+		);
+
+		expect(wire).toContain(MARKER);
+	});
+});


### PR DESCRIPTION
## Repro
A normal read-only session on `openai-codex`/`gpt-5.x` can place literal Harmony control-token text from an ordinary tool result or user message into the next request. The provider then rejects the request before generation with `invalid_prompt` / "Request blocked", and because the offending tool result stays in persisted history, every continuation replays it and fails — the session is permanently poisoned (e.g. a broad `omp://` grep whose results include `omp://toolconv/harmony.md`). Reproduced in-process at the serialization boundary: `cd packages/ai && bun test test/issue-6913-harmony-marker-escaping.test.ts`. Before the fix, both builders emitted the raw marker `<|channel|>analysis` in `input_text` / `function_call_output`.

## Cause
The live agent-loop request builders serialized untrusted text verbatim. `buildResponsesInput` (`packages/ai/src/providers/openai-shared.ts`) routes user text through `convertResponsesInputContent` and tool-result text through `appendResponsesToolResultMessages`; the codex builder `convertMessages` (`packages/ai/src/providers/openai-codex-responses.ts`) does the same via `normalizeInputMessageContent`. None escaped reserved Harmony spellings — only the compaction path (`serializeConversationForSummary`, #5190/#5482) did. So a marker in user/tool data reached the wire unescaped and tripped the provider's prompt validator.

## Fix
- Added `escapeHarmonyControlTokens` to `packages/ai/src/utils/harmony-leak.ts` (single escape helper; covers `start|end|message|channel|constrain|return|call`).
- `convertResponsesInputContent` gained an `escapeControlTokens` flag applied to every `input_text` it emits; `appendResponsesToolResultMessages` escapes its `output` for harmony models, covering all downstream branches (`function_call_output`, `custom_tool_call_output`, orphan/computer notes).
- Both builders compute the gate `preferredDialect(model.id) === "harmony"` and thread it through user text (incl. the codex string path and the developer-string branch) and tool results. Escaping touches only the transport copy — persisted history is byte-for-byte unchanged; non-harmony models are untouched.
- Refactored `serializeConversationForSummary` to reuse the shared helper, removing the duplicated compaction regex.

## Verification
`cd packages/ai && bun test test/issue-6913-harmony-marker-escaping.test.ts` → 3 pass (codex + shared builders escape user/tool markers while persisted messages stay raw; non-harmony model left untouched). Regression suites green: `bun test test/openai-codex-responses-lite.test.ts test/openai-computer-contract.test.ts test/openai-responses-history-payload.test.ts test/openai-responses-empty-tool-result.test.ts test/openai-responses-parallel-tool-result-images.test.ts test/issue-967-vision-guard.test.ts test/harmony-leak.test.ts` (130 pass) and `packages/agent bun test test/serialize-conversation.test.ts` (8 pass). Repo `bun run check:ts` exits 0. Fixes #6913