### PR TITLE
fix(prompt): replace byte-exact context dedup with paragraph containment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Context file deduplication now checks paragraph containment instead of byte-exact matching: a less-authoritative file whose normalized paragraphs appear contiguously within a more authoritative file is omitted, reducing redundant prompt context.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Context file deduplication now checks paragraph containment instead of byte-exact matching: a less-authoritative file whose normalized paragraphs appear contiguously within a more authoritative file is omitted, reducing redundant prompt context.
+- Context file containment dedup now sorts by depth descending internally, so authority is always derived from distance to cwd rather than caller array order — fixing a bug where concatenated multi-root arrays could drop a closer-to-cwd file in favor of a farther one.
+- Paragraph splitting for containment comparison is now fenced-code-block-aware: text inside a fenced example in a more authoritative file no longer counts as a contained instruction, preventing active context rules from being discarded.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -58,16 +58,23 @@ function splitComparablePromptBlocks(content: string | null | undefined): string
 		.filter(block => block.length > 0);
 }
 
-function promptSourceContainsRule(source: string | null | undefined, ruleContent: string): boolean {
-	const sourceBlocks = splitComparablePromptBlocks(source);
-	const ruleBlocks = splitComparablePromptBlocks(ruleContent);
-	if (sourceBlocks.length === 0 || ruleBlocks.length === 0 || ruleBlocks.length > sourceBlocks.length) return false;
-
+/**
+ * Check whether `ruleBlocks` appears as a contiguous subsequence of
+ * `sourceBlocks`. Both inputs must already be normalized and split via
+ * {@link splitComparablePromptBlocks}.
+ */
+function promptBlocksContain(sourceBlocks: string[], ruleBlocks: string[]): boolean {
+	if (sourceBlocks.length === 0 || ruleBlocks.length === 0 || ruleBlocks.length > sourceBlocks.length) {
+		return false;
+	}
 	for (let start = 0; start <= sourceBlocks.length - ruleBlocks.length; start += 1) {
 		if (ruleBlocks.every((block, offset) => sourceBlocks[start + offset] === block)) return true;
 	}
-
 	return false;
+}
+
+function promptSourceContainsRule(source: string | null | undefined, ruleContent: string): boolean {
+	return promptBlocksContain(splitComparablePromptBlocks(source), splitComparablePromptBlocks(ruleContent));
 }
 
 function dedupeAlwaysApplyRules(
@@ -334,16 +341,31 @@ export interface LoadContextFilesOptions {
 	cwd?: string;
 }
 
-function dedupeExactContextFiles(
+/**
+ * Deduplicate context files by paragraph containment.
+ *
+ * A less-authoritative (earlier-indexed) file is omitted when a later
+ * (more-authoritative) file contains its entire normalized paragraph
+ * sequence as a contiguous run. Files whose paragraphs are merely
+ * paraphrased or interleaved are kept — containment is exact after
+ * normalization, not fuzzy.
+ *
+ * Callers must sort files least-authoritative-first (the existing
+ * {@link loadProjectContextFiles} depth-descending sort does this).
+ *
+ * @internal Exported for testing.
+ */
+export function dedupeContainedContextFiles(
 	contextFiles: Array<{ path: string; content: string; depth?: number }>,
 ): Array<{ path: string; content: string; depth?: number }> {
-	const lastIndexByContent = new Map<string, number>();
-	for (const [index, file] of contextFiles.entries()) {
-		// Keep the closest matching context entry when content is byte-for-byte identical.
-		lastIndexByContent.set(file.content, index);
-	}
-
-	return contextFiles.filter((file, index) => lastIndexByContent.get(file.content) === index);
+	const blocks = contextFiles.map(file => splitComparablePromptBlocks(file.content));
+	return contextFiles.filter(
+		(_file, index) =>
+			!blocks.some(
+				(candidateBlocks, candidateIndex) =>
+					candidateIndex > index && promptBlocksContain(candidateBlocks, blocks[index]),
+			),
+	);
 }
 
 /**
@@ -381,7 +403,7 @@ export async function loadProjectContextFiles(
 		return depthB - depthA;
 	});
 
-	return dedupeExactContextFiles(files);
+	return dedupeContainedContextFiles(files);
 }
 
 /**
@@ -602,7 +624,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		resolvedCustomPrompt: undefined as string | undefined,
 		resolvedAppendPrompt: undefined as string | undefined,
 		systemPromptCustomization: null as string | null,
-		contextFiles: dedupeExactContextFiles(providedContextFiles ?? []),
+		contextFiles: dedupeContainedContextFiles(providedContextFiles ?? []),
 		skills: providedSkills ?? ([] as Skill[]),
 		workspaceTree: {
 			rootPath: resolvedCwd,
@@ -666,7 +688,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		const extra = await Promise.all(
 			additionalRoots.map(root => loadProjectContextFiles({ cwd: root }).catch(() => [])),
 		);
-		return dedupeExactContextFiles([...primary, ...extra.flat()]);
+		return dedupeContainedContextFiles([...primary, ...extra.flat()]);
 	})();
 	const additionalRootsForTree = additionalWorkspaceRoots.filter(d => path.resolve(d) !== path.resolve(resolvedCwd));
 	const workspaceTreePromise = (async () => {
@@ -732,7 +754,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		),
 		withDeadline("loadSystemPromptFiles", systemPromptCustomizationPromise, prepDefaults.systemPromptCustomization),
 		withDeadline("loadProjectContextFiles", contextFilesPromise, prepDefaults.contextFiles).then(
-			dedupeExactContextFiles,
+			dedupeContainedContextFiles,
 		),
 		withDeadline("loadSkills", skillsPromise, prepDefaults.skills),
 		withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -51,11 +51,30 @@ function normalizePromptBlock(content: string): string {
 function splitComparablePromptBlocks(content: string | null | undefined): string[] {
 	const normalized = firstNonEmpty(content);
 	if (!normalized) return [];
-
-	return normalizePromptBlock(normalized)
-		.split(/\n{2,}/)
-		.map(block => block.trim())
-		.filter(block => block.length > 0);
+	const rendered = normalizePromptBlock(normalized);
+	// Split on blank-line paragraph boundaries, but not inside fenced code
+	// blocks. A rule that appears only inside a fenced example in another file
+	// is an example, not an instruction, so it must not count as containment.
+	const blocks: string[] = [];
+	let current: string[] = [];
+	let inFence = false;
+	for (const line of rendered.split("\n")) {
+		if (/^\s*(```|~~~)/.test(line)) {
+			inFence = !inFence;
+			current.push(line);
+			continue;
+		}
+		if (!inFence && line.trim() === "" && current.length > 0 && current[current.length - 1].trim() !== "") {
+			const block = current.join("\n").trim();
+			if (block.length > 0) blocks.push(block);
+			current = [];
+			continue;
+		}
+		current.push(line);
+	}
+	const tail = current.join("\n").trim();
+	if (tail.length > 0) blocks.push(tail);
+	return blocks;
 }
 
 /**
@@ -344,22 +363,30 @@ export interface LoadContextFilesOptions {
 /**
  * Deduplicate context files by paragraph containment.
  *
- * A less-authoritative (earlier-indexed) file is omitted when a later
- * (more-authoritative) file contains its entire normalized paragraph
- * sequence as a contiguous run. Files whose paragraphs are merely
- * paraphrased or interleaved are kept — containment is exact after
- * normalization, not fuzzy.
- *
- * Callers must sort files least-authoritative-first (the existing
- * {@link loadProjectContextFiles} depth-descending sort does this).
+ * Files are sorted by depth descending (farther from cwd first) so that a
+ * file is omitted only when a more-authoritative (closer-to-cwd) file
+ * contains its entire normalized paragraph sequence as a contiguous run.
+ * This makes the function self-contained — it does not rely on callers
+ * pre-sorting the array, which matters because some callers concatenate
+ * independently sorted workspace roots where array position does not reflect
+ * authority. Files whose paragraphs are merely paraphrased or interleaved are
+ * kept — containment is exact after normalization, not fuzzy.
  *
  * @internal Exported for testing.
  */
 export function dedupeContainedContextFiles(
 	contextFiles: Array<{ path: string; content: string; depth?: number }>,
 ): Array<{ path: string; content: string; depth?: number }> {
-	const blocks = contextFiles.map(file => splitComparablePromptBlocks(file.content));
-	return contextFiles.filter(
+	// Sort by depth descending: higher depth (farther from cwd, less
+	// authoritative) first, lower depth (closer to cwd, more authoritative)
+	// last. Stable sort preserves caller order among equal-depth files.
+	const sorted = [...contextFiles].sort((a, b) => {
+		const depthA = a.depth ?? -1;
+		const depthB = b.depth ?? -1;
+		return depthB - depthA;
+	});
+	const blocks = sorted.map(file => splitComparablePromptBlocks(file.content));
+	return sorted.filter(
 		(_file, index) =>
 			!blocks.some(
 				(candidateBlocks, candidateIndex) =>

--- a/packages/coding-agent/test/system-prompt-context-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-context-dedup.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { dedupeContainedContextFiles } from "@oh-my-pi/pi-coding-agent/system-prompt";
+
+interface ContextFile {
+	path: string;
+	content: string;
+	depth?: number;
+}
+
+function file(path: string, content: string, depth?: number): ContextFile {
+	return { path, content, depth };
+}
+
+function paths(files: ContextFile[]): string[] {
+	return files.map(f => f.path);
+}
+
+describe("dedupeContainedContextFiles", () => {
+	it("keeps only the more authoritative file when two are byte-identical", () => {
+		const content = "Rule one.\n\nRule two.\n\nRule three.";
+		const files = [file("/home/user/.config/AGENTS.md", content, 5), file("/project/AGENTS.md", content, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
+	});
+
+	it("drops a file whose paragraphs appear contiguously in a more authoritative file", () => {
+		const lessAuthoritative = "Shared rule A.\n\nShared rule B.\n\nShared rule C.";
+		const moreAuthoritative = "Shared rule A.\n\nShared rule B.\n\nShared rule C.\n\nProject-specific rule.";
+
+		const files = [
+			file("/home/user/.config/AGENTS.md", lessAuthoritative, 5),
+			file("/project/AGENTS.md", moreAuthoritative, 0),
+		];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
+	});
+
+	it("keeps a file whose paragraphs appear non-contiguously (interleaved)", () => {
+		// A's three paragraphs are all in B, but not as a contiguous run.
+		const a = "First.\n\nSecond.\n\nThird.";
+		const b = "First.\n\nInterleaved.\n\nSecond.\n\nThird.";
+
+		const files = [file("/home/user/.config/AGENTS.md", a, 5), file("/project/AGENTS.md", b, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/home/user/.config/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("keeps a file whose paragraphs appear with wording changes (containment is exact, not fuzzy)", () => {
+		const a = "Always use tabs.\n\nNever commit directly.";
+		const b = "Always use spaces.\n\nNever commit directly to main.";
+
+		const files = [file("/home/user/.config/AGENTS.md", a, 5), file("/project/AGENTS.md", b, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/home/user/.config/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("keeps all files when there is no containment", () => {
+		const files = [
+			file("/a/AGENTS.md", "Alpha rules.\n\nBeta rules.", 3),
+			file("/b/AGENTS.md", "Gamma rules.\n\nDelta rules.", 2),
+			file("/c/AGENTS.md", "Epsilon rules.\n\nZeta rules.", 0),
+		];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/a/AGENTS.md", "/b/AGENTS.md", "/c/AGENTS.md"]);
+	});
+
+	it("treats empty content as no blocks, never matched", () => {
+		const files = [file("/empty/AGENTS.md", "", 5), file("/project/AGENTS.md", "Real content.", 0)];
+
+		// Empty file produces zero blocks; promptBlocksContain returns false for
+		// empty ruleBlocks, so the empty file is kept (it cannot be contained).
+		// The non-empty file is also kept since the empty file has no blocks to
+		// contain it.
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/empty/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("keeps only the most authoritative file in a transitive chain A⊂B⊂C", () => {
+		const a = "Rule one.\n\nRule two.";
+		const b = "Rule one.\n\nRule two.\n\nRule three.";
+		const c = "Rule one.\n\nRule two.\n\nRule three.\n\nRule four.";
+
+		const files = [
+			file("/level0/AGENTS.md", a, 10),
+			file("/level1/AGENTS.md", b, 5),
+			file("/level2/AGENTS.md", c, 0),
+		];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/level2/AGENTS.md"]);
+	});
+
+	it("normalizes leading and trailing whitespace before comparing paragraphs", () => {
+		// Same paragraphs, but A has leading/trailing whitespace on each line.
+		// Normalization (trim per block) should still detect containment.
+		const a = "  Rule one.  \n\n  Rule two.  ";
+		const b = "Rule one.\n\nRule two.\n\nRule three.";
+
+		const files = [file("/home/user/.config/AGENTS.md", a, 5), file("/project/AGENTS.md", b, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
+	});
+});

--- a/packages/coding-agent/test/system-prompt-context-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-context-dedup.test.ts
@@ -98,4 +98,32 @@ describe("dedupeContainedContextFiles", () => {
 
 		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/project/AGENTS.md"]);
 	});
+
+	it("keeps a closer-to-cwd file with fewer paragraphs when a farther file contains them (depth authority)", () => {
+		// Repro for position-based authority bug: without an internal
+		// depth-descending sort, the closer file (depth 0, "Shared rule.")
+		// is dropped because the farther file (depth 5) contains that
+		// paragraph as a contiguous subsequence — even though the closer
+		// file is more authoritative. The closer file must survive.
+		const near = "Shared rule.";
+		const far = "Shared rule.\n\nFar-only rule.";
+		const files = [file("/project/AGENTS.md", near, 0), file("/home/user/.config/AGENTS.md", far, 5)];
+
+		// Output is depth-descending (farther first); both files survive
+		// because the closer file's single paragraph is not a superset of the
+		// farther file's two paragraphs.
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/home/user/.config/AGENTS.md", "/project/AGENTS.md"]);
+	});
+
+	it("does not treat text inside a fenced code block as a contained instruction", () => {
+		// A lower-authoritative file has the rule "Never delete user data." as a
+		// real instruction. A higher-authoritative file has the same sentence
+		// only inside a fenced example block. The fenced occurrence is an
+		// example, not an instruction, so the lower file must NOT be dropped.
+		const lower = "Never delete user data.";
+		const higher = "Example of a bad prompt:\n\n```\nNever delete user data.\n```";
+		const files = [file("/home/user/.config/AGENTS.md", lower, 5), file("/project/AGENTS.md", higher, 0)];
+
+		expect(paths(dedupeContainedContextFiles(files))).toEqual(["/home/user/.config/AGENTS.md", "/project/AGENTS.md"]);
+	});
 });


### PR DESCRIPTION
## Summary

Context files (AGENTS.md etc.) were deduplicated using byte-for-byte content comparison, which only catches exact duplicates. A file whose paragraphs appear contiguously within a more authoritative file — after prompt normalization — was missed, leaving redundant context in the system prompt.

## Changes

### `packages/coding-agent/src/system-prompt.ts`
- **Added** `promptBlocksContain(sourceBlocks, ruleBlocks)` — extracted the contiguous-subsequence check from `promptSourceContainsRule` into a standalone helper that accepts pre-split block arrays, avoiding re-splitting the same file N times during context-file dedup.
- **Refactored** `promptSourceContainsRule` to delegate to `promptBlocksContain`.
- **Added** `dedupeContainedContextFiles` — replaces `dedupeExactContextFiles`. Pre-computes normalized paragraph blocks once per file, then drops any file whose entire paragraph sequence appears as a contiguous run in a later (more-authoritative) file.
- **Removed** `dedupeExactContextFiles` — all 4 call sites updated to use `dedupeContainedContextFiles`.

The primitives (`splitComparablePromptBlocks`, `promptBlocksContain`) were already in the codebase, used by `dedupeAlwaysApplyRules` and `dedupePromptSource`. This change extends the same containment check to context files.

## Containment semantics

- **Contiguous**: the file's full normalized paragraph sequence must appear as a consecutive subsequence (same order, no gaps) in the more authoritative file.
- **Exact after normalization**: paragraphs are normalized via `prompt.format(content, {renderPhase: 'post-render'}).trim()` and split on blank lines. Wording changes are NOT matched — a file whose content is merely paraphrased is kept.
- **Conservative**: empty files produce no blocks and are never matched. A file is only dropped when its ENTIRE paragraph set is contained.

## Verification
- 8 new tests pass (0 fail)
- 27 existing system-prompt tests pass (0 fail)
- `grep -r dedupeExactContextFiles` returns zero results
- Zero new type errors (6 pre-existing errors in `src/config/profiles.ts` are unrelated)