### PR TITLE
fix(session): serialize scheduled continuations

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -379,6 +379,7 @@ type PostPromptSkipReason = "aborted" | "stale-generation";
 type AgentContinueSkipReason =
 	| PostPromptSkipReason
 	| "session-unavailable"
+	| "agent-busy"
 	| "should-continue-false"
 	| "post-restore-unavailable";
 
@@ -433,6 +434,8 @@ export class AgentSession {
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	#pendingNextTurnMessages: CustomMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
+	/** Coalesces continuations scheduled at the same turn boundary before Agent.continue can begin. */
+	#agentContinueScheduled = false;
 	#queuedMessageDrainScheduled = false;
 	#planModeState: PlanModeState | undefined;
 	/** Session-scoped `/vision` override; undefined = follow persisted `inspect_image.mode`. */
@@ -2800,6 +2803,7 @@ export class AgentSession {
 				try {
 					await scheduler.wait(delayMs, { signal });
 				} catch {
+					options?.onSkip?.("aborted");
 					return;
 				}
 			}
@@ -2822,6 +2826,11 @@ export class AgentSession {
 	}
 
 	#scheduleAgentContinue(options?: ScheduledAgentContinueOptions): void {
+		if (this.#agentContinueScheduled) {
+			this.#skipAgentContinue("agent-busy", options);
+			return;
+		}
+		this.#agentContinueScheduled = true;
 		this.#schedulePostPromptTask(
 			async signal => {
 				// Defense in depth: if compaction/handoff slipped onto the post-prompt queue
@@ -2852,6 +2861,10 @@ export class AgentSession {
 						this.#skipAgentContinue("post-restore-unavailable", options);
 						return;
 					}
+					if (this.agent.state.isStreaming) {
+						this.#skipAgentContinue("agent-busy", options);
+						return;
+					}
 					await this.agent.continue();
 				} catch (error) {
 					logger.warn("agent.continue failed after scheduling", {
@@ -2860,13 +2873,17 @@ export class AgentSession {
 					});
 					options?.onError?.(error);
 				} finally {
+					this.#agentContinueScheduled = false;
 					this.#endInFlight();
 				}
 			},
 			{
 				delayMs: options?.delayMs,
 				generation: options?.generation,
-				onSkip: reason => this.#skipAgentContinue(reason, options),
+				onSkip: reason => {
+					this.#agentContinueScheduled = false;
+					this.#skipAgentContinue(reason, options);
+				},
 			},
 		);
 	}

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -206,6 +206,7 @@ export interface SessionMaintenanceHost {
 				| "aborted"
 				| "stale-generation"
 				| "session-unavailable"
+				| "agent-busy"
 				| "should-continue-false"
 				| "post-restore-unavailable",
 		) => void;

--- a/packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts
@@ -296,4 +296,40 @@ describe("AgentSession queued steer delivery", () => {
 
 		expect(session.agent.peekSteeringQueue()).toEqual([]);
 	});
+
+	it("coalesces competing scheduled continuations with queued work", async () => {
+		const { session, mock } = await createSession([
+			{ content: ["initial"] },
+			{ content: ["queued response"], delayMs: 100 },
+		]);
+		await session.prompt("initial prompt");
+
+		const continueAgent = session.agent.continue.bind(session.agent);
+		let continueCalls = 0;
+		let continuedWhileBusy = false;
+		session.agent.continue = async () => {
+			continueCalls++;
+			continuedWhileBusy ||= session.agent.state.isStreaming;
+			await continueAgent();
+		};
+
+		// Session maintenance and reanswer continuations share this scheduler. Queue
+		// work before scheduling two continuations, so both reach the continuation
+		// boundary in the same turn as they can in production.
+		session.agent.steer({
+			role: "user",
+			content: [{ type: "text", text: "queued steer" }],
+			steering: true,
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+		session.resumeAfterAskReanswer();
+		session.resumeAfterAskReanswer();
+		await session.waitForIdle();
+
+		expect(continuedWhileBusy).toBe(false);
+		expect(continueCalls).toBe(1);
+		expect(mock.calls.length).toBe(2);
+		expect(session.agent.hasQueuedMessages()).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary
- Coalesce competing AgentSession scheduled continuations before they can race Agent.continue().
- Recheck the core agent busy state immediately before continuing.
- Cover competing continuation scheduling with queued work, asserting one continuation and exactly-once delivery.

## Verification
- `bun test packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts`
- `bun run check:types` (from `packages/coding-agent`)

## Reproduction
Before this change, the new deterministic regression invoked `Agent.continue()` twice while the first queued response was still streaming (`continuedWhileBusy === true`).