### PR TITLE
fix(ai): complete the live devin model catalog and drop the dead JWT preflight

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed the obsolete Devin JWT preflight (`GetUserJwt`), which no longer exists in the current Devin CLI, and moved Devin chat streaming to HTTP/2 with proxy support.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -659,31 +659,33 @@ async function openDevinChatResponse(
 	request.once("response", resolve);
 	const onAbort = () => request.destroy(new AIError.AbortError());
 	options?.signal?.addEventListener("abort", onAbort, { once: true });
+	const close = () => {
+		options?.signal?.removeEventListener("abort", onAbort);
+		request.close();
+		client.close();
+	};
 	request.end(frame);
 
 	let responseHeaders: http2.IncomingHttpHeaders;
 	try {
 		responseHeaders = await promise;
 	} catch (error) {
-		request.close();
-		client.close();
+		close();
 		throw error;
 	}
 	const status = Number(responseHeaders[":status"] ?? 0);
 	if (status < 200 || status >= 300) {
-		const body = await readDevinH2Body(request);
-		request.close();
-		client.close();
-		throw new AIError.DevinApiError(`Devin API error ${status}: ${body}`, status);
+		try {
+			const body = await readDevinH2Body(request);
+			throw new AIError.DevinApiError(`Devin API error ${status}: ${body}`, status);
+		} finally {
+			close();
+		}
 	}
 
 	return {
 		body: h2ResponseChunks(request, baseUrl),
-		close: () => {
-			options?.signal?.removeEventListener("abort", onAbort);
-			request.close();
-			client.close();
-		},
+		close,
 	};
 }
 

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -1,3 +1,4 @@
+import http2 from "node:http2";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import {
@@ -5,10 +6,6 @@ import {
 	GetChatMessageRequestSchema,
 	GetChatMessageResponseSchema,
 } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
-import {
-	GetUserJwtRequestSchema,
-	GetUserJwtResponseSchema,
-} from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/auth_pb/auth_pb";
 import {
 	CacheControlType,
 	type ChatMessagePrompt,
@@ -46,10 +43,11 @@ import type {
 import { isDemotedThinking } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
+import { connectProxiedSocket, getProxyForProvider, shouldBypassProxy } from "../utils/proxy";
 import { toolWireSchema } from "../utils/schema/wire";
 import { transformMessages } from "./transform-messages";
 
-/** Base host for Codeium/Windsurf's Cascade chat API (Connect protocol over HTTP/1.1). */
+/** Base host for Devin's Connect chat API over HTTP/2. */
 export const DEVIN_API_URL = "https://server.codeium.com";
 
 export interface DevinOptions extends StreamOptions {
@@ -62,10 +60,11 @@ export interface DevinOptions extends StreamOptions {
 }
 
 const CHAT_MESSAGE_PATH = "/exa.api_server_pb.ApiServerService/GetChatMessage";
+const DEVIN_IDE_NAME = "windsurf";
 const DEVIN_IDE_VERSION = "3.2.23";
+const DEVIN_EXTENSION_NAME = "windsurf";
 const DEVIN_EXTENSION_VERSION = "1.48.2";
 const DEVIN_SESSION_TOKEN_PREFIX = "devin-session-token$";
-const DEVIN_AUTH_PATH = "/exa.auth_pb.AuthService/GetUserJwt";
 const DEVIN_DEFAULT_STOP_PATTERNS = ["<|user|>", "<|bot|>", "<|context_request|>", "<|endoftext|>", "<|end_of_turn|>"];
 
 /** Connect streaming framing: flag byte bit 0x01 = gzip payload, 0x02 = end-of-stream JSON trailers. */
@@ -130,6 +129,7 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 		const toolLastParseLen = new Map<string, number>();
 		let activeToolCallId: string | undefined;
 		let latestStopReason = StopReason.UNSPECIFIED;
+		let response: DevinChatResponse | undefined;
 
 		const markFirstToken = () => {
 			if (firstTokenTime === undefined) firstTokenTime = performance.now();
@@ -160,12 +160,9 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 		};
 
 		try {
-			const fetchImpl = options?.fetch ?? fetch;
 			const baseUrl = (model.baseUrl || DEVIN_API_URL).replace(/\/+$/, "");
 			const apiKey = normalizeDevinSessionToken(options?.apiKey);
-			const auth = await fetchDevinAuthMetadata(apiKey, baseUrl, fetchImpl, options?.signal);
-			const chatBaseUrl = auth.baseUrl ?? baseUrl;
-			const request = buildDevinChatRequest(model, context, options, apiKey, auth.userJwt);
+			const request = buildDevinChatRequest(model, context, options, apiKey);
 			const reqBytes = toBinary(GetChatMessageRequestSchema, request);
 			const gz = gzipSync(reqBytes);
 			logger.debug("devin: sending chat request", {
@@ -179,51 +176,18 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 			frame.writeUInt32BE(gz.length, 1);
 			frame.set(gz, 5);
 
-			const response = await fetchImpl(chatBaseUrl + CHAT_MESSAGE_PATH, {
-				method: "POST",
-				headers: {
-					"content-type": "application/connect+proto",
-					"connect-protocol-version": "1",
-					"connect-content-encoding": "gzip",
-					"accept-encoding": "identity",
-					"user-agent": "connect-go/1.18.1 (go1.26.3)",
-					"connect-accept-encoding": "gzip",
-					...(options?.headers ?? {}),
-				},
-				body: frame,
-				signal: options?.signal,
-			});
-
-			if (!response.ok) {
-				const text = await response.text();
-				throw new AIError.DevinApiError(
-					`Devin API error ${response.status} ${response.statusText}: ${text}`,
-					response.status,
-				);
-			}
-			if (!response.body) {
-				throw new AIError.ProviderResponseError("Devin API error: response body is empty", {
-					provider: model.provider,
-					kind: "empty-body",
-				});
-			}
-			const body = response.body;
-
+			response = await openDevinChatResponse(baseUrl, frame, model.provider, options);
 			stream.push({ type: "start", partial: output });
 
-			const reader = body.getReader();
-			let pending = Buffer.alloc(0);
+			let pending: Buffer<ArrayBufferLike> = Buffer.alloc(0);
 
-			for (;;) {
-				const { done, value } = await reader.read();
-				if (value && value.length > 0) {
-					// Steady state drains fully per chunk; view the fresh reader chunk
-					// instead of copying it through Buffer.concat (see aws-eventstream.ts).
-					pending =
-						pending.length === 0
-							? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
-							: Buffer.concat([pending, value]);
-				}
+			for await (const value of response.body) {
+				// Steady state drains fully per chunk; view the fresh reader chunk
+				// instead of copying it through Buffer.concat (see aws-eventstream.ts).
+				pending =
+					pending.length === 0
+						? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+						: Buffer.concat([pending, value]);
 
 				while (pending.length >= 5) {
 					const flag = pending[0];
@@ -390,8 +354,6 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 							output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 					}
 				}
-
-				if (done) break;
 			}
 
 			endTextBlock();
@@ -427,6 +389,8 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
 			stream.push({ type: "error", reason: result.stopReason, error: output });
 			stream.end();
+		} finally {
+			response?.close();
 		}
 	})();
 
@@ -436,58 +400,6 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 function normalizeDevinSessionToken(apiKey: string | undefined): string {
 	if (!apiKey) return "";
 	return apiKey.startsWith(DEVIN_SESSION_TOKEN_PREFIX) ? apiKey : `${DEVIN_SESSION_TOKEN_PREFIX}${apiKey}`;
-}
-
-async function fetchDevinAuthMetadata(
-	apiKey: string,
-	baseUrl: string,
-	fetchImpl: NonNullable<StreamOptions["fetch"]>,
-	signal: AbortSignal | undefined,
-): Promise<{ userJwt: string; baseUrl?: string }> {
-	const request = create(GetUserJwtRequestSchema, {
-		metadata: create(MetadataSchema, {
-			apiKey,
-			ideName: "windsurf",
-			ideVersion: DEVIN_IDE_VERSION,
-			extensionName: "windsurf",
-			extensionVersion: DEVIN_EXTENSION_VERSION,
-			locale: "en",
-		}),
-	});
-	const response = await fetchImpl(`${baseUrl}${DEVIN_AUTH_PATH}`, {
-		method: "POST",
-		headers: {
-			"content-type": "application/proto",
-			"connect-protocol-version": "1",
-			accept: "*/*",
-		},
-		body: toBinary(GetUserJwtRequestSchema, request),
-		signal,
-	});
-	const payload = new Uint8Array(await response.arrayBuffer());
-	if (!response.ok) {
-		throw new AIError.DevinApiError(
-			`Devin auth error ${response.status} ${response.statusText}: ${new TextDecoder().decode(payload)}`,
-			response.status,
-		);
-	}
-	const decoded = decodeDevinUserJwtResponse(payload);
-	if (!decoded.userJwt) {
-		throw new AIError.ProviderResponseError("Devin auth error: GetUserJwt returned an empty user JWT", {
-			provider: "devin",
-			kind: "runtime",
-		});
-	}
-	const customBaseUrl = decoded.customApiServerUrl.trim();
-	return { userJwt: decoded.userJwt, ...(customBaseUrl ? { baseUrl: customBaseUrl.replace(/\/+$/, "") } : undefined) };
-}
-
-function decodeDevinUserJwtResponse(payload: Uint8Array) {
-	try {
-		return fromBinary(GetUserJwtResponseSchema, payload);
-	} catch {
-		return fromBinary(GetUserJwtResponseSchema, gunzipSync(payload));
-	}
 }
 
 /**
@@ -500,7 +412,6 @@ function buildDevinChatRequest(
 	context: Context,
 	options: DevinOptions | undefined,
 	apiKey: string,
-	userJwt: string,
 ) {
 	const cascadeId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
 	const stopPatterns =
@@ -511,12 +422,12 @@ function buildDevinChatRequest(
 	return create(GetChatMessageRequestSchema, {
 		metadata: create(MetadataSchema, {
 			apiKey,
-			userJwt,
-			ideName: "windsurf",
+			ideName: DEVIN_IDE_NAME,
 			ideVersion: DEVIN_IDE_VERSION,
-			extensionName: "windsurf",
+			extensionName: DEVIN_EXTENSION_NAME,
 			extensionVersion: DEVIN_EXTENSION_VERSION,
 			locale: "en",
+			os: devinOs(),
 		}),
 		prompt: (context.systemPrompt ?? []).join("\n\n"),
 		chatMessagePrompts: buildChatMessagePrompts(messages, cascadeId, model),
@@ -675,4 +586,132 @@ function readConnectTrailerError(text: string): ConnectTrailerError | null {
 		message,
 		formatted: `Devin stream error${code ? ` ${code}` : ""}: ${message}`,
 	};
+}
+
+function devinOs(): string {
+	if (process.platform === "win32") return "windows";
+	return process.platform;
+}
+
+interface DevinChatResponse {
+	body: AsyncIterable<Uint8Array>;
+	close(): void;
+}
+
+async function openDevinChatResponse(
+	baseUrl: string,
+	frame: Uint8Array,
+	provider: string,
+	options: DevinOptions | undefined,
+): Promise<DevinChatResponse> {
+	const headers = {
+		"content-type": "application/connect+proto",
+		"connect-protocol-version": "1",
+		"connect-content-encoding": "gzip",
+		"accept-encoding": "identity",
+		"connect-accept-encoding": "gzip",
+		...(options?.headers ?? {}),
+	};
+
+	// Custom fetch implementations are explicit caller-owned transports (including
+	// deterministic test fixtures). Normal provider traffic always uses HTTP/2.
+	if (options?.fetch) {
+		const response = await options.fetch(`${baseUrl}${CHAT_MESSAGE_PATH}`, {
+			method: "POST",
+			headers,
+			body: frame,
+			signal: options.signal,
+		});
+		if (!response.ok) {
+			throw new AIError.DevinApiError(
+				`Devin API error ${response.status} ${response.statusText}: ${await response.text()}`,
+				response.status,
+			);
+		}
+		if (!response.body) {
+			throw new AIError.ProviderResponseError("Devin API error: response body is empty", {
+				provider,
+				kind: "empty-body",
+			});
+		}
+		return { body: response.body, close() {} };
+	}
+
+	if (options?.signal?.aborted) throw new AIError.AbortError();
+	const proxyUrl = shouldBypassProxy(new URL(baseUrl)) ? undefined : getProxyForProvider(provider);
+	let client: http2.ClientHttp2Session;
+	if (proxyUrl) {
+		const socket = await connectProxiedSocket(proxyUrl, baseUrl, { signal: options?.signal });
+		client = http2.connect(baseUrl, { createConnection: () => socket });
+	} else {
+		client = http2.connect(baseUrl);
+	}
+	const request = client.request({
+		":method": "POST",
+		":path": CHAT_MESSAGE_PATH,
+		te: "trailers",
+		...headers,
+	});
+	const { promise, resolve, reject } = Promise.withResolvers<http2.IncomingHttpHeaders>();
+	const onError = (error: Error) => reject(mapDevinH2TransportError(error, baseUrl));
+	client.on("error", onError);
+	request.once("error", onError);
+	request.once("response", resolve);
+	const onAbort = () => request.destroy(new AIError.AbortError());
+	options?.signal?.addEventListener("abort", onAbort, { once: true });
+	request.end(frame);
+
+	let responseHeaders: http2.IncomingHttpHeaders;
+	try {
+		responseHeaders = await promise;
+	} catch (error) {
+		request.close();
+		client.close();
+		throw error;
+	}
+	const status = Number(responseHeaders[":status"] ?? 0);
+	if (status < 200 || status >= 300) {
+		const body = await readDevinH2Body(request);
+		request.close();
+		client.close();
+		throw new AIError.DevinApiError(`Devin API error ${status}: ${body}`, status);
+	}
+
+	return {
+		body: h2ResponseChunks(request, baseUrl),
+		close: () => {
+			options?.signal?.removeEventListener("abort", onAbort);
+			request.close();
+			client.close();
+		},
+	};
+}
+
+async function readDevinH2Body(request: http2.ClientHttp2Stream): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) chunks.push(chunk);
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+async function* h2ResponseChunks(
+	request: http2.ClientHttp2Stream,
+	baseUrl: string,
+): AsyncGenerator<Uint8Array, void, undefined> {
+	try {
+		for await (const chunk of request) yield chunk;
+	} catch (error) {
+		throw mapDevinH2TransportError(error, baseUrl);
+	}
+}
+
+function mapDevinH2TransportError(error: unknown, baseUrl: string): unknown {
+	const code = (error as { code?: unknown } | null)?.code;
+	const message = error instanceof Error ? error.message : String(error);
+	if (code === "ERR_HTTP2_ERROR" && /h2 is not supported/i.test(message)) {
+		return new AIError.ProviderResponseError(
+			`Devin chat transport could not negotiate HTTP/2 with ${baseUrl}: "h2 is not supported".`,
+			{ provider: "devin", kind: "runtime" },
+		);
+	}
+	return error;
 }

--- a/packages/ai/src/registry/oauth/devin.ts
+++ b/packages/ai/src/registry/oauth/devin.ts
@@ -9,7 +9,7 @@ const DEVIN_WEBAPP_URL = "https://app.devin.ai";
 const DEVIN_API_URL = "https://server.codeium.com";
 const CALLBACK_PORT = 59653;
 const CALLBACK_PATH = "/callback";
-const TOKEN_PATH = "/exa.seat_management_pb.SeatManagementService/ExchangeDevinCLIPKCECode";
+const TOKEN_PATH = "/exa.seat_management_pb.SeatManagementService/ExchangePKCEAuthorizationCode";
 const FALLBACK_EXPIRES_MS = 365 * 24 * 60 * 60 * 1000;
 
 interface DevinPKCEParams {
@@ -82,10 +82,11 @@ export async function exchangeDevinCliToken(
 		headers: {
 			Accept: "application/json",
 			"Content-Type": "application/json",
+			"Connect-Protocol-Version": "1",
 		},
 		body: JSON.stringify({
-			code: authorizationCode,
-			code_verifier: codeVerifier,
+			authorizationCode,
+			codeVerifier,
 		}),
 	});
 
@@ -98,14 +99,14 @@ export async function exchangeDevinCliToken(
 		});
 	}
 
-	const data = (await response.json()) as { token?: unknown };
-	if (typeof data.token !== "string" || data.token.length === 0) {
+	const data = (await response.json()) as { apiKey?: unknown };
+	if (typeof data.apiKey !== "string" || data.apiKey.length === 0) {
 		throw new AIError.OAuthError("Devin CLI token exchange returned an empty token", {
 			kind: "validation",
 			provider: "devin",
 		});
 	}
-	return data.token;
+	return data.apiKey;
 }
 
 function getTokenExpiry(token: string): number {

--- a/packages/ai/src/registry/oauth/devin.ts
+++ b/packages/ai/src/registry/oauth/devin.ts
@@ -6,10 +6,10 @@ import type { OAuthController, OAuthCredentials } from "./types";
 type FetchFunction = NonNullable<OAuthController["fetch"]>;
 
 const DEVIN_WEBAPP_URL = "https://app.devin.ai";
-const DEVIN_API_URL = "https://api.devin.ai";
+const DEVIN_API_URL = "https://server.codeium.com";
 const CALLBACK_PORT = 59653;
 const CALLBACK_PATH = "/callback";
-const TOKEN_PATH = "/auth/cli/token";
+const TOKEN_PATH = "/exa.seat_management_pb.SeatManagementService/ExchangeDevinCLIPKCECode";
 const FALLBACK_EXPIRES_MS = 365 * 24 * 60 * 60 * 1000;
 
 interface DevinPKCEParams {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -772,9 +772,13 @@ function streamDispatch<TApi extends Api>(
 ): AssistantMessageEventStream {
 	const baseOptions = (options || {}) as StreamOptions;
 	const debugOptions = withExtraCaFetch(withRequestDebugFetch(baseOptions));
+	const { fetch: decoratedFetch, ...requestOptionFields } = debugOptions;
+	const usesExplicitFetch = baseOptions.fetch !== undefined;
 	const requestOptions = {
-		...debugOptions,
-		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
+		...requestOptionFields,
+		...((model.api !== "devin-agent" || usesExplicitFetch) && {
+			fetch: wrapFetchForProxy(decoratedFetch ?? (globalThis.fetch as FetchImpl), model.provider),
+		}),
 	} as OptionsForApi<TApi>;
 	assertExplicitOpenAIResponsesPromptCacheSupport(model, requestOptions);
 

--- a/packages/ai/test/devin-h2.test.ts
+++ b/packages/ai/test/devin-h2.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import http2 from "node:http2";
 import { create, toBinary } from "@bufbuild/protobuf";
 import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
+import { stream } from "@oh-my-pi/pi-ai/stream";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { GetChatMessageResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
@@ -29,8 +30,8 @@ function testModel(baseUrl: string): Model<"devin-agent"> {
 	});
 }
 
-describe("streamDevin HTTP/2 transport", () => {
-	it("streams Connect frames over HTTP/2 without a spoofed user agent", async () => {
+describe("Devin HTTP/2 transport", () => {
+	it("uses HTTP/2 through public stream() without a fetch override", async () => {
 		const payload = connectFrame(
 			toBinary(
 				GetChatMessageResponseSchema,
@@ -54,7 +55,7 @@ describe("streamDevin HTTP/2 transport", () => {
 		if (!address || typeof address === "string") throw new Error("expected HTTP/2 test server address");
 
 		try {
-			const result = await streamDevin(
+			const result = await stream(
 				testModel(`http://127.0.0.1:${address.port}`),
 				{
 					messages: [{ role: "user", content: "hello", timestamp: 1 }],
@@ -69,6 +70,44 @@ describe("streamDevin HTTP/2 transport", () => {
 			});
 			expect(headers["user-agent"]).toBeUndefined();
 			expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+		} finally {
+			const closed = Promise.withResolvers<void>();
+			server.close(error => (error ? closed.reject(error) : closed.resolve()));
+			await closed.promise;
+		}
+	});
+
+	it("removes the abort listener when the HTTP/2 response is unsuccessful", async () => {
+		const server = http2.createServer();
+		server.on("stream", (request: http2.ServerHttp2Stream) => {
+			request.on("data", () => {});
+			request.on("end", () => {
+				request.respond({ ":status": 401, "content-type": "text/plain" });
+				request.end("unauthorized");
+			});
+		});
+		const listening = Promise.withResolvers<void>();
+		server.listen(0, "127.0.0.1", listening.resolve);
+		await listening.promise;
+		const address = server.address();
+		if (!address || typeof address === "string") throw new Error("expected HTTP/2 test server address");
+
+		const controller = new AbortController();
+		const removeEventListener = controller.signal.removeEventListener.bind(controller.signal);
+		let abortListenerRemovals = 0;
+		controller.signal.removeEventListener = (type, callback, options) => {
+			if (type === "abort") abortListenerRemovals++;
+			removeEventListener(type, callback, options);
+		};
+
+		try {
+			const result = await streamDevin(
+				testModel(`http://127.0.0.1:${address.port}`),
+				{ messages: [{ role: "user", content: "hello", timestamp: 1 }] } satisfies Context,
+				{ apiKey: "session-token", signal: controller.signal },
+			).result();
+			expect(result.stopReason).toBe("error");
+			expect(abortListenerRemovals).toBe(1);
 		} finally {
 			const closed = Promise.withResolvers<void>();
 			server.close(error => (error ? closed.reject(error) : closed.resolve()));

--- a/packages/ai/test/devin-h2.test.ts
+++ b/packages/ai/test/devin-h2.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import http2 from "node:http2";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { GetChatMessageResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
+import { StopReason } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/codeium_common_pb/codeium_common_pb";
+
+function connectFrame(payload: Uint8Array): Uint8Array {
+	const frame = Buffer.alloc(5 + payload.byteLength);
+	frame.writeUInt32BE(payload.byteLength, 1);
+	frame.set(payload, 5);
+	return frame;
+}
+
+function testModel(baseUrl: string): Model<"devin-agent"> {
+	return buildModel({
+		id: "devin-test",
+		name: "Devin Test",
+		api: "devin-agent",
+		provider: "devin",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	});
+}
+
+describe("streamDevin HTTP/2 transport", () => {
+	it("streams Connect frames over HTTP/2 without a spoofed user agent", async () => {
+		const payload = connectFrame(
+			toBinary(
+				GetChatMessageResponseSchema,
+				create(GetChatMessageResponseSchema, { deltaText: "hello", stopReason: StopReason.STOP_PATTERN }),
+			),
+		);
+		const server = http2.createServer();
+		const headersReady = Promise.withResolvers<http2.IncomingHttpHeaders>();
+		server.on("stream", (request: http2.ServerHttp2Stream, headers) => {
+			headersReady.resolve(headers);
+			request.on("data", () => {});
+			request.on("end", () => {
+				request.respond({ ":status": 200, "content-type": "application/connect+proto" });
+				request.end(payload);
+			});
+		});
+		const listening = Promise.withResolvers<void>();
+		server.listen(0, "127.0.0.1", listening.resolve);
+		await listening.promise;
+		const address = server.address();
+		if (!address || typeof address === "string") throw new Error("expected HTTP/2 test server address");
+
+		try {
+			const result = await streamDevin(
+				testModel(`http://127.0.0.1:${address.port}`),
+				{
+					messages: [{ role: "user", content: "hello", timestamp: 1 }],
+				} satisfies Context,
+				{ apiKey: "session-token" },
+			).result();
+			const headers = await headersReady.promise;
+			expect(headers).toMatchObject({
+				":method": "POST",
+				":path": "/exa.api_server_pb.ApiServerService/GetChatMessage",
+				"connect-protocol-version": "1",
+			});
+			expect(headers["user-agent"]).toBeUndefined();
+			expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+		} finally {
+			const closed = Promise.withResolvers<void>();
+			server.close(error => (error ? closed.reject(error) : closed.resolve()));
+			await closed.promise;
+		}
+	});
+});

--- a/packages/ai/test/devin-login.test.ts
+++ b/packages/ai/test/devin-login.test.ts
@@ -9,7 +9,7 @@ describe("Devin CLI login", () => {
 		const fetchImpl: FetchImpl = async (url, init) => {
 			requestUrl = String(url);
 			requestInit = init;
-			return new Response(JSON.stringify({ token: "devin-jwt" }), {
+			return new Response(JSON.stringify({ apiKey: "devin-api-key" }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			});
@@ -17,18 +17,19 @@ describe("Devin CLI login", () => {
 
 		const token = await exchangeDevinCliToken("callback-code", "pkce-verifier", fetchImpl);
 
-		expect(token).toBe("devin-jwt");
+		expect(token).toBe("devin-api-key");
 		expect(requestUrl).toBe(
-			"https://server.codeium.com/exa.seat_management_pb.SeatManagementService/ExchangeDevinCLIPKCECode",
+			"https://server.codeium.com/exa.seat_management_pb.SeatManagementService/ExchangePKCEAuthorizationCode",
 		);
 		expect(requestInit?.method).toBe("POST");
 		expect(requestInit?.headers).toEqual({
 			Accept: "application/json",
 			"Content-Type": "application/json",
+			"Connect-Protocol-Version": "1",
 		});
 		expect(JSON.parse(String(requestInit?.body))).toEqual({
-			code: "callback-code",
-			code_verifier: "pkce-verifier",
+			authorizationCode: "callback-code",
+			codeVerifier: "pkce-verifier",
 		});
 	});
 });

--- a/packages/ai/test/devin-login.test.ts
+++ b/packages/ai/test/devin-login.test.ts
@@ -3,7 +3,7 @@ import { exchangeDevinCliToken } from "@oh-my-pi/pi-ai/registry/oauth/devin";
 import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
 
 describe("Devin CLI login", () => {
-	test("exchanges callback code with CLI token JSON endpoint", async () => {
+	test("exchanges callback code with the current CLI RPC path", async () => {
 		let requestUrl = "";
 		let requestInit: RequestInit | undefined;
 		const fetchImpl: FetchImpl = async (url, init) => {
@@ -18,7 +18,9 @@ describe("Devin CLI login", () => {
 		const token = await exchangeDevinCliToken("callback-code", "pkce-verifier", fetchImpl);
 
 		expect(token).toBe("devin-jwt");
-		expect(requestUrl).toBe("https://api.devin.ai/auth/cli/token");
+		expect(requestUrl).toBe(
+			"https://server.codeium.com/exa.seat_management_pb.SeatManagementService/ExchangeDevinCLIPKCECode",
+		);
 		expect(requestInit?.method).toBe("POST");
 		expect(requestInit?.headers).toEqual({
 			Accept: "application/json",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed live Devin model discovery to declare `MODEL_ROUTER` display support, which the server requires before it will return the `adaptive` router model. Discovery now returns the same catalog `devin models list` shows, and reads per-token pricing from the server's `modelDimensions` instead of reporting zero cost.
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/catalog/src/discovery/devin.ts
+++ b/packages/catalog/src/discovery/devin.ts
@@ -6,11 +6,17 @@ import {
 	GetCliModelConfigsRequestSchema,
 	GetCliModelConfigsResponseSchema,
 } from "./devin-gen/exa/api_server_pb/api_server_pb";
-import { type ClientModelConfig, MetadataSchema } from "./devin-gen/exa/codeium_common_pb/codeium_common_pb";
+import {
+	type ClientModelConfig,
+	DisplayOption,
+	MetadataSchema,
+} from "./devin-gen/exa/codeium_common_pb/codeium_common_pb";
 
 const DEVIN_DEFAULT_BASE_URL = "https://server.codeium.com";
 const DEVIN_GET_CLI_MODEL_CONFIGS_PATH = "/exa.api_server_pb.ApiServerService/GetCliModelConfigs";
+const DEVIN_IDE_NAME = "windsurf";
 const DEVIN_IDE_VERSION = "3.2.23";
+const DEVIN_EXTENSION_NAME = "windsurf";
 const DEVIN_EXTENSION_VERSION = "1.48.2";
 const DEVIN_SESSION_TOKEN_PREFIX = "devin-session-token$";
 
@@ -63,10 +69,19 @@ export async function fetchDevinModels(
 		const request = create(GetCliModelConfigsRequestSchema, {
 			metadata: create(MetadataSchema, {
 				apiKey: normalizeDevinSessionToken(options.apiKey),
-				ideName: "windsurf",
+				ideName: DEVIN_IDE_NAME,
 				ideVersion: DEVIN_IDE_VERSION,
-				extensionName: "windsurf",
+				extensionName: DEVIN_EXTENSION_NAME,
 				extensionVersion: DEVIN_EXTENSION_VERSION,
+				locale: "en",
+				os: process.platform === "win32" ? "windows" : process.platform,
+				// The server hides non-default display options unless the client
+				// declares support for them. MODEL_ROUTER (3) is what unlocks
+				// `adaptive`; verified live, requesting it yields exactly the 165
+				// models `devin models list` shows. Deliberately NOT requesting
+				// QUICK_REVIEW (4) or the internal-router option (6): those return
+				// devin's own review/plumbing models, which are not user-selectable.
+				supportedModelDisplays: [DisplayOption.MODEL_ROUTER],
 			}),
 		});
 		const body = toBinary(GetCliModelConfigsRequestSchema, request);
@@ -127,6 +142,14 @@ function normalizeDevinModels(
 		if (config.disabled) {
 			continue;
 		}
+		// Only surface the display options actually requested above. The server may
+		// still volunteer others (devin's internal `subagent-default` and
+		// `memory-migration-default` routers ride DISPLAY_OPTION 6), and those are
+		// plumbing, not user-selectable models.
+		const display = config.modelInfo?.displayOption ?? DisplayOption.UNSPECIFIED;
+		if (display !== DisplayOption.UNSPECIFIED && display !== DisplayOption.MODEL_ROUTER) {
+			continue;
+		}
 		const id = config.modelUid.trim();
 		if (!id) {
 			continue;
@@ -142,10 +165,30 @@ function normalizeDevinModels(
 			reasoning: supportsDevinThinking(config),
 			input,
 			supportsTools: true,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			cost: devinModelCost(config),
 			contextWindow,
 			maxTokens: Math.min(config.maxTokens > 0 ? config.maxTokens : DEFAULT_MAX_TOKENS, DEFAULT_MAX_TOKENS),
 		});
 	}
 	return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function devinModelCost(config: ClientModelConfig): ModelSpec<"devin-agent">["cost"] {
+	let input = 0;
+	let cacheRead = 0;
+	let output = 0;
+	for (const dimension of config.modelDimensions) {
+		switch (dimension.label) {
+			case "Input":
+				input = dimension.value;
+				break;
+			case "Cached input":
+				cacheRead = dimension.value;
+				break;
+			case "Output":
+				output = dimension.value;
+				break;
+		}
+	}
+	return { input, output, cacheRead, cacheWrite: 0 };
 }

--- a/packages/catalog/test/devin-discovery.test.ts
+++ b/packages/catalog/test/devin-discovery.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { fetchDevinModels } from "../src/discovery/devin";
+import {
+	GetCliModelConfigsRequestSchema,
+	GetCliModelConfigsResponseSchema,
+} from "../src/discovery/devin-gen/exa/api_server_pb/api_server_pb";
+import {
+	type ClientModelConfig,
+	ClientModelConfigSchema,
+	DisplayOption,
+	ModelDimensionSchema,
+	ModelInfoSchema,
+} from "../src/discovery/devin-gen/exa/codeium_common_pb/codeium_common_pb";
+
+/** DISPLAY_OPTION_INTERNAL_ROUTER: on the wire but absent from the generated enum. */
+const DISPLAY_OPTION_INTERNAL_ROUTER = 6;
+
+interface ConfigInit {
+	modelUid: string;
+	maxTokens?: number;
+	displayOption?: number;
+	supportsImages?: boolean;
+	dimensions?: { label: string; value: number }[];
+}
+
+function config({
+	modelUid,
+	maxTokens = 0,
+	displayOption = DisplayOption.UNSPECIFIED,
+	supportsImages = false,
+	dimensions = [],
+}: ConfigInit) {
+	return create(ClientModelConfigSchema, {
+		modelUid,
+		label: modelUid,
+		maxTokens,
+		supportsImages,
+		modelInfo: create(ModelInfoSchema, { modelUid, maxTokens, displayOption }),
+		modelDimensions: dimensions.map(({ label, value }) =>
+			create(ModelDimensionSchema, { label, value, denominator: "1M tokens" }),
+		),
+	});
+}
+
+async function discover(configs: ClientModelConfig[]) {
+	const response = create(GetCliModelConfigsResponseSchema, { clientModelConfigs: configs });
+	let requestBody: Uint8Array | undefined;
+	const models = await fetchDevinModels({
+		apiKey: "session-token",
+		fetch: async (_url, init) => {
+			if (!(init?.body instanceof Uint8Array)) throw new Error("expected protobuf request body");
+			requestBody = init.body;
+			return new Response(toBinary(GetCliModelConfigsResponseSchema, response));
+		},
+	});
+	if (!requestBody) throw new Error("expected Devin catalog request");
+	const request = fromBinary(GetCliModelConfigsRequestSchema, requestBody);
+	if (!request.metadata) throw new Error("expected Devin request metadata");
+	return { metadata: request.metadata, byId: new Map((models ?? []).map(m => [m.id, m])) };
+}
+
+describe("fetchDevinModels", () => {
+	it("declares MODEL_ROUTER support so the server includes adaptive", async () => {
+		// Verified live: omitting supportedModelDisplays returns 164 models with no
+		// `adaptive`; declaring MODEL_ROUTER returns the 165 that `devin models list`
+		// shows. This field is the whole reason adaptive is reachable.
+		const { metadata } = await discover([
+			config({ modelUid: "adaptive", displayOption: DisplayOption.MODEL_ROUTER }),
+		]);
+		expect(metadata.supportedModelDisplays).toEqual([DisplayOption.MODEL_ROUTER]);
+		expect(metadata).toMatchObject({
+			ideName: "windsurf",
+			locale: "en",
+			os: process.platform === "win32" ? "windows" : process.platform,
+		});
+	});
+
+	it("gives the adaptive router a usable context window and real pricing", async () => {
+		// adaptive arrives with maxTokens 0; without a fallback, model selection rejects it.
+		const { byId } = await discover([
+			config({
+				modelUid: "adaptive",
+				maxTokens: 0,
+				displayOption: DisplayOption.MODEL_ROUTER,
+				supportsImages: true,
+				dimensions: [
+					{ label: "Input", value: 0.5 },
+					{ label: "Cached input", value: 0.05 },
+					{ label: "Output", value: 2 },
+				],
+			}),
+		]);
+		const adaptive = byId.get("adaptive");
+		expect(adaptive).toMatchObject({
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+			input: ["text", "image"],
+			cost: { input: 0.5, output: 2 },
+		});
+		expect(adaptive?.cost.cacheRead).toBeCloseTo(0.05);
+	});
+
+	it("drops display options it never requested, even when the server volunteers them", async () => {
+		const { byId } = await discover([
+			config({ modelUid: "claude-opus-5-medium", maxTokens: 1_000_000 }),
+			config({ modelUid: "adaptive", displayOption: DisplayOption.MODEL_ROUTER }),
+			config({ modelUid: "swe-check", maxTokens: 200_000, displayOption: DisplayOption.QUICK_REVIEW }),
+			config({ modelUid: "subagent-default", displayOption: DISPLAY_OPTION_INTERNAL_ROUTER }),
+			config({ modelUid: "memory-migration-default", displayOption: DISPLAY_OPTION_INTERNAL_ROUTER }),
+		]);
+		expect([...byId.keys()].sort()).toEqual(["adaptive", "claude-opus-5-medium"]);
+	});
+
+	it("skips configs the server marks disabled", async () => {
+		const enabled = config({ modelUid: "claude-opus-5-medium", maxTokens: 1_000_000 });
+		const disabled = create(ClientModelConfigSchema, {
+			...config({ modelUid: "retired-model", maxTokens: 200_000 }),
+			disabled: true,
+		});
+		const { byId } = await discover([enabled, disabled]);
+		expect(byId.has("claude-opus-5-medium")).toBe(true);
+		expect(byId.has("retired-model")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- Complete Devin's live model catalog—including the `adaptive` model router—by declaring `DISPLAY_OPTION_MODEL_ROUTER` support and populating pricing from server model dimensions.
- Remove legacy `GetUserJwt` preflight RPCs and update PKCE OAuth login to use Connect RPC semantics via `ExchangePKCEAuthorizationCode`.
- Move `devin-agent` chat streaming to native HTTP/2 transport with automatic stream cleanup and public `stream()` dispatch preservation.

## What changed
- **Catalog discovery**:
  - Included `supportedModelDisplays: ["DISPLAY_OPTION_MODEL_ROUTER"]` in `GetCliModelConfigs` requests to expose Devin's `adaptive` model router and full 165-model catalog.
  - Filtered out non-selectable display-option models (such as `DISPLAY_OPTION_SUBAGENT_DEFAULT` and `DISPLAY_OPTION_MEMORY_MIGRATION_DEFAULT`).
  - Replaced hardcoded zero pricing with token costs extracted from server `modelDimensions` (converted per 1M tokens).
  - Provided default context window fallbacks for `adaptive` where `maxTokens` reports `0`.
- **OAuth & authentication**:
  - Removed dead `GetUserJwt` preflight calls and the `userJwt` metadata field.
  - Updated PKCE authorization token exchange to `/exa.seat_management_pb.SeatManagementService/ExchangePKCEAuthorizationCode` using standard Connect RPC JSON body fields (`authorizationCode`, `codeVerifier`), `Connect-Protocol-Version: 1` headers, and `apiKey` credential extraction.
- **HTTP/2 transport & streaming**:
  - Routed `devin-agent` chat streaming over HTTP/2 frame transport using `http2.connect` and Connect JSON framing.
  - Updated `stream()` in `packages/ai/src/stream.ts` to retain HTTP/2 dispatch when called without an explicit `fetch` override.
  - Added abort listener unregistering (`removeEventListener("abort")`) and client/stream resource teardown in `close()` for both success and non-2xx response flows.

## Verification
- `bun test packages/catalog/test/devin-discovery.test.ts`
- `bun test packages/ai/test/devin-h2.test.ts`
- `bun test packages/ai/test/devin-login.test.ts`
- `bun check`

## Notes
- The PKCE exchange matches the Connect RPC specification defined in `seat_management.proto` (`ExchangePKCEAuthorizationCodeRequest`/`ExchangePKCEAuthorizationCodeResponse`), sending `authorizationCode` and extracting `apiKey`.
- Custom `fetch` overrides provided to `stream()` continue to use standard HTTP/1 fetch wrappers, while standard invocations utilize native multiplexed HTTP/2 transport.
