### PR TITLE
feat(github): support alternate checkout contexts

### DIFF
--- a/docs/tools/github.md
+++ b/docs/tools/github.md
@@ -17,7 +17,8 @@
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `op` | `"repo_view" \| "pr_create" \| "pr_checkout" \| "pr_push" \| "search_issues" \| "search_prs" \| "search_code" \| "search_commits" \| "search_repos" \| "run_watch"` | Yes | Dispatch selector. `GithubTool.execute()` switches only on this field. |
+| `op` | `"repo_view" \| "file_read" \| "pr_create" \| "pr_checkout" \| "pr_push" \| "search_issues" \| "search_prs" \| "search_code" \| "search_commits" \| "search_repos" \| "run_watch"` | Yes | Dispatch selector. `GithubTool.execute()` switches only on this field. |
+| `cwd` | `string` | No | Local checkout used to infer repository, branch, HEAD, remotes, and PR push metadata. Relative paths resolve from the session directory; linked worktrees and Git submodule checkouts are supported. Defaults to the session directory. Accepted by every op and omitted from the op-specific optional-field lists below. |
 | `repo` | `string` | No | `owner/repo` override. Ignored when the identifier argument is already a full GitHub URL. For `search_issues`/`search_prs`/`search_code`/`search_commits`, defaults to the current checkout's `owner/repo` when omitted (skipped when the query already contains a `repo:`/`org:`/`user:`/`owner:` qualifier or when current-repo resolution fails). Required in practice when `gh` cannot infer repo context from the current checkout. |
 | `branch` | `string` | No | Used by `repo_view`, `pr_push`, and `run_watch`. `run_watch` falls back to current git branch when `run` is omitted; `pr_push` falls back to current branch. |
 | `pr` | `string \| string[]` | No | Used by `pr_checkout`. Each item may be a PR number, branch name, or GitHub PR URL. Array form enables batching. Omitted means current branch PR. |
@@ -56,7 +57,7 @@ The tool returns a single text result built by `buildTextResult()` in `packages/
 
 ## Flow
 1. `GithubTool.createIf()` exposes the tool only when `git.github.available()` finds `gh` on `PATH`.
-2. `GithubTool.execute()` wraps dispatch in `untilAborted()` and switches on `params.op`.
+2. `GithubTool.execute()` resolves an optional `cwd` relative to the session directory, verifies that the selected worktree or submodule checkout is a directory, wraps dispatch in `untilAborted()`, and switches on `params.op`.
 3. Each op normalizes optional strings, arrays, booleans, and numeric caps locally in `packages/coding-agent/src/tools/gh.ts`.
 4. CLI execution goes through `git.github.run/json/text()` in `packages/coding-agent/src/utils/git.ts`:
    - spawns `gh ...` with `Bun.spawn()`;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-call `cwd` selection to the GitHub tool so every operation can target a linked worktree or Git submodule checkout without moving the session.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added per-call `cwd` selection to the GitHub tool so every operation can target a linked worktree or Git submodule checkout without moving the session.
+- Added per-call `cwd` selection to the GitHub tool so every operation can target a linked worktree or Git submodule checkout without moving the session ([#6944](https://github.com/can1357/oh-my-pi/pull/6944) by [@joshrzemien](https://github.com/joshrzemien)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -2,6 +2,7 @@ Op-based `gh` wrapper: repos, repository files, PRs, search, checkout, push, Act
 
 <instruction>
 Pick op via `op`. Beyond the field descriptions, per op:
+- `cwd` — selects the local checkout used to infer repository, branch, HEAD, remotes, and PR push metadata; defaults to the session directory. Set it to a linked worktree or submodule path to operate on that checkout without moving the session.
 - `repo_view` — omit `repo` to view the current checkout.
 - `file_read` — reads `path` from `repo`; omit `repo` for the current checkout and `branch` for its default branch.
 - `pr_create` — `head` defaults to the current branch.

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -1,4 +1,5 @@
 import { type Component, padding, Text, visibleWidth } from "@oh-my-pi/pi-tui";
+import { getProjectDir } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { framedBlock, outputBlockContentWidth, renderStatusLine } from "../tui";
@@ -14,6 +15,7 @@ import {
 	formatExpandHint,
 	formatMoreItems,
 	formatStatusIcon,
+	formatToolWorkingDirectory,
 	PREVIEW_LIMITS,
 	replaceTabs,
 	type ToolUIColor,
@@ -23,6 +25,7 @@ import {
 } from "./render-utils";
 
 type GithubToolRenderArgs = {
+	cwd?: string;
 	op?: string;
 	run?: string;
 	branch?: string;
@@ -113,6 +116,8 @@ function buildOpMeta(args: GithubToolRenderArgs): string[] {
 			break;
 		}
 	}
+	const cwd = formatToolWorkingDirectory(args.cwd, getProjectDir());
+	if (cwd) meta.push(cwd);
 	return meta;
 }
 
@@ -410,7 +415,8 @@ function renderWatchCall(args: GithubToolRenderArgs, options: RenderResultOption
 		metaText = theme.fg("muted", "current HEAD");
 	}
 
-	const header = `${icon} ${titleText}  ${metaText}`;
+	const cwdMeta = buildOpMeta(args);
+	const header = `${icon} ${titleText}  ${metaText}${cwdMeta.length > 0 ? `  ${theme.fg("muted", cwdMeta.join("  "))}` : ""}`;
 	const wait = theme.fg("dim", "waiting for workflow data...");
 	return new Text(`${header}\n${wait}`, 0, 0);
 }
@@ -447,19 +453,20 @@ export const githubToolRenderer = {
 		const watch = result.details?.watch;
 		if (watch) {
 			const isError = result.isError === true;
+			const meta = [getWatchHeader(watch), ...buildOpMeta(args ?? {})];
 			const header = renderStatusLine(
 				isError
 					? {
 							icon: "error",
 							title: "GitHub Run Watch",
 							titleColor: "error",
-							meta: [getWatchHeader(watch)],
+							meta,
 						}
 					: {
 							iconOverride: uiTheme.styledSymbol("tool.gh", "accent"),
 							title: "GitHub Run Watch",
 							titleColor: "accent",
-							meta: [getWatchHeader(watch)],
+							meta,
 						},
 				uiTheme,
 			);

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -14,7 +14,6 @@ import { formatShortSha } from "./gh-format";
 import {
 	formatExpandHint,
 	formatMoreItems,
-	formatStatusIcon,
 	formatToolWorkingDirectory,
 	PREVIEW_LIMITS,
 	replaceTabs,
@@ -397,26 +396,19 @@ function renderFallbackComponent(
 }
 
 function renderWatchCall(args: GithubToolRenderArgs, options: RenderResultOptions, theme: Theme): Component {
-	const icon =
-		options.spinnerFrame !== undefined
-			? formatStatusIcon("running", theme, options.spinnerFrame)
-			: formatStatusIcon("pending", theme);
-
+	const status: ToolUIStatus = options.spinnerFrame !== undefined ? "running" : "pending";
 	const runId = typeof args.run === "string" && args.run.trim().length > 0 ? args.run.trim() : undefined;
 	const branch = typeof args.branch === "string" && args.branch.trim().length > 0 ? args.branch.trim() : undefined;
-
-	const titleText = theme.fg("accent", "GitHub Run Watch");
-	let metaText: string;
-	if (runId) {
-		metaText = theme.fg("muted", `#${runId}`);
-	} else if (branch) {
-		metaText = theme.fg("text", branch);
-	} else {
-		metaText = theme.fg("muted", "current HEAD");
-	}
-
-	const cwdMeta = buildOpMeta(args);
-	const header = `${icon} ${titleText}  ${metaText}${cwdMeta.length > 0 ? `  ${theme.fg("muted", cwdMeta.join("  "))}` : ""}`;
+	const selector = runId ? `#${runId}` : (branch ?? "current HEAD");
+	const header = renderStatusLine(
+		{
+			icon: status,
+			spinnerFrame: options.spinnerFrame,
+			title: "GitHub Run Watch",
+			meta: [selector, ...buildOpMeta(args)],
+		},
+		theme,
+	);
 	const wait = theme.fg("dim", "waiting for workflow data...");
 	return new Text(`${header}\n${wait}`, 0, 0);
 }

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -1539,7 +1539,7 @@ function formatCommitRunWatchSnapshot(
 	const completedRuns = runs.filter(run => run.status === "completed").length;
 	const lines: string[] = [`# Watching GitHub Actions for ${formatShortSha(headSha) ?? headSha}`, ""];
 	pushLine(lines, "Repository", repo);
-	pushLine(lines, "Branch", branch);
+	pushLine(lines, "Branch", branch ?? "detached HEAD");
 	pushLine(lines, "Commit", headSha);
 	pushLine(lines, "Poll", pollCount);
 	pushLine(lines, "Runs", runs.length);
@@ -3825,7 +3825,7 @@ async function executeRunWatch(
 		}
 	}
 
-	let branch: string;
+	let branch: string | undefined;
 	let headSha: string;
 	if (branchInput) {
 		branch = branchInput;
@@ -3844,8 +3844,8 @@ async function executeRunWatch(
 				`Cannot infer the watched commit for ${repo}: current checkout is ${cwdRepo ?? "not a GitHub repository"}. Pass \`branch\` or \`run\` to scope the watch.`,
 			);
 		}
-		branch = await requireCurrentGitBranch(cwd, signal);
 		headSha = await requireCurrentGitHead(cwd, signal);
+		branch = (await git.branch.current(cwd, signal)) ?? undefined;
 	}
 	let pollCount = 0;
 	let settledSuccessSignature: string | undefined;

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -19,6 +19,7 @@ import type { ToolSession } from ".";
 import { formatShortSha } from "./gh-format";
 import { type CacheStatus, getOrFetchView, invalidateAllForNumber, resolveGithubCacheAuthKey } from "./github-cache";
 import type { OutputMeta } from "./output-meta";
+import { resolveToCwd } from "./path-utils";
 import { ToolError, throwIfAborted } from "./tool-errors";
 import { toolResult } from "./tool-result";
 
@@ -262,6 +263,7 @@ const githubSchema = type({
 	op: type(
 		"'repo_view' | 'file_read' | 'pr_create' | 'pr_checkout' | 'pr_push' | 'search_issues' | 'search_prs' | 'search_code' | 'search_commits' | 'search_repos' | 'run_watch'",
 	).describe("github operation"),
+	"cwd?": type("string").describe("linked worktree or submodule directory; defaults to session directory"),
 	"repo?": type("string").describe("owner/repo"),
 	"branch?": type("string").describe("branch"),
 	"path?": type("string").describe("repository-relative file path"),
@@ -2479,36 +2481,52 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<GhToolDetails>> {
 		return untilAborted(signal, async () => {
+			const cwdInput = normalizeOptionalString(params.cwd);
+			const cwd = cwdInput ? resolveToCwd(cwdInput, this.session.cwd) : this.session.cwd;
+			if (cwdInput) {
+				try {
+					const stats = await fs.stat(cwd);
+					if (!stats.isDirectory()) {
+						throw new ToolError(`Working directory is not a directory: ${cwd}`);
+					}
+				} catch (err) {
+					if (isEnoent(err)) {
+						throw new ToolError(`Working directory does not exist: ${cwd}`);
+					}
+					throw err;
+				}
+			}
+
 			switch (params.op) {
 				case "repo_view":
-					return executeRepoView(this.session, params, signal);
+					return executeRepoView(cwd, params, signal);
 				case "file_read":
-					return executeFileRead(this.session, params, signal);
+					return executeFileRead(cwd, params, signal);
 				case "pr_create":
-					return executePrCreate(this.session, params, signal);
+					return executePrCreate(cwd, params, signal);
 				case "pr_checkout":
-					return executePrCheckout(this.session, params, signal);
+					return executePrCheckout(cwd, params, signal);
 				case "pr_push":
-					return executePrPush(this.session, params, signal);
+					return executePrPush(cwd, params, signal);
 				case "search_issues":
-					return executeSearchIssues(this.session, params, signal);
+					return executeSearchIssues(cwd, params, signal);
 				case "search_prs":
-					return executeSearchPrs(this.session, params, signal);
+					return executeSearchPrs(cwd, params, signal);
 				case "search_code":
-					return executeSearchCode(this.session, params, signal);
+					return executeSearchCode(cwd, params, signal);
 				case "search_commits":
-					return executeSearchCommits(this.session, params, signal);
+					return executeSearchCommits(cwd, params, signal);
 				case "search_repos":
-					return executeSearchRepos(this.session, params, signal);
+					return executeSearchRepos(cwd, params, signal);
 				case "run_watch":
-					return executeRunWatch(this.session, this.name, params, signal, onUpdate);
+					return executeRunWatch(this.session, this.name, cwd, params, signal, onUpdate);
 			}
 		});
 	}
 }
 
 async function executeRepoView(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -2523,18 +2541,18 @@ async function executeRepoView(
 	}
 	args.push("--json", GH_REPO_FIELDS.join(","));
 
-	const data = await git.github.json<GhRepoViewData>(session.cwd, args, signal, {
+	const data = await git.github.json<GhRepoViewData>(cwd, args, signal, {
 		repoProvided: Boolean(repo),
 	});
 	return buildTextResult(formatRepoView(data, { repo, branch }), data.url);
 }
 
 async function executeFileRead(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
-	const repo = await resolveGitHubRepo(session.cwd, normalizeOptionalString(params.repo), undefined, signal);
+	const repo = await resolveGitHubRepo(cwd, normalizeOptionalString(params.repo), undefined, signal);
 	const filePath = requireNonEmpty(normalizeOptionalString(params.path), "path");
 	if (filePath.startsWith("/")) {
 		throw new ToolError("path must be repository-relative");
@@ -2555,7 +2573,7 @@ async function executeFileRead(
 	if (branch) {
 		args.push("-f", `ref=${branch}`);
 	}
-	const text = await git.github.text(session.cwd, args, signal, {
+	const text = await git.github.text(cwd, args, signal, {
 		repoProvided: true,
 		trimOutput: false,
 	});
@@ -3185,7 +3203,7 @@ function joinSections(sections: string[]): string[] {
 }
 
 async function executePrCheckout(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3196,7 +3214,7 @@ async function executePrCheckout(
 	const isMulti = prRefs.length > 1;
 
 	const settled = await Promise.allSettled(
-		prRefs.map(prRef => checkoutPullRequest(session, signal, { prRef, repo, force })),
+		prRefs.map(prRef => checkoutPullRequest(cwd, signal, { prRef, repo, force })),
 	);
 	const outcomes: PrCheckoutOutcome[] = [];
 	const failures: Array<{ prRef: string | undefined; reason: unknown }> = [];
@@ -3269,7 +3287,7 @@ interface PrCheckoutOutcome {
 }
 
 async function checkoutPullRequest(
-	session: ToolSession,
+	cwd: string,
 	signal: AbortSignal | undefined,
 	options: PrCheckoutOptions,
 ): Promise<PrCheckoutOutcome> {
@@ -3282,7 +3300,7 @@ async function checkoutPullRequest(
 	appendRepoFlag(args, repo, prRef);
 	args.push("--json", GH_PR_CHECKOUT_FIELDS.join(","));
 
-	const data = await git.github.json<GhPrViewData>(session.cwd, args, signal, {
+	const data = await git.github.json<GhPrViewData>(cwd, args, signal, {
 		repoProvided: Boolean(repo),
 	});
 	const prNumber = data.number;
@@ -3292,7 +3310,7 @@ async function checkoutPullRequest(
 
 	const headRefName = requireNonEmpty(data.headRefName, "head branch");
 	const headRefOid = requireNonEmpty(data.headRefOid, "head commit");
-	const repoRoot = await requireGitRepoRoot(session.cwd, signal);
+	const repoRoot = await requireGitRepoRoot(cwd, signal);
 	const primaryRepoRoot = await requirePrimaryGitRepoRoot(repoRoot, signal);
 	const localBranch = `pr-${prNumber}`;
 	const worktreePath = getWorktreeDir(`${prNumber}-${hashPath(primaryRepoRoot)}`);
@@ -3394,11 +3412,11 @@ function outcomeToSummary(outcome: PrCheckoutOutcome): GhPrCheckoutSummary {
 }
 
 async function executePrPush(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
-	const repoRoot = await requireGitRepoRoot(session.cwd, signal);
+	const repoRoot = await requireGitRepoRoot(cwd, signal);
 	const localBranch = normalizeOptionalString(params.branch) ?? (await requireCurrentGitBranch(repoRoot, signal));
 	const refExists = await git.ref.exists(repoRoot, toLocalBranchRef(localBranch), signal);
 	if (!refExists) {
@@ -3443,7 +3461,7 @@ async function executePrPush(
 }
 
 async function executePrCreate(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3492,7 +3510,7 @@ async function executePrCreate(
 			}
 		}
 
-		const output = await git.github.text(session.cwd, args, signal, {
+		const output = await git.github.text(cwd, args, signal, {
 			repoProvided: Boolean(repo),
 		});
 		const url =
@@ -3507,7 +3525,7 @@ async function executePrCreate(
 		if (resolvedRepo && parsed.prNumber !== undefined) {
 			try {
 				prView = await git.github.json<GhPrViewData>(
-					session.cwd,
+					cwd,
 					[
 						"pr",
 						"view",
@@ -3579,7 +3597,7 @@ function formatPrCreateResult(options: {
 }
 
 async function executeSearchIssues(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3587,11 +3605,11 @@ async function executeSearchIssues(
 	const dateField = resolveSearchDateField("issues", params.dateField);
 	const dateQualifier = buildSearchDateQualifier(dateField, params.since, params.until);
 	const displayQuery = composeSearchQuery([params.query, dateQualifier]);
-	const repo = await resolveSearchRepoScope(session.cwd, normalizeOptionalString(params.repo), displayQuery, signal);
+	const repo = await resolveSearchRepoScope(cwd, normalizeOptionalString(params.repo), displayQuery, signal);
 	const apiQuery = composeSearchQuery([displayQuery, repo ? `repo:${repo}` : undefined, "is:issue"]);
 	const args = buildGhApiSearchArgs("issues", apiQuery, limit);
 
-	const response = await git.github.json<GhApiSearchResponse<GhApiSearchIssueItem>>(session.cwd, args, signal);
+	const response = await git.github.json<GhApiSearchResponse<GhApiSearchIssueItem>>(cwd, args, signal);
 	const items = (response.items ?? []).map(apiIssueToSearchResult);
 	return buildTextResult(formatSearchResults("issues", displayQuery, repo, items), undefined, undefined, {
 		useless: items.length === 0,
@@ -3599,7 +3617,7 @@ async function executeSearchIssues(
 }
 
 async function executeSearchPrs(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3607,11 +3625,11 @@ async function executeSearchPrs(
 	const dateField = resolveSearchDateField("prs", params.dateField);
 	const dateQualifier = buildSearchDateQualifier(dateField, params.since, params.until);
 	const displayQuery = composeSearchQuery([params.query, dateQualifier]);
-	const repo = await resolveSearchRepoScope(session.cwd, normalizeOptionalString(params.repo), displayQuery, signal);
+	const repo = await resolveSearchRepoScope(cwd, normalizeOptionalString(params.repo), displayQuery, signal);
 	const apiQuery = composeSearchQuery([displayQuery, repo ? `repo:${repo}` : undefined, "is:pr"]);
 	const args = buildGhApiSearchArgs("issues", apiQuery, limit);
 
-	const response = await git.github.json<GhApiSearchResponse<GhApiSearchIssueItem>>(session.cwd, args, signal);
+	const response = await git.github.json<GhApiSearchResponse<GhApiSearchIssueItem>>(cwd, args, signal);
 	const items = (response.items ?? []).map(apiIssueToSearchResult);
 	return buildTextResult(formatSearchResults("pull requests", displayQuery, repo, items), undefined, undefined, {
 		useless: items.length === 0,
@@ -3619,7 +3637,7 @@ async function executeSearchPrs(
 }
 
 async function executeSearchCode(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3630,11 +3648,11 @@ async function executeSearchCode(
 		throw new ToolError("search_code does not support since/until; GitHub code search has no date qualifier.");
 	}
 	const limit = resolveSearchLimit(params.limit);
-	const repo = await resolveSearchRepoScope(session.cwd, normalizeOptionalString(params.repo), query, signal);
+	const repo = await resolveSearchRepoScope(cwd, normalizeOptionalString(params.repo), query, signal);
 	const apiQuery = composeSearchQuery([query, repo ? `repo:${repo}` : undefined]);
 	const args = buildGhApiSearchArgs("code", apiQuery, limit, ["Accept: application/vnd.github.text-match+json"]);
 
-	const response = await git.github.json<GhApiSearchResponse<GhApiSearchCodeItem>>(session.cwd, args, signal);
+	const response = await git.github.json<GhApiSearchResponse<GhApiSearchCodeItem>>(cwd, args, signal);
 	const items = (response.items ?? []).map(apiCodeToSearchResult);
 	return buildTextResult(formatSearchCodeResults(query, repo, items), undefined, undefined, {
 		useless: items.length === 0,
@@ -3642,7 +3660,7 @@ async function executeSearchCode(
 }
 
 async function executeSearchCommits(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3650,11 +3668,11 @@ async function executeSearchCommits(
 	const dateField = resolveSearchDateField("commits", params.dateField);
 	const dateQualifier = buildSearchDateQualifier(dateField, params.since, params.until);
 	const displayQuery = composeSearchQuery([params.query, dateQualifier]);
-	const repo = await resolveSearchRepoScope(session.cwd, normalizeOptionalString(params.repo), displayQuery, signal);
+	const repo = await resolveSearchRepoScope(cwd, normalizeOptionalString(params.repo), displayQuery, signal);
 	const apiQuery = composeSearchQuery([displayQuery, repo ? `repo:${repo}` : undefined]);
 	const args = buildGhApiSearchArgs("commits", apiQuery, limit);
 
-	const response = await git.github.json<GhApiSearchResponse<GhApiSearchCommitItem>>(session.cwd, args, signal);
+	const response = await git.github.json<GhApiSearchResponse<GhApiSearchCommitItem>>(cwd, args, signal);
 	const items = (response.items ?? []).map(apiCommitToSearchResult);
 	return buildTextResult(formatSearchCommitsResults(displayQuery, repo, items), undefined, undefined, {
 		useless: items.length === 0,
@@ -3662,7 +3680,7 @@ async function executeSearchCommits(
 }
 
 async function executeSearchRepos(
-	session: ToolSession,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
@@ -3672,7 +3690,7 @@ async function executeSearchRepos(
 	const query = composeSearchQuery([params.query, dateQualifier]);
 	const args = buildGhApiSearchArgs("repositories", query, limit);
 
-	const response = await git.github.json<GhApiSearchResponse<GhApiSearchRepoItem>>(session.cwd, args, signal);
+	const response = await git.github.json<GhApiSearchResponse<GhApiSearchRepoItem>>(cwd, args, signal);
 	const items = (response.items ?? []).map(apiRepoToSearchResult);
 	return buildTextResult(formatSearchReposResults(query, items), undefined, undefined, {
 		useless: items.length === 0,
@@ -3682,6 +3700,7 @@ async function executeSearchRepos(
 async function executeRunWatch(
 	session: ToolSession,
 	toolName: string,
+	cwd: string,
 	params: GithubInput,
 	signal: AbortSignal | undefined,
 	onUpdate: AgentToolUpdateCallback<GhToolDetails> | undefined,
@@ -3689,7 +3708,7 @@ async function executeRunWatch(
 	const branchInput = normalizeOptionalString(params.branch);
 	const explicitRepo = normalizeOptionalString(params.repo);
 	const runReference = parseRunReference(params.run);
-	const repo = await resolveGitHubRepo(session.cwd, explicitRepo, runReference.repo, signal);
+	const repo = await resolveGitHubRepo(cwd, explicitRepo, runReference.repo, signal);
 	const graceSeconds = RUN_WATCH_GRACE_DEFAULT;
 	const tail = resolveTailLimit(params.tail);
 	const watchStartMs = Date.now();
@@ -3718,7 +3737,7 @@ async function executeRunWatch(
 
 			let run: GhRunSnapshot;
 			try {
-				run = await fetchRunSnapshot(session.cwd, repo, runId, signal);
+				run = await fetchRunSnapshot(cwd, repo, runId, signal);
 			} catch (err) {
 				await handlePollError(err);
 				continue;
@@ -3754,7 +3773,7 @@ async function executeRunWatch(
 					});
 					await scheduler.wait(graceSeconds * 1000, { signal });
 					try {
-						const refetched = await fetchRunSnapshot(session.cwd, repo, runId, signal);
+						const refetched = await fetchRunSnapshot(cwd, repo, runId, signal);
 						const refetchedFailed = refetched.jobs.filter(isFailedJob);
 						// An auto-retry can reset job conclusions between
 						// detection and refetch; keep the originally-detected
@@ -3772,7 +3791,7 @@ async function executeRunWatch(
 				}
 
 				const failedJobLogs = await fetchFailedJobLogs(
-					session.cwd,
+					cwd,
 					repo,
 					failedJobs.map(job => ({ run, job })),
 					tail,
@@ -3810,7 +3829,7 @@ async function executeRunWatch(
 	let headSha: string;
 	if (branchInput) {
 		branch = branchInput;
-		headSha = await resolveGitHubBranchHead(session.cwd, repo, branch, signal);
+		headSha = await resolveGitHubBranchHead(cwd, repo, branch, signal);
 	} else {
 		// No branch/run selector — derive the commit from the current checkout,
 		// but only when cwd actually points at `repo`. Otherwise we'd watch an
@@ -3819,14 +3838,14 @@ async function executeRunWatch(
 		// are case-insensitive — `gh repo view` returns the canonical casing
 		// while callers may pass any casing — so the equality check normalizes
 		// both sides before deciding the cwd is a different repo (PR #1951).
-		const cwdRepo = await tryResolveCurrentRepoFresh(session.cwd, signal);
+		const cwdRepo = await tryResolveCurrentRepoFresh(cwd, signal);
 		if (!githubRepoSlugEquals(cwdRepo, repo)) {
 			throw new ToolError(
 				`Cannot infer the watched commit for ${repo}: current checkout is ${cwdRepo ?? "not a GitHub repository"}. Pass \`branch\` or \`run\` to scope the watch.`,
 			);
 		}
-		branch = await requireCurrentGitBranch(session.cwd, signal);
-		headSha = await requireCurrentGitHead(session.cwd, signal);
+		branch = await requireCurrentGitBranch(cwd, signal);
+		headSha = await requireCurrentGitHead(cwd, signal);
 	}
 	let pollCount = 0;
 	let settledSuccessSignature: string | undefined;
@@ -3839,7 +3858,7 @@ async function executeRunWatch(
 
 		let runs: GhRunSnapshot[];
 		try {
-			runs = await fetchRunsForCommit(session.cwd, repo, headSha, signal, completedRunJobsCache);
+			runs = await fetchRunsForCommit(cwd, repo, headSha, signal, completedRunJobsCache);
 		} catch (err) {
 			await handlePollError(err);
 			continue;
@@ -3875,7 +3894,7 @@ async function executeRunWatch(
 				});
 				await scheduler.wait(graceSeconds * 1000, { signal });
 				try {
-					const refetched = await fetchRunsForCommit(session.cwd, repo, headSha, signal, completedRunJobsCache);
+					const refetched = await fetchRunsForCommit(cwd, repo, headSha, signal, completedRunJobsCache);
 					const refetchedPairs = refetched.flatMap(run => run.jobs.filter(isFailedJob).map(job => ({ run, job })));
 					// Keep the originally-detected failure list when an
 					// auto-retry reset the conclusions during the grace window
@@ -3890,7 +3909,7 @@ async function executeRunWatch(
 				}
 			}
 
-			const failedJobLogs = await fetchFailedJobLogs(session.cwd, repo, failedPairs, tail, signal);
+			const failedJobLogs = await fetchFailedJobLogs(cwd, repo, failedPairs, tail, signal);
 			const finalDetails = buildCommitRunWatchDetails(repo, headSha, branch, runs, {
 				state: "completed",
 				failedJobLogs,

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -147,11 +147,13 @@ async function createSubmoduleContextFixture(): Promise<{
 	runGit(parentRoot, ["commit", "-am", "add submodule"]);
 
 	const submoduleRoot = path.join(parentRoot, "submodule");
+	const submoduleHead = runGit(submoduleRoot, ["rev-parse", "HEAD"]);
+	runGit(submoduleRoot, ["checkout", "--detach", submoduleHead]);
 	return {
 		baseDir,
 		parentRoot,
 		submoduleRoot,
-		submoduleHead: runGit(submoduleRoot, ["rev-parse", "HEAD"]),
+		submoduleHead,
 	};
 }
 
@@ -590,7 +592,7 @@ describe("github tool", () => {
 		}
 	});
 
-	it("uses the selected submodule repository, branch, and HEAD for run_watch", async () => {
+	it("uses the selected detached submodule HEAD for run_watch", async () => {
 		const fixture = await createSubmoduleContextFixture();
 		const textSpy = vi
 			.spyOn(git.github, "text")
@@ -600,18 +602,22 @@ describe("github tool", () => {
 			const tool = new GithubTool(createSession(fixture.parentRoot));
 			const abort = new AbortController();
 			let details: { repo?: string; branch?: string; headSha?: string } | undefined;
+			let text: string | undefined;
 			await tool
 				.execute("watch-submodule", { op: "run_watch", cwd: "submodule" }, abort.signal, update => {
 					details = update.details;
+					const content = update.content[0];
+					if (content?.type === "text") text = content.text;
 					abort.abort();
 				})
 				.catch(() => {});
 
 			expect(details).toMatchObject({
 				repo: "owner/submodule",
-				branch: "submodule-main",
 				headSha: fixture.submoduleHead,
 			});
+			expect(details?.branch).toBeUndefined();
+			expect(text).toContain("Branch: detached HEAD");
 			expect(textSpy.mock.calls.filter(call => call[0] === fixture.submoduleRoot)).toHaveLength(2);
 			expect(jsonSpy.mock.calls.some(call => call[0] === fixture.submoduleRoot)).toBe(true);
 		} finally {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -652,6 +652,21 @@ describe("github tool", () => {
 		expect(resultText).toContain("linked-feature");
 	});
 
+	it("flattens newline-bearing cwd metadata in the run_watch pending header", () => {
+		const args = {
+			op: "run_watch",
+			cwd: path.join(process.cwd(), "linked\nspoofed-header"),
+		};
+		const options = { expanded: false } as Parameters<typeof githubToolRenderer.renderCall>[1];
+		const lines = Bun.stripANSI(githubToolRenderer.renderCall(args, options, theme).render(120).join("\n")).split(
+			"\n",
+		);
+
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toContain("linked spoofed-header");
+		expect(lines[1]).toContain("waiting for workflow data");
+	});
+
 	it("reads repository files through the GitHub contents API", async () => {
 		const textSpy = vi.spyOn(git.github, "text").mockResolvedValue('{"version":"16.3.11"}\n');
 		const tool = new GithubTool(createSession());

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -6,6 +6,7 @@ import type { ToolCall } from "@oh-my-pi/pi-ai";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { validateToolArguments } from "@oh-my-pi/pi-ai/utils/validation";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	buildSearchDateQualifier,
@@ -15,6 +16,7 @@ import {
 	parseSearchDateBound,
 	resolveDefaultRepoMemoized,
 } from "@oh-my-pi/pi-coding-agent/tools/gh";
+import { githubToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/gh-renderer";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 import { getAgentDir, hashPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
@@ -41,7 +43,7 @@ process.env.GIT_ASKPASS = "true";
 delete process.env.XDG_CONFIG_HOME;
 
 function createSession(
-	cwd: string = "/tmp/test",
+	cwd: string = os.tmpdir(),
 	settings: Settings = Settings.isolated({ "github.enabled": true }),
 	artifactsDir?: string,
 ): ToolSession {
@@ -86,6 +88,71 @@ function runGit(cwd: string, args: string[]): string {
 	}
 
 	return new TextDecoder().decode(result.stdout).trim();
+}
+
+async function createWorktreeContextFixture(): Promise<{
+	baseDir: string;
+	primaryRoot: string;
+	worktreeRoot: string;
+	primaryHead: string;
+	worktreeHead: string;
+}> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "gh-cwd-worktree-"));
+	const primaryRoot = path.join(baseDir, "primary");
+	const worktreeRoot = path.join(baseDir, "feature");
+	await fs.mkdir(primaryRoot);
+
+	runGit(primaryRoot, ["init", "-b", "main"]);
+	await Bun.write(path.join(primaryRoot, "primary.txt"), "primary\n");
+	runGit(primaryRoot, ["add", "primary.txt"]);
+	runGit(primaryRoot, ["commit", "-m", "primary"]);
+	const primaryHead = runGit(primaryRoot, ["rev-parse", "HEAD"]);
+
+	runGit(primaryRoot, ["worktree", "add", "-b", "feature/worktree", worktreeRoot]);
+	await Bun.write(path.join(worktreeRoot, "worktree.txt"), "worktree\n");
+	runGit(worktreeRoot, ["add", "worktree.txt"]);
+	runGit(worktreeRoot, ["commit", "-m", "worktree"]);
+
+	return {
+		baseDir,
+		primaryRoot,
+		worktreeRoot,
+		primaryHead,
+		worktreeHead: runGit(worktreeRoot, ["rev-parse", "HEAD"]),
+	};
+}
+
+async function createSubmoduleContextFixture(): Promise<{
+	baseDir: string;
+	parentRoot: string;
+	submoduleRoot: string;
+	submoduleHead: string;
+}> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "gh-cwd-submodule-"));
+	const submoduleSource = path.join(baseDir, "submodule-source");
+	const parentRoot = path.join(baseDir, "parent");
+	await fs.mkdir(submoduleSource);
+	await fs.mkdir(parentRoot);
+
+	runGit(submoduleSource, ["init", "-b", "submodule-main"]);
+	await Bun.write(path.join(submoduleSource, "submodule.txt"), "submodule\n");
+	runGit(submoduleSource, ["add", "submodule.txt"]);
+	runGit(submoduleSource, ["commit", "-m", "submodule"]);
+
+	runGit(parentRoot, ["init", "-b", "main"]);
+	await Bun.write(path.join(parentRoot, "parent.txt"), "parent\n");
+	runGit(parentRoot, ["add", "parent.txt"]);
+	runGit(parentRoot, ["commit", "-m", "parent"]);
+	runGit(parentRoot, ["-c", "protocol.file.allow=always", "submodule", "add", submoduleSource, "submodule"]);
+	runGit(parentRoot, ["commit", "-am", "add submodule"]);
+
+	const submoduleRoot = path.join(parentRoot, "submodule");
+	return {
+		baseDir,
+		parentRoot,
+		submoduleRoot,
+		submoduleHead: runGit(submoduleRoot, ["rev-parse", "HEAD"]),
+	};
 }
 
 interface PrFixture {
@@ -394,6 +461,7 @@ describe("getOrFetchPrDiff diff-too-large fallback", () => {
 
 describe("github tool", () => {
 	beforeAll(async () => {
+		await initTheme();
 		prFixtureTemplate = await buildPrFixtureTemplate();
 	});
 
@@ -438,6 +506,152 @@ describe("github tool", () => {
 		expect(text).toContain("Topics: cli, github");
 	});
 
+	it("targets a sibling worktree through cwd and preserves the session checkout", async () => {
+		const fixture = await createWorktreeContextFixture();
+		const jsonSpy = vi.spyOn(git.github, "json").mockResolvedValue({
+			nameWithOwner: "owner/repo",
+			url: "https://github.com/owner/repo",
+		});
+		try {
+			const tool = new GithubTool(createSession(fixture.primaryRoot));
+			const worktreeCwd = path.relative(fixture.primaryRoot, fixture.worktreeRoot);
+			await tool.execute("repo-view-worktree", { op: "repo_view", cwd: worktreeCwd });
+			await tool.execute("repo-view-primary", { op: "repo_view" });
+
+			expect(jsonSpy.mock.calls[0]?.[0]).toBe(fixture.worktreeRoot);
+			expect(jsonSpy.mock.calls[1]?.[0]).toBe(fixture.primaryRoot);
+			expect(jsonSpy.mock.calls[0]?.[1]?.slice(0, 2)).toEqual(["repo", "view"]);
+		} finally {
+			await removeWithRetries(fixture.baseDir);
+		}
+	});
+
+	it("rejects missing and non-directory cwd overrides", async () => {
+		const fixture = await createWorktreeContextFixture();
+		const filePath = path.join(fixture.primaryRoot, "primary.txt");
+		try {
+			const tool = new GithubTool(createSession(fixture.primaryRoot));
+			await expect(tool.execute("missing-cwd", { op: "repo_view", cwd: "missing" })).rejects.toThrow(
+				`Working directory does not exist: ${path.join(fixture.primaryRoot, "missing")}`,
+			);
+			await expect(tool.execute("file-cwd", { op: "repo_view", cwd: filePath })).rejects.toThrow(
+				`Working directory is not a directory: ${filePath}`,
+			);
+		} finally {
+			await removeWithRetries(fixture.baseDir);
+		}
+	});
+
+	it("uses the selected worktree branch and HEAD for run_watch", async () => {
+		const fixture = await createWorktreeContextFixture();
+		const textSpy = vi.spyOn(git.github, "text").mockResolvedValue("owner/repo");
+		const jsonSpy = vi.spyOn(git.github, "json").mockResolvedValue({ workflow_runs: [] });
+		try {
+			const tool = new GithubTool(createSession(fixture.primaryRoot));
+			const worktreeAbort = new AbortController();
+			let worktreeDetails: { repo?: string; branch?: string; headSha?: string } | undefined;
+			await tool
+				.execute(
+					"watch-worktree",
+					{ op: "run_watch", cwd: path.relative(fixture.primaryRoot, fixture.worktreeRoot) },
+					worktreeAbort.signal,
+					update => {
+						worktreeDetails = update.details;
+						worktreeAbort.abort();
+					},
+				)
+				.catch(() => {});
+
+			const primaryAbort = new AbortController();
+			let primaryDetails: { repo?: string; branch?: string; headSha?: string } | undefined;
+			await tool
+				.execute("watch-primary", { op: "run_watch" }, primaryAbort.signal, update => {
+					primaryDetails = update.details;
+					primaryAbort.abort();
+				})
+				.catch(() => {});
+
+			expect(worktreeDetails).toMatchObject({
+				repo: "owner/repo",
+				branch: "feature/worktree",
+				headSha: fixture.worktreeHead,
+			});
+			expect(primaryDetails).toMatchObject({
+				repo: "owner/repo",
+				branch: "main",
+				headSha: fixture.primaryHead,
+			});
+			expect(textSpy.mock.calls.filter(call => call[0] === fixture.worktreeRoot)).toHaveLength(2);
+			expect(textSpy.mock.calls.filter(call => call[0] === fixture.primaryRoot)).toHaveLength(2);
+			expect(jsonSpy.mock.calls.some(call => call[0] === fixture.worktreeRoot)).toBe(true);
+			expect(jsonSpy.mock.calls.some(call => call[0] === fixture.primaryRoot)).toBe(true);
+		} finally {
+			await removeWithRetries(fixture.baseDir);
+		}
+	});
+
+	it("uses the selected submodule repository, branch, and HEAD for run_watch", async () => {
+		const fixture = await createSubmoduleContextFixture();
+		const textSpy = vi
+			.spyOn(git.github, "text")
+			.mockImplementation(async cwd => (cwd === fixture.submoduleRoot ? "owner/submodule" : "owner/parent"));
+		const jsonSpy = vi.spyOn(git.github, "json").mockResolvedValue({ workflow_runs: [] });
+		try {
+			const tool = new GithubTool(createSession(fixture.parentRoot));
+			const abort = new AbortController();
+			let details: { repo?: string; branch?: string; headSha?: string } | undefined;
+			await tool
+				.execute("watch-submodule", { op: "run_watch", cwd: "submodule" }, abort.signal, update => {
+					details = update.details;
+					abort.abort();
+				})
+				.catch(() => {});
+
+			expect(details).toMatchObject({
+				repo: "owner/submodule",
+				branch: "submodule-main",
+				headSha: fixture.submoduleHead,
+			});
+			expect(textSpy.mock.calls.filter(call => call[0] === fixture.submoduleRoot)).toHaveLength(2);
+			expect(jsonSpy.mock.calls.some(call => call[0] === fixture.submoduleRoot)).toBe(true);
+		} finally {
+			await removeWithRetries(fixture.baseDir);
+		}
+	});
+
+	it("shows the selected worktree in run_watch call and result renderers", () => {
+		const args = { op: "run_watch", cwd: path.join(process.cwd(), "linked-feature") };
+		const options = { expanded: true } as Parameters<typeof githubToolRenderer.renderResult>[1];
+		const callText = Bun.stripANSI(githubToolRenderer.renderCall(args, options, theme).render(120).join("\n"));
+		const resultText = Bun.stripANSI(
+			githubToolRenderer
+				.renderResult(
+					{
+						content: [{ type: "text", text: "watching" }],
+						details: {
+							watch: {
+								mode: "commit",
+								state: "watching",
+								repo: "owner/repo",
+								branch: "feature/worktree",
+								headSha: "0123456789abcdef",
+								pollCount: 1,
+								runs: [],
+							},
+						},
+					},
+					options,
+					theme,
+					args,
+				)
+				.render(120)
+				.join("\n"),
+		);
+
+		expect(callText).toContain("linked-feature");
+		expect(resultText).toContain("linked-feature");
+	});
+
 	it("reads repository files through the GitHub contents API", async () => {
 		const textSpy = vi.spyOn(git.github, "text").mockResolvedValue('{"version":"16.3.11"}\n');
 		const tool = new GithubTool(createSession());
@@ -451,7 +665,7 @@ describe("github tool", () => {
 
 		expect(text).toBe('{"version":"16.3.11"}\n');
 		expect(textSpy).toHaveBeenCalledWith(
-			"/tmp/test",
+			os.tmpdir(),
 			[
 				"api",
 				"/repos/can1357/oh-my-pi/contents/packages/coding-agent/package.json",
@@ -1209,6 +1423,7 @@ exec ${JSON.stringify(realGit)} "$@"
 		const wire = toolWireSchema(tool);
 		const properties = wire.properties as Record<string, unknown>;
 		expect(properties.op).toBeDefined();
+		expect(properties.cwd).toBeDefined();
 		expect(properties.interval).toBeUndefined();
 		expect(properties.grace).toBeUndefined();
 	});
@@ -1258,7 +1473,7 @@ exec ${JSON.stringify(realGit)} "$@"
 
 		try {
 			const tool = new GithubTool(
-				createSession("/tmp/test", Settings.isolated({ "github.enabled": true }), artifactsDir),
+				createSession(os.tmpdir(), Settings.isolated({ "github.enabled": true }), artifactsDir),
 			);
 			const result = await tool.execute("run-watch", {
 				op: "run_watch",


### PR DESCRIPTION
## What

Support worktrees and submodules in the native GitHub tool.

- Add a per-call `cwd` selector to every GitHub operation.
- Resolve repository, branch, HEAD, remotes, PR metadata, and Actions context from the selected checkout.
- Show the selected checkout in normal and `run_watch` render paths.
- Document and test linked worktree and Git submodule behavior.

## Why

GitHub operations previously stayed rooted at the session directory, so a session could not reliably target another linked checkout without moving the session or manually supplying every inferred value.

## Testing

- `bun test packages/coding-agent/test/tools/gh.test.ts` — 51 pass, 0 fail.
- `bun test packages/coding-agent/test/tools/gh.test.ts --test-name-pattern "worktree|submodule|cwd override"` — 6 pass, 0 fail.
- `CMAKE_POLICY_VERSION_MINIMUM=3.5 bun check` — pass.
- Live `GithubTool` `repo_view` smoke from the parent session with the feature worktree supplied as `cwd` — resolved `can1357/oh-my-pi` successfully.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)