### PR TITLE
fix(natives): avoid cross-version cache cleanup races

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Fixed accessibility snapshots incorrectly marking a window root as focused based on its app-local AXFocused attribute when another application held global focus; the root annotation now correctly reflects the global window-roster focus flag.
 - Improved coordinate-frame error messages for pointer input before capture, out-of-frame coordinates, and between-display points to clearly explain the capture-frame contract and remedy instead of throwing a generic bounds check.
 - Fixed duplicated characters in AppKit targets on macOS caused by background keyboard events being posted through both CoreGraphics and SkyLight; events are now delivered once via the authenticated SkyLight route.
+### Fixed
+
+- Fixed newer OMP versions deleting a freshly created older native addon cache directory during concurrent startup, which could interrupt extraction with `ENOENT`.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -196,6 +196,12 @@ function isOlderReleaseVersion(candidate, current) {
 	return false;
 }
 
+// A concurrently starting older OMP binary creates or refreshes this directory
+// before extracting its addon. Keep fresh directories long enough for that
+// startup to finish; a later launch can reclaim them once they are genuinely
+// stale.
+const NATIVE_CACHE_CLEANUP_GRACE_MS = 10 * 60_000;
+
 /**
  * Remove version-pinned native cache directories older than the loaded package.
  * Best-effort by design: permission errors and concurrent processes must not
@@ -217,6 +223,8 @@ export function cleanupStaleNativeVersions({ nativesDir, currentVersion }) {
 		if (!entry.isDirectory() || !isOlderReleaseVersion(entry.name, currentVersion)) continue;
 		const targetPath = path.join(nativesDir, entry.name);
 		try {
+			const stat = fs.statSync(targetPath);
+			if (Date.now() - stat.mtimeMs < NATIVE_CACHE_CLEANUP_GRACE_MS) continue;
 			fs.rmSync(targetPath, { recursive: true, force: true });
 			removed.push(targetPath);
 		} catch {

--- a/packages/natives/test/windows-staging.test.ts
+++ b/packages/natives/test/windows-staging.test.ts
@@ -195,18 +195,22 @@ describe("windows native addon staging", () => {
 		const nativesDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-natives-cache-"));
 		const currentMajor = Number.parseInt(packageJson.version, 10);
 		const futureVersion = `${currentMajor + 1}.0.0`;
+		const staleVersion = "15.10.11";
+		const freshVersion = "15.10.12";
 		try {
-			await fs.mkdir(path.join(nativesDir, "15.10.11"));
+			await fs.mkdir(path.join(nativesDir, staleVersion));
+			await fs.mkdir(path.join(nativesDir, freshVersion));
 			await fs.mkdir(path.join(nativesDir, packageJson.version));
 			await fs.mkdir(path.join(nativesDir, futureVersion));
 			await fs.mkdir(path.join(nativesDir, "not-a-version"));
 			await Bun.write(path.join(nativesDir, "README.txt"), "not a version directory");
+			await fs.utimes(path.join(nativesDir, staleVersion), new Date(0), new Date(0));
 
 			const removed = cleanupStaleNativeVersions({ nativesDir, currentVersion: packageJson.version });
 
-			expect(removed.map(filePath => path.basename(filePath))).toEqual(["15.10.11"]);
+			expect(removed.map(filePath => path.basename(filePath))).toEqual([staleVersion]);
 			expect((await fs.readdir(nativesDir)).sort()).toEqual(
-				["README.txt", packageJson.version, futureVersion, "not-a-version"].sort(),
+				["README.txt", freshVersion, packageJson.version, futureVersion, "not-a-version"].sort(),
 			);
 		} finally {
 			await fs.rm(nativesDir, { recursive: true, force: true });


### PR DESCRIPTION
## What

- Keep freshly created older-version native addon cache directories during startup cleanup.
- Continue reclaiming older cache directories after a ten-minute freshness grace.
- Extend the existing native-cache cleanup regression and update the package changelog.

## Why

I hit this while launching an older Oh My Pi runtime alongside a newer one: the newer process deleted the older runtime's freshly created native-addon cache directory, causing extraction to fail with `ENOENT`.

Cleanup already preserves current, newer, and unrecognized cache directories, but it still removed every numerically older directory immediately. That leaves a mirror race where the newer runtime can delete an older runtime's directory between `mkdir` and the temporary addon write. Directory modification time provides a cheap cross-process signal: fresh extraction directories get a bounded grace period, while genuinely stale versions remain eligible for cleanup.

## Testing

- Reproduced before the fix with fresh and stale older-version cache directories: cleanup removed both.
- Re-ran the same scenario after the fix: the fresh `17.0.5` directory survived cleanup by `17.1.8`, then was removed after its modification time was aged beyond the grace period.
- `bun test packages/natives/test/windows-staging.test.ts packages/natives/test/issue-823-repro.test.ts --parallel=1` — 12 passed.
- `bun --cwd=packages/natives run check` — passed.
- `git diff --check` — passed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
