### PR TITLE
fix(catalog): send string tool choice to LM Studio

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed named forced `tool_choice` no longer being enforced on string-only OpenAI-compatible hosts (llama.cpp, LM Studio): the named object degrades to `"required"`, which alone lets the host call any advertised tool, so the request now narrows the advertised tools to the forced one (mirroring the Ollama chat transport). When the forced tool is absent the full tool list is kept and the choice is dropped for an unforced turn ([#6925](https://github.com/can1357/oh-my-pi/issues/6925)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1604,6 +1604,10 @@ function buildParams(
 	if (options?.toolChoice && initialCompat.supportsToolChoice) {
 		params.tool_choice = mapToOpenAICompletionsToolChoice(options.toolChoice);
 	}
+	const forcedToolName =
+		typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice
+			? params.tool_choice.function.name
+			: undefined;
 	if (
 		typeof params.tool_choice === "object" &&
 		params.tool_choice !== null &&
@@ -1611,10 +1615,6 @@ function buildParams(
 	) {
 		params.tool_choice = "required";
 	}
-	const forcedToolName =
-		typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice
-			? params.tool_choice.function.name
-			: undefined;
 	if (
 		forcedToolName !== undefined &&
 		Array.isArray(params.tools) &&

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1613,6 +1613,21 @@ function buildParams(
 		params.tool_choice !== null &&
 		!initialCompat.supportsNamedToolChoice
 	) {
+		// String-only hosts (llama.cpp, LM Studio) accept only none/auto/required,
+		// so a named object degrades to "required". "required" alone lets the host
+		// satisfy the hard choice with ANY advertised tool, defeating the named
+		// force. When the forced tool is present, narrow the advertised tools to it
+		// so "required" still enforces that specific call (mirrors the Ollama chat
+		// transport's selectToolsForToolChoice). When it is absent, leave the full
+		// list intact and let the absent-tool guard below drop the choice for an
+		// unforced turn.
+		if (
+			forcedToolName !== undefined &&
+			Array.isArray(params.tools) &&
+			params.tools.some(tool => tool.type === "function" && tool.function.name === forcedToolName)
+		) {
+			params.tools = params.tools.filter(tool => tool.type === "function" && tool.function.name === forcedToolName);
+		}
 		params.tool_choice = "required";
 	}
 	if (

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1207,7 +1207,18 @@ export function buildParams(
 						);
 			const toolChoice = mapOpenAIResponsesToolChoiceForTools(options.toolChoice, survivingTools, model);
 			if (toolChoice !== undefined && params.tools.length > 0) {
-				params.tool_choice = toolChoice;
+				if (
+					typeof toolChoice === "object" &&
+					toolChoice.type === "function" &&
+					!model.compat.supportsNamedToolChoice
+				) {
+					// String-only hosts cannot receive the named object. Restrict the
+					// catalogue first so "required" still forces the requested tool.
+					params.tools = params.tools.filter(tool => tool.type === "function" && tool.name === toolChoice.name);
+					params.tool_choice = "required";
+				} else {
+					params.tool_choice = toolChoice;
+				}
 			}
 		}
 	}

--- a/packages/ai/test/issue-3593-repro.test.ts
+++ b/packages/ai/test/issue-3593-repro.test.ts
@@ -55,9 +55,12 @@ function capturePayload(target: Model<"openai-completions">): Promise<ChatComple
 	return promise;
 }
 
-describe("issue #3593 — llama.cpp string-only tool_choice", () => {
-	it("downgrades named forced tool_choice to required for llama.cpp", async () => {
-		const payload = await capturePayload(model({}));
+describe("issues #3593 and #6925 — string-only tool_choice hosts", () => {
+	it.each([
+		["llama.cpp", "http://localhost:8080/v1"],
+		["lm-studio", "http://127.0.0.1:1234/v1"],
+	])("downgrades named forced tool_choice to required for %s", async (provider, baseUrl) => {
+		const payload = await capturePayload(model({ provider, baseUrl }));
 
 		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["resolve"]);
 		expect(payload.tool_choice).toBe("required");

--- a/packages/ai/test/issue-3593-repro.test.ts
+++ b/packages/ai/test/issue-3593-repro.test.ts
@@ -15,6 +15,17 @@ const resolveTool: Tool = {
 	parameters: z.object({ action: z.enum(["apply", "discard"]), reason: z.string() }),
 };
 
+const todoTool: Tool = {
+	name: "todo",
+	description: "Track work items",
+	parameters: z.object({ note: z.string() }),
+};
+
+const multiToolContext: Context = {
+	messages: [{ role: "user", content: "Inspect this project.", timestamp: 0 }],
+	tools: [todoTool, resolveTool],
+};
+
 const context: Context = {
 	messages: [{ role: "user", content: "Resolve the pending preview.", timestamp: 0 }],
 	tools: [resolveTool],
@@ -79,6 +90,29 @@ describe("issues #3593 and #6925 — string-only tool_choice hosts", () => {
 		});
 
 		expect(payload.tool_choice).toBeUndefined();
+	});
+
+	it.each([
+		["llama.cpp", "http://localhost:8080/v1"],
+		["lm-studio", "http://127.0.0.1:1234/v1"],
+	])("narrows the advertised tools to the forced one for %s", async (provider, baseUrl) => {
+		const payload = await capturePayload(model({ provider, baseUrl }), {
+			context: multiToolContext,
+			toolChoice: { type: "tool", name: "todo" },
+		});
+
+		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["todo"]);
+		expect(payload.tool_choice).toBe("required");
+	});
+
+	it("keeps every tool for OpenAI's named object, without narrowing", async () => {
+		const payload = await capturePayload(
+			model({ provider: "openai", baseUrl: "https://api.openai.com/v1", id: "gpt-4o-mini", name: "GPT-4o mini" }),
+			{ context: multiToolContext, toolChoice: { type: "tool", name: "todo" } },
+		);
+
+		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["todo", "resolve"]);
+		expect(payload.tool_choice).toEqual({ type: "function", function: { name: "todo" } });
 	});
 
 	it("preserves OpenAI's named tool_choice object", async () => {

--- a/packages/ai/test/issue-3593-repro.test.ts
+++ b/packages/ai/test/issue-3593-repro.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model, ModelSpec, Tool, ToolChoice } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { z } from "zod/v4";
@@ -7,6 +8,11 @@ import { z } from "zod/v4";
 interface ChatCompletionsPayload {
 	tool_choice?: unknown;
 	tools?: Array<{ type?: string; function?: { name?: string } }>;
+}
+
+interface ResponsesPayload {
+	tool_choice?: unknown;
+	tools?: Array<{ type?: string; name?: string }>;
 }
 
 const resolveTool: Tool = {
@@ -49,6 +55,22 @@ function model(overrides: Partial<ModelSpec<"openai-completions">>): Model<"open
 	} satisfies ModelSpec<"openai-completions">);
 }
 
+function responsesModel(overrides: Partial<ModelSpec<"openai-responses">>): Model<"openai-responses"> {
+	return buildModel({
+		id: "qwen-3.6-27b",
+		name: "Qwen 3.6 27B",
+		api: "openai-responses",
+		provider: "lm-studio",
+		baseUrl: "http://127.0.0.1:1234/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131_072,
+		maxTokens: 32_768,
+		...overrides,
+	} satisfies ModelSpec<"openai-responses">);
+}
+
 function abortedSignal(): AbortSignal {
 	const controller = new AbortController();
 	controller.abort();
@@ -65,6 +87,21 @@ function capturePayload(
 		toolChoice: overrides?.toolChoice ?? forcedResolve,
 		signal: abortedSignal(),
 		onPayload: payload => resolve(payload as ChatCompletionsPayload),
+	});
+	return promise;
+}
+
+function captureResponsesPayload(
+	target: Model<"openai-responses">,
+	requestContext: Context,
+	toolChoice: ToolChoice,
+): Promise<ResponsesPayload> {
+	const { promise, resolve } = Promise.withResolvers<ResponsesPayload>();
+	streamOpenAIResponses(target, requestContext, {
+		apiKey: "test-key",
+		toolChoice,
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload as ResponsesPayload),
 	});
 	return promise;
 }
@@ -121,5 +158,43 @@ describe("issues #3593 and #6925 — string-only tool_choice hosts", () => {
 		);
 
 		expect(payload.tool_choice).toEqual({ type: "function", function: { name: "resolve" } });
+	});
+});
+
+describe("issue #6925 — LM Studio Responses string-only tool_choice", () => {
+	it("narrows the advertised tools before downgrading the named choice", async () => {
+		const payload = await captureResponsesPayload(responsesModel({}), multiToolContext, {
+			type: "tool",
+			name: "todo",
+		});
+
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["todo"]);
+		expect(payload.tool_choice).toBe("required");
+	});
+
+	it("keeps every tool and drops the choice when the named tool is absent", async () => {
+		const payload = await captureResponsesPayload(responsesModel({}), multiToolContext, {
+			type: "tool",
+			name: "missing",
+		});
+
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["todo", "resolve"]);
+		expect(payload.tool_choice).toBeUndefined();
+	});
+
+	it("preserves OpenAI's named object and full tool catalogue", async () => {
+		const payload = await captureResponsesPayload(
+			responsesModel({
+				provider: "openai",
+				baseUrl: "https://api.openai.com/v1",
+				id: "gpt-5-mini",
+				name: "GPT-5 Mini",
+			}),
+			multiToolContext,
+			{ type: "tool", name: "todo" },
+		);
+
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["todo", "resolve"]);
+		expect(payload.tool_choice).toEqual({ type: "function", name: "todo" });
 	});
 });

--- a/packages/ai/test/issue-3593-repro.test.ts
+++ b/packages/ai/test/issue-3593-repro.test.ts
@@ -44,11 +44,14 @@ function abortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-function capturePayload(target: Model<"openai-completions">): Promise<ChatCompletionsPayload> {
+function capturePayload(
+	target: Model<"openai-completions">,
+	overrides?: { context?: Context; toolChoice?: ToolChoice },
+): Promise<ChatCompletionsPayload> {
 	const { promise, resolve } = Promise.withResolvers<ChatCompletionsPayload>();
-	streamOpenAICompletions(target, context, {
+	streamOpenAICompletions(target, overrides?.context ?? context, {
 		apiKey: "test-key",
-		toolChoice: forcedResolve,
+		toolChoice: overrides?.toolChoice ?? forcedResolve,
 		signal: abortedSignal(),
 		onPayload: payload => resolve(payload as ChatCompletionsPayload),
 	});
@@ -64,6 +67,18 @@ describe("issues #3593 and #6925 — string-only tool_choice hosts", () => {
 
 		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["resolve"]);
 		expect(payload.tool_choice).toBe("required");
+	});
+
+	it.each([
+		["llama.cpp", "http://localhost:8080/v1"],
+		["lm-studio", "http://127.0.0.1:1234/v1"],
+	])("drops the forced choice for %s when the named tool is absent", async (provider, baseUrl) => {
+		const payload = await capturePayload(model({ provider, baseUrl }), {
+			context: { messages: context.messages, tools: [] },
+			toolChoice: { type: "tool", name: "resolve" },
+		});
+
+		expect(payload.tool_choice).toBeUndefined();
 	});
 
 	it("preserves OpenAI's named tool_choice object", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LM Studio first turns failing with `400 Invalid tool_choice type: 'object'` when eager todo forced a named tool. LM Studio now receives the supported string selector `tool_choice: "required"` while the requested tool remains available ([#6925](https://github.com/can1357/oh-my-pi/issues/6925)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -226,6 +226,12 @@ function detectStrictModeSupport(provider: string, baseUrl: string): boolean {
  */
 const LOCAL_OPENAI_COMPAT_PROVIDERS = new Set(["llama.cpp", "lm-studio", "vllm", "ollama"]);
 
+/** Hosts that accept only none/auto/required rather than a named tool-choice object. */
+const STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS: Record<string, true> = {
+	"llama.cpp": true,
+	"lm-studio": true,
+};
+
 /**
  * Local proxy providers that share the loopback-default baseUrl but forward
  * to an unrelated upstream (OpenAI, Anthropic, …) rather than running a
@@ -481,7 +487,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
 		supportsForcedToolChoice: !requiresEnabledThinking,
-		supportsNamedToolChoice: provider !== "llama.cpp" && provider !== "lm-studio",
+		supportsNamedToolChoice: STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS[provider] !== true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: isMistral,
@@ -686,7 +692,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		disableReasoningOnToolChoice: isDeepseekFamily && reasoningCapable && !isOpenRouter,
 		supportsToolChoice: true,
 		supportsForcedToolChoice: true,
-		supportsNamedToolChoice: true,
+		supportsNamedToolChoice: STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS[spec.provider] !== true,
 		reasoningContentField: "reasoning_content",
 		requiresReasoningContentForToolCalls:
 			(isKimiModel || (isDeepseekFamily && reasoningCapable) || (isOpenRouter && reasoningCapable)) &&

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -481,7 +481,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
 		supportsForcedToolChoice: !requiresEnabledThinking,
-		supportsNamedToolChoice: provider !== "llama.cpp",
+		supportsNamedToolChoice: provider !== "llama.cpp" && provider !== "lm-studio",
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,
 		requiresAssistantAfterToolResult: isMistral,


### PR DESCRIPTION
## Repro
A first turn with eager todo enabled and an `openai-completions` model at LM Studio’s default `http://127.0.0.1:1234/v1` endpoint emitted the named object selector `{"type":"function","function":{"name":"todo"}}`, which LM Studio rejects because it accepts only `none`, `auto`, or `required`. `bun packages/ai/test/.issue-6925-repro.ts` captured that payload on pre-fix `main` and exited 1.

## Cause
`buildOpenAICompat` in `packages/catalog/src/compat/openai.ts` marked only `llama.cpp` as lacking named object tool choices. The `lm-studio` profile therefore retained `supportsNamedToolChoice: true`, and `streamOpenAICompletions` serialized the eager-todo directive as an unsupported object instead of its existing string-only fallback.

## Fix
- Mark `lm-studio` as a string-only named-tool-choice host so forced named turns serialize as `tool_choice: "required"`.
- Extend the OpenAI completions wire regression test to cover both llama.cpp and LM Studio while preserving named selectors for OpenAI.
- Record the user-facing fix in the catalog changelog.

## Verification
`bun test packages/catalog/test/build.test.ts packages/ai/test/issue-3593-repro.test.ts` passed 45 tests with 0 failures; the focused reproduction then emitted `{"tool_choice":"required"}` and exited 0. The pre-publish `bun check` gate passed. Fixes #6925