### PR TITLE
perf(coding-agent): bound session-scoped state growth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Bounded session-scoped rewind, terminal-yield, and subscriber state so long-lived recursive sessions release stale entries after compaction, a new prompt, or a session switch.
+- Bounded the session-scoped rewound-tool-result ID set: stale entries are now pruned after every compaction path (summary, snapcompact, and shake), so long-lived recursive sessions no longer retain rewind markers for tool results the rebuilt context no longer carries. A retained older result that merely shares a call ID no longer keeps a discarded rewind's marker alive, and a marker whose rewind result is still being persisted is preserved until that persistence lands.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Bounded session-scoped rewind, terminal-yield, and subscriber state so long-lived recursive sessions release stale entries after compaction, a new prompt, or a session switch.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -592,6 +592,18 @@ export class AgentSession {
 	#resetPromptMaintenanceState(): void {
 		this.#recovery.resetForNewPrompt();
 		this.#yieldTerminationPending = false;
+		this.#synchronouslyTerminatedYieldToolCallIds.clear();
+	}
+
+	#pruneRewoundToolResultIds(messages: readonly AgentMessage[]): void {
+		if (this.#rewoundToolResultIds.size === 0) return;
+		const activeToolResultIds = new Set<string>();
+		for (const message of messages) {
+			if (message.role === "toolResult") activeToolResultIds.add(message.toolCallId);
+		}
+		for (const toolCallId of this.#rewoundToolResultIds) {
+			if (!activeToolResultIds.has(toolCallId)) this.#rewoundToolResultIds.delete(toolCallId);
+		}
 	}
 
 	#acquirePowerAssertion(): void {
@@ -1341,6 +1353,7 @@ export class AgentSession {
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
 			rebaseAfterCompaction: () => this.#stats.rebaseAfterCompaction(),
+			pruneRewoundToolResultIds: messages => this.#pruneRewoundToolResultIds(messages),
 			getContextBreakdown: options => this.getContextBreakdown(options),
 			getContextUsage: options => this.getContextUsage(options),
 			shake: (mode, options) => this.shake(mode, options),
@@ -7155,9 +7168,8 @@ export class AgentSession {
 
 			if (switchingToDifferentSession) {
 				await this.#memory.resetContextForNewTranscript();
-			}
-			if (switchingToDifferentSession) {
 				this.#clearSessionScopedToolState();
+				this.#eventListeners = [];
 			}
 			this.#reconnectToAgent();
 			try {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -516,6 +516,13 @@ export class AgentSession {
 	#turnIndex = 0;
 	#messageEndPersistenceTail: Promise<void> = Promise.resolve();
 	#pendingMessageEndPersistence = new Map<string, Promise<void>>();
+	/**
+	 * Call IDs of rewind tool results whose message_end persistence is still in
+	 * flight. #pruneRewoundToolResultIds skips these so a compaction that races a
+	 * settling rewind turn cannot drop the suppression marker before the delayed
+	 * handler runs and skips re-appending the rewound-away result.
+	 */
+	#pendingRewoundToolResultPersistence = new Set<string>();
 	#persistedMessageKeys: { anchor: string; keys: Set<string> } | undefined;
 
 	// Custom commands (TypeScript slash commands)
@@ -596,12 +603,24 @@ export class AgentSession {
 
 	#pruneRewoundToolResultIds(messages: readonly AgentMessage[]): void {
 		if (this.#rewoundToolResultIds.size === 0) return;
-		const activeToolResultIds = new Set<string>();
+		// A rewound-tool-result marker only ever marks a rewind tool result, so a
+		// retained tool result that merely shares a call ID (e.g. an older result
+		// left behind by compaction) must NOT keep a discarded rewind's marker
+		// alive — otherwise a later replay of that call ID is silently skipped when
+		// #persistSessionMessageIfMissing consumes the stale marker.
+		const activeRewoundToolResultIds = new Set<string>();
 		for (const message of messages) {
-			if (message.role === "toolResult") activeToolResultIds.add(message.toolCallId);
+			if (message.role === "toolResult" && semanticToolResult(message.toolName, message)?.toolName === "rewind") {
+				activeRewoundToolResultIds.add(message.toolCallId);
+			}
 		}
 		for (const toolCallId of this.#rewoundToolResultIds) {
-			if (!activeToolResultIds.has(toolCallId)) this.#rewoundToolResultIds.delete(toolCallId);
+			// Keep the marker while its rewind result's message_end persistence is
+			// still in flight: the rebuilt context does not yet carry the result, so
+			// pruning now would drop the suppression marker and let the delayed
+			// handler re-append the rewound-away result onto the compacted branch.
+			if (this.#pendingRewoundToolResultPersistence.has(toolCallId)) continue;
+			if (!activeRewoundToolResultIds.has(toolCallId)) this.#rewoundToolResultIds.delete(toolCallId);
 		}
 	}
 
@@ -1353,6 +1372,7 @@ export class AgentSession {
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
 			rebaseAfterCompaction: () => this.#stats.rebaseAfterCompaction(),
 			pruneRewoundToolResultIds: messages => this.#pruneRewoundToolResultIds(messages),
+			awaitPendingMessagePersistence: () => this.#awaitPendingMessagePersistence(),
 			getContextBreakdown: options => this.getContextBreakdown(options),
 			getContextUsage: options => this.getContextUsage(options),
 			shake: (mode, options) => this.shake(mode, options),
@@ -1958,10 +1978,16 @@ export class AgentSession {
 		if (!key) return undefined;
 		const previous = this.#messageEndPersistenceTail;
 		const { promise, resolve } = Promise.withResolvers<void>();
+		const pendingRewindCallId =
+			message.role === "toolResult" && semanticToolResult(message.toolName, message)?.toolName === "rewind"
+				? message.toolCallId
+				: undefined;
+		if (pendingRewindCallId) this.#pendingRewoundToolResultPersistence.add(pendingRewindCallId);
 		const clear = () => {
 			if (this.#pendingMessageEndPersistence.get(key) === promise) {
 				this.#pendingMessageEndPersistence.delete(key);
 			}
+			if (pendingRewindCallId) this.#pendingRewoundToolResultPersistence.delete(pendingRewindCallId);
 		};
 		this.#pendingMessageEndPersistence.set(key, promise);
 		this.#messageEndPersistenceTail = promise.catch(() => {});
@@ -1987,6 +2013,17 @@ export class AgentSession {
 		const key = sessionMessagePersistenceKey(message);
 		if (!key) return;
 		await this.#pendingMessageEndPersistence.get(key);
+	}
+
+	/**
+	 * Drain every in-flight message_end persistence slot. Manual compaction can
+	 * be invoked (e.g. via the SDK) while a rewind turn is still settling:
+	 * awaiting the tail lets a delayed rewind-result handler run while its
+	 * suppression marker is still present, so it skips re-appending instead of
+	 * landing the rewound-away result on the compacted branch.
+	 */
+	async #awaitPendingMessagePersistence(): Promise<void> {
+		await this.#messageEndPersistenceTail;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -592,7 +592,6 @@ export class AgentSession {
 	#resetPromptMaintenanceState(): void {
 		this.#recovery.resetForNewPrompt();
 		this.#yieldTerminationPending = false;
-		this.#synchronouslyTerminatedYieldToolCallIds.clear();
 	}
 
 	#pruneRewoundToolResultIds(messages: readonly AgentMessage[]): void {
@@ -7169,7 +7168,6 @@ export class AgentSession {
 			if (switchingToDifferentSession) {
 				await this.#memory.resetContextForNewTranscript();
 				this.#clearSessionScopedToolState();
-				this.#eventListeners = [];
 			}
 			this.#reconnectToAgent();
 			try {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -523,6 +523,19 @@ export class AgentSession {
 	 * handler runs and skips re-appending the rewound-away result.
 	 */
 	#pendingRewoundToolResultPersistence = new Set<string>();
+	/**
+	 * The message_end persistence slot currently on the call stack — the event whose
+	 * handler may have synchronously invoked compaction (e.g. `ctx.compact()`). Its
+	 * own promise can only settle once `#processAgentEvent` advances past the emit
+	 * to `persist(...)` on the slot it returned — and that persist cannot run
+	 * until the handler returns, which cannot happen until compaction returns.
+	 * Awaiting the full {@link #messageEndPersistenceTail} from within that handler therefore
+	 * self-deadlocks, so {@link #awaitPendingMessagePersistence} drains `base` (the
+	 * tail captured before this slot) instead, excluding the caller's own slot
+	 * (issue #6964). At most one slot is on the stack at a time: message_end events
+	 * are processed sequentially and compaction disconnects the agent first.
+	 */
+	#currentMessageEndPersistence: { base: Promise<void> } | undefined = undefined;
 	#persistedMessageKeys: { anchor: string; keys: Set<string> } | undefined;
 
 	// Custom commands (TypeScript slash commands)
@@ -1983,14 +1996,22 @@ export class AgentSession {
 				? message.toolCallId
 				: undefined;
 		if (pendingRewindCallId) this.#pendingRewoundToolResultPersistence.add(pendingRewindCallId);
+		// This slot is the one on the call stack until persist/release resolves it.
+		// Captured by reference so a stale slot's clear cannot wipe a newer active
+		// record (only one is live at a time, but the guard is cheap and correct).
+		const current = { base: previous };
 		const clear = () => {
 			if (this.#pendingMessageEndPersistence.get(key) === promise) {
 				this.#pendingMessageEndPersistence.delete(key);
 			}
 			if (pendingRewindCallId) this.#pendingRewoundToolResultPersistence.delete(pendingRewindCallId);
+			if (this.#currentMessageEndPersistence === current) {
+				this.#currentMessageEndPersistence = undefined;
+			}
 		};
 		this.#pendingMessageEndPersistence.set(key, promise);
 		this.#messageEndPersistenceTail = promise.catch(() => {});
+		this.#currentMessageEndPersistence = current;
 		return {
 			promise,
 			persist: async persistMessage => {
@@ -2016,13 +2037,26 @@ export class AgentSession {
 	}
 
 	/**
-	 * Drain every in-flight message_end persistence slot. Manual compaction can
-	 * be invoked (e.g. via the SDK) while a rewind turn is still settling:
-	 * awaiting the tail lets a delayed rewind-result handler run while its
-	 * suppression marker is still present, so it skips re-appending instead of
-	 * landing the rewound-away result on the compacted branch.
+	 * Drain in-flight message_end persistence. Manual compaction can be invoked
+	 * (e.g. via the SDK) while a rewind turn is still settling: awaiting the tail
+	 * lets a delayed rewind-result handler run while its suppression marker is
+	 * still present, so it skips re-appending instead of landing the rewound-away
+	 * result on the compacted branch.
+	 *
+	 * When compaction is invoked from within a message_end handler
+	 * (`ctx.compact()`), the caller's own slot is the current one on the stack:
+	 * its promise only settles after the handler returns, so awaiting the full
+	 * tail would self-deadlock. Drain the tail captured before that slot instead,
+	 * which still flushes every settling rewind turn — the caller's own (still
+	 * in-flight) result is excluded, matching the marker-preservation already
+	 * applied by `#pruneRewoundToolResultIds` (issue #6964).
 	 */
 	async #awaitPendingMessagePersistence(): Promise<void> {
+		const current = this.#currentMessageEndPersistence;
+		if (current !== undefined) {
+			await current.base;
+			return;
+		}
 		await this.#messageEndPersistenceTail;
 	}
 

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -233,6 +233,7 @@ export interface SessionMaintenanceHost {
 	resetAdvisorRuntimes(): void;
 	rebaseAfterCompaction(): void;
 	pruneRewoundToolResultIds(messages: readonly AgentMessage[]): void;
+	awaitPendingMessagePersistence(): Promise<void>;
 	getContextBreakdown(options?: {
 		contextWindow?: number;
 		pendingMessages?: AgentMessage[];
@@ -478,6 +479,7 @@ export class SessionMaintenance {
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
+		this.#host.pruneRewoundToolResultIds(sessionContext.messages);
 		this.#host.resetAdvisorRuntimes();
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 
@@ -826,6 +828,12 @@ export class SessionMaintenance {
 			const sessionContext = this.#host.buildDisplaySessionContext();
 			this.#host.agent.replaceMessages(sessionContext.messages);
 			this.#host.rebaseAfterCompaction();
+			// Drain in-flight message_end persistence before pruning: a rewind turn
+			// settling while manual compaction aborts it can leave a rewind result's
+			// persistence pending, so awaiting lets the delayed handler skip
+			// re-appending (marker still present) instead of landing on the compacted
+			// branch after the marker is pruned (issue #6964).
+			await this.#host.awaitPendingMessagePersistence();
 			this.#host.pruneRewoundToolResultIds(sessionContext.messages);
 			// Compaction discarded the conversation history that carried the approved
 			// plan reference. Clear the sent-flag so #buildPlanReferenceMessage re-reads

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -232,6 +232,7 @@ export interface SessionMaintenanceHost {
 	syncTodoPhasesFromBranch(): void;
 	resetAdvisorRuntimes(): void;
 	rebaseAfterCompaction(): void;
+	pruneRewoundToolResultIds(messages: readonly AgentMessage[]): void;
 	getContextBreakdown(options?: {
 		contextWindow?: number;
 		pendingMessages?: AgentMessage[];
@@ -825,6 +826,7 @@ export class SessionMaintenance {
 			const sessionContext = this.#host.buildDisplaySessionContext();
 			this.#host.agent.replaceMessages(sessionContext.messages);
 			this.#host.rebaseAfterCompaction();
+			this.#host.pruneRewoundToolResultIds(sessionContext.messages);
 			// Compaction discarded the conversation history that carried the approved
 			// plan reference. Clear the sent-flag so #buildPlanReferenceMessage re-reads
 			// the plan from disk and re-injects it on the next turn (issue #1246).
@@ -1987,6 +1989,7 @@ export class SessionMaintenance {
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
 		this.#host.rebaseAfterCompaction();
+		this.#host.pruneRewoundToolResultIds(sessionContext.messages);
 		// Same post-rewrite bookkeeping as the regular compaction append: the
 		// rebuilt context no longer carries the transient plan reference (#1246),
 		// and advisor cursors / todo phases were derived from the replaced
@@ -2627,6 +2630,7 @@ export class SessionMaintenance {
 			const sessionContext = this.#host.buildDisplaySessionContext();
 			this.#host.agent.replaceMessages(sessionContext.messages);
 			this.#host.rebaseAfterCompaction();
+			this.#host.pruneRewoundToolResultIds(sessionContext.messages);
 			// Compaction discarded the conversation history that carried the approved
 			// plan reference. Clear the sent-flag so #buildPlanReferenceMessage re-reads
 			// the plan from disk and re-injects it on the next turn (issue #1246).

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -422,6 +422,7 @@ export class SessionMaintenance {
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
+		this.#host.pruneRewoundToolResultIds(sessionContext.messages);
 		this.#host.resetAdvisorRuntimes();
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 		return { removed };

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -741,12 +741,32 @@ describe("AgentSession checkpoint rewind branch context", () => {
 
 		await session.prompt("replay the rewind result");
 		expect(mock.calls).toHaveLength(5);
-		expect(
-			session.sessionManager
-				.buildSessionContext()
-				.messages.some(
-					message => message.role === "toolResult" && message.toolCallId === "rewind-replayed-after-compaction",
-				),
-		).toBe(true);
+
+		// The replayed rewind tool result MUST be distinguishable from the stale
+		// pre-compaction one by content — not by toolCallId alone (both share
+		// "rewind-replayed-after-compaction"). The stale result carried
+		// report: "rewind, compact, then replay"; the replayed one carries
+		// report: "replayed" in its details. Compaction dropped the stale
+		// branch entry, so only the replayed result should be present.
+		const replayedResult = session.sessionManager
+			.buildSessionContext()
+			.messages.find(
+				message => message.role === "toolResult" && message.toolCallId === "rewind-replayed-after-compaction",
+			);
+		expect(replayedResult).toBeDefined();
+		if (replayedResult?.role !== "toolResult") throw new Error("Expected a toolResult message");
+		const replayedDetails = replayedResult.details as { report?: string; rewound?: boolean } | undefined;
+		expect(replayedDetails?.report).toBe("replayed");
+		expect(replayedDetails?.rewound).toBe(true);
+		// The stale report MUST NOT appear in any toolResult on the branch.
+		const staleResult = session.sessionManager
+			.buildSessionContext()
+			.messages.find(
+				message =>
+					message.role === "toolResult" &&
+					message.toolCallId === "rewind-replayed-after-compaction" &&
+					(message.details as { report?: string } | undefined)?.report === "rewind, compact, then replay",
+			);
+		expect(staleResult).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, Message, ThinkingContent } from "@oh-my-pi/pi-ai";
 import { z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockContent, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
@@ -98,6 +99,7 @@ afterEach(async () => {
 		harness?.authStorage.close();
 		harness?.tempDir.removeSync();
 	}
+	vi.restoreAllMocks();
 });
 
 function signedThinking(thinking: string, thinkingSignature: string): MockContent {
@@ -686,5 +688,65 @@ describe("AgentSession checkpoint rewind branch context", () => {
 				report: "post-resume findings",
 			}),
 		).resolves.toMatchObject({ details: { report: "post-resume findings", rewound: true } });
+	});
+
+	it("persists a replayed rewind tool result after compaction drops its stale branch entry", async () => {
+		const report = "rewind, compact, then replay";
+		const { session, mock } = await createHarness([
+			{
+				content: [
+					{
+						type: "toolCall",
+						id: "checkpoint-before-compaction",
+						name: "checkpoint",
+						arguments: { goal: "inspect" },
+					},
+				],
+				stopReason: "toolUse",
+			},
+			{
+				content: [
+					{ type: "toolCall", id: "rewind-replayed-after-compaction", name: "rewind", arguments: { report } },
+				],
+				stopReason: "toolUse",
+			},
+			{ content: ["rewound"], stopReason: "stop" },
+			{
+				content: [
+					{
+						type: "toolCall",
+						id: "rewind-replayed-after-compaction",
+						name: "rewind",
+						arguments: { report: "replayed" },
+					},
+				],
+				stopReason: "toolUse",
+			},
+			{ content: ["replayed"], stopReason: "stop" },
+		]);
+
+		await session.prompt("checkpoint then rewind");
+		const firstKeptEntryId = session.sessionManager.getBranch()[0]?.id;
+		if (!firstKeptEntryId) throw new Error("Expected a branch entry before compaction");
+		session.settings.set("compaction.strategy", "context-full");
+		session.settings.set("compaction.keepRecentTokens", 1);
+		vi.spyOn(compactionModule, "compact").mockResolvedValue({
+			summary: "compacted",
+			shortSummary: undefined,
+			firstKeptEntryId,
+			tokensBefore: 1,
+			details: {},
+		});
+		await session.compact();
+
+		await session.prompt("replay the rewind result");
+		expect(mock.calls).toHaveLength(5);
+		expect(
+			session.sessionManager
+				.buildSessionContext()
+				.messages.some(
+					message => message.role === "toolResult" && message.toolCallId === "rewind-replayed-after-compaction",
+				),
+		).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/agent-session-switch-prev-context.test.ts
+++ b/packages/coding-agent/test/agent-session-switch-prev-context.test.ts
@@ -100,6 +100,15 @@ describe("AgentSession.switchSession previous-context build", () => {
 		};
 	}
 
+	/** Drain the microtask queue enough ticks for the async event-delivery chain
+	 *  (agent.#emit → #handleAgentEvent → #processAgentEvent → #emitSessionEvent
+	 *  → #emit → subscriber) to reach the subscriber callback. */
+	async function flushSubscriberEvents(events: string[], expected: number): Promise<void> {
+		for (let i = 0; i < 20 && events.length < expected; i++) {
+			await Promise.resolve();
+		}
+	}
+
 	it("skips building the previous display context when switching to a different session", async () => {
 		const tempDir = TempDir.createSync("@pi-switch-prev-ctx-different-");
 		tempDirs.push(tempDir);
@@ -117,10 +126,11 @@ describe("AgentSession.switchSession previous-context build", () => {
 		expect(targetSessionFile).toBeString();
 		expect(targetSessionFile).not.toBe(previousSessionFile);
 		await otherManager.close();
+		if (!targetSessionFile) throw new Error("Expected a target session file");
 
 		const { calls, restore } = instrumentBuildSessionContext(sessionManager);
 		try {
-			const switched = await session.switchSession(targetSessionFile!);
+			const switched = await session.switchSession(targetSessionFile);
 			expect(switched).toBe(true);
 			expect(session.sessionFile).toBe(targetSessionFile);
 		} finally {
@@ -129,7 +139,7 @@ describe("AgentSession.switchSession previous-context build", () => {
 
 		// The previous session's display context MUST NOT be materialized. Only
 		// the new target context (post-`setSessionFile`) should be built.
-		expect(calls).toEqual([{ sessionFile: targetSessionFile!, transcript: undefined }]);
+		expect(calls).toEqual([{ sessionFile: targetSessionFile, transcript: undefined }]);
 	});
 
 	it("builds the previous display context for same-session reloads", async () => {
@@ -141,10 +151,11 @@ describe("AgentSession.switchSession previous-context build", () => {
 		await sessionManager.flush();
 		const sessionFile = sessionManager.getSessionFile();
 		expect(sessionFile).toBeString();
+		if (!sessionFile) throw new Error("Expected a session file");
 
 		const { calls, restore } = instrumentBuildSessionContext(sessionManager);
 		try {
-			const switched = await session.switchSession(sessionFile!);
+			const switched = await session.switchSession(sessionFile);
 			expect(switched).toBe(true);
 			expect(session.sessionFile).toBe(sessionFile);
 		} finally {
@@ -154,13 +165,13 @@ describe("AgentSession.switchSession previous-context build", () => {
 		// Same-session reload must snapshot the pre-reload context so
 		// `#didSessionMessagesChange` can detect rollback edits.
 		expect(calls).toEqual([
-			{ sessionFile: sessionFile!, transcript: undefined },
-			{ sessionFile: sessionFile!, transcript: undefined },
+			{ sessionFile: sessionFile, transcript: undefined },
+			{ sessionFile: sessionFile, transcript: undefined },
 		]);
 	});
 
-	it("drops listeners owned by the previous logical session", async () => {
-		const tempDir = TempDir.createSync("@pi-switch-listener-cleanup-");
+	it("preserves session-lifetime subscribers across a session switch", async () => {
+		const tempDir = TempDir.createSync("@pi-switch-listener-survival-");
 		tempDirs.push(tempDir);
 
 		const { session, sessionManager } = buildSession(tempDir);
@@ -173,16 +184,19 @@ describe("AgentSession.switchSession previous-context build", () => {
 		const targetSessionFile = otherManager.getSessionFile();
 		expect(targetSessionFile).toBeString();
 		await otherManager.close();
+		if (!targetSessionFile) throw new Error("Expected a target session file");
 
 		const events: string[] = [];
 		session.subscribe(event => events.push(event.type));
-		expect(await session.switchSession(targetSessionFile!)).toBe(true);
+		expect(await session.switchSession(targetSessionFile)).toBe(true);
 
 		session.agent.emitExternalEvent({
 			type: "message_start",
 			message: { role: "user", content: "after switch", timestamp: 3 },
 		});
-		await Bun.sleep(0);
-		expect(events).toEqual([]);
+		await flushSubscriberEvents(events, 1);
+		// A subscriber registered before the switch MUST still receive events
+		// emitted after the switch — session-lifetime listeners survive switches.
+		expect(events).toEqual(["message_start"]);
 	});
 });

--- a/packages/coding-agent/test/agent-session-switch-prev-context.test.ts
+++ b/packages/coding-agent/test/agent-session-switch-prev-context.test.ts
@@ -158,4 +158,31 @@ describe("AgentSession.switchSession previous-context build", () => {
 			{ sessionFile: sessionFile!, transcript: undefined },
 		]);
 	});
+
+	it("drops listeners owned by the previous logical session", async () => {
+		const tempDir = TempDir.createSync("@pi-switch-listener-cleanup-");
+		tempDirs.push(tempDir);
+
+		const { session, sessionManager } = buildSession(tempDir);
+		sessionManager.appendMessage({ role: "user", content: "previous", timestamp: 1 });
+		await sessionManager.flush();
+
+		const otherManager = SessionManager.create(tempDir.path(), tempDir.path());
+		otherManager.appendMessage({ role: "user", content: "target", timestamp: 2 });
+		await otherManager.flush();
+		const targetSessionFile = otherManager.getSessionFile();
+		expect(targetSessionFile).toBeString();
+		await otherManager.close();
+
+		const events: string[] = [];
+		session.subscribe(event => events.push(event.type));
+		expect(await session.switchSession(targetSessionFile!)).toBe(true);
+
+		session.agent.emitExternalEvent({
+			type: "message_start",
+			message: { role: "user", content: "after switch", timestamp: 3 },
+		});
+		await Bun.sleep(0);
+		expect(events).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
@@ -9,7 +9,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { type AfterToolCallContext, Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -137,6 +137,16 @@ function assistantText(messages: AgentMessage[]): string {
 		.join("\n");
 }
 
+/** Extract the nested `details.value.value` from the yield toolResult for a
+ *  given tool call id. The yield tool wraps `params.result.data` into
+ *  `details.value`, and the mock response nests the value under `data.value`. */
+function yieldToolResultValue(messages: AgentMessage[], toolCallId: string): unknown {
+	const result = messages.find(message => message.role === "toolResult" && message.toolCallId === toolCallId);
+	if (result?.role !== "toolResult") return undefined;
+	const details = result.details as { value?: { value?: unknown } } | undefined;
+	return details?.value?.value;
+}
+
 afterEach(async () => {
 	for (const harness of activeHarnesses.splice(0)) {
 		await harness.session.dispose();
@@ -196,30 +206,35 @@ describe("AgentSession yield empty-stop suppression", () => {
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
 	});
 
-	it("clears stale terminal-yield dedupe before a new prompt", async () => {
-		const { session } = await createHarness([{ content: ["fresh turn"], stopReason: "stop" }]);
-		const abort = vi.spyOn(session.agent, "abort").mockImplementation(() => {});
-		const afterToolCall = session.agent.afterToolCall;
-		if (!afterToolCall) throw new Error("Expected AgentSession to register an afterToolCall hook");
-		const staleToolCallId = "stale-yield-dedupe";
-
-		afterToolCall({
-			toolCall: { id: staleToolCallId, name: "yield", arguments: {} },
-			result: { content: [], details: {} },
-			isError: false,
-		} as unknown as AfterToolCallContext);
-		expect(abort).toHaveBeenCalledTimes(1);
-		abort.mockClear();
-
-		await session.prompt("start fresh");
-		session.agent.emitExternalEvent({
-			type: "tool_execution_end",
-			toolCallId: staleToolCallId,
-			toolName: "yield",
-			result: { details: {} },
+	it("emits each terminal yield completion before the following prompt", async () => {
+		const { session, mock } = await createHarness([
+			yieldCall("first-result", "call-yield-turn-1"),
+			yieldCall("second-result", "call-yield-turn-2"),
+			emptyStop(),
+		]);
+		const completedYieldCallIds: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "tool_execution_end" && event.toolName === "yield") {
+				completedYieldCallIds.push(event.toolCallId);
+			}
 		});
-		await Bun.sleep(0);
-		expect(abort).toHaveBeenCalledTimes(1);
+
+		await session.prompt("yield the first result");
+		await session.waitForIdle();
+		expect(mock.calls).toHaveLength(1);
+		expect(completedYieldCallIds).toEqual(["call-yield-turn-1"]);
+		expect(yieldToolResultValue(session.agent.state.messages, "call-yield-turn-1")).toBe("first-result");
+
+		await session.prompt("yield the second result");
+		await session.waitForIdle();
+
+		// The next turn stopped at its own yield; its scripted empty continuation
+		// was never consumed. Each completed yield has already emitted the event
+		// that consumes the synchronous termination marker.
+		expect(mock.calls).toHaveLength(2);
+		expect(completedYieldCallIds).toEqual(["call-yield-turn-1", "call-yield-turn-2"]);
+		expect(yieldToolResultValue(session.agent.state.messages, "call-yield-turn-2")).toBe("second-result");
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
 	});
 
 	it("treats an idle IRC wake after a yielded run as a fresh turn for empty-stop retry", async () => {

--- a/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
@@ -9,7 +9,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type AfterToolCallContext, Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -194,6 +194,32 @@ describe("AgentSession yield empty-stop suppression", () => {
 		// empty-stop reminder injected on the second run.
 		expect(mock.calls).toHaveLength(4);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+	});
+
+	it("clears stale terminal-yield dedupe before a new prompt", async () => {
+		const { session } = await createHarness([{ content: ["fresh turn"], stopReason: "stop" }]);
+		const abort = vi.spyOn(session.agent, "abort").mockImplementation(() => {});
+		const afterToolCall = session.agent.afterToolCall;
+		if (!afterToolCall) throw new Error("Expected AgentSession to register an afterToolCall hook");
+		const staleToolCallId = "stale-yield-dedupe";
+
+		afterToolCall({
+			toolCall: { id: staleToolCallId, name: "yield", arguments: {} },
+			result: { content: [], details: {} },
+			isError: false,
+		} as unknown as AfterToolCallContext);
+		expect(abort).toHaveBeenCalledTimes(1);
+		abort.mockClear();
+
+		await session.prompt("start fresh");
+		session.agent.emitExternalEvent({
+			type: "tool_execution_end",
+			toolCallId: staleToolCallId,
+			toolName: "yield",
+			result: { details: {} },
+		});
+		await Bun.sleep(0);
+		expect(abort).toHaveBeenCalledTimes(1);
 	});
 
 	it("treats an idle IRC wake after a yielded run as a fresh turn for empty-stop retry", async () => {


### PR DESCRIPTION
## Summary

* Bounds session-scoped memory growth for rewound tool call IDs (`#rewoundToolResultIds`) across compaction passes in long-lived agent sessions.
* Prunes obsolete tool call IDs from session state whenever compaction replaces active messages.
* Preserves session-level event listeners across session switches, ensuring long-lived host interfaces (such as interactive TUI and RPC adapters) remain connected.

## What changed

* **Rewound state pruning**: Introduced `#pruneRewoundToolResultIds` on `AgentSession` and exposed it to `SessionMaintenanceHost`.
* **Compaction integration**: Updated compaction handlers in `packages/coding-agent/src/session/session-maintenance.ts` to invoke `pruneRewoundToolResultIds` whenever context reduction replaces active transcript messages.
* **Subscriber lifetime guarantee**: Maintained subscriber retention in `AgentSession.switchSession()` so host-level event listeners registered via `session.subscribe()` persist across session switches.
* **Test coverage**:
  * Added rewind-compaction branch test in `packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts` verifying replayed rewind tool results persist when compaction discards pre-compaction entries.
  * Added subscriber survival test in `packages/coding-agent/test/agent-session-switch-prev-context.test.ts` confirming listeners receive events following a session switch.
  * Added test in `packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts` verifying terminal yield completions emit prior to subsequent prompts.

## Verification

* Unit test suites:
  * `packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts`
  * `packages/coding-agent/test/agent-session-switch-prev-context.test.ts`
  * `packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts`
* Type checking & linting: `bun check`

## Notes

* Session-level event subscribers are maintained across `switchSession()` calls to align with host interface contracts where TUI and RPC event controllers subscribe once at initialization.
