### PR TITLE
fix(model-registry): preserve oauth.modifyModels projection across reloads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the model picker showing an extension provider's placeholder model list instead of the credential-aware catalog it resolves at registration, so models the account actually has could be missing while unavailable ones stayed listed.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -539,6 +539,12 @@ interface ModelPatch {
  */
 type ModelTransportPolicy = "merge" | "replace";
 
+/**
+ * Credential-aware model projection supplied by an extension provider. Receives
+ * the fully composed catalog and returns the list the host should serve.
+ */
+type ModifyModelsHook = (models: Model<Api>[], credentials: OAuthCredentials) => Model<Api>[];
+
 function applyModelPatch(base: Model<Api>, patch: ModelPatch, transport: ModelTransportPolicy): Model<Api> {
 	const result = { ...base };
 	if (patch.name !== undefined) result.name = patch.name;
@@ -805,6 +811,12 @@ export class ModelRegistry {
 	#runtimeModelOverlays: CustomModelOverlay[] = [];
 	#runtimeProviderApiKeys: Map<string, string> = new Map();
 	#runtimeProviderOverrides: Map<string, ProviderOverride> = new Map();
+	// Credential-aware model projections registered via
+	// `registerProvider({ oauth: { modifyModels } })`. Persisted for the same
+	// reason as #runtimeModelOverlays: the overlays hold the *pre-projection*
+	// definitions, so without re-applying the projection every static reload
+	// would silently revert the provider to its unprojected catalog.
+	#runtimeModelModifiers: Map<string, ModifyModelsHook> = new Map();
 	#runtimeProvidersBySource: Map<string, Set<string>> = new Map();
 	#runtimeProviderSourceByName: Map<string, string> = new Map();
 	// Runtime model managers registered by extensions via fetchDynamicModels.
@@ -1126,6 +1138,38 @@ export class ModelRegistry {
 		});
 	}
 
+	/**
+	 * Re-apply the credential-aware projections registered by extension providers.
+	 *
+	 * `registerProvider` runs `oauth.modifyModels` once and stores the result in
+	 * `#models`, but only the *pre-projection* definitions survive in
+	 * `#runtimeModelOverlays`. Every static reload therefore has to project
+	 * again, or the provider silently reverts to its unprojected catalog — which
+	 * is exactly what the model selector's `refresh("offline")` used to trigger.
+	 *
+	 * A throwing hook degrades to the unprojected list for that provider instead
+	 * of failing the whole composition; one bad extension must not empty the
+	 * registry.
+	 */
+	#applyRuntimeModelModifiers(models: Model<Api>[], providerFilter?: ReadonlySet<string>): Model<Api>[] {
+		if (this.#runtimeModelModifiers.size === 0) return models;
+		let projected = models;
+		for (const [providerName, modifyModels] of this.#runtimeModelModifiers) {
+			if (providerFilter && !providerFilter.has(providerName)) continue;
+			const credential = this.authStorage.getOAuthCredential(providerName);
+			if (!credential) continue;
+			try {
+				projected = modifyModels(projected, credential);
+			} catch (error) {
+				this.#lastDiscoveryWarnings.set(
+					providerName,
+					`modifyModels failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+		return projected;
+	}
+
 	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
 		const select = <T extends { provider: string }>(models: readonly T[]): T[] =>
 			providerFilter ? models.filter(model => providerFilter.has(model.provider)) : [...models];
@@ -1145,7 +1189,10 @@ export class ModelRegistry {
 		// collapse effort-tier variants here so X/X-thinking twins fold.
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
 		return this.#internStaticModels(
-			this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
+			this.#applyRuntimeModelModifiers(
+				this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
+				providerFilter,
+			),
 		);
 	}
 
@@ -1621,7 +1668,11 @@ export class ModelRegistry {
 		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		this.#models = this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides));
+		// Re-project after discovery for the same reason as #composeStaticModels:
+		// the merge above rebuilds from the unprojected runtime overlays.
+		this.#models = this.#applyRuntimeModelModifiers(
+			this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
+		);
 	}
 
 	#configuredDiscoveryCacheProviderId(providerConfig: DiscoveryProviderConfig): string {
@@ -2393,6 +2444,7 @@ export class ModelRegistry {
 		this.#runtimeProviderOverrides.delete(providerName);
 		this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
 		this.#runtimeModelManagers.delete(providerName);
+		this.#runtimeModelModifiers.delete(providerName);
 		this.authStorage.removeConfigApiKey(providerName);
 	}
 
@@ -2542,15 +2594,15 @@ export class ModelRegistry {
 					})
 				: nextModels;
 
+			// Persist the projection so it survives every later #reloadStaticModels()
+			// cycle, then apply it to the list we just composed.
 			if (config.oauth?.modifyModels) {
-				const credential = this.authStorage.getOAuthCredential(providerName);
-				if (credential) {
-					this.#models = config.oauth.modifyModels(withRuntimeTransportOverride, credential);
-					return;
-				}
+				this.#runtimeModelModifiers.set(providerName, config.oauth.modifyModels);
+			} else {
+				this.#runtimeModelModifiers.delete(providerName);
 			}
 
-			this.#models = withRuntimeTransportOverride;
+			this.#models = this.#applyRuntimeModelModifiers(withRuntimeTransportOverride);
 			return;
 		}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2615,7 +2615,11 @@ export class ModelRegistry {
 				this.#runtimeModelModifiers.delete(providerName);
 			}
 
-			this.#models = this.#applyRuntimeModelModifiers(withRuntimeTransportOverride);
+			// Only this provider's hook runs: `nextModels` still carries every other
+			// provider's projection from an earlier registration, so rerunning their
+			// hooks here would feed them their own output. Registrations arrive one
+			// at a time, and full rebuilds go through #composeStaticModels.
+			this.#models = this.#applyRuntimeModelModifiers(withRuntimeTransportOverride, new Set([providerName]));
 			return;
 		}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -817,6 +817,7 @@ export class ModelRegistry {
 	// definitions, so without re-applying the projection every static reload
 	// would silently revert the provider to its unprojected catalog.
 	#runtimeModelModifiers: Map<string, ModifyModelsHook> = new Map();
+	#lastModelModifierWarnings: Map<string, string> = new Map();
 	#runtimeProvidersBySource: Map<string, Set<string>> = new Map();
 	#runtimeProviderSourceByName: Map<string, string> = new Map();
 	// Runtime model managers registered by extensions via fetchDynamicModels.
@@ -1149,7 +1150,7 @@ export class ModelRegistry {
 	 *
 	 * A throwing hook degrades to the unprojected list for that provider instead
 	 * of failing the whole composition; one bad extension must not empty the
-	 * registry.
+	 * registry. The failure is logged (deduped per provider) so it is not silent.
 	 */
 	#applyRuntimeModelModifiers(models: Model<Api>[], providerFilter?: ReadonlySet<string>): Model<Api>[] {
 		if (this.#runtimeModelModifiers.size === 0) return models;
@@ -1161,13 +1162,20 @@ export class ModelRegistry {
 			try {
 				projected = modifyModels(projected, credential);
 			} catch (error) {
-				this.#lastDiscoveryWarnings.set(
-					providerName,
-					`modifyModels failed: ${error instanceof Error ? error.message : String(error)}`,
-				);
+				this.#warnModelModifierFailure(providerName, error instanceof Error ? error.message : String(error));
 			}
 		}
 		return projected;
+	}
+
+	/**
+	 * Dedup key is separate from `#lastDiscoveryWarnings` so a repeated modifier
+	 * failure cannot mask a subsequent discovery failure for the same provider.
+	 */
+	#warnModelModifierFailure(provider: string, error: string): void {
+		if (this.#lastModelModifierWarnings.get(provider) === error) return;
+		this.#lastModelModifierWarnings.set(provider, error);
+		logger.warn("extension model projection failed; serving unprojected catalog", { provider, error });
 	}
 
 	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
@@ -1661,15 +1669,19 @@ export class ModelRegistry {
 		for (const provider of builtInDiscovery.authoritativeProviders) {
 			authoritativeProviders.add(provider);
 		}
-		const baseModels =
-			authoritativeProviders.size > 0 ? dropProviderModels(this.#models, authoritativeProviders) : this.#models;
+		// `this.#models` is already projected here (via #ensureFullSnapshot), and
+		// the overlay merge below only replaces matching provider+id pairs — a
+		// hook's projection-only entries would survive and be fed back into it.
+		// Drop each modifier provider so the merge re-seeds it from the
+		// unprojected overlays, keeping non-idempotent hooks from compounding.
+		const rebuiltProviders = new Set(authoritativeProviders);
+		for (const providerName of this.#runtimeModelModifiers.keys()) rebuiltProviders.add(providerName);
+		const baseModels = rebuiltProviders.size > 0 ? dropProviderModels(this.#models, rebuiltProviders) : this.#models;
 		const resolved = this.#mergeResolvedModels(baseModels, discoveredModels);
 		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
 		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		// Re-project after discovery for the same reason as #composeStaticModels:
-		// the merge above rebuilds from the unprojected runtime overlays.
 		this.#models = this.#applyRuntimeModelModifiers(
 			this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
 		);
@@ -2445,6 +2457,7 @@ export class ModelRegistry {
 		this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
 		this.#runtimeModelManagers.delete(providerName);
 		this.#runtimeModelModifiers.delete(providerName);
+		this.#lastModelModifierWarnings.delete(providerName);
 		this.authStorage.removeConfigApiKey(providerName);
 	}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -785,6 +785,7 @@ export type ResolvedRequestAuth =
  */
 export class ModelRegistry {
 	#models: Model<Api>[] = [];
+	#unprojectedModels: Model<Api>[] = [];
 	#hasFullSnapshot = false;
 	#cachedStandardModels: Model<Api>[] = [];
 	#cachedDiscoverableModels: Model<Api>[] = [];
@@ -1015,6 +1016,15 @@ export class ModelRegistry {
 		if (patch.contextWindow === undefined && patch.maxTokens === undefined && patch.input === undefined) {
 			return current;
 		}
+		const unprojected = resolveProviderModelReference(current.provider, current.id, this.#unprojectedModels);
+		if (unprojected) {
+			const patchedBase = applyModelPatch(unprojected, patch, "merge");
+			this.#unprojectedModels = this.#unprojectedModels.map(candidate =>
+				candidate.provider === unprojected.provider && candidate.id === unprojected.id ? patchedBase : candidate,
+			);
+			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+			return resolveProviderModelReference(current.provider, current.id, this.#models) ?? patchedBase;
+		}
 		const patched = applyModelPatch(current, patch, "merge");
 		this.#models = this.#models.map(candidate =>
 			candidate.provider === current.provider && candidate.id === current.id ? patched : candidate,
@@ -1115,6 +1125,7 @@ export class ModelRegistry {
 
 	#resetStaticComposition(): void {
 		this.#models = [];
+		this.#unprojectedModels = [];
 		this.#hasFullSnapshot = false;
 		this.#internedStaticModels.clear();
 		this.#providerLookupSnapshots.clear();
@@ -1142,25 +1153,25 @@ export class ModelRegistry {
 	/**
 	 * Re-apply the credential-aware projections registered by extension providers.
 	 *
-	 * `registerProvider` runs `oauth.modifyModels` once and stores the result in
-	 * `#models`, but only the *pre-projection* definitions survive in
-	 * `#runtimeModelOverlays`. Every static reload therefore has to project
-	 * again, or the provider silently reverts to its unprojected catalog — which
-	 * is exactly what the model selector's `refresh("offline")` used to trigger.
+	 * Runtime overlays hold the pre-projection definitions, so the registry keeps
+	 * those definitions separate from `#models` and reruns the ordered hooks after
+	 * every catalog rebuild. Otherwise an offline refresh silently restores the
+	 * provider's placeholder catalog.
 	 *
-	 * A throwing hook degrades to the unprojected list for that provider instead
+	 * A throwing hook falls back to the catalog produced by earlier hooks instead
 	 * of failing the whole composition; one bad extension must not empty the
 	 * registry. The failure is logged (deduped per provider) so it is not silent.
+	 * Each hook receives its own array because the public contract permits
+	 * structural mutation before returning.
 	 */
-	#applyRuntimeModelModifiers(models: Model<Api>[], providerFilter?: ReadonlySet<string>): Model<Api>[] {
+	#applyRuntimeModelModifiers(models: Model<Api>[]): Model<Api>[] {
 		if (this.#runtimeModelModifiers.size === 0) return models;
 		let projected = models;
 		for (const [providerName, modifyModels] of this.#runtimeModelModifiers) {
-			if (providerFilter && !providerFilter.has(providerName)) continue;
 			const credential = this.authStorage.getOAuthCredential(providerName);
 			if (!credential) continue;
 			try {
-				projected = modifyModels(projected, credential);
+				projected = modifyModels([...projected], credential);
 			} catch (error) {
 				this.#warnModelModifierFailure(providerName, error instanceof Error ? error.message : String(error));
 			}
@@ -1178,7 +1189,7 @@ export class ModelRegistry {
 		logger.warn("extension model projection failed; serving unprojected catalog", { provider, error });
 	}
 
-	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
+	#composeUnprojectedStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
 		const select = <T extends { provider: string }>(models: readonly T[]): T[] =>
 			providerFilter ? models.filter(model => providerFilter.has(model.provider)) : [...models];
 		let builtInModels = this.#applyHardcodedModelPolicies(
@@ -1193,20 +1204,24 @@ export class ModelRegistry {
 		);
 		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, select(this.#customModelOverlays));
 		const combined = this.#mergeCustomModels(withConfigModels, select(this.#runtimeModelOverlays));
-		// Custom/config providers bypass the model-manager merge point —
-		// collapse effort-tier variants here so X/X-thinking twins fold.
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		return this.#internStaticModels(
-			this.#applyRuntimeModelModifiers(
-				this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
-				providerFilter,
-			),
-		);
+		return this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides));
+	}
+
+	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
+		// A modifier is a whole-catalog transform. Build and project the full catalog
+		// before narrowing a lazy lookup, matching getAll() followed by filtering.
+		const projectFullCatalog = providerFilter !== undefined && this.#runtimeModelModifiers.size > 0;
+		const unprojected = this.#composeUnprojectedStaticModels(projectFullCatalog ? undefined : providerFilter);
+		const projected = this.#applyRuntimeModelModifiers(unprojected);
+		const selected = projectFullCatalog ? projected.filter(model => providerFilter.has(model.provider)) : projected;
+		return this.#internStaticModels(selected);
 	}
 
 	#ensureFullSnapshot(): Model<Api>[] {
 		if (!this.#hasFullSnapshot) {
-			this.#models = this.#composeStaticModels();
+			this.#unprojectedModels = this.#composeUnprojectedStaticModels();
+			this.#models = this.#internStaticModels(this.#applyRuntimeModelModifiers(this.#unprojectedModels));
 			this.#hasFullSnapshot = true;
 			this.#providerLookupSnapshots.clear();
 		}
@@ -1660,7 +1675,7 @@ export class ModelRegistry {
 			discovered.map(model =>
 				mergeDiscoveredModel(
 					model,
-					this.find(model.provider, model.id),
+					resolveProviderModelReference(model.provider, model.id, this.#unprojectedModels),
 					this.#providerOverrides.get(model.provider),
 				),
 			),
@@ -1669,22 +1684,18 @@ export class ModelRegistry {
 		for (const provider of builtInDiscovery.authoritativeProviders) {
 			authoritativeProviders.add(provider);
 		}
-		// `this.#models` is already projected here (via #ensureFullSnapshot), and
-		// the overlay merge below only replaces matching provider+id pairs — a
-		// hook's projection-only entries would survive and be fed back into it.
-		// Drop each modifier provider so the merge re-seeds it from the
-		// unprojected overlays, keeping non-idempotent hooks from compounding.
-		const rebuiltProviders = new Set(authoritativeProviders);
-		for (const providerName of this.#runtimeModelModifiers.keys()) rebuiltProviders.add(providerName);
-		const baseModels = rebuiltProviders.size > 0 ? dropProviderModels(this.#models, rebuiltProviders) : this.#models;
+		const baseModels =
+			authoritativeProviders.size > 0
+				? dropProviderModels(this.#unprojectedModels, authoritativeProviders)
+				: this.#unprojectedModels;
 		const resolved = this.#mergeResolvedModels(baseModels, discoveredModels);
 		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
-		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		this.#models = this.#applyRuntimeModelModifiers(
-			this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides)),
+		this.#unprojectedModels = this.#applyLlamaCppQwenThinkingToModels(
+			this.#applyRuntimeProviderOverrides(withModelOverrides),
 		);
+		this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
 	}
 
 	#configuredDiscoveryCacheProviderId(providerConfig: DiscoveryProviderConfig): string {
@@ -2594,32 +2605,28 @@ export class ModelRegistry {
 			this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(m => m.provider !== providerName);
 			this.#runtimeModelOverlays.push(...newOverlays);
 
-			// Also update #models immediately for the current cycle
-			const nextModels = this.#models.filter(m => m.provider !== providerName);
+			// Update the unprojected snapshot, then rerun every whole-catalog
+			// projection exactly once. Incremental projection is not safe because one
+			// provider's hook may inspect or suppress another provider's models.
+			const nextModels = this.#unprojectedModels.filter(model => model.provider !== providerName);
 			for (const overlay of newOverlays) {
 				nextModels.push(finalizeCustomModel(overlay, { useDefaults: true }));
 			}
 			const runtimeTransportOverride = this.#runtimeProviderOverrides.get(providerName);
-			const withRuntimeTransportOverride = runtimeTransportOverride
+			this.#unprojectedModels = runtimeTransportOverride
 				? nextModels.map(model => {
 						if (model.provider !== providerName) return model;
 						return this.#applyProviderTransportOverrideToModel(model, runtimeTransportOverride);
 					})
 				: nextModels;
 
-			// Persist the projection so it survives every later #reloadStaticModels()
-			// cycle, then apply it to the list we just composed.
 			if (config.oauth?.modifyModels) {
 				this.#runtimeModelModifiers.set(providerName, config.oauth.modifyModels);
 			} else {
 				this.#runtimeModelModifiers.delete(providerName);
 			}
-
-			// Only this provider's hook runs: `nextModels` still carries every other
-			// provider's projection from an earlier registration, so rerunning their
-			// hooks here would feed them their own output. Registrations arrive one
-			// at a time, and full rebuilds go through #composeStaticModels.
-			this.#models = this.#applyRuntimeModelModifiers(withRuntimeTransportOverride, new Set([providerName]));
+			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+			this.#providerLookupSnapshots.clear();
 			return;
 		}
 
@@ -2688,12 +2695,14 @@ export class ModelRegistry {
 				transportOverride,
 			);
 			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
-			this.#models = this.#applyLlamaCppQwenThinkingToModels(
-				this.#models.map(m => {
-					if (m.provider !== providerName) return m;
-					return this.#applyProviderTransportOverrideToModel(m, transportOverride);
+			this.#unprojectedModels = this.#applyLlamaCppQwenThinkingToModels(
+				this.#unprojectedModels.map(model => {
+					if (model.provider !== providerName) return model;
+					return this.#applyProviderTransportOverrideToModel(model, transportOverride);
 				}),
 			);
+			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+			this.#providerLookupSnapshots.clear();
 		}
 	}
 

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1466,6 +1466,44 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(refreshed.contextWindow).toBe(16384);
 		expect(refreshed.maxTokens).toBe(16384);
 		expect(registry.find("llama.cpp", "cold-preset")?.contextWindow).toBe(16384);
+
+		await authStorage.set("projection-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		try {
+			registry.registerProvider(
+				"projection-provider",
+				{
+					api: "anthropic-messages",
+					baseUrl: "https://example.invalid/",
+					models: [
+						{
+							id: "projection-model",
+							name: "Projection Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 8192,
+						},
+					],
+					oauth: {
+						name: "Projection OAuth",
+						login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+						refreshToken: async credentials => credentials,
+						getApiKey: credentials => credentials.access,
+						modifyModels: models => models,
+					},
+				},
+				"ext://metadata-projection",
+			);
+			expect(registry.find("llama.cpp", "cold-preset")?.contextWindow).toBe(16384);
+		} finally {
+			registry.clearSourceRegistrations("ext://metadata-projection");
+		}
 	});
 
 	test("llama.cpp selected model refresh patches newly loaded meta n_ctx and unlimited output limit", async () => {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -15,7 +15,7 @@ import { getOAuthProviders, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oau
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 describe("ModelRegistry runtime provider registration", () => {
 	let tempDir: string;
@@ -806,5 +806,91 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(getProviderModels(registry, "throwing-provider").map(model => model.id)).toEqual(["runtime-model"]);
 		// A broken extension must not take the rest of the catalog down with it.
 		expect(registry.getAll().some(model => model.provider === "anthropic")).toBe(true);
+	});
+
+	test("a throwing modifyModels logs once per distinct failure", async () => {
+		await authStorage.set("noisy-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		try {
+			registry.registerProvider(
+				"noisy-provider",
+				{
+					api: "custom-noisy-api",
+					baseUrl: "https://example.invalid/",
+					streamSimple,
+					models: [baseModel],
+					oauth: {
+						name: "Noisy OAuth",
+						login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+						refreshToken: async credentials => credentials,
+						getApiKey: credentials => credentials.access,
+						modifyModels: () => {
+							throw new Error("boom");
+						},
+					},
+				},
+				"ext://oauth",
+			);
+
+			const modifierWarnings = () =>
+				warn.mock.calls.filter(([message]) => String(message).includes("extension model projection failed"));
+			expect(modifierWarnings()).toHaveLength(1);
+			expect(modifierWarnings()[0]?.[1]).toMatchObject({ provider: "noisy-provider", error: "boom" });
+
+			// Same failure on every later recomposition must not spam the log.
+			await registry.refresh("offline");
+			expect(modifierWarnings()).toHaveLength(1);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	test("a non-idempotent modifyModels does not compound across refreshes", async () => {
+		await authStorage.set("appending-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+
+		// Deliberately append-only: the hook never strips its own prior output, so
+		// feeding it an already-projected list would duplicate on every rebuild.
+		let projectionCount = 0;
+		registry.registerProvider(
+			"appending-provider",
+			{
+				api: "custom-appending-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Appending OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: models => {
+						projectionCount += 1;
+						const seed = models.find(model => model.provider === "appending-provider") as Model<Api>;
+						return [...models, { ...seed, id: `extra-${projectionCount}` }];
+					},
+				},
+			},
+			"ext://oauth",
+		);
+
+		const ids = () => getProviderModels(registry, "appending-provider").map(model => model.id);
+		expect(ids()).toEqual(["runtime-model", "extra-1"]);
+
+		await registry.refresh("offline");
+		expect(ids()).toHaveLength(2);
+
+		await registry.refresh("online");
+		expect(ids()).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -935,12 +935,9 @@ describe("ModelRegistry runtime provider registration", () => {
 		]);
 
 		await registerAppending("appending-second", "custom-appending-second-api");
-		// Registering the second provider must not rerun the first provider's hook
-		// over its own output.
-		expect(getProviderModels(registry, "appending-first").map(model => model.id)).toEqual([
-			"runtime-model",
-			"extra-1",
-		]);
+		// Catalog changes rerun whole-catalog hooks, but each run must start from
+		// the unprojected snapshot rather than accumulating prior output.
+		expect(getProviderModels(registry, "appending-first")).toHaveLength(2);
 		expect(getProviderModels(registry, "appending-second").map(model => model.id)).toEqual([
 			"runtime-model",
 			"extra-1",
@@ -949,5 +946,252 @@ describe("ModelRegistry runtime provider registration", () => {
 		await registry.refresh("offline");
 		expect(getProviderModels(registry, "appending-first")).toHaveLength(2);
 		expect(getProviderModels(registry, "appending-second")).toHaveLength(2);
+	});
+
+	test("provider-scoped lookups preserve whole-catalog modifyModels projections", async () => {
+		const hiddenModel = registry.getAll().find(model => model.provider === "anthropic");
+		expect(hiddenModel).toBeDefined();
+		await authStorage.set("filtering-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+
+		registry.registerProvider(
+			"filtering-provider",
+			{
+				api: "custom-filtering-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Filtering OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: models =>
+						models.filter(model => model.provider !== hiddenModel?.provider || model.id !== hiddenModel.id),
+				},
+			},
+			"ext://oauth",
+		);
+
+		expect(registry.find(hiddenModel!.provider, hiddenModel!.id)).toBeUndefined();
+		const refreshPromise = registry.refresh("offline");
+		// While refresh is awaiting discovery, lookup takes the provider-scoped composition path.
+		expect(registry.find(hiddenModel!.provider, hiddenModel!.id)).toBeUndefined();
+		await refreshPromise;
+		expect(
+			registry.getAll().find(model => model.provider === hiddenModel!.provider && model.id === hiddenModel!.id),
+		).toBeUndefined();
+	});
+
+	test("provider-scoped lookups do not intern other providers' transient projections", async () => {
+		const anthropicId = registry.getAll().find(model => model.provider === "anthropic")?.id;
+		expect(anthropicId).toBeDefined();
+		await authStorage.set("changing-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		let projectionCount = 0;
+		registry.registerProvider(
+			"changing-provider",
+			{
+				api: "custom-changing-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Changing OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: models => {
+						projectionCount += 1;
+						return models.map(model =>
+							model.provider === "changing-provider"
+								? { ...model, name: `projection-${projectionCount}` }
+								: model,
+						);
+					},
+				},
+			},
+			"ext://oauth",
+		);
+
+		const refreshPromise = registry.refresh("offline");
+		expect(registry.find("anthropic", anthropicId!)).toBeDefined();
+		expect(registry.find("changing-provider", "runtime-model")?.name).toBe("projection-3");
+		await refreshPromise;
+	});
+
+	test("registering another provider reapplies whole-catalog modifyModels projections", async () => {
+		await authStorage.set("filtering-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		registry.registerProvider(
+			"filtering-provider",
+			{
+				api: "custom-filtering-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Filtering OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: models => models.filter(model => model.provider !== "later-provider"),
+				},
+			},
+			"ext://oauth",
+		);
+
+		registry.registerProvider(
+			"later-provider",
+			{
+				api: "custom-later-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				apiKey: "RUNTIME_KEY",
+				models: [baseModel],
+			},
+			"ext://runtime",
+		);
+
+		expect(getProviderModels(registry, "later-provider")).toEqual([]);
+	});
+
+	test("runtime transport overrides reapply whole-catalog modifyModels projections", async () => {
+		const proxyBaseUrl = "https://proxy.example.invalid/v1";
+		await authStorage.set("filtering-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		registry.registerProvider(
+			"filtering-provider",
+			{
+				api: "custom-filtering-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Filtering OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: models =>
+						models.filter(model => model.provider !== "anthropic" || model.baseUrl !== proxyBaseUrl),
+				},
+			},
+			"ext://oauth",
+		);
+		expect(getProviderModels(registry, "anthropic").length).toBeGreaterThan(0);
+
+		registry.registerProvider("anthropic", { baseUrl: proxyBaseUrl }, "ext://runtime");
+
+		expect(getProviderModels(registry, "anthropic")).toEqual([]);
+	});
+
+	test("online discovery reapplies modifiers to an unprojected full catalog", async () => {
+		const target = registry.getAll().find(model => model.provider === "anthropic");
+		expect(target).toBeDefined();
+		await authStorage.set("renaming-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		registry.registerProvider(
+			"renaming-provider",
+			{
+				api: "custom-renaming-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Renaming OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: models =>
+						models.map(model =>
+							model.provider === target?.provider && model.id === target.id
+								? { ...model, name: `${model.name} projected` }
+								: model,
+						),
+				},
+			},
+			"ext://oauth",
+		);
+		registry.registerProvider(
+			"dynamic-provider",
+			{
+				api: "custom-dynamic-api",
+				baseUrl: "https://example.invalid/",
+				apiKey: "RUNTIME_KEY",
+				streamSimple,
+				fetchDynamicModels: async () => [{ ...baseModel, id: "dynamic-model" }],
+			},
+			"ext://runtime",
+		);
+
+		expect(registry.find(target!.provider, target!.id)?.name).toBe(`${target!.name} projected`);
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(target!.provider, target!.id)?.name).toBe(`${target!.name} projected`);
+	});
+
+	test("a modifyModels that mutates in place then throws cannot corrupt the catalog", async () => {
+		await authStorage.set("mutating-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		try {
+			const anthropicBefore = registry.getAll().filter(model => model.provider === "anthropic").length;
+			expect(anthropicBefore).toBeGreaterThan(0);
+
+			registry.registerProvider(
+				"mutating-provider",
+				{
+					api: "custom-mutating-api",
+					baseUrl: "https://example.invalid/",
+					streamSimple,
+					models: [baseModel],
+					oauth: {
+						name: "Mutating OAuth",
+						login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+						refreshToken: async credentials => credentials,
+						getApiKey: credentials => credentials.access,
+						// Wipes the array it was handed, then fails.
+						modifyModels: models => {
+							models.length = 0;
+							throw new Error("mutated then failed");
+						},
+					},
+				},
+				"ext://oauth",
+			);
+
+			expect(registry.getAll().filter(model => model.provider === "anthropic")).toHaveLength(anthropicBefore);
+			expect(getProviderModels(registry, "mutating-provider").map(model => model.id)).toEqual(["runtime-model"]);
+
+			await registry.refresh("offline");
+			expect(registry.getAll().filter(model => model.provider === "anthropic")).toHaveLength(anthropicBefore);
+			expect(getProviderModels(registry, "mutating-provider").map(model => model.id)).toEqual(["runtime-model"]);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -3,11 +3,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	type Api,
 	type AssistantMessageEventStream,
 	clearCustomApis,
 	Effort,
 	type FetchImpl,
 	getCustomApi,
+	type Model,
 } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
@@ -720,5 +722,89 @@ describe("ModelRegistry runtime provider registration", () => {
 		registry.syncExtensionSources([]);
 		expect(getCustomApi("custom-oauth-api")).toBeUndefined();
 		expect(getOAuthProviders().some(provider => provider.id === "oauth-provider")).toBe(false);
+	});
+
+	test("oauth.modifyModels projection survives refresh and refreshProvider", async () => {
+		await authStorage.set("projecting-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+
+		// Mirrors a credential-aware provider: the registered `models` array is a
+		// pre-discovery bootstrap, and modifyModels swaps in the catalog the
+		// account actually has.
+		const config: ProviderConfigInput = {
+			api: "custom-projection-api",
+			baseUrl: "https://example.invalid/",
+			streamSimple,
+			models: [baseModel],
+			oauth: {
+				name: "Projecting OAuth",
+				login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+				refreshToken: async credentials => credentials,
+				getApiKey: credentials => credentials.access,
+				modifyModels: models => [
+					...models.filter(model => model.provider !== "projecting-provider"),
+					{
+						...(models.find(model => model.provider === "projecting-provider") as Model<Api>),
+						id: "projected-model",
+						name: "Projected Model",
+					},
+				],
+			},
+		};
+
+		registry.registerProvider("projecting-provider", config, "ext://oauth");
+
+		const projectedIds = () => getProviderModels(registry, "projecting-provider").map(model => model.id);
+		expect(projectedIds()).toEqual(["projected-model"]);
+
+		// The model selector reloads the registry offline every time it opens; the
+		// projection must not fall back to the bootstrap `models` array.
+		await registry.refresh("offline");
+		expect(projectedIds()).toEqual(["projected-model"]);
+
+		await registry.refreshProvider("projecting-provider", "offline");
+		expect(projectedIds()).toEqual(["projected-model"]);
+
+		registry.clearSourceRegistrations("ext://oauth");
+		expect(getProviderModels(registry, "projecting-provider")).toEqual([]);
+	});
+
+	test("a throwing modifyModels degrades to the unprojected catalog", async () => {
+		await authStorage.set("throwing-provider", {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+
+		registry.registerProvider(
+			"throwing-provider",
+			{
+				api: "custom-throwing-api",
+				baseUrl: "https://example.invalid/",
+				streamSimple,
+				models: [baseModel],
+				oauth: {
+					name: "Throwing OAuth",
+					login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+					refreshToken: async credentials => credentials,
+					getApiKey: credentials => credentials.access,
+					modifyModels: () => {
+						throw new Error("boom");
+					},
+				},
+			},
+			"ext://oauth",
+		);
+
+		expect(getProviderModels(registry, "throwing-provider").map(model => model.id)).toEqual(["runtime-model"]);
+		await registry.refresh("offline");
+		expect(getProviderModels(registry, "throwing-provider").map(model => model.id)).toEqual(["runtime-model"]);
+		// A broken extension must not take the rest of the catalog down with it.
+		expect(registry.getAll().some(model => model.provider === "anthropic")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -893,4 +893,61 @@ describe("ModelRegistry runtime provider registration", () => {
 		await registry.refresh("online");
 		expect(ids()).toHaveLength(2);
 	});
+
+	test("a non-idempotent modifyModels does not compound when another provider registers", async () => {
+		// The SDK and CLI loaders drain pending registrations one at a time, so an
+		// earlier provider's projection is still in #models when the next arrives.
+		const registerAppending = async (providerName: string, apiId: string) => {
+			await authStorage.set(providerName, {
+				type: "oauth",
+				access: "access-token",
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+			});
+			let projectionCount = 0;
+			registry.registerProvider(
+				providerName,
+				{
+					api: apiId,
+					baseUrl: "https://example.invalid/",
+					streamSimple,
+					models: [baseModel],
+					oauth: {
+						name: `${providerName} OAuth`,
+						login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+						refreshToken: async credentials => credentials,
+						getApiKey: credentials => credentials.access,
+						modifyModels: models => {
+							projectionCount += 1;
+							const seed = models.find(model => model.provider === providerName) as Model<Api>;
+							return [...models, { ...seed, id: `extra-${projectionCount}` }];
+						},
+					},
+				},
+				"ext://oauth",
+			);
+		};
+
+		await registerAppending("appending-first", "custom-appending-first-api");
+		expect(getProviderModels(registry, "appending-first").map(model => model.id)).toEqual([
+			"runtime-model",
+			"extra-1",
+		]);
+
+		await registerAppending("appending-second", "custom-appending-second-api");
+		// Registering the second provider must not rerun the first provider's hook
+		// over its own output.
+		expect(getProviderModels(registry, "appending-first").map(model => model.id)).toEqual([
+			"runtime-model",
+			"extra-1",
+		]);
+		expect(getProviderModels(registry, "appending-second").map(model => model.id)).toEqual([
+			"runtime-model",
+			"extra-1",
+		]);
+
+		await registry.refresh("offline");
+		expect(getProviderModels(registry, "appending-first")).toHaveLength(2);
+		expect(getProviderModels(registry, "appending-second")).toHaveLength(2);
+	});
 });


### PR DESCRIPTION
## Root cause

`ModelRegistry.registerProvider` runs an extension's `oauth.modifyModels` hook once and assigns the result straight to `#models`. Only the pre-projection definitions get persisted, in `#runtimeModelOverlays`, so any later recomposition rebuilds from those and the projection is gone.

The model selector reloads the registry every time it opens:

```ts
// modes/components/model-selector.ts
this.#modelRegistry.refresh("offline").then(() => this.#syncFromRegistryState())
```

`refresh("offline")` → `#reloadStaticModels()` → `#loadModels()` → `#resetStaticComposition()`, which clears `#hasFullSnapshot`. `getAvailable()` then takes its lazy branch and recomposes from scratch:

```ts
const availableProviders = new Set(this.#knownStaticProviders().filter(isProviderAvailable));
return this.#composeStaticModels(availableProviders);
```

`#composeStaticModels` knows nothing about the hook, so the picker falls back to whatever placeholder list the extension registered in `config.models`. `getAll()` still returns the projected `#models` while `#hasFullSnapshot` holds, which is why `omp models` and the picker disagree — the CLI is right and the picker is wrong. `refreshProvider()` and online-discovery completion drop the projection the same way.

Nothing errors; the picker just quietly lists models the account cannot use and hides the ones it can.

## Fix

- Persist the hook per provider in `#runtimeModelModifiers`, next to the existing `#runtimeProviderApiKeys` / `#runtimeProviderOverrides` maps that are already there to survive reloads.
- Re-apply in `#composeStaticModels`, which is the one choke point both `#ensureFullSnapshot()` and the scoped `getAvailable()` branch go through, and again after online discovery completes.
- Respect the `providerFilter` on scoped compositions so a partial rebuild only runs the hooks it covers.
- Drop the entry in `#clearRuntimeProviderState` so unregistering a source removes its projection.
- A hook that throws now degrades to that provider's unprojected list and records a discovery warning instead of propagating. Before this it could take the whole composition down.

Providers without `oauth.modifyModels` are unaffected — `#applyRuntimeModelModifiers` returns the input untouched when the map is empty.

## Verification

Reproduced with a provider extension that projects a credential-scoped catalog over its registered placeholder list. Before the change the picker showed the placeholder entries — 15 models, including several the account has no access to, and missing the one I actually wanted. `omp models <provider>` at the same moment listed the correct 9. After the change both agree on the 9, the previously missing model shows up with its real context window, and a `modelRoles.default` pointing at it binds instead of silently falling back. Reverting just the `model-registry.ts` hunk brings the stale list straight back.

Added two cases to `test/model-registry-runtime-provider.test.ts` on the existing "survives refresh" harness: one asserting the projection holds across `refresh("offline")` and `refreshProvider(..., "offline")` and is dropped by `clearSourceRegistrations`, one asserting a throwing hook falls back to the provider's own models without emptying the rest of the catalog. Both fail on main.

- `bun test packages/coding-agent/test/model-registry-runtime-provider.test.ts` — 24 pass, 0 fail
- `bun test` over `model-registry*`, `model-picker`, `model-discovery`, `cli-extension-providers` — 190 pass, 0 fail
- `bun run check:ts`, `bun run lint:ts`, `bun run check:tools` — pass

I went through the whole diff; the fix is just moving the projection to the place every rebuild already funnels through, so the picker stops disagreeing with `omp models`.
