### PR TITLE
fix(fetch): add SSRF guard to block requests to internal addresses

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardened `isLocalOrMetadataHost` to catch IPv4-mapped IPv6 and expanded address forms that previously bypassed the string-based checks.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -45,6 +45,7 @@ export * from "./usage/zai";
 export * from "./utils/anthropic-auth";
 export * from "./utils/event-stream";
 export * from "./utils/openrouter-headers";
+export * from "./utils/proxy";
 export * from "./utils/retry";
 export * from "./utils/schema";
 export * from "./utils/thinking-loop";

--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -6,7 +6,34 @@ import type { FetchImpl } from "../types";
 /**
  * Checks if a host is local or cloud metadata, which should always bypass the proxy
  * (e.g. localhost, 127/8, ::1, 169.254.169.254, metadata.google.internal).
+ *
+ * Uses `node:net.BlockList` so that all address normalization is handled by the
+ * runtime — IPv4-mapped IPv6 (`::ffff:127.0.0.1`), fully-expanded forms
+ * (`0:0:0:0:0:0:0:1`), and other representations that string matching missed are
+ * now caught. This is the single classifier shared by provider proxy bypass
+ * decisions and the fetch-tool SSRF guard.
+ *
+ * Limitation: this validates the hostname string only. A public DNS name that
+ * resolves to a private IP (DNS rebinding) is NOT caught here; full mitigation
+ * requires resolving the host before connecting and is out of scope for the
+ * fetch() API surface.
  */
+// Module-level BlockList — built once; address checks are O(1) and side-effect free.
+const privateAddressBlockList = new net.BlockList();
+privateAddressBlockList.addRange("127.0.0.0", "127.255.255.255", "ipv4"); // loopback 127/8
+privateAddressBlockList.addRange("0.0.0.0", "0.255.255.255", "ipv4"); // unspecified 0/8
+privateAddressBlockList.addRange("10.0.0.0", "10.255.255.255", "ipv4"); // RFC1918 10/8
+privateAddressBlockList.addRange("172.16.0.0", "172.31.255.255", "ipv4"); // RFC1918 172.16/12
+privateAddressBlockList.addRange("192.168.0.0", "192.168.255.255", "ipv4"); // RFC1918 192.168/16
+// link-local 169.254/16 — covers IMDS 169.254.169.254 and ECS credentials 169.254.170.2
+privateAddressBlockList.addRange("169.254.0.0", "169.254.255.255", "ipv4");
+// IPv6 loopback ::1, unspecified ::, link-local fe80::/10, unique-local fc00::/7
+// (covers EC2 IPv6 IMDS fd00:ec2::254).
+privateAddressBlockList.addAddress("::1", "ipv6");
+privateAddressBlockList.addAddress("::", "ipv6");
+privateAddressBlockList.addRange("fe80::", "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ipv6");
+privateAddressBlockList.addRange("fc00::", "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ipv6");
+
 export function isLocalOrMetadataHost(host: string): boolean {
 	const lowerHost = host.toLowerCase();
 
@@ -18,26 +45,14 @@ export function isLocalOrMetadataHost(host: string): boolean {
 	// Strip IPv6 brackets before numeric checks.
 	const ip = lowerHost.replace(/^\[|\]$/g, "");
 
-	// IPv4 loopback (127/8), unspecified (0/8), RFC1918 private (10/8, 172.16/12,
-	// 192.168/16) and link-local (169.254/16 — covers IMDS 169.254.169.254 and
-	// ECS credentials 169.254.170.2). None are reachable through a remote egress
-	// proxy, and credential/metadata probes must never leak to one.
-	const v4 = ip.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
-	if (v4) {
-		const a = Number(v4[1]);
-		const b = Number(v4[2]);
-		if (a === 127 || a === 10 || a === 0) return true;
-		if (a === 169 && b === 254) return true;
-		if (a === 192 && b === 168) return true;
-		if (a === 172 && b >= 16 && b <= 31) return true;
-		return false;
+	// Use the runtime's address normalization: BlockList.check handles
+	// canonicalization of every IP form (IPv4, IPv6, mapped, compressed,
+	// expanded) so string-matching bypass vectors like `::ffff:127.0.0.1` or
+	// `0:0:0:0:0:0:0:1` are caught.
+	const family = net.isIP(ip);
+	if (family === 4 || family === 6) {
+		return privateAddressBlockList.check(ip, family === 4 ? "ipv4" : "ipv6");
 	}
-
-	// IPv6 loopback (::1), unspecified (::), link-local (fe80::/10) and
-	// unique-local (fc00::/7 — covers EC2 IPv6 IMDS fd00:ec2::254).
-	if (ip === "::1" || ip === "::") return true;
-	if (/^fe[89ab][0-9a-f]:/.test(ip)) return true;
-	if (/^f[cd][0-9a-f]{2}:/.test(ip)) return true;
 
 	return false;
 }

--- a/packages/ai/test/proxy.test.ts
+++ b/packages/ai/test/proxy.test.ts
@@ -191,7 +191,21 @@ describe("isLocalOrMetadataHost / shouldBypassProxy hard-coded ranges", () => {
 	}
 
 	// IPv6 hosts need bracket form inside a URL.
-	const bypassedV6 = ["::1", "fd00:ec2::254", "fe80::1"];
+	const bypassedV6 = [
+		"::1",
+		"fd00:ec2::254",
+		"fe80::1",
+		"::", // unspecified
+		// IPv4-mapped IPv6 — these previously bypassed string-based checks.
+		"::ffff:127.0.0.1",
+		"::ffff:10.0.0.1",
+		"::ffff:192.168.1.1",
+		"::ffff:172.16.0.1",
+		"::ffff:169.254.169.254",
+		// Fully-expanded forms that are equivalent to compressed addresses.
+		"0:0:0:0:0:0:0:1", // == ::1
+		"0000:0000:0000:0000:0000:0000:0000:0001", // == ::1
+	];
 	for (const host of bypassedV6) {
 		it(`bypasses [${host}]`, () => {
 			expect(isLocalOrMetadataHost(host)).toBe(true);
@@ -205,11 +219,17 @@ describe("isLocalOrMetadataHost / shouldBypassProxy hard-coded ranges", () => {
 		"172.15.0.1", // just below the 172.16/12 block
 		"172.32.0.1", // just above the 172.16/12 block
 		"11.0.0.1", // not RFC1918
+		"8.8.8.8", // public DNS
+		"1.1.1.1", // public DNS
+		"::ffff:8.8.8.8", // IPv4-mapped public — must NOT be flagged
+		"2606:4700:4700::1111", // public IPv6 (Cloudflare)
 	];
 	for (const host of proxied) {
 		it(`does not bypass ${host}`, () => {
 			expect(isLocalOrMetadataHost(host)).toBe(false);
-			expect(shouldBypassProxy(new URL(`https://${host}/x`))).toBe(false);
+			// IPv6 hosts need bracket form inside a URL.
+			const urlHost = host.includes(":") ? `[${host}]` : host;
+			expect(shouldBypassProxy(new URL(`https://${urlHost}/x`))).toBe(false);
 		});
 	}
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed missing SSRF guard in the fetch tool — requests to loopback, RFC1918 private, link-local, and cloud-metadata addresses are now refused before and after every redirect.
+- Fixed missing SSRF guard in the fetch tool — requests to loopback, RFC1918 private, link-local, and cloud-metadata addresses are now refused before and after every redirect. Cross-protocol redirects to `file:` and `data:` targets are rejected; redirect loop exhaustion in `fetchBinary` now returns the correct error; and 301/302/303 redirects downgrade POST to GET per RFC 9110.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed missing SSRF guard in the fetch tool — requests to loopback, RFC1918 private, link-local, and cloud-metadata addresses are now refused before and after every redirect.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/web/scrapers/types.ts
+++ b/packages/coding-agent/src/web/scrapers/types.ts
@@ -2,6 +2,7 @@
  * Shared types and utilities for web-fetch handlers
  */
 import { scheduler } from "node:timers/promises";
+import { isLocalOrMetadataHost } from "@oh-my-pi/pi-ai";
 import { ptree } from "@oh-my-pi/pi-utils";
 import type TurndownService from "turndown";
 
@@ -30,6 +31,8 @@ export type SpecialHandler = (
 
 export const MAX_OUTPUT_CHARS = 500_000;
 export const MAX_BYTES = 50 * 1024 * 1024;
+/** Maximum HTTP redirects to follow manually (matches Node's default). */
+export const MAX_REDIRECTS = 10;
 
 const USER_AGENTS = [
 	"curl/8.0",
@@ -133,10 +136,96 @@ function decodeBody(bytes: Buffer, contentTypeHeader: string): string {
 }
 
 /**
+ * Error thrown when the SSRF guard blocks a URL or redirect target.
+ * Carries the refused hostname so callers can surface a clear message.
+ */
+class SsrfBlockedError extends Error {
+	readonly host: string;
+	constructor(host: string) {
+		super(`Refused to fetch non-public address: ${host}`);
+		this.name = "SsrfBlockedError";
+		this.host = host;
+	}
+}
+
+/**
+ * Check a URL's hostname against the SSRF blocklist. Returns a `LoadPageResult`
+ * error when the host is private/loopback/link-local/metadata, otherwise `null`.
+ */
+function checkSsrfGuard(url: string): LoadPageResult | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		// Unparseable URL — let fetch surface the error; not an SSRF concern.
+		return null;
+	}
+	if (isLocalOrMetadataHost(parsed.hostname)) {
+		return {
+			content: "",
+			contentType: "",
+			finalUrl: url,
+			ok: false,
+			error: `Refused to fetch non-public address: ${parsed.hostname}`,
+		};
+	}
+	return null;
+}
+
+/**
+ * Fetch a URL following redirects manually, SSRF-checking every hop.
+ * Throws {@link SsrfBlockedError} if any redirect target resolves to a
+ * non-public address. Returns the final (non-redirect) response and the
+ * final URL after all redirects.
+ */
+async function fetchWithRedirectGuard(
+	url: string,
+	requestInit: RequestInit,
+	signal?: AbortSignal,
+): Promise<{ response: Response; finalUrl: string }> {
+	let currentUrl = url;
+	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+		if (signal?.aborted) {
+			throw new ToolAbortError();
+		}
+		const response = await fetch(currentUrl, requestInit);
+		// Non-3xx (or 3xx without Location) — terminal response.
+		if (response.status < 300 || response.status >= 400 || response.status === 304) {
+			return { response, finalUrl: currentUrl };
+		}
+		const location = response.headers.get("location");
+		if (!location) {
+			return { response, finalUrl: currentUrl };
+		}
+		void response.body?.cancel().catch(() => {});
+		// Resolve the redirect target relative to the current URL.
+		const redirectUrl = new URL(location, currentUrl).href;
+		const redirectHost = new URL(redirectUrl).hostname;
+		if (isLocalOrMetadataHost(redirectHost)) {
+			throw new SsrfBlockedError(redirectHost);
+		}
+		currentUrl = redirectUrl;
+	}
+	// Exceeded MAX_REDIRECTS — return a synthetic error response.
+	throw new Error(`Redirect loop exceeded ${MAX_REDIRECTS} hops`);
+}
+
+/**
  * Fetch a page with timeout and size limit
+ *
+ * SSRF guard: the initial URL hostname and every redirect target are validated
+ * with {@link isLocalOrMetadataHost} before connecting. Redirects are followed
+ * manually (not via `redirect: "follow"`) so a public URL that 302-redirects to
+ * an internal address cannot bypass the guard. Limitation: this checks the
+ * hostname string only — DNS rebinding (a public name resolving to a private IP)
+ * is not caught; full mitigation requires resolving before connecting.
  */
 export async function loadPage(url: string, options: LoadPageOptions = {}): Promise<LoadPageResult> {
 	const { timeout = 20, headers = {}, maxBytes = MAX_BYTES, signal, method = "GET", body } = options;
+
+	// SSRF guard: refuse non-public addresses before any network activity.
+	const ssrfError = checkSsrfGuard(url);
+	if (ssrfError) return ssrfError;
 
 	let lastError: string | undefined;
 	let retried429 = false;
@@ -159,18 +248,18 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 					"Accept-Encoding": "identity", // Cloudflare Markdown-for-Agents returns corrupted bytes when compression is negotiated
 					...headers,
 				},
-				redirect: "follow",
+				redirect: "manual",
 			};
 
 			if (body !== undefined) {
 				requestInit.body = body;
 			}
 
-			const response = await fetch(url, requestInit);
+			// Follow redirects manually so every hop's hostname is SSRF-checked.
+			const { response, finalUrl } = await fetchWithRedirectGuard(url, requestInit, signal);
 
 			const rawContentType = response.headers.get("content-type") ?? "";
 			const contentType = rawContentType.split(";")[0]?.trim().toLowerCase() ?? "";
-			const finalUrl = response.url;
 
 			if (response.status === 429 && !retried429) {
 				// Rate limited: retry once, honoring a bounded Retry-After. The
@@ -229,6 +318,10 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 		} catch (error) {
 			if (signal?.aborted) {
 				throw new ToolAbortError();
+			}
+			const message = error instanceof SsrfBlockedError ? error.message : undefined;
+			if (message) {
+				return { content: "", contentType: "", finalUrl: url, ok: false, error: message };
 			}
 			lastError = error instanceof Error ? error.message : String(error);
 			if (attempt === USER_AGENTS.length - 1) {

--- a/packages/coding-agent/src/web/scrapers/types.ts
+++ b/packages/coding-agent/src/web/scrapers/types.ts
@@ -184,11 +184,12 @@ async function fetchWithRedirectGuard(
 	signal?: AbortSignal,
 ): Promise<{ response: Response; finalUrl: string }> {
 	let currentUrl = url;
+	let currentInit = requestInit;
 	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
 		if (signal?.aborted) {
 			throw new ToolAbortError();
 		}
-		const response = await fetch(currentUrl, requestInit);
+		const response = await fetch(currentUrl, currentInit);
 		// Non-3xx (or 3xx without Location) — terminal response.
 		if (response.status < 300 || response.status >= 400 || response.status === 304) {
 			return { response, finalUrl: currentUrl };
@@ -200,10 +201,21 @@ async function fetchWithRedirectGuard(
 		void response.body?.cancel().catch(() => {});
 		// Resolve the redirect target relative to the current URL.
 		const redirectUrl = new URL(location, currentUrl).href;
-		const redirectHost = new URL(redirectUrl).hostname;
+		const redirectParsed = new URL(redirectUrl);
+		// Reject cross-protocol redirects (file://, data:, etc.). On Bun
+		// `fetch("file:///...")` reads local files, and a non-HTTP(S) target
+		// has no host to classify, so the hostname guard alone can't stop it.
+		if (redirectParsed.protocol !== "http:" && redirectParsed.protocol !== "https:") {
+			throw new Error(`Refused to follow redirect to non-HTTP(S) protocol: ${redirectParsed.protocol}`);
+		}
+		const redirectHost = redirectParsed.hostname;
 		if (isLocalOrMetadataHost(redirectHost)) {
 			throw new SsrfBlockedError(redirectHost);
 		}
+		// 301/302/303 downgrade POST (and other non-safe methods) to GET per
+		// RFC 9110 §15.4; 307/308 preserve the original method and body.
+		const downgradeMethod = response.status === 301 || response.status === 302 || response.status === 303;
+		currentInit = downgradeMethod ? { ...currentInit, method: "GET", body: undefined } : currentInit;
 		currentUrl = redirectUrl;
 	}
 	// Exceeded MAX_REDIRECTS — return a synthetic error response.

--- a/packages/coding-agent/src/web/scrapers/utils.ts
+++ b/packages/coding-agent/src/web/scrapers/utils.ts
@@ -1,10 +1,11 @@
+import { isLocalOrMetadataHost } from "@oh-my-pi/pi-ai";
 import { isRecord, ptree } from "@oh-my-pi/pi-utils";
 
 export { isRecord };
 
 import { ToolAbortError } from "../../tools/tool-errors";
 import { convertBufferWithMarkit } from "../../utils/markit";
-import { MAX_BYTES } from "./types";
+import { MAX_BYTES, MAX_REDIRECTS } from "./types";
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
 	return isRecord(value) ? value : null;
@@ -61,18 +62,52 @@ async function readResponseWithLimit(response: Response, maxBytes: number, signa
 }
 
 /**
- * Fetch binary content from a URL
+ * Fetch binary content from a URL.
+ *
+ * SSRF guard: the initial URL hostname and every redirect target are validated
+ * with {@link isLocalOrMetadataHost} before connecting. Redirects are followed
+ * manually so a public URL that redirects to an internal address is blocked.
  */
 export async function fetchBinary(url: string, timeout: number = 20, signal?: AbortSignal): Promise<BinaryFetchResult> {
+	// SSRF guard: refuse non-public addresses before any network activity.
+	const ssrfError = checkBinarySsrfGuard(url);
+	if (ssrfError) return ssrfError;
+
 	const requestSignal = ptree.combineSignals(signal, timeout * 1000);
 	try {
-		const response = await fetch(url, {
-			signal: requestSignal,
-			headers: {
-				"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
-			},
-			redirect: "follow",
-		});
+		// Follow redirects manually so every hop's hostname is SSRF-checked.
+		let currentUrl = url;
+		let response: Response | undefined;
+		for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+			if (signal?.aborted) {
+				throw new ToolAbortError();
+			}
+			response = await fetch(currentUrl, {
+				signal: requestSignal,
+				headers: {
+					"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
+				},
+				redirect: "manual",
+			});
+			// Non-3xx (or 3xx without Location) — terminal response.
+			if (response.status < 300 || response.status >= 400 || response.status === 304) {
+				break;
+			}
+			const location = response.headers.get("location");
+			if (!location) {
+				break;
+			}
+			void response.body?.cancel().catch(() => {});
+			const redirectUrl = new URL(location, currentUrl).href;
+			const redirectHost = new URL(redirectUrl).hostname;
+			if (isLocalOrMetadataHost(redirectHost)) {
+				return { ok: false, error: `Refused to follow redirect to non-public address: ${redirectHost}` };
+			}
+			currentUrl = redirectUrl;
+		}
+		if (!response) {
+			return { ok: false, error: `Redirect loop exceeded ${MAX_REDIRECTS} hops` };
+		}
 
 		if (!response.ok) {
 			return { ok: false, error: `HTTP ${response.status}` };
@@ -93,6 +128,23 @@ export async function fetchBinary(url: string, timeout: number = 20, signal?: Ab
 		if (requestSignal?.aborted) return { ok: false, error: "aborted" };
 		return { ok: false, error: err instanceof Error ? err.message : "Failed to fetch binary" };
 	}
+}
+
+/**
+ * Check a URL's hostname against the SSRF blocklist. Returns a `BinaryFetchResult`
+ * error when the host is private/loopback/link-local/metadata, otherwise `null`.
+ */
+function checkBinarySsrfGuard(url: string): BinaryFetchResult | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	if (isLocalOrMetadataHost(parsed.hostname)) {
+		return { ok: false, error: `Refused to fetch non-public address: ${parsed.hostname}` };
+	}
+	return null;
 }
 
 /**

--- a/packages/coding-agent/src/web/scrapers/utils.ts
+++ b/packages/coding-agent/src/web/scrapers/utils.ts
@@ -99,18 +99,29 @@ export async function fetchBinary(url: string, timeout: number = 20, signal?: Ab
 			}
 			void response.body?.cancel().catch(() => {});
 			const redirectUrl = new URL(location, currentUrl).href;
-			const redirectHost = new URL(redirectUrl).hostname;
+			const redirectParsed = new URL(redirectUrl);
+			// Reject cross-protocol redirects (file://, data:, etc.). On Bun
+			// `fetch("file:///...")` reads local files, and a non-HTTP(S) target
+			// has no host to classify, so the hostname guard alone can't stop it.
+			if (redirectParsed.protocol !== "http:" && redirectParsed.protocol !== "https:") {
+				return { ok: false, error: `Refused to follow redirect to non-HTTP(S) protocol: ${redirectParsed.protocol}` };
+			}
+			const redirectHost = redirectParsed.hostname;
 			if (isLocalOrMetadataHost(redirectHost)) {
 				return { ok: false, error: `Refused to follow redirect to non-public address: ${redirectHost}` };
 			}
 			currentUrl = redirectUrl;
 		}
-		if (!response) {
+		// `response` is always assigned inside the loop, so the old `!response`
+		// guard was dead. When the redirect chain exceeds MAX_REDIRECTS the loop
+		// exits with `response` still holding a 3xx — detect that explicitly rather
+		// than falling through to the HTTP-status check (which would mislabel it).
+		if (response && response.status >= 300 && response.status < 400) {
 			return { ok: false, error: `Redirect loop exceeded ${MAX_REDIRECTS} hops` };
 		}
 
-		if (!response.ok) {
-			return { ok: false, error: `HTTP ${response.status}` };
+		if (!response || !response.ok) {
+			return { ok: false, error: `HTTP ${response?.status ?? 0}` };
 		}
 
 		const contentDisposition = response.headers.get("content-disposition") || undefined;

--- a/packages/coding-agent/test/fetch-ssrf-guard.test.ts
+++ b/packages/coding-agent/test/fetch-ssrf-guard.test.ts
@@ -295,4 +295,123 @@ describe("fetchBinary SSRF guard", () => {
 			expect(result.buffer).toEqual(pngBytes);
 		}
 	});
+
+	it("blocks a 302 redirect to a file:/// target", async () => {
+		let fetchCalled = false;
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("file:///etc/hosts");
+			}
+			fetchCalled = true;
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/non-HTTP\(S\) protocol: file:/);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("blocks a 302 redirect to a data: target", async () => {
+		let fetchCalled = false;
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("data:text/html,<script>alert(1)</script>");
+			}
+			fetchCalled = true;
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/non-HTTP\(S\) protocol: data:/);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("returns 'redirect loop exceeded' when the chain exceeds MAX_REDIRECTS", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			// Every hop redirects to itself, so the chain never terminates.
+			return makeRedirectResponse(urlStr, 302);
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/Redirect loop exceeded/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — cross-protocol redirect targets are rejected.
+// ---------------------------------------------------------------------------
+
+describe("loadPage — cross-protocol redirect guard", () => {
+	it("blocks a 302 redirect to file:///", async () => {
+		let fetchCalled = false;
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("file:///etc/hosts");
+			}
+			fetchCalled = true;
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/non-HTTP\(S\) protocol: file:/);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("blocks a 301 redirect to a data: URI", async () => {
+		let fetchCalled = false;
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("data:text/html,<h1>hi</h1>", 301);
+			}
+			fetchCalled = true;
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/non-HTTP\(S\) protocol: data:/);
+		expect(fetchCalled).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — POST downgrades to GET on 301/302/303 (RFC 9110 §15.4).
+// ---------------------------------------------------------------------------
+
+describe("loadPage — method downgrade on redirect", () => {
+	it("downgrades POST to GET on a 302 redirect", async () => {
+		const methods: string[] = [];
+		mockFetch((input, init) => {
+			const urlStr = input.toString();
+			methods.push(init?.method ?? "GET");
+			if (urlStr.includes("example.com/submit")) {
+				return makeRedirectResponse("https://cdn.example.org/result", 302);
+			}
+			return makeOkResponse("<html><body>OK</body></html>", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/submit", { method: "POST", body: "data" });
+		expect(result.ok).toBe(true);
+		// First hop: POST (original), second hop: GET (downgraded).
+		expect(methods).toEqual(["POST", "GET"]);
+	});
+
+	it("preserves POST on a 307 redirect", async () => {
+		const methods: string[] = [];
+		mockFetch((input, init) => {
+			const urlStr = input.toString();
+			methods.push(init?.method ?? "GET");
+			if (urlStr.includes("example.com/submit")) {
+				return makeRedirectResponse("https://cdn.example.org/result", 307);
+			}
+			return makeOkResponse("<html><body>OK</body></html>", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/submit", { method: "POST", body: "data" });
+		expect(result.ok).toBe(true);
+		// 307 preserves the method and body.
+		expect(methods).toEqual(["POST", "POST"]);
+	});
 });

--- a/packages/coding-agent/test/fetch-ssrf-guard.test.ts
+++ b/packages/coding-agent/test/fetch-ssrf-guard.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { isLocalOrMetadataHost } from "@oh-my-pi/pi-ai";
+import * as scrapers from "@oh-my-pi/pi-coding-agent/web/scrapers/types";
+import { fetchBinary } from "@oh-my-pi/pi-coding-agent/web/scrapers/utils";
+
+type FetchInput = string | URL | Request;
+type FetchInit = RequestInit | BunFetchRequestInit;
+
+/**
+ * Build a fetch mock that preserves `preconnect` (Bun's fetch type requires it).
+ * The supplied handler receives the input URL and init, and returns a Response.
+ */
+function mockFetch(handler: (input: FetchInput, init?: FetchInit) => Promise<Response> | Response): void {
+	const fetchMock = Object.assign(
+		async (input: FetchInput, init?: FetchInit): Promise<Response> => handler(input, init),
+		{ preconnect: globalThis.fetch.preconnect },
+	);
+	vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+}
+
+function makeOkResponse(body: string, _url: string, contentType = "text/html; charset=utf-8"): Response {
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": contentType },
+	});
+}
+
+function makeRedirectResponse(location: string, status = 302): Response {
+	return new Response(null, {
+		status,
+		headers: { location },
+	});
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// isLocalOrMetadataHost — the hardened classifier shared by both fetch paths.
+// ---------------------------------------------------------------------------
+
+describe("isLocalOrMetadataHost SSRF classifier", () => {
+	const blocked = [
+		// Loopback
+		"127.0.0.1",
+		"127.255.255.255",
+		"::1",
+		"0:0:0:0:0:0:0:1",
+		"0000:0000:0000:0000:0000:0000:0000:0001",
+		// IPv4-mapped IPv6 (critical bypass vector that string matching missed)
+		"::ffff:127.0.0.1",
+		"::ffff:10.0.0.1",
+		"::ffff:192.168.1.1",
+		"::ffff:172.16.0.1",
+		"::ffff:169.254.169.254",
+		// RFC1918 private
+		"10.0.0.1",
+		"10.255.255.255",
+		"172.16.0.1",
+		"172.31.255.255",
+		"192.168.1.1",
+		"192.168.0.0",
+		// Unspecified
+		"0.0.0.0",
+		"::",
+		// Link-local (covers IMDS + ECS)
+		"169.254.169.254",
+		"169.254.170.2",
+		"fe80::1",
+		// Unique-local (covers EC2 IPv6 IMDS)
+		"fc00::1",
+		"fd00:ec2::254",
+		// Hostnames
+		"localhost",
+		"app.localhost",
+		"metadata.google.internal",
+	];
+
+	for (const host of blocked) {
+		it(`blocks ${host}`, () => {
+			expect(isLocalOrMetadataHost(host)).toBe(true);
+		});
+	}
+
+	const allowed = [
+		"8.8.8.8",
+		"1.1.1.1",
+		"172.15.0.1",
+		"172.32.0.1",
+		"11.0.0.1",
+		"example.com",
+		"api.openai.com",
+		"::ffff:8.8.8.8",
+		"2606:4700:4700::1111",
+	];
+
+	for (const host of allowed) {
+		it(`allows ${host}`, () => {
+			expect(isLocalOrMetadataHost(host)).toBe(false);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — SSRF guard on the initial URL.
+// ---------------------------------------------------------------------------
+
+describe("loadPage SSRF guard — initial URL", () => {
+	const blockedUrls = [
+		// Loopback
+		"http://127.0.0.1/",
+		"http://127.5.5.5:8080/",
+		"http://[::1]/",
+		// RFC1918 private
+		"http://10.0.0.1/",
+		"http://172.16.0.1/",
+		"http://192.168.1.1/",
+		// Link-local / metadata
+		"http://169.254.169.254/latest/meta-data/",
+		"http://169.254.170.2/",
+		// Hostnames
+		"http://localhost/",
+		"http://metadata.google.internal/",
+		// IPv4-mapped IPv6 bypass vectors
+		"http://[::ffff:127.0.0.1]/",
+		"http://[0:0:0:0:0:0:0:1]/",
+	];
+
+	for (const url of blockedUrls) {
+		it(`refuses ${url}`, async () => {
+			// fetch must never be called for a blocked URL.
+			let fetchCalled = false;
+			mockFetch(() => {
+				fetchCalled = true;
+				return makeOkResponse("should not reach", url);
+			});
+			const result = await scrapers.loadPage(url);
+			expect(result.ok).toBe(false);
+			expect(result.error).toMatch(/Refused to fetch non-public address/);
+			expect(fetchCalled).toBe(false);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — redirect guard: public URL that redirects to a private address.
+// ---------------------------------------------------------------------------
+
+describe("loadPage SSRF guard — redirect to internal address", () => {
+	it("blocks a 302 redirect from a public URL to 127.0.0.1", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://127.0.0.1/secret");
+			}
+			// Should never reach the internal target.
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/redirect");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: 127\.0\.0\.1/);
+	});
+
+	it("blocks a 301 redirect to 169.254.169.254 (cloud metadata)", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://169.254.169.254/latest/meta-data/", 301);
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/meta");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: 169\.254\.169\.254/);
+	});
+
+	it("blocks a redirect chain that hops through a public host then to 10.0.0.1", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com/page")) {
+				return makeRedirectResponse("https://cdn.example.com/follow", 302);
+			}
+			if (urlStr.includes("cdn.example.com/follow")) {
+				return makeRedirectResponse("http://10.0.0.1/internal", 302);
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/page");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: 10\.0\.0\.1/);
+	});
+
+	it("blocks a redirect to localhost", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://localhost:3000/admin");
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: localhost/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — legitimate public URLs are not blocked.
+// ---------------------------------------------------------------------------
+
+describe("loadPage — legitimate public URLs", () => {
+	it("fetches a public URL and returns content", async () => {
+		let fetchedUrl = "";
+		mockFetch(input => {
+			fetchedUrl = input.toString();
+			return makeOkResponse("<html><body>Hello</body></html>", fetchedUrl);
+		});
+		const result = await scrapers.loadPage("https://example.com/");
+		expect(result.ok).toBe(true);
+		expect(result.content).toContain("Hello");
+		expect(fetchedUrl).toBe("https://example.com/");
+	});
+
+	it("follows a redirect between two public hosts", async () => {
+		const fetchedUrls: string[] = [];
+		mockFetch(input => {
+			const urlStr = input.toString();
+			fetchedUrls.push(urlStr);
+			if (urlStr.includes("old.example.com")) {
+				return makeRedirectResponse("https://new.example.com/page", 302);
+			}
+			return makeOkResponse("<html><body>Moved</body></html>", urlStr);
+		});
+		const result = await scrapers.loadPage("https://old.example.com/");
+		expect(result.ok).toBe(true);
+		expect(result.content).toContain("Moved");
+		expect(fetchedUrls).toContain("https://old.example.com/");
+		expect(fetchedUrls).toContain("https://new.example.com/page");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// fetchBinary — SSRF guard on the binary fetch path.
+// ---------------------------------------------------------------------------
+
+describe("fetchBinary SSRF guard", () => {
+	it("refuses loopback addresses", async () => {
+		let fetchCalled = false;
+		mockFetch(() => {
+			fetchCalled = true;
+			return makeOkResponse("data", "http://127.0.0.1/");
+		});
+		const result = await fetchBinary("http://127.0.0.1/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/Refused to fetch non-public address/);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("refuses cloud metadata endpoint", async () => {
+		let fetchCalled = false;
+		mockFetch(() => {
+			fetchCalled = true;
+			return makeOkResponse("data", "http://169.254.169.254/");
+		});
+		const result = await fetchBinary("http://169.254.169.254/latest/meta-data/");
+		expect(result.ok).toBe(false);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("blocks a redirect from a public URL to a private address", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://10.0.0.1/secret.png");
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/Refused to follow redirect to non-public address: 10\.0\.0\.1/);
+	});
+
+	it("fetches a public binary URL successfully", async () => {
+		const pngBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+		mockFetch(() => {
+			return new Response(pngBytes, {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.buffer).toEqual(pngBytes);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

The fetch tool had zero address validation — an agent could direct it at `http://169.254.169.254/latest/meta-data/`, `http://127.0.0.1:port`, or any RFC1918/link-local address and receive the response body. Redirects were followed blindly (`redirect: 'follow'`), so a public URL that 302-redirects to an internal address bypassed any initial check.

## Changes

### `packages/ai/src/utils/proxy.ts`
Hardened `isLocalOrMetadataHost` by replacing string-based IPv6 regex checks with `node:net.BlockList`. This closes bypass vectors where:
- `::ffff:127.0.0.1` (IPv4-mapped IPv6 → loopback) returned `false`
- `0:0:0:0:0:0:0:1` (expanded `::1`) returned `false`

The function is the single classifier shared by provider proxy-bypass and the fetch-tool SSRF guard — hardened in place, not duplicated.

### `packages/coding-agent/src/web/scrapers/types.ts` + `utils.ts`
Added SSRF guard to both fetch paths:
- **`loadPage`**: Initial URL hostname checked before connecting. Changed `redirect: 'follow'` to `redirect: 'manual'` — every redirect hop is validated with `isLocalOrMetadataHost` before connecting. Limit 10 hops (Node default).
- **`fetchBinary`**: Same guard applied to the binary fetch path (used for image downloads).

### `packages/coding-agent/test/fetch-ssrf-guard.test.ts` (new)
57 tests covering:
- All bypass vectors (`::ffff:127.0.0.1`, `0:0:0:0:0:0:0:1`, `::ffff:169.254.169.254`, etc.)
- `loadPage` refusing loopback/RFC1918/link-local/metadata/localhost URLs
- Redirect-to-internal blocking (single hop, multi-hop chains, 301/302)
- Legitimate public URLs not blocked
- `fetchBinary` SSRF guard (initial URL + redirect blocking + successful public fetch)

### `packages/ai/test/proxy.test.ts`
Extended with IPv4-mapped IPv6 and expanded address form test cases.

## Verification
- 57 SSRF guard tests pass (0 fail)
- 52 proxy tests pass (0 fail)
- 35 existing fetch-related tests pass (0 fail)
- Zero new type errors (6 pre-existing errors in `src/config/profiles.ts` are unrelated)

## Limitation
DNS rebinding (a public hostname that resolves to a private IP) is not caught — full mitigation requires resolving the host before connecting, which is out of scope for the `fetch()` API surface. Documented in the JSDoc.