### PR TITLE
feat(extensions): expose session async job snapshots

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -158,6 +158,7 @@ Handlers and tool `execute` receive `ctx` with:
 - `modelRegistry`, `model`
 - `models` (read-only model query — see below)
 - `getContextUsage()`
+- `getAsyncJobSnapshot()` returns the current session's read-only async-job snapshot, or `null` when no session owns the context
 - `compact(...)`
 - `isIdle()`, `hasPendingMessages()`, `abort()`
 - `shutdown()`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2891,6 +2891,7 @@
 - Added a read-only `ctx.models` facade for extensions: `list()` (authenticated models), `current()` (live session model), `resolve(spec)` (a model string or role alias → `Model`, using the same settings-backed aliases and match preferences as core selection), and `family(model)` (opaque canonical-identity lineage token for cross-family comparisons). Lets extension tools select models the way core does without reaching into the mutable registry ([#2406](https://github.com/can1357/oh-my-pi/issues/2406))
 - Added RPC prompt lifecycle hints so hosts can distinguish scheduled agent turns from local-only slash commands via `data.agentInvoked` and `prompt_result`.
 - Added extension lifecycle events for tool approval prompts: `tool_approval_requested` before the approval wait and `tool_approval_resolved` after approve, deny, or approval prompt failure.
+- Added `ExtensionContext.getAsyncJobSnapshot()` so extensions can read the owning session's async-job state without relying on process-global job-manager identity
 
 ### Changed
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -10,6 +10,7 @@ import type { Settings } from "../../config/settings";
 import type { LocalProtocolOptions } from "../../internal-urls/local-protocol";
 import type { MemoryRuntimeContext } from "../../memory-backend";
 import { type Theme, theme } from "../../modes/theme/theme";
+import type { AsyncJobSnapshot } from "../../session/agent-session";
 import type { SessionManager } from "../../session/session-manager";
 import type { BranchHandler, NavigateTreeHandler, NewSessionHandler } from "../session-handler-types";
 import { ManagedTimers } from "./managed-timers";
@@ -327,6 +328,7 @@ export class ExtensionRunner {
 	#getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	#compactFn: (instructionsOrOptions?: string | CompactOptions) => Promise<void> = async () => {};
 	#getSystemPromptFn: () => string[] = () => [];
+	#getAsyncJobSnapshotFn: () => AsyncJobSnapshot | null = () => null;
 	#newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	#branchHandler: BranchHandler = async () => ({ cancelled: false });
 	#navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
@@ -392,9 +394,11 @@ export class ExtensionRunner {
 		getMemory?: () => MemoryRuntimeContext | undefined,
 		private readonly settings?: Settings,
 		private readonly localProtocolOptions?: LocalProtocolOptions,
+		getAsyncJobSnapshot?: () => AsyncJobSnapshot | null,
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
+		this.#getAsyncJobSnapshotFn = getAsyncJobSnapshot ?? (() => null);
 	}
 
 	initialize(
@@ -666,6 +670,7 @@ export class ExtensionRunner {
 			ui: this.#uiContext,
 			getContextUsage: () => this.#getContextUsageFn(),
 			compact: instructionsOrOptions => this.#compactFn(instructionsOrOptions),
+			getAsyncJobSnapshot: () => this.#getAsyncJobSnapshotFn(),
 			hasUI: this.hasUI(),
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -49,6 +49,7 @@ import type { LocalProtocolOptions } from "../../internal-urls/local-protocol";
 import type { MemoryRuntimeContext } from "../../memory-backend";
 import type { CustomEditor } from "../../modes/components/custom-editor";
 import type { Theme } from "../../modes/theme/theme";
+import type { AsyncJobSnapshot } from "../../session/agent-session";
 import type { CompactMode } from "../../session/compact-modes";
 import type { CustomMessage, CustomMessagePayload } from "../../session/messages";
 import type { ReadonlySessionManager, SessionManager } from "../../session/session-manager";
@@ -415,6 +416,8 @@ export interface ExtensionContext {
 	ui: ExtensionUIContext;
 	/** Get current context usage for the active model. */
 	getContextUsage(): ContextUsage | undefined;
+	/** Get a read-only snapshot of async jobs owned by this session. */
+	getAsyncJobSnapshot(): AsyncJobSnapshot | null;
 	/** Compact the session context (interactive mode shows UI). */
 	compact(instructionsOrOptions?: string | CompactOptions): Promise<void>;
 	/** Whether UI is available (false in print/RPC mode) */

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -532,6 +532,7 @@ export class ExtensionUiController {
 					await registeredTool.definition.onSession(event, {
 						...runner!.createContext(),
 						ui: uiContext,
+
 						hasUI: true,
 						compact: instructionsOrOptions => this.#compactSession(instructionsOrOptions),
 					});

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2513,6 +2513,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			() => (hasSession ? createSessionMemoryRuntimeContext(session, agentDir, cwd) : undefined),
 			settings,
 			localProtocolOptions,
+			() => (hasSession ? session.getAsyncJobSnapshot() : null),
 		);
 
 		credentialDisabledTarget = extensionRunner;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5170,6 +5170,7 @@ export class AgentSession {
 				void this.dispose().finally(() => process.exit(0));
 			},
 			getContextUsage: () => this.getContextUsage(),
+			getAsyncJobSnapshot: () => this.getAsyncJobSnapshot(),
 			waitForIdle: () => this.waitForIdle(),
 			newSession: async options => {
 				const success = await this.newSession({ parentSession: options?.parentSession });

--- a/packages/coding-agent/test/extension-context-async-jobs.test.ts
+++ b/packages/coding-agent/test/extension-context-async-jobs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type { ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+function createRunner(getAsyncJobSnapshot?: () => AsyncJobSnapshot | null): ExtensionRunner {
+	const runtime = {
+		flagValues: new Map(),
+		pendingProviderRegistrations: [],
+	} as unknown as ExtensionRuntime;
+	return new ExtensionRunner(
+		[],
+		runtime,
+		"/tmp",
+		{} as never,
+		{} as never,
+		undefined,
+		undefined,
+		undefined,
+		getAsyncJobSnapshot,
+	);
+}
+
+describe("ExtensionRunner async job context", () => {
+	it("defaults to null outside a session", () => {
+		expect(createRunner().createContext().getAsyncJobSnapshot()).toBeNull();
+	});
+
+	it("exposes the owning session snapshot", () => {
+		const snapshot: AsyncJobSnapshot = {
+			running: [{ id: "bg-1", type: "bash", status: "running", label: "sleep 30", startTime: 1 }],
+			recent: [],
+			delivery: { queued: 0, delivering: false, pendingJobIds: [] },
+		};
+		expect(
+			createRunner(() => snapshot)
+				.createContext()
+				.getAsyncJobSnapshot(),
+		).toBe(snapshot);
+	});
+});


### PR DESCRIPTION
## What

- Add `ExtensionContext.getAsyncJobSnapshot()` as a read-only view of the owning session's async jobs.
- Wire the session-scoped snapshot through `ExtensionRunner`, the SDK, and fallback extension contexts; runners without a session return `null`.
- Add focused regression coverage plus extension docs and changelog notes.

## Why

Promoted OMP runs a bundled CLI while public extensions resolve package source exports. A plugin importing `AsyncJobManager.instance()` can therefore observe a different singleton from the session that owns the jobs. The extension context must expose the already-authoritative `AgentSession` snapshot instead of requiring process-global identity.

## Testing

- `bun test packages/coding-agent/test/extension-context-async-jobs.test.ts`: 2 passed.
- `bun --cwd=packages/coding-agent run check:types`: passed.
- `biome check` passed for every changed TypeScript file.
- End-to-end smoke used an isolated rebuilt promoted/bundled OMP runtime with an external extension in cmux TUI protocol 12: OMP rendered `1 job`, the extension record simultaneously reported `jobs_running: 1`, a concurrent follow-up completed while `bg_1` remained active, and both returned to `0` after completion.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)