### PR TITLE
feat(ai): proper fallback on multiple API keys per provider

### DIFF
--- a/docs/auth-broker-gateway.md
+++ b/docs/auth-broker-gateway.md
@@ -214,7 +214,7 @@ The gateway has no dedicated env vars — it inherits `OMP_AUTH_BROKER_*` becaus
 
 The broker only owns OAuth credentials and provider-API-key credentials that were uploaded to it. The standard credential ladder in `models.md` (`Auth and API key resolution order`) is preserved, with one addition committed alongside the gateway:
 
-- `AuthStorage.setConfigApiKey / removeConfigApiKey / clearConfigApiKeys` let a `models.yml` `apiKey` beat a stored OAuth token **without** overriding an explicit `--api-key`. This is what allows a broker-resolved OAuth credential to be reliably shadowed by a per-environment `models.yml` config key when both are present.
+- `AuthStorage.setConfigApiKeys / removeConfigApiKey / clearConfigApiKeys` let a `models.yml` `apiKey` or `apiKeys` beat a stored OAuth token **without** overriding an explicit `--api-key`. This is what allows a broker-resolved OAuth credential to be reliably shadowed by a per-environment `models.yml` config key when both are present.
 
 ## See also
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -402,7 +402,7 @@ Keyless providers:
 
 When `OMP_AUTH_BROKER_URL` (or `auth.broker.url`) is set, the local SQLite credential store is replaced by `RemoteAuthCredentialStore`. Layers 2 and 3 above (stored API key / OAuth in `agent.db`) are served from a broker-supplied snapshot whose `refresh` tokens are redacted; expiry triggers `POST /v1/credential/:id/refresh` on the broker rather than a local refresh.
 
-`AuthStorage.setConfigApiKey` lets a `models.yml` `apiKey` win over a broker-resolved OAuth token without overriding a runtime `--api-key`. See [`auth-broker-gateway.md`](./auth-broker-gateway.md) for the full broker / gateway design and env surface (`OMP_AUTH_BROKER_URL`, `OMP_AUTH_BROKER_TOKEN`, `auth.broker.url`, `auth.broker.token`).
+`AuthStorage.setConfigApiKeys` lets a `models.yml` `apiKey` win over a broker-resolved OAuth token without overriding a runtime `--api-key`. See [`auth-broker-gateway.md`](./auth-broker-gateway.md) for the full broker / gateway design and env surface (`OMP_AUTH_BROKER_URL`, `OMP_AUTH_BROKER_TOKEN`, `auth.broker.url`, `auth.broker.token`).
 
 ## Model availability vs all models
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -51,6 +51,9 @@ providers:
   my-provider:
     baseUrl: https://api.example.com/v1
     apiKey: MY_PROVIDER_API_KEY
+    apiKeys:
+      - MY_PROVIDER_FALLBACK_API_KEY
+      - MY_PROVIDER_LAST_RESORT_API_KEY
     api: openai-completions
     headers:
       X-Team: platform
@@ -91,6 +94,26 @@ providers:
             controller: mlx
 ```
 
+### Multiple API keys (`apiKey`, `apiKeys`)
+
+A provider can supply one primary `apiKey` and an ordered `apiKeys` list. The
+effective configured key list is `apiKey` first, followed by `apiKeys`. Each
+entry is trimmed; blank entries are ignored; duplicate values keep their first
+position. This lets a generated config leave optional list entries blank.
+
+Configured keys take precedence over stored OAuth and stored API-key credentials
+(but not the runtime `--api-key` override). Any nonempty configured key list
+suppresses OAuth for that provider. With a session, the first key is chosen
+deterministically for that session; without one, selections rotate round-robin.
+A usage-limit response temporarily blocks the selected key and retries with the
+next unblocked configured key. Comma-separated environment keys use the same
+rotation and are deduplicated; JSON object/array credentials remain one intact
+value.
+
+When `authHeader: true`, `Authorization: Bearer <key>` is materialized from the
+currently selected configured key, so the header changes with rotation rather
+than remaining on the first key.
+
 ### Allowed provider/model `api` values
 
 - `openai-completions`
@@ -104,7 +127,8 @@ providers:
 
 ### Allowed auth/discovery values
 
-- `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models, `oauth` is accepted by schema but does not waive the `apiKey` requirement
+- `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models,
+  `oauth` is accepted by schema but does not waive the `apiKey` / `apiKeys` requirement
 - `discovery.type`: `ollama`, `llama.cpp`, `lm-studio`, `openai-models-list`, `proxy`, or `litellm`
 - `transport`: `pi-native` only. When set, every model under that provider is sent to an `omp auth-gateway` compatible `baseUrl` via `POST /v1/pi/stream`; `apiKey` is the gateway bearer.
 
@@ -115,7 +139,7 @@ providers:
 Required:
 
 - `baseUrl`
-- `apiKey` unless `auth: none`
+- `apiKey` or a nonempty `apiKeys` list unless `auth: none`
 - `api` at provider level or each model
 
 ### Override-only provider (`models` missing or empty)
@@ -124,6 +148,7 @@ Must define at least one of:
 
 - `baseUrl`
 - `apiKey`
+- `apiKeys`
 - `auth: none`
 - `headers`
 - `compat`
@@ -142,7 +167,9 @@ Must define at least one of:
 
 ### Command-resolved secrets
 
-Provider `apiKey` values and provider/model `headers` values may start with `!` to read a secret from command stdout. The command is run with a 10 s timeout, stdout is trimmed, and empty/failing commands are omitted:
+Provider `apiKey` / `apiKeys` values and provider/model `headers` values may start
+with `!` to read a secret from command stdout. The command is run with a 10 s
+timeout, stdout is trimmed, and empty/failing commands are omitted:
 
 ```yaml
 providers:
@@ -379,19 +406,19 @@ Extensions can register providers at runtime (`pi.registerProvider(...)`), inclu
 When requesting a key for a provider, effective order is:
 
 1. Runtime override (CLI `--api-key`)
-2. Stored API key credential in `agent.db`
+2. Configured `models.yml` `apiKey` / `apiKeys`
 3. Stored OAuth credential in `agent.db` (with refresh)
-4. Environment variable mapping (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
-5. ModelRegistry fallback resolver (provider `apiKey` from `models.yml`, env-name-or-literal semantics)
+4. API key persisted by a successful `/login`
+5. Environment variable mapping (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
+6. Other stored API-key credentials
+7. ModelRegistry fallback resolver
 
-`models.yml` `apiKey` behavior:
+`models.yml` key values are first treated as environment variable names. If no
+matching environment variable exists, their literal string is used as the token.
 
-- Value is first treated as an environment variable name.
-- If no env var exists, the literal string is used as the token.
+If `authHeader: true` and a provider key is selected, models get:
 
-If `authHeader: true` and provider `apiKey` is set, models get:
-
-- `Authorization: Bearer <resolved-key>` header injected.
+- `Authorization: Bearer <selected-key>` header injected.
 
 Keyless providers:
 
@@ -402,7 +429,11 @@ Keyless providers:
 
 When `OMP_AUTH_BROKER_URL` (or `auth.broker.url`) is set, the local SQLite credential store is replaced by `RemoteAuthCredentialStore`. Layers 2 and 3 above (stored API key / OAuth in `agent.db`) are served from a broker-supplied snapshot whose `refresh` tokens are redacted; expiry triggers `POST /v1/credential/:id/refresh` on the broker rather than a local refresh.
 
-`AuthStorage.setConfigApiKeys` lets a `models.yml` `apiKey` win over a broker-resolved OAuth token without overriding a runtime `--api-key`. See [`auth-broker-gateway.md`](./auth-broker-gateway.md) for the full broker / gateway design and env surface (`OMP_AUTH_BROKER_URL`, `OMP_AUTH_BROKER_TOKEN`, `auth.broker.url`, `auth.broker.token`).
+`AuthStorage.setConfigApiKeys` lets `models.yml` `apiKey` and `apiKeys` win over
+a broker-resolved OAuth token without overriding a runtime `--api-key`. See
+[`auth-broker-gateway.md`](./auth-broker-gateway.md) for the full broker /
+gateway design and env surface (`OMP_AUTH_BROKER_URL`, `OMP_AUTH_BROKER_TOKEN`,
+`auth.broker.url`, `auth.broker.token`).
 
 ## Model availability vs all models
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Classified concurrent-request caps separately from quota exhaustion so they use a short retry backoff without burning a credential, and rotate credentials for account-scoped 403 caps such as Devin's overall message limit.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added rotation across configured and comma-separated environment API keys after quota exhaustion.
+
 ### Fixed
 
 - Classified concurrent-request caps separately from quota exhaustion so they use a short retry backoff without burning a credential, and rotate credentials for account-scoped 403 caps such as Devin's overall message limit.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -25,7 +25,7 @@ import type {
 	OAuthProvider,
 	OAuthProviderId,
 } from "./registry/oauth/types";
-import { getEnvApiKey, getEnvApiKeyName } from "./stream";
+import { getEnvApiKey, getEnvApiKeyName, getEnvApiKeys } from "./stream";
 import type { Provider } from "./types";
 import type {
 	ClientProviderUsage,
@@ -1238,7 +1238,7 @@ export class AuthStorage {
 	/** Provider -> credentials cache, populated from store on reload(). */
 	#data: Map<string, StoredCredential[]> = new Map();
 	#runtimeOverrides: Map<string, string> = new Map();
-	#configOverrides: Map<string, string> = new Map();
+	#configOverrides: Map<string, string[]> = new Map();
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
@@ -1417,23 +1417,27 @@ export class AuthStorage {
 	}
 
 	/**
-	 * Register a per-provider API key sourced from user configuration
-	 * (e.g. `models.yml` `providers.<name>.apiKey`). Higher priority than
-	 * stored credentials and OAuth tokens — when the user pins a key in
-	 * config, that key is what authenticates outbound requests, regardless
-	 * of whatever the broker happens to have loaded for that provider.
-	 *
-	 * Lower priority than {@link setRuntimeApiKey} so a CLI `--api-key`
-	 * still wins for the duration of a single invocation.
+	 * Register per-provider API keys sourced from user configuration (e.g.
+	 * models.yml `providers.<name>.apiKey` / `apiKeys`). Higher priority than
+	 * stored credentials and OAuth, lower than a CLI `--api-key`.
 	 */
-	setConfigApiKey(provider: string, apiKey: string): void {
-		this.#configOverrides.set(provider, apiKey);
+	setConfigApiKeys(provider: string, apiKeys: readonly string[]): void {
+		const keys = [...new Set(apiKeys.map(apiKey => apiKey.trim()).filter(Boolean))];
+		const previous = this.#configOverrides.get(provider);
+		if (previous?.length === keys.length && previous.every((apiKey, index) => apiKey === keys[index])) return;
+		this.#clearVirtualApiKeyBlocks(provider, "config");
+		if (keys.length === 0) {
+			this.#configOverrides.delete(provider);
+			return;
+		}
+		this.#configOverrides.set(provider, keys);
 	}
 
 	/**
 	 * Remove a single config-sourced API key override.
 	 */
 	removeConfigApiKey(provider: string): void {
+		this.#clearVirtualApiKeyBlocks(provider, "config");
 		this.#configOverrides.delete(provider);
 	}
 
@@ -1442,7 +1446,74 @@ export class AuthStorage {
 	 * re-parsing `models.yml` so removed entries actually disappear.
 	 */
 	clearConfigApiKeys(): void {
+		for (const provider of this.#configOverrides.keys()) this.#clearVirtualApiKeyBlocks(provider, "config");
 		this.#configOverrides.clear();
+	}
+
+	#clearVirtualApiKeyBlocks(provider: string, source: "config" | "env"): void {
+		const providerKey = `${provider}:${source}_api_key`;
+		this.#credentialBackoff.delete(providerKey);
+		this.#credentialBackoffProbeAfter.delete(providerKey);
+	}
+
+	#hasPinnedConfigApiKey(provider: string): boolean {
+		return this.#configOverrides.get(provider)?.length === 1;
+	}
+
+	#selectApiKeyOverride(
+		provider: string,
+		providerKey: string,
+		apiKeys: readonly string[],
+		sessionId?: string,
+	): string | undefined {
+		if (apiKeys.length === 0) return undefined;
+		if (apiKeys.length === 1) return apiKeys[0];
+		const order = this.#getCredentialOrder(providerKey, sessionId, apiKeys.length);
+		const fallback = apiKeys[order[0]];
+		for (const index of order) {
+			if (!this.#isCredentialBlocked(provider, providerKey, index)) return apiKeys[index];
+		}
+		return fallback;
+	}
+
+	#selectConfigApiKey(provider: string, sessionId?: string): string | undefined {
+		return this.#selectApiKeyOverride(
+			provider,
+			`${provider}:config_api_key`,
+			this.#configOverrides.get(provider) ?? [],
+			sessionId,
+		);
+	}
+
+	#selectEnvApiKey(provider: string, sessionId?: string): string | undefined {
+		return this.#selectApiKeyOverride(provider, `${provider}:env_api_key`, getEnvApiKeys(provider), sessionId);
+	}
+
+	#markApiKeyOverrideUsageLimit(
+		provider: string,
+		apiKey: string | undefined,
+		retryAfterMs: number | undefined,
+	): UsageLimitMarkResult | undefined {
+		if (apiKey === undefined) return undefined;
+		for (const [providerKey, keys] of [
+			[`${provider}:config_api_key`, this.#configOverrides.get(provider) ?? []],
+			[`${provider}:env_api_key`, getEnvApiKeys(provider)],
+		] as const) {
+			if (keys.length < 2) continue;
+			const index = keys.indexOf(apiKey);
+			if (index < 0) continue;
+			const blockedUntil = Date.now() + (retryAfterMs ?? AuthStorage.#defaultBackoffMs);
+			this.#markCredentialBlocked(provider, providerKey, index, blockedUntil, undefined, false);
+			let retryAtMs: number | undefined;
+			for (let sibling = 0; sibling < keys.length; sibling += 1) {
+				if (sibling === index) continue;
+				const siblingBlockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, sibling);
+				if (siblingBlockedUntil === undefined) return { switched: true };
+				if (retryAtMs === undefined || siblingBlockedUntil < retryAtMs) retryAtMs = siblingBlockedUntil;
+			}
+			return { switched: false, retryAtMs };
+		}
+		return undefined;
 	}
 
 	/**
@@ -1753,6 +1824,7 @@ export class AuthStorage {
 		credentialIndex: number,
 		blockedUntilMs: number,
 		blockScope: string | undefined = undefined,
+		persist = true,
 	): void {
 		const backoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
 		const backoffMap = this.#credentialBackoff.get(backoffKey) ?? new Map<number, number>();
@@ -1765,6 +1837,7 @@ export class AuthStorage {
 		this.#credentialBackoffProbeAfter.set(backoffKey, probeAfterMap);
 		this.#invalidateUsageReportCache(provider);
 
+		if (!persist) return;
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
 		const credentialId = this.#getStoredCredentials(provider)[credentialIndex]?.id;
@@ -4173,6 +4246,8 @@ export class AuthStorage {
 			signal?: AbortSignal;
 		},
 	): Promise<UsageLimitMarkResult> {
+		const overrideResult = this.#markApiKeyOverrideUsageLimit(provider, options?.apiKey, options?.retryAfterMs);
+		if (overrideResult) return overrideResult;
 		let sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
 			credentialId: options?.credentialId,
 			apiKey: options?.apiKey,
@@ -5125,10 +5200,8 @@ export class AuthStorage {
 			return runtimeKey;
 		}
 
-		const configKey = this.#configOverrides.get(provider);
-		if (configKey) {
-			return configKey;
-		}
+		const configKey = this.#selectConfigApiKey(provider);
+		if (configKey) return configKey;
 
 		// Precedence: a deliberate OAuth/login credential wins, then an explicit env var,
 		// then a stored static api_key (which may be a stale broker-migrated copy) as a last resort.
@@ -5157,7 +5230,7 @@ export class AuthStorage {
 			return this.#configValueResolver(loginApiKeySelection.credential.key);
 		}
 
-		const envKey = getEnvApiKey(provider);
+		const envKey = this.#selectEnvApiKey(provider);
 		if (envKey) return envKey;
 
 		const apiKeySelection = this.#selectCredentialByType(provider, "api_key");
@@ -5191,10 +5264,8 @@ export class AuthStorage {
 		// (e.g. an auth-gateway) and supplied the bearer for that endpoint —
 		// honor it instead of forwarding an upstream OAuth token that the proxy
 		// won't accept.
-		const configKey = this.#configOverrides.get(provider);
-		if (configKey) {
-			return configKey;
-		}
+		const configKey = this.#selectConfigApiKey(provider, sessionId);
+		if (configKey) return configKey;
 
 		// Precedence: a deliberate OAuth/login credential wins, then an explicit env var,
 		// then a stored static api_key (which may be a stale broker-migrated copy) as a last resort.
@@ -5218,7 +5289,7 @@ export class AuthStorage {
 		// suppresses account_uuid for this session.
 		if (sessionId) this.#sessionLastCredential.get(provider)?.delete(sessionId);
 
-		const envKey = getEnvApiKey(provider);
+		const envKey = this.#selectEnvApiKey(provider, sessionId);
 		if (envKey) return envKey;
 		const apiKeySelection = await this.#selectApiKeyCredential(
 			provider,
@@ -5258,7 +5329,7 @@ export class AuthStorage {
 		// Runtime / config overrides intentionally short-circuit OAuth: when the
 		// user has pinned an API key, they expect the OAuth identity to be
 		// suppressed (same contract as `getOAuthAccountId`).
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
 			return undefined;
 		}
 		const resolved = await this.#resolveOAuthSelection(provider, sessionId, options);
@@ -5351,7 +5422,7 @@ export class AuthStorage {
 	 * credential.
 	 */
 	listOAuthAccounts(provider: string, sessionId?: string): OAuthAccountSummary[] {
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
 			return [];
 		}
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
@@ -5380,7 +5451,7 @@ export class AuthStorage {
 	 * handling may still route around an unavailable account.
 	 */
 	pinSessionOAuthAccount(provider: string, sessionId: string, credentialId: number): boolean {
-		if (!sessionId || this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+		if (!sessionId || this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
 			return false;
 		}
 		const stored = this.#getStoredCredentials(provider);
@@ -5400,7 +5471,7 @@ export class AuthStorage {
 	 * exercise each stored account exactly once.
 	 */
 	async getOAuthAccesses(provider: string, options?: AuthApiKeyOptions): Promise<OAuthAccessResolution[]> {
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
 			return [];
 		}
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
@@ -5427,7 +5498,7 @@ export class AuthStorage {
 		position: number,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthAccessResolution | undefined> {
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
 			return undefined;
 		}
 		const selection = this.#getStoredOAuthSelections(provider)[position];

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1547,7 +1547,12 @@ export class AuthStorage {
 		if (apiKeys.length === 0) return undefined;
 		const order = this.#getCredentialOrder(providerKey, sessionId, apiKeys.length);
 		const selectedIndex = order.find(index => !this.#isCredentialBlocked(provider, providerKey, index)) ?? order[0];
-		this.#providerRoundRobinIndex.set(providerKey, selectedIndex);
+		// The cursor drives sessionless round-robin load balancing (via
+		// #getNextRoundRobinIndex). A session-scoped selection starts from its
+		// deterministic hash, so writing that index here would pin every
+		// sessionless request that follows to the session's key instead of
+		// rotating across the pool — advance the cursor only for sessionless picks.
+		if (!sessionId) this.#providerRoundRobinIndex.set(providerKey, selectedIndex);
 		this.#recordSessionCredential(provider, sessionId, source, selectedIndex);
 		return apiKeys[selectedIndex];
 	}
@@ -1602,6 +1607,41 @@ export class AuthStorage {
 				if (retryAtMs === undefined || siblingBlockedUntil < retryAtMs) retryAtMs = siblingBlockedUntil;
 			}
 			return { switched: false, retryAtMs };
+		}
+		return undefined;
+	}
+	/**
+	 * Hard-auth (401 / non-quota 403) failure on a virtual config/env key pool:
+	 * block the failed key for the backoff window and report whether an unblocked
+	 * sibling remains selectable. Mirrors {@link #markApiKeyOverrideUsageLimit}
+	 * so the resolver's next selection skips the dead key instead of re-selecting
+	 * it — without this, {@link #resolveCredentialTarget} (which only searches
+	 * stored rows) resolves nothing for a virtual key, `rotateSessionCredential`
+	 * declines, and the resolver hands back the same key, ending retry on
+	 * duplicate-key suppression. Returns `undefined` when `apiKey` is not a
+	 * virtual pool member so the stored-row path still handles OAuth/api_key.
+	 */
+	#rotateVirtualApiKeyOnHardAuth(provider: string, apiKey: string | undefined): boolean | undefined {
+		for (const [providerKey, keys] of [
+			[`${provider}:config_api_key`, this.#configOverrides.get(provider) ?? []],
+			[`${provider}:env_api_key`, getEnvApiKeys(provider)],
+		] as const) {
+			if (keys.length < 2) continue;
+			const index = apiKey === undefined ? -1 : keys.indexOf(apiKey);
+			if (index < 0 || index >= keys.length) continue;
+			this.#markCredentialBlocked(
+				provider,
+				providerKey,
+				index,
+				Date.now() + AuthStorage.#defaultBackoffMs,
+				undefined,
+				false,
+			);
+			for (let sibling = 0; sibling < keys.length; sibling += 1) {
+				if (sibling === index) continue;
+				if (!this.#isCredentialBlocked(provider, providerKey, sibling)) return true;
+			}
+			return false;
 		}
 		return undefined;
 	}
@@ -6131,6 +6171,9 @@ export class AuthStorage {
 				})
 			).switched;
 		}
+
+		const virtualKeyRotation = this.#rotateVirtualApiKeyOnHardAuth(provider, options?.apiKey);
+		if (virtualKeyRotation !== undefined) return virtualKeyRotation;
 
 		const sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
 			credentialId: options?.credentialId,

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1244,7 +1244,10 @@ export class AuthStorage {
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
 	#sessionLastCredential: Map<
 		string,
-		Map<string, { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number }>
+		Map<
+			string,
+			{ type: AuthCredential["type"] | "config_api_key" | "env_api_key"; index: number; lastUsedAtMs?: number }
+		>
 	> = new Map();
 	/** Recent bearer fingerprints resolved for each durable OAuth row; used only for delayed usage-limit attribution. */
 	#oauthBearerFingerprints: Map<string, Map<number, string[]>> = new Map();
@@ -1456,24 +1459,31 @@ export class AuthStorage {
 		this.#credentialBackoffProbeAfter.delete(providerKey);
 	}
 
-	#hasPinnedConfigApiKey(provider: string): boolean {
-		return this.#configOverrides.get(provider)?.length === 1;
+	#hasConfigApiKeyOverride(provider: string): boolean {
+		return (this.#configOverrides.get(provider)?.length ?? 0) > 0;
+	}
+
+	/** Returns the config key selected by the shared credential-selection state. */
+	getSelectedConfigApiKey(provider: string): string | undefined {
+		const apiKeys = this.#configOverrides.get(provider);
+		if (!apiKeys || apiKeys.length === 0) return undefined;
+		const selectedIndex = this.#providerRoundRobinIndex.get(`${provider}:config_api_key`) ?? 0;
+		return apiKeys[selectedIndex] ?? apiKeys[0];
 	}
 
 	#selectApiKeyOverride(
 		provider: string,
 		providerKey: string,
 		apiKeys: readonly string[],
+		source: "config_api_key" | "env_api_key",
 		sessionId?: string,
 	): string | undefined {
 		if (apiKeys.length === 0) return undefined;
-		if (apiKeys.length === 1) return apiKeys[0];
 		const order = this.#getCredentialOrder(providerKey, sessionId, apiKeys.length);
-		const fallback = apiKeys[order[0]];
-		for (const index of order) {
-			if (!this.#isCredentialBlocked(provider, providerKey, index)) return apiKeys[index];
-		}
-		return fallback;
+		const selectedIndex = order.find(index => !this.#isCredentialBlocked(provider, providerKey, index)) ?? order[0];
+		this.#providerRoundRobinIndex.set(providerKey, selectedIndex);
+		this.#recordSessionCredential(provider, sessionId, source, selectedIndex);
+		return apiKeys[selectedIndex];
 	}
 
 	#selectConfigApiKey(provider: string, sessionId?: string): string | undefined {
@@ -1481,27 +1491,41 @@ export class AuthStorage {
 			provider,
 			`${provider}:config_api_key`,
 			this.#configOverrides.get(provider) ?? [],
+			"config_api_key",
 			sessionId,
 		);
 	}
 
 	#selectEnvApiKey(provider: string, sessionId?: string): string | undefined {
-		return this.#selectApiKeyOverride(provider, `${provider}:env_api_key`, getEnvApiKeys(provider), sessionId);
+		return this.#selectApiKeyOverride(
+			provider,
+			`${provider}:env_api_key`,
+			getEnvApiKeys(provider),
+			"env_api_key",
+			sessionId,
+		);
 	}
 
 	#markApiKeyOverrideUsageLimit(
 		provider: string,
+		sessionId: string | undefined,
 		apiKey: string | undefined,
 		retryAfterMs: number | undefined,
 	): UsageLimitMarkResult | undefined {
-		if (apiKey === undefined) return undefined;
-		for (const [providerKey, keys] of [
-			[`${provider}:config_api_key`, this.#configOverrides.get(provider) ?? []],
-			[`${provider}:env_api_key`, getEnvApiKeys(provider)],
+		const selectedVirtualCredential =
+			apiKey === undefined ? this.#getSessionCredential(provider, sessionId) : undefined;
+		for (const [providerKey, source, keys] of [
+			[`${provider}:config_api_key`, "config_api_key", this.#configOverrides.get(provider) ?? []],
+			[`${provider}:env_api_key`, "env_api_key", getEnvApiKeys(provider)],
 		] as const) {
 			if (keys.length < 2) continue;
-			const index = keys.indexOf(apiKey);
-			if (index < 0) continue;
+			const index =
+				apiKey === undefined
+					? selectedVirtualCredential?.type === source
+						? selectedVirtualCredential.index
+						: -1
+					: keys.indexOf(apiKey);
+			if (index < 0 || index >= keys.length) continue;
 			const blockedUntil = Date.now() + (retryAfterMs ?? AuthStorage.#defaultBackoffMs);
 			this.#markCredentialBlocked(provider, providerKey, index, blockedUntil, undefined, false);
 			let retryAtMs: number | undefined;
@@ -1865,7 +1889,7 @@ export class AuthStorage {
 	#recordSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		type: AuthCredential["type"],
+		type: AuthCredential["type"] | "config_api_key" | "env_api_key",
 		index: number,
 	): void {
 		if (!sessionId) return;
@@ -1873,6 +1897,8 @@ export class AuthStorage {
 		const sessionMap = this.#sessionLastCredential.get(provider) ?? new Map();
 		sessionMap.set(sessionId, { type, index, lastUsedAtMs: nowMs });
 		this.#sessionLastCredential.set(provider, sessionMap);
+
+		if (type === "config_api_key" || type === "env_api_key") return;
 
 		try {
 			const credentialId = this.#getStoredCredentials(provider)[index]?.id;
@@ -1892,7 +1918,9 @@ export class AuthStorage {
 	#getSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-	): { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number } | undefined {
+	):
+		| { type: AuthCredential["type"] | "config_api_key" | "env_api_key"; index: number; lastUsedAtMs?: number }
+		| undefined {
 		if (!sessionId) return undefined;
 		let sessionMap = this.#sessionLastCredential.get(provider);
 		if (sessionMap?.has(sessionId)) {
@@ -2694,7 +2722,7 @@ export class AuthStorage {
 
 		// Runtime / config overrides bypass OAuth account_uuid attribution — the
 		// caller is authenticating with an explicit key, not the broker's OAuth.
-		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) return undefined;
+		if (this.#runtimeOverrides.has(provider) || this.#hasConfigApiKeyOverride(provider)) return undefined;
 
 		// Prefer the session-sticky credential when available.
 		const sessionPref = this.#getSessionCredential(provider, sessionId);
@@ -4224,7 +4252,14 @@ export class AuthStorage {
 		}
 		if (explicit) return undefined;
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
-		return sessionCredential ? { ...sessionCredential, explicit: false } : undefined;
+		if (
+			!sessionCredential ||
+			sessionCredential.type === "config_api_key" ||
+			sessionCredential.type === "env_api_key"
+		) {
+			return undefined;
+		}
+		return { type: sessionCredential.type, index: sessionCredential.index, explicit: false };
 	}
 
 	/**
@@ -4246,7 +4281,12 @@ export class AuthStorage {
 			signal?: AbortSignal;
 		},
 	): Promise<UsageLimitMarkResult> {
-		const overrideResult = this.#markApiKeyOverrideUsageLimit(provider, options?.apiKey, options?.retryAfterMs);
+		const overrideResult = this.#markApiKeyOverrideUsageLimit(
+			provider,
+			sessionId,
+			options?.apiKey,
+			options?.retryAfterMs,
+		);
 		if (overrideResult) return overrideResult;
 		let sessionCredential = await this.#resolveCredentialTarget(provider, sessionId, {
 			credentialId: options?.credentialId,
@@ -5327,9 +5367,9 @@ export class AuthStorage {
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthAccess | undefined> {
 		// Runtime / config overrides intentionally short-circuit OAuth: when the
-		// user has pinned an API key, they expect the OAuth identity to be
+		// user has configured an API key, they expect the OAuth identity to be
 		// suppressed (same contract as `getOAuthAccountId`).
-		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasConfigApiKeyOverride(provider)) {
 			return undefined;
 		}
 		const resolved = await this.#resolveOAuthSelection(provider, sessionId, options);
@@ -5422,7 +5462,7 @@ export class AuthStorage {
 	 * credential.
 	 */
 	listOAuthAccounts(provider: string, sessionId?: string): OAuthAccountSummary[] {
-		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasConfigApiKeyOverride(provider)) {
 			return [];
 		}
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
@@ -5451,7 +5491,7 @@ export class AuthStorage {
 	 * handling may still route around an unavailable account.
 	 */
 	pinSessionOAuthAccount(provider: string, sessionId: string, credentialId: number): boolean {
-		if (!sessionId || this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
+		if (!sessionId || this.#runtimeOverrides.has(provider) || this.#hasConfigApiKeyOverride(provider)) {
 			return false;
 		}
 		const stored = this.#getStoredCredentials(provider);
@@ -5471,7 +5511,7 @@ export class AuthStorage {
 	 * exercise each stored account exactly once.
 	 */
 	async getOAuthAccesses(provider: string, options?: AuthApiKeyOptions): Promise<OAuthAccessResolution[]> {
-		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasConfigApiKeyOverride(provider)) {
 			return [];
 		}
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
@@ -5498,7 +5538,7 @@ export class AuthStorage {
 		position: number,
 		options?: AuthApiKeyOptions,
 	): Promise<OAuthAccessResolution | undefined> {
-		if (this.#runtimeOverrides.has(provider) || this.#hasPinnedConfigApiKey(provider)) {
+		if (this.#runtimeOverrides.has(provider) || this.#hasConfigApiKeyOverride(provider)) {
 			return undefined;
 		}
 		const selection = this.#getStoredOAuthSelections(provider)[position];

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1228,6 +1228,13 @@ type RankedApiKeyCandidate = UsageRankedCandidate<ApiKeyCredential>;
 // AuthStorage Class
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Round-trip snapshot of a provider's config-key quota backoff for reload preservation. */
+type ConfigKeyBackoffSnapshot = {
+	keys: readonly string[];
+	backoff: ReadonlyMap<number, number> | undefined;
+	probeAfter: ReadonlyMap<number, number> | undefined;
+};
+
 /**
  * Credential storage backed by an AuthCredentialStore.
  * Reads from storage on reload(), manages round-robin credential selection,
@@ -1462,6 +1469,54 @@ export class AuthStorage {
 	clearConfigApiKeys(): void {
 		for (const provider of this.#configOverrides.keys()) this.#clearVirtualApiKeyBlocks(provider, "config");
 		this.#configOverrides.clear();
+	}
+
+	/**
+	 * Snapshot each provider's config-key quota backoff (and the key list it was
+	 * recorded against) so {@link restoreConfigKeyBackoffAfterReload} can reapply
+	 * the blocks once a models.yml reload has finished repopulating config keys.
+	 * Providers without an active backoff are omitted; the snapshot is opaque to
+	 * the caller, which only round-trips it back to the restore call.
+	 */
+	snapshotConfigKeyBackoffForReload(): ReadonlyMap<string, ConfigKeyBackoffSnapshot> {
+		const snapshot = new Map<string, ConfigKeyBackoffSnapshot>();
+		for (const [provider, keys] of this.#configOverrides) {
+			const providerKey = `${provider}:config_api_key`;
+			const backoff = this.#credentialBackoff.get(providerKey);
+			const probeAfter = this.#credentialBackoffProbeAfter.get(providerKey);
+			if (!backoff && !probeAfter) continue;
+			snapshot.set(provider, {
+				keys: [...keys],
+				backoff: backoff ? new Map(backoff) : undefined,
+				probeAfter: probeAfter ? new Map(probeAfter) : undefined,
+			});
+		}
+		return snapshot;
+	}
+
+	/**
+	 * Reapply backoffs captured by {@link snapshotConfigKeyBackoffForReload}, but
+	 * only for providers whose config key list survived the reload byte-for-byte.
+	 * The reload's clearConfigApiKeys otherwise wipes every provider's quota
+	 * backoff, letting an unrelated models.yml edit immediately reselect a key
+	 * the server had blocked until a reported reset time. A changed or removed
+	 * key list invalidates the credential indices a backoff is keyed on, so the
+	 * stale block is left cleared.
+	 */
+	restoreConfigKeyBackoffAfterReload(snapshot: ReadonlyMap<string, ConfigKeyBackoffSnapshot>): void {
+		for (const [provider, entry] of snapshot) {
+			const current = this.#configOverrides.get(provider);
+			if (
+				!current ||
+				current.length !== entry.keys.length ||
+				!current.every((apiKey, index) => apiKey === entry.keys[index])
+			) {
+				continue;
+			}
+			const providerKey = `${provider}:config_api_key`;
+			if (entry.backoff) this.#credentialBackoff.set(providerKey, new Map(entry.backoff));
+			if (entry.probeAfter) this.#credentialBackoffProbeAfter.set(providerKey, new Map(entry.probeAfter));
+		}
 	}
 
 	#clearVirtualApiKeyBlocks(provider: string, source: "config" | "env"): void {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -67,6 +67,7 @@ import { opencodeGoUsageProvider } from "./usage/opencode-go";
 import { syntheticUsageProvider } from "./usage/synthetic";
 import { xaiOauthUsageProvider } from "./usage/xai-oauth";
 import { zaiRankingStrategy, zaiUsageProvider } from "./usage/zai";
+import { getHeadersFromError, getRetryAfterMsFromHeaders } from "./utils/retry-after";
 
 const USAGE_RANKING_METRIC_EPSILON = 1e-9;
 /**
@@ -1434,6 +1435,16 @@ export class AuthStorage {
 			return;
 		}
 		this.#configOverrides.set(provider, keys);
+	}
+
+	/**
+	 * Singular compatibility alias for {@link setConfigApiKeys}. The plural API
+	 * superseded the pre-multi-key `setConfigApiKey` (shipped in 15.1.3); keep
+	 * the singular form delegating so existing integrations keep compiling and
+	 * working with a single configured key.
+	 */
+	setConfigApiKey(provider: string, apiKey: string): void {
+		this.setConfigApiKeys(provider, [apiKey]);
 	}
 
 	/**
@@ -3371,11 +3382,23 @@ export class AuthStorage {
 		const entries = this.#getStoredCredentials(provider);
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		if (sessionCredential) {
-			const credential = entries[sessionCredential.index]?.credential;
-			if (credential) {
-				return credential.type === "api_key"
-					? { type: "api_key", apiKey: credential.key }
-					: this.#buildUsageCredential(credential);
+			// Virtual config/env keys are not stored credentials — never dereference
+			// their selection index against the stored array, which would charge an
+			// unrelated stored account. Attribute directly to the resolved virtual key.
+			if (sessionCredential.type === "config_api_key") {
+				const configKeys = this.#configOverrides.get(provider) ?? [];
+				const configKey = configKeys[sessionCredential.index];
+				if (configKey) return { type: "api_key", apiKey: configKey };
+			} else if (sessionCredential.type === "env_api_key") {
+				const envKey = getEnvApiKeys(provider)[sessionCredential.index];
+				if (envKey) return { type: "api_key", apiKey: envKey };
+			} else {
+				const credential = entries[sessionCredential.index]?.credential;
+				if (credential) {
+					return credential.type === "api_key"
+						? { type: "api_key", apiKey: credential.key }
+						: this.#buildUsageCredential(credential);
+				}
 			}
 		}
 		if (entries.length === 1) {
@@ -6038,11 +6061,17 @@ export class AuthStorage {
 		const status = AIError.status(error);
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 		if (AIError.isUsageLimit(error) || isUsageLimitOutcome(status, message)) {
+			// Forward the response's retry interval so an exhausted virtual/config
+			// key is blocked for the server-reported window, not the 60s default —
+			// the internal rotation that lands here (via the resolver's last-chance
+			// path) doesn't otherwise carry retryAfterMs.
+			const retryAfterMs = getRetryAfterMsFromHeaders(getHeadersFromError(error));
 			return (
 				await this.markUsageLimitReached(provider, sessionId, {
 					modelId: options?.modelId,
 					apiKey: options?.apiKey,
 					credentialId: options?.credentialId,
+					retryAfterMs,
 					signal: options?.signal,
 				})
 			).switched;

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -7,7 +7,7 @@ import {
 	ProviderHttpError,
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
-import { isOpaqueStatusBody, isUsageLimitStatus, matchesUsageLimitText, parseRateLimitReason } from "./rate-limit";
+import { isUsageLimitOutcome } from "./rate-limit";
 
 export const Flag = {
 	Class: 0x1000,
@@ -315,14 +315,12 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		if (isAuthFailureText(errorMessage)) kinds |= Flag.AuthFailed;
 
 		const statusClean = errorStatus ? errorStatus : (status({ message: errorMessage }) ?? undefined);
-		const cleanMessage = errorMessage;
-		const isOpaque = isOpaqueStatusBody(cleanMessage);
-
-		const isLimitStatus = isUsageLimitStatus(statusClean);
-		if (
-			matchesUsageLimitText(cleanMessage) ||
-			(isLimitStatus && (isOpaque || parseRateLimitReason(cleanMessage) === "QUOTA_EXHAUSTED"))
-		) {
+		// Use the same status-aware classification as the account-rotation
+		// decision so account-scoped 403 caps (Devin/Codeium "overall message
+		// rate limit") populate Flag.UsageLimit, not just AuthFailed. Concurrent
+		// caps are excluded by isUsageLimitOutcome so they stay transient instead
+		// of burning a healthy sibling credential.
+		if (isUsageLimitOutcome(statusClean, errorMessage)) {
 			kinds |= Flag.UsageLimit;
 		}
 
@@ -333,9 +331,9 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		}
 
 		// Copilot per-client routing flap is transient.
-		if (statusClean === 400 && COPILOT_MODEL_NOT_SUPPORTED_PATTERN.test(cleanMessage)) kinds |= Flag.Transient;
-		if (matchesStrictToolsRejection(cleanMessage, statusClean)) kinds |= Flag.Grammar;
-		if (matchesFastModeUnsupported(cleanMessage, statusClean)) kinds |= Flag.FastModeUnsupported;
+		if (statusClean === 400 && COPILOT_MODEL_NOT_SUPPORTED_PATTERN.test(errorMessage)) kinds |= Flag.Transient;
+		if (matchesStrictToolsRejection(errorMessage, statusClean)) kinds |= Flag.Grammar;
+		if (matchesFastModeUnsupported(errorMessage, statusClean)) kinds |= Flag.FastModeUnsupported;
 	}
 	if (kinds !== 0) return create(kinds);
 	const fallbackStatus = errorStatus ?? (errorMessage ? status({ message: errorMessage }) : undefined);

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -7,7 +7,7 @@ import {
 	ProviderHttpError,
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
-import { isUsageLimitOutcome } from "./rate-limit";
+import { isUsageLimitOutcome, parseRateLimitReason } from "./rate-limit";
 
 export const Flag = {
 	Class: 0x1000,
@@ -322,6 +322,15 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		// of burning a healthy sibling credential.
 		if (isUsageLimitOutcome(statusClean, errorMessage)) {
 			kinds |= Flag.UsageLimit;
+		}
+		// A concurrency cap surfaces as a bare 429 whose body parses to
+		// CONCURRENT_LIMIT. isUsageLimitOutcome withholds UsageLimit so it never
+		// burns a sibling credential, but the wording ("concurrent_limit_*") does
+		// not match the broad transient transport pattern — without this flag
+		// classifyText returns a bare numeric 429 that retriable() rejects, so the
+		// short concurrency backoff (turn recovery) never applies.
+		if (parseRateLimitReason(errorMessage) === "CONCURRENT_LIMIT") {
+			kinds |= Flag.Transient;
 		}
 
 		if (isTimeoutText(errorMessage)) kinds |= Flag.Transient | Flag.Timeout;

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -6,12 +6,14 @@
 export type RateLimitReason =
 	| "QUOTA_EXHAUSTED"
 	| "RATE_LIMIT_EXCEEDED"
+	| "CONCURRENT_LIMIT"
 	| "MODEL_CAPACITY_EXHAUSTED"
 	| "SERVER_ERROR"
 	| "UNKNOWN";
 
 const QUOTA_EXHAUSTED_BACKOFF_MS = 30 * 60 * 1000; // 30 min
 const RATE_LIMIT_EXCEEDED_BACKOFF_MS = 30 * 1000; // 30s
+const CONCURRENT_LIMIT_BACKOFF_MS = 5 * 1000; // 5s
 const MODEL_CAPACITY_BASE_MS = 45 * 1000; // 45s base
 const MODEL_CAPACITY_JITTER_MS = 30 * 1000; // ±15s
 const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
@@ -21,11 +23,15 @@ const ACCOUNT_RATE_LIMIT_PATTERN =
 const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
+const CONCURRENT_LIMIT_PATTERN =
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+const ACCOUNT_SCOPED_403_PATTERN =
+	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
- * Priority order: QUOTA (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
- * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
+ * Priority order: QUOTA (Antigravity "quota will reset") > CONCURRENT_LIMIT > MODEL_CAPACITY >
+ * QUOTA (account) > RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
  *
  * "resource exhausted" maps to MODEL_CAPACITY (transient, short wait)
  * "quota exceeded" / "quota will reset" maps to QUOTA_EXHAUSTED (long wait, switch account)
@@ -40,6 +46,10 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	// MODEL_CAPACITY fallthrough so credential rotation (not 60s backoff) kicks in.
 	if (lower.includes("quota will reset") || lower.includes("exhausted your capacity")) {
 		return "QUOTA_EXHAUSTED";
+	}
+
+	if (CONCURRENT_LIMIT_PATTERN.test(errorMessage)) {
+		return "CONCURRENT_LIMIT";
 	}
 
 	if (
@@ -105,6 +115,8 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 			return QUOTA_EXHAUSTED_BACKOFF_MS;
 		case "RATE_LIMIT_EXCEEDED":
 			return RATE_LIMIT_EXCEEDED_BACKOFF_MS;
+		case "CONCURRENT_LIMIT":
+			return CONCURRENT_LIMIT_BACKOFF_MS;
 		case "MODEL_CAPACITY_EXHAUSTED":
 			return MODEL_CAPACITY_BASE_MS + Math.random() * MODEL_CAPACITY_JITTER_MS;
 		case "SERVER_ERROR":
@@ -151,9 +163,15 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
 	if (message && matchesUsageLimitText(message)) return true;
+	// A 403 is normally an auth failure, but several providers deliver an
+	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,
+	// GitHub Copilot). Rotate only when the body names a cap that resets —
+	// never on a bare 403, which stays an auth failure.
+	if (status === 403 && message && ACCOUNT_SCOPED_403_PATTERN.test(message)) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
-	return parseRateLimitReason(message) === "QUOTA_EXHAUSTED";
+	const reason = parseRateLimitReason(message);
+	return reason === "QUOTA_EXHAUSTED";
 }
 
 /**

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -24,7 +24,7 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 const CONCURRENT_LIMIT_PATTERN =
-	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b/i;
+	/\bconcurren\w*\b[^\n]{0,60}\b(?:limit|quota|request|invocation|exceed\w*|reach\w*)\b|\b(?:limit|quota|exceed\w*|reach\w*)\b[^\n]{0,60}\bconcurren\w*\b|\bconcurren[a-z]*[-_](?:limit|quota|request|invocation|exceed\w*|reach\w*)/i;
 const ACCOUNT_SCOPED_403_PATTERN =
 	/\b(?:overall|account|organization|team|workspace)\b[^\n]{0,40}\b(?:message |request )?rate.?limit\b|\blimit will reset\b|\bwill reset in\b/i;
 
@@ -147,6 +147,9 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  * Returns true for failures that should burn one credential and rotate to a
  * sibling account. Decision tree:
  *
+ *  0. Concurrent caps (CONCURRENT_LIMIT) are transient and shared across every
+ *     key → never rotate; evaluated before the broad usage matcher, which also
+ *     matches the "quota exceeded" wording a concurrent response may carry.
  *  1. Body matches {@link isUsageLimitError} (Codex `usage_limit_reached`,
  *     Anthropic account rate-limit, Google `resource_exhausted`, OpenAI
  *     `insufficient_quota`, …) → rotate.
@@ -162,6 +165,11 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  *     credentials.
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
+	// Concurrent caps are transient and shared across every key — never rotate
+	// credentials for them. Evaluate before the broad usage matcher, which also
+	// matches "quota exceeded" wording a concurrent response may carry, so the
+	// short concurrency backoff is used instead of burning the whole key pool.
+	if (message && parseRateLimitReason(message) === "CONCURRENT_LIMIT") return false;
 	if (message && matchesUsageLimitText(message)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
 	// account-scoped cap with it (Devin/Codeium Connect `permission_denied`,

--- a/packages/ai/src/providers/pi-native-client.ts
+++ b/packages/ai/src/providers/pi-native-client.ts
@@ -26,6 +26,7 @@ import type {
 	Model,
 	SimpleStreamOptions,
 } from "../types";
+import { REQUEST_API_KEY_AUTHORIZATION } from "../types";
 import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
@@ -119,7 +120,17 @@ function buildHeaders(model: Model<Api>, apiKey: string | undefined): Record<str
 		Accept: "text/event-stream",
 		...(model.headers ?? {}),
 	};
-	if (apiKey && !headers.Authorization) {
+	if (headers.Authorization === REQUEST_API_KEY_AUTHORIZATION) {
+		// The agent loop leaves the request-key sentinel in model.headers until
+		// dispatch; resolve it to the gateway bearer here (mirrors the OpenAI
+		// path's materializeRequestAuthorization). With no key, drop the sentinel
+		// rather than sending the raw placeholder on the wire.
+		if (apiKey) {
+			headers.Authorization = `Bearer ${apiKey}`;
+		} else {
+			delete headers.Authorization;
+		}
+	} else if (apiKey && !headers.Authorization) {
 		headers.Authorization = `Bearer ${apiKey}`;
 	}
 	return headers;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -844,7 +844,12 @@ function streamDispatch<TApi extends Api>(
 				apiKey: "vertex-adc",
 				fetch: createVertexAuthenticatedFetch(requestOptions),
 			}
-		: { ...requestOptions, apiKey };
+		: // Resolve the request-key sentinel (authHeader models) against apiKey here
+			// too: the low-level stream() dispatch reaches the OpenAI transport with
+			// model.headers still carrying the placeholder, and resolveOpenAIRequestSetup
+			// keeps an existing model Authorization via `??=`, so without this the
+			// direct stream() path authenticates with the unresolved sentinel.
+			materializeRequestAuthorization(model, { ...requestOptions, apiKey }, apiKey);
 
 	const api: Api = model.api;
 	switch (api) {
@@ -1025,18 +1030,18 @@ function emitBufferedEvents(stream: AssistantMessageEventStream, events: Assista
 	}
 }
 
-function materializeRequestAuthorization<TApi extends Api>(
+function materializeRequestAuthorization<TApi extends Api, TOpt extends SimpleStreamOptions>(
 	model: Model<TApi>,
-	options: SimpleStreamOptions,
+	options: TOpt,
 	apiKey: string,
-): SimpleStreamOptions {
+): TOpt {
 	if (model.headers?.Authorization !== REQUEST_API_KEY_AUTHORIZATION) return options;
 	// A keyless provider (`auth: none`) resolves to the N/A sentinel — don't
 	// materialize it as `Bearer N/A`. Downstream OpenAI transports already omit
 	// Authorization for the sentinel, and keyless endpoints reject a bogus bearer.
 	if (apiKey === NO_AUTH_SENTINEL) return options;
 	if (Object.keys(options.headers ?? {}).some(header => header.toLowerCase() === "authorization")) return options;
-	return { ...options, headers: { ...options.headers, Authorization: `Bearer ${apiKey}` } };
+	return { ...options, headers: { ...options.headers, Authorization: `Bearer ${apiKey}` } } as TOpt;
 }
 
 export function streamSimple<TApi extends Api>(

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -35,6 +35,7 @@ import type { GoogleVertexOptions } from "./providers/google-vertex";
 import { isKimiModel, streamKimi } from "./providers/kimi";
 import type { OllamaChatOptions } from "./providers/ollama";
 import type { OpenAICompletionsOptions } from "./providers/openai-completions";
+import { NO_AUTH_SENTINEL } from "./providers/openai-shared";
 import { streamPiNative } from "./providers/pi-native-client";
 // Heavy provider stream functions are imported lazily via register-builtins,
 // which wraps each provider module in a dynamic import. This keeps the
@@ -1030,6 +1031,10 @@ function materializeRequestAuthorization<TApi extends Api>(
 	apiKey: string,
 ): SimpleStreamOptions {
 	if (model.headers?.Authorization !== REQUEST_API_KEY_AUTHORIZATION) return options;
+	// A keyless provider (`auth: none`) resolves to the N/A sentinel — don't
+	// materialize it as `Bearer N/A`. Downstream OpenAI transports already omit
+	// Authorization for the sentinel, and keyless endpoints reject a bogus bearer.
+	if (apiKey === NO_AUTH_SENTINEL) return options;
 	if (Object.keys(options.headers ?? {}).some(header => header.toLowerCase() === "authorization")) return options;
 	return { ...options, headers: { ...options.headers, Authorization: `Bearer ${apiKey}` } };
 }

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -726,12 +726,20 @@ const serviceProviderMap: Record<string, KeyResolver> = {
  * Will not return API keys for providers that require OAuth tokens.
  * Checks Bun.env, then cwd/.env, then ~/.env.
  */
-export function getEnvApiKey(provider: string): string | undefined {
+export function getEnvApiKeys(provider: string): string[] {
 	const resolver = serviceProviderMap[provider];
-	if (typeof resolver === "string") {
-		return $env[resolver];
-	}
-	return resolver?.();
+	const value = typeof resolver === "string" ? $env[resolver] : resolver?.();
+	return (
+		value
+			?.split(",")
+			.map(apiKey => apiKey.trim())
+			.filter(Boolean) ?? []
+	);
+}
+
+/** Returns the first configured environment API key for callers that do not rotate credentials. */
+export function getEnvApiKey(provider: string): string | undefined {
+	return getEnvApiKeys(provider)[0];
 }
 
 /**

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -73,6 +73,7 @@ import type {
 	ThinkingBudgets,
 	ToolChoice,
 } from "./types";
+import { REQUEST_API_KEY_AUTHORIZATION } from "./types";
 import { resolveCacheRetention } from "./utils";
 import { AssistantMessageEventStream } from "./utils/event-stream";
 import { isFoundryEnabled } from "./utils/foundry";
@@ -729,12 +730,22 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 export function getEnvApiKeys(provider: string): string[] {
 	const resolver = serviceProviderMap[provider];
 	const value = typeof resolver === "string" ? $env[resolver] : resolver?.();
-	return (
-		value
-			?.split(",")
-			.map(apiKey => apiKey.trim())
-			.filter(Boolean) ?? []
-	);
+	const trimmed = value?.trim();
+	if (!trimmed) return [];
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		if (typeof parsed === "object" && parsed !== null) return [trimmed];
+	} catch {
+		// A non-JSON value can be a comma-separated key list.
+	}
+	return [
+		...new Set(
+			trimmed
+				.split(",")
+				.map(apiKey => apiKey.trim())
+				.filter(Boolean),
+		),
+	];
 }
 
 /** Returns the first configured environment API key for callers that do not rotate credentials. */
@@ -1013,6 +1024,16 @@ function emitBufferedEvents(stream: AssistantMessageEventStream, events: Assista
 	}
 }
 
+function materializeRequestAuthorization<TApi extends Api>(
+	model: Model<TApi>,
+	options: SimpleStreamOptions,
+	apiKey: string,
+): SimpleStreamOptions {
+	if (model.headers?.Authorization !== REQUEST_API_KEY_AUTHORIZATION) return options;
+	if (Object.keys(options.headers ?? {}).some(header => header.toLowerCase() === "authorization")) return options;
+	return { ...options, headers: { ...options.headers, Authorization: `Bearer ${apiKey}` } };
+}
+
 export function streamSimple<TApi extends Api>(
 	model: Model<TApi>,
 	context: Context,
@@ -1020,7 +1041,7 @@ export function streamSimple<TApi extends Api>(
 ): AssistantMessageEventStream {
 	const baseOptions = (options || {}) as SimpleStreamOptions;
 	const debugOptions = withExtraCaFetch(withRequestDebugFetch(baseOptions));
-	const requestOptions = {
+	let requestOptions = {
 		...debugOptions,
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
 	} as SimpleStreamOptions;
@@ -1129,6 +1150,10 @@ export function streamSimple<TApi extends Api>(
 		return outer;
 	}
 
+	if (typeof requestOptions.apiKey === "string") {
+		requestOptions = materializeRequestAuthorization(model, requestOptions, requestOptions.apiKey);
+	}
+
 	// Pi-native transport short-circuits the per-provider dispatch entirely:
 	// the gateway resolves provider + credential server-side, so we don't
 	// need an `apiKey` from `getEnvApiKey` here — `options.apiKey` carries
@@ -1166,6 +1191,8 @@ export function streamSimple<TApi extends Api>(
 	if (!apiKey) {
 		throw new AIError.MissingApiKeyError(model.provider);
 	}
+
+	requestOptions = materializeRequestAuthorization(model, requestOptions, apiKey);
 
 	// GitLab Duo - wraps Anthropic/OpenAI behind GitLab AI Gateway direct access tokens
 	if (isGitLabDuoModel(model)) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -57,6 +57,9 @@ export type { AssistantMessageEventStream } from "./utils/event-stream";
  */
 export const OPENAI_MAX_OUTPUT_TOKENS = 64000;
 
+/** Header value resolved to the request's API key immediately before dispatch. */
+export const REQUEST_API_KEY_AUTHORIZATION = "Bearer __PI_REQUEST_API_KEY__";
+
 export interface ApiOptionsMap {
 	"anthropic-messages": AnthropicOptions;
 	"bedrock-converse-stream": BedrockOptions;

--- a/packages/ai/test/auth-storage-account-identity.test.ts
+++ b/packages/ai/test/auth-storage-account-identity.test.ts
@@ -126,7 +126,7 @@ describe("AuthStorage.getOAuthAccountIdentity", () => {
 		]);
 		expect(authStorage.getOAuthAccountIdentity(PROVIDER)?.accountId).toBe("acc-a");
 
-		authStorage.setConfigApiKey(PROVIDER, "gateway-bearer");
+		authStorage.setConfigApiKeys(PROVIDER, ["gateway-bearer"]);
 		// With an explicit bearer in play the session is not using OAuth, so no
 		// account may be reported as "in use".
 		expect(authStorage.getOAuthAccountIdentity(PROVIDER)).toBeUndefined();

--- a/packages/ai/test/auth-storage-config-override.test.ts
+++ b/packages/ai/test/auth-storage-config-override.test.ts
@@ -44,22 +44,22 @@ describe("AuthStorage config-override apiKey", () => {
 		]);
 	}
 
-	test("setConfigApiKey beats OAuth access token for getApiKey", async () => {
+	test("setConfigApiKeys beats OAuth access token for getApiKey", async () => {
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			if (!authStorage) throw new Error("test setup failed");
 			await seedOAuth("anthropic", "oauth-from-broker");
-			authStorage.setConfigApiKey("anthropic", "gateway-bearer");
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer"]);
 
 			expect(await authStorage.getApiKey("anthropic")).toBe("gateway-bearer");
 			expect(await authStorage.peekApiKey("anthropic")).toBe("gateway-bearer");
 		});
 	});
 
-	test("runtime override (--api-key) still beats setConfigApiKey", async () => {
+	test("runtime override (--api-key) still beats setConfigApiKeys", async () => {
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			if (!authStorage) throw new Error("test setup failed");
 			await seedOAuth("anthropic", "oauth-from-broker");
-			authStorage.setConfigApiKey("anthropic", "gateway-bearer");
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer"]);
 			authStorage.setRuntimeApiKey("anthropic", "cli-flag-bearer");
 
 			expect(await authStorage.getApiKey("anthropic")).toBe("cli-flag-bearer");
@@ -70,11 +70,52 @@ describe("AuthStorage config-override apiKey", () => {
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			if (!authStorage) throw new Error("test setup failed");
 			await seedOAuth("anthropic", "oauth-from-broker");
-			authStorage.setConfigApiKey("anthropic", "gateway-bearer");
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer"]);
 			expect(await authStorage.getApiKey("anthropic")).toBe("gateway-bearer");
 
 			authStorage.removeConfigApiKey("anthropic");
 			expect(await authStorage.getApiKey("anthropic")).toBe("oauth-from-broker");
+		});
+	});
+
+	test("rotates to an unblocked configured key after a usage limit", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			authStorage.setConfigApiKeys("anthropic", ["config-first", "config-second"]);
+
+			const first = await authStorage.getApiKey("anthropic", "rotation-session");
+			expect(first).toBeDefined();
+			expect(await authStorage.markUsageLimitReached("anthropic", "rotation-session", { apiKey: first })).toEqual({
+				switched: true,
+			});
+			expect(await authStorage.getApiKey("anthropic", "rotation-session")).not.toBe(first);
+		});
+	});
+
+	test("does not transfer a blocked position to a replacement config key", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			authStorage.setConfigApiKeys("anthropic", ["old-first", "old-second"]);
+			expect(await authStorage.getApiKey("anthropic")).toBe("old-first");
+			await authStorage.markUsageLimitReached("anthropic", undefined, { apiKey: "old-first" });
+
+			authStorage.setConfigApiKeys("anthropic", ["replacement-first", "replacement-second"]);
+			expect(await authStorage.getApiKey("anthropic")).toBe("replacement-second");
+			expect(await authStorage.getApiKey("anthropic")).toBe("replacement-first");
+		});
+	});
+
+	test("rotates comma-separated environment keys after a usage limit", async () => {
+		await withEnv({ ...SUPPRESS_ANTHROPIC_ENV, ANTHROPIC_API_KEY: "env-first, env-second" }, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			const first = await authStorage.getApiKey("anthropic", "env-rotation-session");
+			expect(first).toBeDefined();
+			expect(
+				await authStorage.markUsageLimitReached("anthropic", "env-rotation-session", { apiKey: first }),
+			).toEqual({
+				switched: true,
+			});
+			expect(await authStorage.getApiKey("anthropic", "env-rotation-session")).not.toBe(first);
 		});
 	});
 
@@ -83,8 +124,8 @@ describe("AuthStorage config-override apiKey", () => {
 			if (!authStorage) throw new Error("test setup failed");
 			await seedOAuth("anthropic", "oauth-anthropic");
 			await seedOAuth("openai-codex", "oauth-codex");
-			authStorage.setConfigApiKey("anthropic", "gateway-bearer-A");
-			authStorage.setConfigApiKey("openai-codex", "gateway-bearer-B");
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer-A"]);
+			authStorage.setConfigApiKeys("openai-codex", ["gateway-bearer-B"]);
 
 			authStorage.clearConfigApiKeys();
 
@@ -93,7 +134,7 @@ describe("AuthStorage config-override apiKey", () => {
 		});
 	});
 
-	test("setConfigApiKey suppresses OAuth account_uuid attribution", async () => {
+	test("setConfigApiKeys suppresses OAuth account_uuid attribution", async () => {
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			if (!authStorage) throw new Error("test setup failed");
 			await authStorage.set("anthropic", [
@@ -108,7 +149,7 @@ describe("AuthStorage config-override apiKey", () => {
 			// Sanity: without override, accountId is exposed.
 			expect(authStorage.getOAuthAccountId("anthropic")).toBe("acc-123");
 
-			authStorage.setConfigApiKey("anthropic", "gateway-bearer");
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer"]);
 			// With an explicit config bearer in play, OAuth account attribution
 			// must NOT leak — outbound auth is the gateway bearer, not OAuth.
 			expect(authStorage.getOAuthAccountId("anthropic")).toBeUndefined();
@@ -119,7 +160,7 @@ describe("AuthStorage config-override apiKey", () => {
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			if (!authStorage) throw new Error("test setup failed");
 			await seedOAuth("anthropic", "oauth-from-broker");
-			authStorage.setConfigApiKey("anthropic", "gateway-bearer");
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer"]);
 			expect(authStorage.describeCredentialSource("anthropic")).toBe("config override (models.yml)");
 		});
 	});

--- a/packages/ai/test/auth-storage-config-override.test.ts
+++ b/packages/ai/test/auth-storage-config-override.test.ts
@@ -117,6 +117,56 @@ describe("AuthStorage config-override apiKey", () => {
 		});
 	});
 
+	test("rotates to a sibling configured key after a hard-auth failure", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			authStorage.setConfigApiKeys("anthropic", ["config-first", "config-second"]);
+
+			const first = await authStorage.getApiKey("anthropic", "hard-auth-session");
+			expect(first).toBeDefined();
+			const rotated = await authStorage.rotateSessionCredential("anthropic", "hard-auth-session", {
+				error: Object.assign(new Error("401 authentication_error"), { status: 401 }),
+				apiKey: first,
+			});
+			expect(rotated).toBe(true);
+			expect(await authStorage.getApiKey("anthropic", "hard-auth-session")).not.toBe(first);
+		});
+	});
+
+	test("rotates comma-separated environment keys after a hard-auth failure", async () => {
+		await withEnv({ ...SUPPRESS_ANTHROPIC_ENV, ANTHROPIC_API_KEY: "env-first, env-second" }, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			const first = await authStorage.getApiKey("anthropic", "env-hard-auth-session");
+			expect(first).toBeDefined();
+			const rotated = await authStorage.rotateSessionCredential("anthropic", "env-hard-auth-session", {
+				error: Object.assign(new Error("401 authentication_error"), { status: 401 }),
+				apiKey: first,
+			});
+			expect(rotated).toBe(true);
+			expect(await authStorage.getApiKey("anthropic", "env-hard-auth-session")).not.toBe(first);
+		});
+	});
+
+	test("session selection does not pin sessionless round-robin to one key", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			authStorage.setConfigApiKeys("anthropic", ["pool-a", "pool-b"]);
+
+			// Interleave a recurring session (deterministic hash) before each
+			// sessionless pick. Writing the session's hash index into the shared
+			// round-robin cursor would force every sessionless pick onto one key
+			// instead of rotating across the pool.
+			const sessionKeys: string[] = [];
+			const sessionlessKeys: string[] = [];
+			for (let i = 0; i < 4; i += 1) {
+				sessionKeys.push((await authStorage.getApiKey("anthropic", "sticky-session")) ?? "");
+				sessionlessKeys.push((await authStorage.getApiKey("anthropic")) ?? "");
+			}
+			expect(new Set(sessionKeys).size).toBe(1);
+			expect(new Set(sessionlessKeys).size).toBe(2);
+		});
+	});
+
 	test("clearConfigApiKeys drops every config override at once", async () => {
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			if (!authStorage) throw new Error("test setup failed");

--- a/packages/ai/test/auth-storage-config-override.test.ts
+++ b/packages/ai/test/auth-storage-config-override.test.ts
@@ -163,4 +163,29 @@ describe("AuthStorage config-override apiKey", () => {
 			expect(authStorage.describeCredentialSource("anthropic")).toBe("config override (models.yml)");
 		});
 	});
+	test("preserves a config-key quota backoff across a reload when keys are unchanged", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			authStorage.setConfigApiKeys("anthropic", ["config-first", "config-second"]);
+			expect(await authStorage.getApiKey("anthropic")).toBe("config-first");
+			await authStorage.markUsageLimitReached("anthropic", undefined, { apiKey: "config-first" });
+			// config-first is now backed off → selection rotates to config-second.
+			expect(await authStorage.getApiKey("anthropic")).toBe("config-second");
+
+			// Replay the ModelRegistry.#reloadStaticModels sequence: a models.yml
+			// edit must not wipe a server-reported block for a provider whose key
+			// list is byte-for-byte unchanged.
+			const snapshot = authStorage.snapshotConfigKeyBackoffForReload();
+			authStorage.clearConfigApiKeys();
+			authStorage.setConfigApiKeys("anthropic", ["config-first", "config-second"]);
+			authStorage.restoreConfigKeyBackoffAfterReload(snapshot);
+
+			// config-first (index 0) stays blocked, so blocking config-second
+			// (index 1) leaves no healthy sibling — markUsageLimitReached reports no
+			// switch. Without preservation the reload would have cleared
+			// config-first's block and this would report { switched: true } instead.
+			const blocked = await authStorage.markUsageLimitReached("anthropic", undefined, { apiKey: "config-second" });
+			expect(blocked.switched).toBe(false);
+		});
+	});
 });

--- a/packages/ai/test/auth-storage-config-override.test.ts
+++ b/packages/ai/test/auth-storage-config-override.test.ts
@@ -85,7 +85,7 @@ describe("AuthStorage config-override apiKey", () => {
 
 			const first = await authStorage.getApiKey("anthropic", "rotation-session");
 			expect(first).toBeDefined();
-			expect(await authStorage.markUsageLimitReached("anthropic", "rotation-session", { apiKey: first })).toEqual({
+			expect(await authStorage.markUsageLimitReached("anthropic", "rotation-session")).toEqual({
 				switched: true,
 			});
 			expect(await authStorage.getApiKey("anthropic", "rotation-session")).not.toBe(first);
@@ -110,9 +110,7 @@ describe("AuthStorage config-override apiKey", () => {
 			if (!authStorage) throw new Error("test setup failed");
 			const first = await authStorage.getApiKey("anthropic", "env-rotation-session");
 			expect(first).toBeDefined();
-			expect(
-				await authStorage.markUsageLimitReached("anthropic", "env-rotation-session", { apiKey: first }),
-			).toEqual({
+			expect(await authStorage.markUsageLimitReached("anthropic", "env-rotation-session")).toEqual({
 				switched: true,
 			});
 			expect(await authStorage.getApiKey("anthropic", "env-rotation-session")).not.toBe(first);
@@ -149,9 +147,10 @@ describe("AuthStorage config-override apiKey", () => {
 			// Sanity: without override, accountId is exposed.
 			expect(authStorage.getOAuthAccountId("anthropic")).toBe("acc-123");
 
-			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer"]);
-			// With an explicit config bearer in play, OAuth account attribution
-			// must NOT leak — outbound auth is the gateway bearer, not OAuth.
+			authStorage.setConfigApiKeys("anthropic", ["gateway-bearer-a", "gateway-bearer-b"]);
+			// With explicit config bearers in play, OAuth access and account
+			// attribution must NOT leak — outbound auth is the gateway bearer, not OAuth.
+			expect(await authStorage.getOAuthAccess("anthropic")).toBeUndefined();
 			expect(authStorage.getOAuthAccountId("anthropic")).toBeUndefined();
 		});
 	});

--- a/packages/ai/test/auth-storage-credential-origin.test.ts
+++ b/packages/ai/test/auth-storage-credential-origin.test.ts
@@ -95,7 +95,7 @@ describe("AuthStorage.getCredentialOrigin", () => {
 			await auth.set("openai", [{ type: "api_key", key: "sk-stored" }]);
 			expect(auth.getCredentialOrigin("openai")).toEqual({ kind: "api_key" });
 
-			auth.setConfigApiKey("openai", "gateway-bearer");
+			auth.setConfigApiKeys("openai", ["gateway-bearer"]);
 			expect(auth.getCredentialOrigin("openai")).toEqual({ kind: "config" });
 
 			auth.setRuntimeApiKey("openai", "cli-flag-bearer");

--- a/packages/ai/test/error-id.test.ts
+++ b/packages/ai/test/error-id.test.ts
@@ -126,4 +126,18 @@ describe("error-id classification", () => {
 		expect(AIError.is(id, AIError.Flag.UsageLimit)).toBe(true);
 		expect(assistant.errorId).toBe(id);
 	});
+	it("marks a concurrent-limit 429 transient so it stays retriable", () => {
+		// A concurrent cap is reported as a bare 429 with a `concurrent_limit_*`
+		// body. It must not burn a sibling credential (no UsageLimit) but must stay
+		// retriable (Transient) so the short concurrency backoff applies — the body
+		// wording does not match the broad transient transport pattern, so without
+		// the explicit flag classifyMessage leaves a bare numeric 429 that
+		// retriable() rejects.
+		const id = AIError.classifyMessage(
+			message({ errorStatus: 429, errorMessage: "Maximum concurrent invocation limit reached" }),
+		);
+		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.retriable(id)).toBe(true);
+		expect(AIError.is(id, AIError.Flag.UsageLimit)).toBe(false);
+	});
 });

--- a/packages/ai/test/openai-completions-upstream-provider.test.ts
+++ b/packages/ai/test/openai-completions-upstream-provider.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { stream } from "@oh-my-pi/pi-ai";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { REQUEST_API_KEY_AUTHORIZATION } from "@oh-my-pi/pi-ai/types";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 const model = {
@@ -69,5 +71,37 @@ describe("openai-completions upstream provider capture", () => {
 		}).result();
 
 		expect(result.upstreamProvider).toBeUndefined();
+	});
+});
+
+describe("stream() request-key sentinel materialization", () => {
+	// Contract: the low-level stream() dispatch reaches the OpenAI transport with
+	// model.headers still carrying the `Bearer __PI_REQUEST_API_KEY__` placeholder,
+	// and resolveOpenAIRequestSetup keeps an existing model Authorization via `??=`.
+	// A direct stream() consumer passing a real apiKey must authenticate with that
+	// key, not the unresolved sentinel.
+	it("resolves the authHeader sentinel against apiKey on the direct stream path", async () => {
+		const sentinelModel = {
+			...(getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">),
+			api: "openai-completions",
+			headers: { Authorization: REQUEST_API_KEY_AUTHORIZATION },
+		} satisfies Model<"openai-completions">;
+
+		const captured: { authorization: string | null } = { authorization: null };
+		const fetchMock: FetchImpl = (_input, init) => {
+			captured.authorization = new Headers(init?.headers).get("authorization");
+			return Promise.resolve(
+				createSseResponse([
+					chunk({ choices: [{ index: 0, delta: { content: "Hi" } }] }),
+					chunk({
+						choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+						usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+					}),
+				]),
+			);
+		};
+
+		await stream(sentinelModel, baseContext(), { apiKey: "resolved-bearer", fetch: fetchMock }).result();
+		expect(captured.authorization).toBe("Bearer resolved-bearer");
 	});
 });

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -35,6 +35,13 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Requests per minute limit reached")).toBe("RATE_LIMIT_EXCEEDED");
 	});
 
+	it("classifies concurrent request caps separately from rate limits and quota exhaustion", () => {
+		expect(parseRateLimitReason("Number of concurrent requests exceeded")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Maximum concurrent invocation limit reached")).toBe("CONCURRENT_LIMIT");
+		expect(parseRateLimitReason("Rate limit reached for gpt-4o")).toBe("RATE_LIMIT_EXCEEDED");
+		expect(parseRateLimitReason("Your quota will reset at 07-28")).toBe("QUOTA_EXHAUSTED");
+	});
+
 	it("classifies overloaded 529 as MODEL_CAPACITY_EXHAUSTED", () => {
 		expect(parseRateLimitReason("Service overloaded 529")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
@@ -234,6 +241,16 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(true);
 	});
 
+	it("rotates only account-scoped cap 403s", () => {
+		expect(
+			isUsageLimitOutcome(
+				403,
+				"Devin stream error permission_denied: Reached overall message rate limit. Please try again later. Your limit will reset in 13 minutes.",
+			),
+		).toBe(true);
+		expect(isUsageLimitOutcome(403, "Forbidden")).toBe(false);
+	});
+
 	it("rotates on xAI Grok Build 402 usage-balance exhaustion regardless of status", () => {
 		const message = "402 Grok Build usage balance exhausted";
 		expect(isUsageLimitOutcome(402, message)).toBe(true);
@@ -262,5 +279,9 @@ describe("calculateRateLimitBackoffMs", () => {
 			expect(ms).toBeGreaterThanOrEqual(45_000);
 			expect(ms).toBeLessThanOrEqual(75_000);
 		}
+	});
+
+	it("returns a short backoff for CONCURRENT_LIMIT", () => {
+		expect(calculateRateLimitBackoffMs("CONCURRENT_LIMIT")).toBe(5_000);
 	});
 });

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { __resetVertexTokenCache } from "@oh-my-pi/pi-ai/providers/google-auth";
-import { complete, getEnvApiKey, stream } from "@oh-my-pi/pi-ai/stream";
+import { complete, getEnvApiKey, getEnvApiKeys, stream } from "@oh-my-pi/pi-ai/stream";
 import type { Api, Context, ImageContent, Model, OptionsForApi, Tool, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -404,6 +404,26 @@ describe("Generate E2E Tests", () => {
 			},
 			{ retry: 3 },
 		);
+	});
+
+	describe("environment API key lists", () => {
+		it("preserves structured credentials and deduplicates comma-separated keys", () => {
+			const originalAlibabaCredential = Bun.env.ALIBABA_TOKEN_PLAN_API_KEY;
+			const originalApiKey = Bun.env.ANTHROPIC_API_KEY;
+			try {
+				const credential = '{"token":"structured-token","cookie":"structured-cookie"}';
+				Bun.env.ALIBABA_TOKEN_PLAN_API_KEY = credential;
+				expect(getEnvApiKeys("alibaba-token-plan")).toEqual([credential]);
+
+				Bun.env.ANTHROPIC_API_KEY = "key-a, key-a, key-b, key-a";
+				expect(getEnvApiKeys("anthropic")).toEqual(["key-a", "key-b"]);
+			} finally {
+				if (originalAlibabaCredential === undefined) delete Bun.env.ALIBABA_TOKEN_PLAN_API_KEY;
+				else Bun.env.ALIBABA_TOKEN_PLAN_API_KEY = originalAlibabaCredential;
+				if (originalApiKey === undefined) delete Bun.env.ANTHROPIC_API_KEY;
+				else Bun.env.ANTHROPIC_API_KEY = originalApiKey;
+			}
+		});
 	});
 
 	describe("google-vertex env auth", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `providers.<name>.apiKeys` in `models.yml` for ordered, de-duplicated API-key rotation.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -103,6 +103,10 @@ export function isAuthenticated(apiKey: string | undefined | null): apiKey is st
 	return Boolean(apiKey) && apiKey !== kNoAuth;
 }
 
+function mergeProviderApiKeyConfigs(apiKey: string | undefined, apiKeys: readonly string[] | undefined): string[] {
+	return [...new Set([apiKey, ...(apiKeys ?? [])].filter((value): value is string => Boolean(value?.trim())))];
+}
+
 function isDiscoveryBearerApiKey(apiKey: string | undefined | null): apiKey is string {
 	return isAuthenticated(apiKey) && !LOCAL_PROVIDER_PLACEHOLDERS.has(apiKey);
 }
@@ -785,7 +789,7 @@ export class ModelRegistry {
 	#cachedAuthoritativeProviders: Set<string> = new Set();
 	#internedStaticModels: Map<string, Model<Api>> = new Map();
 	#providerLookupSnapshots: Map<string, Model<Api>[]> = new Map();
-	#customProviderApiKeys: Map<string, string> = new Map();
+	#customProviderApiKeys: Map<string, readonly string[]> = new Map();
 	#keylessProviders: Set<string> = new Set();
 	#discoverableProviders: DiscoveryProviderConfig[] = [];
 	#customModelOverlays: CustomModelOverlay[] = [];
@@ -814,23 +818,23 @@ export class ModelRegistry {
 	#fetch: FetchImpl;
 
 	#resolveCommandBackedApiKey(provider: string): CommandApiKeyResolution {
-		const keyConfig = this.#customProviderApiKeys.get(provider);
-		if (!isCommandConfigValue(keyConfig)) return { configured: false };
-		const value = resolveConfigValue(keyConfig);
-		if (value) {
-			this.authStorage.setConfigApiKey(provider, value);
-			return { configured: true, value };
+		const keyConfigs = this.#customProviderApiKeys.get(provider) ?? [];
+		if (!keyConfigs.some(isCommandConfigValue)) return { configured: false };
+		const apiKeys = keyConfigs.map(resolveConfigValue).filter((apiKey): apiKey is string => apiKey !== undefined);
+		if (apiKeys.length > 0) {
+			this.authStorage.setConfigApiKeys(provider, apiKeys);
+			return { configured: false };
 		}
 		this.authStorage.removeConfigApiKey(provider);
 		return { configured: true };
 	}
 
-	#installProviderApiKey(provider: string, keyConfig: string): void {
-		this.#customProviderApiKeys.set(provider, keyConfig);
-		const resolved = resolveConfigValue(keyConfig);
-		if (resolved) {
-			this.authStorage.setConfigApiKey(provider, resolved);
-		} else if (isCommandConfigValue(keyConfig)) {
+	#installProviderApiKeys(provider: string, keyConfigs: readonly string[]): void {
+		this.#customProviderApiKeys.set(provider, keyConfigs);
+		const apiKeys = keyConfigs.map(resolveConfigValue).filter((apiKey): apiKey is string => apiKey !== undefined);
+		if (apiKeys.length > 0) {
+			this.authStorage.setConfigApiKeys(provider, apiKeys);
+		} else if (keyConfigs.some(isCommandConfigValue)) {
 			this.authStorage.removeConfigApiKey(provider);
 		}
 	}
@@ -868,9 +872,8 @@ export class ModelRegistry {
 		this.#cacheDbPath = modelsPath ? path.join(path.dirname(modelsPath), "models.db") : undefined;
 		// Set up fallback resolver for custom provider API keys
 		this.authStorage.setFallbackResolver(provider => {
-			const keyConfig = this.#customProviderApiKeys.get(provider);
-			if (!keyConfig) return undefined;
-			return resolveConfigValue(keyConfig);
+			const keyConfigs = this.#customProviderApiKeys.get(provider);
+			return keyConfigs?.map(resolveConfigValue).find(Boolean);
 		});
 		// Load config and cache-backed layers synchronously in the constructor.
 		this.#loadModels();
@@ -1042,7 +1045,7 @@ export class ModelRegistry {
 		// Restore runtime API keys before #loadModels — survives because
 		// #loadModels only calls .set() on #customProviderApiKeys, never reassigns it.
 		for (const [k, v] of this.#runtimeProviderApiKeys) {
-			this.#installProviderApiKey(k, v);
+			this.#installProviderApiKeys(k, [v]);
 		}
 		this.#providerOverrides.clear();
 		this.#modelOverrides.clear();
@@ -1496,11 +1499,12 @@ export class ModelRegistry {
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 		for (const [providerName, providerConfig] of providerEntries) {
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
+			const providerApiKeyConfigs = mergeProviderApiKeyConfigs(providerConfig.apiKey, providerConfig.apiKeys);
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
 			if (
 				providerConfig.baseUrl ||
 				resolvedProviderHeaders ||
-				providerConfig.apiKey ||
+				providerApiKeyConfigs.length > 0 ||
 				providerConfig.authHeader !== undefined ||
 				providerConfig.compat ||
 				providerConfig.disableStrictTools ||
@@ -1514,7 +1518,7 @@ export class ModelRegistry {
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
 							: providerConfig.baseUrl,
 					headers: resolvedProviderHeaders,
-					apiKey: providerConfig.apiKey,
+					apiKey: providerApiKeyConfigs[0],
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					remoteCompaction: providerConfig.remoteCompaction,
@@ -1548,8 +1552,8 @@ export class ModelRegistry {
 			// so it wins over OAuth tokens from the broker — when the user pins a
 			// bearer in models.yml (e.g. for an auth-gateway baseUrl), that bearer
 			// must authenticate the outbound request.
-			if (providerConfig.apiKey) {
-				this.#installProviderApiKey(providerName, providerConfig.apiKey);
+			if (providerApiKeyConfigs.length > 0) {
+				this.#installProviderApiKeys(providerName, providerApiKeyConfigs);
 			}
 
 			// Parse per-model overrides
@@ -2121,8 +2125,9 @@ export class ModelRegistry {
 			const modelDefs = providerConfig.models ?? [];
 			if (modelDefs.length === 0) continue; // Override-only, no custom models
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
-			if (providerConfig.apiKey) {
-				this.#installProviderApiKey(providerName, providerConfig.apiKey);
+			const providerApiKeyConfigs = mergeProviderApiKeyConfigs(providerConfig.apiKey, providerConfig.apiKeys);
+			if (providerApiKeyConfigs.length > 0) {
+				this.#installProviderApiKeys(providerName, providerApiKeyConfigs);
 			}
 			for (const modelDef of modelDefs) {
 				const providerCompat = providerConfig.disableStrictTools
@@ -2133,7 +2138,7 @@ export class ModelRegistry {
 					providerConfig.baseUrl!,
 					providerConfig.api as Api | undefined,
 					resolvedProviderHeaders,
-					providerConfig.apiKey,
+					providerApiKeyConfigs[0],
 					providerConfig.authHeader,
 					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
@@ -2222,7 +2227,7 @@ export class ModelRegistry {
 	hasConfiguredAuth(model: Model<Api>): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(model.provider);
 		return (
-			isCommandConfigValue(keyConfig) ||
+			keyConfig?.some(isCommandConfigValue) ||
 			this.#keylessProviders.has(model.provider) ||
 			this.authStorage.hasAuth(model.provider)
 		);
@@ -2236,7 +2241,7 @@ export class ModelRegistry {
 	 */
 	hasCommandBackedApiKey(provider: string): boolean {
 		const keyConfig = this.#customProviderApiKeys.get(provider);
-		return isCommandConfigValue(keyConfig);
+		return keyConfig?.some(isCommandConfigValue) ?? false;
 	}
 
 	getDiscoverableProviders(): string[] {
@@ -2499,7 +2504,7 @@ export class ModelRegistry {
 
 		this.#ensureFullSnapshot();
 		if (config.apiKey) {
-			this.#installProviderApiKey(providerName, config.apiKey);
+			this.#installProviderApiKeys(providerName, [config.apiKey]);
 			// Persist runtime API keys so they survive #reloadStaticModels() cycles
 			this.#runtimeProviderApiKeys.set(providerName, config.apiKey);
 		}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1055,6 +1055,9 @@ export class ModelRegistry {
 		// Drop config-sourced apiKeys from AuthStorage before reload; entries
 		// removed from models.yml must actually disappear from the resolver, not
 		// linger from the previous parse. The post-load setters below repopulate.
+		// Snapshot config-key quota backoffs so an unrelated models.yml edit does
+		// not wipe a server-reported block for a provider whose keys are unchanged.
+		const configKeyBackoff = this.authStorage.snapshotConfigKeyBackoffForReload();
 		this.authStorage.clearConfigApiKeys();
 		// Restore runtime API keys before #loadModels — survives because
 		// #loadModels only calls .set() on #customProviderApiKeys, never reassigns it.
@@ -1066,6 +1069,7 @@ export class ModelRegistry {
 		this.#configError = undefined;
 		this.#providerDiscoveryStates.clear();
 		this.#loadModels();
+		this.authStorage.restoreConfigKeyBackoffAfterReload(configKeyBackoff);
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -105,7 +105,14 @@ export function isAuthenticated(apiKey: string | undefined | null): apiKey is st
 }
 
 function mergeProviderApiKeyConfigs(apiKey: string | undefined, apiKeys: readonly string[] | undefined): string[] {
-	return [...new Set([apiKey, ...(apiKeys ?? [])].filter((value): value is string => Boolean(value?.trim())))];
+	// Trim before resolving indirection so quoted entries like " OPENAI_API_KEY "
+	// or " !secret-command " match their env var / command instead of becoming a
+	// literal bearer — matches the documented models.yml trimming behavior.
+	return [
+		...new Set(
+			[apiKey, ...(apiKeys ?? [])].map(value => value?.trim()).filter((value): value is string => Boolean(value)),
+		),
+	];
 }
 
 function isDiscoveryBearerApiKey(apiKey: string | undefined | null): apiKey is string {
@@ -343,6 +350,7 @@ type HeaderSource = Record<string, string> | undefined;
 interface HeaderResolutionOptions {
 	authHeader?: boolean;
 	apiKey?: string;
+	keyless?: boolean;
 }
 
 function materializeConfigHeaderSources(
@@ -357,7 +365,7 @@ function materializeConfigHeaderSources(
 			if (next) resolved[key] = next;
 		}
 	}
-	if (options?.authHeader && options.apiKey !== kNoAuth) {
+	if (options?.authHeader && !options?.keyless && options.apiKey !== kNoAuth) {
 		resolved.Authorization = options.apiKey ? `Bearer ${options.apiKey}` : REQUEST_API_KEY_AUTHORIZATION;
 	}
 	return Object.keys(resolved).length > 0 ? resolved : undefined;
@@ -610,15 +618,22 @@ function mergeCustomModelHeaders(
 	providerHeaders: Record<string, string> | undefined,
 	modelHeaders: Record<string, string> | undefined,
 	authHeader: boolean | undefined,
+	keyless = false,
 ): Record<string, string> | undefined {
-	return createLiveConfigHeaders([providerHeaders, modelHeaders], { authHeader });
+	return createLiveConfigHeaders([providerHeaders, modelHeaders], { authHeader, keyless });
 }
 
 function mergeAuthHeaderSources(
 	sources: readonly HeaderSource[],
 	authHeader: boolean | undefined,
+	keyless = false,
+	apiKey?: string,
 ): Record<string, string> | undefined {
-	return createLiveConfigHeaders(sources, { authHeader });
+	// Thread the explicit apiKey so a runtime-registered provider with
+	// `authHeader: true` materializes the real bearer instead of the
+	// request-time sentinel. When apiKey is absent the sentinel is kept,
+	// preserving key rotation for keys resolved from AuthStorage at request time.
+	return createLiveConfigHeaders(sources, { authHeader, keyless, apiKey });
 }
 
 /**
@@ -662,7 +677,7 @@ function buildCustomModelOverlay(
 		contextWindow: modelDef.contextWindow,
 		maxTokens: modelDef.maxTokens,
 		omitMaxOutputTokens: modelDef.omitMaxOutputTokens,
-		headers: mergeCustomModelHeaders(providerHeaders, modelDef.headers, authHeader),
+		headers: mergeCustomModelHeaders(providerHeaders, modelDef.headers, authHeader, providerAuth === "none"),
 		compat: mergeCompat(providerCompat, modelDef.compat),
 		contextPromotionTarget: modelDef.contextPromotionTarget,
 		compactionModel: modelDef.compactionModel,
@@ -1517,7 +1532,6 @@ export class ModelRegistry {
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
 							: providerConfig.baseUrl,
 					headers: resolvedProviderHeaders,
-					apiKey: providerApiKeyConfigs[0],
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					remoteCompaction: providerConfig.remoteCompaction,
@@ -2042,6 +2056,8 @@ export class ModelRegistry {
 		const headers = mergeAuthHeaderSources(
 			override.headers ? [entry.headers, override.headers] : [entry.headers],
 			override.authHeader,
+			this.#keylessProviders.has(entry.provider),
+			override.apiKey,
 		);
 		return {
 			...entry,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -10,6 +10,7 @@ import type {
 	SimpleStreamOptions,
 	ThinkingConfig,
 } from "@oh-my-pi/pi-ai/types";
+import { REQUEST_API_KEY_AUTHORIZATION } from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { isVertexExpressOpenAIUrl } from "@oh-my-pi/pi-catalog/hosts";
@@ -341,7 +342,7 @@ type HeaderSource = Record<string, string> | undefined;
 
 interface HeaderResolutionOptions {
 	authHeader?: boolean;
-	apiKeyConfig?: string;
+	apiKey?: string;
 }
 
 function materializeConfigHeaderSources(
@@ -356,9 +357,8 @@ function materializeConfigHeaderSources(
 			if (next) resolved[key] = next;
 		}
 	}
-	if (options?.authHeader && options.apiKeyConfig) {
-		const resolvedKey = resolveConfigValue(options.apiKeyConfig);
-		if (resolvedKey) resolved.Authorization = `Bearer ${resolvedKey}`;
+	if (options?.authHeader && options.apiKey !== kNoAuth) {
+		resolved.Authorization = options.apiKey ? `Bearer ${options.apiKey}` : REQUEST_API_KEY_AUTHORIZATION;
 	}
 	return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
@@ -368,7 +368,9 @@ function createLiveConfigHeaders(
 	options?: HeaderResolutionOptions,
 ): Record<string, string> | undefined {
 	const liveSources = sources.filter((source): source is Record<string, string> => source !== undefined);
-	if (liveSources.length === 0 && (!options?.authHeader || !options.apiKeyConfig)) return undefined;
+	if (liveSources.length === 0 && !options?.authHeader) {
+		return undefined;
+	}
 
 	const localHeaders: Record<string, string> = {};
 	const allSources = [...liveSources, localHeaders];
@@ -608,17 +610,15 @@ function mergeCustomModelHeaders(
 	providerHeaders: Record<string, string> | undefined,
 	modelHeaders: Record<string, string> | undefined,
 	authHeader: boolean | undefined,
-	apiKeyConfig: string | undefined,
 ): Record<string, string> | undefined {
-	return createLiveConfigHeaders([providerHeaders, modelHeaders], { authHeader, apiKeyConfig });
+	return createLiveConfigHeaders([providerHeaders, modelHeaders], { authHeader });
 }
 
 function mergeAuthHeaderSources(
 	sources: readonly HeaderSource[],
 	authHeader: boolean | undefined,
-	apiKeyConfig: string | undefined,
 ): Record<string, string> | undefined {
-	return createLiveConfigHeaders(sources, { authHeader, apiKeyConfig });
+	return createLiveConfigHeaders(sources, { authHeader });
 }
 
 /**
@@ -640,7 +640,6 @@ function buildCustomModelOverlay(
 	providerBaseUrl: string,
 	providerApi: Api | undefined,
 	providerHeaders: Record<string, string> | undefined,
-	providerApiKey: string | undefined,
 	authHeader: boolean | undefined,
 	providerCompat: ModelSpec<Api>["compat"] | undefined,
 	providerAuth: ProviderAuthMode | undefined,
@@ -663,7 +662,7 @@ function buildCustomModelOverlay(
 		contextWindow: modelDef.contextWindow,
 		maxTokens: modelDef.maxTokens,
 		omitMaxOutputTokens: modelDef.omitMaxOutputTokens,
-		headers: mergeCustomModelHeaders(providerHeaders, modelDef.headers, authHeader, providerApiKey),
+		headers: mergeCustomModelHeaders(providerHeaders, modelDef.headers, authHeader),
 		compat: mergeCompat(providerCompat, modelDef.compat),
 		contextPromotionTarget: modelDef.contextPromotionTarget,
 		compactionModel: modelDef.compactionModel,
@@ -2027,7 +2026,12 @@ export class ModelRegistry {
 		};
 	}
 	#applyProviderTransportOverride<
-		T extends { baseUrl?: string; headers?: Record<string, string>; remoteCompaction?: RemoteCompactionConfig<Api> },
+		T extends {
+			provider: string;
+			baseUrl?: string;
+			headers?: Record<string, string>;
+			remoteCompaction?: RemoteCompactionConfig<Api>;
+		},
 	>(
 		entry: T,
 		override: Pick<
@@ -2038,7 +2042,6 @@ export class ModelRegistry {
 		const headers = mergeAuthHeaderSources(
 			override.headers ? [entry.headers, override.headers] : [entry.headers],
 			override.authHeader,
-			override.apiKey,
 		);
 		return {
 			...entry,
@@ -2138,7 +2141,6 @@ export class ModelRegistry {
 					providerConfig.baseUrl!,
 					providerConfig.api as Api | undefined,
 					resolvedProviderHeaders,
-					providerApiKeyConfigs[0],
 					providerConfig.authHeader,
 					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
@@ -2290,11 +2292,16 @@ export class ModelRegistry {
 	/**
 	 * Get provider-level headers without including per-model overrides.
 	 */
-	getProviderHeaders(provider: string): Record<string, string> | undefined {
-		return createLiveConfigHeaders([
-			this.#providerOverrides.get(provider)?.headers,
-			this.#runtimeProviderOverrides.get(provider)?.headers,
-		]);
+	getProviderHeaders(provider: string, apiKey?: string): Record<string, string> | undefined {
+		return createLiveConfigHeaders(
+			[this.#providerOverrides.get(provider)?.headers, this.#runtimeProviderOverrides.get(provider)?.headers],
+			{
+				authHeader:
+					this.#runtimeProviderOverrides.get(provider)?.authHeader ??
+					this.#providerOverrides.get(provider)?.authHeader,
+				apiKey,
+			},
+		);
 	}
 
 	/**
@@ -2324,7 +2331,7 @@ export class ModelRegistry {
 			if (apiKey === undefined) {
 				return { ok: false, error: `No API key found for "${model.provider}"` };
 			}
-			const headers = this.getProviderHeaders(model.provider);
+			const headers = this.getProviderHeaders(model.provider, apiKey);
 			return { ok: true, apiKey, headers };
 		} catch (error) {
 			return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -2518,7 +2525,6 @@ export class ModelRegistry {
 					config.baseUrl!,
 					config.api,
 					config.headers,
-					config.apiKey,
 					config.authHeader,
 					config.compat,
 					undefined,
@@ -2564,7 +2570,6 @@ export class ModelRegistry {
 			const providerBaseUrl = config.baseUrl ?? "";
 			const providerApi = config.api;
 			const providerHeaders = config.headers;
-			const providerApiKey = config.apiKey;
 			const providerAuthHeader = config.authHeader;
 			const providerCompat = config.compat;
 			const managerOptions: ModelManagerOptions<Api> = {
@@ -2586,7 +2591,6 @@ export class ModelRegistry {
 							modelDef.baseUrl ?? providerBaseUrl,
 							modelDef.api ?? providerApi,
 							providerHeaders,
-							providerApiKey,
 							providerAuthHeader,
 							providerCompat,
 							undefined,

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -269,6 +269,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 	const ProviderConfigSchema = type({
 		"baseUrl?": "string",
 		"apiKey?": "string",
+		"apiKeys?": "string[]",
 		"api?": ApiSchema,
 		"headers?": { "[string]": "string" },
 		"compat?": ApiCompatSchema,
@@ -293,6 +294,9 @@ export const getModelsConfigSchemaBundle = once(() => {
 		}
 		if (value.apiKey !== undefined && typeof value.apiKey === "string" && value.apiKey.length === 0) {
 			return ctx.mustBe("apiKey a non-empty string");
+		}
+		if (value.apiKeys?.some(apiKey => apiKey.trim().length === 0)) {
+			return ctx.mustBe("apiKeys entries to be non-empty strings");
 		}
 		return true;
 	});

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -295,9 +295,6 @@ export const getModelsConfigSchemaBundle = once(() => {
 		if (value.apiKey !== undefined && typeof value.apiKey === "string" && value.apiKey.length === 0) {
 			return ctx.mustBe("apiKey a non-empty string");
 		}
-		if (value.apiKeys?.some(apiKey => apiKey.trim().length === 0)) {
-			return ctx.mustBe("apiKeys entries to be non-empty strings");
-		}
 		return true;
 	});
 

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -39,6 +39,7 @@ export function validateProviderConfiguration(
 	mode: ProviderValidationMode,
 ): void {
 	const hasProviderApi = !!config.api;
+	const hasConfiguredApiKey = Boolean(config.apiKey?.trim()) || Boolean(config.apiKeys?.some(apiKey => apiKey.trim()));
 	const models = config.models;
 
 	if (models.length === 0) {
@@ -48,8 +49,7 @@ export function validateProviderConfiguration(
 				!config.baseUrl &&
 				!config.headers &&
 				!config.compat &&
-				!config.apiKey &&
-				!config.apiKeys?.length &&
+				!hasConfiguredApiKey &&
 				config.auth !== "none" &&
 				!config.disableStrictTools &&
 				!config.remoteCompaction &&
@@ -67,13 +67,13 @@ export function validateProviderConfiguration(
 		}
 		const requiresAuth =
 			mode === "runtime-register"
-				? !config.apiKey && !config.apiKeys?.length && !config.oauthConfigured
-				: !config.apiKey && !config.apiKeys?.length && (config.auth ?? "apiKey") !== "none";
+				? !hasConfiguredApiKey && !config.oauthConfigured
+				: !hasConfiguredApiKey && (config.auth ?? "apiKey") !== "none";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"
 					? `Provider ${providerName}: "apiKey" or "oauth" is required when defining models.`
-					: `Provider ${providerName}: "apiKey" is required when defining custom models unless auth is "none".`,
+					: `Provider ${providerName}: "apiKey" or "apiKeys" is required when defining custom models unless auth is "none".`,
 			);
 		}
 	}

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -21,6 +21,7 @@ export interface ProviderValidationConfig {
 	baseUrl?: string;
 	headers?: Record<string, string>;
 	apiKey?: string;
+	apiKeys?: string[];
 	api?: Api;
 	auth?: ProviderAuthMode;
 	oauthConfigured?: boolean;
@@ -48,6 +49,7 @@ export function validateProviderConfiguration(
 				!config.headers &&
 				!config.compat &&
 				!config.apiKey &&
+				!config.apiKeys?.length &&
 				config.auth !== "none" &&
 				!config.disableStrictTools &&
 				!config.remoteCompaction &&
@@ -55,7 +57,7 @@ export function validateProviderConfiguration(
 				!config.discovery
 			) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "auth: none", "compat", "disableStrictTools", "remoteCompaction", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "apiKey", "apiKeys", "auth: none", "compat", "disableStrictTools", "remoteCompaction", "modelOverrides", "discovery", or "models"`,
 				);
 			}
 		}
@@ -65,8 +67,8 @@ export function validateProviderConfiguration(
 		}
 		const requiresAuth =
 			mode === "runtime-register"
-				? !config.apiKey && !config.oauthConfigured
-				: !config.apiKey && (config.auth ?? "apiKey") !== "none";
+				? !config.apiKey && !config.apiKeys?.length && !config.oauthConfigured
+				: !config.apiKey && !config.apiKeys?.length && (config.auth ?? "apiKey") !== "none";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"
@@ -115,6 +117,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", {
 				baseUrl: providerConfig.baseUrl,
 				headers: providerConfig.headers,
 				apiKey: providerConfig.apiKey,
+				apiKeys: providerConfig.apiKeys,
 				api: providerConfig.api as Api | undefined,
 				auth: (providerConfig.auth ?? "apiKey") as ProviderAuthMode,
 				discovery: providerConfig.discovery as ProviderDiscovery | undefined,

--- a/packages/coding-agent/test/cli/auth-gateway-catalog.test.ts
+++ b/packages/coding-agent/test/cli/auth-gateway-catalog.test.ts
@@ -9,7 +9,7 @@ function stubAuthStorage(configKeys?: string[]): AuthStorage {
 	const stub = {
 		setFallbackResolver: () => {},
 		clearConfigApiKeys: () => {},
-		setConfigApiKey: (provider: string) => configKeys?.push(provider),
+		setConfigApiKeys: (provider: string) => configKeys?.push(provider),
 		removeConfigApiKey: () => {},
 		hasAuth: () => true,
 		getAll: () => ({ anthropic: {} }),

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -56,10 +56,13 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 
 		expect(models.length).toBeGreaterThan(1);
 		for (const model of models) {
-			expect(model.headers?.Authorization).toBe("Bearer cmd-api-key");
 			expect(model.headers?.["X-Api-Key"]).toBe("cmd-header");
 		}
-		expect(await registry.getApiKey(models[0])).toBe("cmd-api-key");
+		expect(await registry.getApiKeyAndHeaders(models[0]!)).toEqual({
+			ok: true,
+			apiKey: "cmd-api-key",
+			headers: { Authorization: "Bearer cmd-api-key", "X-Api-Key": "cmd-header" },
+		});
 	});
 
 	test("modelOverrides headers resolve from command stdout", async () => {
@@ -86,7 +89,12 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 
 		expect(model).toBeDefined();
 		expect(model?.headers?.["X-Model-Key"]).toBe("cmd-model-header");
-		expect(model?.headers?.Authorization).toBe("Bearer cmd-api-key");
+		if (!model) throw new Error("Expected custom model");
+		expect(await registry.getApiKeyAndHeaders(model)).toEqual({
+			ok: true,
+			apiKey: "cmd-api-key",
+			headers: { Authorization: "Bearer cmd-api-key" },
+		});
 	});
 
 	test("resolveCommandConfig caches failed executions so they do not retry", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Effort, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
+import { Effort, streamSimple, type Context, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -373,12 +373,96 @@ describe("ModelRegistry", () => {
 			});
 		});
 
-		test("authHeader override applies bearer auth to built-in models without custom models", () => {
+		test("authHeader override applies bearer auth to built-in models without custom models", async () => {
 			const anthropicModels = getModelsForProvider(anthropicAuthHeader, "anthropic");
 			expect(anthropicModels.length).toBeGreaterThan(1);
 			for (const model of anthropicModels) {
-				expect(model.headers?.Authorization).toBe("Bearer issue-929-key");
+				const auth = await anthropicAuthHeader.getApiKeyAndHeaders(model);
+				expect(auth).toEqual({ ok: true, apiKey: "issue-929-key", headers: { Authorization: "Bearer issue-929-key" } });
 			}
+		});
+
+		test("authHeader binds each interleaved session request to its resolved key", async () => {
+			writeRawModelsJson({
+				anthropic: {
+					baseUrl: "https://anthropic-proxy.example.com/v1",
+					apiKeys: ["header-first", "header-second"],
+					authHeader: true,
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("anthropic", "claude-sonnet-4-5");
+			if (!model) throw new Error("Expected bundled Anthropic model");
+
+			const selections = await Promise.all(
+				Array.from({ length: 64 }, async (_, index) => ({
+					sessionId: `auth-header-session-${index}`,
+					apiKey: await registry.getApiKey(model, `auth-header-session-${index}`),
+				})),
+			);
+			const first = selections[0];
+			const second = selections.find(selection => selection.apiKey !== first?.apiKey);
+			if (!first?.apiKey || !second?.apiKey) throw new Error("Expected two distinct configured API keys");
+
+			let releaseFirst!: () => void;
+			const firstRelease = new Promise<void>(resolve => {
+				releaseFirst = resolve;
+			});
+			let markFirstResolved!: () => void;
+			const firstResolved = new Promise<void>(resolve => {
+				markFirstResolved = resolve;
+			});
+			let markSecondResolved!: () => void;
+			const secondResolved = new Promise<void>(resolve => {
+				markSecondResolved = resolve;
+			});
+
+			const firstKeyResolver = registry.resolver(model, first.sessionId);
+			const secondKeyResolver = registry.resolver(model, second.sessionId);
+			const firstResolver = async (context: Parameters<typeof firstKeyResolver>[0]) => {
+				const apiKey = await firstKeyResolver(context);
+				markFirstResolved();
+				await firstRelease;
+				return apiKey;
+			};
+			const secondResolver = async (context: Parameters<typeof secondKeyResolver>[0]) => {
+				const apiKey = await secondKeyResolver(context);
+				markSecondResolved();
+				return apiKey;
+			};
+
+			const observedHeaders: Record<string, string | null> = {};
+			const fetchMock: FetchImpl = async (input, init) => {
+				const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
+				const bodyText = input instanceof Request ? await input.clone().text() : String(init?.body);
+				const body = JSON.parse(bodyText);
+				observedHeaders[body.messages[0].content] = headers.get("Authorization");
+				const events = [
+					{ type: "message_start", message: { id: "msg", usage: { input_tokens: 1, output_tokens: 0 } } },
+					{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+					{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+					{ type: "content_block_stop", index: 0 },
+					{ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 1, output_tokens: 1 } },
+					{ type: "message_stop" },
+				];
+				return new Response(events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+					headers: { "content-type": "text/event-stream" },
+				});
+			};
+			const context = (content: string): Context => ({ messages: [{ role: "user", content, timestamp: 0 }] });
+
+			const firstStream = streamSimple(model, context("first"), { apiKey: firstResolver, fetch: fetchMock });
+			await firstResolved;
+			const secondStream = streamSimple(model, context("second"), { apiKey: secondResolver, fetch: fetchMock });
+			await secondResolved;
+			releaseFirst();
+			await Promise.all([firstStream.result(), secondStream.result()]);
+
+			expect(observedHeaders).toEqual({
+				first: `Bearer ${first.apiKey}`,
+				second: `Bearer ${second.apiKey}`,
+			});
 		});
 
 		test("apiKey-only override supplies fallback auth for built-in models", async () => {
@@ -401,14 +485,14 @@ describe("ModelRegistry", () => {
 				else Bun.env.OPENAI_API_KEY = originalOpenAiKey;
 			}
 		});
-		test("apiKeys combines after apiKey, removes duplicates, and configures auth", async () => {
+		test("apiKeys accepts blank entries, combines after apiKey, removes duplicates, and configures auth", async () => {
 			const originalOpenAiKey = Bun.env.OPENAI_API_KEY;
 			delete Bun.env.OPENAI_API_KEY;
 			try {
 				writeRawModelsJson({
 					openai: {
 						apiKey: "first-key",
-						apiKeys: ["second-key", "first-key", "third-key"],
+						apiKeys: ["second-key", "", "first-key", "third-key"],
 					},
 				});
 
@@ -422,6 +506,32 @@ describe("ModelRegistry", () => {
 				if (originalOpenAiKey === undefined) delete Bun.env.OPENAI_API_KEY;
 				else Bun.env.OPENAI_API_KEY = originalOpenAiKey;
 			}
+		});
+		test("authHeader follows the configured key selected after rotation", async () => {
+			writeRawModelsJson({
+				anthropic: {
+					apiKeys: ["header-first", "header-second"],
+					authHeader: true,
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("anthropic", "claude-sonnet-4-5");
+			if (!model) throw new Error("Expected bundled Anthropic model");
+
+			expect(await registry.getApiKeyAndHeaders(model)).toEqual({
+				ok: true,
+				apiKey: "header-first",
+				headers: { Authorization: "Bearer header-first" },
+			});
+			expect(await authStorage.markUsageLimitReached("anthropic", undefined, { apiKey: "header-first" })).toEqual({
+				switched: true,
+			});
+			expect(await registry.getApiKeyAndHeaders(model)).toEqual({
+				ok: true,
+				apiKey: "header-second",
+				headers: { Authorization: "Bearer header-second" },
+			});
 		});
 
 		test("zhipu-coding-plan glm-5.2 chat resolves the zhipu credential with model-scoped hints", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -401,6 +401,29 @@ describe("ModelRegistry", () => {
 				else Bun.env.OPENAI_API_KEY = originalOpenAiKey;
 			}
 		});
+		test("apiKeys combines after apiKey, removes duplicates, and configures auth", async () => {
+			const originalOpenAiKey = Bun.env.OPENAI_API_KEY;
+			delete Bun.env.OPENAI_API_KEY;
+			try {
+				writeRawModelsJson({
+					openai: {
+						apiKey: "first-key",
+						apiKeys: ["second-key", "first-key", "third-key"],
+					},
+				});
+
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				expect(await registry.getApiKeyForProvider("openai")).toBe("first-key");
+				expect(await authStorage.markUsageLimitReached("openai", undefined, { apiKey: "first-key" })).toEqual({
+					switched: true,
+				});
+				expect(await registry.getApiKeyForProvider("openai")).toBe("second-key");
+			} finally {
+				if (originalOpenAiKey === undefined) delete Bun.env.OPENAI_API_KEY;
+				else Bun.env.OPENAI_API_KEY = originalOpenAiKey;
+			}
+		});
+
 		test("zhipu-coding-plan glm-5.2 chat resolves the zhipu credential with model-scoped hints", async () => {
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
 			const model = registry.find("zhipu-coding-plan", "glm-5.2");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -3,7 +3,15 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Effort, streamSimple, type Context, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
+import {
+	type Context,
+	Effort,
+	type FetchImpl,
+	type Model,
+	type OpenAICompat,
+	streamSimple,
+	type ThinkingConfig,
+} from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -378,7 +386,11 @@ describe("ModelRegistry", () => {
 			expect(anthropicModels.length).toBeGreaterThan(1);
 			for (const model of anthropicModels) {
 				const auth = await anthropicAuthHeader.getApiKeyAndHeaders(model);
-				expect(auth).toEqual({ ok: true, apiKey: "issue-929-key", headers: { Authorization: "Bearer issue-929-key" } });
+				expect(auth).toEqual({
+					ok: true,
+					apiKey: "issue-929-key",
+					headers: { Authorization: "Bearer issue-929-key" },
+				});
 			}
 		});
 
@@ -396,27 +408,18 @@ describe("ModelRegistry", () => {
 			if (!model) throw new Error("Expected bundled Anthropic model");
 
 			const selections = await Promise.all(
-				Array.from({ length: 64 }, async (_, index) => ({
-					sessionId: `auth-header-session-${index}`,
-					apiKey: await registry.getApiKey(model, `auth-header-session-${index}`),
-				})),
+				Array.from({ length: 64 }, async (_, index) => {
+					const sessionId = `auth-header-session-${index}`;
+					return { sessionId, apiKey: await registry.getApiKey(model, sessionId) };
+				}),
 			);
 			const first = selections[0];
 			const second = selections.find(selection => selection.apiKey !== first?.apiKey);
 			if (!first?.apiKey || !second?.apiKey) throw new Error("Expected two distinct configured API keys");
 
-			let releaseFirst!: () => void;
-			const firstRelease = new Promise<void>(resolve => {
-				releaseFirst = resolve;
-			});
-			let markFirstResolved!: () => void;
-			const firstResolved = new Promise<void>(resolve => {
-				markFirstResolved = resolve;
-			});
-			let markSecondResolved!: () => void;
-			const secondResolved = new Promise<void>(resolve => {
-				markSecondResolved = resolve;
-			});
+			const { promise: firstRelease, resolve: releaseFirst } = Promise.withResolvers<void>();
+			const { promise: firstResolved, resolve: markFirstResolved } = Promise.withResolvers<void>();
+			const { promise: secondResolved, resolve: markSecondResolved } = Promise.withResolvers<void>();
 
 			const firstKeyResolver = registry.resolver(model, first.sessionId);
 			const secondKeyResolver = registry.resolver(model, second.sessionId);
@@ -437,24 +440,39 @@ describe("ModelRegistry", () => {
 				const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
 				const bodyText = input instanceof Request ? await input.clone().text() : String(init?.body);
 				const body = JSON.parse(bodyText);
-				observedHeaders[body.messages[0].content] = headers.get("Authorization");
+				const requestContent = body.messages[0].content;
+				const requestText = typeof requestContent === "string" ? requestContent : requestContent[0].text;
+				observedHeaders[requestText] = headers.get("Authorization");
 				const events = [
 					{ type: "message_start", message: { id: "msg", usage: { input_tokens: 1, output_tokens: 0 } } },
 					{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
 					{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
 					{ type: "content_block_stop", index: 0 },
-					{ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 1, output_tokens: 1 } },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "end_turn" },
+						usage: { input_tokens: 1, output_tokens: 1 },
+					},
 					{ type: "message_stop" },
 				];
-				return new Response(events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(""), {
-					headers: { "content-type": "text/event-stream" },
-				});
+				return new Response(
+					events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""),
+					{
+						headers: { "content-type": "text/event-stream" },
+					},
+				);
 			};
 			const context = (content: string): Context => ({ messages: [{ role: "user", content, timestamp: 0 }] });
 
-			const firstStream = streamSimple(model, context("first"), { apiKey: firstResolver, fetch: fetchMock });
+			const firstStream = streamSimple(model, context("first"), {
+				apiKey: firstResolver,
+				fetch: fetchMock,
+			});
 			await firstResolved;
-			const secondStream = streamSimple(model, context("second"), { apiKey: secondResolver, fetch: fetchMock });
+			const secondStream = streamSimple(model, context("second"), {
+				apiKey: secondResolver,
+				fetch: fetchMock,
+			});
 			await secondResolved;
 			releaseFirst();
 			await Promise.all([firstStream.result(), secondStream.result()]);


### PR DESCRIPTION
## Summary
- Adds support for configuring multiple API keys per provider using `apiKeys: string[]` in `models.yml` and comma-separated key lists in environment variables.
- Integrates multi-key configurations into `AuthStorage` for round-robin load distribution, sticky session affinity, and per-credential usage limit rotation.
- Binds request-local `authHeader` dynamically in `streamSimple` via `REQUEST_API_KEY_AUTHORIZATION` sentinel headers instead of static key caching.
- Narrows virtual credential kinds in TypeScript selection returns and adds interleaved Anthropic event-stream test fixtures.

## What changed
- **Multi-key configuration parsing**: Provider definitions in `models.yml` accept an `apiKeys` array alongside single `apiKey` entries. Keys are merged (with `apiKey` prioritized), de-duplicated, and filtered for blank entries. Environment variable lookup (`getEnvApiKeys`) supports comma-separated values while preserving intact JSON objects (such as GCP credentials).
- **Credential storage and rotation**: `AuthStorage` registers each configured key as a distinct `config_api_key` or `env_api_key` target. Non-session requests rotate through available keys via round-robin distribution, active sessions lock to their assigned key via session affinity, and 429/rate-limited keys flagged by `markUsageLimitReached` rotate to remaining non-exhausted keys.
- **Request-local `authHeader` materialization**: Providers with `authHeader: true` use `REQUEST_API_KEY_AUTHORIZATION` as a placeholder during header construction. `streamSimple` in `stream.ts` invokes `materializeRequestAuthorization` to substitute `Bearer ${apiKey}` dynamically for the session's resolved key.
- **Type narrowing refinement**: Updated `AuthStorage.#resolveCredentialTarget` to explicitly return `{ type, index, explicit }` objects rather than using object spreads, allowing TypeScript to narrow virtual credential kinds out of `AuthCredential["type"]`.
- **Interleaved stream test fixture**: Added test cases in `packages/coding-agent/test/model-registry.test.ts` using `Promise.withResolvers` and SSE Anthropic event stream responses to verify that concurrent, interleaved session requests materialize their respective session keys into request headers.

## Verification
- `packages/coding-agent/test/model-registry.test.ts`
- `packages/ai/test/auth-storage-config-override.test.ts`
- `packages/ai/test/stream.test.ts`
- `packages/ai/test/auth-storage-account-identity.test.ts`
- `packages/ai/test/auth-storage-credential-origin.test.ts`

## Notes
- Environment variable values that parse as valid JSON objects bypass comma-splitting to ensure structured credentials remain intact.
- Stacked on #6958.
