### PR TITLE
feat(tools): ask tool schema and interaction upgrades

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added searchable rich ask options, validated custom answers, and diff previews.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -118,10 +118,18 @@ export interface ExtensionUISelectOption {
 
 export type ExtensionUISelectItem = string | ExtensionUISelectOption;
 
+/** Validation applied only when the user chooses `Other (type your own)`. */
 export interface ExtensionAskDialogValidation {
+	/** A safe JavaScript regular expression matched against the complete Other answer.
+	 * Groups and multiple quantified atoms are rejected to keep synchronous UI
+	 * validation bounded; patterns are limited to 256 UTF-16 code units. */
 	pattern?: string;
+	/** Minimum Other-answer length in UTF-16 code units. */
 	minLength?: number;
+	/** Maximum Other-answer length in UTF-16 code units. */
 	maxLength?: number;
+	/** Error shown after validation fails. When omitted, a built-in format error is shown.
+	 * With this validation configured, Other answers over 1,024 UTF-16 code units always fail. */
 	message?: string;
 }
 
@@ -129,6 +137,7 @@ export interface ExtensionAskDialogOption {
 	label: string;
 	description?: string;
 	preview?: string;
+	/** Rendering mode for `preview`; markdown is the default and `diff` renders a patch preview. */
 	previewType?: "markdown" | "diff";
 }
 
@@ -138,9 +147,11 @@ export interface ExtensionAskDialogQuestion {
 	header?: string;
 	options: ExtensionAskDialogOption[];
 	multi?: boolean;
-	/** Recommended option index. A timed-out multi-select chooses exactly this option. */
+	/** Recommended option index. Timeout selects it only while the question is unanswered. */
 	recommended?: number;
+	/** Enables filtering only when there are at least seven options; ignored for shorter lists. */
 	searchable?: boolean;
+	/** Validation for Other answers. */
 	validation?: ExtensionAskDialogValidation;
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -118,10 +118,18 @@ export interface ExtensionUISelectOption {
 
 export type ExtensionUISelectItem = string | ExtensionUISelectOption;
 
+export interface ExtensionAskDialogValidation {
+	pattern?: string;
+	minLength?: number;
+	maxLength?: number;
+	message?: string;
+}
+
 export interface ExtensionAskDialogOption {
 	label: string;
 	description?: string;
 	preview?: string;
+	previewType?: "markdown" | "diff";
 }
 
 export interface ExtensionAskDialogQuestion {
@@ -130,7 +138,10 @@ export interface ExtensionAskDialogQuestion {
 	header?: string;
 	options: ExtensionAskDialogOption[];
 	multi?: boolean;
+	/** Recommended option index. A timed-out multi-select chooses exactly this option. */
 	recommended?: number;
+	searchable?: boolean;
+	validation?: ExtensionAskDialogValidation;
 }
 
 export interface ExtensionAskDialogResultItem {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -588,12 +588,22 @@ export class AskDialogComponent implements Component {
 			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
 		}
 		const question = this.questions[this.#currentQuestionIndex()];
-		const action = question?.multi ? "Space/Enter toggle · n note" : "Enter select · n note";
+		const state = this.#states[this.#currentQuestionIndex()];
+		const searchActive = !!question && !!state && this.#isSearchEnabled(question) && state.searchActive;
+		const isMulti = question?.multi === true;
+		let action = isMulti ? "Space/Enter toggle · n note" : "Enter select · n note";
+		if (searchActive) {
+			// The filter query consumes every printable key (Space, n, …) before
+			// the question actions run, so the footer must not advertise the
+			// toggle/note shortcuts those keys would normally trigger; Enter
+			// still selects the highlighted option.
+			action = isMulti ? "Enter toggle" : "Enter select";
+		}
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		const search =
-			question && this.#states[this.#currentQuestionIndex()] && this.#isSearchEnabled(question)
-				? this.#states[this.#currentQuestionIndex()].searchActive
-					? ` · filter: ${this.#states[this.#currentQuestionIndex()].searchQuery || "type to filter"}`
+			question && state && this.#isSearchEnabled(question)
+				? searchActive
+					? ` · filter: ${state.searchQuery || "type to filter"}`
 					: " · / filter"
 				: "";
 		if (this.#questionCanPage && indicator) {
@@ -609,7 +619,7 @@ export class AskDialogComponent implements Component {
 
 	#handleSearchInput(question: ExtensionAskDialogQuestion, state: QuestionState, keyData: string): boolean {
 		if (!this.#isSearchEnabled(question)) return false;
-		if (!state.searchActive && keyData === "/") {
+		if (!state.searchActive && extractPrintableText(keyData) === "/") {
 			state.searchActive = true;
 			this.#requestRender();
 			return true;

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -19,6 +19,7 @@ import type {
 	ExtensionAskDialogResultItem,
 	ExtensionAskDialogSubmitResult,
 } from "../../extensibility/extensions";
+import { getAskCustomInputValidationError } from "../../tools/ask-validation";
 import { getTabBarTheme } from "../shared";
 import { getMarkdownTheme, highlightCode, theme } from "../theme/theme";
 import {
@@ -29,6 +30,7 @@ import {
 	matchesSelectUp,
 } from "../utils/keybinding-matchers";
 import { CountdownTimer } from "./countdown-timer";
+import { renderDiff } from "./diff";
 import { editorKey } from "./keybinding-hints";
 import { bottomBorder, divider, row, topBorder } from "./overlay-box";
 import { handleTabSwitchKey } from "./selector-helpers";
@@ -55,6 +57,8 @@ const PROMPT_TITLE_CHROME_COLUMNS = 4;
  *  or multi-line question cannot push the option list off-screen. Mirrors the
  *  row-cap pattern used by boundPromptTitle for the prompt editor overlay. */
 const MAX_HEADER_ROWS = 4;
+/** Filtering only appears once a list is long enough to need it. */
+const SEARCHABLE_OPTION_THRESHOLD = 6;
 
 function promptTitleContentWidth(): number {
 	const cols = process.stdout.columns ?? 80;
@@ -105,6 +109,8 @@ interface QuestionState {
 	scrollOffset: number;
 	manualScroll: boolean;
 	timedOut: boolean;
+	searchActive: boolean;
+	searchQuery: string;
 }
 
 type QuestionRowKind = "option" | "other";
@@ -210,7 +216,10 @@ function splitPreviewSegments(preview: string): PreviewSegment[] {
 	return segments;
 }
 
-function renderPreviewContent(preview: string, width: number): string[] {
+function renderPreviewContent(preview: string, previewType: "markdown" | "diff" | undefined, width: number): string[] {
+	if (previewType === "diff") {
+		return [...new Text(renderDiff(preview), 0, 0).render(Math.max(1, width))];
+	}
 	const out: string[] = [];
 	const mdTheme = getMarkdownTheme();
 	const accentStyle = { color: (text: string) => theme.fg("muted", text) };
@@ -227,15 +236,23 @@ function renderPreviewContent(preview: string, width: number): string[] {
 	return out;
 }
 
-function renderCachedPreview(cache: PreviewRenderCache, preview: string, width: number): readonly string[] {
-	let byWidth = cache.get(preview);
+function renderCachedPreview(
+	cache: PreviewRenderCache,
+	preview: string,
+	previewType: "markdown" | "diff" | undefined,
+	width: number,
+): readonly string[] {
+	const cacheKey = `${previewType ?? "markdown"}\u0000${preview}`;
+	let byWidth = cache.get(cacheKey);
 	if (!byWidth) {
 		byWidth = new Map();
-		cache.set(preview, byWidth);
+		cache.set(cacheKey, byWidth);
 	}
 	let rendered = byWidth.get(width);
 	if (!rendered) {
-		rendered = renderPreviewContent(preview, width).map(line => `      ${theme.fg("border", "│")} ${line}`);
+		rendered = renderPreviewContent(preview, previewType, width).map(
+			line => `      ${theme.fg("border", "│")} ${line}`,
+		);
 		byWidth.set(width, rendered);
 	}
 	return rendered;
@@ -327,7 +344,7 @@ function renderRowLabel(
 		}
 		if (option?.preview?.trim()) {
 			const previewWidth = Math.max(1, width - 8);
-			lines.push(...renderCachedPreview(previewCache, option.preview, previewWidth));
+			lines.push(...renderCachedPreview(previewCache, option.preview, option.previewType, previewWidth));
 		}
 	}
 	if (isOther && state.customInput !== undefined) {
@@ -370,6 +387,8 @@ export class AskDialogComponent implements Component {
 				scrollOffset: 0,
 				manualScroll: false,
 				timedOut: false,
+				searchActive: false,
+				searchQuery: "",
 			};
 		});
 		if (options.timeout && options.timeout > 0) {
@@ -402,6 +421,14 @@ export class AskDialogComponent implements Component {
 		// closed/prompt guards, matching HookSelector/HookInput semantics.
 		this.#countdown?.reset();
 		if (matchesSelectCancel(keyData)) {
+			const active = this.#activeQuestionState();
+			if (active?.state.searchActive) {
+				active.state.searchActive = false;
+				active.state.searchQuery = "";
+				active.state.cursorIndex = 0;
+				this.#requestRender();
+				return;
+			}
 			this.#finishCancel();
 			return;
 		}
@@ -479,7 +506,7 @@ export class AskDialogComponent implements Component {
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			const headerRows = tabBarRows + renderQuestionTitle(question, width).length;
-			const rowItems = this.#questionRows(question);
+			const rowItems = this.#questionRows(question, state);
 			const listRows = (listWidth: number): number => {
 				let total = 0;
 				for (const rowItem of rowItems) {
@@ -562,20 +589,59 @@ export class AskDialogComponent implements Component {
 		const question = this.questions[this.#currentQuestionIndex()];
 		const action = question?.multi ? "Space/Enter toggle · n note" : "Enter select · n note";
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
+		const search =
+			question && this.#states[this.#currentQuestionIndex()] && this.#isSearchEnabled(question)
+				? this.#states[this.#currentQuestionIndex()].searchActive
+					? ` · filter: ${this.#states[this.#currentQuestionIndex()].searchQuery || "type to filter"}`
+					: " · / filter"
+				: "";
 		if (this.#questionCanPage && indicator) {
-			return `${action} · ↑/↓${tabs} · ${cancel} · ${pageKeysLabel()} ${indicator}`;
+			return `${action} · ↑/↓${tabs}${search} · ${cancel} · ${pageKeysLabel()} ${indicator}`;
 		}
 		const scroll = indicator ? ` ${indicator} scroll ·` : "";
-		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}`;
+		return `${action} · ↑/↓ move${tabs}${search} ·${scroll} ${cancel}`;
 	}
 
-	#questionRows(question: ExtensionAskDialogQuestion): QuestionRow[] {
-		const rows: QuestionRow[] = question.options.map((option, index) => ({
-			kind: "option",
-			key: `option:${index}`,
-			label: this.#optionLabel(question, option.label, index),
-			optionIndex: index,
-		}));
+	#isSearchEnabled(question: ExtensionAskDialogQuestion): boolean {
+		return question.searchable === true && question.options.length > SEARCHABLE_OPTION_THRESHOLD;
+	}
+
+	#handleSearchInput(question: ExtensionAskDialogQuestion, state: QuestionState, keyData: string): boolean {
+		if (!this.#isSearchEnabled(question)) return false;
+		if (keyData === "/") {
+			state.searchActive = true;
+			this.#requestRender();
+			return true;
+		}
+		if (!state.searchActive) return false;
+		if (keyData === "\b" || keyData === "\x7f") {
+			state.searchQuery = state.searchQuery.slice(0, -1);
+			state.cursorIndex = 0;
+			state.manualScroll = false;
+			this.#requestRender();
+			return true;
+		}
+		if (keyData.length === 0 || keyData.startsWith("\x1b") || /[\n\r\t]/u.test(keyData)) return false;
+		state.searchQuery += keyData;
+		state.cursorIndex = 0;
+		state.manualScroll = false;
+		this.#requestRender();
+		return true;
+	}
+
+	#questionRows(question: ExtensionAskDialogQuestion, state?: QuestionState): QuestionRow[] {
+		const query = state?.searchQuery.trim().toLocaleLowerCase();
+		const rows: QuestionRow[] = question.options.flatMap((option, index) => {
+			if (query && !option.label.toLocaleLowerCase().includes(query)) return [];
+			return [
+				{
+					kind: "option",
+					key: `option:${index}`,
+					label: this.#optionLabel(question, option.label, index),
+					optionIndex: index,
+				},
+			];
+		});
 		rows.push({ kind: "other", key: "other", label: OTHER_OPTION, optionIndex: undefined });
 		return rows;
 	}
@@ -595,7 +661,8 @@ export class AskDialogComponent implements Component {
 		const active = this.#activeQuestionState();
 		if (!active) return;
 		const { question, state } = active;
-		const rows = this.#questionRows(question);
+		if (this.#handleSearchInput(question, state, keyData)) return;
+		const rows = this.#questionRows(question, state);
 		if (matchesSelectPageUp(keyData)) {
 			state.scrollOffset = Math.max(0, state.scrollOffset - Math.max(1, this.#bodyRows - 1));
 			state.manualScroll = true;
@@ -695,22 +762,33 @@ export class AskDialogComponent implements Component {
 	): Promise<void> {
 		this.#promptActive = true;
 		try {
-			const input = await this.callbacks.onPrompt(
-				boundPromptTitle("Custom answer: ", question.question),
-				state.customInput,
-			);
-			if (input === undefined || this.#closed) return;
-			if (input.trim() === "") {
-				// Submitting an empty value unselects the custom answer.
-				state.customInput = undefined;
-				clearNoteIfRow(state, rowItem.key);
+			let prefill = state.customInput;
+			let validationError: string | undefined;
+			while (true) {
+				const title = boundPromptTitle("Custom answer: ", question.question);
+				const input = await this.callbacks.onPrompt(
+					validationError ? `${validationError}\n\n${title}` : title,
+					prefill,
+				);
+				if (input === undefined || this.#closed) return;
+				if (input.trim() === "") {
+					// Submitting an empty value unselects the custom answer.
+					state.customInput = undefined;
+					clearNoteIfRow(state, rowItem.key);
+					return;
+				}
+				validationError = getAskCustomInputValidationError(input, question.validation);
+				if (validationError !== undefined) {
+					prefill = input;
+					continue;
+				}
+				state.customInput = input;
+				if (!question.multi) {
+					state.selectedOptions.clear();
+					clearNoteUnlessRow(state, rowItem.key);
+					this.#advanceAfterQuestion();
+				}
 				return;
-			}
-			state.customInput = input;
-			if (!question.multi) {
-				state.selectedOptions.clear();
-				clearNoteUnlessRow(state, rowItem.key);
-				this.#advanceAfterQuestion();
 			}
 		} finally {
 			this.#promptActive = false;
@@ -744,7 +822,7 @@ export class AskDialogComponent implements Component {
 		const active = this.#activeQuestionState();
 		if (!active) return { lines: [], scrollOffset: 0, indicator: "" };
 		const { question, state } = active;
-		const rowItems = this.#questionRows(question);
+		const rowItems = this.#questionRows(question, state);
 		state.cursorIndex = clamp(state.cursorIndex, 0, Math.max(0, rowItems.length - 1));
 		return this.#renderQuestionList(question, state, rowItems, width, maxRows);
 	}

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -1,6 +1,7 @@
 import {
 	type Component,
 	Ellipsis,
+	extractPrintableText,
 	Markdown,
 	type MarkdownTheme,
 	matchesKey,
@@ -19,7 +20,7 @@ import type {
 	ExtensionAskDialogResultItem,
 	ExtensionAskDialogSubmitResult,
 } from "../../extensibility/extensions";
-import { getAskCustomInputValidationError } from "../../tools/ask-validation";
+import { formatAskValidationTitle, getAskCustomInputValidationError } from "../../tools/ask-validation";
 import { getTabBarTheme } from "../shared";
 import { getMarkdownTheme, highlightCode, theme } from "../theme/theme";
 import {
@@ -614,15 +615,16 @@ export class AskDialogComponent implements Component {
 			return true;
 		}
 		if (!state.searchActive) return false;
-		if (keyData === "\b" || keyData === "\x7f") {
+		if (matchesKey(keyData, "backspace")) {
 			state.searchQuery = state.searchQuery.slice(0, -1);
 			state.cursorIndex = 0;
 			state.manualScroll = false;
 			this.#requestRender();
 			return true;
 		}
-		if (keyData.length === 0 || keyData.startsWith("\x1b") || /[\n\r\t]/u.test(keyData)) return false;
-		state.searchQuery += keyData;
+		const printableText = extractPrintableText(keyData);
+		if (!printableText) return false;
+		state.searchQuery += printableText;
 		state.cursorIndex = 0;
 		state.manualScroll = false;
 		this.#requestRender();
@@ -767,7 +769,10 @@ export class AskDialogComponent implements Component {
 			while (true) {
 				const title = boundPromptTitle("Custom answer: ", question.question);
 				const input = await this.callbacks.onPrompt(
-					validationError ? `${validationError}\n\n${title}` : title,
+					formatAskValidationTitle(validationError, title, {
+						width: promptTitleContentWidth(),
+						maxRows: MAX_PROMPT_TITLE_ROWS,
+					}),
 					prefill,
 				);
 				if (input === undefined || this.#closed) return;

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -423,7 +423,7 @@ export class AskDialogComponent implements Component {
 		this.#countdown?.reset();
 		if (matchesSelectCancel(keyData)) {
 			const active = this.#activeQuestionState();
-			if (active?.state.searchActive) {
+			if (active?.state.searchActive && !this.#isSubmitTab()) {
 				active.state.searchActive = false;
 				active.state.searchQuery = "";
 				active.state.cursorIndex = 0;
@@ -609,14 +609,14 @@ export class AskDialogComponent implements Component {
 
 	#handleSearchInput(question: ExtensionAskDialogQuestion, state: QuestionState, keyData: string): boolean {
 		if (!this.#isSearchEnabled(question)) return false;
-		if (keyData === "/") {
+		if (!state.searchActive && keyData === "/") {
 			state.searchActive = true;
 			this.#requestRender();
 			return true;
 		}
 		if (!state.searchActive) return false;
 		if (matchesKey(keyData, "backspace")) {
-			state.searchQuery = state.searchQuery.slice(0, -1);
+			state.searchQuery = Array.from(state.searchQuery).slice(0, -1).join("");
 			state.cursorIndex = 0;
 			state.manualScroll = false;
 			this.#requestRender();
@@ -776,16 +776,18 @@ export class AskDialogComponent implements Component {
 					prefill,
 				);
 				if (input === undefined || this.#closed) return;
-				if (input.trim() === "") {
-					// Submitting an empty value unselects the custom answer.
-					state.customInput = undefined;
-					clearNoteIfRow(state, rowItem.key);
-					return;
-				}
 				validationError = getAskCustomInputValidationError(input, question.validation);
 				if (validationError !== undefined) {
 					prefill = input;
 					continue;
+				}
+				// With no validation constraint, an empty value unselects the
+				// custom answer; a validated answer (including whitespace the
+				// pattern accepts) is kept, matching the degraded path.
+				if (input.trim() === "" && question.validation === undefined) {
+					state.customInput = undefined;
+					clearNoteIfRow(state, rowItem.key);
+					return;
 				}
 				state.customInput = input;
 				if (!question.multi) {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -28,6 +28,7 @@ import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/comp
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { normalizeCustomMessagePayload, USER_INTERRUPT_LABEL } from "../../session/messages";
+import { getAskCustomInputValidationError } from "../../tools/ask-validation";
 import { setExtensionTerminalTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
 const MAX_WIDGET_LINES = 10;
@@ -801,10 +802,7 @@ export class ExtensionUiController {
 				if (choice.value === ASK_CHAT_OPTION) return "chat";
 				if (choice.value === ASK_NEXT_OPTION) break;
 				if (choice.value === ASK_OTHER_OPTION) {
-					const input = await this.#requestGuestUiString(
-						{ kind: "editor", title: boundPromptTitle("Custom answer: ", question.question) },
-						signal,
-					);
+					const input = await this.#requestGuestAskCustomInput(question, signal);
 					if (input.kind === "unavailable") return "unavailable";
 					// Guest cancelled the Other editor: keep the ask open and
 					// return to the option list instead of cancelling the whole ask.
@@ -838,10 +836,7 @@ export class ExtensionUiController {
 				if (choice.kind === "cancelled") return undefined;
 				if (choice.value === ASK_CHAT_OPTION) return "chat";
 				if (choice.value === ASK_OTHER_OPTION) {
-					const input = await this.#requestGuestUiString(
-						{ kind: "editor", title: boundPromptTitle("Custom answer: ", question.question) },
-						signal,
-					);
+					const input = await this.#requestGuestAskCustomInput(question, signal);
 					if (input.kind === "unavailable") return "unavailable";
 					// Guest cancelled the Other editor: re-show the select list
 					// instead of cancelling the whole ask.
@@ -861,6 +856,29 @@ export class ExtensionUiController {
 			selectedOptions: question.options.map(option => option.label).filter(label => selected.has(label)),
 			customInput,
 		};
+	}
+
+	async #requestGuestAskCustomInput(
+		question: ExtensionAskDialogQuestion,
+		signal: AbortSignal,
+	): Promise<GuestUiResult> {
+		let prefill: string | undefined;
+		let validationError: string | undefined;
+		while (true) {
+			const title = boundPromptTitle("Custom answer: ", question.question);
+			const input = await this.#requestGuestUiString(
+				{
+					kind: "editor",
+					title: validationError ? `${validationError}\n\n${title}` : title,
+					prefill,
+				},
+				signal,
+			);
+			if (input.kind !== "answered") return input;
+			validationError = getAskCustomInputValidationError(input.value, question.validation);
+			if (validationError === undefined) return input;
+			prefill = input.value;
+		}
 	}
 
 	async #requestGuestUiString(request: CollabUiRequestDraft, signal: AbortSignal): Promise<GuestUiResult> {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -28,7 +28,7 @@ import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/comp
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { normalizeCustomMessagePayload, USER_INTERRUPT_LABEL } from "../../session/messages";
-import { getAskCustomInputValidationError } from "../../tools/ask-validation";
+import { formatAskValidationTitle, getAskCustomInputValidationError } from "../../tools/ask-validation";
 import { setExtensionTerminalTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
 const MAX_WIDGET_LINES = 10;
@@ -869,7 +869,7 @@ export class ExtensionUiController {
 			const input = await this.#requestGuestUiString(
 				{
 					kind: "editor",
-					title: validationError ? `${validationError}\n\n${title}` : title,
+					title: formatAskValidationTitle(validationError, title),
 					prefill,
 				},
 				signal,

--- a/packages/coding-agent/src/prompts/tools/ask.md
+++ b/packages/coding-agent/src/prompts/tools/ask.md
@@ -9,6 +9,9 @@ Asks user when you need clarification or input during task execution.
 - Use `questions` for multiple related questions instead of asking one at a time
 - Set `multi: true` on question to allow multiple selections
 - Use short option labels; put explanatory tradeoffs in `description` instead of merging them into the label
+- Long lists (7+ options)? Set `searchable: true`
+- Validate free-text `Other` answers with `validation` when format matters
+- Use `previewType: "diff"` for option previews that change code
 </instruction>
 
 <caution>

--- a/packages/coding-agent/src/tools/ask-validation.ts
+++ b/packages/coding-agent/src/tools/ask-validation.ts
@@ -1,16 +1,107 @@
+import { Ellipsis, replaceTabs, truncateToWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
+import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { ExtensionAskDialogValidation } from "../extensibility/extensions";
+
+/** Custom answers beyond this size fail validation without reaching RegExp. */
+export const MAX_ASK_CUSTOM_INPUT_LENGTH = 1024;
+const MAX_ASK_PATTERN_LENGTH = 256;
+const MAX_ASK_BOUNDED_QUANTIFIER = 64;
+
+/**
+ * Accept a deliberately small, linear-time subset of JavaScript regular
+ * expressions before handing it to the native backtracking engine. Groups,
+ * backreferences, and more than one quantified atom can create exponential or
+ * high-polynomial work; rejecting them keeps model-controlled validation safe
+ * on the synchronous TUI path.
+ */
+export function isSafeAskCustomInputPattern(pattern: string): boolean {
+	if (pattern.length > MAX_ASK_PATTERN_LENGTH) return false;
+
+	let quantifiers = 0;
+	for (let index = 0; index < pattern.length; index++) {
+		const char = pattern[index] ?? "";
+		if (char === "\\") {
+			const escaped = pattern[++index];
+			if (escaped === undefined || /[1-9k]/u.test(escaped)) return false;
+			continue;
+		}
+		if (char === "[") {
+			let closed = false;
+			for (index++; index < pattern.length; index++) {
+				if (pattern[index] === "\\") {
+					index++;
+					continue;
+				}
+				if (pattern[index] === "]") {
+					closed = true;
+					break;
+				}
+			}
+			if (!closed) return false;
+			continue;
+		}
+		if (char === "(" || char === ")") return false;
+		if (char === "*" || char === "+" || char === "?") {
+			if (++quantifiers > 1) return false;
+			continue;
+		}
+		if (char !== "{") continue;
+
+		const end = pattern.indexOf("}", index + 1);
+		if (end === -1) return false;
+		const bounds = pattern.slice(index + 1, end).split(",");
+		if (
+			bounds.length > 2 ||
+			bounds.some(bound => bound !== "" && !/^\d+$/u.test(bound)) ||
+			bounds[0] === "" ||
+			bounds.some(bound => bound !== "" && Number(bound) > MAX_ASK_BOUNDED_QUANTIFIER)
+		) {
+			return false;
+		}
+		if (++quantifiers > 1) return false;
+		index = end;
+	}
+	return true;
+}
+
+/**
+ * Format a validation retry title at the render boundary. All callers share
+ * control-character stripping, whitespace normalization, and a row budget so
+ * extension-provided messages cannot displace the editor.
+ */
+export function formatAskValidationTitle(
+	validationError: string | undefined,
+	title: string,
+	options: { width?: number; maxRows?: number } = {},
+): string {
+	if (validationError === undefined) return title;
+
+	const width = Math.max(1, options.width ?? (process.stdout.columns ?? 80) - 4);
+	const maxRows = Math.max(1, options.maxRows ?? 3);
+	const content = replaceTabs(sanitizeText(`${validationError}\n\n${title}`))
+		.replace(/\s+/g, " ")
+		.trim();
+	const rows = wrapTextWithAnsi(content, width);
+	if (rows.length <= maxRows) return rows.join("\n");
+	const kept = rows.slice(0, maxRows - 1);
+	return [...kept, truncateToWidth(rows[maxRows - 1] ?? "", width, Ellipsis.Unicode)].join("\n");
+}
 
 export function getAskCustomInputValidationError(
 	input: string,
 	validation: ExtensionAskDialogValidation | undefined,
 ): string | undefined {
 	if (!validation) return undefined;
+	if (input.length > MAX_ASK_CUSTOM_INPUT_LENGTH) {
+		return validation.message ?? "Custom answer does not meet the required format.";
+	}
 	let failed = false;
 	if (validation.minLength !== undefined && input.length < validation.minLength) failed = true;
 	if (validation.maxLength !== undefined && input.length > validation.maxLength) failed = true;
 	if (validation.pattern !== undefined) {
 		try {
-			if (!new RegExp(validation.pattern).test(input)) failed = true;
+			if (!isSafeAskCustomInputPattern(validation.pattern) || !new RegExp(validation.pattern).test(input))
+				failed = true;
 		} catch {
 			failed = true;
 		}

--- a/packages/coding-agent/src/tools/ask-validation.ts
+++ b/packages/coding-agent/src/tools/ask-validation.ts
@@ -100,8 +100,17 @@ export function getAskCustomInputValidationError(
 	if (validation.maxLength !== undefined && input.length > validation.maxLength) failed = true;
 	if (validation.pattern !== undefined) {
 		try {
-			if (!isSafeAskCustomInputPattern(validation.pattern) || !new RegExp(validation.pattern).test(input))
+			if (!isSafeAskCustomInputPattern(validation.pattern)) {
 				failed = true;
+			} else {
+				// Require the whole input to match, not just a substring:
+				// unanchored patterns such as `\d+` would otherwise accept
+				// "abc123", and JS `$` admits a trailing line terminator.
+				const match = new RegExp(validation.pattern).exec(input);
+				if (match === null || match.index !== 0 || match[0].length !== input.length) {
+					failed = true;
+				}
+			}
 		} catch {
 			failed = true;
 		}

--- a/packages/coding-agent/src/tools/ask-validation.ts
+++ b/packages/coding-agent/src/tools/ask-validation.ts
@@ -1,0 +1,19 @@
+import type { ExtensionAskDialogValidation } from "../extensibility/extensions";
+
+export function getAskCustomInputValidationError(
+	input: string,
+	validation: ExtensionAskDialogValidation | undefined,
+): string | undefined {
+	if (!validation) return undefined;
+	let failed = false;
+	if (validation.minLength !== undefined && input.length < validation.minLength) failed = true;
+	if (validation.maxLength !== undefined && input.length > validation.maxLength) failed = true;
+	if (validation.pattern !== undefined) {
+		try {
+			if (!new RegExp(validation.pattern).test(input)) failed = true;
+		} catch {
+			failed = true;
+		}
+	}
+	return failed ? (validation.message ?? "Custom answer does not meet the required format.") : undefined;
+}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -12,7 +12,7 @@
  *   - Users will always be able to select "Other" to provide custom text input
  *   - Use multi: true to allow multiple answers to be selected for a question
  *   - Use recommended: <index> to mark the default option; "(Recommended)" suffix is added automatically
- *   - Questions may time out and auto-select the recommended option (configurable, disabled in plan mode)
+ *   - Questions may time out and auto-select the recommended option only when unanswered (configurable, disabled in plan mode)
  */
 
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
@@ -38,7 +38,11 @@ import askDescription from "../prompts/tools/ask.md" with { type: "text" };
 import { vocalizer } from "../tts/vocalizer";
 import { framedBlock, outputBlockContentWidth, renderStatusLine } from "../tui";
 import type { ToolSession } from ".";
-import { getAskCustomInputValidationError } from "./ask-validation";
+import {
+	formatAskValidationTitle,
+	getAskCustomInputValidationError,
+	isSafeAskCustomInputPattern,
+} from "./ask-validation";
 import { formatErrorMessage, formatMeta, formatTitle } from "./render-utils";
 import { ToolAbortError } from "./tool-errors";
 
@@ -56,10 +60,14 @@ const RESERVED_OPTION_LABELS: Record<string, true> = {
 };
 
 const CustomInputValidation = arkType({
-	"pattern?": arkType("string").describe("optional JavaScript regular expression for Other answers"),
-	"minLength?": arkType("number").describe("optional minimum length for Other answers"),
-	"maxLength?": arkType("number").describe("optional maximum length for Other answers"),
-	"message?": arkType("string").describe("message shown when an Other answer fails validation"),
+	"pattern?": arkType("string").describe(
+		"optional safe JavaScript regular expression for Other answers (256 UTF-16 code units maximum)",
+	),
+	"minLength?": arkType("number").describe("optional minimum Other-answer length in UTF-16 code units"),
+	"maxLength?": arkType("number").describe("optional maximum Other-answer length in UTF-16 code units"),
+	"message?": arkType("string").describe(
+		"message shown when an Other answer fails validation; defaults to a format error",
+	),
 }).narrow((validation, ctx) => {
 	if (
 		(validation.minLength !== undefined && (!Number.isInteger(validation.minLength) || validation.minLength < 0)) ||
@@ -75,6 +83,9 @@ const CustomInputValidation = arkType({
 		return ctx.mustBe("defined with minLength no greater than maxLength");
 	}
 	if (validation.pattern !== undefined) {
+		if (!isSafeAskCustomInputPattern(validation.pattern)) {
+			return ctx.mustBe("defined with a safe JavaScript regular expression pattern");
+		}
 		try {
 			new RegExp(validation.pattern);
 		} catch {
@@ -88,7 +99,7 @@ const OptionItem = arkType({
 	label: arkType("string").describe("display label"),
 	"description?": arkType("string").describe("optional explanatory text displayed below the label"),
 	"preview?": arkType("string").describe("optional rich preview content for interactive ask dialogs"),
-	"previewType?": arkType('"markdown" | "diff"').describe("how the rich preview is rendered"),
+	"previewType?": arkType('"markdown" | "diff"').describe("how the rich preview is rendered; defaults to markdown"),
 });
 
 const QuestionItem = arkType({
@@ -98,9 +109,9 @@ const QuestionItem = arkType({
 	options: OptionItem.array().describe("available options"),
 	"multi?": arkType("boolean").describe("allow multiple selections"),
 	"recommended?": arkType("number").describe(
-		"recommended option index; timeout chooses exactly this option, including for multi-select",
+		"recommended option index; timeout chooses this option only when the question has no selections",
 	),
-	"searchable?": arkType("boolean").describe("allow filtering long option lists in the rich ask dialog"),
+	"searchable?": arkType("boolean").describe("allow filtering in rich ask dialogs with at least seven options"),
 	"validation?": CustomInputValidation.describe("optional validation applied only to Other custom answers"),
 }).narrow((question, ctx) => {
 	const reserved = question.options.find(option => RESERVED_OPTION_LABELS[option.label] === true);
@@ -590,7 +601,10 @@ async function askSingleQuestion(
 		let prefill: string | undefined;
 		let validationError: string | undefined;
 		while (true) {
-			const editorTitle = validationError ? `${validationError}\n\n${baseTitle}` : baseTitle;
+			const editorTitle = formatAskValidationTitle(validationError, baseTitle, {
+				width: customInputContentWidth(),
+				maxRows: MAX_CUSTOM_INPUT_TITLE_ROWS,
+			});
 			const showCustomInput = () => ui.editor(editorTitle, prefill, dialogOptions, { promptStyle: true });
 			const input = signal ? await untilAborted(signal, showCustomInput) : await showCustomInput();
 			if (input === undefined) return { input };

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -42,6 +42,7 @@ import {
 	formatAskValidationTitle,
 	getAskCustomInputValidationError,
 	isSafeAskCustomInputPattern,
+	MAX_ASK_CUSTOM_INPUT_LENGTH,
 } from "./ask-validation";
 import { formatErrorMessage, formatMeta, formatTitle } from "./render-utils";
 import { ToolAbortError } from "./tool-errors";
@@ -70,10 +71,18 @@ const CustomInputValidation = arkType({
 	),
 }).narrow((validation, ctx) => {
 	if (
-		(validation.minLength !== undefined && (!Number.isInteger(validation.minLength) || validation.minLength < 0)) ||
-		(validation.maxLength !== undefined && (!Number.isInteger(validation.maxLength) || validation.maxLength < 0))
+		(validation.minLength !== undefined &&
+			(!Number.isInteger(validation.minLength) ||
+				validation.minLength < 0 ||
+				validation.minLength > MAX_ASK_CUSTOM_INPUT_LENGTH)) ||
+		(validation.maxLength !== undefined &&
+			(!Number.isInteger(validation.maxLength) ||
+				validation.maxLength < 0 ||
+				validation.maxLength > MAX_ASK_CUSTOM_INPUT_LENGTH))
 	) {
-		return ctx.mustBe("defined with non-negative integer minLength and maxLength values");
+		return ctx.mustBe(
+			`defined with non-negative integer minLength and maxLength values no greater than ${MAX_ASK_CUSTOM_INPUT_LENGTH}`,
+		);
 	}
 	if (
 		validation.minLength !== undefined &&

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -32,12 +32,13 @@ import {
 import { prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type as arkType } from "arktype";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
-import type { ExtensionUISelectItem } from "../extensibility/extensions";
+import type { ExtensionAskDialogValidation, ExtensionUISelectItem } from "../extensibility/extensions";
 import { getMarkdownTheme, type Theme, theme } from "../modes/theme/theme";
 import askDescription from "../prompts/tools/ask.md" with { type: "text" };
 import { vocalizer } from "../tts/vocalizer";
 import { framedBlock, outputBlockContentWidth, renderStatusLine } from "../tui";
 import type { ToolSession } from ".";
+import { getAskCustomInputValidationError } from "./ask-validation";
 import { formatErrorMessage, formatMeta, formatTitle } from "./render-utils";
 import { ToolAbortError } from "./tool-errors";
 
@@ -54,10 +55,40 @@ const RESERVED_OPTION_LABELS: Record<string, true> = {
 	[NEXT_OPTION]: true,
 };
 
+const CustomInputValidation = arkType({
+	"pattern?": arkType("string").describe("optional JavaScript regular expression for Other answers"),
+	"minLength?": arkType("number").describe("optional minimum length for Other answers"),
+	"maxLength?": arkType("number").describe("optional maximum length for Other answers"),
+	"message?": arkType("string").describe("message shown when an Other answer fails validation"),
+}).narrow((validation, ctx) => {
+	if (
+		(validation.minLength !== undefined && (!Number.isInteger(validation.minLength) || validation.minLength < 0)) ||
+		(validation.maxLength !== undefined && (!Number.isInteger(validation.maxLength) || validation.maxLength < 0))
+	) {
+		return ctx.mustBe("defined with non-negative integer minLength and maxLength values");
+	}
+	if (
+		validation.minLength !== undefined &&
+		validation.maxLength !== undefined &&
+		validation.minLength > validation.maxLength
+	) {
+		return ctx.mustBe("defined with minLength no greater than maxLength");
+	}
+	if (validation.pattern !== undefined) {
+		try {
+			new RegExp(validation.pattern);
+		} catch {
+			return ctx.mustBe("defined with a valid JavaScript regular expression pattern");
+		}
+	}
+	return true;
+});
+
 const OptionItem = arkType({
 	label: arkType("string").describe("display label"),
 	"description?": arkType("string").describe("optional explanatory text displayed below the label"),
 	"preview?": arkType("string").describe("optional rich preview content for interactive ask dialogs"),
+	"previewType?": arkType('"markdown" | "diff"').describe("how the rich preview is rendered"),
 });
 
 const QuestionItem = arkType({
@@ -66,7 +97,11 @@ const QuestionItem = arkType({
 	"header?": arkType("string").describe("optional short display chip for rich ask dialogs"),
 	options: OptionItem.array().describe("available options"),
 	"multi?": arkType("boolean").describe("allow multiple selections"),
-	"recommended?": arkType("number").describe("recommended option index"),
+	"recommended?": arkType("number").describe(
+		"recommended option index; timeout chooses exactly this option, including for multi-select",
+	),
+	"searchable?": arkType("boolean").describe("allow filtering long option lists in the rich ask dialog"),
+	"validation?": CustomInputValidation.describe("optional validation applied only to Other custom answers"),
 }).narrow((question, ctx) => {
 	const reserved = question.options.find(option => RESERVED_OPTION_LABELS[option.label] === true);
 	return (
@@ -416,6 +451,7 @@ interface AskSingleQuestionOptions {
 	recommended?: number;
 	timeout?: number;
 	signal?: AbortSignal;
+	validation?: ExtensionAskDialogValidation;
 	initialSelection?: Pick<SelectionResult, "selectedOptions" | "customInput" | "note">;
 	navigation?: NavigationControls;
 }
@@ -456,7 +492,7 @@ async function askSingleQuestion(
 	multi: boolean,
 	options: AskSingleQuestionOptions = {},
 ): Promise<SelectionResult> {
-	const { recommended, timeout, signal, initialSelection, navigation } = options;
+	const { recommended, timeout, signal, validation, initialSelection, navigation } = options;
 	const doneLabel = getDoneOptionLabel();
 	let selectedOptions = [...(initialSelection?.selectedOptions ?? [])];
 	let customInput = initialSelection?.customInput;
@@ -550,10 +586,18 @@ async function askSingleQuestion(
 		context: CustomInputContext,
 	): Promise<{ input: string | undefined }> => {
 		const dialogOptions = signal ? { signal } : undefined;
-		const editorTitle = formatCustomInputTitle(title, optionsToShow, context);
-		const showCustomInput = () => ui.editor(editorTitle, undefined, dialogOptions, { promptStyle: true });
-		const input = signal ? await untilAborted(signal, showCustomInput) : await showCustomInput();
-		return { input };
+		const baseTitle = formatCustomInputTitle(title, optionsToShow, context);
+		let prefill: string | undefined;
+		let validationError: string | undefined;
+		while (true) {
+			const editorTitle = validationError ? `${validationError}\n\n${baseTitle}` : baseTitle;
+			const showCustomInput = () => ui.editor(editorTitle, prefill, dialogOptions, { promptStyle: true });
+			const input = signal ? await untilAborted(signal, showCustomInput) : await showCustomInput();
+			if (input === undefined) return { input };
+			validationError = getAskCustomInputValidationError(input, validation);
+			if (validationError === undefined) return { input };
+			prefill = input;
+		}
 	};
 
 	const promptWithProgress = navigation?.progressText ? `${question} (${navigation.progressText})` : question;
@@ -903,9 +947,12 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 								label: option.label,
 								...(option.description?.trim() ? { description: option.description.trim() } : {}),
 								...(option.preview?.trim() ? { preview: option.preview } : {}),
+								...(option.previewType !== undefined ? { previewType: option.previewType } : {}),
 							})),
 							...(q.multi !== undefined ? { multi: q.multi } : {}),
 							...(q.recommended !== undefined ? { recommended: q.recommended } : {}),
+							...(q.searchable !== undefined ? { searchable: q.searchable } : {}),
+							...(q.validation !== undefined ? { validation: q.validation } : {}),
 						})),
 						{ timeout: timeout ?? undefined, signal },
 					);
@@ -1000,6 +1047,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 						signal,
 						initialSelection: options?.previous,
 						navigation: options?.navigation,
+						validation: q.validation,
 					},
 				);
 				return { optionLabels, selectedOptions, customInput, note, navigation, cancelled, timedOut };

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1392,6 +1392,34 @@ describe("AskDialogComponent", () => {
 		expect(filtered).toContain("filter: beta");
 	});
 
+	it("accepts Kitty Backspace while filtering a searchable option list", () => {
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose one?",
+					searchable: true,
+					options: [
+						{ label: "Alpha" },
+						{ label: "Beta target" },
+						{ label: "Gamma" },
+						{ label: "Delta" },
+						{ label: "Epsilon" },
+						{ label: "Zeta" },
+						{ label: "Eta" },
+					],
+				},
+			],
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+		);
+
+		component.handleInput("/");
+		for (const character of "betx") component.handleInput(character);
+		component.handleInput("\x1b[127u");
+
+		expect(render(component)).toContain("filter: bet");
+	});
+
 	it("renders diff previews with added and removed lines", () => {
 		const questions: ExtensionAskDialogQuestion[] = [
 			{
@@ -1414,7 +1442,7 @@ describe("AskDialogComponent", () => {
 			{
 				id: "q1",
 				question: "Enter a numeric code",
-				validation: { pattern: "^\\d+$", message: "Enter digits only" },
+				validation: { pattern: "^\\d+$", message: `Enter digits\tonly\n\x1b[31m ${"long ".repeat(100)}` },
 				options: [{ label: "Option A" }],
 			},
 		];
@@ -1427,7 +1455,10 @@ describe("AskDialogComponent", () => {
 		await Promise.resolve();
 
 		expect(onPrompt).toHaveBeenCalledTimes(2);
-		expect(onPrompt.mock.calls[1]?.[0]).toContain("Enter digits only");
+		const retryTitle = onPrompt.mock.calls[1]?.[0] ?? "";
+		expect(retryTitle).toContain("Enter digits only");
+		expect(retryTitle).not.toContain("\x1b");
+		expect(retryTitle.split("\n")).toHaveLength(3);
 		expect(onPrompt.mock.calls[1]?.[1]).toBe("letters");
 		expect(onSubmit.mock.calls[0]?.[0].results[0].customInput).toBe("42");
 	});

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1420,6 +1420,79 @@ describe("AskDialogComponent", () => {
 		expect(render(component)).toContain("filter: bet");
 	});
 
+	it("activates search via a Kitty CSI-u slash sequence", () => {
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose one?",
+					searchable: true,
+					options: [
+						{ label: "Alpha" },
+						{ label: "Beta target" },
+						{ label: "Gamma" },
+						{ label: "Delta" },
+						{ label: "Epsilon" },
+						{ label: "Zeta" },
+						{ label: "Eta" },
+					],
+				},
+			],
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+		);
+
+		expect(render(component)).toContain("Alpha");
+		// The Kitty keyboard protocol reports "/" as the CSI-u sequence \x1b[47u.
+		component.handleInput("\x1b[47u");
+		for (const character of "beta") component.handleInput(character);
+
+		const filtered = render(component);
+		expect(filtered).toContain("Beta target");
+		expect(filtered).not.toContain("Alpha");
+		expect(filtered).toContain("filter: beta");
+	});
+
+	it("hides toggle and note shortcuts from the footer while a search filter is active", () => {
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose multiple?",
+				searchable: true,
+				multi: true,
+				options: [
+					{ label: "Alpha target" },
+					{ label: "Beta target" },
+					{ label: "Gamma target" },
+					{ label: "Delta target" },
+					{ label: "Epsilon target" },
+					{ label: "Zeta target" },
+					{ label: "Eta target" },
+				],
+			},
+		];
+		const component = new AskDialogComponent(questions, {
+			onSubmit: vi.fn(),
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+
+		// Before filtering, the footer advertises the multi-select shortcuts.
+		const idle = render(component);
+		expect(idle).toContain("Space/Enter toggle");
+		expect(idle).toContain("n note");
+
+		// Activate the filter and type a query.
+		component.handleInput("/");
+		for (const character of "beta") component.handleInput(character);
+
+		// While filtering, Space and n are consumed by the query, so the footer
+		// must stop advertising the shortcuts they would normally trigger.
+		const filtering = render(component);
+		expect(filtering).not.toContain("Space/Enter toggle");
+		expect(filtering).not.toContain("n note");
+		expect(filtering).toContain("filter: beta");
+	});
+
 	it("renders diff previews with added and removed lines", () => {
 		const questions: ExtensionAskDialogQuestion[] = [
 			{

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1362,4 +1362,73 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		expect(onSubmit.mock.calls[0][0].results[0].customInput).toBeUndefined();
 	});
+
+	it("filters a searchable long option list after typed input", () => {
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose one?",
+				searchable: true,
+				options: [
+					{ label: "Alpha" },
+					{ label: "Beta target" },
+					{ label: "Gamma" },
+					{ label: "Delta" },
+					{ label: "Epsilon" },
+					{ label: "Zeta" },
+					{ label: "Eta" },
+				],
+			},
+		];
+		const component = new AskDialogComponent(questions, { onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() });
+
+		expect(render(component)).toContain("Alpha");
+		component.handleInput("/");
+		for (const character of "beta") component.handleInput(character);
+
+		const filtered = render(component);
+		expect(filtered).toContain("Beta target");
+		expect(filtered).not.toContain("Alpha");
+		expect(filtered).toContain("filter: beta");
+	});
+
+	it("renders diff previews with added and removed lines", () => {
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Review the patch?",
+				options: [{ label: "Apply", preview: "- old value\n+ new value", previewType: "diff" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, { onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() });
+
+		const previewLine = component.render(80).find(line => line.includes("new value"));
+		expect(previewLine).toContain("new value");
+		expect(previewLine).toContain("\x1b[");
+	});
+
+	it("re-prompts Other answers that fail validation with the configured message", async () => {
+		const onPrompt = vi.fn().mockResolvedValueOnce("letters").mockResolvedValueOnce("42");
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Enter a numeric code",
+				validation: { pattern: "^\\d+$", message: "Enter digits only" },
+				options: [{ label: "Option A" }],
+			},
+		];
+		const component = new AskDialogComponent(questions, { onSubmit, onCancel: vi.fn(), onPrompt });
+
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPrompt).toHaveBeenCalledTimes(2);
+		expect(onPrompt.mock.calls[1]?.[0]).toContain("Enter digits only");
+		expect(onPrompt.mock.calls[1]?.[1]).toBe("letters");
+		expect(onSubmit.mock.calls[0]?.[0].results[0].customInput).toBe("42");
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { Container, setKeybindings } from "@oh-my-pi/pi-tui";
+import type { CollabUiRequestDraft } from "@oh-my-pi/pi-wire";
+import type { CollabGuestUiResult, CollabHost } from "../../../src/collab/host";
 import { KeybindingsManager } from "../../../src/config/keybindings";
 import type { ExtensionAskDialogQuestion, ExtensionUIContext } from "../../../src/extensibility/extensions";
 import { AskDialogComponent } from "../../../src/modes/components/ask-dialog";
@@ -18,7 +20,7 @@ beforeAll(async () => {
 	setThemeInstance(dark);
 });
 
-function makeHarness() {
+function makeHarness(options: { collabHost?: Pick<CollabHost, "requestGuestUi"> } = {}) {
 	const editor = new CustomEditor(getEditorTheme());
 	const editorContainer = new Container();
 	editorContainer.addChild(editor);
@@ -43,6 +45,7 @@ function makeHarness() {
 			uiContext = context;
 		},
 		addAutocompleteProvider,
+		...(options.collabHost === undefined ? {} : { collabHost: options.collabHost }),
 	} as unknown as InteractiveModeContext;
 
 	const controller = new ExtensionUiController(ctx);
@@ -246,5 +249,69 @@ describe("ExtensionUiController editor UI", () => {
 
 		expect(harness.addAutocompleteProvider).toHaveBeenCalledTimes(1);
 		expect(harness.addAutocompleteProvider).toHaveBeenCalledWith(factory);
+	});
+
+	it("retries invalid guest Other input with sanitized title and prefill", async () => {
+		const responses: CollabGuestUiResult[] = [
+			{ kind: "answered", value: "Other (type your own)" },
+			{ kind: "answered", value: "INVALID" },
+			{ kind: "answered", value: "42" },
+		];
+		const requestGuestUi = vi.fn<
+			(request: CollabUiRequestDraft, signal?: AbortSignal) => Promise<CollabGuestUiResult>
+		>(async () => responses.shift() ?? { kind: "unavailable" });
+		const harness = makeHarness({ collabHost: { requestGuestUi } });
+
+		const result = await harness.controller.showAskDialog([
+			{
+				id: "code",
+				question: "Enter the code",
+				options: [{ label: "Skip" }],
+				validation: { pattern: "^\\d+$", message: "Digits\tonly\n\x1b[31m" },
+			},
+		]);
+
+		expect(result).toEqual({
+			kind: "submit",
+			results: [
+				{
+					id: "code",
+					question: "Enter the code",
+					options: ["Skip"],
+					multi: false,
+					selectedOptions: [],
+					customInput: "42",
+				},
+			],
+		});
+		const editorRequests = requestGuestUi.mock.calls
+			.map(([request]) => request)
+			.filter((request): request is Extract<CollabUiRequestDraft, { kind: "editor" }> => request.kind === "editor");
+		expect(editorRequests).toHaveLength(2);
+		expect(editorRequests[1]?.prefill).toBe("INVALID");
+		expect(editorRequests[1]?.title).toContain("Digits only");
+		expect(editorRequests[1]?.title).not.toContain("\x1b");
+	});
+
+	it("returns to the guest select list when its Other editor is cancelled", async () => {
+		const responses: CollabGuestUiResult[] = [
+			{ kind: "answered", value: "Other (type your own)" },
+			{ kind: "answered", value: undefined },
+			{ kind: "answered", value: "Skip" },
+		];
+		const requestGuestUi = vi.fn<
+			(request: CollabUiRequestDraft, signal?: AbortSignal) => Promise<CollabGuestUiResult>
+		>(async () => responses.shift() ?? { kind: "unavailable" });
+		const harness = makeHarness({ collabHost: { requestGuestUi } });
+
+		const result = await harness.controller.showAskDialog([
+			{ id: "code", question: "Enter the code", options: [{ label: "Skip" }] },
+		]);
+
+		expect(result).toMatchObject({
+			kind: "submit",
+			results: [{ selectedOptions: ["Skip"], customInput: undefined }],
+		});
+		expect(requestGuestUi.mock.calls).toHaveLength(3);
 	});
 });

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1598,6 +1598,68 @@ describe("AskTool rich ask dialog", () => {
 		});
 	});
 
+	it("accepts schema upgrades and forwards them to the rich dialog", async () => {
+		const tool = new AskTool(createSession());
+		const askDialog = vi.fn().mockResolvedValue({
+			kind: "submit",
+			results: [
+				{
+					id: "q1",
+					question: "Q1?",
+					options: ["Option A"],
+					multi: false,
+					selectedOptions: ["Option A"],
+					note: "My Custom Note",
+					timedOut: undefined,
+				},
+			],
+		});
+		const context = createContext({ askDialog });
+
+		const result = await tool.execute(
+			"call-rich-dialog",
+			{
+				questions: [
+					{
+						id: "q1",
+						question: "Q1?",
+						header: "Chip Header",
+						searchable: true,
+						validation: { pattern: "^[a-z]+$", minLength: 2, maxLength: 8, message: "Use lowercase letters" },
+						options: [{ label: "Option A", preview: "My Preview", previewType: "diff" }],
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(askDialog).toHaveBeenCalledTimes(1);
+		// Check that rich-only schema fields were forwarded.
+		expect(askDialog.mock.calls[0][0]).toEqual([
+			{
+				id: "q1",
+				question: "Q1?",
+				header: "Chip Header",
+				searchable: true,
+				validation: { pattern: "^[a-z]+$", minLength: 2, maxLength: 8, message: "Use lowercase letters" },
+				options: [{ label: "Option A", preview: "My Preview", previewType: "diff" }],
+			},
+		]);
+
+		// Verify result contains details with note mapping
+		expect(result.details).toEqual({
+			question: "Q1?",
+			options: ["Option A"],
+			multi: false,
+			selectedOptions: ["Option A"],
+			customInput: undefined,
+			note: "My Custom Note",
+			timedOut: undefined,
+		});
+	});
+
 	it("aborts and throws ToolAbortError when askDialog returns undefined", async () => {
 		const tool = new AskTool(createSession());
 		const abort = vi.fn();
@@ -1690,5 +1752,49 @@ describe("AskTool rich ask dialog", () => {
 			questions: [{ id: "q1", question: "Q?", options: [{ label: "Next →" }] }],
 		});
 		expect(reservedNext instanceof type.errors).toBe(true);
+	});
+
+	it("validates schema upgrades and preserves reserved-label protection", async () => {
+		const tool = new AskTool(createSession());
+
+		const valid = tool.parameters({
+			questions: [
+				{
+					id: "q1",
+					question: "Q?",
+					searchable: true,
+					validation: { pattern: "^[a-z]+$", minLength: 1, maxLength: 12, message: "Use letters" },
+					options: [{ label: "ok", preview: "+ added", previewType: "diff" }],
+				},
+			],
+		});
+		expect(valid instanceof type.errors).toBe(false);
+
+		const invalidValidation = tool.parameters({
+			questions: [
+				{
+					id: "q1",
+					question: "Q?",
+					validation: { minLength: 5, maxLength: 2 },
+					options: [{ label: "ok" }],
+				},
+			],
+		});
+		expect(invalidValidation instanceof type.errors).toBe(true);
+
+		const invalidPattern = tool.parameters({
+			questions: [{ id: "q1", question: "Q?", validation: { pattern: "[" }, options: [{ label: "ok" }] }],
+		});
+		expect(invalidPattern instanceof type.errors).toBe(true);
+
+		const invalidPreviewType = tool.parameters({
+			questions: [{ id: "q1", question: "Q?", options: [{ label: "ok", previewType: "code" }] }],
+		});
+		expect(invalidPreviewType instanceof type.errors).toBe(true);
+
+		const reservedOther = tool.parameters({
+			questions: [{ id: "q1", question: "Q?", options: [{ label: "Other (type your own)" }] }],
+		});
+		expect(reservedOther instanceof type.errors).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -10,6 +10,7 @@ import type {
 import { getThemeByName, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { AskTool, askToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/ask";
+import { getAskCustomInputValidationError } from "@oh-my-pi/pi-coding-agent/tools/ask-validation";
 import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import { type } from "arktype";
 
@@ -1787,6 +1788,14 @@ describe("AskTool rich ask dialog", () => {
 		});
 		expect(invalidPattern instanceof type.errors).toBe(true);
 
+		const unsafePattern = tool.parameters({
+			questions: [{ id: "q1", question: "Q?", validation: { pattern: "^(a+)+$" }, options: [{ label: "ok" }] }],
+		});
+		expect(unsafePattern instanceof type.errors).toBe(true);
+		expect(getAskCustomInputValidationError("a".repeat(2_000), { pattern: "^a+$" })).toBeDefined();
+		expect(getAskCustomInputValidationError(`${"a".repeat(1_024)}!`, { pattern: "^a+$" })).toBeDefined();
+		expect(getAskCustomInputValidationError(`${"a".repeat(24)}!`, { pattern: "^(a+)+$" })).toBeDefined();
+
 		const invalidPreviewType = tool.parameters({
 			questions: [{ id: "q1", question: "Q?", options: [{ label: "ok", previewType: "code" }] }],
 		});
@@ -1796,5 +1805,54 @@ describe("AskTool rich ask dialog", () => {
 			questions: [{ id: "q1", question: "Q?", options: [{ label: "Other (type your own)" }] }],
 		});
 		expect(reservedOther instanceof type.errors).toBe(true);
+	});
+
+	it("retries invalid degraded Other input with sanitized title and prefill", async () => {
+		const tool = new AskTool(createSession());
+		const editor = vi.fn().mockResolvedValueOnce("letters").mockResolvedValueOnce("42");
+		const context = createContext({
+			select: async () => "Other (type your own)",
+			editor,
+		});
+
+		const result = await tool.execute(
+			"call-degraded-validation",
+			{
+				questions: [
+					{
+						id: "code",
+						question: "Enter a numeric code",
+						options: [{ label: "Skip" }],
+						validation: { pattern: "^\\d+$", message: "Digits\tonly\n\x1b[31m" },
+					},
+				],
+			},
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.details?.customInput).toBe("42");
+		expect(editor).toHaveBeenCalledTimes(2);
+		expect(editor.mock.calls[1]?.[1]).toBe("letters");
+		expect(editor.mock.calls[1]?.[0]).toContain("Digits only");
+		expect(editor.mock.calls[1]?.[0]).not.toContain("\x1b");
+	});
+
+	it("returns to degraded selection when Other input is cancelled", async () => {
+		const tool = new AskTool(createSession());
+		const select = vi.fn().mockResolvedValueOnce("Other (type your own)").mockResolvedValueOnce("Skip");
+		const context = createContext({ select, editor: async () => undefined });
+
+		const result = await tool.execute(
+			"call-degraded-cancel",
+			{ questions: [{ id: "code", question: "Enter a code", options: [{ label: "Skip" }] }] },
+			undefined,
+			undefined,
+			context,
+		);
+
+		expect(result.details?.selectedOptions).toEqual(["Skip"]);
+		expect(select).toHaveBeenCalledTimes(2);
 	});
 });


### PR DESCRIPTION
## Summary
- Upgrades the interactive `ask` tool with option searchability, custom answer validation (`pattern`, `minLength`, `maxLength`), and dedicated diff previews (`previewType: "diff"`).
- Adds static regular expression safety analysis (`isSafeAskCustomInputPattern`) to reject ReDoS-prone patterns before evaluation on the synchronous TUI path.
- Sanitizes title and prompt error presentation (`formatAskValidationTitle`), decodes printable search input (`extractPrintableText`), and bounds custom answer length at 1024 UTF-16 code units.
- Hardens guest cancellation, retry loops, and degraded fallback handling across collaborative guest UI channels.

## What changed
- **Schema & Extensibility Contracts (`types.ts`, `ask.ts`)**: Added `searchable?: boolean`, `previewType?: "markdown" | "diff"`, and `validation` (`pattern`, `minLength`, `maxLength`, `message`) to ArkType tool schemas and extension interfaces. Enforced label guards for reserved options (`Other (type your own)`, `Chat about this`, `Next ->`).
- **Input Validation & Safety (`ask-validation.ts`)**: Implemented `isSafeAskCustomInputPattern` to reject complex RegExp features (groups, backreferences `\1`–`\9`, multiple quantifiers, or bounded quantifiers >64). Created `formatAskValidationTitle` for control-char stripping, whitespace normalization, and row-budgeted title truncation. Capped free-text input at 1024 UTF-16 code units.
- **Interactive TUI Components (`ask-dialog.ts`)**: Added real-time option filtering when `searchable: true` or when option list size reaches `SEARCHABLE_OPTION_THRESHOLD` (7). Integrated `matchesKey` and `extractPrintableText` to support terminal input including Kitty backspace (`\x1b[127u`). Added search query clearing on Esc key and syntax-highlighted rendering for diff previews.
- **Controller & Guest Execution (`extension-ui-controller.ts`)**: Structured guest answer retry loops with formatted validation titles and prefill values. Handled guest cancellations (`kind: "cancelled"`) cleanly without leaving interactive dialogs in hung or invalid states. Applied typed `CollabGuestUiResult` and `CollabUiRequestDraft` interfaces throughout.

## Verification
- Test suites covering schema validation, safe regular expressions, interactive component search/rendering, and controller guest handling:
  - `packages/coding-agent/test/tools/ask.test.ts`
  - `packages/coding-agent/test/modes/components/ask-dialog.test.ts`
  - `packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts`
- Recorded checks: `bun check` clean, `bun test packages/coding-agent/test/tools/ask.test.ts`, `bun test packages/coding-agent/test/modes/components/ask-dialog.test.ts`, and `bun test packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts`.

## Notes
- Custom regular expression validation patterns supplied by callers or extensions are checked with `isSafeAskCustomInputPattern` before matching to guarantee synchronous TUI thread execution cannot be stalled by ReDoS or catastrophic backtracking.
- Custom answer input strings are capped at 1024 UTF-16 code units prior to regex evaluation.
