### PR TITLE
feat(secrets): obfuscate user-facing messages before JSONL persistence

### DIFF
--- a/packages/coding-agent/src/__tests__/obfuscator-jsonl-seam.test.ts
+++ b/packages/coding-agent/src/__tests__/obfuscator-jsonl-seam.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { SecretObfuscator } from "../secrets/obfuscator";
+import { BlobStore } from "../session/blob-store";
+import type { FileEntry, SessionMessageEntry } from "../session/session-entries";
+import { prepareEntryForPersistence } from "../session/session-persistence";
+
+const SECRET = "my-secret-value-1234";
+
+function makeBlobStore(): BlobStore {
+	const dir = mkdtempSync(join(tmpdir(), "omp-jsonl-seam-test-"));
+	return new BlobStore(dir);
+}
+
+function makeMessageEntry(message: AgentMessage): SessionMessageEntry {
+	return {
+		type: "message",
+		id: "entry-1",
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		message,
+	};
+}
+
+function makeUserMessage(content: string): AgentMessage {
+	return {
+		role: "user",
+		content,
+		timestamp: Date.now(),
+	};
+}
+
+function makeUserMessageBlocks(text: string): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+function makeAssistantMessage(text: string): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic" as never,
+		provider: "anthropic" as never,
+		model: "test-model",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as never,
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("Tier-1 Task 5: pre-persist JSONL seam", () => {
+	describe("prepareEntryForPersistence with obfuscator", () => {
+		it("obfuscates a user message with string content — secret replaced by #HASH# placeholder", () => {
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: SECRET }]);
+			const blobStore = makeBlobStore();
+			const entry = makeMessageEntry(makeUserMessage(`Please use ${SECRET} for the API call.`));
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, obfuscator);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("user");
+			if (msg.role !== "user") return;
+			expect(typeof msg.content).toBe("string");
+			expect(msg.content as string).not.toContain(SECRET);
+			expect(msg.content as string).toMatch(/\$\$(?:[A-Z0-9]+_)?[A-Z0-9]{4,}(?::[ULCM])?\$\$/);
+		});
+
+		it("obfuscates a user message with content blocks — text block secret replaced", () => {
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: SECRET }]);
+			const blobStore = makeBlobStore();
+			const entry = makeMessageEntry(makeUserMessageBlocks(`The key is ${SECRET}.`));
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, obfuscator);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("user");
+			if (msg.role !== "user") return;
+			expect(Array.isArray(msg.content)).toBe(true);
+			const blocks = msg.content as Array<{ type: string; text?: string }>;
+			const textBlock = blocks.find(b => b.type === "text");
+			expect(textBlock).toBeDefined();
+			expect(textBlock?.text).not.toContain(SECRET);
+			expect(textBlock?.text).toMatch(/\$\$(?:[A-Z0-9]+_)?[A-Z0-9]{4,}(?::[ULCM])?\$\$/);
+		});
+
+		it("obfuscates a developer message with string content", () => {
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: SECRET }]);
+			const blobStore = makeBlobStore();
+			const entry = makeMessageEntry({
+				role: "developer",
+				content: `System note: ${SECRET} is the key.`,
+				timestamp: Date.now(),
+			} as AgentMessage);
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, obfuscator);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("developer");
+			if (msg.role !== "developer") return;
+			expect(msg.content as string).not.toContain(SECRET);
+			expect(msg.content as string).toMatch(/\$\$(?:[A-Z0-9]+_)?[A-Z0-9]{4,}(?::[ULCM])?\$\$/);
+		});
+
+		it("obfuscates a toolResult message with content blocks", () => {
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: SECRET }]);
+			const blobStore = makeBlobStore();
+			const entry = makeMessageEntry({
+				role: "toolResult",
+				toolCallId: "tc-1",
+				toolName: "read",
+				content: [{ type: "text", text: `Output contains ${SECRET}.` }],
+				isError: false,
+				timestamp: Date.now(),
+			} as AgentMessage);
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, obfuscator);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("toolResult");
+			if (msg.role !== "toolResult") return;
+			const blocks = msg.content as Array<{ type: string; text?: string }>;
+			const textBlock = blocks.find(b => b.type === "text");
+			expect(textBlock?.text).not.toContain(SECRET);
+			expect(textBlock?.text).toMatch(/\$\$(?:[A-Z0-9]+_)?[A-Z0-9]{4,}(?::[ULCM])?\$\$/);
+		});
+	});
+
+	describe("prepareEntryForPersistence without obfuscator (fail-open)", () => {
+		it("passes plaintext through unchanged when obfuscator is undefined", () => {
+			const blobStore = makeBlobStore();
+			const original = `Please use ${SECRET} for the API call.`;
+			const entry = makeMessageEntry(makeUserMessage(original));
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, undefined);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("user");
+			if (msg.role !== "user") return;
+			expect(msg.content as string).toBe(original);
+			expect(msg.content as string).toContain(SECRET);
+		});
+
+		it("passes plaintext through unchanged when obfuscator has no secrets", () => {
+			const obfuscator = new SecretObfuscator([]);
+			const blobStore = makeBlobStore();
+			const original = `Please use ${SECRET} for the API call.`;
+			const entry = makeMessageEntry(makeUserMessage(original));
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, obfuscator);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("user");
+			if (msg.role !== "user") return;
+			expect(msg.content as string).toBe(original);
+			expect(msg.content as string).toContain(SECRET);
+		});
+	});
+
+	describe("assistant messages are not double-obfuscated", () => {
+		it("preserves placeholders in assistant content — no double obfuscation", () => {
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: SECRET }]);
+			const placeholder = obfuscator.obfuscate(SECRET);
+			expect(placeholder).toMatch(/^\$\$(?:[A-Z0-9]+_)?[A-Z0-9]{4,}(?::[ULCM])?\$\$$/);
+
+			const blobStore = makeBlobStore();
+			// Assistant message that already contains a placeholder (from a
+			// previous obfuscation pass). The seam must NOT re-process it.
+			const entry = makeMessageEntry(makeAssistantMessage(`I see the key is ${placeholder}.`));
+
+			const result = prepareEntryForPersistence(entry as FileEntry, blobStore, obfuscator);
+
+			expect(result.type).toBe("message");
+			if (result.type !== "message") return;
+			const msg = result.message;
+			expect(msg.role).toBe("assistant");
+			if (msg.role !== "assistant") return;
+			const blocks = msg.content as Array<{ type: string; text?: string }>;
+			const textBlock = blocks.find(b => b.type === "text");
+			// The placeholder is preserved verbatim — not double-obfuscated.
+			expect(textBlock?.text).toContain(placeholder);
+			expect(textBlock?.text).not.toContain(SECRET);
+		});
+	});
+
+	describe("non-message entries pass through", () => {
+		it("model_change entry is not affected by the obfuscator", () => {
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: SECRET }]);
+			const blobStore = makeBlobStore();
+			const entry = {
+				type: "model_change",
+				id: "mc-1",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				model: "anthropic/claude-test",
+				role: "default",
+			} as FileEntry;
+
+			const result = prepareEntryForPersistence(entry, blobStore, obfuscator);
+
+			expect(result.type).toBe("model_change");
+		});
+	});
+});

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -18,6 +18,7 @@ import {
 	stringifyJson,
 	toError,
 } from "@oh-my-pi/pi-utils";
+import type { SecretObfuscator } from "../secrets/obfuscator";
 import type { StructuredSubagentSchemaMode } from "../task/types";
 import { ArtifactManager } from "./artifacts";
 import { type BlobPutOptions, type BlobPutResult, BlobStore } from "./blob-store";
@@ -446,6 +447,10 @@ export class SessionManager {
 	 * in-memory (pre-blob-externalization) entry, so inline images survive.
 	 */
 	onEntryAppended?: (entry: SessionEntry) => void;
+	/** Secret obfuscator for pre-persist JSONL seam. Set after construction. */
+	#obfuscator: SecretObfuscator | undefined;
+	/** True when the `secrets.enabled` setting is on (R2 fail-closed gate). */
+	#secretsEnabledSetting = false;
 
 	#turnBudgetTotal: number | null = null;
 	#turnBudgetHard = false;
@@ -500,8 +505,20 @@ export class SessionManager {
 		this.#persist = persist;
 		this.#storage = storage;
 		this.#blobs = new BlobStore(getBlobsDir());
-
 		if (persist && sessionDir) this.#storage.ensureDirSync(sessionDir);
+	}
+
+	/**
+	 * Set the secret obfuscator used by the pre-persist JSONL seam. Called
+	 * after construction once the obfuscator is created. When `secretsEnabled`
+	 * is true but `obfuscator` is undefined (a bug — secrets are enabled but
+	 * the obfuscator failed to initialize), the seam fails closed: user-facing
+	 * message content is replaced with `[REDACTED — obfuscator unavailable]`
+	 * rather than writing plaintext to disk.
+	 */
+	setObfuscator(obfuscator: SecretObfuscator | undefined, secretsEnabled: boolean): void {
+		this.#obfuscator = obfuscator;
+		this.#secretsEnabledSetting = secretsEnabled;
 	}
 
 	#rememberBreadcrumb(cwd: string, sessionFile: string, fresh = false): void {
@@ -719,7 +736,29 @@ export class SessionManager {
 	}
 
 	#lineFor(entry: FileEntry): string {
-		return `${stringifyJson(prepareEntryForPersistence(entry, this.#blobs)) ?? "null"}\n`;
+		const obfuscator = this.#obfuscator;
+		const prepared =
+			this.#secretsEnabledSetting && !obfuscator
+				? prepareEntryForPersistence(this.#redactEntryFailClosed(entry), this.#blobs, undefined)
+				: prepareEntryForPersistence(entry, this.#blobs, obfuscator);
+		return `${stringifyJson(prepared) ?? "null"}\n`;
+	}
+
+	/**
+	 * R2 fail-closed: when `secrets.enabled` is on but the obfuscator is
+	 * undefined (a bug — secrets are enabled but the obfuscator failed to
+	 * initialize), replace user-facing message content with a redaction
+	 * marker rather than writing plaintext to disk. Non-message entries and
+	 * assistant messages pass through (assistant output is model-authored, not
+	 * operator plaintext).
+	 */
+	#redactEntryFailClosed(entry: FileEntry): FileEntry {
+		if (entry.type !== "message") return entry;
+		const message = entry.message;
+		if (message.role !== "user" && message.role !== "developer" && message.role !== "toolResult") return entry;
+		const marker = "[REDACTED — obfuscator unavailable]";
+		const redactedContent = typeof message.content === "string" ? marker : [{ type: "text" as const, text: marker }];
+		return { ...entry, message: { ...message, content: redactedContent } } as FileEntry;
 	}
 
 	#titleSlotLine(): string {

--- a/packages/coding-agent/src/session/session-persistence.ts
+++ b/packages/coding-agent/src/session/session-persistence.ts
@@ -1,4 +1,5 @@
 import { isAnthropicWebSearchHistoryBlock } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
+import type { SecretObfuscator } from "../secrets/obfuscator";
 import {
 	type BlobStore,
 	externalizeImageDataSync,
@@ -6,7 +7,7 @@ import {
 	isBlobRef,
 	isImageDataUrl,
 } from "./blob-store";
-import type { FileEntry } from "./session-entries";
+import type { FileEntry, SessionMessageEntry } from "./session-entries";
 
 const MAX_PERSIST_CHARS = 500_000;
 const TRUNCATION_NOTICE = "\n\n[Session persistence truncated large content]";
@@ -287,7 +288,51 @@ function stripReplayedReasoningSignatures(entry: FileEntry): FileEntry {
 	if (!changed) return entry;
 	return { ...entry, message: { ...message, content } };
 }
+export function prepareEntryForPersistence(
+	entry: FileEntry,
+	blobStore: BlobStore,
+	obfuscator?: SecretObfuscator,
+): FileEntry {
+	let result = stripReplayedReasoningSignatures(entry);
+	if (obfuscator?.hasSecrets() && result.type === "message") {
+		const obfuscated = obfuscateMessageForPersistence(obfuscator, result.message);
+		if (obfuscated !== result.message) {
+			result = { ...result, message: obfuscated };
+		}
+	}
+	return truncateForPersistence(result, blobStore) as FileEntry;
+}
 
-export function prepareEntryForPersistence(entry: FileEntry, blobStore: BlobStore): FileEntry {
-	return truncateForPersistence(stripReplayedReasoningSignatures(entry), blobStore) as FileEntry;
+/**
+ * Obfuscate secret values in user-facing message content before persistence.
+ * Only `user`, `developer`, and `toolResult` messages can carry operator
+ * secrets; assistant output passes through untouched (placeholders already
+ * present are preserved — no double obfuscation). Image blocks are never
+ * walked.
+ */
+function obfuscateMessageForPersistence(
+	obfuscator: SecretObfuscator,
+	message: SessionMessageEntry["message"],
+): SessionMessageEntry["message"] {
+	if (message.role !== "user" && message.role !== "developer" && message.role !== "toolResult") {
+		return message;
+	}
+	if (typeof message.content === "string") {
+		const content = obfuscator.obfuscate(message.content);
+		if (content === message.content) return message;
+		return { ...message, content } as SessionMessageEntry["message"];
+	}
+	if (Array.isArray(message.content)) {
+		let changed = false;
+		const newContent = message.content.map(block => {
+			if (block.type !== "text") return block;
+			const text = obfuscator.obfuscate(block.text);
+			if (text === block.text) return block;
+			changed = true;
+			return { ...block, text };
+		});
+		if (!changed) return message;
+		return { ...message, content: newContent as typeof message.content };
+	}
+	return message;
 }


### PR DESCRIPTION
## Problem

Session JSONL is written **before** the obfuscator's outbound seam ever runs: a user pasting a known secret, or a tool result echoing one, lands on disk in plaintext — in every session file, forever, and in every log shipped for debugging.

## What this PR does

- `prepareEntryForPersistence` gains an obfuscator path: **user/developer/toolResult** message content is obfuscated *before* the entry is written to the session log. Assistant content is never double-obfuscated (placeholders pass through untouched).
- `SessionManager.setObfuscator(obfuscator, secretsEnabled)` wires it post-construction.
- **Fail-closed:** when secrets are enabled but the obfuscator failed to initialize, user-facing content is written as `[REDACTED — obfuscator unavailable]` rather than plaintext.

## Scope (documented in tests)

The guarantee is "**no plaintext of *known* secrets**" (values registered via `secrets.yml` or `addSecret()`). Unregistered pasted secrets still land in the log — closing that needs the runtime registration from PR #6927.

## Tests

8 tests (`obfuscator-jsonl-seam`): user string content, content blocks, developer messages, toolResult messages, no double-obfuscation of assistant content, fail-closed path. Full suite green; `tsc --noEmit` clean.

Depends on: nothing. Complements: #6927 (runtime registration).