### PR TITLE
fix(ai): classify concurrency limits and rotate on account-scoped 403s

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Classified concurrent-request caps separately from quota exhaustion so they use a short retry backoff without burning a credential, and rotate credentials for account-scoped 403 caps such as Devin's overall message limit.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -3,7 +3,7 @@ import type { OAuthAccess } from "./auth-storage";
 import * as AIError from "./error";
 import { isAuthRetryableError, isInvalidatedOAuthTokenError } from "./error/auth-classify";
 import { isUsageLimit } from "./error/flags";
-import { isUsageLimitOutcome } from "./error/rate-limit";
+import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./error/rate-limit";
 
 /**
  * Context passed to an {@link ApiKeyResolver} on each resolution attempt.
@@ -93,11 +93,14 @@ export const AUTH_RETRY_MAX_ATTEMPTS = 64;
 function isDirectCredentialRotationError(error: unknown): boolean {
 	if (isUsageLimit(error) || isInvalidatedOAuthTokenError(error)) return true;
 	const status = AIError.status(error);
-	// 403: the token is valid but access was denied, so refreshing the same
-	// credential can't help — rotate straight through the sibling pool.
-	if (status === 403) return true;
 	const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
-	if (status === undefined && message !== undefined && extractHttpStatusFromError({ message }) === 403) return true;
+	// A 403 normally means a valid token lacks access, so rotate through
+	// siblings. A concurrency-cap 403 is transient instead; do not burn a
+	// sibling before the caller's backoff layer can retry it.
+	const isForbidden =
+		status === 403 ||
+		(status === undefined && message !== undefined && extractHttpStatusFromError({ message }) === 403);
+	if (isForbidden && !isConcurrencyCapExclusion(status, message)) return true;
 	return isUsageLimitOutcome(status, message);
 }
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -12,7 +12,7 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
-import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
+import { $env, extractRetryHint, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
@@ -5927,8 +5927,13 @@ export class AuthStorage {
 		const status = AIError.status(error);
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 		if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
+			// Thread the provider-specified reset window (e.g. Devin "Your limit
+			// will reset in 13 minutes") into the block duration so the credential
+			// is not reselected and hammered while the cap remains active.
+			const retryAfterMs = extractRetryHint(undefined, message);
 			return (
 				await this.markUsageLimitReached(provider, sessionId, {
+					retryAfterMs,
 					modelId: options?.modelId,
 					apiKey: options?.apiKey,
 					credentialId: options?.credentialId,

--- a/packages/ai/src/error/auth-classify.ts
+++ b/packages/ai/src/error/auth-classify.ts
@@ -1,6 +1,6 @@
 import { extractHttpStatusFromError } from "@oh-my-pi/pi-utils";
 import { isOAuthExpiry, isUsageLimit } from "./flags";
-import { isUsageLimitOutcome } from "./rate-limit";
+import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./rate-limit";
 
 /**
  * Whether an OAuth refresh failure is definitive (the credential must be
@@ -38,9 +38,16 @@ export function isAuthRetryableError(error: unknown): boolean {
 	if (isUsageLimit(error)) return true;
 	if (isInvalidatedOAuthTokenError(error)) return true;
 	const httpStatus = extractHttpStatusFromError(error);
-	if (httpStatus === 401 || httpStatus === 403) return true;
 	const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
+	// A 403 concurrency cap is transient (shed-and-backoff), not an auth
+	// failure — exclude it from the top-level auth-retry gate so the caller's
+	// transient backoff owns it instead of force-refreshing the same account
+	// and rotating to a sibling whose production resolver would treat the cap
+	// as a hard-auth failure. Mirrors the streaming gate in stream.ts.
+	if (httpStatus === 401) return true;
+	if (httpStatus === 403) return !isConcurrencyCapExclusion(httpStatus, message);
 	const embeddedStatus = message ? extractHttpStatusFromError({ message }) : undefined;
-	if (embeddedStatus === 401 || embeddedStatus === 403) return true;
+	if (embeddedStatus === 401) return true;
+	if (embeddedStatus === 403) return !isConcurrencyCapExclusion(embeddedStatus, message);
 	return isUsageLimitOutcome(httpStatus ?? embeddedStatus, message);
 }

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -9,6 +9,7 @@ import {
 } from "./classes";
 import {
 	isAccountScopedCapText,
+	isConcurrencyCapExclusion,
 	isOpaqueStatusBody,
 	isUsageLimitStatus,
 	matchesUsageLimitText,
@@ -410,7 +411,7 @@ export function classify(error: unknown, api?: Api): number {
 			if (code === "overloaded_error" || code === "rate_limit_error") {
 				linkKinds |= Flag.Transient;
 			}
-			if (codeStatus === 401 || codeStatus === 403) {
+			if (codeStatus === 401 || (codeStatus === 403 && !isConcurrencyCapExclusion(codeStatus, link.message))) {
 				linkKinds |= Flag.AuthFailed;
 			} else if (codeStatus === 429) {
 				if ((linkKinds & Flag.UsageLimit) === 0) {

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -7,7 +7,13 @@ import {
 	ProviderHttpError,
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
-import { isOpaqueStatusBody, isUsageLimitStatus, matchesUsageLimitText, parseRateLimitReason } from "./rate-limit";
+import {
+	isAccountScopedCapText,
+	isOpaqueStatusBody,
+	isUsageLimitStatus,
+	matchesUsageLimitText,
+	parseRateLimitReason,
+} from "./rate-limit";
 
 export const Flag = {
 	Class: 0x1000,
@@ -333,6 +339,7 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		if (
 			!concurrencyExcluded &&
 			(matchesUsageLimitText(cleanMessage) ||
+				((statusClean === 403 || statusClean === undefined) && isAccountScopedCapText(cleanMessage)) ||
 				(isLimitStatus &&
 					(isOpaque || reason === "QUOTA_EXHAUSTED" || (isBillingCapStatus && reason === "CONCURRENT_LIMIT"))))
 		) {
@@ -341,6 +348,11 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 
 		if (isTimeoutText(errorMessage)) kinds |= Flag.Transient | Flag.Timeout;
 		else if (isTransientErrorText(errorMessage)) kinds |= Flag.Transient;
+		// A concurrency cap (e.g. Vertex "Online prediction concurrent requests
+		// quota exceeded") is transient — shed-and-backoff. The bare wording need
+		// not match TRANSIENT_TRANSPORT_PATTERN, so flag it explicitly to keep
+		// AIError.retriable from treating the temporary cap as terminal.
+		if (reason === "CONCURRENT_LIMIT") kinds |= Flag.Transient;
 		if ((api === "openai-responses" || api === "openai-codex-responses") && isStaleResponsesText(errorMessage)) {
 			kinds |= Flag.StaleResponsesItem;
 		}

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -319,9 +319,22 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		const isOpaque = isOpaqueStatusBody(cleanMessage);
 
 		const isLimitStatus = isUsageLimitStatus(statusClean);
+		const reason = parseRateLimitReason(cleanMessage);
+		// Concurrency caps (e.g. Vertex "Online prediction concurrent requests
+		// quota exceeded") are shed-and-backoff, not credential-rotatable —
+		// exclude them even when the quota-worded phrasing matches the generic
+		// usage-limit text matcher, whose `quota.?exceeded` arm would otherwise
+		// set Flag.UsageLimit and burn a healthy sibling credential. HTTP 402 is
+		// excluded from this gate: it is categorically an account-billing cap, so
+		// a 402 whose body merely mentions concurrency still classifies as a
+		// usage limit, mirroring isUsageLimitOutcome.
+		const isBillingCapStatus = statusClean === 402;
+		const concurrencyExcluded = reason === "CONCURRENT_LIMIT" && !isBillingCapStatus;
 		if (
-			matchesUsageLimitText(cleanMessage) ||
-			(isLimitStatus && (isOpaque || parseRateLimitReason(cleanMessage) === "QUOTA_EXHAUSTED"))
+			!concurrencyExcluded &&
+			(matchesUsageLimitText(cleanMessage) ||
+				(isLimitStatus &&
+					(isOpaque || reason === "QUOTA_EXHAUSTED" || (isBillingCapStatus && reason === "CONCURRENT_LIMIT"))))
 		) {
 			kinds |= Flag.UsageLimit;
 		}

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -24,9 +24,19 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 const CONCURRENT_LIMIT_PATTERN =
-	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+	// Require an actual cap signal (limit/quota/exceeded/reached) near "concurrent".
+	// Bare nouns ("concurrent request is not supported", "only one concurrent
+	// invocation is supported") are deterministic 4xx feature rejections, not
+	// transient caps — matching them here would set Flag.Transient and retry the
+	// rejection instead of surfacing it.
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
 const ACCOUNT_SCOPED_403_PATTERN =
-	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
+	// The bare "limit will reset" / "will reset in" phrasing also appears on
+	// statusless per-minute transients ("Rate limit will reset in 30 seconds"),
+	// so gate the reset-window alternative on account-specific wording (Devin's
+	// "Your limit will reset in …"); the overall/account qualifiers arm above
+	// already covers the rest.
+	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\byour\b[^\n]{0,30}\b(?:limit )?will reset\b/i;
 
 /**
  * Classify a rate-limit error message into a reason category.

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -29,8 +29,13 @@ const CONCURRENT_LIMIT_PATTERN =
 	// structured snake_case codes ("concurrent_limit_exceeded",
 	// "concurrent_requests_limit_reached", "concurrency_quota_exceeded") need the
 	// third alternative. Bare space-separated concurrency feature rejections stay
-	// excluded because they neither use `[-_]` nor carry a cap keyword.
-	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b|\bconcurren[a-z]*[-_](?:[a-z]+[_-])*(?:limit|quota|exceed\w*|reach\w*)/i;
+	// excluded because they neither use `[-_]` nor carry a cap keyword. The fourth
+	// alternative covers the common statusless adapter phrasing "Too many concurrent
+	// requests" / "Too many concurrent invocations", where "too many" is the cap
+	// signal — no limit/quota/exceeded/reached keyword appears, so the first three
+	// alternatives miss it and the generic "too many requests" substring check also
+	// fails (the intervening word breaks the match).
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b|\bconcurren[a-z]*[-_](?:[a-z]+[_-])*(?:limit|quota|exceed\w*|reach\w*)|\btoo many concurrent\b/i;
 const ACCOUNT_SCOPED_403_PATTERN =
 	// The bare "limit will reset" / "will reset in" phrasing also appears on
 	// statusless per-minute transients ("Rate limit will reset in 30 seconds"),

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -25,11 +25,12 @@ const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 const CONCURRENT_LIMIT_PATTERN =
 	// Require an actual cap signal (limit/quota/exceeded/reached) near "concurrent".
-	// Bare nouns ("concurrent request is not supported", "only one concurrent
-	// invocation is supported") are deterministic 4xx feature rejections, not
-	// transient caps — matching them here would set Flag.Transient and retry the
-	// rejection instead of surfacing it.
-	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+	// The first two alternatives rely on `\b`, which treats `_` as a word char, so
+	// structured snake_case codes ("concurrent_limit_exceeded",
+	// "concurrent_requests_limit_reached", "concurrency_quota_exceeded") need the
+	// third alternative. Bare space-separated concurrency feature rejections stay
+	// excluded because they neither use `[-_]` nor carry a cap keyword.
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b|\bconcurren[a-z]*[-_](?:[a-z]+[_-])*(?:limit|quota|exceed\w*|reach\w*)/i;
 const ACCOUNT_SCOPED_403_PATTERN =
 	// The bare "limit will reset" / "will reset in" phrasing also appears on
 	// statusless per-minute transients ("Rate limit will reset in 30 seconds"),
@@ -180,7 +181,7 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 	// still an exhausted billing cap and must rotate; gate the exclusion on the
 	// status not being that categorical billing cap.
 	const isBillingCapStatus = status === 402;
-	if (message && parseRateLimitReason(message) === "CONCURRENT_LIMIT" && !isBillingCapStatus) return false;
+	if (isConcurrencyCapExclusion(status, message)) return false;
 	if (message && matchesUsageLimitText(message)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
 	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
@@ -235,4 +236,13 @@ export function matchesUsageLimitText(errorMessage: string): boolean {
  */
 export function isAccountScopedCapText(message: string): boolean {
 	return ACCOUNT_SCOPED_403_PATTERN.test(message);
+}
+
+/**
+ * A concurrency cap on a non-billing status is shed-and-backoff, not
+ * credential-rotatable. This mirrors the exclusion in {@link isUsageLimitOutcome}
+ * for the 403 auth-retry entry points. A 402 remains a categorical billing cap.
+ */
+export function isConcurrencyCapExclusion(status: number | undefined, message: string | undefined): boolean {
+	return message !== undefined && parseRateLimitReason(message) === "CONCURRENT_LIMIT" && status !== 402;
 }

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -6,12 +6,14 @@
 export type RateLimitReason =
 	| "QUOTA_EXHAUSTED"
 	| "RATE_LIMIT_EXCEEDED"
+	| "CONCURRENT_LIMIT"
 	| "MODEL_CAPACITY_EXHAUSTED"
 	| "SERVER_ERROR"
 	| "UNKNOWN";
 
 const QUOTA_EXHAUSTED_BACKOFF_MS = 30 * 60 * 1000; // 30 min
 const RATE_LIMIT_EXCEEDED_BACKOFF_MS = 30 * 1000; // 30s
+const CONCURRENT_LIMIT_BACKOFF_MS = 5 * 1000; // 5s
 const MODEL_CAPACITY_BASE_MS = 45 * 1000; // 45s base
 const MODEL_CAPACITY_JITTER_MS = 30 * 1000; // ±15s
 const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
@@ -21,11 +23,15 @@ const ACCOUNT_RATE_LIMIT_PATTERN =
 const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
+const CONCURRENT_LIMIT_PATTERN =
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+const ACCOUNT_SCOPED_403_PATTERN =
+	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
- * Priority order: QUOTA (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
- * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
+ * Priority order: QUOTA (Antigravity "quota will reset") > CONCURRENT_LIMIT > MODEL_CAPACITY >
+ * QUOTA (account) > RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
  *
  * "resource exhausted" maps to MODEL_CAPACITY (transient, short wait)
  * "quota exceeded" / "quota will reset" maps to QUOTA_EXHAUSTED (long wait, switch account)
@@ -40,6 +46,10 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	// MODEL_CAPACITY fallthrough so credential rotation (not 60s backoff) kicks in.
 	if (lower.includes("quota will reset") || lower.includes("exhausted your capacity")) {
 		return "QUOTA_EXHAUSTED";
+	}
+
+	if (CONCURRENT_LIMIT_PATTERN.test(errorMessage)) {
+		return "CONCURRENT_LIMIT";
 	}
 
 	if (
@@ -105,6 +115,8 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 			return QUOTA_EXHAUSTED_BACKOFF_MS;
 		case "RATE_LIMIT_EXCEEDED":
 			return RATE_LIMIT_EXCEEDED_BACKOFF_MS;
+		case "CONCURRENT_LIMIT":
+			return CONCURRENT_LIMIT_BACKOFF_MS;
 		case "MODEL_CAPACITY_EXHAUSTED":
 			return MODEL_CAPACITY_BASE_MS + Math.random() * MODEL_CAPACITY_JITTER_MS;
 		case "SERVER_ERROR":
@@ -151,9 +163,15 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
 	if (message && matchesUsageLimitText(message)) return true;
+	// A 403 is normally an auth failure, but several providers deliver an
+	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
+	// GitHub Copilot). Rotate only when the body names a cap that resets —
+	// never on a bare 403, which stays an auth failure.
+	if (status === 403 && message && ACCOUNT_SCOPED_403_PATTERN.test(message)) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
-	return parseRateLimitReason(message) === "QUOTA_EXHAUSTED";
+	const reason = parseRateLimitReason(message);
+	return reason === "QUOTA_EXHAUSTED";
 }
 
 /**

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -174,9 +174,11 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 	if (message && matchesUsageLimitText(message)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
 	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
-	// GitHub Copilot). Rotate only when the body names a cap that resets —
-	// never on a bare 403, which stays an auth failure.
-	if (status === 403 && message && ACCOUNT_SCOPED_403_PATTERN.test(message)) return true;
+	// GitHub Copilot). Devin's end-of-stream Connect trailer carries no HTTP
+	// status at all (it arrives as a `permission_denied` ValidationError), so
+	// accept an undefined status too — but only when the body names a cap that
+	// resets, never on a bare 403, which stays an auth failure.
+	if ((status === 403 || status === undefined) && message && isAccountScopedCapText(message)) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
 	const reason = parseRateLimitReason(message);
@@ -212,4 +214,15 @@ export function matchesUsageLimitText(errorMessage: string): boolean {
 		ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage) ||
 		OPENROUTER_DAILY_FREE_LIMIT_PATTERN.test(errorMessage)
 	);
+}
+
+/**
+ * Account-scoped cap phrasing delivered on a 403 (or a statusless Connect
+ * trailer): "Reached overall message rate limit", "Your limit will reset in …".
+ * Kept separate from {@link matchesUsageLimitText} because the bare wording is
+ * ambiguous without the 403 / statusless-account context; consumed by both
+ * {@link isUsageLimitOutcome} (rotation decision) and `flags.ts` (Flag.UsageLimit).
+ */
+export function isAccountScopedCapText(message: string): boolean {
+	return ACCOUNT_SCOPED_403_PATTERN.test(message);
 }

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -154,14 +154,23 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  *  3. Body is absent or {@link isOpaqueStatusBody opaque} (just the status,
  *     empty JSON, HTTP framing only) → rotate conservatively: the server
  *     gave us nothing else to go on.
- *  4. Body has content → defer to {@link parseRateLimitReason}. Only
- *     `QUOTA_EXHAUSTED` rotates; `RATE_LIMIT_EXCEEDED` (`Too many requests`,
+ *  4. Body has content → defer to {@link parseRateLimitReason}. `QUOTA_EXHAUSTED`
+ *     rotates; for the categorical 402 billing cap a `CONCURRENT_LIMIT` body
+ *     also rotates (the cap is concurrent-worded but the status is still an
+ *     exhausted billing cap). `RATE_LIMIT_EXCEEDED` (`Too many requests`,
  *     per-minute caps), `MODEL_CAPACITY_EXHAUSTED` (`Service overloaded`),
  *     `SERVER_ERROR`, and `UNKNOWN` (`Please retry in 5s`) stay in the
  *     provider's own backoff layer so transient 429s don't burn sibling
  *     credentials.
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
+	// Concurrency caps are shed-and-backoff, not credential-rotatable — but only
+	// for quota-worded 429 / other statuses. HTTP 402 is categorically an
+	// account-billing cap, so a 402 whose body happens to mention concurrency is
+	// still an exhausted billing cap and must rotate; gate the exclusion on the
+	// status not being that categorical billing cap.
+	const isBillingCapStatus = status === 402;
+	if (message && parseRateLimitReason(message) === "CONCURRENT_LIMIT" && !isBillingCapStatus) return false;
 	if (message && matchesUsageLimitText(message)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
 	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
@@ -171,7 +180,9 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
 	const reason = parseRateLimitReason(message);
-	return reason === "QUOTA_EXHAUSTED";
+	// For the categorical 402 billing cap a concurrency-worded body is still an
+	// exhausted cap (rotate); for 429 / other only QUOTA_EXHAUSTED rotates.
+	return reason === "QUOTA_EXHAUSTED" || (isBillingCapStatus && reason === "CONCURRENT_LIMIT");
 }
 
 /**

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -21,7 +21,7 @@ import { createAuthRetryKeyState, isApiKeyResolver, resolveNextAuthRetryKey } fr
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
 import { isInvalidatedOAuthTokenError } from "./error/auth-classify";
-import { isUsageLimitOutcome } from "./error/rate-limit";
+import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { CursorOptions } from "./providers/cursor";
@@ -985,7 +985,7 @@ function isRetryableUpstreamError(error: unknown, status: number | undefined, me
 	// instead of burning siblings.
 	if (AIError.isUsageLimit(error)) return true;
 	if (isInvalidatedOAuthTokenError(error)) return true;
-	if (status === 401 || status === 403) return true;
+	if (status === 401 || (status === 403 && !isConcurrencyCapExclusion(status, message))) return true;
 	return isUsageLimitOutcome(status, message);
 }
 

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -275,6 +275,32 @@ describe("withAuth", () => {
 		expect(contexts.map(ctx => ctx.lastChance)).toEqual([false, true, true, true]);
 	});
 
+	it("does not directly rotate through every sibling on a 403 concurrency cap", async () => {
+		const keys: string[] = [];
+		const contexts: ApiKeyResolveContext[] = [];
+		const pool = ["k0", "k1", "k2", "k3"];
+		let resolveIndex = 0;
+		const concurrencyCap = Object.assign(new Error("concurrent requests limit reached"), { status: 403 });
+
+		await expect(
+			withAuth(
+				ctx => {
+					contexts.push(ctx);
+					return ctx.error === undefined ? pool[0] : pool[++resolveIndex];
+				},
+				async key => {
+					keys.push(key);
+					throw concurrencyCap;
+				},
+			),
+		).rejects.toBe(concurrencyCap);
+
+		// The concurrency classification takes precedence over plain-403 direct
+		// rotation: refresh once, then take only the legacy sibling switch.
+		expect(keys).toEqual(["k0", "k1", "k2"]);
+		expect(contexts.map(ctx => ctx.lastChance)).toEqual([false, false, true]);
+	});
+
 	it("surfaces the last 403 when every sibling is denied", async () => {
 		const errors = [authError(403), authError(403)];
 		const resolved = ["k0", "k1", "k0"];

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -91,6 +91,20 @@ describe("isAuthRetryableError", () => {
 		expect(isAuthRetryableError(new Error("network blip"))).toBe(false);
 		expect(isAuthRetryableError(undefined)).toBe(false);
 	});
+	// A 403 concurrency cap is transient (shed-and-backoff), not an auth
+	// failure — it must be excluded from the top-level auth-retry gate so
+	// withAuth throws it to the caller's transient backoff instead of
+	// force-refreshing the same account and rotating to a sibling.
+	it("excludes 403 concurrency caps from the auth-retry gate", () => {
+		expect(isAuthRetryableError(Object.assign(new Error("concurrent requests limit reached"), { status: 403 }))).toBe(
+			false,
+		);
+		expect(isAuthRetryableError(Object.assign(new Error("Too many concurrent requests"), { status: 403 }))).toBe(
+			false,
+		);
+		// A bare 403 without concurrency wording still rotates.
+		expect(isAuthRetryableError(authError(403))).toBe(true);
+	});
 });
 
 describe("withAuth", () => {
@@ -275,18 +289,16 @@ describe("withAuth", () => {
 		expect(contexts.map(ctx => ctx.lastChance)).toEqual([false, true, true, true]);
 	});
 
-	it("does not directly rotate through every sibling on a 403 concurrency cap", async () => {
+	it("surfaces a 403 concurrency cap without entering the auth-retry path", async () => {
 		const keys: string[] = [];
 		const contexts: ApiKeyResolveContext[] = [];
-		const pool = ["k0", "k1", "k2", "k3"];
-		let resolveIndex = 0;
 		const concurrencyCap = Object.assign(new Error("concurrent requests limit reached"), { status: 403 });
 
 		await expect(
 			withAuth(
 				ctx => {
 					contexts.push(ctx);
-					return ctx.error === undefined ? pool[0] : pool[++resolveIndex];
+					return ctx.error === undefined ? "k0" : ctx.lastChance ? "k2" : "k1";
 				},
 				async key => {
 					keys.push(key);
@@ -295,10 +307,14 @@ describe("withAuth", () => {
 			),
 		).rejects.toBe(concurrencyCap);
 
-		// The concurrency classification takes precedence over plain-403 direct
-		// rotation: refresh once, then take only the legacy sibling switch.
-		expect(keys).toEqual(["k0", "k1", "k2"]);
-		expect(contexts.map(ctx => ctx.lastChance)).toEqual([false, false, true]);
+		// The concurrency cap is excluded from the top-level auth-retry gate
+		// (isAuthRetryableError), so withAuth throws it immediately — no
+		// force-refresh, no sibling rotation. The caller's transient backoff
+		// owns the retry, preserving the still-valid credential.
+		expect(keys).toEqual(["k0"]);
+		expect(contexts.map(ctx => ({ lastChance: ctx.lastChance, hasError: ctx.error !== undefined }))).toEqual([
+			{ lastChance: false, hasError: false },
+		]);
 	});
 
 	it("surfaces the last 403 when every sibling is denied", async () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
-import { classify, classifyMessage, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
+import { classify, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
 import {
 	calculateRateLimitBackoffMs,
+	isConcurrencyCapExclusion,
 	isUsageLimitOutcome,
 	isUsageLimitStatus,
 	parseRateLimitReason,
@@ -38,6 +39,9 @@ describe("parseRateLimitReason", () => {
 	it("classifies concurrent request caps separately from rate limits and quota exhaustion", () => {
 		expect(parseRateLimitReason("Number of concurrent requests exceeded")).toBe("CONCURRENT_LIMIT");
 		expect(parseRateLimitReason("Maximum concurrent invocation limit reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("concurrent_limit_exceeded")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("concurrent_requests_limit_reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("concurrency_quota_exceeded")).toBe("CONCURRENT_LIMIT");
 		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
 		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
 	});
@@ -277,30 +281,6 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimit(message)).toBe(false);
 	});
 
-	// agent-session gates Copilot credential removal on AuthFailed && !UsageLimit.
-	// A 403 whose body is a recognized account cap carries UsageLimit, so the gate
-	// suppresses removal and retains the still-valid credential; a plain 401 has no
-	// UsageLimit, so removal proceeds. Pin the gate condition for both shapes.
-	it("keeps Copilot credentials for a 403 account cap, removes on a 401", () => {
-		const cap = new ProviderHttpError(
-			"Reached overall message rate limit. Your limit will reset in 13 minutes.",
-			403,
-		);
-		const capId = classifyMessage({
-			errorId: classify(cap),
-			errorMessage: "GitHub Copilot access denied (HTTP 403).",
-			errorStatus: 403,
-		});
-		expect(is(capId, Flag.AuthFailed) && !is(capId, Flag.UsageLimit)).toBe(false);
-		const auth = new ProviderHttpError("401 Unauthorized", 401);
-		const authId = classifyMessage({
-			errorId: classify(auth),
-			errorMessage: "GitHub Copilot authentication failed (HTTP 401).",
-			errorStatus: 401,
-		});
-		expect(is(authId, Flag.AuthFailed) && !is(authId, Flag.UsageLimit)).toBe(true);
-	});
-
 	it("rotates on xAI Grok Build 402 usage-balance exhaustion regardless of status", () => {
 		const message = "402 Grok Build usage balance exhausted";
 		expect(isUsageLimitOutcome(402, message)).toBe(true);
@@ -331,6 +311,14 @@ describe("isUsageLimitOutcome", () => {
 		expect(parseRateLimitReason(message)).toBe("CONCURRENT_LIMIT");
 		expect(isUsageLimitOutcome(429, message)).toBe(false);
 		expect(isUsageLimit(message)).toBe(false);
+	});
+
+	it("excludes non-billing concurrency caps from credential rotation", () => {
+		const message = "concurrent requests limit reached";
+		expect(isConcurrencyCapExclusion(403, message)).toBe(true);
+		expect(isConcurrencyCapExclusion(undefined, message)).toBe(true);
+		expect(isConcurrencyCapExclusion(402, message)).toBe(false);
+		expect(isConcurrencyCapExclusion(403, "Forbidden")).toBe(false);
 	});
 
 	// The same bare concurrency wording can reach turn recovery without a

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
-import { isUsageLimit } from "@oh-my-pi/pi-ai/error/flags";
+import { classify, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
 import {
 	calculateRateLimitBackoffMs,
 	isUsageLimitOutcome,
@@ -241,13 +241,16 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(true);
 	});
 
-	it("rotates only account-scoped cap 403s", () => {
-		expect(
-			isUsageLimitOutcome(
-				403,
-				"Devin stream error permission_denied: Reached overall message rate limit. Please try again later. Your limit will reset in 13 minutes.",
-			),
-		).toBe(true);
+	it("rotates only account-scoped cap 403s and statusless trailers", () => {
+		const devinTrailer =
+			"Devin stream error permission_denied: Reached overall message rate limit. Please try again later. Your limit will reset in 13 minutes.";
+		// HTTP 403 with the account-scoped body rotates.
+		expect(isUsageLimitOutcome(403, devinTrailer)).toBe(true);
+		// Devin's Connect trailer carries no HTTP status (a permission_denied
+		// ValidationError), so it must rotate on an undefined status too —
+		// otherwise the exhausted credential is retried as a transient failure.
+		expect(isUsageLimitOutcome(undefined, devinTrailer)).toBe(true);
+		expect(isUsageLimit(devinTrailer)).toBe(true);
 		expect(isUsageLimitOutcome(403, "Forbidden")).toBe(false);
 	});
 
@@ -281,6 +284,18 @@ describe("isUsageLimitOutcome", () => {
 		expect(parseRateLimitReason(message)).toBe("CONCURRENT_LIMIT");
 		expect(isUsageLimitOutcome(429, message)).toBe(false);
 		expect(isUsageLimit(message)).toBe(false);
+	});
+
+	// The same bare concurrency wording can reach turn recovery without a
+	// preserved HTTP status (Vertex/Bedrock paths that bypass API-key
+	// resolution). The body misses TRANSIENT_TRANSPORT_PATTERN, so without an
+	// explicit Flag.Transient the temporary cap classifies as terminal and is
+	// never retried. It must stay shed-and-backoff (transient/retriable).
+	it("keeps statusless concurrency caps transient and retriable", () => {
+		const message = "Online prediction concurrent requests quota exceeded";
+		const id = classify(message);
+		expect(is(id, Flag.Transient)).toBe(true);
+		expect(retriable(id)).toBe(true);
 	});
 
 	// HTTP 402 is categorically an account-billing cap, so a 402 whose body is

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
-import { classify, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
+import { classify, classifyMessage, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
 import {
 	calculateRateLimitBackoffMs,
 	isUsageLimitOutcome,
@@ -40,6 +40,18 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Maximum concurrent invocation limit reached")).toBe("CONCURRENT_LIMIT");
 		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
 		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
+	});
+
+	// Deterministic 4xx feature rejections worded with bare concurrency nouns
+	// ("concurrent request/invocation is not supported") must not classify as a
+	// concurrency cap — doing so would set Flag.Transient and retry the rejection
+	// instead of surfacing it. A cap needs an explicit limit/quota/exceeded/reached
+	// signal near "concurrent".
+	it("does not classify bare concurrency feature rejections as CONCURRENT_LIMIT", () => {
+		expect(parseRateLimitReason("Concurrent invocation is not supported")).not.toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Only one concurrent request is supported")).not.toBe("CONCURRENT_LIMIT");
+		// The deterministic rejection must surface as a hard error, not be retried.
+		expect(is(classify("Concurrent invocation is not supported"), Flag.Transient)).toBe(false);
 	});
 
 	it("classifies overloaded 529 as MODEL_CAPACITY_EXHAUSTED", () => {
@@ -252,6 +264,41 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(undefined, devinTrailer)).toBe(true);
 		expect(isUsageLimit(devinTrailer)).toBe(true);
 		expect(isUsageLimitOutcome(403, "Forbidden")).toBe(false);
+	});
+
+	// A statusless per-minute reset-window transient ("Rate limit will reset in
+	// 30 seconds") is ordinary throttling (RATE_LIMIT_EXCEEDED), not an account
+	// usage cap. The reset-window alternative is gated on account scope so it stays
+	// in the backoff lane instead of rotating the credential.
+	it("does not rotate on a statusless per-minute reset-window transient", () => {
+		const message = "Rate limit will reset in 30 seconds";
+		expect(parseRateLimitReason(message)).toBe("RATE_LIMIT_EXCEEDED");
+		expect(isUsageLimitOutcome(undefined, message)).toBe(false);
+		expect(isUsageLimit(message)).toBe(false);
+	});
+
+	// agent-session gates Copilot credential removal on AuthFailed && !UsageLimit.
+	// A 403 whose body is a recognized account cap carries UsageLimit, so the gate
+	// suppresses removal and retains the still-valid credential; a plain 401 has no
+	// UsageLimit, so removal proceeds. Pin the gate condition for both shapes.
+	it("keeps Copilot credentials for a 403 account cap, removes on a 401", () => {
+		const cap = new ProviderHttpError(
+			"Reached overall message rate limit. Your limit will reset in 13 minutes.",
+			403,
+		);
+		const capId = classifyMessage({
+			errorId: classify(cap),
+			errorMessage: "GitHub Copilot access denied (HTTP 403).",
+			errorStatus: 403,
+		});
+		expect(is(capId, Flag.AuthFailed) && !is(capId, Flag.UsageLimit)).toBe(false);
+		const auth = new ProviderHttpError("401 Unauthorized", 401);
+		const authId = classifyMessage({
+			errorId: classify(auth),
+			errorMessage: "GitHub Copilot authentication failed (HTTP 401).",
+			errorStatus: 401,
+		});
+		expect(is(authId, Flag.AuthFailed) && !is(authId, Flag.UsageLimit)).toBe(true);
 	});
 
 	it("rotates on xAI Grok Build 402 usage-balance exhaustion regardless of status", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -270,6 +270,36 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(401, "Invalid API key")).toBe(false);
 		expect(isUsageLimitOutcome(400, "invalid_request_error: model unsupported")).toBe(false);
 	});
+
+	// Vertex returns "Online prediction concurrent requests quota exceeded" for a
+	// concurrent-request cap. The generic USAGE_LIMIT_PATTERN matches
+	// `quota.?exceeded`, but this is a concurrency cap (5s backoff, no rotation),
+	// not account quota exhaustion. CONCURRENT_LIMIT must take precedence so the
+	// credential is not burned.
+	it("does not rotate on Vertex quota-worded concurrency caps", () => {
+		const message = "Online prediction concurrent requests quota exceeded";
+		expect(parseRateLimitReason(message)).toBe("CONCURRENT_LIMIT");
+		expect(isUsageLimitOutcome(429, message)).toBe(false);
+		expect(isUsageLimit(message)).toBe(false);
+	});
+
+	// HTTP 402 is categorically an account-billing cap, so a 402 whose body is
+	// worded as a concurrency cap still rotates — the billing-cap status wins
+	// over the concurrency exclusion. The identical concurrency wording on a
+	// quota-worded 429 stays non-rotatable (5s backoff). This pins the
+	// 402-billing-cap > concurrency-exclusion precedence in both the rotation
+	// decision (isUsageLimitOutcome) and the Flag.UsageLimit classification
+	// (isUsageLimit).
+	it("rotates on 402 concurrency-worded billing caps but not 429 concurrency caps", () => {
+		const message = "concurrent requests limit reached";
+		expect(parseRateLimitReason(message)).toBe("CONCURRENT_LIMIT");
+		// 402 billing cap wins: rotate.
+		expect(isUsageLimitOutcome(402, message)).toBe(true);
+		expect(isUsageLimit(Object.assign(new Error(message), { status: 402 }))).toBe(true);
+		// 429 concurrency cap: shed-and-backoff, do not rotate.
+		expect(isUsageLimitOutcome(429, message)).toBe(false);
+		expect(isUsageLimit(Object.assign(new Error(message), { status: 429 }))).toBe(false);
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -45,6 +45,18 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
 		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
 	});
+	// Statusless adapter phrasing "Too many concurrent requests" / "Too many
+	// concurrent invocations" carries no limit/quota/exceeded/reached keyword,
+	// so the first three pattern alternatives miss it. The generic "too many
+	// requests" substring check also fails (the intervening word breaks the
+	// match). Without the dedicated alternative these fall to UNKNOWN and the
+	// temporary cap becomes terminal instead of retrying with the 5s backoff.
+	it("classifies statusless 'too many concurrent' phrasing as CONCURRENT_LIMIT", () => {
+		expect(parseRateLimitReason("Too many concurrent requests")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Too many concurrent invocations")).toBe("CONCURRENT_LIMIT");
+		// The cap must be retriable (Transient), not terminal.
+		expect(is(classify("Too many concurrent requests"), Flag.Transient)).toBe(true);
+	});
 
 	// Deterministic 4xx feature rejections worded with bare concurrency nouns
 	// ("concurrent request/invocation is not supported") must not classify as a

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -35,6 +35,13 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Requests per minute limit reached")).toBe("RATE_LIMIT_EXCEEDED");
 	});
 
+	it("classifies concurrent request caps separately from rate limits and quota exhaustion", () => {
+		expect(parseRateLimitReason("Number of concurrent requests exceeded")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Maximum concurrent invocation limit reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
+		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
+	});
+
 	it("classifies overloaded 529 as MODEL_CAPACITY_EXHAUSTED", () => {
 		expect(parseRateLimitReason("Service overloaded 529")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
@@ -234,6 +241,16 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(true);
 	});
 
+	it("rotates only account-scoped cap 403s", () => {
+		expect(
+			isUsageLimitOutcome(
+				403,
+				"Devin stream error permission_denied: Reached overall message rate limit. Please try again later. Your limit will reset in 13 minutes.",
+			),
+		).toBe(true);
+		expect(isUsageLimitOutcome(403, "Forbidden")).toBe(false);
+	});
+
 	it("rotates on xAI Grok Build 402 usage-balance exhaustion regardless of status", () => {
 		const message = "402 Grok Build usage balance exhausted";
 		expect(isUsageLimitOutcome(402, message)).toBe(true);
@@ -262,5 +279,9 @@ describe("calculateRateLimitBackoffMs", () => {
 			expect(ms).toBeGreaterThanOrEqual(45_000);
 			expect(ms).toBeLessThanOrEqual(75_000);
 		}
+	});
+
+	it("returns a short backoff for CONCURRENT_LIMIT", () => {
+		expect(calculateRateLimitBackoffMs("CONCURRENT_LIMIT")).toBe(5_000);
 	});
 });

--- a/packages/ai/test/stream-auth-retry.test.ts
+++ b/packages/ai/test/stream-auth-retry.test.ts
@@ -120,6 +120,41 @@ describe("streamSimple resolver auth retry", () => {
 		expect((contexts[1]!.error as { status?: number }).status).toBe(401);
 	});
 
+	it("surfaces a 403 concurrency cap for transient backoff without rotating credentials", async () => {
+		const keys: unknown[] = [];
+		const contexts: ApiKeyResolveContext[] = [];
+		const concurrencyCap = Object.assign(new Error("concurrent requests limit reached"), { status: 403 });
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => stream.fail(concurrencyCap));
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const stream = streamSimple(model(), context, {
+			apiKey: async ctx => {
+				contexts.push(ctx);
+				return ctx.error === undefined ? "old-key" : ctx.lastChance ? "sibling-key" : "refresh-key";
+			},
+		});
+		await expect(
+			(async () => {
+				for await (const _event of stream) {
+					// drain
+				}
+			})(),
+		).rejects.toBe(concurrencyCap);
+
+		expect(keys).toEqual(["old-key"]);
+		expect(contexts.map(ctx => ({ lastChance: ctx.lastChance, hasError: ctx.error !== undefined }))).toEqual([
+			{ lastChance: false, hasError: false },
+		]);
+	});
+
 	it("buffers the start event and retries on a 401 error event before content", async () => {
 		const keys: unknown[] = [];
 		const eventTypes: string[] = [];

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Classified concurrent-request caps (including statusless "Too many concurrent requests" phrasing) as transient with a 5s backoff instead of treating them as auth failures, so a Copilot 403 concurrency cap no longer deletes still-valid credentials. Account-scoped 403 caps (Devin overall message limit, xAI spending-limit) still rotate to a sibling credential.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2537,14 +2537,17 @@ export class AgentSession {
 			// outside the session transcript (issue #6177).
 			logProviderTurnError(msg);
 
-			// Invalidate GitHub Copilot credentials on auth failure so stale tokens
-			// aren't reused on the next request
-			if (
-				msg.stopReason === "error" &&
-				msg.provider === "github-copilot" &&
-				AIError.is(AIError.classifyMessage(msg), AIError.Flag.AuthFailed)
-			) {
-				await this.#modelRegistry.authStorage.remove("github-copilot");
+			// Invalidate GitHub Copilot credentials on a hard auth failure (401, or an
+			// expired/revoked token) so stale tokens aren't reused on the next request.
+			// A 403 whose body is a recognized account usage cap is NOT an auth failure —
+			// the credential is valid, only temporarily blocked until its reset window —
+			// so gate the removal on the absence of Flag.UsageLimit and keep the
+			// still-valid credential around until the cap resets.
+			if (msg.stopReason === "error" && msg.provider === "github-copilot") {
+				const errorId = AIError.classifyMessage(msg);
+				if (AIError.is(errorId, AIError.Flag.AuthFailed) && !AIError.is(errorId, AIError.Flag.UsageLimit)) {
+					await this.#modelRegistry.authStorage.remove("github-copilot");
+				}
 			}
 
 			if (this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp === msg.timestamp) {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1312,6 +1312,22 @@ export class TurnRecovery {
 		let delayMs = staleOpenAIResponsesReplayError
 			? 0
 			: calculateRetryBackoffDelayMs(retrySettings.baseDelayMs, this.#retryAttempt);
+		// Concurrency caps shed-and-backoff (5s) rather than burning a sibling
+		// credential, so the usage-limit rotation branch below is deliberately
+		// skipped for them. Apply the reason-based backoff to the transient
+		// same-model retry path too — otherwise the default exponential base
+		// (≈500ms) re-hits the cap immediately and burns the retry budget while
+		// the concurrency slot stays occupied. A categorical 402 billing cap whose
+		// body merely mentions concurrency is still a usage limit (handled below),
+		// so gate on the flag matching the rotation decision.
+		if (
+			!staleOpenAIResponsesReplayError &&
+			!AIError.is(id, AIError.Flag.UsageLimit) &&
+			parseRateLimitReason(errorMessage) === "CONCURRENT_LIMIT"
+		) {
+			const concurrentBackoffMs = calculateRateLimitBackoffMs("CONCURRENT_LIMIT");
+			if (concurrentBackoffMs > delayMs) delayMs = concurrentBackoffMs;
+		}
 		let switchedCredential = false;
 		let switchedModel = false;
 		// Set when a usage-limit error pinned the wait to credential

--- a/packages/coding-agent/test/agent-session-copilot-credential-removal.test.ts
+++ b/packages/coding-agent/test/agent-session-copilot-credential-removal.test.ts
@@ -1,0 +1,72 @@
+import { expect, it, spyOn } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+it("removes a Copilot credential for 401 but retains it for a 403 account cap", async () => {
+	const tempDir = TempDir.createSync("@pi-copilot-credential-removal-");
+	const authStorage = await AuthStorage.create(tempDir.join("testauth.db"));
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+	const agent = new Agent({
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry,
+	});
+	const removeSpy = spyOn(authStorage, "remove").mockResolvedValue(undefined);
+
+	try {
+		const unauthorized: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "openai-responses",
+			provider: "github-copilot",
+			model: "gpt-5-mini",
+			stopReason: "error",
+			errorMessage: "GitHub Copilot authentication failed (HTTP 401).",
+			errorStatus: 401,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		agent.emitExternalEvent({ type: "message_end", message: unauthorized });
+		agent.emitExternalEvent({ type: "agent_end", messages: [unauthorized] });
+		await session.waitForIdle();
+		expect(removeSpy).toHaveBeenCalledWith("github-copilot");
+
+		removeSpy.mockClear();
+		const accountCap: AssistantMessage = {
+			...unauthorized,
+			errorMessage: "Reached overall message rate limit. Your limit will reset in 13 minutes.",
+			errorStatus: 403,
+			timestamp: Date.now(),
+		};
+		agent.emitExternalEvent({ type: "message_end", message: accountCap });
+		agent.emitExternalEvent({ type: "agent_end", messages: [accountCap] });
+		await session.waitForIdle();
+		expect(removeSpy).not.toHaveBeenCalled();
+	} finally {
+		await session.dispose();
+		removeSpy.mockRestore();
+		authStorage.close();
+		tempDir.removeSync();
+	}
+});

--- a/packages/coding-agent/test/agent-session-copilot-credential-removal.test.ts
+++ b/packages/coding-agent/test/agent-session-copilot-credential-removal.test.ts
@@ -1,6 +1,8 @@
 import { expect, it, spyOn } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -62,6 +64,67 @@ it("removes a Copilot credential for 401 but retains it for a 403 account cap", 
 		agent.emitExternalEvent({ type: "message_end", message: accountCap });
 		agent.emitExternalEvent({ type: "agent_end", messages: [accountCap] });
 		await session.waitForIdle();
+		expect(removeSpy).not.toHaveBeenCalled();
+	} finally {
+		await session.dispose();
+		removeSpy.mockRestore();
+		authStorage.close();
+		tempDir.removeSync();
+	}
+});
+
+it("retains a Copilot credential for a 403 concurrency cap", async () => {
+	const tempDir = TempDir.createSync("@pi-copilot-concurrency-cap-");
+	const authStorage = await AuthStorage.create(tempDir.join("testauth.db"));
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+	const agent = new Agent({
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+	});
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false, "retry.enabled": false }),
+		modelRegistry,
+	});
+	const removeSpy = spyOn(authStorage, "remove").mockResolvedValue(undefined);
+
+	try {
+		// Simulate the real provider catch-block flow: finalize() calls
+		// classify(ProviderHttpError(...)) and sets errorId on the message.
+		// Without the F3 fix, classify() structurally adds AuthFailed for every
+		// 403 ProviderHttpError, and the agent-session guard deletes the
+		// still-valid credential.
+		const cap403 = new ProviderHttpError("Too many concurrent requests", 403);
+		const concurrencyCap: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "openai-responses",
+			provider: "github-copilot",
+			model: "gpt-5-mini",
+			stopReason: "error",
+			errorMessage: "Too many concurrent requests",
+			errorStatus: 403,
+			errorId: AIError.classify(cap403, "openai-responses"),
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+		agent.emitExternalEvent({ type: "message_end", message: concurrencyCap });
+		agent.emitExternalEvent({ type: "agent_end", messages: [concurrencyCap] });
+		await session.waitForIdle();
+		// A concurrency cap is transient — the credential is still valid, so
+		// it must NOT be removed. Without the AuthFailed suppression in
+		// classify(), the structural 403 sets Flag.AuthFailed and the guard
+		// deletes the credential.
 		expect(removeSpy).not.toHaveBeenCalled();
 	} finally {
 		await session.dispose();

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Retry-delay extraction now recognizes account-reset hints ("will reset in …" / "reset in …") and gives them precedence over short generic retry hints ("please retry in 5s"), so a body carrying both honours the longer account reset window.
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -85,7 +85,11 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 			if (totalMs > 0) return totalMs;
 		}
 	}
-	for (const pattern of [PLEASE_RETRY_PATTERN, RETRY_DELAY_FIELD_PATTERN, TRY_AGAIN_PATTERN, WILL_RESET_IN_PATTERN]) {
+	// Account-reset hints ("will reset in …") take precedence over short
+	// retry hints ("please retry in 5s"): a body carrying both must honour the
+	// longer account window, not the shorter generic one. QUOTA_RESET_PATTERN
+	// ("reset after …") above already runs first and stays first.
+	for (const pattern of [WILL_RESET_IN_PATTERN, PLEASE_RETRY_PATTERN, RETRY_DELAY_FIELD_PATTERN, TRY_AGAIN_PATTERN]) {
 		const match = pattern.exec(body);
 		if (match?.[1]) {
 			const value = Number.parseFloat(match[1]);

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -10,6 +10,8 @@ const RETRY_DELAY_FIELD_PATTERN = /"retryDelay":\s*"([0-9.]+)(ms|s)"/i;
 // "try again in 5 min" / "try again in ~158 min." / "try again in 2h" /
 // "try again in 90 minutes" / "try again in 1 hour"
 const TRY_AGAIN_PATTERN = /try again in\s+~?\s*([0-9.]+)\s*(ms|sec|s|minutes?|mins?|m|hours?|hrs?|h)\b/i;
+// "Your limit will reset in 13 minutes" / "reset in 13 minutes" / "will reset in 2h"
+const WILL_RESET_IN_PATTERN = /(?:will\s+)?reset in\s+~?\s*([0-9.]+)\s*(ms|sec|s|minutes?|mins?|m|hours?|hrs?|h)\b/i;
 
 /**
  * Server-suggested retry delay extraction. Merges the patterns historically used
@@ -83,7 +85,7 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 			if (totalMs > 0) return totalMs;
 		}
 	}
-	for (const pattern of [PLEASE_RETRY_PATTERN, RETRY_DELAY_FIELD_PATTERN, TRY_AGAIN_PATTERN]) {
+	for (const pattern of [PLEASE_RETRY_PATTERN, RETRY_DELAY_FIELD_PATTERN, TRY_AGAIN_PATTERN, WILL_RESET_IN_PATTERN]) {
 		const match = pattern.exec(body);
 		if (match?.[1]) {
 			const value = Number.parseFloat(match[1]);

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { fetchWithRetry } from "@oh-my-pi/pi-utils/fetch-retry";
+import { extractRetryHint, fetchWithRetry } from "@oh-my-pi/pi-utils/fetch-retry";
 
 describe("fetchWithRetry", () => {
 	it("routes requests through the `fetch` override when provided", async () => {
@@ -77,5 +77,23 @@ describe("fetchWithRetry", () => {
 		expect(response.status).toBe(429);
 		expect(await response.text()).toBe("slow down");
 		expect(attempt).toBe(1);
+	});
+});
+
+describe("extractRetryHint", () => {
+	// Devin returns HTTP 403 with "Your limit will reset in 13 minutes" for an
+	// account-scoped message rate cap. Without recognizing "will reset in", the
+	// credential is blocked for the 1-minute default instead of 13 minutes and
+	// can be reselected and hammered while the cap remains active.
+	it("parses Devin 'Your limit will reset in 13 minutes' as 13 minutes", () => {
+		expect(extractRetryHint(undefined, "Your limit will reset in 13 minutes")).toBe(13 * 60_000);
+	});
+
+	it("parses bare 'reset in 13 minutes' phrasing", () => {
+		expect(extractRetryHint(undefined, "reset in 13 minutes")).toBe(13 * 60_000);
+	});
+
+	it("parses 'will reset in 2h' phrasing", () => {
+		expect(extractRetryHint(undefined, "will reset in 2h")).toBe(2 * 60 * 60_000);
 	});
 });

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -96,4 +96,12 @@ describe("extractRetryHint", () => {
 	it("parses 'will reset in 2h' phrasing", () => {
 		expect(extractRetryHint(undefined, "will reset in 2h")).toBe(2 * 60 * 60_000);
 	});
+
+	// A quota body can carry both a generic retry hint and the account reset
+	// window ("Please retry in 5s. Your limit will reset in 13 minutes"). The
+	// account-reset hint must take precedence so the exhausted credential stays
+	// blocked for the full stated window instead of the short generic retry.
+	it("prefers the account reset window over a shorter retry hint", () => {
+		expect(extractRetryHint(undefined, "Please retry in 5s. Your limit will reset in 13 minutes")).toBe(13 * 60_000);
+	});
 });


### PR DESCRIPTION
## Summary
- Separates transient concurrency limits from account quota exhaustion by introducing a `CONCURRENT_LIMIT` classification with a 5-second retry backoff.
- Excludes concurrency caps (such as Vertex's quota-worded concurrency error) from credential rotation while preserving HTTP 402 billing cap rotation precedence.
- Enables credential rotation for account-scoped HTTP 403 rate limits (e.g., Devin message caps) and extracts provider reset windows to prevent premature credential reselection.

## What changed
- **`CONCURRENT_LIMIT` classification & backoff**: Added `CONCURRENT_LIMIT` to `RateLimitReason` with a short 5-second backoff (`CONCURRENT_LIMIT_BACKOFF_MS`). Matched concurrency error phrasings across Anthropic, OpenAI, Vertex, Bedrock, and DeepSeek.
- **Shed-and-backoff vs. credential rotation**: Excluded `CONCURRENT_LIMIT` errors from `isUsageLimitOutcome` rotation and `Flag.UsageLimit` classification on non-billing HTTP status codes (e.g. 429). This prevents Vertex's `Online prediction concurrent requests quota exceeded` from matching generic `quota.?exceeded` rules and incorrectly burning healthy credentials.
- **HTTP 402 billing precedence**: Categorical HTTP 402 billing/balance caps override the concurrency exclusion. An HTTP 402 response whose body mentions concurrency still classifies as a usage limit and rotates credentials.
- **Account-scoped 403 rotation**: Updated `isUsageLimitOutcome` with `ACCOUNT_SCOPED_403_PATTERN` to rotate credentials on 403 responses that explicitly state an account-level message/request rate limit or reset window (e.g., Devin `permission_denied`). Bare 403 responses remain unrotated auth failures.
- **Reset window extraction & storage**: Added `WILL_RESET_IN_PATTERN` to `extractRetryHint` in `@oh-my-pi/pi-utils/fetch-retry` to parse phrases like "Your limit will reset in 13 minutes". `AuthStorage.markUsageLimitReached` passes this `retryAfterMs` into the credential block duration so capped credentials are not reselected before their reset window expires.

## Verification
- `packages/ai/test/rate-limit-utils.test.ts`
- `packages/utils/test/fetch-retry.test.ts`

## Notes
- HTTP 402 precedence ensures account balance depletion always rotates credentials, regardless of whether the provider frames the error text around concurrent execution bounds or account quota limits.
