### PR TITLE
feat(ai): per-credential in-flight concurrency caps

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -11,7 +11,7 @@ import {
 	EventStream,
 	isApiKeyResolver,
 	type Model,
-	resolveApiKeyOnce,
+	resolveApiKeyResolutionOnce,
 	seedApiKeyResolver,
 	streamSimple,
 	stripSchemaDescriptions,
@@ -1584,7 +1584,7 @@ async function streamAssistantResponse(
 				? providerAbortSignals[0]!
 				: AbortSignal.any(providerAbortSignals);
 	const requestApiKey = (config.getApiKey ? await config.getApiKey(model) : undefined) ?? config.apiKey;
-	const resolvedApiKey = await resolveApiKeyOnce(requestApiKey, finalRequestSignal);
+	const resolvedApiKey = await resolveApiKeyResolutionOnce(requestApiKey, finalRequestSignal);
 	const apiKey = isApiKeyResolver(requestApiKey) ? seedApiKeyResolver(resolvedApiKey, requestApiKey) : requestApiKey;
 
 	// Re-resolve metadata after credential selection so the per-request value

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Classified concurrent-request caps separately from quota exhaustion so they use a short retry backoff without burning a credential, and rotate credentials for account-scoped 403 caps such as Devin's overall message limit.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Applied provider in-flight request caps per stored credential so independently authenticated accounts can use their configured concurrency in parallel; concurrent-limit responses now shed one local slot for the affected credential and retry without rotating it.
+
 ### Fixed
 
 - Classified concurrent-request caps separately from quota exhaustion so they use a short retry backoff without burning a credential, and rotate credentials for account-scoped 403 caps such as Devin's overall message limit.

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -21,7 +21,7 @@
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { extractHttpStatusFromError, extractRetryHint, logger } from "@oh-my-pi/pi-utils";
 import type { ApiKeyResolver } from "../auth-retry";
-import type { AuthStorage } from "../auth-storage";
+import type { ApiKeyResolution, AuthStorage } from "../auth-storage";
 import * as AIError from "../error";
 import { classifyGatewayError } from "../error/gateway";
 import { isUsageLimitOutcome } from "../error/rate-limit";
@@ -239,7 +239,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 	signal: AbortSignal,
 	format: string,
 	peer: string,
-): Promise<string | undefined> {
+): Promise<ApiKeyResolution | undefined> {
 	const message = error instanceof Error ? error.message : String(error);
 	const status = extractHttpStatusFromError(error);
 	if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
@@ -261,7 +261,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 			error: message,
 		});
 		if (!switched) return undefined;
-		return storage.getApiKey(provider, sessionId, { modelId: model.id, signal });
+		return storage.getApiKeyResolution(provider, sessionId, { modelId: model.id, signal });
 	}
 	await storage.invalidateCredentialMatching(provider, oldKey, { sessionId, signal });
 	logger.debug("auth-gateway retrying provider request after credential invalidation", {
@@ -270,7 +270,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 		peer,
 		error: message,
 	});
-	return storage.getApiKey(provider, sessionId, { modelId: model.id, signal });
+	return storage.getApiKeyResolution(provider, sessionId, { modelId: model.id, signal });
 }
 
 /**
@@ -290,25 +290,29 @@ function buildGatewayApiKeyResolver(
 	storage: AuthStorage,
 	model: Model<Api>,
 	sessionId: string,
-	initialKey: string,
+	initialResolution: ApiKeyResolution,
 	requestSignal: AbortSignal,
 	format: string,
 	peer: string,
 ): ApiKeyResolver {
-	let lastKey = initialKey;
+	// Track the most recent bearer so the switch step (c) invalidates the
+	// credential that actually failed. Resolutions carry the stable credentialId
+	// so the per-credential in-flight cap buckets each stored account separately
+	// instead of collapsing every gateway account into one "default" bucket.
+	let lastKey = initialResolution.apiKey;
 	return async ({ lastChance, error, signal }) => {
 		const sig = signal ?? requestSignal;
 		if (error === undefined) {
-			lastKey = initialKey;
-			return initialKey;
+			lastKey = initialResolution.apiKey;
+			return initialResolution;
 		}
 		if (!lastChance) {
-			const refreshed = await storage.getApiKey(model.provider, sessionId, {
+			const refreshed = await storage.getApiKeyResolution(model.provider, sessionId, {
 				modelId: model.id,
 				signal: sig,
 				forceRefresh: true,
 			});
-			lastKey = refreshed ?? lastKey;
+			lastKey = refreshed?.apiKey ?? lastKey;
 			return refreshed;
 		}
 		const next = await refreshGatewayApiKeyAfterAuthError(
@@ -322,7 +326,7 @@ function buildGatewayApiKeyResolver(
 			format,
 			peer,
 		);
-		lastKey = next ?? lastKey;
+		lastKey = next?.apiKey ?? lastKey;
 		return next;
 	};
 }
@@ -414,9 +418,9 @@ async function handleFormatEndpoint(
 	// expected to resolve the credential and pass it as `options.apiKey`.
 	// For OAuth providers this returns the access token (refreshed via the
 	// broker override on AuthStorage when needed).
-	let apiKey: string | undefined;
+	let initialResolution: ApiKeyResolution | undefined;
 	try {
-		apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
+		initialResolution = await bootOpts.storage.getApiKeyResolution(model.provider, sessionId, {
 			modelId: model.id,
 			signal: controller.signal,
 		});
@@ -427,7 +431,7 @@ async function handleFormatEndpoint(
 		return route.module.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return clientClosedResponse(route);
-	if (!apiKey) {
+	if (!initialResolution?.apiKey) {
 		return route.module.formatError(
 			401,
 			"authentication_error",
@@ -440,7 +444,7 @@ async function handleFormatEndpoint(
 		bootOpts.storage,
 		model,
 		sessionId,
-		apiKey,
+		initialResolution,
 		controller.signal,
 		route.label,
 		peer,
@@ -578,9 +582,9 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	const sessionId = parsed.options.sessionId ?? deriveSessionId(parsed.modelId, parsed.context);
 	parsed.options.sessionId ??= sessionId;
 
-	let apiKey: string | undefined;
+	let resolution: ApiKeyResolution | undefined;
 	try {
-		apiKey = await bootOpts.storage.getApiKey(model.provider, sessionId, {
+		resolution = await bootOpts.storage.getApiKeyResolution(model.provider, sessionId, {
 			modelId: model.id,
 			signal: controller.signal,
 		});
@@ -591,13 +595,14 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		return piNative.formatError(classified.status, classified.type, classified.message);
 	}
 	if (controller.signal.aborted) return aborted();
-	if (!apiKey) {
+	if (!resolution?.apiKey) {
 		return piNative.formatError(
 			401,
 			"authentication_error",
 			`No credential available for provider ${model.provider}`,
 		);
 	}
+	const apiKey = resolution.apiKey;
 
 	// Build the SimpleStreamOptions actually handed to `streamSimple`. We
 	// trust the client's options (already allow-listed by `parseRequest`) and
@@ -608,7 +613,7 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 		bootOpts.storage,
 		model,
 		sessionId,
-		apiKey,
+		resolution,
 		controller.signal,
 		"pi-native",
 		peer,

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -1,5 +1,5 @@
 import { extractHttpStatusFromError } from "@oh-my-pi/pi-utils";
-import type { OAuthAccess } from "./auth-storage";
+import type { ApiKeyResolution, OAuthAccess } from "./auth-storage";
 import * as AIError from "./error";
 import { isAuthRetryableError, isInvalidatedOAuthTokenError } from "./error/auth-classify";
 import { isUsageLimit } from "./error/flags";
@@ -30,19 +30,25 @@ export interface ApiKeyResolveContext {
 	error: unknown;
 	/** Bearer used by the failed attempt, when the caller can expose it. */
 	previousKey?: string;
+	/** SQLite credential row used by the failed attempt, when known. */
+	previousCredentialId?: number;
 	/** Caller cancel signal, threaded into any credential refresh / rotation work. */
 	signal?: AbortSignal;
+}
+
+/** Normalizes legacy string resolvers into a request-scoped selection. */
+export function toApiKeyResolution(value: ApiKeyResolution | string | undefined): ApiKeyResolution | undefined {
+	if (value === undefined || value === "") return undefined;
+	return typeof value === "string" ? { apiKey: value } : value;
 }
 
 /**
  * Resolves the API key to send for a request, retried through the a/b/c policy
  * described on {@link ApiKeyResolveContext}.
  */
-export interface ApiKeyResolver {
-	(ctx: ApiKeyResolveContext): Promise<string | undefined> | string | undefined;
-	/** SQLite credential row selected for the most recent resolution, if stored. */
-	credentialId?: number;
-}
+export type ApiKeyResolver = (
+	ctx: ApiKeyResolveContext,
+) => Promise<ApiKeyResolution | string | undefined> | ApiKeyResolution | string | undefined;
 
 /** A static bearer string, or a {@link ApiKeyResolver} that mints/rotates one. */
 export type ApiKey = string | ApiKeyResolver;
@@ -57,9 +63,17 @@ export function isApiKeyResolver(key: ApiKey | undefined): key is ApiKeyResolver
  * `lastChance: false`). Static keys pass through unchanged.
  */
 export async function resolveApiKeyOnce(key: ApiKey | undefined, signal?: AbortSignal): Promise<string | undefined> {
+	return (await resolveApiKeyResolutionOnce(key, signal))?.apiKey;
+}
+
+/** Resolves an API key together with request-scoped credential identity. */
+export async function resolveApiKeyResolutionOnce(
+	key: ApiKey | undefined,
+	signal?: AbortSignal,
+): Promise<ApiKeyResolution | undefined> {
 	if (key === undefined) return undefined;
-	if (isApiKeyResolver(key)) return (await key({ lastChance: false, error: undefined, signal })) || undefined;
-	return key;
+	if (isApiKeyResolver(key)) return toApiKeyResolution(await key({ lastChance: false, error: undefined, signal }));
+	return { apiKey: key };
 }
 
 /**
@@ -70,19 +84,18 @@ export async function resolveApiKeyOnce(key: ApiKey | undefined, signal?: AbortS
  * first initial resolution reuses `seed`, and all later resolutions delegate to
  * `resolver`.
  */
-export function seedApiKeyResolver(seed: string | undefined, resolver: ApiKeyResolver): ApiKeyResolver {
+export function seedApiKeyResolver(
+	seed: ApiKeyResolution | string | undefined,
+	resolver: ApiKeyResolver,
+): ApiKeyResolver {
 	let seedPending = seed !== undefined;
-	const seeded: ApiKeyResolver = async ctx => {
+	return ctx => {
 		if (seedPending && ctx.error === undefined) {
 			seedPending = false;
-			seeded.credentialId = resolver.credentialId;
 			return seed;
 		}
-		const resolved = await resolver(ctx);
-		seeded.credentialId = resolver.credentialId;
-		return resolved;
+		return resolver(ctx);
 	};
-	return seeded;
 }
 
 // Re-exported from the error module (its new home); see error/auth-classify.ts.
@@ -109,6 +122,25 @@ function isDirectCredentialRotationError(error: unknown): boolean {
 	return isUsageLimitOutcome(status, message);
 }
 
+/** Resolve one retry step with its exact credential identity. */
+export async function resolveRetryApiKey(
+	resolver: ApiKeyResolver,
+	lastChance: boolean,
+	error: unknown,
+	signal?: AbortSignal,
+	previousKey?: string,
+	previousCredentialId?: number,
+): Promise<ApiKeyResolution | undefined> {
+	try {
+		const rotateSibling = lastChance || (!lastChance && isDirectCredentialRotationError(error));
+		return toApiKeyResolution(
+			await resolver({ lastChance: rotateSibling, error, signal, previousKey, previousCredentialId }),
+		);
+	} catch {
+		return undefined;
+	}
+}
+
 /** Resolve a single retry step, swallowing resolver failures into `undefined`. */
 export async function resolveRetryKey(
 	resolver: ApiKeyResolver,
@@ -116,13 +148,9 @@ export async function resolveRetryKey(
 	error: unknown,
 	signal?: AbortSignal,
 	previousKey?: string,
+	previousCredentialId?: number,
 ): Promise<string | undefined> {
-	try {
-		const rotateSibling = lastChance || (!lastChance && isDirectCredentialRotationError(error));
-		return (await resolver({ lastChance: rotateSibling, error, signal, previousKey })) || undefined;
-	} catch {
-		return undefined;
-	}
+	return (await resolveRetryApiKey(resolver, lastChance, error, signal, previousKey, previousCredentialId))?.apiKey;
 }
 
 export interface AuthRetryKeyState {
@@ -130,6 +158,8 @@ export interface AuthRetryKeyState {
 	attemptedKeys: Set<string>;
 	/** Bearer used by the most recent failed attempt. */
 	lastKey: string;
+	/** SQLite credential row used by the most recent failed attempt, when known. */
+	lastCredentialId?: number;
 	/** Whether the current credential already consumed its 401 refresh-same retry. */
 	refreshedCurrent: boolean;
 	/** Whether the legacy non-usage auth path already switched to one sibling. */
@@ -138,21 +168,28 @@ export interface AuthRetryKeyState {
 	attempts: number;
 }
 
-export function createAuthRetryKeyState(initialKey: string): AuthRetryKeyState {
+export function createAuthRetryKeyState(initialKey: string, initialCredentialId?: number): AuthRetryKeyState {
 	return {
 		attemptedKeys: new Set([initialKey]),
 		lastKey: initialKey,
+		lastCredentialId: initialCredentialId,
 		refreshedCurrent: false,
 		legacyAuthSwitchUsed: false,
 		attempts: 1,
 	};
 }
 
-function acceptRetryKey(state: AuthRetryKeyState, key: string, refreshedCurrent: boolean): string | undefined {
+function acceptRetryKey(
+	state: AuthRetryKeyState,
+	key: string,
+	refreshedCurrent: boolean,
+	credentialId?: number,
+): string | undefined {
 	if (state.attemptedKeys.has(key) || state.attempts >= AUTH_RETRY_MAX_ATTEMPTS) return undefined;
 	state.attemptedKeys.add(key);
 	state.attempts += 1;
 	state.lastKey = key;
+	state.lastCredentialId = credentialId;
 	state.refreshedCurrent = refreshedCurrent;
 	return key;
 }
@@ -163,28 +200,47 @@ export async function resolveNextAuthRetryKey(
 	error: unknown,
 	signal?: AbortSignal,
 ): Promise<string | undefined> {
-	if (signal?.aborted) return undefined;
-	if (state.attempts >= AUTH_RETRY_MAX_ATTEMPTS) return undefined;
+	return (await resolveNextAuthRetryApiKey(state, resolver, error, signal))?.apiKey;
+}
+
+/** Resolves the next auth retry key with the credential identity selected for that attempt. */
+export async function resolveNextAuthRetryApiKey(
+	state: AuthRetryKeyState,
+	resolver: ApiKeyResolver,
+	error: unknown,
+	signal?: AbortSignal,
+): Promise<ApiKeyResolution | undefined> {
+	if (signal?.aborted || state.attempts >= AUTH_RETRY_MAX_ATTEMPTS) return undefined;
 	const directRotation = isDirectCredentialRotationError(error);
 	if (!directRotation) {
 		if (state.legacyAuthSwitchUsed) return undefined;
 		if (!state.refreshedCurrent) {
-			const refreshed = await resolveRetryKey(resolver, false, error, signal, state.lastKey);
+			const refreshed = await resolveRetryApiKey(
+				resolver,
+				false,
+				error,
+				signal,
+				state.lastKey,
+				state.lastCredentialId,
+			);
 			state.refreshedCurrent = true;
 			if (signal?.aborted) return undefined;
 			if (refreshed !== undefined) {
-				const accepted = acceptRetryKey(state, refreshed, true);
-				if (accepted !== undefined) return accepted;
+				const accepted = acceptRetryKey(state, refreshed.apiKey, true, refreshed.credentialId);
+				if (accepted !== undefined) return refreshed;
 			}
 		}
 	}
 
 	if (signal?.aborted) return undefined;
-	const rotated = await resolveRetryKey(resolver, true, error, signal, state.lastKey);
+	const rotated = await resolveRetryApiKey(resolver, true, error, signal, state.lastKey, state.lastCredentialId);
 	if (signal?.aborted || rotated === undefined) return undefined;
-	const accepted = acceptRetryKey(state, rotated, !directRotation);
-	if (accepted !== undefined && !directRotation) state.legacyAuthSwitchUsed = true;
-	return accepted;
+	const accepted = acceptRetryKey(state, rotated.apiKey, !directRotation, rotated.credentialId);
+	if (accepted !== undefined) {
+		if (!directRotation) state.legacyAuthSwitchUsed = true;
+		return rotated;
+	}
+	return undefined;
 }
 
 function oauthCredentialIdentity(access: OAuthAccess): string {
@@ -234,23 +290,23 @@ export async function withAuth<T>(
 
 	const resolver = key;
 	const signal = opts?.signal;
-	const initialKey = await resolveRetryKey(resolver, false, undefined, signal);
-	if (initialKey === undefined) throw missingKey();
+	const initial = await resolveRetryApiKey(resolver, false, undefined, signal);
+	if (initial === undefined) throw missingKey();
 
-	const state = createAuthRetryKeyState(initialKey);
+	const state = createAuthRetryKeyState(initial.apiKey, initial.credentialId);
 	let lastError: unknown;
 	try {
-		return await attempt(initialKey);
+		return await attempt(initial.apiKey);
 	} catch (error) {
 		if (!isAuthError(error)) throw error;
 		lastError = error;
 	}
 
 	while (true) {
-		const nextKey = await resolveNextAuthRetryKey(state, resolver, lastError, signal);
-		if (nextKey === undefined) break;
+		const next = await resolveNextAuthRetryApiKey(state, resolver, lastError, signal);
+		if (next === undefined) break;
 		try {
-			return await attempt(nextKey);
+			return await attempt(next.apiKey);
 		} catch (error) {
 			if (!isAuthError(error)) throw error;
 			lastError = error;

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -38,7 +38,11 @@ export interface ApiKeyResolveContext {
  * Resolves the API key to send for a request, retried through the a/b/c policy
  * described on {@link ApiKeyResolveContext}.
  */
-export type ApiKeyResolver = (ctx: ApiKeyResolveContext) => Promise<string | undefined> | string | undefined;
+export interface ApiKeyResolver {
+	(ctx: ApiKeyResolveContext): Promise<string | undefined> | string | undefined;
+	/** SQLite credential row selected for the most recent resolution, if stored. */
+	credentialId?: number;
+}
 
 /** A static bearer string, or a {@link ApiKeyResolver} that mints/rotates one. */
 export type ApiKey = string | ApiKeyResolver;
@@ -68,13 +72,17 @@ export async function resolveApiKeyOnce(key: ApiKey | undefined, signal?: AbortS
  */
 export function seedApiKeyResolver(seed: string | undefined, resolver: ApiKeyResolver): ApiKeyResolver {
 	let seedPending = seed !== undefined;
-	return ctx => {
+	const seeded: ApiKeyResolver = async ctx => {
 		if (seedPending && ctx.error === undefined) {
 			seedPending = false;
+			seeded.credentialId = resolver.credentialId;
 			return seed;
 		}
-		return resolver(ctx);
+		const resolved = await resolver(ctx);
+		seeded.credentialId = resolver.credentialId;
+		return resolved;
 	};
+	return seeded;
 }
 
 // Re-exported from the error module (its new home); see error/auth-classify.ts.

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -39,7 +39,8 @@ export interface ApiKeyResolveContext {
 /** Normalizes legacy string resolvers into a request-scoped selection. */
 export function toApiKeyResolution(value: ApiKeyResolution | string | undefined): ApiKeyResolution | undefined {
 	if (value === undefined || value === "") return undefined;
-	return typeof value === "string" ? { apiKey: value } : value;
+	if (typeof value === "string") return { apiKey: value };
+	return value.apiKey === "" ? undefined : value;
 }
 
 /**

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5222,11 +5222,12 @@ export class AuthStorage {
 		);
 		if (loginApiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", loginApiKeySelection.index);
+			const credentialId = this.#getStoredCredentials(provider)[loginApiKeySelection.index]?.id;
 			const apiKey = await this.#configValueResolver(loginApiKeySelection.credential.key);
 			if (apiKey) {
 				return {
 					apiKey,
-					credentialId: this.#getStoredCredentials(provider)[loginApiKeySelection.index]?.id,
+					credentialId,
 				};
 			}
 		}
@@ -5246,11 +5247,12 @@ export class AuthStorage {
 		);
 		if (apiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);
+			const credentialId = this.#getStoredCredentials(provider)[apiKeySelection.index]?.id;
 			const apiKey = await this.#configValueResolver(apiKeySelection.credential.key);
 			if (apiKey) {
 				return {
 					apiKey,
-					credentialId: this.#getStoredCredentials(provider)[apiKeySelection.index]?.id,
+					credentialId,
 				};
 			}
 		}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -6040,18 +6040,14 @@ export class AuthStorage {
 		const resolve = async (requestOptions: {
 			forceRefresh?: boolean;
 			signal?: AbortSignal;
-		}): Promise<string | undefined> => {
-			const apiKey = await this.getApiKey(provider, sessionId, { baseUrl, modelId, ...requestOptions });
-			const selected = this.#getSessionCredential(provider, sessionId);
-			resolver.credentialId =
-				this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)
-					? undefined
-					: selected
-						? this.#getStoredCredentials(provider)[selected.index]?.id
-						: undefined;
-			return apiKey;
+		}): Promise<{ apiKey: string; credentialId?: number } | undefined> => {
+			if (this.getApiKey !== AuthStorage.prototype.getApiKey) {
+				const apiKey = await this.getApiKey(provider, sessionId, { baseUrl, modelId, ...requestOptions });
+				return apiKey === undefined ? undefined : { apiKey };
+			}
+			return this.getApiKeyResolution(provider, sessionId, { baseUrl, modelId, ...requestOptions });
 		};
-		const resolver: ApiKeyResolver = async ({ lastChance, error, signal, previousKey }) => {
+		const resolver: ApiKeyResolver = async ({ lastChance, error, signal, previousKey, previousCredentialId }) => {
 			if (error === undefined) return resolve({ signal });
 			if (lastChance) {
 				const switched = await this.rotateSessionCredential(provider, sessionId, {
@@ -6059,7 +6055,7 @@ export class AuthStorage {
 					modelId,
 					signal,
 					apiKey: previousKey,
-					credentialId: resolver.credentialId,
+					credentialId: previousCredentialId,
 				});
 				if (!switched) {
 					const status = AIError.status(error);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1203,6 +1203,11 @@ type StoredCredential = { id: number; credential: AuthCredential };
 type CredentialSelection<T extends AuthCredential> = { credential: T; index: number };
 type OAuthSelection = CredentialSelection<OAuthCredential>;
 type ApiKeySelection = CredentialSelection<ApiKeyCredential>;
+/** An API-key selection plus the stable SQLite row id captured from the same
+ * snapshot as the credential bytes. Re-reading the id by positional index
+ * after an await is unsafe — a broker reload or credential removal during
+ * usage ranking shifts indices and re-attributes the key to a sibling row. */
+type ApiKeyCredentialSelection = { credential: ApiKeyCredential; index: number; credentialId: number };
 type StoredOAuthSelection = { credentialId: number; credential: OAuthCredential; index: number };
 
 type UsageCandidate<T extends AuthCredential> = {
@@ -2028,10 +2033,14 @@ export class AuthStorage {
 		sessionId: string | undefined,
 		options: AuthApiKeyOptions | undefined,
 		filter?: (credential: ApiKeyCredential) => boolean,
-	): Promise<ApiKeySelection | undefined> {
-		const credentials = this.#getCredentialsForProvider(provider)
-			.map((credential, index) => ({ credential, index }))
-			.filter((entry): entry is ApiKeySelection => {
+	): Promise<ApiKeyCredentialSelection | undefined> {
+		// Snapshot the full stored set ONCE, pairing each row with its stable id.
+		// The credential bytes and the id both originate here, before any await, so
+		// a broker reload or credential removal during the usage-ranking await below
+		// cannot re-pair the resolved key with a sibling row by positional index.
+		const credentials: ApiKeyCredentialSelection[] = this.#getStoredCredentials(provider)
+			.map((entry, index) => ({ credential: entry.credential, index, credentialId: entry.id }))
+			.filter((entry): entry is ApiKeyCredentialSelection => {
 				if (entry.credential.type !== "api_key") return false;
 				return filter?.(entry.credential) ?? true;
 			});
@@ -2041,12 +2050,12 @@ export class AuthStorage {
 
 		const providerKey = this.#getProviderTypeKey(provider, "api_key");
 		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
-		const fallback = credentials[order[0]];
+		const fallback = credentials[order[0] ?? 0];
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		if (!strategy) {
 			for (const idx of order) {
 				const candidate = credentials[idx];
-				if (!this.#isCredentialBlocked(provider, providerKey, candidate.index)) {
+				if (candidate && !this.#isCredentialBlocked(provider, providerKey, candidate.index)) {
 					return candidate;
 				}
 			}
@@ -2067,7 +2076,14 @@ export class AuthStorage {
 			blockScope,
 			blockScopes,
 		});
-		return candidates[0]?.selection ?? fallback;
+		const ranked = candidates[0]?.selection;
+		if (!ranked) return fallback;
+		// #rankApiKeySelections forwards its input selections by reference, so the
+		// ranked pick is one of the entries above; recover its stable id rather than
+		// re-reading the (possibly shifted) positional index from a fresh snapshot.
+		return (
+			credentials.find(entry => entry.index === ranked.index && entry.credential === ranked.credential) ?? fallback
+		);
 	}
 
 	#clearProviderSessionCredentialCache(provider: string): void {
@@ -5222,7 +5238,7 @@ export class AuthStorage {
 		);
 		if (loginApiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", loginApiKeySelection.index);
-			const credentialId = this.#getStoredCredentials(provider)[loginApiKeySelection.index]?.id;
+			const credentialId = loginApiKeySelection.credentialId;
 			const apiKey = await this.#configValueResolver(loginApiKeySelection.credential.key);
 			if (apiKey) {
 				return {
@@ -5247,7 +5263,7 @@ export class AuthStorage {
 		);
 		if (apiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);
-			const credentialId = this.#getStoredCredentials(provider)[apiKeySelection.index]?.id;
+			const credentialId = apiKeySelection.credentialId;
 			const apiKey = await this.#configValueResolver(apiKeySelection.credential.key);
 			if (apiKey) {
 				return {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -812,6 +812,12 @@ type AuthApiKeyOptions = {
 };
 type OAuthResolutionResult = { apiKey: string; credential: OAuthCredential; credentialId?: number };
 
+/** A resolved bearer plus its stored credential row when one supplied it. */
+export interface ApiKeyResolution {
+	apiKey: string;
+	credentialId?: number;
+}
+
 /**
  * Refreshed OAuth access plus identity metadata returned by
  * {@link AuthStorage.getOAuthAccess}. Callers that authenticate via a bearer
@@ -5180,11 +5186,21 @@ export class AuthStorage {
 	 * 7. Fallback resolver (models.yml custom providers, last-resort)
 	 */
 	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
+		return (await this.getApiKeyResolution(provider, sessionId, options))?.apiKey;
+	}
+
+	/**
+	 * Resolve a bearer and, for stored OAuth/API-key credentials, its stable SQLite
+	 * row id. Explicit runtime/config/env keys intentionally have no row id.
+	 */
+	async getApiKeyResolution(
+		provider: string,
+		sessionId?: string,
+		options?: AuthApiKeyOptions,
+	): Promise<ApiKeyResolution | undefined> {
 		// Runtime override takes highest priority
 		const runtimeKey = this.#runtimeOverrides.get(provider);
-		if (runtimeKey) {
-			return runtimeKey;
-		}
+		if (runtimeKey) return { apiKey: runtimeKey };
 
 		// Config override: explicit apiKey pinned in models.yml beats the broker's
 		// OAuth credentials. The user redirected a provider at a custom baseUrl
@@ -5192,16 +5208,12 @@ export class AuthStorage {
 		// honor it instead of forwarding an upstream OAuth token that the proxy
 		// won't accept.
 		const configKey = this.#configOverrides.get(provider);
-		if (configKey) {
-			return configKey;
-		}
+		if (configKey) return { apiKey: configKey };
 
 		// Precedence: a deliberate OAuth/login credential wins, then an explicit env var,
 		// then a stored static api_key (which may be a stale broker-migrated copy) as a last resort.
 		const oauthResolved = await this.#resolveOAuthSelection(provider, sessionId, options);
-		if (oauthResolved) {
-			return oauthResolved.apiKey;
-		}
+		if (oauthResolved) return { apiKey: oauthResolved.apiKey, credentialId: oauthResolved.credentialId };
 		const loginApiKeySelection = await this.#selectApiKeyCredential(
 			provider,
 			sessionId,
@@ -5210,7 +5222,13 @@ export class AuthStorage {
 		);
 		if (loginApiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", loginApiKeySelection.index);
-			return this.#configValueResolver(loginApiKeySelection.credential.key);
+			const apiKey = await this.#configValueResolver(loginApiKeySelection.credential.key);
+			if (apiKey) {
+				return {
+					apiKey,
+					credentialId: this.#getStoredCredentials(provider)[loginApiKeySelection.index]?.id,
+				};
+			}
 		}
 
 		// Past OAuth: the session sticky (if any) is stale — the request authenticates via
@@ -5219,7 +5237,7 @@ export class AuthStorage {
 		if (sessionId) this.#sessionLastCredential.get(provider)?.delete(sessionId);
 
 		const envKey = getEnvApiKey(provider);
-		if (envKey) return envKey;
+		if (envKey) return { apiKey: envKey };
 		const apiKeySelection = await this.#selectApiKeyCredential(
 			provider,
 			sessionId,
@@ -5228,11 +5246,18 @@ export class AuthStorage {
 		);
 		if (apiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);
-			return this.#configValueResolver(apiKeySelection.credential.key);
+			const apiKey = await this.#configValueResolver(apiKeySelection.credential.key);
+			if (apiKey) {
+				return {
+					apiKey,
+					credentialId: this.#getStoredCredentials(provider)[apiKeySelection.index]?.id,
+				};
+			}
 		}
 
 		// Fall back to custom resolver (e.g., models.json custom providers)
-		return this.#fallbackResolver?.(provider) ?? undefined;
+		const fallbackKey = this.#fallbackResolver?.(provider);
+		return fallbackKey ? { apiKey: fallbackKey } : undefined;
 	}
 
 	/**
@@ -6012,16 +6037,29 @@ export class AuthStorage {
 	 */
 	resolver(provider: string, options?: { sessionId?: string; baseUrl?: string; modelId?: string }): ApiKeyResolver {
 		const { sessionId, baseUrl, modelId } = options ?? {};
-		return async ({ lastChance, error, signal, previousKey }) => {
-			if (error === undefined) {
-				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal });
-			}
+		const resolve = async (requestOptions: {
+			forceRefresh?: boolean;
+			signal?: AbortSignal;
+		}): Promise<string | undefined> => {
+			const apiKey = await this.getApiKey(provider, sessionId, { baseUrl, modelId, ...requestOptions });
+			const selected = this.#getSessionCredential(provider, sessionId);
+			resolver.credentialId =
+				this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)
+					? undefined
+					: selected
+						? this.#getStoredCredentials(provider)[selected.index]?.id
+						: undefined;
+			return apiKey;
+		};
+		const resolver: ApiKeyResolver = async ({ lastChance, error, signal, previousKey }) => {
+			if (error === undefined) return resolve({ signal });
 			if (lastChance) {
 				const switched = await this.rotateSessionCredential(provider, sessionId, {
 					error,
 					modelId,
 					signal,
 					apiKey: previousKey,
+					credentialId: resolver.credentialId,
 				});
 				if (!switched) {
 					const status = AIError.status(error);
@@ -6031,10 +6069,11 @@ export class AuthStorage {
 					// because a peer may have refreshed the failed bearer.
 					if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) return undefined;
 				}
-				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal });
+				return resolve({ signal });
 			}
-			return this.getApiKey(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+			return resolve({ forceRefresh: true, signal });
 		};
+		return resolver;
 	}
 
 	// ─── Auth Broker integration ────────────────────────────────────────────

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -7,7 +7,13 @@ import {
 	ProviderHttpError,
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
-import { isOpaqueStatusBody, isUsageLimitStatus, matchesUsageLimitText, parseRateLimitReason } from "./rate-limit";
+import {
+	ACCOUNT_SCOPED_403_PATTERN,
+	isOpaqueStatusBody,
+	isUsageLimitStatus,
+	matchesUsageLimitText,
+	parseRateLimitReason,
+} from "./rate-limit";
 
 export const Flag = {
 	Class: 0x1000,
@@ -319,8 +325,15 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		const isOpaque = isOpaqueStatusBody(cleanMessage);
 
 		const isLimitStatus = isUsageLimitStatus(statusClean);
+		// Mirror isUsageLimitOutcome: a 403 carrying an account-scoped cap
+		// (Devin/Codeium "overall message rate limit ... will reset in …",
+		// GitHub Copilot) is a usage-limit outcome, not an auth failure —
+		// classify it as UsageLimit so turn recovery honours the recorded
+		// reset/backoff instead of generic short retries.
+		const isAccountScopedCap = statusClean === 403 && ACCOUNT_SCOPED_403_PATTERN.test(cleanMessage);
 		if (
 			matchesUsageLimitText(cleanMessage) ||
+			isAccountScopedCap ||
 			(isLimitStatus && (isOpaque || parseRateLimitReason(cleanMessage) === "QUOTA_EXHAUSTED"))
 		) {
 			kinds |= Flag.UsageLimit;

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -6,12 +6,14 @@
 export type RateLimitReason =
 	| "QUOTA_EXHAUSTED"
 	| "RATE_LIMIT_EXCEEDED"
+	| "CONCURRENT_LIMIT"
 	| "MODEL_CAPACITY_EXHAUSTED"
 	| "SERVER_ERROR"
 	| "UNKNOWN";
 
 const QUOTA_EXHAUSTED_BACKOFF_MS = 30 * 60 * 1000; // 30 min
 const RATE_LIMIT_EXCEEDED_BACKOFF_MS = 30 * 1000; // 30s
+const CONCURRENT_LIMIT_BACKOFF_MS = 5 * 1000; // 5s
 const MODEL_CAPACITY_BASE_MS = 45 * 1000; // 45s base
 const MODEL_CAPACITY_JITTER_MS = 30 * 1000; // ±15s
 const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
@@ -21,11 +23,15 @@ const ACCOUNT_RATE_LIMIT_PATTERN =
 const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
+const CONCURRENT_LIMIT_PATTERN =
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+const ACCOUNT_SCOPED_403_PATTERN =
+	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
- * Priority order: QUOTA (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
- * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
+ * Priority order: QUOTA (Antigravity "quota will reset") > CONCURRENT_LIMIT > MODEL_CAPACITY >
+ * QUOTA (account) > RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
  *
  * "resource exhausted" maps to MODEL_CAPACITY (transient, short wait)
  * "quota exceeded" / "quota will reset" maps to QUOTA_EXHAUSTED (long wait, switch account)
@@ -40,6 +46,10 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	// MODEL_CAPACITY fallthrough so credential rotation (not 60s backoff) kicks in.
 	if (lower.includes("quota will reset") || lower.includes("exhausted your capacity")) {
 		return "QUOTA_EXHAUSTED";
+	}
+
+	if (CONCURRENT_LIMIT_PATTERN.test(errorMessage)) {
+		return "CONCURRENT_LIMIT";
 	}
 
 	if (
@@ -105,6 +115,8 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 			return QUOTA_EXHAUSTED_BACKOFF_MS;
 		case "RATE_LIMIT_EXCEEDED":
 			return RATE_LIMIT_EXCEEDED_BACKOFF_MS;
+		case "CONCURRENT_LIMIT":
+			return CONCURRENT_LIMIT_BACKOFF_MS;
 		case "MODEL_CAPACITY_EXHAUSTED":
 			return MODEL_CAPACITY_BASE_MS + Math.random() * MODEL_CAPACITY_JITTER_MS;
 		case "SERVER_ERROR":
@@ -151,9 +163,15 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
 	if (message && matchesUsageLimitText(message)) return true;
+	// A 403 is normally an auth failure, but several providers deliver an
+	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
+	// GitHub Copilot). Rotate only when the body names a cap that resets —
+	// never on a bare 403, which stays an auth failure.
+	if (status === 403 && message && ACCOUNT_SCOPED_403_PATTERN.test(message)) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
-	return parseRateLimitReason(message) === "QUOTA_EXHAUSTED";
+	const reason = parseRateLimitReason(message);
+	return reason === "QUOTA_EXHAUSTED";
 }
 
 /**

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -24,8 +24,8 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 const CONCURRENT_LIMIT_PATTERN =
-	/\bconcurrent_(?:request_)?limit(?:_[a-z0-9]+)*\b|\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b/i;
-const ACCOUNT_SCOPED_403_PATTERN =
+	/\bconcurrent_(?:request_)?limit(?:_[a-z0-9]+)*\b|\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b|\b(?:too many|maximum)\b[^\n]{0,40}\bconcurren[a-z0-9]*\b[^\n]{0,20}\brequests?\b/i;
+export const ACCOUNT_SCOPED_403_PATTERN =
 	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 
 /**

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -24,7 +24,7 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 const CONCURRENT_LIMIT_PATTERN =
-	/\bconcurrent_(?:request_)?limit(?:_[a-z0-9]+)*\b|\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b/i;
+	/\bconcurrent_(?:request_)?limit(?:_[a-z0-9]+)*\b|\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b[^\n]{0,60}\b(?:limit|quota|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b/i;
 const ACCOUNT_SCOPED_403_PATTERN =
 	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 
@@ -162,6 +162,7 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  *     credentials.
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
+	if (message && parseRateLimitReason(message) === "CONCURRENT_LIMIT") return false;
 	if (message && matchesUsageLimitText(message)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
 	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -24,7 +24,7 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 const CONCURRENT_LIMIT_PATTERN =
-	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+	/\bconcurrent_(?:request_)?limit(?:_[a-z0-9]+)*\b|\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren[a-z0-9]*(?:_[a-z0-9]+)*\b/i;
 const ACCOUNT_SCOPED_403_PATTERN =
 	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -17,7 +17,12 @@ import { CATALOG_PROVIDERS, type ProviderCatalogEntry } from "@oh-my-pi/pi-catal
 import { CODEX_BASE_URL } from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, $pickenv, getConfigRootDir, isEnoent, logger, withExtraCaFetch } from "@oh-my-pi/pi-utils";
 import { getCustomApi } from "./api-registry";
-import { createAuthRetryKeyState, isApiKeyResolver, resolveNextAuthRetryKey } from "./auth-retry";
+import {
+	createAuthRetryKeyState,
+	isApiKeyResolver,
+	resolveNextAuthRetryApiKey,
+	toApiKeyResolution,
+} from "./auth-retry";
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
 import { isInvalidatedOAuthTokenError } from "./error/auth-classify";
@@ -180,7 +185,8 @@ function resolveProviderInFlightLimit(
 	const value = limits[provider];
 	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
 	const configuredLimit = Math.max(1, Math.floor(value));
-	return reducedProviderInFlightLimits.get(providerInFlightKey(provider, options?.credentialId)) ?? configuredLimit;
+	const learnedLimit = reducedProviderInFlightLimits.get(providerInFlightKey(provider, options?.credentialId));
+	return learnedLimit === undefined ? configuredLimit : Math.min(learnedLimit, configuredLimit);
 }
 
 function providerInFlightKey(provider: string, credentialId: number | undefined): string {
@@ -1027,9 +1033,111 @@ function createAssistantAuthError(message: AssistantMessage): Error {
 }
 
 function emitBufferedEvents(stream: AssistantMessageEventStream, events: AssistantMessageEvent[]): void {
-	for (const event of events) {
-		stream.push(event);
-	}
+	for (const event of events) stream.push(event);
+}
+
+const adaptiveConcurrencyRetryDispatch = Symbol("adaptiveConcurrencyRetryDispatch");
+type InternalSimpleStreamOptions = SimpleStreamOptions & {
+	[adaptiveConcurrencyRetryDispatch]?: true;
+};
+
+function withAdaptiveConcurrencyRetry(
+	model: Model<Api>,
+	options: InternalSimpleStreamOptions,
+	dispatch: () => AssistantMessageEventStream,
+): AssistantMessageEventStream {
+	const outer = new AssistantMessageEventStream();
+	const signal = options.signal;
+	const runAttempt = async (): Promise<AuthRetryFailure | undefined> => {
+		const bufferedEvents: AssistantMessageEvent[] = [];
+		let emittedReplayUnsafeEvent = false;
+		const flush = (): void => {
+			emitBufferedEvents(outer, bufferedEvents);
+			bufferedEvents.length = 0;
+		};
+		try {
+			const inner = dispatch();
+			for await (const event of inner) {
+				if (!emittedReplayUnsafeEvent && event.type === "start") {
+					bufferedEvents.push(event);
+					continue;
+				}
+				if (
+					!emittedReplayUnsafeEvent &&
+					event.type === "error" &&
+					(isConcurrentLimitError(event.error.errorMessage) ||
+						isRetryableUpstreamError(
+							event.error,
+							extractStatusFromAssistantError(event.error),
+							event.error.errorMessage,
+						))
+				) {
+					return {
+						error: createAssistantAuthError(event.error),
+						bufferedEvents,
+						terminalEvent: event,
+						concurrentLimit: isConcurrentLimitError(event.error.errorMessage),
+					};
+				}
+				flush();
+				emittedReplayUnsafeEvent = true;
+				outer.push(event);
+				if (outer.done) return undefined;
+			}
+			flush();
+			if (!outer.done) outer.end(await inner.result());
+		} catch (error) {
+			const message = error instanceof Error ? error.message : undefined;
+			if (
+				!emittedReplayUnsafeEvent &&
+				(isConcurrentLimitError(message) || isRetryableUpstreamError(error, AIError.status(error), message))
+			) {
+				return { error, bufferedEvents, concurrentLimit: isConcurrentLimitError(message) };
+			}
+			flush();
+			outer.fail(error);
+		}
+		return undefined;
+	};
+	const emitFailure = (failure: AuthRetryFailure): void => {
+		emitBufferedEvents(outer, failure.bufferedEvents);
+		if (failure.terminalEvent) {
+			outer.push(failure.terminalEvent);
+		} else {
+			outer.fail(failure.error);
+		}
+	};
+
+	void (async () => {
+		let failure = await runAttempt();
+		if (!failure) return;
+		if (failure.concurrentLimit) {
+			reduceProviderInFlightLimit(model.provider, options);
+			try {
+				if (options.providerRetryWait) {
+					await options.providerRetryWait(calculateRateLimitBackoffMs("CONCURRENT_LIMIT"), signal);
+				} else {
+					await scheduler.wait(calculateRateLimitBackoffMs("CONCURRENT_LIMIT"), { signal });
+				}
+			} catch (error) {
+				if (signal?.aborted) outer.fail(signal.reason ?? new AIError.AbortError());
+				else outer.fail(error);
+				return;
+			}
+			if (signal?.aborted) {
+				outer.fail(signal.reason ?? new AIError.AbortError());
+				return;
+			}
+			failure = await runAttempt();
+			if (!failure) return;
+			if (failure.concurrentLimit) {
+				emitFailure(failure);
+				return;
+			}
+		}
+		emitFailure(failure);
+	})();
+	return outer;
 }
 
 export function streamSimple<TApi extends Api>(
@@ -1065,7 +1173,12 @@ export function streamSimple<TApi extends Api>(
 			};
 
 			try {
-				const inner = streamSimple(model, context, { ...requestOptions, apiKey, credentialId });
+				const inner = streamSimple(model, context, {
+					...requestOptions,
+					apiKey,
+					credentialId,
+					[adaptiveConcurrencyRetryDispatch]: true,
+				} as InternalSimpleStreamOptions);
 				for await (const event of inner) {
 					if (!emittedReplayUnsafeEvent && event.type === "start") {
 						bufferedEvents.push(event);
@@ -1118,11 +1231,55 @@ export function streamSimple<TApi extends Api>(
 		};
 
 		void (async () => {
+			// One credential attempt followed by the bounded, cancellation-aware
+			// adaptive-concurrency backoff. A concurrent-limit failure reduces THIS
+			// credential's learned in-flight limit, waits once, then retries the SAME
+			// credential — never rotating a busy sibling away. A second concurrent
+			// failure is `concurrent-exhausted` so the caller emits instead of
+			// burning another sibling; any other failure is `rotatable` and enters
+			// auth rotation as before. Retry stays bounded (one wait per credential)
+			// and request-scoped.
+			type AttemptOutcome =
+				| { kind: "finalized" }
+				| { kind: "success" }
+				| { kind: "concurrent-exhausted"; failure: AuthRetryFailure }
+				| { kind: "rotatable"; failure: AuthRetryFailure };
+			const attemptWithConcurrentBackoff = async (
+				apiKey: string,
+				credentialId: number | undefined,
+			): Promise<AttemptOutcome> => {
+				let failure = await runAttempt(apiKey, credentialId);
+				if (!failure) return { kind: "success" };
+				if (!failure.concurrentLimit) return { kind: "rotatable", failure };
+				reduceProviderInFlightLimit(model.provider, { ...requestOptions, credentialId });
+				const delay = calculateRateLimitBackoffMs("CONCURRENT_LIMIT");
+				try {
+					if (requestOptions.providerRetryWait) {
+						await requestOptions.providerRetryWait(delay, signal);
+					} else {
+						await scheduler.wait(delay, { signal });
+					}
+				} catch (error) {
+					outer.fail(signal?.aborted ? (signal.reason ?? new AIError.AbortError()) : error);
+					return { kind: "finalized" };
+				}
+				if (signal?.aborted) {
+					outer.fail(signal.reason ?? new AIError.AbortError());
+					return { kind: "finalized" };
+				}
+				const retry = await runAttempt(apiKey, credentialId);
+				if (!retry) return { kind: "success" };
+				return retry.concurrentLimit
+					? { kind: "concurrent-exhausted", failure: retry }
+					: { kind: "rotatable", failure: retry };
+			};
+
 			let lastKey: string | undefined;
 			let credentialId: number | undefined;
 			try {
-				lastKey = (await apiKeyResolver({ lastChance: false, error: undefined, signal })) || undefined;
-				credentialId = apiKeyResolver.credentialId;
+				const resolved = toApiKeyResolution(await apiKeyResolver({ lastChance: false, error: undefined, signal }));
+				lastKey = resolved?.apiKey;
+				credentialId = resolved?.credentialId;
 			} catch (error) {
 				// A thrown resolver is a broker/OAuth/network failure, not a missing
 				// key — surface the cause instead of masking it as "No API key".
@@ -1138,37 +1295,45 @@ export function streamSimple<TApi extends Api>(
 				outer.fail(new AIError.MissingApiKeyError(model.provider));
 				return;
 			}
-			const retryState = createAuthRetryKeyState(lastKey);
-			let failure = await runAttempt(lastKey, credentialId);
-			if (!failure) return;
-			if (failure.concurrentLimit) {
-				reduceProviderInFlightLimit(model.provider, { ...requestOptions, credentialId });
-				await Bun.sleep(calculateRateLimitBackoffMs("CONCURRENT_LIMIT"));
-				if (signal?.aborted) {
-					emitFailure(failure);
-					return;
-				}
-				failure = await runAttempt(lastKey, credentialId);
-				if (!failure) return;
-				if (failure.concurrentLimit) {
-					emitFailure(failure);
-					return;
-				}
+			const retryState = createAuthRetryKeyState(lastKey, credentialId);
+			let outcome = await attemptWithConcurrentBackoff(lastKey, credentialId);
+			if (outcome.kind === "finalized" || outcome.kind === "success") return;
+			if (outcome.kind === "concurrent-exhausted") {
+				emitFailure(outcome.failure);
+				return;
 			}
+			let failure = outcome.failure;
 			while (true) {
 				// Caller aborted between attempts: don't mint a fresh token or fire
 				// another doomed request — emit the captured failure instead.
 				if (signal?.aborted) break;
-				const nextKey = await resolveNextAuthRetryKey(retryState, apiKeyResolver, failure.error, signal);
-				if (nextKey === undefined) break;
-				credentialId = apiKeyResolver.credentialId;
-				const next = await runAttempt(nextKey, credentialId);
-				if (!next) return;
-				failure = next;
+				const next = await resolveNextAuthRetryApiKey(retryState, apiKeyResolver, failure.error, signal);
+				if (next === undefined) break;
+				credentialId = next.credentialId;
+				outcome = await attemptWithConcurrentBackoff(next.apiKey, credentialId);
+				if (outcome.kind === "finalized" || outcome.kind === "success") return;
+				if (outcome.kind === "concurrent-exhausted") {
+					emitFailure(outcome.failure);
+					return;
+				}
+				failure = outcome.failure;
 			}
 			emitFailure(failure);
 		})();
 		return outer;
+	}
+
+	const internalRequestOptions = requestOptions as InternalSimpleStreamOptions;
+	if (
+		!internalRequestOptions[adaptiveConcurrencyRetryDispatch] &&
+		resolveProviderInFlightLimit(model.provider, internalRequestOptions) !== undefined
+	) {
+		return withAdaptiveConcurrencyRetry(model, internalRequestOptions, () =>
+			streamSimple(model, context, {
+				...internalRequestOptions,
+				[adaptiveConcurrencyRetryDispatch]: true,
+			} as InternalSimpleStreamOptions),
+		);
 	}
 
 	// Pi-native transport short-circuits the per-provider dispatch entirely:

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -200,7 +200,12 @@ function reduceProviderInFlightLimit(
 	const currentLimit = resolveProviderInFlightLimit(provider, options);
 	if (currentLimit === undefined) return;
 	const key = providerInFlightKey(provider, options?.credentialId);
-	reducedProviderInFlightLimits.set(key, Math.max(1, currentLimit - 1));
+	const reduced = Math.max(1, currentLimit - 1);
+	reducedProviderInFlightLimits.set(key, reduced);
+	// Mirror the reduction into the shared lease directory so peer processes
+	// acquiring the same credential bucket observe the lower cap instead of
+	// refilling the slot the provider just rejected.
+	void persistProviderInFlightLearnedCap(providerInFlightDir(key), reduced);
 }
 
 function providerInFlightRoot(): string {
@@ -259,6 +264,34 @@ async function writeProviderInFlightInfo(dir: string, token: string): Promise<vo
 	} catch (error) {
 		await fs.rm(tempPath, { force: true }).catch(() => {});
 		throw error;
+	}
+}
+
+// The learned concurrency cap a provider rejected is shared across every OMP
+// process using the same lease directory: a reduction observed by one process
+// must bound acquires in the others, or queued peers refill the rejected slot
+// and keep the provider over its true limit. The value lives next to the leases
+// as a plain `.learned-cap` file (min-write so a stale in-process snapshot can
+// never raise the shared floor); reads are best-effort and degrade to the
+// configured cap when the file is absent or unreadable.
+async function readProviderInFlightLearnedCap(dir: string): Promise<number | undefined> {
+	try {
+		const content = await fs.readFile(path.join(dir, ".learned-cap"), "utf-8");
+		const parsed = Number.parseInt(content, 10);
+		return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function persistProviderInFlightLearnedCap(dir: string, cap: number): Promise<void> {
+	try {
+		await fs.mkdir(dir, { recursive: true });
+		const existing = await readProviderInFlightLearnedCap(dir);
+		const next = existing === undefined ? cap : Math.min(existing, cap);
+		await Bun.write(path.join(dir, ".learned-cap"), String(next));
+	} catch {
+		// Best-effort: cross-process coordination degrades to in-process only.
 	}
 }
 
@@ -422,8 +455,10 @@ async function tryAcquireProviderInFlightLease(
 	try {
 		const dir = providerInFlightDir(provider);
 		await fs.mkdir(dir, { recursive: true });
+		const learnedCap = await readProviderInFlightLearnedCap(dir);
+		const effectiveLimit = learnedCap === undefined ? limit : Math.min(learnedCap, limit);
 		const active = await cleanupProviderInFlightLeases(dir);
-		if (active >= limit) return null;
+		if (active >= effectiveLimit) return null;
 
 		const leaseDir = path.join(dir, `${process.pid}-${Date.now()}-${crypto.randomUUID()}`);
 		const token = crypto.randomUUID();
@@ -579,6 +614,16 @@ export const __providerInFlightForTesting = {
 	},
 	resetReducedLimits(): void {
 		reducedProviderInFlightLimits.clear();
+	},
+	async learnedCap(provider: string, credentialId?: number): Promise<number | undefined> {
+		return readProviderInFlightLearnedCap(providerInFlightDir(providerInFlightKey(provider, credentialId)));
+	},
+	async clearLearnedCap(provider: string, credentialId?: number): Promise<void> {
+		await fs
+			.rm(path.join(providerInFlightDir(providerInFlightKey(provider, credentialId)), ".learned-cap"), {
+				force: true,
+			})
+			.catch(() => {});
 	},
 };
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -21,7 +21,7 @@ import { createAuthRetryKeyState, isApiKeyResolver, resolveNextAuthRetryKey } fr
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
 import { isInvalidatedOAuthTokenError } from "./error/auth-classify";
-import { isUsageLimitOutcome } from "./error/rate-limit";
+import { calculateRateLimitBackoffMs, isUsageLimitOutcome, parseRateLimitReason } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { CursorOptions } from "./providers/cursor";
@@ -166,6 +166,7 @@ const PROVIDER_INFLIGHT_SIGNAL_FALLBACK_MS = 250;
 
 let configuredProviderMaxInFlightRequests: Record<string, number> = {};
 let providerInFlightRootOverride: string | undefined;
+const reducedProviderInFlightLimits = new Map<string, number>();
 
 export function configureProviderMaxInFlightRequests(limits: Record<string, number> | undefined): void {
 	configuredProviderMaxInFlightRequests = limits ?? {};
@@ -173,12 +174,27 @@ export function configureProviderMaxInFlightRequests(limits: Record<string, numb
 
 function resolveProviderInFlightLimit(
 	provider: string,
-	options?: Pick<StreamOptions, "maxInFlightRequests">,
+	options?: Pick<StreamOptions, "maxInFlightRequests" | "credentialId">,
 ): number | undefined {
 	const limits = options?.maxInFlightRequests ?? configuredProviderMaxInFlightRequests;
 	const value = limits[provider];
 	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
-	return Math.max(1, Math.floor(value));
+	const configuredLimit = Math.max(1, Math.floor(value));
+	return reducedProviderInFlightLimits.get(providerInFlightKey(provider, options?.credentialId)) ?? configuredLimit;
+}
+
+function providerInFlightKey(provider: string, credentialId: number | undefined): string {
+	return `${provider}#${credentialId ?? "default"}`;
+}
+
+function reduceProviderInFlightLimit(
+	provider: string,
+	options: Pick<StreamOptions, "maxInFlightRequests" | "credentialId"> | undefined,
+): void {
+	const currentLimit = resolveProviderInFlightLimit(provider, options);
+	if (currentLimit === undefined) return;
+	const key = providerInFlightKey(provider, options?.credentialId);
+	reducedProviderInFlightLimits.set(key, Math.max(1, currentLimit - 1));
 }
 
 function providerInFlightRoot(): string {
@@ -533,20 +549,20 @@ export const __providerInFlightForTesting = {
 	setRoot(root: string | undefined): void {
 		providerInFlightRootOverride = root;
 	},
-	providerDir(provider: string): string {
-		return providerInFlightDir(provider);
+	providerDir(provider: string, credentialId?: number): string {
+		return providerInFlightDir(providerInFlightKey(provider, credentialId));
 	},
-	lockDir(provider: string): string {
-		return providerInFlightLockDir(provider);
+	lockDir(provider: string, credentialId?: number): string {
+		return providerInFlightLockDir(providerInFlightKey(provider, credentialId));
 	},
-	async captureStaleLockRelease(provider: string): Promise<(() => Promise<void>) | null> {
-		const lockDir = providerInFlightLockDir(provider);
+	async captureStaleLockRelease(provider: string, credentialId?: number): Promise<(() => Promise<void>) | null> {
+		const lockDir = providerInFlightLockDir(providerInFlightKey(provider, credentialId));
 		const stale = await readProviderInFlightStaleLock(lockDir);
 		if (!stale) return null;
 		return () => releaseProviderInFlightStaleLock(lockDir, stale);
 	},
-	async captureLockDirRelease(provider: string): Promise<(() => Promise<void>) | null> {
-		const lockDir = providerInFlightLockDir(provider);
+	async captureLockDirRelease(provider: string, credentialId?: number): Promise<(() => Promise<void>) | null> {
+		const lockDir = providerInFlightLockDir(providerInFlightKey(provider, credentialId));
 		try {
 			const identity = await readProviderInFlightLockIdentity(lockDir);
 			return () => releaseProviderInFlightLockDirIfSame(lockDir, identity);
@@ -554,9 +570,14 @@ export const __providerInFlightForTesting = {
 			return null;
 		}
 	},
+	resetReducedLimits(): void {
+		reducedProviderInFlightLimits.clear();
+	},
 };
 
-function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal" | "maxInFlightRequests">>(
+function withProviderInFlightLimit<
+	TOptions extends Pick<StreamOptions, "signal" | "maxInFlightRequests" | "credentialId">,
+>(
 	model: Model<Api>,
 	options: TOptions | undefined,
 	dispatch: () => AssistantMessageEventStream,
@@ -567,6 +588,7 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 	// exempt (see `healLeakedThinking`); healing is otherwise idempotent.
 	const limit = resolveProviderInFlightLimit(model.provider, options);
 	if (limit === undefined) return healLeakedThinking(model, dispatch());
+	const inFlightKey = providerInFlightKey(model.provider, options?.credentialId);
 
 	const outer = new AssistantMessageEventStream();
 	void (async () => {
@@ -579,7 +601,7 @@ function withProviderInFlightLimit<TOptions extends Pick<StreamOptions, "signal"
 		};
 		try {
 			const startedWaitingAt = Date.now();
-			release = await acquireProviderInFlightSlot(model.provider, limit, options?.signal);
+			release = await acquireProviderInFlightSlot(inFlightKey, limit, options?.signal);
 			if (Date.now() - startedWaitingAt >= PROVIDER_INFLIGHT_SIGNAL_FALLBACK_MS) {
 				logger.debug("Provider in-flight limit wait completed", { provider: model.provider, limit });
 			}
@@ -961,6 +983,7 @@ type AuthRetryFailure = {
 	error: unknown;
 	bufferedEvents: AssistantMessageEvent[];
 	terminalEvent?: Extract<AssistantMessageEvent, { type: "error" }>;
+	concurrentLimit?: boolean;
 };
 
 function extractStatusFromAssistantError(message: AssistantMessage): number | undefined {
@@ -987,6 +1010,10 @@ function isRetryableUpstreamError(error: unknown, status: number | undefined, me
 	if (isInvalidatedOAuthTokenError(error)) return true;
 	if (status === 401 || status === 403) return true;
 	return isUsageLimitOutcome(status, message);
+}
+
+function isConcurrentLimitError(message: string | undefined): boolean {
+	return message !== undefined && parseRateLimitReason(message) === "CONCURRENT_LIMIT";
 }
 
 function createAssistantAuthError(message: AssistantMessage): Error {
@@ -1026,7 +1053,10 @@ export function streamSimple<TApi extends Api>(
 		// (so the caller can retry with a fresh key) instead of surfaced. Once any
 		// non-start event escapes, retry is no longer safe and the failure is
 		// emitted directly.
-		const runAttempt = async (apiKey: string): Promise<AuthRetryFailure | undefined> => {
+		const runAttempt = async (
+			apiKey: string,
+			credentialId: number | undefined,
+		): Promise<AuthRetryFailure | undefined> => {
 			const bufferedEvents: AssistantMessageEvent[] = [];
 			let emittedReplayUnsafeEvent = false;
 			const flushBuffered = (): void => {
@@ -1035,7 +1065,7 @@ export function streamSimple<TApi extends Api>(
 			};
 
 			try {
-				const inner = streamSimple(model, context, { ...requestOptions, apiKey });
+				const inner = streamSimple(model, context, { ...requestOptions, apiKey, credentialId });
 				for await (const event of inner) {
 					if (!emittedReplayUnsafeEvent && event.type === "start") {
 						bufferedEvents.push(event);
@@ -1044,13 +1074,19 @@ export function streamSimple<TApi extends Api>(
 					if (
 						!emittedReplayUnsafeEvent &&
 						event.type === "error" &&
-						isRetryableUpstreamError(
-							event.error,
-							extractStatusFromAssistantError(event.error),
-							event.error.errorMessage,
-						)
+						(isConcurrentLimitError(event.error.errorMessage) ||
+							isRetryableUpstreamError(
+								event.error,
+								extractStatusFromAssistantError(event.error),
+								event.error.errorMessage,
+							))
 					) {
-						return { error: createAssistantAuthError(event.error), bufferedEvents, terminalEvent: event };
+						return {
+							error: createAssistantAuthError(event.error),
+							bufferedEvents,
+							terminalEvent: event,
+							concurrentLimit: isConcurrentLimitError(event.error.errorMessage),
+						};
 					}
 					flushBuffered();
 					emittedReplayUnsafeEvent = true;
@@ -1060,15 +1096,12 @@ export function streamSimple<TApi extends Api>(
 				flushBuffered();
 				if (!outer.done) outer.end(await inner.result());
 			} catch (error) {
+				const message = error instanceof Error ? error.message : undefined;
 				if (
 					!emittedReplayUnsafeEvent &&
-					isRetryableUpstreamError(
-						error,
-						AIError.status(error),
-						error instanceof Error ? error.message : undefined,
-					)
+					(isConcurrentLimitError(message) || isRetryableUpstreamError(error, AIError.status(error), message))
 				) {
-					return { error, bufferedEvents };
+					return { error, bufferedEvents, concurrentLimit: isConcurrentLimitError(message) };
 				}
 				flushBuffered();
 				outer.fail(error);
@@ -1086,8 +1119,10 @@ export function streamSimple<TApi extends Api>(
 
 		void (async () => {
 			let lastKey: string | undefined;
+			let credentialId: number | undefined;
 			try {
 				lastKey = (await apiKeyResolver({ lastChance: false, error: undefined, signal })) || undefined;
+				credentialId = apiKeyResolver.credentialId;
 			} catch (error) {
 				// A thrown resolver is a broker/OAuth/network failure, not a missing
 				// key — surface the cause instead of masking it as "No API key".
@@ -1104,15 +1139,30 @@ export function streamSimple<TApi extends Api>(
 				return;
 			}
 			const retryState = createAuthRetryKeyState(lastKey);
-			let failure = await runAttempt(lastKey);
+			let failure = await runAttempt(lastKey, credentialId);
 			if (!failure) return;
+			if (failure.concurrentLimit) {
+				reduceProviderInFlightLimit(model.provider, { ...requestOptions, credentialId });
+				await Bun.sleep(calculateRateLimitBackoffMs("CONCURRENT_LIMIT"));
+				if (signal?.aborted) {
+					emitFailure(failure);
+					return;
+				}
+				failure = await runAttempt(lastKey, credentialId);
+				if (!failure) return;
+				if (failure.concurrentLimit) {
+					emitFailure(failure);
+					return;
+				}
+			}
 			while (true) {
 				// Caller aborted between attempts: don't mint a fresh token or fire
 				// another doomed request — emit the captured failure instead.
 				if (signal?.aborted) break;
 				const nextKey = await resolveNextAuthRetryKey(retryState, apiKeyResolver, failure.error, signal);
 				if (nextKey === undefined) break;
-				const next = await runAttempt(nextKey);
+				credentialId = apiKeyResolver.credentialId;
+				const next = await runAttempt(nextKey, credentialId);
 				if (!next) return;
 				failure = next;
 			}
@@ -1470,6 +1520,7 @@ function mapOptionsForApi<TApi extends Api>(
 		codexSseMaxAttempts: options?.codexSseMaxAttempts,
 		providerSessionState: options?.providerSessionState,
 		maxInFlightRequests: options?.maxInFlightRequests,
+		credentialId: options?.credentialId,
 		onPayload: options?.onPayload,
 		onResponse: options?.onResponse,
 		onSseEvent: options?.onSseEvent,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -190,7 +190,7 @@ function resolveProviderInFlightLimit(
 }
 
 function providerInFlightKey(provider: string, credentialId: number | undefined): string {
-	return `${provider}#${credentialId ?? "default"}`;
+	return `${provider.length}:${provider}#${credentialId ?? "default"}`;
 }
 
 function reduceProviderInFlightLimit(
@@ -534,13 +534,14 @@ async function releaseProviderInFlightLease(lease: ProviderInFlightLease): Promi
 
 async function acquireProviderInFlightSlot(
 	provider: string,
-	limit: number | undefined,
+	resolveLimit: () => number | undefined,
 	signal?: AbortSignal,
 ): Promise<() => Promise<void>> {
-	if (limit === undefined) return async () => {};
 	let loggedWait = false;
 	while (true) {
 		if (signal?.aborted) throw signal.reason ?? new AIError.AbortError("Provider request aborted before dispatch");
+		const limit = resolveLimit();
+		if (limit === undefined) return async () => {};
 		const lease = await tryAcquireProviderInFlightLease(provider, limit, signal);
 		if (lease) return () => releaseProviderInFlightLease(lease);
 		if (!loggedWait) {
@@ -607,7 +608,11 @@ function withProviderInFlightLimit<
 		};
 		try {
 			const startedWaitingAt = Date.now();
-			release = await acquireProviderInFlightSlot(inFlightKey, limit, options?.signal);
+			release = await acquireProviderInFlightSlot(
+				inFlightKey,
+				() => resolveProviderInFlightLimit(model.provider, options),
+				options?.signal,
+			);
 			if (Date.now() - startedWaitingAt >= PROVIDER_INFLIGHT_SIGNAL_FALLBACK_MS) {
 				logger.debug("Provider in-flight limit wait completed", { provider: model.provider, limit });
 			}
@@ -1248,7 +1253,7 @@ export function streamSimple<TApi extends Api>(
 				apiKey: string,
 				credentialId: number | undefined,
 			): Promise<AttemptOutcome> => {
-				let failure = await runAttempt(apiKey, credentialId);
+				const failure = await runAttempt(apiKey, credentialId);
 				if (!failure) return { kind: "success" };
 				if (!failure.concurrentLimit) return { kind: "rotatable", failure };
 				reduceProviderInFlightLimit(model.provider, { ...requestOptions, credentialId });

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -474,6 +474,11 @@ export interface StreamOptions {
 	 */
 	maxInFlightRequests?: Record<string, number>;
 	/**
+	 * SQLite credential row selected by the API-key resolver for this request.
+	 * Internal dispatch metadata: providers must not serialize it upstream.
+	 */
+	credentialId?: number;
+	/**
 	 * Optional callback for inspecting or replacing provider payloads before sending.
 	 * Return undefined to keep the payload unchanged.
 	 */

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -45,12 +45,11 @@ describe("isApiKeyResolver / resolveApiKeyOnce", () => {
 	});
 
 	it("keeps a preflight resolver credential id when reusing its seed", async () => {
-		const resolver = Object.assign(() => "stored", { credentialId: 17 });
+		const resolver = () => ({ apiKey: "stored", credentialId: 17 });
 		const seed = await resolveApiKeyOnce(resolver);
-		const seeded = seedApiKeyResolver(seed, resolver);
+		const seeded = seedApiKeyResolver({ apiKey: seed!, credentialId: 17 }, resolver);
 
-		expect(await seeded({ lastChance: false, error: undefined })).toBe("stored");
-		expect(seeded.credentialId).toBe(17);
+		expect(await seeded({ lastChance: false, error: undefined })).toEqual({ apiKey: "stored", credentialId: 17 });
 	});
 });
 

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -44,6 +44,10 @@ describe("isApiKeyResolver / resolveApiKeyOnce", () => {
 		expect(seen).toEqual({ lastChance: false, error: undefined, signal: undefined });
 	});
 
+	it("treats a structured empty bearer as missing", async () => {
+		expect(await resolveApiKeyOnce(() => ({ apiKey: "", credentialId: 17 }))).toBeUndefined();
+	});
+
 	it("keeps a preflight resolver credential id when reusing its seed", async () => {
 		const resolver = () => ({ apiKey: "stored", credentialId: 17 });
 		const seed = await resolveApiKeyOnce(resolver);

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -5,6 +5,7 @@ import {
 	isApiKeyResolver,
 	isAuthRetryableError,
 	resolveApiKeyOnce,
+	seedApiKeyResolver,
 	withAuth,
 	withOAuthAccess,
 } from "@oh-my-pi/pi-ai";
@@ -41,6 +42,15 @@ describe("isApiKeyResolver / resolveApiKeyOnce", () => {
 		expect(resolved).toBe("minted");
 		// Initial resolve must look like an initial resolve, not a retry.
 		expect(seen).toEqual({ lastChance: false, error: undefined, signal: undefined });
+	});
+
+	it("keeps a preflight resolver credential id when reusing its seed", async () => {
+		const resolver = Object.assign(() => "stored", { credentialId: 17 });
+		const seed = await resolveApiKeyOnce(resolver);
+		const seeded = seedApiKeyResolver(seed, resolver);
+
+		expect(await seeded({ lastChance: false, error: undefined })).toBe("stored");
+		expect(seeded.credentialId).toBe(17);
 	});
 });
 

--- a/packages/ai/test/auth-storage-credential-id-race.test.ts
+++ b/packages/ai/test/auth-storage-credential-id-race.test.ts
@@ -30,8 +30,8 @@ describe("AuthStorage.getApiKeyResolution captures credentialId before configVal
 	// the code is sitting at the capture site, then blocks until the test
 	// releases it after mutating the stored credential set. No sleeps — the
 	// deferred promise is the sole synchronization point.
-	let resolverGate: ReturnType<typeof Promise.withResolvers<void>>;
-	let resolverEntered: ReturnType<typeof Promise.withResolvers<void>>;
+	let resolverGate: PromiseWithResolvers<void>;
+	let resolverEntered: PromiseWithResolvers<void>;
 	let resolverKey: string | undefined;
 
 	beforeEach(async () => {

--- a/packages/ai/test/auth-storage-credential-id-race.test.ts
+++ b/packages/ai/test/auth-storage-credential-id-race.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type ApiKeyCredential,
+	type AuthCredentialStore,
+	AuthStorage,
+	SqliteAuthCredentialStore,
+} from "@oh-my-pi/pi-ai/auth-storage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+/**
+ * Regression guard for the credentialId capture in
+ * {@link AuthStorage.getApiKeyResolution}: the SQLite row id attributed to a
+ * resolution is read BEFORE awaiting `configValueResolver`, so a mutation of
+ * the stored credential set during that await (e.g. a config reload that drops
+ * or reorders rows) cannot re-attribute the resolved key to a different row.
+ *
+ * The resolved key always comes from the pre-await selection's `.key`; this
+ * test pins that the paired `credentialId` comes from the same snapshot rather
+ * than re-reading the (now-shifted) positional index after the await.
+ */
+describe("AuthStorage.getApiKeyResolution captures credentialId before configValueResolver await", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+
+	// The resolver is gated: on entry it announces that selection is done and
+	// the code is sitting at the capture site, then blocks until the test
+	// releases it after mutating the stored credential set. No sleeps — the
+	// deferred promise is the sole synchronization point.
+	let resolverGate: ReturnType<typeof Promise.withResolvers<void>>;
+	let resolverEntered: ReturnType<typeof Promise.withResolvers<void>>;
+	let resolverKey: string | undefined;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-cred-id-race-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		resolverGate = Promise.withResolvers<void>();
+		resolverEntered = Promise.withResolvers<void>();
+		resolverKey = undefined;
+		authStorage = new AuthStorage(store, {
+			configValueResolver: async (config: string) => {
+				resolverKey = config;
+				resolverEntered.resolve();
+				await resolverGate.promise;
+				return config;
+			},
+		});
+	});
+
+	afterEach(async () => {
+		authStorage?.close();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir.length > 0) {
+			await removeWithRetries(tempDir);
+		}
+		tempDir = "";
+	});
+
+	/**
+	 * Seeds two api_key credentials, starts a resolution that blocks inside
+	 * `configValueResolver`, removes the selected (index-0) credential while the
+	 * await is pending, then releases the resolver. The resolution must still be
+	 * attributed to the pre-await credential, even though index 0 then holds a
+	 * different row. Reverting the capture (computing the id after the await)
+	 * returns the survivor's id and fails the final assertion.
+	 */
+	async function resolveWhileSnapshotMutates(
+		provider: string,
+		credentials: [ApiKeyCredential, ApiKeyCredential],
+	): Promise<void> {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set(provider, credentials);
+		const rows = authStorage.listStoredCredentials(provider);
+		expect(rows.length).toBe(2);
+		const [rowA, rowB] = rows;
+		if (!rowA || !rowB) throw new Error("seed credentials not present");
+		const selectedId = rowA.id;
+		const survivorId = rowB.id;
+		expect(survivorId).not.toBe(selectedId);
+
+		const resolutionPromise = authStorage.getApiKeyResolution(provider);
+		// Selection has run and the resolver is now blocked at the capture site.
+		await resolverEntered.promise;
+		expect(resolverKey).toBe(credentials[0].key);
+
+		// Mutate the stored set while the await is still pending: drop the
+		// selected row so positional index 0 now points at the survivor.
+		await authStorage.removeCredential(provider, selectedId);
+		const shifted = authStorage.listStoredCredentials(provider)[0];
+		expect(shifted?.id).toBe(survivorId);
+
+		resolverGate.resolve();
+		const resolution = await resolutionPromise;
+
+		// The resolved key comes from the pre-await credential...
+		expect(resolution?.apiKey).toBe(credentials[0].key);
+		// ...so its attributed credentialId must be the pre-await row, not the
+		// post-mutation index-0 survivor.
+		expect(resolution?.credentialId).toBe(selectedId);
+	}
+
+	test("login api_key branch (source: login)", async () => {
+		await resolveWhileSnapshotMutates("cred-id-race-login", [
+			{ type: "api_key", key: "key-login-A", source: "login" },
+			{ type: "api_key", key: "key-login-B", source: "login" },
+		]);
+	});
+
+	test("stored api_key branch (source is not login)", async () => {
+		await resolveWhileSnapshotMutates("cred-id-race-static", [
+			{ type: "api_key", key: "key-static-A" },
+			{ type: "api_key", key: "key-static-B" },
+		]);
+	});
+});

--- a/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
+++ b/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
@@ -168,8 +168,8 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 			previousKey: failed,
 		});
 
-		expect(retry).toBe(sticky);
-		expect(retry).not.toBe(failed);
+		expect(retry).toEqual(expect.objectContaining({ apiKey: sticky }));
+		expect(retry).not.toEqual(expect.objectContaining({ apiKey: failed }));
 
 		const laterSelections = new Set<string>();
 		for (let index = 0; index < 6; index += 1) {
@@ -209,7 +209,7 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 			previousKey,
 		});
 
-		expect(retry).toBe(sibling.credential.access);
+		expect(retry).toEqual(expect.objectContaining({ apiKey: sibling.credential.access }));
 		expect(await authStorage.getApiKey(PROVIDER, sessionId)).toBe(sibling.credential.access);
 	});
 
@@ -238,7 +238,7 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 			previousKey,
 		});
 
-		expect(retry).toBe(refreshedKey);
+		expect(retry).toEqual(expect.objectContaining({ apiKey: refreshedKey }));
 		expect(await authStorage.getApiKey(PROVIDER, sessionId)).toBe(refreshedKey);
 		expect(
 			store

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -24,6 +24,7 @@ afterEach(async () => {
 	clearCustomApis();
 	configureProviderMaxInFlightRequests(undefined);
 	__providerInFlightForTesting.setRoot(undefined);
+	__providerInFlightForTesting.resetReducedLimits();
 	if (limiterRoot !== undefined) {
 		await fs.rm(limiterRoot, { recursive: true, force: true });
 		limiterRoot = undefined;
@@ -83,6 +84,38 @@ describe("provider in-flight request limits", () => {
 		expect(secondMessage.content).toEqual([{ type: "text", text: "reply 2" }]);
 		expect(maxActive).toBe(1);
 		expect(mock.calls).toHaveLength(2);
+	});
+
+	test("allows one in-flight request per credential for the same provider", async () => {
+		registerMockApi();
+		const bothStarted = Promise.withResolvers<void>();
+		const releaseBoth = Promise.withResolvers<void>();
+		let active = 0;
+		let maxActive = 0;
+		const mock = createMockModel({
+			provider: "tests",
+			handler: async () => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				if (active === 2) bothStarted.resolve();
+				try {
+					await releaseBoth.promise;
+					return { content: ["reply"] };
+				} finally {
+					active--;
+				}
+			},
+		});
+
+		const options = { maxInFlightRequests: { tests: 1 } };
+		const first = streamSimple(mock.model, context(), { ...options, credentialId: 1 });
+		const second = streamSimple(mock.model, context(), { ...options, credentialId: 2 });
+		await bothStarted.promise;
+
+		expect(mock.calls).toHaveLength(2);
+		expect(maxActive).toBe(2);
+		releaseBoth.resolve();
+		await Promise.all([first.result(), second.result()]);
 	});
 
 	test("removes an aborted queued request without dispatching it", async () => {

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -335,6 +335,104 @@ describe("provider in-flight request limits", () => {
 		expect(mock.calls).toHaveLength(0);
 	});
 
+	test("adapts static API keys after a concurrent-limit response", async () => {
+		registerMockApi();
+		const mock = createMockModel({
+			provider: "tests",
+			responses: [{ errorMessage: "concurrent_limit_reached", stopReason: "error" }, { content: ["recovered"] }],
+		});
+		const waits: number[] = [];
+
+		const result = await streamSimple(mock.model, context(), {
+			apiKey: "static-key",
+			maxInFlightRequests: { tests: 2 },
+			providerRetryWait: async delayMs => void waits.push(delayMs),
+		}).result();
+
+		expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+		expect(mock.calls.map(call => call.options?.apiKey)).toEqual(["static-key", "static-key"]);
+		expect(waits).toEqual([5_000]);
+	});
+
+	test("adapts keyless direct providers after a concurrent-limit response", async () => {
+		registerMockApi();
+		const mock = createMockModel({
+			provider: "tests",
+			responses: [{ errorMessage: "concurrent_limit_reached", stopReason: "error" }, { content: ["recovered"] }],
+		});
+		const waits: number[] = [];
+
+		await expect(
+			streamSimple(mock.model, context(), {
+				maxInFlightRequests: { tests: 2 },
+				providerRetryWait: async delayMs => void waits.push(delayMs),
+			}).result(),
+		).resolves.toMatchObject({ content: [{ type: "text", text: "recovered" }] });
+		expect(mock.calls).toHaveLength(2);
+		expect(waits).toEqual([5_000]);
+	});
+
+	test("does not let a learned cap exceed a lowered live static-key cap", async () => {
+		registerMockApi();
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		let calls = 0;
+		const mock = createMockModel({
+			provider: "tests",
+			handler: async () => {
+				calls += 1;
+				if (calls === 1) return { errorMessage: "concurrent_request_limit_reached", stopReason: "error" };
+				if (calls === 2) return { content: ["learned"] };
+				if (calls === 3) {
+					started.resolve();
+					await release.promise;
+				}
+				return { content: ["done"] };
+			},
+		});
+
+		await streamSimple(mock.model, context(), {
+			apiKey: "static-key",
+			maxInFlightRequests: { tests: 3 },
+			providerRetryWait: async () => {},
+		}).result();
+		const first = streamSimple(mock.model, context(), { apiKey: "static-key", maxInFlightRequests: { tests: 1 } });
+		await started.promise;
+		const second = streamSimple(mock.model, context(), { apiKey: "static-key", maxInFlightRequests: { tests: 1 } });
+		await Bun.sleep(20);
+		expect(calls).toBe(3);
+
+		release.resolve();
+		await Promise.all([first.result(), second.result()]);
+		expect(calls).toBe(4);
+	});
+
+	test("aborts a static-key concurrent-limit backoff without waiting", async () => {
+		registerMockApi();
+		const controller = new AbortController();
+		const backoffStarted = Promise.withResolvers<void>();
+		const mock = createMockModel({
+			provider: "tests",
+			responses: [{ errorMessage: "concurrent_limit_reached", stopReason: "error" }],
+		});
+		const stream = streamSimple(mock.model, context(), {
+			apiKey: "static-key",
+			maxInFlightRequests: { tests: 1 },
+			signal: controller.signal,
+			providerRetryWait: async (_delayMs, signal) => {
+				backoffStarted.resolve();
+				await new Promise<never>((_resolve, reject) =>
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true }),
+				);
+			},
+		});
+		const result = stream.result();
+		await backoffStarted.promise;
+		controller.abort();
+		await expect(result).rejects.toMatchObject({ name: "AbortError" });
+		expect(mock.calls).toHaveLength(1);
+	});
+
 	test("uses opaque path segments for provider ids", async () => {
 		const dir = limiterDir("..");
 		const relative = path.relative(limiterRoot!, dir);

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -421,9 +421,9 @@ describe("provider in-flight request limits", () => {
 			signal: controller.signal,
 			providerRetryWait: async (_delayMs, signal) => {
 				backoffStarted.resolve();
-				await new Promise<never>((_resolve, reject) =>
-					signal?.addEventListener("abort", () => reject(signal.reason), { once: true }),
-				);
+				const aborted = Promise.withResolvers<never>();
+				signal?.addEventListener("abort", () => aborted.reject(signal.reason), { once: true });
+				await aborted.promise;
 			},
 		});
 		const result = stream.result();

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -407,6 +407,67 @@ describe("provider in-flight request limits", () => {
 		expect(calls).toBe(4);
 	});
 
+	test("persists a learned cap reduction to the shared lease directory", async () => {
+		registerMockApi();
+		const mock = createMockModel({
+			provider: "tests",
+			responses: [{ errorMessage: "concurrent_limit_reached", stopReason: "error" }, { content: ["recovered"] }],
+		});
+		await streamSimple(mock.model, context(), {
+			apiKey: "static-key",
+			maxInFlightRequests: { tests: 3 },
+			providerRetryWait: async () => {},
+		}).result();
+		// Configured cap 3, reduced by one rejection → shared learned cap 2,
+		// visible to a peer process through the lease directory rather than only
+		// in this process's in-memory map.
+		expect(await __providerInFlightForTesting.learnedCap("tests")).toBe(2);
+	});
+
+	test("observes a learned cap written by another process", async () => {
+		registerMockApi();
+		const twoRunning = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		let active = 0;
+		let maxActive = 0;
+		const mock = createMockModel({
+			provider: "tests",
+			handler: async () => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				if (active === 2) twoRunning.resolve();
+				try {
+					await release.promise;
+					return { content: ["reply"] };
+				} finally {
+					active--;
+				}
+			},
+		});
+		// Simulate a peer process that already lowered the cap from 3 to 2 in the
+		// shared lease directory, then clear the in-memory map so this process
+		// must read the reduction from disk to honour it.
+		const dir = __providerInFlightForTesting.providerDir("tests");
+		await fs.mkdir(dir, { recursive: true });
+		await Bun.write(path.join(dir, ".learned-cap"), "2");
+		__providerInFlightForTesting.resetReducedLimits();
+
+		const options = { maxInFlightRequests: { tests: 3 } };
+		const first = streamSimple(mock.model, context(), options);
+		const second = streamSimple(mock.model, context(), options);
+		const third = streamSimple(mock.model, context(), options);
+		await twoRunning.promise;
+		await Bun.sleep(20);
+
+		// Only two run concurrently — the third is queued behind the peer's cap.
+		expect(maxActive).toBe(2);
+		expect(mock.calls).toHaveLength(2);
+
+		release.resolve();
+		await Promise.all([first.result(), second.result(), third.result()]);
+		expect(maxActive).toBe(2);
+	});
+
 	test("aborts a static-key concurrent-limit backoff without waiting", async () => {
 		registerMockApi();
 		const controller = new AbortController();

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -42,6 +42,7 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("concurrent_request_limit_reached")).toBe("CONCURRENT_LIMIT");
 		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
 		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
+		expect(parseRateLimitReason("authentication failed for concurrent request")).toBe("UNKNOWN");
 	});
 
 	it("classifies overloaded 529 as MODEL_CAPACITY_EXHAUSTED", () => {
@@ -216,6 +217,8 @@ describe("isUsageLimitOutcome", () => {
 		// UNKNOWN but carries a transient retry hint — body is informative,
 		// so we defer to parseRateLimitReason and stay out of the quota lane.
 		expect(isUsageLimitOutcome(429, "Please retry in 5s")).toBe(false);
+		expect(isUsageLimitOutcome(429, "concurrent_limit_reached")).toBe(false);
+		expect(isUsageLimitOutcome(429, "concurrent_request_limit_reached")).toBe(false);
 	});
 
 	it("still rotates on 429 with explicit account rate-limit framing", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -45,6 +45,14 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("authentication failed for concurrent request")).toBe("UNKNOWN");
 	});
 
+	it("classifies implicit 'too many'/'maximum' concurrent-request caps", () => {
+		expect(parseRateLimitReason("Too many concurrent requests")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Maximum number of concurrent requests")).toBe("CONCURRENT_LIMIT");
+		// Guard retained: descriptive "concurrent request" wording with no cap
+		// signal stays UNKNOWN and never triggers slot shedding.
+		expect(parseRateLimitReason("supports concurrent requests")).toBe("UNKNOWN");
+	});
+
 	it("classifies overloaded 529 as MODEL_CAPACITY_EXHAUSTED", () => {
 		expect(parseRateLimitReason("Service overloaded 529")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
@@ -137,6 +145,18 @@ describe("isUsageLimit", () => {
 				"Cloud Code Assist API error (429): Individual quota reached. Contact your administrator to enable overages.",
 			),
 		).toBe(true);
+	});
+
+	it("classifies an account-scoped 403 cap as a usage limit (mirrors isUsageLimitOutcome)", () => {
+		// Devin returns HTTP 403 permission_denied with an account message-rate
+		// limit. isUsageLimitOutcome rotates on it; the flag classifier must set
+		// Flag.UsageLimit too so turn recovery honours the recorded reset/backoff
+		// rather than treating it as a generic auth/transient failure.
+		const message =
+			"Devin stream error permission_denied: Reached overall message rate limit. Please try again later. Your limit will reset in 13 minutes.";
+		expect(isUsageLimit(Object.assign(new Error(message), { status: 403 }))).toBe(true);
+		// A bare 403 with no cap wording stays an auth failure, not a usage limit.
+		expect(isUsageLimit(Object.assign(new Error("Forbidden"), { status: 403 }))).toBe(false);
 	});
 
 	// Anthropic returns a `rate_limit_error` when the account's monthly spend

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -35,6 +35,13 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Requests per minute limit reached")).toBe("RATE_LIMIT_EXCEEDED");
 	});
 
+	it("classifies concurrent request caps separately from rate limits and quota exhaustion", () => {
+		expect(parseRateLimitReason("Number of concurrent requests exceeded")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Maximum concurrent invocation limit reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
+		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
+	});
+
 	it("classifies overloaded 529 as MODEL_CAPACITY_EXHAUSTED", () => {
 		expect(parseRateLimitReason("Service overloaded 529")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
@@ -234,6 +241,16 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(true);
 	});
 
+	it("rotates only account-scoped cap 403s", () => {
+		expect(
+			isUsageLimitOutcome(
+				403,
+				"Devin stream error permission_denied: Reached overall message rate limit. Please try again later. Your limit will reset in 13 minutes.",
+			),
+		).toBe(true);
+		expect(isUsageLimitOutcome(403, "Forbidden")).toBe(false);
+	});
+
 	it("rotates on xAI Grok Build 402 usage-balance exhaustion regardless of status", () => {
 		const message = "402 Grok Build usage balance exhausted";
 		expect(isUsageLimitOutcome(402, message)).toBe(true);
@@ -262,5 +279,9 @@ describe("calculateRateLimitBackoffMs", () => {
 			expect(ms).toBeGreaterThanOrEqual(45_000);
 			expect(ms).toBeLessThanOrEqual(75_000);
 		}
+	});
+
+	it("returns a short backoff for CONCURRENT_LIMIT", () => {
+		expect(calculateRateLimitBackoffMs("CONCURRENT_LIMIT")).toBe(5_000);
 	});
 });

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -38,6 +38,8 @@ describe("parseRateLimitReason", () => {
 	it("classifies concurrent request caps separately from rate limits and quota exhaustion", () => {
 		expect(parseRateLimitReason("Number of concurrent requests exceeded")).toBe("CONCURRENT_LIMIT");
 		expect(parseRateLimitReason("Maximum concurrent invocation limit reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("concurrent_limit_reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("concurrent_request_limit_reached")).toBe("CONCURRENT_LIMIT");
 		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
 		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
 	});

--- a/packages/ai/test/stream-auth-retry.test.ts
+++ b/packages/ai/test/stream-auth-retry.test.ts
@@ -84,6 +84,63 @@ describe("streamSimple resolver auth retry", () => {
 		unregisterCustomApis(SOURCE_ID);
 	});
 
+	it("keeps credential identity scoped to each concurrent resolver invocation", async () => {
+		const bothResolving = Promise.withResolvers<void>();
+		const releaseResolutions = Promise.withResolvers<void>();
+		const bothDispatched = Promise.withResolvers<void>();
+		const releaseDispatches = Promise.withResolvers<void>();
+		const dispatched: Array<{ apiKey: unknown; credentialId: number | undefined }> = [];
+		let active = 0;
+		let maxActive = 0;
+		let resolves = 0;
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				dispatched.push({ apiKey: options?.apiKey, credentialId: options?.credentialId });
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(async () => {
+					active += 1;
+					maxActive = Math.max(maxActive, active);
+					if (active === 2) bothDispatched.resolve();
+					await releaseDispatches.promise;
+					active -= 1;
+					ok(stream);
+				});
+				return stream;
+			},
+			SOURCE_ID,
+		);
+		const resolver = async () => {
+			const index = resolves++;
+			if (resolves === 2) bothResolving.resolve();
+			await releaseResolutions.promise;
+			return { apiKey: `key-${index}`, credentialId: index + 10 };
+		};
+
+		const first = streamSimple(model(), context, {
+			apiKey: resolver,
+			maxInFlightRequests: { "test-provider": 1 },
+		}).result();
+		const second = streamSimple(model(), context, {
+			apiKey: resolver,
+			maxInFlightRequests: { "test-provider": 1 },
+		}).result();
+		await bothResolving.promise;
+		releaseResolutions.resolve();
+		await bothDispatched.promise;
+		expect(maxActive).toBe(2);
+		releaseDispatches.resolve();
+		await Promise.all([first, second]);
+
+		expect(dispatched).toHaveLength(2);
+		expect(dispatched).toEqual(
+			expect.arrayContaining([
+				{ apiKey: "key-0", credentialId: 10 },
+				{ apiKey: "key-1", credentialId: 11 },
+			]),
+		);
+	});
+
 	it("retries with a refreshed key when a 401 is thrown before the first event", async () => {
 		const keys: unknown[] = [];
 		const contexts: ApiKeyResolveContext[] = [];
@@ -719,5 +776,125 @@ describe("streamSimple resolver auth retry", () => {
 
 		expect((caught as Error).message).toMatch(/No API key for provider/);
 		expect(attempts).toBe(0);
+	});
+
+	it("waits and retries a sibling that hits the concurrency cap instead of rotating away", async () => {
+		const keys: unknown[] = [];
+		const waits: number[] = [];
+		const unexpected: string[] = [];
+		let bAttempts = 0;
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const key = options?.apiKey;
+					if (key === "credential-A") {
+						// First credential is invalid → rotates to a sibling.
+						stream.push({ type: "start", partial: assistant() });
+						stream.push({
+							type: "error",
+							reason: "error",
+							error: assistantError(
+								'{"type":"error","error":{"type":"authentication_error","message":"Invalid credentials"}}',
+								401,
+							),
+						});
+						return;
+					}
+					if (key === "credential-B") {
+						bAttempts += 1;
+						if (bAttempts === 1) {
+							stream.push({ type: "start", partial: assistant() });
+							stream.push({
+								type: "error",
+								reason: "error",
+								error: assistantError("concurrent_limit_reached"),
+							});
+							return;
+						}
+						ok(stream);
+						return;
+					}
+					unexpected.push(key as string);
+					ok(stream);
+				});
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const stream = streamSimple(model(), context, {
+			apiKey: async ctx => (ctx.error === undefined ? "credential-A" : "credential-B"),
+			providerRetryWait: async delayMs => void waits.push(delayMs),
+		});
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect((await stream.result()).content).toEqual([{ type: "text", text: "ok" }]);
+		// credential-A rotated to credential-B, which hit the concurrency cap, had
+		// its learned limit reduced, waited once, then retried the SAME sibling.
+		expect(keys).toEqual(["credential-A", "credential-B", "credential-B"]);
+		expect(bAttempts).toBe(2);
+		expect(unexpected).toEqual([]);
+		expect(waits).toEqual([5_000]);
+	});
+
+	it("aborts a sibling concurrent-limit backoff without retrying or rotating", async () => {
+		const controller = new AbortController();
+		const keys: unknown[] = [];
+		const backoffStarted = Promise.withResolvers<void>();
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const key = options?.apiKey;
+					if (key === "credential-A") {
+						stream.push({ type: "start", partial: assistant() });
+						stream.push({
+							type: "error",
+							reason: "error",
+							error: assistantError(
+								'{"type":"error","error":{"type":"authentication_error","message":"Invalid credentials"}}',
+								401,
+							),
+						});
+						return;
+					}
+					// credential-B is saturated: every attempt reports the cap. The
+					// bounded backoff wait is what we abort.
+					stream.push({ type: "start", partial: assistant() });
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: assistantError("concurrent_limit_reached"),
+					});
+				});
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const stream = streamSimple(model(), context, {
+			apiKey: async ctx => (ctx.error === undefined ? "credential-A" : "credential-B"),
+			signal: controller.signal,
+			providerRetryWait: async (_delayMs, signal) => {
+				backoffStarted.resolve();
+				await new Promise<never>((_resolve, reject) =>
+					signal?.addEventListener("abort", () => reject(signal.reason), { once: true }),
+				);
+			},
+		});
+		const result = stream.result();
+		await backoffStarted.promise;
+		controller.abort();
+		await expect(result).rejects.toMatchObject({ name: "AbortError" });
+		// credential-B was dispatched once (the saturating attempt) but the aborted
+		// wait never retried it and never rotated to a third credential.
+		expect(keys).toEqual(["credential-A", "credential-B"]);
 	});
 });

--- a/packages/ai/test/stream-auth-retry.test.ts
+++ b/packages/ai/test/stream-auth-retry.test.ts
@@ -884,9 +884,9 @@ describe("streamSimple resolver auth retry", () => {
 			signal: controller.signal,
 			providerRetryWait: async (_delayMs, signal) => {
 				backoffStarted.resolve();
-				await new Promise<never>((_resolve, reject) =>
-					signal?.addEventListener("abort", () => reject(signal.reason), { once: true }),
-				);
+				const aborted = Promise.withResolvers<never>();
+				signal?.addEventListener("abort", () => aborted.reject(signal.reason), { once: true });
+				await aborted.promise;
 			},
 		});
 		const result = stream.result();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified that `providers.maxInFlightRequests` applies independently to each selected credential.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -58,16 +58,15 @@ export function createApiKeyResolver(
 	const resolve = async (requestOptions: {
 		forceRefresh?: boolean;
 		signal?: AbortSignal;
-	}): Promise<string | undefined> => {
+	}): Promise<{ apiKey: string; credentialId?: number } | undefined> => {
 		const resolved = registry.getApiKeyResolutionForProvider
 			? await registry.getApiKeyResolutionForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions })
 			: undefined;
-		resolver.credentialId = resolved?.credentialId;
-		return (
-			resolved?.apiKey ?? registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions })
-		);
+		if (resolved) return resolved;
+		const apiKey = await registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions });
+		return apiKey === undefined ? undefined : { apiKey };
 	};
-	const resolver: ApiKeyResolver = async ({ lastChance, error, signal, previousKey }) => {
+	const resolver: ApiKeyResolver = async ({ lastChance, error, signal, previousKey, previousCredentialId }) => {
 		if (error === undefined) return resolve({ signal });
 		if (lastChance) {
 			// Account constraint (401 / usage / account-rate-limit): rotate to a
@@ -80,7 +79,7 @@ export function createApiKeyResolver(
 				modelId,
 				signal,
 				apiKey: previousKey,
-				credentialId: resolver.credentialId,
+				credentialId: previousCredentialId,
 			});
 			if (!switched) {
 				const status = AIError.status(error);

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -59,10 +59,9 @@ export function createApiKeyResolver(
 		forceRefresh?: boolean;
 		signal?: AbortSignal;
 	}): Promise<{ apiKey: string; credentialId?: number } | undefined> => {
-		const resolved = registry.getApiKeyResolutionForProvider
-			? await registry.getApiKeyResolutionForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions })
-			: undefined;
-		if (resolved) return resolved;
+		if (registry.getApiKeyResolutionForProvider) {
+			return registry.getApiKeyResolutionForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions });
+		}
 		const apiKey = await registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions });
 		return apiKey === undefined ? undefined : { apiKey };
 	};

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -24,6 +24,11 @@ export interface ApiKeyResolverRegistry {
 		sessionId?: string,
 		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined>;
+	getApiKeyResolutionForProvider?(
+		provider: string,
+		sessionId?: string,
+		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
+	): Promise<{ apiKey: string; credentialId?: number } | undefined>;
 	authStorage: Pick<AuthStorage, "rotateSessionCredential">;
 	/**
 	 * Build an {@link ApiKeyResolver} implementing the central a/b/c auth-retry
@@ -45,15 +50,25 @@ export interface ApiKeyResolverRegistry {
  * Also usable standalone for structural registries that don't carry the method.
  */
 export function createApiKeyResolver(
-	registry: Pick<ApiKeyResolverRegistry, "getApiKeyForProvider" | "authStorage">,
+	registry: Pick<ApiKeyResolverRegistry, "getApiKeyForProvider" | "getApiKeyResolutionForProvider" | "authStorage">,
 	provider: string,
 	options: ApiKeyResolverOptions = {},
 ): ApiKeyResolver {
 	const { sessionId, baseUrl, modelId } = options;
-	return async ({ lastChance, error, signal, previousKey }) => {
-		if (error === undefined) {
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
-		}
+	const resolve = async (requestOptions: {
+		forceRefresh?: boolean;
+		signal?: AbortSignal;
+	}): Promise<string | undefined> => {
+		const resolved = registry.getApiKeyResolutionForProvider
+			? await registry.getApiKeyResolutionForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions })
+			: undefined;
+		resolver.credentialId = resolved?.credentialId;
+		return (
+			resolved?.apiKey ?? registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, ...requestOptions })
+		);
+	};
+	const resolver: ApiKeyResolver = async ({ lastChance, error, signal, previousKey }) => {
+		if (error === undefined) return resolve({ signal });
 		if (lastChance) {
 			// Account constraint (401 / usage / account-rate-limit): rotate to a
 			// sibling credential. We do NOT honor any retry-after here — if a
@@ -65,6 +80,7 @@ export function createApiKeyResolver(
 				modelId,
 				signal,
 				apiKey: previousKey,
+				credentialId: resolver.credentialId,
 			});
 			if (!switched) {
 				const status = AIError.status(error);
@@ -74,8 +90,9 @@ export function createApiKeyResolver(
 				// auth decline can instead mean a peer refreshed the bearer.
 				if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) return undefined;
 			}
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
+			return resolve({ signal });
 		}
-		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
+		return resolve({ forceRefresh: true, signal });
 	};
+	return resolver;
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2338,12 +2338,21 @@ export class ModelRegistry {
 		sessionId?: string,
 		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined> {
+		return (await this.getApiKeyResolutionForProvider(provider, sessionId, options))?.apiKey;
+	}
+
+	/** Resolve a bearer with the stored credential row that supplied it, when applicable. */
+	async getApiKeyResolutionForProvider(
+		provider: string,
+		sessionId?: string,
+		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
+	): Promise<{ apiKey: string; credentialId?: number } | undefined> {
 		const commandKey = this.#resolveCommandBackedApiKey(provider);
-		if (commandKey.configured) return commandKey.value;
+		if (commandKey.configured) return commandKey.value ? { apiKey: commandKey.value } : undefined;
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
-			return kNoAuth;
+			return { apiKey: kNoAuth };
 		}
-		return this.authStorage.getApiKey(provider, sessionId, {
+		return this.authStorage.getApiKeyResolution(provider, sessionId, {
 			baseUrl: options?.baseUrl,
 			modelId: options?.modelId,
 			forceRefresh: options?.forceRefresh,

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -372,7 +372,7 @@ class ProviderLimitsSubmenu extends Container {
 			new Text(
 				theme.fg(
 					"muted",
-					"Select a provider, enter a positive number to cap concurrent LLM requests, or clear it for unlimited.",
+					"Select a provider, enter a positive number to cap concurrent LLM requests per credential, or clear it for unlimited.",
 				),
 				0,
 				0,

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -31,13 +31,21 @@ function lastAssistant(session: AgentSession): AssistantMessage {
 }
 
 function resolveInitialApiKey(
-	apiKey: string | ((ctx: ApiKeyResolveContext) => string | Promise<string | undefined> | undefined) | undefined,
+	apiKey:
+		| string
+		| ((
+				ctx: ApiKeyResolveContext,
+		  ) =>
+				| string
+				| { apiKey: string; credentialId?: number }
+				| Promise<string | { apiKey: string; credentialId?: number } | undefined>
+				| undefined)
+		| undefined,
 ): string {
 	const resolved = typeof apiKey === "function" ? apiKey({ lastChance: false, error: undefined }) : apiKey;
-	if (typeof resolved !== "string") {
-		throw new Error("Expected API key to be resolved before streaming");
-	}
-	return resolved;
+	if (typeof resolved === "string") return resolved;
+	if (resolved !== undefined && typeof resolved === "object" && "apiKey" in resolved) return resolved.apiKey;
+	throw new Error("Expected API key to be resolved before streaming");
 }
 
 /**

--- a/packages/coding-agent/test/agent-session-retry-recovery.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-recovery.test.ts
@@ -72,13 +72,21 @@ function retryRecovery(recovery: AssistantRetryRecovery["recovery"], note: strin
 }
 
 function resolveInitialApiKey(
-	apiKey: string | ((ctx: ApiKeyResolveContext) => string | Promise<string | undefined> | undefined) | undefined,
+	apiKey:
+		| string
+		| ((
+				ctx: ApiKeyResolveContext,
+		  ) =>
+				| string
+				| { apiKey: string; credentialId?: number }
+				| Promise<string | { apiKey: string; credentialId?: number } | undefined>
+				| undefined)
+		| undefined,
 ): string {
 	const resolved = typeof apiKey === "function" ? apiKey({ lastChance: false, error: undefined }) : apiKey;
-	if (typeof resolved !== "string") {
-		throw new Error("Expected API key to be resolved before streaming");
-	}
-	return resolved;
+	if (typeof resolved === "string") return resolved;
+	if (resolved !== undefined && typeof resolved === "object" && "apiKey" in resolved) return resolved.apiKey;
+	throw new Error("Expected API key to be resolved before streaming");
 }
 
 interface AssistantEntry {

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -248,6 +248,31 @@ describe("AuthStorage account rotation", () => {
 		});
 	});
 
+	test("API key resolver does not re-enter an authoritative resolution miss", async () => {
+		let resolutionCalls = 0;
+		let fallbackCalls = 0;
+		const registry: Parameters<typeof createApiKeyResolver>[0] = {
+			async getApiKeyForProvider() {
+				fallbackCalls += 1;
+				return "unexpected-key";
+			},
+			async getApiKeyResolutionForProvider() {
+				resolutionCalls += 1;
+				return undefined;
+			},
+			authStorage: {
+				async rotateSessionCredential() {
+					return false;
+				},
+			},
+		};
+		const resolver = createApiKeyResolver(registry, "openai-codex");
+
+		expect(await resolver({ lastChance: false, error: undefined })).toBeUndefined();
+		expect(resolutionCalls).toBe(1);
+		expect(fallbackCalls).toBe(0);
+	});
+
 	test("API key resolver stops when a usage-limit rotation has no unblocked sibling", async () => {
 		const resolvedKeys = ["quota-blocked-B", "quota-blocked-A"];
 		const registry: Parameters<typeof createApiKeyResolver>[0] = {

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -217,11 +217,12 @@ describe("AuthStorage account rotation", () => {
 		const refreshed = await resolver({
 			lastChance: true,
 			error: Object.assign(new Error("401 authentication_error"), { status: 401 }),
-			previousKey: initial,
+			previousKey: typeof initial === "string" ? initial : initial?.apiKey,
+			previousCredentialId: typeof initial === "string" ? undefined : initial?.credentialId,
 		});
 
-		expect(initial).toBe("stale-access");
-		expect(refreshed).toBe("refreshed-access");
+		expect(initial).toEqual({ apiKey: "stale-access" });
+		expect(refreshed).toEqual({ apiKey: "refreshed-access" });
 		expect(rotationTargets).toEqual(["stale-access"]);
 	});
 
@@ -241,8 +242,10 @@ describe("AuthStorage account rotation", () => {
 		};
 		const resolver = createApiKeyResolver(registry, "openai-codex");
 
-		expect(await resolver({ lastChance: false, error: undefined })).toBe("stored-key");
-		expect(resolver.credentialId).toBe(17);
+		expect(await resolver({ lastChance: false, error: undefined })).toEqual({
+			apiKey: "stored-key",
+			credentialId: 17,
+		});
 	});
 
 	test("API key resolver stops when a usage-limit rotation has no unblocked sibling", async () => {

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -225,6 +225,26 @@ describe("AuthStorage account rotation", () => {
 		expect(rotationTargets).toEqual(["stale-access"]);
 	});
 
+	test("API key resolver exposes the selected stored credential id alongside the resolved bearer", async () => {
+		const registry: Parameters<typeof createApiKeyResolver>[0] = {
+			async getApiKeyForProvider() {
+				return "fallback-key";
+			},
+			async getApiKeyResolutionForProvider() {
+				return { apiKey: "stored-key", credentialId: 17 };
+			},
+			authStorage: {
+				async rotateSessionCredential() {
+					return false;
+				},
+			},
+		};
+		const resolver = createApiKeyResolver(registry, "openai-codex");
+
+		expect(await resolver({ lastChance: false, error: undefined })).toBe("stored-key");
+		expect(resolver.credentialId).toBe(17);
+	});
+
 	test("API key resolver stops when a usage-limit rotation has no unblocked sibling", async () => {
 		const resolvedKeys = ["quota-blocked-B", "quota-blocked-A"];
 		const registry: Parameters<typeof createApiKeyResolver>[0] = {


### PR DESCRIPTION
## Summary
- Keys in-flight concurrency caps by provider and credential identity (`${provider}#${credentialId ?? "default"}`) so multi-account configurations scale throughput per credential instead of sharing a single provider limit.
- Integrates rate-limit classification from #6958 to trigger adaptive backoff and learned limit reduction on `CONCURRENT_LIMIT` responses rather than prematurely rotating healthy accounts.
- Threads request-scoped credential identity (`ApiKeyResolution` carrying `credentialId`) through `AuthStorage`, API key resolvers, and `streamSimple` retry loops.
- Replaces fixed sleep delays with cancellation-aware wait timers that immediately release in-flight queue slots upon `AbortSignal` trigger.

## What changed
- **Per-credential concurrency limits**: Updated `resolveProviderInFlightLimit` and in-flight lease management to key storage directories by `providerInFlightKey(provider, credentialId)`. Multiple credentials for the same provider each receive their own concurrency bucket while single-credential setups preserve existing behavior.
- **Request-scoped credential identity**: Added `ApiKeyResolution` (`{ apiKey: string; credentialId?: number }`) returned by `AuthStorage.getApiKeyResolution()` and `ApiKeyResolverRegistry.getApiKeyResolutionForProvider()`. `toApiKeyResolution()` normalizes string and object outputs, threading `credentialId` into retry state, stream options, and rotation triggers.
- **Adaptive concurrency retries & learned cap reduction**: On `CONCURRENT_LIMIT` errors, requests perform bounded exponential backoff on the active credential and lower the credential's learned cap (`reducedProviderInFlightLimits`). Rotated sibling credentials also receive cancellation-aware concurrency backoff before auth rotation moves to subsequent credentials.
- **Cancellation-aware abort handling**: Switched auth retry and queue polling loops to `scheduler.wait` and `providerRetryWait` with signal monitoring. Aborting an in-flight wait cleans up queue slots and surfaces `AbortError` without hanging.

## Verification
Executed test suites covering per-credential limit isolation, concurrency backoff, abort cleanup, and credential rotation:
- `bun test packages/ai/test/provider-inflight.test.ts`
- `bun test packages/ai/test/stream-auth-retry.test.ts`
- `bun test packages/ai/test/auth-retry.test.ts`
- `bun test packages/ai/test/auth-storage-force-refresh-rotate.test.ts`
- `bun test packages/coding-agent/test/auth-storage-rotation.test.ts`
- `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts`
- `bun test packages/coding-agent/test/agent-session-retry-recovery.test.ts`

## Notes
- Depends on #6958 for `CONCURRENT_LIMIT` classification.
- Fallback API key strings without stored row IDs map to `credentialId = undefined` (`${provider}#default`), preserving legacy single-bucket behavior for non-persisted credentials.
