### PR TITLE
perf(coding-agent): stabilize the system-prompt cache prefix

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Agent provider contexts now carry the stable system-prompt prefix boundary, preserving explicit cache placement through normal, side-channel, and append-only calls.
+
 ## [17.1.7] - 2026-07-27
 
 ### Changed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1511,6 +1511,7 @@ async function prepareProviderCall(
 	} else {
 		llmContext = {
 			systemPrompt: context.systemPrompt,
+			stableSystemPromptBlockCount: context.stableSystemPromptBlockCount,
 			messages: normalizedMessages,
 			tools: normalizeTools(context.tools, !!config.intentTracing, exampleDialect, pruneToolDescriptions),
 		};

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -756,14 +756,18 @@ export class Agent {
 	 * shape and avoiding tool-markup leakage). `llmMessages` is already converted
 	 * (and, in production, obfuscated) by the caller.
 	 *
-	 * `systemPrompt` defaults to the live agent prompt so the side request hits the
-	 * same cached prefix as the main loop. Callers that must pin a different prompt
-	 * (e.g. handoff generation, which uses the base prompt rather than a per-turn
-	 * `before_agent_start` hook override) pass it explicitly.
+	 * `prompt` defaults to the live agent state so the side request hits the
+	 * same cached prefix as the main loop. Callers that must pin a different
+	 * prompt (e.g. handoff generation, which uses the base prompt plan rather
+	 * than a per-turn `before_agent_start` hook override) pass it explicitly;
+	 * both `systemPrompt` and `stableSystemPromptBlockCount` are carried
+	 * structurally so the declared cache breakpoint survives regardless of
+	 * whether the prompt array is the live state's own reference.
 	 */
 	async buildSideRequestContext(
 		llmMessages: Message[],
-		systemPrompt: string[] = this.#state.systemPrompt,
+		prompt: Pick<AgentContext, "systemPrompt" | "stableSystemPromptBlockCount"> = this.#state,
+		options?: { anthropicBillingSeed?: string },
 	): Promise<Context> {
 		const model = this.#state.model;
 		if (!model) throw new Error("No active model on agent");
@@ -778,9 +782,9 @@ export class Agent {
 					this.#pruneToolDescriptions,
 				) ?? []);
 		let context: Context = {
-			systemPrompt,
-			stableSystemPromptBlockCount:
-				systemPrompt === this.#state.systemPrompt ? this.#state.stableSystemPromptBlockCount : undefined,
+			systemPrompt: prompt.systemPrompt,
+			stableSystemPromptBlockCount: prompt.stableSystemPromptBlockCount,
+			...(options?.anthropicBillingSeed !== undefined && { anthropicBillingSeed: options.anthropicBillingSeed }),
 			messages,
 			tools,
 		};

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -777,7 +777,13 @@ export class Agent {
 					preferredDialect(model.id),
 					this.#pruneToolDescriptions,
 				) ?? []);
-		let context: Context = { systemPrompt, messages, tools };
+		let context: Context = {
+			systemPrompt,
+			stableSystemPromptBlockCount:
+				systemPrompt === this.#state.systemPrompt ? this.#state.stableSystemPromptBlockCount : undefined,
+			messages,
+			tools,
+		};
 		if (this.#transformProviderContext) context = await this.#transformProviderContext(context, model);
 		return context;
 	}
@@ -865,8 +871,9 @@ export class Agent {
 	}
 
 	// State mutators
-	setSystemPrompt(v: string[] | string) {
+	setSystemPrompt(v: string[] | string, stableSystemPromptBlockCount?: number) {
 		this.#state.systemPrompt = typeof v === "string" ? [v] : v;
+		this.#state.stableSystemPromptBlockCount = stableSystemPromptBlockCount;
 	}
 
 	setModel(m: Model) {
@@ -1211,6 +1218,7 @@ export class Agent {
 
 		const context: AgentContext = {
 			systemPrompt: this.#state.systemPrompt,
+			stableSystemPromptBlockCount: this.#state.stableSystemPromptBlockCount,
 			messages: this.#state.messages.slice(),
 			tools: this.#state.tools,
 		};
@@ -1323,6 +1331,7 @@ export class Agent {
 					await Bun.sleep(0);
 				}
 				context.systemPrompt = this.#state.systemPrompt;
+				context.stableSystemPromptBlockCount = this.#state.stableSystemPromptBlockCount;
 				context.tools = this.#toolsForModel(this.#state.model ?? model);
 			},
 			beforeModelCall:

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -766,7 +766,7 @@ export class Agent {
 	 */
 	async buildSideRequestContext(
 		llmMessages: Message[],
-		prompt: Pick<AgentContext, "systemPrompt" | "stableSystemPromptBlockCount"> = this.#state,
+		prompt: string[] | Pick<AgentContext, "systemPrompt" | "stableSystemPromptBlockCount"> = this.#state,
 		options?: { anthropicBillingSeed?: string },
 	): Promise<Context> {
 		const model = this.#state.model;
@@ -781,9 +781,15 @@ export class Agent {
 					preferredDialect(model.id),
 					this.#pruneToolDescriptions,
 				) ?? []);
+		// Preserve the previous array form: existing SDK callers may pass a bare
+		// prompt array. Normalize it into a plan so the cache boundary carries
+		// instead of silently becoming undefined.
+		const promptPlan: Pick<AgentContext, "systemPrompt" | "stableSystemPromptBlockCount"> = Array.isArray(prompt)
+			? { systemPrompt: prompt }
+			: prompt;
 		let context: Context = {
-			systemPrompt: prompt.systemPrompt,
-			stableSystemPromptBlockCount: prompt.stableSystemPromptBlockCount,
+			systemPrompt: promptPlan.systemPrompt,
+			stableSystemPromptBlockCount: promptPlan.stableSystemPromptBlockCount,
 			...(options?.anthropicBillingSeed !== undefined && { anthropicBillingSeed: options.anthropicBillingSeed }),
 			messages,
 			tools,

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -69,6 +69,8 @@ export class StablePrefix {
 	build(context: AgentContext, options: BuildOptions): boolean {
 		const snapshot = takeSnapshot(context, options);
 		if (this.#snapshot && this.#snapshot.fingerprint === snapshot.fingerprint) {
+			this.#snapshot.systemPrompt = snapshot.systemPrompt;
+			this.#snapshot.stableSystemPromptBlockCount = snapshot.stableSystemPromptBlockCount;
 			return false;
 		}
 		this.#snapshot = snapshot;
@@ -327,13 +329,20 @@ function takeSnapshot(context: AgentContext, options: BuildOptions): StablePrefi
 		systemPrompt,
 		stableSystemPromptBlockCount: context.stableSystemPromptBlockCount,
 		tools,
-		fingerprint: computeFingerprint(systemPrompt, tools, options),
+		fingerprint: computeFingerprint(systemPrompt, tools, options, context.stableSystemPromptBlockCount),
 	};
 }
 
-function computeFingerprint(systemPrompt: string[], tools: Tool[], options: BuildOptions): string {
+function computeFingerprint(
+	systemPrompt: string[],
+	tools: Tool[],
+	options: BuildOptions,
+	stableSystemPromptBlockCount?: number,
+): string {
+	const stableSystemPrompt =
+		stableSystemPromptBlockCount === undefined ? systemPrompt : systemPrompt.slice(0, stableSystemPromptBlockCount);
 	const payload = JSON.stringify({
-		s: systemPrompt,
+		s: stableSystemPrompt,
 		t: tools.map(t => ({
 			n: t.name,
 			d: t.description,
@@ -342,6 +351,7 @@ function computeFingerprint(systemPrompt: string[], tools: Tool[], options: Buil
 			cf: t.customFormat,
 			cw: t.customWireName,
 		})),
+		b: stableSystemPromptBlockCount ?? null,
 		i: options.intentTracing,
 		ex: options.exampleDialect,
 		pd: options.pruneToolDescriptions,

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -26,6 +26,7 @@ import type { AgentContext } from "./types";
 /** Frozen system prompt + tool spec snapshot. */
 export interface StablePrefixSnapshot {
 	systemPrompt: string[];
+	stableSystemPromptBlockCount?: number;
 	tools: Tool[];
 	fingerprint: string;
 }
@@ -84,10 +85,14 @@ export class StablePrefix {
 	 * Returns the cached prefix.
 	 * @throws if `build()` was never called.
 	 */
-	toContext(): { systemPrompt: string[]; tools: Tool[] } {
+	toContext(): { systemPrompt: string[]; stableSystemPromptBlockCount?: number; tools: Tool[] } {
 		const s = this.#snapshot;
 		if (!s) throw new Error("StablePrefix.toContext() called before build()");
-		return { systemPrompt: s.systemPrompt, tools: s.tools };
+		return {
+			systemPrompt: s.systemPrompt,
+			stableSystemPromptBlockCount: s.stableSystemPromptBlockCount,
+			tools: s.tools,
+		};
 	}
 }
 
@@ -182,8 +187,8 @@ export class AppendOnlyContextManager {
 
 	build(context: AgentContext, options: BuildOptions): Context {
 		this.prefix.build(context, options);
-		const { systemPrompt, tools } = this.prefix.toContext();
-		return { systemPrompt, messages: this.log.toMessages(), tools };
+		const { systemPrompt, stableSystemPromptBlockCount, tools } = this.prefix.toContext();
+		return { systemPrompt, stableSystemPromptBlockCount, messages: this.log.toMessages(), tools };
 	}
 
 	/**
@@ -320,6 +325,7 @@ function takeSnapshot(context: AgentContext, options: BuildOptions): StablePrefi
 		normalizeTools(context.tools, options.intentTracing, options.exampleDialect, options.pruneToolDescriptions) ?? [];
 	return {
 		systemPrompt,
+		stableSystemPromptBlockCount: context.stableSystemPromptBlockCount,
 		tools,
 		fingerprint: computeFingerprint(systemPrompt, tools, options),
 	};

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -651,6 +651,8 @@ export type AgentMessage = Message | CustomAgentMessages[keyof CustomAgentMessag
  */
 export interface AgentState {
 	systemPrompt: string[];
+	/** Leading system-prompt blocks that can retain an explicit provider cache breakpoint. */
+	stableSystemPromptBlockCount?: number;
 	model: Model;
 	thinkingLevel?: Effort;
 	disableReasoning?: boolean;
@@ -830,6 +832,7 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 // AgentContext is like Context but uses AgentTool
 export interface AgentContext {
 	systemPrompt: string[];
+	stableSystemPromptBlockCount?: number;
 	messages: AgentMessage[];
 	tools?: AgentTool<any>[];
 }

--- a/packages/agent/test/agent-side-request-context.test.ts
+++ b/packages/agent/test/agent-side-request-context.test.ts
@@ -202,4 +202,44 @@ describe("Agent — buildSideRequestContext", () => {
 		expect(transformSpy).toHaveBeenCalledTimes(1);
 		expect(context.systemPrompt).toEqual(["transformed-system"]);
 	});
+
+	it("preserves the declared cache boundary for an explicitly passed prompt", async () => {
+		// Models the handoff path: a freshly allocated prompt plan (a separate
+		// array, not the agent's live state reference) carries its own cache
+		// breakpoint structurally — no array-reference identity comparison.
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["live-turn-prompt"],
+				stableSystemPromptBlockCount: 3,
+				tools: [tool],
+			},
+		});
+
+		const context = await agent.buildSideRequestContext(
+			[{ role: "user", content: [{ type: "text", text: "Q?" }], timestamp: Date.now() }],
+			{ systemPrompt: ["base-prompt"], stableSystemPromptBlockCount: 1 },
+		);
+
+		expect(context.systemPrompt).toEqual(["base-prompt"]);
+		expect(context.stableSystemPromptBlockCount).toBe(1);
+	});
+
+	it("inherits the live cache boundary for argument-less side requests", async () => {
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["live-prompt"],
+				stableSystemPromptBlockCount: 2,
+				tools: [tool],
+			},
+		});
+
+		const context = await agent.buildSideRequestContext([
+			{ role: "user", content: [{ type: "text", text: "Q?" }], timestamp: Date.now() },
+		]);
+
+		expect(context.systemPrompt).toEqual(["live-prompt"]);
+		expect(context.stableSystemPromptBlockCount).toBe(2);
+	});
 });

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -146,6 +146,66 @@ describe("StablePrefix", () => {
 		p.build(makeContext({ systemPrompt: ["V2"] }), BUILD_OPTS);
 		expect(p.version).toBe(2); // unchanged = no increment
 	});
+	it("rebuilds, increments version, and changes fingerprint when only stableSystemPromptBlockCount changes", () => {
+		const p = new StablePrefix();
+		const base = { systemPrompt: ["Hello"], tools: [makeTool("read")] };
+
+		p.build(makeContext({ ...base, stableSystemPromptBlockCount: 1 }), BUILD_OPTS);
+		const fp1 = p.fingerprint;
+		expect(p.version).toBe(1);
+		expect(p.toContext().stableSystemPromptBlockCount).toBe(1);
+
+		const changed2 = p.build(makeContext({ ...base, stableSystemPromptBlockCount: 2 }), BUILD_OPTS);
+		expect(changed2).toBe(true);
+		const fp2 = p.fingerprint;
+		expect(fp2).not.toBe(fp1);
+		expect(p.version).toBe(2);
+		expect(p.toContext().stableSystemPromptBlockCount).toBe(2);
+
+		const changed3 = p.build(makeContext({ ...base, stableSystemPromptBlockCount: undefined }), BUILD_OPTS);
+		expect(changed3).toBe(true);
+		expect(p.fingerprint).not.toBe(fp2);
+		expect(p.version).toBe(3);
+		expect(p.toContext().stableSystemPromptBlockCount).toBeUndefined();
+	});
+	it("keeps prefix stable and updates the volatile system-prompt suffix", () => {
+		const p = new StablePrefix();
+		const tools = [makeTool("read")];
+
+		p.build(
+			makeContext({ systemPrompt: ["Stable", "Volatile A"], stableSystemPromptBlockCount: 1, tools }),
+			BUILD_OPTS,
+		);
+		const fp = p.fingerprint;
+		const version = p.version;
+
+		const changed = p.build(
+			makeContext({ systemPrompt: ["Stable", "Volatile B"], stableSystemPromptBlockCount: 1, tools }),
+			BUILD_OPTS,
+		);
+		expect(changed).toBe(false);
+		expect(p.version).toBe(version);
+		expect(p.fingerprint).toBe(fp);
+		expect(p.toContext().systemPrompt).toEqual(["Stable", "Volatile B"]);
+	});
+
+	it("rebuilds when the stable system block changes", () => {
+		const p = new StablePrefix();
+		const tools = [makeTool("read")];
+
+		p.build(makeContext({ systemPrompt: ["Old", "Volatile"], stableSystemPromptBlockCount: 1, tools }), BUILD_OPTS);
+		const fp = p.fingerprint;
+		const version = p.version;
+
+		const changed = p.build(
+			makeContext({ systemPrompt: ["New", "Volatile"], stableSystemPromptBlockCount: 1, tools }),
+			BUILD_OPTS,
+		);
+		expect(changed).toBe(true);
+		expect(p.version).toBe(version + 1);
+		expect(p.fingerprint).not.toBe(fp);
+		expect(p.toContext().systemPrompt).toEqual(["New", "Volatile"]);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Anthropic explicit prompt caching can target a declared stable system-prompt prefix instead of invalidating it when later system blocks change.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3123,10 +3123,20 @@ function resolveSystemCacheBreakpointIndex(
 ): number | null | undefined {
 	if (stableSystemPromptBlockCount === undefined) return undefined;
 	if (stableSystemPromptBlockCount <= 0 || !systemBlocks) return null;
-	const promptBlockCount = normalizeSystemPrompts(systemPrompt).length;
-	if (promptBlockCount === 0) return null;
-	const prefixBlockCount = systemBlocks.length - promptBlockCount;
-	return prefixBlockCount + Math.min(stableSystemPromptBlockCount, promptBlockCount) - 1;
+	// The built systemBlocks carry only the normalized (blank-dropped) prompts,
+	// so the provider-added prefix offset (billing header + Claude Code
+	// instruction + extra instructions) is systemBlocks.length minus the full
+	// normalized prompt count.
+	const normalizedTotal = normalizeSystemPrompts(systemPrompt);
+	if (normalizedTotal.length === 0) return null;
+	// Normalize the raw leading slice independently: a blank entry inside the
+	// stable region is dropped, so the stable count is the normalized length of
+	// the raw slice(0, stableSystemPromptBlockCount) — not the raw boundary
+	// itself. Slicing clamps the boundary to the available prompts.
+	const stableCount = normalizeSystemPrompts(systemPrompt?.slice(0, stableSystemPromptBlockCount)).length;
+	if (stableCount === 0) return null;
+	const prefixBlockCount = systemBlocks.length - normalizedTotal.length;
+	return prefixBlockCount + stableCount - 1;
 }
 
 function applyPromptCaching(
@@ -3405,7 +3415,7 @@ function buildParams(
 	// Pre-compute system blocks so they occupy the right slot in the serialized body.
 	const shouldInjectClaudeCodeInstruction = isOAuthToken && !model.id.startsWith("claude-3-5-haiku");
 	const firstUserMessageText = shouldInjectClaudeCodeInstruction
-		? extractClaudeCodeFirstUserMessageText(context.messages)
+		? (context.anthropicBillingSeed ?? extractClaudeCodeFirstUserMessageText(context.messages))
 		: "";
 	const systemBlocks = buildAnthropicSystemBlocks(context.systemPrompt, {
 		includeClaudeCodeInstruction: shouldInjectClaudeCodeInstruction,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2780,11 +2780,15 @@ type SystemBlockOptions = {
 function applyClaudeCodeSystemCache(
 	blocks: AnthropicSystemBlock[],
 	cacheControl: AnthropicCacheControl | undefined,
+	cacheBreakpointIndex = blocks.length - 1,
 ): number {
 	if (!cacheControl || blocks.length === 0) return 0;
-	const lastIndex = blocks.length - 1;
-	if (blocks[lastIndex].cache_control != null) return 0;
-	blocks[lastIndex] = { ...blocks[lastIndex], cache_control: cloneAnthropicCacheControl(cacheControl) };
+	if (cacheBreakpointIndex < 0 || cacheBreakpointIndex >= blocks.length) return 0;
+	if (blocks[cacheBreakpointIndex].cache_control != null) return 0;
+	blocks[cacheBreakpointIndex] = {
+		...blocks[cacheBreakpointIndex],
+		cache_control: cloneAnthropicCacheControl(cacheControl),
+	};
 	return 1;
 }
 
@@ -3083,14 +3087,17 @@ type CacheControlBlock = {
 	cache_control?: AnthropicCacheControl | null;
 };
 
-function applyCacheControlToLastBlock<T extends CacheControlBlock>(
+function applyCacheControlToBlock<T extends CacheControlBlock>(
 	blocks: T[],
 	cacheControl: AnthropicCacheControl,
+	cacheBreakpointIndex = blocks.length - 1,
 ): boolean {
-	if (blocks.length === 0) return false;
-	const lastIndex = blocks.length - 1;
-	if (blocks[lastIndex].cache_control != null) return false;
-	blocks[lastIndex] = { ...blocks[lastIndex], cache_control: cloneAnthropicCacheControl(cacheControl) };
+	if (cacheBreakpointIndex < 0 || cacheBreakpointIndex >= blocks.length) return false;
+	if (blocks[cacheBreakpointIndex].cache_control != null) return false;
+	blocks[cacheBreakpointIndex] = {
+		...blocks[cacheBreakpointIndex],
+		cache_control: cloneAnthropicCacheControl(cacheControl),
+	};
 	return true;
 }
 
@@ -3098,27 +3105,35 @@ function applyCacheControlToLastTextBlock(
 	blocks: Array<ContentBlockParam & CacheControlBlock>,
 	cacheControl: AnthropicCacheControl,
 ): boolean {
-	if (blocks.length === 0) return false;
 	for (let i = blocks.length - 1; i >= 0; i--) {
-		if (blocks[i].type === "text") {
-			if (blocks[i].cache_control != null) return false;
-			blocks[i] = { ...blocks[i], cache_control: cloneAnthropicCacheControl(cacheControl) };
-			return true;
-		}
+		if (blocks[i].type !== "text") continue;
+		return applyCacheControlToBlock(blocks, cacheControl, i);
 	}
-	// No text block — fall back to the last block that accepts cache_control;
-	// thinking/redacted_thinking blocks reject the field with a 400.
 	for (let i = blocks.length - 1; i >= 0; i--) {
-		const type = blocks[i].type;
-		if (type === "thinking" || type === "redacted_thinking") continue;
-		if (blocks[i].cache_control != null) return false;
-		blocks[i] = { ...blocks[i], cache_control: cloneAnthropicCacheControl(cacheControl) };
-		return true;
+		if (blocks[i].type === "thinking" || blocks[i].type === "redacted_thinking") continue;
+		return applyCacheControlToBlock(blocks, cacheControl, i);
 	}
 	return false;
 }
 
-function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?: AnthropicCacheControl): void {
+function resolveSystemCacheBreakpointIndex(
+	systemBlocks: readonly AnthropicSystemBlock[] | undefined,
+	systemPrompt: readonly string[] | undefined,
+	stableSystemPromptBlockCount: number | undefined,
+): number | null | undefined {
+	if (stableSystemPromptBlockCount === undefined) return undefined;
+	if (stableSystemPromptBlockCount <= 0 || !systemBlocks) return null;
+	const promptBlockCount = normalizeSystemPrompts(systemPrompt).length;
+	if (promptBlockCount === 0) return null;
+	const prefixBlockCount = systemBlocks.length - promptBlockCount;
+	return prefixBlockCount + Math.min(stableSystemPromptBlockCount, promptBlockCount) - 1;
+}
+
+function applyPromptCaching(
+	params: MessageCreateParamsStreaming,
+	cacheControl?: AnthropicCacheControl,
+	systemCacheBreakpointIndex?: number | null,
+): void {
 	if (!cacheControl) return;
 
 	const MAX_CACHE_BREAKPOINTS = 4;
@@ -3130,13 +3145,20 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 		isCCLayout =
 			params.system.length >= 3 &&
 			(params.system[0] as { text?: string }).text?.startsWith(CLAUDE_BILLING_HEADER_PREFIX) === true;
-		if (isCCLayout) {
+		if (systemCacheBreakpointIndex !== null && isCCLayout) {
 			const placed = Math.min(
 				MAX_CACHE_BREAKPOINTS - cacheBreakpointsUsed,
-				applyClaudeCodeSystemCache(params.system as AnthropicSystemBlock[], cacheControl),
+				applyClaudeCodeSystemCache(
+					params.system as AnthropicSystemBlock[],
+					cacheControl,
+					systemCacheBreakpointIndex,
+				),
 			);
 			cacheBreakpointsUsed += placed;
-		} else if (applyCacheControlToLastBlock(params.system, cacheControl)) {
+		} else if (
+			systemCacheBreakpointIndex !== null &&
+			applyCacheControlToBlock(params.system, cacheControl, systemCacheBreakpointIndex)
+		) {
 			cacheBreakpointsUsed++;
 		}
 	}
@@ -3389,6 +3411,11 @@ function buildParams(
 		includeClaudeCodeInstruction: shouldInjectClaudeCodeInstruction,
 		firstUserMessageText,
 	});
+	const systemCacheBreakpointIndex = resolveSystemCacheBreakpointIndex(
+		systemBlocks,
+		context.systemPrompt,
+		context.stableSystemPromptBlockCount,
+	);
 
 	// Pre-compute tools.
 	let tools: AnthropicWireTool[] | undefined;
@@ -3579,7 +3606,7 @@ function buildParams(
 
 	disableThinkingIfToolChoiceForced(params, model);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
-	applyPromptCaching(params, cacheControl);
+	applyPromptCaching(params, cacheControl, systemCacheBreakpointIndex);
 	enforceCacheControlLimit(params, 4);
 	normalizeCacheControlTtlOrdering(params);
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1088,6 +1088,11 @@ export interface Context {
 	systemPrompt?: string[];
 	/** Number of leading system-prompt blocks safe to cache independently of volatile suffix blocks. */
 	stableSystemPromptBlockCount?: number;
+	/**
+	 * Session-stable seed for Anthropic OAuth's Claude Code billing header.
+	 * It is provider request metadata, never a model-visible message.
+	 */
+	anthropicBillingSeed?: string;
 	messages: Message[];
 	tools?: Tool[];
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1086,6 +1086,8 @@ export interface Tool<TParameters extends TSchema = TSchema> {
 
 export interface Context {
 	systemPrompt?: string[];
+	/** Number of leading system-prompt blocks safe to cache independently of volatile suffix blocks. */
+	stableSystemPromptBlockCount?: number;
 	messages: Message[];
 	tools?: Tool[];
 }

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -292,6 +292,179 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.system?.[3]).toEqual({ type: "text", text: "Volatile repository context" });
 	});
 
+	it("keeps the OAuth system prefix through cache_control stable for a side request", async () => {
+		const mainPayload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			systemPrompt: ["Stable harness instructions", "Volatile turn context"],
+			stableSystemPromptBlockCount: 1,
+			messages: [{ role: "user", content: "Main request establishes this session seed", timestamp: Date.now() }],
+		})) as {
+			system?: Array<{ cache_control?: unknown }>;
+			messages?: unknown[];
+		};
+		const sidePayload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			systemPrompt: ["Stable harness instructions", "Fresh side-turn context"],
+			stableSystemPromptBlockCount: 1,
+			anthropicBillingSeed: "Main request establishes this session seed",
+			messages: [
+				{ role: "developer", content: "Do not call tools.", timestamp: Date.now() },
+				{ role: "user", content: "A side request with different model-visible content", timestamp: Date.now() },
+			],
+		})) as {
+			system?: Array<{ cache_control?: unknown }>;
+			messages?: unknown[];
+		};
+
+		const mainBreakpoint = mainPayload.system?.findIndex(block => block.cache_control !== undefined) ?? -1;
+		const sideBreakpoint = sidePayload.system?.findIndex(block => block.cache_control !== undefined) ?? -1;
+		expect(mainBreakpoint).toBeGreaterThanOrEqual(0);
+		expect(sideBreakpoint).toBe(mainBreakpoint);
+		// This is the provider-facing serialized cache prefix, not source shape.
+		expect(JSON.stringify(mainPayload.system?.slice(0, mainBreakpoint + 1))).toBe(
+			JSON.stringify(sidePayload.system?.slice(0, sideBreakpoint + 1)),
+		);
+		expect(JSON.stringify(sidePayload.messages)).not.toBe(JSON.stringify(mainPayload.messages));
+	});
+
+	it("lands cache_control on the stable block, never the volatile suffix, when a blank sits inside the stable raw slice (OAuth)", async () => {
+		// Raw prompts ["stable", "", "volatile"] with raw boundary 2. The blank
+		// entry is dropped by normalizeSystemPrompts, so the normalized stable
+		// slice is just ["stable"] (count 1). The breakpoint must land on the
+		// stable block — never on the volatile suffix.
+		const payload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			systemPrompt: ["stable", "", "volatile"],
+			stableSystemPromptBlockCount: 2,
+			messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+		})) as { system?: Array<{ type?: string; text?: string; cache_control?: unknown }> };
+
+		// OAuth layout: [billing, claudeCodeInstruction, "stable", "volatile"].
+		expect(payload.system?.[2]).toEqual({
+			type: "text",
+			text: "stable",
+			cache_control: { type: "ephemeral", ttl: "1h" },
+		});
+		expect(payload.system?.[3]).toEqual({ type: "text", text: "volatile" });
+		expect(payload.system?.[3]?.cache_control).toBeUndefined();
+	});
+
+	it("lands cache_control on the stable block for the blank-in-stable-slice case with API-key (no provider prefix)", async () => {
+		// API-key layout has no billing/instruction prefix, so system blocks are
+		// just the normalized prompts: ["stable", "volatile"]. The breakpoint
+		// must land on index 0 ("stable"), not index 1 ("volatile").
+		const payload = (await captureAnthropicPayload(
+			ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["stable", "", "volatile"],
+				stableSystemPromptBlockCount: 2,
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{ isOAuth: false },
+		)) as { system?: Array<{ type?: string; text?: string; cache_control?: unknown }> };
+
+		expect(payload.system?.[0]).toEqual({
+			type: "text",
+			text: "stable",
+			cache_control: { type: "ephemeral", ttl: "1h" },
+		});
+		expect(payload.system?.[1]).toEqual({ type: "text", text: "volatile" });
+		expect(payload.system?.[1]?.cache_control).toBeUndefined();
+	});
+
+	it("returns null (no system breakpoint) when stableSystemPromptBlockCount is 0", async () => {
+		// A boundary of 0 disables the system cache breakpoint. The system blocks
+		// should still be built, but none of them should carry cache_control from
+		// the stable-prefix path — only the trailing-default path may place one.
+		const payload = (await captureAnthropicPayload(
+			ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["stable", "volatile"],
+				stableSystemPromptBlockCount: 0,
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{ isOAuth: false },
+		)) as { system?: Array<{ type?: string; text?: string; cache_control?: unknown }> };
+
+		// With boundary 0 the resolver returns null, so applyPromptCaching skips
+		// the system array entirely (both branches gate on !== null) and
+		// buildAnthropicSystemBlocks was called without cacheControl. No system
+		// block should carry cache_control; the breakpoint goes to the message
+		// level instead.
+		expect(payload.system?.[0]?.cache_control).toBeUndefined();
+		expect(payload.system?.[1]?.cache_control).toBeUndefined();
+	});
+
+	it("keeps the byte-identical serialized stable prefix across volatile suffix changes (OAuth)", async () => {
+		// Two turns that differ only in the volatile suffix must produce
+		// byte-identical serialized system blocks up to and including the
+		// cache_control breakpoint. We compare the JSON-serialized prefix slice.
+		const baseContext: Context = {
+			systemPrompt: ["stable harness", "", "volatile-turn-one"],
+			stableSystemPromptBlockCount: 2,
+			messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+		};
+		const payloadA = (await captureAnthropicPayload(ANTHROPIC_MODEL, baseContext)) as {
+			system?: Array<{ type?: string; text?: string; cache_control?: unknown }>;
+		};
+		const payloadB = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			...baseContext,
+			systemPrompt: ["stable harness", "", "volatile-turn-two"],
+		})) as { system?: Array<{ type?: string; text?: string; cache_control?: unknown }> };
+
+		// The stable prefix is blocks [0..2] (billing, instruction, "stable harness").
+		// The breakpoint sits on block 2. Blocks 0-2 must be byte-identical.
+		const prefixA = JSON.stringify(payloadA.system?.slice(0, 3));
+		const prefixB = JSON.stringify(payloadB.system?.slice(0, 3));
+		expect(prefixB).toBe(prefixA);
+		// The volatile suffix differs.
+		expect(payloadA.system?.[3]?.text).toBe("volatile-turn-one");
+		expect(payloadB.system?.[3]?.text).toBe("volatile-turn-two");
+	});
+
+	it("keeps serialized bytes through Anthropic's cache breakpoint across date and recall turn suffixes (OAuth)", async () => {
+		// These contexts model consecutive session turns after the cacheable harness
+		// plan has been built. Date and recall are intentionally different on each
+		// turn; only the serialized blocks through the provider's cache breakpoint
+		// may remain byte-identical.
+		const firstTurn: Context = {
+			systemPrompt: [
+				"stable harness",
+				"Today is 2026-07-29.",
+				"<memories>\n<fact>first recalled fact</fact>\n</memories>",
+			],
+			stableSystemPromptBlockCount: 1,
+			messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+		};
+		const payloadA = (await captureAnthropicPayload(ANTHROPIC_MODEL, firstTurn)) as {
+			system?: Array<{ type?: string; text?: string; cache_control?: unknown }>;
+		};
+		const payloadB = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			...firstTurn,
+			systemPrompt: [
+				"stable harness",
+				"Today is 2026-07-30.",
+				"<memories>\n<fact>second recalled fact</fact>\n</memories>",
+			],
+		})) as { system?: Array<{ type?: string; text?: string; cache_control?: unknown }> };
+
+		const breakpointA = payloadA.system?.findIndex(block => block.cache_control !== undefined);
+		const breakpointB = payloadB.system?.findIndex(block => block.cache_control !== undefined);
+		expect(breakpointA).toBe(2);
+		expect(breakpointB).toBe(breakpointA);
+
+		// This is the provider-wire measurement: compare actual JSON bytes through
+		// the block carrying cache_control, rather than a pre-provider prompt array.
+		const prefixA = JSON.stringify(payloadA.system?.slice(0, breakpointA! + 1));
+		const prefixB = JSON.stringify(payloadB.system?.slice(0, breakpointB! + 1));
+		expect(prefixB).toBe(prefixA);
+		expect(payloadA.system?.slice(breakpointA! + 1).map(block => block.text)).toEqual([
+			"Today is 2026-07-29.",
+			"<memories>\n<fact>first recalled fact</fact>\n</memories>",
+		]);
+		expect(payloadB.system?.slice(breakpointB! + 1).map(block => block.text)).toEqual([
+			"Today is 2026-07-30.",
+			"<memories>\n<fact>second recalled fact</fact>\n</memories>",
+		]);
+	});
+
 	it("caches tool-result-only user messages in OAuth request payloads", async () => {
 		const payload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
 			systemPrompt: ["Stay concise."],

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -277,6 +277,21 @@ describe("Anthropic request fingerprint alignment", () => {
 		});
 	});
 
+	it("places the system cache breakpoint at the stable prefix boundary", async () => {
+		const payload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			systemPrompt: ["Stable harness instructions", "Volatile repository context"],
+			stableSystemPromptBlockCount: 1,
+			messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+		})) as { system?: Array<{ type?: string; text?: string; cache_control?: unknown }> };
+
+		expect(payload.system?.[2]).toEqual({
+			type: "text",
+			text: "Stable harness instructions",
+			cache_control: { type: "ephemeral", ttl: "1h" },
+		});
+		expect(payload.system?.[3]).toEqual({ type: "text", text: "Volatile repository context" });
+	});
+
 	it("caches tool-result-only user messages in OAuth request payloads", async () => {
 		const payload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
 			systemPrompt: ["Stay concise."],

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- System prompts now isolate the stable harness prefix from volatile project context, tool inventory, current date, and promoted memory so provider prompt caches remain warm across routine session changes.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/hindsight/backend.ts
+++ b/packages/coding-agent/src/hindsight/backend.ts
@@ -106,6 +106,11 @@ export const hindsightBackend: MemoryBackend = {
 		return await state.beforeAgentStartPrompt(promptText);
 	},
 
+	async beforeSideRequestPrompt(session: AgentSession, promptText: string): Promise<string | undefined> {
+		const state = session.getHindsightSessionState();
+		return await state?.beforeSideRequestPrompt(promptText);
+	},
+
 	async clear(_agentDir, _cwd, session): Promise<void> {
 		// Hindsight memory is server-side. The local cache is what we can wipe —
 		// operators who want to delete the upstream bank should use the Hindsight

--- a/packages/coding-agent/src/hindsight/backend.ts
+++ b/packages/coding-agent/src/hindsight/backend.ts
@@ -89,15 +89,13 @@ export const hindsightBackend: MemoryBackend = {
 
 		const state = session?.getHindsightSessionState();
 		const primary = state?.aliasOf ?? state;
-		const recallSnippet = primary?.lastRecallSnippet;
 		const mentalModelsSnippet = primary?.mentalModelsSnippet;
 
-		// Order: static instructions → mental models (stable, curated) → recall
-		// (volatile per turn). Stable context first so the LLM's prior is
-		// anchored on curated knowledge.
+		// Stable developer instructions only: static instructions → mental
+		// models (stable, curated). Volatile recall context is injected per
+		// turn via `beforeAgentStartPrompt` and never enters the stable prefix.
 		const parts = [STATIC_INSTRUCTIONS];
 		if (mentalModelsSnippet) parts.push(mentalModelsSnippet);
-		if (recallSnippet) parts.push(recallSnippet);
 		return parts.join("\n\n");
 	},
 

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -456,6 +456,19 @@ export class HindsightSessionState {
 		return context;
 	}
 
+	async beforeSideRequestPrompt(promptText: string): Promise<string | undefined> {
+		if (!this.config.autoRecall) return undefined;
+		const latestPrompt = promptText.trim();
+		if (!latestPrompt) return undefined;
+
+		const history = extractMessages(this.session.sessionManager);
+		const queryMessages = [...history, { role: "user" as const, content: latestPrompt }];
+		const query = composeRecallQuery(latestPrompt, queryMessages, this.config.recallContextTurns);
+		const truncated = truncateRecallQuery(query, latestPrompt, this.config.recallMaxQueryChars);
+		const { context, ok } = await this.recallForContext(truncated);
+		return ok ? context ?? undefined : undefined;
+	}
+
 	async recallForCompaction(messages: HindsightMessage[]): Promise<string | undefined> {
 		const lastUser = messages.findLast(m => m.role === "user");
 		if (!lastUser) return undefined;

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -466,7 +466,7 @@ export class HindsightSessionState {
 		const query = composeRecallQuery(latestPrompt, queryMessages, this.config.recallContextTurns);
 		const truncated = truncateRecallQuery(query, latestPrompt, this.config.recallMaxQueryChars);
 		const { context, ok } = await this.recallForContext(truncated);
-		return ok ? context ?? undefined : undefined;
+		return ok ? (context ?? undefined) : undefined;
 	}
 
 	async recallForCompaction(messages: HindsightMessage[]): Promise<string | undefined> {

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -426,7 +426,6 @@ export class HindsightSessionState {
 		if (!context) return;
 
 		this.lastRecallSnippet = context;
-		await this.#refreshBaseSystemPromptAfter("recall");
 	}
 
 	async beforeAgentStartPrompt(promptText: string): Promise<string | undefined> {
@@ -434,7 +433,11 @@ export class HindsightSessionState {
 			await Promise.race([this.mentalModelsLoadPromise, Bun.sleep(MENTAL_MODEL_FIRST_TURN_DEADLINE_MS)]);
 		}
 
-		if (!this.config.autoRecall || this.hasRecalledForFirstTurn) return undefined;
+		// Aliases never start recall; they replay the primary's cached snippet.
+		if (this.aliasOf) return this.aliasOf.lastRecallSnippet;
+
+		if (!this.config.autoRecall) return undefined;
+		if (this.hasRecalledForFirstTurn) return this.lastRecallSnippet;
 
 		const latestPrompt = promptText.trim();
 		if (!latestPrompt) return undefined;
@@ -540,7 +543,7 @@ export class HindsightSessionState {
 		this.retainQueue.dispose();
 	}
 
-	async #refreshBaseSystemPromptAfter(reason: "recall" | "MM load" | "MM reload" | "MM TTL reload"): Promise<void> {
+	async #refreshBaseSystemPromptAfter(reason: "MM load" | "MM reload" | "MM TTL reload"): Promise<void> {
 		try {
 			await this.session.refreshBaseSystemPrompt();
 		} catch (err) {

--- a/packages/coding-agent/src/memory-backend/local-backend.ts
+++ b/packages/coding-agent/src/memory-backend/local-backend.ts
@@ -24,6 +24,9 @@ export const localBackend: MemoryBackend = {
 	async buildDeveloperInstructions(agentDir, settings, session) {
 		return buildMemoryToolDeveloperInstructions(agentDir, settings, session);
 	},
+	async beforeSideRequestPrompt() {
+		return undefined;
+	},
 	async clear(agentDir, cwd, session) {
 		clearMemoryToolDeveloperInstructionsCache(session);
 		await clearMemoryData(agentDir, cwd);

--- a/packages/coding-agent/src/memory-backend/off-backend.ts
+++ b/packages/coding-agent/src/memory-backend/off-backend.ts
@@ -11,6 +11,9 @@ export const offBackend: MemoryBackend = {
 	async buildDeveloperInstructions() {
 		return undefined;
 	},
+	async beforeSideRequestPrompt() {
+		return undefined;
+	},
 	async clear() {},
 	async enqueue() {},
 	async status() {

--- a/packages/coding-agent/src/memory-backend/types.ts
+++ b/packages/coding-agent/src/memory-backend/types.ts
@@ -153,6 +153,13 @@ export interface MemoryBackend {
 	beforeAgentStartPrompt?(session: AgentSession, promptText: string): Promise<string | undefined>;
 
 	/**
+	 * Inject volatile recall context for an ephemeral side request. This operation
+	 * MUST recall for `promptText` each time and MUST NOT replace the snippet
+	 * cached by `beforeAgentStartPrompt` for normal agent turns.
+	 */
+	beforeSideRequestPrompt(session: AgentSession, promptText: string): Promise<string | undefined>;
+
+	/**
 	 * Optional hook to splice extra context into a compaction summarization.
 	 *
 	 * Called from the compaction call site before the LLM summary is requested.

--- a/packages/coding-agent/src/memory-backend/types.ts
+++ b/packages/coding-agent/src/memory-backend/types.ts
@@ -143,9 +143,12 @@ export interface MemoryBackend {
 	 * system prompt before the agent starts generating.
 	 *
 	 * This is the only place a backend can affect the very first answer of a
-	 * fresh session. The returned text is appended to the already-built base
-	 * system prompt for this turn only; callers may separately cache it and
-	 * surface it through `buildDeveloperInstructions()` on later rebuilds.
+	 * fresh session. The returned text is volatile: it is appended to the
+	 * already-built base system prompt for this turn only and is never folded
+	 * into the stable developer instructions. Backends cache the snippet and
+	 * replay it on every subsequent call until the session's transcript resets,
+	 * so the recalled context persists across turns without entering the
+	 * stable prefix.
 	 */
 	beforeAgentStartPrompt?(session: AgentSession, promptText: string): Promise<string | undefined>;
 

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -110,12 +110,11 @@ export const mnemopiBackend: MemoryBackend = {
 		}
 	},
 
-	async buildDeveloperInstructions(_agentDir, settings, session): Promise<string | undefined> {
-		const state = getMnemopiSessionState(session);
-		const primary = state?.aliasOf ?? state;
-		const parts = [STATIC_INSTRUCTIONS];
-		if (primary?.lastRecallSnippet) parts.push(primary.lastRecallSnippet);
-		const rendered = parts.join("\n\n").trim();
+	async buildDeveloperInstructions(_agentDir, settings, _session): Promise<string | undefined> {
+		// Stable developer instructions only: static instructions. Volatile
+		// recall context is injected per turn via `beforeAgentStartPrompt` and
+		// never enters the stable prefix.
+		const rendered = STATIC_INSTRUCTIONS.trim();
 		if (!rendered) return undefined;
 		return truncateApproxTokens(rendered, settings.get("mnemopi.injectionTokenLimit"));
 	},

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -124,6 +124,11 @@ export const mnemopiBackend: MemoryBackend = {
 		return await state?.beforeAgentStartPrompt(promptText);
 	},
 
+	async beforeSideRequestPrompt(session, promptText): Promise<string | undefined> {
+		const state = getMnemopiSessionState(session);
+		return await state?.beforeSideRequestPrompt(promptText);
+	},
+
 	async clear(agentDir, _cwd, session): Promise<void> {
 		const previous = session ? setMnemopiSessionState(session, undefined) : undefined;
 		await previous?.dispose({ consolidate: false });

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -475,6 +475,18 @@ export class MnemopiSessionState {
 		return context;
 	}
 
+	async beforeSideRequestPrompt(promptText: string): Promise<string | undefined> {
+		if (!this.config.autoRecall) return undefined;
+		const latestPrompt = promptText.trim();
+		if (!latestPrompt) return undefined;
+
+		const history = extractMessages(this.session.sessionManager);
+		const queryMessages = [...history, { role: "user" as const, content: latestPrompt }];
+		const query = composeRecallQuery(latestPrompt, queryMessages, this.config.recallContextTurns);
+		const truncated = truncateRecallQuery(query, latestPrompt, this.config.recallMaxQueryChars);
+		return await this.recallForContext(truncated);
+	}
+
 	async recallForCompaction(messages: AgentMessage[]): Promise<string | undefined> {
 		const flat = flattenAgentMessages(messages);
 		const lastUser = flat.findLast(message => message.role === "user");

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -457,7 +457,11 @@ export class MnemopiSessionState {
 	}
 
 	async beforeAgentStartPrompt(promptText: string): Promise<string | undefined> {
-		if (!this.config.autoRecall || this.hasRecalledForFirstTurn) return undefined;
+		// Aliases never start recall; they replay the primary's cached snippet.
+		if (this.aliasOf) return this.aliasOf.lastRecallSnippet;
+
+		if (!this.config.autoRecall) return undefined;
+		if (this.hasRecalledForFirstTurn) return this.lastRecallSnippet;
 		const latestPrompt = promptText.trim();
 		if (!latestPrompt) return undefined;
 		const history = extractMessages(this.session.sessionManager);
@@ -579,11 +583,6 @@ export class MnemopiSessionState {
 		this.hasRecalledForFirstTurn = true;
 		if (!context) return;
 		this.lastRecallSnippet = context;
-		try {
-			await this.session.refreshBaseSystemPrompt();
-		} catch (error) {
-			if (this.config.debug) logger.debug("Mnemopi: prompt refresh after recall failed", { error: String(error) });
-		}
 	}
 
 	/**

--- a/packages/coding-agent/src/prompts/system/project-prompt.md
+++ b/packages/coding-agent/src/prompts/system/project-prompt.md
@@ -48,7 +48,7 @@ This session also spans the additional directories below. This list is the CURRE
 {{/each}}
 </workspace-roots>
 {{/if}}
-Today is {{date}}, and the current working directory is '{{cwd}}'.
+The current working directory is '{{cwd}}'.
 
 <critical>
 - Each response MUST advance the task. There is no stopping condition other than completion.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -68,17 +68,6 @@ Special URLs for internal resources; with most FS/bash tools they auto-resolve t
 - `pr://<N>` (or `pr://<owner>/<repo>/<N>`): GitHub PR, same cache; `?comments=0` drops comments. Bare lists recent PRs; `?state=open|closed|merged|all&limit=&author=&label=`.
 - `omp://`: harness docs; AVOID unless the user asks about the harness itself.
 
-{{#if toolInfo.length}}
-{{#if toolListMode}}
-# Tool Inventory
-{{#each toolInfo}}
-- {{#if label}}{{label}}: `{{name}}`{{else}}`{{name}}`{{/if}}
-{{/each}}
-{{else}}
-{{toolInventory}}
-{{/if}}
-{{/if}}
-
 {{#has tools "computer"}}
 # Computer Use
 The `{{toolRefs.computer}}` tool is explicitly enabled and available in this session.

--- a/packages/coding-agent/src/prompts/system/tool-inventory.md
+++ b/packages/coding-agent/src/prompts/system/tool-inventory.md
@@ -1,0 +1,10 @@
+{{#if toolInfo.length}}
+{{#if toolListMode}}
+# Tool Inventory
+{{#each toolInfo}}
+- {{#if label}}{{label}}: `{{name}}`{{else}}`{{name}}`{{/if}}
+{{/each}}
+{{else}}
+{{toolInventory}}
+{{/if}}
+{{/if}}

--- a/packages/coding-agent/src/prompts/system/turn-context.md
+++ b/packages/coding-agent/src/prompts/system/turn-context.md
@@ -1,0 +1,1 @@
+Today is {{date}}.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -155,10 +155,10 @@ import { createSnapcompactSavingsRecorder } from "./session/snapcompact-savings-
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
 import {
-	type BuildSystemPromptResult,
 	buildSystemPrompt as buildSystemPromptInternal,
 	loadProjectContextFiles as loadContextFilesInternal,
 	projectSystemPromptToolMetadata,
+	type SystemPromptPlan,
 } from "./system-prompt";
 import { AgentOutputManager } from "./task/output-manager";
 import { wrapStreamFnWithProviderConcurrency } from "./task/provider-concurrency";
@@ -819,7 +819,7 @@ export interface BuildSystemPromptOptions {
  * The returned `systemPrompt` preserves the stable harness prompt and dynamic project context
  * as separate entries so providers can cache prompt prefixes without concatenating blocks.
  */
-export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
+export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<SystemPromptPlan> {
 	const toolNames = options.tools?.map(tool => tool.name);
 	const toolMap = options.tools ? new Map(options.tools.map(tool => [tool.name, tool])) : undefined;
 	const promptTools = toolMap
@@ -2647,7 +2647,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const rebuildSystemPrompt = async (
 			toolNames: string[],
 			tools: Map<string, AgentTool>,
-		): Promise<BuildSystemPromptResult> => {
+		): Promise<SystemPromptPlan> => {
 			toolContextStore.setToolNames(toolNames);
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);
 			const memoryInstructions = memoryBackend
@@ -2763,6 +2763,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			return {
 				systemPrompt: typeof customPrompt === "string" ? [customPrompt] : customPrompt,
 				stableSystemPromptBlockCount: undefined,
+				compositionPolicy: "verbatim",
 			};
 		};
 
@@ -2871,12 +2872,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 
 		setActiveToolNames(initialToolNames);
-		const { systemPrompt, stableSystemPromptBlockCount } = await logger.time(
+		const systemPromptPlan = await logger.time(
 			"buildSystemPrompt",
 			rebuildSystemPrompt,
 			initialToolNames,
 			toolRegistry,
 		);
+		const { systemPrompt, stableSystemPromptBlockCount } = systemPromptPlan;
 
 		const promptTemplates = await promptTemplatesPromise;
 		toolSession.promptTemplates = promptTemplates;
@@ -3192,6 +3194,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			preferWebsockets: preferOpenAICodexWebsockets,
 			convertToLlm: convertToLlmFinal,
 			rebuildSystemPrompt,
+			systemPromptPlan,
 			getXdevToolEntries: () => (toolSession.xdev ? xdevEntries(toolSession.xdev) : []),
 			xdev: toolSession.xdev,
 			presentationPinnedToolNames: explicitlyRequestedToolNameSet,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2762,6 +2762,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					: options.systemPrompt;
 			return {
 				systemPrompt: typeof customPrompt === "string" ? [customPrompt] : customPrompt,
+				stableSystemPromptBlockCount: undefined,
 			};
 		};
 
@@ -2870,7 +2871,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 
 		setActiveToolNames(initialToolNames);
-		const { systemPrompt } = await logger.time(
+		const { systemPrompt, stableSystemPromptBlockCount } = await logger.time(
 			"buildSystemPrompt",
 			rebuildSystemPrompt,
 			initialToolNames,
@@ -2994,6 +2995,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		agent = new Agent({
 			initialState: {
 				systemPrompt,
+				stableSystemPromptBlockCount,
 				model,
 				thinkingLevel: toReasoningEffort(effectiveThinkingLevel),
 				disableReasoning: shouldDisableReasoning(effectiveThinkingLevel),

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -25,6 +25,7 @@ import type { ContextUsage } from "../extensibility/extensions/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
 import type { SecretObfuscator } from "../secrets/obfuscator";
+import type { SystemPromptPlan } from "../system-prompt";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { XdevState } from "../tools/xdev";
 import type { SessionManager } from "./session-manager";
@@ -174,10 +175,9 @@ export interface AgentSessionConfig {
 	/** Current session message-to-LLM conversion pipeline. */
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	/** System prompt builder that can consider tool availability. */
-	rebuildSystemPrompt?: (
-		toolNames: string[],
-		tools: Map<string, AgentTool>,
-	) => Promise<{ systemPrompt: string[]; stableSystemPromptBlockCount?: number }>;
+	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<SystemPromptPlan>;
+	/** Initial system prompt plan, retained by SessionTools across prompt rebuilds. */
+	systemPromptPlan?: SystemPromptPlan;
 	/** Local calendar date provider used by turn-bound prompt context. */
 	getLocalCalendarDate?: () => string;
 	/** Tools mounted under `xd://`, for `/tools` display. */

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -174,8 +174,11 @@ export interface AgentSessionConfig {
 	/** Current session message-to-LLM conversion pipeline. */
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	/** System prompt builder that can consider tool availability. */
-	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
-	/** Local calendar date provider used by prompt-cache invalidation. */
+	rebuildSystemPrompt?: (
+		toolNames: string[],
+		tools: Map<string, AgentTool>,
+	) => Promise<{ systemPrompt: string[]; stableSystemPromptBlockCount?: number }>;
+	/** Local calendar date provider used by turn-bound prompt context. */
 	getLocalCalendarDate?: () => string;
 	/** Tools mounted under `xd://`, for `/tools` display. */
 	getXdevToolEntries?: () => Array<{ name: string; summary: string }>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -399,7 +399,8 @@ type SetSessionNameWithTrigger = (
 	trigger?: SessionNameTrigger,
 ) => Promise<boolean>;
 
-export class AgentSession { readonly agent: Agent;
+export class AgentSession {
+	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
 	readonly settings: Settings;
 	/** Entries of tools mounted under `xd://`; empty when virtual devices are unmounted. */
@@ -8434,4 +8435,5 @@ export class AgentSession { readonly agent: Agent;
 	 */
 	get extensionRunner(): ExtensionRunner | undefined {
 		return this.#extensionRunner;
-	} }
+	}
+}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -399,8 +399,7 @@ type SetSessionNameWithTrigger = (
 	trigger?: SessionNameTrigger,
 ) => Promise<boolean>;
 
-export class AgentSession {
-	readonly agent: Agent;
+export class AgentSession { readonly agent: Agent;
 	readonly sessionManager: SessionManager;
 	readonly settings: Settings;
 	/** Entries of tools mounted under `xd://`; empty when virtual devices are unmounted. */
@@ -4085,6 +4084,10 @@ export class AgentSession {
 		return this.#tools.buildSystemPromptForAgentStart(promptText);
 	}
 
+	#buildSystemPromptForSideRequest(promptText: string): Promise<SystemPromptPlan> {
+		return this.#tools.buildSystemPromptForSideRequest(promptText);
+	}
+
 	/** Replaces connected MCP tools and enables them immediately. */
 	refreshMCPTools(mcpTools: CustomTool[]): Promise<void> {
 		return this.#tools.refreshMCPTools(mcpTools);
@@ -6826,7 +6829,7 @@ export class AgentSession {
 		const cacheSessionId = this.sessionId;
 		const snapshot = this.#buildEphemeralSnapshot(args.promptText);
 		const llmMessages = await this.convertMessagesToLlm(snapshot, args.signal);
-		const systemPromptPlan = await this.#buildSystemPromptForAgentStart(args.promptText);
+		const systemPromptPlan = await this.#buildSystemPromptForSideRequest(args.promptText);
 		const context = await this.agent.buildSideRequestContext(llmMessages, systemPromptPlan, {
 			anthropicBillingSeed: this.#getSideRequestAnthropicBillingSeed(cacheSessionId),
 		});
@@ -8431,5 +8434,4 @@ export class AgentSession {
 	 */
 	get extensionRunner(): ExtensionRunner | undefined {
 		return this.#extensionRunner;
-	}
-}
+	} }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -172,6 +172,7 @@ import {
 	obfuscateProviderContext,
 	type SecretObfuscator,
 } from "../secrets/obfuscator";
+import type { SystemPromptPlan } from "../system-prompt";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -502,6 +503,7 @@ export class AgentSession {
 	#providerSessionId: string | undefined;
 	#freshProviderSessionId: string | undefined;
 	#inheritedProviderPromptCacheKey: string | undefined;
+	#sideRequestAnthropicBillingSeed: { sessionId: string; seed: string } | undefined;
 	#autolearnCaptureAbortController: AbortController | undefined;
 	#autolearnCaptureTask: Promise<void> | undefined;
 	#isDisposed = false;
@@ -1109,7 +1111,7 @@ export class AgentSession {
 			getMcpServerInstructions: config.getMcpServerInstructions,
 			xdev: config.xdev,
 			setActiveToolNames: config.setActiveToolNames,
-			baseSystemPrompt: this.agent.state.systemPrompt,
+			baseSystemPromptPlan: config.systemPromptPlan,
 			skills: config.skills,
 			skillWarnings: config.skillWarnings,
 			skillsSettings: config.skillsSettings,
@@ -1364,7 +1366,7 @@ export class AgentSession {
 			thinkingLevel: () => this.thinkingLevel,
 			sessionId: () => this.sessionId,
 			sessionFile: () => this.sessionFile,
-			baseSystemPrompt: () => this.#tools.baseSystemPrompt,
+			baseSystemPromptPlan: () => this.#tools.baseSystemPromptPlan,
 			assertVibeSessionTransitionAllowed: action => this.#assertVibeSessionTransitionAllowed(action),
 			setSkipPostTurnMaintenance: timestamp => {
 				this.#maintenance.skipPostTurnMaintenanceAssistantTimestamp = timestamp;
@@ -4079,9 +4081,7 @@ export class AgentSession {
 		return this.#tools.refreshBaseSystemPrompt();
 	}
 
-	#buildSystemPromptForAgentStart(
-		promptText: string,
-	): Promise<{ systemPrompt: string[]; stableSystemPromptBlockCount: number | undefined }> {
+	#buildSystemPromptForAgentStart(promptText: string): Promise<SystemPromptPlan> {
 		return this.#tools.buildSystemPromptForAgentStart(promptText);
 	}
 
@@ -6826,7 +6826,10 @@ export class AgentSession {
 		const cacheSessionId = this.sessionId;
 		const snapshot = this.#buildEphemeralSnapshot(args.promptText);
 		const llmMessages = await this.convertMessagesToLlm(snapshot, args.signal);
-		const context = await this.agent.buildSideRequestContext(llmMessages);
+		const systemPromptPlan = await this.#buildSystemPromptForAgentStart(args.promptText);
+		const context = await this.agent.buildSideRequestContext(llmMessages, systemPromptPlan, {
+			anthropicBillingSeed: this.#getSideRequestAnthropicBillingSeed(cacheSessionId),
+		});
 		const options = this.prepareSimpleStreamOptions(
 			{
 				apiKey: this.#modelRegistry.resolver(model, cacheSessionId),
@@ -6954,6 +6957,31 @@ export class AgentSession {
 		return messages;
 	}
 
+	#getSideRequestAnthropicBillingSeed(sessionId: string): string {
+		if (this.#sideRequestAnthropicBillingSeed?.sessionId === sessionId) {
+			return this.#sideRequestAnthropicBillingSeed.seed;
+		}
+
+		const firstUserMessage = this.messages.find((message): message is UserMessage => message.role === "user");
+		// No persisted user message yet (e.g. a side request before the first main
+		// turn): return a transient empty seed WITHOUT freezing it. Freezing "" here
+		// would make every later side request derive an empty Anthropic billing
+		// header while main OAuth requests derive a nonempty one from the first user
+		// text, breaking prefix identity through cache_control. Only a first user
+		// message *object* — including an explicit empty-text one — is a settled
+		// seed worth caching for the rest of the provider session.
+		if (firstUserMessage === undefined) {
+			return "";
+		}
+		const content = firstUserMessage.content;
+		const seed =
+			typeof content === "string"
+				? content
+				: (content.find((block): block is TextContent => block.type === "text")?.text ?? "");
+		this.#sideRequestAnthropicBillingSeed = { sessionId, seed };
+		return seed;
+	}
+
 	// =========================================================================
 	// Session Management
 	// =========================================================================
@@ -7026,7 +7054,7 @@ export class AgentSession {
 		const previousAutoResolvedLevel = this.autoResolvedThinkingLevel();
 		const previousServiceTierByFamily = this.serviceTierByFamily;
 		const previousTools = [...this.agent.state.tools];
-		const previousBaseSystemPrompt = this.#tools.baseSystemPrompt;
+		const previousBaseSystemPromptPlan = this.#tools.baseSystemPromptPlan;
 		const previousSystemPrompt = this.agent.state.systemPrompt;
 		const previousStableSystemPromptBlockCount = this.agent.state.stableSystemPromptBlockCount;
 		const previousFreshProviderSessionId = this.#freshProviderSessionId;
@@ -7192,7 +7220,7 @@ export class AgentSession {
 			this.#syncAgentSessionId(previousSessionState.sessionId);
 			this.#memory.rekeyForCurrentSessionId();
 			this.agent.setTools(previousTools);
-			this.#tools.setBaseSystemPrompt(previousBaseSystemPrompt, previousStableSystemPromptBlockCount);
+			this.#tools.setBaseSystemPrompt(previousBaseSystemPromptPlan);
 			this.agent.setSystemPrompt(previousSystemPrompt, previousStableSystemPromptBlockCount);
 			this.agent.replaceMessages(previousAgentMessages);
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -399,6 +399,25 @@ type SetSessionNameWithTrigger = (
 	trigger?: SessionNameTrigger,
 ) => Promise<boolean>;
 
+/**
+ * Extracts the first text of the first user message from provider-visible
+ * (`Message[]`) output, mirroring the Anthropic provider's Claude Code billing-seed
+ * extraction so a side-request seed matches the main request's derivation.
+ */
+function firstUserMessageText(messages: readonly Message[]): string {
+	for (const message of messages) {
+		if (message.role !== "user") continue;
+		const { content } = message;
+		if (typeof content === "string") return content;
+		if (Array.isArray(content)) {
+			for (const block of content) {
+				if (block.type === "text") return block.text;
+			}
+		}
+		return "";
+	}
+	return "";
+}
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -6833,7 +6852,7 @@ export class AgentSession {
 		const llmMessages = await this.convertMessagesToLlm(snapshot, args.signal);
 		const systemPromptPlan = await this.#buildSystemPromptForSideRequest(args.promptText);
 		const context = await this.agent.buildSideRequestContext(llmMessages, systemPromptPlan, {
-			anthropicBillingSeed: this.#getSideRequestAnthropicBillingSeed(cacheSessionId),
+			anthropicBillingSeed: this.#getSideRequestAnthropicBillingSeed(cacheSessionId, llmMessages),
 		});
 		const options = this.prepareSimpleStreamOptions(
 			{
@@ -6962,32 +6981,31 @@ export class AgentSession {
 		return messages;
 	}
 
-	#getSideRequestAnthropicBillingSeed(sessionId: string): string {
+	#getSideRequestAnthropicBillingSeed(sessionId: string, providerMessages: readonly Message[]): string {
 		if (this.#sideRequestAnthropicBillingSeed?.sessionId === sessionId) {
 			return this.#sideRequestAnthropicBillingSeed.seed;
 		}
 
-		const firstUserMessage = this.messages.find((message): message is UserMessage => message.role === "user");
-		// No persisted user message yet (e.g. a side request before the first main
-		// turn): return a transient empty seed WITHOUT freezing it. Freezing "" here
-		// would make every later side request derive an empty Anthropic billing
-		// header while main OAuth requests derive a nonempty one from the first user
-		// text, breaking prefix identity through cache_control. Only a first user
-		// message *object* — including an explicit empty-text one — is a settled
-		// seed worth caching for the rest of the provider session.
-		if (firstUserMessage === undefined) {
+		// Only a first user message persisted into the main turn's history is a
+		// settled seed worth caching. Before that, the only user message in the
+		// ephemeral snapshot is the side prompt itself, so return a transient empty
+		// seed WITHOUT freezing it. Freezing "" here would make every later side
+		// request derive an empty Anthropic billing header while main OAuth requests
+		// derive a nonempty one from the first user text, breaking prefix identity
+		// through cache_control. Only a first user message *object* — including an
+		// explicit empty-text one — is a settled seed worth caching.
+		if (!this.messages.some(message => message.role === "user")) {
 			return "";
 		}
-		const content = firstUserMessage.content;
-		const rawSeed =
-			typeof content === "string"
-				? content
-				: (content.find((block): block is TextContent => block.type === "text")?.text ?? "");
-		// The main OAuth turn derives its Claude Code billing-header seed from the
-		// provider-visible (obfuscated) first-user text. Derive the side seed from
-		// the same obfuscated text so a secret in the first user message does not
-		// split the main/side system-prefix cache breakpoint.
-		const seed = this.#obfuscateTextForProvider(rawSeed) ?? "";
+
+		// Derive the seed from the provider-visible first user message: the same
+		// text — after `transformContext` (context-hook rewriting) and outbound
+		// obfuscation — that the main OAuth request builds its Claude Code billing
+		// header from. The ephemeral side prompt is appended last, so the first user
+		// message here is the persisted one. Reading the raw persisted text instead
+		// would miss a context-hook rewrite of the first user message and split the
+		// main/side system-prefix cache breakpoint.
+		const seed = firstUserMessageText(providerMessages);
 		this.#sideRequestAnthropicBillingSeed = { sessionId, seed };
 		return seed;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6978,10 +6978,15 @@ export class AgentSession {
 			return "";
 		}
 		const content = firstUserMessage.content;
-		const seed =
+		const rawSeed =
 			typeof content === "string"
 				? content
 				: (content.find((block): block is TextContent => block.type === "text")?.text ?? "");
+		// The main OAuth turn derives its Claude Code billing-header seed from the
+		// provider-visible (obfuscated) first-user text. Derive the side seed from
+		// the same obfuscated text so a secret in the first user message does not
+		// split the main/side system-prefix cache breakpoint.
+		const seed = this.#obfuscateTextForProvider(rawSeed) ?? "";
 		this.#sideRequestAnthropicBillingSeed = { sessionId, seed };
 		return seed;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1311,6 +1311,7 @@ export class AgentSession {
 			sessionId: () => this.sessionId,
 			messages: () => this.messages,
 			baseSystemPrompt: () => this.#tools.baseSystemPrompt,
+			baseSystemPromptPlan: () => this.#tools.baseSystemPromptPlan,
 			goalModeState: () => this.#goalModeState,
 			planReferencePath: () => this.#planReferencePath,
 			nonMessageTokenSource: () => this,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -984,10 +984,6 @@ export class AgentSession {
 			setHindsightSessionState: state => this.setHindsightSessionState(state),
 			getMnemopiSessionState: () => this.getMnemopiSessionState(),
 			takeMnemopiSessionState: () => setMnemopiSessionState(this, undefined),
-			setBaseSystemPrompt: prompt => {
-				this.#tools.setBaseSystemPrompt(prompt);
-				this.agent.setSystemPrompt(prompt);
-			},
 			refreshBaseSystemPrompt: () => this.#tools.refreshBaseSystemPrompt(),
 			replaceMemoryTools: tools => this.#tools.replaceMemoryTools(tools),
 		};
@@ -1091,8 +1087,6 @@ export class AgentSession {
 			model: () => this.model,
 			memoryBackendSession: () => this,
 			clearInheritedProviderPromptCacheKey: () => this.#clearInheritedProviderPromptCacheKey(),
-			clearMemoryPromotionSnapshot: () => this.#memory.clearPromotionSnapshot(),
-			captureMemoryPromotionSnapshot: prompt => this.#memory.capturePromotionSnapshot(prompt),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),
 			notifyCommandMetadataChanged: () => this.#notifyCommandMetadataChanged(),
 			localProtocolOptions: () => this.#localProtocolOptions(),
@@ -4085,7 +4079,9 @@ export class AgentSession {
 		return this.#tools.refreshBaseSystemPrompt();
 	}
 
-	#buildSystemPromptForAgentStart(promptText: string): Promise<string[]> {
+	#buildSystemPromptForAgentStart(
+		promptText: string,
+	): Promise<{ systemPrompt: string[]; stableSystemPromptBlockCount: number | undefined }> {
 		return this.#tools.buildSystemPromptForAgentStart(promptText);
 	}
 
@@ -5017,7 +5013,7 @@ export class AgentSession {
 				const result = await this.#extensionRunner.emitBeforeAgentStart(
 					expandedText,
 					options?.images,
-					beforeAgentStartSystemPrompt,
+					beforeAgentStartSystemPrompt.systemPrompt,
 				);
 				if (result?.messages) {
 					const promptAttribution: "user" | "agent" | undefined =
@@ -5048,10 +5044,16 @@ export class AgentSession {
 				if (result?.systemPrompt !== undefined) {
 					this.agent.setSystemPrompt(result.systemPrompt);
 				} else {
-					this.agent.setSystemPrompt(beforeAgentStartSystemPrompt);
+					this.agent.setSystemPrompt(
+						beforeAgentStartSystemPrompt.systemPrompt,
+						beforeAgentStartSystemPrompt.stableSystemPromptBlockCount,
+					);
 				}
 			} else {
-				this.agent.setSystemPrompt(beforeAgentStartSystemPrompt);
+				this.agent.setSystemPrompt(
+					beforeAgentStartSystemPrompt.systemPrompt,
+					beforeAgentStartSystemPrompt.stableSystemPromptBlockCount,
+				);
 			}
 
 			// Bail out if a newer abort/prompt cycle has started since we began setup
@@ -7026,7 +7028,7 @@ export class AgentSession {
 		const previousTools = [...this.agent.state.tools];
 		const previousBaseSystemPrompt = this.#tools.baseSystemPrompt;
 		const previousSystemPrompt = this.agent.state.systemPrompt;
-		const previousBaseSystemPromptBeforeMemoryPromotion = this.#memory.promotionSnapshot;
+		const previousStableSystemPromptBlockCount = this.agent.state.stableSystemPromptBlockCount;
 		const previousFreshProviderSessionId = this.#freshProviderSessionId;
 		const previousInheritedProviderPromptCacheKey = this.#inheritedProviderPromptCacheKey;
 
@@ -7190,9 +7192,8 @@ export class AgentSession {
 			this.#syncAgentSessionId(previousSessionState.sessionId);
 			this.#memory.rekeyForCurrentSessionId();
 			this.agent.setTools(previousTools);
-			this.#tools.setBaseSystemPrompt(previousBaseSystemPrompt);
-			this.#memory.restorePromotionSnapshot(previousBaseSystemPromptBeforeMemoryPromotion);
-			this.agent.setSystemPrompt(previousSystemPrompt);
+			this.#tools.setBaseSystemPrompt(previousBaseSystemPrompt, previousStableSystemPromptBlockCount);
+			this.agent.setSystemPrompt(previousSystemPrompt, previousStableSystemPromptBlockCount);
 			this.agent.replaceMessages(previousAgentMessages);
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -10,12 +10,14 @@ import {
 } from "@oh-my-pi/pi-agent-core";
 import { generateHandoffFromContext, renderHandoffPrompt } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Message, Model, ServiceTier, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
-import { logger, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
 import type { ExtensionRunner, SessionBeforeSwitchResult } from "../extensibility/extensions";
+import turnContextPrompt from "../prompts/system/turn-context.md" with { type: "text" };
 import { obfuscateProviderContext, type SecretObfuscator } from "../secrets/obfuscator";
 import type { SystemPromptPlan } from "../system-prompt";
+import { formatLocalCalendarDate } from "../utils/local-date";
 import type { HandoffResult, SessionHandoffOptions } from "./agent-session-types";
 import type { BashSessionTransition } from "./bash-runner";
 import type { SessionContext } from "./session-context";
@@ -166,11 +168,16 @@ export class SessionHandoff {
 			const handoffLlmMessages = await this.#host.convertMessagesToLlm(handoffSnapshot, handoffSignal);
 			// Base system prompt, not a per-turn `before_agent_start` hook override —
 			// the handoff seeds a fresh session and must not carry prompt-specific
-			// hook state. Matches the prompt the old handoff path sent.
-			const handoffContext = await this.#host.agent.buildSideRequestContext(
-				handoffLlmMessages,
-				this.#host.baseSystemPromptPlan(),
-			);
+			// memory or extension hook state. The date lives in the volatile turn
+			// suffix now (moved out of buildSystemPrompt), so compose it onto the
+			// base plan without pulling in before_agent_start recall: relative dates
+			// in the transcript/handoff instructions must resolve against today.
+			const handoffBasePlan = this.#host.baseSystemPromptPlan();
+			const handoffDateContext = prompt.render(turnContextPrompt, { date: formatLocalCalendarDate() }).trim();
+			const handoffPromptPlan: SystemPromptPlan = handoffDateContext
+				? { ...handoffBasePlan, systemPrompt: [...handoffBasePlan.systemPrompt, handoffDateContext] }
+				: handoffBasePlan;
+			const handoffContext = await this.#host.agent.buildSideRequestContext(handoffLlmMessages, handoffPromptPlan);
 			const handoffStreamOptions = this.#host.prepareSimpleStreamOptions(
 				{
 					apiKey: this.#host.modelRegistry.resolver(model, cacheSessionId),

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -15,6 +15,7 @@ import type { ModelRegistry } from "../config/model-registry";
 import type { Settings } from "../config/settings";
 import type { ExtensionRunner, SessionBeforeSwitchResult } from "../extensibility/extensions";
 import { obfuscateProviderContext, type SecretObfuscator } from "../secrets/obfuscator";
+import type { SystemPromptPlan } from "../system-prompt";
 import type { HandoffResult, SessionHandoffOptions } from "./agent-session-types";
 import type { BashSessionTransition } from "./bash-runner";
 import type { SessionContext } from "./session-context";
@@ -42,7 +43,7 @@ export interface SessionHandoffHost {
 	thinkingLevel(): ThinkingLevel | undefined;
 	sessionId(): string;
 	sessionFile(): string | undefined;
-	baseSystemPrompt(): string[];
+	baseSystemPromptPlan(): SystemPromptPlan;
 	assertVibeSessionTransitionAllowed(action: string): void;
 	setSkipPostTurnMaintenance(timestamp: number | undefined): void;
 	obfuscateTextForProvider(text: string | undefined): string | undefined;
@@ -168,7 +169,7 @@ export class SessionHandoff {
 			// hook state. Matches the prompt the old handoff path sent.
 			const handoffContext = await this.#host.agent.buildSideRequestContext(
 				handoffLlmMessages,
-				this.#host.baseSystemPrompt(),
+				this.#host.baseSystemPromptPlan(),
 			);
 			const handoffStreamOptions = this.#host.prepareSimpleStreamOptions(
 				{

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -32,6 +32,12 @@ function createHandoffFileName(date = new Date()): string {
 	return `handoff-${fileTimestamp}.md`;
 }
 
+/** Append the date-only turn-context block to a base plan (verbatim plans opt out at the call site). */
+function withDateContext(plan: SystemPromptPlan): SystemPromptPlan {
+	const dateContext = prompt.render(turnContextPrompt, { date: formatLocalCalendarDate() }).trim();
+	return dateContext ? { ...plan, systemPrompt: [...plan.systemPrompt, dateContext] } : plan;
+}
+
 /** Capabilities borrowed from the owning AgentSession. */
 export interface SessionHandoffHost {
 	agent: Agent;
@@ -172,11 +178,15 @@ export class SessionHandoff {
 			// suffix now (moved out of buildSystemPrompt), so compose it onto the
 			// base plan without pulling in before_agent_start recall: relative dates
 			// in the transcript/handoff instructions must resolve against today.
+			// Mirror buildSystemPromptForAgentStart / buildSystemPromptForSideRequest:
+			// a `verbatim` plan (NULL_PROMPT or an explicit systemPrompt) must NOT
+			// gain turn-specific context — appending the date would make a null
+			// prompt nonempty and break the verbatim contract the session asked for.
 			const handoffBasePlan = this.#host.baseSystemPromptPlan();
-			const handoffDateContext = prompt.render(turnContextPrompt, { date: formatLocalCalendarDate() }).trim();
-			const handoffPromptPlan: SystemPromptPlan = handoffDateContext
-				? { ...handoffBasePlan, systemPrompt: [...handoffBasePlan.systemPrompt, handoffDateContext] }
-				: handoffBasePlan;
+			const handoffPromptPlan: SystemPromptPlan =
+				handoffBasePlan.compositionPolicy === "append-turn-context"
+					? withDateContext(handoffBasePlan)
+					: handoffBasePlan;
 			const handoffContext = await this.#host.agent.buildSideRequestContext(handoffLlmMessages, handoffPromptPlan);
 			const handoffStreamOptions = this.#host.prepareSimpleStreamOptions(
 				{

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -46,7 +46,7 @@ import type { AssistantMessage, CodexCompactionContext, Message, Model, Provider
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, prompt } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import type { ModelRegistry } from "../config/model-registry";
 import { MODEL_ROLE_IDS } from "../config/model-roles";
@@ -60,7 +60,10 @@ import type { MemoryBackendOperationContext } from "../memory-backend/types";
 import type { NonMessageTokenSource } from "../modes/utils/context-usage";
 import { computeNonMessageTokens } from "../modes/utils/context-usage";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
+import turnContextPrompt from "../prompts/system/turn-context.md" with { type: "text" };
+import type { SystemPromptPlan } from "../system-prompt";
 import type { ConfiguredThinkingLevel } from "../thinking";
+import { formatLocalCalendarDate } from "../utils/local-date";
 import type { AgentSessionEvent } from "./agent-session-events";
 import type { ContextUsageBreakdown, HandoffResult, SessionHandoffOptions } from "./agent-session-types";
 import { findCompactMode } from "./compact-modes";
@@ -187,6 +190,7 @@ export interface SessionMaintenanceHost {
 	sessionId(): string;
 	messages(): AgentMessage[];
 	baseSystemPrompt(): string[];
+	baseSystemPromptPlan(): SystemPromptPlan;
 	goalModeState(): GoalModeState | undefined;
 	planReferencePath(): string;
 	nonMessageTokenSource(): NonMessageTokenSource;
@@ -275,6 +279,27 @@ export class SessionMaintenance {
 
 	get #goalModeState(): GoalModeState | undefined {
 		return this.#host.goalModeState();
+	}
+
+	/**
+	 * The base system prompt handed to the summarizer as `remoteInstructions`,
+	 * with the date-only turn-context block restored for `append-turn-context`
+	 * plans. The date moved out of the base project prompt into the volatile
+	 * turn suffix, so without this the summarizer would no longer know today's
+	 * date and could anchor relative dates ("tomorrow") in the transcript
+	 * incorrectly. Verbatim plans (NULL_PROMPT / explicit systemPrompt) opt out,
+	 * matching buildSystemPromptForAgentStart — and they never carried the date
+	 * in the base prompt before this refactor either. No prompt-specific recall
+	 * is pulled in, only the date.
+	 */
+	#compactionRemoteInstructions(): string {
+		const plan = this.#host.baseSystemPromptPlan();
+		const blocks = [...plan.systemPrompt];
+		if (plan.compositionPolicy === "append-turn-context") {
+			const dateContext = prompt.render(turnContextPrompt, { date: formatLocalCalendarDate() }).trim();
+			if (dateContext) blocks.push(dateContext);
+		}
+		return blocks.join("\n\n");
 	}
 
 	constructor(host: SessionMaintenanceHost) {
@@ -785,7 +810,7 @@ export class SessionMaintenance {
 						{
 							promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
 							extraContext: compactionPrep.hookContext,
-							remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
+							remoteInstructions: this.#compactionRemoteInstructions(),
 							convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),
 							codexCompaction,
 						},
@@ -2499,7 +2524,7 @@ export class SessionMaintenance {
 								{
 									promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
 									extraContext: compactionPrep.hookContext,
-									remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
+									remoteInstructions: this.#compactionRemoteInstructions(),
 									metadata: this.#host.agent.metadataForProvider(candidate.provider),
 									initiatorOverride: "agent",
 									convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),

--- a/packages/coding-agent/src/session/session-memory.ts
+++ b/packages/coding-agent/src/session/session-memory.ts
@@ -20,7 +20,6 @@ export interface SessionMemoryHost {
 	setHindsightSessionState(state: HindsightSessionState | undefined): void;
 	getMnemopiSessionState(): MnemopiSessionState | undefined;
 	takeMnemopiSessionState(): MnemopiSessionState | undefined;
-	setBaseSystemPrompt(prompt: string[]): void;
 	refreshBaseSystemPrompt(): Promise<void>;
 	replaceMemoryTools(tools: AgentTool[]): Promise<void>;
 }
@@ -33,7 +32,6 @@ export class SessionMemory {
 	readonly #createMemoryTools: (() => Promise<AgentTool[]>) | undefined;
 	#memoryBackendTransition: Promise<void> = Promise.resolve();
 	#localMemoryStartupAbort: AbortController | undefined;
-	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 
 	constructor(
 		host: SessionMemoryHost,
@@ -54,25 +52,6 @@ export class SessionMemory {
 		return this.#memoryBackendTransition;
 	}
 
-	/** Base prompt captured before a per-turn memory promotion. */
-	get promotionSnapshot(): string[] | undefined {
-		return this.#baseSystemPromptBeforeMemoryPromotion;
-	}
-
-	/** Clears the per-turn memory promotion after a canonical prompt rebuild. */
-	clearPromotionSnapshot(): void {
-		this.#baseSystemPromptBeforeMemoryPromotion = undefined;
-	}
-
-	/** Captures the canonical prompt before the first per-turn memory promotion. */
-	capturePromotionSnapshot(prompt: string[]): void {
-		this.#baseSystemPromptBeforeMemoryPromotion ??= prompt;
-	}
-
-	/** Restores a promotion snapshot while rolling back a failed session switch. */
-	restorePromotionSnapshot(prompt: string[] | undefined): void {
-		this.#baseSystemPromptBeforeMemoryPromotion = prompt;
-	}
 	/** Rekeys every active memory backend to the current provider session. */
 	rekeyForCurrentSessionId(): void {
 		this.#rekeyHindsightMemoryForCurrentSessionId();
@@ -93,7 +72,6 @@ export class SessionMemory {
 		this.#host.getMnemopiSessionState()?.setSessionId(sid);
 	}
 
-	/** New session file: reset auto-recall / retain-threshold counters for the new transcript. */
 	#resetHindsightConversationTrackingIfHindsight(): boolean {
 		if (this.#host.settings.get("memory.backend") !== "hindsight") return false;
 		const state = this.#host.getHindsightSessionState();
@@ -110,16 +88,11 @@ export class SessionMemory {
 		return true;
 	}
 
-	/** Resets transcript-scoped memory counters and removes a promoted prompt. */
+	/** Resets transcript-scoped memory counters. */
 	async resetContextForNewTranscript(): Promise<void> {
-		const hadPromotedMemoryPrompt = this.#baseSystemPromptBeforeMemoryPromotion !== undefined;
 		const resetHindsight = this.#resetHindsightConversationTrackingIfHindsight();
 		const resetMnemopi = this.#resetMnemopiConversationTrackingIfMnemopi();
-		if (hadPromotedMemoryPrompt) {
-			this.#host.setBaseSystemPrompt(this.#baseSystemPromptBeforeMemoryPromotion!);
-			this.#baseSystemPromptBeforeMemoryPromotion = undefined;
-		}
-		if (resetHindsight || resetMnemopi || hadPromotedMemoryPrompt) {
+		if (resetHindsight || resetMnemopi) {
 			await this.#host.refreshBaseSystemPrompt();
 		}
 	}

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -17,6 +17,7 @@ import { MEMORY_BACKEND_TOOL_NAMES } from "../memory-backend/tool-names";
 import type { MemoryBackendStartOptions } from "../memory-backend/types";
 import turnContextPrompt from "../prompts/system/turn-context.md" with { type: "text" };
 import xdevMountNoticePrompt from "../prompts/system/xdev-mount-notice.md" with { type: "text" };
+import type { SystemPromptPlan } from "../system-prompt";
 import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
 import { computerExposureMode } from "../tools/computer/exposure";
@@ -71,24 +72,16 @@ interface SessionToolsOptions {
 	builtInToolNames?: Iterable<string>;
 	presentationPinnedToolNames?: ReadonlySet<string>;
 	ensureWriteRegistered?: () => Promise<boolean>;
-	rebuildSystemPrompt?: (
-		toolNames: string[],
-		tools: Map<string, AgentTool>,
-	) => Promise<{ systemPrompt: string[]; stableSystemPromptBlockCount?: number }>;
+	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<SystemPromptPlan>;
 	getLocalCalendarDate?: () => string;
 	getMcpServerInstructions?: () => Map<string, string> | undefined;
 	xdev?: XdevState;
 	setActiveToolNames?: (names: Iterable<string>) => void;
-	baseSystemPrompt: string[];
+	baseSystemPromptPlan?: SystemPromptPlan;
 	skills?: Skill[];
 	skillWarnings?: SkillWarning[];
 	skillsSettings?: SkillsSettings;
 	skillsReloadable?: boolean;
-}
-
-interface SystemPromptForAgentStart {
-	systemPrompt: string[];
-	stableSystemPromptBlockCount: number | undefined;
 }
 
 export interface MountedMCPToolRouteSource {
@@ -181,8 +174,7 @@ export class SessionTools {
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
-	#baseSystemPrompt: string[];
-	#stableSystemPromptBlockCount: number | undefined;
+	#systemPromptPlan: SystemPromptPlan;
 	#lastAppliedToolSignature: string | undefined;
 	#mcpRefreshTail: Promise<void> = Promise.resolve();
 	#promptModelKey: string | undefined;
@@ -216,8 +208,12 @@ export class SessionTools {
 		}
 		if (this.#xdev) this.#xdev.decorateExecution = tool => this.#wrapToolForAcpPermission(tool);
 		this.#setActiveToolNames = options.setActiveToolNames;
-		this.#baseSystemPrompt = options.baseSystemPrompt;
-		this.#stableSystemPromptBlockCount = this.#host.agent.state.stableSystemPromptBlockCount;
+		const agentStateBoundary = this.#host.agent.state.stableSystemPromptBlockCount;
+		this.#systemPromptPlan = options.baseSystemPromptPlan ?? {
+			systemPrompt: this.#host.agent.state.systemPrompt,
+			stableSystemPromptBlockCount: agentStateBoundary ?? this.#host.agent.state.systemPrompt.length,
+			compositionPolicy: "append-turn-context",
+		};
 		this.#skills = options.skills ?? [];
 		this.#skillWarnings = options.skillWarnings ?? [];
 		this.#skillsSettings = options.skillsSettings;
@@ -232,13 +228,17 @@ export class SessionTools {
 
 	/** Current stable base system prompt. */
 	get baseSystemPrompt(): string[] {
-		return this.#baseSystemPrompt;
+		return this.#systemPromptPlan.systemPrompt;
+	}
+
+	/** Current base system prompt plan. */
+	get baseSystemPromptPlan(): SystemPromptPlan {
+		return this.#systemPromptPlan;
 	}
 
 	/** Replaces the controller-owned base prompt without applying it to the agent. */
-	setBaseSystemPrompt(prompt: string[], stableSystemPromptBlockCount?: number): void {
-		this.#baseSystemPrompt = prompt;
-		this.#stableSystemPromptBlockCount = stableSystemPromptBlockCount;
+	setBaseSystemPrompt(plan: SystemPromptPlan): void {
+		this.#systemPromptPlan = plan;
 	}
 
 	/** Skills currently rendered into the system prompt. */
@@ -607,16 +607,14 @@ export class SessionTools {
 		this.#setMountedNames(mountNames);
 		this.#setActiveToolNames?.(validToolNames);
 
-		let rebuiltSystemPrompt: string[] | undefined;
-		let rebuiltStableSystemPromptBlockCount: number | undefined;
+		let rebuiltSystemPromptPlan: SystemPromptPlan | undefined;
 		let rebuiltSignature: string | undefined;
 		try {
 			if (this.#rebuildSystemPrompt) {
 				const signature = this.#computeAppliedToolSignature(validToolNames, tools);
 				if (signature !== this.#lastAppliedToolSignature) {
 					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
-					rebuiltSystemPrompt = built.systemPrompt;
-					rebuiltStableSystemPromptBlockCount = built.stableSystemPromptBlockCount;
+					rebuiltSystemPromptPlan = built;
 					rebuiltSignature = signature;
 				}
 			}
@@ -634,11 +632,13 @@ export class SessionTools {
 
 		this.#notifyXdevMountDelta(previousMounted);
 		this.#host.agent.setTools(tools);
-		if (rebuiltSystemPrompt && rebuiltSignature) {
+		if (rebuiltSystemPromptPlan && rebuiltSignature) {
 			if (this.#lastAppliedToolSignature !== undefined) this.#host.clearInheritedProviderPromptCacheKey();
-			this.#baseSystemPrompt = rebuiltSystemPrompt;
-			this.#stableSystemPromptBlockCount = rebuiltStableSystemPromptBlockCount;
-			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt, this.#stableSystemPromptBlockCount);
+			this.#systemPromptPlan = rebuiltSystemPromptPlan;
+			this.#host.agent.setSystemPrompt(
+				this.#systemPromptPlan.systemPrompt,
+				this.#systemPromptPlan.stableSystemPromptBlockCount,
+			);
 			this.#lastAppliedToolSignature = rebuiltSignature;
 			this.#promptModelKey = this.#currentPromptModelKey();
 		}
@@ -972,18 +972,22 @@ export class SessionTools {
 		if (this.#host.isDisposed() || !this.#rebuildSystemPrompt) return;
 		const activeToolNames = this.getActiveToolNames();
 		this.#setActiveToolNames?.(activeToolNames);
-		const previousBaseSystemPrompt = this.#baseSystemPrompt;
+		const previousSystemPromptPlan = this.#systemPromptPlan;
 		const built = await this.#rebuildSystemPrompt(activeToolNames, this.#toolRegistry);
 		if (this.#host.isDisposed()) return;
-		this.#baseSystemPrompt = built.systemPrompt;
-		this.#stableSystemPromptBlockCount = built.stableSystemPromptBlockCount;
+		this.#systemPromptPlan = built;
 		if (
-			previousBaseSystemPrompt.length !== this.#baseSystemPrompt.length ||
-			previousBaseSystemPrompt.some((part, index) => part !== this.#baseSystemPrompt[index])
+			previousSystemPromptPlan.systemPrompt.length !== this.#systemPromptPlan.systemPrompt.length ||
+			previousSystemPromptPlan.systemPrompt.some(
+				(part, index) => part !== this.#systemPromptPlan.systemPrompt[index],
+			)
 		) {
 			this.#host.clearInheritedProviderPromptCacheKey();
 		}
-		this.#host.agent.setSystemPrompt(this.#baseSystemPrompt, this.#stableSystemPromptBlockCount);
+		this.#host.agent.setSystemPrompt(
+			this.#systemPromptPlan.systemPrompt,
+			this.#systemPromptPlan.stableSystemPromptBlockCount,
+		);
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we
@@ -995,23 +999,25 @@ export class SessionTools {
 	}
 
 	/** Builds the stable prompt plus volatile turn context before an agent run. */
-	async buildSystemPromptForAgentStart(promptText: string): Promise<SystemPromptForAgentStart> {
+	async buildSystemPromptForAgentStart(promptText: string): Promise<SystemPromptPlan> {
+		if (this.#systemPromptPlan.compositionPolicy === "verbatim") return this.#systemPromptPlan;
+
 		const turnContext = prompt.render(turnContextPrompt, { date: this.#getLocalCalendarDate() }).trim();
 		const backend = await resolveMemoryBackend(this.#host.settings);
 		if (!backend.beforeAgentStartPrompt) {
 			return {
-				systemPrompt: [...this.#baseSystemPrompt, turnContext],
-				stableSystemPromptBlockCount: this.#stableSystemPromptBlockCount,
+				...this.#systemPromptPlan,
+				systemPrompt: [...this.#systemPromptPlan.systemPrompt, turnContext],
 			};
 		}
 
 		try {
 			const injected = await backend.beforeAgentStartPrompt(this.#host.memoryBackendSession(), promptText);
 			return {
+				...this.#systemPromptPlan,
 				systemPrompt: injected
-					? [...this.#baseSystemPrompt, turnContext, injected]
-					: [...this.#baseSystemPrompt, turnContext],
-				stableSystemPromptBlockCount: this.#stableSystemPromptBlockCount,
+					? [...this.#systemPromptPlan.systemPrompt, turnContext, injected]
+					: [...this.#systemPromptPlan.systemPrompt, turnContext],
 			};
 		} catch (err) {
 			logger.debug("Memory backend beforeAgentStartPrompt failed", {
@@ -1019,8 +1025,8 @@ export class SessionTools {
 				error: String(err),
 			});
 			return {
-				systemPrompt: [...this.#baseSystemPrompt, turnContext],
-				stableSystemPromptBlockCount: this.#stableSystemPromptBlockCount,
+				...this.#systemPromptPlan,
+				systemPrompt: [...this.#systemPromptPlan.systemPrompt, turnContext],
 			};
 		}
 	}

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1031,6 +1031,32 @@ export class SessionTools {
 		}
 	}
 
+	/** Builds the stable prompt plus side-request recall context for an ephemeral turn. */
+	async buildSystemPromptForSideRequest(promptText: string): Promise<SystemPromptPlan> {
+		if (this.#systemPromptPlan.compositionPolicy === "verbatim") return this.#systemPromptPlan;
+
+		const turnContext = prompt.render(turnContextPrompt, { date: this.#getLocalCalendarDate() }).trim();
+		const backend = await resolveMemoryBackend(this.#host.settings);
+		try {
+			const injected = await backend.beforeSideRequestPrompt(this.#host.memoryBackendSession(), promptText);
+			return {
+				...this.#systemPromptPlan,
+				systemPrompt: injected
+					? [...this.#systemPromptPlan.systemPrompt, turnContext, injected]
+					: [...this.#systemPromptPlan.systemPrompt, turnContext],
+			};
+		} catch (err) {
+			logger.debug("Memory backend beforeSideRequestPrompt failed", {
+				backend: backend.id,
+				error: String(err),
+			});
+			return {
+				...this.#systemPromptPlan,
+				systemPrompt: [...this.#systemPromptPlan.systemPrompt, turnContext],
+			};
+		}
+	}
+
 	/**
 	 * Compose a stable signature for the inputs that `rebuildSystemPrompt` reads.
 	 * Two calls producing identical signatures are guaranteed to produce identical

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -634,11 +634,12 @@ export class SessionTools {
 		this.#host.agent.setTools(tools);
 		if (rebuiltSystemPromptPlan && rebuiltSignature) {
 			if (this.#lastAppliedToolSignature !== undefined) this.#host.clearInheritedProviderPromptCacheKey();
-			this.#systemPromptPlan = rebuiltSystemPromptPlan;
-			this.#host.agent.setSystemPrompt(
-				this.#systemPromptPlan.systemPrompt,
-				this.#systemPromptPlan.stableSystemPromptBlockCount,
-			);
+			// Carry the live turn suffix (date + recalled memory) across this
+			// rebuild, just like refreshBaseSystemPrompt(): this path is reached
+			// mid-turn via deferred MCP discovery (refreshMCPTools), and setting
+			// the base-only plan would strip the suffix before the next tool-loop
+			// model call copies it via syncContextBeforeModelCall.
+			this.#commitBasePlanPreservingTurnSuffix(rebuiltSystemPromptPlan, this.#systemPromptPlan);
 			this.#lastAppliedToolSignature = rebuiltSignature;
 			this.#promptModelKey = this.#currentPromptModelKey();
 		}
@@ -975,33 +976,13 @@ export class SessionTools {
 		const previousSystemPromptPlan = this.#systemPromptPlan;
 		const built = await this.#rebuildSystemPrompt(activeToolNames, this.#toolRegistry);
 		if (this.#host.isDisposed()) return;
-		this.#systemPromptPlan = built;
 		if (
-			previousSystemPromptPlan.systemPrompt.length !== this.#systemPromptPlan.systemPrompt.length ||
-			previousSystemPromptPlan.systemPrompt.some(
-				(part, index) => part !== this.#systemPromptPlan.systemPrompt[index],
-			)
+			previousSystemPromptPlan.systemPrompt.length !== built.systemPrompt.length ||
+			previousSystemPromptPlan.systemPrompt.some((part, index) => part !== built.systemPrompt[index])
 		) {
 			this.#host.clearInheritedProviderPromptCacheKey();
 		}
-		// A turn in flight composes the base plan with a volatile turn suffix
-		// (date, and any recalled-memory injection from before_agent_start).
-		// Setting the base-only plan here would strip that suffix mid-turn, so
-		// syncContextBeforeModelCall would send the base plan without the
-		// date/memory context on the next tool-loop model call. Carry the live
-		// suffix (the part of the current agent prompt beyond the previous base)
-		// so only the stable base is refreshed, not the active turn's context.
-		const liveSystemPrompt = this.#host.agent.state.systemPrompt;
-		const previousBase = previousSystemPromptPlan.systemPrompt;
-		const turnSuffix =
-			liveSystemPrompt.length > previousBase.length &&
-			previousBase.every((part, index) => liveSystemPrompt[index] === part)
-				? liveSystemPrompt.slice(previousBase.length)
-				: [];
-		this.#host.agent.setSystemPrompt(
-			[...this.#systemPromptPlan.systemPrompt, ...turnSuffix],
-			this.#systemPromptPlan.stableSystemPromptBlockCount,
-		);
+		this.#commitBasePlanPreservingTurnSuffix(built, previousSystemPromptPlan);
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we
@@ -1010,6 +991,29 @@ export class SessionTools {
 			.map(name => this.#toolRegistry.get(name))
 			.filter((tool): tool is AgentTool => tool != null);
 		this.#lastAppliedToolSignature = this.#computeAppliedToolSignature(activeToolNames, activeTools);
+	}
+
+	/**
+	 * Commit a freshly rebuilt base {@link SystemPromptPlan} as the session's
+	 * stable prompt while preserving any volatile turn suffix currently on the
+	 * live agent prompt (the date block plus recalled-memory injection from
+	 * before_agent_start). Tool/model refreshes can land mid-turn — deferred
+	 * MCP discovery fires refreshMCPTools → applyActiveToolsByName while a turn
+	 * streams — and committing the base-only plan would strip that suffix, so
+	 * the next tool-loop model call would lose the date/memory context. Carry
+	 * the live suffix (the part of the current agent prompt beyond the previous
+	 * base) so only the stable base is refreshed.
+	 */
+	#commitBasePlanPreservingTurnSuffix(newPlan: SystemPromptPlan, previousPlan: SystemPromptPlan): void {
+		this.#systemPromptPlan = newPlan;
+		const liveSystemPrompt = this.#host.agent.state.systemPrompt;
+		const previousBase = previousPlan.systemPrompt;
+		const turnSuffix =
+			liveSystemPrompt.length > previousBase.length &&
+			previousBase.every((part, index) => liveSystemPrompt[index] === part)
+				? liveSystemPrompt.slice(previousBase.length)
+				: [];
+		this.#host.agent.setSystemPrompt([...newPlan.systemPrompt, ...turnSuffix], newPlan.stableSystemPromptBlockCount);
 	}
 
 	/** Builds the stable prompt plus volatile turn context before an agent run. */

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -15,6 +15,7 @@ import { deduplicateMCPToolsByName } from "../mcp/tool-bridge";
 import { resolveMemoryBackend } from "../memory-backend/resolve";
 import { MEMORY_BACKEND_TOOL_NAMES } from "../memory-backend/tool-names";
 import type { MemoryBackendStartOptions } from "../memory-backend/types";
+import turnContextPrompt from "../prompts/system/turn-context.md" with { type: "text" };
 import xdevMountNoticePrompt from "../prompts/system/xdev-mount-notice.md" with { type: "text" };
 import { usesCodexTaskPrompt } from "../task/prompt-policy";
 import { isMCPToolName, normalizeToolNames } from "../tools/builtin-names";
@@ -52,8 +53,6 @@ export interface SessionToolsHost {
 	model(): Model | undefined;
 	memoryBackendSession(): MemoryBackendStartOptions["session"];
 	clearInheritedProviderPromptCacheKey(): void;
-	clearMemoryPromotionSnapshot(): void;
-	captureMemoryPromotionSnapshot(prompt: string[]): void;
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
 	notifyCommandMetadataChanged(): void;
 	localProtocolOptions(): LocalProtocolOptions;
@@ -72,7 +71,10 @@ interface SessionToolsOptions {
 	builtInToolNames?: Iterable<string>;
 	presentationPinnedToolNames?: ReadonlySet<string>;
 	ensureWriteRegistered?: () => Promise<boolean>;
-	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
+	rebuildSystemPrompt?: (
+		toolNames: string[],
+		tools: Map<string, AgentTool>,
+	) => Promise<{ systemPrompt: string[]; stableSystemPromptBlockCount?: number }>;
 	getLocalCalendarDate?: () => string;
 	getMcpServerInstructions?: () => Map<string, string> | undefined;
 	xdev?: XdevState;
@@ -82,6 +84,11 @@ interface SessionToolsOptions {
 	skillWarnings?: SkillWarning[];
 	skillsSettings?: SkillsSettings;
 	skillsReloadable?: boolean;
+}
+
+interface SystemPromptForAgentStart {
+	systemPrompt: string[];
+	stableSystemPromptBlockCount: number | undefined;
 }
 
 export interface MountedMCPToolRouteSource {
@@ -175,6 +182,7 @@ export class SessionTools {
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
+	#stableSystemPromptBlockCount: number | undefined;
 	#lastAppliedToolSignature: string | undefined;
 	#mcpRefreshTail: Promise<void> = Promise.resolve();
 	#promptModelKey: string | undefined;
@@ -209,6 +217,7 @@ export class SessionTools {
 		if (this.#xdev) this.#xdev.decorateExecution = tool => this.#wrapToolForAcpPermission(tool);
 		this.#setActiveToolNames = options.setActiveToolNames;
 		this.#baseSystemPrompt = options.baseSystemPrompt;
+		this.#stableSystemPromptBlockCount = this.#host.agent.state.stableSystemPromptBlockCount;
 		this.#skills = options.skills ?? [];
 		this.#skillWarnings = options.skillWarnings ?? [];
 		this.#skillsSettings = options.skillsSettings;
@@ -227,8 +236,9 @@ export class SessionTools {
 	}
 
 	/** Replaces the controller-owned base prompt without applying it to the agent. */
-	setBaseSystemPrompt(prompt: string[]): void {
+	setBaseSystemPrompt(prompt: string[], stableSystemPromptBlockCount?: number): void {
 		this.#baseSystemPrompt = prompt;
+		this.#stableSystemPromptBlockCount = stableSystemPromptBlockCount;
 	}
 
 	/** Skills currently rendered into the system prompt. */
@@ -598,6 +608,7 @@ export class SessionTools {
 		this.#setActiveToolNames?.(validToolNames);
 
 		let rebuiltSystemPrompt: string[] | undefined;
+		let rebuiltStableSystemPromptBlockCount: number | undefined;
 		let rebuiltSignature: string | undefined;
 		try {
 			if (this.#rebuildSystemPrompt) {
@@ -605,6 +616,7 @@ export class SessionTools {
 				if (signature !== this.#lastAppliedToolSignature) {
 					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
 					rebuiltSystemPrompt = built.systemPrompt;
+					rebuiltStableSystemPromptBlockCount = built.stableSystemPromptBlockCount;
 					rebuiltSignature = signature;
 				}
 			}
@@ -625,8 +637,8 @@ export class SessionTools {
 		if (rebuiltSystemPrompt && rebuiltSignature) {
 			if (this.#lastAppliedToolSignature !== undefined) this.#host.clearInheritedProviderPromptCacheKey();
 			this.#baseSystemPrompt = rebuiltSystemPrompt;
-			this.#host.clearMemoryPromotionSnapshot();
-			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
+			this.#stableSystemPromptBlockCount = rebuiltStableSystemPromptBlockCount;
+			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt, this.#stableSystemPromptBlockCount);
 			this.#lastAppliedToolSignature = rebuiltSignature;
 			this.#promptModelKey = this.#currentPromptModelKey();
 		}
@@ -964,14 +976,14 @@ export class SessionTools {
 		const built = await this.#rebuildSystemPrompt(activeToolNames, this.#toolRegistry);
 		if (this.#host.isDisposed()) return;
 		this.#baseSystemPrompt = built.systemPrompt;
-		this.#host.clearMemoryPromotionSnapshot();
+		this.#stableSystemPromptBlockCount = built.stableSystemPromptBlockCount;
 		if (
 			previousBaseSystemPrompt.length !== this.#baseSystemPrompt.length ||
 			previousBaseSystemPrompt.some((part, index) => part !== this.#baseSystemPrompt[index])
 		) {
 			this.#host.clearInheritedProviderPromptCacheKey();
 		}
-		this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
+		this.#host.agent.setSystemPrompt(this.#baseSystemPrompt, this.#stableSystemPromptBlockCount);
 		this.#promptModelKey = this.#currentPromptModelKey();
 		// Refresh the cached signature so a subsequent `applyActiveToolsByName` with
 		// the same tool set does not re-rebuild on top of the explicit refresh we
@@ -982,43 +994,34 @@ export class SessionTools {
 		this.#lastAppliedToolSignature = this.#computeAppliedToolSignature(activeToolNames, activeTools);
 	}
 
-	/** Applies one-turn memory prompt injection before an agent run. */
-	async buildSystemPromptForAgentStart(promptText: string): Promise<string[]> {
+	/** Builds the stable prompt plus volatile turn context before an agent run. */
+	async buildSystemPromptForAgentStart(promptText: string): Promise<SystemPromptForAgentStart> {
+		const turnContext = prompt.render(turnContextPrompt, { date: this.#getLocalCalendarDate() }).trim();
 		const backend = await resolveMemoryBackend(this.#host.settings);
-		if (!backend.beforeAgentStartPrompt) return this.#baseSystemPrompt;
+		if (!backend.beforeAgentStartPrompt) {
+			return {
+				systemPrompt: [...this.#baseSystemPrompt, turnContext],
+				stableSystemPromptBlockCount: this.#stableSystemPromptBlockCount,
+			};
+		}
 
 		try {
 			const injected = await backend.beforeAgentStartPrompt(this.#host.memoryBackendSession(), promptText);
-			if (!injected) return this.#baseSystemPrompt;
-
-			const previousBaseSystemPrompt = this.#baseSystemPrompt;
-			try {
-				await this.refreshBaseSystemPrompt();
-			} catch (refreshErr) {
-				logger.debug("Memory backend prompt refresh after beforeAgentStartPrompt failed", {
-					backend: backend.id,
-					error: String(refreshErr),
-				});
-			}
-
-			if (
-				this.#baseSystemPrompt.length !== previousBaseSystemPrompt.length ||
-				this.#baseSystemPrompt.some((part, index) => part !== previousBaseSystemPrompt[index])
-			) {
-				return this.#baseSystemPrompt;
-			}
-
-			this.#host.captureMemoryPromotionSnapshot(previousBaseSystemPrompt);
-			const stablePrompt = [...previousBaseSystemPrompt, injected];
-			this.#baseSystemPrompt = stablePrompt;
-			this.#host.agent.setSystemPrompt(stablePrompt);
-			return stablePrompt;
+			return {
+				systemPrompt: injected
+					? [...this.#baseSystemPrompt, turnContext, injected]
+					: [...this.#baseSystemPrompt, turnContext],
+				stableSystemPromptBlockCount: this.#stableSystemPromptBlockCount,
+			};
 		} catch (err) {
 			logger.debug("Memory backend beforeAgentStartPrompt failed", {
 				backend: backend.id,
 				error: String(err),
 			});
-			return this.#baseSystemPrompt;
+			return {
+				systemPrompt: [...this.#baseSystemPrompt, turnContext],
+				stableSystemPromptBlockCount: this.#stableSystemPromptBlockCount,
+			};
 		}
 	}
 
@@ -1056,11 +1059,6 @@ export class SessionTools {
 	 * closure-captured ones cannot change at runtime regardless of skip behavior.
 	 * For everything else, callers must explicitly call {@link refreshBaseSystemPrompt}
 	 * after side-effecting changes; see the memory hooks and {@link syncAfterModelChange}.
-	 *
-	 * The current calendar date IS covered (appended as a segment) because
-	 * `buildSystemPrompt` injects it into the prompt body (`Today is '{{date}}'`).
-	 * Without this, a session spanning midnight with only tool-stable MCP
-	 * reconnects would keep yesterday's date indefinitely.
 	 */
 	#computeAppliedToolSignature(toolNames: string[], tools: AgentTool[]): string {
 		// Order-preserving join: any reorder must produce a different signature so
@@ -1094,8 +1092,7 @@ export class SessionTools {
 		// the provider cache prefix byte-stable. Mounted MCP routes are the narrow
 		// exception above, bounded to the exact projection rendered in the global
 		// route guidance so churn wholly behind its fallback does not rebuild.
-		const date = this.#getLocalCalendarDate();
-		return `${nameSegment}\u0003${descriptionSegment}\u0007${instructionsSegment}\u0008${mountedMCPRouteSegment}|${date}`;
+		return `${nameSegment}\u0003${descriptionSegment}\u0007${instructionsSegment}\u0008${mountedMCPRouteSegment}`;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -984,8 +984,22 @@ export class SessionTools {
 		) {
 			this.#host.clearInheritedProviderPromptCacheKey();
 		}
+		// A turn in flight composes the base plan with a volatile turn suffix
+		// (date, and any recalled-memory injection from before_agent_start).
+		// Setting the base-only plan here would strip that suffix mid-turn, so
+		// syncContextBeforeModelCall would send the base plan without the
+		// date/memory context on the next tool-loop model call. Carry the live
+		// suffix (the part of the current agent prompt beyond the previous base)
+		// so only the stable base is refreshed, not the active turn's context.
+		const liveSystemPrompt = this.#host.agent.state.systemPrompt;
+		const previousBase = previousSystemPromptPlan.systemPrompt;
+		const turnSuffix =
+			liveSystemPrompt.length > previousBase.length &&
+			previousBase.every((part, index) => liveSystemPrompt[index] === part)
+				? liveSystemPrompt.slice(previousBase.length)
+				: [];
 		this.#host.agent.setSystemPrompt(
-			this.#systemPromptPlan.systemPrompt,
+			[...this.#systemPromptPlan.systemPrompt, ...turnSuffix],
 			this.#systemPromptPlan.stableSystemPromptBlockCount,
 		);
 		this.#promptModelKey = this.#currentPromptModelKey();

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -558,6 +558,14 @@ export interface SystemPromptPlan {
 	compositionPolicy: SystemPromptCompositionPolicy;
 }
 
+/**
+ * Compatibility alias for the pre-rename result type. The package exposes source
+ * modules through its `./*` export map, so external TypeScript SDK consumers
+ * importing `BuildSystemPromptResult` from `@oh-my-pi/pi-coding-agent/system-prompt`
+ * must keep compiling; `SystemPromptPlan` is the canonical name.
+ */
+export type BuildSystemPromptResult = SystemPromptPlan;
+
 /** Controls whether the session may append turn-specific context to a prompt plan. */
 export type SystemPromptCompositionPolicy = "append-turn-context" | "verbatim";
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -24,10 +24,10 @@ import friendlyPersonality from "./prompts/system/personalities/friendly.md" wit
 import pragmaticPersonality from "./prompts/system/personalities/pragmatic.md" with { type: "text" };
 import projectPromptTemplate from "./prompts/system/project-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
+import toolInventoryTemplate from "./prompts/system/tool-inventory.md" with { type: "text" };
 import { normalizeConcurrencyLimit } from "./task/parallel";
 import { usesCodexTaskPrompt } from "./task/prompt-policy";
 import { type ActiveRepoContext, resolveActiveRepoContext } from "./utils/active-repo-context";
-import { formatLocalCalendarDate } from "./utils/local-date";
 import { normalizePromptPath } from "./utils/prompt-path";
 import { AGENTS_MD_LIMIT, buildWorkspaceTree, type WorkspaceTree } from "./workspace-tree";
 
@@ -552,12 +552,14 @@ export interface BuildSystemPromptOptions {
 export interface BuildSystemPromptResult {
 	/** Ordered system prompt blocks. Providers should preserve entries as distinct messages/blocks. */
 	systemPrompt: string[];
+	/** Number of leading blocks that remain stable across project-context and tool changes. */
+	stableSystemPromptBlockCount?: number;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
 export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
 	if ($env.NULL_PROMPT === "true") {
-		return { systemPrompt: [] };
+		return { systemPrompt: [], stableSystemPromptBlockCount: 0 };
 	}
 
 	const {
@@ -763,8 +765,6 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		}
 	}
 
-	const date = formatLocalCalendarDate();
-	const dateTime = date;
 	const promptCwd = normalizePromptPath(resolvedCwd);
 	const activeRepoContextPrompt = renderActiveRepoContextPrompt(activeRepoContext);
 
@@ -850,8 +850,6 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		skills: filteredSkills,
 		rules: rules ?? [],
 		alwaysApplyRules: injectedAlwaysApplyRules,
-		date,
-		dateTime,
 		cwd: promptCwd,
 		additionalWorkspaceRoots: additionalWorkspaceRoots.filter(d => path.resolve(d) !== path.resolve(resolvedCwd)),
 		model: includeModelInPrompt ? (model ?? "") : "",
@@ -878,6 +876,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	if (toolNames.includes("computer")) {
 		systemPrompt.push(computerSafetyPrompt.trim());
 	}
+	const stableSystemPromptBlockCount = systemPrompt.length;
 	// Custom prompt templates already render context files and append text; the
 	// project footer still carries environment, cwd, workspace, and dir-context.
 	const projectPrompt = prompt
@@ -889,6 +888,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	if (activeRepoContextPrompt) {
 		systemPrompt.push(activeRepoContextPrompt);
 	}
+	const renderedToolInventory = prompt.render(toolInventoryTemplate, data).trim();
+	if (renderedToolInventory) {
+		systemPrompt.push(renderedToolInventory);
+	}
 
-	return { systemPrompt };
+	return { systemPrompt, stableSystemPromptBlockCount };
 }

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -549,17 +549,22 @@ export interface BuildSystemPromptOptions {
 }
 
 /** Result of building provider-facing system prompt messages. */
-export interface BuildSystemPromptResult {
+export interface SystemPromptPlan {
 	/** Ordered system prompt blocks. Providers should preserve entries as distinct messages/blocks. */
 	systemPrompt: string[];
 	/** Number of leading blocks that remain stable across project-context and tool changes. */
 	stableSystemPromptBlockCount?: number;
+	/** Whether turn-specific context may be appended to the bundled prompt. */
+	compositionPolicy: SystemPromptCompositionPolicy;
 }
 
+/** Controls whether the session may append turn-specific context to a prompt plan. */
+export type SystemPromptCompositionPolicy = "append-turn-context" | "verbatim";
+
 /** Build the system prompt with tools, guidelines, and context */
-export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
+export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<SystemPromptPlan> {
 	if ($env.NULL_PROMPT === "true") {
-		return { systemPrompt: [], stableSystemPromptBlockCount: 0 };
+		return { systemPrompt: [], stableSystemPromptBlockCount: 0, compositionPolicy: "verbatim" };
 	}
 
 	const {
@@ -893,5 +898,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		systemPrompt.push(renderedToolInventory);
 	}
 
-	return { systemPrompt, stableSystemPromptBlockCount };
+	return {
+		systemPrompt,
+		stableSystemPromptBlockCount,
+		compositionPolicy: "append-turn-context",
+	};
 }

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -876,17 +876,25 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		xdevDocs,
 		autoQaEnabled,
 	};
-	const rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
+	// Custom prompt templates embed volatile project context (context files,
+	// append text) directly. Strip those from the stable-block render so only
+	// the (stable) custom instructions are cached; the project footer below
+	// re-adds them in a non-stable block so a context/append change does not
+	// cold-miss the otherwise reusable custom-prefix bytes.
+	const stableRenderData = resolvedCustomPrompt ? { ...data, contextFiles: [], appendPrompt: "" } : data;
+	const rendered = prompt.render(
+		resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate,
+		stableRenderData,
+	);
 	const systemPrompt = [rendered];
 	if (toolNames.includes("computer")) {
 		systemPrompt.push(computerSafetyPrompt.trim());
 	}
 	const stableSystemPromptBlockCount = systemPrompt.length;
-	// Custom prompt templates already render context files and append text; the
-	// project footer still carries environment, cwd, workspace, and dir-context.
-	const projectPrompt = prompt
-		.render(projectPromptTemplate, resolvedCustomPrompt ? { ...data, contextFiles: [], appendPrompt: "" } : data)
-		.trim();
+	// The project footer carries volatile project/context data (context files,
+	// append text, environment, cwd, workspace, dir-context) for both the
+	// bundled and custom prompt, after the stable cache breakpoint.
+	const projectPrompt = prompt.render(projectPromptTemplate, data).trim();
 	if (projectPrompt) {
 		systemPrompt.push(projectPrompt);
 	}

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -1890,6 +1890,68 @@ describe("AgentSession handoff", () => {
 		expect(handoffCall[0].systemPrompt).toEqual(["Test", expect.stringMatching(/^Today is .+\.$/)]);
 	});
 
+	it("does not append the turn-context date for a verbatim system-prompt plan on handoff", async () => {
+		// A verbatim plan (NULL_PROMPT or an explicit systemPrompt) must reach the
+		// handoff summarizer byte-for-byte — appending the date would make a null
+		// prompt nonempty and break the verbatim contract, mirroring
+		// buildSystemPromptForAgentStart / buildSystemPromptForSideRequest.
+		await session.dispose();
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const verbatimAgent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Custom verbatim prompt"],
+				tools: [],
+				messages: [],
+			},
+		});
+		session = new AgentSession({
+			agent: verbatimAgent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			obfuscator,
+			systemPromptPlan: {
+				systemPrompt: ["Custom verbatim prompt"],
+				stableSystemPromptBlockCount: 1,
+				compositionPolicy: "verbatim",
+			},
+		});
+		sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "seed" }],
+			timestamp: Date.now() - 2,
+		});
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "seed response" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			stopReason: "stop",
+			usage: {
+				input: 16,
+				output: 8,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 24,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now() - 1,
+		});
+
+		const generateHandoffSpy = vi
+			.spyOn(compactionModule, "generateHandoffFromContext")
+			.mockResolvedValue("## Goal\nContinue from here");
+		await session.handoff();
+
+		const handoffCall = generateHandoffSpy.mock.calls[0];
+		if (!handoffCall) throw new Error("Expected generateHandoffFromContext call");
+		const handoffSystemPrompt = handoffCall[0].systemPrompt ?? [];
+		expect(handoffSystemPrompt).toEqual(["Custom verbatim prompt"]);
+		expect(handoffSystemPrompt.join("\n")).not.toContain("Today is ");
+	});
+
 	it("forwards the agent's provider prompt-cache key to the handoff request", async () => {
 		// Cache parity: the live loop routes on the agent's promptCacheKey
 		// (providerPromptCacheKey), so handoff must reuse it rather than this.sessionId

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -1884,7 +1884,10 @@ describe("AgentSession handoff", () => {
 		expect(mock.calls.map(c => c.context.systemPrompt?.join("\n\n") ?? "")).toEqual(["Hook override"]);
 		const handoffCall = generateHandoffSpy.mock.calls[0];
 		if (!handoffCall) throw new Error("Expected generateHandoffFromContext call");
-		expect(handoffCall[0].systemPrompt).toEqual(["Test"]);
+		// The handoff uses the base prompt (not the before_agent_start hook
+		// override), now composed with the volatile turn-context date suffix so
+		// relative dates in the transcript resolve against today.
+		expect(handoffCall[0].systemPrompt).toEqual(["Test", expect.stringMatching(/^Today is .+\.$/)]);
 	});
 
 	it("forwards the agent's provider prompt-cache key to the handoff request", async () => {

--- a/packages/coding-agent/test/agent-session-memory-backend.test.ts
+++ b/packages/coding-agent/test/agent-session-memory-backend.test.ts
@@ -83,6 +83,7 @@ describe("AgentSession memory backend lifecycle", () => {
 			builtInToolNames: [read.name],
 			rebuildSystemPrompt: async toolNames => ({
 				systemPrompt: [`backend:${settings.get("memory.backend")};tools:${toolNames.sort().join(",")}`],
+				compositionPolicy: "append-turn-context",
 			}),
 		});
 		return session;

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -18,6 +18,7 @@ import {
 	type SimpleStreamOptions,
 	type TextContent,
 } from "@oh-my-pi/pi-ai";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -77,6 +78,36 @@ async function withNativeDialectEnv<T>(fn: () => Promise<T>): Promise<T> {
 			Bun.env.PI_DIALECT = previous;
 		}
 	}
+}
+
+const ANTHROPIC_SERIALIZATION_MODEL = buildModel({
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+} as ModelSpec<"anthropic-messages">);
+
+function captureAnthropicSystemPrefix(context: Context): Promise<string> {
+	const { promise, resolve } = Promise.withResolvers<string>();
+	const controller = new AbortController();
+	controller.abort();
+	streamAnthropic(ANTHROPIC_SERIALIZATION_MODEL, context, {
+		apiKey: "sk-ant-oat-test",
+		isOAuth: true,
+		signal: controller.signal,
+		onPayload: payload => {
+			const system = (payload as { system?: Array<{ cache_control?: unknown }> }).system ?? [];
+			const breakpoint = system.findIndex(block => block.cache_control !== undefined);
+			resolve(breakpoint >= 0 ? JSON.stringify(system.slice(0, breakpoint + 1)) : "");
+		},
+	});
+	return promise;
 }
 
 describe("AgentSession message pipeline", () => {
@@ -339,6 +370,65 @@ describe("AgentSession message pipeline", () => {
 		expect(capturedOptions?.sessionId).toStartWith(`${session.sessionId}:side:`);
 	});
 
+	it("builds a fresh recalled prompt plan for every ephemeral side request", async () => {
+		const model = buildModel({
+			id: "side-fresh-prompt-model",
+			name: "Side Fresh Prompt Model",
+			api: "anthropic",
+			provider: "test-provider",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const contexts: Context[] = [];
+		const fakeBackend: MemoryBackend = {
+			id: "mnemopi",
+			async start() {},
+			async buildDeveloperInstructions() {
+				return undefined;
+			},
+			async clear() {},
+			async enqueue() {},
+			async beforeAgentStartPrompt(_session, promptText) {
+				return `<memories>recall for ${promptText}</memories>`;
+			},
+		};
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["stable prefix"], messages: [], tools: [] },
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false, "memory.backend": "mnemopi" }),
+			modelRegistry: createModelRegistryStub() as never,
+			sideStreamFn: (_model, context) => {
+				contexts.push(context);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage("Side answer");
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		sessions.push(session);
+
+		await session.runEphemeralTurn({ promptText: "before the first main turn" });
+		// A completed main turn would leave this volatile suffix on the live agent.
+		// Side requests must rebuild from the stable plan rather than inherit it.
+		agent.setSystemPrompt(["stable prefix", "stale live volatile suffix"]);
+		await session.runEphemeralTurn({ promptText: "after recall" });
+
+		expect(contexts).toHaveLength(2);
+		expect(contexts[0]?.systemPrompt?.join("\n")).toContain("recall for before the first main turn");
+		expect(contexts[1]?.systemPrompt?.join("\n")).toContain("recall for after recall");
+		expect(contexts[1]?.systemPrompt?.join("\n")).not.toContain("stale live volatile suffix");
+	});
+
 	it("rotates ephemeral side-channel credentials on Google Resource exhausted", async () => {
 		const api = "test-ephemeral-google-resource-exhausted";
 		const googleErrorMessage = "Google API error (429): Resource exhausted. Please try again later.";
@@ -581,12 +671,96 @@ describe("AgentSession message pipeline", () => {
 			await agent.prompt("Main Question?");
 			await session.runEphemeralTurn({ promptText: `Side Question ${secret}?` });
 
-			// The static prefix (system prompt + tools) is left untouched, so it stays byte-identical
-			// between the main turn and the side turn and the prompt cache prefix survives.
-			expect(JSON.stringify(mainContext?.systemPrompt)).toBe(JSON.stringify(sideContext?.systemPrompt));
+			// The declared stable prefix must be byte-identical between the main turn
+			// and the side turn so the prompt cache prefix survives.
+			const boundary = sideContext?.stableSystemPromptBlockCount ?? 0;
+			expect(boundary).toBeGreaterThan(0);
+			const mainStable = (mainContext?.systemPrompt ?? []).slice(0, boundary);
+			const sideStable = (sideContext?.systemPrompt ?? []).slice(0, boundary);
+			expect(JSON.stringify(mainStable)).toBe(JSON.stringify(sideStable));
+			// The volatile suffix (after the stable boundary) carries turn context.
+			const sideVolatile = (sideContext?.systemPrompt ?? []).slice(boundary).join("\n");
+			expect(sideVolatile).toContain("Today is ");
 			expect(JSON.stringify(mainContext?.tools)).toBe(JSON.stringify(sideContext?.tools));
 			// The side turn's user prompt secret is redacted from the outbound messages.
 			expect(JSON.stringify(sideContext?.messages)).not.toContain(secret);
+		});
+	});
+
+	it("does not freeze an empty Anthropic billing seed before the first persisted user turn", async () => {
+		await withNativeDialectEnv(async () => {
+			const api = "test-ephemeral-empty-billing-seed";
+			const contexts: Context[] = [];
+			registerCustomApi(api, (_model, context, _options) => {
+				contexts.push(context);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage("Answer");
+					stream.push({ type: "text_delta", contentIndex: 0, delta: "Answer", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			});
+
+			const model = buildModel({
+				id: "side-model-empty-billing-seed",
+				name: "Side Model Empty Billing Seed",
+				api,
+				provider: "test-provider",
+				baseUrl: "",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 4096,
+				maxTokens: 1024,
+			} as ModelSpec<Api>) as Model<Api>;
+			const agent = new Agent({
+				initialState: { model, systemPrompt: ["stable harness instructions"], messages: [], tools: [] },
+			});
+			const session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "compaction.enabled": false }),
+				modelRegistry: createModelRegistryStub() as never,
+			});
+			sessions.push(session);
+
+			// 1) Side request before any persisted user message: a transient empty seed
+			// is allowed, but it must NOT be frozen for the rest of the session.
+			await session.runEphemeralTurn({ promptText: "side request before main" });
+			// 2) The main turn persists a real first user message; the provider derives
+			// the OAuth billing header from that first user text itself.
+			await agent.prompt("Main request establishes this session seed");
+			// 3) A side request after the main turn must adopt the settled seed so its
+			// billing-header fingerprint matches the main turn's.
+			await session.runEphemeralTurn({ promptText: "side request after main" });
+
+			// Identify each captured context by its billing-seed signature rather than a
+			// fixed call index, so the test stays robust to any incidental internal calls.
+			// Main never carries a seed override (the provider derives it from messages);
+			// side requests always carry an explicit (possibly "") seed.
+			const preMainSide = contexts[0];
+			const mainContext = contexts.find(context => context.anthropicBillingSeed === undefined);
+			const postMainSide = contexts[contexts.length - 1];
+			// no-user case: a transient empty seed is allowed but never cached/frozen.
+			expect(preMainSide?.anthropicBillingSeed).toBe("");
+			// the main turn was captured and derives its seed from messages (no override).
+			expect(mainContext).toBeDefined();
+			expect(mainContext?.anthropicBillingSeed).toBeUndefined();
+			// a later side turn ran after the main turn.
+			expect(postMainSide).not.toBe(preMainSide);
+			const mainSeed = "Main request establishes this session seed";
+			// post-main side: adopted the settled first-user-text seed (NOT frozen "").
+			expect(postMainSide?.anthropicBillingSeed).toBe(mainSeed);
+
+			// Serialized provider proof: the post-main side and the main OAuth system
+			// prefixes through cache_control must be byte-identical.
+			const mainPrefix = await captureAnthropicSystemPrefix(mainContext!);
+			const sidePrefix = await captureAnthropicSystemPrefix(postMainSide!);
+			expect(mainPrefix.length).toBeGreaterThan(0);
+			expect(sidePrefix).toBe(mainPrefix);
+			// ...while their model-visible message arrays legitimately differ.
+			expect(JSON.stringify(mainContext!.messages)).not.toBe(JSON.stringify(postMainSide!.messages));
 		});
 	});
 
@@ -739,6 +913,7 @@ describe("AgentSession message pipeline", () => {
 				systemPrompt: remembered
 					? ["base", `static memory instructions\n\n${injected}`]
 					: ["base", "static memory instructions"],
+				compositionPolicy: "append-turn-context",
 			}),
 		});
 		sessions.push(session);
@@ -1021,6 +1196,7 @@ describe("AgentSession message pipeline", () => {
 				systemPrompt: remembered
 					? ["base", `static memory instructions\n\n${injected}`]
 					: ["base", "static memory instructions"],
+				compositionPolicy: "append-turn-context",
 			}),
 		});
 		sessions.push(session);
@@ -1110,6 +1286,7 @@ describe("AgentSession message pipeline", () => {
 				systemPrompt: remembered
 					? ["base", `static memory instructions\n\n${injected}`]
 					: ["base", "static memory instructions"],
+				compositionPolicy: "append-turn-context",
 			}),
 		});
 		sessions.push(session);
@@ -1203,6 +1380,7 @@ describe("AgentSession message pipeline", () => {
 				systemPrompt: remembered
 					? ["base", `static memory instructions\n\n${injected}`]
 					: ["base", "static memory instructions"],
+				compositionPolicy: "append-turn-context",
 			}),
 		});
 		sessions.push(session);
@@ -1224,6 +1402,192 @@ describe("AgentSession message pipeline", () => {
 		const forkedPrompt = contexts[1]!.systemPrompt?.join("\n") ?? "";
 		const occurrences = forkedPrompt.split(injected).length - 1;
 		expect(occurrences).toBe(1);
+	});
+
+	it("delivers a string systemPrompt override verbatim with no date or backend recall side effects", async () => {
+		using tempDir = TempDir.createSync("@pi-verbatim-string-");
+		const api = "test-verbatim-string-cache";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "verbatim-string-model",
+			name: "Verbatim String Model",
+			api,
+			provider: "test-provider",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("test-provider", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const override = "You are a verbatim string override.";
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model,
+			systemPrompt: override,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		try {
+			await session.sendUserMessage("hello");
+			expect(contexts).toHaveLength(1);
+			const system = contexts[0]?.systemPrompt ?? [];
+			// Verbatim bytes — exactly the override string, no date or recall appended.
+			expect(system).toEqual([override]);
+			expect(system.join("\n")).not.toContain("Today is ");
+			expect(system.join("\n")).not.toContain("<memories>");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("delivers an array systemPrompt override verbatim with no date or backend recall side effects", async () => {
+		using tempDir = TempDir.createSync("@pi-verbatim-array-");
+		const api = "test-verbatim-array-cache";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "verbatim-array-model",
+			name: "Verbatim Array Model",
+			api,
+			provider: "test-provider",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("test-provider", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const override = ["block one", "block two"];
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model,
+			systemPrompt: override,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		try {
+			await session.sendUserMessage("hello");
+			expect(contexts).toHaveLength(1);
+			const system = contexts[0]?.systemPrompt ?? [];
+			// Verbatim bytes — exactly the override array, no date or recall appended.
+			expect(system).toEqual(override);
+			expect(system.join("\n")).not.toContain("Today is ");
+			expect(system.join("\n")).not.toContain("<memories>");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("delivers a callback systemPrompt override verbatim with no date or backend recall side effects", async () => {
+		using tempDir = TempDir.createSync("@pi-verbatim-callback-");
+		const api = "test-verbatim-callback-cache";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "verbatim-callback-model",
+			name: "Verbatim Callback Model",
+			api,
+			provider: "test-provider",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("test-provider", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const override = "You are a callback override.";
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model,
+			systemPrompt: () => override,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		try {
+			await session.sendUserMessage("hello");
+			expect(contexts).toHaveLength(1);
+			const system = contexts[0]?.systemPrompt ?? [];
+			// Verbatim bytes — exactly the callback return, no date or recall appended.
+			expect(system).toEqual([override]);
+			expect(system.join("\n")).not.toContain("Today is ");
+			expect(system.join("\n")).not.toContain("<memories>");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
 	});
 
 	it("ephemeral side-channel forwards native tools, injects developer reminder, leaves toolChoice auto", async () => {

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -767,6 +767,77 @@ describe("AgentSession message pipeline", () => {
 		});
 	});
 
+	it("derives the Anthropic billing seed from the obfuscated first user message so a secret never splits the main/side cache breakpoint", async () => {
+		await withNativeDialectEnv(async () => {
+			const api = "test-ephemeral-obfuscated-billing-seed";
+			const secret = "BILLING_SEED_SECRET_TOKEN_12345";
+			const contexts: Context[] = [];
+			registerCustomApi(api, (_model, context, _options) => {
+				contexts.push(context);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage("Answer");
+					stream.push({ type: "text_delta", contentIndex: 0, delta: "Answer", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			});
+
+			const model = buildModel({
+				id: "side-model-obfuscated-billing-seed",
+				name: "Side Model Obfuscated Billing Seed",
+				api,
+				provider: "test-provider",
+				baseUrl: "",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 4096,
+				maxTokens: 1024,
+			} as ModelSpec<Api>) as Model<Api>;
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+			const agent = new Agent({
+				initialState: { model, systemPrompt: ["stable harness instructions"], messages: [], tools: [] },
+			});
+			const session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "compaction.enabled": false }),
+				modelRegistry: createModelRegistryStub() as never,
+				obfuscator,
+			});
+			sessions.push(session);
+
+			// The first persisted user message carries the secret in plaintext. The
+			// provider derives the Claude Code billing-header seed from the
+			// provider-visible (obfuscated) form of this text.
+			const firstUserText = `main request carries ${secret}`;
+			await agent.prompt(firstUserText);
+			// A side request after the main turn derives its seed from the same
+			// provider-visible first-user text.
+			await session.runEphemeralTurn({ promptText: "unrelated side request" });
+
+			// Main never carries a seed override (the provider derives it from
+			// messages); the side request always carries an explicit seed.
+			const mainContext = contexts.find(context => context.anthropicBillingSeed === undefined);
+			const sideContext = contexts[contexts.length - 1];
+			expect(mainContext).toBeDefined();
+			expect(sideContext).not.toBe(mainContext);
+
+			const expectedSeed = obfuscator.obfuscate(firstUserText);
+			// Sanity: the obfuscator really redacts the secret (guards a no-op).
+			expect(expectedSeed).not.toBe(firstUserText);
+			expect(expectedSeed).not.toContain(secret);
+			// F2 contract: the side-request seed is the obfuscated derivation — the
+			// same provider-visible text the main OAuth request derives its billing
+			// header from — so a secret in the first user message cannot split the
+			// main/side cache breakpoint. Reverting to the raw seed fails here.
+			expect(sideContext?.anthropicBillingSeed).toBe(expectedSeed);
+			// The raw secret must never reach the provider-bound seed.
+			expect(sideContext?.anthropicBillingSeed).not.toContain(secret);
+		});
+	});
+
 	it("records raw SSE diagnostics into the session buffer before request hooks", async () => {
 		const requestOnSseEvent = vi.fn();
 		const session = new AgentSession({

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -395,6 +395,9 @@ describe("AgentSession message pipeline", () => {
 			async beforeAgentStartPrompt(_session, promptText) {
 				return `<memories>recall for ${promptText}</memories>`;
 			},
+			async beforeSideRequestPrompt(_session, promptText) {
+				return `<memories>recall for ${promptText}</memories>`;
+			},
 		};
 		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
 		const agent = new Agent({
@@ -871,6 +874,9 @@ describe("AgentSession message pipeline", () => {
 				remembered = true;
 				return injected;
 			},
+			async beforeSideRequestPrompt() {
+				return undefined;
+			},
 		};
 		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
 		registerCustomApi(api, (_model, context) => {
@@ -1150,6 +1156,9 @@ describe("AgentSession message pipeline", () => {
 				remembered = true;
 				return injected;
 			},
+			async beforeSideRequestPrompt() {
+				return undefined;
+			},
 		};
 		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
 		registerCustomApi(api, (_model, context) => {
@@ -1239,6 +1248,9 @@ describe("AgentSession message pipeline", () => {
 				if (remembered || !recallAvailable) return undefined;
 				remembered = true;
 				return injected;
+			},
+			async beforeSideRequestPrompt() {
+				return undefined;
 			},
 		};
 		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
@@ -1333,6 +1345,9 @@ describe("AgentSession message pipeline", () => {
 				if (remembered) return undefined;
 				remembered = true;
 				return injected;
+			},
+			async beforeSideRequestPrompt() {
+				return undefined;
 			},
 		};
 		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -27,7 +27,7 @@ import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
 import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
 import { type MnemopiSessionState, setMnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
-import { obfuscateProviderContext, SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets";
+import { obfuscateMessages, obfuscateProviderContext, SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm, wrapSteeringForModel } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -805,6 +805,14 @@ describe("AgentSession message pipeline", () => {
 				settings: Settings.isolated({ "compaction.enabled": false }),
 				modelRegistry: createModelRegistryStub() as never,
 				obfuscator,
+				// Mirror production (sdk.ts convertToLlmFinal): obfuscate the
+				// provider-visible message text inside the conversion pipeline so the
+				// side-request billing seed — now derived from this converted snapshot —
+				// sees the same redacted first-user text the main OAuth turn sends.
+				convertToLlm: (messages: AgentMessage[]) => {
+					const converted = convertToLlm(messages);
+					return obfuscator.hasSecrets() ? obfuscateMessages(obfuscator, converted) : converted;
+				},
 			});
 			sessions.push(session);
 
@@ -838,6 +846,81 @@ describe("AgentSession message pipeline", () => {
 		});
 	});
 
+	it("derives the side billing seed from a context-hook-rewritten first user message", async () => {
+		await withNativeDialectEnv(async () => {
+			const api = "test-ephemeral-transformed-billing-seed";
+			const contexts: Context[] = [];
+			registerCustomApi(api, (_model, context, _options) => {
+				contexts.push(context);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage("Answer");
+					stream.push({ type: "text_delta", contentIndex: 0, delta: "Answer", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			});
+
+			const model = buildModel({
+				id: "side-model-transformed-billing-seed",
+				name: "Side Model Transformed Billing Seed",
+				api,
+				provider: "test-provider",
+				baseUrl: "",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 4096,
+				maxTokens: 1024,
+			} as ModelSpec<Api>) as Model<Api>;
+			const firstUserText = "raw first user text";
+			const transformedFirstUserText = "context hook rewrote the first user text";
+			const transformContext = async (messages: AgentMessage[]): Promise<AgentMessage[]> =>
+				messages.map(message => {
+					if (message.role !== "user") return message;
+					if (typeof message.content === "string") {
+						return message.content === firstUserText
+							? { ...message, content: transformedFirstUserText }
+							: message;
+					}
+					return {
+						...message,
+						content: message.content.map(block =>
+							block.type === "text" && block.text === firstUserText
+								? { ...block, text: transformedFirstUserText }
+								: block,
+						),
+					};
+				});
+			const agent = new Agent({
+				initialState: { model, systemPrompt: ["stable harness instructions"], messages: [], tools: [] },
+				transformContext,
+			});
+			const session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "compaction.enabled": false }),
+				modelRegistry: createModelRegistryStub() as never,
+				transformContext,
+			});
+			sessions.push(session);
+
+			await agent.prompt(firstUserText);
+			await session.runEphemeralTurn({ promptText: "unrelated side request" });
+
+			const mainContext = contexts.find(context => context.anthropicBillingSeed === undefined);
+			const sideContext = contexts.at(-1);
+			expect(mainContext).toBeDefined();
+			expect(sideContext).not.toBe(mainContext);
+			expect(getConvertedUserText(mainContext?.messages.find(message => message.role === "user"))).toBe(
+				transformedFirstUserText,
+			);
+			expect(sideContext?.anthropicBillingSeed).toBe(transformedFirstUserText);
+			expect(await captureAnthropicSystemPrefix(sideContext!)).toBe(
+				await captureAnthropicSystemPrefix(mainContext!),
+			);
+		});
+	});
 	it("records raw SSE diagnostics into the session buffer before request hooks", async () => {
 		const requestOnSseEvent = vi.fn();
 		const session = new AgentSession({

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -679,7 +679,7 @@ describe("AgentSession message pipeline", () => {
 		await Bun.sleep(0);
 	});
 
-	it("keeps first-turn memory in the stable prompt on the next turn", async () => {
+	it("keeps promoted memory turn-bound instead of persisting it in the provider prefix", async () => {
 		const api = "test-injected-memory-append-only-cache";
 		const contexts: Context[] = [];
 		let remembered = false;
@@ -750,7 +750,7 @@ describe("AgentSession message pipeline", () => {
 		const firstSystemPrompt = contexts[0]!.systemPrompt;
 		expect(firstSystemPrompt).toBeDefined();
 		expect(firstSystemPrompt!.join("\n")).toContain(injected);
-		expect(contexts[1]!.systemPrompt).toEqual(firstSystemPrompt);
+		expect(contexts[1]!.systemPrompt?.join("\n")).not.toContain(injected);
 	});
 
 	it("preserves append-only prefixes in subagent sessions when context handlers rewrite prior turns", async () => {

--- a/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
@@ -163,7 +163,7 @@ describe("AgentSession plan-mode convergence", () => {
 			rebuildSystemPrompt: options?.rebuildGate
 				? async () => {
 						if (options.rebuildGate?.fail) throw new Error("rebuild failed");
-						return { systemPrompt: ["Test"] };
+						return { systemPrompt: ["Test"], compositionPolicy: "append-turn-context" };
 					}
 				: undefined,
 		});

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1119,4 +1119,31 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(session.getToolByName(oldTool.name)).toBeUndefined();
 		expect(session.getToolByName(newTool.name)).toBeDefined();
 	});
+
+	it("preserves the volatile turn suffix when a tool refresh rebuilds mid-turn", async () => {
+		// Deferred MCP discovery (refreshMCPTools → applyActiveToolsByName) can
+		// complete while a turn is streaming, so the live prompt already carries
+		// a volatile suffix (date + recalled memory from before_agent_start).
+		// The rebuild must refresh only the stable base and carry that suffix
+		// across, or the next tool-loop model call loses the date/memory context.
+		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`);
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search");
+		await session.refreshMCPTools([search]);
+		const base = session.systemPrompt; // ["tools:read,mcp__nucleus_search"]
+
+		// Simulate the in-flight turn suffix a real turn composes.
+		const dateSuffix = "Today is 2026-07-30.";
+		const memorySuffix = "recalled-memory-injection";
+		session.agent.setSystemPrompt([...base, dateSuffix, memorySuffix], base.length);
+
+		// A different tool set forces a rebuild, which must preserve the suffix.
+		const fetch = createMcpCustomTool("mcp__nucleus_fetch", "nucleus", "fetch", "Fetch");
+		await session.refreshMCPTools([search, fetch]);
+
+		expect(session.systemPrompt).toEqual([
+			"tools:read,mcp__nucleus_search,mcp__nucleus_fetch",
+			dateSuffix,
+			memorySuffix,
+		]);
+	});
 });

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { Message, Model } from "@oh-my-pi/pi-ai";
+import type { Context, Message, Model } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponseSource } from "@oh-my-pi/pi-ai/providers/mock";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import * as memoryBackend from "@oh-my-pi/pi-coding-agent/memory-backend";
+import type { MemoryBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/types";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -110,7 +112,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 	): {
 		session: AgentSession;
 		/** Provider-call message snapshots (LLM-converted), one per model request. */
-		contexts: Message[][];
+		contexts: Context[];
 		/** Mutable registry shared with the session, for lifecycle-only mount fixtures. */
 		toolRegistry: Map<string, AgentTool>;
 	} {
@@ -122,7 +124,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		toolRegistry.set(initialMcp.name, initialMcp as unknown as AgentTool);
 		if (options.xdev && !options.lazyWrite) toolRegistry.set(writeTool.name, writeTool);
 		const mock = options.responses ? createMockModel({ responses: options.responses }) : undefined;
-		const contexts: Message[][] = [];
+		const contexts: Context[] = [];
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: {
@@ -138,7 +140,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			convertToLlm,
 			streamFn: mock
 				? (model, context, streamOptions) => {
-						contexts.push([...context.messages]);
+						contexts.push(context);
 						return mock.stream(model, context, streamOptions);
 					}
 				: undefined,
@@ -157,6 +159,8 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			},
 			rebuildSystemPrompt: async (toolNames, _tools) => ({
 				systemPrompt: [await rebuildSystemPrompt(toolNames)],
+				stableSystemPromptBlockCount: 1,
+				compositionPolicy: "append-turn-context",
 			}),
 			getMcpServerInstructions: options.getMcpServerInstructions,
 			getLocalCalendarDate: options.getLocalCalendarDate,
@@ -523,6 +527,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			},
 			rebuildSystemPrompt: async (_toolNames, tools) => ({
 				systemPrompt: [tools.get("bash")?.description ?? "missing bash"],
+				compositionPolicy: "append-turn-context",
 			}),
 		});
 		sessions.push(session);
@@ -736,10 +741,12 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([dynamicTool]);
 		expect(rebuildCount).toBe(baseline + 1);
 	});
-	it("rebuilds when the local calendar date rolls over between tool-stable MCP refreshes", async () => {
-		// `buildSystemPrompt` injects today's local date into the prompt body. The
-		// signature reads the same date provider so a session spanning local midnight
-		// must rebuild after an MCP reconnect with an otherwise identical tool set.
+	it("does not rebuild the stable base when the local calendar date rolls over between tool-stable MCP refreshes", async () => {
+		// The date is a volatile turn-context suffix, not part of the rebuild
+		// signature. A session spanning local midnight with an otherwise
+		// identical tool set must NOT rebuild the stable base prompt — the
+		// per-turn context block picks up the new date without invalidating the
+		// cache breakpoint.
 		let currentDate = "2026-06-30";
 		let rebuildCount = 0;
 		const { session } = newSession(
@@ -761,13 +768,99 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 		currentDate = "2026-07-01";
 
-		// Same tools, new local calendar day: date segment changed, must rebuild.
+		// Same tools, new local calendar day: date is volatile, NOT in the
+		// rebuild signature — the stable base must NOT rebuild.
 		await session.refreshMCPTools([tool]);
-		expect(rebuildCount).toBe(2);
+		expect(rebuildCount).toBe(1);
 
-		// Same tools, same new local day: skip again.
+		// Same tools, same new local day: still skip.
 		await session.refreshMCPTools([tool]);
-		expect(rebuildCount).toBe(2);
+		expect(rebuildCount).toBe(1);
+	});
+
+	it("keeps stable blocks byte-identical across two turns while date and recall live after the stable boundary", async () => {
+		// The stable prefix (blocks [0, stableSystemPromptBlockCount)) must be
+		// byte-identical across turns. The volatile suffix (date + recall) may
+		// change per turn but must appear only after the stable boundary.
+		let currentDate = "2026-06-30";
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			getLocalCalendarDate: () => currentDate,
+			responses: [{ content: ["first answer"] }, { content: ["second answer"] }],
+		});
+		const tool = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search");
+		await session.refreshMCPTools([tool]);
+
+		await session.prompt("first");
+		const firstContext = contexts[0];
+		if (!firstContext) throw new Error("expected first provider context");
+		const firstSystem = firstContext.systemPrompt ?? [];
+		const stableCount = session.agent.state.stableSystemPromptBlockCount ?? 0;
+		const firstStable = firstSystem.slice(0, stableCount);
+
+		currentDate = "2026-07-01";
+
+		await session.prompt("second");
+		const secondContext = contexts[1];
+		if (!secondContext) throw new Error("expected second provider context");
+		const secondSystem = secondContext.systemPrompt ?? [];
+		const secondStable = secondSystem.slice(0, stableCount);
+
+		// Stable prefix is byte-identical despite the date change.
+		expect(secondStable).toEqual(firstStable);
+		// The volatile suffix differs (date changed) and lives after the boundary.
+		const firstVolatile = firstSystem.slice(stableCount).join("\n");
+		const secondVolatile = secondSystem.slice(stableCount).join("\n");
+		expect(firstVolatile).toContain("2026-06-30");
+		expect(secondVolatile).toContain("2026-07-01");
+		expect(firstVolatile).not.toContain("2026-07-01");
+		expect(secondVolatile).not.toContain("2026-06-30");
+		// The stable prefix never contains the date.
+		expect(firstStable.join("\n")).not.toContain("Today is ");
+		expect(secondStable.join("\n")).not.toContain("Today is ");
+	});
+
+	it("injects memory recall exactly once on every turn after one backend call and never in the stable base", async () => {
+		// The memory backend's beforeAgentStartPrompt is called once per turn.
+		// The recalled block must appear in the volatile suffix (after the stable
+		// boundary) on every turn, and must never enter the stable base blocks.
+		let recallCalls = 0;
+		const injected = "<memories>recall payload</memories>";
+		const fakeBackend: MemoryBackend = {
+			id: "mnemopi",
+			async start() {},
+			async buildDeveloperInstructions() {
+				return "static memory instructions";
+			},
+			async clear() {},
+			async enqueue() {},
+			async beforeAgentStartPrompt() {
+				recallCalls++;
+				return injected;
+			},
+		};
+		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			responses: [{ content: ["first answer"] }, { content: ["second answer"] }, { content: ["third answer"] }],
+		});
+		const tool = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search");
+		await session.refreshMCPTools([tool]);
+
+		await session.prompt("first");
+		await session.prompt("second");
+		await session.prompt("third");
+
+		expect(contexts).toHaveLength(3);
+		expect(recallCalls).toBe(3);
+		const stableCount = session.agent.state.stableSystemPromptBlockCount ?? 0;
+		for (const ctx of contexts) {
+			const system = ctx.systemPrompt ?? [];
+			const stable = system.slice(0, stableCount).join("\n");
+			const volatile = system.slice(stableCount).join("\n");
+			// Recall appears in the volatile suffix on every turn.
+			expect(volatile).toContain(injected);
+			// Recall never enters the stable base.
+			expect(stable).not.toContain(injected);
+		}
 	});
 	it("does not rebuild when MCP server instructions change only beyond the 4000-char truncation boundary", async () => {
 		// `rebuildSystemPrompt` (sdk.ts) truncates each server instruction to 4000 chars
@@ -845,12 +938,12 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await firstPrompt;
 		expect(rebuildCount).toBe(2);
 		expect(contexts).toHaveLength(1);
-		expect(mountNoticesIn(contexts[0])).toHaveLength(0);
+		expect(mountNoticesIn(contexts[0].messages)).toHaveLength(0);
 
 		// The next user prompt carries one coalesced notice for both mounts.
 		await session.prompt("again");
 		expect(contexts).toHaveLength(2);
-		const mountNotices = mountNoticesIn(contexts[1]);
+		const mountNotices = mountNoticesIn(contexts[1].messages);
 		expect(mountNotices).toHaveLength(1);
 		expect(mountNotices[0]).toContain("became available");
 		expect(mountNotices[0]).toContain("xd://mcp__nucleus_search");
@@ -862,7 +955,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(rebuildCount).toBe(3);
 		expect(contexts).toHaveLength(2);
 		await session.prompt("third");
-		const allNotices = mountNoticesIn(contexts[2]);
+		const allNotices = mountNoticesIn(contexts[2].messages);
 		expect(allNotices).toHaveLength(2);
 		expect(allNotices[1]).toContain("No longer mounted");
 		expect(allNotices[1]).toContain("xd://mcp__nucleus_fetch");
@@ -880,7 +973,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		await session.prompt("hello");
 
-		const notices = mountNoticesIn(contexts[0]);
+		const notices = mountNoticesIn(contexts[0].messages);
 		expect(notices).toHaveLength(1);
 		expect(notices[0]).toContain("xd://mcp__nucleus_search");
 		expect(notices[0]).not.toContain("TAIL");
@@ -898,7 +991,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		await session.prompt("hello");
 
-		const notices = mountNoticesIn(contexts[0]);
+		const notices = mountNoticesIn(contexts[0].messages);
 		expect(notices).toHaveLength(1);
 		expect(notices[0]).toContain("## mcp__nucleus_search");
 		expect(notices[0]).toContain("## Schema");
@@ -919,7 +1012,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 
 		await session.prompt("hello");
-		const notices = mountNoticesIn(contexts[0]);
+		const notices = mountNoticesIn(contexts[0].messages);
 		expect(notices).toHaveLength(1);
 		expect(notices[0]).toContain("xd://mcp__nucleus_search");
 		expect(notices[0]).not.toContain("mcp__nucleus_fetch");
@@ -942,7 +1035,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 		expect(notices).toEqual([]);
 		await session.prompt("hello");
-		const delivered = mountNoticesIn(contexts[0]);
+		const delivered = mountNoticesIn(contexts[0].messages);
 		expect(delivered).toHaveLength(1);
 		expect(delivered[0]).toContain("xd://mcp__nucleus_search");
 	});
@@ -1005,30 +1098,22 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 	it("rolls back RPC catalog replacement when prompt rebuild fails", async () => {
 		let failRebuild = false;
-		let date = "2026-07-16";
-		const xdevState = createTestXdevState();
-		const { session } = newSession(
-			async toolNames => {
-				if (failRebuild) throw new Error("rebuild failed");
-				return `tools:${toolNames.join(",")}`;
-			},
-			{ xdev: xdevState, getLocalCalendarDate: () => date },
-		);
+		const { session } = newSession(async toolNames => {
+			if (failRebuild) throw new Error("rebuild failed");
+			return `tools:${toolNames.join(",")}`;
+		});
 		const oldTool = { ...createBasicTool("rpc_old", "RPC Old"), loadMode: "discoverable" as const };
 		const newTool = { ...createBasicTool("rpc_new", "RPC New"), loadMode: "discoverable" as const };
 		await session.refreshRpcHostTools([oldTool]);
-		date = "2026-07-17";
 		failRebuild = true;
 
 		await expect(session.refreshRpcHostTools([newTool])).rejects.toThrow("rebuild failed");
 		expect(session.getToolByName(oldTool.name)).toBeDefined();
 		expect(session.getToolByName(newTool.name)).toBeUndefined();
-		expect(session.getMountedXdevToolNames()).toContain(oldTool.name);
 
 		failRebuild = false;
 		await session.refreshRpcHostTools([newTool]);
 		expect(session.getToolByName(oldTool.name)).toBeUndefined();
 		expect(session.getToolByName(newTool.name)).toBeDefined();
-		expect(session.getMountedXdevToolNames()).toContain(newTool.name);
 	});
 });

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -837,6 +837,9 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 				recallCalls++;
 				return injected;
 			},
+			async beforeSideRequestPrompt() {
+				return undefined;
+			},
 		};
 		vi.spyOn(memoryBackend, "resolveMemoryBackend").mockResolvedValue(fakeBackend);
 		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -88,7 +88,7 @@ async function createGoalHarness(shared: SharedFixture): Promise<GoalHarness> {
 		settings,
 		modelRegistry,
 		toolRegistry,
-		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"], compositionPolicy: "append-turn-context" }),
 	});
 	const mode = new InteractiveMode(session, "test");
 	const toolSession = createToolSession(tempDir.path(), settings, {

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -63,7 +63,7 @@ async function createHarness(options?: { goalEnabled?: boolean }): Promise<Guide
 		settings,
 		modelRegistry,
 		toolRegistry,
-		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"], compositionPolicy: "append-turn-context" }),
 	});
 	// Mirror sdk.ts assembly: the goal tool is pre-registered (hidden) whenever
 	// goal.enabled, so /guided-goal can activate it by name for the interview.

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -338,7 +338,9 @@ describe("hindsightBackend first-turn injection", () => {
 		expect(session.getHindsightSessionState()?.lastRecallSnippet).toBe(block);
 	});
 
-	it("keeps the <memories> wrapper in buildDeveloperInstructions", async () => {
+	it("excludes recall payload from buildDeveloperInstructions", async () => {
+		// Volatile recall context must never enter the stable developer
+		// instructions; it is injected per turn via beforeAgentStartPrompt only.
 		const settings = Settings.isolated({
 			"memory.backend": "hindsight",
 			"hindsight.apiUrl": "http://localhost:8888",
@@ -354,18 +356,20 @@ describe("hindsightBackend first-turn injection", () => {
 
 		const state = session.getHindsightSessionState();
 		expect(state).toBeDefined();
-		state!.lastRecallSnippet = "<memories>\nremembered fact\n</memories>";
+		if (!state) return;
+		state.lastRecallSnippet = "<memories>\nremembered fact\n</memories>";
 
 		const prompt = await hindsightBackend.buildDeveloperInstructions("/tmp", settings, session as never);
-		expect(prompt).toContain("<memories>");
-		expect(prompt).toContain("</memories>");
-		expect(prompt).toContain("remembered fact");
+		expect(prompt).toBeDefined();
+		// The static instructions mention `<memories>` in prose, but the
+		// actual recalled payload ("remembered fact") must be absent.
+		expect(prompt).not.toContain("remembered fact");
+		expect(prompt).not.toContain("<memories>\nremembered fact");
 	});
 
-	it("places the <mental_models> block above the <memories> recall block in developer instructions", async () => {
-		// Stable, curated semantic memory must come first so the LLM's prior is
-		// anchored on it; the volatile per-turn recall block follows. Ordering
-		// is part of the integration's behavioural contract.
+	it("keeps mental_models in developer instructions but excludes recall payload", async () => {
+		// Stable, curated semantic memory stays in the stable prefix; the
+		// volatile per-turn recall block is injected via the hook only.
 		const settings = Settings.isolated({
 			"memory.backend": "hindsight",
 			"hindsight.apiUrl": "http://localhost:8888",
@@ -381,19 +385,90 @@ describe("hindsightBackend first-turn injection", () => {
 		});
 		const state = session.getHindsightSessionState();
 		expect(state).toBeDefined();
-		state!.mentalModelsSnippet = "<mental_models>\n# User Preferences\nprefers tabs\n</mental_models>";
-		state!.lastRecallSnippet = "<memories>\nrecalled fact\n</memories>";
+		if (!state) return;
+		state.mentalModelsSnippet = "<mental_models>\n# User Preferences\nprefers tabs\n</mental_models>";
+		state.lastRecallSnippet = "<memories>\nrecalled fact\n</memories>";
 
 		const prompt = await hindsightBackend.buildDeveloperInstructions("/tmp", settings, session as never);
 		expect(prompt).toBeDefined();
-		// `<memories>` and `<mental_models>` are mentioned in STATIC_INSTRUCTIONS
-		// bullets too. Match the actual injected block opener (tag + newline)
-		// to disambiguate documentation prose from the injected payloads.
-		const mmIdx = prompt!.indexOf("<mental_models>\n");
-		const memIdx = prompt!.indexOf("<memories>\n");
+		if (!prompt) return;
+		// Mental models block is stable and present.
+		const mmIdx = prompt.indexOf("<mental_models>\n");
 		expect(mmIdx).toBeGreaterThanOrEqual(0);
-		expect(memIdx).toBeGreaterThanOrEqual(0);
-		expect(mmIdx).toBeLessThan(memIdx);
+		// The recalled payload must not appear in the stable prefix.
+		expect(prompt).not.toContain("recalled fact");
+		expect(prompt).not.toContain("<memories>\nrecalled fact");
+	});
+
+	it("calls recall exactly once and replays the cached snippet on repeated hook calls", async () => {
+		// A successful recall is replayed once per turn until the transcript
+		// resets; the underlying recall API must not be hit again.
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+		});
+		const session = makeFakeSession({
+			sessionId: "s-replay",
+			entries: [{ role: "assistant", text: "previous assistant context" }],
+		});
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const recallSpy = vi.spyOn(HindsightApi.prototype, "recall").mockResolvedValue({
+			results: [{ id: "1", text: "Can prefers concise communication" }],
+		} as never);
+
+		const first = await hindsightBackend.beforeAgentStartPrompt?.(
+			session as never,
+			"What do I know about this user?",
+		);
+		expect(first).toContain("<memories>");
+		expect(first).toContain("Can prefers concise communication");
+		expect(recallSpy).toHaveBeenCalledTimes(1);
+
+		// Subsequent calls replay the cached snippet without re-calling recall.
+		const second = await hindsightBackend.beforeAgentStartPrompt?.(session as never, "another prompt this turn");
+		expect(second).toBe(first);
+		expect(recallSpy).toHaveBeenCalledTimes(1);
+
+		const third = await hindsightBackend.beforeAgentStartPrompt?.(
+			session as never,
+			"What do I know about this user?",
+		);
+		expect(third).toBe(first);
+		expect(recallSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns undefined from the hook when auto recall is off", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+			"hindsight.autoRecall": false,
+		});
+		const session = makeFakeSession({ sessionId: "s-noauto" });
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const recallSpy = vi.spyOn(HindsightApi.prototype, "recall").mockResolvedValue({
+			results: [{ id: "1", text: "should not appear" }],
+		} as never);
+
+		const block = await hindsightBackend.beforeAgentStartPrompt?.(
+			session as never,
+			"What do I know about this user?",
+		);
+		expect(block).toBeUndefined();
+		expect(recallSpy).not.toHaveBeenCalled();
 	});
 
 	it("reloadMentalModelsForSession refreshes the cached snippet and base prompt", async () => {

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -444,6 +444,40 @@ describe("hindsightBackend first-turn injection", () => {
 		expect(recallSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("recalls independently for side prompts without replacing the main cached snippet", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+		});
+		const session = makeFakeSession({
+			sessionId: "s-side-recall",
+			entries: [{ role: "assistant", text: "previous assistant context" }],
+		});
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		const recallSpy = vi.spyOn(HindsightApi.prototype, "recall").mockImplementation(async (_bankId, query) => ({
+			results: [{ id: query, text: `memory for ${query}` }],
+		}) as never);
+		const main = await hindsightBackend.beforeAgentStartPrompt?.(session as never, "main prompt");
+		const sideOne = await hindsightBackend.beforeSideRequestPrompt(session as never, "first side prompt");
+		const sideTwo = await hindsightBackend.beforeSideRequestPrompt(session as never, "second side prompt");
+		const replayedMain = await hindsightBackend.beforeAgentStartPrompt?.(session as never, "later main prompt");
+
+		expect(recallSpy).toHaveBeenCalledTimes(3);
+		expect(recallSpy.mock.calls[1]?.[1]).toContain("first side prompt");
+		expect(recallSpy.mock.calls[2]?.[1]).toContain("second side prompt");
+		expect(sideOne).toContain("first side prompt");
+		expect(sideTwo).toContain("second side prompt");
+		expect(replayedMain).toBe(main);
+		expect(session.getHindsightSessionState()?.lastRecallSnippet).toBe(main);
+	});
+
 	it("returns undefined from the hook when auto recall is off", async () => {
 		const settings = Settings.isolated({
 			"memory.backend": "hindsight",

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -461,9 +461,12 @@ describe("hindsightBackend first-turn injection", () => {
 			taskDepth: 0,
 		});
 
-		const recallSpy = vi.spyOn(HindsightApi.prototype, "recall").mockImplementation(async (_bankId, query) => ({
-			results: [{ id: query, text: `memory for ${query}` }],
-		}) as never);
+		const recallSpy = vi.spyOn(HindsightApi.prototype, "recall").mockImplementation(
+			async (_bankId, query) =>
+				({
+					results: [{ id: query, text: `memory for ${query}` }],
+				}) as never,
+		);
 		const main = await hindsightBackend.beforeAgentStartPrompt?.(session as never, "main prompt");
 		const sideOne = await hindsightBackend.beforeSideRequestPrompt(session as never, "first side prompt");
 		const sideTwo = await hindsightBackend.beforeSideRequestPrompt(session as never, "second side prompt");

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -109,7 +109,7 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 				? async () => {
 						if (options.rebuildGate) options.rebuildGate.calls = (options.rebuildGate.calls ?? 0) + 1;
 						if (options.rebuildGate?.fail) throw new Error("rebuild failed");
-						return { systemPrompt: ["Test"] };
+						return { systemPrompt: ["Test"], compositionPolicy: "append-turn-context" };
 					}
 				: undefined,
 			xdev,

--- a/packages/coding-agent/test/mnemopi-backend.test.ts
+++ b/packages/coding-agent/test/mnemopi-backend.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { mnemopiBackend } from "@oh-my-pi/pi-coding-agent/mnemopi/backend";
+import { getMnemopiSessionState, type MnemopiSessionState } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function makeFakeSession(settings: Settings) {
+	const listeners = new Set<(event: unknown) => void>();
+	return {
+		sessionId: "mnemopi-side-recall",
+		settings,
+		sessionManager: {
+			getEntries: () => [
+				{
+					id: "previous-assistant",
+					parentId: null,
+					timestamp: new Date(0).toISOString(),
+					type: "message" as const,
+					message: {
+						role: "assistant" as const,
+						content: [{ type: "text" as const, text: "previous assistant context" }],
+						model: "x",
+						provider: "x",
+						api: "x",
+						stopReason: "end_turn" as const,
+						timestamp: 0,
+					},
+				},
+			],
+			getCwd: () => "/tmp",
+			getSessionFile: () => null,
+			getSessionId: () => "mnemopi-side-recall",
+		},
+		subscribe(listener: (event: unknown) => void) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+	};
+}
+
+afterEach(() => {
+	resetSettingsForTest();
+	vi.restoreAllMocks();
+});
+
+describe("mnemopiBackend side-request recall", () => {
+	it("recalls independently for side prompts without replacing the main cached snippet", async () => {
+		const tempDir = await TempDir.create("@mnemopi-side-recall-");
+		let state: MnemopiSessionState | undefined;
+		try {
+			const settings = Settings.isolated({
+				"memory.backend": "mnemopi",
+				"mnemopi.dbPath": path.join(tempDir.path(), "mnemopi.db"),
+				"mnemopi.noEmbeddings": true,
+				"mnemopi.llmMode": "none",
+			});
+			const session = makeFakeSession(settings);
+			await mnemopiBackend.start({
+				session: session as never,
+				settings,
+				modelRegistry: {
+					getApiKeyForProvider: async () => undefined,
+				} as never,
+				agentDir: tempDir.path(),
+				taskDepth: 0,
+			});
+
+			state = getMnemopiSessionState(session as never);
+			expect(state).toBeDefined();
+			if (!state) return;
+			const recallSpy = vi.spyOn(state, "collectScopedRecallResults").mockImplementation(async query => [
+				{ id: query, content: `memory for ${query}` } as never,
+			]);
+
+			const main = await mnemopiBackend.beforeAgentStartPrompt(session as never, "main prompt");
+			const sideOne = await mnemopiBackend.beforeSideRequestPrompt(session as never, "first side prompt");
+			const sideTwo = await mnemopiBackend.beforeSideRequestPrompt(session as never, "second side prompt");
+			const replayedMain = await mnemopiBackend.beforeAgentStartPrompt(session as never, "later main prompt");
+
+			expect(recallSpy).toHaveBeenCalledTimes(3);
+			expect(recallSpy.mock.calls[1]?.[0]).toContain("first side prompt");
+			expect(recallSpy.mock.calls[2]?.[0]).toContain("second side prompt");
+			expect(sideOne).toContain("first side prompt");
+			expect(sideTwo).toContain("second side prompt");
+			expect(replayedMain).toBe(main);
+			expect(state.lastRecallSnippet).toBe(main);
+		} finally {
+			await state?.dispose({ consolidate: false });
+			await Bun.sleep(0);
+			await tempDir.remove();
+		}
+	});
+});

--- a/packages/coding-agent/test/mnemopi-backend.test.ts
+++ b/packages/coding-agent/test/mnemopi-backend.test.ts
@@ -69,14 +69,16 @@ describe("mnemopiBackend side-request recall", () => {
 			state = getMnemopiSessionState(session as never);
 			expect(state).toBeDefined();
 			if (!state) return;
-			const recallSpy = vi.spyOn(state, "collectScopedRecallResults").mockImplementation(async query => [
-				{ id: query, content: `memory for ${query}` } as never,
-			]);
+			const beforeAgentStartPrompt = mnemopiBackend.beforeAgentStartPrompt;
+			if (!beforeAgentStartPrompt) throw new Error("Mnemopi backend must support agent-start recall");
+			const recallSpy = vi
+				.spyOn(state, "collectScopedRecallResults")
+				.mockImplementation(async query => [{ id: query, content: `memory for ${query}` } as never]);
 
-			const main = await mnemopiBackend.beforeAgentStartPrompt(session as never, "main prompt");
+			const main = await beforeAgentStartPrompt(session as never, "main prompt");
 			const sideOne = await mnemopiBackend.beforeSideRequestPrompt(session as never, "first side prompt");
 			const sideTwo = await mnemopiBackend.beforeSideRequestPrompt(session as never, "second side prompt");
-			const replayedMain = await mnemopiBackend.beforeAgentStartPrompt(session as never, "later main prompt");
+			const replayedMain = await beforeAgentStartPrompt(session as never, "later main prompt");
 
 			expect(recallSpy).toHaveBeenCalledTimes(3);
 			expect(recallSpy.mock.calls[1]?.[0]).toContain("first side prompt");

--- a/packages/coding-agent/test/modes/controllers/resume-outer-preflight.test.ts
+++ b/packages/coding-agent/test/modes/controllers/resume-outer-preflight.test.ts
@@ -47,7 +47,7 @@ async function createMode(opts: { flushFails?: boolean } = {}): Promise<{
 		settings,
 		modelRegistry,
 		toolRegistry,
-		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"], compositionPolicy: "append-turn-context" }),
 	});
 	const mode = new InteractiveMode(session, "test");
 	vi.spyOn(mode, "addMessageToChat").mockReturnValue([]);

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -59,11 +59,11 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		const promptText = systemPrompt.join("\n\n");
 		const normalizedProjectDir = projectDir.replace(/\\/g, "/");
+		// The date lives in the volatile turn-context suffix, not the stable base;
+		// buildSystemPrompt must not render "Today is" — only the cwd line.
+		expect(promptText).not.toContain("Today is ");
 		expect(promptText).toMatch(
-			new RegExp(
-				`^Today is [^,\\n]+, and the current working directory is '${escapeRegExp(normalizedProjectDir)}'\\.$`,
-				"m",
-			),
+			new RegExp(`The current working directory is '${escapeRegExp(normalizedProjectDir)}'\\.`),
 		);
 	});
 
@@ -162,15 +162,12 @@ describe("SYSTEM.md prompt assembly", () => {
 		const promptText = systemPrompt.join("\n\n");
 		const normalizedProjectDir = projectDir.replace(/\\/g, "/");
 		const appendMatches = promptText.match(new RegExp(escapeRegExp(appendPrompt), "g")) ?? [];
-		expect(systemPrompt).toHaveLength(2);
 		expect(promptText).toContain("CLI custom prompt");
 		expect(promptText).toContain("<workspace-tree>");
 		expect(promptText).toContain("<dir-context>");
+		expect(promptText).not.toContain("Today is ");
 		expect(promptText).toMatch(
-			new RegExp(
-				`^Today is [^,\\n]+, and the current working directory is '${escapeRegExp(normalizedProjectDir)}'\\.$`,
-				"m",
-			),
+			new RegExp(`The current working directory is '${escapeRegExp(normalizedProjectDir)}'\\.`),
 		);
 		expect(appendMatches).toHaveLength(1);
 		expect(promptText).not.toContain("Discovered project SYSTEM prompt");
@@ -293,5 +290,53 @@ describe("SYSTEM.md prompt assembly", () => {
 		const promptText = systemPrompt.join("\n\n");
 		const matches = promptText.match(new RegExp(escapeRegExp(sharedContent), "g")) ?? [];
 		expect(matches).toHaveLength(1);
+	});
+});
+
+describe("SystemPromptPlan composition policy", () => {
+	let originalNullPrompt: string | undefined;
+
+	beforeEach(() => {
+		originalNullPrompt = Bun.env.NULL_PROMPT;
+	});
+
+	afterEach(() => {
+		if (originalNullPrompt === undefined) delete Bun.env.NULL_PROMPT;
+		else Bun.env.NULL_PROMPT = originalNullPrompt;
+	});
+
+	it("returns an empty verbatim plan under NULL_PROMPT", async () => {
+		Bun.env.NULL_PROMPT = "true";
+		const plan = await buildSystemPrompt({
+			cwd: os.tmpdir(),
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: [],
+		});
+		expect(plan.systemPrompt).toEqual([]);
+		expect(plan.stableSystemPromptBlockCount).toBe(0);
+		expect(plan.compositionPolicy).toBe("verbatim");
+	});
+
+	it("returns append-turn-context policy for a normal build", async () => {
+		delete Bun.env.NULL_PROMPT;
+		const plan = await buildSystemPrompt({
+			cwd: os.tmpdir(),
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: [],
+			workspaceTree: {
+				rootPath: os.tmpdir(),
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: [],
+			},
+		});
+		expect(plan.compositionPolicy).toBe("append-turn-context");
+		expect(plan.stableSystemPromptBlockCount).toBeGreaterThan(0);
+		expect(plan.stableSystemPromptBlockCount).toBeLessThan(plan.systemPrompt.length);
 	});
 });

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -113,6 +113,25 @@ describe("system prompt tool inventory", () => {
 		return text.slice(inventoryStart, inventoryEnd);
 	}
 
+	it("separates the stable harness prefix from volatile project and inventory blocks", async () => {
+		const result = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["read", "bash"],
+			tools: TOOLS,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools: true,
+			inlineToolDescriptors: false,
+		});
+
+		expect(result.stableSystemPromptBlockCount).toBe(1);
+		expect(result.systemPrompt[0]).not.toContain("# Tool Inventory");
+		expect(result.systemPrompt.at(-1)).toContain("# Tool Inventory");
+		expect(result.systemPrompt.join("\n\n")).not.toContain("Today is ");
+	});
+
 	async function renderMountedWebSearch(opts: {
 		nativeTools: boolean;
 		directDefinition: boolean;

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -9,8 +9,9 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { buildSystemPrompt, type SystemPromptPlan } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { usesCodexTaskPrompt } from "@oh-my-pi/pi-coding-agent/task/prompt-policy";
+import { formatLocalCalendarDate } from "@oh-my-pi/pi-coding-agent/utils/local-date";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 import { cleanupTempHome } from "./helpers/temp-home-cleanup";
 
@@ -22,68 +23,22 @@ const EMPTY_TREE = {
 	agentsMdFiles: [],
 };
 
-async function expectPromptDateFromStartupTimezone(options: {
-	tempDir: string;
-	tempHomeDir: string;
-	timeZone: string;
-	now: string;
-	expectedDate: string;
-	rejectedDate: string;
-}): Promise<void> {
-	const scenarioPath = path.join(options.tempDir, "prompt-date-timezone.test.ts");
-	await Bun.write(
-		scenarioPath,
-		`import { expect, it, setSystemTime } from "bun:test";
-import { buildSystemPrompt } from ${JSON.stringify(path.resolve(import.meta.dir, "../src/system-prompt.ts"))};
-
-it("renders the prompt date in the startup timezone", async () => {
-	setSystemTime(new Date(process.env.OMP_TEST_NOW!));
-	try {
-		const { systemPrompt } = await buildSystemPrompt({
-			cwd: process.cwd(),
-			contextFiles: [],
-			skills: [],
-			rules: [],
-			toolNames: [],
-			workspaceTree: {
-				rootPath: process.cwd(),
-				rendered: "",
-				truncated: false,
-				totalLines: 0,
-				agentsMdFiles: [],
-			},
-			activeRepoContext: null,
-		});
-		const rendered = systemPrompt.join("\\n\\n");
-		expect(rendered).toContain(\`Today is \${process.env.OMP_EXPECTED_DATE}\`);
-		expect(rendered).not.toContain(\`Today is \${process.env.OMP_REJECTED_DATE}\`);
-	} finally {
-		setSystemTime();
-	}
-});
-`,
-	);
-	const child = Bun.spawn([process.execPath, "test", scenarioPath], {
-		cwd: options.tempDir,
-		env: {
-			...process.env,
-			HOME: options.tempHomeDir,
-			TZ: options.timeZone,
-			OMP_TEST_NOW: options.now,
-			OMP_EXPECTED_DATE: options.expectedDate,
-			OMP_REJECTED_DATE: options.rejectedDate,
-		},
-		stdout: "pipe",
-		stderr: "pipe",
+describe("formatLocalCalendarDate timezone", () => {
+	it("formats the local calendar date in the host timezone, not UTC", () => {
+		// 2026-07-01T03:15:00Z is 2026-06-30 in America/Los_Angeles (UTC-7).
+		// formatLocalCalendarDate uses getFullYear/getMonth/getDate which respect TZ.
+		const previousTz = process.env.TZ;
+		try {
+			process.env.TZ = "America/Los_Angeles";
+			const date = new Date("2026-07-01T03:15:00Z");
+			expect(formatLocalCalendarDate(date)).toBe("2026-06-30");
+			expect(formatLocalCalendarDate(date)).not.toBe("2026-07-01");
+		} finally {
+			if (previousTz === undefined) delete process.env.TZ;
+			else process.env.TZ = previousTz;
+		}
 	});
-	const [stdout, stderr, exitCode] = await Promise.all([
-		new Response(child.stdout).text(),
-		new Response(child.stderr).text(),
-		child.exited,
-	]);
-	expect(`${stdout}\n${stderr}`).toContain("1 pass");
-	expect(exitCode).toBe(0);
-}
+});
 
 describe("system prompt model identifier", () => {
 	let tempDir = "";
@@ -113,15 +68,19 @@ describe("system prompt model identifier", () => {
 		expect(systemPrompt.join("\n\n")).toContain("Model: anthropic/claude-opus-4");
 	});
 
-	it("renders the prompt date from the startup local timezone rather than UTC", async () => {
-		await expectPromptDateFromStartupTimezone({
-			tempDir,
-			tempHomeDir,
-			timeZone: "America/Los_Angeles",
-			now: "2026-07-01T03:15:00Z",
-			expectedDate: "2026-06-30",
-			rejectedDate: "2026-07-01",
+	it("does not render the date into the stable base prompt", async () => {
+		// The date is a volatile suffix injected per-turn via turn-context.md;
+		// buildSystemPrompt must keep it out of the stable prefix so the cache
+		// breakpoint is byte-stable across midnight.
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: [],
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
 		});
+		expect(systemPrompt.join("\n\n")).not.toContain("Today is ");
 	});
 
 	it("omits the model line when no model is provided", async () => {
@@ -135,6 +94,43 @@ describe("system prompt model identifier", () => {
 		});
 
 		expect(systemPrompt.join("\n\n")).not.toContain("Model:");
+	});
+});
+
+describe("SystemPromptPlan NULL_PROMPT and verbatim override", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+	let originalNullPrompt: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-null-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-null-home-"));
+		originalHome = process.env.HOME;
+		originalNullPrompt = Bun.env.NULL_PROMPT;
+		process.env.HOME = tempHomeDir;
+	});
+
+	afterEach(() => {
+		if (originalNullPrompt === undefined) delete Bun.env.NULL_PROMPT;
+		else Bun.env.NULL_PROMPT = originalNullPrompt;
+		cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome }))();
+	});
+
+	it("returns empty verbatim plan with no date or backend side effects under NULL_PROMPT", async () => {
+		Bun.env.NULL_PROMPT = "true";
+		const plan = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: [],
+		});
+		expect(plan.systemPrompt).toEqual([]);
+		expect(plan.stableSystemPromptBlockCount).toBe(0);
+		expect(plan.compositionPolicy).toBe("verbatim");
+		// No date rendered — the volatile suffix is never built under NULL_PROMPT.
+		expect(plan.systemPrompt.join("\n\n")).not.toContain("Today is ");
 	});
 });
 
@@ -187,11 +183,7 @@ describe("AgentSession model-change prompt refresh", () => {
 		return [defaultPolicy, codexPolicy];
 	}
 
-	function newSession(
-		model: Model,
-		settings: Settings,
-		rebuild: () => Promise<{ systemPrompt: string[] }>,
-	): AgentSession {
+	function newSession(model: Model, settings: Settings, rebuild: () => Promise<SystemPromptPlan>): AgentSession {
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: { model, systemPrompt: ["initial"], tools: [], messages: [] },
@@ -216,7 +208,10 @@ describe("AgentSession model-change prompt refresh", () => {
 		session = newSession(modelA, Settings.isolated({ "compaction.enabled": false }), async () => {
 			rebuildCount++;
 			const active = session?.model;
-			return { systemPrompt: [`model:${active ? `${active.provider}/${active.id}` : ""}`] };
+			return {
+				systemPrompt: [`model:${active ? `${active.provider}/${active.id}` : ""}`],
+				compositionPolicy: "append-turn-context",
+			};
 		});
 
 		await session.setModel(modelB);
@@ -239,7 +234,7 @@ describe("AgentSession model-change prompt refresh", () => {
 			Settings.isolated({ "compaction.enabled": false, includeModelInPrompt: false }),
 			async () => {
 				rebuildCount++;
-				return { systemPrompt: ["unchanged"] };
+				return { systemPrompt: ["unchanged"], compositionPolicy: "append-turn-context" };
 			},
 		);
 
@@ -259,7 +254,7 @@ describe("AgentSession model-change prompt refresh", () => {
 			Settings.isolated({ "compaction.enabled": false, includeModelInPrompt: false }),
 			async () => {
 				rebuildCount++;
-				return { systemPrompt: ["policy changed"] };
+				return { systemPrompt: ["policy changed"], compositionPolicy: "append-turn-context" };
 			},
 		);
 


### PR DESCRIPTION
## Summary

* Reorders system prompt construction to isolate a stable prefix ahead of volatile repository context and dynamic tool inventories, so provider prompt caching (Anthropic system breakpoints) survives the churn that happens **every turn**. Scope of the win is stated precisely under "What the prefix does and does not survive" below — this is not a claim that the prefix never invalidates.
* Introduces `SystemPromptPlan` and stable block count boundaries across agent context, side-request builders, and session tools, ensuring side calls hit the same cached system prefix without mutating main session recall state.
* Normalizes Anthropic system breakpoint alignment across empty blocks and pre-computed billing headers while deriving deterministic billing seed identity for secret-obfuscated sessions.

## What changed

* **System Prompt Stabilization**: Restructured `buildSystemPrompt` to return a `SystemPromptPlan` with an explicit `stableSystemPromptBlockCount`. Base instructions, rules, guidelines, and safety prompts are placed prior to the boundary, while volatile components like active repository status (`activeRepoContext`) and rendered tool inventory sit after. Moved local date rendering into per-turn context (`turn-context.md`) to prevent midnight date transitions from invalidating the stable prompt signature.
* **Provider System Cache Mapping**: Updated Anthropic provider prompt caching (`resolveSystemCacheBreakpointIndex`, `applyClaudeCodeSystemCache`, `applyCacheControlToBlock`) to map `stableSystemPromptBlockCount` to the normalized prompt array after filtering blank entries and accounting for Claude Code billing headers and instruction prefixes.
* **Side Request Context & Prompt Plans**: Extended `buildSideRequestContext` and `buildSystemPromptForSideRequest` to carry structural `SystemPromptPlan` boundaries, ensuring side-channel turns share the cached system prefix while preserving memory recall state (`hasRecalledForFirstTurn`) on main turns.
* **Billing Seed Identity & Obfuscation**: Added `anthropicBillingSeed` context propagation so secret-obfuscated sessions derive a consistent billing seed from raw session messages while preserving obfuscated text for `convertToLlmFinal()`.
* **Verbatim Composition Policy**: Added `compositionPolicy` (`"append-turn-context"` | `"verbatim"`) to `SystemPromptPlan` to support `NULL_PROMPT` and custom override system prompts without injecting unexpected turn context.

## What the prefix does and does not survive

Block 0 is the rendered main template, and that template is conditional on the active tool set, skills, rules, and several settings (`{{#has tools "…"}}`, `{{#if skills.length}}`, `{{#if alwaysApplyRules.length}}`, `{{#if xdevTools.length}}` and friends). Those conditionals sit *inside* the stable region, so the honest boundary is:

**Survives — the per-turn churn this PR targets:**

- The local date (moved into `turn-context.md`, so a midnight rollover no longer invalidates).
- Memory/recall snippets, including fresh per-side-request recall.
- `activeRepoContext` — branch, status, routine git updates.
- The rendered tool inventory.
- Side-channel turns (`/btw`, IRC, ephemeral requests), which now share the main prefix instead of minting their own.

**Does not survive — session-level events that re-render block 0:**

- Connecting or dropping an MCP server, or any change to the active tool set (`/tools` toggle).
- A change in the matched skills or rules for the session.
- Toggling a setting the template branches on.

That is the intended trade: those events are session-level and rare, while date/recall/repo-context churn was invalidating the prefix on essentially every turn. Moving the tool-set gates behind the boundary as well would require splitting the template, which is deliberately out of scope here.

## Verification

* Commands executed:
  * `bun test packages/ai/test/anthropic-alignment.test.ts`
  * `bun check`
* Focused test suites:
  * `packages/ai/test/anthropic-alignment.test.ts`
  * `packages/agent/test/agent-side-request-context.test.ts`
  * `packages/agent/test/append-only-context.test.ts`
  * `packages/coding-agent/test/agent-session-message-pipeline.test.ts`
  * `packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts`
  * `packages/coding-agent/test/hindsight-backend.test.ts`
  * `packages/coding-agent/test/mnemopi-backend.test.ts`
  * `packages/coding-agent/test/system-prompt-dedup.test.ts`
  * `packages/coding-agent/test/system-prompt-inventory.test.ts`
  * `packages/coding-agent/test/system-prompt-model.test.ts`

## Notes

* `SystemPromptPlan` enforces a `"verbatim"` composition policy when `NULL_PROMPT=true` or custom system prompt overrides are active, ensuring append-only turn context does not mutate explicit caller-specified prompt replacements.

## CI status

Both failing checks are inherited, not introduced here. Neither was "fixed" in this branch, because neither is this branch's defect:

- **`Test coding-agent native/unit`** — `test/models-config-lazy-validator.test.ts > models config validation resources are retained only for a custom config` times out at 5000ms. It fails identically when checked out at pristine `upstream/main` in a clean worktree, so it is a base artifact. This PR touches nothing in the models-config validator.
- **`Test TS workspace fast`** — `test/oauth-barrel-import.test.ts`, whose fixture subprocess is reaped as `killed 1 dangling process`. It fails on 10 of 11 unrelated PRs in this batch and passes on one, so it is flaky rather than deterministic; `main` is green and the suite passes locally at CI's own parallelism.

Both share one signature: a test that spawns a subprocess, hitting the 5s per-test timeout on a loaded runner.
