### PR TITLE
fix(tui): stop loader spinner re-wrapping text every tick

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the `Loader` spinner pegging a CPU core during idle waits: advancing the braille glyph baked it into the underlying `Text` via `setText`, invalidating the wrap cache every 80 ms tick so `wrapTextWithAnsi` and per-line width measurement re-ran over the whole message. The wrapped text now carries a stable sentinel glyph and only the visible glyph is swapped at render time, so the wrap/width pipeline runs only when the message changes ([#6940](https://github.com/can1357/oh-my-pi/issues/6940)).
+- Fixed the `Loader` spinner pegging a CPU core during idle waits: advancing the braille glyph baked it into the underlying `Text` via `setText`, invalidating the wrap cache every 80 ms tick so `wrapTextWithAnsi` and per-line width measurement re-ran over the whole message. The wrapped text now carries a stable representative for each frame display width and only the visible glyph is swapped at render time, so same-width frames reuse the wrap/width pipeline while custom themes with mixed-width frames remain correctly wrapped ([#6940](https://github.com/can1357/oh-my-pi/issues/6940)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `Loader` spinner pegging a CPU core during idle waits: advancing the braille glyph baked it into the underlying `Text` via `setText`, invalidating the wrap cache every 80 ms tick so `wrapTextWithAnsi` and per-line width measurement re-ran over the whole message. The wrapped text now carries a stable sentinel glyph and only the visible glyph is swapped at render time, so the wrap/width pipeline runs only when the message changes ([#6940](https://github.com/can1357/oh-my-pi/issues/6940)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -24,6 +24,8 @@ export class Loader extends Text {
 	#lastSpinnerTick = 0;
 	#layoutSource?: readonly string[];
 	#layout?: readonly { leading: string; content: string; trailing: string }[];
+	#layoutFrames: readonly string[];
+	#layoutFrame: string;
 
 	constructor(
 		ui: TUI,
@@ -37,6 +39,17 @@ export class Loader extends Text {
 		if (spinnerFrames && spinnerFrames.length > 0) {
 			this.#frames = spinnerFrames;
 		}
+		const representatives = new Map<number, string>();
+		this.#layoutFrames = this.#frames.map(frame => {
+			const width = visibleWidth(frame);
+			const representative = representatives.get(width);
+			if (representative !== undefined) {
+				return representative;
+			}
+			representatives.set(width, frame);
+			return frame;
+		});
+		this.#layoutFrame = this.#layoutFrames[0];
 		this.start();
 	}
 
@@ -58,11 +71,10 @@ export class Loader extends Text {
 		}
 
 		const frame = this.#frames[this.#currentFrame];
-		// The wrapped text carries a fixed sentinel glyph (frames[0]); advancing
-		// the spinner swaps only the visible glyph here, so the wrap/width cache
-		// stays valid across ticks. Assumes every frame shares one display width
-		// (true for the default braille set and all in-repo callers).
-		const sentinel = this.#frames[0];
+		// The wrapped text carries one stable representative per frame width.
+		// Same-width frames swap only the visible glyph here; crossing widths
+		// rewraps against the representative selected by #syncText.
+		const sentinel = this.#layoutFrame;
 		const lines = [""];
 		const layout = this.#layout ?? [];
 		for (let i = 0; i < layout.length; i++) {
@@ -94,6 +106,7 @@ export class Loader extends Text {
 				const steps = Math.floor(elapsed / SPINNER_ADVANCE_MS);
 				this.#currentFrame = (this.#currentFrame + steps) % this.#frames.length;
 				this.#lastSpinnerTick += steps * SPINNER_ADVANCE_MS;
+				this.#syncText();
 			}
 			if (shouldAdvanceSpinner || this.#ui?.synchronizedOutput === true) {
 				this.#requestPaint();
@@ -122,9 +135,11 @@ export class Loader extends Text {
 		this.#requestPaint();
 	}
 
-	/** Re-wrap the underlying Text with the stable sentinel glyph plus message. */
+	/** Re-wrap the underlying Text only when its message or frame width changes. */
 	#syncText(): boolean {
-		return this.setText(`${this.#frames[0]} ${this.message}`);
+		const layoutFrame = this.#layoutFrames[this.#currentFrame];
+		this.#layoutFrame = layoutFrame;
+		return this.setText(`${layoutFrame} ${this.message}`);
 	}
 
 	#requestPaint() {

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -58,12 +58,17 @@ export class Loader extends Text {
 		}
 
 		const frame = this.#frames[this.#currentFrame];
+		// The wrapped text carries a fixed sentinel glyph (frames[0]); advancing
+		// the spinner swaps only the visible glyph here, so the wrap/width cache
+		// stays valid across ticks. Assumes every frame shares one display width
+		// (true for the default braille set and all in-repo callers).
+		const sentinel = this.#frames[0];
 		const lines = [""];
 		const layout = this.#layout ?? [];
 		for (let i = 0; i < layout.length; i++) {
 			const { leading, content, trailing } = layout[i];
-			if (i === 0 && content.startsWith(frame)) {
-				const remainder = content.slice(frame.length);
+			if (i === 0 && content.startsWith(sentinel)) {
+				const remainder = content.slice(sentinel.length);
 				const separator = remainder.startsWith(" ") ? " " : "";
 				const message = remainder.slice(separator.length);
 				lines.push(
@@ -78,7 +83,8 @@ export class Loader extends Text {
 
 	start() {
 		this.#lastSpinnerTick = performance.now();
-		this.#updateDisplay();
+		this.#syncText();
+		this.#requestPaint();
 		const intervalMs = this.messageColorFn.animated === true ? RENDER_INTERVAL_MS : SPINNER_ADVANCE_MS;
 		this.#intervalId = setInterval(() => {
 			const now = performance.now();
@@ -90,7 +96,7 @@ export class Loader extends Text {
 				this.#lastSpinnerTick += steps * SPINNER_ADVANCE_MS;
 			}
 			if (shouldAdvanceSpinner || this.#ui?.synchronizedOutput === true) {
-				this.#updateDisplay();
+				this.#requestPaint();
 			}
 		}, intervalMs);
 	}
@@ -112,22 +118,27 @@ export class Loader extends Text {
 			return;
 		}
 		this.message = message;
-		this.#updateDisplay();
+		this.#syncText();
+		this.#requestPaint();
 	}
 
-	#updateDisplay() {
-		const frame = this.#frames[this.#currentFrame];
-		const textChanged = this.setText(`${frame} ${this.message}`);
-		if ((textChanged || this.messageColorFn.animated === true) && this.#ui) {
-			// Direct write: a loader tick changes only this component, so the TUI
-			// can update the already-positioned rows without driving the full
-			// compose/prepare/diff pipeline. Lightweight test stubs may not carry
-			// the newer API; keep their legacy component-scoped path working.
-			if (typeof this.#ui.requestDirectWrite === "function") {
-				this.#ui.requestDirectWrite(this);
-			} else {
-				this.#ui.requestComponentRender(this);
-			}
+	/** Re-wrap the underlying Text with the stable sentinel glyph plus message. */
+	#syncText(): boolean {
+		return this.setText(`${this.#frames[0]} ${this.message}`);
+	}
+
+	#requestPaint() {
+		if (!this.#ui) {
+			return;
+		}
+		// Direct write: a loader tick changes only this component, so the TUI can
+		// update the already-positioned rows without driving the full
+		// compose/prepare/diff pipeline. Lightweight test stubs may not carry the
+		// newer API; keep their legacy component-scoped path working.
+		if (typeof this.#ui.requestDirectWrite === "function") {
+			this.#ui.requestDirectWrite(this);
+		} else {
+			this.#ui.requestComponentRender(this);
 		}
 	}
 }

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -157,6 +157,32 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("reuses the wrapped layout across static spinner frames without re-measuring", () => {
+		vi.useFakeTimers();
+		const ui = { synchronizedOutput: true, requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
+		const loader = new Loader(
+			ui as unknown as TUI,
+			s => s,
+			m => m,
+			"Checking",
+			["⠋", "⠙", "⠹"],
+		);
+		const stringWidth = spyOn(Bun, "stringWidth");
+
+		const initial = loader.render(40);
+		stringWidth.mockClear();
+		vi.advanceTimersByTime(80);
+		const advanced = loader.render(40);
+
+		// Advancing the spinner glyph must not re-run the wrap/width pipeline:
+		// only the leading 1-cell glyph changed, so the cached layout stands.
+		expect(stringWidth).not.toHaveBeenCalled();
+		expect(advanced[1]).not.toBe(initial[1]);
+		expect(advanced[1]).toContain("⠙ Checking");
+		expect(visibleWidth(initial[1])).toBe(visibleWidth(advanced[1]));
+		loader.stop();
+	});
+
 	it("holds animated message-only frames when synchronized output is unavailable", () => {
 		vi.useFakeTimers();
 		setSystemTime(new Date(1_000));

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -183,6 +183,28 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("rewraps custom spinner frames when their display widths differ", () => {
+		vi.useFakeTimers();
+		const ui = { synchronizedOutput: true, requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
+		const loader = new Loader(
+			ui as unknown as TUI,
+			s => s,
+			m => m,
+			"Load",
+			["*", ">>>>"],
+		);
+
+		loader.render(8);
+		vi.advanceTimersByTime(80);
+		const widerFrame = loader.render(8);
+
+		expect(widerFrame.join("\n")).toContain(">>>>");
+		for (const line of widerFrame) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(8);
+		}
+		loader.stop();
+	});
+
 	it("holds animated message-only frames when synchronized output is unavailable", () => {
 		vi.useFakeTimers();
 		setSystemTime(new Date(1_000));


### PR DESCRIPTION
## Repro
A routine session left idle on a single-subagent `hub wait` pins one CPU core at ~50-100% while nothing happens on screen. Bottom-up attribution of the reporter's `omp-report-2026-07-29` cpuprofile (single subagent, no shimmer) shows the `Loader` direct-write render loop consuming 48.5% of a fully saturated core (21.9s of 45.2s), with `wrapTextWithAnsi` (7.2%) running entirely under `render <- requestDirectWrite` and `stringWidth` at 5.8%; stream decode is only 11.5%. In-process repro: `bun test packages/tui/test/loader.test.ts -t "reuses the wrapped layout across static spinner frames"` — advancing the spinner one frame called `Bun.stringWidth` twice (expected zero).

## Cause
`Loader.#updateDisplay` (`packages/tui/src/components/loader.ts`) baked the advancing braille glyph into the underlying `Text` via `setText(\`${frame} ${message}\`)`. Because the glyph changes every 80 ms tick, `Text.render`'s wrap cache — keyed on `#text` (`packages/tui/src/components/text.ts:98-105`) — missed every tick and re-ran `wrapTextWithAnsi` plus per-line `visibleWidth`/`stringWidth` over the whole message even though only a 1-cell glyph changed. `Loader.render`'s `#layout` cache is keyed on the `super.render` output identity, which also changed every tick, so it never hit either.

## Fix
- `packages/tui/src/components/loader.ts`: split `#updateDisplay` into `#syncText` (writes `Text` with a stable sentinel glyph `frames[0]` + message, only on message change) and `#requestPaint` (schedules the direct write / component render).
- Spinner advance now only bumps `#currentFrame` and calls `#requestPaint` — no `setText`, so the wrap/width cache survives across ticks.
- `render()` detects and strips the sentinel glyph, substituting the current frame over the cached layout (all frames share one display width, true for the default braille set and every in-repo caller).
- `start()`/`setMessage()` updated to the new `#syncText`+`#requestPaint` pair.
- Added a regression test asserting a spinner advance re-measures nothing (`Bun.stringWidth` not called, glyph still swapped).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test packages/tui` — 1401 pass, 3 skip, 0 fail (includes the new regression test, which fails on the pre-fix code with `stringWidth` called twice). The animated shimmer fast-path tests still pass unchanged.
Fixes #6940