### PR TITLE
feat(coding-agent): allow checkpoint/rewind/learn/manage_skill in subagents when explicitly requested

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in subagent access to `checkpoint`, `rewind`, `learn`, and `manage_skill` when explicitly listed in an agent definition's `tools:` frontmatter. Listing one of `checkpoint`/`rewind` auto-includes the other. Settings (`checkpoint.enabled`, `autolearn.enabled`) remain master toggles.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/prompts/tools/checkpoint.md
+++ b/packages/coding-agent/src/prompts/tools/checkpoint.md
@@ -5,7 +5,7 @@ Use this when you need to investigate with many intermediate tool calls (read/gr
 Rules:
 - You MUST call `rewind` before yielding after starting a checkpoint.
 - You NEVER call `checkpoint` while another checkpoint is active.
-- Disabled by default in subagents. To enable, list `checkpoint` and `rewind` in the agent definition's `tools:` frontmatter (requires `checkpoint.enabled` setting).
+- Disabled by default in subagents. To enable, list `checkpoint` or `rewind` in the agent definition's `tools:` frontmatter (the sister tool is auto-included; requires `checkpoint.enabled` setting).
 
 Typical flow:
 1. `checkpoint(goal: …)`

--- a/packages/coding-agent/src/prompts/tools/checkpoint.md
+++ b/packages/coding-agent/src/prompts/tools/checkpoint.md
@@ -5,7 +5,7 @@ Use this when you need to investigate with many intermediate tool calls (read/gr
 Rules:
 - You MUST call `rewind` before yielding after starting a checkpoint.
 - You NEVER call `checkpoint` while another checkpoint is active.
-- Not available in subagents.
+- Disabled by default in subagents. To enable, list `checkpoint` and `rewind` in the agent definition's `tools:` frontmatter (requires `checkpoint.enabled` setting).
 
 Typical flow:
 1. `checkpoint(goal: …)`

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2796,8 +2796,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Checkpoint and rewind are a pair: `createTools` auto-includes the sister
 		// tool in the registry, but an explicit `toolNames` list would otherwise
 		// drop it from the ACTIVE set — leaving the agent able to checkpoint but
-		// unable to rewind (or vice versa). Mirror the pairing here.
-		if (!restrictToolNames && explicitlyRequestedToolNames) {
+		// unable to rewind (or vice versa). Mirror the pairing here. Unlike the
+		// manage_skill/learn mirror above, this is a safety pairing — it applies
+		// to restricted sessions too.
+		if (explicitlyRequestedToolNames) {
 			if (builtInToolNames.includes("checkpoint") && !explicitlyRequestedToolNames.includes("rewind")) {
 				explicitlyRequestedToolNames.push("rewind");
 			} else if (builtInToolNames.includes("rewind") && !explicitlyRequestedToolNames.includes("checkpoint")) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2793,6 +2793,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			}
 		}
+		// Checkpoint and rewind are a pair: `createTools` auto-includes the sister
+		// tool in the registry, but an explicit `toolNames` list would otherwise
+		// drop it from the ACTIVE set — leaving the agent able to checkpoint but
+		// unable to rewind (or vice versa). Mirror the pairing here.
+		if (!restrictToolNames && explicitlyRequestedToolNames) {
+			if (builtInToolNames.includes("checkpoint") && !explicitlyRequestedToolNames.includes("rewind")) {
+				explicitlyRequestedToolNames.push("rewind");
+			} else if (builtInToolNames.includes("rewind") && !explicitlyRequestedToolNames.includes("checkpoint")) {
+				explicitlyRequestedToolNames.push("checkpoint");
+			}
+		}
 		const requestedToolNames = explicitlyRequestedToolNames ?? toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
 		const defaultInactiveToolNames = new Set(

--- a/packages/coding-agent/src/tools/checkpoint.ts
+++ b/packages/coding-agent/src/tools/checkpoint.ts
@@ -50,11 +50,6 @@ export interface RewindToolDetails {
 	meta?: OutputMeta;
 }
 
-function isTopLevelSession(session: ToolSession): boolean {
-	const depth = session.taskDepth;
-	return depth === undefined || depth === 0;
-}
-
 export class CheckpointTool implements AgentTool<typeof checkpointSchema, CheckpointToolDetails> {
 	readonly name = "checkpoint";
 	readonly approval = "read" as const;
@@ -71,7 +66,6 @@ export class CheckpointTool implements AgentTool<typeof checkpointSchema, Checkp
 	}
 
 	static createIf(session: ToolSession): CheckpointTool | null {
-		if (!isTopLevelSession(session)) return null;
 		return new CheckpointTool(session);
 	}
 
@@ -82,9 +76,6 @@ export class CheckpointTool implements AgentTool<typeof checkpointSchema, Checkp
 		_onUpdate?: AgentToolUpdateCallback<CheckpointToolDetails>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<CheckpointToolDetails>> {
-		if (!isTopLevelSession(this.session)) {
-			throw new ToolError("Checkpoint not available in subagents.");
-		}
 		if (this.session.getCheckpointState?.()) {
 			throw new ToolError("Checkpoint already active.");
 		}
@@ -117,7 +108,6 @@ export class RewindTool implements AgentTool<typeof rewindSchema, RewindToolDeta
 	}
 
 	static createIf(session: ToolSession): RewindTool | null {
-		if (!isTopLevelSession(session)) return null;
 		return new RewindTool(session);
 	}
 
@@ -128,9 +118,6 @@ export class RewindTool implements AgentTool<typeof rewindSchema, RewindToolDeta
 		_onUpdate?: AgentToolUpdateCallback<RewindToolDetails>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<RewindToolDetails>> {
-		if (!isTopLevelSession(this.session)) {
-			throw new ToolError("Checkpoint not available in subagents.");
-		}
 		if (!this.session.getCheckpointState?.()) {
 			if (this.session.getLastCompletedRewind?.()) {
 				throw new ToolError(

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -502,6 +502,17 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// unreachable, in which case eval dispatches exclusively to the others.
 	const allowEval = effectivePythonAllowed || allowJs || effectiveRubyAllowed || effectiveJuliaAllowed;
 
+	// Checkpoint and rewind are a pair: listing one without the other strands
+	// the agent (it can checkpoint but not rewind, or vice versa). Auto-include
+	// the sister tool so a one-sided frontmatter `tools:` entry still works.
+	// Runs before the restricted-scope block so it applies to all sessions.
+	if (requestedTools && session.settings.get("checkpoint.enabled")) {
+		if (requestedTools.includes("checkpoint") && !requestedTools.includes("rewind")) {
+			requestedTools.push("rewind");
+		} else if (requestedTools.includes("rewind") && !requestedTools.includes("checkpoint")) {
+			requestedTools.push("checkpoint");
+		}
+	}
 	// Auto-include AST counterparts when their text-based sibling is present.
 	// Restricted callers own the active list and must not have it widened.
 	if (requestedTools && !restrictToolNames) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -505,8 +505,9 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Checkpoint and rewind are a pair: listing one without the other strands
 	// the agent (it can checkpoint but not rewind, or vice versa). Auto-include
 	// the sister tool so a one-sided frontmatter `tools:` entry still works.
-	// Like the AST/auto-learn siblings below, restricted callers own the list.
-	if (requestedTools && !restrictToolNames && session.settings.get("checkpoint.enabled")) {
+	// Unlike the AST/auto-learn convenience auto-includes below, this is a
+	// safety pairing — it applies to restricted sessions too.
+	if (requestedTools && session.settings.get("checkpoint.enabled")) {
 		if (requestedTools.includes("checkpoint") && !requestedTools.includes("rewind")) {
 			requestedTools.push("rewind");
 		} else if (requestedTools.includes("rewind") && !requestedTools.includes("checkpoint")) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -505,8 +505,8 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Checkpoint and rewind are a pair: listing one without the other strands
 	// the agent (it can checkpoint but not rewind, or vice versa). Auto-include
 	// the sister tool so a one-sided frontmatter `tools:` entry still works.
-	// Runs before the restricted-scope block so it applies to all sessions.
-	if (requestedTools && session.settings.get("checkpoint.enabled")) {
+	// Like the AST/auto-learn siblings below, restricted callers own the list.
+	if (requestedTools && !restrictToolNames && session.settings.get("checkpoint.enabled")) {
 		if (requestedTools.includes("checkpoint") && !requestedTools.includes("rewind")) {
 			requestedTools.push("rewind");
 		} else if (requestedTools.includes("rewind") && !requestedTools.includes("checkpoint")) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -574,7 +574,11 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "ask") return session.settings.get("ask.enabled");
 		if (name === "browser") return session.settings.get("browser.enabled");
 		if (name === "computer") return session.settings.get("computer.enabled");
-		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");
+		if (name === "checkpoint" || name === "rewind")
+			return (
+				session.settings.get("checkpoint.enabled") &&
+				((session.taskDepth ?? 0) === 0 || requestedTools !== undefined)
+			);
 		if (name === "hub") {
 			return (
 				!restrictToolNames && session.enableIrc !== false && isIrcEnabled(session.settings, session.taskDepth ?? 0)
@@ -584,11 +588,15 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			return ["hindsight", "mnemopi"].includes(session.settings.get("memory.backend") ?? "");
 		}
 		if (name === "memory_edit") return session.settings.get("memory.backend") === "mnemopi";
-		if (name === "manage_skill") return session.settings.get("autolearn.enabled") && (session.taskDepth ?? 0) === 0;
+		if (name === "manage_skill")
+			return (
+				session.settings.get("autolearn.enabled") &&
+				((session.taskDepth ?? 0) === 0 || requestedTools !== undefined)
+			);
 		if (name === "learn") {
 			return (
 				session.settings.get("autolearn.enabled") &&
-				(session.taskDepth ?? 0) === 0 &&
+				((session.taskDepth ?? 0) === 0 || requestedTools !== undefined) &&
 				["hindsight", "mnemopi", "local"].includes(session.settings.get("memory.backend") ?? "")
 			);
 		}

--- a/packages/coding-agent/test/autolearn-tools-gating.test.ts
+++ b/packages/coding-agent/test/autolearn-tools-gating.test.ts
@@ -71,7 +71,7 @@ describe("autolearn tool gating", () => {
 		expect(noBackend).not.toContain("learn");
 	});
 
-	it("excludes the tools from a subagent even with an explicit list", async () => {
+	it("excludes the tools from a subagent when not in the explicit list", async () => {
 		// taskDepth > 0: the controller never runs here, so a subagent's explicit
 		// whitelist must not be silently widened with write-capable tools.
 		const sub = (
@@ -88,6 +88,18 @@ describe("autolearn tool gating", () => {
 		).map(t => t.name);
 		expect(subDiscovered).not.toContain("manage_skill");
 		expect(subDiscovered).not.toContain("learn");
+	});
+
+	it("allows the tools in a subagent when explicitly requested in toolNames", async () => {
+		// Frontmatter tools: list overrides the taskDepth gate.
+		const sub = (
+			await createTools(makeSession({ "autolearn.enabled": true, "memory.backend": "mnemopi" }, { taskDepth: 1 }), [
+				"manage_skill",
+				"learn",
+			])
+		).map(t => t.name);
+		expect(sub).toContain("manage_skill");
+		expect(sub).toContain("learn");
 	});
 
 	it("offers learn with the file-based local backend", async () => {

--- a/packages/coding-agent/test/sdk-autolearn-active-tools.test.ts
+++ b/packages/coding-agent/test/sdk-autolearn-active-tools.test.ts
@@ -122,4 +122,23 @@ describe("createAgentSession auto-learn tool activation", () => {
 		expect(names).toContain("checkpoint");
 		expect(names).toContain("rewind");
 	});
+
+	it("activates checkpoint and rewind in a restricted session with one-sided toolNames", async () => {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "checkpoint.enabled": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames: ["checkpoint"],
+			requireYieldTool: true,
+			restrictToolNames: true,
+		});
+		sessions.push(session);
+		const names = session.getActiveToolNames();
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
 });

--- a/packages/coding-agent/test/sdk-autolearn-active-tools.test.ts
+++ b/packages/coding-agent/test/sdk-autolearn-active-tools.test.ts
@@ -86,4 +86,40 @@ describe("createAgentSession auto-learn tool activation", () => {
 		expect(names).toContain("read");
 		expect(names).not.toContain("manage_skill");
 	});
+
+	it("activates checkpoint and rewind when only checkpoint is in an explicit toolNames list", async () => {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "checkpoint.enabled": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames: ["checkpoint"],
+			requireYieldTool: true,
+		});
+		sessions.push(session);
+		const names = session.getActiveToolNames();
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
+
+	it("activates checkpoint and rewind when only rewind is in an explicit toolNames list", async () => {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "checkpoint.enabled": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames: ["rewind"],
+			requireYieldTool: true,
+		});
+		sessions.push(session);
+		const names = session.getActiveToolNames();
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
 });

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -301,6 +301,60 @@ describe("createTools", () => {
 		expect(session.isToolActive?.("read")).toBe(false);
 	});
 
+	it("allows checkpoint/rewind in subagent when explicitly requested and enabled", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+				["checkpoint", "rewind"],
+			)
+		).map(t => t.name);
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
+
+	it("excludes checkpoint/rewind from subagent when not explicitly requested", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+			)
+		).map(t => t.name);
+		expect(names).not.toContain("checkpoint");
+		expect(names).not.toContain("rewind");
+	});
+
+	it("excludes checkpoint/rewind from subagent when disabled even if explicitly requested", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": false }),
+				}),
+				["checkpoint", "rewind"],
+			)
+		).map(t => t.name);
+		expect(names).not.toContain("checkpoint");
+		expect(names).not.toContain("rewind");
+	});
+
+	it("allows checkpoint/rewind at top level when enabled and explicitly requested", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+				["checkpoint", "rewind"],
+			)
+		).map(t => t.name);
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
+
 	it("HIDDEN_TOOLS contains yield and goal", () => {
 		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual(["goal", "yield"]);
 	});

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -397,6 +397,21 @@ describe("createTools", () => {
 		expect(names).not.toContain("rewind");
 	});
 
+	it("auto-pairs checkpoint/rewind in a restricted subagent with one-sided list", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					restrictToolNames: true,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+				["checkpoint"],
+			)
+		).map(t => t.name);
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
+
 	it("HIDDEN_TOOLS contains yield and goal", () => {
 		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual(["goal", "yield"]);
 	});

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -355,6 +355,48 @@ describe("createTools", () => {
 		expect(names).toContain("rewind");
 	});
 
+	it("auto-includes rewind when only checkpoint is in the explicit list", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+				["checkpoint"],
+			)
+		).map(t => t.name);
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
+
+	it("auto-includes checkpoint when only rewind is in the explicit list", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+				["rewind"],
+			)
+		).map(t => t.name);
+		expect(names).toContain("checkpoint");
+		expect(names).toContain("rewind");
+	});
+
+	it("does not auto-include checkpoint/rewind when neither is requested", async () => {
+		const names = (
+			await createTools(
+				createTestSession({
+					taskDepth: 1,
+					settings: createSettingsWithOverrides({ "checkpoint.enabled": true }),
+				}),
+				["read"],
+			)
+		).map(t => t.name);
+		expect(names).not.toContain("checkpoint");
+		expect(names).not.toContain("rewind");
+	});
+
 	it("HIDDEN_TOOLS contains yield and goal", () => {
 		expect(Object.keys(HIDDEN_TOOLS).sort()).toEqual(["goal", "yield"]);
 	});


### PR DESCRIPTION
## What

Allow `checkpoint`, `rewind`, `learn`, and `manage_skill` in subagents when explicitly listed in the agent definition's `tools:` frontmatter.

## Why

Closes #3762. Long-context research subagents benefit from checkpoint/rewind to minimize context cost. The tools are storage-safe in subagents (per-session state, serialized file writes). Learn/manage_skill are similarly safe — they use per-file serialization chains that already handle sibling subagents.

## Use case

An agent definition with `tools: [read, grep, glob, checkpoint, rewind, yield]` spawned for exploratory research: the subagent creates a checkpoint, investigates, then rewinds to a concise report before yielding.

## Backward compatibility

Yes. Default behavior is unchanged — all four tools remain excluded from the default subagent tool set. Only explicit frontmatter `tools:` lists unlock them. Settings (`checkpoint.enabled`, `autolearn.enabled`) remain master toggles.

## Changes

- `packages/coding-agent/src/tools/index.ts` — `isToolAllowed` closure: relax three `taskDepth === 0` gates to `(taskDepth === 0 || requestedTools !== undefined)`. The `requestedTools` variable is already captured by the closure; no signature change needed.
- `packages/coding-agent/src/tools/checkpoint.ts` — remove `isTopLevelSession` function and its 4 guard sites (2x `createIf`, 2x `execute`). Gating is now handled entirely by `isToolAllowed`.
- `packages/coding-agent/src/prompts/tools/checkpoint.md` — replace stale "Not available in subagents" with enablement docs.
- `packages/coding-agent/test/tools/index.test.ts` — add 4 tests covering subagent explicit-request, subagent no-request, disabled-setting, and top-level paths.
- `packages/coding-agent/test/autolearn-tools-gating.test.ts` — update subagent exclusion test name and add explicit-request test.