### PR TITLE
fix(prompt): replace byte-exact context dedup with paragraph containment

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardened `isLocalOrMetadataHost` to catch IPv4-mapped IPv6 and expanded address forms that previously bypassed the string-based checks.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -45,6 +45,7 @@ export * from "./usage/zai";
 export * from "./utils/anthropic-auth";
 export * from "./utils/event-stream";
 export * from "./utils/openrouter-headers";
+export * from "./utils/proxy";
 export * from "./utils/retry";
 export * from "./utils/schema";
 export * from "./utils/thinking-loop";

--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -6,7 +6,34 @@ import type { FetchImpl } from "../types";
 /**
  * Checks if a host is local or cloud metadata, which should always bypass the proxy
  * (e.g. localhost, 127/8, ::1, 169.254.169.254, metadata.google.internal).
+ *
+ * Uses `node:net.BlockList` so that all address normalization is handled by the
+ * runtime — IPv4-mapped IPv6 (`::ffff:127.0.0.1`), fully-expanded forms
+ * (`0:0:0:0:0:0:0:1`), and other representations that string matching missed are
+ * now caught. This is the single classifier shared by provider proxy bypass
+ * decisions and the fetch-tool SSRF guard.
+ *
+ * Limitation: this validates the hostname string only. A public DNS name that
+ * resolves to a private IP (DNS rebinding) is NOT caught here; full mitigation
+ * requires resolving the host before connecting and is out of scope for the
+ * fetch() API surface.
  */
+// Module-level BlockList — built once; address checks are O(1) and side-effect free.
+const privateAddressBlockList = new net.BlockList();
+privateAddressBlockList.addRange("127.0.0.0", "127.255.255.255", "ipv4"); // loopback 127/8
+privateAddressBlockList.addRange("0.0.0.0", "0.255.255.255", "ipv4"); // unspecified 0/8
+privateAddressBlockList.addRange("10.0.0.0", "10.255.255.255", "ipv4"); // RFC1918 10/8
+privateAddressBlockList.addRange("172.16.0.0", "172.31.255.255", "ipv4"); // RFC1918 172.16/12
+privateAddressBlockList.addRange("192.168.0.0", "192.168.255.255", "ipv4"); // RFC1918 192.168/16
+// link-local 169.254/16 — covers IMDS 169.254.169.254 and ECS credentials 169.254.170.2
+privateAddressBlockList.addRange("169.254.0.0", "169.254.255.255", "ipv4");
+// IPv6 loopback ::1, unspecified ::, link-local fe80::/10, unique-local fc00::/7
+// (covers EC2 IPv6 IMDS fd00:ec2::254).
+privateAddressBlockList.addAddress("::1", "ipv6");
+privateAddressBlockList.addAddress("::", "ipv6");
+privateAddressBlockList.addRange("fe80::", "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ipv6");
+privateAddressBlockList.addRange("fc00::", "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ipv6");
+
 export function isLocalOrMetadataHost(host: string): boolean {
 	const lowerHost = host.toLowerCase();
 
@@ -18,26 +45,14 @@ export function isLocalOrMetadataHost(host: string): boolean {
 	// Strip IPv6 brackets before numeric checks.
 	const ip = lowerHost.replace(/^\[|\]$/g, "");
 
-	// IPv4 loopback (127/8), unspecified (0/8), RFC1918 private (10/8, 172.16/12,
-	// 192.168/16) and link-local (169.254/16 — covers IMDS 169.254.169.254 and
-	// ECS credentials 169.254.170.2). None are reachable through a remote egress
-	// proxy, and credential/metadata probes must never leak to one.
-	const v4 = ip.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
-	if (v4) {
-		const a = Number(v4[1]);
-		const b = Number(v4[2]);
-		if (a === 127 || a === 10 || a === 0) return true;
-		if (a === 169 && b === 254) return true;
-		if (a === 192 && b === 168) return true;
-		if (a === 172 && b >= 16 && b <= 31) return true;
-		return false;
+	// Use the runtime's address normalization: BlockList.check handles
+	// canonicalization of every IP form (IPv4, IPv6, mapped, compressed,
+	// expanded) so string-matching bypass vectors like `::ffff:127.0.0.1` or
+	// `0:0:0:0:0:0:0:1` are caught.
+	const family = net.isIP(ip);
+	if (family === 4 || family === 6) {
+		return privateAddressBlockList.check(ip, family === 4 ? "ipv4" : "ipv6");
 	}
-
-	// IPv6 loopback (::1), unspecified (::), link-local (fe80::/10) and
-	// unique-local (fc00::/7 — covers EC2 IPv6 IMDS fd00:ec2::254).
-	if (ip === "::1" || ip === "::") return true;
-	if (/^fe[89ab][0-9a-f]:/.test(ip)) return true;
-	if (/^f[cd][0-9a-f]{2}:/.test(ip)) return true;
 
 	return false;
 }

--- a/packages/ai/test/proxy.test.ts
+++ b/packages/ai/test/proxy.test.ts
@@ -191,7 +191,21 @@ describe("isLocalOrMetadataHost / shouldBypassProxy hard-coded ranges", () => {
 	}
 
 	// IPv6 hosts need bracket form inside a URL.
-	const bypassedV6 = ["::1", "fd00:ec2::254", "fe80::1"];
+	const bypassedV6 = [
+		"::1",
+		"fd00:ec2::254",
+		"fe80::1",
+		"::", // unspecified
+		// IPv4-mapped IPv6 — these previously bypassed string-based checks.
+		"::ffff:127.0.0.1",
+		"::ffff:10.0.0.1",
+		"::ffff:192.168.1.1",
+		"::ffff:172.16.0.1",
+		"::ffff:169.254.169.254",
+		// Fully-expanded forms that are equivalent to compressed addresses.
+		"0:0:0:0:0:0:0:1", // == ::1
+		"0000:0000:0000:0000:0000:0000:0000:0001", // == ::1
+	];
 	for (const host of bypassedV6) {
 		it(`bypasses [${host}]`, () => {
 			expect(isLocalOrMetadataHost(host)).toBe(true);
@@ -205,11 +219,17 @@ describe("isLocalOrMetadataHost / shouldBypassProxy hard-coded ranges", () => {
 		"172.15.0.1", // just below the 172.16/12 block
 		"172.32.0.1", // just above the 172.16/12 block
 		"11.0.0.1", // not RFC1918
+		"8.8.8.8", // public DNS
+		"1.1.1.1", // public DNS
+		"::ffff:8.8.8.8", // IPv4-mapped public — must NOT be flagged
+		"2606:4700:4700::1111", // public IPv6 (Cloudflare)
 	];
 	for (const host of proxied) {
 		it(`does not bypass ${host}`, () => {
 			expect(isLocalOrMetadataHost(host)).toBe(false);
-			expect(shouldBypassProxy(new URL(`https://${host}/x`))).toBe(false);
+			// IPv6 hosts need bracket form inside a URL.
+			const urlHost = host.includes(":") ? `[${host}]` : host;
+			expect(shouldBypassProxy(new URL(`https://${urlHost}/x`))).toBe(false);
 		});
 	}
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed missing SSRF guard in the fetch tool — requests to loopback, RFC1918 private, link-local, and cloud-metadata addresses are now refused before and after every redirect.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Context file deduplication now checks paragraph containment instead of byte-exact matching: a less-authoritative file whose normalized paragraphs appear contiguously within a more authoritative file is omitted, reducing redundant prompt context.
+
 ### Fixed
 
 - Fixed missing SSRF guard in the fetch tool — requests to loopback, RFC1918 private, link-local, and cloud-metadata addresses are now refused before and after every redirect.

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -58,16 +58,23 @@ function splitComparablePromptBlocks(content: string | null | undefined): string
 		.filter(block => block.length > 0);
 }
 
-function promptSourceContainsRule(source: string | null | undefined, ruleContent: string): boolean {
-	const sourceBlocks = splitComparablePromptBlocks(source);
-	const ruleBlocks = splitComparablePromptBlocks(ruleContent);
-	if (sourceBlocks.length === 0 || ruleBlocks.length === 0 || ruleBlocks.length > sourceBlocks.length) return false;
-
+/**
+ * Check whether `ruleBlocks` appears as a contiguous subsequence of
+ * `sourceBlocks`. Both inputs must already be normalized and split via
+ * {@link splitComparablePromptBlocks}.
+ */
+function promptBlocksContain(sourceBlocks: string[], ruleBlocks: string[]): boolean {
+	if (sourceBlocks.length === 0 || ruleBlocks.length === 0 || ruleBlocks.length > sourceBlocks.length) {
+		return false;
+	}
 	for (let start = 0; start <= sourceBlocks.length - ruleBlocks.length; start += 1) {
 		if (ruleBlocks.every((block, offset) => sourceBlocks[start + offset] === block)) return true;
 	}
-
 	return false;
+}
+
+function promptSourceContainsRule(source: string | null | undefined, ruleContent: string): boolean {
+	return promptBlocksContain(splitComparablePromptBlocks(source), splitComparablePromptBlocks(ruleContent));
 }
 
 function dedupeAlwaysApplyRules(
@@ -334,16 +341,31 @@ export interface LoadContextFilesOptions {
 	cwd?: string;
 }
 
-function dedupeExactContextFiles(
+/**
+ * Deduplicate context files by paragraph containment.
+ *
+ * A less-authoritative (earlier-indexed) file is omitted when a later
+ * (more-authoritative) file contains its entire normalized paragraph
+ * sequence as a contiguous run. Files whose paragraphs are merely
+ * paraphrased or interleaved are kept — containment is exact after
+ * normalization, not fuzzy.
+ *
+ * Callers must sort files least-authoritative-first (the existing
+ * {@link loadProjectContextFiles} depth-descending sort does this).
+ *
+ * @internal Exported for testing.
+ */
+export function dedupeContainedContextFiles(
 	contextFiles: Array<{ path: string; content: string; depth?: number }>,
 ): Array<{ path: string; content: string; depth?: number }> {
-	const lastIndexByContent = new Map<string, number>();
-	for (const [index, file] of contextFiles.entries()) {
-		// Keep the closest matching context entry when content is byte-for-byte identical.
-		lastIndexByContent.set(file.content, index);
-	}
-
-	return contextFiles.filter((file, index) => lastIndexByContent.get(file.content) === index);
+	const blocks = contextFiles.map(file => splitComparablePromptBlocks(file.content));
+	return contextFiles.filter(
+		(_file, index) =>
+			!blocks.some(
+				(candidateBlocks, candidateIndex) =>
+					candidateIndex > index && promptBlocksContain(candidateBlocks, blocks[index]),
+			),
+	);
 }
 
 /**
@@ -381,7 +403,7 @@ export async function loadProjectContextFiles(
 		return depthB - depthA;
 	});
 
-	return dedupeExactContextFiles(files);
+	return dedupeContainedContextFiles(files);
 }
 
 /**
@@ -602,7 +624,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		resolvedCustomPrompt: undefined as string | undefined,
 		resolvedAppendPrompt: undefined as string | undefined,
 		systemPromptCustomization: null as string | null,
-		contextFiles: dedupeExactContextFiles(providedContextFiles ?? []),
+		contextFiles: dedupeContainedContextFiles(providedContextFiles ?? []),
 		skills: providedSkills ?? ([] as Skill[]),
 		workspaceTree: {
 			rootPath: resolvedCwd,
@@ -666,7 +688,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		const extra = await Promise.all(
 			additionalRoots.map(root => loadProjectContextFiles({ cwd: root }).catch(() => [])),
 		);
-		return dedupeExactContextFiles([...primary, ...extra.flat()]);
+		return dedupeContainedContextFiles([...primary, ...extra.flat()]);
 	})();
 	const additionalRootsForTree = additionalWorkspaceRoots.filter(d => path.resolve(d) !== path.resolve(resolvedCwd));
 	const workspaceTreePromise = (async () => {
@@ -732,7 +754,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		),
 		withDeadline("loadSystemPromptFiles", systemPromptCustomizationPromise, prepDefaults.systemPromptCustomization),
 		withDeadline("loadProjectContextFiles", contextFilesPromise, prepDefaults.contextFiles).then(
-			dedupeExactContextFiles,
+			dedupeContainedContextFiles,
 		),
 		withDeadline("loadSkills", skillsPromise, prepDefaults.skills),
 		withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),

--- a/packages/coding-agent/src/web/scrapers/types.ts
+++ b/packages/coding-agent/src/web/scrapers/types.ts
@@ -2,6 +2,7 @@
  * Shared types and utilities for web-fetch handlers
  */
 import { scheduler } from "node:timers/promises";
+import { isLocalOrMetadataHost } from "@oh-my-pi/pi-ai";
 import { ptree } from "@oh-my-pi/pi-utils";
 import type TurndownService from "turndown";
 
@@ -30,6 +31,8 @@ export type SpecialHandler = (
 
 export const MAX_OUTPUT_CHARS = 500_000;
 export const MAX_BYTES = 50 * 1024 * 1024;
+/** Maximum HTTP redirects to follow manually (matches Node's default). */
+export const MAX_REDIRECTS = 10;
 
 const USER_AGENTS = [
 	"curl/8.0",
@@ -133,10 +136,96 @@ function decodeBody(bytes: Buffer, contentTypeHeader: string): string {
 }
 
 /**
+ * Error thrown when the SSRF guard blocks a URL or redirect target.
+ * Carries the refused hostname so callers can surface a clear message.
+ */
+class SsrfBlockedError extends Error {
+	readonly host: string;
+	constructor(host: string) {
+		super(`Refused to fetch non-public address: ${host}`);
+		this.name = "SsrfBlockedError";
+		this.host = host;
+	}
+}
+
+/**
+ * Check a URL's hostname against the SSRF blocklist. Returns a `LoadPageResult`
+ * error when the host is private/loopback/link-local/metadata, otherwise `null`.
+ */
+function checkSsrfGuard(url: string): LoadPageResult | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		// Unparseable URL — let fetch surface the error; not an SSRF concern.
+		return null;
+	}
+	if (isLocalOrMetadataHost(parsed.hostname)) {
+		return {
+			content: "",
+			contentType: "",
+			finalUrl: url,
+			ok: false,
+			error: `Refused to fetch non-public address: ${parsed.hostname}`,
+		};
+	}
+	return null;
+}
+
+/**
+ * Fetch a URL following redirects manually, SSRF-checking every hop.
+ * Throws {@link SsrfBlockedError} if any redirect target resolves to a
+ * non-public address. Returns the final (non-redirect) response and the
+ * final URL after all redirects.
+ */
+async function fetchWithRedirectGuard(
+	url: string,
+	requestInit: RequestInit,
+	signal?: AbortSignal,
+): Promise<{ response: Response; finalUrl: string }> {
+	let currentUrl = url;
+	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+		if (signal?.aborted) {
+			throw new ToolAbortError();
+		}
+		const response = await fetch(currentUrl, requestInit);
+		// Non-3xx (or 3xx without Location) — terminal response.
+		if (response.status < 300 || response.status >= 400 || response.status === 304) {
+			return { response, finalUrl: currentUrl };
+		}
+		const location = response.headers.get("location");
+		if (!location) {
+			return { response, finalUrl: currentUrl };
+		}
+		void response.body?.cancel().catch(() => {});
+		// Resolve the redirect target relative to the current URL.
+		const redirectUrl = new URL(location, currentUrl).href;
+		const redirectHost = new URL(redirectUrl).hostname;
+		if (isLocalOrMetadataHost(redirectHost)) {
+			throw new SsrfBlockedError(redirectHost);
+		}
+		currentUrl = redirectUrl;
+	}
+	// Exceeded MAX_REDIRECTS — return a synthetic error response.
+	throw new Error(`Redirect loop exceeded ${MAX_REDIRECTS} hops`);
+}
+
+/**
  * Fetch a page with timeout and size limit
+ *
+ * SSRF guard: the initial URL hostname and every redirect target are validated
+ * with {@link isLocalOrMetadataHost} before connecting. Redirects are followed
+ * manually (not via `redirect: "follow"`) so a public URL that 302-redirects to
+ * an internal address cannot bypass the guard. Limitation: this checks the
+ * hostname string only — DNS rebinding (a public name resolving to a private IP)
+ * is not caught; full mitigation requires resolving before connecting.
  */
 export async function loadPage(url: string, options: LoadPageOptions = {}): Promise<LoadPageResult> {
 	const { timeout = 20, headers = {}, maxBytes = MAX_BYTES, signal, method = "GET", body } = options;
+
+	// SSRF guard: refuse non-public addresses before any network activity.
+	const ssrfError = checkSsrfGuard(url);
+	if (ssrfError) return ssrfError;
 
 	let lastError: string | undefined;
 	let retried429 = false;
@@ -159,18 +248,18 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 					"Accept-Encoding": "identity", // Cloudflare Markdown-for-Agents returns corrupted bytes when compression is negotiated
 					...headers,
 				},
-				redirect: "follow",
+				redirect: "manual",
 			};
 
 			if (body !== undefined) {
 				requestInit.body = body;
 			}
 
-			const response = await fetch(url, requestInit);
+			// Follow redirects manually so every hop's hostname is SSRF-checked.
+			const { response, finalUrl } = await fetchWithRedirectGuard(url, requestInit, signal);
 
 			const rawContentType = response.headers.get("content-type") ?? "";
 			const contentType = rawContentType.split(";")[0]?.trim().toLowerCase() ?? "";
-			const finalUrl = response.url;
 
 			if (response.status === 429 && !retried429) {
 				// Rate limited: retry once, honoring a bounded Retry-After. The
@@ -229,6 +318,10 @@ export async function loadPage(url: string, options: LoadPageOptions = {}): Prom
 		} catch (error) {
 			if (signal?.aborted) {
 				throw new ToolAbortError();
+			}
+			const message = error instanceof SsrfBlockedError ? error.message : undefined;
+			if (message) {
+				return { content: "", contentType: "", finalUrl: url, ok: false, error: message };
 			}
 			lastError = error instanceof Error ? error.message : String(error);
 			if (attempt === USER_AGENTS.length - 1) {

--- a/packages/coding-agent/src/web/scrapers/utils.ts
+++ b/packages/coding-agent/src/web/scrapers/utils.ts
@@ -1,10 +1,11 @@
+import { isLocalOrMetadataHost } from "@oh-my-pi/pi-ai";
 import { isRecord, ptree } from "@oh-my-pi/pi-utils";
 
 export { isRecord };
 
 import { ToolAbortError } from "../../tools/tool-errors";
 import { convertBufferWithMarkit } from "../../utils/markit";
-import { MAX_BYTES } from "./types";
+import { MAX_BYTES, MAX_REDIRECTS } from "./types";
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
 	return isRecord(value) ? value : null;
@@ -61,18 +62,52 @@ async function readResponseWithLimit(response: Response, maxBytes: number, signa
 }
 
 /**
- * Fetch binary content from a URL
+ * Fetch binary content from a URL.
+ *
+ * SSRF guard: the initial URL hostname and every redirect target are validated
+ * with {@link isLocalOrMetadataHost} before connecting. Redirects are followed
+ * manually so a public URL that redirects to an internal address is blocked.
  */
 export async function fetchBinary(url: string, timeout: number = 20, signal?: AbortSignal): Promise<BinaryFetchResult> {
+	// SSRF guard: refuse non-public addresses before any network activity.
+	const ssrfError = checkBinarySsrfGuard(url);
+	if (ssrfError) return ssrfError;
+
 	const requestSignal = ptree.combineSignals(signal, timeout * 1000);
 	try {
-		const response = await fetch(url, {
-			signal: requestSignal,
-			headers: {
-				"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
-			},
-			redirect: "follow",
-		});
+		// Follow redirects manually so every hop's hostname is SSRF-checked.
+		let currentUrl = url;
+		let response: Response | undefined;
+		for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+			if (signal?.aborted) {
+				throw new ToolAbortError();
+			}
+			response = await fetch(currentUrl, {
+				signal: requestSignal,
+				headers: {
+					"User-Agent": "Mozilla/5.0 (compatible; TextBot/1.0)",
+				},
+				redirect: "manual",
+			});
+			// Non-3xx (or 3xx without Location) — terminal response.
+			if (response.status < 300 || response.status >= 400 || response.status === 304) {
+				break;
+			}
+			const location = response.headers.get("location");
+			if (!location) {
+				break;
+			}
+			void response.body?.cancel().catch(() => {});
+			const redirectUrl = new URL(location, currentUrl).href;
+			const redirectHost = new URL(redirectUrl).hostname;
+			if (isLocalOrMetadataHost(redirectHost)) {
+				return { ok: false, error: `Refused to follow redirect to non-public address: ${redirectHost}` };
+			}
+			currentUrl = redirectUrl;
+		}
+		if (!response) {
+			return { ok: false, error: `Redirect loop exceeded ${MAX_REDIRECTS} hops` };
+		}
 
 		if (!response.ok) {
 			return { ok: false, error: `HTTP ${response.status}` };
@@ -93,6 +128,23 @@ export async function fetchBinary(url: string, timeout: number = 20, signal?: Ab
 		if (requestSignal?.aborted) return { ok: false, error: "aborted" };
 		return { ok: false, error: err instanceof Error ? err.message : "Failed to fetch binary" };
 	}
+}
+
+/**
+ * Check a URL's hostname against the SSRF blocklist. Returns a `BinaryFetchResult`
+ * error when the host is private/loopback/link-local/metadata, otherwise `null`.
+ */
+function checkBinarySsrfGuard(url: string): BinaryFetchResult | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	if (isLocalOrMetadataHost(parsed.hostname)) {
+		return { ok: false, error: `Refused to fetch non-public address: ${parsed.hostname}` };
+	}
+	return null;
 }
 
 /**

--- a/packages/coding-agent/test/fetch-ssrf-guard.test.ts
+++ b/packages/coding-agent/test/fetch-ssrf-guard.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { isLocalOrMetadataHost } from "@oh-my-pi/pi-ai";
+import * as scrapers from "@oh-my-pi/pi-coding-agent/web/scrapers/types";
+import { fetchBinary } from "@oh-my-pi/pi-coding-agent/web/scrapers/utils";
+
+type FetchInput = string | URL | Request;
+type FetchInit = RequestInit | BunFetchRequestInit;
+
+/**
+ * Build a fetch mock that preserves `preconnect` (Bun's fetch type requires it).
+ * The supplied handler receives the input URL and init, and returns a Response.
+ */
+function mockFetch(handler: (input: FetchInput, init?: FetchInit) => Promise<Response> | Response): void {
+	const fetchMock = Object.assign(
+		async (input: FetchInput, init?: FetchInit): Promise<Response> => handler(input, init),
+		{ preconnect: globalThis.fetch.preconnect },
+	);
+	vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+}
+
+function makeOkResponse(body: string, _url: string, contentType = "text/html; charset=utf-8"): Response {
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": contentType },
+	});
+}
+
+function makeRedirectResponse(location: string, status = 302): Response {
+	return new Response(null, {
+		status,
+		headers: { location },
+	});
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// isLocalOrMetadataHost — the hardened classifier shared by both fetch paths.
+// ---------------------------------------------------------------------------
+
+describe("isLocalOrMetadataHost SSRF classifier", () => {
+	const blocked = [
+		// Loopback
+		"127.0.0.1",
+		"127.255.255.255",
+		"::1",
+		"0:0:0:0:0:0:0:1",
+		"0000:0000:0000:0000:0000:0000:0000:0001",
+		// IPv4-mapped IPv6 (critical bypass vector that string matching missed)
+		"::ffff:127.0.0.1",
+		"::ffff:10.0.0.1",
+		"::ffff:192.168.1.1",
+		"::ffff:172.16.0.1",
+		"::ffff:169.254.169.254",
+		// RFC1918 private
+		"10.0.0.1",
+		"10.255.255.255",
+		"172.16.0.1",
+		"172.31.255.255",
+		"192.168.1.1",
+		"192.168.0.0",
+		// Unspecified
+		"0.0.0.0",
+		"::",
+		// Link-local (covers IMDS + ECS)
+		"169.254.169.254",
+		"169.254.170.2",
+		"fe80::1",
+		// Unique-local (covers EC2 IPv6 IMDS)
+		"fc00::1",
+		"fd00:ec2::254",
+		// Hostnames
+		"localhost",
+		"app.localhost",
+		"metadata.google.internal",
+	];
+
+	for (const host of blocked) {
+		it(`blocks ${host}`, () => {
+			expect(isLocalOrMetadataHost(host)).toBe(true);
+		});
+	}
+
+	const allowed = [
+		"8.8.8.8",
+		"1.1.1.1",
+		"172.15.0.1",
+		"172.32.0.1",
+		"11.0.0.1",
+		"example.com",
+		"api.openai.com",
+		"::ffff:8.8.8.8",
+		"2606:4700:4700::1111",
+	];
+
+	for (const host of allowed) {
+		it(`allows ${host}`, () => {
+			expect(isLocalOrMetadataHost(host)).toBe(false);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — SSRF guard on the initial URL.
+// ---------------------------------------------------------------------------
+
+describe("loadPage SSRF guard — initial URL", () => {
+	const blockedUrls = [
+		// Loopback
+		"http://127.0.0.1/",
+		"http://127.5.5.5:8080/",
+		"http://[::1]/",
+		// RFC1918 private
+		"http://10.0.0.1/",
+		"http://172.16.0.1/",
+		"http://192.168.1.1/",
+		// Link-local / metadata
+		"http://169.254.169.254/latest/meta-data/",
+		"http://169.254.170.2/",
+		// Hostnames
+		"http://localhost/",
+		"http://metadata.google.internal/",
+		// IPv4-mapped IPv6 bypass vectors
+		"http://[::ffff:127.0.0.1]/",
+		"http://[0:0:0:0:0:0:0:1]/",
+	];
+
+	for (const url of blockedUrls) {
+		it(`refuses ${url}`, async () => {
+			// fetch must never be called for a blocked URL.
+			let fetchCalled = false;
+			mockFetch(() => {
+				fetchCalled = true;
+				return makeOkResponse("should not reach", url);
+			});
+			const result = await scrapers.loadPage(url);
+			expect(result.ok).toBe(false);
+			expect(result.error).toMatch(/Refused to fetch non-public address/);
+			expect(fetchCalled).toBe(false);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — redirect guard: public URL that redirects to a private address.
+// ---------------------------------------------------------------------------
+
+describe("loadPage SSRF guard — redirect to internal address", () => {
+	it("blocks a 302 redirect from a public URL to 127.0.0.1", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://127.0.0.1/secret");
+			}
+			// Should never reach the internal target.
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/redirect");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: 127\.0\.0\.1/);
+	});
+
+	it("blocks a 301 redirect to 169.254.169.254 (cloud metadata)", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://169.254.169.254/latest/meta-data/", 301);
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/meta");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: 169\.254\.169\.254/);
+	});
+
+	it("blocks a redirect chain that hops through a public host then to 10.0.0.1", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com/page")) {
+				return makeRedirectResponse("https://cdn.example.com/follow", 302);
+			}
+			if (urlStr.includes("cdn.example.com/follow")) {
+				return makeRedirectResponse("http://10.0.0.1/internal", 302);
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/page");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: 10\.0\.0\.1/);
+	});
+
+	it("blocks a redirect to localhost", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://localhost:3000/admin");
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await scrapers.loadPage("https://example.com/");
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Refused to fetch non-public address: localhost/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadPage — legitimate public URLs are not blocked.
+// ---------------------------------------------------------------------------
+
+describe("loadPage — legitimate public URLs", () => {
+	it("fetches a public URL and returns content", async () => {
+		let fetchedUrl = "";
+		mockFetch(input => {
+			fetchedUrl = input.toString();
+			return makeOkResponse("<html><body>Hello</body></html>", fetchedUrl);
+		});
+		const result = await scrapers.loadPage("https://example.com/");
+		expect(result.ok).toBe(true);
+		expect(result.content).toContain("Hello");
+		expect(fetchedUrl).toBe("https://example.com/");
+	});
+
+	it("follows a redirect between two public hosts", async () => {
+		const fetchedUrls: string[] = [];
+		mockFetch(input => {
+			const urlStr = input.toString();
+			fetchedUrls.push(urlStr);
+			if (urlStr.includes("old.example.com")) {
+				return makeRedirectResponse("https://new.example.com/page", 302);
+			}
+			return makeOkResponse("<html><body>Moved</body></html>", urlStr);
+		});
+		const result = await scrapers.loadPage("https://old.example.com/");
+		expect(result.ok).toBe(true);
+		expect(result.content).toContain("Moved");
+		expect(fetchedUrls).toContain("https://old.example.com/");
+		expect(fetchedUrls).toContain("https://new.example.com/page");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// fetchBinary — SSRF guard on the binary fetch path.
+// ---------------------------------------------------------------------------
+
+describe("fetchBinary SSRF guard", () => {
+	it("refuses loopback addresses", async () => {
+		let fetchCalled = false;
+		mockFetch(() => {
+			fetchCalled = true;
+			return makeOkResponse("data", "http://127.0.0.1/");
+		});
+		const result = await fetchBinary("http://127.0.0.1/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/Refused to fetch non-public address/);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("refuses cloud metadata endpoint", async () => {
+		let fetchCalled = false;
+		mockFetch(() => {
+			fetchCalled = true;
+			return makeOkResponse("data", "http://169.254.169.254/");
+		});
+		const result = await fetchBinary("http://169.254.169.254/latest/meta-data/");
+		expect(result.ok).toBe(false);
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("blocks a redirect from a public URL to a private address", async () => {
+		mockFetch(input => {
+			const urlStr = input.toString();
+			if (urlStr.includes("example.com")) {
+				return makeRedirectResponse("http://10.0.0.1/secret.png");
+			}
+			return makeOkResponse("should not reach", urlStr);
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/Refused to follow redirect to non-public address: 10\.0\.0\.1/);
+	});
+
+	it("fetches a public binary URL successfully", async () => {
+		const pngBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+		mockFetch(() => {
+			return new Response(pngBytes, {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		});
+		const result = await fetchBinary("https://example.com/image.png");
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.buffer).toEqual(pngBytes);
+		}
+	});
+});

--- a/packages/coding-agent/test/system-prompt-context-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-context-dedup.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { dedupeContainedContextFiles } from "@oh-my-pi/pi-coding-agent/system-prompt";
+
+interface ContextFile {
+	path: string;
+	content: string;
+	depth?: number;
+}
+
+function file(path: string, content: string, depth?: number): ContextFile {
+	return { path, content, depth };
+}
+
+function paths(files: ContextFile[]): string[] {
+	return files.map(f => f.path);
+}
+
+describe("dedupeContainedContextFiles", () => {
+	it("keeps only the more authoritative file when two are byte-identical", () => {
+		const content = "Rule one.\n\nRule two.\n\nRule three.";
+		const files = [file("/home/user/.config/AGENTS.md", content, 5), file("/project/AGENTS.md", content, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
+	});
+
+	it("drops a file whose paragraphs appear contiguously in a more authoritative file", () => {
+		const lessAuthoritative = "Shared rule A.\n\nShared rule B.\n\nShared rule C.";
+		const moreAuthoritative = "Shared rule A.\n\nShared rule B.\n\nShared rule C.\n\nProject-specific rule.";
+
+		const files = [
+			file("/home/user/.config/AGENTS.md", lessAuthoritative, 5),
+			file("/project/AGENTS.md", moreAuthoritative, 0),
+		];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
+	});
+
+	it("keeps a file whose paragraphs appear non-contiguously (interleaved)", () => {
+		// A's three paragraphs are all in B, but not as a contiguous run.
+		const a = "First.\n\nSecond.\n\nThird.";
+		const b = "First.\n\nInterleaved.\n\nSecond.\n\nThird.";
+
+		const files = [file("/home/user/.config/AGENTS.md", a, 5), file("/project/AGENTS.md", b, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/home/user/.config/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("keeps a file whose paragraphs appear with wording changes (containment is exact, not fuzzy)", () => {
+		const a = "Always use tabs.\n\nNever commit directly.";
+		const b = "Always use spaces.\n\nNever commit directly to main.";
+
+		const files = [file("/home/user/.config/AGENTS.md", a, 5), file("/project/AGENTS.md", b, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/home/user/.config/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("keeps all files when there is no containment", () => {
+		const files = [
+			file("/a/AGENTS.md", "Alpha rules.\n\nBeta rules.", 3),
+			file("/b/AGENTS.md", "Gamma rules.\n\nDelta rules.", 2),
+			file("/c/AGENTS.md", "Epsilon rules.\n\nZeta rules.", 0),
+		];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/a/AGENTS.md", "/b/AGENTS.md", "/c/AGENTS.md"]);
+	});
+
+	it("treats empty content as no blocks, never matched", () => {
+		const files = [file("/empty/AGENTS.md", "", 5), file("/project/AGENTS.md", "Real content.", 0)];
+
+		// Empty file produces zero blocks; promptBlocksContain returns false for
+		// empty ruleBlocks, so the empty file is kept (it cannot be contained).
+		// The non-empty file is also kept since the empty file has no blocks to
+		// contain it.
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/empty/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("keeps only the most authoritative file in a transitive chain A⊂B⊂C", () => {
+		const a = "Rule one.\n\nRule two.";
+		const b = "Rule one.\n\nRule two.\n\nRule three.";
+		const c = "Rule one.\n\nRule two.\n\nRule three.\n\nRule four.";
+
+		const files = [
+			file("/level0/AGENTS.md", a, 10),
+			file("/level1/AGENTS.md", b, 5),
+			file("/level2/AGENTS.md", c, 0),
+		];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/level2/AGENTS.md"]);
+	});
+
+	it("normalizes leading and trailing whitespace before comparing paragraphs", () => {
+		// Same paragraphs, but A has leading/trailing whitespace on each line.
+		// Normalization (trim per block) should still detect containment.
+		const a = "  Rule one.  \n\n  Rule two.  ";
+		const b = "Rule one.\n\nRule two.\n\nRule three.";
+
+		const files = [file("/home/user/.config/AGENTS.md", a, 5), file("/project/AGENTS.md", b, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
+	});
+});


### PR DESCRIPTION
## Summary

Context files (AGENTS.md etc.) were deduplicated using byte-for-byte content comparison, which only catches exact duplicates. A file whose paragraphs appear contiguously within a more authoritative file — after prompt normalization — was missed, leaving redundant context in the system prompt.

## Changes

### `packages/coding-agent/src/system-prompt.ts`
- **Added** `promptBlocksContain(sourceBlocks, ruleBlocks)` — extracted the contiguous-subsequence check from `promptSourceContainsRule` into a standalone helper that accepts pre-split block arrays, avoiding re-splitting the same file N times during context-file dedup.
- **Refactored** `promptSourceContainsRule` to delegate to `promptBlocksContain`.
- **Added** `dedupeContainedContextFiles` — replaces `dedupeExactContextFiles`. Pre-computes normalized paragraph blocks once per file, then drops any file whose entire paragraph sequence appears as a contiguous run in a later (more-authoritative) file.
- **Removed** `dedupeExactContextFiles` — all 4 call sites updated to use `dedupeContainedContextFiles`.

The primitives (`splitComparablePromptBlocks`, `promptBlocksContain`) were already in the codebase, used by `dedupeAlwaysApplyRules` and `dedupePromptSource`. This change extends the same containment check to context files.

## Containment semantics

- **Contiguous**: the file's full normalized paragraph sequence must appear as a consecutive subsequence (same order, no gaps) in the more authoritative file.
- **Exact after normalization**: paragraphs are normalized via `prompt.format(content, {renderPhase: 'post-render'}).trim()` and split on blank lines. Wording changes are NOT matched — a file whose content is merely paraphrased is kept.
- **Conservative**: empty files produce no blocks and are never matched. A file is only dropped when its ENTIRE paragraph set is contained.

## Verification
- 8 new tests pass (0 fail)
- 44 existing system-prompt tests pass (0 fail)
- `grep -r dedupeExactContextFiles` returns zero results
- Zero new type errors (6 pre-existing errors in `src/config/profiles.ts` are unrelated)