### PR TITLE
fix(search): make configured provider order exact

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -699,7 +699,7 @@ searxng:
 
 | Key | Type | Default | Values / notes |
 |---|---|---|---|
-| `providers.webSearchOrder` | array | `[]` | Provider IDs in priority order for `web_search` (`perplexity`, `gemini`, `anthropic`, `codex`, `zai`, `exa`, `jina`, `kagi`, `tavily`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`, …). Duplicates and unknown IDs are ignored; unlisted providers retain their built-in relative order afterward. Empty = built-in order. Replaces the removed `providers.webSearch` enum (a legacy value migrates to the head of this list). |
+| `providers.webSearchOrder` | array | `[]` | Exact provider allowlist in fallback order for `web_search` (`perplexity`, `gemini`, `anthropic`, `codex`, `zai`, `exa`, `jina`, `kagi`, `tavily`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`, …). Duplicates and unknown IDs are ignored; unlisted providers are never attempted. Empty = built-in automatic chain. Replaces the removed `providers.webSearch` enum (a legacy concrete value migrates to a singleton list). |
 | `providers.webSearchGeminiModel` | string | _(unset)_ | Gemini model ID for Google Search grounding when `web_search` uses Gemini; defaults to `gemini-2.5-flash`, overridden by `GEMINI_SEARCH_MODEL`. |
 | `providers.imageOrder` | array | `[]` | Image-generation provider IDs in priority order (`openai`, `openai-codex`, `antigravity`, `xai`, `gemini`, `openrouter`). Unlisted providers follow the active session provider and the built-in order. Replaces the removed `providers.image` enum (a legacy value migrates to the head of this list). |
 | `providers.fetch` | enum | `auto` | `auto`, `native`, `trafilatura`, `lynx`, `parallel`, `jina`. |

--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -83,9 +83,9 @@ Streaming: none. `WebSearchTool.execute()` forwards its `AbortSignal` into `exec
 ## Flow
 1. `WebSearchTool.execute()` in `packages/coding-agent/src/web/search/index.ts` delegates directly to `executeSearch()`.
 2. `executeSearch()` computes ordered provider candidates without loading their modules:
-   - if `params.provider` is set and not `"auto"`, it loads that provider only to check `isExplicitlyAvailable()`; if false, it uses the auto candidates.
-   - otherwise it uses the module-global preferred provider from `packages/coding-agent/src/web/search/provider.ts`.
-3. `resolveProviderCandidates()` puts an included preferred provider first (gated by `isExplicitlyAvailable()`), then the effective provider order excluding it. `providers.webSearchOrder` prioritizes listed providers and appends unlisted providers in `SEARCH_PROVIDER_ORDER`; an empty list preserves the built-in order. Excluded providers are skipped entirely, including as the preferred candidate. As `executeSearch()` walks those candidates, it loads a module and checks availability only when the candidate is reached.
+   - if `params.provider` is set and not `"auto"`, that provider is the only candidate and is checked with `isExplicitlyAvailable()`.
+   - otherwise it uses the module-global provider chain from `packages/coding-agent/src/web/search/provider.ts`.
+3. `resolveProviderCandidates()` uses a non-empty `providers.webSearchOrder` as the exact ordered allowlist; an empty list preserves the built-in automatic chain. Excluded providers are skipped entirely. As `executeSearch()` walks those candidates, it loads a module and checks availability only when the candidate is reached.
 4. If no providers are available (for example, after excluding DuckDuckGo and lacking configured keyed/OAuth providers), `executeSearch()` returns `Error: No web search provider configured.` with `details.response.provider = "none"`.
 5. For each provider in order, `executeSearch()` calls `provider.search()` with:
    - `query`,
@@ -102,7 +102,7 @@ Streaming: none. `WebSearchTool.execute()` forwards its `AbortSignal` into `exec
 ## Modes / Variants
 - **Provider selection**
   - **Forced provider**: internal callers may pass `provider`; a non-`auto` value is the only attempted provider, while `auto` (or omitting it) walks the configured chain. This field is not in the model-facing schema.
-  - **Configured order**: `setSearchProviderOrder()` prioritizes the valid, first-occurrence provider IDs in `providers.webSearchOrder`; providers omitted from the setting follow in their built-in relative order. Listed providers are explicit selections — they resolve through `isExplicitlyAvailable()`, so e.g. a hand-listed Perplexity may fall back to anonymous search. Wired from settings in `packages/coding-agent/src/config/provider-globals.ts` (SDK startup, cwd reloads, live settings changes).
+  - **Configured order**: `setSearchProviderOrder()` retains the valid, first-occurrence provider IDs in `providers.webSearchOrder` as the complete chain; omitted providers are never attempted. An empty setting restores the built-in automatic chain. Listed providers are explicit selections — they resolve through `isExplicitlyAvailable()`, so e.g. a hand-listed Perplexity may fall back to anonymous search. Wired from settings in `packages/coding-agent/src/config/provider-globals.ts` (SDK startup, cwd reloads, live settings changes).
   - **Excluded providers**: `setExcludedSearchProviders()` records providers `resolveProviderCandidates()` must skip, including as fallbacks. Wired from the `providers.webSearchExclude` setting via the same `provider-globals.ts` paths.
   - **Default auto chain order** (25 providers): `perplexity`, `gemini`, `anthropic`, `codex`, `xai`, `zai`, `exa`, `tinyfish`, `jina`, `kagi`, `tavily`, `firecrawl`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`, `duckduckgo`, `bing`, `yahoo`, `startpage`, `google`, `ecosia`, `mojeek`, `public` (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/types.ts`). `public` is explicit-only: its `isAvailable()` returns `false` so the auto chain never fans out implicitly.
 - **Provider adapters**

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed explicit web-search provider orders silently falling through to unlisted providers, including paid providers.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4798,8 +4798,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "providers",
 			group: "Services",
 			label: "Web Search Provider Order",
-			description:
-				"Prioritized providers for the web_search tool; unlisted providers retain their default order afterward",
+			description: "Exact ordered provider allowlist for web_search; empty uses the built-in automatic chain",
 			options: SEARCH_PROVIDER_CHOICES,
 			ordered: true,
 		},

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -40,7 +40,7 @@ import { AgentStorage } from "../session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-providers";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { INSPECT_IMAGE_MODES } from "../utils/inspect-image-mode";
-import { isSearchProviderId, SEARCH_PROVIDER_ORDER } from "../web/search/types";
+import { isSearchProviderId } from "../web/search/types";
 import { withFileLock } from "./file-lock";
 import {
 	type BashInterceptorRule,
@@ -1797,11 +1797,10 @@ export class Settings {
 		delete raw["mcp.discoveryDefaultServers"];
 
 		// providers.webSearch / providers.image (single preferred provider) →
-		// providers.webSearchOrder / providers.imageOrder (priority lists). A
-		// concrete legacy choice becomes the head of the new list with every
-		// remaining provider appended in its built-in order, so the old
-		// preference stays #1 and the fallback chain is written out explicitly.
-		// "auto" (or an unknown id) just drops the key — the default chain.
+		// providers.webSearchOrder / providers.imageOrder (priority lists).
+		// A concrete web-search choice becomes the complete singleton allowlist.
+		// Image migration preserves its historical fallback chain. "auto" (or an
+		// unknown id) drops the legacy key and leaves the default chain active.
 		const providerPrefsObj = raw.providers as Record<string, unknown> | undefined;
 		const migrateProviderPreference = (
 			legacyKey: string,
@@ -1825,9 +1824,7 @@ export class Settings {
 			delete raw[flatLegacyKey];
 		};
 		migrateProviderPreference("webSearch", "webSearchOrder", value =>
-			value !== "auto" && isSearchProviderId(value)
-				? [value, ...SEARCH_PROVIDER_ORDER.filter(id => id !== value)]
-				: undefined,
+			value !== "auto" && isSearchProviderId(value) ? [value] : undefined,
 		);
 		migrateProviderPreference("image", "imageOrder", value =>
 			value !== "auto" && isImageProviderId(value)

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/web-search.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/web-search.ts
@@ -6,12 +6,7 @@ import {
 	truncateToWidth,
 } from "@oh-my-pi/pi-tui";
 import { getSearchProvider, setSearchProviderOrder } from "../../../web/search/provider";
-import {
-	isSearchProviderId,
-	SEARCH_PROVIDER_OPTIONS,
-	SEARCH_PROVIDER_ORDER,
-	type SearchProviderId,
-} from "../../../web/search/types";
+import { isSearchProviderId, SEARCH_PROVIDER_OPTIONS, type SearchProviderId } from "../../../web/search/types";
 import { getSelectListTheme, theme } from "../../theme/theme";
 import type { SetupSceneHost, SetupTab } from "./types";
 
@@ -125,9 +120,8 @@ export class WebSearchTab implements SetupTab {
 
 	#apply(value: string): void {
 		if (value !== "auto" && !isSearchProviderId(value)) return;
-		// The wizard picks one favorite; persist it as the head of the priority
-		// list with the remaining providers in their built-in order (auto = reset).
-		const order = value === "auto" ? [] : [value, ...SEARCH_PROVIDER_ORDER.filter(id => id !== value)];
+		// The wizard selects the complete provider allowlist (auto = built-in chain).
+		const order = value === "auto" ? [] : [value];
 		this.host.ctx.settings.set("providers.webSearchOrder", order);
 		setSearchProviderOrder(order);
 		const label = WEB_SEARCH_ITEMS.find(item => item.value === value)?.label ?? value;

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -195,19 +195,14 @@ let orderedProvIds: readonly SearchProviderId[] = SEARCH_PROVIDER_ORDER;
 let explicitProvIds = new Set<SearchProviderId>();
 
 /**
- * Prioritize configured providers while retaining every unlisted provider in
- * its built-in relative order. Invalid IDs are ignored defensively. Listed
- * providers are treated as explicit selections: they resolve through
- * `isExplicitlyAvailable`, so e.g. a hand-listed Perplexity may fall back to
- * anonymous search exactly like the retired single-preference setting did.
+ * Set the configured provider chain. A non-empty list is an exact allowlist;
+ * an empty list restores the built-in automatic chain. Invalid IDs are ignored
+ * defensively, and listed providers retain explicit-selection semantics.
  */
 export function setSearchProviderOrder(providers: readonly SearchProviderId[]): void {
 	const prioritized = new Set(providers.filter(id => SEARCH_PROVIDER_ORDER.includes(id)));
 	explicitProvIds = prioritized;
-	orderedProvIds =
-		prioritized.size === 0
-			? SEARCH_PROVIDER_ORDER
-			: [...prioritized, ...SEARCH_PROVIDER_ORDER.filter(id => !prioritized.has(id))];
+	orderedProvIds = prioritized.size === 0 ? SEARCH_PROVIDER_ORDER : [...prioritized];
 }
 
 /** Providers excluded from web search resolution via settings. */

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -17,7 +17,6 @@ import {
 } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/tools/image-providers";
-import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import * as fileLock from "../src/config/file-lock";
@@ -873,15 +872,12 @@ describe("Settings", () => {
 	});
 
 	describe("provider preference migration", () => {
-		it("expands a legacy providers.webSearch choice into the head of webSearchOrder", async () => {
-			await writeSettings({ providers: { webSearch: "exa" } });
+		it("migrates a legacy providers.webSearch choice into an exact singleton order", async () => {
+			await writeSettings({ providers: { webSearch: "codex" } });
 
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 
-			expect(settings.get("providers.webSearchOrder")).toEqual([
-				"exa",
-				...SEARCH_PROVIDER_ORDER.filter(id => id !== "exa"),
-			]);
+			expect(settings.get("providers.webSearchOrder")).toEqual(["codex"]);
 		});
 
 		it("drops legacy providers.webSearch auto without seeding an order", async () => {

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -491,7 +491,7 @@ describe("setup wizard web search tab", () => {
 		expect(SEARCH_PROVIDER_OPTIONS.slice(1).map(option => option.value)).toEqual([...SEARCH_PROVIDER_ORDER]);
 	});
 
-	it("persists the highlighted provider as the head of the web search order", async () => {
+	it("persists the highlighted provider as the exact web search order", async () => {
 		const settings = Settings.isolated();
 		const host = {
 			ctx: {
@@ -511,10 +511,7 @@ describe("setup wizard web search tab", () => {
 
 		const expected = SEARCH_PROVIDER_OPTIONS[1]!.value;
 		expect(expected).not.toBe("auto");
-		expect(settings.get("providers.webSearchOrder")).toEqual([
-			expected,
-			...SEARCH_PROVIDER_ORDER.filter(id => id !== expected),
-		]);
+		expect(settings.get("providers.webSearchOrder")).toEqual([expected]);
 	});
 
 	it("can select the last provider in the setup TUI list", async () => {
@@ -540,10 +537,7 @@ describe("setup wizard web search tab", () => {
 		const lastOption = SEARCH_PROVIDER_OPTIONS[SEARCH_PROVIDER_OPTIONS.length - 1]!;
 		const lastValue = lastOption.value;
 		if (lastValue === "auto") throw new Error("last option must be a concrete provider");
-		expect(settings.get("providers.webSearchOrder")).toEqual([
-			lastValue,
-			...SEARCH_PROVIDER_ORDER.filter(id => id !== lastValue),
-		]);
+		expect(settings.get("providers.webSearchOrder")).toEqual([lastValue]);
 	});
 });
 

--- a/packages/coding-agent/test/web/search/provider-chain.test.ts
+++ b/packages/coding-agent/test/web/search/provider-chain.test.ts
@@ -39,26 +39,28 @@ afterEach(() => {
 });
 
 describe("resolveProviderCandidates", () => {
-	it("orders the forced provider before configured and built-in fallbacks", () => {
+	it("orders the forced provider before the exact configured chain", () => {
 		setSearchProviderOrder(["gemini", "exa"]);
 
 		const candidates = resolveProviderCandidates("perplexity");
 
-		expect(candidates[0]).toEqual({ id: "perplexity", explicit: true });
-		expect(candidates.slice(1).map(candidate => candidate.id)).toEqual([
-			"gemini",
-			"exa",
-			...SEARCH_PROVIDER_ORDER.filter(id => id !== "perplexity" && id !== "gemini" && id !== "exa"),
+		expect(candidates).toEqual([
+			{ id: "perplexity", explicit: true },
+			{ id: "gemini", explicit: true },
+			{ id: "exa", explicit: true },
 		]);
 	});
 
-	it("marks configured-order entries explicit so hand-listed providers keep explicit-selection semantics", () => {
-		setSearchProviderOrder(["perplexity"]);
+	it("treats a non-empty configured order as the exact explicit allowlist", () => {
+		setSearchProviderOrder(["codex"]);
 
-		const candidates = resolveProviderCandidates();
+		expect(resolveProviderCandidates()).toEqual([{ id: "codex", explicit: true }]);
+	});
 
-		expect(candidates[0]).toEqual({ id: "perplexity", explicit: true });
-		expect(candidates[1]?.explicit).toBe(false);
+	it("retains the built-in automatic chain for an empty order", () => {
+		setSearchProviderOrder([]);
+
+		expect(resolveProviderCandidates()).toEqual(SEARCH_PROVIDER_ORDER.map(id => ({ id, explicit: false })));
 	});
 
 	it("omits excluded providers without resolving them", () => {
@@ -75,9 +77,10 @@ describe("resolveProviderCandidates", () => {
 
 		controller.handleSettingChange("providers.webSearchOrder", ["exa", "not-a-provider", "exa", "gemini"]);
 
-		const candidates = resolveProviderCandidates();
-		expect(candidates.slice(0, 2).map(candidate => candidate.id)).toEqual(["exa", "gemini"]);
-		expect(candidates).toHaveLength(SEARCH_PROVIDER_ORDER.length);
+		expect(resolveProviderCandidates()).toEqual([
+			{ id: "exa", explicit: true },
+			{ id: "gemini", explicit: true },
+		]);
 	});
 });
 


### PR DESCRIPTION
## Root cause

The 17.1.0 migration expanded a legacy `providers.webSearch: codex` preference into every search provider. `setSearchProviderOrder` then appended every unlisted provider. A Codex timeout therefore silently continued into providers Fred never selected, including authenticated Perplexity through an OpenRouter API key.

## Fix

- empty `webSearchOrder` keeps the built-in automatic chain
- non-empty `webSearchOrder` is the exact ordered allowlist
- legacy single-provider migration and setup-wizard selection persist singleton lists
- docs and settings copy state the allowlist contract

## Verification

- `bun test packages/coding-agent/test/web/search/provider-chain.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/setup-wizard.test.ts` — 109 pass, 0 fail
- `bun run check:types` in `packages/coding-agent` — pass
- targeted `biome check` on changed TypeScript — pass
- simulated Codex fetch failure returns provider `codex` with the original error; no candidate fallback