### PR TITLE
feat(session): paraphrase retry on classifier refusal

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in retry.refusalParaphrase setting that rewrites an Anthropic classifier refusal with a tiny or smol model and retries the same model once, with the rewrite logged and surfaced to the session.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1507,6 +1507,32 @@ export const SETTINGS_SCHEMA = {
 			description: "Allow retry recovery to switch to configured fallback models",
 		},
 	},
+	"retry.refusalParaphrase": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Refusal Paraphrase",
+			description:
+				"On an Anthropic content refusal, paraphrase the triggering prompt with a fast model and retry once before falling back.",
+		},
+	},
+	"retry.refusalParaphraseRole": {
+		type: "enum",
+		values: ["tiny", "smol"] as const,
+		default: "smol",
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Refusal Paraphrase Model",
+			description: "Role used to rewrite a false-positive Anthropic refusal before one same-model retry.",
+			options: [
+				{ value: "tiny", label: "Tiny" },
+				{ value: "smol", label: "Smol" },
+			],
+		},
+	},
 	"retry.usageAwareFallback": {
 		type: "boolean",
 		default: false,
@@ -5587,6 +5613,8 @@ export interface RetrySettings {
 	baseDelayMs: number;
 	maxDelayMs: number;
 	modelFallback: boolean;
+	refusalParaphrase: boolean;
+	refusalParaphraseRole: "tiny" | "smol";
 	usageAwareFallback: boolean;
 	usageReservePct: number;
 	usageReservePolicy: "confirm" | "auto" | "fail-closed";

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -188,6 +188,7 @@ export class EventController {
 			auto_retry_end: e => this.#handleAutoRetryEnd(e),
 			retry_fallback_applied: e => this.#handleRetryFallbackApplied(e),
 			retry_fallback_succeeded: e => this.#handleRetryFallbackSucceeded(e),
+			refusal_paraphrase_applied: e => this.#handleRefusalParaphraseApplied(e),
 			ttsr_triggered: e => this.#handleTtsrTriggered(e),
 			todo_reminder: e => this.#handleTodoReminder(e),
 			todo_auto_clear: e => this.#handleTodoAutoClear(e),
@@ -1559,6 +1560,16 @@ export class EventController {
 		event: Extract<AgentSessionEvent, { type: "retry_fallback_succeeded" }>,
 	): Promise<void> {
 		this.ctx.showStatus(`Fallback succeeded on ${event.model}`);
+	}
+
+	async #handleRefusalParaphraseApplied(
+		event: Extract<AgentSessionEvent, { type: "refusal_paraphrase_applied" }>,
+	): Promise<void> {
+		const original = previewLine(sanitizeText(event.originalText), TRUNCATE_LENGTHS.LINE);
+		const paraphrased = previewLine(sanitizeText(event.paraphrasedText), TRUNCATE_LENGTHS.LINE);
+		this.ctx.showWarning(
+			`Prompt rewritten after a classifier refusal; retrying once. Original: ${original} Retry: ${paraphrased}`,
+		);
 	}
 
 	async #handleTtsrTriggered(event: Extract<AgentSessionEvent, { type: "ttsr_triggered" }>): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -122,6 +122,7 @@ const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
 	"auto_retry_end",
 	"retry_fallback_applied",
 	"retry_fallback_succeeded",
+	"refusal_paraphrase_applied",
 	"ttsr_triggered",
 	"todo_reminder",
 	"todo_auto_clear",

--- a/packages/coding-agent/src/prompts/system/refusal-paraphrase.md
+++ b/packages/coding-agent/src/prompts/system/refusal-paraphrase.md
@@ -1,0 +1,1 @@
+Rewrite the user's request to preserve its legitimate intent while using clear, neutral wording that avoids a false-positive safety classifier refusal. Do not add capabilities, instructions, or claims. Return only the rewritten request.

--- a/packages/coding-agent/src/prompts/system/refusal-paraphrase.md
+++ b/packages/coding-agent/src/prompts/system/refusal-paraphrase.md
@@ -1,1 +1,1 @@
-Rewrite the user's request to preserve its legitimate intent while using clear, neutral wording that avoids a false-positive safety classifier refusal. Do not add capabilities, instructions, or claims. Return only the rewritten request.
+Rewrite the user's request in clear, neutral wording that preserves its original intent. Do not add, remove, or change capabilities, instructions, or claims. Return only the rewritten request.

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -47,6 +47,7 @@ export type AgentSessionEvent =
 	  }
 	| { type: "retry_fallback_applied"; from: string; to: string; role: string }
 	| { type: "retry_fallback_succeeded"; model: string; role: string }
+	| { type: "refusal_paraphrase_applied"; originalText: string; paraphrasedText: string }
 	| { type: "ttsr_triggered"; rules: Rule[] }
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }
 	| { type: "todo_auto_clear" }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -952,6 +952,8 @@ export class AgentSession {
 			streamingEditAbortTriggered: () => this.#streamingEditGuard.abortTriggered,
 			promptGeneration: () => this.#promptGeneration,
 			sessionId: () => this.sessionId,
+			obfuscateTextForProvider: text => this.#obfuscateTextForProvider(text) ?? text,
+			deobfuscateFromProvider: text => this.#deobfuscateFromProvider(text),
 			emitSessionEvent: event => this.#emitSessionEvent(event),
 			scheduleAgentContinue: options => this.#scheduleAgentContinue(options),
 			waitForSessionMessagePersistence: message => this.#waitForSessionMessagePersistence(message),

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -29,6 +29,7 @@ import {
 	resolveModelRoleValue,
 	resolveRoleSelection,
 } from "../config/model-resolver";
+import { formatModelRoleAlias } from "../config/model-roles";
 import type { Settings } from "../config/settings";
 import type { RecoveredRetryError } from "../extensibility/shared-events";
 import emptyStopRetryTemplate from "../prompts/system/empty-stop-retry.md" with { type: "text" };
@@ -95,6 +96,18 @@ function hasNonWhitespace(value: string): boolean {
 	return NON_WHITESPACE_RE.test(value);
 }
 
+/**
+ * The subset of {@link AgentMessage} that `SessionManager.appendMessage`
+ * accepts — every role except the structural `branchSummary`/
+ * `compactionSummary` summaries, which live in their own entry types.
+ */
+type PersistableAgentMessage = Parameters<SessionManager["appendMessage"]>[0];
+
+/** True for agent messages that can be re-appended to a session branch. */
+function isPersistableAgentMessage(message: AgentMessage): message is PersistableAgentMessage {
+	return message.role !== "branchSummary" && message.role !== "compactionSummary";
+}
+
 function syntheticToolResultTailStart(messages: readonly AgentMessage[]): number {
 	let index = messages.length;
 	while (index > 0 && isSyntheticToolResultMessage(messages[index - 1])) {
@@ -144,7 +157,7 @@ export interface TurnRecoveryHost {
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
 	scheduleAgentContinue(options: { delayMs?: number; generation?: number; onError?: (error: unknown) => void }): void;
 	waitForSessionMessagePersistence(message: AssistantMessage): Promise<void>;
-	appendSessionMessage(message: AssistantMessage | UserMessage): void;
+	appendSessionMessage(message: PersistableAgentMessage): void;
 	sessionMessageAlreadyPersisted(message: AssistantMessage): boolean;
 	setModelWithProviderSessionReset(model: Model): Promise<void>;
 	resetCurrentResponsesProviderSession(reason: string): void;
@@ -1750,7 +1763,9 @@ export class TurnRecovery {
 		const availableModels = this.#host.modelRegistry.getAvailable();
 		const configuredRole = this.#host.settings.getGroup("retry").refusalParaphraseRole;
 		const configuredResolution = resolveRoleSelection([configuredRole], this.#host.settings, availableModels);
-		const aliasResolution = resolveModelRoleValue("@smol", availableModels, { settings: this.#host.settings });
+		const aliasResolution = resolveModelRoleValue(formatModelRoleAlias(configuredRole), availableModels, {
+			settings: this.#host.settings,
+		});
 		const resolved =
 			configuredResolution ??
 			(aliasResolution.model
@@ -1832,6 +1847,13 @@ export class TurnRecovery {
 					this.#host.sessionManager.branch(userEntry.parentId);
 				}
 				this.#host.appendSessionMessage(rewrittenUserMessage);
+				// Recreate the post-user segment (generated @file context,
+				// before_agent_start extension messages, etc.) on the replacement
+				// branch so a reload/transcript rebuild keeps the same companions the
+				// live retry sees via `rewrittenMessages` below.
+				for (const companion of messages.slice(userIndex + 1, assistantIndex)) {
+					if (isPersistableAgentMessage(companion)) this.#host.appendSessionMessage(companion);
+				}
 			});
 			const rewrittenMessages = messages.slice();
 			rewrittenMessages[userIndex] = rewrittenUserMessage;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -15,17 +15,19 @@ import type {
 	Model,
 	TextContent,
 	ToolChoice,
+	UserMessage,
 } from "@oh-my-pi/pi-ai";
-import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@oh-my-pi/pi-ai";
+import { calculateRateLimitBackoffMs, completeSimple, parseRateLimitReason } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
-import { formatModelStringWithRouting, resolveModelOverride } from "../config/model-resolver";
+import { formatModelStringWithRouting, resolveModelOverride, resolveRoleSelection } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
 import type { RecoveredRetryError } from "../extensibility/shared-events";
 import emptyStopRetryTemplate from "../prompts/system/empty-stop-retry.md" with { type: "text" };
+import refusalParaphraseTemplate from "../prompts/system/refusal-paraphrase.md" with { type: "text" };
 import thinkingLoopRedirectTemplate from "../prompts/system/thinking-loop-redirect.md" with { type: "text" };
 import unexpectedStopRetryTemplate from "../prompts/system/unexpected-stop-retry.md" with { type: "text" };
 import {
@@ -63,7 +65,26 @@ const UNEXPECTED_STOP_MAX_RETRIES = 3;
 const UNEXPECTED_STOP_TIMEOUT_MS = 4000;
 const EMPTY_STOP_MAX_RETRIES = 3;
 const SIBLING_UNBLOCK_BUFFER_MS = 1_000;
+const REFUSAL_PARAPHRASE_MAX_TOKENS = 1024;
 const NON_WHITESPACE_RE = /\S/;
+
+function replaceUserText(content: UserMessage["content"], text: string): UserMessage["content"] {
+	if (typeof content === "string") return text;
+	if (content.every(block => block.type === "text" && block.textSignature === undefined)) return text;
+	const rewritten: typeof content = [];
+	let replaced = false;
+	for (const block of content) {
+		if (block.type !== "text") {
+			rewritten.push(block);
+			continue;
+		}
+		if (!replaced) {
+			rewritten.push({ ...block, text });
+			replaced = true;
+		}
+	}
+	return rewritten;
+}
 
 function hasNonWhitespace(value: string): boolean {
 	return NON_WHITESPACE_RE.test(value);
@@ -156,6 +177,7 @@ export class TurnRecovery {
 	readonly #host: TurnRecoveryHost;
 	#retryAbortController: AbortController | undefined;
 	#retryAttempt = 0;
+	#refusalParaphraseUsed = false;
 	#retryPromise: Promise<void> | undefined;
 	#retryResolve: (() => void) | undefined;
 	#activeRetryFallback: ActiveRetryFallbackState | undefined;
@@ -198,6 +220,7 @@ export class TurnRecovery {
 	resetForNewPrompt(): void {
 		this.#emptyStopRetryCount = 0;
 		this.#unexpectedStopRetryCount = 0;
+		this.#refusalParaphraseUsed = false;
 		this.#acceptTerminalEmptyStopForPrompt = false;
 	}
 
@@ -1305,6 +1328,11 @@ export class TurnRecovery {
 			: retrySettings.maxRetries;
 		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
 
+		if (classifierRefusal && !this.#refusalParaphraseUsed && retrySettings.refusalParaphrase) {
+			this.#refusalParaphraseUsed = true;
+			if (await this.#retryRefusalWithParaphrase(message, generation, maxRetries)) return true;
+		}
+
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
 		const staleOpenAIResponsesReplayError = AIError.is(id, AIError.Flag.StaleResponsesItem);
@@ -1653,9 +1681,7 @@ export class TurnRecovery {
 				await this.#host.agent.prompt(messages, options);
 				return;
 			} catch (err) {
-				if (!(err instanceof AgentBusyError)) {
-					throw err;
-				}
+				if (!(err instanceof AgentBusyError)) throw err;
 				if (Date.now() >= deadline) {
 					throw new Error("Timed out waiting for prior agent run to finish before prompting.");
 				}
@@ -1674,12 +1700,103 @@ export class TurnRecovery {
 		return this.#host.settings.get("retry.enabled") ?? true;
 	}
 
-	/**
-	 * Toggle auto-retry setting.
-	 */
+	/** Toggle auto-retry setting. */
 	setAutoRetryEnabled(enabled: boolean): void {
 		this.#host.settings.set("retry.enabled", enabled);
 	}
+
+	async #retryRefusalWithParaphrase(
+		assistantMessage: AssistantMessage,
+		generation: number,
+		maxRetries: number,
+	): Promise<boolean> {
+		const messages = this.#host.agent.state.messages;
+		const userIndex = messages.findLastIndex(message => message.role === "user");
+		const userMessage = messages[userIndex];
+		if (userMessage?.role !== "user") return false;
+		const originalText =
+			typeof userMessage.content === "string"
+				? userMessage.content
+				: userMessage.content
+						.filter((content): content is TextContent => content.type === "text")
+						.map(content => content.text)
+						.join("\n")
+						.trim();
+		if (!hasNonWhitespace(originalText)) return false;
+
+		const resolved = resolveRoleSelection(
+			[this.#host.settings.getGroup("retry").refusalParaphraseRole, "smol"],
+			this.#host.settings,
+			this.#host.modelRegistry.getAvailable(),
+		);
+		if (!resolved) return false;
+
+		const abortController = new AbortController();
+		this.#retryAbortController?.abort();
+		this.#retryAbortController = abortController;
+		const registryApiKey = this.#host.modelRegistry.resolver(resolved.model, this.#host.sessionId());
+		let response: AssistantMessage;
+		try {
+			response = await completeSimple(
+				resolved.model,
+				{
+					systemPrompt: [prompt.render(refusalParaphraseTemplate)],
+					messages: [{ role: "user", content: originalText, timestamp: Date.now() }],
+				},
+				{
+					apiKey: async context => {
+						const apiKey = await registryApiKey(context);
+						if (apiKey !== undefined) return apiKey;
+						const agentApiKey = await this.#host.agent.getApiKey?.(resolved.model);
+						return typeof agentApiKey === "function" ? agentApiKey(context) : agentApiKey;
+					},
+					maxTokens: REFUSAL_PARAPHRASE_MAX_TOKENS,
+					disableReasoning: true,
+					signal: abortController.signal,
+				},
+			);
+		} catch (error) {
+			logger.debug("refusal paraphrase retry failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return false;
+		} finally {
+			if (this.#retryAbortController === abortController) this.#retryAbortController = undefined;
+		}
+		if (response.stopReason === "error") return false;
+		const paraphrasedText = response.content
+			.filter((content): content is TextContent => content.type === "text")
+			.map(content => content.text)
+			.join("\n")
+			.trim();
+		if (!hasNonWhitespace(paraphrasedText)) return false;
+
+		const rewrittenMessages = messages.slice();
+		rewrittenMessages[userIndex] = { ...userMessage, content: replaceUserText(userMessage.content, paraphrasedText) };
+		this.#host.agent.replaceMessages(rewrittenMessages);
+		this.removeAssistantMessageFromActiveContext(assistantMessage, "refusal-paraphrase");
+		logger.warn("Retrying classifier refusal with paraphrased user prompt", { originalText, paraphrasedText });
+		await this.#host.emitSessionEvent({
+			type: "refusal_paraphrase_applied",
+			originalText,
+			paraphrasedText,
+		});
+		await this.#host.emitSessionEvent({
+			type: "auto_retry_start",
+			attempt: this.#retryAttempt,
+			maxAttempts: maxRetries,
+			delayMs: 0,
+			errorMessage: assistantMessage.errorMessage || "Unknown error",
+			errorId: assistantMessage.errorId,
+		});
+		this.#host.scheduleAgentContinue({
+			delayMs: 1,
+			generation,
+			onError: error => void this.#failRetryAfterLocalContinueError(assistantMessage, error),
+		});
+		return true;
+	}
+
 	/**
 	 * Manually retry the last failed assistant turn.
 	 * Removes the error message from active agent state when present and
@@ -1719,6 +1836,7 @@ export class TurnRecovery {
 
 		// Reset retry budget for a fresh attempt
 		this.#retryAttempt = 0;
+		this.#refusalParaphraseUsed = false;
 
 		// Re-attempt the turn
 		this.#host.scheduleAgentContinue({ delayMs: 1 });

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1356,6 +1356,30 @@ export class TurnRecovery {
 		) {
 			this.#refusalParaphraseUsed = true;
 			if (await this.#retryRefusalWithParaphrase(message, generation, maxRetries)) return true;
+			// Escape / abort_retry cancels the paraphrase's provider call or
+			// persistence wait by aborting #retryAbortController, which
+			// #retryRefusalWithParaphrase leaves in place on abort. Distinguish
+			// that user-initiated cancel from an ordinary paraphrase miss (no
+			// resolved model, empty paraphrase, non-"stop" stop reason, etc.) and
+			// close the retry saga here instead of falling through to model
+			// fallback, which would schedule another provider request the user
+			// just asked to stop. Mirrors the backoff-wait cancellation path.
+			if (this.#retryAbortController?.signal.aborted) {
+				if (this.#retryAttempt > 1) {
+					await this.persistTerminalEmptyErrorTurn(message);
+					await this.#host.emitSessionEvent({
+						type: "auto_retry_end",
+						success: false,
+						attempt: this.#retryAttempt - 1,
+						finalError: "Retry cancelled",
+					});
+					this.#clearPendingRecoveredRetryErrors();
+				}
+				this.#retryAttempt = 0;
+				this.#retryAbortController = undefined;
+				this.resolveRetry();
+				return false;
+			}
 		}
 
 		const errorMessage = message.errorMessage || "Unknown error";
@@ -1852,7 +1876,26 @@ export class TurnRecovery {
 				// branch so a reload/transcript rebuild keeps the same companions the
 				// live retry sees via `rewrittenMessages` below.
 				for (const companion of messages.slice(userIndex + 1, assistantIndex)) {
-					if (isPersistableAgentMessage(companion)) this.#host.appendSessionMessage(companion);
+					if (!isPersistableAgentMessage(companion)) continue;
+					// `custom`/`hookMessage` companions (e.g. a before_agent_start
+					// extension message) were originally persisted as
+					// `custom_message` entries with normalization
+					// (stripInternalDetailsFields). Recreate them through that path
+					// instead of a generic `message` entry so type-based consumers
+					// (custom-message branch editing, tree rendering) still recognize
+					// them on reload/transcript rebuild, matching the live path at
+					// AgentSession message_end handling.
+					if (companion.role === "custom" || companion.role === "hookMessage") {
+						this.#host.sessionManager.appendCustomMessageEntry(
+							companion.customType,
+							companion.content,
+							companion.display,
+							companion.details,
+							companion.attribution ?? "agent",
+						);
+					} else {
+						this.#host.appendSessionMessage(companion);
+					}
 				}
 			});
 			const rewrittenMessages = messages.slice();
@@ -1884,7 +1927,13 @@ export class TurnRecovery {
 			});
 			return true;
 		} finally {
-			if (this.#retryAbortController === abortController) this.#retryAbortController = undefined;
+			// Leave the controller in place when it was aborted (Escape /
+			// abort_retry) so #handleRetryableError can detect the cancellation
+			// and close the retry saga rather than falling through to model
+			// fallback; the caller clears it after handling.
+			if (this.#retryAbortController === abortController && !abortController.signal.aborted) {
+				this.#retryAbortController = undefined;
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -137,7 +137,7 @@ export interface TurnRecoveryHost {
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
 	scheduleAgentContinue(options: { delayMs?: number; generation?: number; onError?: (error: unknown) => void }): void;
 	waitForSessionMessagePersistence(message: AssistantMessage): Promise<void>;
-	appendSessionMessage(message: AssistantMessage): void;
+	appendSessionMessage(message: AssistantMessage | UserMessage): void;
 	sessionMessageAlreadyPersisted(message: AssistantMessage): boolean;
 	setModelWithProviderSessionReset(model: Model): Promise<void>;
 	resetCurrentResponsesProviderSession(reason: string): void;
@@ -1328,7 +1328,12 @@ export class TurnRecovery {
 			: retrySettings.maxRetries;
 		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
 
-		if (classifierRefusal && !this.#refusalParaphraseUsed && retrySettings.refusalParaphrase) {
+		if (
+			classifierRefusal &&
+			!retryBudgetExhausted &&
+			!this.#refusalParaphraseUsed &&
+			retrySettings.refusalParaphrase
+		) {
 			this.#refusalParaphraseUsed = true;
 			if (await this.#retryRefusalWithParaphrase(message, generation, maxRetries)) return true;
 		}
@@ -1669,7 +1674,9 @@ export class TurnRecovery {
 	 * Cancel in-progress retry.
 	 */
 	abortRetry(): void {
-		this.#retryAbortController?.abort();
+		const controller = this.#retryAbortController;
+		if (!controller) return;
+		controller.abort();
 		// Note: _retryAttempt is reset in the catch block of _autoRetry
 		this.resolveRetry();
 	}
@@ -1711,7 +1718,10 @@ export class TurnRecovery {
 		maxRetries: number,
 	): Promise<boolean> {
 		const messages = this.#host.agent.state.messages;
-		const userIndex = messages.findLastIndex(message => message.role === "user");
+		const assistantIndex = messages.findLastIndex(
+			message => message.role === "assistant" && this.#isSameAssistantMessage(message, assistantMessage),
+		);
+		const userIndex = assistantIndex - 1;
 		const userMessage = messages[userIndex];
 		if (userMessage?.role !== "user") return false;
 		const originalText =
@@ -1737,64 +1747,103 @@ export class TurnRecovery {
 		const registryApiKey = this.#host.modelRegistry.resolver(resolved.model, this.#host.sessionId());
 		let response: AssistantMessage;
 		try {
-			response = await completeSimple(
-				resolved.model,
-				{
-					systemPrompt: [prompt.render(refusalParaphraseTemplate)],
-					messages: [{ role: "user", content: originalText, timestamp: Date.now() }],
-				},
-				{
-					apiKey: async context => {
-						const apiKey = await registryApiKey(context);
-						if (apiKey !== undefined) return apiKey;
-						const agentApiKey = await this.#host.agent.getApiKey?.(resolved.model);
-						return typeof agentApiKey === "function" ? agentApiKey(context) : agentApiKey;
+			try {
+				response = await completeSimple(
+					resolved.model,
+					{
+						systemPrompt: [prompt.render(refusalParaphraseTemplate)],
+						messages: [{ role: "user", content: originalText, timestamp: Date.now() }],
 					},
-					maxTokens: REFUSAL_PARAPHRASE_MAX_TOKENS,
-					disableReasoning: true,
-					signal: abortController.signal,
-				},
-			);
-		} catch (error) {
-			logger.debug("refusal paraphrase retry failed", {
-				error: error instanceof Error ? error.message : String(error),
+					{
+						apiKey: async context => {
+							const apiKey = await registryApiKey(context);
+							if (apiKey !== undefined) return apiKey;
+							const agentApiKey = await this.#host.agent.getApiKey?.(resolved.model);
+							return typeof agentApiKey === "function" ? agentApiKey(context) : agentApiKey;
+						},
+						maxTokens: REFUSAL_PARAPHRASE_MAX_TOKENS,
+						disableReasoning: true,
+						metadata: this.#host.agent.metadataForProvider(resolved.model.provider),
+						sessionId: this.#host.sessionId(),
+						signal: abortController.signal,
+					},
+				);
+			} catch (error) {
+				logger.debug("refusal paraphrase retry failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return false;
+			}
+
+			if (abortController.signal.aborted || response.stopReason !== "stop") return false;
+			const paraphrasedText = response.content
+				.filter((content): content is TextContent => content.type === "text")
+				.map(content => content.text)
+				.join("\n")
+				.trim();
+			if (!hasNonWhitespace(paraphrasedText)) return false;
+
+			const rewrittenUserMessage = {
+				...userMessage,
+				content: replaceUserText(userMessage.content, paraphrasedText),
+			};
+			await this.#host.waitForSessionMessagePersistence(assistantMessage);
+			if (abortController.signal.aborted) return false;
+			const branch = this.#host.sessionManager.getBranch();
+			const userEntry = branch
+				.slice()
+				.reverse()
+				.find(
+					entry =>
+						entry.type === "message" &&
+						entry.message.role === "user" &&
+						(entry.message === userMessage || entry.message.timestamp === userMessage.timestamp),
+				);
+			if (userEntry?.type !== "message" || userEntry.message.role !== "user") return false;
+
+			// Commit the rewrite: Escape may still cancel the provider call and persistence
+			// wait above, but cannot split the synchronous state mutation, lifecycle
+			// events, and continuation scheduling below.
+			if (this.#retryAbortController === abortController) this.#retryAbortController = undefined;
+			this.#host.withBashBranchTransition(() => {
+				if (userEntry.parentId === null) {
+					this.#host.sessionManager.resetLeaf();
+				} else {
+					this.#host.sessionManager.branch(userEntry.parentId);
+				}
+				this.#host.appendSessionMessage(rewrittenUserMessage);
 			});
-			return false;
+			const rewrittenMessages = messages.slice();
+			rewrittenMessages[userIndex] = rewrittenUserMessage;
+			this.#host.agent.replaceMessages(rewrittenMessages);
+			this.removeAssistantMessageFromActiveContext(assistantMessage, "refusal-paraphrase");
+			logger.warn("Retrying classifier refusal with paraphrased user prompt", {
+				model: `${resolved.model.provider}/${resolved.model.id}`,
+				originalLength: originalText.length,
+				paraphrasedLength: paraphrasedText.length,
+			});
+			await this.#host.emitSessionEvent({
+				type: "refusal_paraphrase_applied",
+				originalText,
+				paraphrasedText,
+			});
+			await this.#host.emitSessionEvent({
+				type: "auto_retry_start",
+				attempt: this.#retryAttempt,
+				maxAttempts: maxRetries,
+				delayMs: 0,
+				errorMessage: assistantMessage.errorMessage || "Unknown error",
+				errorId: assistantMessage.errorId,
+			});
+			this.#host.scheduleAgentContinue({
+				delayMs: 1,
+				generation,
+				onError: error => void this.#failRetryAfterLocalContinueError(assistantMessage, error),
+			});
+			return true;
 		} finally {
 			if (this.#retryAbortController === abortController) this.#retryAbortController = undefined;
 		}
-		if (response.stopReason === "error") return false;
-		const paraphrasedText = response.content
-			.filter((content): content is TextContent => content.type === "text")
-			.map(content => content.text)
-			.join("\n")
-			.trim();
-		if (!hasNonWhitespace(paraphrasedText)) return false;
-
-		const rewrittenMessages = messages.slice();
-		rewrittenMessages[userIndex] = { ...userMessage, content: replaceUserText(userMessage.content, paraphrasedText) };
-		this.#host.agent.replaceMessages(rewrittenMessages);
-		this.removeAssistantMessageFromActiveContext(assistantMessage, "refusal-paraphrase");
-		logger.warn("Retrying classifier refusal with paraphrased user prompt", { originalText, paraphrasedText });
-		await this.#host.emitSessionEvent({
-			type: "refusal_paraphrase_applied",
-			originalText,
-			paraphrasedText,
-		});
-		await this.#host.emitSessionEvent({
-			type: "auto_retry_start",
-			attempt: this.#retryAttempt,
-			maxAttempts: maxRetries,
-			delayMs: 0,
-			errorMessage: assistantMessage.errorMessage || "Unknown error",
-			errorId: assistantMessage.errorId,
-		});
-		this.#host.scheduleAgentContinue({
-			delayMs: 1,
-			generation,
-			onError: error => void this.#failRetryAfterLocalContinueError(assistantMessage, error),
-		});
-		return true;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -23,7 +23,12 @@ import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
-import { formatModelStringWithRouting, resolveModelOverride, resolveRoleSelection } from "../config/model-resolver";
+import {
+	formatModelStringWithRouting,
+	resolveModelOverride,
+	resolveModelRoleValue,
+	resolveRoleSelection,
+} from "../config/model-resolver";
 import type { Settings } from "../config/settings";
 import type { RecoveredRetryError } from "../extensibility/shared-events";
 import emptyStopRetryTemplate from "../prompts/system/empty-stop-retry.md" with { type: "text" };
@@ -134,6 +139,8 @@ export interface TurnRecoveryHost {
 	streamingEditAbortTriggered(): boolean;
 	promptGeneration(): number;
 	sessionId(): string;
+	obfuscateTextForProvider(text: string): string;
+	deobfuscateFromProvider(text: string): string;
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
 	scheduleAgentContinue(options: { delayMs?: number; generation?: number; onError?: (error: unknown) => void }): void;
 	waitForSessionMessagePersistence(message: AssistantMessage): Promise<void>;
@@ -1721,7 +1728,13 @@ export class TurnRecovery {
 		const assistantIndex = messages.findLastIndex(
 			message => message.role === "assistant" && this.#isSameAssistantMessage(message, assistantMessage),
 		);
-		const userIndex = assistantIndex - 1;
+		let userIndex = assistantIndex - 1;
+		while (userIndex >= 0) {
+			const candidate = messages[userIndex];
+			if (candidate?.role === "user") break;
+			if (candidate?.role === "assistant" || candidate?.role === "developer") return false;
+			userIndex--;
+		}
 		const userMessage = messages[userIndex];
 		if (userMessage?.role !== "user") return false;
 		const originalText =
@@ -1734,17 +1747,22 @@ export class TurnRecovery {
 						.trim();
 		if (!hasNonWhitespace(originalText)) return false;
 
-		const resolved = resolveRoleSelection(
-			[this.#host.settings.getGroup("retry").refusalParaphraseRole, "smol"],
-			this.#host.settings,
-			this.#host.modelRegistry.getAvailable(),
-		);
+		const availableModels = this.#host.modelRegistry.getAvailable();
+		const configuredRole = this.#host.settings.getGroup("retry").refusalParaphraseRole;
+		const configuredResolution = resolveRoleSelection([configuredRole], this.#host.settings, availableModels);
+		const aliasResolution = resolveModelRoleValue("@smol", availableModels, { settings: this.#host.settings });
+		const resolved =
+			configuredResolution ??
+			(aliasResolution.model
+				? { model: aliasResolution.model, thinkingLevel: aliasResolution.thinkingLevel }
+				: undefined);
 		if (!resolved) return false;
 
 		const abortController = new AbortController();
 		this.#retryAbortController?.abort();
 		this.#retryAbortController = abortController;
 		const registryApiKey = this.#host.modelRegistry.resolver(resolved.model, this.#host.sessionId());
+		const originalTextForProvider = this.#host.obfuscateTextForProvider(originalText);
 		let response: AssistantMessage;
 		try {
 			try {
@@ -1752,7 +1770,7 @@ export class TurnRecovery {
 					resolved.model,
 					{
 						systemPrompt: [prompt.render(refusalParaphraseTemplate)],
-						messages: [{ role: "user", content: originalText, timestamp: Date.now() }],
+						messages: [{ role: "user", content: originalTextForProvider, timestamp: Date.now() }],
 					},
 					{
 						apiKey: async context => {
@@ -1776,10 +1794,14 @@ export class TurnRecovery {
 			}
 
 			if (abortController.signal.aborted || response.stopReason !== "stop") return false;
-			const paraphrasedText = response.content
-				.filter((content): content is TextContent => content.type === "text")
-				.map(content => content.text)
-				.join("\n")
+			const paraphrasedText = this.#host
+				.deobfuscateFromProvider(
+					response.content
+						.filter((content): content is TextContent => content.type === "text")
+						.map(content => content.text)
+						.join("\n")
+						.trim(),
+				)
 				.trim();
 			if (!hasNonWhitespace(paraphrasedText)) return false;
 
@@ -1801,10 +1823,8 @@ export class TurnRecovery {
 				);
 			if (userEntry?.type !== "message" || userEntry.message.role !== "user") return false;
 
-			// Commit the rewrite: Escape may still cancel the provider call and persistence
-			// wait above, but cannot split the synchronous state mutation, lifecycle
-			// events, and continuation scheduling below.
-			if (this.#retryAbortController === abortController) this.#retryAbortController = undefined;
+			// Keep cancellation armed through lifecycle event delivery and continuation
+			// scheduling, so Escape closes the active retry saga in either window.
 			this.#host.withBashBranchTransition(() => {
 				if (userEntry.parentId === null) {
 					this.#host.sessionManager.resetLeaf();

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -9,7 +9,7 @@ import {
 	type ModelUsageHealth,
 	type ProviderSessionState,
 } from "@oh-my-pi/pi-ai";
-import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -101,6 +101,7 @@ describe("AgentSession retry fallback", () => {
 		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
 		authStorage.setRuntimeApiKey("devin", "devin-test-key");
 		authStorage.setRuntimeApiKey("openai-codex", "openai-codex-test-key");
+		registerMockApi();
 		sharedRegistry = new ModelRegistry(authStorage);
 	});
 
@@ -1521,6 +1522,110 @@ describe("AgentSession retry fallback", () => {
 		const recovered = session.getLastAssistantMessage();
 		expect(recovered?.stopReason).toBe("stop");
 		expect(recovered?.content).toEqual([{ type: "text", text: "recovered" }]);
+	});
+
+	it("retries an Anthropic classifier refusal once with a paraphrased user prompt", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primaryModel) throw new Error("Expected bundled test model to exist");
+
+		const paraphraseModel = createMockModel({
+			id: "refusal-paraphraser",
+			responses: [{ content: ["Explain the same request in neutral, legitimate terms."] }],
+		});
+		const primaryMock = createMockModel({
+			responses: [
+				{
+					stopReason: "error",
+					stopDetails: { type: "refusal", category: "cyber", explanation: "Classifier declined." },
+					errorMessage: "Refusal (cyber): Classifier declined.",
+				},
+				{ content: ["Recovered on the same model."] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => primaryMock.stream(model, context, options),
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.modelFallback": false,
+			"retry.refusalParaphrase": true,
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		settings.setModelRole("smol", "mock/refusal-paraphraser");
+		const getAvailable = vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([primaryModel, paraphraseModel]);
+		const paraphraseEvents: Array<Extract<AgentSessionEvent, { type: "refusal_paraphrase_applied" }>> = [];
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.subscribe(event => {
+			if (event.type === "refusal_paraphrase_applied") paraphraseEvents.push(event);
+		});
+
+		await session.prompt("Explain how to bypass the classifier.");
+		await session.waitForIdle();
+
+		expect(paraphraseModel.calls).toHaveLength(1);
+		expect(paraphraseModel.calls[0]?.context.messages).toEqual([
+			{ role: "user", content: "Explain how to bypass the classifier.", timestamp: expect.any(Number) },
+		]);
+		expect(primaryMock.calls).toHaveLength(2);
+		expect(primaryMock.calls[1]?.context.messages.at(-1)).toMatchObject({
+			role: "user",
+			content: "Explain the same request in neutral, legitimate terms.",
+		});
+		expect(session.model).toBe(primaryModel);
+		expect(paraphraseEvents).toEqual([
+			{
+				type: "refusal_paraphrase_applied",
+				originalText: "Explain how to bypass the classifier.",
+				paraphrasedText: "Explain the same request in neutral, legitimate terms.",
+			},
+		]);
+		getAvailable.mockRestore();
+	});
+
+	it("leaves classifier refusals unchanged when paraphrase retry is disabled by default", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primaryModel) throw new Error("Expected bundled test model to exist");
+
+		const paraphraseModel = createMockModel({ id: "disabled-refusal-paraphraser" });
+		const primaryMock = createMockModel({
+			responses: [
+				{
+					stopReason: "error",
+					stopDetails: { type: "refusal", category: "cyber", explanation: "Classifier declined." },
+					errorMessage: "Refusal (cyber): Classifier declined.",
+				},
+			],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => primaryMock.stream(model, context, options),
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.modelFallback": false });
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		settings.setModelRole("smol", "mock/disabled-refusal-paraphraser");
+		const getAvailable = vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([primaryModel, paraphraseModel]);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		await session.prompt("Explain how to bypass the classifier.");
+		await session.waitForIdle();
+
+		expect(paraphraseModel.calls).toHaveLength(0);
+		expect(primaryMock.calls).toHaveLength(1);
+		expect(session.getLastAssistantMessage()?.stopReason).toBe("error");
+		getAvailable.mockRestore();
 	});
 
 	it("does not exceed retry.maxRetries for classifier fallback chains", async () => {

--- a/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
+++ b/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
@@ -9,7 +9,7 @@ import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TurnRecovery, type TurnRecoveryHost } from "@oh-my-pi/pi-coding-agent/session/turn-recovery";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
 
 const refusal: AssistantMessage = {
 	role: "assistant",
@@ -31,6 +31,9 @@ const refusal: AssistantMessage = {
 	timestamp: 2,
 };
 
+const originalUserMessage = { role: "user" as const, content: "Explain how to bypass the classifier.", timestamp: 1 };
+const rewrittenPrompt = "Explain the request in neutral, legitimate terms.";
+
 describe("TurnRecovery refusal paraphrase", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -48,40 +51,57 @@ describe("TurnRecovery refusal paraphrase", () => {
 		vi.restoreAllMocks();
 	});
 
-	function createRecovery(enabled: boolean): {
+	function createRecovery(
+		options: {
+			maxRetries?: number;
+			stopReason?: "length" | "aborted" | "error";
+			waitForSessionMessagePersistence?: (message: AssistantMessage) => Promise<void>;
+			onSessionEvent?: (event: AgentSessionEvent) => Promise<void>;
+		} = {},
+	): {
 		recovery: TurnRecovery;
 		paraphraseModel: MockModel;
 		events: AgentSessionEvent[];
 		scheduled: Parameters<TurnRecoveryHost["scheduleAgentContinue"]>[0][];
 		agent: Agent;
+		sessionManager: SessionManager;
 	} {
 		const primaryModel = createMockModel({ provider: "anthropic", id: "claude-opus-5" });
 		const paraphraseModel = createMockModel({
 			id: "refusal-paraphraser",
-			responses: [{ content: ["Explain the request in neutral, legitimate terms."] }],
+			responses: [
+				options.stopReason
+					? { content: ["partial rewrite"], stopReason: options.stopReason }
+					: { content: [rewrittenPrompt] },
+			],
 		});
+		const userMessage = { ...originalUserMessage };
 		const agent = new Agent({
 			getApiKey: () => "primary-test-key",
 			initialState: {
 				model: primaryModel,
 				systemPrompt: ["Test"],
 				tools: [],
-				messages: [{ role: "user", content: "Explain how to bypass the classifier.", timestamp: 1 }, refusal],
+				messages: [userMessage, refusal],
 			},
 			streamFn: primaryModel.stream,
 		});
+		agent.setMetadataResolver(() => ({ account_uuid: "selected-account" }));
 		const settings = Settings.isolated({
 			"retry.modelFallback": false,
-			"retry.refusalParaphrase": enabled,
+			"retry.refusalParaphrase": true,
+			"retry.maxRetries": options.maxRetries ?? 10,
 		});
 		settings.setModelRole("smol", "mock/refusal-paraphraser");
 		const modelRegistry = new ModelRegistry(authStorage);
 		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([paraphraseModel]);
 		const events: AgentSessionEvent[] = [];
 		const scheduled: Parameters<TurnRecoveryHost["scheduleAgentContinue"]>[0][] = [];
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage(userMessage);
 		const host: TurnRecoveryHost = {
 			agent,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager,
 			settings,
 			modelRegistry,
 			configWarnings: [],
@@ -99,12 +119,15 @@ describe("TurnRecovery refusal paraphrase", () => {
 			sessionId: () => "refusal-paraphrase-test",
 			emitSessionEvent: async event => {
 				events.push(event);
+				await options.onSessionEvent?.(event);
 			},
-			scheduleAgentContinue: options => {
-				scheduled.push(options);
+			scheduleAgentContinue: request => {
+				scheduled.push(request);
 			},
-			waitForSessionMessagePersistence: async () => {},
-			appendSessionMessage: () => {},
+			waitForSessionMessagePersistence: options.waitForSessionMessagePersistence ?? (async () => {}),
+			appendSessionMessage: message => {
+				sessionManager.appendMessage(message);
+			},
 			sessionMessageAlreadyPersisted: () => false,
 			setModelWithProviderSessionReset: async () => {},
 			resetCurrentResponsesProviderSession: () => {},
@@ -112,47 +135,112 @@ describe("TurnRecovery refusal paraphrase", () => {
 			runAutoCompaction: async () => ({ deferredHandoff: false, continuationScheduled: false }),
 			withBashBranchTransition: operation => operation(),
 		};
-		return { recovery: new TurnRecovery(host), paraphraseModel, events, scheduled, agent };
+		return { recovery: new TurnRecovery(host), paraphraseModel, events, scheduled, agent, sessionManager };
 	}
 
-	it("retries a refusal once with a rewritten user message and emits both texts", async () => {
-		const { recovery, paraphraseModel, events, scheduled, agent } = createRecovery(true);
+	it("persists a successful rewrite and retains its provider attribution", async () => {
+		const { recovery, paraphraseModel, agent, sessionManager } = createRecovery();
+		const warn = vi.spyOn(logger, "warn");
 
 		expect(await recovery.handleRetryableError(refusal)).toBe(true);
-
-		expect(paraphraseModel.calls).toHaveLength(1);
-		expect(paraphraseModel.calls[0]?.context.messages).toEqual([
-			{ role: "user", content: "Explain how to bypass the classifier.", timestamp: expect.any(Number) },
-		]);
-		expect(agent.state.messages).toEqual([
-			{ role: "user", content: "Explain the request in neutral, legitimate terms.", timestamp: 1 },
-		]);
-		expect(events).toEqual([
-			{
-				type: "refusal_paraphrase_applied",
-				originalText: "Explain how to bypass the classifier.",
-				paraphrasedText: "Explain the request in neutral, legitimate terms.",
-			},
-			{
-				type: "auto_retry_start",
-				attempt: 1,
-				maxAttempts: 10,
-				delayMs: 0,
-				errorMessage: "Refusal (cyber): Classifier declined.",
-				errorId: undefined,
-			},
-		]);
-		expect(scheduled).toEqual([{ delayMs: 1, generation: 1, onError: expect.any(Function) }]);
+		expect(paraphraseModel.calls[0]?.options).toMatchObject({
+			sessionId: "refusal-paraphrase-test",
+			metadata: { account_uuid: "selected-account" },
+		});
+		expect(sessionManager.buildSessionContext().messages).toEqual(agent.state.messages);
+		expect(agent.state.messages).toEqual([{ ...originalUserMessage, content: rewrittenPrompt }]);
+		expect(warn).toHaveBeenCalledWith("Retrying classifier refusal with paraphrased user prompt", {
+			model: "mock/refusal-paraphraser",
+			originalLength: originalUserMessage.content.length,
+			paraphrasedLength: rewrittenPrompt.length,
+		});
 	});
 
-	it("leaves a refusal on the existing path when the setting is disabled", async () => {
-		const { recovery, paraphraseModel, events, scheduled, agent } = createRecovery(false);
+	for (const stopReason of ["length", "aborted", "error"] as const) {
+		it(`does not replace context from a ${stopReason} paraphrase response`, async () => {
+			const { recovery, events, scheduled, agent, sessionManager } = createRecovery({ stopReason });
+
+			expect(await recovery.handleRetryableError(refusal)).toBe(false);
+			expect(agent.state.messages).toEqual([originalUserMessage, refusal]);
+			expect(sessionManager.buildSessionContext().messages).toEqual([originalUserMessage]);
+			expect(events).toEqual([]);
+			expect(scheduled).toEqual([]);
+		});
+	}
+
+	it("does not paraphrase when the retry budget is exhausted", async () => {
+		const { recovery, paraphraseModel, agent } = createRecovery({ maxRetries: 0 });
 
 		expect(await recovery.handleRetryableError(refusal)).toBe(false);
-
 		expect(paraphraseModel.calls).toHaveLength(0);
-		expect(agent.state.messages).toHaveLength(2);
-		expect(events).toEqual([]);
-		expect(scheduled).toEqual([]);
+		expect(agent.state.messages).toEqual([originalUserMessage, refusal]);
 	});
+
+	it("does not rewrite an older user turn behind a synthetic developer trigger", async () => {
+		const { recovery, paraphraseModel, agent } = createRecovery();
+		const syntheticPrompt = { role: "developer" as const, content: "Continue the guided task.", timestamp: 3 };
+		const syntheticRefusal = { ...refusal, timestamp: 4 };
+		agent.replaceMessages([originalUserMessage, syntheticPrompt, syntheticRefusal]);
+
+		expect(await recovery.handleRetryableError(syntheticRefusal)).toBe(false);
+		expect(paraphraseModel.calls).toHaveLength(0);
+		expect(agent.state.messages).toEqual([originalUserMessage, syntheticPrompt, syntheticRefusal]);
+	});
+
+	it("honours an abort that lands during the persistence wait, before branch mutation and scheduling", async () => {
+		let releasePersistence: (() => void) | undefined;
+		let signalEnteredPersistence: (() => void) | undefined;
+		const persistenceBlocked = new Promise<void>(resolve => {
+			releasePersistence = resolve;
+		});
+		const enteredPersistence = new Promise<void>(resolve => {
+			signalEnteredPersistence = resolve;
+		});
+		const { recovery, agent, sessionManager, events, scheduled } = createRecovery({
+			waitForSessionMessagePersistence: async () => {
+				signalEnteredPersistence?.();
+				await persistenceBlocked;
+			},
+		});
+
+		const pending = recovery.handleRetryableError(refusal);
+		// Wait until the paraphrase call has resolved and the recovery has parked
+		// on the persistence wait — the exact window where Escape must still cancel.
+		await enteredPersistence;
+		recovery.abortRetry();
+		releasePersistence?.();
+
+		expect(await pending).toBe(false);
+		// No persisted branch rewrite and no scheduled continuation.
+		expect(agent.state.messages).toEqual([originalUserMessage, refusal]);
+		expect(sessionManager.buildSessionContext().messages).toEqual([originalUserMessage]);
+		expect(scheduled).toEqual([]);
+		expect(events.map(event => event.type)).not.toContain("refusal_paraphrase_applied");
+	});
+
+	for (const abortDuring of ["refusal_paraphrase_applied", "auto_retry_start"] as const) {
+		it(`commits atomically when Escape lands during ${abortDuring} delivery`, async () => {
+			const delivery = Promise.withResolvers<void>();
+			const enteredDelivery = Promise.withResolvers<void>();
+			const { recovery, agent, sessionManager, events, scheduled } = createRecovery({
+				onSessionEvent: async event => {
+					if (event.type !== abortDuring) return;
+					enteredDelivery.resolve();
+					await delivery.promise;
+				},
+			});
+
+			const pending = recovery.handleRetryableError(refusal);
+			await enteredDelivery.promise;
+			recovery.abortRetry();
+			delivery.resolve();
+
+			expect(await pending).toBe(true);
+			expect(agent.state.messages).toEqual([{ ...originalUserMessage, content: rewrittenPrompt }]);
+			expect(sessionManager.buildSessionContext().messages).toEqual(agent.state.messages);
+			expect(events.map(event => event.type)).toEqual(["refusal_paraphrase_applied", "auto_retry_start"]);
+			expect(recovery.retryPromise).toBeDefined();
+			expect(scheduled).toEqual([expect.objectContaining({ delayMs: 1, generation: 1 })]);
+		});
+	}
 });

--- a/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
+++ b/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
@@ -66,6 +66,8 @@ describe("TurnRecovery refusal paraphrase", () => {
 			paraphraseRole?: "tiny" | "smol";
 			configuredSmolRole?: string;
 			extraAvailableModels?: MockModel[];
+			modelFallback?: boolean;
+			fallbackChains?: Record<string, string[]>;
 		} = {},
 	): {
 		recovery: TurnRecovery;
@@ -74,6 +76,7 @@ describe("TurnRecovery refusal paraphrase", () => {
 		scheduled: Parameters<TurnRecoveryHost["scheduleAgentContinue"]>[0][];
 		agent: Agent;
 		sessionManager: SessionManager;
+		modelRegistry: ModelRegistry;
 	} {
 		const primaryModel = createMockModel({ provider: "anthropic", id: "claude-opus-5" });
 		const paraphraseModel = createMockModel({
@@ -98,9 +101,10 @@ describe("TurnRecovery refusal paraphrase", () => {
 		});
 		agent.setMetadataResolver(() => ({ account_uuid: "selected-account" }));
 		const settings = Settings.isolated({
-			"retry.modelFallback": false,
+			"retry.modelFallback": options.modelFallback ?? false,
 			"retry.refusalParaphrase": true,
 			"retry.maxRetries": options.maxRetries ?? 10,
+			"retry.fallbackChains": options.fallbackChains ?? {},
 		});
 		if (options.paraphraseRole) settings.set("retry.refusalParaphraseRole", options.paraphraseRole);
 		if (options.configuredSmolRole) {
@@ -155,7 +159,15 @@ describe("TurnRecovery refusal paraphrase", () => {
 			runAutoCompaction: async () => ({ deferredHandoff: false, continuationScheduled: false }),
 			withBashBranchTransition: operation => operation(),
 		};
-		return { recovery: new TurnRecovery(host), paraphraseModel, events, scheduled, agent, sessionManager };
+		return {
+			recovery: new TurnRecovery(host),
+			paraphraseModel,
+			events,
+			scheduled,
+			agent,
+			sessionManager,
+			modelRegistry,
+		};
 	}
 
 	it("persists a successful rewrite and retains its provider attribution", async () => {
@@ -187,6 +199,29 @@ describe("TurnRecovery refusal paraphrase", () => {
 			expect(scheduled).toEqual([]);
 		});
 	}
+	it("stops recovery instead of falling through to model fallback when paraphrase cancellation is requested", async () => {
+		const fallbackModel = createMockModel({ provider: "mock", id: "fallback-model" });
+		let recovery!: TurnRecovery;
+		const setup = createRecovery({
+			modelFallback: true,
+			fallbackChains: { "anthropic/claude-opus-5": ["mock/fallback-model"] },
+			extraAvailableModels: [fallbackModel],
+			// Simulate Escape / abort_retry during the paraphrase persistence
+			// wait, after the paraphrase controller has become the active retry
+			// controller.
+			waitForSessionMessagePersistence: async () => {
+				recovery.abortRetry();
+			},
+		});
+		recovery = setup.recovery;
+		vi.spyOn(setup.modelRegistry, "find").mockImplementation((provider, id) =>
+			provider === "mock" && id === "fallback-model" ? fallbackModel : undefined,
+		);
+
+		expect(await recovery.handleRetryableError(refusal)).toBe(false);
+		expect(setup.paraphraseModel.calls).toHaveLength(1);
+		expect(setup.scheduled).toEqual([]);
+	});
 
 	it("does not paraphrase when the retry budget is exhausted", async () => {
 		const { recovery, paraphraseModel, agent } = createRecovery({ maxRetries: 0 });
@@ -223,11 +258,26 @@ describe("TurnRecovery refusal paraphrase", () => {
 		expect(await recovery.handleRetryableError(companionRefusal)).toBe(true);
 		expect(paraphraseModel.calls).toHaveLength(1);
 		expect(agent.state.messages).toEqual([{ ...originalUserMessage, content: rewrittenPrompt }, companion]);
-		// The replacement branch must recreate the post-user companion so a
-		// reload/transcript rebuild keeps the same context the live retry sees.
+		// The replacement branch must recreate the post-user companion as a
+		// custom_message entry (not a generic message) so type-based consumers
+		// (custom-message branch editing, tree rendering) still recognize it on
+		// reload/transcript rebuild, and normalization runs on it. A fresh entry
+		// timestamp is inherent to the custom-message path, so match the
+		// companion's observable fields rather than object identity.
+		expect(
+			sessionManager
+				.getBranch()
+				.some(entry => entry.type === "custom_message" && entry.customType === "before-agent-start"),
+		).toBe(true);
 		expect(sessionManager.buildSessionContext().messages).toEqual([
 			{ ...originalUserMessage, content: rewrittenPrompt },
-			companion,
+			expect.objectContaining({
+				role: "custom",
+				customType: "before-agent-start",
+				content: "Extra turn context.",
+				display: false,
+				attribution: "agent",
+			}),
 		]);
 	});
 

--- a/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
+++ b/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session-events";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TurnRecovery, type TurnRecoveryHost } from "@oh-my-pi/pi-coding-agent/session/turn-recovery";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const refusal: AssistantMessage = {
+	role: "assistant",
+	content: [],
+	api: "mock",
+	provider: "anthropic",
+	model: "claude-opus-5",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "error",
+	stopDetails: { type: "refusal", category: "cyber", explanation: "Classifier declined." },
+	errorMessage: "Refusal (cyber): Classifier declined.",
+	timestamp: 2,
+};
+
+describe("TurnRecovery refusal paraphrase", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@turn-recovery-paraphrase-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("mock", "mock-test-key");
+		registerMockApi();
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	function createRecovery(enabled: boolean): {
+		recovery: TurnRecovery;
+		paraphraseModel: MockModel;
+		events: AgentSessionEvent[];
+		scheduled: Parameters<TurnRecoveryHost["scheduleAgentContinue"]>[0][];
+		agent: Agent;
+	} {
+		const primaryModel = createMockModel({ provider: "anthropic", id: "claude-opus-5" });
+		const paraphraseModel = createMockModel({
+			id: "refusal-paraphraser",
+			responses: [{ content: ["Explain the request in neutral, legitimate terms."] }],
+		});
+		const agent = new Agent({
+			getApiKey: () => "primary-test-key",
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [{ role: "user", content: "Explain how to bypass the classifier.", timestamp: 1 }, refusal],
+			},
+			streamFn: primaryModel.stream,
+		});
+		const settings = Settings.isolated({
+			"retry.modelFallback": false,
+			"retry.refusalParaphrase": enabled,
+		});
+		settings.setModelRole("smol", "mock/refusal-paraphraser");
+		const modelRegistry = new ModelRegistry(authStorage);
+		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([paraphraseModel]);
+		const events: AgentSessionEvent[] = [];
+		const scheduled: Parameters<TurnRecoveryHost["scheduleAgentContinue"]>[0][] = [];
+		const host: TurnRecoveryHost = {
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			configWarnings: [],
+			model: () => primaryModel,
+			thinkingLevel: () => undefined,
+			configuredThinkingLevel: () => undefined,
+			setThinkingLevel: () => {},
+			thinkingLevelCeiling: () => undefined,
+			isDisposed: () => false,
+			isStreaming: () => false,
+			isCompacting: () => false,
+			abortInProgress: () => false,
+			streamingEditAbortTriggered: () => false,
+			promptGeneration: () => 1,
+			sessionId: () => "refusal-paraphrase-test",
+			emitSessionEvent: async event => {
+				events.push(event);
+			},
+			scheduleAgentContinue: options => {
+				scheduled.push(options);
+			},
+			waitForSessionMessagePersistence: async () => {},
+			appendSessionMessage: () => {},
+			sessionMessageAlreadyPersisted: () => false,
+			setModelWithProviderSessionReset: async () => {},
+			resetCurrentResponsesProviderSession: () => {},
+			maybeAutoRedeemCodexReset: async () => false,
+			runAutoCompaction: async () => ({ deferredHandoff: false, continuationScheduled: false }),
+			withBashBranchTransition: operation => operation(),
+		};
+		return { recovery: new TurnRecovery(host), paraphraseModel, events, scheduled, agent };
+	}
+
+	it("retries a refusal once with a rewritten user message and emits both texts", async () => {
+		const { recovery, paraphraseModel, events, scheduled, agent } = createRecovery(true);
+
+		expect(await recovery.handleRetryableError(refusal)).toBe(true);
+
+		expect(paraphraseModel.calls).toHaveLength(1);
+		expect(paraphraseModel.calls[0]?.context.messages).toEqual([
+			{ role: "user", content: "Explain how to bypass the classifier.", timestamp: expect.any(Number) },
+		]);
+		expect(agent.state.messages).toEqual([
+			{ role: "user", content: "Explain the request in neutral, legitimate terms.", timestamp: 1 },
+		]);
+		expect(events).toEqual([
+			{
+				type: "refusal_paraphrase_applied",
+				originalText: "Explain how to bypass the classifier.",
+				paraphrasedText: "Explain the request in neutral, legitimate terms.",
+			},
+			{
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 10,
+				delayMs: 0,
+				errorMessage: "Refusal (cyber): Classifier declined.",
+				errorId: undefined,
+			},
+		]);
+		expect(scheduled).toEqual([{ delayMs: 1, generation: 1, onError: expect.any(Function) }]);
+	});
+
+	it("leaves a refusal on the existing path when the setting is disabled", async () => {
+		const { recovery, paraphraseModel, events, scheduled, agent } = createRecovery(false);
+
+		expect(await recovery.handleRetryableError(refusal)).toBe(false);
+
+		expect(paraphraseModel.calls).toHaveLength(0);
+		expect(agent.state.messages).toHaveLength(2);
+		expect(events).toEqual([]);
+		expect(scheduled).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
+++ b/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
@@ -57,6 +57,12 @@ describe("TurnRecovery refusal paraphrase", () => {
 			stopReason?: "length" | "aborted" | "error";
 			waitForSessionMessagePersistence?: (message: AssistantMessage) => Promise<void>;
 			onSessionEvent?: (event: AgentSessionEvent) => Promise<void>;
+			paraphrasedText?: string;
+			useSmolPriorityDefault?: boolean;
+			paraphraseModelId?: string;
+			paraphraseModelProvider?: string;
+			obfuscateTextForProvider?: (text: string) => string;
+			deobfuscateFromProvider?: (text: string) => string;
 		} = {},
 	): {
 		recovery: TurnRecovery;
@@ -68,11 +74,12 @@ describe("TurnRecovery refusal paraphrase", () => {
 	} {
 		const primaryModel = createMockModel({ provider: "anthropic", id: "claude-opus-5" });
 		const paraphraseModel = createMockModel({
-			id: "refusal-paraphraser",
+			id: options.paraphraseModelId ?? "refusal-paraphraser",
+			provider: options.paraphraseModelProvider,
 			responses: [
 				options.stopReason
 					? { content: ["partial rewrite"], stopReason: options.stopReason }
-					: { content: [rewrittenPrompt] },
+					: { content: [options.paraphrasedText ?? rewrittenPrompt] },
 			],
 		});
 		const userMessage = { ...originalUserMessage };
@@ -92,7 +99,9 @@ describe("TurnRecovery refusal paraphrase", () => {
 			"retry.refusalParaphrase": true,
 			"retry.maxRetries": options.maxRetries ?? 10,
 		});
-		settings.setModelRole("smol", "mock/refusal-paraphraser");
+		if (!options.useSmolPriorityDefault) {
+			settings.setModelRole("smol", `mock/${options.paraphraseModelId ?? "refusal-paraphraser"}`);
+		}
 		const modelRegistry = new ModelRegistry(authStorage);
 		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([paraphraseModel]);
 		const events: AgentSessionEvent[] = [];
@@ -117,6 +126,8 @@ describe("TurnRecovery refusal paraphrase", () => {
 			streamingEditAbortTriggered: () => false,
 			promptGeneration: () => 1,
 			sessionId: () => "refusal-paraphrase-test",
+			obfuscateTextForProvider: options.obfuscateTextForProvider ?? (text => text),
+			deobfuscateFromProvider: options.deobfuscateFromProvider ?? (text => text),
 			emitSessionEvent: async event => {
 				events.push(event);
 				await options.onSessionEvent?.(event);
@@ -187,28 +198,67 @@ describe("TurnRecovery refusal paraphrase", () => {
 		expect(agent.state.messages).toEqual([originalUserMessage, syntheticPrompt, syntheticRefusal]);
 	});
 
+	it("rewrites the user turn when companion messages precede the refusal", async () => {
+		const { recovery, paraphraseModel, agent } = createRecovery();
+		const companion = {
+			role: "custom" as const,
+			customType: "before-agent-start",
+			content: "Extra turn context.",
+			display: false,
+			attribution: "agent" as const,
+			timestamp: 3,
+		};
+		const companionRefusal = { ...refusal, timestamp: 4 };
+		agent.replaceMessages([originalUserMessage, companion, companionRefusal]);
+
+		expect(await recovery.handleRetryableError(companionRefusal)).toBe(true);
+		expect(paraphraseModel.calls).toHaveLength(1);
+		expect(agent.state.messages).toEqual([{ ...originalUserMessage, content: rewrittenPrompt }, companion]);
+	});
+
+	it("obfuscates the paraphrase request and restores the rewritten response", async () => {
+		const { recovery, paraphraseModel, agent } = createRecovery({
+			paraphrasedText: "Explain <secret> in neutral terms.",
+			obfuscateTextForProvider: text => text.replace("classifier", "<secret>"),
+			deobfuscateFromProvider: text => text.replace("<secret>", "classifier"),
+		});
+
+		expect(await recovery.handleRetryableError(refusal)).toBe(true);
+		expect(paraphraseModel.calls[0]?.context.messages).toMatchObject([
+			{ role: "user", content: "Explain how to bypass the <secret>." },
+		]);
+		expect(agent.state.messages).toEqual([
+			{ ...originalUserMessage, content: "Explain classifier in neutral terms." },
+		]);
+	});
+
+	it("resolves an unset paraphrase role through @smol", async () => {
+		const { recovery, paraphraseModel } = createRecovery({
+			useSmolPriorityDefault: true,
+			paraphraseModelId: "zai-glm-4.7",
+			paraphraseModelProvider: "cerebras",
+		});
+
+		expect(await recovery.handleRetryableError(refusal)).toBe(true);
+		expect(paraphraseModel.calls).toHaveLength(1);
+	});
+
 	it("honours an abort that lands during the persistence wait, before branch mutation and scheduling", async () => {
-		let releasePersistence: (() => void) | undefined;
-		let signalEnteredPersistence: (() => void) | undefined;
-		const persistenceBlocked = new Promise<void>(resolve => {
-			releasePersistence = resolve;
-		});
-		const enteredPersistence = new Promise<void>(resolve => {
-			signalEnteredPersistence = resolve;
-		});
+		const persistenceBlocked = Promise.withResolvers<void>();
+		const enteredPersistence = Promise.withResolvers<void>();
 		const { recovery, agent, sessionManager, events, scheduled } = createRecovery({
 			waitForSessionMessagePersistence: async () => {
-				signalEnteredPersistence?.();
-				await persistenceBlocked;
+				enteredPersistence.resolve();
+				await persistenceBlocked.promise;
 			},
 		});
 
 		const pending = recovery.handleRetryableError(refusal);
 		// Wait until the paraphrase call has resolved and the recovery has parked
 		// on the persistence wait — the exact window where Escape must still cancel.
-		await enteredPersistence;
+		await enteredPersistence.promise;
 		recovery.abortRetry();
-		releasePersistence?.();
+		persistenceBlocked.resolve();
 
 		expect(await pending).toBe(false);
 		// No persisted branch rewrite and no scheduled continuation.
@@ -239,7 +289,7 @@ describe("TurnRecovery refusal paraphrase", () => {
 			expect(agent.state.messages).toEqual([{ ...originalUserMessage, content: rewrittenPrompt }]);
 			expect(sessionManager.buildSessionContext().messages).toEqual(agent.state.messages);
 			expect(events.map(event => event.type)).toEqual(["refusal_paraphrase_applied", "auto_retry_start"]);
-			expect(recovery.retryPromise).toBeDefined();
+			expect(recovery.retryPromise).toBeUndefined();
 			expect(scheduled).toEqual([expect.objectContaining({ delayMs: 1, generation: 1 })]);
 		});
 	}

--- a/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
+++ b/packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts
@@ -63,6 +63,9 @@ describe("TurnRecovery refusal paraphrase", () => {
 			paraphraseModelProvider?: string;
 			obfuscateTextForProvider?: (text: string) => string;
 			deobfuscateFromProvider?: (text: string) => string;
+			paraphraseRole?: "tiny" | "smol";
+			configuredSmolRole?: string;
+			extraAvailableModels?: MockModel[];
 		} = {},
 	): {
 		recovery: TurnRecovery;
@@ -99,11 +102,17 @@ describe("TurnRecovery refusal paraphrase", () => {
 			"retry.refusalParaphrase": true,
 			"retry.maxRetries": options.maxRetries ?? 10,
 		});
-		if (!options.useSmolPriorityDefault) {
+		if (options.paraphraseRole) settings.set("retry.refusalParaphraseRole", options.paraphraseRole);
+		if (options.configuredSmolRole) {
+			settings.setModelRole("smol", options.configuredSmolRole);
+		} else if (!options.useSmolPriorityDefault) {
 			settings.setModelRole("smol", `mock/${options.paraphraseModelId ?? "refusal-paraphraser"}`);
 		}
 		const modelRegistry = new ModelRegistry(authStorage);
-		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([paraphraseModel]);
+		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([
+			paraphraseModel,
+			...(options.extraAvailableModels ?? []),
+		]);
 		const events: AgentSessionEvent[] = [];
 		const scheduled: Parameters<TurnRecoveryHost["scheduleAgentContinue"]>[0][] = [];
 		const sessionManager = SessionManager.inMemory();
@@ -199,7 +208,7 @@ describe("TurnRecovery refusal paraphrase", () => {
 	});
 
 	it("rewrites the user turn when companion messages precede the refusal", async () => {
-		const { recovery, paraphraseModel, agent } = createRecovery();
+		const { recovery, paraphraseModel, agent, sessionManager } = createRecovery();
 		const companion = {
 			role: "custom" as const,
 			customType: "before-agent-start",
@@ -214,6 +223,12 @@ describe("TurnRecovery refusal paraphrase", () => {
 		expect(await recovery.handleRetryableError(companionRefusal)).toBe(true);
 		expect(paraphraseModel.calls).toHaveLength(1);
 		expect(agent.state.messages).toEqual([{ ...originalUserMessage, content: rewrittenPrompt }, companion]);
+		// The replacement branch must recreate the post-user companion so a
+		// reload/transcript rebuild keeps the same context the live retry sees.
+		expect(sessionManager.buildSessionContext().messages).toEqual([
+			{ ...originalUserMessage, content: rewrittenPrompt },
+			companion,
+		]);
 	});
 
 	it("obfuscates the paraphrase request and restores the rewritten response", async () => {
@@ -241,6 +256,25 @@ describe("TurnRecovery refusal paraphrase", () => {
 
 		expect(await recovery.handleRetryableError(refusal)).toBe(true);
 		expect(paraphraseModel.calls).toHaveLength(1);
+	});
+
+	it("honours the configured paraphrase role alias instead of @smol when the role is unset", async () => {
+		// refusalParaphraseRole is `tiny`, but modelRoles.tiny is unset while
+		// modelRoles.smol is explicitly configured. The fallback must resolve the
+		// selected role's chain (@tiny -> MODEL_PRIO.smol), not @smol, so the
+		// user's choice of Tiny is not silently overridden by the smol role.
+		const smolConfiguredModel = createMockModel({ provider: "mock", id: "smol-explicit", responses: [] });
+		const { recovery, paraphraseModel } = createRecovery({
+			paraphraseRole: "tiny",
+			paraphraseModelId: "zai-glm-4.7",
+			paraphraseModelProvider: "cerebras",
+			configuredSmolRole: "mock/smol-explicit",
+			extraAvailableModels: [smolConfiguredModel],
+		});
+
+		expect(await recovery.handleRetryableError(refusal)).toBe(true);
+		expect(paraphraseModel.calls).toHaveLength(1);
+		expect(smolConfiguredModel.calls).toHaveLength(0);
 	});
 
 	it("honours an abort that lands during the persistence wait, before branch mutation and scheduling", async () => {


### PR DESCRIPTION
## Summary

- Adds an opt-in `retry.refusalParaphrase` setting that handles false-positive Anthropic classifier refusals by rewording the triggering user prompt via a dedicated lightweight model before attempting a single same-model retry.
- Bounds paraphrase recovery to exactly one attempt per turn, respecting overall retry attempt limits and falling back to standard model fallback if the paraphrased prompt is also refused or fails to complete cleanly.
- Ensures atomic branch state rewrites and complete cancellation support up to and across the branch commit point.
- Emits dedicated session events (`refusal_paraphrase_applied` and `auto_retry_start`) so prompt mutations are transparently logged and surfaced in UI and RPC controllers.

## What changed

- **Settings & Configuration**: Added `retry.refusalParaphrase` (boolean, default `false`) and `retry.refusalParaphraseRole` (enum: `"tiny"` | `"smol"`, default `"smol"`) under the `Retry & Fallback` configuration group.
- **Turn Recovery Integration**: Intercepts Anthropic classifier refusals (`stopDetails.type` of `"refusal"` or `"sensitive"`) in `TurnRecovery.handleRetryableError()` when paraphrase retry is enabled and the turn retry budget is not exhausted.
- **Paraphrase Execution**: Requests a prompt rephrase via `completeSimple` using system instructions from `refusal-paraphrase.md`, bounded max tokens, `disableReasoning: true`, and session/provider metadata. Skips prompt mutation if completion yields non-stop stop reasons (`length`, `aborted`, `error`), empty text, or an execution error.
- **Atomic Branch & Message Mutation**: Identifies the user turn directly preceding the assistant refusal, awaits assistant message persistence, and uses `withBashBranchTransition` to atomically update the session branch leaf, append the paraphrased user message, update in-memory agent messages, and remove the assistant refusal from active context.
- **Cancellation & Lifecycle Safety**: Checks abort signals before model execution, after completion, and during persistence wait windows. Exits cleanly without mutating session state if aborted before commit. Once committed, cancellation during event dispatch preserves the committed branch and scheduled continuation.
- **Event Notification**: Emits `refusal_paraphrase_applied` (with original and paraphrased prompt text) and `auto_retry_start` events to surface user-facing warnings and maintain consistent retry lifecycle state.

## Verification

- `packages/coding-agent/test/turn-recovery-refusal-paraphrase.test.ts`
- `packages/coding-agent/test/agent-session-retry-fallback.test.ts`

## Notes

- Refusal paraphrase is disabled by default (`retry.refusalParaphrase: false`), retaining byte-identical default recovery behavior. User prompts are only rewritten when explicitly enabled.
